### PR TITLE
ibrl: use rdtsc based timer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
 name = "agave-install"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-instant",
  "agave-logger",
  "bincode",
  "bzip2",
@@ -176,6 +177,10 @@ dependencies = [
  "winapi",
  "winreg",
 ]
+
+[[package]]
+name = "agave-instant"
+version = "4.1.0-alpha.0"
 
 [[package]]
 name = "agave-io-uring"
@@ -398,6 +403,7 @@ dependencies = [
 name = "agave-validator"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-instant",
  "agave-logger",
  "agave-snapshots",
  "agave-votor",
@@ -565,6 +571,7 @@ dependencies = [
 name = "agave-watchtower"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-instant",
  "agave-logger",
  "clap 2.33.3",
  "humantime",
@@ -6929,6 +6936,7 @@ dependencies = [
 name = "solana-accounts-cluster-bench"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-instant",
  "agave-logger",
  "clap 2.33.3",
  "log",
@@ -7189,6 +7197,7 @@ dependencies = [
 name = "solana-bench-streamer"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-instant",
  "clap 3.2.23",
  "crossbeam-channel",
  "solana-net-utils",
@@ -7491,6 +7500,7 @@ name = "solana-cli"
 version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-instant",
  "agave-logger",
  "agave-syscalls",
  "agave-votor-messages",
@@ -7869,6 +7879,7 @@ dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-bls-cert-verify",
  "agave-feature-set",
+ "agave-instant",
  "agave-logger",
  "agave-math-utils",
  "agave-reserved-account-keys",
@@ -8323,6 +8334,7 @@ dependencies = [
 name = "solana-faucet-cli"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-instant",
  "agave-logger",
  "clap 2.33.3",
  "log",
@@ -8440,6 +8452,7 @@ name = "solana-genesis"
 version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-instant",
  "agave-logger",
  "agave-snapshots",
  "base64 0.22.1",
@@ -8631,6 +8644,7 @@ dependencies = [
 name = "solana-gossip-cli"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-instant",
  "agave-logger",
  "clap 2.33.3",
  "log",
@@ -8758,6 +8772,7 @@ dependencies = [
 name = "solana-keygen"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-instant",
  "agave-votor-messages",
  "bs58",
  "clap 3.2.23",
@@ -9096,6 +9111,9 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "4.1.0-alpha.0"
+dependencies = [
+ "agave-instant",
+]
 
 [[package]]
 name = "solana-merkle-tree"
@@ -9357,6 +9375,7 @@ dependencies = [
 name = "solana-poh-bench"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-instant",
  "agave-logger",
  "clap 3.2.23",
  "num_cpus",
@@ -10491,6 +10510,7 @@ dependencies = [
 name = "solana-stake-accounts"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-instant",
  "clap 2.33.3",
  "solana-account 4.1.0",
  "solana-clap-utils",
@@ -10748,6 +10768,9 @@ dependencies = [
 [[package]]
 name = "solana-svm-measure"
 version = "4.1.0-alpha.0"
+dependencies = [
+ "agave-instant",
+]
 
 [[package]]
 name = "solana-svm-test-harness"
@@ -11040,6 +11063,7 @@ dependencies = [
 name = "solana-tokens"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-instant",
  "agave-logger",
  "assert_matches",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "gossip",
     "gossip-cli",
     "install",
+    "instant",
     "io-uring",
     "keygen",
     "lattice-hash",
@@ -193,6 +194,7 @@ agave-bls12-381 = { path = "bls12-381", version = "=4.1.0-alpha.0", features = [
 agave-feature-set = { path = "feature-set", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-fs = { path = "fs", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=4.1.0-alpha.0" }
+agave-instant = { path = "instant", version = "=4.1.0-alpha.0" }
 agave-io-uring = { path = "io-uring", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-logger = { path = "logger", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-math-utils = { path = "math-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -16,6 +16,7 @@ agave-unstable-api = []
 dev-context-only-utils = []
 
 [dependencies]
+agave-instant = { workspace = true }
 agave-logger = { workspace = true }
 clap = { workspace = true }
 log = { workspace = true }

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -1128,6 +1128,7 @@ fn run_accounts_bench(
 }
 
 fn main() {
+    agave_instant::Instant::memoize();
     agave_logger::setup_with_default("solana=info");
     let matches = App::new(crate_name!())
         .about(crate_description!())

--- a/accounts-db/store-tool/Cargo.toml
+++ b/accounts-db/store-tool/Cargo.toml
@@ -17,6 +17,7 @@ dummy-for-ci-check = []
 frozen-abi = []
 
 [dependencies]
+agave-instant = { workspace = true }
 ahash = { workspace = true }
 clap = { workspace = true }
 rayon = { workspace = true }

--- a/accounts-db/store-tool/src/main.rs
+++ b/accounts-db/store-tool/src/main.rs
@@ -21,6 +21,7 @@ const CMD_INSPECT: &str = "inspect";
 const CMD_SEARCH: &str = "search";
 
 fn main() {
+    agave_instant::Instant::memoize();
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -15,6 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 agave-unstable-api = []
 
 [dependencies]
+agave-instant = { workspace = true }
 clap = { version = "3.1.5", default-features = false, features = ["cargo", "std", "suggestions"] }
 crossbeam-channel = { workspace = true }
 solana-net-utils = { workspace = true }

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -77,6 +77,7 @@ fn sink(exit: Arc<AtomicBool>, rvs: Arc<AtomicUsize>, r: PacketBatchReceiver) ->
 }
 
 fn main() -> Result<()> {
+    agave_instant::Instant::memoize();
     let matches = Command::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -20,6 +20,7 @@ dummy-for-ci-check = []
 frozen-abi = []
 
 [dependencies]
+agave-instant = { workspace = true }
 agave-logger = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -162,6 +162,7 @@ fn create_client(
 }
 
 fn main() {
+    agave_instant::Instant::memoize();
     agave_logger::setup_with_default_filter();
     solana_metrics::set_panic_hook("bench-tps", /*version:*/ None);
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,6 +28,7 @@ remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-instant = { workspace = true }
 agave-logger = { workspace = true }
 agave-syscalls = { workspace = true }
 agave-votor-messages = { workspace = true }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -228,6 +228,7 @@ pub fn parse_args<'a>(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn error::Error>> {
+    agave_instant::Instant::memoize();
     agave_logger::setup_with_default("off");
     let matches = get_clap_app(
         crate_name!(),

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -187,6 +187,7 @@ shaq = { workspace = true }
 sysctl = { workspace = true }
 
 [dev-dependencies]
+agave-instant = { workspace = true }
 agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
 agave-scheduler-bindings = { path = "../scheduler-bindings", features = ["agave-unstable-api"] }
 bencher = { workspace = true }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -128,6 +128,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-instant"
+version = "4.1.0-alpha.0"
+
+[[package]]
 name = "agave-io-uring"
 version = "4.1.0-alpha.0"
 dependencies = [
@@ -143,6 +147,7 @@ name = "agave-ledger-tool"
 version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-instant",
  "agave-logger",
  "agave-reserved-account-keys",
  "agave-snapshots",
@@ -321,6 +326,7 @@ dependencies = [
 name = "agave-store-tool"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-instant",
  "ahash 0.8.12",
  "clap",
  "rayon",
@@ -6055,6 +6061,7 @@ name = "solana-bench-tps"
 version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-instant",
  "agave-logger",
  "chrono",
  "clap",
@@ -6967,6 +6974,7 @@ name = "solana-genesis"
 version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-instant",
  "agave-logger",
  "agave-snapshots",
  "base64 0.22.1",
@@ -7526,6 +7534,9 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "4.1.0-alpha.0"
+dependencies = [
+ "agave-instant",
+]
 
 [[package]]
 name = "solana-merkle-tree"
@@ -8830,6 +8841,9 @@ dependencies = [
 [[package]]
 name = "solana-svm-measure"
 version = "4.1.0-alpha.0"
+dependencies = [
+ "agave-instant",
+]
 
 [[package]]
 name = "solana-svm-timings"

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -45,6 +45,7 @@ used_underscore_binding = "deny"
 [workspace.dependencies]
 agave-banking-stage-ingress-types = { path = "../banking-stage-ingress-types", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-feature-set = { path = "../feature-set", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+agave-instant = { path = "../instant", version = "=4.1.0-alpha.0" }
 agave-logger = { path = "../logger", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "../reserved-account-keys", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-snapshots = { path = "../snapshots", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }

--- a/faucet-cli/Cargo.toml
+++ b/faucet-cli/Cargo.toml
@@ -17,6 +17,7 @@ name = "solana-faucet"
 path = "src/main.rs"
 
 [dependencies]
+agave-instant = { workspace = true }
 agave-logger = { workspace = true }
 clap = { workspace = true }
 log = { workspace = true }

--- a/faucet-cli/src/main.rs
+++ b/faucet-cli/src/main.rs
@@ -18,6 +18,7 @@ use {
 
 #[tokio::main]
 async fn main() {
+    agave_instant::Instant::memoize();
     let default_keypair = solana_cli_config::Config::default().keypair_path;
 
     agave_logger::setup_with_default_filter();

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -26,6 +26,7 @@ agave-unstable-api = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-instant = { workspace = true }
 agave-logger = { workspace = true }
 agave-snapshots = { workspace = true }
 base64 = { workspace = true }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -341,6 +341,7 @@ fn rent_exempt_check(stake_lamports: u64, exempt: u64) -> io::Result<()> {
 #[allow(deprecated)]
 #[allow(clippy::cognitive_complexity)]
 fn main() -> Result<(), Box<dyn error::Error>> {
+    agave_instant::Instant::memoize();
     let default_faucet_pubkey = solana_cli_config::Config::default().keypair_path;
     let fee_rate_governor = FeeRateGovernor::default();
     let (

--- a/gossip-cli/Cargo.toml
+++ b/gossip-cli/Cargo.toml
@@ -18,6 +18,7 @@ bench = false
 agave-unstable-api = []
 
 [dependencies]
+agave-instant = { workspace = true }
 agave-logger = { workspace = true }
 clap = { workspace = true }
 log = { workspace = true }

--- a/gossip-cli/src/main.rs
+++ b/gossip-cli/src/main.rs
@@ -400,6 +400,7 @@ fn get_gossip_address(matches: &ArgMatches, entrypoint_addrs: &[SocketAddr]) -> 
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
+    agave_instant::Instant::memoize();
     agave_logger::setup_with_default_filter();
 
     let matches = parse_matches();

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 agave-unstable-api = []
 
 [dependencies]
+agave-instant = { workspace = true }
 agave-logger = { workspace = true }
 bincode = { workspace = true }
 bzip2 = { workspace = true }

--- a/install/src/main.rs
+++ b/install/src/main.rs
@@ -1,3 +1,4 @@
 fn main() -> Result<(), String> {
+    agave_instant::Instant::memoize();
     agave_install::main()
 }

--- a/instant/Cargo.toml
+++ b/instant/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
-name = "solana-measure"
-documentation = "https://docs.rs/solana-measure"
+name = "agave-instant"
 version = { workspace = true }
 authors = { workspace = true }
 description = { workspace = true }
@@ -9,11 +8,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
 [features]
-agave-unstable-api = []
+default = []
+rdtsc = []
 
-[dependencies]
-agave-instant = { workspace = true }
+[lints]
+workspace = true

--- a/instant/src/lib.rs
+++ b/instant/src/lib.rs
@@ -1,0 +1,243 @@
+#![allow(clippy::arithmetic_side_effects)]
+
+#[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+use std::sync::OnceLock;
+use std::time::Instant as StdInstant;
+
+// ── Public API ────────────────────────────────────────────────────────────
+
+/// A high-resolution timer matching the `std::time::Instant` interface.
+///
+/// When the `rdtsc` feature is enabled, the target is x86/x86_64, and the
+/// CPU advertises an invariant TSC, `Instant::now()` reads the hardware
+/// counter directly via `RDTSC`.  In all other cases it falls back to
+/// `std::time::Instant`, which has exactly the same semantics as the
+/// original `measure_us!` macro before this crate existed.
+///
+/// Call [`Instant::memoize`] once at process startup to pre-calibrate. Otherwise,
+/// calibration is done lazily on the first [`elapsed_us`](Instant::elapsed_us)
+/// call that needs it.
+pub struct Instant {
+    inner: Inner,
+}
+
+impl Instant {
+    /// Capture the current time.
+    #[inline(always)]
+    pub fn now() -> Self {
+        Self {
+            inner: Inner::now(),
+        }
+    }
+
+    /// Elapsed microseconds since [`Instant::now`] was called.
+    #[inline(always)]
+    pub fn elapsed_us(&self) -> u64 {
+        self.inner.elapsed_us()
+    }
+
+    /// Elapsed nanoseconds since [`Instant::now`] was called.
+    #[inline(always)]
+    pub fn elapsed_ns(&self) -> u64 {
+        self.inner.elapsed_ns()
+    }
+
+    /// Calibrate the TSC and enable the RDTSC fast path.
+    ///
+    /// Applications sensitive to timing performance should call this once at
+    /// process startup to pre-calibrate and avoid lazy init. Without this call,
+    /// calibration is done lazily on first use (in the first
+    /// [`elapsed_us`](Instant::elapsed_us) that uses RDTSC).
+    ///
+    /// On non-x86 targets, or when the `rdtsc` feature is disabled, this is a
+    /// no-op.
+    pub fn memoize() {
+        #[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+        {
+            let tps = *TICKS_PER_SECOND.get_or_init(calibrate);
+            MUL_US.get_or_init(|| mul_from_tps(1_000_000, tps));
+            MUL_NS.get_or_init(|| mul_from_tps(1_000_000_000, tps));
+        }
+    }
+}
+
+// ── Internal enum ─────────────────────────────────────────────────────────
+
+enum Inner {
+    #[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+    Rdtsc(u64),
+    StdInstant(StdInstant),
+}
+
+impl Inner {
+    #[inline(always)]
+    fn now() -> Self {
+        #[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+        if check_cpu_supports_invariant_tsc() {
+            return Self::Rdtsc(rdtsc());
+        }
+        Self::StdInstant(StdInstant::now())
+    }
+
+    #[inline(always)]
+    fn elapsed_us(&self) -> u64 {
+        match self {
+            #[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+            Self::Rdtsc(start) => {
+                let ticks = rdtsc().wrapping_sub(*start);
+                ((ticks as u128 * mul_us() as u128) >> SHIFT) as u64
+            }
+            Self::StdInstant(start) => start.elapsed().as_micros() as u64,
+        }
+    }
+
+    #[inline(always)]
+    fn elapsed_ns(&self) -> u64 {
+        match self {
+            #[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+            Self::Rdtsc(start) => {
+                let ticks = rdtsc().wrapping_sub(*start);
+                ((ticks as u128 * mul_ns() as u128) >> SHIFT) as u64
+            }
+            Self::StdInstant(start) => start.elapsed().as_nanos() as u64,
+        }
+    }
+}
+
+// ── Calibration ───────────────────────────────────────────────────────────
+//
+// Lazily initialized via OnceLock: either by Instant::memoize() at startup, or
+// on first mul_us() call when an RDTSC-based Instant needs the value.
+
+#[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+static TICKS_PER_SECOND: OnceLock<u64> = OnceLock::new();
+
+#[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+static MUL_US: OnceLock<u64> = OnceLock::new();
+
+#[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+static MUL_NS: OnceLock<u64> = OnceLock::new();
+
+/// Returns `true` when `/proc/cpuinfo` lists both `constant_tsc` and
+/// `nonstop_tsc`, indicating an invariant TSC suitable for wall-clock use.
+/// Always `false` on non-x86 targets.
+pub fn check_cpu_supports_invariant_tsc() -> bool {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        static SUPPORTS: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *SUPPORTS.get_or_init(|| {
+            std::fs::read_to_string("/proc/cpuinfo")
+                .map(|s| s.contains("constant_tsc") && s.contains("nonstop_tsc"))
+                .unwrap_or(false)
+        })
+    }
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    false
+}
+
+// ── x86/x86_64 internals ─────────────────────────────────────────────────
+
+#[cfg(all(feature = "rdtsc", target_arch = "x86_64"))]
+#[inline(always)]
+fn rdtsc() -> u64 {
+    unsafe {
+        core::arch::x86_64::_mm_lfence();
+        core::arch::x86_64::_rdtsc()
+    }
+}
+
+#[cfg(all(feature = "rdtsc", target_arch = "x86"))]
+#[inline(always)]
+fn rdtsc() -> u64 {
+    unsafe {
+        core::arch::x86::_mm_lfence();
+        core::arch::x86::_rdtsc()
+    }
+}
+
+#[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+const SHIFT: u32 = 32;
+
+/// Precomputed multiplier for converting ticks to microseconds via shift.
+/// Lazily derives from ticks_per_second on first call if [`Instant::memoize`]
+/// was not invoked at startup.
+#[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+fn mul_us() -> u64 {
+    *MUL_US.get_or_init(|| {
+        let tps = *TICKS_PER_SECOND.get_or_init(calibrate);
+        mul_from_tps(1_000_000, tps)
+    })
+}
+
+/// Precomputed multiplier for converting ticks to nanoseconds via shift.
+#[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+fn mul_ns() -> u64 {
+    *MUL_NS.get_or_init(|| {
+        let tps = *TICKS_PER_SECOND.get_or_init(calibrate);
+        mul_from_tps(1_000_000_000, tps)
+    })
+}
+
+/// `(units_per_second << SHIFT) / ticks_per_second`
+#[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+fn mul_from_tps(units_per_second: u128, ticks_per_second: u64) -> u64 {
+    ((units_per_second << SHIFT) / ticks_per_second as u128) as u64
+}
+
+/// 1 s warmup + 1 s measurement → ticks per second.
+#[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+fn calibrate() -> u64 {
+    use std::time::Duration;
+
+    let warmup = Duration::from_millis(1000);
+    let measure = Duration::from_millis(1000);
+
+    let t0 = StdInstant::now();
+    while t0.elapsed() < warmup {}
+
+    let t1 = StdInstant::now();
+    let tsc0 = rdtsc();
+    while t1.elapsed() < measure {}
+    let tsc1 = rdtsc();
+    let elapsed_ns = t1.elapsed().as_nanos() as u128;
+
+    ((tsc1 - tsc0) as u128 * 1_000_000_000 / elapsed_ns.max(1)) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_instant_accuracy() {
+        let instant = Instant::now();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let us = instant.elapsed_us();
+        assert!(
+            (9_000..=30_000).contains(&us),
+            "unexpected elapsed_us: {us}"
+        );
+    }
+
+    #[cfg(all(feature = "rdtsc", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[test]
+    fn test_rdtsc_accuracy() {
+        Instant::memoize();
+        for i in 0..5 {
+            let rdtsc_instant = Inner::Rdtsc(rdtsc());
+            let std_instant = Inner::StdInstant(StdInstant::now());
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            let rdtsc_us = rdtsc_instant.elapsed_us();
+            let instant_us = std_instant.elapsed_us();
+            let pct_diff =
+                ((rdtsc_us as f64 - instant_us as f64) / instant_us as f64 * 100.0) as i64;
+            println!(
+                "  [{i}] Instant: {instant_us} µs  |  rdtsc: {rdtsc_us} µs  |  diff: {pct_diff}%"
+            );
+            assert!(
+                pct_diff.unsigned_abs() < 5,
+                "rdtsc calibration off by {pct_diff}%"
+            );
+        }
+    }
+}

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -23,6 +23,7 @@ remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
 remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
+agave-instant = { workspace = true }
 agave-votor-messages = { workspace = true }
 bs58 = { workspace = true, features = ["std"] }
 clap = { version = "3.1.5", default-features = false, features = ["cargo", "std", "suggestions"] }

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -504,6 +504,7 @@ fn write_bls_pubkey_file(
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
+    agave_instant::Instant::memoize();
     let default_num_threads = num_cpus::get().to_string();
     let matches = app(&default_num_threads, solana_version::version!())
         .try_get_matches()

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -21,6 +21,7 @@ frozen-abi = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-instant = { workspace = true }
 agave-logger = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 agave-snapshots = { workspace = true }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -844,6 +844,7 @@ static GLOBAL: Jemalloc = Jemalloc;
 
 #[allow(clippy::cognitive_complexity)]
 fn main() {
+    agave_instant::Instant::memoize();
     // Ignore SIGUSR1 to prevent long-running calls being killed by logrotate
     // in warehouse deployments
     #[cfg(unix)]

--- a/measure/src/lib.rs
+++ b/measure/src/lib.rs
@@ -2,3 +2,5 @@
 #![allow(clippy::arithmetic_side_effects)]
 pub mod macros;
 pub mod measure;
+
+pub use agave_instant;

--- a/measure/src/macros.rs
+++ b/measure/src/macros.rs
@@ -15,6 +15,7 @@
 /// ```
 /// // Measure functions
 /// # use solana_measure::{measure_time, measure_us, meas_dur};
+/// # agave_instant::Instant::memoize();
 /// # fn foo() {}
 /// # fn bar(x: i32) {}
 /// # fn add(x: i32, y: i32) -> i32 {x + y}
@@ -29,6 +30,7 @@
 /// ```
 /// // Measure methods
 /// # use solana_measure::{measure_time, measure_us, meas_dur};
+/// # agave_instant::Instant::memoize();
 /// # struct Foo {
 /// #     f: i32,
 /// # }
@@ -67,6 +69,7 @@
 /// ```
 /// // The `name` parameter is optional
 /// # use solana_measure::{measure_time, measure_us};
+/// # agave_instant::Instant::memoize();
 /// # fn meow() {};
 /// let (result, measure) = measure_time!(meow());
 /// let (result, measure_us) = measure_us!(meow());
@@ -87,8 +90,9 @@ macro_rules! measure_time {
 #[macro_export]
 macro_rules! measure_us {
     ($expr:expr) => {{
-        let (result, duration) = $crate::meas_dur!($expr);
-        (result, duration.as_micros() as u64)
+        let instant = $crate::agave_instant::Instant::now();
+        let result = $expr;
+        (result, instant.elapsed_us())
     }};
 }
 
@@ -182,6 +186,8 @@ mod tests {
 
     #[test]
     fn test_measure_us_macro() {
+        crate::agave_instant::Instant::memoize();
+
         // Ensure that the measurement side actually works
         {
             let (_result, measure) = measure_us!(sleep(Duration::from_millis(1)));

--- a/poh-bench/Cargo.toml
+++ b/poh-bench/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 agave-unstable-api = []
 
 [dependencies]
+agave-instant = { workspace = true }
 agave-logger = { workspace = true }
 clap = { version = "3.1.5", default-features = false, features = ["cargo", "std", "suggestions"] }
 num_cpus = { workspace = true }

--- a/poh-bench/src/main.rs
+++ b/poh-bench/src/main.rs
@@ -10,6 +10,7 @@ use {
 };
 
 fn main() {
+    agave_instant::Instant::memoize();
     agave_logger::setup();
 
     let matches = Command::new(crate_name!())

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -128,6 +128,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-instant"
+version = "4.1.0-alpha.0"
+
+[[package]]
 name = "agave-io-uring"
 version = "4.1.0-alpha.0"
 dependencies = [
@@ -300,6 +304,7 @@ dependencies = [
 name = "agave-validator"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-instant",
  "agave-logger",
  "agave-snapshots",
  "agave-votor",
@@ -7368,6 +7373,9 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "4.1.0-alpha.0"
+dependencies = [
+ "agave-instant",
+]
 
 [[package]]
 name = "solana-merkle-tree"
@@ -9475,6 +9483,9 @@ dependencies = [
 [[package]]
 name = "solana-svm-measure"
 version = "4.1.0-alpha.0"
+dependencies = [
+ "agave-instant",
+]
 
 [[package]]
 name = "solana-svm-test-harness-fixture"

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -19,6 +19,7 @@ remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
 remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
+agave-instant = { workspace = true }
 clap = { workspace = true }
 solana-account = { workspace = true }
 solana-clap-utils = { workspace = true }

--- a/stake-accounts/src/main.rs
+++ b/stake-accounts/src/main.rs
@@ -232,6 +232,7 @@ fn send_and_confirm_messages<S: Signers>(
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
+    agave_instant::Instant::memoize();
     let command_args = parse_args(env::args_os());
     let config = Config::load(&command_args.config_file).unwrap_or_default();
     let json_rpc_url = command_args.url.unwrap_or(config.json_rpc_url);

--- a/svm-measure/Cargo.toml
+++ b/svm-measure/Cargo.toml
@@ -14,3 +14,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 agave-unstable-api = []
+
+[dependencies]
+agave-instant = { workspace = true }

--- a/svm-measure/src/lib.rs
+++ b/svm-measure/src/lib.rs
@@ -2,3 +2,5 @@
 #![allow(clippy::arithmetic_side_effects)]
 pub mod macros;
 pub mod measure;
+
+pub use agave_instant;

--- a/svm-measure/src/macros.rs
+++ b/svm-measure/src/macros.rs
@@ -15,6 +15,7 @@
 /// ```
 /// // Measure functions
 /// # use solana_svm_measure::{measure_time, measure_us, meas_dur};
+/// # agave_instant::Instant::memoize();
 /// # fn foo() {}
 /// # fn bar(x: i32) {}
 /// # fn add(x: i32, y: i32) -> i32 {x + y}
@@ -29,6 +30,7 @@
 /// ```
 /// // Measure methods
 /// # use solana_svm_measure::{measure_time, measure_us, meas_dur};
+/// # agave_instant::Instant::memoize();
 /// # struct Foo {
 /// #     f: i32,
 /// # }
@@ -67,6 +69,7 @@
 /// ```
 /// // The `name` parameter is optional
 /// # use solana_svm_measure::{measure_time, measure_us};
+/// # agave_instant::Instant::memoize();
 /// # fn meow() {};
 /// let (result, measure) = measure_time!(meow());
 /// let (result, measure_us) = measure_us!(meow());
@@ -87,8 +90,9 @@ macro_rules! measure_time {
 #[macro_export]
 macro_rules! measure_us {
     ($expr:expr) => {{
-        let (result, duration) = $crate::meas_dur!($expr);
-        (result, duration.as_micros() as u64)
+        let instant = $crate::agave_instant::Instant::now();
+        let result = $expr;
+        (result, instant.elapsed_us())
     }};
 }
 
@@ -182,6 +186,8 @@ mod tests {
 
     #[test]
     fn test_measure_us_macro() {
+        crate::agave_instant::Instant::memoize();
+
         // Ensure that the measurement side actually works
         {
             let (_result, measure) = measure_us!(sleep(Duration::from_millis(1)));

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -16,6 +16,7 @@ remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
 remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
+agave-instant = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
 clap = { version = "2.33.0", default-features = false, features = ["suggestions"] }
 console = { workspace = true }

--- a/tokens/src/main.rs
+++ b/tokens/src/main.rs
@@ -16,6 +16,7 @@ use {
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
+    agave_instant::Instant::memoize();
     let command_args = parse_args(env::args_os())?;
     let config = if Path::new(&command_args.config_file).exists() {
         Config::load(&command_args.config_file)?

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -18,6 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 agave-unstable-api = []
 
 [dependencies]
+agave-instant = { workspace = true }
 agave-logger = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-votor = { workspace = true }

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -55,6 +55,7 @@ enum Output {
 }
 
 fn main() {
+    agave_instant::Instant::memoize();
     // Debugging panics is easier with a backtrace
     if env::var_os("RUST_BACKTRACE").is_none() {
         // Safety: env update is made before any spawned threads might access the environment

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -15,6 +15,7 @@ use {
 static GLOBAL: Jemalloc = Jemalloc;
 
 pub fn main() {
+    agave_instant::Instant::memoize();
     let default_args = DefaultArgs::new();
     let solana_version = solana_version::version!();
     let cli_app = app(solana_version, &default_args);

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 agave-unstable-api = []
 
 [dependencies]
+agave-instant = { workspace = true }
 agave-logger = { workspace = true }
 clap = { workspace = true }
 humantime = { workspace = true }

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -452,6 +452,7 @@ fn validate_endpoints(
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
+    agave_instant::Instant::memoize();
     agave_logger::setup_with_default_filter();
     solana_metrics::set_panic_hook("watchtower", /*version:*/ None);
 


### PR DESCRIPTION
`Instant::now()` is expensive as shit. use an rdtsc based timer everywhere we use `measure_us!`.

#10591 brings down the simple transfer dispatch time from 2.18us to 0.875us.

this pr brings it down further from 0.875us to 0.43us.