### PR TITLE
clippy: Box result in RpcCustomError::SendTransactionPreflightFailure

### DIFF
--- a/rpc-client-api/src/custom_error.rs
+++ b/rpc-client-api/src/custom_error.rs
@@ -40,7 +40,7 @@ pub enum RpcCustomError {
     #[error("SendTransactionPreflightFailure")]
     SendTransactionPreflightFailure {
         message: String,
-        result: RpcSimulateTransactionResult,
+        result: Box<RpcSimulateTransactionResult>,
     },
     #[error("TransactionSignatureVerificationFailure")]
     TransactionSignatureVerificationFailure,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3912,7 +3912,7 @@ pub mod rpc_full {
                     }
                     return Err(RpcCustomError::SendTransactionPreflightFailure {
                         message: format!("Transaction simulation failed: {err}"),
-                        result: RpcSimulateTransactionResult {
+                        result: Box::new(RpcSimulateTransactionResult {
                             err: Some(err.into()),
                             logs: Some(logs),
                             accounts: None,
@@ -3927,7 +3927,7 @@ pub mod rpc_full {
                             pre_token_balances: None,
                             post_token_balances: None,
                             loaded_addresses: None,
-                        },
+                        }),
                     }
                     .into());
                 }


### PR DESCRIPTION
#### Problem
Clippy in Rust toolchain 1.94 reports `clippy:result-large-err` warning for large error in `rpc` code. 

```
error: the `Err`-variant returned from this closure is very large
    --> rpc/src/rpc.rs:1384:45
     |
1384 |   ...                   .spawn_blocking(move || {
     |  _______________________________________^
1385 | | ...                       confirmed_block
1386 | | ...                           .encode_with_options(encoding, encoding_options)
1387 | | ...                           .map_err(RpcCustomError::from)
1388 | | ...                   })
     | |_______________________^ the `Err`-variant is at least 376 bytes
     |
     = help: try reducing the size of `solana_rpc_client_api::custom_error::RpcCustomError`, for example by boxing large elements or replacing it with `Box<solana_rpc_client_api::custom_error::RpcCustomError>`
```

#### Summary of Changes
Box `result` field in `SendTransactionPreflightFailure` variant