### PR TITLE
xdp: get source ip address in execute

### DIFF
--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -264,7 +264,7 @@ pub fn execute(
     #[cfg(target_os = "linux")]
     let maybe_xdp_retransmit_builder = {
         use {
-            agave_xdp::xdp_retransmitter::{XdpRetransmitBuilder, master_ip_if_bonded},
+            agave_xdp::{get_src_device_ip, xdp_retransmitter::XdpRetransmitBuilder},
             caps::{
                 CapSet,
                 Capability::{CAP_BPF, CAP_NET_ADMIN, CAP_NET_RAW, CAP_PERFMON, CAP_SYS_NICE},
@@ -340,11 +340,8 @@ pub fn execute(
                 .expect("failed to get local address")
                 .port();
             let src_ip = match node.bind_ip_addrs.active() {
-                IpAddr::V4(ip) if !ip.is_unspecified() => Some(ip),
-                IpAddr::V4(_unspecified) => xdp_config
-                    .interface
-                    .as_ref()
-                    .and_then(|iface| master_ip_if_bonded(iface)),
+                IpAddr::V4(ip) if !ip.is_unspecified() => ip,
+                IpAddr::V4(_unspecified) => get_src_device_ip(xdp_config.interface.clone()),
                 _ => panic!("IPv6 not supported"),
             };
             XdpRetransmitBuilder::new(xdp_config, src_port, src_ip, exit.clone())

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -32,7 +32,7 @@ pub mod xdp_retransmitter;
 
 #[cfg(target_os = "linux")]
 pub use program::load_xdp_program;
-use std::io;
+use std::{io, net::Ipv4Addr};
 
 #[cfg(target_os = "linux")]
 pub fn set_cpu_affinity(cpus: impl IntoIterator<Item = usize>) -> Result<(), io::Error> {
@@ -77,4 +77,46 @@ pub fn get_cpu() -> Result<usize, io::Error> {
 #[cfg(not(target_os = "linux"))]
 pub fn get_cpu() -> Result<usize, io::Error> {
     unimplemented!()
+}
+
+#[cfg(target_os = "linux")]
+/// Get the IPv4 address of the device
+pub fn get_src_device_ip(maybe_interface: Option<String>) -> Ipv4Addr {
+    let src_device = if let Some(interface) = maybe_interface {
+        if let Some(ip) = master_ip_if_bonded(&interface) {
+            return ip;
+        } else {
+            crate::device::NetworkDevice::new(interface).unwrap()
+        }
+    } else {
+        crate::device::NetworkDevice::new_from_default_route().unwrap()
+    };
+    src_device
+        .ipv4_addr()
+        .expect("no src_ip provided, device must have an IPv4 address")
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn get_src_device_ip(_maybe_interface: Option<String>) -> Ipv4Addr {
+    unimplemented!()
+}
+
+/// Returns the IPv4 address of the master interface if the given interface is part of a bond.
+#[cfg(target_os = "linux")]
+fn master_ip_if_bonded(interface: &str) -> Option<Ipv4Addr> {
+    let master_ifindex_path = format!("/sys/class/net/{interface}/master/ifindex");
+    if let Ok(contents) = std::fs::read_to_string(&master_ifindex_path) {
+        let idx = contents.trim().parse().unwrap();
+        return Some(
+            crate::device::NetworkDevice::new_from_index(idx)
+                .and_then(|dev| dev.ipv4_addr())
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "failed to open bond master interface for {interface}: master index \
+                         {idx}: {e}"
+                    )
+                }),
+        );
+    }
+    None
 }

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -26,16 +26,16 @@ use {
 pub struct TxLoopConfigBuilder {
     zero_copy: bool,
     maybe_src_mac: Option<MacAddress>,
-    maybe_src_ip: Option<Ipv4Addr>,
+    src_ip: Ipv4Addr,
     src_port: u16,
 }
 
 impl TxLoopConfigBuilder {
-    pub fn new(src_port: u16) -> Self {
+    pub fn new(src_ip: Ipv4Addr, src_port: u16) -> Self {
         Self {
             zero_copy: false,
             maybe_src_mac: None,
-            maybe_src_ip: None,
+            src_ip,
             src_port,
         }
     }
@@ -50,16 +50,11 @@ impl TxLoopConfigBuilder {
         self
     }
 
-    pub fn override_src_ip(&mut self, ip: Ipv4Addr) -> &mut Self {
-        self.maybe_src_ip = Some(ip);
-        self
-    }
-
     pub fn build_with_src_device(self, src_device: &NetworkDevice) -> TxLoopConfig {
         let Self {
             zero_copy,
             maybe_src_mac,
-            maybe_src_ip,
+            src_ip,
             src_port,
         } = self;
 
@@ -68,13 +63,6 @@ impl TxLoopConfigBuilder {
             src_device
                 .mac_addr()
                 .expect("no src_mac provided, device must have a MAC address")
-        });
-
-        let src_ip = maybe_src_ip.unwrap_or_else(|| {
-            // if no source IP is provided, use the device's IPv4 address
-            src_device
-                .ipv4_addr()
-                .expect("no src_ip provided, device must have an IPv4 address")
         });
 
         TxLoopConfig {

--- a/xdp/src/xdp_retransmitter.rs
+++ b/xdp/src/xdp_retransmitter.rs
@@ -146,7 +146,7 @@ impl XdpRetransmitBuilder {
     pub fn new(
         config: XdpConfig,
         src_port: u16,
-        src_ip: Option<Ipv4Addr>,
+        src_ip: Ipv4Addr,
         exit: Arc<AtomicBool>,
     ) -> Result<Self, Box<dyn Error>> {
         use {
@@ -169,11 +169,8 @@ impl XdpRetransmitBuilder {
             NetworkDevice::new_from_default_route().unwrap()
         });
 
-        let mut tx_loop_config_builder = TxLoopConfigBuilder::new(src_port);
+        let mut tx_loop_config_builder = TxLoopConfigBuilder::new(src_ip, src_port);
         tx_loop_config_builder.zero_copy(zero_copy);
-        if let Some(src_ip) = src_ip {
-            tx_loop_config_builder.override_src_ip(src_ip);
-        }
         let tx_loop_config = tx_loop_config_builder.build_with_src_device(&dev);
 
         let reserved_cores = cpus.iter().cloned().collect::<HashSet<_>>();
@@ -340,29 +337,4 @@ impl XdpRetransmitter {
         }
         Ok(())
     }
-}
-
-/// Returns the IPv4 address of the master interface if the given interface is part of a bond.
-#[cfg(target_os = "linux")]
-pub fn master_ip_if_bonded(interface: &str) -> Option<Ipv4Addr> {
-    let master_ifindex_path = format!("/sys/class/net/{interface}/master/ifindex");
-    if let Ok(contents) = std::fs::read_to_string(&master_ifindex_path) {
-        let idx = contents.trim().parse().unwrap();
-        return Some(
-            NetworkDevice::new_from_index(idx)
-                .and_then(|dev| dev.ipv4_addr())
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "failed to open bond master interface for {interface}: master index \
-                         {idx}: {e}"
-                    )
-                }),
-        );
-    }
-    None
-}
-
-#[cfg(not(target_os = "linux"))]
-pub fn master_ip_if_bonded(_interface: &str) -> Option<Ipv4Addr> {
-    None
 }


### PR DESCRIPTION
#### Problem

Currently, we try to build source ip address if not specified by user in two places: in execute and in `tx_loop`.

#### Summary of Changes

This PR moves all the code to one place simplifying the code and allowing early failure.
Prerequisite for https://github.com/anza-xyz/agave/pull/10830
