### PR TITLE
max processing age api

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -207,7 +207,7 @@ pub(crate) mod external {
             transaction_data::TransactionData, transaction_view::SanitizedTransactionView,
         },
         solana_account::ReadableAccount,
-        solana_clock::{MAX_PROCESSING_AGE, Slot},
+        solana_clock::Slot,
         solana_cost_model::cost_model::CostModel,
         solana_message::v0::LoadedAddresses,
         solana_pubkey::Pubkey,
@@ -919,7 +919,7 @@ pub(crate) mod external {
                 .check_transactions_with_processed_slots(
                     txs,
                     &[const { Ok(()) }; MAX_TRANSACTIONS_PER_MESSAGE],
-                    MAX_PROCESSING_AGE,
+                    working_bank.max_processing_age(),
                     true,
                     &mut error_counters,
                 );

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -2146,7 +2146,7 @@ mod tests {
             tests::{create_slow_genesis_config, sanitize_transactions},
         },
         crossbeam_channel::unbounded,
-        solana_clock::{MAX_PROCESSING_AGE, Slot},
+        solana_clock::Slot,
         solana_genesis_config::GenesisConfig,
         solana_keypair::Keypair,
         solana_ledger::genesis_utils::GenesisConfigInfo,
@@ -2635,7 +2635,7 @@ mod tests {
             .check_transactions(
                 &sanitized_txs,
                 &vec![Ok(()); sanitized_txs.len()],
-                MAX_PROCESSING_AGE,
+                bank.max_processing_age(),
                 &mut TransactionErrorMetrics::default(),
             )
             .into_iter()

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -6,7 +6,6 @@ use {
         scheduler_messages::MaxAge,
     },
     itertools::Itertools,
-    solana_clock::MAX_PROCESSING_AGE,
     solana_fee::FeeFeatures,
     solana_fee_structure::FeeBudgetLimits,
     solana_measure::measure_us,
@@ -131,8 +130,12 @@ impl Consumer {
     ) -> ProcessTransactionBatchOutput {
         let mut error_counters = TransactionErrorMetrics::default();
         let pre_results = vec![Ok(()); txs.len()];
-        let check_results =
-            bank.check_transactions(txs, &pre_results, MAX_PROCESSING_AGE, &mut error_counters);
+        let check_results = bank.check_transactions(
+            txs,
+            &pre_results,
+            bank.max_processing_age(),
+            &mut error_counters,
+        );
         let check_results: Vec<_> = check_results
             .into_iter()
             .zip(txs.iter())
@@ -333,7 +336,7 @@ impl Consumer {
         let (load_and_execute_transactions_output, load_execute_us) =
             measure_us!(bank.load_and_execute_transactions(
                 batch,
-                MAX_PROCESSING_AGE,
+                bank.max_processing_age(),
                 &mut execute_and_commit_timings.execute_timings,
                 &mut error_counters,
                 TransactionProcessingConfig {

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -22,7 +22,7 @@ use {
     crossbeam_channel::{RecvTimeoutError, TryRecvError},
     solana_accounts_db::account_locks::validate_account_locks,
     solana_address_lookup_table_interface::state::estimate_last_valid_slot,
-    solana_clock::{Epoch, MAX_PROCESSING_AGE, Slot},
+    solana_clock::{Epoch, Slot},
     solana_cost_model::cost_model::CostModel,
     solana_fee_structure::FeeBudgetLimits,
     solana_message::v0::LoadedAddresses,
@@ -272,7 +272,7 @@ impl TransactionViewReceiveAndBuffer {
                     working_bank.check_transactions::<RuntimeTransaction<_>>(
                         &transactions,
                         &lock_results[..transactions.len()],
-                        MAX_PROCESSING_AGE,
+                        working_bank.max_processing_age(),
                         &mut error_counters,
                     )
                 };

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -21,7 +21,6 @@ use {
         },
         validator::SchedulerPacing,
     },
-    solana_clock::MAX_PROCESSING_AGE,
     solana_cost_model::cost_tracker::SharedBlockCost,
     solana_measure::measure_us,
     solana_runtime::{bank::Bank, bank_forks::SharableBanks},
@@ -233,7 +232,7 @@ where
                         bank.feature_set
                             .is_active(&agave_feature_set::relax_intrabatch_account_locks::ID),
                         |txs, results| {
-                            Self::pre_graph_filter(txs, results, bank, MAX_PROCESSING_AGE)
+                            Self::pre_graph_filter(txs, results, bank, bank.max_processing_age())
                         },
                         |_| PreLockFilterAction::AttemptToSchedule // no pre-lock filter for now
                     )?
@@ -359,7 +358,7 @@ where
         let results = bank.check_transactions::<R::Transaction>(
             &txs,
             &lock_results,
-            MAX_PROCESSING_AGE,
+            bank.max_processing_age(),
             &mut error_counters,
         );
 

--- a/core/tests/scheduler_cost_adjustment.rs
+++ b/core/tests/scheduler_cost_adjustment.rs
@@ -1,7 +1,6 @@
 #![cfg(test)]
 use {
     solana_account::{Account, ReadableAccount},
-    solana_clock::MAX_PROCESSING_AGE,
     solana_compute_budget::compute_budget_limits::MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
     solana_compute_budget_interface::ComputeBudgetInstruction,
     solana_cost_model::cost_model::CostModel,
@@ -88,7 +87,7 @@ impl TestSetup {
         let commit_result = bank
             .load_execute_and_commit_transactions(
                 &batch,
-                MAX_PROCESSING_AGE,
+                bank.max_processing_age(),
                 ExecutionRecordingConfig::new_single_setting(false),
                 &mut ExecuteTimings::default(),
                 None,

--- a/core/tests/scheduler_cost_adjustment.rs
+++ b/core/tests/scheduler_cost_adjustment.rs
@@ -87,7 +87,6 @@ impl TestSetup {
         let commit_result = bank
             .load_execute_and_commit_transactions(
                 &batch,
-                bank.max_processing_age(),
                 ExecutionRecordingConfig::new_single_setting(false),
                 &mut ExecuteTimings::default(),
                 None,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -19,7 +19,7 @@ use {
     solana_accounts_db::{
         accounts_db::AccountsDbConfig, accounts_update_notifier_interface::AccountsUpdateNotifier,
     },
-    solana_clock::{MAX_PROCESSING_AGE, Slot},
+    solana_clock::Slot,
     solana_cost_model::{cost_model::CostModel, transaction_cost::TransactionCost},
     solana_entry::entry::{self, Entry, EntrySlice, EntryType, create_ticks},
     solana_genesis_config::GenesisConfig,
@@ -247,7 +247,7 @@ pub fn execute_batch<'a>(
         .bank()
         .load_execute_and_commit_transactions_with_pre_commit_callback(
             batch,
-            MAX_PROCESSING_AGE,
+            batch.bank().max_processing_age(),
             ExecutionRecordingConfig::new_single_setting(transaction_status_sender.is_some()),
             timings,
             log_messages_bytes_limit,
@@ -4695,7 +4695,7 @@ pub mod tests {
         let batch = bank.prepare_batch_for_tests(txs);
         let (commit_results, _) = batch.bank().load_execute_and_commit_transactions(
             &batch,
-            MAX_PROCESSING_AGE,
+            batch.bank().max_processing_age(),
             ExecutionRecordingConfig::new_single_setting(false),
             &mut ExecuteTimings::default(),
             None,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -247,7 +247,6 @@ pub fn execute_batch<'a>(
         .bank()
         .load_execute_and_commit_transactions_with_pre_commit_callback(
             batch,
-            batch.bank().max_processing_age(),
             ExecutionRecordingConfig::new_single_setting(transaction_status_sender.is_some()),
             timings,
             log_messages_bytes_limit,
@@ -4695,7 +4694,6 @@ pub mod tests {
         let batch = bank.prepare_batch_for_tests(txs);
         let (commit_results, _) = batch.bank().load_execute_and_commit_transactions(
             &batch,
-            batch.bank().max_processing_age(),
             ExecutionRecordingConfig::new_single_setting(false),
             &mut ExecuteTimings::default(),
             None,

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -151,7 +151,6 @@ fn load_execute_and_commit_transaction(bank: &Bank, tx: Transaction) -> Transact
     let mut commit_results = bank
         .load_execute_and_commit_transactions(
             &tx_batch,
-            bank.max_processing_age(),
             ExecutionRecordingConfig {
                 enable_cpi_recording: true,
                 enable_log_recording: true,
@@ -5580,7 +5579,6 @@ fn test_function_call_args() {
     let result = bank
         .load_execute_and_commit_transactions(
             &tx_batch,
-            bank.max_processing_age(),
             ExecutionRecordingConfig {
                 enable_cpi_recording: false,
                 enable_log_recording: false,

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -17,7 +17,7 @@ use {
     solana_account::{AccountSharedData, ReadableAccount},
     solana_account_info::MAX_PERMITTED_DATA_INCREASE,
     solana_client_traits::SyncClient,
-    solana_clock::{MAX_PROCESSING_AGE, UnixTimestamp},
+    solana_clock::UnixTimestamp,
     solana_cluster_type::ClusterType,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
@@ -151,7 +151,7 @@ fn load_execute_and_commit_transaction(bank: &Bank, tx: Transaction) -> Transact
     let mut commit_results = bank
         .load_execute_and_commit_transactions(
             &tx_batch,
-            MAX_PROCESSING_AGE,
+            bank.max_processing_age(),
             ExecutionRecordingConfig {
                 enable_cpi_recording: true,
                 enable_log_recording: true,
@@ -5580,7 +5580,7 @@ fn test_function_call_args() {
     let result = bank
         .load_execute_and_commit_transactions(
             &tx_batch,
-            MAX_PROCESSING_AGE,
+            bank.max_processing_age(),
             ExecutionRecordingConfig {
                 enable_cpi_recording: false,
                 enable_log_recording: false,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -30,7 +30,7 @@ use {
         },
     },
     solana_client::connection_cache::Protocol,
-    solana_clock::{MAX_PROCESSING_AGE, Slot, UnixTimestamp},
+    solana_clock::{Slot, UnixTimestamp},
     solana_commitment_config::{CommitmentConfig, CommitmentLevel},
     solana_entry::entry::Entry,
     solana_epoch_info::EpochInfo,
@@ -3855,7 +3855,8 @@ pub mod rpc_full {
                 // It provides a fallback timeout for durable-nonce transaction retries in case of
                 // malicious packing of the retry queue. Durable-nonce transactions are otherwise
                 // retried until the nonce is advanced.
-                last_valid_block_height = preflight_bank.block_height() + MAX_PROCESSING_AGE as u64;
+                last_valid_block_height =
+                    preflight_bank.block_height() + preflight_bank.max_processing_age() as u64;
             }
 
             if !skip_preflight {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -536,6 +536,7 @@ impl PartialEq for Bank {
             rc: _,
             status_cache: _,
             blockhash_queue,
+            max_processing_age,
             ancestors: _,
             hash,
             parent_hash,
@@ -603,6 +604,7 @@ impl PartialEq for Bank {
             // is added to the struct, this PartialEq is accordingly updated.
         } = self;
         *blockhash_queue.read().unwrap() == *other.blockhash_queue.read().unwrap()
+            && *max_processing_age == other.max_processing_age
             && *hash.read().unwrap() == *other.hash.read().unwrap()
             && parent_hash == &other.parent_hash
             && parent_slot == &other.parent_slot
@@ -751,6 +753,9 @@ pub struct Bank {
 
     /// FIFO queue of `recent_blockhash` items
     blockhash_queue: RwLock<BlockhashQueue>,
+
+    /// Maximum age in slots a blockhash can be for a tx to be processed.
+    max_processing_age: usize,
 
     /// The set of parents including this bank
     pub ancestors: Ancestors,
@@ -1086,6 +1091,7 @@ impl Bank {
             rc: BankRc::new(accounts),
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
             blockhash_queue: RwLock::<BlockhashQueue>::default(),
+            max_processing_age: MAX_PROCESSING_AGE,
             ancestors: Ancestors::default(),
             hash: RwLock::<Hash>::default(),
             parent_hash: Hash::default(),
@@ -1322,7 +1328,7 @@ impl Bank {
             bank_id,
             epoch,
             blockhash_queue,
-
+            max_processing_age: parent.max_processing_age,
             // TODO: clean this up, so much special-case copying...
             hashes_per_tick: parent.hashes_per_tick,
             ticks_per_slot: parent.ticks_per_slot,
@@ -1896,6 +1902,7 @@ impl Bank {
             rc: bank_rc,
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
             blockhash_queue: RwLock::new(fields.blockhash_queue),
+            max_processing_age: MAX_PROCESSING_AGE,
             ancestors,
             hash: RwLock::new(fields.hash),
             parent_hash: fields.parent_hash,
@@ -2450,7 +2457,7 @@ impl Bank {
     }
 
     pub fn max_processing_age(&self) -> usize {
-        MAX_PROCESSING_AGE
+        self.max_processing_age
     }
 
     // Calculates the starting-slot for inflation from the activation slot.
@@ -2899,7 +2906,7 @@ impl Bank {
 
     pub fn is_blockhash_valid(&self, hash: &Hash) -> bool {
         let blockhash_queue = self.blockhash_queue.read().unwrap();
-        blockhash_queue.is_hash_valid_for_age(hash, self.max_processing_age())
+        blockhash_queue.is_hash_valid_for_age(hash, self.max_processing_age)
     }
 
     pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> u64 {
@@ -2954,7 +2961,7 @@ impl Bank {
         // length is made variable by epoch
         blockhash_queue
             .get_hash_age(blockhash)
-            .map(|age| self.block_height + self.max_processing_age() as u64 - age)
+            .map(|age| self.block_height + self.max_processing_age as u64 - age)
     }
 
     /// Query the alpenglow genesis certificate account.
@@ -3397,7 +3404,7 @@ impl Bank {
             // After simulation, transactions will need to be forwarded to the leader
             // for processing. During forwarding, the transaction could expire if the
             // delay is not accounted for.
-            self.max_processing_age()
+            self.max_processing_age
                 .saturating_sub(MAX_TRANSACTION_FORWARDING_DELAY),
             &mut timings,
             &mut TransactionErrorMetrics::default(),
@@ -4087,14 +4094,12 @@ impl Bank {
     pub fn load_execute_and_commit_transactions(
         &self,
         batch: &TransactionBatch<impl TransactionWithMeta>,
-        max_age: usize,
         recording_config: ExecutionRecordingConfig,
         timings: &mut ExecuteTimings,
         log_messages_bytes_limit: Option<usize>,
     ) -> (Vec<TransactionCommitResult>, Option<BalanceCollector>) {
         self.do_load_execute_and_commit_transactions_with_pre_commit_callback(
             batch,
-            max_age,
             recording_config,
             timings,
             log_messages_bytes_limit,
@@ -4106,7 +4111,6 @@ impl Bank {
     pub fn load_execute_and_commit_transactions_with_pre_commit_callback<'a>(
         &'a self,
         batch: &TransactionBatch<impl TransactionWithMeta>,
-        max_age: usize,
         recording_config: ExecutionRecordingConfig,
         timings: &mut ExecuteTimings,
         log_messages_bytes_limit: Option<usize>,
@@ -4117,7 +4121,6 @@ impl Bank {
     ) -> Result<(Vec<TransactionCommitResult>, Option<BalanceCollector>)> {
         self.do_load_execute_and_commit_transactions_with_pre_commit_callback(
             batch,
-            max_age,
             recording_config,
             timings,
             log_messages_bytes_limit,
@@ -4128,7 +4131,6 @@ impl Bank {
     fn do_load_execute_and_commit_transactions_with_pre_commit_callback<'a>(
         &'a self,
         batch: &TransactionBatch<impl TransactionWithMeta>,
-        max_age: usize,
         recording_config: ExecutionRecordingConfig,
         timings: &mut ExecuteTimings,
         log_messages_bytes_limit: Option<usize>,
@@ -4142,7 +4144,7 @@ impl Bank {
             balance_collector,
         } = self.load_and_execute_transactions(
             batch,
-            max_age,
+            self.max_processing_age,
             timings,
             &mut TransactionErrorMetrics::default(),
             TransactionProcessingConfig {
@@ -4192,7 +4194,6 @@ impl Bank {
 
         let (mut commit_results, ..) = self.load_execute_and_commit_transactions(
             &batch,
-            self.max_processing_age(),
             ExecutionRecordingConfig {
                 enable_cpi_recording: false,
                 enable_log_recording: true,
@@ -4235,7 +4236,6 @@ impl Bank {
     ) -> Vec<Result<()>> {
         self.load_execute_and_commit_transactions(
             batch,
-            self.max_processing_age(),
             ExecutionRecordingConfig::new_single_setting(false),
             &mut ExecuteTimings::default(),
             None,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2449,6 +2449,10 @@ impl Bank {
         self.epoch_schedule().get_slots_in_epoch(epoch) as f64 / self.slots_per_year
     }
 
+    pub fn max_processing_age(&self) -> usize {
+        MAX_PROCESSING_AGE
+    }
+
     // Calculates the starting-slot for inflation from the activation slot.
     // This method assumes that `pico_inflation` will be enabled before `full_inflation`, giving
     // precedence to the latter. However, since `pico_inflation` is fixed-rate Inflation, should
@@ -2895,7 +2899,7 @@ impl Bank {
 
     pub fn is_blockhash_valid(&self, hash: &Hash) -> bool {
         let blockhash_queue = self.blockhash_queue.read().unwrap();
-        blockhash_queue.is_hash_valid_for_age(hash, MAX_PROCESSING_AGE)
+        blockhash_queue.is_hash_valid_for_age(hash, self.max_processing_age())
     }
 
     pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> u64 {
@@ -2950,7 +2954,7 @@ impl Bank {
         // length is made variable by epoch
         blockhash_queue
             .get_hash_age(blockhash)
-            .map(|age| self.block_height + MAX_PROCESSING_AGE as u64 - age)
+            .map(|age| self.block_height + self.max_processing_age() as u64 - age)
     }
 
     /// Query the alpenglow genesis certificate account.
@@ -3393,7 +3397,8 @@ impl Bank {
             // After simulation, transactions will need to be forwarded to the leader
             // for processing. During forwarding, the transaction could expire if the
             // delay is not accounted for.
-            MAX_PROCESSING_AGE - MAX_TRANSACTION_FORWARDING_DELAY,
+            self.max_processing_age()
+                .saturating_sub(MAX_TRANSACTION_FORWARDING_DELAY),
             &mut timings,
             &mut TransactionErrorMetrics::default(),
             TransactionProcessingConfig {
@@ -4187,7 +4192,7 @@ impl Bank {
 
         let (mut commit_results, ..) = self.load_execute_and_commit_transactions(
             &batch,
-            MAX_PROCESSING_AGE,
+            self.max_processing_age(),
             ExecutionRecordingConfig {
                 enable_cpi_recording: false,
                 enable_log_recording: true,
@@ -4230,7 +4235,7 @@ impl Bank {
     ) -> Vec<Result<()>> {
         self.load_execute_and_commit_transactions(
             batch,
-            MAX_PROCESSING_AGE,
+            self.max_processing_age(),
             ExecutionRecordingConfig::new_single_setting(false),
             &mut ExecuteTimings::default(),
             None,

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -2,7 +2,7 @@ use {
     super::{Bank, BankStatusCache},
     agave_feature_set::{FeatureSet, raise_cpi_nesting_limit_to_8},
     solana_accounts_db::blockhash_queue::BlockhashQueue,
-    solana_clock::{MAX_PROCESSING_AGE, MAX_TRANSACTION_FORWARDING_DELAY, Slot},
+    solana_clock::{MAX_TRANSACTION_FORWARDING_DELAY, Slot},
     solana_fee::{FeeFeatures, calculate_fee_details},
     solana_fee_structure::{FeeBudgetLimits, FeeDetails},
     solana_nonce::state::{Data as NonceData, DurableNonce},
@@ -37,7 +37,7 @@ impl Bank {
         self.check_transactions(
             transactions,
             filter,
-            (MAX_PROCESSING_AGE)
+            self.max_processing_age()
                 .saturating_sub(max_tx_fwd_delay)
                 .saturating_sub(forward_transactions_to_leader_at_slot_offset as usize),
             &mut error_counters,

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -37,7 +37,7 @@ impl Bank {
         self.check_transactions(
             transactions,
             filter,
-            self.max_processing_age()
+            self.max_processing_age
                 .saturating_sub(max_tx_fwd_delay)
                 .saturating_sub(forward_transactions_to_leader_at_slot_offset as usize),
             &mut error_counters,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1750,7 +1750,6 @@ fn test_interleaving_locks() {
     let commit_results = bank
         .load_execute_and_commit_transactions(
             &lock_result,
-            MAX_PROCESSING_AGE,
             ExecutionRecordingConfig::new_single_setting(false),
             &mut ExecuteTimings::default(),
             None,
@@ -1831,7 +1830,6 @@ fn test_load_and_execute_commit_transactions_fees_only() {
     let commit_results = bank
         .load_execute_and_commit_transactions(
             &batch,
-            MAX_PROCESSING_AGE,
             ExecutionRecordingConfig::new_single_setting(true),
             &mut ExecuteTimings::default(),
             None,
@@ -1897,7 +1895,6 @@ fn test_load_and_execute_commit_transactions_failure() {
     let commit_results = bank
         .load_execute_and_commit_transactions(
             &batch,
-            MAX_PROCESSING_AGE,
             ExecutionRecordingConfig::new_single_setting(true),
             &mut ExecuteTimings::default(),
             None,
@@ -1971,7 +1968,6 @@ fn test_load_and_execute_commit_transactions_success() {
     let commit_results = bank
         .load_execute_and_commit_transactions(
             &batch,
-            MAX_PROCESSING_AGE,
             ExecutionRecordingConfig::new_single_setting(true),
             &mut ExecuteTimings::default(),
             None,
@@ -4631,7 +4627,6 @@ fn test_pre_post_transaction_balances() {
     let lock_result = bank0.prepare_batch_for_tests(txs);
     let (commit_results, balance_collector) = bank0.load_execute_and_commit_transactions(
         &lock_result,
-        MAX_PROCESSING_AGE,
         ExecutionRecordingConfig {
             enable_cpi_recording: false,
             enable_log_recording: false,
@@ -8194,7 +8189,6 @@ fn test_tx_log_order(relax_intrabatch_account_locks: bool) {
     let commit_results = bank
         .load_execute_and_commit_transactions(
             &batch,
-            MAX_PROCESSING_AGE,
             ExecutionRecordingConfig {
                 enable_cpi_recording: false,
                 enable_log_recording: true,
@@ -8310,7 +8304,6 @@ fn test_tx_return_data() {
         let commit_results = bank
             .load_execute_and_commit_transactions(
                 &batch,
-                MAX_PROCESSING_AGE,
                 ExecutionRecordingConfig {
                     enable_cpi_recording: false,
                     enable_log_recording: false,
@@ -12259,7 +12252,6 @@ fn test_temporary_account_execute_and_commit() {
 
     let (commit_results, _) = bank.load_execute_and_commit_transactions(
         &batch,
-        MAX_PROCESSING_AGE,
         ExecutionRecordingConfig::default(),
         &mut ExecuteTimings::default(),
         None,
@@ -12348,7 +12340,6 @@ fn test_temporary_account_recreated_execute_and_commit() {
 
     let (commit_results, _) = bank.load_execute_and_commit_transactions(
         &batch,
-        MAX_PROCESSING_AGE,
         ExecutionRecordingConfig::default(),
         &mut ExecuteTimings::default(),
         None,

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -2931,7 +2931,7 @@ mod tests {
         super::*,
         crate::sleepless_testing,
         assert_matches::assert_matches,
-        solana_clock::{MAX_PROCESSING_AGE, Slot},
+        solana_clock::Slot,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::blockstore_processor::{TransactionStatusBatch, TransactionStatusMessage},
@@ -4544,7 +4544,7 @@ mod tests {
                 genesis_config.hash(),
             ));
         let mut bank = Bank::new_for_tests(&genesis_config);
-        for _ in 0..MAX_PROCESSING_AGE {
+        for _ in 0..bank.max_processing_age() {
             bank.fill_bank_with_ticks_for_tests();
             bank.freeze();
             let slot = bank.slot();


### PR DESCRIPTION
#### Problem
`MAX_PROCESSING_AGE` is used directly in a large number of places. We may want to change this in the future (e.g. double it if we halve slot times). This is part of consensus, so we would need to synchronously change on slot boundary.

#### Summary of Changes
Hide MAX_PROCESSING_AGE inside a Bank API so that we can tie the behavior to a slot/Bank.

Note that there are still a few places where `MAX_PROCESSING_AGE` is used to derive other constants. These will need to be tackled later