### PR TITLE
fix shrink test

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5340,7 +5340,7 @@ fn test_shrink_candidate_slots_cached() {
     // No more slots should be shrunk
     assert_eq!(bank2.shrink_candidate_slots(), 0);
     // alive_counts represents the count of alive accounts in the three slots 0,1,2
-    assert_eq!(alive_counts, vec![13, 1, 6]);
+    assert_eq!(alive_counts, vec![14, 1, 6]);
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
#11119 collided with #11116 and caused `test_shrink_candidate_slots_cached` to break

#### Summary of Changes
Fix accounting in shrink test to have the correct expectations on num accounts