### PR TITLE
delete deprecated stake config

### DIFF
--- a/account-decoder/src/parse_config.rs
+++ b/account-decoder/src/parse_config.rs
@@ -8,31 +8,21 @@ use {
     serde_json::Value,
     solana_config_interface::state::{ConfigKeys, get_config_data},
     solana_pubkey::Pubkey,
-    solana_stake_interface::config::{
-        Config as StakeConfig, {self as stake_config},
-    },
 };
 
-pub fn parse_config(data: &[u8], pubkey: &Pubkey) -> Result<ConfigAccountType, ParseAccountError> {
-    let parsed_account = if pubkey == &stake_config::id() {
-        get_config_data(data)
-            .ok()
-            .and_then(|data| deserialize::<StakeConfig>(data).ok())
-            .map(|config| ConfigAccountType::StakeConfig(config.into()))
-    } else {
-        deserialize::<ConfigKeys>(data).ok().and_then(|key_list| {
-            if !key_list.keys.is_empty() && key_list.keys[0].0 == validator_info::id() {
-                parse_config_data::<String>(data, key_list.keys).and_then(|validator_info| {
-                    Some(ConfigAccountType::ValidatorInfo(UiConfig {
-                        keys: validator_info.keys,
-                        config_data: serde_json::from_str(&validator_info.config_data).ok()?,
-                    }))
-                })
-            } else {
-                None
-            }
-        })
-    };
+pub fn parse_config(data: &[u8], _pubkey: &Pubkey) -> Result<ConfigAccountType, ParseAccountError> {
+    let parsed_account = deserialize::<ConfigKeys>(data).ok().and_then(|key_list| {
+        if !key_list.keys.is_empty() && key_list.keys[0].0 == validator_info::id() {
+            parse_config_data::<String>(data, key_list.keys).and_then(|validator_info| {
+                Some(ConfigAccountType::ValidatorInfo(UiConfig {
+                    keys: validator_info.keys,
+                    config_data: serde_json::from_str(&validator_info.config_data).ok()?,
+                }))
+            })
+        } else {
+            None
+        }
+    });
     parsed_account.ok_or(ParseAccountError::AccountNotParsable(
         ParsableAccount::Config,
     ))
@@ -56,7 +46,6 @@ where
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase", tag = "type", content = "info")]
 pub enum ConfigAccountType {
-    StakeConfig(UiStakeConfig),
     ValidatorInfo(UiConfig<Value>),
 }
 
@@ -65,26 +54,6 @@ pub enum ConfigAccountType {
 pub struct UiConfigKey {
     pub pubkey: String,
     pub signer: bool,
-}
-
-#[deprecated(
-    since = "1.16.7",
-    note = "Please use `solana_stake_interface::state::warmup_cooldown_rate()` instead"
-)]
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct UiStakeConfig {
-    pub warmup_cooldown_rate: f64,
-    pub slash_penalty: u8,
-}
-
-impl From<StakeConfig> for UiStakeConfig {
-    fn from(config: StakeConfig) -> Self {
-        Self {
-            warmup_cooldown_rate: config.warmup_cooldown_rate,
-            slash_penalty: config.slash_penalty,
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -121,19 +90,6 @@ mod test {
 
     #[test]
     fn test_parse_config() {
-        let stake_config = StakeConfig {
-            warmup_cooldown_rate: 0.25,
-            slash_penalty: 50,
-        };
-        let stake_config_account = create_config_account(vec![], &stake_config, 10);
-        assert_eq!(
-            parse_config(stake_config_account.data(), &stake_config::id()).unwrap(),
-            ConfigAccountType::StakeConfig(UiStakeConfig {
-                warmup_cooldown_rate: 0.25,
-                slash_penalty: 50,
-            }),
-        );
-
         let validator_info = ValidatorInfo {
             info: serde_json::to_string(&json!({
                 "name": "Solana",

--- a/account-decoder/src/parse_stake.rs
+++ b/account-decoder/src/parse_stake.rs
@@ -118,11 +118,6 @@ pub struct UiDelegation {
     pub stake: StringAmount,
     pub activation_epoch: StringAmount,
     pub deactivation_epoch: StringAmount,
-    #[deprecated(
-        since = "1.16.7",
-        note = "Please use `solana_stake_interface::state::warmup_cooldown_rate()` instead"
-    )]
-    pub warmup_cooldown_rate: f64,
 }
 
 impl From<Delegation> for UiDelegation {
@@ -133,7 +128,6 @@ impl From<Delegation> for UiDelegation {
             stake: delegation.stake.to_string(),
             activation_epoch: delegation.activation_epoch.to_string(),
             deactivation_epoch: delegation.deactivation_epoch.to_string(),
-            warmup_cooldown_rate: delegation.warmup_cooldown_rate,
         }
     }
 }
@@ -222,7 +216,6 @@ mod test {
                         stake: 20.to_string(),
                         activation_epoch: 2.to_string(),
                         deactivation_epoch: u64::MAX.to_string(),
-                        warmup_cooldown_rate: 0.25,
                     },
                     credits_observed: 10,
                 })


### PR DESCRIPTION
#### Problem
`struct UiStakeConfig` and `warmup_cooldown_rate` in `UiDelegation` have been deprecated since `1.16.7`

#### Summary of Changes
delete them