### PR TITLE
11102: Uses `WelfordStats` instead of `Histogram` in bls_sigverifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7870,6 +7870,7 @@ dependencies = [
  "agave-bls-cert-verify",
  "agave-feature-set",
  "agave-logger",
+ "agave-math-utils",
  "agave-reserved-account-keys",
  "agave-scheduler-bindings",
  "agave-scheduling-utils",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -44,6 +44,7 @@ agave-banking-stage-ingress-types = { workspace = true }
 agave-bls-cert-verify = { workspace = true }
 agave-feature-set = { workspace = true }
 agave-logger = { workspace = true }
+agave-math-utils = { workspace = true }
 agave-scheduler-bindings = { workspace = true }
 agave-scheduling-utils = { workspace = true }
 agave-snapshots = { workspace = true }

--- a/core/src/bls_sigverify/bls_cert_sigverify.rs
+++ b/core/src/bls_sigverify/bls_cert_sigverify.rs
@@ -69,8 +69,7 @@ pub(super) fn verify_and_send_certificates(
     measure.stop();
     stats
         .fn_verify_and_send_certs_stats
-        .increment(measure.as_us())
-        .unwrap();
+        .add_sample(measure.as_us());
     Ok(stats)
 }
 

--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -148,8 +148,7 @@ impl SigVerifier {
             let (verify_res, verify_time_us) = measure_us!(self.verify_and_send_batches(batches));
             self.stats
                 .verify_and_send_batch_us
-                .increment(verify_time_us)
-                .unwrap();
+                .add_sample(verify_time_us);
             self.stats.maybe_report();
             if let Err(e) = verify_res {
                 error!("verify_and_send_batch() failed with {e}. Exiting.");
@@ -166,8 +165,7 @@ impl SigVerifier {
             measure_us!(self.extract_and_filter_msgs(batches, &root_bank,));
         self.stats
             .extract_filter_msgs_us
-            .increment(extract_msgs_us)
-            .unwrap();
+            .add_sample(extract_msgs_us);
 
         let (votes_result, certs_result) = self.thread_pool.join(
             || {
@@ -251,7 +249,7 @@ impl SigVerifier {
                 }
             }
         }
-        self.stats.num_pkts.increment(num_pkts).unwrap();
+        self.stats.num_pkts.add_sample(num_pkts);
         (certs, votes)
     }
 
@@ -488,7 +486,6 @@ mod tests {
         assert_eq!(receiver.try_iter().flatten().count(), 2);
         assert_eq!(verifier.stats.vote_stats.pool_sent, 1);
         assert_eq!(verifier.stats.cert_stats.pool_sent, 1);
-        assert_eq!(verifier.stats.num_pkts.get(2).unwrap(), 1);
         let received_verified_votes1 = votes_for_repair_receiver.try_recv().unwrap();
         assert_eq!(
             received_verified_votes1,
@@ -513,7 +510,6 @@ mod tests {
         assert_eq!(receiver.try_iter().flatten().count(), 1);
         assert_eq!(verifier.stats.vote_stats.pool_sent, 1);
         assert_eq!(verifier.stats.cert_stats.pool_sent, 0);
-        assert_eq!(verifier.stats.num_pkts.get(1).unwrap(), 1);
         let received_verified_votes2 = votes_for_repair_receiver.try_recv().unwrap();
         assert_eq!(
             received_verified_votes2,
@@ -536,7 +532,7 @@ mod tests {
             .unwrap();
         assert_eq!(receiver.try_iter().flatten().count(), 1);
         assert_eq!(verifier.stats.vote_stats.pool_sent, 1);
-        assert_eq!(verifier.stats.num_pkts.get(1).unwrap(), 1);
+        assert_eq!(verifier.stats.cert_stats.pool_sent, 0);
         let received_verified_votes3 = votes_for_repair_receiver.try_recv().unwrap();
         assert_eq!(
             received_verified_votes3,
@@ -555,8 +551,8 @@ mod tests {
         let packets = vec![Packet::default()];
         let packet_batches = vec![RecycledPacketBatch::new(packets).into()];
         verifier.verify_and_send_batches(packet_batches).unwrap();
-
-        assert_eq!(verifier.stats.num_pkts.get(1).unwrap(), 1);
+        assert_eq!(verifier.stats.vote_stats.pool_sent, 0);
+        assert_eq!(verifier.stats.cert_stats.pool_sent, 0);
         assert_eq!(verifier.stats.num_malformed_pkts, 1);
 
         // Expect no messages since the packet was malformed
@@ -673,7 +669,6 @@ mod tests {
         verifier.verify_and_send_batches(packet_batches).unwrap();
         expect_no_receive(&receiver);
         assert_eq!(verifier.stats.vote_stats.pool_sent, 0);
-        assert_eq!(verifier.stats.num_pkts.get(1).unwrap(), 1);
         assert_eq!(verifier.stats.num_discarded_pkts, 1);
     }
 
@@ -755,13 +750,13 @@ mod tests {
             num_votes,
             "Did not send all valid packets"
         );
-        assert_eq!(verifier.stats.vote_stats.distinct_votes_stats.entries(), 1);
+        assert_eq!(verifier.stats.vote_stats.distinct_votes_stats.count(), 1);
         assert_eq!(
             verifier
                 .stats
                 .vote_stats
                 .distinct_votes_stats
-                .mean()
+                .mean::<u64>()
                 .unwrap(),
             2
         );
@@ -1304,7 +1299,7 @@ mod tests {
 
         assert_eq!(message_receiver.try_iter().flatten().count(), 1);
         assert_eq!(verifier.stats.num_verified_certs_received, 0);
-        assert_eq!(verifier.stats.num_pkts.get(1).unwrap(), 1);
+        assert_eq!(verifier.stats.cert_stats.certs_to_sig_verify, 1);
 
         vote_messages.pop(); // Remove one signature
         let mut builder2 = CertificateBuilder::new(cert_type);
@@ -1318,8 +1313,8 @@ mod tests {
         verifier.stats = SigVerifierStats::default();
         verifier.verify_and_send_batches(packet_batches2).unwrap();
         expect_no_receive(&message_receiver);
-        assert_eq!(verifier.stats.num_pkts.get(1).unwrap(), 1);
         assert_eq!(verifier.stats.num_verified_certs_received, 1);
+        assert_eq!(verifier.stats.cert_stats.certs_to_sig_verify, 0);
     }
 
     fn messages_to_batches(messages: &[ConsensusMessage]) -> Vec<PacketBatch> {

--- a/core/src/bls_sigverify/bls_vote_sigverify.rs
+++ b/core/src/bls_sigverify/bls_vote_sigverify.rs
@@ -98,8 +98,7 @@ pub(super) fn verify_and_send_votes(
     measure.stop();
     stats
         .fn_verify_and_send_votes_stats
-        .increment(measure.as_us())
-        .unwrap();
+        .add_sample(measure.as_us());
     Ok(stats)
 }
 
@@ -201,10 +200,7 @@ fn verify_votes(
     // Fallback to individual verification
     let (verified_votes, time_us) =
         measure_us!(verify_individual_votes(votes_to_verify, thread_pool));
-    stats
-        .fn_verify_individual_votes_stats
-        .increment(time_us)
-        .unwrap();
+    stats.fn_verify_individual_votes_stats.add_sample(time_us);
     verified_votes
 }
 
@@ -261,8 +257,7 @@ fn verify_votes_optimistic(
     measure.stop();
     stats
         .fn_verify_votes_optimistic_stats
-        .increment(measure.as_us())
-        .unwrap();
+        .add_sample(measure.as_us());
     verified
 }
 
@@ -297,8 +292,7 @@ fn aggregate_pubkeys_by_payload(
 
     stats
         .distinct_votes_stats
-        .increment(grouped_votes.len() as u64)
-        .unwrap();
+        .add_sample(grouped_votes.len() as u64);
 
     let (distinct_payloads, distinct_pubkeys_results): (Vec<_>, Vec<_>) = grouped_votes
         .into_par_iter()

--- a/core/src/bls_sigverify/stats.rs
+++ b/core/src/bls_sigverify/stats.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
 use {
-    histogram::Histogram,
+    agave_math_utils::welford_stats::WelfordStats,
     std::time::{Duration, Instant},
 };
 
@@ -15,11 +15,11 @@ pub(super) struct SigVerifierStats {
     /// Stats for sigverifying certs.
     pub(super) cert_stats: SigVerifyCertStats,
     /// Stats on how long [`verify_and_send_batch`] took.
-    pub(super) verify_and_send_batch_us: Histogram,
+    pub(super) verify_and_send_batch_us: WelfordStats,
     /// Stats on how long [`extract_and_filter_msgs`] took.
-    pub(super) extract_filter_msgs_us: Histogram,
+    pub(super) extract_filter_msgs_us: WelfordStats,
     /// Number of packets received.
-    pub(super) num_pkts: Histogram,
+    pub(super) num_pkts: WelfordStats,
     /// Number of discarded packets received from the streamer.
     pub(super) num_discarded_pkts: u64,
     /// Number of times we failed to deserialize a packet.
@@ -43,8 +43,8 @@ impl Default for SigVerifierStats {
         Self {
             vote_stats: SigVerifyVoteStats::default(),
             cert_stats: SigVerifyCertStats::default(),
-            extract_filter_msgs_us: Histogram::new(),
-            num_pkts: Histogram::default(),
+            extract_filter_msgs_us: WelfordStats::default(),
+            num_pkts: WelfordStats::default(),
             discard_vote_invalid_rank: 0,
             num_discarded_pkts: 0,
             num_malformed_pkts: 0,
@@ -52,7 +52,7 @@ impl Default for SigVerifierStats {
             num_old_votes_received: 0,
             num_old_certs_received: 0,
             num_verified_certs_received: 0,
-            verify_and_send_batch_us: Histogram::default(),
+            verify_and_send_batch_us: WelfordStats::default(),
             last_report: Instant::now(),
         }
     }
@@ -85,7 +85,7 @@ impl SigVerifierStats {
             "bls_sig_verifier_stats",
             (
                 "extract_and_verify_us_count",
-                extract_filter_msgs_us.entries(),
+                extract_filter_msgs_us.count(),
                 i64
             ),
             (
@@ -109,16 +109,6 @@ impl SigVerifierStats {
             ("num_malformed_pkts", *num_malformed_pkts, i64),
             ("num_old_certs_received", *num_old_certs_received, i64),
             (
-                "verify_and_send_batch_us_90pct",
-                verify_and_send_batch_us.percentile(90.0).unwrap_or(0),
-                i64
-            ),
-            (
-                "verify_and_send_batch_us_min",
-                verify_and_send_batch_us.minimum().unwrap_or(0),
-                i64
-            ),
-            (
                 "verify_and_send_batch_us_max",
                 verify_and_send_batch_us.maximum().unwrap_or(0),
                 i64
@@ -130,18 +120,12 @@ impl SigVerifierStats {
             ),
             (
                 "verify_and_send_batch_us_count",
-                verify_and_send_batch_us.entries(),
+                verify_and_send_batch_us.count(),
                 i64
             ),
-            (
-                "num_pkts_90pct",
-                num_pkts.percentile(90.0).unwrap_or(0),
-                i64
-            ),
-            ("num_pkts_min", num_pkts.minimum().unwrap_or(0), i64),
             ("num_pkts_max", num_pkts.maximum().unwrap_or(0), i64),
             ("num_pkts_mean", num_pkts.mean().unwrap_or(0), i64),
-            ("num_pkts_count", num_pkts.entries(), i64),
+            ("num_pkts_count", num_pkts.count(), i64),
         );
         *self = SigVerifierStats::default();
     }
@@ -168,7 +152,7 @@ pub(super) struct SigVerifyCertStats {
     pub(super) pool_channel_full: u64,
 
     /// Stats for [`verify_and_send_certificates`].
-    pub(super) fn_verify_and_send_certs_stats: Histogram,
+    pub(super) fn_verify_and_send_certs_stats: WelfordStats,
 }
 
 impl SigVerifyCertStats {
@@ -191,7 +175,7 @@ impl SigVerifyCertStats {
         self.pool_sent += pool_sent;
         self.pool_channel_full += pool_channel_full;
         self.fn_verify_and_send_certs_stats
-            .merge(&fn_verify_and_send_certs_stats);
+            .merge(fn_verify_and_send_certs_stats);
     }
 
     pub(super) fn report(&self) {
@@ -220,7 +204,7 @@ impl SigVerifyCertStats {
             ("pool_channel_full", *pool_channel_full, i64),
             (
                 "fn_verify_and_send_certs_count",
-                fn_verify_and_send_certs_stats.entries(),
+                fn_verify_and_send_certs_stats.count(),
                 i64
             ),
             (
@@ -262,14 +246,14 @@ pub(super) struct SigVerifyVoteStats {
     pub(super) repair_channel_full: u64,
 
     /// Stats for [`verify_and_send_votes`].
-    pub(super) fn_verify_and_send_votes_stats: Histogram,
+    pub(super) fn_verify_and_send_votes_stats: WelfordStats,
     /// Stats for [`verify_votes_optimistic`].
-    pub(super) fn_verify_votes_optimistic_stats: Histogram,
+    pub(super) fn_verify_votes_optimistic_stats: WelfordStats,
     /// Stats for [`verify_individual_votes`].
-    pub(super) fn_verify_individual_votes_stats: Histogram,
+    pub(super) fn_verify_individual_votes_stats: WelfordStats,
 
     /// Stats for number of distinct votes in batches.
-    pub(super) distinct_votes_stats: Histogram,
+    pub(super) distinct_votes_stats: WelfordStats,
 }
 
 impl SigVerifyVoteStats {
@@ -303,12 +287,12 @@ impl SigVerifyVoteStats {
         self.pool_sent += pool_sent;
         self.pool_channel_full += pool_channel_full;
         self.fn_verify_and_send_votes_stats
-            .merge(&fn_verify_and_send_votes_stats);
+            .merge(fn_verify_and_send_votes_stats);
         self.fn_verify_votes_optimistic_stats
-            .merge(&fn_verify_votes_optimistic_stats);
+            .merge(fn_verify_votes_optimistic_stats);
         self.fn_verify_individual_votes_stats
-            .merge(&fn_verify_individual_votes_stats);
-        self.distinct_votes_stats.merge(&distinct_votes_stats);
+            .merge(fn_verify_individual_votes_stats);
+        self.distinct_votes_stats.merge(distinct_votes_stats);
     }
 
     pub(super) fn report(&self) {
@@ -344,7 +328,7 @@ impl SigVerifyVoteStats {
             ("pool_channel_full", *pool_channel_full, i64),
             (
                 "fn_verify_and_send_votes_count",
-                fn_verify_and_send_votes_stats.entries(),
+                fn_verify_and_send_votes_stats.count(),
                 i64
             ),
             (
@@ -354,7 +338,7 @@ impl SigVerifyVoteStats {
             ),
             (
                 "fn_verify_votes_optimistic_count",
-                fn_verify_votes_optimistic_stats.entries(),
+                fn_verify_votes_optimistic_stats.count(),
                 i64
             ),
             (
@@ -364,7 +348,7 @@ impl SigVerifyVoteStats {
             ),
             (
                 "fn_verify_individual_votes_count",
-                fn_verify_individual_votes_stats.entries(),
+                fn_verify_individual_votes_stats.count(),
                 i64
             ),
             (
@@ -372,7 +356,7 @@ impl SigVerifyVoteStats {
                 fn_verify_individual_votes_stats.mean().unwrap_or(0),
                 i64
             ),
-            ("distinct_votes_count", distinct_votes_stats.entries(), i64),
+            ("distinct_votes_count", distinct_votes_stats.count(), i64),
             (
                 "distinct_votes_mean",
                 distinct_votes_stats.mean().unwrap_or(0),

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6540,6 +6540,7 @@ dependencies = [
  "agave-bls-cert-verify",
  "agave-feature-set",
  "agave-logger",
+ "agave-math-utils",
  "agave-scheduler-bindings",
  "agave-scheduling-utils",
  "agave-snapshots",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6468,6 +6468,7 @@ dependencies = [
  "agave-bls-cert-verify",
  "agave-feature-set",
  "agave-logger",
+ "agave-math-utils",
  "agave-scheduler-bindings",
  "agave-scheduling-utils",
  "agave-snapshots",


### PR DESCRIPTION

#### Problem
`Histogram` crate is no longer maintained.  We recently developed `WelfordStats` to help us track similar stats.


#### Summary of Changes
Adopts the sigverifier to use `WelfordStats`

Fixes #11102 