### PR TITLE
cli: run BadParameter instead of panic for program-v4 deploy arg valid…

### DIFF
--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -397,10 +397,11 @@ pub fn parse_program_v4_subcommand(
             let authority_signer_index = signer_info
                 .index_of(authority_pubkey)
                 .expect("Authority signer is missing");
-            assert!(
-                program_address.is_some() != program_signer_index.is_some(),
-                "Requires either --program-keypair or --program-id",
-            );
+            if program_address.is_some() == program_signer_index.is_some() {
+                return Err(CliError::BadParameter(
+                    "Requires either --program-keypair or --program-id".to_string(),
+                ));
+            }
 
             CliCommandInfo {
                 command: CliCommand::ProgramV4(ProgramV4CliCommand::Deploy {


### PR DESCRIPTION
#### Problem 

- program-v4 deploy panics when neither or both of --program-id/--program-keypair are provided due to an assert! in argument validation.

#### Solution

- Replace the assert! with a CliError::BadParameter so invalid arg combinations return a clean error instead of crashing.