### PR TITLE
streamer: use a fixed threshold to tell if node is staked

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1468,7 +1468,7 @@ pub mod test {
         agave_logger::setup();
 
         let client_keypair = Keypair::new();
-        let stakes = HashMap::from([(client_keypair.pubkey(), 100_000)]);
+        let stakes = HashMap::from([(client_keypair.pubkey(), 100_000_000_000_000)]);
         let staked_nodes = StakedNodes::new(
             Arc::new(stakes),
             HashMap::<Pubkey, u64>::default(), // overrides

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -39,7 +39,6 @@ pub(crate) struct StakedStreamLoadEMA {
     stats: Arc<StreamerStats>,
     max_staked_load_in_throttling_window: u64,
     max_unstaked_load_in_throttling_window: u64,
-    max_streams_per_ms: u64,
     staked_throttling_on_load_threshold: u64, // in streams/STREAM_LOAD_EMA_INTERVAL_MS
     staked_throttling_enabled: AtomicBool,
 }
@@ -79,7 +78,6 @@ impl StakedStreamLoadEMA {
             stats,
             max_staked_load_in_throttling_window,
             max_unstaked_load_in_throttling_window,
-            max_streams_per_ms,
             staked_throttling_on_load_threshold,
             staked_throttling_enabled: AtomicBool::new(false),
         }
@@ -186,10 +184,6 @@ impl StakedStreamLoadEMA {
                 }
             }
         }
-    }
-
-    pub(crate) fn max_streams_per_ms(&self) -> u64 {
-        self.max_streams_per_ms
     }
 }
 

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -8,10 +8,7 @@ use {
                 ConnectionTable, ConnectionTableKey, ConnectionTableType, get_connection_stake,
                 update_open_connections_stat,
             },
-            stream_throttle::{
-                ConnectionStreamCounter, STREAM_THROTTLING_INTERVAL_MS, StakedStreamLoadEMA,
-                throttle_stream,
-            },
+            stream_throttle::{ConnectionStreamCounter, StakedStreamLoadEMA, throttle_stream},
         },
         quic::{
             DEFAULT_MAX_QUIC_CONNECTIONS_PER_STAKED_PEER,
@@ -53,6 +50,10 @@ const REFERENCE_RTT_MS: u32 = 50;
 
 /// Above this RTT we stop scaling for BDP
 const MAX_RTT_MS: u32 = 350;
+
+/// Mimimal amount of lamports staked after which a remote peer is considered staked
+/// Currently set to 10K SOL.
+const STAKED_CONNECTION_MIN_LAMPORTS: u64 = 10000 * 1_000_000_000;
 
 #[derive(Clone)]
 pub struct SwQosConfig {
@@ -302,44 +303,30 @@ impl SwQos {
 
 impl QosController<SwQosConnectionContext> for SwQos {
     fn build_connection_context(&self, connection: &Connection) -> SwQosConnectionContext {
-        get_connection_stake(connection, &self.staked_nodes).map_or(
-            SwQosConnectionContext {
-                peer_type: ConnectionPeerType::Unstaked,
-                total_stake: 0,
-                remote_pubkey: None,
-                in_staked_table: false,
-                remote_address: connection.remote_address(),
-                stream_counter: None,
-                last_update: Arc::new(AtomicU64::new(timing::timestamp())),
-            },
-            |(pubkey, stake, total_stake)| {
-                // The heuristic is that the stake should be large enough to have 1 stream pass through within one throttle
-                // interval during which we allow max (MAX_STREAMS_PER_MS * STREAM_THROTTLING_INTERVAL_MS) streams.
+        let remote_address = connection.remote_address();
+        let last_update = Arc::new(AtomicU64::new(timing::timestamp()));
 
-                let peer_type = {
-                    let max_streams_per_ms = self.staked_stream_load_ema.max_streams_per_ms();
-                    let min_stake_ratio =
-                        1_f64 / (max_streams_per_ms * STREAM_THROTTLING_INTERVAL_MS) as f64;
-                    let stake_ratio = stake as f64 / total_stake as f64;
-                    if stake_ratio < min_stake_ratio {
-                        // If it is a staked connection with ultra low stake ratio, treat it as unstaked.
-                        ConnectionPeerType::Unstaked
-                    } else {
-                        ConnectionPeerType::Staked(stake)
-                    }
-                };
-
-                SwQosConnectionContext {
-                    peer_type,
-                    total_stake,
-                    remote_pubkey: Some(pubkey),
-                    in_staked_table: false,
-                    remote_address: connection.remote_address(),
-                    last_update: Arc::new(AtomicU64::new(timing::timestamp())),
-                    stream_counter: None,
+        let (peer_type, total_stake, remote_pubkey) =
+            match get_connection_stake(connection, &self.staked_nodes) {
+                None => (ConnectionPeerType::Unstaked, 0, None),
+                Some((_, stake, _)) if stake < STAKED_CONNECTION_MIN_LAMPORTS => {
+                    // If it is a connection with ultra low stake, treat it as unstaked.
+                    (ConnectionPeerType::Unstaked, 0, None)
                 }
-            },
-        )
+                Some((pubkey, stake, total_stake)) => {
+                    (ConnectionPeerType::Staked(stake), total_stake, Some(pubkey))
+                }
+            };
+
+        SwQosConnectionContext {
+            peer_type,
+            total_stake,
+            remote_pubkey,
+            in_staked_table: false,
+            remote_address,
+            stream_counter: None,
+            last_update,
+        }
     }
 
     #[allow(clippy::manual_async_fn)]

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -415,7 +415,7 @@ async fn test_connection_pruned_and_reopened() {
 #[tokio::test]
 async fn test_staked_connection() {
     let stake_identity = Keypair::new();
-    let stakes = HashMap::from([(stake_identity.pubkey(), 100_000)]);
+    let stakes = HashMap::from([(stake_identity.pubkey(), 100_000_000_000_000)]);
     let staked_nodes = StakedNodes::new(Arc::new(stakes), HashMap::<Pubkey, u64>::default());
 
     let SpawnTestServerResult {
@@ -716,7 +716,7 @@ async fn test_rate_limiting_establish_connection() {
 #[tokio::test]
 async fn test_update_identity() {
     let stake_identity = Keypair::new();
-    let stakes = HashMap::from([(stake_identity.pubkey(), 100_000)]);
+    let stakes = HashMap::from([(stake_identity.pubkey(), 100_000_000_000_000)]);
     let staked_nodes = StakedNodes::new(Arc::new(stakes), HashMap::<Pubkey, u64>::default());
 
     let SpawnTestServerResult {


### PR DESCRIPTION
#### Problem

- Streamer relies of a fraction of total stake to tell if node is staked or not
- This creates issues where a node can get reclassified as unstaked if stake_overrides are used (as they inflate the total supply as perceived by streamer)
- This also couples the anti-DOS measure (not allowing 1 lamport accounts to take up staked slots) with service rate configuration (as higher service rate reduces the threshold)

#### Summary of Changes

- Decouple the two
- Fix the "staked threshold" at 10K SOL (is this a good amount?)