### PR TITLE
Deprecates getLargestAccounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Release channels have their own copy of this changelog:
 ## 4.1.0-Unreleased
 ### RPC
 #### Breaking
+#### Deprecations
+* The `getLargestAccounts` RPC method is now deprecated.
 #### Changes
 ### Validator
 #### Breaking

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -903,6 +903,10 @@ pub async fn process_command(config: &CliConfig<'_>) -> ProcessResult {
         CliCommand::GetSlot => process_get_slot(&rpc_client, config).await,
         CliCommand::GetBlockHeight => process_get_block_height(&rpc_client, config).await,
         CliCommand::LargestAccounts { filter } => {
+            eprintln!(
+                "Warning: This command uses the deprecated 'getLargestAccounts' RPC method and \
+                 may be removed in a future major release."
+            );
             process_largest_accounts(&rpc_client, config, filter.clone()).await
         }
         CliCommand::GetTransactionCount => process_get_transaction_count(&rpc_client, config).await,

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1357,6 +1357,7 @@ pub async fn process_show_block_production(
     Ok(config.output_format.formatted_string(&block_production))
 }
 
+#[allow(deprecated)]
 pub async fn process_largest_accounts(
     rpc_client: &RpcClient,
     config: &CliConfig<'_>,

--- a/rpc-client-types/src/request.rs
+++ b/rpc-client-types/src/request.rs
@@ -10,7 +10,9 @@ use {
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum RpcRequest {
-    Custom { method: &'static str },
+    Custom {
+        method: &'static str,
+    },
     DeregisterNode,
     GetAccountInfo,
     GetBalance,
@@ -31,6 +33,11 @@ pub enum RpcRequest {
     GetInflationGovernor,
     GetInflationRate,
     GetInflationReward,
+    #[deprecated(
+        since = "4.1.0",
+        note = "This uses the deprecated `getLargestAccounts` RPC method and may be removed in a \
+                future major release"
+    )]
     GetLargestAccounts,
     GetLatestBlockhash,
     GetLeaderSchedule,

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -2125,6 +2125,7 @@ impl RpcClient {
     /// # Examples
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// # use solana_rpc_client_api::{
     /// #     client_error::Error,
     /// #     config::RpcLargestAccountsConfig,
@@ -2147,6 +2148,12 @@ impl RpcClient {
     /// # })?;
     /// # Ok::<(), Error>(())
     /// ```
+    #[allow(deprecated)]
+    #[deprecated(
+        since = "4.1.0",
+        note = "This uses the deprecated `getLargestAccounts` RPC method and may be removed in a \
+                future major release"
+    )]
     pub async fn get_largest_accounts_with_config(
         &self,
         config: RpcLargestAccountsConfig,

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -1846,6 +1846,7 @@ impl RpcClient {
     /// # Examples
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// # use solana_rpc_client_api::{
     /// #     client_error::Error,
     /// #     config::{RpcLargestAccountsConfig, RpcLargestAccountsFilter},
@@ -1864,6 +1865,12 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), Error>(())
     /// ```
+    #[allow(deprecated)]
+    #[deprecated(
+        since = "4.1.0",
+        note = "This uses the deprecated `getLargestAccounts` RPC method and may be removed in a \
+                future major release"
+    )]
     pub fn get_largest_accounts_with_config(
         &self,
         config: RpcLargestAccountsConfig,


### PR DESCRIPTION
#### Problem

The `getLargestAccounts` rpc method is expensive as it requires scanning all accounts. This causes accounts-db to be suboptimal in order to implement this method.


#### Summary of Changes

Deprecate agave's impl of `getLargestAccounts`.