### PR TITLE
Remove direct mutability of feature set internals

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -37,16 +37,8 @@ impl FeatureSet {
         &self.active
     }
 
-    pub fn active_mut(&mut self) -> &mut AHashMap<Pubkey, u64> {
-        &mut self.active
-    }
-
     pub fn inactive(&self) -> &AHashSet<Pubkey> {
         &self.inactive
-    }
-
-    pub fn inactive_mut(&mut self) -> &mut AHashSet<Pubkey> {
-        &mut self.inactive
     }
 
     pub fn is_active(&self, feature_id: &Pubkey) -> bool {

--- a/reserved-account-keys/src/lib.rs
+++ b/reserved-account-keys/src/lib.rs
@@ -228,7 +228,7 @@ mod tests {
 
         // Updating the active set with an activated feature should also activate
         // the corresponding reserved key from inactive to active
-        feature_set.active_mut().insert(feature_ids[0], 0);
+        feature_set.activate(&feature_ids[0], 0);
         reserved_account_keys.update_active_set(&feature_set);
 
         assert!(reserved_account_keys.is_reserved(&active_reserved_key));
@@ -237,7 +237,7 @@ mod tests {
 
         // Update the active set again to ensure that the inactive map is
         // properly retained
-        feature_set.active_mut().insert(feature_ids[1], 0);
+        feature_set.activate(&feature_ids[1], 0);
         reserved_account_keys.update_active_set(&feature_set);
 
         assert!(reserved_account_keys.is_reserved(&active_reserved_key));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5455,15 +5455,13 @@ impl Bank {
 
     pub fn deactivate_feature(&mut self, id: &Pubkey) {
         let mut feature_set = Arc::make_mut(&mut self.feature_set).clone();
-        feature_set.active_mut().remove(id);
-        feature_set.inactive_mut().insert(*id);
+        feature_set.deactivate(id);
         self.feature_set = Arc::new(feature_set);
     }
 
     pub fn activate_feature(&mut self, id: &Pubkey) {
         let mut feature_set = Arc::make_mut(&mut self.feature_set).clone();
-        feature_set.inactive_mut().remove(id);
-        feature_set.active_mut().insert(*id, 0);
+        feature_set.activate(id, 0);
         self.feature_set = Arc::new(feature_set);
     }
 

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -1485,7 +1485,7 @@ pub(crate) mod tests {
 
         // Add the feature to the bank's inactive feature set.
         let mut feature_set = FeatureSet::all_enabled();
-        feature_set.inactive_mut().insert(*feature_id);
+        feature_set.deactivate(feature_id);
         root_bank.feature_set = Arc::new(feature_set);
 
         // Initialize the source buffer account.
@@ -1570,7 +1570,7 @@ pub(crate) mod tests {
 
         // Set up the feature set with the migration feature marked as active.
         let mut feature_set = FeatureSet::all_enabled();
-        feature_set.active_mut().insert(*feature_id, 0);
+        feature_set.activate(feature_id, 0);
         bank.feature_set = Arc::new(feature_set);
         bank.store_account_and_update_capitalization(
             feature_id,
@@ -1744,7 +1744,7 @@ pub(crate) mod tests {
         // Now, add the feature ID as active, and run `finish_init` again to
         // make sure the feature is idempotent.
         let mut feature_set = FeatureSet::all_enabled();
-        feature_set.active_mut().insert(*feature_id, 0);
+        feature_set.activate(feature_id, 0);
         bank.feature_set = Arc::new(feature_set);
         bank.store_account_and_update_capitalization(
             feature_id,
@@ -2017,7 +2017,7 @@ pub(crate) mod tests {
 
         // Add the feature to the bank's inactive feature set.
         let mut feature_set = FeatureSet::all_enabled();
-        feature_set.inactive_mut().insert(*feature_id);
+        feature_set.deactivate(feature_id);
         root_bank.feature_set = Arc::new(feature_set);
 
         // Initialize the source buffer account.

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6581,7 +6581,7 @@ fn test_compute_active_feature_set() {
         .parse::<Pubkey>()
         .unwrap();
     let mut feature_set = FeatureSet::default();
-    feature_set.inactive_mut().insert(test_feature);
+    feature_set.deactivate(&test_feature);
     bank.feature_set = Arc::new(feature_set.clone());
 
     let (feature_set, new_activations) = bank.compute_active_feature_set(true);


### PR DESCRIPTION
#### Problem
- We expose fns to directly modify the internal maps of feature-set
- Want to add a bool snapshot (basically a more generalized version of what's in https://github.com/anza-xyz/agave/pull/10591)
- Easier to do snapshot without our internals exposed everywhere

#### Summary of Changes
- Remove `active_mut` and `inactive_mut` on `FeatureSet`
	- Update users appropriately 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
