### PR TITLE
Bump rust to 1.94 and nightly to 2026-01-18

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2025-12-05
+  nightly_version=2026-01-18
 fi
 
 

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -726,88 +726,86 @@ impl SystemMonitorService {
         const CPUID_MANUFACTURER_EDX_AMD: u32 = 0x69746e65;
         const CPUID_MANUFACTURER_ECX_AMD: u32 = 0x444d4163;
 
-        unsafe {
-            let cpuid_mfr = __cpuid(0);
-            let cpuid_empty = CpuidResult {
-                eax: 0,
-                ebx: 0,
-                ecx: 0,
-                edx: 0,
-            };
-
-            let max_leaf = match CpuidParamValue::try_from(std::cmp::min(
-                cpuid_mfr.eax,
-                CPUID_PARAM_MAX_SUPPORTED_VALUE,
-            )) {
-                Ok(val) => val,
-                Err(_err) => CpuidParamValue::Manufacturer,
-            };
-
-            let mfr_id = if cpuid_mfr.ebx == CPUID_MANUFACTURER_EBX_INTEL
-                && cpuid_mfr.edx == CPUID_MANUFACTURER_EDX_INTEL
-                && cpuid_mfr.ecx == CPUID_MANUFACTURER_ECX_INTEL
-            {
-                CpuManufacturer::Intel // GenuineIntel
-            } else if cpuid_mfr.ebx == CPUID_MANUFACTURER_EBX_AMD
-                && cpuid_mfr.edx == CPUID_MANUFACTURER_EDX_AMD
-                && cpuid_mfr.ecx == CPUID_MANUFACTURER_ECX_AMD
-            {
-                CpuManufacturer::Amd // AuthenticAMD
-            } else {
-                CpuManufacturer::Other // anything else
-            };
-
-            let cpuid_processor = if CpuidParamValue::Processor <= max_leaf {
-                __cpuid(CpuidParamValue::Processor.into())
-            } else {
-                cpuid_empty
-            };
-            let cpuid_cache = if CpuidParamValue::Cache <= max_leaf {
-                __cpuid(CpuidParamValue::Cache.into())
-            } else {
-                cpuid_empty
-            };
-            let cpuid_topology = if CpuidParamValue::Topology <= max_leaf {
-                __cpuid(CpuidParamValue::Topology.into())
-            } else {
-                cpuid_empty
-            };
-            let cpuid_extended_0 = if CpuidParamValue::Extended <= max_leaf {
-                __cpuid_count(CpuidParamValue::Extended.into(), 0)
-            } else {
-                cpuid_empty
-            };
-            let cpuid_extended_1 = if CpuidParamValue::Extended <= max_leaf {
-                if 1 <= __get_cpuid_max(CpuidParamValue::Extended.into()).1 {
-                    __cpuid_count(CpuidParamValue::Extended.into(), 1)
-                } else {
-                    cpuid_empty
-                }
-            } else {
-                cpuid_empty
-            };
-
-            datapoint_info!(
-                "cpuid-values",
-                ("manufacturer_id", i64::from(mfr_id), i64),
-                ("cpuid_processor_eax", i64::from(cpuid_processor.eax), i64),
-                ("cpuid_processor_ebx", i64::from(cpuid_processor.ebx), i64),
-                ("cpuid_processor_ecx", i64::from(cpuid_processor.ecx), i64),
-                ("cpuid_processor_edx", i64::from(cpuid_processor.edx), i64),
-                ("cpuid_cache_eax", i64::from(cpuid_cache.eax), i64),
-                ("cpuid_cache_ebx", i64::from(cpuid_cache.ebx), i64),
-                ("cpuid_cache_ecx", i64::from(cpuid_cache.ecx), i64),
-                ("cpuid_cache_edx", i64::from(cpuid_cache.edx), i64),
-                ("cpuid_topology_eax", i64::from(cpuid_topology.eax), i64),
-                ("cpuid_topology_ebx", i64::from(cpuid_topology.ebx), i64),
-                ("cpuid_topology_ecx", i64::from(cpuid_topology.ecx), i64),
-                ("cpuid_topology_edx", i64::from(cpuid_topology.edx), i64),
-                ("cpuid_extended_0_ebx", i64::from(cpuid_extended_0.ebx), i64),
-                ("cpuid_extended_0_ecx", i64::from(cpuid_extended_0.ecx), i64),
-                ("cpuid_extended_0_edx", i64::from(cpuid_extended_0.edx), i64),
-                ("cpuid_extended_1_eax", i64::from(cpuid_extended_1.eax), i64),
-            );
+        let cpuid_mfr = __cpuid(0);
+        let cpuid_empty = CpuidResult {
+            eax: 0,
+            ebx: 0,
+            ecx: 0,
+            edx: 0,
         };
+
+        let max_leaf = match CpuidParamValue::try_from(std::cmp::min(
+            cpuid_mfr.eax,
+            CPUID_PARAM_MAX_SUPPORTED_VALUE,
+        )) {
+            Ok(val) => val,
+            Err(_err) => CpuidParamValue::Manufacturer,
+        };
+
+        let mfr_id = if cpuid_mfr.ebx == CPUID_MANUFACTURER_EBX_INTEL
+            && cpuid_mfr.edx == CPUID_MANUFACTURER_EDX_INTEL
+            && cpuid_mfr.ecx == CPUID_MANUFACTURER_ECX_INTEL
+        {
+            CpuManufacturer::Intel // GenuineIntel
+        } else if cpuid_mfr.ebx == CPUID_MANUFACTURER_EBX_AMD
+            && cpuid_mfr.edx == CPUID_MANUFACTURER_EDX_AMD
+            && cpuid_mfr.ecx == CPUID_MANUFACTURER_ECX_AMD
+        {
+            CpuManufacturer::Amd // AuthenticAMD
+        } else {
+            CpuManufacturer::Other // anything else
+        };
+
+        let cpuid_processor = if CpuidParamValue::Processor <= max_leaf {
+            __cpuid(CpuidParamValue::Processor.into())
+        } else {
+            cpuid_empty
+        };
+        let cpuid_cache = if CpuidParamValue::Cache <= max_leaf {
+            __cpuid(CpuidParamValue::Cache.into())
+        } else {
+            cpuid_empty
+        };
+        let cpuid_topology = if CpuidParamValue::Topology <= max_leaf {
+            __cpuid(CpuidParamValue::Topology.into())
+        } else {
+            cpuid_empty
+        };
+        let cpuid_extended_0 = if CpuidParamValue::Extended <= max_leaf {
+            __cpuid_count(CpuidParamValue::Extended.into(), 0)
+        } else {
+            cpuid_empty
+        };
+        let cpuid_extended_1 = if CpuidParamValue::Extended <= max_leaf {
+            if 1 <= __get_cpuid_max(CpuidParamValue::Extended.into()).1 {
+                __cpuid_count(CpuidParamValue::Extended.into(), 1)
+            } else {
+                cpuid_empty
+            }
+        } else {
+            cpuid_empty
+        };
+
+        datapoint_info!(
+            "cpuid-values",
+            ("manufacturer_id", i64::from(mfr_id), i64),
+            ("cpuid_processor_eax", i64::from(cpuid_processor.eax), i64),
+            ("cpuid_processor_ebx", i64::from(cpuid_processor.ebx), i64),
+            ("cpuid_processor_ecx", i64::from(cpuid_processor.ecx), i64),
+            ("cpuid_processor_edx", i64::from(cpuid_processor.edx), i64),
+            ("cpuid_cache_eax", i64::from(cpuid_cache.eax), i64),
+            ("cpuid_cache_ebx", i64::from(cpuid_cache.ebx), i64),
+            ("cpuid_cache_ecx", i64::from(cpuid_cache.ecx), i64),
+            ("cpuid_cache_edx", i64::from(cpuid_cache.edx), i64),
+            ("cpuid_topology_eax", i64::from(cpuid_topology.eax), i64),
+            ("cpuid_topology_ebx", i64::from(cpuid_topology.ebx), i64),
+            ("cpuid_topology_ecx", i64::from(cpuid_topology.ecx), i64),
+            ("cpuid_topology_edx", i64::from(cpuid_topology.edx), i64),
+            ("cpuid_extended_0_ebx", i64::from(cpuid_extended_0.ebx), i64),
+            ("cpuid_extended_0_ecx", i64::from(cpuid_extended_0.ecx), i64),
+            ("cpuid_extended_0_edx", i64::from(cpuid_extended_0.edx), i64),
+            ("cpuid_extended_1_eax", i64::from(cpuid_extended_1.eax), i64),
+        );
     }
 
     fn report_cpu_stats() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.94.0"


### PR DESCRIPTION
#### Problem
New Rust toolchain is available

#### Summary of Changes
* Bump toolchain to 1.94 and nightly to 2026-01-18
* remove `unsafe` block around __cpuid checks (relaxed by https://github.com/rust-lang/stdarch/pull/1935)

Fixes #11035
