### PR TITLE
Upstreams using BlsPubkeyAffine instead of BlsPubkey

### DIFF
--- a/bls-cert-verify/benches/cert_verify.rs
+++ b/bls-cert-verify/benches/cert_verify.rs
@@ -8,7 +8,7 @@ use {
     bitvec::vec::BitVec,
     criterion::{BenchmarkId, Criterion, criterion_group, criterion_main},
     solana_bls_signatures::{
-        keypair::Keypair as BlsKeypair, pubkey::Pubkey as BlsPubkey,
+        keypair::Keypair as BlsKeypair, pubkey::PubkeyAffine as BlsPubkeyAffine,
         signature::Signature as BlsSignature,
     },
     solana_hash::Hash,
@@ -107,7 +107,7 @@ fn bench_verify_cert(c: &mut Criterion) {
         let keypairs = create_bls_keypairs(size);
 
         // Pre-calculate public keys to simulate efficient Bank lookup
-        let pubkeys: Vec<BlsPubkey> = keypairs.iter().map(|kp| kp.public.into()).collect();
+        let pubkeys: Vec<BlsPubkeyAffine> = keypairs.iter().map(|kp| kp.public).collect();
         let pubkeys_ref = &pubkeys;
 
         // Base2 Setup

--- a/bls-cert-verify/src/cert_verify.rs
+++ b/bls-cert-verify/src/cert_verify.rs
@@ -9,7 +9,7 @@ use {
     rayon::{iter::IntoParallelRefIterator, join},
     solana_bls_signatures::{
         BlsError, PubkeyProjective, Signature as BlsSignature, SignatureProjective,
-        VerifiablePubkey, pubkey::Pubkey as BlsPubkey, signature::AsSignatureAffine,
+        VerifiablePubkey, pubkey::PubkeyAffine as BlsPubkeyAffine, signature::AsSignatureAffine,
     },
     solana_signer_store::{DecodeError, Decoded, decode},
     thiserror::Error,
@@ -60,7 +60,7 @@ pub enum Error {
 pub fn verify_certificate(
     cert: &Certificate,
     max_validators: usize,
-    mut rank_map: impl FnMut(usize) -> Option<(u64, BlsPubkey)>,
+    mut rank_map: impl FnMut(usize) -> Option<(u64, BlsPubkeyAffine)>,
 ) -> Result<u64, Error> {
     let mut total_stake = 0u64;
 
@@ -133,7 +133,7 @@ pub fn verify_base2<S: AsSignatureAffine>(
     signature: &S,
     ranks: &[u8],
     max_validators: usize,
-    rank_map: impl FnMut(usize) -> Option<BlsPubkey>,
+    rank_map: impl FnMut(usize) -> Option<BlsPubkeyAffine>,
 ) -> Result<(), Error> {
     let ranks = decode(ranks, max_validators).map_err(Error::Decode)?;
     let ranks = match ranks {
@@ -147,7 +147,7 @@ fn verify_single_vote_signature<S: AsSignatureAffine>(
     payload: &[u8],
     signature: &S,
     ranks: &BitVec<u8>,
-    rank_map: impl FnMut(usize) -> Option<BlsPubkey>,
+    rank_map: impl FnMut(usize) -> Option<BlsPubkeyAffine>,
 ) -> Result<(), Error> {
     let pubkeys = collect_pubkeys(ranks, rank_map)?;
     let agg_pubkey = aggregate_pubkeys(&pubkeys)?;
@@ -166,7 +166,7 @@ fn verify_base3(
     signature: &BlsSignature,
     ranks: &[u8],
     max_validators: usize,
-    mut rank_map: impl FnMut(usize) -> Option<BlsPubkey>,
+    mut rank_map: impl FnMut(usize) -> Option<BlsPubkeyAffine>,
 ) -> Result<(), Error> {
     let ranks = decode(ranks, max_validators).map_err(Error::Decode)?;
     match ranks {
@@ -195,15 +195,15 @@ fn verify_base3(
 }
 
 /// Aggregates a slice of public keys into a single projective public key.
-pub fn aggregate_pubkeys(pubkeys: &[BlsPubkey]) -> Result<PubkeyProjective, Error> {
+pub fn aggregate_pubkeys(pubkeys: &[BlsPubkeyAffine]) -> Result<PubkeyProjective, Error> {
     PubkeyProjective::par_aggregate(pubkeys.par_iter()).map_err(Error::VerifySig)
 }
 
 /// Collects public keys sequentially based on the provided ranks bitmap.
 pub fn collect_pubkeys(
     ranks: &BitVec<u8>,
-    mut rank_map: impl FnMut(usize) -> Option<BlsPubkey>,
-) -> Result<Vec<BlsPubkey>, Error> {
+    mut rank_map: impl FnMut(usize) -> Option<BlsPubkeyAffine>,
+) -> Result<Vec<BlsPubkeyAffine>, Error> {
     let mut pubkeys = Vec::with_capacity(ranks.count_ones());
     for rank in ranks.iter_ones() {
         let pubkey = rank_map(rank).ok_or(Error::MissingRank)?;
@@ -276,7 +276,7 @@ mod test {
         );
         assert_eq!(
             verify_certificate(&cert, 10, |rank| {
-                bls_keypairs.get(rank).map(|kp| (100, kp.public.into()))
+                bls_keypairs.get(rank).map(|kp| (100, kp.public))
             })
             .unwrap(),
             600
@@ -309,7 +309,7 @@ mod test {
         let cert = builder.build().expect("Failed to build certificate");
         assert_eq!(
             verify_certificate(&cert, 10, |rank| {
-                bls_keypairs.get(rank).map(|kp| (100, kp.public.into()))
+                bls_keypairs.get(rank).map(|kp| (100, kp.public))
             })
             .unwrap(),
             700
@@ -338,7 +338,7 @@ mod test {
         };
         assert_eq!(
             verify_certificate(&cert, 10, |rank| {
-                bls_keypairs.get(rank).map(|kp| (100, kp.public.into()))
+                bls_keypairs.get(rank).map(|kp| (100, kp.public))
             })
             .unwrap_err(),
             Error::VerifySig(BlsError::PointConversion)

--- a/core/benches/bls_vote_sigverify.rs
+++ b/core/benches/bls_vote_sigverify.rs
@@ -77,7 +77,7 @@ fn generate_test_data(num_distinct_messages: usize, batch_size: usize) -> Vec<Vo
 
         votes_to_verify.push(VotePayload {
             vote_message,
-            bls_pubkey: bls_keypair.public.into(),
+            bls_pubkey: bls_keypair.public,
             pubkey: Keypair::new().pubkey(),
         });
     }

--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -19,7 +19,7 @@ use {
     },
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TryRecvError},
     rayon::{ThreadPool, ThreadPoolBuilder},
-    solana_bls_signatures::pubkey::Pubkey as BlsPubkey,
+    solana_bls_signatures::pubkey::PubkeyAffine as BlsPubkeyAffine,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::leader_schedule_cache::LeaderScheduleCache,
@@ -254,7 +254,11 @@ impl SigVerifier {
     }
 
     /// If this vote should be verified, then returns the sender's Pubkey and BlsPubkey.
-    fn keep_vote(&mut self, vote: &VoteMessage, root_bank: &Bank) -> Option<(Pubkey, BlsPubkey)> {
+    fn keep_vote(
+        &mut self,
+        vote: &VoteMessage,
+        root_bank: &Bank,
+    ) -> Option<(Pubkey, BlsPubkeyAffine)> {
         let root_slot = root_bank.slot();
         let Some(rank_map) = root_bank.get_rank_map(vote.vote.slot()) else {
             self.stats.discard_vote_no_epoch_stakes += 1;

--- a/core/src/bls_sigverify/bls_vote_sigverify.rs
+++ b/core/src/bls_sigverify/bls_vote_sigverify.rs
@@ -28,7 +28,7 @@ use {
     },
     solana_bls_signatures::{
         BlsError,
-        pubkey::{Pubkey as BlsPubkey, PubkeyProjective, VerifiablePubkey},
+        pubkey::{PubkeyAffine as BlsPubkeyAffine, PubkeyProjective, VerifiablePubkey},
         signature::SignatureProjective,
     },
     solana_clock::Slot,
@@ -45,7 +45,7 @@ use {
 #[derive(Clone, Debug)]
 pub(super) struct VotePayload {
     pub vote_message: VoteMessage,
-    pub bls_pubkey: BlsPubkey,
+    pub bls_pubkey: BlsPubkeyAffine,
     pub pubkey: Pubkey,
 }
 
@@ -281,7 +281,7 @@ fn aggregate_pubkeys_by_payload(
     stats: &mut SigVerifyVoteStats,
 ) -> (Vec<Vec<u8>>, Result<Vec<PubkeyProjective>, BlsError>) {
     debug_assert!(current_thread_index().is_some());
-    let mut grouped_votes: HashMap<&Vote, Vec<&BlsPubkey>> = HashMap::new();
+    let mut grouped_votes: HashMap<&Vote, Vec<&BlsPubkeyAffine>> = HashMap::new();
 
     for v in votes {
         grouped_votes

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -1,7 +1,10 @@
 use {
     crate::stakes::{DeserializableStakes, SerdeStakesToStakeFormat, Stakes},
     serde::{Deserialize, Serialize},
-    solana_bls_signatures::{Pubkey as BLSPubkey, PubkeyCompressed as BLSPubkeyCompressed},
+    solana_bls_signatures::{
+        BLS_PUBLIC_KEY_COMPRESSED_SIZE,
+        pubkey::{PubkeyAffine as BLSPubkeyAffine, PubkeyCompressed as BLSPubkeyCompressed},
+    },
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
     solana_stake_interface::state::Stake,
@@ -17,65 +20,84 @@ pub type EpochAuthorizedVoters = HashMap<Pubkey, Pubkey>;
 
 /// Entry in the [`BLSPubkeyToRankMap`] associating a validator's identity
 /// pubkey and BLS pubkey with its stake.
-#[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct BLSPubkeyStakeEntry {
     pub pubkey: Pubkey,
-    pub bls_pubkey: BLSPubkey,
+    pub bls_pubkey: BLSPubkeyAffine,
     pub stake: u64,
 }
 
-/// Container to store a mapping from validator [`BLSPubkey`] to rank.
+/// Container to store a mapping from validator [`BLSPubkeyAffine`] to rank.
 ///
 /// A validator with a smaller rank has a higher stake.
-/// Container also supports lookups from rank to [`(Pubkey, BLSPubkey)`].
-#[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+/// Container also supports lookups from rank to [`BLSPubkeyStakeEntry`].
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct BLSPubkeyToRankMap {
-    /// Mapping from validator [`BLSPubkey`] to rank.
-    rank_map: HashMap<BLSPubkey, u16>,
-    /// Mapping from rank to [`BLSPubkeyStakeEntry`].
-    //
-    // TODO(wen): We can make sorted_pubkeys a Vec<BLSPubkey> after we remove ed25519
-    // pubkey from the consensus pool.
+    rank_map: HashMap<BLSPubkeyCompressed, u16>,
     sorted_pubkeys: Vec<BLSPubkeyStakeEntry>,
+}
+
+// Even though BLSPubkeyToRankMap is not serialized in `VersionedEpochStakes`, still need to
+// derive `frozen-abi` for it because `VersionedEpochStakes` cannot derive `Default`.
+#[cfg(feature = "frozen-abi")]
+impl solana_frozen_abi::abi_example::AbiExample for BLSPubkeyToRankMap {
+    fn example() -> Self {
+        Self {
+            rank_map: HashMap::new(),
+            sorted_pubkeys: Vec::new(),
+        }
+    }
+}
+
+pub(crate) fn bls_pubkey_compressed_bytes_to_bls_pubkey(
+    bls_pubkey_compressed_bytes: [u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
+) -> Option<(BLSPubkeyCompressed, BLSPubkeyAffine)> {
+    let bls_pubkey_compressed: BLSPubkeyCompressed =
+        bincode::deserialize(&bls_pubkey_compressed_bytes).ok()?;
+    let bls_pubkey_affine = BLSPubkeyAffine::try_from(bls_pubkey_compressed).ok()?;
+    Some((bls_pubkey_compressed, bls_pubkey_affine))
 }
 
 impl BLSPubkeyToRankMap {
     pub fn new(epoch_vote_accounts_hash_map: &VoteAccountsHashMap) -> Self {
-        let mut pubkey_stake_pair_vec: Vec<(Pubkey, BLSPubkey, u64)> = epoch_vote_accounts_hash_map
-            .iter()
-            .filter_map(|(pubkey, (stake, account))| {
-                if *stake > 0 {
-                    account
-                        .vote_state_view()
-                        .bls_pubkey_compressed()
-                        .and_then(|bls_pubkey_compressed_bytes| {
-                            let bls_pubkey_compressed =
-                                BLSPubkeyCompressed(bls_pubkey_compressed_bytes);
-                            BLSPubkey::try_from(bls_pubkey_compressed).ok()
-                        })
-                        .map(|bls_pubkey| (*pubkey, bls_pubkey, *stake))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        pubkey_stake_pair_vec.sort_by(|(_, a_pubkey, a_stake), (_, b_pubkey, b_stake)| {
-            b_stake.cmp(a_stake).then(a_pubkey.cmp(b_pubkey))
-        });
+        let mut pubkey_stake_pair_vec: Vec<(Pubkey, BLSPubkeyCompressed, BLSPubkeyAffine, u64)> =
+            epoch_vote_accounts_hash_map
+                .iter()
+                .filter_map(|(pubkey, (stake, account))| {
+                    if *stake > 0 {
+                        account
+                            .vote_state_view()
+                            .bls_pubkey_compressed()
+                            .and_then(bls_pubkey_compressed_bytes_to_bls_pubkey)
+                            .map(|(bls_pubkey_compressed, bls_pubkey)| {
+                                (*pubkey, bls_pubkey_compressed, bls_pubkey, *stake)
+                            })
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+        pubkey_stake_pair_vec.sort_by(
+            |(_, a_pubkey_compressed, _, a_stake), (_, b_pubkey_compressed, _, b_stake)| {
+                b_stake
+                    .cmp(a_stake)
+                    .then(a_pubkey_compressed.cmp(b_pubkey_compressed))
+            },
+        );
         let mut sorted_pubkeys = Vec::new();
         let mut bls_pubkey_to_rank_map = HashMap::new();
-        for (rank, (pubkey, bls_pubkey, stake)) in pubkey_stake_pair_vec.into_iter().enumerate() {
+        for (rank, (pubkey, bls_pubkey_compressed, bls_pubkey, stake)) in
+            pubkey_stake_pair_vec.into_iter().enumerate()
+        {
             let entry = BLSPubkeyStakeEntry {
                 pubkey,
                 bls_pubkey,
                 stake,
             };
             sorted_pubkeys.push(entry);
-            bls_pubkey_to_rank_map.insert(bls_pubkey, rank as u16);
+            bls_pubkey_to_rank_map.insert(bls_pubkey_compressed, rank as u16);
         }
         Self {
             rank_map: bls_pubkey_to_rank_map,
@@ -91,8 +113,9 @@ impl BLSPubkeyToRankMap {
         self.rank_map.len()
     }
 
-    pub fn get_rank(&self, bls_pubkey: &BLSPubkey) -> Option<&u16> {
-        self.rank_map.get(bls_pubkey)
+    pub fn get_rank(&self, bls_pubkey: &BLSPubkeyAffine) -> Option<&u16> {
+        let bls_pubkey_compressed = BLSPubkeyCompressed(bls_pubkey.to_bytes_compressed());
+        self.rank_map.get(&bls_pubkey_compressed)
     }
 
     pub fn get_pubkey_stake_entry(&self, index: usize) -> Option<&BLSPubkeyStakeEntry> {
@@ -484,11 +507,10 @@ pub(crate) mod tests {
         assert_eq!(bls_pubkey_to_rank_map.len(), num_vote_accounts);
         for (pubkey, (stake, vote_account)) in epoch_vote_accounts {
             let vote_state_view = vote_account.vote_state_view();
-            let bls_pubkey_compressed = bincode::deserialize::<BLSPubkeyCompressed>(
-                &vote_state_view.bls_pubkey_compressed().unwrap(),
+            let (_comp, bls_pubkey) = bls_pubkey_compressed_bytes_to_bls_pubkey(
+                vote_state_view.bls_pubkey_compressed().unwrap(),
             )
             .unwrap();
-            let bls_pubkey = BLSPubkey::try_from(bls_pubkey_compressed).unwrap();
             let index = bls_pubkey_to_rank_map.get_rank(&bls_pubkey).unwrap();
             assert!(index >= &0 && index < &(num_vote_accounts as u16));
             assert_eq!(

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -148,8 +148,9 @@ mod tests {
         agave_votor_messages::consensus_message::VoteMessage,
         bitvec::vec::BitVec,
         solana_bls_signatures::{
-            Keypair as BlsKeypair, Pubkey as BLSPubkey, Signature as BLSSignature,
+            Keypair as BlsKeypair, Signature as BLSSignature,
             SignatureCompressed as BlsSignatureCompressed, SignatureProjective,
+            pubkey::PubkeyCompressed as BLSPubkeyCompressed,
         },
         solana_hash::Hash,
         solana_signer_store::encode_base2,
@@ -195,7 +196,12 @@ mod tests {
             .collect::<Vec<_>>();
         let keypair_map = validator_keypairs
             .iter()
-            .map(|k| (BLSPubkey::from(k.bls_keypair.public), k.bls_keypair.clone()))
+            .map(|k| {
+                (
+                    BLSPubkeyCompressed::from(k.bls_keypair.public),
+                    k.bls_keypair.clone(),
+                )
+            })
             .collect::<HashMap<_, _>>();
         let genesis = create_genesis_config_with_alpenglow_vote_accounts(
             1_000_000_000,
@@ -211,8 +217,9 @@ mod tests {
             .bls_pubkey_to_rank_map();
         let signing_keys = (0..num_validators)
             .map(|index| {
+                let pubkey_affine = rank_map.get_pubkey_stake_entry(index).unwrap().bls_pubkey;
                 keypair_map
-                    .get(&rank_map.get_pubkey_stake_entry(index).unwrap().bls_pubkey)
+                    .get(&BLSPubkeyCompressed::from(pubkey_affine))
                     .unwrap()
             })
             .collect::<Vec<_>>();

--- a/votor/src/consensus_rewards/entry.rs
+++ b/votor/src/consensus_rewards/entry.rs
@@ -119,7 +119,7 @@ impl Entry {
 mod tests {
     use {
         super::*,
-        solana_bls_signatures::{Keypair as BlsKeypair, Pubkey as BlsPubkey},
+        solana_bls_signatures::{Keypair as BlsKeypair, PubkeyCompressed as BlsPubkeyCompressed},
         solana_epoch_schedule::EpochSchedule,
         solana_hash::Hash,
         solana_pubkey::Pubkey,
@@ -160,7 +160,12 @@ mod tests {
             .collect::<Vec<_>>();
         let keypair_map = validator_keypairs
             .iter()
-            .map(|k| (BlsPubkey::from(k.bls_keypair.public), k.bls_keypair.clone()))
+            .map(|k| {
+                (
+                    BlsPubkeyCompressed::from(k.bls_keypair.public),
+                    k.bls_keypair.clone(),
+                )
+            })
             .collect::<HashMap<_, _>>();
         let mut genesis_config = create_genesis_config_with_alpenglow_vote_accounts(
             1_000_000_000,
@@ -174,8 +179,9 @@ mod tests {
         let rank_map = bank.get_rank_map(slot).unwrap().clone();
         let signing_keys = (0..max_validators)
             .map(|index| {
+                let pubkey_affine = rank_map.get_pubkey_stake_entry(index).unwrap().bls_pubkey;
                 keypair_map
-                    .get(&rank_map.get_pubkey_stake_entry(index).unwrap().bls_pubkey)
+                    .get(&BlsPubkeyCompressed::from(pubkey_affine))
                     .unwrap()
                     .clone()
             })

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -12,8 +12,7 @@ use {
     },
     crossbeam_channel::{SendError, Sender},
     solana_bls_signatures::{
-        BlsError, Pubkey as BLSPubkey, keypair::Keypair as BLSKeypair,
-        pubkey::PubkeyCompressed as BLSPubkeyCompressed,
+        BlsError, keypair::Keypair as BLSKeypair, pubkey::PubkeyCompressed as BLSPubkeyCompressed,
     },
     solana_clock::Slot,
     solana_keypair::Keypair,
@@ -214,7 +213,7 @@ pub fn generate_vote_tx(
 
     let bls_keypair = get_or_insert_bls_keypair(derived_bls_keypairs, &authorized_voter_keypair)
         .unwrap_or_else(|e| panic!("Failed to derive my own BLS keypair: {e:?}"));
-    let my_bls_pubkey: BLSPubkey = bls_keypair.public.into();
+    let my_bls_pubkey = bls_keypair.public;
     if my_bls_pubkey != bls_pubkey_in_vote_account {
         panic!(
             "Vote account bls_pubkey mismatch: {bls_pubkey_in_vote_account:?} (expected: \
@@ -222,22 +221,14 @@ pub fn generate_vote_tx(
         );
     }
     let vote_serialized = bincode::serialize(&vote).unwrap();
-
-    let epoch = bank.epoch_schedule().get_epoch(vote.slot());
-
-    let Some(epoch_stakes) = bank.epoch_stakes(epoch) else {
-        panic!(
-            "The bank {} doesn't have its own epoch_stakes for {}",
-            bank.slot(),
-            epoch
-        );
-    };
-    let Some(my_rank) = epoch_stakes
-        .bls_pubkey_to_rank_map()
-        .get_rank(&my_bls_pubkey)
-    else {
+    let rank_map = bank
+        .epoch_stakes_from_slot(vote.slot())
+        .unwrap_or_else(|| panic!("could not find epoch stakes for slot {}", vote.slot()))
+        .bls_pubkey_to_rank_map();
+    let Some(my_rank) = rank_map.get_rank(&my_bls_pubkey) else {
         return GenerateVoteTxResult::NoRankFound;
     };
+
     GenerateVoteTxResult::ConsensusMessage(ConsensusMessage::Vote(VoteMessage {
         vote: *vote,
         signature: bls_keypair.sign(&vote_serialized).into(),
@@ -589,7 +580,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "The bank 0 doesn't have its own epoch_stakes for")]
+    #[should_panic(expected = "could not find epoch stakes for slot 1000000000")]
     fn test_panic_on_future_slot() {
         agave_logger::setup();
         let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();


### PR DESCRIPTION


In https://github.com/anza-xyz/alpenglow/pull/757 we decided to store BLSPubkeyAffine instead of BlsPubkey in the rank map.  This upstreams the change.  This will help backport the changes to the bls sigverifier to the alpenglow repo.
