### PR TITLE
refactor(scheduler-bindings): RAII shmem files earlier

### DIFF
--- a/scheduling-utils/src/handshake/client.rs
+++ b/scheduling-utils/src/handshake/client.rs
@@ -72,11 +72,11 @@ fn connect_path(
     // Send the logon message to the server.
     send_logon(&mut stream, logon)?;
 
-    // Receive the server's response & on success the FDs for the newly allocated shared memory.
-    let fds = recv_response(&mut stream)?;
+    // Receive the server's response & on success the files for the newly allocated shared memory.
+    let files = recv_response(&mut stream)?;
 
     // Join the shared memory regions.
-    let session = setup_session(&logon, fds)?;
+    let session = setup_session(&logon, files)?;
 
     Ok(session)
 }
@@ -98,7 +98,7 @@ fn send_logon(stream: &mut UnixStream, logon: ClientLogon) -> Result<(), ClientH
     Ok(())
 }
 
-fn recv_response(stream: &mut UnixStream) -> Result<Vec<i32>, ClientHandshakeError> {
+fn recv_response(stream: &mut UnixStream) -> Result<Vec<File>, ClientHandshakeError> {
     // Receive the requested FDs.
     let mut buf = [0; 1024];
     let mut iov = [IoSliceMut::new(&mut buf)];
@@ -121,28 +121,33 @@ fn recv_response(stream: &mut UnixStream) -> Result<Vec<i32>, ClientHandshakeErr
         return Err(ClientHandshakeError::Rejected(reason.to_string()));
     }
 
-    // Extract FDs.
+    // Extract FDs and immediately wrap in `File` for RAII ownership.
     let mut cmsgs = msg.cmsgs().unwrap();
     let fds = match cmsgs.next() {
         Some(ControlMessageOwned::ScmRights(fds)) => fds,
         Some(msg) => panic!("Unexpected; msg={msg:?}"),
         None => panic!(),
     };
+    // SAFETY: FDs were just received via `ScmRights` and are valid.
+    let files = fds
+        .into_iter()
+        .map(|fd| unsafe { File::from_raw_fd(fd) })
+        .collect();
 
-    Ok(fds)
+    Ok(files)
 }
 
 pub fn setup_session(
     logon: &ClientLogon,
-    fds: Vec<i32>,
+    files: Vec<File>,
 ) -> Result<ClientSession, ClientHandshakeError> {
-    let [allocator_fd, tpu_to_pack_fd, progress_tracker_fd] = fds[..GLOBAL_SHMEM] else {
-        panic!();
+    if files.len() < GLOBAL_SHMEM {
+        return Err(ClientHandshakeError::ProtocolViolation);
+    }
+    let (global_files, worker_files) = files.split_at(GLOBAL_SHMEM);
+    let [allocator_file, tpu_to_pack_file, progress_tracker_file] = global_files else {
+        unreachable!();
     };
-    // SAFETY: `allocator_fd` represents a valid file descriptor that was just returned to us via
-    // `ScmRights`.
-    let allocator_file = unsafe { File::from_raw_fd(allocator_fd) };
-    let worker_fds = &fds[GLOBAL_SHMEM..];
 
     // Setup requested allocators.
     let allocators = (0..logon.allocator_handles)
@@ -155,25 +160,25 @@ pub fn setup_session(
                 .checked_add(offset)
                 .unwrap();
 
-            unsafe { Allocator::join(&allocator_file, u32::try_from(id).unwrap()) }
+            unsafe { Allocator::join(allocator_file, u32::try_from(id).unwrap()) }
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    // Ensure worker_fds length matches expectations.
-    if worker_fds.is_empty()
-        || !worker_fds.len().is_multiple_of(2)
-        || worker_fds.len() / 2 != logon.worker_count
+    // Ensure worker file count matches expectations.
+    if worker_files.is_empty()
+        || !worker_files.len().is_multiple_of(2)
+        || worker_files.len() / 2 != logon.worker_count
     {
         return Err(ClientHandshakeError::ProtocolViolation);
     }
 
-    // NB: After creating & mapping the queues we are fine to drop the FDs as mmap will keep the
+    // NB: After creating & mapping the queues we are fine to drop the files as mmap will keep the
     // underlying object alive until process exit or munmap.
     let session = ClientSession {
         allocators,
-        tpu_to_pack: unsafe { shaq::Consumer::join(&File::from_raw_fd(tpu_to_pack_fd))? },
-        progress_tracker: unsafe { shaq::Consumer::join(&File::from_raw_fd(progress_tracker_fd))? },
-        workers: worker_fds
+        tpu_to_pack: unsafe { shaq::Consumer::join(tpu_to_pack_file)? },
+        progress_tracker: unsafe { shaq::Consumer::join(progress_tracker_file)? },
+        workers: worker_files
             .chunks(2)
             .map(|window| {
                 let [pack_to_worker, worker_to_pack] = window else {
@@ -181,16 +186,15 @@ pub fn setup_session(
                 };
 
                 Ok(ClientWorkerSession {
-                    pack_to_worker: unsafe {
-                        shaq::Producer::join(&File::from_raw_fd(*pack_to_worker))?
-                    },
-                    worker_to_pack: unsafe {
-                        shaq::Consumer::join(&File::from_raw_fd(*worker_to_pack))?
-                    },
+                    pack_to_worker: unsafe { shaq::Producer::join(pack_to_worker)? },
+                    worker_to_pack: unsafe { shaq::Consumer::join(worker_to_pack)? },
                 })
             })
             .collect::<Result<_, ClientHandshakeError>>()?,
     };
+
+    // Drop the file handles now that mmaps are completed.
+    drop(files);
 
     Ok(session)
 }


### PR DESCRIPTION
#### Problem

- We care i32s representing file ownership longer than necessary which makes code in the upcoming agave-bridge unsafer than needed.

#### Summary of Changes

- Immediately conver i32 -> File after logon.
- Also return error instead of panic on file count mismatch for client side.
