### PR TITLE
gossip: remove direction awareness on retaining crds value

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -19,7 +19,7 @@ use {
         contact_info::{self, ContactInfo, ContactInfoQuery, Error as ContactInfoError},
         crds::{Crds, Cursor, GossipRoute},
         crds_data::{self, CrdsData, EpochSlotsIndex, LowestSlot, MAX_VOTES, SnapshotHashes, Vote},
-        crds_filter::{GossipFilterDirection, should_retain_crds_value},
+        crds_filter::should_retain_crds_value,
         crds_gossip::CrdsGossip,
         crds_gossip_error::CrdsGossipError,
         crds_gossip_pull::{
@@ -1226,7 +1226,7 @@ impl ClusterInfo {
             self.flush_push_queue();
             self.gossip
                 .new_push_messages(&self_id, timestamp(), stakes, |value| {
-                    should_retain_crds_value(value, stakes, GossipFilterDirection::EgressPush)
+                    should_retain_crds_value(value, stakes)
                 })
         };
         self.stats
@@ -1622,13 +1622,7 @@ impl ClusterInfo {
                 &requests,
                 output_size_limit,
                 now,
-                |value| {
-                    should_retain_crds_value(
-                        value,
-                        stakes,
-                        GossipFilterDirection::EgressPullResponse,
-                    )
-                },
+                |value| should_retain_crds_value(value, stakes),
                 &self.stats,
             )
         };
@@ -2061,9 +2055,7 @@ impl ClusterInfo {
             if let Protocol::PullResponse(_, values) | Protocol::PushMessage(_, values) =
                 &mut protocol
             {
-                values.retain(|value| {
-                    should_retain_crds_value(value, stakes, GossipFilterDirection::Ingress)
-                });
+                values.retain(|value| should_retain_crds_value(value, stakes));
                 if values.is_empty() {
                     return None;
                 }

--- a/gossip/src/crds_filter.rs
+++ b/gossip/src/crds_filter.rs
@@ -4,12 +4,6 @@ use {
     std::collections::HashMap,
 };
 
-pub(crate) enum GossipFilterDirection {
-    Ingress,
-    EgressPush,
-    EgressPullResponse,
-}
-
 /// Minimum number of staked nodes for enforcing stakes in gossip.
 const MIN_NUM_STAKED_NODES: usize = 500;
 
@@ -18,16 +12,9 @@ const MIN_NUM_STAKED_NODES: usize = 500;
 pub(crate) const MIN_STAKE_FOR_GOSSIP: u64 = solana_native_token::LAMPORTS_PER_SOL;
 
 /// Returns false if the CRDS value should be discarded.
-/// `direction` controls whether we are looking at
-/// incoming packet (via Push or PullResponse) or
-/// we are about to make a packet
 #[inline]
 #[must_use]
-pub(crate) fn should_retain_crds_value(
-    value: &CrdsValue,
-    stakes: &HashMap<Pubkey, u64>,
-    direction: GossipFilterDirection,
-) -> bool {
+pub(crate) fn should_retain_crds_value(value: &CrdsValue, stakes: &HashMap<Pubkey, u64>) -> bool {
     let retain_if_staked = || {
         stakes.len() < MIN_NUM_STAKED_NODES || {
             let stake = stakes.get(&value.pubkey()).copied();
@@ -35,7 +22,6 @@ pub(crate) fn should_retain_crds_value(
         }
     };
 
-    use GossipFilterDirection::*;
     match value.data() {
         // All nodes can send ContactInfo
         CrdsData::ContactInfo(_) => true,
@@ -45,20 +31,11 @@ pub(crate) fn should_retain_crds_value(
         CrdsData::DuplicateShred(_, _)
         | CrdsData::LowestSlot(0, _)
         | CrdsData::RestartHeaviestFork(_)
-        | CrdsData::RestartLastVotedForkSlots(_) => retain_if_staked(),
+        | CrdsData::RestartLastVotedForkSlots(_)
         // Unstaked nodes can technically send EpochSlots, but we do not want them
         // eating gossip bandwidth
-        CrdsData::EpochSlots(_, _) => match direction {
-            // always store if we have received them
-            // to avoid getting them again in PullResponses
-            Ingress => true,
-            // only forward if the origin is staked
-            EgressPush | EgressPullResponse => retain_if_staked(),
-        },
-        CrdsData::Vote(_, _) => match direction {
-            Ingress | EgressPush => true,
-            EgressPullResponse => retain_if_staked(),
-        },
+        | CrdsData::EpochSlots(_, _)
+        | CrdsData::Vote(_, _) => retain_if_staked(),
         // Fully deprecated messages
         CrdsData::AccountsHashes(_) => false,
         CrdsData::LegacyContactInfo(_) => false,


### PR DESCRIPTION
#### Problem
Unstaked nodes should not create `EpochSlot` or `Vote` gossip messages. We started the process of preventing the propagation of these message types from unstaked nodes. We need to finish it

#### Summary of Changes
This PR will fully drop propagation support for unstaked `EpochSlot` and `Vote` messages

Plot below shows received `PullResponse`s on an unstaked node on mainet.
Left is master, Right is this PR
<img width="2480" height="770" alt="Screenshot 2026-03-11 at 1 52 08 PM" src="https://github.com/user-attachments/assets/f85ae58b-436c-4c67-8799-230b02f06fad" />
^ we see no increase in `PullResponse`s. The lack of increase shows that we don't have a mismatch between this node and other nodes on what is in our crds table. 
