### PR TITLE
chore(deps): bump solana-frozen-abi to 3.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8394,9 +8394,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "3.2.1"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03508c0e945920c8a9ecb7d81bf20d0ad28ac6c65d629a362a3475e2a3037a5d"
+checksum = "20f53dbf77043d26b7a2f5f516f704b35daf9d0be036fe8e64c3f92924292c61"
 dependencies = [
  "bincode",
  "boxcar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -441,7 +441,7 @@ solana-fee = { path = "fee", version = "=4.1.0-alpha.0", features = ["agave-unst
 solana-fee-calculator = "3.1.0"
 solana-fee-structure = "3.0.0"
 solana-file-download = "3.1.4"
-solana-frozen-abi = "3.2.1"
+solana-frozen-abi = "3.2.2"
 solana-frozen-abi-macro = "3.2.1"
 solana-genesis = { path = "genesis", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-genesis-config = "4.0.0"


### PR DESCRIPTION
#### Problem
3.2.1 pins dashmap to 5.x

#### Summary of Changes
Bump to 3.2.2 with relaxed deps pinning
