### PR TITLE
feat: TransactionView implements instruction layout from SIMD-0385 (transaction v1).

### DIFF
--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         bytes::{
             advance_offset_for_array, check_remaining, optimized_read_compressed_u16, read_byte,
-            unchecked_read_byte, unchecked_read_slice_data,
+            read_slice_data, unchecked_read_byte, unchecked_read_slice_data,
         },
         result::Result,
     },
@@ -22,10 +22,44 @@ pub(crate) struct InstructionsFrame {
 
 #[derive(Debug)]
 pub(crate) struct InstructionFrame {
-    num_accounts: u16,
+    /// Per-instruction anchor offset.
+    ///
+    /// - legacy/v0: start of the serialized CompiledInstruction
+    /// - v1: start of the 4-byte InstructionHeader entry
+    offset: u16,
+
+    program_id_index: u8,
+    num_accounts: u16, // NOTE: v1 spec-ed it as u8
     data_len: u16,
-    num_accounts_len: u8, // either 1 or 2
-    data_len_len: u8,     // either 1 or 2
+
+    /// how to interpret frame between different transaction version
+    repr: InstructionFrameRepr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InstructionFrameRepr {
+    /// Legacy and v0:
+    /// [program_id_index][short_vec accounts][accounts...][short_vec data][data...]
+    LegacyAndV0 {
+        num_accounts_len: u8, // either 1 or 2
+        data_len_len: u8,     // either 1 or 2
+    },
+
+    /// V1:
+    /// header lives at `offset`, payload lives elsewhere.
+    V1 {
+        /// Start of this instruction's payload:
+        /// [account_indexes...][instruction_data...]
+        payload_offset: u16,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+struct V1InstructionHeader {
+    offset: u16,
+    program_id_index: u8,
+    num_accounts: u8,
+    data_len: u16,
 }
 
 impl InstructionsFrame {
@@ -58,13 +92,15 @@ impl InstructionsFrame {
         // each instruction to find the total size of the instructions,
         // and check for any malformed instructions or buffer overflows.
         for _index in 0..num_instructions {
+            let instruction_offset = *offset as u16;
+
             // Each instruction has 3 pieces:
             // 1. Program ID index (u8)
             // 2. Accounts indexes ([u8])
             // 3. Data ([u8])
 
             // Read the program ID index.
-            let _program_id_index = read_byte(bytes, offset)?;
+            let program_id_index = read_byte(bytes, offset)?;
 
             // Read the number of account indexes, and then update the offset
             // to skip over the account indexes.
@@ -81,10 +117,14 @@ impl InstructionsFrame {
             advance_offset_for_array::<u8>(bytes, offset, data_len)?;
 
             frames.push(InstructionFrame {
+                offset: instruction_offset,
+                program_id_index,
                 num_accounts,
-                num_accounts_len,
                 data_len,
-                data_len_len,
+                repr: InstructionFrameRepr::LegacyAndV0 {
+                    num_accounts_len,
+                    data_len_len,
+                },
             });
         }
 
@@ -93,6 +133,81 @@ impl InstructionsFrame {
             offset: instructions_offset,
             frames,
         })
+    }
+
+    #[inline(always)]
+    pub(crate) fn try_new_for_v1(
+        bytes: &[u8],
+        offset: &mut usize,
+        num_instructions: u8, // NOTE: v1 spec-ed it out as u8
+    ) -> Result<Self> {
+        let headers_offset = *offset as u16;
+
+        // advance instruction headers
+        let headers = Self::parse_v1_instruction_headers(bytes, offset, num_instructions)?;
+        // then advance instruction payloads
+        let frames = Self::build_v1_instruction_frames(bytes, &headers, offset)?;
+
+        Ok(Self {
+            num_instructions: num_instructions.into(),
+            offset: headers_offset,
+            frames,
+        })
+    }
+
+    fn parse_v1_instruction_headers(
+        bytes: &[u8],
+        offset: &mut usize,
+        num_instructions: u8,
+    ) -> Result<Vec<V1InstructionHeader>> {
+        let mut headers = Vec::with_capacity(num_instructions as usize);
+
+        for _ in 0..(num_instructions as usize) {
+            let header_offset = *offset as u16;
+            let program_id_index = read_byte(bytes, offset)?;
+            let num_instruction_accounts = read_byte(bytes, offset)?;
+            let num_instruction_data_bytes = u16::from_le_bytes(
+                unsafe { read_slice_data::<u8>(bytes, offset, 2) }?
+                    .try_into()
+                    .map_err(|_| crate::result::TransactionViewError::ParseError)?,
+            );
+
+            headers.push(V1InstructionHeader {
+                offset: header_offset,
+                program_id_index,
+                num_accounts: num_instruction_accounts,
+                data_len: num_instruction_data_bytes,
+            });
+        }
+
+        Ok(headers)
+    }
+
+    fn build_v1_instruction_frames(
+        bytes: &[u8],
+        headers: &[V1InstructionHeader],
+        offset: &mut usize,
+    ) -> Result<Vec<InstructionFrame>> {
+        let mut frames = Vec::with_capacity(headers.len());
+
+        for header in headers {
+            let payload_len = u16::from(header.num_accounts).wrapping_add(header.data_len);
+
+            frames.push(InstructionFrame {
+                offset: header.offset,
+                num_accounts: header.num_accounts as u16,
+                data_len: header.data_len,
+                program_id_index: header.program_id_index,
+                repr: InstructionFrameRepr::V1 {
+                    payload_offset: *offset as u16,
+                },
+            });
+
+            // advance offset
+            advance_offset_for_array::<u8>(bytes, offset, payload_len)?;
+        }
+
+        Ok(frames)
     }
 }
 
@@ -112,55 +227,103 @@ impl<'a> Iterator for InstructionsIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.index < self.num_instructions {
             let InstructionFrame {
+                offset: _,
+                program_id_index,
                 num_accounts,
-                num_accounts_len,
                 data_len,
-                data_len_len,
+                repr,
             } = self.frames[usize::from(self.index)];
 
             self.index = self.index.wrapping_add(1);
 
-            // Each instruction has 3 pieces:
-            // 1. Program ID index (u8)
-            // 2. Accounts indexes ([u8])
-            // 3. Data ([u8])
-
-            // Read the program ID index.
-            // SAFETY: Offset and length checks have been done in the initial parsing.
-            let program_id_index = unsafe { unchecked_read_byte(self.bytes, &mut self.offset) };
-
-            // Move offset to accounts offset - do not re-parse u16.
-            self.offset = self.offset.wrapping_add(usize::from(num_accounts_len));
-            const _: () = assert!(core::mem::align_of::<u8>() == 1, "u8 alignment");
-            // SAFETY:
-            // - The offset is checked to be valid in the byte slice.
-            // - The alignment of u8 is 1.
-            // - The slice length is checked to be valid.
-            // - `u8` cannot be improperly initialized.
-            // - Offset and length checks have been done in the initial parsing.
-            let accounts = unsafe {
-                unchecked_read_slice_data::<u8>(self.bytes, &mut self.offset, num_accounts)
-            };
-
-            // Move offset to accounts offset - do not re-parse u16.
-            self.offset = self.offset.wrapping_add(usize::from(data_len_len));
-            const _: () = assert!(core::mem::align_of::<u8>() == 1, "u8 alignment");
-            // SAFETY:
-            // - The offset is checked to be valid in the byte slice.
-            // - The alignment of u8 is 1.
-            // - The slice length is checked to be valid.
-            // - `u8` cannot be improperly initialized.
-            // - Offset and length checks have been done in the initial parsing.
-            let data =
-                unsafe { unchecked_read_slice_data::<u8>(self.bytes, &mut self.offset, data_len) };
-
-            Some(SVMInstruction {
-                program_id_index,
-                accounts,
-                data,
-            })
+            match repr {
+                InstructionFrameRepr::LegacyAndV0 {
+                    num_accounts_len,
+                    data_len_len,
+                } => Some(self.for_legacy_and_v0(
+                    program_id_index,
+                    num_accounts,
+                    num_accounts_len,
+                    data_len,
+                    data_len_len,
+                )),
+                InstructionFrameRepr::V1 { payload_offset } => {
+                    Some(self.for_v1(program_id_index, num_accounts, data_len, payload_offset))
+                }
+            }
         } else {
             None
+        }
+    }
+}
+
+impl<'a> InstructionsIterator<'a> {
+    fn for_legacy_and_v0(
+        &mut self,
+        program_id_index: u8,
+        num_accounts: u16,
+        num_accounts_len: u8,
+        data_len: u16,
+        data_len_len: u8,
+    ) -> <InstructionsIterator<'a> as Iterator>::Item {
+        // Each instruction has 3 pieces:
+        // 1. Program ID index (u8)
+        // 2. Accounts indexes ([u8])
+        // 3. Data ([u8])
+
+        // Read the program ID index.
+        // SAFETY: Offset and length checks have been done in the initial parsing.
+        let _unused_program_id_index = unsafe { unchecked_read_byte(self.bytes, &mut self.offset) };
+
+        // Move offset to accounts offset - do not re-parse u16.
+        self.offset = self.offset.wrapping_add(usize::from(num_accounts_len));
+        const _: () = assert!(core::mem::align_of::<u8>() == 1, "u8 alignment");
+        // SAFETY:
+        // - The offset is checked to be valid in the byte slice.
+        // - The alignment of u8 is 1.
+        // - The slice length is checked to be valid.
+        // - `u8` cannot be improperly initialized.
+        // - Offset and length checks have been done in the initial parsing.
+        let accounts =
+            unsafe { unchecked_read_slice_data::<u8>(self.bytes, &mut self.offset, num_accounts) };
+
+        // Move offset to accounts offset - do not re-parse u16.
+        self.offset = self.offset.wrapping_add(usize::from(data_len_len));
+        const _: () = assert!(core::mem::align_of::<u8>() == 1, "u8 alignment");
+        // SAFETY:
+        // - The offset is checked to be valid in the byte slice.
+        // - The alignment of u8 is 1.
+        // - The slice length is checked to be valid.
+        // - `u8` cannot be improperly initialized.
+        // - Offset and length checks have been done in the initial parsing.
+        let data =
+            unsafe { unchecked_read_slice_data::<u8>(self.bytes, &mut self.offset, data_len) };
+
+        SVMInstruction {
+            program_id_index,
+            accounts,
+            data,
+        }
+    }
+
+    fn for_v1(
+        &mut self,
+        program_id_index: u8,
+        num_accounts: u16,
+        data_len: u16,
+        payload_offset: u16,
+    ) -> <InstructionsIterator<'a> as Iterator>::Item {
+        self.offset = payload_offset as usize;
+        let accounts =
+            unsafe { unchecked_read_slice_data::<u8>(self.bytes, &mut self.offset, num_accounts) };
+
+        let data =
+            unsafe { unchecked_read_slice_data::<u8>(self.bytes, &mut self.offset, data_len) };
+
+        SVMInstruction {
+            program_id_index,
+            accounts,
+            data,
         }
     }
 }
@@ -276,5 +439,362 @@ mod tests {
 
         let mut offset = 0;
         assert!(InstructionsFrame::try_new(&bytes, &mut offset).is_err());
+    }
+
+    #[test]
+    fn test_txv1_instruction_data() {
+        let mut message = solana_message::v1::Message::default();
+        message.instructions = vec![CompiledInstruction {
+            program_id_index: 0,
+            accounts: vec![1, 2, 3],
+            data: vec![4, 5, 6, 7, 8, 9, 10],
+        }];
+
+        let serialized = solana_message::v1::serialize(&message);
+
+        let mut offset = 41; // instruction headers starts at offset 41 for no config, 0 addresses, per spec
+        let instructions_frame =
+            InstructionsFrame::try_new_for_v1(&serialized, &mut offset, 1).unwrap();
+        assert_eq!(instructions_frame.num_instructions, 1);
+        assert_eq!(instructions_frame.frames.len(), 1);
+        let instruction_frame = &instructions_frame.frames[0];
+        assert_eq!(instruction_frame.offset, 41);
+        assert_eq!(instruction_frame.program_id_index, 0);
+        assert_eq!(instruction_frame.num_accounts, 3);
+        assert_eq!(instruction_frame.data_len, 7);
+        assert!(matches!(
+            instruction_frame.repr,
+            InstructionFrameRepr::V1 { payload_offset: 45 }
+        ));
+    }
+
+    #[test]
+    fn test_txv1_instructions_iterator() {
+        let mut message = solana_message::v1::Message::default();
+        message.instructions = vec![
+            CompiledInstruction {
+                program_id_index: 0,
+                accounts: vec![1, 2, 3],
+                data: vec![4, 5, 6, 7, 8, 9, 10],
+            },
+            CompiledInstruction {
+                program_id_index: 10,
+                accounts: vec![11, 12],
+                data: vec![13, 14, 15, 16, 17, 18, 19, 20],
+            },
+        ];
+
+        let serialized = solana_message::v1::serialize(&message);
+
+        let mut offset = 41; // instruction headers starts at offset 41 for no config, 0 addresses, per spec
+        let instructions_frame =
+            InstructionsFrame::try_new_for_v1(&serialized, &mut offset, 2).unwrap();
+
+        let mut iter = InstructionsIterator {
+            bytes: &serialized,
+            offset,
+            num_instructions: instructions_frame.num_instructions,
+            index: 0,
+            frames: &instructions_frame.frames,
+        };
+
+        assert_eq!(
+            iter.next(),
+            Some(SVMInstruction {
+                program_id_index: 0,
+                accounts: &[1, 2, 3],
+                data: &[4, 5, 6, 7, 8, 9, 10]
+            })
+        );
+        assert_eq!(
+            iter.next(),
+            Some(SVMInstruction {
+                program_id_index: 10,
+                accounts: &[11, 12],
+                data: &[13, 14, 15, 16, 17, 18, 19, 20]
+            })
+        );
+        assert_eq!(iter.next(), None);
+    }
+
+    fn short_u16_1(x: u8) -> Vec<u8> {
+        vec![x]
+    }
+
+    // short_vec / compact-u16 encoding for 128..=16383 style values
+    fn short_u16_2(x: u16) -> Vec<u8> {
+        assert!(x >= 128);
+        vec![((x & 0x7f) as u8) | 0x80, (x >> 7) as u8]
+    }
+
+    #[test]
+    fn test_try_new_legacy_single_instruction() {
+        // num_instructions = 1
+        // instruction:
+        //   program_id_index = 7
+        //   num_accounts = 2
+        //   accounts = [3, 4]
+        //   data_len = 3
+        //   data = [9, 8, 7]
+        let bytes = vec![
+            1, // num_instructions
+            7, // program_id_index
+            2, // num_accounts
+            3, 4, // account indexes
+            3, // data_len
+            9, 8, 7, // data
+        ];
+
+        let mut offset = 0;
+        let frame = InstructionsFrame::try_new(&bytes, &mut offset).unwrap();
+
+        assert_eq!(frame.num_instructions, 1);
+        assert_eq!(frame.offset, 1);
+        assert_eq!(frame.frames.len(), 1);
+        assert_eq!(offset, bytes.len());
+
+        let ix = &frame.frames[0];
+        assert_eq!(ix.offset, 1);
+        assert_eq!(ix.program_id_index, 7);
+        assert_eq!(ix.num_accounts, 2);
+        assert_eq!(ix.data_len, 3);
+
+        match ix.repr {
+            InstructionFrameRepr::LegacyAndV0 {
+                num_accounts_len,
+                data_len_len,
+            } => {
+                assert_eq!(num_accounts_len, 1);
+                assert_eq!(data_len_len, 1);
+            }
+            _ => panic!("expected legacy/v0 repr"),
+        }
+    }
+
+    #[test]
+    fn test_try_new_legacy_two_byte_lengths() {
+        let num_accounts = 128u16;
+        let data_len = 130u16;
+
+        let mut bytes = Vec::new();
+        bytes.push(1); // num_instructions
+        bytes.push(42); // program_id_index
+        bytes.extend_from_slice(&short_u16_2(num_accounts));
+        bytes.extend(std::iter::repeat_n(5u8, num_accounts as usize));
+        bytes.extend_from_slice(&short_u16_2(data_len));
+        bytes.extend(std::iter::repeat_n(9u8, data_len as usize));
+
+        let mut offset = 0;
+        let frame = InstructionsFrame::try_new(&bytes, &mut offset).unwrap();
+
+        assert_eq!(frame.num_instructions, 1);
+        assert_eq!(frame.offset, 1);
+        assert_eq!(frame.frames.len(), 1);
+        assert_eq!(offset, bytes.len());
+
+        let ix = &frame.frames[0];
+        assert_eq!(ix.offset, 1);
+        assert_eq!(ix.program_id_index, 42);
+        assert_eq!(ix.num_accounts, num_accounts);
+        assert_eq!(ix.data_len, data_len);
+
+        match ix.repr {
+            InstructionFrameRepr::LegacyAndV0 {
+                num_accounts_len,
+                data_len_len,
+            } => {
+                assert_eq!(num_accounts_len, 2);
+                assert_eq!(data_len_len, 2);
+            }
+            _ => panic!("expected legacy/v0 repr"),
+        }
+    }
+
+    #[test]
+    fn test_try_new_for_v1_single_instruction() {
+        // one v1 instruction
+        // header:
+        //   program_id_index = 9
+        //   num_accounts = 2
+        //   data_len = 3
+        // payload:
+        //   accounts = [10, 11]
+        //   data = [1, 2, 3]
+        let bytes = vec![
+            9, // program_id_index
+            2, // num_accounts
+            3, 0, // data_len (u16 LE)
+            10, 11, // payload accounts
+            1, 2, 3, // payload data
+        ];
+
+        let mut offset = 0;
+        let frame = InstructionsFrame::try_new_for_v1(&bytes, &mut offset, 1).unwrap();
+
+        assert_eq!(frame.num_instructions, 1);
+        assert_eq!(frame.offset, 0);
+        assert_eq!(frame.frames.len(), 1);
+        assert_eq!(offset, bytes.len());
+
+        let ix = &frame.frames[0];
+        assert_eq!(ix.offset, 0);
+        assert_eq!(ix.program_id_index, 9);
+        assert_eq!(ix.num_accounts, 2);
+        assert_eq!(ix.data_len, 3);
+
+        match ix.repr {
+            InstructionFrameRepr::V1 { payload_offset } => {
+                assert_eq!(payload_offset, 4);
+            }
+            _ => panic!("expected v1 repr"),
+        }
+    }
+
+    #[test]
+    fn test_try_new_for_v1_two_instructions() {
+        // headers:
+        //   ix0: pid=1, accounts=2, data_len=1
+        //   ix1: pid=7, accounts=1, data_len=2
+        //
+        // payloads:
+        //   ix0: [20, 21] [99]
+        //   ix1: [42] [5, 6]
+        let bytes = vec![
+            // header 0
+            1, 2, 1, 0, // header 1
+            7, 1, 2, 0, // payload 0
+            20, 21, 99, // payload 1
+            42, 5, 6,
+        ];
+
+        let mut offset = 0;
+        let frame = InstructionsFrame::try_new_for_v1(&bytes, &mut offset, 2).unwrap();
+
+        assert_eq!(frame.num_instructions, 2);
+        assert_eq!(frame.offset, 0);
+        assert_eq!(frame.frames.len(), 2);
+        assert_eq!(offset, bytes.len());
+
+        let ix0 = &frame.frames[0];
+        assert_eq!(ix0.offset, 0);
+        assert_eq!(ix0.program_id_index, 1);
+        assert_eq!(ix0.num_accounts, 2);
+        assert_eq!(ix0.data_len, 1);
+        match ix0.repr {
+            InstructionFrameRepr::V1 { payload_offset } => assert_eq!(payload_offset, 8),
+            _ => panic!("expected v1 repr"),
+        }
+
+        let ix1 = &frame.frames[1];
+        assert_eq!(ix1.offset, 4);
+        assert_eq!(ix1.program_id_index, 7);
+        assert_eq!(ix1.num_accounts, 1);
+        assert_eq!(ix1.data_len, 2);
+        match ix1.repr {
+            InstructionFrameRepr::V1 { payload_offset } => assert_eq!(payload_offset, 11),
+            _ => panic!("expected v1 repr"),
+        }
+    }
+
+    #[test]
+    fn test_try_new_for_v1_truncated_header_fails() {
+        // num_instructions = 1, but only 3 header bytes instead of 4
+        let bytes = vec![
+            9, // program_id_index
+            2, // num_accounts
+            3, // incomplete data_len
+        ];
+
+        let mut offset = 0;
+        assert!(InstructionsFrame::try_new_for_v1(&bytes, &mut offset, 1).is_err());
+    }
+
+    #[test]
+    fn test_try_new_for_v1_truncated_payload_fails() {
+        // header says payload len = 2 + 3 = 5, but only 4 bytes provided
+        let bytes = vec![
+            9, 2, 3, 0, // header
+            10, 11, 1, 2, // truncated payload
+        ];
+
+        let mut offset = 0;
+        assert!(InstructionsFrame::try_new_for_v1(&bytes, &mut offset, 1).is_err());
+    }
+
+    #[test]
+    fn test_try_new_legacy_truncated_payload_fails() {
+        // data_len says 3, only 2 bytes provided
+        let bytes = vec![
+            1, // num_instructions
+            7, // program_id_index
+            1, // num_accounts
+            9, // account idx
+            3, // data_len
+            1, 2, // truncated data
+        ];
+
+        let mut offset = 0;
+        assert!(InstructionsFrame::try_new(&bytes, &mut offset).is_err());
+    }
+
+    #[test]
+    fn test_try_new_for_v1_zero_instructions() {
+        let bytes = vec![];
+        let mut offset = 0;
+
+        let frame = InstructionsFrame::try_new_for_v1(&bytes, &mut offset, 0).unwrap();
+        assert_eq!(frame.num_instructions, 0);
+        assert_eq!(frame.offset, 0);
+        assert!(frame.frames.is_empty());
+        assert_eq!(offset, 0);
+    }
+
+    #[test]
+    fn test_parse_v1_headers_advances_then_payloads_advance() {
+        // This specifically checks the contract that:
+        // - parse_v1_instruction_headers advances offset by 4 * num_instructions
+        // - build_v1_instruction_frames advances by total payload length
+        let bytes = vec![
+            // headers (2 * 4 bytes)
+            3, 1, 2, 0, // pid=3, accounts=1, data_len=2
+            4, 2, 1, 0, // pid=4, accounts=2, data_len=1
+            // payloads
+            99, 7, 8, // 1 + 2
+            10, 11, 12, // 2 + 1
+        ];
+
+        let mut offset = 0;
+        let headers =
+            InstructionsFrame::parse_v1_instruction_headers(&bytes, &mut offset, 2).unwrap();
+        assert_eq!(offset, 8);
+        assert_eq!(headers.len(), 2);
+        assert_eq!(headers[0].offset, 0);
+        assert_eq!(headers[1].offset, 4);
+
+        let frames =
+            InstructionsFrame::build_v1_instruction_frames(&bytes, &headers, &mut offset).unwrap();
+        assert_eq!(offset, bytes.len());
+        assert_eq!(frames.len(), 2);
+
+        match frames[0].repr {
+            InstructionFrameRepr::V1 { payload_offset } => assert_eq!(payload_offset, 8),
+            _ => panic!("expected v1 repr"),
+        }
+        match frames[1].repr {
+            InstructionFrameRepr::V1 { payload_offset } => assert_eq!(payload_offset, 11),
+            _ => panic!("expected v1 repr"),
+        }
+    }
+
+    #[test]
+    fn test_try_new_legacy_zero_instructions() {
+        let bytes = short_u16_1(0);
+        let mut offset = 0;
+
+        let frame = InstructionsFrame::try_new(&bytes, &mut offset).unwrap();
+        assert_eq!(frame.num_instructions, 0);
+        assert_eq!(frame.offset, 1);
+        assert!(frame.frames.is_empty());
+        assert_eq!(offset, 1);
     }
 }

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -26,6 +26,7 @@ pub(crate) struct InstructionFrame {
     ///
     /// - legacy/v0: start of the serialized CompiledInstruction
     /// - v1: start of the 4-byte InstructionHeader entry
+    #[allow(dead_code)]
     offset: u16,
 
     program_id_index: u8,
@@ -47,6 +48,7 @@ pub(crate) enum InstructionFrameRepr {
 
     /// V1:
     /// header lives at `offset`, payload lives elsewhere.
+    #[allow(dead_code)]
     V1 {
         /// Start of this instruction's payload:
         /// [account_indexes...][instruction_data...]
@@ -54,6 +56,7 @@ pub(crate) enum InstructionFrameRepr {
     },
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 struct V1InstructionHeader {
     offset: u16,
@@ -135,6 +138,7 @@ impl InstructionsFrame {
         })
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) fn try_new_for_v1(
         bytes: &[u8],
@@ -155,6 +159,7 @@ impl InstructionsFrame {
         })
     }
 
+    #[allow(dead_code)]
     fn parse_v1_instruction_headers(
         bytes: &[u8],
         offset: &mut usize,
@@ -183,6 +188,7 @@ impl InstructionsFrame {
         Ok(headers)
     }
 
+    #[allow(dead_code)]
     fn build_v1_instruction_frames(
         bytes: &[u8],
         headers: &[V1InstructionHeader],

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -449,12 +449,14 @@ mod tests {
 
     #[test]
     fn test_txv1_instruction_data() {
-        let mut message = solana_message::v1::Message::default();
-        message.instructions = vec![CompiledInstruction {
-            program_id_index: 0,
-            accounts: vec![1, 2, 3],
-            data: vec![4, 5, 6, 7, 8, 9, 10],
-        }];
+        let message = solana_message::v1::Message {
+            instructions: vec![CompiledInstruction {
+                program_id_index: 0,
+                accounts: vec![1, 2, 3],
+                data: vec![4, 5, 6, 7, 8, 9, 10],
+            }],
+            ..solana_message::v1::Message::default()
+        };
 
         let serialized = solana_message::v1::serialize(&message);
 
@@ -476,19 +478,21 @@ mod tests {
 
     #[test]
     fn test_txv1_instructions_iterator() {
-        let mut message = solana_message::v1::Message::default();
-        message.instructions = vec![
-            CompiledInstruction {
-                program_id_index: 0,
-                accounts: vec![1, 2, 3],
-                data: vec![4, 5, 6, 7, 8, 9, 10],
-            },
-            CompiledInstruction {
-                program_id_index: 10,
-                accounts: vec![11, 12],
-                data: vec![13, 14, 15, 16, 17, 18, 19, 20],
-            },
-        ];
+        let message = solana_message::v1::Message {
+            instructions: vec![
+                CompiledInstruction {
+                    program_id_index: 0,
+                    accounts: vec![1, 2, 3],
+                    data: vec![4, 5, 6, 7, 8, 9, 10],
+                },
+                CompiledInstruction {
+                    program_id_index: 10,
+                    accounts: vec![11, 12],
+                    data: vec![13, 14, 15, 16, 17, 18, 19, 20],
+                },
+            ],
+            ..solana_message::v1::Message::default()
+        };
 
         let serialized = solana_message::v1::serialize(&message);
 

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -4,7 +4,7 @@ use {
             advance_offset_for_array, check_remaining, optimized_read_compressed_u16, read_byte,
             unchecked_read_byte, unchecked_read_slice_data,
         },
-        result::Result,
+        result::{Result, TransactionViewError},
     },
     core::fmt::{Debug, Formatter},
     solana_svm_transaction::instruction::SVMInstruction,
@@ -210,7 +210,9 @@ impl InstructionsFrame {
         let mut frames = Vec::with_capacity(headers.len());
 
         for header in headers {
-            let payload_len = u16::from(header.num_accounts).wrapping_add(header.data_len);
+            let payload_len = u16::from(header.num_accounts)
+                .checked_add(header.data_len)
+                .ok_or(TransactionViewError::ParseError)?;
 
             frames.push(InstructionFrame {
                 offset: header.offset,
@@ -862,23 +864,16 @@ mod tests {
     }
 
     #[test]
-    #[cfg(miri)]
-    fn miri_ub_v1_payload_len_wraps() {
+    fn data_len_max_header_fails_parse() {
         // header: pid=1, accounts=1, data_len=65535
         let bytes = vec![1, 1, 0xff, 0xff];
         let mut offset = 0;
-        let frame = InstructionsFrame::try_new_for_v1(&bytes, &mut offset, 1).unwrap();
-
-        let mut iter = InstructionsIterator {
-            bytes: &bytes,
-            offset,
-            num_instructions: frame.num_instructions,
-            index: 0,
-            frames: &frame.frames,
-        };
-
-        // Should trip an out-of-bounds read under Miri.
-        let _ = iter.next();
+        assert_eq!(
+            InstructionsFrame::try_new_for_v1(&bytes, &mut offset, 1)
+                .err()
+                .unwrap(),
+            TransactionViewError::ParseError
+        );
     }
 
     #[test]

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -155,6 +155,7 @@ impl InstructionsFrame {
 
         // advance instruction headers
         let headers = Self::parse_v1_instruction_headers(bytes, offset, num_instructions)?;
+
         // then advance instruction payloads
         let frames = Self::build_v1_instruction_frames(bytes, &headers, offset)?;
 
@@ -171,12 +172,21 @@ impl InstructionsFrame {
         offset: &mut usize,
         num_instructions: u8,
     ) -> Result<Vec<V1InstructionHeader>> {
+        // check have enough bytes for headers
+        check_remaining(
+            bytes,
+            *offset,
+            4usize.wrapping_mul(usize::from(num_instructions)),
+        )?;
+
         let mut headers = Vec::with_capacity(num_instructions as usize);
 
         for _ in 0..(num_instructions as usize) {
             let header_offset = *offset as u16;
             let program_id_index = read_byte(bytes, offset)?;
             let num_instruction_accounts = read_byte(bytes, offset)?;
+            // SAFETY:
+            // - Offset and length checks have been done in the initial parsing.
             let num_instruction_data_bytes = u16::from_le_bytes(
                 unsafe { read_slice_data::<u8>(bytes, offset, 2) }?
                     .try_into()
@@ -249,19 +259,23 @@ impl<'a> Iterator for InstructionsIterator<'a> {
             self.index = self.index.wrapping_add(1);
 
             match repr {
+                // SAFETY: `InstructionFrame` metadata was validated during initial parsing,
+                // so the encoded lengths and data ranges for this instruction are in-bounds.
                 InstructionFrameRepr::LegacyAndV0 {
                     num_accounts_len,
                     data_len_len,
-                } => Some(self.for_legacy_and_v0(
-                    program_id_index,
-                    num_accounts,
-                    num_accounts_len,
-                    data_len,
-                    data_len_len,
-                )),
-                InstructionFrameRepr::V1 { payload_offset } => {
-                    Some(self.for_v1(program_id_index, num_accounts, data_len, payload_offset))
-                }
+                } => Some(unsafe {
+                    self.for_legacy_and_v0(
+                        program_id_index,
+                        num_accounts,
+                        num_accounts_len,
+                        data_len,
+                        data_len_len,
+                    )
+                }),
+                InstructionFrameRepr::V1 { payload_offset } => Some(unsafe {
+                    self.for_v1(program_id_index, num_accounts, data_len, payload_offset)
+                }),
             }
         } else {
             None
@@ -270,7 +284,22 @@ impl<'a> Iterator for InstructionsIterator<'a> {
 }
 
 impl<'a> InstructionsIterator<'a> {
-    fn for_legacy_and_v0(
+    /// Builds the next legacy/v0 instruction using pre-validated frame metadata.
+    ///
+    /// # Safety
+    /// The caller must ensure that:
+    /// - `self.offset` points to the beginning of a serialized legacy/v0 instruction
+    ///   in `self.bytes`.
+    /// - `num_accounts_len` and `data_len_len` are the exact encoded lengths of the
+    ///   compact-u16 account-count and data-length fields for that instruction.
+    /// - `num_accounts` and `data_len` exactly match the serialized instruction at
+    ///   `self.offset`.
+    /// - The byte ranges implied by those values are fully in bounds of `self.bytes`.
+    ///
+    /// These invariants are expected to have been established by the initial
+    /// instruction frame parsing. Violating them may cause out-of-bounds unchecked
+    /// reads and undefined behavior.
+    unsafe fn for_legacy_and_v0(
         &mut self,
         program_id_index: u8,
         num_accounts: u16,
@@ -318,7 +347,28 @@ impl<'a> InstructionsIterator<'a> {
         }
     }
 
-    fn for_v1(
+    /// Builds the next v1 instruction using pre-validated frame metadata.
+    ///
+    /// # Safety
+    /// The caller must ensure that:
+    ///
+    /// - `payload_offset` points to the beginning of this instruction’s payload
+    ///   (i.e. the first account index byte) within `self.bytes`.
+    /// - `num_accounts` and `data_len` exactly match the instruction header that
+    ///   was previously parsed for this instruction.
+    /// - The byte range
+    ///   `payload_offset .. payload_offset + num_accounts + data_len`
+    ///   lies entirely within `self.bytes`.
+    /// - `self.bytes` has not been mutated since the initial parsing that produced
+    ///   the instruction frames.
+    ///
+    /// These invariants are expected to have been established during the initial
+    /// tx-v1 instruction parsing phase, where header and payload bounds were
+    /// validated together.
+    ///
+    /// Violating any of these conditions may result in out-of-bounds unchecked
+    /// reads and thus undefined behavior.
+    unsafe fn for_v1(
         &mut self,
         program_id_index: u8,
         num_accounts: u16,
@@ -326,9 +376,21 @@ impl<'a> InstructionsIterator<'a> {
         payload_offset: u16,
     ) -> <InstructionsIterator<'a> as Iterator>::Item {
         self.offset = payload_offset as usize;
+        // SAFETY:
+        // - The offset is checked to be valid in the byte slice.
+        // - The alignment of u8 is 1.
+        // - The slice length is checked to be valid.
+        // - `u8` cannot be improperly initialized.
+        // - Offset and length checks have been done in the initial parsing.
         let accounts =
             unsafe { unchecked_read_slice_data::<u8>(self.bytes, &mut self.offset, num_accounts) };
 
+        // SAFETY:
+        // - The offset is checked to be valid in the byte slice.
+        // - The alignment of u8 is 1.
+        // - The slice length is checked to be valid.
+        // - `u8` cannot be improperly initialized.
+        // - Offset and length checks have been done in the initial parsing.
         let data =
             unsafe { unchecked_read_slice_data::<u8>(self.bytes, &mut self.offset, data_len) };
 

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         bytes::{
             advance_offset_for_array, check_remaining, optimized_read_compressed_u16, read_byte,
-            read_slice_data, unchecked_read_byte, unchecked_read_slice_data,
+            unchecked_read_byte, unchecked_read_slice_data,
         },
         result::Result,
     },
@@ -185,13 +185,10 @@ impl InstructionsFrame {
             let header_offset = *offset as u16;
             let program_id_index = read_byte(bytes, offset)?;
             let num_instruction_accounts = read_byte(bytes, offset)?;
-            // SAFETY:
-            // - Offset and length checks have been done in the initial parsing.
-            let num_instruction_data_bytes = u16::from_le_bytes(
-                unsafe { read_slice_data::<u8>(bytes, offset, 2) }?
-                    .try_into()
-                    .map_err(|_| crate::result::TransactionViewError::ParseError)?,
-            );
+            // Offset and length checks have been done in the initial parsing.
+            let data_len_lo = read_byte(bytes, offset).unwrap();
+            let data_len_hi = read_byte(bytes, offset).unwrap();
+            let num_instruction_data_bytes = u16::from_le_bytes([data_len_lo, data_len_hi]);
 
             headers.push(V1InstructionHeader {
                 offset: header_offset,

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -862,6 +862,26 @@ mod tests {
     }
 
     #[test]
+    #[cfg(miri)]
+    fn miri_ub_v1_payload_len_wraps() {
+        // header: pid=1, accounts=1, data_len=65535
+        let bytes = vec![1, 1, 0xff, 0xff];
+        let mut offset = 0;
+        let frame = InstructionsFrame::try_new_for_v1(&bytes, &mut offset, 1).unwrap();
+
+        let mut iter = InstructionsIterator {
+            bytes: &bytes,
+            offset,
+            num_instructions: frame.num_instructions,
+            index: 0,
+            frames: &frame.frames,
+        };
+
+        // Should trip an out-of-bounds read under Miri.
+        let _ = iter.next();
+    }
+
+    #[test]
     fn test_try_new_legacy_zero_instructions() {
         let bytes = short_u16_1(0);
         let mut offset = 0;

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -33,7 +33,7 @@ pub(crate) struct InstructionFrame {
     num_accounts: u16, // NOTE: v1 spec-ed it as u8
     data_len: u16,
 
-    /// how to interpret frame between different transaction version
+    /// Version specific frame interpretation data.
     repr: InstructionFrameRepr,
 }
 

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -186,8 +186,8 @@ impl InstructionsFrame {
             let program_id_index = read_byte(bytes, offset)?;
             let num_instruction_accounts = read_byte(bytes, offset)?;
             // Offset and length checks have been done in the initial parsing.
-            let data_len_lo = read_byte(bytes, offset).unwrap();
-            let data_len_hi = read_byte(bytes, offset).unwrap();
+            let data_len_lo = read_byte(bytes, offset)?;
+            let data_len_hi = read_byte(bytes, offset)?;
             let num_instruction_data_bytes = u16::from_le_bytes([data_len_lo, data_len_hi]);
 
             headers.push(V1InstructionHeader {

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -40,7 +40,10 @@ pub(crate) struct InstructionFrame {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InstructionFrameRepr {
     /// Legacy and v0:
+    ///
+    /// ```notrust
     /// [program_id_index][short_vec accounts][accounts...][short_vec data][data...]
+    /// ```
     LegacyAndV0 {
         num_accounts_len: u8, // either 1 or 2
         data_len_len: u8,     // either 1 or 2
@@ -51,7 +54,10 @@ pub(crate) enum InstructionFrameRepr {
     #[allow(dead_code)]
     V1 {
         /// Start of this instruction's payload:
+        ///
+        /// ```notrust
         /// [account_indexes...][instruction_data...]
+        /// ```
         payload_offset: u16,
     },
 }


### PR DESCRIPTION
#### Problem

Extend `InstructionFrame` to support the tx-v1 instruction layout defined in SIMD-0385. v1 instructions split metadata and payload into two regions:

  - InstructionHeaders: fixed-size entries containing
    (program_id_index, num_accounts, data_len)
  - InstructionPayloads: concatenated account indexes + instruction data

#### Summary of Changes
- Add `InstructionFrameRepr` enum to distinguish legacy/v0 vs v1 layouts
- Store per-instruction `offset`, `program_id_index`, `num_accounts`, `data_len`
- Implement `try_new_for_v1`, `parse_v1_instruction_headers`, and
  `build_v1_instruction_frames`
- Preserve existing API and behavior for legacy/v0 parsing
- Extended `InstructionsIterator` to support tx-v1 instructions

Note: `InstructionsFrame` and `InstructionsIterator` API stay the same to keep downstream code compatible.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
