### PR TITLE
feat: TransactionView implements TransactionConfig layout from SIMD-0385 (transaction v1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ dependencies = [
  "solana-keypair",
  "solana-message",
  "solana-packet 4.1.0",
+ "solana-program-runtime",
  "solana-pubkey 4.1.0",
  "solana-sdk-ids",
  "solana-short-vec",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
  "solana-hash 4.2.0",
  "solana-message",
  "solana-packet 4.1.0",
+ "solana-program-runtime",
  "solana-pubkey 4.1.0",
  "solana-sdk-ids",
  "solana-short-vec",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "solana-hash 4.2.0",
  "solana-message",
  "solana-packet 4.1.0",
+ "solana-program-runtime",
  "solana-pubkey 4.1.0",
  "solana-sdk-ids",
  "solana-short-vec",

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -17,6 +17,7 @@ dev-context-only-utils = []
 solana-hash = { workspace = true }
 solana-message = { workspace = true }
 solana-packet = { workspace = true }
+solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true }

--- a/transaction-view/src/lib.rs
+++ b/transaction-view/src/lib.rs
@@ -13,6 +13,7 @@ pub mod result;
 mod sanitize;
 mod signature_frame;
 pub mod static_account_keys_frame;
+mod transaction_config_frame;
 pub mod transaction_data;
 mod transaction_frame;
 pub mod transaction_version;

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -11,7 +11,8 @@ pub(crate) fn sanitize(
     sanitize_signatures(view)?;
     sanitize_account_access(view)?;
     sanitize_instructions(view, enable_instruction_accounts_limit)?;
-    sanitize_address_table_lookups(view)
+    sanitize_address_table_lookups(view)?;
+    sanitize_transaction_config(view)
 }
 
 fn sanitize_signatures(view: &UnsanitizedTransactionView<impl TransactionData>) -> Result<()> {
@@ -110,6 +111,14 @@ fn sanitize_address_table_lookups(
         }
     }
 
+    Ok(())
+}
+
+fn sanitize_transaction_config(
+    _view: &UnsanitizedTransactionView<impl TransactionData>,
+) -> Result<()> {
+    // NOTE: necessary to validate configured values here? Particularly requested-heap-size
+    // should be multiple of 1024?
     Ok(())
 }
 

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -123,21 +123,24 @@ fn sanitize_address_table_lookups(
 fn sanitize_transaction_config(
     view: &UnsanitizedTransactionView<impl TransactionData>,
 ) -> Result<()> {
-    let compute_unit_limit = view.compute_unit_limit();
-    if compute_unit_limit > MAX_COMPUTE_UNIT_LIMIT {
-        return Err(TransactionViewError::SanitizeError);
-    }
+    if let Some(transaction_config_view) = view.transaction_config() {
+        let compute_unit_limit = transaction_config_view.compute_unit_limit();
+        if compute_unit_limit > MAX_COMPUTE_UNIT_LIMIT {
+            return Err(TransactionViewError::SanitizeError);
+        }
 
-    let loaded_accounts_data_size_limit = view.loaded_accounts_data_size_limit();
-    if loaded_accounts_data_size_limit > MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.into() {
-        return Err(TransactionViewError::SanitizeError);
-    }
+        let loaded_accounts_data_size_limit =
+            transaction_config_view.loaded_accounts_data_size_limit();
+        if loaded_accounts_data_size_limit > MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.into() {
+            return Err(TransactionViewError::SanitizeError);
+        }
 
-    let requested_heap_size = view.requested_heap_size();
-    if !(MIN_HEAP_FRAME_BYTES..=MAX_HEAP_FRAME_BYTES).contains(&requested_heap_size)
-        || !requested_heap_size.is_multiple_of(1024)
-    {
-        return Err(TransactionViewError::SanitizeError);
+        let requested_heap_size = transaction_config_view.requested_heap_size();
+        if !(MIN_HEAP_FRAME_BYTES..=MAX_HEAP_FRAME_BYTES).contains(&requested_heap_size)
+            || !requested_heap_size.is_multiple_of(1024)
+        {
+            return Err(TransactionViewError::SanitizeError);
+        }
     }
 
     Ok(())

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -1,7 +1,13 @@
-use crate::{
-    result::{Result, TransactionViewError},
-    transaction_data::TransactionData,
-    transaction_view::UnsanitizedTransactionView,
+use {
+    crate::{
+        result::{Result, TransactionViewError},
+        transaction_data::TransactionData,
+        transaction_view::UnsanitizedTransactionView,
+    },
+    solana_program_runtime::execution_budget::{
+        MAX_COMPUTE_UNIT_LIMIT, MAX_HEAP_FRAME_BYTES, MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
+        MIN_HEAP_FRAME_BYTES,
+    },
 };
 
 pub(crate) fn sanitize(
@@ -115,10 +121,25 @@ fn sanitize_address_table_lookups(
 }
 
 fn sanitize_transaction_config(
-    _view: &UnsanitizedTransactionView<impl TransactionData>,
+    view: &UnsanitizedTransactionView<impl TransactionData>,
 ) -> Result<()> {
-    // NOTE: necessary to validate configured values here? Particularly requested-heap-size
-    // should be multiple of 1024?
+    let compute_unit_limit = view.compute_unit_limit();
+    if compute_unit_limit > MAX_COMPUTE_UNIT_LIMIT {
+        return Err(TransactionViewError::SanitizeError);
+    }
+
+    let loaded_accounts_data_size_limit = view.loaded_accounts_data_size_limit();
+    if loaded_accounts_data_size_limit > MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.into() {
+        return Err(TransactionViewError::SanitizeError);
+    }
+
+    let requested_heap_size = view.requested_heap_size();
+    if !(MIN_HEAP_FRAME_BYTES..=MAX_HEAP_FRAME_BYTES).contains(&requested_heap_size)
+        || !requested_heap_size.is_multiple_of(1024)
+    {
+        return Err(TransactionViewError::SanitizeError);
+    }
+
     Ok(())
 }
 

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -1,13 +1,7 @@
-use {
-    crate::{
-        result::{Result, TransactionViewError},
-        transaction_data::TransactionData,
-        transaction_view::UnsanitizedTransactionView,
-    },
-    solana_program_runtime::execution_budget::{
-        MAX_COMPUTE_UNIT_LIMIT, MAX_HEAP_FRAME_BYTES, MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
-        MIN_HEAP_FRAME_BYTES,
-    },
+use crate::{
+    result::{Result, TransactionViewError},
+    transaction_data::TransactionData,
+    transaction_view::UnsanitizedTransactionView,
 };
 
 pub(crate) fn sanitize(
@@ -17,10 +11,7 @@ pub(crate) fn sanitize(
     sanitize_signatures(view)?;
     sanitize_account_access(view)?;
     sanitize_instructions(view, enable_instruction_accounts_limit)?;
-    sanitize_address_table_lookups(view)?;
-    sanitize_transaction_config(view)?;
-
-    Ok(())
+    sanitize_address_table_lookups(view)
 }
 
 fn sanitize_signatures(view: &UnsanitizedTransactionView<impl TransactionData>) -> Result<()> {
@@ -114,32 +105,6 @@ fn sanitize_address_table_lookups(
         // Check that there is at least one account lookup.
         if address_table_lookup.writable_indexes.is_empty()
             && address_table_lookup.readonly_indexes.is_empty()
-        {
-            return Err(TransactionViewError::SanitizeError);
-        }
-    }
-
-    Ok(())
-}
-
-fn sanitize_transaction_config(
-    view: &UnsanitizedTransactionView<impl TransactionData>,
-) -> Result<()> {
-    if let Some(transaction_config_view) = view.transaction_config() {
-        let compute_unit_limit = transaction_config_view.compute_unit_limit();
-        if compute_unit_limit > MAX_COMPUTE_UNIT_LIMIT {
-            return Err(TransactionViewError::SanitizeError);
-        }
-
-        let loaded_accounts_data_size_limit =
-            transaction_config_view.loaded_accounts_data_size_limit();
-        if loaded_accounts_data_size_limit > MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.into() {
-            return Err(TransactionViewError::SanitizeError);
-        }
-
-        let requested_heap_size = transaction_config_view.requested_heap_size();
-        if !(MIN_HEAP_FRAME_BYTES..=MAX_HEAP_FRAME_BYTES).contains(&requested_heap_size)
-            || !requested_heap_size.is_multiple_of(1024)
         {
             return Err(TransactionViewError::SanitizeError);
         }

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -18,7 +18,9 @@ pub(crate) fn sanitize(
     sanitize_account_access(view)?;
     sanitize_instructions(view, enable_instruction_accounts_limit)?;
     sanitize_address_table_lookups(view)?;
-    sanitize_transaction_config(view)
+    sanitize_transaction_config(view)?;
+
+    Ok(())
 }
 
 fn sanitize_signatures(view: &UnsanitizedTransactionView<impl TransactionData>) -> Result<()> {

--- a/transaction-view/src/transaction_config_frame.rs
+++ b/transaction-view/src/transaction_config_frame.rs
@@ -3,7 +3,7 @@ use {
         bytes::{advance_offset_for_array, check_remaining},
         result::{Result, TransactionViewError},
     },
-    core::fmt::Debug,
+    solana_program_runtime::execution_budget::MIN_HEAP_FRAME_BYTES,
 };
 
 /// Metadata for accessing the tx-v1 transaction config section.
@@ -52,7 +52,6 @@ pub(crate) struct TransactionConfigFrame {
 impl TransactionConfigFrame {
     pub(crate) const MASK_SIZE: usize = core::mem::size_of::<u32>();
     pub(crate) const CONFIG_VALUE_SIZE: usize = 4;
-    pub(crate) const DEFAULT_REQUESTED_HEAP_SIZE: u32 = 32 * 1024;
 
     /// Sentinel for legacy / v0 transactions.
     #[inline(always)]
@@ -65,7 +64,7 @@ impl TransactionConfigFrame {
             priority_fee_lamports: 0,
             compute_unit_limit: 0,
             loaded_accounts_data_size_limit: 0,
-            requested_heap_size: Self::DEFAULT_REQUESTED_HEAP_SIZE,
+            requested_heap_size: MIN_HEAP_FRAME_BYTES,
         }
     }
 
@@ -115,7 +114,7 @@ impl TransactionConfigFrame {
             priority_fee_lamports: 0,
             compute_unit_limit: 0,
             loaded_accounts_data_size_limit: 0,
-            requested_heap_size: Self::DEFAULT_REQUESTED_HEAP_SIZE,
+            requested_heap_size: MIN_HEAP_FRAME_BYTES,
         };
 
         // parse and read actual config values if set
@@ -272,10 +271,7 @@ mod tests {
         assert_eq!(frame.priority_fee_lamports, 0);
         assert_eq!(frame.compute_unit_limit, 0);
         assert_eq!(frame.loaded_accounts_data_size_limit, 0);
-        assert_eq!(
-            frame.requested_heap_size,
-            TransactionConfigFrame::DEFAULT_REQUESTED_HEAP_SIZE
-        );
+        assert_eq!(frame.requested_heap_size, MIN_HEAP_FRAME_BYTES);
     }
 
     #[test]
@@ -358,10 +354,7 @@ mod tests {
         assert_eq!(frame.priority_fee_lamports, 0);
         assert_eq!(frame.compute_unit_limit, 0);
         assert_eq!(frame.loaded_accounts_data_size_limit, 0);
-        assert_eq!(
-            frame.requested_heap_size,
-            TransactionConfigFrame::DEFAULT_REQUESTED_HEAP_SIZE
-        );
+        assert_eq!(frame.requested_heap_size, MIN_HEAP_FRAME_BYTES);
     }
 
     #[test]
@@ -387,10 +380,7 @@ mod tests {
         assert_eq!(frame.num_values, 2);
         assert_eq!(frame.priority_fee_lamports, fee);
         assert_eq!(frame.compute_unit_limit, 0);
-        assert_eq!(
-            frame.requested_heap_size,
-            TransactionConfigFrame::DEFAULT_REQUESTED_HEAP_SIZE
-        );
+        assert_eq!(frame.requested_heap_size, MIN_HEAP_FRAME_BYTES);
     }
 
     #[test]

--- a/transaction-view/src/transaction_config_frame.rs
+++ b/transaction-view/src/transaction_config_frame.rs
@@ -1,0 +1,498 @@
+use {
+    crate::{
+        bytes::{advance_offset_for_array, check_remaining},
+        result::{Result, TransactionViewError},
+    },
+    core::fmt::Debug,
+};
+
+/// Metadata for accessing the tx-v1 transaction config section.
+///
+/// This frame is a permanent part of `TransactionFrame`, but it is only
+/// applicable to tx-v1. For legacy and v0 transactions, use
+/// `TransactionConfigFrame::not_applicable()`.
+///
+/// Layout, per SIMD-0385:
+///   TransactionConfigMask (u32 LE)
+///   ...
+///   ConfigValues [[u8; 4]]   // len = popcount(mask)
+///
+/// Notes:
+/// - `offset == 0` is reserved to mean "not applicable" (legacy/v0).
+/// - Parsed tx-v1 config frames should always have `offset != 0`.
+/// - `try_new()` parses only the 4-byte mask at the current offset.
+/// - `with_values_offset()` is called later, once the parser has advanced
+///   past the addresses section and knows where `ConfigValues` begins.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct TransactionConfigFrame {
+    /// Offset of the 4-byte TransactionConfigMask.
+    ///
+    /// `0` means "not applicable" (legacy/v0).
+    pub(crate) mask_offset: u16,
+
+    /// Decoded TransactionConfigMask.
+    pub(crate) mask: u32,
+
+    /// Offset of the first ConfigValues word.
+    ///
+    /// `0` means "not applicable" (legacy/v0)
+    pub(crate) values_offset: u16,
+
+    /// Number of 4-byte words in ConfigValues.
+    pub(crate) num_values: u8,
+
+    /// priority fee in lamports
+    pub(crate) priority_fee_lamports: u64,
+    pub(crate) compute_unit_limit: u32,
+    pub(crate) loaded_accounts_data_size_limit: u32,
+    pub(crate) requested_heap_size: u32,
+}
+
+#[allow(dead_code)]
+impl TransactionConfigFrame {
+    pub(crate) const MASK_SIZE: usize = core::mem::size_of::<u32>();
+    pub(crate) const CONFIG_VALUE_SIZE: usize = 4;
+    pub(crate) const DEFAULT_REQUESTED_HEAP_SIZE: u32 = 32 * 1024;
+
+    /// Sentinel for legacy / v0 transactions.
+    #[inline(always)]
+    pub(crate) const fn not_applicable() -> Self {
+        Self {
+            mask_offset: 0,
+            mask: 0,
+            values_offset: 0,
+            num_values: 0,
+            priority_fee_lamports: 0,
+            compute_unit_limit: 0,
+            loaded_accounts_data_size_limit: 0,
+            requested_heap_size: Self::DEFAULT_REQUESTED_HEAP_SIZE,
+        }
+    }
+
+    /// Returns true if this frame represents a tx-v1 transaction config.
+    #[inline(always)]
+    pub(crate) const fn is_present(&self) -> bool {
+        self.mask_offset != 0
+    }
+
+    #[inline(always)]
+    pub(crate) const fn is_not_applicable(&self) -> bool {
+        !self.is_present()
+    }
+
+    /// Config Mask has been successfully parsed before advancing to `ConfigValues`
+    /// region; Now can try to create TransactionConfigFrame by parsing values.
+    #[inline(always)]
+    pub(crate) fn try_new(
+        bytes: &[u8],
+        mask_offset: usize,
+        mask: u32,
+        offset: &mut usize,
+    ) -> Result<Self> {
+        assert!(mask_offset > 0, "txv1 mask offset must be greater than 0");
+
+        Self::sanitize_mask(mask)?;
+        let num_values = mask.count_ones() as u8;
+        let mask_offset =
+            u16::try_from(mask_offset).map_err(|_| TransactionViewError::SanitizeError)?;
+        let values_offset =
+            u16::try_from(*offset).map_err(|_| TransactionViewError::SanitizeError)?;
+        // Validate that the config-values region is in bounds.
+        check_remaining(
+            bytes,
+            values_offset as usize,
+            (num_values as usize).wrapping_mul(Self::CONFIG_VALUE_SIZE),
+        )?;
+        // advance offset
+        advance_offset_for_array::<u32>(bytes, offset, num_values as u16)?;
+
+        // create frame with default config values
+        let mut frame = Self {
+            mask_offset,
+            mask,
+            values_offset,
+            num_values,
+            priority_fee_lamports: 0,
+            compute_unit_limit: 0,
+            loaded_accounts_data_size_limit: 0,
+            requested_heap_size: Self::DEFAULT_REQUESTED_HEAP_SIZE,
+        };
+
+        // parse and read actual config values if set
+        frame.priority_fee_lamports(bytes)?;
+        frame.compute_unit_limit(bytes)?;
+        frame.loaded_accounts_data_size_limit(bytes)?;
+        frame.requested_heap_size(bytes)?;
+
+        Ok(frame)
+    }
+
+    /// Validate mask semantics.
+    ///
+    /// Bits 0 and 1 together encode one logical 8-byte priority-fee field,
+    /// so they must either both be set or both be clear.
+    #[inline(always)]
+    fn sanitize_mask(mask: u32) -> Result<()> {
+        let bit0 = Self::has_bit(mask, 0);
+        let bit1 = Self::has_bit(mask, 1);
+        if bit0 ^ bit1 {
+            return Err(TransactionViewError::SanitizeError);
+        }
+
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn has_bit(mask: u32, bit: u8) -> bool {
+        bit < 32 && ((mask >> bit) & 1) != 0
+    }
+
+    /// Bits 0 and 1 form one logical 8-byte priority-fee field.
+    #[inline(always)]
+    fn priority_fee_lamports(&mut self, bytes: &[u8]) -> Result<()> {
+        let bit0 = Self::has_bit(self.mask, 0);
+        let bit1 = Self::has_bit(self.mask, 1);
+
+        if !bit0 && !bit1 {
+            return Ok(());
+        }
+        if bit0 ^ bit1 {
+            return Err(TransactionViewError::SanitizeError);
+        }
+
+        let lo_offset = self
+            .word_offset(0)
+            .ok_or(TransactionViewError::ParseError)?;
+        let hi_offset = self
+            .word_offset(1)
+            .ok_or(TransactionViewError::ParseError)?;
+
+        let lo = bytes
+            .get(lo_offset..lo_offset.wrapping_add(Self::CONFIG_VALUE_SIZE))
+            .ok_or(TransactionViewError::ParseError)?;
+        let hi = bytes
+            .get(hi_offset..hi_offset.wrapping_add(Self::CONFIG_VALUE_SIZE))
+            .ok_or(TransactionViewError::ParseError)?;
+
+        let mut out = [0u8; 8];
+        out[..Self::CONFIG_VALUE_SIZE].copy_from_slice(lo);
+        out[Self::CONFIG_VALUE_SIZE..].copy_from_slice(hi);
+        self.priority_fee_lamports = u64::from_le_bytes(out);
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn compute_unit_limit(&mut self, bytes: &[u8]) -> Result<()> {
+        if Self::has_bit(self.mask, 2) {
+            self.compute_unit_limit = self
+                .read_u32_for_bit(bytes, 2)
+                .ok_or(TransactionViewError::ParseError)?;
+        }
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn loaded_accounts_data_size_limit(&mut self, bytes: &[u8]) -> Result<()> {
+        if Self::has_bit(self.mask, 3) {
+            self.loaded_accounts_data_size_limit = self
+                .read_u32_for_bit(bytes, 3)
+                .ok_or(TransactionViewError::ParseError)?;
+        }
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn requested_heap_size(&mut self, bytes: &[u8]) -> Result<()> {
+        if Self::has_bit(self.mask, 4) {
+            self.requested_heap_size = self
+                .read_u32_for_bit(bytes, 4)
+                .ok_or(TransactionViewError::ParseError)?;
+        }
+        Ok(())
+    }
+
+    /// Return the packed word index for a given set bit. Eg: counts
+    /// bits set below `bit`.
+    ///
+    /// Example:
+    ///   mask = 0b0001_1100
+    ///   bit 2 -> 0
+    ///   bit 3 -> 1
+    ///   bit 4 -> 2
+    #[inline(always)]
+    pub(crate) fn word_index_for_bit(&self, bit: u8) -> Option<u8> {
+        if self.is_not_applicable() || !Self::has_bit(self.mask, bit) {
+            return None;
+        }
+
+        let mask_before_bit = (1u32 << bit).wrapping_sub(1);
+        Some((self.mask & mask_before_bit).count_ones() as u8)
+    }
+
+    #[inline(always)]
+    fn word_offset(&self, bit: u8) -> Option<usize> {
+        let word_index = usize::from(self.word_index_for_bit(bit)?);
+        Some(
+            usize::from(self.values_offset)
+                .wrapping_add(word_index.wrapping_mul(Self::CONFIG_VALUE_SIZE)),
+        )
+    }
+
+    #[inline(always)]
+    pub(crate) fn read_u32_for_bit(&self, bytes: &[u8], bit: u8) -> Option<u32> {
+        let offset = self.word_offset(bit)?;
+        let word = bytes.get(offset..offset.wrapping_add(4))?;
+        Some(u32::from_le_bytes(word.try_into().ok()?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn u32le(x: u32) -> [u8; 4] {
+        x.to_le_bytes()
+    }
+
+    fn u64_words_le(x: u64) -> ([u8; 4], [u8; 4]) {
+        let bytes = x.to_le_bytes();
+        (
+            [bytes[0], bytes[1], bytes[2], bytes[3]],
+            [bytes[4], bytes[5], bytes[6], bytes[7]],
+        )
+    }
+
+    #[test]
+    fn test_not_applicable_defaults() {
+        let frame = TransactionConfigFrame::not_applicable();
+
+        assert!(frame.is_not_applicable());
+        assert!(!frame.is_present());
+        assert_eq!(TransactionConfigFrame::sanitize_mask(frame.mask), Ok(()));
+        assert_eq!(frame.priority_fee_lamports, 0);
+        assert_eq!(frame.compute_unit_limit, 0);
+        assert_eq!(frame.loaded_accounts_data_size_limit, 0);
+        assert_eq!(
+            frame.requested_heap_size,
+            TransactionConfigFrame::DEFAULT_REQUESTED_HEAP_SIZE
+        );
+    }
+
+    #[test]
+    fn test_try_new_zero_mask_is_present() {
+        let mask = 0u32;
+        let bytes = mask.to_le_bytes();
+        let mut buf = vec![0u8; 5];
+        let mask_offset = 5;
+        buf.extend_from_slice(&bytes);
+
+        let mut offset = buf.len();
+        let frame = TransactionConfigFrame::try_new(&buf, mask_offset, mask, &mut offset).unwrap();
+
+        assert!(frame.is_present());
+        assert_eq!(frame.mask_offset, 5);
+        assert_eq!(frame.mask, 0);
+        assert_eq!(frame.num_values, 0);
+        assert_eq!(offset, 9);
+    }
+
+    #[test]
+    fn test_try_new_invalid_priority_fee_half_set_low_bit() {
+        let mask = 0b00001u32;
+        let bytes = mask.to_le_bytes();
+        let mut buf = vec![0u8; 5];
+        let mask_offset = 5;
+        buf.extend_from_slice(&bytes);
+        let mut offset = 5;
+
+        assert_eq!(
+            TransactionConfigFrame::try_new(&buf, mask_offset, mask, &mut offset),
+            Err(TransactionViewError::SanitizeError)
+        );
+    }
+
+    #[test]
+    fn test_try_new_invalid_priority_fee_half_set_high_bit() {
+        let mask = 0b00010u32;
+        let bytes = mask.to_le_bytes();
+        let mut buf = vec![0u8; 5];
+        let mask_offset = 5;
+        buf.extend_from_slice(&bytes);
+        let mut offset = 5;
+
+        assert_eq!(
+            TransactionConfigFrame::try_new(&buf, mask_offset, mask, &mut offset),
+            Err(TransactionViewError::SanitizeError)
+        );
+    }
+
+    #[test]
+    fn test_with_values_offset_checks_remaining() {
+        // bits 0,1,2 => 3 words => 12 bytes needed
+        let mask = 0b00111u32;
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[7u8; 3]);
+        let mask_offset = bytes.len();
+        bytes.extend_from_slice(&mask.to_le_bytes());
+
+        let mut offset = bytes.len();
+        assert_eq!(
+            TransactionConfigFrame::try_new(&bytes, mask_offset, mask, &mut offset),
+            Err(TransactionViewError::ParseError)
+        );
+    }
+
+    #[test]
+    fn test_read_defaults_when_bits_unset() {
+        let mask = 0u32;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[1u8; 2]);
+        let mask_offset = bytes.len();
+        bytes.extend_from_slice(&mask.to_le_bytes());
+
+        let mut offset = bytes.len();
+        let frame =
+            TransactionConfigFrame::try_new(&bytes, mask_offset, mask, &mut offset).unwrap();
+
+        assert_eq!(frame.priority_fee_lamports, 0);
+        assert_eq!(frame.compute_unit_limit, 0);
+        assert_eq!(frame.loaded_accounts_data_size_limit, 0);
+        assert_eq!(
+            frame.requested_heap_size,
+            TransactionConfigFrame::DEFAULT_REQUESTED_HEAP_SIZE
+        );
+    }
+
+    #[test]
+    fn test_priority_fee_only() {
+        let mask = 0b00011u32;
+        let fee = 123_456_789u64;
+        let (lo, hi) = u64_words_le(fee);
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[9u8; 4]);
+        let mask_offset = bytes.len();
+        bytes.extend_from_slice(&mask.to_le_bytes());
+        let values_offset = bytes.len();
+        bytes.extend_from_slice(&lo);
+        bytes.extend_from_slice(&hi);
+
+        let mut offset = values_offset;
+        let frame = TransactionConfigFrame::try_new(&bytes, mask_offset, mask, &mut offset)
+            .inspect(|_| assert_eq!(offset, bytes.len()))
+            .unwrap();
+
+        assert!(frame.is_present());
+        assert_eq!(frame.num_values, 2);
+        assert_eq!(frame.priority_fee_lamports, fee);
+        assert_eq!(frame.compute_unit_limit, 0);
+        assert_eq!(
+            frame.requested_heap_size,
+            TransactionConfigFrame::DEFAULT_REQUESTED_HEAP_SIZE
+        );
+    }
+
+    #[test]
+    fn test_all_initial_fields_present() {
+        // bits 0,1,2,3,4 => priority fee + cu + loaded data size + heap size
+        let mask = 0b1_1111u32;
+        let fee = 99u64;
+        let cu = 1_400_000u32;
+        let loaded = 64_000u32;
+        let heap = 64 * 1024u32;
+
+        let (fee_lo, fee_hi) = u64_words_le(fee);
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[9u8; 7]);
+        let mask_offset = bytes.len();
+        bytes.extend_from_slice(&mask.to_le_bytes());
+        let values_offset = bytes.len();
+        bytes.extend_from_slice(&fee_lo);
+        bytes.extend_from_slice(&fee_hi);
+        bytes.extend_from_slice(&u32le(cu));
+        bytes.extend_from_slice(&u32le(loaded));
+        bytes.extend_from_slice(&u32le(heap));
+
+        let mut offset = values_offset;
+        let frame = TransactionConfigFrame::try_new(&bytes, mask_offset, mask, &mut offset)
+            .inspect(|_| assert_eq!(offset, bytes.len()))
+            .unwrap();
+
+        assert!(frame.is_present());
+        assert_eq!(frame.num_values, 5);
+        assert_eq!(frame.priority_fee_lamports, fee);
+        assert_eq!(frame.compute_unit_limit, cu);
+        assert_eq!(frame.loaded_accounts_data_size_limit, loaded);
+        assert_eq!(frame.requested_heap_size, heap);
+    }
+
+    #[test]
+    fn test_sparse_bits_word_indexing() {
+        // bits 2 and 4 only
+        let mask = 0b10100u32;
+        let cu = 777u32;
+        let heap = 48 * 1024u32;
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[1u8; 3]);
+        let mask_offset = bytes.len();
+        bytes.extend_from_slice(&mask.to_le_bytes());
+        let values_offset = bytes.len();
+        bytes.extend_from_slice(&u32le(cu)); // bit 2 -> word 0
+        bytes.extend_from_slice(&u32le(heap)); // bit 4 -> word 1
+
+        let mut offset = values_offset;
+        let frame = TransactionConfigFrame::try_new(&bytes, mask_offset, mask, &mut offset)
+            .inspect(|_| assert_eq!(offset, bytes.len()))
+            .unwrap();
+
+        assert_eq!(frame.word_index_for_bit(2), Some(0));
+        assert_eq!(frame.word_index_for_bit(4), Some(1));
+        assert_eq!(frame.word_index_for_bit(3), None);
+
+        assert_eq!(frame.compute_unit_limit, cu);
+        assert_eq!(frame.loaded_accounts_data_size_limit, 0);
+        assert_eq!(frame.requested_heap_size, heap);
+    }
+
+    #[test]
+    fn test_truncated_priority_fee_values() {
+        let mask = 0b00011u32;
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[5u8; 2]);
+        let mask_offset = bytes.len();
+        bytes.extend_from_slice(&mask.to_le_bytes());
+        let values_offset = bytes.len();
+        bytes.extend_from_slice(&[1, 2, 3, 4]); // only one word present
+
+        let mut offset = values_offset;
+        assert_eq!(
+            TransactionConfigFrame::try_new(&bytes, mask_offset, mask, &mut offset),
+            Err(TransactionViewError::ParseError)
+        );
+    }
+
+    #[test]
+    fn test_sanitize_values_region_after_attach() {
+        let mask = 0b00100u32; // one value
+        let value = 123u32;
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[8u8; 6]);
+        let mask_offset = bytes.len();
+        bytes.extend_from_slice(&mask.to_le_bytes());
+        let values_offset = bytes.len();
+        bytes.extend_from_slice(&value.to_le_bytes());
+        let eof = bytes.len();
+
+        let mut offset = values_offset;
+        let frame = TransactionConfigFrame::try_new(&bytes, mask_offset, mask, &mut offset)
+            .inspect(|_| assert_eq!(offset, eof))
+            .unwrap();
+
+        assert_eq!(frame.compute_unit_limit, value);
+    }
+}

--- a/transaction-view/src/transaction_config_frame.rs
+++ b/transaction-view/src/transaction_config_frame.rs
@@ -128,10 +128,18 @@ impl TransactionConfigFrame {
 
     /// Validate mask semantics.
     ///
+    /// Check unknown / reserved bits are not used; And
     /// Bits 0 and 1 together encode one logical 8-byte priority-fee field,
     /// so they must either both be set or both be clear.
     #[inline(always)]
     fn sanitize_mask(mask: u32) -> Result<()> {
+        const ALLOWED_TRANSACTION_CONFIG_MASK: u32 = 0b1_1111;
+
+        // Reject unknown / reserved bits
+        if mask & !ALLOWED_TRANSACTION_CONFIG_MASK != 0 {
+            return Err(TransactionViewError::SanitizeError);
+        }
+
         let bit0 = Self::has_bit(mask, 0);
         let bit1 = Self::has_bit(mask, 1);
         if bit0 ^ bit1 {

--- a/transaction-view/src/transaction_config_frame.rs
+++ b/transaction-view/src/transaction_config_frame.rs
@@ -253,6 +253,39 @@ impl TransactionConfigFrame {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct TransactionConfigView<'a> {
+    pub(crate) transaction_config_frame: &'a TransactionConfigFrame,
+}
+
+impl<'a> TransactionConfigView<'a> {
+    #[inline(always)]
+    pub fn priority_fee_lamports(&self) -> u64 {
+        self.transaction_config_frame.priority_fee_lamports
+    }
+
+    #[inline(always)]
+    pub fn compute_unit_limit(&self) -> u32 {
+        self.transaction_config_frame.compute_unit_limit
+    }
+
+    #[inline(always)]
+    pub fn loaded_accounts_data_size_limit(&self) -> u32 {
+        self.transaction_config_frame
+            .loaded_accounts_data_size_limit
+    }
+
+    #[inline(always)]
+    pub fn requested_heap_size(&self) -> u32 {
+        self.transaction_config_frame.requested_heap_size
+    }
+
+    #[inline(always)]
+    pub fn mask(&self) -> u32 {
+        self.transaction_config_frame.mask
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/transaction-view/src/transaction_config_frame.rs
+++ b/transaction-view/src/transaction_config_frame.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        bytes::{advance_offset_for_array, check_remaining},
+        bytes::{advance_offset_for_array, check_remaining, unchecked_read_slice_data},
         result::{Result, TransactionViewError},
     },
     solana_program_runtime::execution_budget::MIN_HEAP_FRAME_BYTES,
@@ -40,12 +40,6 @@ pub(crate) struct TransactionConfigFrame {
 
     /// Number of 4-byte words in ConfigValues.
     pub(crate) num_values: u8,
-
-    /// priority fee in lamports
-    pub(crate) priority_fee_lamports: u64,
-    pub(crate) compute_unit_limit: u32,
-    pub(crate) loaded_accounts_data_size_limit: u32,
-    pub(crate) requested_heap_size: u32,
 }
 
 #[allow(dead_code)]
@@ -61,10 +55,6 @@ impl TransactionConfigFrame {
             mask: 0,
             values_offset: 0,
             num_values: 0,
-            priority_fee_lamports: 0,
-            compute_unit_limit: 0,
-            loaded_accounts_data_size_limit: 0,
-            requested_heap_size: MIN_HEAP_FRAME_BYTES,
         }
     }
 
@@ -105,25 +95,12 @@ impl TransactionConfigFrame {
         // advance offset
         advance_offset_for_array::<u32>(bytes, offset, num_values as u16)?;
 
-        // create frame with default config values
-        let mut frame = Self {
+        Ok(Self {
             mask_offset,
             mask,
             values_offset,
             num_values,
-            priority_fee_lamports: 0,
-            compute_unit_limit: 0,
-            loaded_accounts_data_size_limit: 0,
-            requested_heap_size: MIN_HEAP_FRAME_BYTES,
-        };
-
-        // parse and read actual config values if set
-        frame.priority_fee_lamports(bytes)?;
-        frame.compute_unit_limit(bytes)?;
-        frame.loaded_accounts_data_size_limit(bytes)?;
-        frame.requested_heap_size(bytes)?;
-
-        Ok(frame)
+        })
     }
 
     /// Validate mask semantics.
@@ -140,6 +117,7 @@ impl TransactionConfigFrame {
             return Err(TransactionViewError::SanitizeError);
         }
 
+        // priority fee uses first 2 bits
         let bit0 = Self::has_bit(mask, 0);
         let bit1 = Self::has_bit(mask, 1);
         if bit0 ^ bit1 {
@@ -152,70 +130,6 @@ impl TransactionConfigFrame {
     #[inline(always)]
     fn has_bit(mask: u32, bit: u8) -> bool {
         bit < 32 && ((mask >> bit) & 1) != 0
-    }
-
-    /// Bits 0 and 1 form one logical 8-byte priority-fee field.
-    #[inline(always)]
-    fn priority_fee_lamports(&mut self, bytes: &[u8]) -> Result<()> {
-        let bit0 = Self::has_bit(self.mask, 0);
-        let bit1 = Self::has_bit(self.mask, 1);
-
-        if !bit0 && !bit1 {
-            return Ok(());
-        }
-        if bit0 ^ bit1 {
-            return Err(TransactionViewError::SanitizeError);
-        }
-
-        let lo_offset = self
-            .word_offset(0)
-            .ok_or(TransactionViewError::ParseError)?;
-        let hi_offset = self
-            .word_offset(1)
-            .ok_or(TransactionViewError::ParseError)?;
-
-        let lo = bytes
-            .get(lo_offset..lo_offset.wrapping_add(Self::CONFIG_VALUE_SIZE))
-            .ok_or(TransactionViewError::ParseError)?;
-        let hi = bytes
-            .get(hi_offset..hi_offset.wrapping_add(Self::CONFIG_VALUE_SIZE))
-            .ok_or(TransactionViewError::ParseError)?;
-
-        let mut out = [0u8; 8];
-        out[..Self::CONFIG_VALUE_SIZE].copy_from_slice(lo);
-        out[Self::CONFIG_VALUE_SIZE..].copy_from_slice(hi);
-        self.priority_fee_lamports = u64::from_le_bytes(out);
-        Ok(())
-    }
-
-    #[inline(always)]
-    fn compute_unit_limit(&mut self, bytes: &[u8]) -> Result<()> {
-        if Self::has_bit(self.mask, 2) {
-            self.compute_unit_limit = self
-                .read_u32_for_bit(bytes, 2)
-                .ok_or(TransactionViewError::ParseError)?;
-        }
-        Ok(())
-    }
-
-    #[inline(always)]
-    fn loaded_accounts_data_size_limit(&mut self, bytes: &[u8]) -> Result<()> {
-        if Self::has_bit(self.mask, 3) {
-            self.loaded_accounts_data_size_limit = self
-                .read_u32_for_bit(bytes, 3)
-                .ok_or(TransactionViewError::ParseError)?;
-        }
-        Ok(())
-    }
-
-    #[inline(always)]
-    fn requested_heap_size(&mut self, bytes: &[u8]) -> Result<()> {
-        if Self::has_bit(self.mask, 4) {
-            self.requested_heap_size = self
-                .read_u32_for_bit(bytes, 4)
-                .ok_or(TransactionViewError::ParseError)?;
-        }
-        Ok(())
     }
 
     /// Return the packed word index for a given set bit. Eg: counts
@@ -244,40 +158,79 @@ impl TransactionConfigFrame {
                 .wrapping_add(word_index.wrapping_mul(Self::CONFIG_VALUE_SIZE)),
         )
     }
-
-    #[inline(always)]
-    pub(crate) fn read_u32_for_bit(&self, bytes: &[u8], bit: u8) -> Option<u32> {
-        let offset = self.word_offset(bit)?;
-        let word = bytes.get(offset..offset.wrapping_add(4))?;
-        Some(u32::from_le_bytes(word.try_into().ok()?))
-    }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct TransactionConfigView<'a> {
     pub(crate) transaction_config_frame: &'a TransactionConfigFrame,
+    pub(crate) bytes: &'a [u8],
 }
 
 impl<'a> TransactionConfigView<'a> {
     #[inline(always)]
     pub fn priority_fee_lamports(&self) -> u64 {
-        self.transaction_config_frame.priority_fee_lamports
+        // bit 0 and 1 have been sanitized to be in same state,
+        // return default if bits not set
+        if let Some(mut lo_offset) = self.transaction_config_frame.word_offset(0) {
+            // SAFETY:
+            // - The offsets are checked to be valid in the byte slice.
+            let value: [u8; 8] =
+                unsafe { unchecked_read_slice_data::<u8>(self.bytes, &mut lo_offset, 8) }
+                    .try_into()
+                    .unwrap();
+            u64::from_le_bytes(value)
+        } else {
+            // return default
+            0
+        }
     }
 
     #[inline(always)]
     pub fn compute_unit_limit(&self) -> u32 {
-        self.transaction_config_frame.compute_unit_limit
+        if let Some(mut value_offset) = self.transaction_config_frame.word_offset(2) {
+            // SAFETY:
+            // - The offsets are checked to be valid in the byte slice.
+            let value: [u8; 4] =
+                unsafe { unchecked_read_slice_data::<u8>(self.bytes, &mut value_offset, 4) }
+                    .try_into()
+                    .unwrap();
+            u32::from_le_bytes(value)
+        } else {
+            // return default
+            0
+        }
     }
 
     #[inline(always)]
     pub fn loaded_accounts_data_size_limit(&self) -> u32 {
-        self.transaction_config_frame
-            .loaded_accounts_data_size_limit
+        if let Some(mut value_offset) = self.transaction_config_frame.word_offset(3) {
+            // SAFETY:
+            // - The offsets are checked to be valid in the byte slice.
+            let value: [u8; 4] =
+                unsafe { unchecked_read_slice_data::<u8>(self.bytes, &mut value_offset, 4) }
+                    .try_into()
+                    .unwrap();
+            u32::from_le_bytes(value)
+        } else {
+            // return default
+            0
+        }
     }
 
     #[inline(always)]
     pub fn requested_heap_size(&self) -> u32 {
-        self.transaction_config_frame.requested_heap_size
+        if let Some(mut value_offset) = self.transaction_config_frame.word_offset(4) {
+            // SAFETY:
+            // - The offsets are checked to be valid in the byte slice.
+            let value: [u8; 4] =
+                unsafe { unchecked_read_slice_data::<u8>(self.bytes, &mut value_offset, 4) }
+                    .try_into()
+                    .unwrap();
+            u32::from_le_bytes(value)
+        } else {
+            // return default
+            MIN_HEAP_FRAME_BYTES
+        }
     }
 
     #[inline(always)]
@@ -309,10 +262,6 @@ mod tests {
         assert!(frame.is_not_applicable());
         assert!(!frame.is_present());
         assert_eq!(TransactionConfigFrame::sanitize_mask(frame.mask), Ok(()));
-        assert_eq!(frame.priority_fee_lamports, 0);
-        assert_eq!(frame.compute_unit_limit, 0);
-        assert_eq!(frame.loaded_accounts_data_size_limit, 0);
-        assert_eq!(frame.requested_heap_size, MIN_HEAP_FRAME_BYTES);
     }
 
     #[test]
@@ -391,11 +340,15 @@ mod tests {
         let mut offset = bytes.len();
         let frame =
             TransactionConfigFrame::try_new(&bytes, mask_offset, mask, &mut offset).unwrap();
+        let view = TransactionConfigView {
+            transaction_config_frame: &frame,
+            bytes: &bytes,
+        };
 
-        assert_eq!(frame.priority_fee_lamports, 0);
-        assert_eq!(frame.compute_unit_limit, 0);
-        assert_eq!(frame.loaded_accounts_data_size_limit, 0);
-        assert_eq!(frame.requested_heap_size, MIN_HEAP_FRAME_BYTES);
+        assert_eq!(view.priority_fee_lamports(), 0);
+        assert_eq!(view.compute_unit_limit(), 0);
+        assert_eq!(view.loaded_accounts_data_size_limit(), 0);
+        assert_eq!(view.requested_heap_size(), MIN_HEAP_FRAME_BYTES);
     }
 
     #[test]
@@ -416,12 +369,17 @@ mod tests {
         let frame = TransactionConfigFrame::try_new(&bytes, mask_offset, mask, &mut offset)
             .inspect(|_| assert_eq!(offset, bytes.len()))
             .unwrap();
-
         assert!(frame.is_present());
         assert_eq!(frame.num_values, 2);
-        assert_eq!(frame.priority_fee_lamports, fee);
-        assert_eq!(frame.compute_unit_limit, 0);
-        assert_eq!(frame.requested_heap_size, MIN_HEAP_FRAME_BYTES);
+
+        let view = TransactionConfigView {
+            transaction_config_frame: &frame,
+            bytes: &bytes,
+        };
+        assert_eq!(view.priority_fee_lamports(), fee);
+        assert_eq!(view.compute_unit_limit(), 0);
+        assert_eq!(view.loaded_accounts_data_size_limit(), 0);
+        assert_eq!(view.requested_heap_size(), MIN_HEAP_FRAME_BYTES);
     }
 
     #[test]
@@ -450,13 +408,17 @@ mod tests {
         let frame = TransactionConfigFrame::try_new(&bytes, mask_offset, mask, &mut offset)
             .inspect(|_| assert_eq!(offset, bytes.len()))
             .unwrap();
-
         assert!(frame.is_present());
         assert_eq!(frame.num_values, 5);
-        assert_eq!(frame.priority_fee_lamports, fee);
-        assert_eq!(frame.compute_unit_limit, cu);
-        assert_eq!(frame.loaded_accounts_data_size_limit, loaded);
-        assert_eq!(frame.requested_heap_size, heap);
+
+        let view = TransactionConfigView {
+            transaction_config_frame: &frame,
+            bytes: &bytes,
+        };
+        assert_eq!(view.priority_fee_lamports(), fee);
+        assert_eq!(view.compute_unit_limit(), cu);
+        assert_eq!(view.loaded_accounts_data_size_limit(), loaded);
+        assert_eq!(view.requested_heap_size(), heap);
     }
 
     #[test]
@@ -478,14 +440,18 @@ mod tests {
         let frame = TransactionConfigFrame::try_new(&bytes, mask_offset, mask, &mut offset)
             .inspect(|_| assert_eq!(offset, bytes.len()))
             .unwrap();
-
         assert_eq!(frame.word_index_for_bit(2), Some(0));
         assert_eq!(frame.word_index_for_bit(4), Some(1));
         assert_eq!(frame.word_index_for_bit(3), None);
 
-        assert_eq!(frame.compute_unit_limit, cu);
-        assert_eq!(frame.loaded_accounts_data_size_limit, 0);
-        assert_eq!(frame.requested_heap_size, heap);
+        let view = TransactionConfigView {
+            transaction_config_frame: &frame,
+            bytes: &bytes,
+        };
+        assert_eq!(view.priority_fee_lamports(), 0);
+        assert_eq!(view.compute_unit_limit(), cu);
+        assert_eq!(view.loaded_accounts_data_size_limit(), 0);
+        assert_eq!(view.requested_heap_size(), heap);
     }
 
     #[test]
@@ -504,26 +470,5 @@ mod tests {
             TransactionConfigFrame::try_new(&bytes, mask_offset, mask, &mut offset),
             Err(TransactionViewError::ParseError)
         );
-    }
-
-    #[test]
-    fn test_sanitize_values_region_after_attach() {
-        let mask = 0b00100u32; // one value
-        let value = 123u32;
-
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(&[8u8; 6]);
-        let mask_offset = bytes.len();
-        bytes.extend_from_slice(&mask.to_le_bytes());
-        let values_offset = bytes.len();
-        bytes.extend_from_slice(&value.to_le_bytes());
-        let eof = bytes.len();
-
-        let mut offset = values_offset;
-        let frame = TransactionConfigFrame::try_new(&bytes, mask_offset, mask, &mut offset)
-            .inspect(|_| assert_eq!(offset, eof))
-            .unwrap();
-
-        assert_eq!(frame.compute_unit_limit, value);
     }
 }

--- a/transaction-view/src/transaction_config_frame.rs
+++ b/transaction-view/src/transaction_config_frame.rs
@@ -18,11 +18,8 @@ use {
 ///   ConfigValues [[u8; 4]]   // len = popcount(mask)
 ///
 /// Notes:
-/// - `offset == 0` is reserved to mean "not applicable" (legacy/v0).
-/// - Parsed tx-v1 config frames should always have `offset != 0`.
-/// - `try_new()` parses only the 4-byte mask at the current offset.
-/// - `with_values_offset()` is called later, once the parser has advanced
-///   past the addresses section and knows where `ConfigValues` begins.
+/// - `mask_offset == 0` is reserved to mean "not applicable" (legacy/v0).
+/// - Parsed tx-v1 config frames should always have `mask_offset != 0`.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct TransactionConfigFrame {
     /// Offset of the 4-byte TransactionConfigMask.
@@ -308,7 +305,7 @@ mod tests {
     }
 
     #[test]
-    fn test_with_values_offset_checks_remaining() {
+    fn test_try_new_invalid_config_values() {
         // bits 0,1,2 => 3 words => 12 bytes needed
         let mask = 0b00111u32;
 

--- a/transaction-view/src/transaction_config_frame.rs
+++ b/transaction-view/src/transaction_config_frame.rs
@@ -42,7 +42,7 @@ pub(crate) struct TransactionConfigFrame {
 #[allow(dead_code)]
 impl TransactionConfigFrame {
     pub(crate) const MASK_SIZE: usize = core::mem::size_of::<u32>();
-    pub(crate) const CONFIG_VALUE_SIZE: usize = 4;
+    pub(crate) const CONFIG_VALUE_SIZE: usize = core::mem::size_of::<u32>();
 
     /// Sentinel for legacy / v0 transactions.
     #[inline(always)]
@@ -59,11 +59,6 @@ impl TransactionConfigFrame {
     #[inline(always)]
     pub(crate) const fn is_present(&self) -> bool {
         self.mask_offset != 0
-    }
-
-    #[inline(always)]
-    pub(crate) const fn is_not_applicable(&self) -> bool {
-        !self.is_present()
     }
 
     /// Config Mask has been successfully parsed before advancing to `ConfigValues`
@@ -134,7 +129,7 @@ impl TransactionConfigFrame {
     ///   bit 4 -> 2
     #[inline(always)]
     pub(crate) fn word_index_for_bit(&self, bit: u8) -> Option<u8> {
-        if self.is_not_applicable() || !Self::has_bit(self.mask, bit) {
+        if !self.is_present() || !Self::has_bit(self.mask, bit) {
             return None;
         }
 
@@ -251,7 +246,6 @@ mod tests {
     fn test_not_applicable_defaults() {
         let frame = TransactionConfigFrame::not_applicable();
 
-        assert!(frame.is_not_applicable());
         assert!(!frame.is_present());
         assert_eq!(TransactionConfigFrame::sanitize_mask(frame.mask), Ok(()));
     }

--- a/transaction-view/src/transaction_config_frame.rs
+++ b/transaction-view/src/transaction_config_frame.rs
@@ -338,6 +338,30 @@ mod tests {
     }
 
     #[test]
+    fn test_unknown_bits_rejected() {
+        // Single unknown bit (bit 5)
+        assert_eq!(
+            TransactionConfigFrame::sanitize_mask(0b10_0000),
+            Err(TransactionViewError::SanitizeError)
+        );
+        // Multiple unknown bits
+        assert_eq!(
+            TransactionConfigFrame::sanitize_mask(0b1111_1111),
+            Err(TransactionViewError::SanitizeError)
+        );
+        // High bits set
+        assert_eq!(
+            TransactionConfigFrame::sanitize_mask(1 << 31),
+            Err(TransactionViewError::SanitizeError)
+        );
+        // Unknown bits mixed with valid bits
+        assert_eq!(
+            TransactionConfigFrame::sanitize_mask(0b1_1111 | (1 << 16)),
+            Err(TransactionViewError::SanitizeError)
+        );
+    }
+
+    #[test]
     fn test_priority_fee_only() {
         let mask = 0b00011u32;
         let fee = 123_456_789u64;

--- a/transaction-view/src/transaction_config_frame.rs
+++ b/transaction-view/src/transaction_config_frame.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        bytes::{advance_offset_for_array, check_remaining, unchecked_read_slice_data},
+        bytes::{advance_offset_for_array, unchecked_read_slice_data},
         result::{Result, TransactionViewError},
     },
     solana_program_runtime::execution_budget::MIN_HEAP_FRAME_BYTES,
@@ -86,12 +86,7 @@ impl TransactionConfigFrame {
             u16::try_from(mask_offset).map_err(|_| TransactionViewError::SanitizeError)?;
         let values_offset =
             u16::try_from(*offset).map_err(|_| TransactionViewError::SanitizeError)?;
-        // Validate that the config-values region is in bounds.
-        check_remaining(
-            bytes,
-            values_offset as usize,
-            (num_values as usize).wrapping_mul(Self::CONFIG_VALUE_SIZE),
-        )?;
+
         // advance offset
         advance_offset_for_array::<u32>(bytes, offset, num_values as u16)?;
 

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -141,33 +141,10 @@ impl TransactionFrame {
         self.message_header.offset
     }
 
-    /// Return transaction_config.priority_fee_lamports if txv1, otherwise
-    /// default `0` lamports
+    /// Return transaction_config_frame
     #[inline]
-    pub fn priority_fee_lamports(&self) -> u64 {
-        self.transaction_config_frame.priority_fee_lamports
-    }
-
-    /// Return transaction_config.compute_unit_limit if txv1, otherwise
-    /// default value `0`
-    #[inline]
-    pub fn compute_unit_limit(&self) -> u32 {
-        self.transaction_config_frame.compute_unit_limit
-    }
-
-    /// Return transaction_config.loaded_accounts_bytes_size_limit if txv1, otherwise
-    /// default value `0`
-    #[inline]
-    pub fn loaded_accounts_data_size_limit(&self) -> u32 {
-        self.transaction_config_frame
-            .loaded_accounts_data_size_limit
-    }
-
-    /// Return transaction_config.requested_heap_size if txv1, otherwise
-    /// default DEFAULT_REQUESTED_HEAP_SIZE`
-    #[inline]
-    pub fn requested_heap_size(&self) -> u32 {
-        self.transaction_config_frame.requested_heap_size
+    pub(crate) fn transaction_config_frame(&self) -> &TransactionConfigFrame {
+        &self.transaction_config_frame
     }
 }
 

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -7,6 +7,7 @@ use {
         result::{Result, TransactionViewError},
         signature_frame::SignatureFrame,
         static_account_keys_frame::StaticAccountKeysFrame,
+        transaction_config_frame::TransactionConfigFrame,
         transaction_version::TransactionVersion,
     },
     solana_hash::Hash,
@@ -28,6 +29,8 @@ pub(crate) struct TransactionFrame {
     instructions: InstructionsFrame,
     /// Address table lookup framing data.
     address_table_lookup: AddressTableLookupFrame,
+    /// Tranasaction config framing data
+    transaction_config_frame: TransactionConfigFrame,
 }
 
 impl TransactionFrame {
@@ -68,6 +71,7 @@ impl TransactionFrame {
             recent_blockhash_offset,
             instructions,
             address_table_lookup,
+            transaction_config_frame: TransactionConfigFrame::not_applicable(),
         })
     }
 
@@ -135,6 +139,35 @@ impl TransactionFrame {
     #[inline]
     pub(crate) fn message_offset(&self) -> u16 {
         self.message_header.offset
+    }
+
+    /// Return transaction_config.priority_fee_lamports if txv1, otherwise
+    /// default `0` lamports
+    #[inline]
+    pub fn priority_fee_lamports(&self) -> u64 {
+        self.transaction_config_frame.priority_fee_lamports
+    }
+
+    /// Return transaction_config.compute_unit_limit if txv1, otherwise
+    /// default value `0`
+    #[inline]
+    pub fn compute_unit_limit(&self) -> u32 {
+        self.transaction_config_frame.compute_unit_limit
+    }
+
+    /// Return transaction_config.loaded_accounts_bytes_size_limit if txv1, otherwise
+    /// default value `0`
+    #[inline]
+    pub fn loaded_accounts_data_size_limit(&self) -> u32 {
+        self.transaction_config_frame
+            .loaded_accounts_data_size_limit
+    }
+
+    /// Return transaction_config.requested_heap_size if txv1, otherwise
+    /// default DEFAULT_REQUESTED_HEAP_SIZE`
+    #[inline]
+    pub fn requested_heap_size(&self) -> u32 {
+        self.transaction_config_frame.requested_heap_size
     }
 }
 

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -29,7 +29,7 @@ pub(crate) struct TransactionFrame {
     instructions: InstructionsFrame,
     /// Address table lookup framing data.
     address_table_lookup: AddressTableLookupFrame,
-    /// Tranasaction config framing data
+    /// Transaction config framing data
     transaction_config_frame: TransactionConfigFrame,
 }
 

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -2,8 +2,8 @@ use {
     crate::{
         address_table_lookup_frame::AddressTableLookupIterator,
         instructions_frame::InstructionsIterator, result::Result, sanitize::sanitize,
-        transaction_data::TransactionData, transaction_frame::TransactionFrame,
-        transaction_version::TransactionVersion,
+        transaction_config_frame::TransactionConfigView, transaction_data::TransactionData,
+        transaction_frame::TransactionFrame, transaction_version::TransactionVersion,
     },
     core::fmt::{Debug, Formatter},
     solana_hash::Hash,
@@ -160,33 +160,19 @@ impl<const SANITIZED: bool, D: TransactionData> TransactionView<SANITIZED, D> {
         unsafe { self.frame.address_table_lookup_iter(data) }
     }
 
-    /// Return transaction_config.priority_fee_lamports if txv1, otherwise
-    /// default `0` lamports
+    /// Return Some(TransactionConfigView) for V1, None for legacy/V0
     #[inline]
-    pub fn priority_fee_lamports(&self) -> u64 {
-        self.frame.priority_fee_lamports()
+    pub fn transaction_config(&self) -> Option<TransactionConfigView<'_>> {
+        let transaction_config_frame = self.frame.transaction_config_frame();
+        if transaction_config_frame.is_present() {
+            Some(TransactionConfigView {
+                transaction_config_frame,
+            })
+        } else {
+            None
+        }
     }
 
-    /// Return transaction_config.compute_unit_limit if txv1, otherwise
-    /// default value `0`
-    #[inline]
-    pub fn compute_unit_limit(&self) -> u32 {
-        self.frame.compute_unit_limit()
-    }
-
-    /// Return transaction_config.loaded_accounts_data_size_limit if txv1, otherwise
-    /// default value `0`
-    #[inline]
-    pub fn loaded_accounts_data_size_limit(&self) -> u32 {
-        self.frame.loaded_accounts_data_size_limit()
-    }
-
-    /// Return transaction_config.requested_heap_size if txv1, otherwise
-    /// default DEFAULT_REQUESTED_HEAP_SIZE`
-    #[inline]
-    pub fn requested_heap_size(&self) -> u32 {
-        self.frame.requested_heap_size()
-    }
     /// Return the full serialized transaction data.
     #[inline]
     pub fn data(&self) -> &[u8] {
@@ -419,6 +405,8 @@ mod tests {
                 .map(|x| x.len() as u8)
                 .unwrap_or(0)
         );
+
+        assert!(view.transaction_config().is_none());
     }
 
     fn multiple_transfers() -> VersionedTransaction {

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -167,6 +167,7 @@ impl<const SANITIZED: bool, D: TransactionData> TransactionView<SANITIZED, D> {
         if transaction_config_frame.is_present() {
             Some(TransactionConfigView {
                 transaction_config_frame,
+                bytes: self.data(),
             })
         } else {
             None

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -160,6 +160,33 @@ impl<const SANITIZED: bool, D: TransactionData> TransactionView<SANITIZED, D> {
         unsafe { self.frame.address_table_lookup_iter(data) }
     }
 
+    /// Return transaction_config.priority_fee_lamports if txv1, otherwise
+    /// default `0` lamports
+    #[inline]
+    pub fn priority_fee_lamports(&self) -> u64 {
+        self.frame.priority_fee_lamports()
+    }
+
+    /// Return transaction_config.compute_unit_limit if txv1, otherwise
+    /// default value `0`
+    #[inline]
+    pub fn compute_unit_limit(&self) -> u32 {
+        self.frame.compute_unit_limit()
+    }
+
+    /// Return transaction_config.loaded_accounts_data_size_limit if txv1, otherwise
+    /// default value `0`
+    #[inline]
+    pub fn loaded_accounts_data_size_limit(&self) -> u32 {
+        self.frame.loaded_accounts_data_size_limit()
+    }
+
+    /// Return transaction_config.requested_heap_size if txv1, otherwise
+    /// default DEFAULT_REQUESTED_HEAP_SIZE`
+    #[inline]
+    pub fn requested_heap_size(&self) -> u32 {
+        self.frame.requested_heap_size()
+    }
     /// Return the full serialized transaction data.
     #[inline]
     pub fn data(&self) -> &[u8] {
@@ -237,34 +264,6 @@ impl<D: TransactionData> TransactionView<true, D> {
             )
             .wrapping_add(self.total_writable_lookup_accounts()),
         )
-    }
-
-    /// Return transaction_config.priority_fee_lamports if txv1, otherwise
-    /// default `0` lamports
-    #[inline]
-    pub fn priority_fee_lamports(&self) -> u64 {
-        self.frame.priority_fee_lamports()
-    }
-
-    /// Return transaction_config.compute_unit_limit if txv1, otherwise
-    /// default value `0`
-    #[inline]
-    pub fn compute_unit_limit(&self) -> u32 {
-        self.frame.compute_unit_limit()
-    }
-
-    /// Return transaction_config.loaded_accounts_data_size_limit if txv1, otherwise
-    /// default value `0`
-    #[inline]
-    pub fn loaded_accounts_data_size_limit(&self) -> u32 {
-        self.frame.loaded_accounts_data_size_limit()
-    }
-
-    /// Return transaction_config.requested_heap_size if txv1, otherwise
-    /// default DEFAULT_REQUESTED_HEAP_SIZE`
-    #[inline]
-    pub fn requested_heap_size(&self) -> u32 {
-        self.frame.requested_heap_size()
     }
 }
 

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -238,6 +238,34 @@ impl<D: TransactionData> TransactionView<true, D> {
             .wrapping_add(self.total_writable_lookup_accounts()),
         )
     }
+
+    /// Return transaction_config.priority_fee_lamports if txv1, otherwise
+    /// default `0` lamports
+    #[inline]
+    pub fn priority_fee_lamports(&self) -> u64 {
+        self.frame.priority_fee_lamports()
+    }
+
+    /// Return transaction_config.compute_unit_limit if txv1, otherwise
+    /// default value `0`
+    #[inline]
+    pub fn compute_unit_limit(&self) -> u32 {
+        self.frame.compute_unit_limit()
+    }
+
+    /// Return transaction_config.loaded_accounts_data_size_limit if txv1, otherwise
+    /// default value `0`
+    #[inline]
+    pub fn loaded_accounts_data_size_limit(&self) -> u32 {
+        self.frame.loaded_accounts_data_size_limit()
+    }
+
+    /// Return transaction_config.requested_heap_size if txv1, otherwise
+    /// default DEFAULT_REQUESTED_HEAP_SIZE`
+    #[inline]
+    pub fn requested_heap_size(&self) -> u32 {
+        self.frame.requested_heap_size()
+    }
 }
 
 // Manual implementation of `Debug` - avoids bound on `D`.

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -164,14 +164,12 @@ impl<const SANITIZED: bool, D: TransactionData> TransactionView<SANITIZED, D> {
     #[inline]
     pub fn transaction_config(&self) -> Option<TransactionConfigView<'_>> {
         let transaction_config_frame = self.frame.transaction_config_frame();
-        if transaction_config_frame.is_present() {
-            Some(TransactionConfigView {
+        transaction_config_frame
+            .is_present()
+            .then_some(TransactionConfigView {
                 transaction_config_frame,
                 bytes: self.data(),
             })
-        } else {
-            None
-        }
     }
 
     /// Return the full serialized transaction data.


### PR DESCRIPTION
#### Problem

Add `TransactionConfigFrame` to support the transaction configuration layout introduced in SIMD-0385. The frame parses `TransactionConfigMask` and packed config values, store parsed config values for quick access.

The frame is always present in `TransactionFrame`; legacy/v0 transactions use a zeroed sentinel to indicate "not applicable", following the same approach as `AddressTableLookupFrame`.

#### Summary of Changes
- Add `TransactionConfigFrame`
- Extend `InstructionFrame` to include `TransactionConfigFrame`
- Add `TransactionConfigView` to access config values
- tests

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
