### PR TITLE
cli: add snapshot time to supply output

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2121,6 +2121,7 @@ pub struct CliSupply {
     pub circulating: u64,
     pub non_circulating: u64,
     pub non_circulating_accounts: Vec<String>,
+    pub timestamp: Option<UnixTimestamp>,
     #[serde(skip_serializing)]
     pub print_accounts: bool,
 }
@@ -2132,6 +2133,7 @@ impl From<RpcSupply> for CliSupply {
             circulating: rpc_supply.circulating,
             non_circulating: rpc_supply.non_circulating,
             non_circulating_accounts: rpc_supply.non_circulating_accounts,
+            timestamp: None,
             print_accounts: false,
         }
     }
@@ -2163,6 +2165,16 @@ impl fmt::Display for CliSupply {
                 build_balance_message(self.non_circulating, false, false)
             ),
         )?;
+
+        if let Some(timestamp) = self.timestamp {
+            let snapshot_time = Utc
+                .timestamp_opt(timestamp, 0)
+                .single()
+                .map(|ts| ts.format("%Y-%m-%d %H:%M:%S").to_string())
+                .unwrap_or_else(|| unix_timestamp_to_string(timestamp));
+            writeln_name_value(f, "Snapshot Time (UTC):", &snapshot_time)?;
+        }
+
         if self.print_accounts {
             writeln!(f)?;
             writeln_name_value(f, "Non-Circulating Accounts:", " ")?;

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1380,7 +1380,13 @@ pub async fn process_supply(
     print_accounts: bool,
 ) -> ProcessResult {
     let supply_response = rpc_client.supply().await?;
+    let timestamp = rpc_client
+        .get_block_time(supply_response.context.slot)
+        .await
+        .ok();
+
     let mut supply: CliSupply = supply_response.value.into();
+    supply.timestamp = timestamp;
     supply.print_accounts = print_accounts;
     Ok(config.output_format.formatted_string(&supply))
 }


### PR DESCRIPTION
#### Problem
- There was no snapshot time of the supply output.

#### Summary of Changes
- Added snapshot time formatted as YYYY-MM-DD HH:MM:SS.
```
Total: 1327724812.287192345 SOL
Circulating: 1011859922.619690657 SOL
Non-Circulating: 315864889.667501628 SOL
Snapshot Time (UTC): 2026-03-12 06:33:39
```