### PR TITLE
program-runtime: gate HashMap/Hashset imports for dev-context-only-utils

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -8,6 +8,7 @@ use {
     solana_sdk_ids::sysvar,
     solana_svm_type_overrides::sync::Arc,
     solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
+    std::collections::{HashMap, HashSet},
 };
 use {
     crate::{
@@ -46,7 +47,6 @@ use {
         alloc::Layout,
         borrow::Cow,
         cell::RefCell,
-        collections::{HashMap, HashSet},
         fmt::{self, Debug},
         rc::Rc,
     },


### PR DESCRIPTION
#### Problem
- Imported HashMap/HashSet in a non-cfg import block even though they are only used under dev-context-only-utils, causing unused-import warnings in regular builds.

#### Summary of Changes
- Move HashMap/HashSet into the #[cfg(feature ="dev-context-only-utils")] import block to match usage and eliminate the warnings.