### PR TITLE
chore: reformat cargo files to conformant toml syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -543,7 +543,7 @@ solana-svm-test-harness-instr = { path = "svm-test-harness/instr", version = "=4
 solana-svm-timings = { path = "svm-timings", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm-transaction = { path = "svm-transaction", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm-type-overrides = { path = "svm-type-overrides", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-system-interface = { version = "3.1", features = ["alloc","bincode","serde","wincode"] }
+solana-system-interface = { version = "3.1", features = ["alloc", "bincode", "serde", "wincode"] }
 solana-system-program = { path = "programs/system", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-system-transaction = "4.0.0"
 solana-sysvar = "4.0.0"

--- a/banks-interface/Cargo.toml
+++ b/banks-interface/Cargo.toml
@@ -21,14 +21,14 @@ agave-unstable-api = []
 
 [dependencies]
 serde = { workspace = true }
-solana-account = { workspace = true, features = [ "serde" ] }
+solana-account = { workspace = true, features = ["serde"] }
 solana-clock = { workspace = true }
-solana-commitment-config = { workspace = true, features = [ "serde" ] }
+solana-commitment-config = { workspace = true, features = ["serde"] }
 solana-hash = { workspace = true }
-solana-message = { workspace = true, features = [ "serde" ] }
+solana-message = { workspace = true, features = ["serde"] }
 solana-pubkey = { workspace = true }
-solana-signature = { workspace = true, features = [ "serde" ] }
-solana-transaction = { workspace = true, features = [ "serde" ] }
-solana-transaction-context = { workspace = true, features = [ "serde" ] }
-solana-transaction-error = { workspace = true, features = [ "serde" ] }
+solana-signature = { workspace = true, features = ["serde"] }
+solana-transaction = { workspace = true, features = ["serde"] }
+solana-transaction-context = { workspace = true, features = ["serde"] }
+solana-transaction-error = { workspace = true, features = ["serde"] }
 tarpc = { workspace = true, features = ["full"] }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -17,10 +17,7 @@ crate-type = ["lib"]
 name = "solana_ledger"
 
 [features]
-dev-context-only-utils = [
-    "solana-perf/dev-context-only-utils",
-    "solana-runtime/dev-context-only-utils",
-]
+dev-context-only-utils = ["solana-perf/dev-context-only-utils", "solana-runtime/dev-context-only-utils"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -18,10 +18,7 @@ name = "solana_rpc"
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = [
-    "solana-ledger/dev-context-only-utils",
-    "solana-rpc/dev-context-only-utils",
-]
+dev-context-only-utils = ["solana-ledger/dev-context-only-utils", "solana-rpc/dev-context-only-utils"]
 
 [dependencies]
 agave-feature-set = { workspace = true }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -20,10 +20,7 @@ name = "solana_svm"
 default = ["metrics"]
 agave-unstable-api = []
 dummy-for-ci-check = ["metrics"]
-dev-context-only-utils = [
-    "dep:qualifier_attr",
-    "solana-program-runtime/dev-context-only-utils",
-]
+dev-context-only-utils = ["dep:qualifier_attr", "solana-program-runtime/dev-context-only-utils"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/tpu-client/Cargo.toml
+++ b/tpu-client/Cargo.toml
@@ -17,11 +17,7 @@ default = ["spinner"]
 agave-unstable-api = []
 # Support tpu-client methods that feature a spinner progress bar for
 # command-line interfaces
-spinner = [
-    "dep:indicatif",
-    "dep:solana-message",
-    "solana-rpc-client/spinner",
-]
+spinner = ["dep:indicatif", "dep:solana-message", "solana-rpc-client/spinner"]
 
 [dependencies]
 bincode = { workspace = true }

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -57,7 +57,7 @@ assert_matches = { workspace = true }
 bencher = { workspace = true }
 bs58 = { workspace = true }
 solana-genesis-config = { workspace = true }
-solana-ledger = { path = "../ledger", features = ["agave-unstable-api","dev-context-only-utils"] }
+solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-signature = { workspace = true, features = ["rand"] }
 solana-transaction = { workspace = true }

--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -25,7 +25,8 @@ log = { workspace = true }
 serde = { workspace = true }
 solana-address = { workspace = true, features = ["curve25519"] }
 solana-bls-signatures = { workspace = true, features = [
-    "bytemuck", "solana-signer-derive",
+    "bytemuck",
+    "solana-signer-derive",
 ] }
 solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }


### PR DESCRIPTION
#### Problem
Using newer cargo sort forces the syntax in `Cargo.toml` files to be normalized.

#### Summary of Changes
Apply re-formatting.
