### PR TITLE
avoid lock contention on quinn connection state

### DIFF
--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -182,7 +182,7 @@ impl SimpleQos {
         mut connection_table_l: MutexGuard<ConnectionTable<TokenBucket>>,
         conn_context: &SimpleQosConnectionContext,
     ) -> Result<(Arc<AtomicU64>, CancellationToken, Arc<TokenBucket>), ConnectionHandlerError> {
-        let remote_addr = connection.remote_address();
+        let remote_addr = conn_context.remote_address;
 
         // this will never overflow u32 for reasonable MAX_RTT
         let rtt = connection.rtt().clamp(MIN_RTT, MAX_RTT).as_millis() as u32;
@@ -291,7 +291,7 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
             const PRUNE_RANDOM_SAMPLE_SIZE: usize = 2;
             let remote_pubkey = conn_context.remote_pubkey()?;
             if self.banlist.is_banned(&remote_pubkey) {
-                let remote_address = connection.remote_address();
+                let remote_address = conn_context.remote_address;
                 info!("Rejecting banned pubkey {remote_pubkey} from {remote_address:?}");
                 self.stats
                     .connection_add_failed_banned
@@ -314,8 +314,7 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
                         debug!(
                             "Pruned {} staked connections to make room for new staked connection \
                              from {}",
-                            num_pruned,
-                            connection.remote_address(),
+                            num_pruned, conn_context.remote_address,
                         );
                         self.stats
                             .num_evictions_staked
@@ -361,7 +360,7 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
     ) -> impl Future<Output = usize> + Send {
         async move {
             let stable_id = connection.stable_id();
-            let remote_addr = connection.remote_address();
+            let remote_addr = conn_context.remote_address;
 
             let mut connection_table = self.staked_connection_table.lock().await;
             let removed_connection_count = connection_table.remove_connection(

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -201,7 +201,7 @@ impl SwQos {
             conn_context.peer_type(),
             conn_context.total_stake,
         ));
-        let remote_addr = connection.remote_address();
+        let remote_addr = conn_context.remote_address;
 
         let max_connections_per_peer = match conn_context.peer_type() {
             ConnectionPeerType::Unstaked => self.config.max_connections_per_unstaked_peer,
@@ -302,13 +302,14 @@ impl SwQos {
 
 impl QosController<SwQosConnectionContext> for SwQos {
     fn build_connection_context(&self, connection: &Connection) -> SwQosConnectionContext {
+        let remote_address = connection.remote_address();
         get_connection_stake(connection, &self.staked_nodes).map_or(
             SwQosConnectionContext {
                 peer_type: ConnectionPeerType::Unstaked,
                 total_stake: 0,
                 remote_pubkey: None,
                 in_staked_table: false,
-                remote_address: connection.remote_address(),
+                remote_address,
                 stream_counter: None,
                 last_update: Arc::new(AtomicU64::new(timing::timestamp())),
             },
@@ -334,7 +335,7 @@ impl QosController<SwQosConnectionContext> for SwQos {
                     total_stake,
                     remote_pubkey: Some(pubkey),
                     in_staked_table: false,
-                    remote_address: connection.remote_address(),
+                    remote_address,
                     last_update: Arc::new(AtomicU64::new(timing::timestamp())),
                     stream_counter: None,
                 }
@@ -476,7 +477,7 @@ impl QosController<SwQosConnectionContext> for SwQos {
             };
 
             let stable_id = connection.stable_id();
-            let remote_addr = connection.remote_address();
+            let remote_addr = conn_context.remote_address;
 
             let removed_count = lock.remove_connection(
                 ConnectionTableKey::new(remote_addr.ip(), conn_context.remote_pubkey()),


### PR DESCRIPTION
#### Problem

When `connection.remote_address()` is called, it internally does `self.0.state.lock("remote_address")...`.

Since connection handling is extremely intensive during leader slots, this may impact performance.

#### Summary of Changes

We already have `remote_address` in `connection_context` everywhere except when `connection_context` is being created.
This PR replaces calls to `remote_address()` with the cached address from `connection_context`.


