### PR TITLE
ledger: Remove `collect()` from `LedgerColumn::multi_get_keys`

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3804,7 +3804,7 @@ impl Blockstore {
         let keys = self.data_shred_cf.multi_get_keys(keys);
         let mut shreds =
             self.data_shred_cf
-                .multi_get_bytes(&keys)
+                .multi_get_bytes(keys)
                 .zip(indices)
                 .map(|(shred, index)| {
                     shred?.ok_or_else(|| {
@@ -3947,7 +3947,7 @@ impl Blockstore {
 
         let deduped_shred_checks: Vec<(Hash, bool)> = self
             .data_shred_cf
-            .multi_get_bytes(&keys)
+            .multi_get_bytes(keys)
             .enumerate()
             .map(|(offset, shred_bytes)| {
                 let shred_bytes = shred_bytes.ok().flatten().ok_or_else(|| {
@@ -3989,7 +3989,7 @@ impl Blockstore {
     /// element's children slots.
     pub fn get_slots_since(&self, slots: &[Slot]) -> Result<HashMap<Slot, Vec<Slot>>> {
         let keys = self.meta_cf.multi_get_keys(slots.iter().copied());
-        let slot_metas = self.meta_cf.multi_get(&keys);
+        let slot_metas = self.meta_cf.multi_get(keys);
 
         let mut slots_since: HashMap<Slot, Vec<Slot>> = HashMap::with_capacity(slots.len());
         for meta in slot_metas.into_iter() {
@@ -5660,7 +5660,7 @@ pub mod tests {
         let keys = blockstore
             .meta_cf
             .multi_get_keys(0..TEST_PUT_ENTRY_COUNT as Slot);
-        let values = blockstore.meta_cf.multi_get(&keys);
+        let values = blockstore.meta_cf.multi_get(keys);
         for (i, value) in values.enumerate().take(TEST_PUT_ENTRY_COUNT) {
             let k = u64::try_from(i).unwrap();
             assert_eq!(

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -355,16 +355,17 @@ impl Rocks {
     }
 
     fn multi_get_cf<'a, K, I>(
-        &self,
+        &'a self,
         cf: &ColumnFamily,
         keys: I,
-    ) -> impl Iterator<Item = Result<Option<DBPinnableSlice<'_>>>> + use<'_, K, I>
+    ) -> impl Iterator<Item = Result<Option<DBPinnableSlice<'a>>>> + use<'a, K, I>
     where
-        K: AsRef<[u8]> + 'a + ?Sized,
-        I: IntoIterator<Item = &'a K>,
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = K>,
     {
+        let key_storage: Vec<K> = keys.into_iter().collect();
         self.db
-            .batched_multi_get_cf(cf, keys, /*sorted_input:*/ false)
+            .batched_multi_get_cf(cf, key_storage.iter(), /*sorted_input:*/ false)
             .into_iter()
             .map(|out| out.map_err(BlockstoreError::RocksDb))
     }
@@ -598,23 +599,22 @@ where
         result
     }
 
-    /// Create a key type suitable for use with multi_get_bytes() and
-    /// multi_get(). Those functions return iterators, so the keys must be
-    /// created with a separate function in order to live long enough
-    pub(crate) fn multi_get_keys<I>(&self, keys: I) -> Vec<<C as Column>::Key>
+    /// Create an iterator over keys suitable for use with multi_get_bytes()
+    /// and multi_get().
+    pub(crate) fn multi_get_keys<I>(
+        &self,
+        keys: I,
+    ) -> impl Iterator<Item = <C as Column>::Key> + use<C, I>
     where
         I: IntoIterator<Item = C::Index>,
     {
-        keys.into_iter().map(|index| C::key(&index)).collect()
+        keys.into_iter().map(|index| C::key(&index))
     }
 
-    pub(crate) fn multi_get_bytes<'a, K>(
+    pub(crate) fn multi_get_bytes<'a>(
         &'a self,
-        keys: impl IntoIterator<Item = &'a K> + 'a,
-    ) -> impl Iterator<Item = Result<Option<BlockstoreByteReference<'a>>>> + 'a
-    where
-        K: AsRef<[u8]> + 'a + ?Sized,
-    {
+        keys: impl IntoIterator<Item = <C as Column>::Key> + 'a,
+    ) -> impl Iterator<Item = Result<Option<BlockstoreByteReference<'a>>>> + 'a {
         let is_perf_enabled = maybe_enable_rocksdb_perf(
             self.column_options.rocks_perf_sample_interval,
             &self.read_perf_status,
@@ -786,13 +786,10 @@ impl<C> LedgerColumn<C>
 where
     C: TypedColumn + ColumnName,
 {
-    pub(crate) fn multi_get<'a, K>(
+    pub(crate) fn multi_get<'a>(
         &'a self,
-        keys: impl IntoIterator<Item = &'a K> + 'a,
-    ) -> impl Iterator<Item = Result<Option<C::Type>>> + 'a
-    where
-        K: AsRef<[u8]> + 'a + ?Sized,
-    {
+        keys: impl IntoIterator<Item = <C as Column>::Key> + 'a,
+    ) -> impl Iterator<Item = Result<Option<C::Type>>> + 'a {
         let is_perf_enabled = maybe_enable_rocksdb_perf(
             self.column_options.rocks_perf_sample_interval,
             &self.read_perf_status,


### PR DESCRIPTION
#### Problem

`LedgerColumn::multi_get_keys` collects the keys to a vector. That's an unnecessary memory allocation, because all the callers of `multi_get_keys` can work with an iterator of keys and do not need an owned collection.

#### Summary of Changes

Instead of returning a vector, return a lazy iterator.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
