### PR TITLE
chore: fix dcou feature cfg condition

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -18,7 +18,7 @@ cargo_build_sbf_sanity() {
   pushd programs/sbf
   # Generate the sanity programs list
   if [ ! -f target/sanity_programs.txt ]; then
-    cargo test --features="sbf_rust,sbf_sanity_list" --test programs test_program_sbf_sanity
+    cargo test --features="sbf_rust,sbf_sanity_list,dev_context_only_utils" --test programs test_program_sbf_sanity
   fi
   mapfile -t rust_programs < <(cat target/sanity_programs.txt)
 
@@ -32,7 +32,7 @@ cargo_build_sbf_sanity() {
   done
   popd
 
-  SBF_OUT_DIR=target/deploy cargo test --features=sbf_rust --test programs test_program_sbf_sanity
+  SBF_OUT_DIR=target/deploy cargo test --features="sbf_rust,dev_context_only_utils" --test programs test_program_sbf_sanity
   popd
 }
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -271,7 +271,7 @@ fn test_program_sbf_sanity() {
         }
     }
 
-    #[cfg(not(feature = "sbf_sanity_list"))]
+    #[cfg(all(not(feature = "sbf_sanity_list"), feature = "dev_context_only_utils"))]
     for program in programs.iter() {
         println!("Test program: {:?}", program.0);
 
@@ -324,7 +324,10 @@ fn test_program_sbf_sanity() {
 }
 
 #[test]
-#[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
+#[cfg(all(
+    any(feature = "sbf_c", feature = "sbf_rust"),
+    feature = "dev_context_only_utils"
+))]
 fn test_program_sbf_loader_deprecated() {
     agave_logger::setup();
 
@@ -460,7 +463,7 @@ fn test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "dev_context_only_utils"))]
 fn test_program_sbf_duplicate_accounts() {
     agave_logger::setup();
 
@@ -574,7 +577,7 @@ fn test_program_sbf_duplicate_accounts() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "dev_context_only_utils"))]
 fn test_program_sbf_error_handling() {
     agave_logger::setup();
 
@@ -669,7 +672,10 @@ fn test_program_sbf_error_handling() {
 }
 
 #[test]
-#[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
+#[cfg(all(
+    any(feature = "sbf_c", feature = "sbf_rust"),
+    feature = "dev_context_only_utils"
+))]
 fn test_return_data_and_log_data_syscall() {
     agave_logger::setup();
 
@@ -1398,7 +1404,7 @@ fn test_program_sbf_invoke_sanity() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "dev_context_only_utils"))]
 fn test_program_sbf_program_id_spoofing() {
     let spoof1_elf = harness::file::load_program_elf("solana_sbf_rust_spoof1");
     let spoof1_system_elf = harness::file::load_program_elf("solana_sbf_rust_spoof1_system");
@@ -1528,7 +1534,7 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "dev_context_only_utils"))]
 fn test_program_sbf_ro_modify() {
     agave_logger::setup();
 
@@ -1579,7 +1585,7 @@ fn test_program_sbf_ro_modify() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "dev_context_only_utils"))]
 fn test_program_sbf_call_depth() {
     agave_logger::setup();
 
@@ -1617,7 +1623,7 @@ fn test_program_sbf_call_depth() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "dev_context_only_utils"))]
 fn test_program_sbf_compute_budget() {
     agave_logger::setup();
 
@@ -1657,6 +1663,7 @@ fn test_program_sbf_compute_budget() {
 }
 
 #[test]
+#[cfg(feature = "dev_context_only_utils")]
 fn assert_instruction_count() {
     agave_logger::setup();
 
@@ -1816,7 +1823,7 @@ fn test_program_sbf_instruction_introspection() {
     [1, 10, 50, 100, 255, 500, 1000, 1024]  // MAX_RETURN_DATA = 1024
 )]
 #[allow(clippy::arithmetic_side_effects)]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "dev_context_only_utils"))]
 fn test_program_sbf_r2_instruction_data_pointer(num_accounts: usize, input_data_len: usize) {
     agave_logger::setup();
 
@@ -2354,7 +2361,10 @@ fn test_program_sbf_invoke_in_same_tx_as_undeployment() {
 }
 
 #[test]
-#[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
+#[cfg(all(
+    any(feature = "sbf_c", feature = "sbf_rust"),
+    feature = "dev_context_only_utils"
+))]
 fn test_program_sbf_disguised_as_sbf_loader() {
     agave_logger::setup();
 
@@ -2406,7 +2416,7 @@ fn test_program_sbf_disguised_as_sbf_loader() {
 }
 
 #[test]
-#[cfg(feature = "sbf_c")]
+#[cfg(all(feature = "sbf_c", feature = "dev_context_only_utils"))]
 fn test_program_reads_from_program_account() {
     use solana_loader_v4_interface::state::LoaderV4State;
     agave_logger::setup();
@@ -2467,7 +2477,7 @@ fn test_program_reads_from_program_account() {
 }
 
 #[test]
-#[cfg(feature = "sbf_c")]
+#[cfg(all(feature = "sbf_c", feature = "dev_context_only_utils"))]
 fn test_program_sbf_c_dup() {
     agave_logger::setup();
 
@@ -2711,7 +2721,7 @@ fn test_program_sbf_upgrade_via_cpi() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "dev_context_only_utils"))]
 fn test_program_sbf_ro_account_modify() {
     agave_logger::setup();
 
@@ -4677,7 +4687,7 @@ fn test_deplete_cost_meter_with_access_violation() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "dev_context_only_utils"))]
 fn test_program_sbf_deplete_cost_meter_with_divide_by_zero() {
     agave_logger::setup();
 
@@ -5759,7 +5769,7 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
     [1, 10, 50, 100, 255, 500, 1000, 1024]
 )]
 #[allow(clippy::arithmetic_side_effects)]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "dev_context_only_utils"))]
 fn test_program_sbf_rust_direct_account_pointers(num_accounts: usize, input_data_len: usize) {
     agave_logger::setup();
 

--- a/svm-test-harness/Cargo.toml
+++ b/svm-test-harness/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 [[bin]]
 name = "test_exec_instr"
 path = "bin/test_exec_instr.rs"
-required-features = ["fuzz"]
+required-features = ["fuzz", "dev-context-only-utils"]
 
 [features]
 agave-unstable-api = []

--- a/svm-test-harness/instr/Cargo.toml
+++ b/svm-test-harness/instr/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = []
+dev-context-only-utils = ["solana-program-runtime/dev-context-only-utils"]
 dummy-for-ci-check = ["fuzz"]
 metrics = ["solana-program-runtime/metrics", "solana-svm/metrics"]
 fuzz = [
@@ -38,7 +38,7 @@ solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true, features = ["serde"] }
 solana-loader-v4-interface = { workspace = true }
 solana-precompile-error = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true, features = ["sysvar"] }
 solana-sdk-ids = { workspace = true }

--- a/svm-test-harness/instr/src/fuzz.rs
+++ b/svm-test-harness/instr/src/fuzz.rs
@@ -1,8 +1,9 @@
 #![allow(clippy::missing_safety_doc)]
 
+#[cfg(feature = "dev-context-only-utils")]
+use crate::execute_instr_with_callback;
 use {
     crate::{
-        execute_instr_with_callback,
         fixture::{
             instr_context::InstrContext,
             proto::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
@@ -62,6 +63,7 @@ pub unsafe extern "C" fn sol_compat_init(_log_level: i32) {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sol_compat_fini() {}
 
+#[cfg(feature = "dev-context-only-utils")]
 pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects> {
     let cu_avail = input.cu_avail;
 
@@ -120,6 +122,7 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects
     instr_effects.map(Into::into)
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sol_compat_instr_execute_v1(
     out_ptr: *mut u8,

--- a/svm-test-harness/instr/src/lib.rs
+++ b/svm-test-harness/instr/src/lib.rs
@@ -4,16 +4,18 @@
 //! execute program instructions directly against the VM.
 
 pub mod file;
-mod harness;
 pub mod keyed_account;
 pub mod logger;
 pub mod program_cache;
 pub mod sysvar_cache;
 
-pub use {
-    harness::{execute_instr, execute_instr_with_callback},
-    solana_svm_test_harness_fixture as fixture,
-};
+pub use solana_svm_test_harness_fixture as fixture;
 
-#[cfg(feature = "fuzz")]
+#[cfg(all(feature = "fuzz", feature = "dev-context-only-utils"))]
 pub mod fuzz;
+
+#[cfg(feature = "dev-context-only-utils")]
+mod harness;
+
+#[cfg(feature = "dev-context-only-utils")]
+pub use harness::{execute_instr, execute_instr_with_callback};

--- a/svm-test-harness/src/lib.rs
+++ b/svm-test-harness/src/lib.rs
@@ -1,3 +1,5 @@
 //! Solana SVM test harness.
 
-pub use {solana_svm_test_harness_fixture as fixture, solana_svm_test_harness_instr as instr};
+pub use solana_svm_test_harness_fixture as fixture;
+#[cfg(feature = "dev-context-only-utils")]
+pub use solana_svm_test_harness_instr as instr;


### PR DESCRIPTION
#### Problem

secondary pipeline is red: https://buildkite.com/anza/agave-secondary/builds/3610#019cddf6-7bf1-4218-9484-eb183c8d3e6f/L76

looks like we accidentally enabled dcou for crates where it's not allowed.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
