### PR TITLE
Remove noisy info logging in block-production

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1875,8 +1875,8 @@ impl Default for ConsumeWorkerCountMetrics {
 
 impl ConsumeWorkerCountMetrics {
     fn report_and_reset(&self, id: &str) {
-        datapoint_info!(
-            "banking_stage_worker_counts",
+        let datapoint = create_datapoint!(
+            @point "banking_stage_worker_counts",
             "id" => id,
             ("max_queue_len", self.max_queue_len.swap(0, Ordering::Relaxed), i64),
             (
@@ -1929,6 +1929,7 @@ impl ConsumeWorkerCountMetrics {
                 i64
             ),
         );
+        solana_metrics::submit(datapoint, log::Level::Trace);
     }
 }
 
@@ -1947,8 +1948,8 @@ struct ConsumeWorkerTimingMetrics {
 
 impl ConsumeWorkerTimingMetrics {
     fn report_and_reset(&self, id: &str) {
-        datapoint_info!(
-            "banking_stage_worker_timing",
+        let datapoint = create_datapoint!(
+            @point "banking_stage_worker_timing",
             "id" => id,
             (
                 "cost_model_us",
@@ -1988,6 +1989,7 @@ impl ConsumeWorkerTimingMetrics {
                 i64
             ),
         );
+        solana_metrics::submit(datapoint, log::Level::Trace);
     }
 }
 
@@ -2021,8 +2023,8 @@ struct ConsumeWorkerTransactionErrorMetrics {
 
 impl ConsumeWorkerTransactionErrorMetrics {
     fn report_and_reset(&self, id: &str) {
-        datapoint_info!(
-            "banking_stage_worker_error_metrics",
+        let datapoint = create_datapoint!(
+            @point "banking_stage_worker_error_metrics",
             "id" => id,
             ("total", self.total.swap(0, Ordering::Relaxed), i64),
             (
@@ -2132,6 +2134,7 @@ impl ConsumeWorkerTransactionErrorMetrics {
                 i64
             ),
         );
+        solana_metrics::submit(datapoint, log::Level::Trace);
     }
 }
 

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -450,8 +450,8 @@ impl SchedulingDetails {
                     self.sum_starting_queue_size / self.num_schedule_calls;
                 let avg_starting_buffer_size =
                     self.sum_starting_buffer_size / self.num_schedule_calls;
-                datapoint_info!(
-                    "scheduling_details",
+                let datapoint = create_datapoint!(
+                    @point "scheduling_details",
                     ("num_schedule_calls", self.num_schedule_calls, i64),
                     ("min_starting_queue_size", self.min_starting_queue_size, i64),
                     ("max_starting_queue_size", self.max_starting_queue_size, i64),
@@ -479,6 +479,7 @@ impl SchedulingDetails {
                         i64
                     ),
                 );
+                solana_metrics::submit(datapoint, log::Level::Trace);
                 *self = Self {
                     last_report: now,
                     ..Self::default()


### PR DESCRIPTION
#### Problem
- some metrics for workers and scheduler are submitted on 20ms intervals
- using the datapoint_info! macro makes this crowd the logs 

#### Summary of Changes
- Use create_datapoint! macro to manually submit datapoints with trace level
	- Unlike datapoint_trace! this submits the metric **regardless** of the enabled log level. And only logs it if trace logging is enabled.

Fixes #11069
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
