### PR TITLE
Cleanup: Remove `program_indices`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -465,12 +465,9 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
     pub fn prepare_top_level_instructions(
         &mut self,
         message: &'ix_data impl SVMMessage,
-        program_indices: &[IndexOfAccount],
     ) -> Result<(), (u8, InstructionError)> {
-        for (top_level_instruction_index, ((_, instruction), program_account_index)) in message
-            .program_instructions_iter()
-            .zip(program_indices.iter())
-            .enumerate()
+        for (top_level_instruction_index, (_, instruction)) in
+            message.program_instructions_iter().enumerate()
         {
             let mut transaction_callee_map: Vec<u16> = vec![u16::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
 
@@ -496,7 +493,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             self.transaction_context
                 .configure_instruction_at_index(
                     top_level_instruction_index,
-                    *program_account_index,
+                    instruction.program_id_index as u16,
                     instruction_accounts,
                     transaction_callee_map,
                     Cow::Borrowed(instruction.data),
@@ -1027,10 +1024,8 @@ pub fn mock_process_instruction_with_feature_set<
 
     pre_adjustments(&mut invoke_context);
 
-    let compiled_ix = sanitized_message.instructions().first().unwrap();
-    let program_account_index = compiled_ix.program_id_index as u16;
     invoke_context
-        .prepare_top_level_instructions(&sanitized_message, &[program_account_index])
+        .prepare_top_level_instructions(&sanitized_message)
         .unwrap();
 
     let result = invoke_context.process_instruction(&mut 0, &mut ExecuteTimings::default());
@@ -1668,7 +1663,7 @@ mod tests {
         }
 
         invoke_context
-            .prepare_top_level_instructions(&sanitized, &[90, 90])
+            .prepare_top_level_instructions(&sanitized)
             .unwrap();
 
         test_case_1(&invoke_context);
@@ -1735,7 +1730,7 @@ mod tests {
                 .unwrap();
 
         invoke_context
-            .prepare_top_level_instructions(&sanitized, &[90, 90])
+            .prepare_top_level_instructions(&sanitized)
             .unwrap();
 
         {

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -245,7 +245,6 @@ mod tests {
 
         let loaded0 = LoadedTransaction {
             accounts: transaction_accounts0,
-            program_indices: vec![],
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),
@@ -254,7 +253,6 @@ mod tests {
 
         let loaded1 = LoadedTransaction {
             accounts: transaction_accounts1,
-            program_indices: vec![],
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),
@@ -317,7 +315,6 @@ mod tests {
 
         let loaded = LoadedTransaction {
             accounts: transaction_accounts,
-            program_indices: vec![],
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::FeePayerOnly {
                 fee_payer: (from_address, from_account_pre.clone()),
@@ -408,7 +405,6 @@ mod tests {
 
         let loaded = LoadedTransaction {
             accounts: transaction_accounts,
-            program_indices: vec![],
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::SeparateNonceAndFeePayer {
                 nonce: (nonce_address, nonce_account_pre.clone()),
@@ -516,7 +512,6 @@ mod tests {
 
         let loaded = LoadedTransaction {
             accounts: transaction_accounts,
-            program_indices: vec![],
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::SameNonceAndFeePayer {
                 nonce: (nonce_address, nonce_account_pre.clone()),

--- a/svm-test-harness/instr/src/harness.rs
+++ b/svm-test-harness/instr/src/harness.rs
@@ -108,11 +108,8 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
             compute_budget.to_cost(),
         );
 
-        let compiled_ix = sanitized_message.instructions().first()?;
-        let program_account_index = compiled_ix.program_id_index as u16;
-
         invoke_context
-            .prepare_top_level_instructions(&sanitized_message, &[program_account_index])
+            .prepare_top_level_instructions(&sanitized_message)
             .ok()?;
 
         if invoke_context.is_precompile(&input.instruction.program_id) {

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -135,11 +135,10 @@ pub(crate) struct LoadedTransactionAccount {
 #[cfg_attr(feature = "dev-context-only-utils", derive(Default))]
 #[cfg_attr(
     feature = "dev-context-only-utils",
-    field_qualifiers(program_indices(pub), compute_budget(pub))
+    field_qualifiers(compute_budget(pub))
 )]
 pub struct LoadedTransaction {
     pub accounts: Vec<KeyedAccountSharedData>,
-    pub(crate) program_indices: Vec<IndexOfAccount>,
     pub fee_details: FeeDetails,
     pub rollback_accounts: RollbackAccounts,
     pub(crate) compute_budget: SVMTransactionExecutionBudget,
@@ -422,7 +421,6 @@ pub(crate) fn load_transaction<CB: TransactionProcessingCallback>(
             match load_result {
                 Ok(loaded_tx_accounts) => TransactionLoadResult::Loaded(LoadedTransaction {
                     accounts: loaded_tx_accounts.accounts,
-                    program_indices: loaded_tx_accounts.program_indices,
                     fee_details: tx_details.fee_details,
                     rollback_accounts: tx_details.rollback_accounts,
                     compute_budget: tx_details.compute_budget,
@@ -441,7 +439,6 @@ pub(crate) fn load_transaction<CB: TransactionProcessingCallback>(
 #[derive(PartialEq, Eq, Debug, Clone)]
 struct LoadedTransactionAccounts {
     pub(crate) accounts: Vec<KeyedAccountSharedData>,
-    pub(crate) program_indices: Vec<IndexOfAccount>,
     pub(crate) loaded_accounts_data_size: u32,
 }
 
@@ -483,7 +480,6 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
 
     let mut loaded_transaction_accounts = LoadedTransactionAccounts {
         accounts: Vec::with_capacity(account_keys.len()),
-        program_indices: Vec::with_capacity(message.num_instructions()),
         loaded_accounts_data_size: 0,
     };
 
@@ -565,7 +561,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
         collect_loaded_account(account_loader, account_key, loaded_account)?;
     }
 
-    for (program_id, instruction) in message.program_instructions_iter() {
+    for (program_id, _) in message.program_instructions_iter() {
         let Some(program_account) = account_loader.load_account(program_id) else {
             error_metrics.account_not_found += 1;
             return Err(TransactionError::ProgramAccountNotFound);
@@ -576,10 +572,6 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
             error_metrics.invalid_program_for_execution += 1;
             return Err(TransactionError::InvalidProgramForExecution);
         }
-
-        loaded_transaction_accounts
-            .program_indices
-            .push(instruction.program_id_index as IndexOfAccount);
     }
 
     Ok(loaded_transaction_accounts)
@@ -966,8 +958,6 @@ mod tests {
                 assert_eq!(loaded_transaction.accounts.len(), 2);
                 assert_eq!(loaded_transaction.accounts[0].1, accounts[0].1);
                 assert_eq!(loaded_transaction.accounts[1].1, accounts[1].1);
-                assert_eq!(loaded_transaction.program_indices.len(), 1);
-                assert_eq!(loaded_transaction.program_indices[0], 1);
             }
             TransactionLoadResult::FeesOnly(fees_only_tx) => panic!("{}", fees_only_tx.load_error),
             TransactionLoadResult::NotLoaded(e) => panic!("{e}"),
@@ -1026,9 +1016,6 @@ mod tests {
             TransactionLoadResult::Loaded(loaded_transaction) => {
                 assert_eq!(loaded_transaction.accounts.len(), 3);
                 assert_eq!(loaded_transaction.accounts[0].1, accounts[0].1);
-                assert_eq!(loaded_transaction.program_indices.len(), 2);
-                assert_eq!(loaded_transaction.program_indices[0], 1);
-                assert_eq!(loaded_transaction.program_indices[1], 2);
             }
             TransactionLoadResult::FeesOnly(fees_only_tx) => panic!("{}", fees_only_tx.load_error),
             TransactionLoadResult::NotLoaded(e) => panic!("{e}"),
@@ -1140,7 +1127,6 @@ mod tests {
         let mut error_metrics = TransactionErrorMetrics::default();
         let mut acc = LoadedTransactionAccounts {
             accounts: vec![],
-            program_indices: vec![],
             loaded_accounts_data_size: 0,
         };
 
@@ -1360,7 +1346,6 @@ mod tests {
             result.unwrap(),
             LoadedTransactionAccounts {
                 accounts: vec![(fee_payer_address, fee_payer_account)],
-                program_indices: vec![],
                 loaded_accounts_data_size: 0,
             }
         );
@@ -1574,7 +1559,6 @@ mod tests {
                         mock_bank.accounts_map[&key1.pubkey()].0.clone()
                     ),
                 ],
-                program_indices: vec![1],
                 loaded_accounts_data_size,
             }
         );
@@ -1762,7 +1746,6 @@ mod tests {
                         mock_bank.accounts_map[&key1.pubkey()].0.clone()
                     ),
                 ],
-                program_indices: vec![1],
                 loaded_accounts_data_size,
             }
         );
@@ -1852,7 +1835,6 @@ mod tests {
                     ),
                     (key3.pubkey(), account_data),
                 ],
-                program_indices: vec![1, 1],
                 loaded_accounts_data_size,
             }
         );
@@ -2011,7 +1993,6 @@ mod tests {
                     ),
                     (key3.pubkey(), account_data),
                 ],
-                program_indices: vec![1, 1],
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
                 compute_budget: SVMTransactionExecutionBudget::default(),

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -103,7 +103,6 @@ mod tests {
         solana_signer::Signer,
         solana_svm_callback::InvokeContextCallback,
         solana_svm_feature_set::SVMFeatureSet,
-        solana_svm_transaction::svm_message::SVMStaticMessage,
         solana_transaction_context::transaction::TransactionContext,
         std::{
             collections::{HashMap, HashSet},

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -3,7 +3,6 @@ use {
     solana_svm_measure::measure_us,
     solana_svm_timings::{ExecuteDetailsTimings, ExecuteTimings},
     solana_svm_transaction::svm_message::SVMMessage,
-    solana_transaction_context::IndexOfAccount,
     solana_transaction_error::TransactionError,
 };
 
@@ -14,15 +13,12 @@ use {
 /// The accounts are committed back to the bank only if every instruction succeeds.
 pub(crate) fn process_message<'ix_data>(
     message: &'ix_data impl SVMMessage,
-    program_indices: &[IndexOfAccount],
     invoke_context: &mut InvokeContext<'_, 'ix_data>,
     execute_timings: &mut ExecuteTimings,
     accumulated_consumed_units: &mut u64,
 ) -> Result<(), TransactionError> {
-    debug_assert_eq!(program_indices.len(), message.num_instructions());
-
     invoke_context
-        .prepare_top_level_instructions(message, program_indices)
+        .prepare_top_level_instructions(message)
         .map_err(|(ix_idx, err)| TransactionError::InstructionError(ix_idx, err))?;
 
     for (top_level_instruction_index, (program_id, instruction)) in
@@ -84,7 +80,7 @@ mod tests {
         solana_ed25519_program::new_ed25519_instruction_with_signature,
         solana_hash::Hash,
         solana_instruction::{AccountMeta, Instruction, error::InstructionError},
-        solana_keypair::Keypair,
+        solana_keypair::{Address, Keypair},
         solana_message::{AccountKeys, Message, SanitizedMessage},
         solana_precompile_error::PrecompileError,
         solana_program_runtime::{
@@ -107,8 +103,12 @@ mod tests {
         solana_signer::Signer,
         solana_svm_callback::InvokeContextCallback,
         solana_svm_feature_set::SVMFeatureSet,
+        solana_svm_transaction::svm_message::SVMStaticMessage,
         solana_transaction_context::transaction::TransactionContext,
-        std::{collections::HashSet, sync::Arc},
+        std::{
+            collections::{HashMap, HashSet},
+            sync::Arc,
+        },
     };
 
     struct MockCallback {}
@@ -186,7 +186,6 @@ mod tests {
         ];
         let mut transaction_context =
             TransactionContext::new(accounts.clone(), Rent::default(), 1, 3, 1);
-        let program_indices = vec![2];
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             mock_system_program_id,
@@ -240,7 +239,6 @@ mod tests {
         );
         let result = process_message(
             &message,
-            &program_indices,
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,
@@ -299,7 +297,6 @@ mod tests {
         );
         let result = process_message(
             &message,
-            &program_indices,
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,
@@ -347,7 +344,6 @@ mod tests {
         );
         let result = process_message(
             &message,
-            &program_indices,
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,
@@ -432,7 +428,6 @@ mod tests {
         ];
         let mut transaction_context =
             TransactionContext::new(accounts.clone(), Rent::default(), 1, 3, 1);
-        let program_indices = vec![2];
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             mock_program_id,
@@ -484,7 +479,6 @@ mod tests {
         );
         let result = process_message(
             &message,
-            &program_indices,
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,
@@ -528,7 +522,6 @@ mod tests {
         );
         let result = process_message(
             &message,
-            &program_indices,
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,
@@ -568,7 +561,6 @@ mod tests {
         );
         let result = process_message(
             &message,
-            &program_indices,
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,
@@ -650,17 +642,18 @@ mod tests {
         secp256r1_account.set_executable(true);
         let mut mock_program_account = AccountSharedData::new(1, 0, &native_loader::id());
         mock_program_account.set_executable(true);
-        let accounts = vec![
+
+        let fee_payer = Pubkey::new_unique();
+        let accounts_map: HashMap<Address, AccountSharedData> = HashMap::from([
             (
-                Pubkey::new_unique(),
+                fee_payer,
                 AccountSharedData::new(1, 0, &system_program::id()),
             ),
             (secp256k1_program::id(), secp256k1_account),
             (ed25519_program::id(), ed25519_account),
             (solana_secp256r1_program::id(), secp256r1_account),
             (mock_program_id, mock_program_account),
-        ];
-        let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 4, 4);
+        ]);
 
         let message = new_sanitized_message(Message::new(
             &[
@@ -669,8 +662,16 @@ mod tests {
                 secp256r1_instruction_for_test(),
                 Instruction::new_with_bytes(mock_program_id, &[], vec![]),
             ],
-            Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
+            Some(&fee_payer),
         ));
+
+        let accounts = message
+            .account_keys()
+            .iter()
+            .map(|key| (*key, accounts_map.get(key).unwrap().clone()))
+            .collect();
+        let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 4, 4);
+
         let sysvar_cache = SysvarCache::default();
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
@@ -718,9 +719,13 @@ mod tests {
             SVMTransactionExecutionBudget::default(),
             SVMTransactionExecutionCost::default(),
         );
+
+        for item in message.instructions_iter() {
+            std::println!("pid: {}", item.program_id_index);
+        }
+
         let result = process_message(
             &message,
-            &[1, 2, 3, 4],
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -719,11 +719,6 @@ mod tests {
             SVMTransactionExecutionBudget::default(),
             SVMTransactionExecutionCost::default(),
         );
-
-        for item in message.instructions_iter() {
-            std::println!("pid: {}", item.program_id_index);
-        }
-
         let result = process_message(
             &message,
             &mut invoke_context,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -982,7 +982,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let mut process_message_time = Measure::start("process_message_time");
         let process_result = process_message(
             tx,
-            &loaded_transaction.program_indices,
             &mut invoke_context,
             execute_timings,
             &mut executed_units,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1544,7 +1544,6 @@ mod tests {
 
         let loaded_transaction = LoadedTransaction {
             accounts: vec![(Pubkey::new_unique(), AccountSharedData::default())],
-            program_indices: vec![0],
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),
@@ -1639,7 +1638,6 @@ mod tests {
                 (key1, AccountSharedData::default()),
                 (key2, AccountSharedData::default()),
             ],
-            program_indices: vec![0],
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),


### PR DESCRIPTION
#### Problem

As @buffalojoec indicated in https://github.com/anza-xyz/agave/pull/10557#discussion_r2907032413, `program_indices` are not necessary in `process_message`, `prepare_top_level_instructions` and in any of the data structures `LoadedTransaction` and `LoadedTransactionAccounts`, because `SVMMessage` already returns the index of the program account in the transaction.

#### Summary of Changes

1. Remove the extra parameter from functions and simplify to inner loops.
2. Remove the parameter form the data structures and adjust tests.