### PR TITLE
Refactor - Wrap ProgramRuntimeEnvironment in a newtype

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -3218,9 +3218,11 @@ fn verify_elf(
         false,
     )
     .unwrap();
-    let executable =
-        Executable::<InvokeContext>::from_elf(program_data, Arc::new(program_runtime_environment))
-            .map_err(|err| format!("ELF error: {err}"))?;
+    let executable = Executable::<InvokeContext>::from_elf(
+        program_data,
+        program_runtime_environment.inner().clone(),
+    )
+    .map_err(|err| format!("ELF error: {err}"))?;
 
     executable
         .verify::<RequisiteVerifier>()

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -3220,7 +3220,7 @@ fn verify_elf(
     .unwrap();
     let executable = Executable::<InvokeContext>::from_elf(
         program_data,
-        program_runtime_environment.inner().clone(),
+        Arc::clone(&*program_runtime_environment),
     )
     .map_err(|err| format!("ELF error: {err}"))?;
 

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -767,9 +767,11 @@ pub async fn process_deploy_program(
         )
         .into());
     }
-    let executable =
-        Executable::<InvokeContext>::from_elf(program_data, Arc::new(program_runtime_environment))
-            .map_err(|err| format!("ELF error: {err}"))?;
+    let executable = Executable::<InvokeContext>::from_elf(
+        program_data,
+        program_runtime_environment.inner().clone(),
+    )
+    .map_err(|err| format!("ELF error: {err}"))?;
     executable
         .verify::<RequisiteVerifier>()
         .map_err(|err| format!("ELF error: {err}"))?;

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -769,7 +769,7 @@ pub async fn process_deploy_program(
     }
     let executable = Executable::<InvokeContext>::from_elf(
         program_data,
-        program_runtime_environment.inner().clone(),
+        Arc::clone(&*program_runtime_environment),
     )
     .map_err(|err| format!("ELF error: {err}"))?;
     executable

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -285,7 +285,7 @@ fn load_program<'a>(
     let mut verified_executable = if is_elf {
         let result = ProgramCacheEntry::new(
             &loader_key,
-            Arc::new(program_runtime_environment),
+            program_runtime_environment.clone(),
             slot,
             slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
             &contents,
@@ -302,7 +302,7 @@ fn load_program<'a>(
     } else {
         assemble::<InvokeContext>(
             std::str::from_utf8(contents.as_slice()).unwrap(),
-            Arc::new(program_runtime_environment),
+            program_runtime_environment.inner().clone(),
         )
         .map_err(|err| format!("Assembling executable failed: {err:?}"))
         .and_then(|executable| {

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -302,7 +302,7 @@ fn load_program<'a>(
     } else {
         assemble::<InvokeContext>(
             std::str::from_utf8(contents.as_slice()).unwrap(),
-            program_runtime_environment.inner().clone(),
+            Arc::clone(&*program_runtime_environment),
         )
         .map_err(|err| format!("Assembling executable failed: {err:?}"))
         .and_then(|executable| {

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -17,7 +17,7 @@ use {
         invoke_context::InvokeContext,
         loaded_programs::{
             DELAY_VISIBILITY_SLOT_OFFSET, LoadProgramMetrics, ProgramCacheEntry,
-            ProgramCacheEntryType,
+            ProgramCacheEntryType, ProgramRuntimeEnvironment,
         },
         serialization::serialize_parameters,
         with_mock_invoke_context,
@@ -285,7 +285,7 @@ fn load_program<'a>(
     let mut verified_executable = if is_elf {
         let result = ProgramCacheEntry::new(
             &loader_key,
-            program_runtime_environment.clone(),
+            ProgramRuntimeEnvironment::clone(&program_runtime_environment),
             slot,
             slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
             &contents,

--- a/program-runtime/src/deploy.rs
+++ b/program-runtime/src/deploy.rs
@@ -26,7 +26,7 @@ use {
 fn morph_into_deployment_environment(
     from: ProgramRuntimeEnvironment,
 ) -> Result<BuiltinProgram<InvokeContext<'static, 'static>>, ElfError> {
-    let mut config = from.get_config().clone();
+    let mut config = from.inner().get_config().clone();
     config.reject_broken_elfs = true;
     // Once the tests are being build using a toolchain which supports the newer SBPF versions,
     // the deployment of older versions will be disabled:
@@ -35,7 +35,7 @@ fn morph_into_deployment_environment(
 
     let mut result = BuiltinProgram::new_loader(config);
 
-    for (_key, (name, value)) in from.get_function_registry().iter() {
+    for (_key, (name, value)) in from.inner().get_function_registry().iter() {
         // Deployment of programs with sol_alloc_free is disabled. So do not register the syscall.
         if name != *b"sol_alloc_free_" {
             result.register_function(unsafe { std::str::from_utf8_unchecked(name) }, value)?;

--- a/program-runtime/src/deploy.rs
+++ b/program-runtime/src/deploy.rs
@@ -24,7 +24,7 @@ use {
 };
 
 fn morph_into_deployment_environment<'a>(
-    from: Arc<BuiltinProgram<InvokeContext<'a, 'a>>>,
+    from: ProgramRuntimeEnvironment,
 ) -> Result<BuiltinProgram<InvokeContext<'a, 'a>>, ElfError> {
     let mut config = from.get_config().clone();
     config.reject_broken_elfs = true;

--- a/program-runtime/src/deploy.rs
+++ b/program-runtime/src/deploy.rs
@@ -23,9 +23,9 @@ use {
     std::{cell::RefCell, rc::Rc},
 };
 
-fn morph_into_deployment_environment<'a>(
+fn morph_into_deployment_environment(
     from: ProgramRuntimeEnvironment,
-) -> Result<BuiltinProgram<InvokeContext<'a, 'a>>, ElfError> {
+) -> Result<BuiltinProgram<InvokeContext<'static, 'static>>, ElfError> {
     let mut config = from.get_config().clone();
     config.reject_broken_elfs = true;
     // Once the tests are being build using a toolchain which supports the newer SBPF versions,

--- a/program-runtime/src/deploy.rs
+++ b/program-runtime/src/deploy.rs
@@ -26,7 +26,7 @@ use {
 fn morph_into_deployment_environment(
     from: ProgramRuntimeEnvironment,
 ) -> Result<BuiltinProgram<InvokeContext<'static, 'static>>, ElfError> {
-    let mut config = from.inner().get_config().clone();
+    let mut config = (*from).get_config().clone();
     config.reject_broken_elfs = true;
     // Once the tests are being build using a toolchain which supports the newer SBPF versions,
     // the deployment of older versions will be disabled:
@@ -35,7 +35,7 @@ fn morph_into_deployment_environment(
 
     let mut result = BuiltinProgram::new_loader(config);
 
-    for (_key, (name, value)) in from.inner().get_function_registry().iter() {
+    for (_key, (name, value)) in (*from).get_function_registry().iter() {
         // Deployment of programs with sol_alloc_free is disabled. So do not register the syscall.
         if name != *b"sol_alloc_free_" {
             result.register_function(unsafe { std::str::from_utf8_unchecked(name) }, value)?;

--- a/program-runtime/src/deploy.rs
+++ b/program-runtime/src/deploy.rs
@@ -61,11 +61,13 @@ pub fn deploy_program(
 ) -> Result<(), InstructionError> {
     #[cfg(feature = "metrics")]
     let mut register_syscalls_time = Measure::start("register_syscalls_time");
-    let deployment_program_runtime_environment =
-        morph_into_deployment_environment(program_runtime_environment.clone()).map_err(|e| {
-            ic_logger_msg!(log_collector, "Failed to register syscalls: {}", e);
-            InstructionError::ProgramEnvironmentSetupFailure
-        })?;
+    let deployment_program_runtime_environment = morph_into_deployment_environment(
+        ProgramRuntimeEnvironment::clone(&program_runtime_environment),
+    )
+    .map_err(|e| {
+        ic_logger_msg!(log_collector, "Failed to register syscalls: {}", e);
+        InstructionError::ProgramEnvironmentSetupFailure
+    })?;
     #[cfg(feature = "metrics")]
     {
         register_syscalls_time.stop();

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -586,6 +586,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         let mut vm = EbpfVm::new(
             self.environment_config
                 .program_runtime_environment_for_execution
+                .inner()
                 .clone(),
             SBPFVersion::V0,
             // Removes lifetime tracking

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -584,10 +584,11 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         let empty_memory_mapping =
             MemoryMapping::new(Vec::new(), &mock_config, SBPFVersion::V0).unwrap();
         let mut vm = EbpfVm::new(
-            self.environment_config
-                .program_runtime_environment_for_execution
-                .inner()
-                .clone(),
+            Arc::clone(
+                &*self
+                    .environment_config
+                    .program_runtime_environment_for_execution,
+            ),
             SBPFVersion::V0,
             // Removes lifetime tracking
             unsafe { std::mem::transmute::<&mut InvokeContext, &mut InvokeContext>(self) },

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -6,7 +6,6 @@ use {
     solana_instruction::AccountMeta,
     solana_message::{LegacyMessage, Message, SanitizedMessage},
     solana_sdk_ids::sysvar,
-    solana_svm_type_overrides::sync::Arc,
     solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
     std::collections::{HashMap, HashSet},
 };
@@ -39,6 +38,7 @@ use {
     solana_svm_measure::measure::Measure,
     solana_svm_timings::{ExecuteDetailsTimings, ExecuteTimings},
     solana_svm_transaction::svm_message::SVMMessage,
+    solana_svm_type_overrides::sync::Arc,
     solana_transaction_context::{
         IndexOfAccount, MAX_ACCOUNTS_PER_TRANSACTION, instruction::InstructionContext,
         instruction_accounts::InstructionAccount, transaction::TransactionContext,
@@ -585,7 +585,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             MemoryMapping::new(Vec::new(), &mock_config, SBPFVersion::V0).unwrap();
         let mut vm = EbpfVm::new(
             Arc::clone(
-                &*self
+                &**self
                     .environment_config
                     .program_runtime_environment_for_execution,
             ),

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -346,7 +346,7 @@ impl ProgramCacheEntry {
     /// hasn't changed since it was unloaded.
     pub unsafe fn reload(
         loader_key: &Pubkey,
-        program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static, 'static>>>,
+        program_runtime_environment: ProgramRuntimeEnvironment,
         deployment_slot: Slot,
         effective_slot: Slot,
         elf_bytes: &[u8],
@@ -368,7 +368,7 @@ impl ProgramCacheEntry {
 
     fn new_internal(
         loader_key: &Pubkey,
-        program_runtime_environment: Arc<BuiltinProgram<InvokeContext<'static, 'static>>>,
+        program_runtime_environment: ProgramRuntimeEnvironment,
         deployment_slot: Slot,
         effective_slot: Slot,
         elf_bytes: &[u8],

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -25,13 +25,41 @@ use {
 #[cfg(feature = "metrics")]
 use {solana_svm_measure::measure::Measure, solana_svm_timings::ExecuteDetailsTimings};
 
-pub type ProgramRuntimeEnvironment = Arc<BuiltinProgram<InvokeContext<'static, 'static>>>;
+#[derive(Clone, Debug)]
+pub struct ProgramRuntimeEnvironment(Arc<BuiltinProgram<InvokeContext<'static, 'static>>>);
+impl std::hash::Hash for ProgramRuntimeEnvironment {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        Arc::<BuiltinProgram<InvokeContext<'static, 'static>>>::as_ptr(&self.0).hash(state);
+    }
+}
+impl PartialEq for ProgramRuntimeEnvironment {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+impl Eq for ProgramRuntimeEnvironment {}
+impl ProgramRuntimeEnvironment {
+    pub fn from(inner: BuiltinProgram<InvokeContext<'static, 'static>>) -> Self {
+        Self(Arc::new(inner))
+    }
+
+    pub const fn from_ref<'a>(
+        inner: &'a Arc<BuiltinProgram<InvokeContext<'static, 'static>>>,
+    ) -> &'a Self {
+        // Safety: This wrapper type is transparent and shares the same representation as the underlying type
+        unsafe { std::mem::transmute(inner) }
+    }
+
+    pub fn inner(&self) -> &Arc<BuiltinProgram<InvokeContext<'static, 'static>>> {
+        &self.0
+    }
+}
 #[cfg(feature = "dev-context-only-utils")]
 pub fn get_mock_program_runtime_environment() -> ProgramRuntimeEnvironment {
     static MOCK_ENVIRONMENT: std::sync::OnceLock<ProgramRuntimeEnvironment> =
         std::sync::OnceLock::<ProgramRuntimeEnvironment>::new();
     MOCK_ENVIRONMENT
-        .get_or_init(|| Arc::new(BuiltinProgram::new_mock()))
+        .get_or_init(|| ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock()))
         .clone()
 }
 
@@ -177,7 +205,9 @@ impl ProgramCacheEntryType {
     /// Returns a reference to its environment if it has one
     pub fn get_environment(&self) -> Option<&ProgramRuntimeEnvironment> {
         match self {
-            ProgramCacheEntryType::Loaded(program) => Some(program.get_loader()),
+            ProgramCacheEntryType::Loaded(program) => {
+                Some(ProgramRuntimeEnvironment::from_ref(program.get_loader()))
+            }
             ProgramCacheEntryType::FailedVerification(env)
             | ProgramCacheEntryType::Unloaded(env) => Some(env),
             _ => None,
@@ -378,7 +408,7 @@ impl ProgramCacheEntry {
     ) -> Result<Self, Box<dyn std::error::Error>> {
         #[cfg(feature = "metrics")]
         let load_elf_time = Measure::start("load_elf_time");
-        let executable = Executable::load(elf_bytes, program_runtime_environment.clone())?;
+        let executable = Executable::load(elf_bytes, program_runtime_environment.inner().clone())?;
 
         #[cfg(feature = "metrics")]
         {
@@ -822,7 +852,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             env_opt: Option<&ProgramRuntimeEnvironment>,
         ) -> bool {
             env_opt
-                .map(|env| Arc::ptr_eq(env, program_runtime_environment))
+                .map(|env| env == program_runtime_environment)
                 .unwrap_or(true)
         }
         match &mut self.index {
@@ -893,7 +923,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                             .program
                             .get_environment()
                             .zip(entry.program.get_environment())
-                            .map(|(a, b)| !Arc::ptr_eq(a, b))
+                            .map(|(a, b)| a != b)
                             .unwrap_or(false)
                         || existing == &entry
                 });
@@ -959,7 +989,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 // getting used by an older slot.
                                 if let Some(entry_env) = entry.program.get_environment()
                                     && let Some(env) = first_ancestor_env
-                                    && !Arc::ptr_eq(entry_env, env)
+                                    && entry_env != env
                                 {
                                     return true;
                                 }
@@ -1000,7 +1030,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         let Some(environment) = entry.program.get_environment() else {
             return true;
         };
-        Arc::ptr_eq(environment, program_runtime_environment)
+        environment == program_runtime_environment
     }
 
     fn matches_criteria(
@@ -1407,7 +1437,7 @@ mod tests {
             .unwrap()
             .read_to_end(&mut elf)
             .unwrap();
-        let executable = Executable::load(&elf, env).unwrap();
+        let executable = Executable::load(&elf, env.inner().clone()).unwrap();
         ProgramCacheEntryType::Loaded(executable)
     }
 
@@ -1542,7 +1572,7 @@ mod tests {
             });
 
         // Add tombstones entries for program
-        let env = Arc::new(BuiltinProgram::new_mock());
+        let env = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
         for slot in 21..31 {
             set_tombstone(
                 cache,
@@ -1834,7 +1864,9 @@ mod tests {
             let mut cache = ProgramCache::<TestForkGraph>::new(0);
             for (deployment_slot, effective_slot) in entries {
                 let entry = Arc::new(ProgramCacheEntry {
-                    program: new_loaded_entry(Arc::new(BuiltinProgram::new_mock())), // Assign them different environments
+                    program: new_loaded_entry(ProgramRuntimeEnvironment::from(
+                        BuiltinProgram::new_mock(),
+                    )), // Assign them different environments
                     account_owner: ProgramCacheEntryOwner::LoaderV2,
                     account_size: 0,
                     deployment_slot,
@@ -1924,7 +1956,9 @@ mod tests {
     }
 
     #[test_case(
-        ProgramCacheEntryType::Unloaded(Arc::new(BuiltinProgram::new_mock())),
+        ProgramCacheEntryType::Unloaded(ProgramRuntimeEnvironment::from(
+            BuiltinProgram::new_mock()
+        )),
         new_loaded_entry(get_mock_program_runtime_environment())
     )]
     #[test_case(
@@ -1998,7 +2032,9 @@ mod tests {
             latest_access_slot: AtomicU64::default(),
         });
         let loaded_entry_upcoming_env = Arc::new(ProgramCacheEntry {
-            program: ProgramCacheEntryType::Unloaded(Arc::new(BuiltinProgram::new_mock())),
+            program: ProgramCacheEntryType::Unloaded(ProgramRuntimeEnvironment::from(
+                BuiltinProgram::new_mock(),
+            )),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
             account_size: 0,
             deployment_slot: 10,
@@ -2159,7 +2195,7 @@ mod tests {
 
         let program1 = Pubkey::new_unique();
         cache.assign_program(&env, program1, 10, new_test_entry(10, 10));
-        let new_env = Arc::new(BuiltinProgram::new_mock());
+        let new_env = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
         let upcoming_environment = Some(new_env.clone());
         let updated_program = Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(new_env.clone()),
@@ -2634,7 +2670,7 @@ mod tests {
     fn test_extract_different_environment() {
         let mut cache = ProgramCache::<TestForkGraphSpecific>::new(0);
         let env = get_mock_program_runtime_environment();
-        let other_env = Arc::new(BuiltinProgram::new_mock());
+        let other_env = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
 
         // Fork graph created for the test
         //                0

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -25,6 +25,7 @@ use {
 #[cfg(feature = "metrics")]
 use {solana_svm_measure::measure::Measure, solana_svm_timings::ExecuteDetailsTimings};
 
+#[repr(transparent)]
 #[derive(Clone, Debug)]
 pub struct ProgramRuntimeEnvironment(Arc<BuiltinProgram<InvokeContext<'static, 'static>>>);
 impl std::hash::Hash for ProgramRuntimeEnvironment {

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -39,6 +39,13 @@ impl PartialEq for ProgramRuntimeEnvironment {
     }
 }
 impl Eq for ProgramRuntimeEnvironment {}
+impl std::ops::Deref for ProgramRuntimeEnvironment {
+    type Target = Arc<BuiltinProgram<InvokeContext<'static, 'static>>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 impl ProgramRuntimeEnvironment {
     pub fn from(inner: BuiltinProgram<InvokeContext<'static, 'static>>) -> Self {
         Self(Arc::new(inner))
@@ -49,10 +56,6 @@ impl ProgramRuntimeEnvironment {
     ) -> &'a Self {
         // Safety: This wrapper type is transparent and shares the same representation as the underlying type
         unsafe { std::mem::transmute(inner) }
-    }
-
-    pub fn inner(&self) -> &Arc<BuiltinProgram<InvokeContext<'static, 'static>>> {
-        &self.0
     }
 }
 #[cfg(feature = "dev-context-only-utils")]
@@ -409,7 +412,7 @@ impl ProgramCacheEntry {
     ) -> Result<Self, Box<dyn std::error::Error>> {
         #[cfg(feature = "metrics")]
         let load_elf_time = Measure::start("load_elf_time");
-        let executable = Executable::load(elf_bytes, program_runtime_environment.inner().clone())?;
+        let executable = Executable::load(elf_bytes, Arc::clone(&*program_runtime_environment))?;
 
         #[cfg(feature = "metrics")]
         {
@@ -1438,7 +1441,7 @@ mod tests {
             .unwrap()
             .read_to_end(&mut elf)
             .unwrap();
-        let executable = Executable::load(&elf, env.inner().clone()).unwrap();
+        let executable = Executable::load(&elf, Arc::clone(&*env)).unwrap();
         ProgramCacheEntryType::Loaded(executable)
     }
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1144,9 +1144,13 @@ mod test_utils {
     use solana_program_runtime::loaded_programs::LoadProgramMetrics;
     #[cfg(feature = "svm-internal")]
     use {
-        super::*, agave_syscalls::create_program_runtime_environment,
-        solana_account::ReadableAccount, solana_loader_v4_interface::state::LoaderV4State,
-        solana_program_runtime::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET,
+        super::*,
+        agave_syscalls::create_program_runtime_environment,
+        solana_account::ReadableAccount,
+        solana_loader_v4_interface::state::LoaderV4State,
+        solana_program_runtime::loaded_programs::{
+            DELAY_VISIBILITY_SLOT_OFFSET, ProgramRuntimeEnvironment,
+        },
         solana_sdk_ids::loader_v4,
     };
 
@@ -1192,11 +1196,10 @@ mod test_utils {
                     .data()
                     .get(programdata_data_offset.min(account.data().len())..)
                     .unwrap();
-                let program_runtime_environment = program_runtime_environment.clone();
                 let effective_slot = DELAY_VISIBILITY_SLOT_OFFSET;
                 let loaded_program = ProgramCacheEntry::new(
                     owner,
-                    program_runtime_environment,
+                    ProgramRuntimeEnvironment::from_ref(&program_runtime_environment).clone(),
                     0,
                     effective_slot,
                     programdata,
@@ -1229,8 +1232,8 @@ mod tests {
         solana_epoch_schedule::EpochSchedule,
         solana_instruction::{AccountMeta, error::InstructionError},
         solana_program_runtime::{
-            invoke_context::mock_process_instruction, vm::calculate_heap_cost,
-            with_mock_invoke_context,
+            invoke_context::mock_process_instruction, loaded_programs::ProgramRuntimeEnvironment,
+            vm::calculate_heap_cost, with_mock_invoke_context,
         },
         solana_pubkey::Pubkey,
         solana_rent::Rent,
@@ -3371,7 +3374,7 @@ mod tests {
         )];
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
         let program_id = Pubkey::new_unique();
-        let env = Arc::new(BuiltinProgram::new_mock());
+        let env = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
         let program = ProgramCacheEntry {
             program: ProgramCacheEntryType::Unloaded(env),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
@@ -3413,7 +3416,7 @@ mod tests {
         )];
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
         let program_id = Pubkey::new_unique();
-        let env = Arc::new(BuiltinProgram::new_mock());
+        let env = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
         let program = ProgramCacheEntry {
             program: ProgramCacheEntryType::Unloaded(env),
             account_owner: ProgramCacheEntryOwner::LoaderV2,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1144,13 +1144,9 @@ mod test_utils {
     use solana_program_runtime::loaded_programs::LoadProgramMetrics;
     #[cfg(feature = "svm-internal")]
     use {
-        super::*,
-        agave_syscalls::create_program_runtime_environment,
-        solana_account::ReadableAccount,
-        solana_loader_v4_interface::state::LoaderV4State,
-        solana_program_runtime::loaded_programs::{
-            DELAY_VISIBILITY_SLOT_OFFSET, ProgramRuntimeEnvironment,
-        },
+        super::*, agave_syscalls::create_program_runtime_environment,
+        solana_account::ReadableAccount, solana_loader_v4_interface::state::LoaderV4State,
+        solana_program_runtime::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET,
         solana_sdk_ids::loader_v4,
     };
 
@@ -1170,8 +1166,8 @@ mod test_utils {
             invoke_context.get_compute_budget(),
             false, /* deployment */
             false, /* debugging_features */
-        );
-        let program_runtime_environment = Arc::new(program_runtime_environment.unwrap());
+        )
+        .unwrap();
         let num_accounts = invoke_context.transaction_context.get_number_of_accounts();
         for index in 0..num_accounts {
             let account = invoke_context
@@ -1199,7 +1195,7 @@ mod test_utils {
                 let effective_slot = DELAY_VISIBILITY_SLOT_OFFSET;
                 let loaded_program = ProgramCacheEntry::new(
                     owner,
-                    ProgramRuntimeEnvironment::from_ref(&program_runtime_environment).clone(),
+                    program_runtime_environment.clone(),
                     0,
                     effective_slot,
                     programdata,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1144,9 +1144,13 @@ mod test_utils {
     use solana_program_runtime::loaded_programs::LoadProgramMetrics;
     #[cfg(feature = "svm-internal")]
     use {
-        super::*, agave_syscalls::create_program_runtime_environment,
-        solana_account::ReadableAccount, solana_loader_v4_interface::state::LoaderV4State,
-        solana_program_runtime::loaded_programs::DELAY_VISIBILITY_SLOT_OFFSET,
+        super::*,
+        agave_syscalls::create_program_runtime_environment,
+        solana_account::ReadableAccount,
+        solana_loader_v4_interface::state::LoaderV4State,
+        solana_program_runtime::loaded_programs::{
+            DELAY_VISIBILITY_SLOT_OFFSET, ProgramRuntimeEnvironment,
+        },
         solana_sdk_ids::loader_v4,
     };
 
@@ -1195,7 +1199,7 @@ mod test_utils {
                 let effective_slot = DELAY_VISIBILITY_SLOT_OFFSET;
                 let loaded_program = ProgramCacheEntry::new(
                     owner,
-                    program_runtime_environment.clone(),
+                    ProgramRuntimeEnvironment::clone(&program_runtime_environment),
                     0,
                     effective_slot,
                     programdata,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4451,15 +4451,13 @@ impl Bank {
             .as_ref()
             .unwrap_or(&ComputeBudget::new_with_defaults(simd_0268_active))
             .to_budget();
-        ProgramRuntimeEnvironment::from(
-            create_program_runtime_environment(
-                &feature_set.runtime_features(),
-                &compute_budget,
-                false, /* deployment */
-                false, /* debugging_features */
-            )
-            .unwrap(),
+        create_program_runtime_environment(
+            &feature_set.runtime_features(),
+            &compute_budget,
+            false, /* deployment */
+            false, /* debugging_features */
         )
+        .unwrap()
     }
 
     pub fn set_tick_height(&self, tick_height: u64) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1600,7 +1600,9 @@ impl Bank {
                 .transaction_processor
                 .program_runtime_environment
                 .clone();
-            let changed_program_runtime_environment = *upcoming_environment != *new_environment;
+            // Here we actually want to compare the content of the environments, thus use `inner`
+            let changed_program_runtime_environment =
+                upcoming_environment.inner() != new_environment.inner();
             if changed_program_runtime_environment {
                 upcoming_environment = new_environment;
                 epoch_boundary_preparation.programs_to_recompile = program_cache
@@ -4449,7 +4451,7 @@ impl Bank {
             .as_ref()
             .unwrap_or(&ComputeBudget::new_with_defaults(simd_0268_active))
             .to_budget();
-        Arc::new(
+        ProgramRuntimeEnvironment::from(
             create_program_runtime_environment(
                 &feature_set.runtime_features(),
                 &compute_budget,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1600,9 +1600,8 @@ impl Bank {
                 .transaction_processor
                 .program_runtime_environment
                 .clone();
-            // Here we actually want to compare the content of the environments, thus use `inner`
-            let changed_program_runtime_environment =
-                upcoming_environment.inner() != new_environment.inner();
+            // Here we actually want to compare the content of the environments, thus the deref.
+            let changed_program_runtime_environment = *upcoming_environment != *new_environment;
             if changed_program_runtime_environment {
                 upcoming_environment = new_environment;
                 epoch_boundary_preparation.programs_to_recompile = program_cache

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -17,7 +17,7 @@ use {
     solana_program_runtime::{
         deploy::deploy_program,
         invoke_context::{EnvironmentConfig, InvokeContext},
-        loaded_programs::{LoadProgramMetrics, ProgramCacheForTxBatch},
+        loaded_programs::{LoadProgramMetrics, ProgramCacheForTxBatch, ProgramRuntimeEnvironment},
         sysvar_cache::SysvarCache,
     },
     solana_pubkey::Pubkey,
@@ -190,7 +190,7 @@ impl Bank {
                 dummy_invoke_context.get_log_collector(),
                 &mut load_program_metrics,
                 dummy_invoke_context.program_cache_for_tx_batch,
-                program_runtime_environment.clone(),
+                ProgramRuntimeEnvironment::clone(&program_runtime_environment),
                 program_id,
                 &bpf_loader_upgradeable::id(),
                 // The size of the program cache entry is the size of the program account

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10640,10 +10640,10 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase() {
             .unwrap();
         let slot_versions = program_cache.get_slot_versions_for_tests(&program_keypair.pubkey());
         assert_eq!(slot_versions.len(), 1);
-        assert!(Arc::ptr_eq(
+        assert_eq!(
             slot_versions[0].program.get_environment().unwrap(),
-            &current_env
-        ));
+            &current_env,
+        );
     }
     goto_end_of_slot(bank.clone());
     let bank = new_from_parent_with_fork_next_slot(bank, bank_forks.as_ref());
@@ -10655,14 +10655,14 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase() {
             .unwrap();
         let slot_versions = program_cache.get_slot_versions_for_tests(&program_keypair.pubkey());
         assert_eq!(slot_versions.len(), 2);
-        assert!(Arc::ptr_eq(
+        assert_eq!(
             slot_versions[0].program.get_environment().unwrap(),
-            &upcoming_env
-        ));
-        assert!(Arc::ptr_eq(
+            &upcoming_env,
+        );
+        assert_eq!(
             slot_versions[1].program.get_environment().unwrap(),
-            &current_env
-        ));
+            &current_env,
+        );
     }
 
     // Advance the bank to cross the epoch boundary and activate the feature.

--- a/svm-test-harness/instr/src/fuzz.rs
+++ b/svm-test-harness/instr/src/fuzz.rs
@@ -16,7 +16,7 @@ use {
     solana_precompile_error::PrecompileError,
     solana_pubkey::Pubkey,
     solana_svm_callback::InvokeContextCallback,
-    std::{env, ffi::c_int, sync::Arc},
+    std::{env, ffi::c_int},
 };
 
 /// Callback with full precompile support for fuzz testing.
@@ -88,15 +88,13 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> Option<ProtoInstrEffects
     // When testing with protobuf, we fill the program cache from input accounts.
     let mut program_cache = {
         let slot = sysvar_cache.get_clock().unwrap().slot;
-        let environment = Arc::new(
-            create_program_runtime_environment(
-                &instr_context.feature_set,
-                &compute_budget.to_budget(),
-                false, /* deployment */
-                false, /* debugging_features */
-            )
-            .unwrap(),
-        );
+        let environment = create_program_runtime_environment(
+            &instr_context.feature_set,
+            &compute_budget.to_budget(),
+            false, /* deployment */
+            false, /* debugging_features */
+        )
+        .unwrap();
 
         let mut cache = crate::program_cache::new_with_builtins(slot);
         crate::program_cache::fill_from_accounts(

--- a/svm-test-harness/instr/src/harness.rs
+++ b/svm-test-harness/instr/src/harness.rs
@@ -7,7 +7,7 @@ use {
     solana_instruction_error::InstructionError,
     solana_program_runtime::{
         invoke_context::{EnvironmentConfig, InvokeContext, mock_compile_message},
-        loaded_programs::ProgramCacheForTxBatch,
+        loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironment},
         sysvar_cache::SysvarCache,
     },
     solana_pubkey::Pubkey,
@@ -16,7 +16,7 @@ use {
     solana_svm_timings::ExecuteTimings,
     solana_svm_transaction::svm_message::SVMStaticMessage,
     solana_transaction_context::transaction::TransactionContext,
-    std::{rc::Rc, sync::Arc},
+    std::rc::Rc,
 };
 
 /// Default callback with no precompile support.
@@ -72,7 +72,7 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
         sanitized_message.num_instructions(),
     );
 
-    let environment = Arc::new(
+    let environment = ProgramRuntimeEnvironment::from(
         create_program_runtime_environment(
             &input.feature_set,
             &compute_budget.to_budget(),

--- a/svm-test-harness/instr/src/harness.rs
+++ b/svm-test-harness/instr/src/harness.rs
@@ -7,7 +7,7 @@ use {
     solana_instruction_error::InstructionError,
     solana_program_runtime::{
         invoke_context::{EnvironmentConfig, InvokeContext, mock_compile_message},
-        loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironment},
+        loaded_programs::ProgramCacheForTxBatch,
         sysvar_cache::SysvarCache,
     },
     solana_pubkey::Pubkey,
@@ -72,15 +72,13 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
         sanitized_message.num_instructions(),
     );
 
-    let environment = ProgramRuntimeEnvironment::from(
-        create_program_runtime_environment(
-            &input.feature_set,
-            &compute_budget.to_budget(),
-            false, /* deployment */
-            false, /* debugging_features */
-        )
-        .unwrap(),
-    );
+    let program_runtime_environment = create_program_runtime_environment(
+        &input.feature_set,
+        &compute_budget.to_budget(),
+        false, /* deployment */
+        false, /* debugging_features */
+    )
+    .unwrap();
 
     let result = {
         #[expect(deprecated)]
@@ -99,8 +97,8 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
                 blockhash_lamports_per_signature,
                 callback,
                 &feature_set,
-                &environment,
-                &environment,
+                &program_runtime_environment,
+                &program_runtime_environment,
                 sysvar_cache,
             ),
             Some(log_collector.clone()),
@@ -288,15 +286,13 @@ mod tests {
         // Create Program Cache
         let mut program_cache = crate::program_cache::new_with_builtins(slot);
 
-        let environments = Arc::new(
-            create_program_runtime_environment(
-                &context.feature_set,
-                &compute_budget.to_budget(),
-                false, /* deployment */
-                false, /* debugging_features */
-            )
-            .unwrap(),
-        );
+        let environments = create_program_runtime_environment(
+            &context.feature_set,
+            &compute_budget.to_budget(),
+            false, /* deployment */
+            false, /* debugging_features */
+        )
+        .unwrap();
 
         crate::program_cache::fill_from_accounts(
             &mut program_cache,

--- a/svm-test-harness/instr/src/program_cache.rs
+++ b/svm-test-harness/instr/src/program_cache.rs
@@ -42,7 +42,7 @@ pub fn add_program(
     feature_set: &SVMFeatureSet,
     compute_budget: &ComputeBudget,
 ) {
-    let program_runtime_environment = Arc::new(
+    let program_runtime_environment = ProgramRuntimeEnvironment::from(
         create_program_runtime_environment(
             feature_set,
             &compute_budget.to_budget(),

--- a/svm-test-harness/instr/src/program_cache.rs
+++ b/svm-test-harness/instr/src/program_cache.rs
@@ -42,15 +42,13 @@ pub fn add_program(
     feature_set: &SVMFeatureSet,
     compute_budget: &ComputeBudget,
 ) {
-    let program_runtime_environment = ProgramRuntimeEnvironment::from(
-        create_program_runtime_environment(
-            feature_set,
-            &compute_budget.to_budget(),
-            false, /* reject_deployment_of_broken_elfs */
-            false, /* debugging_features */
-        )
-        .unwrap(),
-    );
+    let program_runtime_environment = create_program_runtime_environment(
+        feature_set,
+        &compute_budget.to_budget(),
+        false, /* reject_deployment_of_broken_elfs */
+        false, /* debugging_features */
+    )
+    .unwrap();
 
     let entry = ProgramCacheEntry::new(
         loader_key,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -463,7 +463,7 @@ mod tests {
         let loader = bpf_loader_upgradeable::id();
         let size = buffer.len();
         let slot: Slot = 2;
-        let environment = ProgramRuntimeEnvironment::new(BuiltinProgram::new_mock());
+        let environment = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
 
         let result = ProgramCacheEntry::new(
             &loader,
@@ -790,17 +790,11 @@ mod tests {
             .unwrap();
             assert_ne!(
                 is_upcoming_env,
-                Arc::ptr_eq(
-                    result.program.get_environment().unwrap(),
-                    &current_environment,
-                )
+                result.program.get_environment().unwrap() == &current_environment,
             );
             assert_eq!(
                 is_upcoming_env,
-                Arc::ptr_eq(
-                    result.program.get_environment().unwrap(),
-                    &upcoming_environment,
-                )
+                result.program.get_environment().unwrap() == &upcoming_environment,
             );
         }
     }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -108,7 +108,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
 
         ProgramAccountLoadResult::ProgramOfLoaderV1(program_account) => ProgramCacheEntry::new(
             program_account.owner(),
-            program_runtime_environment.clone(),
+            ProgramRuntimeEnvironment::clone(program_runtime_environment),
             0,
             DELAY_VISIBILITY_SLOT_OFFSET,
             program_account.data(),
@@ -120,7 +120,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
 
         ProgramAccountLoadResult::ProgramOfLoaderV2(program_account) => ProgramCacheEntry::new(
             program_account.owner(),
-            program_runtime_environment.clone(),
+            ProgramRuntimeEnvironment::clone(program_runtime_environment),
             0,
             DELAY_VISIBILITY_SLOT_OFFSET,
             program_account.data(),
@@ -141,7 +141,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
             .and_then(|programdata| {
                 ProgramCacheEntry::new(
                     program_account.owner(),
-                    program_runtime_environment.clone(),
+                    ProgramRuntimeEnvironment::clone(program_runtime_environment),
                     deployment_slot,
                     deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
                     programdata,
@@ -164,7 +164,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
                 .and_then(|elf_bytes| {
                     ProgramCacheEntry::new(
                         &loader_v4::id(),
-                        program_runtime_environment.clone(),
+                        ProgramRuntimeEnvironment::clone(program_runtime_environment),
                         deployment_slot,
                         deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
                         elf_bytes,
@@ -178,7 +178,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
         }
     }
     .unwrap_or_else(|(deployment_slot, owner)| {
-        let env = program_runtime_environment.clone();
+        let env = ProgramRuntimeEnvironment::clone(program_runtime_environment);
         ProgramCacheEntry::new_tombstone(
             deployment_slot,
             owner,
@@ -467,7 +467,7 @@ mod tests {
 
         let result = ProgramCacheEntry::new(
             &loader,
-            environment.clone(),
+            ProgramRuntimeEnvironment::clone(&environment),
             slot,
             slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
             &buffer,
@@ -573,7 +573,7 @@ mod tests {
         let program_runtime_environment = get_mock_program_runtime_environment();
         let expected = ProgramCacheEntry::new(
             account_data.owner(),
-            program_runtime_environment.clone(),
+            ProgramRuntimeEnvironment::clone(&program_runtime_environment),
             0,
             DELAY_VISIBILITY_SLOT_OFFSET,
             account_data.data(),
@@ -665,7 +665,7 @@ mod tests {
         let program_runtime_environment = get_mock_program_runtime_environment();
         let expected = ProgramCacheEntry::new(
             account_data.owner(),
-            program_runtime_environment.clone(),
+            ProgramRuntimeEnvironment::clone(&program_runtime_environment),
             0,
             DELAY_VISIBILITY_SLOT_OFFSET,
             account_data.data(),
@@ -748,7 +748,7 @@ mod tests {
         let program_runtime_environment = get_mock_program_runtime_environment();
         let expected = ProgramCacheEntry::new(
             account_data.owner(),
-            program_runtime_environment.clone(),
+            ProgramRuntimeEnvironment::clone(&program_runtime_environment),
             0,
             DELAY_VISIBILITY_SLOT_OFFSET,
             account_data.data(),
@@ -767,7 +767,8 @@ mod tests {
         account_data.set_owner(bpf_loader::id());
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         let upcoming_environment = get_mock_program_runtime_environment();
-        let current_environment = batch_processor.program_runtime_environment.clone();
+        let current_environment =
+            ProgramRuntimeEnvironment::clone(&batch_processor.program_runtime_environment);
         {
             let mut epoch_boundary_preparation =
                 batch_processor.epoch_boundary_preparation.write().unwrap();

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -225,7 +225,9 @@ impl<FG: ForkGraph> Default for TransactionBatchProcessor<FG> {
             sysvar_cache: RwLock::<SysvarCache>::default(),
             epoch_boundary_preparation: Arc::new(RwLock::new(EpochBoundaryPreparation::default())),
             global_program_cache: Arc::new(RwLock::new(ProgramCache::new(Slot::default()))),
-            program_runtime_environment: Arc::new(BuiltinProgram::new_loader(VmConfig::default())),
+            program_runtime_environment: ProgramRuntimeEnvironment::from(
+                BuiltinProgram::new_loader(VmConfig::default()),
+            ),
             builtin_program_ids: RwLock::new(HashSet::new()),
             execution_cost: SVMTransactionExecutionCost::default(),
         }
@@ -275,7 +277,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .write()
             .unwrap()
             .set_fork_graph(fork_graph);
-        let empty_loader = || Arc::new(BuiltinProgram::new_loader(VmConfig::default()));
+        let empty_loader = || ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
         processor
             .global_program_cache
             .write()
@@ -329,7 +331,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .unwrap()
             .upcoming_environment
             && &self.program_runtime_environment == upcoming_environment
-            && !Arc::ptr_eq(&self.program_runtime_environment, upcoming_environment)
+            && &self.program_runtime_environment != upcoming_environment
         {
             self.program_runtime_environment = upcoming_environment.clone();
         }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -306,7 +306,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             sysvar_cache: RwLock::<SysvarCache>::default(),
             epoch_boundary_preparation: self.epoch_boundary_preparation.clone(),
             global_program_cache: self.global_program_cache.clone(),
-            program_runtime_environment: self.program_runtime_environment.clone(),
+            program_runtime_environment: ProgramRuntimeEnvironment::clone(
+                &self.program_runtime_environment,
+            ),
             builtin_program_ids: RwLock::new(self.builtin_program_ids.read().unwrap().clone()),
             execution_cost: self.execution_cost,
         }
@@ -344,7 +346,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .read()
             .unwrap()
             .get_upcoming_environment_for_epoch(epoch)
-            .unwrap_or_else(|| self.program_runtime_environment.clone())
+            .unwrap_or_else(|| ProgramRuntimeEnvironment::clone(&self.program_runtime_environment))
     }
 
     pub fn sysvar_cache(&self) -> RwLockReadGuard<'_, SysvarCache> {

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -144,7 +144,7 @@ fn svm_concurrent() {
         5,
         2,
         Arc::downgrade(&fork_graph),
-        Some(Arc::new(create_custom_loader())),
+        Some(create_custom_loader()),
     ));
 
     mock_bank.configure_sysvars();

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -138,7 +138,7 @@ impl SvmTestEnvironment<'_> {
             EXECUTION_SLOT,
             EXECUTION_EPOCH,
             Arc::downgrade(&fork_graph),
-            Some(Arc::new(create_custom_loader())),
+            Some(create_custom_loader()),
         );
 
         // The sysvars must be put in the cache

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -395,5 +395,5 @@ pub fn create_custom_loader() -> ProgramRuntimeEnvironment {
         .expect("Registration failed");
     SyscallGetEpochScheduleSysvar::register(&mut loader, "sol_get_epoch_schedule_sysvar")
         .expect("Registration failed");
-    Arc::new(loader)
+    ProgramRuntimeEnvironment::from(loader)
 }

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -16,7 +16,7 @@ use {
     solana_program_runtime::{
         execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
         invoke_context::InvokeContext,
-        loaded_programs::{BlockRelation, ForkGraph, ProgramCacheEntry},
+        loaded_programs::{BlockRelation, ForkGraph, ProgramCacheEntry, ProgramRuntimeEnvironment},
         solana_sbpf::{
             program::{BuiltinProgram, SBPFVersion},
             vm::Config,
@@ -356,7 +356,7 @@ pub fn register_builtins(
     );
 }
 
-pub fn create_custom_loader<'a>() -> BuiltinProgram<InvokeContext<'a, 'a>> {
+pub fn create_custom_loader() -> ProgramRuntimeEnvironment {
     let compute_budget = SVMTransactionExecutionBudget::default();
     let vm_config = Config {
         max_call_depth: compute_budget.max_call_depth,
@@ -395,5 +395,5 @@ pub fn create_custom_loader<'a>() -> BuiltinProgram<InvokeContext<'a, 'a>> {
         .expect("Registration failed");
     SyscallGetEpochScheduleSysvar::register(&mut loader, "sol_get_epoch_schedule_sysvar")
         .expect("Registration failed");
-    loader
+    Arc::new(loader)
 }

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -288,12 +288,12 @@ macro_rules! register_feature_gated_function {
     };
 }
 
-pub fn create_program_runtime_environment<'a, 'ix_data>(
+pub fn create_program_runtime_environment(
     feature_set: &SVMFeatureSet,
     compute_budget: &SVMTransactionExecutionBudget,
     reject_deployment_of_broken_elfs: bool,
     debugging_features: bool,
-) -> Result<BuiltinProgram<InvokeContext<'a, 'ix_data>>, Error> {
+) -> Result<BuiltinProgram<InvokeContext<'static, 'static>>, Error> {
     let enable_alt_bn128_syscall = feature_set.enable_alt_bn128_syscall;
     let enable_alt_bn128_compression_syscall = feature_set.enable_alt_bn128_compression_syscall;
     let enable_big_mod_exp_syscall = feature_set.enable_big_mod_exp_syscall;

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -24,6 +24,7 @@ use {
         cpi::CpiError,
         execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
         invoke_context::InvokeContext,
+        loaded_programs::ProgramRuntimeEnvironment,
         memory::{MemoryTranslationError, translate_vm_slice},
         stable_log, translate_inner, translate_slice_inner, translate_type_inner,
     },
@@ -293,7 +294,7 @@ pub fn create_program_runtime_environment(
     compute_budget: &SVMTransactionExecutionBudget,
     reject_deployment_of_broken_elfs: bool,
     debugging_features: bool,
-) -> Result<BuiltinProgram<InvokeContext<'static, 'static>>, Error> {
+) -> Result<ProgramRuntimeEnvironment, Error> {
     let enable_alt_bn128_syscall = feature_set.enable_alt_bn128_syscall;
     let enable_alt_bn128_compression_syscall = feature_set.enable_alt_bn128_compression_syscall;
     let enable_big_mod_exp_syscall = feature_set.enable_big_mod_exp_syscall;
@@ -525,7 +526,7 @@ pub fn create_program_runtime_environment(
     // Log data
     SyscallLogData::register(&mut result, "sol_log_data")?;
 
-    Ok(result)
+    Ok(ProgramRuntimeEnvironment::from(result))
 }
 
 fn translate_type<T>(

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -954,7 +954,6 @@ impl TestValidator {
             true,
             false,
         )?;
-        let program_runtime_environment = Arc::new(program_runtime_environment);
 
         let mut accounts = config.accounts.clone();
         for (address, account) in solana_program_binaries::spl_programs(&config.rent) {
@@ -969,9 +968,11 @@ impl TestValidator {
         }
         for upgradeable_program in &config.upgradeable_programs {
             let data = solana_program_test::read_file(&upgradeable_program.program_path);
-            let executable =
-                Executable::<InvokeContext>::from_elf(&data, program_runtime_environment.clone())
-                    .map_err(|err| format!("ELF error: {err}"))?;
+            let executable = Executable::<InvokeContext>::from_elf(
+                &data,
+                program_runtime_environment.inner().clone(),
+            )
+            .map_err(|err| format!("ELF error: {err}"))?;
             executable
                 .verify::<RequisiteVerifier>()
                 .map_err(|err| format!("ELF error: {err}"))?;

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -970,7 +970,7 @@ impl TestValidator {
             let data = solana_program_test::read_file(&upgradeable_program.program_path);
             let executable = Executable::<InvokeContext>::from_elf(
                 &data,
-                program_runtime_environment.inner().clone(),
+                Arc::clone(&*program_runtime_environment),
             )
             .map_err(|err| format!("ELF error: {err}"))?;
             executable


### PR DESCRIPTION
#### Problem

All places which compare `ProgramRuntimeEnvironment` currently have to explicitly use `Arc::ptr_eq()`. It would be nice to abstract that into a type. Furthermore, this would also allow us to use `ProgramRuntimeEnvironment` as a key in index structures.

#### Summary of Changes

- Uses type alias `ProgramRuntimeEnvironment` instead of `Arc<BuiltinProgram<InvokeContext<'a, 'a>>>` everywhere.
- Removes generic lifetime from `morph_into_deployment_environment()`.
- Wraps `ProgramRuntimeEnvironment` in a [newtype](https://doc.rust-lang.org/stable/book/ch20-03-advanced-types.html#using-the-newtype-pattern-for-type-safety-and-abstraction).
- Changes return type of `create_program_runtime_environment()` to `ProgramRuntimeEnvironment`.