### PR TITLE
Sets bank_hash_details_dir in replay_stage::tests::setup_forks_from_tree()

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4688,6 +4688,7 @@ pub(crate) mod tests {
         crossbeam_channel::unbounded,
         itertools::Itertools,
         solana_account::{ReadableAccount, state_traits::StateMut},
+        solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
         solana_client::connection_cache::ConnectionCache,
         solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
         solana_entry::entry::{self, Entry},
@@ -4712,6 +4713,7 @@ pub(crate) mod tests {
             slot_status_notifier::SlotStatusNotifierInterface,
         },
         solana_runtime::{
+            bank::BankTestConfig,
             commitment::{BlockCommitment, VOTE_THRESHOLD_SIZE},
             genesis_utils::{GenesisConfigInfo, ValidatorVoteKeypairs},
         },
@@ -9198,7 +9200,16 @@ pub(crate) mod tests {
         num_keys: usize,
         generate_votes: Option<GenerateVotes>,
     ) -> (VoteSimulator, Blockstore) {
-        let mut vote_simulator = VoteSimulator::new(num_keys);
+        let ledger_path = get_tmp_ledger_path!();
+        let mut vote_simulator = VoteSimulator::new_with(
+            num_keys,
+            BankTestConfig {
+                accounts_db_config: AccountsDbConfig {
+                    bank_hash_details_dir: ledger_path.clone(),
+                    ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+                },
+            },
+        );
         let pubkeys: Vec<Pubkey> = vote_simulator
             .validator_keypairs
             .values()
@@ -9208,7 +9219,6 @@ pub(crate) mod tests {
             .map(|generate_votes| generate_votes(pubkeys))
             .unwrap_or_default();
         vote_simulator.fill_bank_forks(tree.clone(), &cluster_votes, true);
-        let ledger_path = get_tmp_ledger_path!();
         let blockstore = Blockstore::open(&ledger_path).unwrap();
         blockstore.add_tree(tree, false, true, 2, Hash::default());
         (vote_simulator, blockstore)

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -23,7 +23,7 @@ use {
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_runtime::{
-        bank::Bank,
+        bank::{Bank, BankTestConfig},
         bank_forks::BankForks,
         genesis_utils::{
             GenesisConfigInfo, ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts,
@@ -51,6 +51,10 @@ pub struct VoteSimulator {
 
 impl VoteSimulator {
     pub fn new(num_keypairs: usize) -> Self {
+        Self::new_with(num_keypairs, BankTestConfig::default())
+    }
+
+    pub fn new_with(num_keypairs: usize, bank_test_config: BankTestConfig) -> Self {
         let (
             validator_keypairs,
             node_pubkeys,
@@ -58,7 +62,7 @@ impl VoteSimulator {
             bank_forks,
             progress,
             heaviest_subtree_fork_choice,
-        ) = Self::init_state(num_keypairs);
+        ) = Self::init_state(num_keypairs, bank_test_config);
         Self {
             validator_keypairs,
             node_pubkeys,
@@ -344,6 +348,7 @@ impl VoteSimulator {
     #[allow(clippy::type_complexity)]
     fn init_state(
         num_keypairs: usize,
+        bank_test_config: BankTestConfig,
     ) -> (
         HashMap<Pubkey, ValidatorVoteKeypairs>,
         Vec<Pubkey>,
@@ -368,7 +373,7 @@ impl VoteSimulator {
             .collect();
 
         let (bank_forks, progress, heaviest_subtree_fork_choice) =
-            initialize_state(&keypairs, 10_000);
+            initialize_state_with(&keypairs, 10_000, bank_test_config);
         (
             keypairs,
             node_pubkeys,
@@ -389,6 +394,18 @@ pub fn initialize_state(
     ProgressMap,
     HeaviestSubtreeForkChoice,
 ) {
+    initialize_state_with(validator_keypairs_map, stake, BankTestConfig::default())
+}
+
+pub fn initialize_state_with(
+    validator_keypairs_map: &HashMap<Pubkey, ValidatorVoteKeypairs>,
+    stake: u64,
+    bank_test_config: BankTestConfig,
+) -> (
+    Arc<RwLock<BankForks>>,
+    ProgressMap,
+    HeaviestSubtreeForkChoice,
+) {
     let validator_keypairs: Vec<_> = validator_keypairs_map.values().collect();
     let GenesisConfigInfo {
         mut genesis_config,
@@ -402,7 +419,8 @@ pub fn initialize_state(
 
     genesis_config.epoch_schedule = EpochSchedule::without_warmup();
     genesis_config.poh_config.hashes_per_tick = Some(2);
-    let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    let (bank0, bank_forks) = Bank::new_with_config_for_tests(&genesis_config, bank_test_config)
+        .wrap_with_bank_forks_for_tests();
     bank0.set_block_id(Some(Hash::new_unique()));
 
     for pubkey in validator_keypairs_map.keys() {


### PR DESCRIPTION
#### Problem

After https://github.com/anza-xyz/agave/pull/9736 merged, tests started leaving behind bank hash details files.

This is because some tests call `dump_then_repair_correct_slots()`, which writes bank hash details files. Those tests no longer had a temp dir being created for them to put the bank hash details files in. And the default value for tests is an empty path, which results in the cwd.

(Another question is why tests are writing these files in the first place, but I'm not trying to fix/solve that here.)


#### Summary of Changes

Set the bank hash details dir to the ledger path.