### PR TITLE
feat(alpenglow): send block headers

### DIFF
--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -476,6 +476,14 @@ impl BlockComponent {
         Self::BlockMarker(marker)
     }
 
+    pub fn new_block_header(parent_slot: Slot, parent_block_id: Hash) -> Self {
+        let header = BlockHeaderV1 {
+            parent_slot,
+            parent_block_id,
+        };
+        Self::new_block_marker(VersionedBlockMarker::new_block_header(header))
+    }
+
     pub const fn as_marker(&self) -> Option<&VersionedBlockMarker> {
         match self {
             Self::BlockMarker(m) => Some(m),

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -54,6 +54,7 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { workspace = true }
+agave-votor-messages = { path = "../votor-messages", features = ["dev-context-only-utils"] }
 assert_matches = { workspace = true }
 bencher = { workspace = true }
 bs58 = { workspace = true }

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -148,7 +148,7 @@ impl BroadcastStageType {
                 exit_sender,
                 blockstore,
                 bank_forks,
-                FailEntryVerificationBroadcastRun::new(shred_version),
+                FailEntryVerificationBroadcastRun::new(shred_version, migration_status),
                 xdp_sender,
             ),
 
@@ -160,7 +160,7 @@ impl BroadcastStageType {
                 exit_sender,
                 blockstore,
                 bank_forks,
-                BroadcastFakeShredsRun::new(0, shred_version),
+                BroadcastFakeShredsRun::new(0, shred_version, migration_status),
                 xdp_sender,
             ),
 

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -221,7 +221,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                 .filter(|s| s.is_data())
                 .cloned()
                 .collect();
-            if let Some(shred) = header_data.iter().max_by_key(|shred| shred.index()) {
+            if let Some(shred) = header_data.last() {
                 self.chained_merkle_root = shred.merkle_root().unwrap();
             }
             self.next_shred_index += header_data.len() as u32;
@@ -233,6 +233,9 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             {
                 self.next_code_index = index + 1;
             }
+            let header_shreds = Arc::new(header_shreds);
+            blockstore_sender.send((header_shreds.clone(), None))?;
+            socket_sender.send((header_shreds, None))?;
             header_data
         } else {
             vec![]
@@ -301,10 +304,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                 );
                 self.next_shred_index += u32::try_from(original_last_data_shred.len()).unwrap();
                 // Update chained_merkle_root to the merkle root of the original last FEC set
-                if let Some(shred) = original_last_data_shred
-                    .iter()
-                    .max_by_key(|shred| shred.index())
-                {
+                if let Some(shred) = original_last_data_shred.last() {
                     self.chained_merkle_root = shred.merkle_root().unwrap();
                 }
                 (original_last_data_shred, partition_last_data_shred)

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -5,7 +5,7 @@ use {
     agave_votor_messages::migration::MigrationStatus,
     crossbeam_channel::Sender,
     itertools::Itertools,
-    solana_entry::entry::Entry,
+    solana_entry::{block_component::BlockComponent, entry::Entry},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
@@ -103,7 +103,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 
-        if bank.slot() != self.current_slot {
+        let send_header = if bank.slot() != self.current_slot {
             self.chained_merkle_root = broadcast_utils::get_chained_merkle_root_from_parent(
                 bank.slot(),
                 bank.parent_slot(),
@@ -115,7 +115,11 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             self.current_slot = bank.slot();
             self.prev_entry_hash = None;
             self.num_slots_broadcasted += 1;
-        }
+
+            true
+        } else {
+            false
+        };
 
         if receive_results.entries.is_empty() {
             return Ok(());
@@ -192,6 +196,48 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         )
         .expect("Expected to create a new shredder");
 
+        // Generate header shreds for new slot
+        let header_data_shreds = if send_header
+            && self
+                .migration_status
+                .should_allow_block_markers(bank.slot())
+        {
+            let header =
+                BlockComponent::new_block_header(bank.parent_slot(), self.chained_merkle_root);
+            let header_shreds: Vec<_> = shredder
+                .make_merkle_shreds_from_component(
+                    keypair,
+                    &header,
+                    false,
+                    self.chained_merkle_root,
+                    self.next_shred_index,
+                    self.next_code_index,
+                    &self.reed_solomon_cache,
+                    &mut stats,
+                )
+                .collect();
+            let header_data: Vec<_> = header_shreds
+                .iter()
+                .filter(|s| s.is_data())
+                .cloned()
+                .collect();
+            if let Some(shred) = header_data.iter().max_by_key(|shred| shred.index()) {
+                self.chained_merkle_root = shred.merkle_root().unwrap();
+            }
+            self.next_shred_index += header_data.len() as u32;
+            if let Some(index) = header_shreds
+                .iter()
+                .filter(|s| !s.is_data())
+                .map(Shred::index)
+                .max()
+            {
+                self.next_code_index = index + 1;
+            }
+            header_data
+        } else {
+            vec![]
+        };
+
         // Avoid generating an empty FEC set
         let (data_shreds, coding_shreds) = if !receive_results.entries.is_empty() {
             shredder.entries_to_merkle_shreds_for_tests(
@@ -263,6 +309,8 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                 }
                 (original_last_data_shred, partition_last_data_shred)
             });
+
+        let data_shreds: Vec<_> = header_data_shreds.into_iter().chain(data_shreds).collect();
 
         if !data_shreds.is_empty() {
             let data_shreds = Arc::new(data_shreds);

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -1,6 +1,7 @@
 use {
     super::*,
-    solana_entry::entry::Entry,
+    agave_votor_messages::migration::MigrationStatus,
+    solana_entry::{block_component::BlockComponent, entry::Entry},
     solana_gossip::contact_info::ContactInfo,
     solana_hash::Hash,
     solana_keypair::Keypair,
@@ -13,19 +14,31 @@ pub(super) struct BroadcastFakeShredsRun {
     carryover_entry: Option<WorkingBankEntry>,
     partition: usize,
     shred_version: u16,
+    current_slot: Slot,
+    chained_merkle_root: Hash,
+    next_shred_index: u32,
     next_code_index: u32,
     reed_solomon_cache: Arc<ReedSolomonCache>,
+    migration_status: Arc<MigrationStatus>,
 }
 
 impl BroadcastFakeShredsRun {
-    pub(super) fn new(partition: usize, shred_version: u16) -> Self {
+    pub(super) fn new(
+        partition: usize,
+        shred_version: u16,
+        migration_status: Arc<MigrationStatus>,
+    ) -> Self {
         Self {
             last_blockhash: Hash::default(),
             carryover_entry: None,
             partition,
             shred_version,
+            current_slot: 0,
+            chained_merkle_root: Hash::default(),
+            next_shred_index: 0,
             next_code_index: 0,
             reed_solomon_cache: Arc::<ReedSolomonCache>::default(),
+            migration_status,
         }
     }
 }
@@ -48,25 +61,34 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         let bank = receive_results.bank;
         let last_tick_height = receive_results.last_tick_height;
 
-        let next_shred_index = blockstore
-            .meta(bank.slot())
-            .expect("Database error")
-            .map(|meta| meta.consumed)
-            .unwrap_or(0) as u32;
-        let chained_merkle_root = match next_shred_index.checked_sub(1) {
-            None => broadcast_utils::get_chained_merkle_root_from_parent(
+        let send_header = if bank.slot() != self.current_slot {
+            self.chained_merkle_root = broadcast_utils::get_chained_merkle_root_from_parent(
                 bank.slot(),
                 bank.parent_slot(),
                 blockstore,
             )
-            .unwrap(),
-            Some(index) => {
+            .unwrap();
+            self.next_shred_index = 0;
+            self.next_code_index = 0;
+            self.current_slot = bank.slot();
+
+            true
+        } else {
+            let next_shred_index = blockstore
+                .meta(bank.slot())
+                .expect("Database error")
+                .map(|meta| meta.consumed)
+                .unwrap_or(0) as u32;
+            self.next_shred_index = next_shred_index;
+            if let Some(index) = next_shred_index.checked_sub(1) {
                 let shred = blockstore
                     .get_data_shred(bank.slot(), u64::from(index))
                     .unwrap()
                     .unwrap();
-                shred::layout::get_merkle_root(&shred).unwrap()
+                self.chained_merkle_root = shred::layout::get_merkle_root(&shred).unwrap();
             }
+
+            false
         };
 
         let num_entries = receive_results.entries.len();
@@ -79,12 +101,42 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         )
         .expect("Expected to create a new shredder");
 
+        // Generate header shreds for new slot
+        if send_header
+            && self
+                .migration_status
+                .should_allow_block_markers(bank.slot())
+        {
+            let header =
+                BlockComponent::new_block_header(bank.parent_slot(), self.chained_merkle_root);
+            let header_shreds: Vec<_> = shredder
+                .make_merkle_shreds_from_component(
+                    keypair,
+                    &header,
+                    false,
+                    self.chained_merkle_root,
+                    self.next_shred_index,
+                    self.next_code_index,
+                    &self.reed_solomon_cache,
+                    &mut ProcessShredsStats::default(),
+                )
+                .collect();
+            for shred in &header_shreds {
+                if shred.is_data() {
+                    self.next_shred_index = self.next_shred_index.max(shred.index() + 1);
+                    self.chained_merkle_root = shred.merkle_root().unwrap();
+                } else {
+                    self.next_code_index = self.next_code_index.max(shred.index() + 1);
+                }
+            }
+        }
+
         let (data_shreds, coding_shreds) = shredder.entries_to_merkle_shreds_for_tests(
             keypair,
             &receive_results.entries,
             last_tick_height == bank.max_tick_height(),
-            chained_merkle_root,
-            next_shred_index,
+            self.chained_merkle_root,
+            self.next_shred_index,
             self.next_code_index,
             &self.reed_solomon_cache,
             &mut ProcessShredsStats::default(),
@@ -104,8 +156,8 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             keypair,
             &fake_entries,
             last_tick_height == bank.max_tick_height(),
-            chained_merkle_root,
-            next_shred_index,
+            self.chained_merkle_root,
+            self.next_shred_index,
             self.next_code_index,
             &self.reed_solomon_cache,
             &mut ProcessShredsStats::default(),

--- a/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -124,11 +124,19 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             for shred in &header_shreds {
                 if shred.is_data() {
                     self.next_shred_index = self.next_shred_index.max(shred.index() + 1);
-                    self.chained_merkle_root = shred.merkle_root().unwrap();
                 } else {
                     self.next_code_index = self.next_code_index.max(shred.index() + 1);
                 }
             }
+
+            // Set the chained merkle root to the last data shred's root
+            if let Some(shred) = header_shreds.iter().filter(|s| s.is_data()).last() {
+                self.chained_merkle_root = shred.merkle_root().unwrap();
+            }
+
+            let header_shreds = Arc::new(header_shreds);
+            blockstore_sender.send((header_shreds.clone(), None))?;
+            socket_sender.send((header_shreds, None))?;
         }
 
         let (data_shreds, coding_shreds) = shredder.entries_to_merkle_shreds_for_tests(

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -135,13 +135,12 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
                     self.next_code_index = self.next_code_index.max(shred.index() + 1);
                 }
             }
-            if let Some(shred) = header_shreds
-                .iter()
-                .filter(|s| s.is_data())
-                .max_by_key(|shred| shred.index())
-            {
+            if let Some(shred) = header_shreds.iter().filter(|s| s.is_data()).last() {
                 self.chained_merkle_root = shred.merkle_root().unwrap();
             }
+            let header_shreds = Arc::new(header_shreds);
+            blockstore_sender.send((header_shreds.clone(), None))?;
+            socket_sender.send((header_shreds, None))?;
         }
 
         let (data_shreds, coding_shreds) = shredder.entries_to_merkle_shreds_for_tests(

--- a/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -1,6 +1,8 @@
 use {
     super::*,
     crate::cluster_nodes::ClusterNodesCache,
+    agave_votor_messages::migration::MigrationStatus,
+    solana_entry::block_component::BlockComponent,
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
@@ -21,10 +23,11 @@ pub(super) struct FailEntryVerificationBroadcastRun {
     next_code_index: u32,
     cluster_nodes_cache: Arc<ClusterNodesCache<BroadcastStage>>,
     reed_solomon_cache: Arc<ReedSolomonCache>,
+    migration_status: Arc<MigrationStatus>,
 }
 
 impl FailEntryVerificationBroadcastRun {
-    pub(super) fn new(shred_version: u16) -> Self {
+    pub(super) fn new(shred_version: u16, migration_status: Arc<MigrationStatus>) -> Self {
         let cluster_nodes_cache = Arc::new(ClusterNodesCache::<BroadcastStage>::new(
             CLUSTER_NODES_CACHE_NUM_EPOCH_CAP,
             CLUSTER_NODES_CACHE_TTL,
@@ -39,6 +42,7 @@ impl FailEntryVerificationBroadcastRun {
             next_code_index: 0,
             cluster_nodes_cache,
             reed_solomon_cache: Arc::<ReedSolomonCache>::default(),
+            migration_status,
         }
     }
 }
@@ -59,7 +63,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 
-        if bank.slot() != self.current_slot {
+        let send_header = if bank.slot() != self.current_slot {
             self.chained_merkle_root = broadcast_utils::get_chained_merkle_root_from_parent(
                 bank.slot(),
                 bank.parent_slot(),
@@ -69,7 +73,11 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             self.next_shred_index = 0;
             self.next_code_index = 0;
             self.current_slot = bank.slot();
-        }
+
+            true
+        } else {
+            false
+        };
 
         // 2) If we're past SLOT_TO_RESOLVE, insert the correct shreds so validators can repair
         // and make progress
@@ -99,6 +107,42 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             self.shred_version,
         )
         .expect("Expected to create a new shredder");
+
+        // Generate header shreds for new slot
+        if send_header
+            && self
+                .migration_status
+                .should_allow_block_markers(bank.slot())
+        {
+            let header =
+                BlockComponent::new_block_header(bank.parent_slot(), self.chained_merkle_root);
+            let header_shreds: Vec<_> = shredder
+                .make_merkle_shreds_from_component(
+                    keypair,
+                    &header,
+                    false,
+                    self.chained_merkle_root,
+                    self.next_shred_index,
+                    self.next_code_index,
+                    &self.reed_solomon_cache,
+                    &mut stats,
+                )
+                .collect();
+            for shred in &header_shreds {
+                if shred.is_data() {
+                    self.next_shred_index = self.next_shred_index.max(shred.index() + 1);
+                } else {
+                    self.next_code_index = self.next_code_index.max(shred.index() + 1);
+                }
+            }
+            if let Some(shred) = header_shreds
+                .iter()
+                .filter(|s| s.is_data())
+                .max_by_key(|shred| shred.index())
+            {
+                self.chained_merkle_root = shred.merkle_root().unwrap();
+            }
+        }
 
         let (data_shreds, coding_shreds) = shredder.entries_to_merkle_shreds_for_tests(
             keypair,

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -8,7 +8,7 @@ use {
     crate::cluster_nodes::ClusterNodesCache,
     agave_votor::event::VotorEventSender,
     agave_votor_messages::migration::MigrationStatus,
-    solana_entry::{block_component::BlockComponent, entry::Entry},
+    solana_entry::block_component::BlockComponent,
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::shred::{
@@ -41,6 +41,8 @@ pub struct StandardBroadcastRun {
     reed_solomon_cache: Arc<ReedSolomonCache>,
     migration_status: Arc<MigrationStatus>,
     votor_event_sender: VotorEventSender,
+    max_data_shreds_per_slot: u32,
+    max_code_shreds_per_slot: u32,
 }
 
 #[derive(Debug)]
@@ -77,6 +79,8 @@ impl StandardBroadcastRun {
             reed_solomon_cache: Arc::<ReedSolomonCache>::default(),
             migration_status,
             votor_event_sender,
+            max_data_shreds_per_slot: MAX_DATA_SHREDS_PER_SLOT as u32,
+            max_code_shreds_per_slot: MAX_CODE_SHREDS_PER_SLOT as u32,
         }
     }
 
@@ -106,7 +110,7 @@ impl StandardBroadcastRun {
                 // self.next_shred_index and self.next_code_index
                 .inspect(|shred| self.process_shreds_stats.record_shred(shred))
                 .collect();
-        if let Some(shred) = shreds.iter().max_by_key(|shred| shred.fec_set_index()) {
+        if let Some(shred) = shreds.last() {
             self.chained_merkle_root = shred.merkle_root().unwrap();
         }
         self.report_and_reset_stats(/*was_interrupted:*/ true);
@@ -114,52 +118,6 @@ impl StandardBroadcastRun {
         shreds
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn entries_to_shreds(
-        &mut self,
-        keypair: &Keypair,
-        entries: &[Entry],
-        reference_tick: u8,
-        is_slot_end: bool,
-        process_stats: &mut ProcessShredsStats,
-        max_data_shreds_per_slot: u32,
-        max_code_shreds_per_slot: u32,
-    ) -> std::result::Result<Vec<Shred>, BroadcastError> {
-        let shreds: Vec<_> =
-            Shredder::new(self.slot, self.parent, reference_tick, self.shred_version)
-                .unwrap()
-                .make_merkle_shreds_from_entries(
-                    keypair,
-                    entries,
-                    is_slot_end,
-                    self.chained_merkle_root,
-                    self.next_shred_index,
-                    self.next_code_index,
-                    &self.reed_solomon_cache,
-                    process_stats,
-                )
-                .inspect(|shred| {
-                    process_stats.record_shred(shred);
-                    let next_index = match shred.shred_type() {
-                        ShredType::Code => &mut self.next_code_index,
-                        ShredType::Data => &mut self.next_shred_index,
-                    };
-                    *next_index = (*next_index).max(shred.index() + 1);
-                })
-                .collect();
-        if let Some(shred) = shreds.iter().max_by_key(|shred| shred.fec_set_index()) {
-            self.chained_merkle_root = shred.merkle_root().unwrap();
-        }
-        if self.next_shred_index > max_data_shreds_per_slot {
-            return Err(BroadcastError::TooManyShreds);
-        }
-        if self.next_code_index > max_code_shreds_per_slot {
-            return Err(BroadcastError::TooManyShreds);
-        }
-        Ok(shreds)
-    }
-
-    #[allow(clippy::too_many_arguments)]
     fn component_to_shreds(
         &mut self,
         keypair: &Keypair,
@@ -167,8 +125,6 @@ impl StandardBroadcastRun {
         reference_tick: u8,
         is_slot_end: bool,
         process_stats: &mut ProcessShredsStats,
-        max_data_shreds_per_slot: u32,
-        max_code_shreds_per_slot: u32,
     ) -> std::result::Result<Vec<Shred>, BroadcastError> {
         let shreds: Vec<_> =
             Shredder::new(self.slot, self.parent, reference_tick, self.shred_version)
@@ -192,13 +148,13 @@ impl StandardBroadcastRun {
                     *next_index = (*next_index).max(shred.index() + 1);
                 })
                 .collect();
-        if let Some(shred) = shreds.iter().max_by_key(|shred| shred.fec_set_index()) {
+        if let Some(shred) = shreds.last() {
             self.chained_merkle_root = shred.merkle_root().unwrap();
         }
-        if self.next_shred_index > max_data_shreds_per_slot {
+        if self.next_shred_index > self.max_data_shreds_per_slot {
             return Err(BroadcastError::TooManyShreds);
         }
-        if self.next_code_index > max_code_shreds_per_slot {
+        if self.next_code_index > self.max_code_shreds_per_slot {
             return Err(BroadcastError::TooManyShreds);
         }
         Ok(shreds)
@@ -247,7 +203,7 @@ impl StandardBroadcastRun {
 
         let mut to_shreds_time = Measure::start("broadcast_to_shreds");
 
-        let send_header = if self.slot != bank.slot() {
+        let maybe_send_header = if self.slot != bank.slot() {
             // Finish previous slot if it was interrupted.
             if !self.completed {
                 let shreds = self.finish_prev_slot(keypair, bank.ticks_per_slot() as u8);
@@ -316,43 +272,34 @@ impl StandardBroadcastRun {
             .saturating_add(bank.ticks_per_slot())
             .saturating_sub(bank.max_tick_height());
 
-        let mut header_shreds = if send_header
+        let mut header_shreds = if maybe_send_header
             && self
                 .migration_status
                 .should_allow_block_markers(bank.slot())
         {
             let header = BlockComponent::new_block_header(self.parent, self.chained_merkle_root);
-            self.component_to_shreds(
-                keypair,
-                &header,
-                reference_tick as u8,
-                false,
-                process_stats,
-                MAX_DATA_SHREDS_PER_SLOT as u32,
-                MAX_CODE_SHREDS_PER_SLOT as u32,
-            )
-            .unwrap()
+            self.component_to_shreds(keypair, &header, reference_tick as u8, false, process_stats)
+                .unwrap()
         } else {
             vec![]
         };
 
-        let component_shreds = self
-            .entries_to_shreds(
+        let entry_component = BlockComponent::new_entry_batch(entries).unwrap();
+        let entry_shreds = self
+            .component_to_shreds(
                 keypair,
-                &entries,
+                &entry_component,
                 reference_tick as u8,
                 is_last_in_slot,
                 process_stats,
-                MAX_DATA_SHREDS_PER_SLOT as u32,
-                MAX_CODE_SHREDS_PER_SLOT as u32,
             )
             .unwrap();
 
-        let shreds = if send_header {
-            header_shreds.extend_from_slice(&component_shreds);
+        let shreds = if maybe_send_header {
+            header_shreds.extend(entry_shreds);
             header_shreds
         } else {
-            component_shreds
+            entry_shreds
         };
         // Insert the first data shred synchronously so that blockstore stores
         // that the leader started this block. This must be done before the
@@ -567,6 +514,7 @@ impl BroadcastRun for StandardBroadcastRun {
 mod test {
     use {
         super::*,
+        assert_matches::assert_matches,
         crossbeam_channel::unbounded,
         rand::Rng,
         solana_entry::entry::create_ticks,
@@ -666,29 +614,25 @@ mod test {
         assert!(shred.verify(&keypair.pubkey()));
     }
 
-    fn alpenglow_migration_status() -> MigrationStatus {
-        let status = MigrationStatus::post_migration_status();
-        status.alpenglow_rooted_new_epoch(0);
-        status
-    }
-
     #[test_case(MigrationStatus::default(), 1 ; "pre_migration")]
-    #[test_case(alpenglow_migration_status(), 2 ; "alpenglow_enabled")]
+    #[test_case(MigrationStatus::post_migration_status(), 2 ; "alpenglow_enabled")]
     fn test_slot_interrupt(migration_status: MigrationStatus, shred_multiplier: u64) {
         // Setup
         let num_shreds_per_slot = DATA_SHREDS_PER_FEC_BLOCK as u64;
         let (blockstore, genesis_config, cluster_info, bank0, leader_keypair, socket, bank_forks) =
             setup(num_shreds_per_slot);
 
+        let bank1 = Arc::new(Bank::new_from_parent(bank0.clone(), *bank0.leader(), 1));
+
         // Insert 1 less than the number of ticks needed to finish the slot
         let ticks0 = create_ticks(genesis_config.ticks_per_slot - 1, 0, genesis_config.hash());
         let receive_results = ReceiveResults {
             entries: ticks0.clone(),
-            bank: bank0.clone(),
+            bank: bank1.clone(),
             last_tick_height: (ticks0.len() - 1) as u64,
         };
 
-        // Step 1: Make an incomplete transmission for slot 0
+        // Step 1: Make an incomplete transmission for slot 1
         let (votor_event_sender, _votor_event_receiver) = unbounded();
         let mut standard_broadcast_run =
             StandardBroadcastRun::new(0, Arc::new(migration_status), votor_event_sender);
@@ -707,10 +651,10 @@ mod test {
             standard_broadcast_run.next_shred_index as u64,
             shred_multiplier * num_shreds_per_slot
         );
-        assert_eq!(standard_broadcast_run.slot, 0);
+        assert_eq!(standard_broadcast_run.slot, 1);
         assert_eq!(standard_broadcast_run.parent, 0);
         // Make sure the slot is not complete
-        assert!(!blockstore.is_full(0));
+        assert!(!blockstore.is_full(1));
         // Modify the stats, should reset later
         standard_broadcast_run.process_shreds_stats.receive_elapsed = 10;
         // Broadcast stats should exist, and 1 batch should have been sent,
@@ -740,19 +684,19 @@ mod test {
         // so entry data starts at that offset.
         let header_shred_offset = (shred_multiplier - 1) * num_shreds_per_slot;
         assert_eq!(
-            blockstore.get_slot_entries(0, header_shred_offset).unwrap(),
+            blockstore.get_slot_entries(1, header_shred_offset).unwrap(),
             ticks0
         );
         assert_eq!(
             blockstore
-                .get_slot_entries(0, shred_multiplier * num_shreds_per_slot)
+                .get_slot_entries(1, shred_multiplier * num_shreds_per_slot)
                 .unwrap(),
             vec![],
         );
 
         // Step 2: Make a transmission for another bank that interrupts the transmission for
-        // slot 0
-        let bank2 = Arc::new(Bank::new_from_parent(bank0.clone(), *bank0.leader(), 2));
+        // slot 1
+        let bank2 = Arc::new(Bank::new_from_parent(bank1, *bank0.leader(), 2));
         let interrupted_slot = standard_broadcast_run.slot;
         // Interrupting the slot should cause the unfinished_slot and stats to reset
         let num_shreds = 1;
@@ -779,14 +723,14 @@ mod test {
             .unwrap();
 
         // The shred index should have reset to 0, which makes it possible for the
-        // index < the previous shred index for slot 0
+        // index < the previous shred index for slot 1
         // When alpenglow is enabled, new slots include both header and component shreds
         assert_eq!(
             standard_broadcast_run.next_shred_index as usize,
             shred_multiplier as usize * DATA_SHREDS_PER_FEC_BLOCK
         );
         assert_eq!(standard_broadcast_run.slot, 2);
-        assert_eq!(standard_broadcast_run.parent, 0);
+        assert_eq!(standard_broadcast_run.parent, 1);
 
         // Check that the stats were reset as well
         assert_eq!(
@@ -814,12 +758,12 @@ mod test {
 
         // Try to fetch the incomplete ticks from blockstore, should succeed
         assert_eq!(
-            blockstore.get_slot_entries(0, header_shred_offset).unwrap(),
+            blockstore.get_slot_entries(1, header_shred_offset).unwrap(),
             ticks0
         );
         assert_eq!(
             blockstore
-                .get_slot_entries(0, shred_multiplier * num_shreds_per_slot)
+                .get_slot_entries(1, shred_multiplier * num_shreds_per_slot)
                 .unwrap(),
             vec![],
         );
@@ -911,7 +855,7 @@ mod test {
     }
 
     #[test]
-    fn entries_to_shreds_max() {
+    fn test_component_to_shreds_max() {
         agave_logger::setup();
         let keypair = Keypair::new();
         let (votor_event_sender, _votor_event_receiver) = unbounded();
@@ -919,20 +863,16 @@ mod test {
             StandardBroadcastRun::new(0, Arc::new(MigrationStatus::default()), votor_event_sender);
         bs.slot = 1;
         bs.parent = 0;
+        bs.max_data_shreds_per_slot = 1000;
+        bs.max_code_shreds_per_slot = 1000;
         let entries = create_ticks(10_000, 1, solana_hash::Hash::default());
 
         let mut stats = ProcessShredsStats::default();
 
+        let component =
+            BlockComponent::new_entry_batch(entries[0..entries.len() - 2].to_vec()).unwrap();
         let (data, coding) = bs
-            .entries_to_shreds(
-                &keypair,
-                &entries[0..entries.len() - 2],
-                0,
-                false,
-                &mut stats,
-                1000,
-                1000,
-            )
+            .component_to_shreds(&keypair, &component, 0, false, &mut stats)
             .unwrap()
             .into_iter()
             .partition::<Vec<_>, _>(Shred::is_data);
@@ -940,8 +880,10 @@ mod test {
         assert!(!data.is_empty());
         assert!(!coding.is_empty());
 
-        let r = bs.entries_to_shreds(&keypair, &entries, 0, false, &mut stats, 10, 10);
-        info!("{r:?}");
+        bs.max_data_shreds_per_slot = 10;
+        bs.max_code_shreds_per_slot = 10;
+        let component = BlockComponent::new_entry_batch(entries).unwrap();
+        let r = bs.component_to_shreds(&keypair, &component, 0, false, &mut stats);
         assert_matches!(r, Err(BroadcastError::TooManyShreds));
     }
 }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -8,7 +8,7 @@ use {
     crate::cluster_nodes::ClusterNodesCache,
     agave_votor::event::VotorEventSender,
     agave_votor_messages::migration::MigrationStatus,
-    solana_entry::entry::Entry,
+    solana_entry::{block_component::BlockComponent, entry::Entry},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::shred::{
@@ -159,6 +159,51 @@ impl StandardBroadcastRun {
         Ok(shreds)
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn component_to_shreds(
+        &mut self,
+        keypair: &Keypair,
+        component: &BlockComponent,
+        reference_tick: u8,
+        is_slot_end: bool,
+        process_stats: &mut ProcessShredsStats,
+        max_data_shreds_per_slot: u32,
+        max_code_shreds_per_slot: u32,
+    ) -> std::result::Result<Vec<Shred>, BroadcastError> {
+        let shreds: Vec<_> =
+            Shredder::new(self.slot, self.parent, reference_tick, self.shred_version)
+                .unwrap()
+                .make_merkle_shreds_from_component(
+                    keypair,
+                    component,
+                    is_slot_end,
+                    self.chained_merkle_root,
+                    self.next_shred_index,
+                    self.next_code_index,
+                    &self.reed_solomon_cache,
+                    process_stats,
+                )
+                .inspect(|shred| {
+                    process_stats.record_shred(shred);
+                    let next_index = match shred.shred_type() {
+                        ShredType::Code => &mut self.next_code_index,
+                        ShredType::Data => &mut self.next_shred_index,
+                    };
+                    *next_index = (*next_index).max(shred.index() + 1);
+                })
+                .collect();
+        if let Some(shred) = shreds.iter().max_by_key(|shred| shred.fec_set_index()) {
+            self.chained_merkle_root = shred.merkle_root().unwrap();
+        }
+        if self.next_shred_index > max_data_shreds_per_slot {
+            return Err(BroadcastError::TooManyShreds);
+        }
+        if self.next_code_index > max_code_shreds_per_slot {
+            return Err(BroadcastError::TooManyShreds);
+        }
+        Ok(shreds)
+    }
+
     #[cfg(test)]
     fn test_process_receive_results(
         &mut self,
@@ -202,7 +247,7 @@ impl StandardBroadcastRun {
 
         let mut to_shreds_time = Measure::start("broadcast_to_shreds");
 
-        if self.slot != bank.slot() {
+        let send_header = if self.slot != bank.slot() {
             // Finish previous slot if it was interrupted.
             if !self.completed {
                 let shreds = self.finish_prev_slot(keypair, bank.ticks_per_slot() as u8);
@@ -257,7 +302,11 @@ impl StandardBroadcastRun {
             self.num_batches = 0;
             process_stats.receive_elapsed = 0;
             process_stats.coalesce_elapsed = 0;
-        }
+
+            true
+        } else {
+            false
+        };
 
         // 2) Convert entries to shreds and coding shreds
         let is_last_in_slot = last_tick_height == bank.max_tick_height();
@@ -266,7 +315,28 @@ impl StandardBroadcastRun {
         let reference_tick = last_tick_height
             .saturating_add(bank.ticks_per_slot())
             .saturating_sub(bank.max_tick_height());
-        let shreds = self
+
+        let mut header_shreds = if send_header
+            && self
+                .migration_status
+                .should_allow_block_markers(bank.slot())
+        {
+            let header = BlockComponent::new_block_header(self.parent, self.chained_merkle_root);
+            self.component_to_shreds(
+                keypair,
+                &header,
+                reference_tick as u8,
+                false,
+                process_stats,
+                MAX_DATA_SHREDS_PER_SLOT as u32,
+                MAX_CODE_SHREDS_PER_SLOT as u32,
+            )
+            .unwrap()
+        } else {
+            vec![]
+        };
+
+        let component_shreds = self
             .entries_to_shreds(
                 keypair,
                 &entries,
@@ -277,6 +347,13 @@ impl StandardBroadcastRun {
                 MAX_CODE_SHREDS_PER_SLOT as u32,
             )
             .unwrap();
+
+        let shreds = if send_header {
+            header_shreds.extend_from_slice(&component_shreds);
+            header_shreds
+        } else {
+            component_shreds
+        };
         // Insert the first data shred synchronously so that blockstore stores
         // that the leader started this block. This must be done before the
         // blocks are sent out over the wire, so that the slots we have already
@@ -507,6 +584,7 @@ mod test {
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         std::{ops::Deref, sync::Arc, time::Duration},
+        test_case::test_case,
     };
 
     #[allow(clippy::type_complexity)]
@@ -588,8 +666,15 @@ mod test {
         assert!(shred.verify(&keypair.pubkey()));
     }
 
-    #[test]
-    fn test_slot_interrupt() {
+    fn alpenglow_migration_status() -> MigrationStatus {
+        let status = MigrationStatus::post_migration_status();
+        status.alpenglow_rooted_new_epoch(0);
+        status
+    }
+
+    #[test_case(MigrationStatus::default(), 1 ; "pre_migration")]
+    #[test_case(alpenglow_migration_status(), 2 ; "alpenglow_enabled")]
+    fn test_slot_interrupt(migration_status: MigrationStatus, shred_multiplier: u64) {
         // Setup
         let num_shreds_per_slot = DATA_SHREDS_PER_FEC_BLOCK as u64;
         let (blockstore, genesis_config, cluster_info, bank0, leader_keypair, socket, bank_forks) =
@@ -606,7 +691,7 @@ mod test {
         // Step 1: Make an incomplete transmission for slot 0
         let (votor_event_sender, _votor_event_receiver) = unbounded();
         let mut standard_broadcast_run =
-            StandardBroadcastRun::new(0, Arc::new(MigrationStatus::default()), votor_event_sender);
+            StandardBroadcastRun::new(0, Arc::new(migration_status), votor_event_sender);
         standard_broadcast_run
             .test_process_receive_results(
                 &leader_keypair,
@@ -617,9 +702,10 @@ mod test {
                 &bank_forks,
             )
             .unwrap();
+        // When alpenglow is enabled, new slots include both header and component shreds
         assert_eq!(
             standard_broadcast_run.next_shred_index as u64,
-            num_shreds_per_slot
+            shred_multiplier * num_shreds_per_slot
         );
         assert_eq!(standard_broadcast_run.slot, 0);
         assert_eq!(standard_broadcast_run.parent, 0);
@@ -649,10 +735,18 @@ mod test {
                 .num_batches(),
             1
         );
-        // Try to fetch ticks from blockstore, nothing should break
-        assert_eq!(blockstore.get_slot_entries(0, 0).unwrap(), ticks0);
+        // Try to fetch ticks from blockstore, nothing should break.
+        // When headers are enabled, header shreds occupy the first num_shreds_per_slot indices,
+        // so entry data starts at that offset.
+        let header_shred_offset = (shred_multiplier - 1) * num_shreds_per_slot;
         assert_eq!(
-            blockstore.get_slot_entries(0, num_shreds_per_slot).unwrap(),
+            blockstore.get_slot_entries(0, header_shred_offset).unwrap(),
+            ticks0
+        );
+        assert_eq!(
+            blockstore
+                .get_slot_entries(0, shred_multiplier * num_shreds_per_slot)
+                .unwrap(),
             vec![],
         );
 
@@ -686,9 +780,10 @@ mod test {
 
         // The shred index should have reset to 0, which makes it possible for the
         // index < the previous shred index for slot 0
+        // When alpenglow is enabled, new slots include both header and component shreds
         assert_eq!(
             standard_broadcast_run.next_shred_index as usize,
-            DATA_SHREDS_PER_FEC_BLOCK
+            shred_multiplier as usize * DATA_SHREDS_PER_FEC_BLOCK
         );
         assert_eq!(standard_broadcast_run.slot, 2);
         assert_eq!(standard_broadcast_run.parent, 0);
@@ -718,9 +813,14 @@ mod test {
         );
 
         // Try to fetch the incomplete ticks from blockstore, should succeed
-        assert_eq!(blockstore.get_slot_entries(0, 0).unwrap(), ticks0);
         assert_eq!(
-            blockstore.get_slot_entries(0, num_shreds_per_slot).unwrap(),
+            blockstore.get_slot_entries(0, header_shred_offset).unwrap(),
+            ticks0
+        );
+        assert_eq!(
+            blockstore
+                .get_slot_entries(0, shred_multiplier * num_shreds_per_slot)
+                .unwrap(),
             vec![],
         );
     }


### PR DESCRIPTION
This PR upstreams https://github.com/anza-xyz/alpenglow/pull/571.

#### Problem and Summary of Changes

This PR constructs and disseminates block headers at the start of each new slot so that validators can identify the parent slot and parent block ID for a given block. See https://github.com/solana-foundation/solana-improvement-documents/pull/337 for more detail.