### PR TITLE
Sets bank_hash_details_dir in LocalCluster

### DIFF
--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -190,6 +190,7 @@ impl LocalCluster {
                 .0,
         ];
         config.tower_storage = Arc::new(FileTowerStorage::new(ledger_path.to_path_buf()));
+        config.accounts_db_config.bank_hash_details_dir = ledger_path.to_path_buf();
 
         let snapshot_config = &mut config.snapshot_config;
         let dummy: PathBuf = DUMMY_SNAPSHOT_CONFIG_PATH_MARKER.into();


### PR DESCRIPTION
#### Problem

After https://github.com/anza-xyz/agave/pull/9736 merged, tests started leaving behind bank hash details files.

Similar to PR #11258, but this one is for local-cluster tests.


#### Summary of Changes

Set the bank hash details dir to the ledger path for local cluster tests.