### PR TITLE
build: replace `cargo-sort` with `taplo`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,9 @@ used_underscore_binding = "deny"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
-agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 agave-bls-cert-verify = { path = "bls-cert-verify", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-bls12-381 = { path = "bls12-381", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-feature-set = { path = "feature-set", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -198,11 +200,17 @@ agave-logger = { path = "logger", version = "=4.1.0-alpha.0", features = ["agave
 agave-math-utils = { path = "math-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-precompiles = { path = "precompiles", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-random = { path = "random", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-agave-scheduler-bindings = { path = "scheduler-bindings", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
+agave-scheduler-bindings = { path = "scheduler-bindings", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 agave-scheduling-utils = { path = "scheduling-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-snapshots = { path = "snapshots", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-agave-syscalls = { path = "syscalls", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+agave-syscalls = { path = "syscalls", version = "=4.1.0-alpha.0", default-features = false, features = [
+    "agave-unstable-api",
+] }
 agave-transaction-view = { path = "transaction-view", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-votor = { path = "votor", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-votor-messages = { path = "votor-messages", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -385,7 +393,9 @@ socket2 = "0.6.3"
 soketto = "0.8"
 solana-account = "4.1.0"
 solana-account-decoder = { path = "account-decoder", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-account-info = "3.1.0"
 solana-accounts-db = { path = "accounts-db", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-address = "2.3.0"
@@ -401,10 +411,14 @@ solana-bloom = { path = "bloom", version = "=4.1.0-alpha.0", features = ["agave-
 solana-bls-signatures = { version = "3.2.0", features = ["serde"] }
 solana-bn254 = "3.2.1"
 solana-borsh = "3.0.1"
-solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=4.1.0-alpha.0", default-features = false, features = [
+    "agave-unstable-api",
+] }
 solana-bucket-map = { path = "bucket_map", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-builtins = { path = "builtins", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-builtins-default-costs = { path = "builtins-default-costs", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-builtins-default-costs = { path = "builtins-default-costs", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-clap-utils = { path = "clap-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-clap-v3-utils = { path = "clap-v3-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-cli = { path = "cli", version = "=4.1.0-alpha.0", default-features = false }
@@ -416,11 +430,17 @@ solana-clock = "3.0.1"
 solana-cluster-type = "3.1.0"
 solana-commitment-config = "3.1.1"
 solana-compute-budget = { path = "compute-budget", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-compute-budget-interface = "3.0.0"
-solana-compute-budget-program = { path = "programs/compute-budget", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-compute-budget-program = { path = "programs/compute-budget", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-config-interface = "2.0.0"
-solana-connection-cache = { path = "connection-cache", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+solana-connection-cache = { path = "connection-cache", version = "=4.1.0-alpha.0", default-features = false, features = [
+    "agave-unstable-api",
+] }
 solana-core = { path = "core", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-cost-model = { path = "cost-model", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-cpi = "3.1.0"
@@ -446,7 +466,9 @@ solana-frozen-abi-macro = "3.2.1"
 solana-genesis = { path = "genesis", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-genesis-config = "4.0.0"
 solana-genesis-utils = { path = "genesis-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-gossip = { path = "gossip", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-hard-forks = "3.0.1"
 solana-hash = "4.2.0"
@@ -463,7 +485,9 @@ solana-ledger = { path = "ledger", version = "=4.1.0-alpha.0", features = ["agav
 solana-loader-v2-interface = "3.0.0"
 solana-loader-v3-interface = "6.1.0"
 solana-loader-v4-interface = "3.1.0"
-solana-loader-v4-program = { path = "programs/loader-v4", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+solana-loader-v4-program = { path = "programs/loader-v4", version = "=4.1.0-alpha.0", default-features = false, features = [
+    "agave-unstable-api",
+] }
 solana-local-cluster = { path = "local-cluster", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-measure = { path = "measure", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-merkle-tree = { path = "merkle-tree", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -497,7 +521,9 @@ solana-pubkey = { version = "4.1.0", default-features = false }
 solana-pubsub-client = { path = "pubsub-client", version = "=4.1.0-alpha.0" }
 solana-quic-client = { path = "quic-client", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-remote-wallet = { path = "remote-wallet", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+solana-remote-wallet = { path = "remote-wallet", version = "=4.1.0-alpha.0", default-features = false, features = [
+    "agave-unstable-api",
+] }
 solana-rent = "4.1.0"
 solana-reward-info = "5.0.0"
 solana-rpc = { path = "rpc", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -506,7 +532,9 @@ solana-rpc-client-api = { path = "rpc-client-api", version = "=4.1.0-alpha.0" }
 solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=4.1.0-alpha.0" }
 solana-rpc-client-types = { path = "rpc-client-types", version = "=4.1.0-alpha.0" }
 solana-runtime = { path = "runtime", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-runtime-transaction = { path = "runtime-transaction", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-runtime-transaction = { path = "runtime-transaction", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-sanitize = "3.0.1"
 solana-sbpf = { version = "=0.16.0", default-features = false }
 solana-sdk-ids = "3.1.0"
@@ -515,7 +543,9 @@ solana-secp256k1-recover = "3.1.1"
 solana-secp256r1-program = "3.0.0"
 solana-seed-derivable = "3.0.0"
 solana-seed-phrase = "3.0.0"
-solana-send-transaction-service = { path = "send-transaction-service", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-send-transaction-service = { path = "send-transaction-service", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-serde = "3.0.0"
 solana-serde-varint = "3.0.1"
 solana-serialize-utils = "3.1.1"
@@ -542,8 +572,10 @@ solana-svm-test-harness-fixture = { path = "svm-test-harness/fixture", version =
 solana-svm-test-harness-instr = { path = "svm-test-harness/instr", version = "=4.1.0-alpha.0" }
 solana-svm-timings = { path = "svm-timings", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm-transaction = { path = "svm-transaction", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm-type-overrides = { path = "svm-type-overrides", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-system-interface = { version = "3.1", features = ["alloc","bincode","serde","wincode"] }
+solana-svm-type-overrides = { path = "svm-type-overrides", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
+solana-system-interface = { version = "3.1", features = ["alloc", "bincode", "serde", "wincode"] }
 solana-system-program = { path = "programs/system", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-system-transaction = "4.0.0"
 solana-sysvar = "4.0.0"
@@ -552,25 +584,44 @@ solana-test-validator = { path = "test-validator", version = "=4.1.0-alpha.0" }
 solana-time-utils = "3.0.0"
 solana-tls-utils = { path = "tls-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-tps-client = { path = "tps-client", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-tpu-client = { path = "tpu-client", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+solana-tpu-client = { path = "tpu-client", version = "=4.1.0-alpha.0", default-features = false, features = [
+    "agave-unstable-api",
+] }
 solana-tpu-client-next = { path = "tpu-client-next", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-transaction = "4.0.0"
-solana-transaction-context = { path = "transaction-context", version = "=4.1.0-alpha.0", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-context = { path = "transaction-context", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+    "bincode",
+] }
 solana-transaction-error = "3.1.0"
-solana-transaction-status = { path = "transaction-status", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-transaction-status = { path = "transaction-status", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
+solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-turbine = { path = "turbine", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-udp-client = { path = "udp-client", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
+solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-validator-exit = "3.0.0"
 solana-version = { path = "version", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-vote = { path = "vote", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-vote-interface = "5.0.0"
-solana-vote-program = { path = "programs/vote", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
-solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-vote-program = { path = "programs/vote", version = "=4.1.0-alpha.0", default-features = false, features = [
+    "agave-unstable-api",
+] }
+solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-zk-sdk = "5.0.1"
-solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 spl-associated-token-account-interface = "2.0.0"
 spl-generic-token = "2.0.0"
 spl-memo-interface = "2.0.0"

--- a/banks-interface/Cargo.toml
+++ b/banks-interface/Cargo.toml
@@ -21,14 +21,14 @@ agave-unstable-api = []
 
 [dependencies]
 serde = { workspace = true }
-solana-account = { workspace = true, features = [ "serde" ] }
+solana-account = { workspace = true, features = ["serde"] }
 solana-clock = { workspace = true }
-solana-commitment-config = { workspace = true, features = [ "serde" ] }
+solana-commitment-config = { workspace = true, features = ["serde"] }
 solana-hash = { workspace = true }
-solana-message = { workspace = true, features = [ "serde" ] }
+solana-message = { workspace = true, features = ["serde"] }
 solana-pubkey = { workspace = true }
-solana-signature = { workspace = true, features = [ "serde" ] }
-solana-transaction = { workspace = true, features = [ "serde" ] }
-solana-transaction-context = { workspace = true, features = [ "serde" ] }
-solana-transaction-error = { workspace = true, features = [ "serde" ] }
+solana-signature = { workspace = true, features = ["serde"] }
+solana-transaction = { workspace = true, features = ["serde"] }
+solana-transaction-context = { workspace = true, features = ["serde"] }
+solana-transaction-error = { workspace = true, features = ["serde"] }
 tarpc = { workspace = true, features = ["full"] }

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -83,7 +83,7 @@ RUN \
   rustup target add wasm32-unknown-unknown && \
   cargo install cargo-audit && \
   cargo install cargo-hack && \
-  cargo install cargo-sort@^2 && \
+  cargo install taplo-cli && \
   cargo install mdbook && \
   cargo install mdbook-linkcheck && \
   cargo install svgbob_cli && \

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -15,13 +15,9 @@ eval "$(ci/channel-info.sh)"
 export RUST_BACKTRACE=1
 export RUSTFLAGS="-D warnings -A incomplete_features"
 
-# sort
-if [[ -n $CI ]]; then
-  # exclude from printing "Checking xxx ..."
-  _ scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" sort --workspace --check > /dev/null
-else
-  _ scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" sort --workspace --check
-fi
+# toml format & lint
+_ taplo check
+_ taplo fmt --check
 
 # check dev-context-only-utils isn't used in normal dependencies
 _ scripts/check-dev-context-only-utils.sh tree

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,7 +44,15 @@ humantime = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
 pretty-hex = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "rustls-tls-native-roots", "json"] }
+reqwest = { workspace = true, features = [
+    "blocking",
+    "brotli",
+    "deflate",
+    "gzip",
+    "rustls-tls",
+    "rustls-tls-native-roots",
+    "json",
+] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 solana-account = { workspace = true }

--- a/clippy.toml
+++ b/clippy.toml
@@ -4,7 +4,7 @@ too-many-arguments-threshold = 9
 disallowed-methods = [
     { path = "std::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_with_config, bind_to, etc instead for proper socket configuration." },
     { path = "tokio::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_to_async or bind_to_with_config_non_blocking instead for proper socket configuration." },
-    { path = "lazy_static::initialize", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." }
+    { path = "lazy_static::initialize", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." },
 ]
 
 disallowed-macros = [

--- a/compute-budget-instruction/Cargo.toml
+++ b/compute-budget-instruction/Cargo.toml
@@ -37,7 +37,10 @@ solana-transaction-error = { workspace = true }
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-builtins-default-costs = { path = "../builtins-default-costs", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-builtins-default-costs = { path = "../builtins-default-costs", features = [
+    "agave-unstable-api",
+    "dev-context-only-utils",
+] }
 solana-compute-budget-instruction = { path = ".", features = ["agave-unstable-api"] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -196,7 +196,9 @@ fs_extra = { workspace = true }
 serde_json = { workspace = true }
 serial_test = { workspace = true }
 solana-account = { workspace = true, features = ["dev-context-only-utils"] }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api"] }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = [
+    "agave-unstable-api",
+] }
 solana-client = { path = "../client", features = ["dev-context-only-utils"] }
 solana-compute-budget-interface = { workspace = true }
 solana-compute-budget-program = { path = "../programs/compute-budget", features = ["agave-unstable-api"] }
@@ -212,7 +214,10 @@ solana-program-runtime = { path = "../program-runtime", features = ["agave-unsta
 solana-rpc = { path = "../rpc", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-signer-store = { workspace = true }
 solana-system-program = { path = "../programs/system", features = ["agave-unstable-api"] }
-solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", features = [
+    "agave-unstable-api",
+    "dev-context-only-utils",
+] }
 solana-vote = { path = "../vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
 spl-memo-interface = { workspace = true }
 static_assertions = { workspace = true }

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -68,7 +68,10 @@ agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["
 itertools = { workspace = true }
 rand = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
-solana-compute-budget-instruction = { path = "../compute-budget-instruction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-compute-budget-instruction = { path = "../compute-budget-instruction", features = [
+    "agave-unstable-api",
+    "dev-context-only-utils",
+] }
 solana-compute-budget-interface = { workspace = true }
 solana-compute-budget-program = { path = "../programs/compute-budget", features = ["agave-unstable-api"] }
 solana-cost-model = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
@@ -76,7 +79,10 @@ solana-hash = { workspace = true, features = ["atomic"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime-transaction = { path = "../runtime-transaction", features = [
+    "agave-unstable-api",
+    "dev-context-only-utils",
+] }
 solana-signer = { workspace = true }
 solana-system-program = { path = "../programs/system", features = ["agave-unstable-api"] }
 solana-system-transaction = { workspace = true }

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -43,10 +43,14 @@ manual_let_else = "deny"
 used_underscore_binding = "deny"
 
 [workspace.dependencies]
-agave-banking-stage-ingress-types = { path = "../banking-stage-ingress-types", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+agave-banking-stage-ingress-types = { path = "../banking-stage-ingress-types", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 agave-feature-set = { path = "../feature-set", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-logger = { path = "../logger", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "../reserved-account-keys", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 agave-snapshots = { path = "../snapshots", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-syscalls = { path = "../syscalls", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 ahash = "0.8.11"
@@ -81,7 +85,9 @@ solana-account = "4.0.0"
 solana-account-decoder = { path = "../account-decoder", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-accounts-db = { path = "../accounts-db", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-bench-tps = { path = "../bench-tps", version = "=4.1.0-alpha.0" }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-clap-utils = { path = "../clap-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-cli-config = { path = "../cli-config", version = "=4.1.0-alpha.0" }
 solana-cli-output = { path = "../cli-output", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -91,7 +97,9 @@ solana-cluster-type = "3.1.0"
 solana-commitment-config = "3.0.0"
 solana-compute-budget = { path = "../compute-budget", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-compute-budget-interface = "3.0.0"
-solana-connection-cache = { path = "../connection-cache", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+solana-connection-cache = { path = "../connection-cache", version = "=4.1.0-alpha.0", default-features = false, features = [
+    "agave-unstable-api",
+] }
 solana-core = { path = "../core", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-cost-model = { path = "../cost-model", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-entry = { path = "../entry", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -101,7 +109,9 @@ solana-fee-calculator = "3.1.0"
 solana-genesis = { path = "../genesis", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-genesis-config = "4.0.0"
 solana-genesis-utils = { path = "../genesis-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-gossip = { path = "../gossip", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-hash = "4.2.0"
 solana-inflation = "3.0.0"
@@ -127,32 +137,51 @@ solana-rpc-client = { path = "../rpc-client", version = "=4.1.0-alpha.0", defaul
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=4.1.0-alpha.0" }
 solana-rpc-client-nonce-utils = { path = "../rpc-client-nonce-utils", version = "=4.1.0-alpha.0" }
 solana-runtime = { path = "../runtime", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-runtime-transaction = { path = "../runtime-transaction", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-runtime-transaction = { path = "../runtime-transaction", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-sbpf = { version = "=0.16.0", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-shred-version = "3.0.1"
 solana-signature = { version = "3.3.0", default-features = false }
 solana-signer = "3.0.0"
 solana-stake-interface = "3.0.0"
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-streamer = { path = "../streamer", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm-callback = { path = "../svm-callback", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm-feature-set = { path = "../svm-feature-set", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm-log-collector = { path = "../svm-log-collector", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm-type-overrides = { path = "../svm-type-overrides", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-svm-log-collector = { path = "../svm-log-collector", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
+solana-svm-type-overrides = { path = "../svm-type-overrides", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-system-interface = "3.1"
 solana-system-transaction = "4.0.0"
 solana-test-validator = { path = "../test-validator", version = "=4.1.0-alpha.0" }
 solana-time-utils = "3.0.0"
 solana-tps-client = { path = "../tps-client", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-tpu-client = { path = "../tpu-client", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+solana-tpu-client = { path = "../tpu-client", version = "=4.1.0-alpha.0", default-features = false, features = [
+    "agave-unstable-api",
+] }
 solana-transaction = "4.0.0"
-solana-transaction-context = { path = "../transaction-context", version = "=4.1.0-alpha.0", features = ["agave-unstable-api", "bincode"] }
-solana-transaction-status = { path = "../transaction-status", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+solana-transaction-context = { path = "../transaction-context", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+    "bincode",
+] }
+solana-transaction-status = { path = "../transaction-status", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
+solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", version = "=4.1.0-alpha.0", features = [
+    "agave-unstable-api",
+] }
 solana-version = { path = "../version", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-vote = { path = "../vote", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-vote-program = { path = "../programs/vote", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+solana-vote-program = { path = "../programs/vote", version = "=4.1.0-alpha.0", default-features = false, features = [
+    "agave-unstable-api",
+] }
 tempfile = "3.23.0"
 thiserror = "2.0.17"
 tokio = "1.48.0"

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -41,7 +41,7 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
-solana-account  = { workspace = true }
+solana-account = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-clap-utils = { workspace = true }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -128,9 +128,9 @@ wincode = { workspace = true }
 [dependencies.rocksdb]
 # Avoid the vendored bzip2 within rocksdb-sys that can cause linker conflicts
 # when also using the bzip2 crate
-version = "0.24.0"
 default-features = false
 features = ["lz4"]
+version = "0.24.0"
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }

--- a/platform-tools-sdk/cargo-build-sbf/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "3.1.5", default-features = false, features = ["cargo", "env"
 itertools = { workspace = true }
 log = { workspace = true, features = ["std"] }
 regex = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "rustls-tls", "rustls-tls-native-roots", "json" ] }
+reqwest = { workspace = true, features = ["blocking", "rustls-tls", "rustls-tls-native-roots", "json"] }
 semver = { workspace = true }
 serde = { workspace = true }
 solana-file-download = "=3.1.4"

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["cdylib"]
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(feature, values("custom-panic", "custom-heap"))'
+    'cfg(feature, values("custom-panic", "custom-heap"))',
 ]
 
 [workspace]

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/package-metadata/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(feature, values("custom-panic", "custom-heap"))'
+    'cfg(feature, values("custom-panic", "custom-heap"))',
 ]
 
 [workspace]

--- a/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
+++ b/platform-tools-sdk/cargo-build-sbf/tests/crates/workspace-metadata/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["cdylib"]
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(feature, values("custom-panic", "custom-heap"))'
+    'cfg(feature, values("custom-panic", "custom-heap"))',
 ]
 
 [workspace]

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -65,7 +65,11 @@ solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-slot-hashes = { workspace = true }
 solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable-api"] }
-solana-transaction-context = { path = "../../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+solana-transaction-context = { path = "../../transaction-context", features = [
+    "agave-unstable-api",
+    "bincode",
+    "dev-context-only-utils",
+] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -49,7 +49,11 @@ solana-sha256-hasher = { workspace = true }
 solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable-api"] }
 solana-svm-feature-set = { path = "../../svm-feature-set", features = ["agave-unstable-api"] }
 solana-system-program = { path = ".", features = ["agave-unstable-api"] }
-solana-transaction-context = { path = "../../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+solana-transaction-context = { path = "../../transaction-context", features = [
+    "agave-unstable-api",
+    "bincode",
+    "dev-context-only-utils",
+] }
 
 [[bench]]
 name = "system"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -117,9 +117,15 @@ solana-program-runtime = { path = "../program-runtime", features = ["agave-unsta
 solana-rent = { workspace = true }
 solana-rpc = { path = ".", features = ["dev-context-only-utils"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime-transaction = { path = "../runtime-transaction", features = [
+    "agave-unstable-api",
+    "dev-context-only-utils",
+] }
 solana-sdk-ids = { workspace = true }
-solana-send-transaction-service = { path = "../send-transaction-service", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-send-transaction-service = { path = "../send-transaction-service", features = [
+    "agave-unstable-api",
+    "dev-context-only-utils",
+] }
 solana-sha256-hasher = { workspace = true }
 solana-stake-interface = { workspace = true }
 solana-svm-log-collector = { path = "../svm-log-collector", features = ["agave-unstable-api"] }

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -39,7 +39,10 @@ agave-reserved-account-keys = { workspace = true }
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-compute-budget-instruction = { path = "../compute-budget-instruction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-compute-budget-instruction = { path = "../compute-budget-instruction", features = [
+    "agave-unstable-api",
+    "dev-context-only-utils",
+] }
 solana-compute-budget-interface = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -194,15 +194,25 @@ solana-instruction-error = { workspace = true }
 solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-runtime = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime-transaction = { path = "../runtime-transaction", features = [
+    "agave-unstable-api",
+    "dev-context-only-utils",
+] }
 solana-sdk-ids = { workspace = true }
 solana-secp256k1-program = { workspace = true, features = ["bincode"] }
 solana-signature = { workspace = true, features = ["std"] }
 solana-signer-store = { workspace = true }
 solana-stake-interface = { workspace = true, features = ["sysvar"] }
 solana-svm = { path = "../svm", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
-solana-vote-program = { path = "../programs/vote", default-features = false, features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-transaction-context = { path = "../transaction-context", features = [
+    "agave-unstable-api",
+    "bincode",
+    "dev-context-only-utils",
+] }
+solana-vote-program = { path = "../programs/vote", default-features = false, features = [
+    "agave-unstable-api",
+    "dev-context-only-utils",
+] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -95,7 +95,9 @@ libsecp256k1 = { workspace = true }
 openssl = { workspace = true }
 rand = { workspace = true }
 shuttle = { workspace = true }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api"] }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = [
+    "agave-unstable-api",
+] }
 solana-clock = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
@@ -121,7 +123,11 @@ solana-system-program = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-sysvar = { workspace = true }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+solana-transaction-context = { path = "../transaction-context", features = [
+    "agave-unstable-api",
+    "bincode",
+    "dev-context-only-utils",
+] }
 spl-token-interface = { workspace = true }
 test-case = { workspace = true }
 

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -72,7 +72,11 @@ solana-program-runtime = { path = "../program-runtime", features = ["agave-unsta
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-slot-hashes = { workspace = true }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+solana-transaction-context = { path = "../transaction-context", features = [
+    "agave-unstable-api",
+    "bincode",
+    "dev-context-only-utils",
+] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,26 @@
+exclude = [
+    ".direnv/**",
+    ".venv/**",
+    ".cargo/**",
+]
+
+[formatting]
+allowed_blank_lines = 1
+array_auto_expand = true
+array_auto_collapse = false
+column_width = 120
+indent_string = "    "
+
+[[rule]]
+keys = [
+    "lints.clippy",
+    "dependencies",
+    "dev-dependencies",
+    "build-dependencies",
+    "toolchain",
+    "workspace.dependencies",
+    "patch",
+]
+
+[rule.formatting]
+reorder_keys = true

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -55,4 +55,8 @@ solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
 solana-streamer = { path = "../streamer", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-tpu-client-next = { path = ".", features = ["agave-unstable-api", "websocket-node-address-service", "dev-context-only-utils"] }
+solana-tpu-client-next = { path = ".", features = [
+    "agave-unstable-api",
+    "websocket-node-address-service",
+    "dev-context-only-utils",
+] }

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -57,7 +57,7 @@ assert_matches = { workspace = true }
 bencher = { workspace = true }
 bs58 = { workspace = true }
 solana-genesis-config = { workspace = true }
-solana-ledger = { path = "../ledger", features = ["agave-unstable-api","dev-context-only-utils"] }
+solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-signature = { workspace = true, features = ["rand"] }
 solana-transaction = { workspace = true }

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -25,5 +25,8 @@ unwrap_none = { workspace = true }
 [dev-dependencies]
 solana-instruction = { workspace = true }
 solana-message = { workspace = true }
-solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime-transaction = { path = "../runtime-transaction", features = [
+    "agave-unstable-api",
+    "dev-context-only-utils",
+] }
 test-case = { workspace = true }

--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -25,7 +25,8 @@ log = { workspace = true }
 serde = { workspace = true }
 solana-address = { workspace = true, features = ["curve25519"] }
 solana-bls-signatures = { workspace = true, features = [
-    "bytemuck", "solana-signer-derive",
+    "bytemuck",
+    "solana-signer-derive",
 ] }
 solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }


### PR DESCRIPTION
#### Problem

- `cargo-sort` is not a full toml formatter leading to time wasted by devs manually formatting toml files.

#### Summary of Changes

- Replace `cargo-sort` with `taplo`.