### PR TITLE
bls_sigverify: refactor arguments

### DIFF
--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -49,52 +49,41 @@ pub(super) const NUM_SLOTS_FOR_VERIFY: Slot = 90_000;
 /// We ban the sender for 2 days which roughly corresponds to an epoch
 pub(super) const BAN_TIMEOUT: Duration = Duration::from_hours(48);
 
+pub(crate) struct SigVerifierContext {
+    pub(crate) migration_status: Arc<MigrationStatus>,
+    pub(crate) banlist: Arc<SimpleQosBanlist>,
+    pub(crate) sharable_banks: SharableBanks,
+    pub(crate) cluster_info: Arc<ClusterInfo>,
+    pub(crate) leader_schedule: Arc<LeaderScheduleCache>,
+    pub(crate) num_threads: usize,
+}
+
+pub(crate) struct SigVerifierChannels {
+    pub(crate) packet_receiver: Receiver<PacketBatch>,
+    pub(crate) channel_to_repair: VerifiedVoterSlotsSender,
+    pub(crate) channel_to_reward: Sender<AddVoteMessage>,
+    pub(crate) channel_to_pool: Sender<Vec<ConsensusMessage>>,
+    pub(crate) channel_to_metrics: ConsensusMetricsEventSender,
+}
+
 /// Starts the BLS sigverifier service in its own dedicated thread.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn spawn_service(
     exit: Arc<AtomicBool>,
-    migration_status: Arc<MigrationStatus>,
-    packet_receiver: Receiver<PacketBatch>,
-    banlist: Arc<SimpleQosBanlist>,
-    sharable_banks: SharableBanks,
-    channel_to_repair: VerifiedVoterSlotsSender,
-    channel_to_reward: Sender<AddVoteMessage>,
-    channel_to_pool: Sender<Vec<ConsensusMessage>>,
-    channel_to_metrics: ConsensusMetricsEventSender,
-    cluster_info: Arc<ClusterInfo>,
-    leader_schedule: Arc<LeaderScheduleCache>,
-    num_threads: usize,
+    context: SigVerifierContext,
+    channels: SigVerifierChannels,
 ) -> thread::JoinHandle<()> {
-    let verifier = SigVerifier::new(
-        migration_status,
-        banlist,
-        sharable_banks,
-        channel_to_repair,
-        channel_to_reward,
-        channel_to_pool,
-        channel_to_metrics,
-        cluster_info,
-        leader_schedule,
-        num_threads,
-    );
+    let verifier = SigVerifier::new(context, channels);
 
     Builder::new()
         .name("solSigVerBLS".to_string())
-        .spawn(move || verifier.run(exit, packet_receiver))
+        .spawn(move || verifier.run(exit))
         .unwrap()
 }
 
 struct SigVerifier {
     migration_status: Arc<MigrationStatus>,
     banlist: Arc<SimpleQosBanlist>,
-    /// Channel to send msgs to repair on.
-    channel_to_repair: VerifiedVoterSlotsSender,
-    /// Channel to send msgs to consensus rewards container to.
-    channel_to_reward: Sender<AddVoteMessage>,
-    /// Channel to send msgs to consensus pool to.
-    channel_to_pool: Sender<Vec<ConsensusMessage>>,
-    /// Channel to send msgs to consensus metrics container to.
-    channel_to_metrics: ConsensusMetricsEventSender,
+    channels: SigVerifierChannels,
     /// Container to look up root banks from.
     sharable_banks: SharableBanks,
     stats: SigVerifierStats,
@@ -109,19 +98,15 @@ struct SigVerifier {
 }
 
 impl SigVerifier {
-    #[allow(clippy::too_many_arguments)]
-    fn new(
-        migration_status: Arc<MigrationStatus>,
-        banlist: Arc<SimpleQosBanlist>,
-        sharable_banks: SharableBanks,
-        channel_to_repair: VerifiedVoterSlotsSender,
-        channel_to_reward: Sender<AddVoteMessage>,
-        channel_to_pool: Sender<Vec<ConsensusMessage>>,
-        channel_to_metrics: ConsensusMetricsEventSender,
-        cluster_info: Arc<ClusterInfo>,
-        leader_schedule: Arc<LeaderScheduleCache>,
-        num_threads: usize,
-    ) -> Self {
+    fn new(context: SigVerifierContext, channels: SigVerifierChannels) -> Self {
+        let SigVerifierContext {
+            migration_status,
+            banlist,
+            sharable_banks,
+            cluster_info,
+            leader_schedule,
+            num_threads,
+        } = context;
         let thread_pool = ThreadPoolBuilder::new()
             .num_threads(num_threads)
             .thread_name(|i| format!("solSigVerBLS{i:02}"))
@@ -130,10 +115,7 @@ impl SigVerifier {
         Self {
             migration_status,
             banlist,
-            channel_to_repair,
-            channel_to_reward,
-            channel_to_pool,
-            channel_to_metrics,
+            channels,
             sharable_banks,
             stats: SigVerifierStats::default(),
             verified_certs: HashSet::new(),
@@ -144,10 +126,10 @@ impl SigVerifier {
         }
     }
 
-    fn run(mut self, exit: Arc<AtomicBool>, packet_receiver: Receiver<PacketBatch>) {
+    fn run(mut self, exit: Arc<AtomicBool>) {
         while !exit.load(Ordering::Relaxed) {
             const SOFT_RECEIVE_CAP: usize = 5000;
-            let Ok(batches) = recv_batches(&packet_receiver, SOFT_RECEIVE_CAP) else {
+            let Ok(batches) = recv_batches(&self.channels.packet_receiver, SOFT_RECEIVE_CAP) else {
                 error!("packet_receiver disconnected:  Exiting.");
                 return;
             };
@@ -184,12 +166,9 @@ impl SigVerifier {
                     &root_bank,
                     &self.cluster_info,
                     &self.leader_schedule,
-                    &self.channel_to_pool,
-                    &self.channel_to_repair,
-                    &self.channel_to_reward,
-                    &self.channel_to_metrics,
                     &self.banlist,
                     &self.thread_pool,
+                    &self.channels,
                 )
             },
             || {
@@ -197,7 +176,7 @@ impl SigVerifier {
                     &mut self.verified_certs,
                     certs_to_verify,
                     &root_bank,
-                    &self.channel_to_pool,
+                    &self.channels.channel_to_pool,
                     &self.banlist,
                     &self.thread_pool,
                 )
@@ -424,19 +403,25 @@ mod tests {
             SocketAddrSpace::Unspecified,
         ));
         let leader_schedule = Arc::new(LeaderScheduleCache::new_from_bank(&sharable_banks.root()));
+        let (_packet_sender, packet_receiver) = crossbeam_channel::unbounded();
         (
             validator_keypairs,
             SigVerifier::new(
-                Arc::new(MigrationStatus::default()),
-                banlist,
-                sharable_banks,
-                votes_for_repair_sender,
-                reward_votes_sender,
-                message_sender,
-                consensus_metrics_sender,
-                cluster_info,
-                leader_schedule,
-                4,
+                SigVerifierContext {
+                    migration_status: Arc::new(MigrationStatus::default()),
+                    banlist,
+                    sharable_banks,
+                    cluster_info,
+                    leader_schedule,
+                    num_threads: 4,
+                },
+                SigVerifierChannels {
+                    packet_receiver,
+                    channel_to_repair: votes_for_repair_sender,
+                    channel_to_reward: reward_votes_sender,
+                    channel_to_pool: message_sender,
+                    channel_to_metrics: consensus_metrics_sender,
+                },
             ),
         )
     }
@@ -1298,17 +1283,23 @@ mod tests {
             SocketAddrSpace::Unspecified,
         ));
         let leader_schedule = Arc::new(LeaderScheduleCache::new_from_bank(&sharable_banks.root()));
+        let (_packet_sender, packet_receiver) = crossbeam_channel::unbounded();
         let mut sig_verifier = SigVerifier::new(
-            Arc::new(MigrationStatus::default()),
-            new_test_banlist(),
-            sharable_banks,
-            votes_for_repair_sender,
-            reward_votes_sender,
-            message_sender,
-            consensus_metrics_sender,
-            cluster_info,
-            leader_schedule,
-            4,
+            SigVerifierContext {
+                migration_status: Arc::new(MigrationStatus::default()),
+                banlist: new_test_banlist(),
+                sharable_banks,
+                cluster_info,
+                leader_schedule,
+                num_threads: 4,
+            },
+            SigVerifierChannels {
+                packet_receiver,
+                channel_to_repair: votes_for_repair_sender,
+                channel_to_reward: reward_votes_sender,
+                channel_to_pool: message_sender,
+                channel_to_metrics: consensus_metrics_sender,
+            },
         );
 
         let vote = Vote::new_skip_vote(2);

--- a/core/src/bls_sigverify/bls_vote_sigverify.rs
+++ b/core/src/bls_sigverify/bls_vote_sigverify.rs
@@ -2,26 +2,18 @@
 use qualifier_attr::qualifiers;
 use {
     super::{errors::SigVerifyVoteError, stats::SigVerifyVoteStats},
-    crate::{
-        bls_sigverify::{
-            bls_sigverifier::{BAN_TIMEOUT, NUM_SLOTS_FOR_VERIFY},
-            utils::{
-                send_votes_to_metrics, send_votes_to_pool, send_votes_to_repair,
-                send_votes_to_rewards,
-            },
+    crate::bls_sigverify::{
+        bls_sigverifier::{BAN_TIMEOUT, NUM_SLOTS_FOR_VERIFY, SigVerifierChannels},
+        utils::{
+            send_votes_to_metrics, send_votes_to_pool, send_votes_to_repair, send_votes_to_rewards,
         },
-        cluster_info_vote_listener::VerifiedVoterSlotsSender,
     },
-    agave_votor::{
-        consensus_metrics::{ConsensusMetricsEvent, ConsensusMetricsEventSender},
-        consensus_rewards,
-    },
+    agave_votor::{consensus_metrics::ConsensusMetricsEvent, consensus_rewards},
     agave_votor_messages::{
         consensus_message::{ConsensusMessage, VoteMessage},
         reward_certificate::AddVoteMessage,
         vote::Vote,
     },
-    crossbeam_channel::Sender,
     rayon::{
         ThreadPool, current_thread_index,
         iter::{Either, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator},
@@ -67,18 +59,14 @@ impl VotePayload {
 /// to rewards container and repair.
 ///
 /// Any vote that fails fallback individual signature verification will have its sender banlisted.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn verify_and_send_votes(
     votes_to_verify: Vec<VotePayload>,
     root_bank: &Bank,
     cluster_info: &ClusterInfo,
     leader_schedule: &LeaderScheduleCache,
-    channel_to_pool: &Sender<Vec<ConsensusMessage>>,
-    channel_to_repair: &VerifiedVoterSlotsSender,
-    channel_to_reward: &Sender<AddVoteMessage>,
-    channel_to_metrics: &ConsensusMetricsEventSender,
     banlist: &SimpleQosBanlist,
     thread_pool: &ThreadPool,
+    channels: &SigVerifierChannels,
 ) -> Result<SigVerifyVoteStats, SigVerifyVoteError> {
     let mut measure = Measure::start("verify_and_send_votes");
     let mut stats = SigVerifyVoteStats::default();
@@ -92,10 +80,10 @@ pub(super) fn verify_and_send_votes(
     let (votes_for_pool, msgs_for_repair, msg_for_reward, msg_for_metrics) =
         process_verified_votes(&verified_votes, root_bank, cluster_info, leader_schedule);
 
-    send_votes_to_pool(votes_for_pool, channel_to_pool, &mut stats)?;
-    send_votes_to_repair(msgs_for_repair, channel_to_repair, &mut stats)?;
-    send_votes_to_rewards(msg_for_reward, channel_to_reward, &mut stats)?;
-    send_votes_to_metrics(msg_for_metrics, channel_to_metrics, &mut stats)?;
+    send_votes_to_pool(votes_for_pool, &channels.channel_to_pool, &mut stats)?;
+    send_votes_to_repair(msgs_for_repair, &channels.channel_to_repair, &mut stats)?;
+    send_votes_to_rewards(msg_for_reward, &channels.channel_to_reward, &mut stats)?;
+    send_votes_to_metrics(msg_for_metrics, &channels.channel_to_metrics, &mut stats)?;
 
     measure.stop();
     stats

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -6,7 +6,7 @@ use {
         admin_rpc_post_init::{KeyUpdaterType, KeyUpdaters},
         banking_trace::BankingTracer,
         block_creation_loop::ReplayHighestFrozen,
-        bls_sigverify::bls_sigverifier,
+        bls_sigverify::bls_sigverifier::{self, SigVerifierChannels, SigVerifierContext},
         cluster_info_vote_listener::{
             DuplicateConfirmedSlotsReceiver, GossipVerifiedVoteHashReceiver,
             VerifiedVoterSlotsReceiver, VerifiedVoterSlotsSender, VoteTracker,
@@ -308,17 +308,21 @@ impl Tvu {
             let sharable_banks = bank_forks.read().unwrap().sharable_banks();
             let bls_sigverifier_t = bls_sigverifier::spawn_service(
                 exit.clone(),
-                migration_status.clone(),
-                bls_packet_receiver,
-                banlist,
-                sharable_banks,
-                verified_voter_slots_sender,
-                reward_votes_sender,
-                consensus_message_sender.clone(),
-                consensus_metrics_sender.clone(),
-                cluster_info.clone(),
-                leader_schedule_cache.clone(),
-                tvu_config.bls_sigverify_threads.get(),
+                SigVerifierContext {
+                    migration_status: migration_status.clone(),
+                    banlist,
+                    sharable_banks,
+                    cluster_info: cluster_info.clone(),
+                    leader_schedule: leader_schedule_cache.clone(),
+                    num_threads: tvu_config.bls_sigverify_threads.get(),
+                },
+                SigVerifierChannels {
+                    packet_receiver: bls_packet_receiver,
+                    channel_to_repair: verified_voter_slots_sender,
+                    channel_to_reward: reward_votes_sender,
+                    channel_to_pool: consensus_message_sender.clone(),
+                    channel_to_metrics: consensus_metrics_sender.clone(),
+                },
             );
 
             let mut key_notifiers = key_notifiers.write().unwrap();


### PR DESCRIPTION
#### Problem
Follow up to #11223 

We use `#[allow(clippy(too_many_arguments))]`

#### Summary of Changes
Split into a context and channels struct to reduce # of args
