### PR TITLE
cli: return BadParameter for sign-only ALL/AVAILABLE amounts

### DIFF
--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -243,7 +243,7 @@ pub fn parse_nonce_create_account(
     let (nonce_account, nonce_account_pubkey) =
         signer_of(matches, "nonce_account_keypair", wallet_manager)?;
     let seed = matches.value_of("seed").map(|s| s.to_string());
-    let amount = SpendAmount::new_from_matches(matches, "amount");
+    let amount = SpendAmount::new_from_matches(matches, "amount")?;
     let nonce_authority = pubkey_of_signer(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
     let memo = matches.value_of(MEMO_ARG.name).map(String::from);
 

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -33,24 +33,28 @@ impl Default for SpendAmount {
 }
 
 impl SpendAmount {
-    pub fn new(amount: Option<u64>, sign_only: bool) -> Self {
+    pub fn new(amount: Option<u64>, sign_only: bool) -> Result<Self, CliError> {
         match amount {
-            Some(lamports) => Self::Some(lamports),
-            None if !sign_only => Self::All,
-            _ => panic!("ALL amount not supported for sign-only operations"),
+            Some(lamports) => Ok(Self::Some(lamports)),
+            None if !sign_only => Ok(Self::All),
+            _ => Err(CliError::BadParameter(
+                "ALL amount not supported for sign-only operations".to_string(),
+            )),
         }
     }
 
-    pub fn new_from_matches(matches: &ArgMatches<'_>, name: &str) -> Self {
+    pub fn new_from_matches(matches: &ArgMatches<'_>, name: &str) -> Result<Self, CliError> {
         let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
         let amount = lamports_of_sol(matches, name);
         if amount.is_some() {
             return SpendAmount::new(amount, sign_only);
         }
         match matches.value_of(name).unwrap_or("ALL") {
-            "ALL" if !sign_only => SpendAmount::All,
-            "AVAILABLE" if !sign_only => SpendAmount::Available,
-            _ => panic!("Only specific amounts are supported for sign-only operations"),
+            "ALL" if !sign_only => Ok(SpendAmount::All),
+            "AVAILABLE" if !sign_only => Ok(SpendAmount::Available),
+            _ => Err(CliError::BadParameter(
+                "Only specific amounts are supported for sign-only operations".to_string(),
+            )),
         }
     }
 }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -817,7 +817,7 @@ pub fn parse_create_stake_account(
         )
     };
 
-    let amount = SpendAmount::new_from_matches(matches, "amount");
+    let amount = SpendAmount::new_from_matches(matches, "amount")?;
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let dump_transaction_message = matches.is_present(DUMP_TRANSACTION_MESSAGE.name);
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
@@ -1206,7 +1206,7 @@ pub fn parse_stake_withdraw_stake(
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();
     let destination_account_pubkey =
         pubkey_of_signer(matches, "destination_account_pubkey", wallet_manager)?.unwrap();
-    let amount = SpendAmount::new_from_matches(matches, "amount");
+    let amount = SpendAmount::new_from_matches(matches, "amount")?;
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let dump_transaction_message = matches.is_present(DUMP_TRANSACTION_MESSAGE.name);
     let blockhash_query = BlockhashQuery::new_from_matches(matches);

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -824,7 +824,7 @@ pub fn parse_withdraw_from_vote_account(
         pubkey_of_signer(matches, "vote_account_pubkey", wallet_manager)?.unwrap();
     let destination_account_pubkey =
         pubkey_of_signer(matches, "destination_account_pubkey", wallet_manager)?.unwrap();
-    let mut withdraw_amount = SpendAmount::new_from_matches(matches, "amount");
+    let mut withdraw_amount = SpendAmount::new_from_matches(matches, "amount")?;
     // As a safeguard for vote accounts for running validators, `ALL` withdraws only the amount in
     // excess of the rent-exempt minimum. In order to close the account with this subcommand, a
     // validator must specify the withdrawal amount precisely.

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -612,7 +612,7 @@ pub fn parse_transfer(
     default_signer: &DefaultSigner,
     wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
-    let amount = SpendAmount::new_from_matches(matches, "amount");
+    let amount = SpendAmount::new_from_matches(matches, "amount")?;
     let to = pubkey_of_signer(matches, "to", wallet_manager)?.unwrap();
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let dump_transaction_message = matches.is_present(DUMP_TRANSACTION_MESSAGE.name);


### PR DESCRIPTION
 #### Problem

 - transfer with --sign-only could panic when amount keywords like ALL were
 used, due to panic-based handling in shared SpendAmount parsing.

 #### Solution

 - Replaced panic paths in SpendAmount parsing with CliError::BadParameter,
 so invalid sign-only amount inputs return a clean error instead of
 crashing.