### PR TITLE
scripts: Fix build-agave-xdp-ebpf.sh

### DIFF
--- a/scripts/build-agave-xdp-ebpf.sh
+++ b/scripts/build-agave-xdp-ebpf.sh
@@ -15,7 +15,7 @@ echo "Using nightly toolchain: $rust_nightly"
 
 if ! command -v bpf-linker &> /dev/null; then
     echo "Installing bpf-linker..."
-    cargo install bpf-linker==0.9.15
+    cargo install bpf-linker --version 0.9.15
 fi
 
 rustup component add rust-src --toolchain "$rust_nightly"


### PR DESCRIPTION
#### Problem
The command to install a specific version of `bpf-linker` is incorrect.

#### Summary of Changes
Fix it
