### PR TITLE
Update bench-tps to use VersionedTransaction

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -27,7 +27,7 @@ use {
     solana_system_interface::instruction as system_instruction,
     solana_time_utils::timestamp,
     solana_tps_client::*,
-    solana_transaction::Transaction,
+    solana_transaction::{Transaction, versioned::VersionedTransaction},
     spl_instruction_padding_interface::instruction::wrap_instruction,
     std::{
         collections::{HashSet, VecDeque},
@@ -93,7 +93,7 @@ fn get_transaction_loaded_accounts_data_size(enable_padding: bool) -> u32 {
 
 #[derive(Debug, PartialEq, Default, Eq, Clone)]
 pub(crate) struct TimestampedTransaction {
-    transaction: Transaction,
+    transaction: VersionedTransaction,
     timestamp: Option<u64>,
     compute_unit_price: Option<u64>,
 }
@@ -647,7 +647,7 @@ fn transfer_with_compute_unit_price_and_padding(
     instruction_padding_config: &Option<InstructionPaddingConfig>,
     compute_unit_price: Option<u64>,
     skip_tx_account_data_size: bool,
-) -> Transaction {
+) -> VersionedTransaction {
     let from_pubkey = from_keypair.pubkey();
     let transfer_instruction = system_instruction::transfer(&from_pubkey, to, lamports);
     let instruction = if let Some(instruction_padding_config) = instruction_padding_config {
@@ -684,7 +684,7 @@ fn transfer_with_compute_unit_price_and_padding(
         ])
     }
     let message = Message::new(&instructions, Some(&from_pubkey));
-    Transaction::new(&[from_keypair], message, recent_blockhash)
+    Transaction::new(&[from_keypair], message, recent_blockhash).into()
 }
 
 fn get_nonce_accounts<T: 'static + TpsClient + Send + Sync + ?Sized>(
@@ -756,7 +756,7 @@ fn nonced_transfer_with_padding(
     nonce_hash: Hash,
     skip_tx_account_data_size: bool,
     instruction_padding_config: &Option<InstructionPaddingConfig>,
-) -> Transaction {
+) -> VersionedTransaction {
     let from_pubkey = from_keypair.pubkey();
     let transfer_instruction = system_instruction::transfer(&from_pubkey, to, lamports);
     let instruction = if let Some(instruction_padding_config) = instruction_padding_config {
@@ -785,7 +785,7 @@ fn nonced_transfer_with_padding(
         nonce_account,
         &nonce_authority.pubkey(),
     );
-    Transaction::new(&[from_keypair, nonce_authority], message, nonce_hash)
+    Transaction::new(&[from_keypair, nonce_authority], message, nonce_hash).into()
 }
 
 fn generate_nonced_system_txs<T: 'static + TpsClient + Send + Sync + ?Sized>(

--- a/bench-tps/src/send_batch.rs
+++ b/bench-tps/src/send_batch.rs
@@ -245,7 +245,10 @@ where
 
     fn send<C: TpsClient + ?Sized>(&self, client: &Arc<C>) {
         let mut send_txs = Measure::start("send_and_clone_txs");
-        let batch: Vec<_> = self.iter().map(|(_keypair, tx)| tx.clone()).collect();
+        let batch: Vec<_> = self
+            .iter()
+            .map(|(_keypair, tx)| tx.clone().into())
+            .collect();
         let result = client.send_batch(batch);
         send_txs.stop();
         if result.is_err() {

--- a/client/src/nonblocking/tpu_client.rs
+++ b/client/src/nonblocking/tpu_client.rs
@@ -10,7 +10,7 @@ use {
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_signer::signers::Signers,
     solana_tpu_client::nonblocking::tpu_client::{Result, TpuClient as BackendTpuClient},
-    solana_transaction::Transaction,
+    solana_transaction::{Transaction, versioned::VersionedTransaction},
     solana_transaction_error::{TransactionError, TransportResult},
     std::sync::Arc,
 };
@@ -47,7 +47,10 @@ where
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
     /// Returns the last error if all sends fail
-    pub async fn try_send_transaction(&self, transaction: &Transaction) -> TransportResult<()> {
+    pub async fn try_send_transaction(
+        &self,
+        transaction: &VersionedTransaction,
+    ) -> TransportResult<()> {
         self.tpu_client.try_send_transaction(transaction).await
     }
 

--- a/client/src/tpu_client.rs
+++ b/client/src/tpu_client.rs
@@ -9,7 +9,7 @@ use {
     solana_rpc_client::rpc_client::RpcClient,
     solana_signer::signers::Signers,
     solana_tpu_client::tpu_client::{Result, TpuClient as BackendTpuClient},
-    solana_transaction::Transaction,
+    solana_transaction::{Transaction, versioned::VersionedTransaction},
     solana_transaction_error::{TransactionError, TransportResult},
     solana_udp_client::{UdpConfig, UdpConnectionManager, UdpPool},
     std::sync::Arc,
@@ -55,14 +55,17 @@ where
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
     /// Returns the last error if all sends fail
-    pub fn try_send_transaction(&self, transaction: &Transaction) -> TransportResult<()> {
+    pub fn try_send_transaction(&self, transaction: &VersionedTransaction) -> TransportResult<()> {
         self.tpu_client.try_send_transaction(transaction)
     }
 
     /// Serialize and send a batch of transactions to the current and upcoming leader TPUs according
     /// to fanout size
     /// Returns the last error if all sends fail
-    pub fn try_send_transaction_batch(&self, transactions: &[Transaction]) -> TransportResult<()> {
+    pub fn try_send_transaction_batch(
+        &self,
+        transactions: &[VersionedTransaction],
+    ) -> TransportResult<()> {
         self.tpu_client.try_send_transaction_batch(transactions)
     }
 

--- a/tps-client/src/bank_client.rs
+++ b/tps-client/src/bank_client.rs
@@ -10,17 +10,18 @@ use {
     solana_rpc_client_api::config::RpcBlockConfig,
     solana_runtime::bank_client::BankClient,
     solana_signature::Signature,
-    solana_transaction::Transaction,
+    solana_transaction::versioned::VersionedTransaction,
     solana_transaction_error::TransactionResult as Result,
     solana_transaction_status::UiConfirmedBlock,
 };
 
 impl TpsClient for BankClient {
-    fn send_transaction(&self, transaction: Transaction) -> TpsClientResult<Signature> {
-        AsyncClient::async_send_transaction(self, transaction).map_err(|err| err.into())
+    fn send_transaction(&self, transaction: VersionedTransaction) -> TpsClientResult<Signature> {
+        AsyncClient::async_send_versioned_transaction(self, transaction).map_err(|err| err.into())
     }
-    fn send_batch(&self, transactions: Vec<Transaction>) -> TpsClientResult<()> {
-        AsyncClient::async_send_batch(self, transactions).map_err(|err| err.into())
+    fn send_batch(&self, transactions: Vec<VersionedTransaction>) -> TpsClientResult<()> {
+        AsyncClient::async_send_versioned_transaction_batch(self, transactions)
+            .map_err(|err| err.into())
     }
     fn get_latest_blockhash(&self) -> TpsClientResult<Hash> {
         SyncClient::get_latest_blockhash(self).map_err(|err| err.into())

--- a/tps-client/src/lib.rs
+++ b/tps-client/src/lib.rs
@@ -12,7 +12,7 @@ use {
     solana_rpc_client_api::{client_error::Error as ClientError, config::RpcBlockConfig},
     solana_signature::Signature,
     solana_tpu_client::tpu_client::TpuSenderError,
-    solana_transaction::Transaction,
+    solana_transaction::versioned::VersionedTransaction,
     solana_transaction_error::{TransactionResult as Result, TransportError},
     solana_transaction_status::UiConfirmedBlock,
     std::{
@@ -42,10 +42,10 @@ pub type TpsClientResult<T> = std::result::Result<T, TpsClientError>;
 
 pub trait TpsClient {
     /// Send a signed transaction without confirmation
-    fn send_transaction(&self, transaction: Transaction) -> TpsClientResult<Signature>;
+    fn send_transaction(&self, transaction: VersionedTransaction) -> TpsClientResult<Signature>;
 
     /// Send a batch of signed transactions without confirmation.
-    fn send_batch(&self, transactions: Vec<Transaction>) -> TpsClientResult<()>;
+    fn send_batch(&self, transactions: Vec<VersionedTransaction>) -> TpsClientResult<()>;
 
     /// Get latest blockhash
     fn get_latest_blockhash(&self) -> TpsClientResult<Hash>;

--- a/tps-client/src/rpc_client.rs
+++ b/tps-client/src/rpc_client.rs
@@ -10,13 +10,13 @@ use {
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::config::RpcBlockConfig,
     solana_signature::Signature,
-    solana_transaction::Transaction,
+    solana_transaction::versioned::VersionedTransaction,
     solana_transaction_error::TransactionResult as Result,
     solana_transaction_status::UiConfirmedBlock,
 };
 
 impl TpsClient for RpcClient {
-    fn send_transaction(&self, transaction: Transaction) -> TpsClientResult<Signature> {
+    fn send_transaction(&self, transaction: VersionedTransaction) -> TpsClientResult<Signature> {
         RpcClient::send_transaction_with_config(
             self,
             &transaction,
@@ -28,7 +28,7 @@ impl TpsClient for RpcClient {
         .map_err(|err| err.into())
     }
 
-    fn send_batch(&self, transactions: Vec<Transaction>) -> TpsClientResult<()> {
+    fn send_batch(&self, transactions: Vec<VersionedTransaction>) -> TpsClientResult<()> {
         for transaction in transactions {
             TpsClient::send_transaction(self, transaction)?;
         }

--- a/tps-client/src/tpu_client.rs
+++ b/tps-client/src/tpu_client.rs
@@ -12,7 +12,7 @@ use {
     solana_rpc_client_api::config::RpcBlockConfig,
     solana_signature::Signature,
     solana_tpu_client::tpu_client::TpuClient,
-    solana_transaction::Transaction,
+    solana_transaction::versioned::VersionedTransaction,
     solana_transaction_error::TransactionResult as Result,
     solana_transaction_status::UiConfirmedBlock,
 };
@@ -23,12 +23,12 @@ where
     M: ConnectionManager<ConnectionPool = P, NewConnectionConfig = C>,
     C: NewConnectionConfig,
 {
-    fn send_transaction(&self, transaction: Transaction) -> TpsClientResult<Signature> {
+    fn send_transaction(&self, transaction: VersionedTransaction) -> TpsClientResult<Signature> {
         let signature = transaction.signatures[0];
         self.try_send_transaction(&transaction)?;
         Ok(signature)
     }
-    fn send_batch(&self, transactions: Vec<Transaction>) -> TpsClientResult<()> {
+    fn send_batch(&self, transactions: Vec<VersionedTransaction>) -> TpsClientResult<()> {
         self.try_send_transaction_batch(&transactions)?;
         Ok(())
     }

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -23,7 +23,7 @@ use {
         response::{RpcContactInfo, SlotUpdate},
     },
     solana_signer::SignerError,
-    solana_transaction::Transaction,
+    solana_transaction::{Transaction, versioned::VersionedTransaction},
     solana_transaction_error::{TransportError, TransportResult},
     std::{
         collections::{HashMap, HashSet},
@@ -410,7 +410,10 @@ where
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
     /// Returns the last error if all sends fail
-    pub async fn try_send_transaction(&self, transaction: &Transaction) -> TransportResult<()> {
+    pub async fn try_send_transaction(
+        &self,
+        transaction: &VersionedTransaction,
+    ) -> TransportResult<()> {
         let wire_transaction = serialize(transaction).expect("serialization should succeed");
         self.try_send_wire_transaction(wire_transaction).await
     }

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -94,7 +94,7 @@ where
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
     /// Returns the last error if all sends fail
-    pub fn try_send_transaction(&self, transaction: &Transaction) -> TransportResult<()> {
+    pub fn try_send_transaction(&self, transaction: &VersionedTransaction) -> TransportResult<()> {
         self.invoke(self.tpu_client.try_send_transaction(transaction))
     }
 
@@ -139,7 +139,10 @@ where
     /// Serialize and send a batch of transactions to the current and upcoming leader TPUs according
     /// to fanout size
     /// Returns the last error if all sends fail
-    pub fn try_send_transaction_batch(&self, transactions: &[Transaction]) -> TransportResult<()> {
+    pub fn try_send_transaction_batch(
+        &self,
+        transactions: &[VersionedTransaction],
+    ) -> TransportResult<()> {
         let wire_transactions = transactions
             .into_par_iter()
             .map(|tx| bincode::serialize(&tx).expect("serialize Transaction in send_batch"))


### PR DESCRIPTION
#### Problem

This PR updates bench-tps and the related TPS client plumbing to use VersionedTransaction instead of Transaction. The goal is to make the bench path compatible with versioned transaction handling and prepare it for tx-v1 benchmarking.

#### Summary of Changes
- Change bench-tps transaction storage and transaction-building helpers to return/store VersionedTransaction.
- Update batch sending in bench-tps to send versioned transactions through TpsClient.
- Update TpsClient trait and its RPC/TPU client implementations to accept VersionedTransaction for single-send and batch-send paths.
- Update sync and nonblocking TPU client wrappers to forward VersionedTransaction through the existing send path.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
