### PR TITLE
wip: send generated certs from consensus pool to bls sigverifier

### DIFF
--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -17,7 +17,7 @@ use {
         migration::MigrationStatus,
         reward_certificate::AddVoteMessage,
     },
-    crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TryRecvError},
+    crossbeam_channel::{Receiver, Sender, TryRecvError, select},
     rayon::{ThreadPool, ThreadPoolBuilder},
     solana_bls_signatures::pubkey::PubkeyAffine as BlsPubkeyAffine,
     solana_clock::Slot,
@@ -64,6 +64,7 @@ pub(crate) struct SigVerifierChannels {
     pub(crate) channel_to_reward: Sender<AddVoteMessage>,
     pub(crate) channel_to_pool: Sender<Vec<ConsensusMessage>>,
     pub(crate) channel_to_metrics: ConsensusMetricsEventSender,
+    pub(crate) channel_from_pool: Receiver<Vec<CertificateType>>,
 }
 
 /// Starts the BLS sigverifier service in its own dedicated thread.
@@ -73,11 +74,18 @@ pub(crate) fn spawn_service(
     channels: SigVerifierChannels,
 ) -> thread::JoinHandle<()> {
     let verifier = SigVerifier::new(context, channels);
-
     Builder::new()
         .name("solSigVerBLS".to_string())
         .spawn(move || verifier.run(exit))
         .unwrap()
+}
+
+enum RecvMsgsResult {
+    Batches(Vec<PacketBatch>),
+    GeneratedCerts(Vec<CertificateType>),
+    Timeout,
+    PacketReceiverDisconnected,
+    ChannelFromPoolDisconnected,
 }
 
 struct SigVerifier {
@@ -128,25 +136,54 @@ impl SigVerifier {
 
     fn run(mut self, exit: Arc<AtomicBool>) {
         while !exit.load(Ordering::Relaxed) {
-            const SOFT_RECEIVE_CAP: usize = 5000;
-            let Ok(batches) = recv_batches(&self.channels.packet_receiver, SOFT_RECEIVE_CAP) else {
-                error!("packet_receiver disconnected:  Exiting.");
-                return;
-            };
-            if batches.is_empty() || self.migration_status.is_pre_feature_activation() {
+            if self.migration_status.is_pre_feature_activation() {
+                thread::sleep(Duration::from_secs(1));
                 continue;
             }
 
-            let (verify_res, verify_time_us) = measure_us!(self.verify_and_send_batches(batches));
-            self.stats
-                .verify_and_send_batch_us
-                .add_sample(verify_time_us);
-            self.stats.maybe_report();
-            if let Err(e) = verify_res {
-                error!("verify_and_send_batch() failed with {e}. Exiting.");
-                break;
+            match self.recv_msgs() {
+                RecvMsgsResult::Timeout => continue,
+                RecvMsgsResult::PacketReceiverDisconnected => {
+                    error!("packet_receiver disconnected:  Exiting.");
+                    break;
+                }
+                RecvMsgsResult::ChannelFromPoolDisconnected => {
+                    error!("channel from pool disconnected:  Exiting.");
+                    break;
+                }
+                RecvMsgsResult::GeneratedCerts(certs) => {
+                    self.handle_generated_certs(certs);
+                }
+                RecvMsgsResult::Batches(batches) => {
+                    if let Err(()) = self.handle_batches(batches) {
+                        break;
+                    }
+                }
             }
+            self.stats.maybe_report();
         }
+        self.stats.do_report();
+    }
+
+    /// Handles received `batches` from the network.
+    fn handle_batches(&mut self, batches: Vec<PacketBatch>) -> Result<(), ()> {
+        if batches.is_empty() {
+            return Ok(());
+        }
+        let (verify_res, verify_time_us) = measure_us!(self.verify_and_send_batches(batches));
+        self.stats
+            .verify_and_send_batch_us
+            .add_sample(verify_time_us);
+        if let Err(e) = verify_res {
+            error!("verify_and_send_batch() failed with {e}. Exiting.");
+            return Err(());
+        }
+        Ok(())
+    }
+
+    /// Handles certs that were generated from our own consensus pool.
+    fn handle_generated_certs(&mut self, certs: Vec<CertificateType>) {
+        self.verified_certs.extend(certs);
     }
 
     fn verify_and_send_batches(&mut self, batches: Vec<PacketBatch>) -> Result<(), SigVerifyError> {
@@ -281,40 +318,49 @@ impl SigVerifier {
         self.stats.num_old_votes_received += 1;
         None
     }
-}
 
-/// Receives a `Vec<PacketBatch>` from the `receiver` while adhering to the `soft_receive_cap` limit.
-///
-/// Returns `Err(())` if the channel disconnected.
-fn recv_batches(
-    receiver: &Receiver<PacketBatch>,
-    soft_receive_cap: usize,
-) -> Result<Vec<PacketBatch>, ()> {
-    let batch = match receiver.recv_timeout(Duration::from_secs(1)) {
-        Ok(b) => b,
-        Err(e) => match e {
-            RecvTimeoutError::Timeout => {
-                return Ok(vec![]);
-            }
-            RecvTimeoutError::Disconnected => {
-                return Err(());
-            }
-        },
-    };
-    let mut batches = Vec::with_capacity(soft_receive_cap);
-    batches.push(batch);
-    while batches.len() < soft_receive_cap {
-        match receiver.try_recv() {
-            Ok(b) => {
-                batches.push(b);
-            }
-            Err(e) => match e {
-                TryRecvError::Empty => return Ok(batches),
-                TryRecvError::Disconnected => return Err(()),
+    /// Receives messages from various channels.
+    ///
+    /// Concurrently polls the channels to receive [`PacketBatch`] from the network and
+    /// generated [`CertificateType`] from the consensus pool.
+    ///
+    /// When receiving [`PacketBatch`], attempts to perform additional batching.
+    fn recv_msgs(&self) -> RecvMsgsResult {
+        let batch = select! {
+            recv(&self.channels.packet_receiver) -> res => {
+                match res {
+                    Err(_) => return RecvMsgsResult::PacketReceiverDisconnected,
+                    Ok(batch) => batch,
+                }
             },
+            recv(&self.channels.channel_from_pool) -> res => {
+                match res {
+                    Err(_) => return RecvMsgsResult::ChannelFromPoolDisconnected,
+                    Ok(certs) => return RecvMsgsResult::GeneratedCerts(certs)
+                }
+            }
+            default(Duration::from_secs(1)) => return RecvMsgsResult::Timeout
+
+        };
+
+        const SOFT_RECEIVE_CAP: usize = 5000;
+        let mut batches = Vec::with_capacity(SOFT_RECEIVE_CAP);
+        batches.push(batch);
+        while batches.len() < SOFT_RECEIVE_CAP {
+            match self.channels.packet_receiver.try_recv() {
+                Ok(b) => {
+                    batches.push(b);
+                }
+                Err(e) => match e {
+                    TryRecvError::Empty => break,
+                    TryRecvError::Disconnected => {
+                        return RecvMsgsResult::ChannelFromPoolDisconnected;
+                    }
+                },
+            }
         }
+        RecvMsgsResult::Batches(batches)
     }
-    Ok(batches)
 }
 
 #[cfg(test)]
@@ -365,6 +411,7 @@ mod tests {
         _reward_receiver: Receiver<AddVoteMessage>,
         pool_receiver: Receiver<Vec<ConsensusMessage>>,
         _metrics_receiver: ConsensusMetricsEventReceiver,
+        _cert_types_sender: Sender<Vec<CertificateType>>,
     }
 
     impl TestContext {
@@ -406,6 +453,7 @@ mod tests {
             let (channel_to_reward, reward_receiver) = crossbeam_channel::unbounded();
             let (packet_sender, packet_receiver) = crossbeam_channel::unbounded();
             let (channel_to_metrics, metrics_receiver) = crossbeam_channel::unbounded();
+            let (cert_types_sender, channel_from_pool) = crossbeam_channel::unbounded();
 
             let banlist = new_test_banlist();
             let verifier = SigVerifier::new(
@@ -423,6 +471,7 @@ mod tests {
                     channel_to_reward,
                     channel_to_pool,
                     channel_to_metrics,
+                    channel_from_pool,
                 },
             );
             Self {
@@ -434,6 +483,7 @@ mod tests {
                 _reward_receiver: reward_receiver,
                 pool_receiver,
                 _metrics_receiver: metrics_receiver,
+                _cert_types_sender: cert_types_sender,
             }
         }
     }
@@ -1231,6 +1281,7 @@ mod tests {
         let (votes_for_repair_sender, _) = crossbeam_channel::unbounded();
         let (consensus_metrics_sender, _) = crossbeam_channel::unbounded();
         let (reward_votes_sender, _reward_votes_receiver) = crossbeam_channel::unbounded();
+        let (_cert_types_sender, channel_from_pool) = crossbeam_channel::unbounded();
         let validator_keypairs = (0..10)
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect::<Vec<_>>();
@@ -1273,6 +1324,7 @@ mod tests {
                 channel_to_reward: reward_votes_sender,
                 channel_to_pool: message_sender,
                 channel_to_metrics: consensus_metrics_sender,
+                channel_from_pool,
             },
         );
 

--- a/core/src/bls_sigverify/stats.rs
+++ b/core/src/bls_sigverify/stats.rs
@@ -59,7 +59,7 @@ impl Default for SigVerifierStats {
 }
 
 impl SigVerifierStats {
-    pub(super) fn maybe_report(&mut self) {
+    pub(super) fn do_report(&mut self) {
         let Self {
             vote_stats,
             cert_stats,
@@ -73,12 +73,8 @@ impl SigVerifierStats {
             discard_vote_invalid_rank,
             discard_vote_no_epoch_stakes,
             verify_and_send_batch_us,
-            last_report,
+            last_report: _,
         } = self;
-        if last_report.elapsed() < STATS_INTERVAL_DURATION {
-            return;
-        }
-
         vote_stats.report();
         cert_stats.report();
         datapoint_info!(
@@ -128,6 +124,13 @@ impl SigVerifierStats {
             ("num_pkts_count", num_pkts.count(), i64),
         );
         *self = SigVerifierStats::default();
+    }
+
+    pub(super) fn maybe_report(&mut self) {
+        if self.last_report.elapsed() < STATS_INTERVAL_DURATION {
+            return;
+        }
+        self.do_report();
     }
 }
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -262,6 +262,7 @@ impl Tvu {
         // streamer and sigverify for A2A BLS messages
         let (consensus_message_sender, consensus_message_receiver) =
             bounded(MAX_ALPENGLOW_PACKET_NUM);
+        let (cert_types_sender, cert_types_receiver) = bounded(MAX_ALPENGLOW_PACKET_NUM);
         let (reward_votes_sender, reward_votes_receiver) = bounded(MAX_ALPENGLOW_PACKET_NUM);
         let (consensus_metrics_sender, consensus_metrics_receiver) =
             bounded(MAX_IN_FLIGHT_CONSENSUS_EVENTS);
@@ -322,6 +323,7 @@ impl Tvu {
                     channel_to_reward: reward_votes_sender,
                     channel_to_pool: consensus_message_sender.clone(),
                     channel_to_metrics: consensus_metrics_sender.clone(),
+                    channel_from_pool: cert_types_receiver,
                 },
             );
 
@@ -471,6 +473,7 @@ impl Tvu {
             rpc_subscriptions: rpc_subscriptions.clone(),
             snapshot_controller: snapshot_controller.clone(),
             bls_sender: bls_sender.clone(),
+            channel_to_bls_sigverifier: cert_types_sender,
             commitment_sender: votor_commitment_sender,
             drop_bank_sender: drop_bank_sender.clone(),
             bank_notification_sender: bank_notification_sender.clone(),

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -14,7 +14,7 @@ use {
         voting_service::BLSOp,
     },
     agave_votor_messages::{
-        consensus_message::{Certificate, ConsensusMessage},
+        consensus_message::{Certificate, CertificateType, ConsensusMessage},
         migration::MigrationStatus,
     },
     crossbeam_channel::{Receiver, Sender, TrySendError, select},
@@ -54,6 +54,7 @@ pub(crate) struct ConsensusPoolContext {
     // consider adding a separate pathway in consensus_pool.add_message() for ingesting own votes
     pub(crate) consensus_message_receiver: Receiver<Vec<ConsensusMessage>>,
 
+    pub(crate) channel_to_bls_sigverifier: Sender<Vec<CertificateType>>,
     pub(crate) bls_sender: Sender<BLSOp>,
     pub(crate) event_sender: VotorEventSender,
     pub(crate) commitment_sender: Sender<CommitmentAggregationData>,
@@ -80,6 +81,7 @@ impl ConsensusPoolService {
     fn maybe_update_root_and_send_new_certificates(
         consensus_pool: &mut ConsensusPool,
         sharable_banks: &SharableBanks,
+        channel_to_bls_sigverifier: &Sender<Vec<CertificateType>>,
         bls_sender: &Sender<BLSOp>,
         new_finalized_slot: Option<Slot>,
         new_certificates_to_send: Vec<Arc<Certificate>>,
@@ -95,10 +97,24 @@ impl ConsensusPoolService {
         let bank = sharable_banks.root();
         consensus_pool.prune_old_state(bank.slot());
         stats.prune_old_state_called += 1;
-        // Send new certificates to peers
+        Self::send_to_bls_sigverifier(channel_to_bls_sigverifier, &new_certificates_to_send)?;
         Self::send_certificates(bls_sender, new_certificates_to_send, stats)
     }
 
+    /// Sends generated certs to the bls sigverifier.
+    fn send_to_bls_sigverifier(
+        channel_to_bls_sigverifier: &Sender<Vec<CertificateType>>,
+        certs: &[Arc<Certificate>],
+    ) -> Result<(), AddVoteError> {
+        let msg = certs.iter().map(|c| c.cert_type).collect::<Vec<_>>();
+        match channel_to_bls_sigverifier.try_send(msg) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => unimplemented!(),
+            Err(TrySendError::Disconnected(_)) => unimplemented!(),
+        }
+    }
+
+    /// Sends generated certs to peers.
     fn send_certificates(
         bls_sender: &Sender<BLSOp>,
         certificates_to_send: Vec<Arc<Certificate>>,
@@ -158,6 +174,7 @@ impl ConsensusPoolService {
         Self::maybe_update_root_and_send_new_certificates(
             consensus_pool,
             &ctx.sharable_banks,
+            &ctx.channel_to_bls_sigverifier,
             &ctx.bls_sender,
             new_finalized_slot,
             new_certificates_to_send,
@@ -470,6 +487,8 @@ mod tests {
         consensus_pool: ConsensusPool,
         bls_sender: Sender<BLSOp>,
         bls_receiver: Receiver<BLSOp>,
+        channel_to_bls_sigverifier: Sender<Vec<CertificateType>>,
+        _cert_types_receiver: Receiver<Vec<CertificateType>>,
         commitment_sender: Sender<CommitmentAggregationData>,
         commitment_receiver: Receiver<CommitmentAggregationData>,
         validator_keypairs: Vec<ValidatorVoteKeypairs>,
@@ -485,6 +504,7 @@ mod tests {
         fn default() -> Self {
             let (bls_sender, bls_receiver) = crossbeam_channel::unbounded();
             let (commitment_sender, commitment_receiver) = crossbeam_channel::unbounded();
+            let (channel_to_bls_sigverifier, cert_types_receiver) = crossbeam_channel::unbounded();
 
             // Create 10 node validatorvotekeypairs vec
             let validator_keypairs = (0..10)
@@ -519,6 +539,8 @@ mod tests {
                 consensus_pool,
                 bls_sender,
                 bls_receiver,
+                channel_to_bls_sigverifier,
+                _cert_types_receiver: cert_types_receiver,
                 commitment_sender,
                 commitment_receiver,
                 validator_keypairs,
@@ -584,6 +606,7 @@ mod tests {
                 ConsensusPoolService::maybe_update_root_and_send_new_certificates(
                     &mut ctx.consensus_pool,
                     &ctx.sharable_banks,
+                    &ctx.channel_to_bls_sigverifier,
                     &ctx.bls_sender,
                     new_finalized_slot,
                     new_certificates_to_send,
@@ -663,6 +686,7 @@ mod tests {
         ConsensusPoolService::maybe_update_root_and_send_new_certificates(
             &mut ctx.consensus_pool,
             &ctx.sharable_banks,
+            &ctx.channel_to_bls_sigverifier,
             &ctx.bls_sender,
             new_finalized_slot,
             new_certificates_to_send,
@@ -733,6 +757,7 @@ mod tests {
             leader_schedule_cache: ctx.leader_schedule_cache.clone(),
             consensus_message_receiver: crossbeam_channel::unbounded().1,
             bls_sender: ctx.bls_sender.clone(),
+            channel_to_bls_sigverifier: ctx.channel_to_bls_sigverifier.clone(),
             event_sender: crossbeam_channel::unbounded().0,
             commitment_sender: ctx.commitment_sender.clone(),
         };
@@ -842,6 +867,7 @@ mod tests {
         let result = ConsensusPoolService::maybe_update_root_and_send_new_certificates(
             &mut ctx.consensus_pool,
             &ctx.sharable_banks,
+            &ctx.channel_to_bls_sigverifier,
             &ctx.bls_sender,
             Some(5), // new finalized slot
             certificates,

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -59,7 +59,7 @@ use {
         voting_utils::VotingContext,
     },
     agave_votor_messages::{
-        consensus_message::ConsensusMessage,
+        consensus_message::{CertificateType, ConsensusMessage},
         reward_certificate::{AddVoteMessage, BuildRewardCertsRequest, BuildRewardCertsResponse},
     },
     crossbeam_channel::{Receiver, Sender},
@@ -108,6 +108,7 @@ pub struct VotorConfig {
     // Senders / Notifiers
     pub snapshot_controller: Option<Arc<SnapshotController>>,
     pub bls_sender: Sender<BLSOp>,
+    pub channel_to_bls_sigverifier: Sender<Vec<CertificateType>>,
     pub commitment_sender: Sender<CommitmentAggregationData>,
     pub drop_bank_sender: Sender<Vec<BankWithScheduler>>,
     pub bank_notification_sender: Option<BankNotificationSenderConfig>,
@@ -161,6 +162,7 @@ impl Votor {
             rpc_subscriptions,
             snapshot_controller,
             bls_sender,
+            channel_to_bls_sigverifier,
             commitment_sender,
             drop_bank_sender,
             bank_notification_sender,
@@ -243,6 +245,7 @@ impl Votor {
             sharable_banks: sharable_banks.clone(),
             leader_schedule_cache: leader_schedule_cache.clone(),
             consensus_message_receiver,
+            channel_to_bls_sigverifier,
             bls_sender,
             event_sender,
             commitment_sender,


### PR DESCRIPTION
#### Problem

In normal cases, a validator would often generate the relevant certs before they receive it over the network.  So we wouldn't have to sig verify certs we already have.

#### Summary of Changes

Sends generated certs from the consensus pool to the bls sigverifier to avoid doing unnecessary work.
