### PR TITLE
bls-sigverifier: ensures we always report stats on error

### DIFF
--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -131,7 +131,7 @@ impl SigVerifier {
             const SOFT_RECEIVE_CAP: usize = 5000;
             let Ok(batches) = recv_batches(&self.channels.packet_receiver, SOFT_RECEIVE_CAP) else {
                 error!("packet_receiver disconnected:  Exiting.");
-                return;
+                break;
             };
             if batches.is_empty() || self.migration_status.is_pre_feature_activation() {
                 continue;
@@ -141,12 +141,13 @@ impl SigVerifier {
             self.stats
                 .verify_and_send_batch_us
                 .add_sample(verify_time_us);
-            self.stats.maybe_report();
             if let Err(e) = verify_res {
                 error!("verify_and_send_batch() failed with {e}. Exiting.");
                 break;
             }
+            self.stats.maybe_report();
         }
+        self.stats.do_report();
     }
 
     fn verify_and_send_batches(&mut self, batches: Vec<PacketBatch>) -> Result<(), SigVerifyError> {

--- a/core/src/bls_sigverify/stats.rs
+++ b/core/src/bls_sigverify/stats.rs
@@ -59,7 +59,19 @@ impl Default for SigVerifierStats {
 }
 
 impl SigVerifierStats {
+    /// Reports stats if they have not been reported in some time.
+    ///
+    /// Also resets all stats.
     pub(super) fn maybe_report(&mut self) {
+        if self.last_report.elapsed() < STATS_INTERVAL_DURATION {
+            return;
+        }
+        self.do_report();
+        *self = SigVerifierStats::default();
+    }
+
+    /// Reports stats regardless of when they were last reported.
+    pub(super) fn do_report(&mut self) {
         let Self {
             vote_stats,
             cert_stats,
@@ -73,11 +85,8 @@ impl SigVerifierStats {
             discard_vote_invalid_rank,
             discard_vote_no_epoch_stakes,
             verify_and_send_batch_us,
-            last_report,
+            last_report: _,
         } = self;
-        if last_report.elapsed() < STATS_INTERVAL_DURATION {
-            return;
-        }
 
         vote_stats.report();
         cert_stats.report();
@@ -127,7 +136,6 @@ impl SigVerifierStats {
             ("num_pkts_mean", num_pkts.mean().unwrap_or(0), i64),
             ("num_pkts_count", num_pkts.count(), i64),
         );
-        *self = SigVerifierStats::default();
     }
 }
 


### PR DESCRIPTION

#### Problem

Before we were not guaranteed that we would report stats on an error before exiting.

#### Summary of Changes

This PR changes it to so that we always report stats before exiting.
