### PR TITLE
Cleans up consensus pool stats

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -149,7 +149,7 @@ impl ConsensusPool {
             highest_finalized_slot: None,
             highest_finalized_with_notarize: None,
             parent_ready_tracker,
-            stats: ConsensusPoolStats::new(),
+            stats: ConsensusPoolStats::default(),
             slot_stake_counters_map: BTreeMap::new(),
             migration_status: None,
         }
@@ -246,7 +246,7 @@ impl ConsensusPool {
             });
             let new_cert = Arc::new(cert_builder.build()?);
             self.insert_certificate(cert_type, new_cert.clone(), events);
-            self.stats.incr_cert_type(&new_cert.cert_type, true);
+            self.stats.incr_generated_cert(&new_cert.cert_type);
             new_certificates_to_send.push(new_cert);
         }
         Ok(new_certificates_to_send)
@@ -485,8 +485,7 @@ impl ConsensusPool {
         }
         let cert = Arc::new(cert);
         self.insert_certificate(cert_type, cert.clone(), events);
-
-        self.stats.incr_cert_type(&cert_type, false);
+        self.stats.incr_ingested_cert(&cert_type);
 
         Ok(vec![cert])
     }

--- a/votor/src/consensus_pool/stats.rs
+++ b/votor/src/consensus_pool/stats.rs
@@ -18,8 +18,8 @@ struct CertificateStats {
 
 impl CertificateStats {
     /// Increments the stats associated with the certificate type by one.
-    fn increment(&mut self, certificate: &CertificateType) {
-        match certificate {
+    fn increment(&mut self, cert_type: &CertificateType) {
+        match cert_type {
             CertificateType::Finalize(_) => self.finalize = self.finalize.saturating_add(1),
             CertificateType::FinalizeFast(_, _) => {
                 self.finalize_fast = self.finalize_fast.saturating_add(1)
@@ -34,44 +34,91 @@ impl CertificateStats {
     }
 
     fn record(&self, header: &'static str) {
+        let Self {
+            finalize,
+            finalize_fast,
+            notarize,
+            notarize_fallback,
+            skip,
+            genesis,
+        } = self;
         datapoint_info!(
             header,
-            ("finalize", self.finalize, i64),
-            ("finalize_fast", self.finalize_fast, i64),
-            ("notarize", self.notarize, i64),
-            ("notarize_fallback", self.notarize_fallback, i64),
-            ("skip", self.skip, i64),
+            ("finalize", *finalize, i64),
+            ("finalize_fast", *finalize_fast, i64),
+            ("notarize", *notarize, i64),
+            ("notarize_fallback", *notarize_fallback, i64),
+            ("skip", *skip, i64),
+            ("genesis", *genesis, i64),
         )
     }
 }
 
-pub(crate) struct ConsensusPoolStats {
-    pub(crate) conflicting_votes: u32,
-    pub(crate) event_safe_to_notarize: u32,
-    pub(crate) event_safe_to_skip: u32,
-    pub(crate) exist_certs: u32,
-    pub(crate) exist_votes: u32,
-    pub(crate) incoming_certs: u32,
-    pub(crate) incoming_votes: u32,
-    pub(crate) out_of_range_certs: u32,
-    pub(crate) out_of_range_votes: u32,
+#[derive(Default)]
+struct VoteStats {
+    finalize: u64,
+    notarize: u64,
+    notar_fallback: u64,
+    skip: u64,
+    skip_fallback: u64,
+    genesis: u64,
+}
 
-    new_certs_generated: CertificateStats,
-    new_certs_ingested: CertificateStats,
-    pub(crate) ingested_votes: Vec<u32>,
+impl VoteStats {
+    fn increment(&mut self, vote_type: &VoteType) {
+        match vote_type {
+            VoteType::Finalize => self.finalize = self.finalize.saturating_add(1),
+            VoteType::Notarize => self.notarize = self.notarize.saturating_add(1),
+            VoteType::NotarizeFallback => {
+                self.notar_fallback = self.notar_fallback.saturating_add(1)
+            }
+            VoteType::Skip => self.skip = self.skip.saturating_add(1),
+            VoteType::SkipFallback => self.skip_fallback = self.skip_fallback.saturating_add(1),
+            VoteType::Genesis => self.genesis = self.genesis.saturating_add(1),
+        }
+    }
 
-    pub(crate) last_request_time: Instant,
+    fn record(&self, header: &'static str) {
+        let Self {
+            finalize,
+            notarize,
+            notar_fallback,
+            skip,
+            skip_fallback,
+            genesis,
+        } = self;
+        datapoint_info!(
+            header,
+            ("finalize", *finalize, i64),
+            ("notarize", *notarize, i64),
+            ("notar_fallback", *notar_fallback, i64),
+            ("skip", *skip, i64),
+            ("skip_fallback", *skip_fallback, i64),
+            ("genesis", *genesis, i64),
+        )
+    }
+}
+
+pub(super) struct ConsensusPoolStats {
+    pub(super) conflicting_votes: u32,
+    pub(super) event_safe_to_notarize: u32,
+    pub(super) event_safe_to_skip: u32,
+    pub(super) exist_certs: u32,
+    pub(super) exist_votes: u32,
+    pub(super) incoming_certs: u32,
+    pub(super) incoming_votes: u32,
+    pub(super) out_of_range_certs: u32,
+    pub(super) out_of_range_votes: u32,
+
+    certs_generated: CertificateStats,
+    certs_ingested: CertificateStats,
+    ingested_votes: VoteStats,
+
+    pub(super) last_request_time: Instant,
 }
 
 impl Default for ConsensusPoolStats {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ConsensusPoolStats {
-    pub fn new() -> Self {
-        let num_vote_types = (VoteType::Genesis as usize).saturating_add(1);
         Self {
             conflicting_votes: 0,
             event_safe_to_notarize: 0,
@@ -83,98 +130,70 @@ impl ConsensusPoolStats {
             out_of_range_certs: 0,
             out_of_range_votes: 0,
 
-            new_certs_ingested: CertificateStats::default(),
-            new_certs_generated: CertificateStats::default(),
-            ingested_votes: vec![0; num_vote_types],
+            certs_ingested: CertificateStats::default(),
+            certs_generated: CertificateStats::default(),
+            ingested_votes: VoteStats::default(),
 
             last_request_time: Instant::now(),
         }
     }
+}
 
-    pub fn incr_ingested_vote_type(&mut self, vote_type: VoteType) {
-        let index = vote_type as usize;
-
-        self.ingested_votes[index] = self.ingested_votes[index].saturating_add(1);
+impl ConsensusPoolStats {
+    pub(super) fn incr_ingested_vote_type(&mut self, vote_type: VoteType) {
+        self.ingested_votes.increment(&vote_type);
     }
 
-    pub fn incr_cert_type(&mut self, certificate: &CertificateType, is_generated: bool) {
-        if is_generated {
-            self.new_certs_generated.increment(certificate);
-        } else {
-            self.new_certs_ingested.increment(certificate);
-        }
+    pub(super) fn incr_generated_cert(&mut self, cert_type: &CertificateType) {
+        self.certs_generated.increment(cert_type);
+    }
+
+    pub(super) fn incr_ingested_cert(&mut self, cert_type: &CertificateType) {
+        self.certs_ingested.increment(cert_type);
     }
 
     /// Reports the certificate related statistics.
     fn report(&self) {
+        let Self {
+            conflicting_votes,
+            event_safe_to_notarize,
+            event_safe_to_skip,
+            exist_certs,
+            exist_votes,
+            incoming_certs,
+            incoming_votes,
+            ingested_votes,
+            certs_generated,
+            certs_ingested,
+            out_of_range_certs,
+            out_of_range_votes,
+            last_request_time: _,
+        } = self;
         datapoint_info!(
-            "consensus_pool_stats",
-            ("conflicting_votes", self.conflicting_votes as i64, i64),
-            ("event_safe_to_skip", self.event_safe_to_skip as i64, i64),
+            "consensus_pool",
+            ("conflicting_votes", *conflicting_votes as i64, i64),
+            ("event_safe_to_skip", *event_safe_to_skip as i64, i64),
             (
                 "event_safe_to_notarize",
-                self.event_safe_to_notarize as i64,
+                *event_safe_to_notarize as i64,
                 i64
             ),
-            ("exist_votes", self.exist_votes as i64, i64),
-            ("exist_certs", self.exist_certs as i64, i64),
-            ("incoming_votes", self.incoming_votes as i64, i64),
-            ("incoming_certs", self.incoming_certs as i64, i64),
-            ("out_of_range_votes", self.out_of_range_votes as i64, i64),
-            ("out_of_range_certs", self.out_of_range_certs as i64, i64),
+            ("exist_votes", *exist_votes as i64, i64),
+            ("exist_certs", *exist_certs as i64, i64),
+            ("incoming_votes", *incoming_votes as i64, i64),
+            ("incoming_certs", *incoming_certs as i64, i64),
+            ("out_of_range_votes", *out_of_range_votes as i64, i64),
+            ("out_of_range_certs", *out_of_range_certs as i64, i64),
         );
-
-        datapoint_info!(
-            "consensus_ingested_votes",
-            (
-                "finalize",
-                *self
-                    .ingested_votes
-                    .get(VoteType::Finalize as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-            (
-                "notarize",
-                *self
-                    .ingested_votes
-                    .get(VoteType::Notarize as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-            (
-                "notarize_fallback",
-                *self
-                    .ingested_votes
-                    .get(VoteType::NotarizeFallback as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-            (
-                "skip",
-                *self.ingested_votes.get(VoteType::Skip as usize).unwrap() as i64,
-                i64
-            ),
-            (
-                "skip_fallback",
-                *self
-                    .ingested_votes
-                    .get(VoteType::SkipFallback as usize)
-                    .unwrap() as i64,
-                i64
-            ),
-        );
-
-        self.new_certs_ingested
-            .record("consensus_pool_ingested_certs");
-        self.new_certs_generated
-            .record("consensus_pool_generated_certs");
+        ingested_votes.record("consensus_pool_ingested_votes");
+        certs_ingested.record("consensus_pool_ingested_certs");
+        certs_generated.record("consensus_pool_generated_certs");
     }
 
-    pub fn maybe_report(&mut self) {
+    pub(super) fn maybe_report(&mut self) {
         if self.last_request_time.elapsed() >= STATS_REPORT_INTERVAL {
             self.report();
-            *self = Self::new();
+            *self = Self::default();
         }
     }
 }


### PR DESCRIPTION
#### Problem

The consensus pool stats have various problems that make them hard to read on grafana and hard to update / maintain.

I plan on adding more logic to the consensus pool which will require updating the stats and so I needed this cleanup.


#### Summary of Changes

- Use a proper struct for tracking vote stats instead of a vec which might break if we add new vote types of change their order.
- do not expose structs and members unnecessarily
- rename various fields to make them shorter and cleaner
- reduce boolean blindness
- use struct deconstruction to ensure that we report all stats.  This helped catch one stat that was not being reported.
