### PR TITLE
cost tracker set max

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -172,9 +172,7 @@ fn bench_banking(
     let bank = bank_forks.read().unwrap().get(0).unwrap();
 
     // set cost tracker limits to MAX so it will not filter out TXs
-    bank.write_cost_tracker()
-        .unwrap()
-        .set_limits(u64::MAX, u64::MAX, u64::MAX);
+    bank.write_cost_tracker().unwrap().set_limits_max();
 
     debug!("threads: {num_threads} txs: {txes}");
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1116,9 +1116,7 @@ mod tests {
         } = create_slow_genesis_config(lamports);
         let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         // set cost tracker limits to MAX so it will not filter out TXs
-        bank.write_cost_tracker()
-            .unwrap()
-            .set_limits(u64::MAX, u64::MAX, u64::MAX);
+        bank.write_cost_tracker().unwrap().set_limits_max();
 
         // Transfer more than the balance of the mint keypair, should cause a
         // InstructionError::InsufficientFunds that is then committed.
@@ -1184,9 +1182,7 @@ mod tests {
         bank.ns_per_slot = u128::MAX;
         let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
         // set cost tracker limits to MAX so it will not filter out TXs
-        bank.write_cost_tracker()
-            .unwrap()
-            .set_limits(u64::MAX, u64::MAX, u64::MAX);
+        bank.write_cost_tracker().unwrap().set_limits_max();
 
         let mut transactions = vec![];
         let destination = Pubkey::new_unique();

--- a/cost-model/benches/cost_tracker.rs
+++ b/cost-model/benches/cost_tracker.rs
@@ -18,7 +18,7 @@ struct BenchSetup {
 fn setup(num_transactions: usize, contentious_transactions: bool) -> BenchSetup {
     let mut cost_tracker = CostTracker::default();
     // set cost_tracker with max limits to stretch testing
-    cost_tracker.set_limits(u64::MAX, u64::MAX, u64::MAX);
+    cost_tracker.set_limits_max();
 
     let max_accounts_per_tx = 128;
     let pubkey = Pubkey::new_unique();

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -152,6 +152,10 @@ impl CostTracker {
         self.vote_cost_limit = vote_cost_limit;
     }
 
+    pub fn set_limits_max(&mut self) {
+        self.set_limits(u64::MAX, u64::MAX, u64::MAX);
+    }
+
     pub fn in_flight_transaction_count(&self) -> usize {
         self.in_flight_transaction_count.0
     }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -962,9 +962,7 @@ pub fn process_blockstore_from_root(
         }
         if opts.no_block_cost_limits {
             warn!("setting block cost limits to MAX");
-            bank.write_cost_tracker()
-                .unwrap()
-                .set_limits(u64::MAX, u64::MAX, u64::MAX);
+            bank.write_cost_tracker().unwrap().set_limits_max();
         }
         assert!(bank.parent().is_none());
         (bank.slot(), bank.hash())

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -4275,9 +4275,7 @@ mod tests {
             bank.slot().checked_add(1).unwrap(),
         ));
         // Revert the block cost limit
-        bank.write_cost_tracker()
-            .unwrap()
-            .set_limits(u64::MAX, u64::MAX, u64::MAX);
+        bank.write_cost_tracker().unwrap().set_limits_max();
 
         let context = SchedulingContext::for_production(bank.clone());
         let scheduler = pool.take_scheduler(context).unwrap();


### PR DESCRIPTION
#### Problem
Cost tracker API currently forces users to understand how to set each dimension in order to accomplish "unthrottle this thing"

Additionally, this requires updating each site if we want to add a new dynamic dimension (which is what I plan to do)

#### Summary of Changes
Create a new API to set all limits to max that can be called