### PR TITLE
status cache max age

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -273,7 +273,7 @@ fn get_default_max_status_cache_entries() -> u64 {
         .status_cache
         .read()
         .unwrap()
-        .max_cache_entries() as u64
+        .max_root_entries() as u64
 }
 
 #[test]
@@ -337,7 +337,7 @@ fn test_slots_to_snapshot() {
 
 #[test]
 fn test_bank_forks_status_cache_snapshot() {
-    // create banks up to slot (MAX_CACHE_ENTRIES * 2) + 1 while transferring 1 lamport into 2 different accounts each time
+    // create banks up to slot (`max_root_entries` * 2) + 1 while transferring 1 lamport into 2 different accounts each time
     // this is done to ensure the AccountStorageEntries keep getting cleaned up as the root moves
     // ahead. Also tests the status_cache purge and status cache snapshotting.
     // Makes sure that the last bank is restored correctly

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -264,33 +264,34 @@ fn goto_end_of_slot(bank: &Bank) {
     }
 }
 
-fn root_bank_status_cache_max_entries(bank_forks: &Arc<RwLock<BankForks>>) -> usize {
-    bank_forks
+fn get_default_max_status_cache_entries() -> u64 {
+    SnapshotTestConfig::new(SnapshotInterval::Disabled, SnapshotInterval::Disabled)
+        .bank_forks
         .read()
         .unwrap()
         .root_bank()
         .status_cache
         .read()
         .unwrap()
-        .max_cache_entries()
+        .max_cache_entries() as u64
 }
 
 #[test]
 fn test_slots_to_snapshot() {
     agave_logger::setup();
-    const NEVER_SNAPSHOT_INTERVAL_SLOTS: Slot = 1_000_000;
+    let status_cache_max_entries = get_default_max_status_cache_entries();
+    let num_set_roots = status_cache_max_entries * 2;
 
     for add_root_interval in &[1, 3, 9] {
         let (snapshot_sender, _snapshot_receiver) = unbounded();
         // Make sure this test never clears bank.slots_since_snapshot
         let snapshot_test_config = SnapshotTestConfig::new(
-            SnapshotInterval::Slots(NonZeroU64::new(NEVER_SNAPSHOT_INTERVAL_SLOTS).unwrap()),
+            SnapshotInterval::Slots(
+                NonZeroU64::new((*add_root_interval * num_set_roots * 2) as Slot).unwrap(),
+            ),
             SnapshotInterval::Disabled,
         );
         let bank_forks = snapshot_test_config.bank_forks.clone();
-        let status_cache_max_entries = root_bank_status_cache_max_entries(&bank_forks);
-        // Exceed the cache window by one root to trigger eviction behavior.
-        let num_set_roots = status_cache_max_entries + 1;
         let bank_forks_r = bank_forks.read().unwrap();
         let mut current_bank = bank_forks_r[0].clone();
         drop(bank_forks_r);
@@ -317,8 +318,7 @@ fn test_slots_to_snapshot() {
         }
 
         let num_old_slots = num_set_roots * *add_root_interval - status_cache_max_entries + 1;
-        let expected_slots_to_snapshot =
-            num_old_slots as u64..=num_set_roots as u64 * *add_root_interval as u64;
+        let expected_slots_to_snapshot = num_old_slots..=num_set_roots * *add_root_interval;
 
         let slots_to_snapshot = bank_forks
             .read()
@@ -337,20 +337,16 @@ fn test_slots_to_snapshot() {
 
 #[test]
 fn test_bank_forks_status_cache_snapshot() {
-    // Create banks beyond the status-cache limit while transferring 1 lamport
-    // into 2 different accounts each time. This ensures AccountStorageEntries
-    // keep getting cleaned up as the root moves ahead and status-cache
-    // purge/snapshot behavior is exercised.
-    let status_cache_max_entries = {
-        let snapshot_test_config =
-            SnapshotTestConfig::new(SnapshotInterval::Disabled, SnapshotInterval::Disabled);
-        root_bank_status_cache_max_entries(&snapshot_test_config.bank_forks)
-    };
+    // create banks up to slot (MAX_CACHE_ENTRIES * 2) + 1 while transferring 1 lamport into 2 different accounts each time
+    // this is done to ensure the AccountStorageEntries keep getting cleaned up as the root moves
+    // ahead. Also tests the status_cache purge and status cache snapshotting.
+    // Makes sure that the last bank is restored correctly
+    let status_cache_max_entries = get_default_max_status_cache_entries();
     let key1 = Keypair::new().pubkey();
     let key2 = Keypair::new().pubkey();
     for set_root_interval in &[1, 4] {
         run_bank_forks_snapshot_n(
-            (status_cache_max_entries + 1) as u64,
+            status_cache_max_entries + 1,
             |bank, mint_keypair| {
                 let tx = system_transaction::transfer(
                     mint_keypair,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -30,7 +30,6 @@ use {
         snapshot_controller::SnapshotController,
         snapshot_package::SnapshotPackage,
         snapshot_utils,
-        status_cache::MAX_CACHE_ENTRIES,
     },
     solana_sha256_hasher::hashv,
     solana_signer::Signer,
@@ -265,21 +264,33 @@ fn goto_end_of_slot(bank: &Bank) {
     }
 }
 
+fn root_bank_status_cache_max_entries(bank_forks: &Arc<RwLock<BankForks>>) -> usize {
+    bank_forks
+        .read()
+        .unwrap()
+        .root_bank()
+        .status_cache
+        .read()
+        .unwrap()
+        .max_cache_entries()
+}
+
 #[test]
 fn test_slots_to_snapshot() {
     agave_logger::setup();
-    let num_set_roots = MAX_CACHE_ENTRIES * 2;
+    const NEVER_SNAPSHOT_INTERVAL_SLOTS: Slot = 1_000_000;
 
     for add_root_interval in &[1, 3, 9] {
         let (snapshot_sender, _snapshot_receiver) = unbounded();
         // Make sure this test never clears bank.slots_since_snapshot
         let snapshot_test_config = SnapshotTestConfig::new(
-            SnapshotInterval::Slots(
-                NonZeroU64::new((*add_root_interval * num_set_roots * 2) as Slot).unwrap(),
-            ),
+            SnapshotInterval::Slots(NonZeroU64::new(NEVER_SNAPSHOT_INTERVAL_SLOTS).unwrap()),
             SnapshotInterval::Disabled,
         );
         let bank_forks = snapshot_test_config.bank_forks.clone();
+        let status_cache_max_entries = root_bank_status_cache_max_entries(&bank_forks);
+        // Exceed the cache window by one root to trigger eviction behavior.
+        let num_set_roots = status_cache_max_entries + 1;
         let bank_forks_r = bank_forks.read().unwrap();
         let mut current_bank = bank_forks_r[0].clone();
         drop(bank_forks_r);
@@ -305,7 +316,7 @@ fn test_slots_to_snapshot() {
             );
         }
 
-        let num_old_slots = num_set_roots * *add_root_interval - MAX_CACHE_ENTRIES + 1;
+        let num_old_slots = num_set_roots * *add_root_interval - status_cache_max_entries + 1;
         let expected_slots_to_snapshot =
             num_old_slots as u64..=num_set_roots as u64 * *add_root_interval as u64;
 
@@ -326,15 +337,20 @@ fn test_slots_to_snapshot() {
 
 #[test]
 fn test_bank_forks_status_cache_snapshot() {
-    // create banks up to slot (MAX_CACHE_ENTRIES * 2) + 1 while transferring 1 lamport into 2 different accounts each time
-    // this is done to ensure the AccountStorageEntries keep getting cleaned up as the root moves
-    // ahead. Also tests the status_cache purge and status cache snapshotting.
-    // Makes sure that the last bank is restored correctly
+    // Create banks beyond the status-cache limit while transferring 1 lamport
+    // into 2 different accounts each time. This ensures AccountStorageEntries
+    // keep getting cleaned up as the root moves ahead and status-cache
+    // purge/snapshot behavior is exercised.
+    let status_cache_max_entries = {
+        let snapshot_test_config =
+            SnapshotTestConfig::new(SnapshotInterval::Disabled, SnapshotInterval::Disabled);
+        root_bank_status_cache_max_entries(&snapshot_test_config.bank_forks)
+    };
     let key1 = Keypair::new().pubkey();
     let key2 = Keypair::new().pubkey();
     for set_root_interval in &[1, 4] {
         run_bank_forks_snapshot_n(
-            (MAX_CACHE_ENTRIES * 2) as u64,
+            (status_cache_max_entries + 1) as u64,
             |bank, mint_keypair| {
                 let tx = system_transaction::transfer(
                     mint_keypair,

--- a/runtime/benches/status_cache.rs
+++ b/runtime/benches/status_cache.rs
@@ -6,7 +6,7 @@ use {
     rand::{Rng, SeedableRng, rngs::SmallRng},
     solana_accounts_db::ancestors::Ancestors,
     solana_hash::{HASH_BYTES, Hash},
-    solana_runtime::{bank::BankStatusCache, status_cache::*},
+    solana_runtime::bank::BankStatusCache,
     solana_sha256_hasher::hash,
     solana_signature::{SIGNATURE_BYTES, Signature},
     test::Bencher,
@@ -39,9 +39,13 @@ fn bench_status_cache_serialize(bencher: &mut Bencher) {
 fn bench_status_cache_serialize_max(bencher: &mut Bencher) {
     // Fill up the status cache to better match what intense runtime usage would
     // look like.
-    let max_cache_entries = MAX_CACHE_ENTRIES as u64;
     let mut status_cache = BankStatusCache::default();
-    fill_status_cache(&mut status_cache, max_cache_entries, 100_000);
+    let max_cache_entries = status_cache.max_cache_entries() as u64;
+    fill_status_cache(
+        &mut status_cache,
+        max_cache_entries,
+        100_000,
+    );
 
     assert!(status_cache.roots().contains(&0));
     bencher.iter(|| {
@@ -54,7 +58,7 @@ fn bench_status_cache_root_slot_deltas(bencher: &mut Bencher) {
     let mut status_cache = BankStatusCache::default();
 
     // fill the status cache
-    let slots: Vec<_> = (42..).take(MAX_CACHE_ENTRIES).collect();
+    let slots: Vec<_> = (42..).take(status_cache.max_cache_entries()).collect();
     for slot in &slots {
         for _ in 0..5 {
             status_cache.insert(&Hash::new_unique(), Hash::new_unique(), *slot, Ok(()));
@@ -88,8 +92,8 @@ fn fill_status_cache_slot(
 fn bench_status_cache_check_and_insert(bencher: &mut Bencher) {
     // Fill up the status cache to better match what intense runtime usage would
     // look like.
-    let max_cache_entries = MAX_CACHE_ENTRIES as u64;
     let mut status_cache = BankStatusCache::default();
+    let max_cache_entries = status_cache.max_cache_entries() as u64;
     fill_status_cache(&mut status_cache, max_cache_entries - 1, 100_000);
 
     // Manually fill the last slot so we can save off the blockhash to use for
@@ -127,8 +131,8 @@ fn bench_status_cache_check_and_insert(bencher: &mut Bencher) {
 fn bench_status_cache_add_roots(bencher: &mut Bencher) {
     // Fill up the status cache to better match what intense runtime usage would
     // look like.
-    let max_cache_entries = MAX_CACHE_ENTRIES as u64;
     let mut status_cache = BankStatusCache::default();
+    let max_cache_entries = status_cache.max_cache_entries() as u64;
     fill_status_cache(&mut status_cache, max_cache_entries, 100_000);
     let start_slot = max_cache_entries + 1;
     bencher.iter(|| {

--- a/runtime/benches/status_cache.rs
+++ b/runtime/benches/status_cache.rs
@@ -41,11 +41,7 @@ fn bench_status_cache_serialize_max(bencher: &mut Bencher) {
     // look like.
     let mut status_cache = BankStatusCache::default();
     let max_cache_entries = status_cache.max_cache_entries() as u64;
-    fill_status_cache(
-        &mut status_cache,
-        max_cache_entries,
-        100_000,
-    );
+    fill_status_cache(&mut status_cache, max_cache_entries, 100_000);
 
     assert!(status_cache.roots().contains(&0));
     bencher.iter(|| {

--- a/runtime/benches/status_cache.rs
+++ b/runtime/benches/status_cache.rs
@@ -40,8 +40,8 @@ fn bench_status_cache_serialize_max(bencher: &mut Bencher) {
     // Fill up the status cache to better match what intense runtime usage would
     // look like.
     let mut status_cache = BankStatusCache::default();
-    let max_cache_entries = status_cache.max_cache_entries() as u64;
-    fill_status_cache(&mut status_cache, max_cache_entries, 100_000);
+    let max_root_entries = status_cache.max_root_entries() as u64;
+    fill_status_cache(&mut status_cache, max_root_entries, 100_000);
 
     assert!(status_cache.roots().contains(&0));
     bencher.iter(|| {
@@ -54,7 +54,7 @@ fn bench_status_cache_root_slot_deltas(bencher: &mut Bencher) {
     let mut status_cache = BankStatusCache::default();
 
     // fill the status cache
-    let slots: Vec<_> = (42..).take(status_cache.max_cache_entries()).collect();
+    let slots: Vec<_> = (42..).take(status_cache.max_root_entries()).collect();
     for slot in &slots {
         for _ in 0..5 {
             status_cache.insert(&Hash::new_unique(), Hash::new_unique(), *slot, Ok(()));
@@ -65,8 +65,8 @@ fn bench_status_cache_root_slot_deltas(bencher: &mut Bencher) {
     bencher.iter(|| test::black_box(status_cache.root_slot_deltas()));
 }
 
-fn fill_status_cache(status_cache: &mut BankStatusCache, max_cache_entries: u64, num_txs: usize) {
-    for slot in 0..max_cache_entries {
+fn fill_status_cache(status_cache: &mut BankStatusCache, max_root_entries: u64, num_txs: usize) {
+    for slot in 0..max_root_entries {
         let blockhash = Hash::new_unique();
         fill_status_cache_slot(status_cache, &blockhash, slot, num_txs);
     }
@@ -89,15 +89,15 @@ fn bench_status_cache_check_and_insert(bencher: &mut Bencher) {
     // Fill up the status cache to better match what intense runtime usage would
     // look like.
     let mut status_cache = BankStatusCache::default();
-    let max_cache_entries = status_cache.max_cache_entries() as u64;
-    fill_status_cache(&mut status_cache, max_cache_entries - 1, 100_000);
+    let max_root_entries = status_cache.max_root_entries() as u64;
+    fill_status_cache(&mut status_cache, max_root_entries - 1, 100_000);
 
     // Manually fill the last slot so we can save off the blockhash to use for
     // querying and inserting into.
     let blockhash = Hash::new_unique();
-    fill_status_cache_slot(&mut status_cache, &blockhash, max_cache_entries, 100_000);
+    fill_status_cache_slot(&mut status_cache, &blockhash, max_root_entries, 100_000);
 
-    let slot = max_cache_entries + 1;
+    let slot = max_root_entries + 1;
     let ancestors = Ancestors::from((slot - 32..slot).collect::<Vec<u64>>());
 
     // Pre-generate unique tx_hashes so we don't spend benchmark time generating
@@ -128,11 +128,11 @@ fn bench_status_cache_add_roots(bencher: &mut Bencher) {
     // Fill up the status cache to better match what intense runtime usage would
     // look like.
     let mut status_cache = BankStatusCache::default();
-    let max_cache_entries = status_cache.max_cache_entries() as u64;
-    fill_status_cache(&mut status_cache, max_cache_entries, 100_000);
-    let start_slot = max_cache_entries + 1;
+    let max_root_entries = status_cache.max_root_entries() as u64;
+    fill_status_cache(&mut status_cache, max_root_entries, 100_000);
+    let start_slot = max_root_entries + 1;
     bencher.iter(|| {
-        for root in start_slot..start_slot + max_cache_entries {
+        for root in start_slot..start_slot + max_root_entries {
             status_cache.add_root(root);
         }
     });

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3452,8 +3452,8 @@ fn test_status_cache_ancestors() {
     let (parent, _bank_forks) = create_simple_test_arc_bank(500);
     let bank1 = Arc::new(new_from_parent(parent));
     let mut bank = bank1;
-    let max_cache_entries = bank.status_cache.read().unwrap().max_cache_entries();
-    for _ in 0..max_cache_entries * 2 {
+    let max_root_entries = bank.status_cache.read().unwrap().max_root_entries();
+    for _ in 0..max_root_entries * 2 {
         bank = Arc::new(new_from_parent(bank));
         bank.squash();
     }
@@ -3461,7 +3461,7 @@ fn test_status_cache_ancestors() {
     let bank = new_from_parent(bank);
     assert_eq!(
         bank.status_cache_ancestors(),
-        (bank.slot() - max_cache_entries as u64..=bank.slot()).collect::<Vec<_>>()
+        (bank.slot() - max_root_entries as u64..=bank.slot()).collect::<Vec<_>>()
     );
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -21,7 +21,6 @@ use {
         stake_history::StakeHistory,
         stake_utils,
         stakes::InvalidCacheEntryReason,
-        status_cache::MAX_CACHE_ENTRIES,
     },
     agave_feature_set::{self as feature_set, FeatureSet},
     agave_reserved_account_keys::ReservedAccount,
@@ -3453,7 +3452,8 @@ fn test_status_cache_ancestors() {
     let (parent, _bank_forks) = create_simple_test_arc_bank(500);
     let bank1 = Arc::new(new_from_parent(parent));
     let mut bank = bank1;
-    for _ in 0..MAX_CACHE_ENTRIES * 2 {
+    let max_cache_entries = bank.status_cache.read().unwrap().max_cache_entries();
+    for _ in 0..max_cache_entries * 2 {
         bank = Arc::new(new_from_parent(bank));
         bank.squash();
     }
@@ -3461,7 +3461,7 @@ fn test_status_cache_ancestors() {
     let bank = new_from_parent(bank);
     assert_eq!(
         bank.status_cache_ancestors(),
-        (bank.slot() - MAX_CACHE_ENTRIES as u64..=bank.slot()).collect::<Vec<_>>()
+        (bank.slot() - max_cache_entries as u64..=bank.slot()).collect::<Vec<_>>()
     );
 }
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -508,13 +508,13 @@ fn verify_slot_deltas(
     slot_deltas: &[BankSlotDelta],
     bank: &Bank,
 ) -> std::result::Result<(), VerifySlotDeltasError> {
-    let max_cache_entries = bank.status_cache.read().unwrap().max_cache_entries();
-    let info = verify_slot_deltas_structural(slot_deltas, bank.slot(), max_cache_entries)?;
+    let max_root_entries = bank.status_cache.read().unwrap().max_root_entries();
+    let info = verify_slot_deltas_structural(slot_deltas, bank.slot(), max_root_entries)?;
     verify_slot_deltas_with_history(
         &info.slots,
         &bank.get_slot_history(),
         bank.slot(),
-        max_cache_entries,
+        max_root_entries,
     )
 }
 
@@ -523,14 +523,14 @@ fn verify_slot_deltas(
 fn verify_slot_deltas_structural(
     slot_deltas: &[BankSlotDelta],
     bank_slot: Slot,
-    max_cache_entries: usize,
+    max_root_entries: usize,
 ) -> std::result::Result<VerifySlotDeltasStructuralInfo, VerifySlotDeltasError> {
     // there should not be more entries than that status cache's max
     let num_entries = slot_deltas.len();
-    if num_entries > max_cache_entries {
+    if num_entries > max_root_entries {
         return Err(VerifySlotDeltasError::TooManyEntries(
             num_entries,
-            max_cache_entries,
+            max_root_entries,
         ));
     }
 
@@ -576,7 +576,7 @@ fn verify_slot_deltas_with_history(
     slots_from_slot_deltas: &HashSet<Slot>,
     slot_history: &SlotHistory,
     bank_slot: Slot,
-    max_cache_entries: usize,
+    max_root_entries: usize,
 ) -> std::result::Result<(), VerifySlotDeltasError> {
     // ensure the slot history is valid (as much as possible), since we're using it to verify the
     // slot deltas
@@ -590,7 +590,7 @@ fn verify_slot_deltas_with_history(
         return Err(VerifySlotDeltasError::SlotNotFoundInHistory(*slot));
     }
 
-    // all slots in the history should be in the slot deltas (up to MAX_CACHE_ENTRIES)
+    // all slots in the history should be in the slot deltas (up to max_root_entries)
     // this ensures nothing was removed from the status cache
     //
     // go through the slot history and make sure there's an entry for each slot
@@ -600,7 +600,7 @@ fn verify_slot_deltas_with_history(
     let slot_missing_from_deltas = (slot_history.oldest()..=slot_history.newest())
         .rev()
         .filter(|slot| slot_history.check(*slot) == Check::Found)
-        .take(max_cache_entries)
+        .take(max_root_entries)
         .find(|slot| !slots_from_slot_deltas.contains(slot));
     if let Some(slot) = slot_missing_from_deltas {
         return Err(VerifySlotDeltasError::SlotNotFoundInDeltas(slot));
@@ -2365,26 +2365,26 @@ mod tests {
 
     #[test]
     fn test_verify_slot_deltas_structural_bad_too_many_entries() {
-        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
-        let bank_slot = max_cache_entries as Slot + 1;
+        let max_root_entries = StatusCache::<()>::default().max_root_entries();
+        let bank_slot = max_root_entries as Slot + 1;
         let slot_deltas: Vec<_> = (0..bank_slot)
             .map(|slot| (slot, true, Status::default()))
             .collect();
 
         let result =
-            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_cache_entries);
+            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_root_entries);
         assert_eq!(
             result,
             Err(VerifySlotDeltasError::TooManyEntries(
-                max_cache_entries + 1,
-                max_cache_entries
+                max_root_entries + 1,
+                max_root_entries
             )),
         );
     }
 
     #[test]
     fn test_verify_slot_deltas_structural_good() {
-        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
+        let max_root_entries = StatusCache::<()>::default().max_root_entries();
         // NOTE: slot deltas do not need to be sorted
         let slot_deltas = vec![
             (222, true, Status::default()),
@@ -2394,7 +2394,7 @@ mod tests {
 
         let bank_slot = 333;
         let result =
-            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_cache_entries);
+            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_root_entries);
         assert_eq!(
             result,
             Ok(VerifySlotDeltasStructuralInfo {
@@ -2405,7 +2405,7 @@ mod tests {
 
     #[test]
     fn test_verify_slot_deltas_structural_bad_slot_not_root() {
-        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
+        let max_root_entries = StatusCache::<()>::default().max_root_entries();
         let slot_deltas = vec![
             (111, true, Status::default()),
             (222, false, Status::default()), // <-- slot is not a root
@@ -2414,13 +2414,13 @@ mod tests {
 
         let bank_slot = 333;
         let result =
-            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_cache_entries);
+            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_root_entries);
         assert_eq!(result, Err(VerifySlotDeltasError::SlotIsNotRoot(222)));
     }
 
     #[test]
     fn test_verify_slot_deltas_structural_bad_slot_greater_than_bank() {
-        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
+        let max_root_entries = StatusCache::<()>::default().max_root_entries();
         let slot_deltas = vec![
             (222, true, Status::default()),
             (111, true, Status::default()),
@@ -2429,7 +2429,7 @@ mod tests {
 
         let bank_slot = 444;
         let result =
-            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_cache_entries);
+            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_root_entries);
         assert_eq!(
             result,
             Err(VerifySlotDeltasError::SlotGreaterThanMaxRoot(
@@ -2440,7 +2440,7 @@ mod tests {
 
     #[test]
     fn test_verify_slot_deltas_structural_bad_slot_has_multiple_entries() {
-        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
+        let max_root_entries = StatusCache::<()>::default().max_root_entries();
         let slot_deltas = vec![
             (111, true, Status::default()),
             (222, true, Status::default()),
@@ -2449,7 +2449,7 @@ mod tests {
 
         let bank_slot = 222;
         let result =
-            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_cache_entries);
+            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_root_entries);
         assert_eq!(
             result,
             Err(VerifySlotDeltasError::SlotHasMultipleEntries(111)),
@@ -2458,7 +2458,7 @@ mod tests {
 
     #[test]
     fn test_verify_slot_deltas_with_history_good() {
-        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
+        let max_root_entries = StatusCache::<()>::default().max_root_entries();
         let mut slots_from_slot_deltas = HashSet::default();
         let mut slot_history = SlotHistory::default();
         // note: slot history expects slots to be added in numeric order
@@ -2472,14 +2472,14 @@ mod tests {
             &slots_from_slot_deltas,
             &slot_history,
             bank_slot,
-            max_cache_entries,
+            max_root_entries,
         );
         assert_eq!(result, Ok(()));
     }
 
     #[test]
     fn test_verify_slot_deltas_with_history_bad_slot_not_in_history() {
-        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
+        let max_root_entries = StatusCache::<()>::default().max_root_entries();
         let slots_from_slot_deltas = HashSet::from([
             0, // slot history has slot 0 added by default
             444, 222,
@@ -2492,7 +2492,7 @@ mod tests {
             &slots_from_slot_deltas,
             &slot_history,
             bank_slot,
-            max_cache_entries,
+            max_root_entries,
         );
 
         assert_eq!(
@@ -2503,7 +2503,7 @@ mod tests {
 
     #[test]
     fn test_verify_slot_deltas_with_history_bad_slot_not_in_deltas() {
-        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
+        let max_root_entries = StatusCache::<()>::default().max_root_entries();
         let slots_from_slot_deltas = HashSet::from([
             0, // slot history has slot 0 added by default
             444, 222,
@@ -2519,7 +2519,7 @@ mod tests {
             &slots_from_slot_deltas,
             &slot_history,
             bank_slot,
-            max_cache_entries,
+            max_root_entries,
         );
 
         assert_eq!(

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -23,7 +23,6 @@ use {
             self, BankSnapshotInfo, StorageAndNextAccountsFileId, UnarchivedSnapshots,
             rebuild_storages_from_snapshot_dir, verify_and_unarchive_snapshots,
         },
-        status_cache,
     },
     agave_fs::dirs,
     agave_snapshots::{
@@ -509,8 +508,14 @@ fn verify_slot_deltas(
     slot_deltas: &[BankSlotDelta],
     bank: &Bank,
 ) -> std::result::Result<(), VerifySlotDeltasError> {
-    let info = verify_slot_deltas_structural(slot_deltas, bank.slot())?;
-    verify_slot_deltas_with_history(&info.slots, &bank.get_slot_history(), bank.slot())
+    let max_cache_entries = bank.status_cache.read().unwrap().max_cache_entries();
+    let info = verify_slot_deltas_structural(slot_deltas, bank.slot(), max_cache_entries)?;
+    verify_slot_deltas_with_history(
+        &info.slots,
+        &bank.get_slot_history(),
+        bank.slot(),
+        max_cache_entries,
+    )
 }
 
 /// Verify that the snapshot's slot deltas are not corrupt/invalid
@@ -518,13 +523,14 @@ fn verify_slot_deltas(
 fn verify_slot_deltas_structural(
     slot_deltas: &[BankSlotDelta],
     bank_slot: Slot,
+    max_cache_entries: usize,
 ) -> std::result::Result<VerifySlotDeltasStructuralInfo, VerifySlotDeltasError> {
     // there should not be more entries than that status cache's max
     let num_entries = slot_deltas.len();
-    if num_entries > status_cache::MAX_CACHE_ENTRIES {
+    if num_entries > max_cache_entries {
         return Err(VerifySlotDeltasError::TooManyEntries(
             num_entries,
-            status_cache::MAX_CACHE_ENTRIES,
+            max_cache_entries,
         ));
     }
 
@@ -570,6 +576,7 @@ fn verify_slot_deltas_with_history(
     slots_from_slot_deltas: &HashSet<Slot>,
     slot_history: &SlotHistory,
     bank_slot: Slot,
+    max_cache_entries: usize,
 ) -> std::result::Result<(), VerifySlotDeltasError> {
     // ensure the slot history is valid (as much as possible), since we're using it to verify the
     // slot deltas
@@ -593,7 +600,7 @@ fn verify_slot_deltas_with_history(
     let slot_missing_from_deltas = (slot_history.oldest()..=slot_history.newest())
         .rev()
         .filter(|slot| slot_history.check(*slot) == Check::Found)
-        .take(status_cache::MAX_CACHE_ENTRIES)
+        .take(max_cache_entries)
         .find(|slot| !slots_from_slot_deltas.contains(slot));
     if let Some(slot) = slot_missing_from_deltas {
         return Err(VerifySlotDeltasError::SlotNotFoundInDeltas(slot));
@@ -825,7 +832,7 @@ mod tests {
                 purge_old_bank_snapshots, purge_old_bank_snapshots_at_startup,
                 snapshot_storage_rebuilder::get_slot_and_append_vec_id,
             },
-            status_cache::Status,
+            status_cache::{Status, StatusCache},
         },
         agave_snapshots::{error::VerifySlotDeltasError, paths::get_bank_snapshot_dir},
         semver::Version,
@@ -2358,23 +2365,26 @@ mod tests {
 
     #[test]
     fn test_verify_slot_deltas_structural_bad_too_many_entries() {
-        let bank_slot = status_cache::MAX_CACHE_ENTRIES as Slot + 1;
+        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
+        let bank_slot = max_cache_entries as Slot + 1;
         let slot_deltas: Vec<_> = (0..bank_slot)
             .map(|slot| (slot, true, Status::default()))
             .collect();
 
-        let result = verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot);
+        let result =
+            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_cache_entries);
         assert_eq!(
             result,
             Err(VerifySlotDeltasError::TooManyEntries(
-                status_cache::MAX_CACHE_ENTRIES + 1,
-                status_cache::MAX_CACHE_ENTRIES
+                max_cache_entries + 1,
+                max_cache_entries
             )),
         );
     }
 
     #[test]
     fn test_verify_slot_deltas_structural_good() {
+        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
         // NOTE: slot deltas do not need to be sorted
         let slot_deltas = vec![
             (222, true, Status::default()),
@@ -2383,7 +2393,8 @@ mod tests {
         ];
 
         let bank_slot = 333;
-        let result = verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot);
+        let result =
+            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_cache_entries);
         assert_eq!(
             result,
             Ok(VerifySlotDeltasStructuralInfo {
@@ -2394,6 +2405,7 @@ mod tests {
 
     #[test]
     fn test_verify_slot_deltas_structural_bad_slot_not_root() {
+        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
         let slot_deltas = vec![
             (111, true, Status::default()),
             (222, false, Status::default()), // <-- slot is not a root
@@ -2401,12 +2413,14 @@ mod tests {
         ];
 
         let bank_slot = 333;
-        let result = verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot);
+        let result =
+            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_cache_entries);
         assert_eq!(result, Err(VerifySlotDeltasError::SlotIsNotRoot(222)));
     }
 
     #[test]
     fn test_verify_slot_deltas_structural_bad_slot_greater_than_bank() {
+        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
         let slot_deltas = vec![
             (222, true, Status::default()),
             (111, true, Status::default()),
@@ -2414,7 +2428,8 @@ mod tests {
         ];
 
         let bank_slot = 444;
-        let result = verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot);
+        let result =
+            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_cache_entries);
         assert_eq!(
             result,
             Err(VerifySlotDeltasError::SlotGreaterThanMaxRoot(
@@ -2425,6 +2440,7 @@ mod tests {
 
     #[test]
     fn test_verify_slot_deltas_structural_bad_slot_has_multiple_entries() {
+        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
         let slot_deltas = vec![
             (111, true, Status::default()),
             (222, true, Status::default()),
@@ -2432,7 +2448,8 @@ mod tests {
         ];
 
         let bank_slot = 222;
-        let result = verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot);
+        let result =
+            verify_slot_deltas_structural(slot_deltas.as_slice(), bank_slot, max_cache_entries);
         assert_eq!(
             result,
             Err(VerifySlotDeltasError::SlotHasMultipleEntries(111)),
@@ -2441,6 +2458,7 @@ mod tests {
 
     #[test]
     fn test_verify_slot_deltas_with_history_good() {
+        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
         let mut slots_from_slot_deltas = HashSet::default();
         let mut slot_history = SlotHistory::default();
         // note: slot history expects slots to be added in numeric order
@@ -2450,13 +2468,18 @@ mod tests {
         }
 
         let bank_slot = 444;
-        let result =
-            verify_slot_deltas_with_history(&slots_from_slot_deltas, &slot_history, bank_slot);
+        let result = verify_slot_deltas_with_history(
+            &slots_from_slot_deltas,
+            &slot_history,
+            bank_slot,
+            max_cache_entries,
+        );
         assert_eq!(result, Ok(()));
     }
 
     #[test]
     fn test_verify_slot_deltas_with_history_bad_slot_not_in_history() {
+        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
         let slots_from_slot_deltas = HashSet::from([
             0, // slot history has slot 0 added by default
             444, 222,
@@ -2465,8 +2488,12 @@ mod tests {
         slot_history.add(444); // <-- slot history is missing slot 222
 
         let bank_slot = 444;
-        let result =
-            verify_slot_deltas_with_history(&slots_from_slot_deltas, &slot_history, bank_slot);
+        let result = verify_slot_deltas_with_history(
+            &slots_from_slot_deltas,
+            &slot_history,
+            bank_slot,
+            max_cache_entries,
+        );
 
         assert_eq!(
             result,
@@ -2476,6 +2503,7 @@ mod tests {
 
     #[test]
     fn test_verify_slot_deltas_with_history_bad_slot_not_in_deltas() {
+        let max_cache_entries = StatusCache::<()>::default().max_cache_entries();
         let slots_from_slot_deltas = HashSet::from([
             0, // slot history has slot 0 added by default
             444, 222,
@@ -2487,8 +2515,12 @@ mod tests {
         slot_history.add(444);
 
         let bank_slot = 444;
-        let result =
-            verify_slot_deltas_with_history(&slots_from_slot_deltas, &slot_history, bank_slot);
+        let result = verify_slot_deltas_with_history(
+            &slots_from_slot_deltas,
+            &slot_history,
+            bank_slot,
+            max_cache_entries,
+        );
 
         assert_eq!(
             result,

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -52,6 +52,7 @@ pub struct StatusCache<T: Serialize + Clone> {
     // check if a tx_key was seen on a fork and for rpc to retrieve the tx_result
     cache: KeyStatusMap<T>,
     roots: HashSet<Slot>,
+    max_cache_entries: usize,
     // slot_deltas[slot][blockhash] => [(tx_key, tx_result), ...] used to serialize for snapshots
     // and to rebuild cache[blockhash][tx_key] from a snapshot
     slot_deltas: SlotDeltaMap<T>,
@@ -63,6 +64,7 @@ impl<T: Serialize + Clone> Default for StatusCache<T> {
             cache: HashMap::default(),
             // 0 is always a root
             roots: HashSet::from([0]),
+            max_cache_entries: MAX_CACHE_ENTRIES,
             slot_deltas: HashMap::default(),
         }
     }
@@ -162,7 +164,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
 
     /// Add a known root fork.
     ///
-    /// Roots are always valid ancestors. After MAX_CACHE_ENTRIES, roots are removed, and any old
+    /// Roots are always valid ancestors. After `max_cache_entries`, roots are removed, and any old
     /// keys are cleared.
     pub fn add_root(&mut self, fork: Slot) {
         self.roots.insert(fork);
@@ -171,6 +173,15 @@ impl<T: Serialize + Clone> StatusCache<T> {
 
     pub fn roots(&self) -> &HashSet<Slot> {
         &self.roots
+    }
+
+    pub fn max_cache_entries(&self) -> usize {
+        self.max_cache_entries
+    }
+
+    pub fn set_max_cache_entries(&mut self, max_cache_entries: usize) {
+        self.max_cache_entries = max_cache_entries.max(1);
+        self.purge_roots();
     }
 
     /// Insert a new key using the given blockhash at the given slot.
@@ -211,7 +222,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
     }
 
     pub fn purge_roots(&mut self) {
-        if self.roots.len() > MAX_CACHE_ENTRIES {
+        if self.roots.len() > self.max_cache_entries {
             if let Some(min) = self.roots.iter().min().cloned() {
                 self.roots.remove(&min);
                 self.cache.retain(|_, (fork, _, _)| *fork > min);
@@ -414,7 +425,7 @@ mod tests {
         let ancestors = Ancestors::from(vec![0]);
         status_cache.insert(&blockhash, sig, 0, ());
         status_cache.insert(&blockhash, sig, 1, ());
-        for i in 0..(MAX_CACHE_ENTRIES + 1) {
+        for i in 0..(status_cache.max_cache_entries() + 1) {
             status_cache.add_root(i as u64);
         }
         assert!(
@@ -431,7 +442,7 @@ mod tests {
         let blockhash = hash(Hash::default().as_ref());
         let ancestors = Ancestors::default();
         status_cache.insert(&blockhash, sig, 0, ());
-        for i in 0..(MAX_CACHE_ENTRIES + 1) {
+        for i in 0..(status_cache.max_cache_entries() + 1) {
             status_cache.add_root(i as u64);
         }
         assert_eq!(status_cache.get_status(sig, &blockhash, &ancestors), None);
@@ -503,7 +514,7 @@ mod tests {
         status_cache.insert(&blockhash, sig, 0, ());
         status_cache.insert(&blockhash, sig, 1, ());
         status_cache.insert(&blockhash2, sig, 1, ());
-        for i in 0..(MAX_CACHE_ENTRIES + 1) {
+        for i in 0..(status_cache.max_cache_entries() + 1) {
             status_cache.add_root(i as u64);
         }
         assert_eq!(status_cache.slot_deltas.len(), 1);
@@ -678,7 +689,8 @@ mod shuttle_tests {
     fn do_test_shuttle_purge_nonce_overlap() {
         let status_cache = Arc::new(BankStatusCache::default());
         // fill the cache so that the next add_root() will purge the oldest root
-        for i in 0..MAX_CACHE_ENTRIES {
+        let max_cache_entries = status_cache.read().unwrap().max_cache_entries();
+        for i in 0..max_cache_entries {
             status_cache.write().unwrap().add_root(i as u64);
         }
 
@@ -699,7 +711,7 @@ mod shuttle_tests {
                 status_cache
                     .write()
                     .unwrap()
-                    .add_root(MAX_CACHE_ENTRIES as Slot + 1);
+                    .add_root(max_cache_entries as Slot + 1);
             }
         });
 
@@ -710,7 +722,7 @@ mod shuttle_tests {
                 status_cache.write().unwrap().insert(
                     &blockhash1,
                     key2,
-                    MAX_CACHE_ENTRIES as Slot + 2,
+                    max_cache_entries as Slot + 2,
                     (),
                 );
             }
@@ -719,7 +731,7 @@ mod shuttle_tests {
         th_insert.join().unwrap();
 
         let mut ancestors2 = Ancestors::default();
-        ancestors2.insert(MAX_CACHE_ENTRIES as Slot + 2);
+        ancestors2.insert(max_cache_entries as Slot + 2);
 
         assert!(
             status_cache

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -452,6 +452,69 @@ mod tests {
     }
 
     #[test]
+    fn test_max_root_entries() {
+        const INITIAL_MAX_ROOT_ENTRIES: usize = 4;
+        const GROWN_MAX_ROOT_ENTRIES: usize = 6;
+        const SHRUNK_MAX_ROOT_ENTRIES: usize = 3;
+
+        let mut status_cache = BankStatusCache::default();
+        let ancestors = Ancestors::default();
+        let oldest_sig = Signature::from([1_u8; 64]);
+        let oldest_blockhash = Hash::new_unique();
+        let newest_sig = Signature::from([2_u8; 64]);
+        let newest_blockhash = Hash::new_unique();
+
+        status_cache.set_max_root_entries(NonZeroUsize::new(INITIAL_MAX_ROOT_ENTRIES).unwrap());
+
+        status_cache.insert(&oldest_blockhash, oldest_sig, 0, ());
+        status_cache.insert(&newest_blockhash, newest_sig, 3, ());
+        for root in 1..INITIAL_MAX_ROOT_ENTRIES as Slot {
+            status_cache.add_root(root);
+        }
+
+        assert_eq!(status_cache.roots(), &HashSet::from([0_u64, 1, 2, 3]));
+        assert_eq!(
+            status_cache.get_status(oldest_sig, &oldest_blockhash, &ancestors),
+            Some((0, ()))
+        );
+        assert_eq!(
+            status_cache.get_status(newest_sig, &newest_blockhash, &ancestors),
+            Some((3, ()))
+        );
+
+        status_cache.set_max_root_entries(NonZeroUsize::new(GROWN_MAX_ROOT_ENTRIES).unwrap());
+        for root in INITIAL_MAX_ROOT_ENTRIES as Slot..GROWN_MAX_ROOT_ENTRIES as Slot {
+            status_cache.add_root(root);
+        }
+
+        assert_eq!(status_cache.roots(), &HashSet::from([0_u64, 1, 2, 3, 4, 5]));
+        assert_eq!(
+            status_cache.get_status(oldest_sig, &oldest_blockhash, &ancestors),
+            Some((0, ()))
+        );
+        assert_eq!(
+            status_cache.get_status(newest_sig, &newest_blockhash, &ancestors),
+            Some((3, ()))
+        );
+
+        status_cache.set_max_root_entries(NonZeroUsize::new(SHRUNK_MAX_ROOT_ENTRIES).unwrap());
+
+        assert_eq!(status_cache.roots(), &HashSet::from([3_u64, 4, 5]));
+        assert_eq!(
+            status_cache.get_status(oldest_sig, &oldest_blockhash, &ancestors),
+            None
+        );
+        assert_eq!(
+            status_cache.get_status(newest_sig, &newest_blockhash, &ancestors),
+            Some((3, ()))
+        );
+        assert!(!status_cache.cache.contains_key(&oldest_blockhash));
+        assert!(status_cache.cache.contains_key(&newest_blockhash));
+        assert!(!status_cache.slot_deltas.contains_key(&0));
+        assert!(status_cache.slot_deltas.contains_key(&3));
+    }
+
+    #[test]
     fn test_clear_signatures_sigs_are_gone() {
         let sig = Signature::default();
         let mut status_cache = BankStatusCache::default();

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -180,7 +180,11 @@ impl<T: Serialize + Clone> StatusCache<T> {
     }
 
     pub fn set_max_cache_entries(&mut self, max_cache_entries: usize) {
-        self.max_cache_entries = max_cache_entries.max(1);
+        debug_assert!(
+            max_cache_entries > 0,
+            "max_cache_entries must be greater than zero"
+        );
+        self.max_cache_entries = max_cache_entries;
         self.purge_roots();
     }
 
@@ -425,7 +429,7 @@ mod tests {
         let ancestors = Ancestors::from(vec![0]);
         status_cache.insert(&blockhash, sig, 0, ());
         status_cache.insert(&blockhash, sig, 1, ());
-        for i in 0..(status_cache.max_cache_entries() + 1) {
+        for i in 0..=status_cache.max_cache_entries() {
             status_cache.add_root(i as u64);
         }
         assert!(
@@ -442,7 +446,7 @@ mod tests {
         let blockhash = hash(Hash::default().as_ref());
         let ancestors = Ancestors::default();
         status_cache.insert(&blockhash, sig, 0, ());
-        for i in 0..(status_cache.max_cache_entries() + 1) {
+        for i in 0..=status_cache.max_cache_entries() {
             status_cache.add_root(i as u64);
         }
         assert_eq!(status_cache.get_status(sig, &blockhash, &ancestors), None);
@@ -514,7 +518,7 @@ mod tests {
         status_cache.insert(&blockhash, sig, 0, ());
         status_cache.insert(&blockhash, sig, 1, ());
         status_cache.insert(&blockhash2, sig, 1, ());
-        for i in 0..(status_cache.max_cache_entries() + 1) {
+        for i in 0..=status_cache.max_cache_entries() {
             status_cache.add_root(i as u64);
         }
         assert_eq!(status_cache.slot_deltas.len(), 1);

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -21,7 +21,7 @@ use {
 // The maximum number of entries to store in the cache. This is the same as the number of recent
 // blockhashes because we automatically reject txs that use older blockhashes so we don't need to
 // track those explicitly.
-const MAX_CACHE_ENTRIES: usize = MAX_RECENT_BLOCKHASHES;
+const MAX_ROOT_ENTRIES: usize = MAX_RECENT_BLOCKHASHES;
 
 // Only store 20 bytes of the tx keys processed to save some memory.
 const CACHED_KEY_SIZE: usize = 20;
@@ -55,7 +55,7 @@ pub struct StatusCache<T: Serialize + Clone> {
     // check if a tx_key was seen on a fork and for rpc to retrieve the tx_result
     cache: KeyStatusMap<T>,
     roots: HashSet<Slot>,
-    max_cache_entries: NonZeroUsize,
+    max_root_entries: NonZeroUsize,
     // slot_deltas[slot][blockhash] => [(tx_key, tx_result), ...] used to serialize for snapshots
     // and to rebuild cache[blockhash][tx_key] from a snapshot
     slot_deltas: SlotDeltaMap<T>,
@@ -67,7 +67,7 @@ impl<T: Serialize + Clone> Default for StatusCache<T> {
             cache: HashMap::default(),
             // 0 is always a root
             roots: HashSet::from([0]),
-            max_cache_entries: NonZero::new(MAX_CACHE_ENTRIES).unwrap(),
+            max_root_entries: NonZero::new(MAX_ROOT_ENTRIES).unwrap(),
             slot_deltas: HashMap::default(),
         }
     }
@@ -167,7 +167,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
 
     /// Add a known root fork.
     ///
-    /// Roots are always valid ancestors. After `max_cache_entries`, roots are removed, and any old
+    /// Roots are always valid ancestors. After `max_root_entries`, roots are removed, and any old
     /// keys are cleared.
     pub fn add_root(&mut self, fork: Slot) {
         self.roots.insert(fork);
@@ -178,12 +178,12 @@ impl<T: Serialize + Clone> StatusCache<T> {
         &self.roots
     }
 
-    pub fn max_cache_entries(&self) -> usize {
-        self.max_cache_entries.into()
+    pub fn max_root_entries(&self) -> usize {
+        self.max_root_entries.into()
     }
 
-    pub fn set_max_cache_entries(&mut self, max_cache_entries: NonZeroUsize) {
-        self.max_cache_entries = max_cache_entries;
+    pub fn set_max_root_entries(&mut self, max_root_entries: NonZeroUsize) {
+        self.max_root_entries = max_root_entries;
         self.purge_roots();
     }
 
@@ -225,7 +225,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
     }
 
     pub fn purge_roots(&mut self) {
-        if self.roots.len() > self.max_cache_entries() {
+        if self.roots.len() > self.max_root_entries() {
             if let Some(min) = self.roots.iter().min().cloned() {
                 self.roots.remove(&min);
                 self.cache.retain(|_, (fork, _, _)| *fork > min);
@@ -428,7 +428,7 @@ mod tests {
         let ancestors = Ancestors::from(vec![0]);
         status_cache.insert(&blockhash, sig, 0, ());
         status_cache.insert(&blockhash, sig, 1, ());
-        for i in 0..=status_cache.max_cache_entries() {
+        for i in 0..=status_cache.max_root_entries() {
             status_cache.add_root(i as u64);
         }
         assert!(
@@ -445,7 +445,7 @@ mod tests {
         let blockhash = hash(Hash::default().as_ref());
         let ancestors = Ancestors::default();
         status_cache.insert(&blockhash, sig, 0, ());
-        for i in 0..=status_cache.max_cache_entries() {
+        for i in 0..=status_cache.max_root_entries() {
             status_cache.add_root(i as u64);
         }
         assert_eq!(status_cache.get_status(sig, &blockhash, &ancestors), None);
@@ -517,7 +517,7 @@ mod tests {
         status_cache.insert(&blockhash, sig, 0, ());
         status_cache.insert(&blockhash, sig, 1, ());
         status_cache.insert(&blockhash2, sig, 1, ());
-        for i in 0..=status_cache.max_cache_entries() {
+        for i in 0..=status_cache.max_root_entries() {
             status_cache.add_root(i as u64);
         }
         assert_eq!(status_cache.slot_deltas.len(), 1);
@@ -692,8 +692,8 @@ mod shuttle_tests {
     fn do_test_shuttle_purge_nonce_overlap() {
         let status_cache = Arc::new(BankStatusCache::default());
         // fill the cache so that the next add_root() will purge the oldest root
-        let max_cache_entries = status_cache.read().unwrap().max_cache_entries();
-        for i in 0..max_cache_entries {
+        let max_root_entries = status_cache.read().unwrap().max_root_entries();
+        for i in 0..max_root_entries {
             status_cache.write().unwrap().add_root(i as u64);
         }
 
@@ -714,7 +714,7 @@ mod shuttle_tests {
                 status_cache
                     .write()
                     .unwrap()
-                    .add_root(max_cache_entries as Slot + 1);
+                    .add_root(max_root_entries as Slot + 1);
             }
         });
 
@@ -725,7 +725,7 @@ mod shuttle_tests {
                 status_cache.write().unwrap().insert(
                     &blockhash1,
                     key2,
-                    max_cache_entries as Slot + 2,
+                    max_root_entries as Slot + 2,
                     (),
                 );
             }
@@ -734,7 +734,7 @@ mod shuttle_tests {
         th_insert.join().unwrap();
 
         let mut ancestors2 = Ancestors::default();
-        ancestors2.insert(max_cache_entries as Slot + 2);
+        ancestors2.insert(max_root_entries as Slot + 2);
 
         assert!(
             status_cache

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -225,7 +225,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
     }
 
     pub fn purge_roots(&mut self) {
-        if self.roots.len() > self.max_root_entries() {
+        while self.roots.len() > self.max_root_entries() {
             if let Some(min) = self.roots.iter().min().cloned() {
                 self.roots.remove(&min);
                 self.cache.retain(|_, (fork, _, _)| *fork > min);

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -7,7 +7,10 @@ use {
     solana_accounts_db::ancestors::Ancestors,
     solana_clock::{MAX_RECENT_BLOCKHASHES, Slot},
     solana_hash::Hash,
-    std::collections::{HashSet, hash_map::Entry},
+    std::{
+        collections::{HashSet, hash_map::Entry},
+        num::{NonZero, NonZeroUsize},
+    },
 };
 #[cfg(not(feature = "shuttle-test"))]
 use {
@@ -52,7 +55,7 @@ pub struct StatusCache<T: Serialize + Clone> {
     // check if a tx_key was seen on a fork and for rpc to retrieve the tx_result
     cache: KeyStatusMap<T>,
     roots: HashSet<Slot>,
-    max_cache_entries: usize,
+    max_cache_entries: NonZeroUsize,
     // slot_deltas[slot][blockhash] => [(tx_key, tx_result), ...] used to serialize for snapshots
     // and to rebuild cache[blockhash][tx_key] from a snapshot
     slot_deltas: SlotDeltaMap<T>,
@@ -64,7 +67,7 @@ impl<T: Serialize + Clone> Default for StatusCache<T> {
             cache: HashMap::default(),
             // 0 is always a root
             roots: HashSet::from([0]),
-            max_cache_entries: MAX_CACHE_ENTRIES,
+            max_cache_entries: NonZero::new(MAX_CACHE_ENTRIES).unwrap(),
             slot_deltas: HashMap::default(),
         }
     }
@@ -176,14 +179,10 @@ impl<T: Serialize + Clone> StatusCache<T> {
     }
 
     pub fn max_cache_entries(&self) -> usize {
-        self.max_cache_entries
+        self.max_cache_entries.into()
     }
 
-    pub fn set_max_cache_entries(&mut self, max_cache_entries: usize) {
-        debug_assert!(
-            max_cache_entries > 0,
-            "max_cache_entries must be greater than zero"
-        );
+    pub fn set_max_cache_entries(&mut self, max_cache_entries: NonZeroUsize) {
         self.max_cache_entries = max_cache_entries;
         self.purge_roots();
     }
@@ -226,7 +225,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
     }
 
     pub fn purge_roots(&mut self) {
-        if self.roots.len() > self.max_cache_entries {
+        if self.roots.len() > self.max_cache_entries() {
             if let Some(min) = self.roots.iter().min().cloned() {
                 self.roots.remove(&min);
                 self.cache.retain(|_, (fork, _, _)| *fork > min);

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -18,7 +18,7 @@ use {
 // The maximum number of entries to store in the cache. This is the same as the number of recent
 // blockhashes because we automatically reject txs that use older blockhashes so we don't need to
 // track those explicitly.
-pub const MAX_CACHE_ENTRIES: usize = MAX_RECENT_BLOCKHASHES;
+const MAX_CACHE_ENTRIES: usize = MAX_RECENT_BLOCKHASHES;
 
 // Only store 20 bytes of the tx keys processed to save some memory.
 const CACHED_KEY_SIZE: usize = 20;


### PR DESCRIPTION
#### Problem
`MAX_CACHE_ENTRIES` is currently used publicly and across a few crates, which makes it impossible to change this value dynamically. Changing this dynamically in response to, for example, slot time changes is desirable.

#### Summary of Changes
make `MAX_CACHE_ENTRIES` local and grab the current value through the status cache