### PR TITLE
`ConsensusPool` informs `BlsSigverifier` which certs it already has.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "log",
  "lru",
  "parking_lot 0.12.3",
+ "qualifier_attr",
  "rand 0.9.2",
  "serde",
  "serde_bytes",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ dev-context-only-utils = [
     "solana-perf/dev-context-only-utils",
     "solana-runtime/dev-context-only-utils",
     "solana-streamer/dev-context-only-utils",
+    "agave-votor/dev-context-only-utils",
 ]
 frozen-abi = [
     "dep:solana-frozen-abi",

--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -11,6 +11,7 @@ use {
     agave_votor::{
         consensus_metrics::ConsensusMetricsEventSender,
         consensus_rewards::{self},
+        generated_cert_types::GeneratedCertTypes,
     },
     agave_votor_messages::{
         consensus_message::{CertificateType, ConsensusMessage, VoteMessage},
@@ -56,6 +57,7 @@ pub(crate) struct SigVerifierContext {
     pub(crate) cluster_info: Arc<ClusterInfo>,
     pub(crate) leader_schedule: Arc<LeaderScheduleCache>,
     pub(crate) num_threads: usize,
+    pub(crate) generated_cert_types: Arc<GeneratedCertTypes>,
 }
 
 pub(crate) struct SigVerifierChannels {
@@ -95,6 +97,7 @@ struct SigVerifier {
     leader_schedule: Arc<LeaderScheduleCache>,
     /// thread pool to use for all parallel tasks
     thread_pool: ThreadPool,
+    generated_cert_types: Arc<GeneratedCertTypes>,
 }
 
 impl SigVerifier {
@@ -106,6 +109,7 @@ impl SigVerifier {
             cluster_info,
             leader_schedule,
             num_threads,
+            generated_cert_types,
         } = context;
         let thread_pool = ThreadPoolBuilder::new()
             .num_threads(num_threads)
@@ -123,6 +127,7 @@ impl SigVerifier {
             cluster_info,
             leader_schedule,
             thread_pool,
+            generated_cert_types,
         }
     }
 
@@ -155,7 +160,7 @@ impl SigVerifier {
         self.maybe_prune_caches(root_bank.slot());
 
         let ((certs_to_verify, votes_to_verify), extract_msgs_us) =
-            measure_us!(self.extract_and_filter_msgs(batches, &root_bank,));
+            measure_us!(self.extract_and_filter_msgs(batches, &root_bank));
         self.stats
             .extract_filter_msgs_us
             .add_sample(extract_msgs_us);
@@ -241,6 +246,10 @@ impl SigVerifier {
                     }
                     if self.verified_certs.contains(&cert.cert_type) {
                         self.stats.num_verified_certs_received += 1;
+                        continue;
+                    }
+                    if self.generated_cert_types.has_cert(&cert.cert_type) {
+                        self.stats.num_generated_certs_received += 1;
                         continue;
                     }
                     certs.push(CertPayload {
@@ -366,6 +375,7 @@ mod tests {
         _reward_receiver: Receiver<AddVoteMessage>,
         pool_receiver: Receiver<Vec<ConsensusMessage>>,
         _metrics_receiver: ConsensusMetricsEventReceiver,
+        generated_cert_types: Arc<GeneratedCertTypes>,
     }
 
     impl TestContext {
@@ -408,6 +418,7 @@ mod tests {
             let (packet_sender, packet_receiver) = crossbeam_channel::unbounded();
             let (channel_to_metrics, metrics_receiver) = crossbeam_channel::unbounded();
 
+            let generated_cert_types = Arc::new(GeneratedCertTypes::default());
             let banlist = new_test_banlist();
             let verifier = SigVerifier::new(
                 SigVerifierContext {
@@ -417,6 +428,7 @@ mod tests {
                     cluster_info,
                     leader_schedule,
                     num_threads: 4,
+                    generated_cert_types: generated_cert_types.clone(),
                 },
                 SigVerifierChannels {
                     packet_receiver,
@@ -435,6 +447,7 @@ mod tests {
                 _reward_receiver: reward_receiver,
                 pool_receiver,
                 _metrics_receiver: metrics_receiver,
+                generated_cert_types,
             }
         }
     }
@@ -1273,6 +1286,7 @@ mod tests {
                 cluster_info,
                 leader_schedule,
                 num_threads: 4,
+                generated_cert_types: Arc::new(GeneratedCertTypes::default()),
             },
             SigVerifierChannels {
                 packet_receiver,
@@ -1488,6 +1502,25 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn generated_certs_are_filtered() {
+        let mut ctx = TestContext::new();
+        let slot = 1235;
+        let cert_type = CertificateType::Skip(slot);
+        ctx.generated_cert_types.insert_cert(cert_type);
+        let cert = create_signed_certificate_message(
+            &ctx.validator_keypairs,
+            cert_type,
+            &(0..ctx.validator_keypairs.len()).collect::<Vec<usize>>(),
+        );
+        let consensus_message = ConsensusMessage::Certificate(cert);
+        let packet_batches = messages_to_batches(&[consensus_message]);
+        ctx.verifier
+            .verify_and_send_batches(packet_batches)
+            .unwrap();
+        assert_eq!(ctx.verifier.stats.num_generated_certs_received, 1);
     }
 
     fn messages_to_batches(messages: &[ConsensusMessage]) -> Vec<PacketBatch> {

--- a/core/src/bls_sigverify/stats.rs
+++ b/core/src/bls_sigverify/stats.rs
@@ -34,6 +34,8 @@ pub(super) struct SigVerifierStats {
     pub(super) num_old_certs_received: u64,
     /// Number of already verified certs received.
     pub(super) num_verified_certs_received: u64,
+    /// Number of certs received that the node has already generated.
+    pub(super) num_generated_certs_received: u64,
     /// Last time the stats were reported.
     pub(super) last_report: Instant,
 }
@@ -52,6 +54,7 @@ impl Default for SigVerifierStats {
             num_old_votes_received: 0,
             num_old_certs_received: 0,
             num_verified_certs_received: 0,
+            num_generated_certs_received: 0,
             verify_and_send_batch_us: WelfordStats::default(),
             last_report: Instant::now(),
         }
@@ -82,6 +85,7 @@ impl SigVerifierStats {
             num_old_votes_received,
             num_old_certs_received,
             num_verified_certs_received,
+            num_generated_certs_received,
             discard_vote_invalid_rank,
             discard_vote_no_epoch_stakes,
             verify_and_send_batch_us,
@@ -108,6 +112,11 @@ impl SigVerifierStats {
             (
                 "num_verified_certs_received",
                 *num_verified_certs_received,
+                i64
+            ),
+            (
+                "num_generated_certs_received",
+                *num_generated_certs_received,
                 i64
             ),
             (

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -27,6 +27,7 @@ use {
     agave_votor::{
         consensus_metrics::MAX_IN_FLIGHT_CONSENSUS_EVENTS,
         event::{LeaderWindowInfo, VotorEventReceiver, VotorEventSender},
+        generated_cert_types::GeneratedCertTypes,
         vote_history::VoteHistory,
         vote_history_storage::VoteHistoryStorage,
         voting_service::{VotingService as BLSVotingService, VotingServiceOverride},
@@ -264,6 +265,7 @@ impl Tvu {
         let (reward_votes_sender, reward_votes_receiver) = bounded(MAX_ALPENGLOW_PACKET_NUM);
         let (consensus_metrics_sender, consensus_metrics_receiver) =
             bounded(MAX_IN_FLIGHT_CONSENSUS_EVENTS);
+        let generated_cert_types = Arc::new(GeneratedCertTypes::default());
 
         // The BLS socket is currently only available on Testnet and Development clusters.
         // Closer to release we will enable this for all clusters.
@@ -314,6 +316,7 @@ impl Tvu {
                     cluster_info: cluster_info.clone(),
                     leader_schedule: leader_schedule_cache.clone(),
                     num_threads: tvu_config.bls_sigverify_threads.get(),
+                    generated_cert_types: generated_cert_types.clone(),
                 },
                 SigVerifierChannels {
                     packet_receiver: bls_packet_receiver,
@@ -484,6 +487,7 @@ impl Tvu {
             reward_votes_receiver,
             reward_certs_sender,
             build_reward_certs_receiver,
+            generated_cert_types,
         };
         let votor = Votor::new(votor_config);
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "log",
  "lru",
  "parking_lot 0.12.5",
+ "qualifier_attr",
  "serde",
  "serde_bytes",
  "solana-accounts-db",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -391,6 +391,7 @@ dependencies = [
  "log",
  "lru",
  "parking_lot 0.12.2",
+ "qualifier_attr",
  "serde",
  "serde_bytes",
  "solana-accounts-db",

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -39,6 +39,7 @@ itertools = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
 parking_lot = { workspace = true }
+qualifier_attr = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 solana-accounts-db = { workspace = true }

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -13,6 +13,7 @@ use {
             vote_pool::{DuplicateBlockVotePool, SimpleVotePool, VotePool},
         },
         event::VotorEvent,
+        generated_cert_types::GeneratedCertTypes,
     },
     agave_votor_messages::{
         consensus_message::{Block, Certificate, CertificateType, ConsensusMessage, VoteMessage},
@@ -108,6 +109,9 @@ pub(crate) struct ConsensusPool {
     vote_pools: BTreeMap<PoolId, VotePool>,
     /// Completed certificates
     completed_certificates: BTreeMap<CertificateType, Arc<Certificate>>,
+    /// Set of certs that the pool has generated itself.  Used to inform the bls sigverifier so it
+    /// can drop certs that the pool does not need.
+    generated_cert_types: Arc<GeneratedCertTypes>,
     /// Tracks slots which have reached the parent ready condition:
     /// - They have a potential parent block with a NotarizeFallback certificate
     /// - All slots from the parent have a Skip certificate
@@ -123,20 +127,27 @@ pub(crate) struct ConsensusPool {
     slot_stake_counters_map: BTreeMap<Slot, SlotStakeCounters>,
     /// Stores details about the genesis vote during the migration
     migration_status: Option<Arc<MigrationStatus>>,
+    /// The slot at which the state was last pruned.
+    last_pruned_slot: Slot,
 }
 
 impl ConsensusPool {
     pub(crate) fn new_from_root_bank_pre_migration(
         my_pubkey: Pubkey,
         bank: &Bank,
+        generated_cert_types: Arc<GeneratedCertTypes>,
         migration_status: Arc<MigrationStatus>,
     ) -> Self {
-        let mut pool = Self::new_from_root_bank(my_pubkey, bank);
+        let mut pool = Self::new_from_root_bank(my_pubkey, bank, generated_cert_types);
         pool.migration_status = Some(migration_status);
         pool
     }
 
-    pub fn new_from_root_bank(my_pubkey: Pubkey, bank: &Bank) -> Self {
+    pub fn new_from_root_bank(
+        my_pubkey: Pubkey,
+        bank: &Bank,
+        generated_cert_types: Arc<GeneratedCertTypes>,
+    ) -> Self {
         // To account for genesis and snapshots we allow default block id until
         // block id can be serialized  as part of the snapshot
         let root_block = (bank.slot(), bank.block_id().unwrap_or_default());
@@ -152,6 +163,8 @@ impl ConsensusPool {
             stats: ConsensusPoolStats::default(),
             slot_stake_counters_map: BTreeMap::new(),
             migration_status: None,
+            generated_cert_types,
+            last_pruned_slot: 0,
         }
     }
 
@@ -246,6 +259,7 @@ impl ConsensusPool {
             });
             let new_cert = Arc::new(cert_builder.build()?);
             self.insert_certificate(cert_type, new_cert.clone(), events);
+            self.generated_cert_types.insert_cert(cert_type);
             self.stats.incr_generated_cert(&new_cert.cert_type);
             new_certificates_to_send.push(new_cert);
         }
@@ -609,21 +623,18 @@ impl ConsensusPool {
         true
     }
 
-    /// Cleanup any old slots from the certificate pool
-    pub(crate) fn prune_old_state(&mut self, root_slot: Slot) {
-        // `completed_certificates`` now only contains entries >= `slot`
+    /// Prunes state relevant for slots older than `root_slot`.
+    pub(crate) fn maybe_prune(&mut self, root_slot: Slot) {
+        if self.last_pruned_slot >= root_slot {
+            return;
+        }
         self.completed_certificates
-            .retain(|cert_type, _| match cert_type {
-                CertificateType::Finalize(s)
-                | CertificateType::FinalizeFast(s, _)
-                | CertificateType::Notarize(s, _)
-                | CertificateType::NotarizeFallback(s, _)
-                | CertificateType::Genesis(s, _)
-                | CertificateType::Skip(s) => s >= &root_slot,
-            });
+            .retain(|c, _| c.slot() >= root_slot);
+        self.generated_cert_types.prune(root_slot);
         self.vote_pools = self.vote_pools.split_off(&(root_slot, VoteType::Finalize));
         self.slot_stake_counters_map = self.slot_stake_counters_map.split_off(&root_slot);
         self.parent_ready_tracker.set_root(root_slot);
+        self.last_pruned_slot = root_slot;
     }
 
     /// Updates the pubkey used for logging purposes only.
@@ -698,6 +709,7 @@ mod tests {
         validators: Vec<ValidatorVoteKeypairs>,
         bank_forks: Arc<RwLock<BankForks>>,
         pool: ConsensusPool,
+        generated_cert_types: Arc<GeneratedCertTypes>,
     }
 
     impl TestContext {
@@ -708,10 +720,16 @@ mod tests {
                 .collect::<Vec<_>>();
             let bank_forks = create_bank_forks(&validator_keypairs);
             let root_bank = bank_forks.read().unwrap().root_bank();
+            let generated_cert_types = Arc::new(GeneratedCertTypes::default());
             Self {
                 validators: validator_keypairs,
-                pool: ConsensusPool::new_from_root_bank(Pubkey::new_unique(), &root_bank),
+                pool: ConsensusPool::new_from_root_bank(
+                    Pubkey::new_unique(),
+                    &root_bank,
+                    generated_cert_types.clone(),
+                ),
                 bank_forks,
+                generated_cert_types,
             }
         }
 
@@ -1732,12 +1750,12 @@ mod tests {
         assert!(ctx.pool.is_finalized(2));
 
         let new_bank = Arc::new(create_bank(2, root_bank, SlotLeader::new_unique()));
-        ctx.pool.prune_old_state(new_bank.slot());
+        ctx.pool.maybe_prune(new_bank.slot());
         // Check that cert for 1 is gone, but cert for 2 is still there
         assert!(!ctx.pool.skip_certified(1));
         assert!(ctx.pool.is_finalized(2));
         let new_bank = Arc::new(create_bank(3, new_bank, SlotLeader::new_unique()));
-        ctx.pool.prune_old_state(new_bank.slot());
+        ctx.pool.maybe_prune(new_bank.slot());
         // Now both certs should be gone
         assert!(!ctx.pool.skip_certified(1));
         assert!(!ctx.pool.is_finalized(2));
@@ -2055,5 +2073,30 @@ mod tests {
         ctx.pool.update_pubkey(new_pubkey);
         assert_eq!(ctx.pool.my_pubkey(), new_pubkey);
         assert_eq!(ctx.pool.parent_ready_tracker.my_pubkey(), new_pubkey);
+    }
+
+    #[test]
+    fn received_certs_do_not_set_generated_certs() {
+        let mut ctx = TestContext::new();
+        let slot = ctx.bank_forks.read().unwrap().root_bank().slot() + 1;
+        let hash = Hash::default();
+        let cert_type = CertificateType::NotarizeFallback(slot, hash);
+        let cert = Certificate {
+            cert_type,
+            signature: BLSSignature::default(),
+            bitmap: Vec::new(),
+        };
+        ctx.add_message(ConsensusMessage::Certificate(cert));
+        assert!(!ctx.generated_cert_types.has_cert(&cert_type));
+    }
+
+    #[test]
+    fn created_certs_do_set_generated_certs() {
+        let mut ctx = TestContext::new();
+        let slot = ctx.bank_forks.read().unwrap().root_bank().slot() + 1;
+        let vote = Vote::new_skip_vote(slot);
+        ctx.add_certificate(vote);
+        let cert_type = CertificateType::Skip(slot);
+        assert!(ctx.generated_cert_types.has_cert(&cert_type));
     }
 }

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -11,6 +11,7 @@ use {
             AddVoteError, ConsensusPool, parent_ready_tracker::BlockProductionParent,
         },
         event::{LeaderWindowInfo, VotorEvent, VotorEventSender},
+        generated_cert_types::GeneratedCertTypes,
         voting_service::BLSOp,
     },
     agave_votor_messages::{
@@ -41,6 +42,7 @@ use {
 pub(crate) struct ConsensusPoolContext {
     pub(crate) exit: Arc<AtomicBool>,
     pub(crate) migration_status: Arc<MigrationStatus>,
+    pub(crate) generated_cert_types: Arc<GeneratedCertTypes>,
 
     pub(crate) cluster_info: Arc<ClusterInfo>,
     pub(crate) my_vote_pubkey: Pubkey,
@@ -93,7 +95,7 @@ impl ConsensusPoolService {
             stats.new_finalized_slot += 1;
         }
         let bank = sharable_banks.root();
-        consensus_pool.prune_old_state(bank.slot());
+        consensus_pool.maybe_prune(bank.slot());
         stats.prune_old_state_called += 1;
         // Send new certificates to peers
         Self::send_certificates(bls_sender, new_certificates_to_send, stats)
@@ -188,11 +190,16 @@ impl ConsensusPoolService {
         // Unlike the other votor threads, consensus pool starts even before alpenglow is enabled
         // As it is required to track the Genesis Vote.
         let mut consensus_pool = if ctx.migration_status.is_alpenglow_enabled() {
-            ConsensusPool::new_from_root_bank(my_pubkey, &root_bank)
+            ConsensusPool::new_from_root_bank(
+                my_pubkey,
+                &root_bank,
+                ctx.generated_cert_types.clone(),
+            )
         } else {
             ConsensusPool::new_from_root_bank_pre_migration(
                 my_pubkey,
                 &root_bank,
+                ctx.generated_cert_types.clone(),
                 ctx.migration_status.clone(),
             )
         };
@@ -512,7 +519,11 @@ mod tests {
                 Arc::new(LeaderScheduleCache::new_from_bank(&sharable_banks.root()));
 
             let root_bank = sharable_banks.root();
-            let consensus_pool = ConsensusPool::new_from_root_bank(my_pubkey, &root_bank);
+            let consensus_pool = ConsensusPool::new_from_root_bank(
+                my_pubkey,
+                &root_bank,
+                Arc::new(GeneratedCertTypes::default()),
+            );
             let my_vote_pubkey = Pubkey::new_unique();
 
             TestContext {
@@ -722,6 +733,7 @@ mod tests {
         let mut pool_ctx = ConsensusPoolContext {
             exit: ctx.exit.clone(),
             migration_status: Arc::new(MigrationStatus::post_migration_status()),
+            generated_cert_types: Arc::new(GeneratedCertTypes::default()),
             cluster_info: Arc::new(ClusterInfo::new(
                 ContactInfo::new_localhost(&ctx.my_pubkey, 0),
                 Arc::new(ctx.validator_keypairs[0].node_keypair.insecure_clone()),

--- a/votor/src/generated_cert_types.rs
+++ b/votor/src/generated_cert_types.rs
@@ -1,0 +1,29 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
+use {
+    agave_votor_messages::consensus_message::CertificateType, parking_lot::RwLock,
+    solana_clock::Slot, std::collections::HashSet,
+};
+
+/// A simple container that allows the consensus pool to communicate with the bls sigverifier
+/// which certs it has already generated and therefore does not need anymore.
+#[derive(Default)]
+pub struct GeneratedCertTypes(RwLock<HashSet<CertificateType>>);
+
+impl GeneratedCertTypes {
+    /// Returns `true` if the pool already has the `cert_type`.
+    pub fn has_cert(&self, cert_type: &CertificateType) -> bool {
+        self.0.read().contains(cert_type)
+    }
+
+    /// Inserts the `cert_type` into the container.
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    pub(crate) fn insert_cert(&self, cert_type: CertificateType) {
+        self.0.write().insert(cert_type);
+    }
+
+    /// Prunes the container, it drops all certs older than `root_slot` as they are no longer needed.
+    pub(crate) fn prune(&self, root_slot: Slot) {
+        self.0.write().retain(|c| c.slot() >= root_slot);
+    }
+}

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -19,6 +19,7 @@ mod consensus_pool_service;
 pub mod consensus_rewards;
 pub mod event;
 mod event_handler;
+pub mod generated_cert_types;
 pub mod root_utils;
 mod staked_validators_cache;
 mod timer_manager;

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -51,6 +51,7 @@ use {
         consensus_rewards::ConsensusRewardsService,
         event::{LeaderWindowInfo, VotorEventReceiver, VotorEventSender},
         event_handler::{EventHandler, EventHandlerContext},
+        generated_cert_types::GeneratedCertTypes,
         root_utils::RootContext,
         timer_manager::TimerManager,
         vote_history::VoteHistory,
@@ -95,6 +96,7 @@ pub struct VotorConfig {
     pub wait_for_vote_to_start_leader: bool,
     pub vote_history: VoteHistory,
     pub vote_history_storage: Arc<dyn VoteHistoryStorage>,
+    pub generated_cert_types: Arc<GeneratedCertTypes>,
 
     // Shared state
     pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
@@ -175,6 +177,7 @@ impl Votor {
             reward_votes_receiver,
             build_reward_certs_receiver,
             reward_certs_sender,
+            generated_cert_types,
         } = config;
 
         let migration_status = bank_forks.read().unwrap().migration_status();
@@ -237,6 +240,7 @@ impl Votor {
         let consensus_pool_context = ConsensusPoolContext {
             exit: exit.clone(),
             migration_status,
+            generated_cert_types,
             cluster_info: cluster_info.clone(),
             my_vote_pubkey: vote_account,
             blockstore,


### PR DESCRIPTION
#### Problem

Under normal conditions, chances are that a node would generate certs itself before it receives them over the network.  In these cases, we do not need to sigverifier the certs received over the network.


#### Summary of Changes

This PR introduces a way for the consensus pool to inform the bls sigverifier which certs it has already generated and the bls sigverifier uses the information to decide which of the received certs it should actually verify.

The approach uses a lock to share the information as there should only be a couple of certs per slot so the potential lock contention should be minimal.

Closes: #11067 
