### PR TITLE
dynamic repair tick

### DIFF
--- a/core/src/repair/repair_generic_traversal.rs
+++ b/core/src/repair/repair_generic_traversal.rs
@@ -122,6 +122,7 @@ pub fn get_closest_completion(
     slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
     processed_slots: &mut HashSet<Slot>,
     limit: usize,
+    ticks_per_second: u64,
     outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
 ) -> (Vec<ShredRepairType>, /* processed slots */ usize) {
     let mut slot_dists: Vec<(Slot, u64)> = Vec::default();
@@ -199,6 +200,7 @@ pub fn get_closest_completion(
                 blockstore,
                 path_slot,
                 slot_meta,
+                ticks_per_second,
                 limit - repairs.len(),
                 outstanding_repairs,
             );
@@ -215,6 +217,7 @@ pub mod test {
     use {
         super::*,
         crate::repair::repair_service::sleep_shred_deferment_period,
+        solana_clock::DEFAULT_TICKS_PER_SECOND,
         solana_hash::Hash,
         solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path},
         trees::{Tree, TreeWalk, tr},
@@ -269,6 +272,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut processed_slots,
             10,
+            DEFAULT_TICKS_PER_SECOND,
             &mut outstanding_requests,
         );
         assert_eq!(repairs, []);
@@ -297,6 +301,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut processed_slots,
             1,
+            DEFAULT_TICKS_PER_SECOND,
             &mut outstanding_requests,
         );
         assert_eq!(repairs, [ShredRepairType::Shred(1, 30)]);
@@ -309,6 +314,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut processed_slots,
             4,
+            DEFAULT_TICKS_PER_SECOND,
             &mut outstanding_requests,
         );
         assert_eq!(repairs.len(), 4);
@@ -322,6 +328,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut processed_slots,
             1,
+            DEFAULT_TICKS_PER_SECOND,
             &mut outstanding_requests,
         );
         assert_eq!(repairs.len(), 0);

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -23,7 +23,7 @@ use {
     lru::LruCache,
     rand::prelude::IndexedRandom as _,
     solana_client::connection_cache::Protocol,
-    solana_clock::{DEFAULT_TICKS_PER_SECOND, MS_PER_TICK, Slot},
+    solana_clock::Slot,
     solana_epoch_schedule::EpochSchedule,
     solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
@@ -56,12 +56,12 @@ use {
 #[cfg(test)]
 use {
     crate::repair::duplicate_repair_status::DuplicateSlotRepairStatus,
-    solana_clock::DEFAULT_MS_PER_SLOT, solana_keypair::Keypair,
+    solana_clock::{DEFAULT_MS_PER_SLOT, DEFAULT_TICKS_PER_SECOND},
+    solana_keypair::Keypair,
 };
 
 // Time to defer repair requests to allow for turbine propagation
 const DEFER_REPAIR_THRESHOLD: Duration = Duration::from_millis(250);
-const DEFER_REPAIR_THRESHOLD_TICKS: u64 = DEFER_REPAIR_THRESHOLD.as_millis() as u64 / MS_PER_TICK;
 
 // This is the amount of time we will wait for a repair request to be fulfilled
 // before making another request. Value is based on reasonable upper bound of
@@ -73,6 +73,10 @@ const REPAIR_REQUEST_TIMEOUT_MS: u64 = 150;
 // target node is not provided. This number was chosen to provide reasonable
 // chance of sampling duplicate in the event of cluster partition.
 const NUM_PEERS_TO_SAMPLE_FOR_REPAIRS: usize = 10;
+
+fn defer_repair_threshold_ticks(ticks_per_second: u64) -> u64 {
+    DEFER_REPAIR_THRESHOLD.as_millis() as u64 * ticks_per_second / 1_000
+}
 
 pub type AncestorDuplicateSlotsSender = CrossbeamSender<AncestorDuplicateSlotToRepair>;
 pub type AncestorDuplicateSlotsReceiver = CrossbeamReceiver<AncestorDuplicateSlotToRepair>;
@@ -554,6 +558,7 @@ impl RepairService {
     fn identify_repairs(
         blockstore: &Blockstore,
         root_bank: Arc<Bank>,
+        ticks_per_second: u64,
         _repair_info: &RepairInfo,
         repair_weight: &mut RepairWeight,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
@@ -575,6 +580,7 @@ impl RepairService {
             MAX_REPAIR_LENGTH,
             MAX_UNKNOWN_LAST_INDEX_REPAIRS,
             MAX_CLOSEST_COMPLETION_REPAIRS,
+            ticks_per_second,
             repair_metrics,
             outstanding_repairs,
         )
@@ -694,6 +700,10 @@ impl RepairService {
             outstanding_repairs,
         } = repair_tracker;
         let root_bank = sharable_banks.root();
+        // The tick rate can change, which changes the tick -> wall clock math
+        // for how long we're willing to wait on turbine shreds. Re-check every
+        // iteration.
+        let ticks_per_second = sharable_banks.root().ticks_per_second().max(1);
 
         Self::update_weighting_heuristic(
             blockstore,
@@ -708,6 +718,7 @@ impl RepairService {
         let repairs = Self::identify_repairs(
             blockstore,
             root_bank.clone(),
+            ticks_per_second,
             repair_info,
             repair_weight,
             outstanding_repairs,
@@ -788,9 +799,11 @@ impl RepairService {
         blockstore: &Blockstore,
         slot: Slot,
         slot_meta: &SlotMeta,
+        ticks_per_second: u64,
         max_repairs: usize,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) -> Vec<ShredRepairType> {
+        let defer_repair_threshold_ticks = defer_repair_threshold_ticks(ticks_per_second);
         if max_repairs == 0 || slot_meta.is_full() {
             vec![]
         } else if slot_meta.consumed == slot_meta.received {
@@ -803,11 +816,11 @@ impl RepairService {
                 .map(u64::from)
             {
                 // System time is not monotonic
-                let ticks_since_first_insert = DEFAULT_TICKS_PER_SECOND
-                    * timestamp().saturating_sub(slot_meta.first_shred_timestamp)
+                let ticks_since_first_insert = ticks_per_second
+                    .saturating_mul(timestamp().saturating_sub(slot_meta.first_shred_timestamp))
                     / 1_000;
                 if ticks_since_first_insert
-                    < reference_tick.saturating_add(DEFER_REPAIR_THRESHOLD_TICKS)
+                    < reference_tick.saturating_add(defer_repair_threshold_ticks)
                 {
                     return vec![];
                 }
@@ -825,7 +838,7 @@ impl RepairService {
                 .find_missing_data_indexes(
                     slot,
                     slot_meta.first_shred_timestamp,
-                    DEFER_REPAIR_THRESHOLD_TICKS,
+                    defer_repair_threshold_ticks,
                     slot_meta.consumed,
                     slot_meta.received,
                     max_repairs,
@@ -847,6 +860,7 @@ impl RepairService {
         repairs: &mut Vec<ShredRepairType>,
         max_repairs: usize,
         slot: Slot,
+        ticks_per_second: u64,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) {
         let mut pending_slots = vec![slot];
@@ -857,6 +871,7 @@ impl RepairService {
                     blockstore,
                     slot,
                     &slot_meta,
+                    ticks_per_second,
                     max_repairs - repairs.len(),
                     outstanding_repairs,
                 );
@@ -1041,6 +1056,7 @@ impl RepairService {
                 blockstore,
                 slot,
                 &meta,
+                DEFAULT_TICKS_PER_SECOND,
                 max_repairs - repairs.len(),
                 &mut HashMap::default(),
             );
@@ -1064,6 +1080,7 @@ impl RepairService {
                     blockstore,
                     slot,
                     &slot_meta,
+                    DEFAULT_TICKS_PER_SECOND,
                     MAX_REPAIR_PER_DUPLICATE,
                     &mut HashMap::default(),
                 ))
@@ -1301,6 +1318,7 @@ mod test {
                 MAX_REPAIR_LENGTH,
                 MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                 MAX_CLOSEST_COMPLETION_REPAIRS,
+                DEFAULT_TICKS_PER_SECOND,
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
             ),
@@ -1333,6 +1351,7 @@ mod test {
                 MAX_REPAIR_LENGTH,
                 MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                 MAX_CLOSEST_COMPLETION_REPAIRS,
+                DEFAULT_TICKS_PER_SECOND,
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
             ),
@@ -1390,6 +1409,7 @@ mod test {
                 MAX_REPAIR_LENGTH,
                 MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                 MAX_CLOSEST_COMPLETION_REPAIRS,
+                DEFAULT_TICKS_PER_SECOND,
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
             ),
@@ -1405,6 +1425,7 @@ mod test {
                 expected.len() - 2,
                 MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                 MAX_CLOSEST_COMPLETION_REPAIRS,
+                DEFAULT_TICKS_PER_SECOND,
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
             )[..],
@@ -1447,6 +1468,7 @@ mod test {
                 MAX_REPAIR_LENGTH,
                 MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                 MAX_CLOSEST_COMPLETION_REPAIRS,
+                DEFAULT_TICKS_PER_SECOND,
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
             ),

--- a/core/src/repair/repair_weight.rs
+++ b/core/src/repair/repair_weight.rs
@@ -208,6 +208,7 @@ impl RepairWeight {
         max_new_shreds: usize,
         max_unknown_last_index_repairs: usize,
         max_closest_completion_repairs: usize,
+        ticks_per_second: u64,
         repair_metrics: &mut RepairMetrics,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) -> Vec<ShredRepairType> {
@@ -239,6 +240,7 @@ impl RepairWeight {
             &mut slot_meta_cache,
             &mut best_shreds_repairs,
             max_new_shreds,
+            ticks_per_second,
             outstanding_repairs,
         );
         let num_best_shreds_repairs = best_shreds_repairs.len();
@@ -275,6 +277,7 @@ impl RepairWeight {
             &mut slot_meta_cache,
             &mut processed_slots,
             max_closest_completion_repairs,
+            ticks_per_second,
             outstanding_repairs,
         );
         let num_closest_completion_repairs = closest_completion_repairs.len();
@@ -502,6 +505,7 @@ impl RepairWeight {
         slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
         repairs: &mut Vec<ShredRepairType>,
         max_new_shreds: usize,
+        ticks_per_second: u64,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) {
         let root_tree = self.trees.get(&self.root).expect("Root tree must exist");
@@ -511,6 +515,7 @@ impl RepairWeight {
             slot_meta_cache,
             repairs,
             max_new_shreds,
+            ticks_per_second,
             outstanding_repairs,
         );
     }
@@ -628,6 +633,7 @@ impl RepairWeight {
         slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
         processed_slots: &mut HashSet<Slot>,
         max_new_repairs: usize,
+        ticks_per_second: u64,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) -> (Vec<ShredRepairType>, /* processed slots */ usize) {
         let mut repairs = Vec::default();
@@ -643,6 +649,7 @@ impl RepairWeight {
                 slot_meta_cache,
                 processed_slots,
                 max_new_repairs - repairs.len(),
+                ticks_per_second,
                 outstanding_repairs,
             );
             repairs.extend(new_repairs);

--- a/core/src/repair/repair_weighted_traversal.rs
+++ b/core/src/repair/repair_weighted_traversal.rs
@@ -79,6 +79,7 @@ pub fn get_best_repair_shreds(
     slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
     repairs: &mut Vec<ShredRepairType>,
     max_new_shreds: usize,
+    ticks_per_second: u64,
     outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
 ) {
     let initial_len = repairs.len();
@@ -104,6 +105,7 @@ pub fn get_best_repair_shreds(
                         blockstore,
                         slot,
                         slot_meta,
+                        ticks_per_second,
                         max_repairs - repairs.len(),
                         outstanding_repairs,
                     );
@@ -125,6 +127,7 @@ pub fn get_best_repair_shreds(
                                 repairs,
                                 max_repairs,
                                 *new_child_slot,
+                                ticks_per_second,
                                 outstanding_repairs,
                             );
                         }
@@ -141,6 +144,7 @@ pub mod test {
     use {
         super::*,
         crate::repair::repair_service::sleep_shred_deferment_period,
+        solana_clock::DEFAULT_TICKS_PER_SECOND,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::{
@@ -235,6 +239,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut repairs,
             6,
+            DEFAULT_TICKS_PER_SECOND,
             &mut outstanding_repairs,
         );
         assert_eq!(
@@ -267,6 +272,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut repairs,
             6,
+            DEFAULT_TICKS_PER_SECOND,
             &mut outstanding_repairs,
         );
         assert_eq!(
@@ -312,6 +318,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut repairs,
             4,
+            DEFAULT_TICKS_PER_SECOND,
             &mut outstanding_repairs,
         );
         assert_eq!(
@@ -336,6 +343,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut repairs,
             5,
+            DEFAULT_TICKS_PER_SECOND,
             &mut outstanding_repairs,
         );
         let expected_repairs = [1, 7, 8, 3, 5]
@@ -352,6 +360,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut repairs,
             1,
+            DEFAULT_TICKS_PER_SECOND,
             &mut outstanding_repairs,
         );
         assert_eq!(repairs, expected_repairs);
@@ -375,6 +384,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut repairs,
             usize::MAX,
+            DEFAULT_TICKS_PER_SECOND,
             &mut outstanding_repairs,
         );
         let last_shred = blockstore.meta(0).unwrap().unwrap().received;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5162,6 +5162,14 @@ impl Bank {
         self.ticks_per_slot
     }
 
+    /// Return the target number of ticks per second for this bank.
+    pub fn ticks_per_second(&self) -> u64 {
+        let ticks_per_slot = u128::from(self.ticks_per_slot.max(1));
+        let ns_per_tick = self.ns_per_slot.saturating_div(ticks_per_slot).max(1);
+        u64::try_from(1_000_000_000u128.saturating_div(ns_per_tick))
+            .expect("ticks per second must fit in u64")
+    }
+
     /// Return the number of slots per year
     pub fn slots_per_year(&self) -> f64 {
         self.slots_per_year


### PR DESCRIPTION
#### Problem
Repair currently uses `DEFAULT_TICKS_PER_SECOND` constant to translate tick --> wall clock time when deciding how long to wait before requesting repairs. It would be better if this was dynamic so it would respond if we change ticks per second (e.g. by cutting slot times in half)

#### Summary of Changes
Plumb `ticks_per_second` through repair, and update this from working bank every repair iteration