### PR TITLE
power of 2 ticks

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -929,7 +929,6 @@ mod tests {
             record_channels::record_channels,
             transaction_recorder::RecordTransactionsSummary,
         },
-        solana_poh_config::PohConfig,
         solana_pubkey::Pubkey,
         solana_runtime::{bank::Bank, genesis_utils::bootstrap_validator_stake_lamports},
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
@@ -1001,86 +1000,6 @@ mod tests {
         exit.store(true, Ordering::Relaxed);
         banking_stage.join().unwrap();
         poh_service.join().unwrap();
-    }
-
-    #[test]
-    fn test_banking_stage_tick() {
-        agave_logger::setup();
-        let GenesisConfigInfo {
-            mut genesis_config, ..
-        } = create_genesis_config(2);
-        genesis_config.ticks_per_slot = 4;
-        let num_extra_ticks = 4;
-        let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-        let start_hash = bank.last_blockhash();
-        let banking_tracer = BankingTracer::new_disabled();
-        let Channels {
-            non_vote_sender,
-            non_vote_receiver,
-            tpu_vote_sender,
-            tpu_vote_receiver,
-            gossip_vote_sender,
-            gossip_vote_receiver,
-        } = banking_tracer.create_channels();
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Arc::new(
-            Blockstore::open(ledger_path.path())
-                .expect("Expected to be able to open database ledger"),
-        );
-        let poh_config = PohConfig {
-            target_tick_count: Some(bank.max_tick_height() + num_extra_ticks),
-            ..PohConfig::default()
-        };
-        let (
-            exit,
-            poh_recorder,
-            _poh_controller,
-            transaction_recorder,
-            poh_service,
-            entry_receiver,
-        ) = create_test_recorder(bank.clone(), blockstore, Some(poh_config), None);
-        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-
-        let banking_stage = BankingStage::new_num_threads(
-            BlockProductionMethod::CentralScheduler,
-            poh_recorder.clone(),
-            transaction_recorder,
-            non_vote_receiver,
-            tpu_vote_receiver,
-            gossip_vote_receiver,
-            mpsc::channel(1).1,
-            DEFAULT_NUM_WORKERS,
-            SchedulerConfig {
-                scheduler_pacing: SchedulerPacing::Disabled,
-            },
-            None,
-            replay_vote_sender,
-            None,
-            bank_forks,
-            None,
-        );
-        trace!("sending bank");
-        drop(non_vote_sender);
-        drop(tpu_vote_sender);
-        drop(gossip_vote_sender);
-        exit.store(true, Ordering::Relaxed);
-        poh_service.join().unwrap();
-        drop(poh_recorder);
-        banking_stage.join().unwrap();
-
-        trace!("getting entries");
-        let entries: Vec<_> = entry_receiver
-            .iter()
-            .map(|(_bank, (entry, _tick_height))| entry)
-            .collect();
-        trace!("done");
-        assert_eq!(entries.len(), genesis_config.ticks_per_slot as usize);
-        assert!(
-            entries
-                .verify(&start_hash, &entry::thread_pool_for_tests())
-                .status()
-        );
-        assert_eq!(entries[entries.len() - 1].hash, bank.last_blockhash());
     }
 
     #[test]

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1010,7 +1010,7 @@ mod tests {
             mut genesis_config, ..
         } = create_genesis_config(2);
         genesis_config.ticks_per_slot = 4;
-        let num_extra_ticks = 2;
+        let num_extra_ticks = 4;
         let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         let start_hash = bank.last_blockhash();
         let banking_tracer = BankingTracer::new_disabled();

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -1117,6 +1117,7 @@ mod tests {
         super::*,
         crossbeam_channel::bounded,
         solana_clock::DEFAULT_TICKS_PER_SLOT,
+        solana_entry::entry::{self, EntrySlice},
         solana_leader_schedule::SlotLeader,
         solana_ledger::{
             blockstore::Blockstore,
@@ -1230,6 +1231,55 @@ mod tests {
         assert!(poh_recorder.working_bank.is_some());
         poh_recorder.clear_bank(true);
         assert!(poh_recorder.working_bank.is_none());
+    }
+
+    #[test]
+    fn test_poh_recorder_tick_verifies() {
+        // Setup
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path())
+            .expect("Expected to be able to open database ledger");
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let prev_hash = bank0.last_blockhash();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(
+            0,
+            prev_hash,
+            bank0.clone(),
+            Some((4, 4)),
+            bank0.ticks_per_slot(),
+            Arc::new(blockstore),
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank0)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+        poh_recorder.set_bank_for_test(bank0.clone());
+
+        // Tick through bank0.
+        let num_new_ticks = poh_recorder.tick_height() + bank0.ticks_per_slot();
+        for _ in 0..num_new_ticks {
+            poh_recorder.tick();
+        }
+
+        // Collect the tick entries produced.
+        let mut entries = vec![];
+        while let Ok((_bank, (entry, _tick_height))) = entry_receiver.try_recv() {
+            assert!(entry.is_tick());
+            entries.push(entry);
+        }
+
+        // Confirm correct number of entries received.
+        assert_eq!(entries.len(), num_new_ticks as usize);
+
+        // Confirm the entries verify properly.
+        assert!(
+            entries
+                .verify(&prev_hash, &entry::thread_pool_for_tests())
+                .status()
+        );
+
+        // Confirm entry hash and blockhash are in sync.
+        assert_eq!(entries[entries.len() - 1].hash, bank0.last_blockhash());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
`test_banking_stage_tick` doesn't need to be a part of banking_stage at all. It seems to be verifying poh_recorder: 
1. produces the correct number of ticks
2. the ticks verify
3. the last tick hash and blockhash are consistent

#### Summary of Changes
Delete `test_banking_stage_tick`. Add `test_poh_recorder_tick_verifies` to capture the spirit of what the old test was doing.