### PR TITLE
poh dynamic from bank

### DIFF
--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -684,15 +684,15 @@ impl PohRecorder {
 
     // Derives the target tick duration in nanoseconds based on the Bank's
     // `ns_per_slot` and `ticks_per_slot`
-    pub fn target_tick_duration_ns(&self) -> u64 {
+    pub fn target_tick_ns(&self) -> u64 {
         let ns_per_slot = self
             .working_bank
             .as_ref()
             .map(|working_bank| working_bank.bank.ns_per_slot)
             .unwrap_or(self.start_bank.ns_per_slot);
         let ticks_per_slot = u128::from(self.ticks_per_slot.max(1));
-        let target_tick_duration_ns = ns_per_slot.saturating_div(ticks_per_slot);
-        u64::try_from(target_tick_duration_ns).unwrap_or(u64::MAX)
+        let target_tick_ns = ns_per_slot.saturating_div(ticks_per_slot);
+        u64::try_from(target_tick_ns).unwrap_or(u64::MAX)
     }
 
     pub fn start_slot(&self) -> Slot {

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -682,6 +682,19 @@ impl PohRecorder {
         self.ticks_per_slot
     }
 
+    // Derives the target tick duration in nanoseconds based on the Bank's
+    // `ns_per_slot` and `ticks_per_slot`
+    pub fn target_tick_duration_ns(&self) -> u64 {
+        let ns_per_slot = self
+            .working_bank
+            .as_ref()
+            .map(|working_bank| working_bank.bank.ns_per_slot)
+            .unwrap_or(self.start_bank.ns_per_slot);
+        let ticks_per_slot = u128::from(self.ticks_per_slot.max(1));
+        let target_tick_duration_ns = ns_per_slot.saturating_div(ticks_per_slot);
+        u64::try_from(target_tick_duration_ns).unwrap_or(u64::MAX)
+    }
+
     pub fn start_slot(&self) -> Slot {
         self.start_bank.slot()
     }

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -149,18 +149,14 @@ impl PohService {
                     if let Some(cores) = core_affinity::get_core_ids() {
                         core_affinity::set_for_current(cores[pinned_cpu_core]);
                     }
-                    let target_ns_per_tick = Self::target_ns_per_tick(
-                        ticks_per_slot,
-                        poh_config.target_tick_duration.as_nanos() as u64,
-                    );
                     Self::tick_producer(
                         poh_recorder,
+                        &poh_config,
                         &poh_exit,
                         ticks_per_slot,
                         hashes_per_batch,
                         &mut record_receiver,
                         poh_service_receiver,
-                        target_ns_per_tick,
                         &migration_status.shutdown_poh,
                     )
                 }
@@ -195,9 +191,10 @@ impl PohService {
         Self { tick_producer }
     }
 
+    // Adjusts the target nanoseconds per PoH tick to enable hitting slot time
+    // targets by compensating for time spent outside of PoH, such as network
+    // propagation.
     pub fn target_ns_per_tick(ticks_per_slot: u64, target_tick_duration_ns: u64) -> u64 {
-        // Account for some extra time outside of PoH generation to account
-        // for processing time outside PoH.
         let adjustment_per_tick = TARGET_SLOT_ADJUSTMENT_NS
             .checked_div(ticks_per_slot)
             .unwrap_or(0);
@@ -220,13 +217,14 @@ impl PohService {
         if should_shutdown_for_test_producers {
             record_receiver.shutdown();
         }
+        let mut target_tick_duration = Duration::from_nanos(
+            Self::effective_target_tick_duration_ns(&poh_recorder, poh_config),
+        );
         while !poh_exit.load(Ordering::Relaxed) && !shutdown_poh.load(Ordering::Relaxed) {
             let service_message =
                 Self::check_for_service_message(&poh_service_receiver, record_receiver);
             loop {
-                let remaining_tick_time = poh_config
-                    .target_tick_duration
-                    .saturating_sub(last_tick.elapsed());
+                let remaining_tick_time = target_tick_duration.saturating_sub(last_tick.elapsed());
                 Self::read_record_receiver_and_process(
                     &poh_recorder,
                     record_receiver,
@@ -270,6 +268,9 @@ impl PohService {
 
             if let Some(service_message) = service_message {
                 Self::handle_service_message(&poh_recorder, service_message, record_receiver);
+                target_tick_duration = Duration::from_nanos(
+                    Self::effective_target_tick_duration_ns(&poh_recorder, poh_config),
+                );
                 should_shutdown_for_test_producers =
                     Self::should_shutdown_for_test_producers(&poh_recorder);
                 if should_shutdown_for_test_producers {
@@ -334,15 +335,16 @@ impl PohService {
         if should_shutdown_for_test_producers {
             record_receiver.shutdown();
         }
+        let mut target_tick_duration = Duration::from_nanos(
+            Self::effective_target_tick_duration_ns(&poh_recorder, poh_config),
+        );
 
         while elapsed_ticks < num_ticks {
             let service_message =
                 Self::check_for_service_message(&poh_service_receiver, record_receiver);
 
             loop {
-                let remaining_tick_time = poh_config
-                    .target_tick_duration
-                    .saturating_sub(last_tick.elapsed());
+                let remaining_tick_time = target_tick_duration.saturating_sub(last_tick.elapsed());
                 Self::read_record_receiver_and_process(
                     &poh_recorder,
                     record_receiver,
@@ -391,6 +393,9 @@ impl PohService {
             }
             if let Some(service_message) = service_message {
                 Self::handle_service_message(&poh_recorder, service_message, record_receiver);
+                target_tick_duration = Duration::from_nanos(
+                    Self::effective_target_tick_duration_ns(&poh_recorder, poh_config),
+                );
                 should_shutdown_for_test_producers =
                     Self::should_shutdown_for_test_producers(&poh_recorder);
                 if should_shutdown_for_test_producers {
@@ -531,18 +536,22 @@ impl PohService {
 
     fn tick_producer(
         poh_recorder: Arc<RwLock<PohRecorder>>,
+        poh_config: &PohConfig,
         poh_exit: &AtomicBool,
         ticks_per_slot: u64,
         hashes_per_batch: u64,
         record_receiver: &mut RecordReceiver,
         poh_service_receiver: PohServiceMessageReceiver,
-        target_ns_per_tick: u64,
         shutdown_poh: &AtomicBool,
     ) {
         let poh = poh_recorder.read().unwrap().poh.clone();
         let mut timing = PohTiming::new();
         let mut next_record = None;
         let mut should_exit = poh_exit.load(Ordering::Relaxed);
+        let mut target_ns_per_tick = Self::target_ns_per_tick(
+            ticks_per_slot,
+            Self::effective_target_tick_duration_ns(&poh_recorder, poh_config),
+        );
 
         loop {
             // If we should exit, close the channel so no more records are accepted,
@@ -596,6 +605,10 @@ impl PohService {
             if let Some(service_message) = service_message {
                 if !should_exit {
                     Self::handle_service_message(&poh_recorder, service_message, record_receiver);
+                    target_ns_per_tick = Self::target_ns_per_tick(
+                        ticks_per_slot,
+                        Self::effective_target_tick_duration_ns(&poh_recorder, poh_config),
+                    );
                 }
             }
 
@@ -618,6 +631,21 @@ impl PohService {
             }
             Err(_) => None,
         }
+    }
+
+    // Reconcile the banks values versus the optional (test only) poh_config
+    // overrides.
+    fn effective_target_tick_duration_ns(
+        poh_recorder: &RwLock<PohRecorder>,
+        poh_config: &PohConfig,
+    ) -> u64 {
+        poh_recorder
+            .read()
+            .unwrap()
+            .target_tick_duration_ns()
+            // Tests can set the bank timing absurdly high. Preserve the config
+            // override so the short-lived producers still make progress.
+            .min(poh_config.target_tick_duration.as_nanos() as u64)
     }
 
     fn handle_service_message(

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -194,11 +194,11 @@ impl PohService {
     // Adjusts the target nanoseconds per PoH tick to enable hitting slot time
     // targets by compensating for time spent outside of PoH, such as network
     // propagation.
-    pub fn target_ns_per_tick(ticks_per_slot: u64, target_tick_duration_ns: u64) -> u64 {
+    pub fn target_tick_ns_adjusted(ticks_per_slot: u64, target_tick_ns: u64) -> u64 {
         let adjustment_per_tick = TARGET_SLOT_ADJUSTMENT_NS
             .checked_div(ticks_per_slot)
             .unwrap_or(0);
-        target_tick_duration_ns.saturating_sub(adjustment_per_tick)
+        target_tick_ns.saturating_sub(adjustment_per_tick)
     }
 
     fn low_power_tick_producer(
@@ -217,9 +217,8 @@ impl PohService {
         if should_shutdown_for_test_producers {
             record_receiver.shutdown();
         }
-        let mut target_tick_duration = Duration::from_nanos(
-            Self::effective_target_tick_duration_ns(&poh_recorder, poh_config),
-        );
+        let mut target_tick_duration =
+            Duration::from_nanos(Self::target_tick_ns_reconciled(&poh_recorder, poh_config));
         while !poh_exit.load(Ordering::Relaxed) && !shutdown_poh.load(Ordering::Relaxed) {
             let service_message =
                 Self::check_for_service_message(&poh_service_receiver, record_receiver);
@@ -268,9 +267,10 @@ impl PohService {
 
             if let Some(service_message) = service_message {
                 Self::handle_service_message(&poh_recorder, service_message, record_receiver);
-                target_tick_duration = Duration::from_nanos(
-                    Self::effective_target_tick_duration_ns(&poh_recorder, poh_config),
-                );
+                target_tick_duration = Duration::from_nanos(Self::target_tick_ns_reconciled(
+                    &poh_recorder,
+                    poh_config,
+                ));
                 should_shutdown_for_test_producers =
                     Self::should_shutdown_for_test_producers(&poh_recorder);
                 if should_shutdown_for_test_producers {
@@ -335,9 +335,8 @@ impl PohService {
         if should_shutdown_for_test_producers {
             record_receiver.shutdown();
         }
-        let mut target_tick_duration = Duration::from_nanos(
-            Self::effective_target_tick_duration_ns(&poh_recorder, poh_config),
-        );
+        let mut target_tick_duration =
+            Duration::from_nanos(Self::target_tick_ns_reconciled(&poh_recorder, poh_config));
 
         while elapsed_ticks < num_ticks {
             let service_message =
@@ -393,9 +392,10 @@ impl PohService {
             }
             if let Some(service_message) = service_message {
                 Self::handle_service_message(&poh_recorder, service_message, record_receiver);
-                target_tick_duration = Duration::from_nanos(
-                    Self::effective_target_tick_duration_ns(&poh_recorder, poh_config),
-                );
+                target_tick_duration = Duration::from_nanos(Self::target_tick_ns_reconciled(
+                    &poh_recorder,
+                    poh_config,
+                ));
                 should_shutdown_for_test_producers =
                     Self::should_shutdown_for_test_producers(&poh_recorder);
                 if should_shutdown_for_test_producers {
@@ -548,9 +548,9 @@ impl PohService {
         let mut timing = PohTiming::new();
         let mut next_record = None;
         let mut should_exit = poh_exit.load(Ordering::Relaxed);
-        let mut target_ns_per_tick = Self::target_ns_per_tick(
+        let mut target_ns_per_tick = Self::target_tick_ns_adjusted(
             ticks_per_slot,
-            Self::effective_target_tick_duration_ns(&poh_recorder, poh_config),
+            Self::target_tick_ns_reconciled(&poh_recorder, poh_config),
         );
 
         loop {
@@ -605,9 +605,9 @@ impl PohService {
             if let Some(service_message) = service_message {
                 if !should_exit {
                     Self::handle_service_message(&poh_recorder, service_message, record_receiver);
-                    target_ns_per_tick = Self::target_ns_per_tick(
+                    target_ns_per_tick = Self::target_tick_ns_adjusted(
                         ticks_per_slot,
-                        Self::effective_target_tick_duration_ns(&poh_recorder, poh_config),
+                        Self::target_tick_ns_reconciled(&poh_recorder, poh_config),
                     );
                 }
             }
@@ -635,14 +635,14 @@ impl PohService {
 
     // Reconcile the banks values versus the optional (test only) poh_config
     // overrides.
-    fn effective_target_tick_duration_ns(
+    fn target_tick_ns_reconciled(
         poh_recorder: &RwLock<PohRecorder>,
         poh_config: &PohConfig,
     ) -> u64 {
         poh_recorder
             .read()
             .unwrap()
-            .target_tick_duration_ns()
+            .target_tick_ns()
             // Tests can set the bank timing absurdly high. Preserve the config
             // override so the short-lived producers still make progress.
             .min(poh_config.target_tick_duration.as_nanos() as u64)


### PR DESCRIPTION
#### Problem
PoH does not respect target slot times from the Bank, which makes it incapable of changing dynamically, for example, if we want to reduce slot times

#### Summary of Changes
Derive target tick durations from the Bank