### PR TITLE
core: Remove `collect()` from `Consumer::process_and_record_transactions`

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -130,13 +130,13 @@ impl Consumer {
     ) -> ProcessTransactionBatchOutput {
         let mut error_counters = TransactionErrorMetrics::default();
         let pre_results = vec![Ok(()); txs.len()];
-        let check_results = bank.check_transactions(
-            txs,
-            &pre_results,
-            bank.max_processing_age(),
-            &mut error_counters,
-        );
-        let check_results: Vec<_> = check_results
+        let check_results = bank
+            .check_transactions(
+                txs,
+                &pre_results,
+                bank.max_processing_age(),
+                &mut error_counters,
+            )
             .into_iter()
             .zip(txs.iter())
             .map(|(result, tx)| match result {
@@ -148,8 +148,7 @@ impl Consumer {
                     }
                 }
                 Err(err) => Err(err),
-            })
-            .collect();
+            });
         let mut output = self.process_and_record_transactions_with_pre_results(
             bank,
             txs,


### PR DESCRIPTION
#### Problem

Pre-results in `Consumer::process_and_record_transactions` were collected into a vector, before being passed further.

#### Summary of Changes

`Consumer::process_and_record_transactions_with_pre_results` already accepts lazy iterators (`impl IntoIterator`) as inputs. The mentioned `collect()` is unnecessary and can be just removed.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
