### PR TITLE
cli: improve stake rent and minimum delegation

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1499,15 +1499,24 @@ pub async fn process_create_stake_account(
             return Err(CliError::BadParameter(err_msg).into());
         }
 
-        let minimum_balance = rpc_client
+        let rent_exempt_balance = rpc_client
             .get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())
             .await?;
-        if lamports < minimum_balance {
+        if lamports < rent_exempt_balance {
             return Err(CliError::BadParameter(format!(
-                "need at least {minimum_balance} lamports for stake account to be rent exempt, \
-                 provided lamports: {lamports}"
+                "need at least {rent_exempt_balance} lamports for stake account to be rent \
+                 exempt, provided lamports: {lamports}"
             ))
             .into());
+        }
+
+        let minimum_delegation = rpc_client.get_stake_minimum_delegation().await?;
+        let minimum_total_lamports = rent_exempt_balance.saturating_add(minimum_delegation);
+        if lamports < minimum_total_lamports {
+            eprintln!(
+                "Warning: need at least {minimum_total_lamports} lamports to delegate this stake \
+                 account, provided lamports: {lamports}"
+            );
         }
 
         if let Some(nonce_account) = &nonce_account {
@@ -2437,7 +2446,7 @@ pub fn build_stake_state(
     match stake_state {
         StakeStateV2::Stake(
             Meta {
-                rent_exempt_reserve,
+                rent_exempt_reserve: _, // deprecated: this value is meaningless
                 authorized,
                 lockup,
             },
@@ -2485,7 +2494,6 @@ pub fn build_stake_state(
                 lockup,
                 use_lamports_unit,
                 current_epoch,
-                rent_exempt_reserve: Some(*rent_exempt_reserve),
                 active_stake: u64_some_if_not_zero(effective),
                 activating_stake: u64_some_if_not_zero(activating),
                 deactivating_stake: u64_some_if_not_zero(deactivating),
@@ -2503,7 +2511,7 @@ pub fn build_stake_state(
             ..CliStakeState::default()
         },
         StakeStateV2::Initialized(Meta {
-            rent_exempt_reserve,
+            rent_exempt_reserve: _, // deprecated: this value is meaningless
             authorized,
             lockup,
         }) => {
@@ -2519,7 +2527,6 @@ pub fn build_stake_state(
                 authorized: Some(authorized.into()),
                 lockup,
                 use_lamports_unit,
-                rent_exempt_reserve: Some(*rent_exempt_reserve),
                 ..CliStakeState::default()
             }
         }
@@ -2860,6 +2867,31 @@ pub async fn process_delegate_stake(
                 sanity_check_result?;
             } else {
                 println!("--force supplied, ignoring: {err}");
+            }
+        }
+
+        if !force {
+            let stake_account = rpc_client.get_account(stake_account_pubkey).await?;
+            if stake_account.owner != stake::program::id() {
+                return Err(CliError::BadParameter(format!(
+                    "{stake_account_pubkey} is not a stake account",
+                ))
+                .into());
+            }
+
+            let rent_exempt_balance = rpc_client
+                .get_minimum_balance_for_rent_exemption(stake_account.data.len())
+                .await?;
+            let minimum_delegation = rpc_client.get_stake_minimum_delegation().await?;
+            let minimum_total_lamports = rent_exempt_balance.saturating_add(minimum_delegation);
+            let stake_account_lamports = stake_account.lamports;
+
+            if stake_account_lamports < minimum_total_lamports {
+                return Err(CliError::BadParameter(format!(
+                    "need at least {minimum_total_lamports} lamports to delegate this stake \
+                     account, available lamports: {stake_account_lamports}"
+                ))
+                .into());
             }
         }
     }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2446,7 +2446,7 @@ pub fn build_stake_state(
     match stake_state {
         StakeStateV2::Stake(
             Meta {
-                rent_exempt_reserve: _, // deprecated: this value is meaningless
+                rent_exempt_reserve,
                 authorized,
                 lockup,
             },
@@ -2494,6 +2494,7 @@ pub fn build_stake_state(
                 lockup,
                 use_lamports_unit,
                 current_epoch,
+                rent_exempt_reserve: Some(*rent_exempt_reserve),
                 active_stake: u64_some_if_not_zero(effective),
                 activating_stake: u64_some_if_not_zero(activating),
                 deactivating_stake: u64_some_if_not_zero(deactivating),
@@ -2511,7 +2512,7 @@ pub fn build_stake_state(
             ..CliStakeState::default()
         },
         StakeStateV2::Initialized(Meta {
-            rent_exempt_reserve: _, // deprecated: this value is meaningless
+            rent_exempt_reserve,
             authorized,
             lockup,
         }) => {
@@ -2527,6 +2528,7 @@ pub fn build_stake_state(
                 authorized: Some(authorized.into()),
                 lockup,
                 use_lamports_unit,
+                rent_exempt_reserve: Some(*rent_exempt_reserve),
                 ..CliStakeState::default()
             }
         }


### PR DESCRIPTION
#### Problem
minor qol fixes for rent and minimum delegation changes

#### Summary of Changes
* warn if creating a stake account below minimum delegation
* bail if delegating a stake account below minimum delegation
* do not display `Meta.rent_exempt_reserve` for `ShowStakeAccount`

`Split` is the other major rent/mindel-fussy instruction but `process_split()` handles both well already