### PR TITLE
ibrl precursor: update all tests to have a bank with a fork graph

### DIFF
--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -802,7 +802,8 @@ mod tests {
 
     fn setup_test_slot_boundary_banks() -> TestSlotBoundaryComponents {
         let genesis = create_genesis_config(10);
-        let first_bank = Arc::new(Bank::new_for_tests(&genesis.genesis_config));
+        let (first_bank, _bank_forks) =
+            Bank::new_for_tests(&genesis.genesis_config).wrap_with_bank_forks_for_tests();
 
         // Create a child descended from the first bank
         let next_bank = Arc::new(Bank::new_from_parent(

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -855,9 +855,10 @@ pub(crate) mod tests {
         let genesis_config =
             genesis_utils::create_genesis_config_with_vote_accounts(100, &[&keypair], vec![200])
                 .genesis_config;
-        let bank_0 = Bank::new_for_tests(&genesis_config);
+        let (bank_0, _bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let mut bank = Bank::new_from_parent(
-            Arc::new(bank_0),
+            bank_0,
             SlotLeader::new_unique(),
             MINIMUM_SLOTS_PER_EPOCH, // This puts us in epoch 1
         );
@@ -939,9 +940,9 @@ pub(crate) mod tests {
         let config =
             genesis_utils::create_genesis_config_with_vote_accounts(100, &[&keypair_a], vec![200])
                 .genesis_config;
-        let bank_0 = Bank::new_for_tests(&config);
+        let (bank_0, _bank_forks) = Bank::new_for_tests(&config).wrap_with_bank_forks_for_tests();
         let bank = Bank::new_from_parent(
-            Arc::new(bank_0),
+            bank_0,
             SlotLeader::new_unique(),
             MINIMUM_SLOTS_PER_EPOCH - 1,
         );
@@ -954,12 +955,8 @@ pub(crate) mod tests {
         let config =
             genesis_utils::create_genesis_config_with_vote_accounts(100, &[&keypair_b], vec![200])
                 .genesis_config;
-        let bank_0 = Bank::new_for_tests(&config);
-        let bank = Bank::new_from_parent(
-            Arc::new(bank_0),
-            SlotLeader::new_unique(),
-            MINIMUM_SLOTS_PER_EPOCH,
-        );
+        let (bank_0, _bank_forks) = Bank::new_for_tests(&config).wrap_with_bank_forks_for_tests();
+        let bank = Bank::new_from_parent(bank_0, SlotLeader::new_unique(), MINIMUM_SLOTS_PER_EPOCH);
         assert_eq!(bank.epoch(), 1);
         vote_storage.cache_epoch_boundary_info(&bank);
         vote_storage.insert_batch(VoteSource::Gossip, votes().into_iter());
@@ -970,12 +967,15 @@ pub(crate) mod tests {
         );
 
         // Previously unstaked votes are removed
+        // Use warp_from_parent: it explicitly calls update_epoch_stakes(get_epoch(slot)),
+        // which populates epoch_stakes with the key cache_epoch_boundary_info expects
+        // (bank.epoch()). new_from_parent uses get_leader_schedule_epoch which can differ.
         let config =
             genesis_utils::create_genesis_config_with_vote_accounts(100, &[&keypair_c], vec![200])
                 .genesis_config;
-        let bank_0 = Bank::new_for_tests(&config);
+        let (bank_0, _bank_forks) = Bank::new_for_tests(&config).wrap_with_bank_forks_for_tests();
         let bank = Bank::warp_from_parent(
-            Arc::new(bank_0),
+            bank_0,
             SlotLeader::new_unique(),
             3 * MINIMUM_SLOTS_PER_EPOCH,
         );

--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -1264,7 +1264,8 @@ mod tests {
             stakes_vec,
         );
         let bank0 = Bank::new_for_tests(&genesis.genesis_config);
-        let bank5 = Bank::new_from_parent(Arc::new(bank0), SlotLeader::default(), 5);
+        let (bank0, _temp_bank_forks) = bank0.wrap_with_bank_forks_for_tests();
+        let bank5 = Bank::new_from_parent(bank0, SlotLeader::default(), 5);
         let bank_forks = BankForks::new_rw_arc(bank5);
 
         bank_forks.write().unwrap().set_root(5, None, None);

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1023,7 +1023,10 @@ mod tests {
     #[test]
     fn test_update_new_root() {
         let SetupComponents {
-            vote_tracker, bank, ..
+            vote_tracker,
+            bank,
+            bank_forks: _bank_forks,
+            ..
         } = setup();
 
         // Check outdated slots are purged with new root
@@ -1104,13 +1107,10 @@ mod tests {
                 vec![stake_per_validator; validator_voting_keypairs.len()],
             );
 
-        let bank0 = Bank::new_for_tests(&genesis_config);
+        let (bank0, _bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         // Votes for slots less than the provided root bank's slot should not be processed
-        let bank3 = Arc::new(Bank::new_from_parent(
-            Arc::new(bank0),
-            SlotLeader::default(),
-            3,
-        ));
+        let bank3 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 3));
         let vote_slots = vec![1, 2];
         send_vote_txs(
             vote_slots,
@@ -1213,11 +1213,13 @@ mod tests {
 
     fn run_test_process_votes(hash: Option<Hash>) {
         // Create some voters at genesis
+        // Must match `setup()`'s `vec![100; validator_voting_keypairs.len()]` stake per validator.
         let stake_per_validator = 100;
         let SetupComponents {
             vote_tracker,
             validator_voting_keypairs,
             subscriptions,
+            bank: bank0,
             ..
         } = setup();
         let (votes_txs_sender, votes_txs_receiver) = unbounded();
@@ -1225,14 +1227,6 @@ mod tests {
         let (gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = unbounded();
         let (verified_voter_slots_sender, verified_voter_slots_receiver) = unbounded();
         let mut latest_vote_slot_per_validator = HashMap::new();
-
-        let GenesisConfigInfo { genesis_config, .. } =
-            genesis_utils::create_genesis_config_with_vote_accounts(
-                10_000,
-                &validator_voting_keypairs,
-                vec![stake_per_validator; validator_voting_keypairs.len()],
-            );
-        let bank0 = Bank::new_for_tests(&genesis_config);
 
         let gossip_vote_slots = vec![1, 2];
         let replay_vote_slots = vec![3, 4];
@@ -1367,22 +1361,14 @@ mod tests {
     #[test]
     fn test_process_votes2() {
         // Create some voters at genesis
+        let stake_per_validator = 100;
         let SetupComponents {
             vote_tracker,
             validator_voting_keypairs,
             subscriptions,
+            bank: bank0,
             ..
         } = setup();
-
-        // Create bank with the voters
-        let stake_per_validator = 100;
-        let GenesisConfigInfo { genesis_config, .. } =
-            genesis_utils::create_genesis_config_with_vote_accounts(
-                10_000,
-                &validator_voting_keypairs,
-                vec![stake_per_validator; validator_voting_keypairs.len()],
-            );
-        let bank0 = Bank::new_for_tests(&genesis_config);
 
         // Send some votes to process
         let (votes_txs_sender, votes_txs_receiver) = unbounded();
@@ -1801,8 +1787,7 @@ mod tests {
             );
         let bank = Bank::new_for_tests(&genesis_config);
         let exit = Arc::new(AtomicBool::new(false));
-        let bank_forks = BankForks::new_rw_arc(bank);
-        let bank = bank_forks.read().unwrap().get(0).unwrap();
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let vote_tracker = VoteTracker::default();
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
@@ -1911,6 +1896,7 @@ mod tests {
     struct SetupComponents {
         vote_tracker: Arc<VoteTracker>,
         bank: Arc<Bank>,
+        bank_forks: Arc<RwLock<BankForks>>,
         validator_voting_keypairs: Vec<ValidatorVoteKeypairs>,
         subscriptions: Arc<RpcSubscriptions>,
     }
@@ -1927,8 +1913,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let vote_tracker = VoteTracker::default();
         let exit = Arc::new(AtomicBool::new(false));
-        let bank_forks = BankForks::new_rw_arc(bank);
-        let bank = bank_forks.read().unwrap().get(0).unwrap();
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -1943,6 +1928,7 @@ mod tests {
         SetupComponents {
             vote_tracker: Arc::new(vote_tracker),
             bank,
+            bank_forks,
             validator_voting_keypairs,
             subscriptions,
         }
@@ -2070,8 +2056,7 @@ mod tests {
             );
         let bank = Bank::new_for_tests(&genesis_config);
         let exit = Arc::new(AtomicBool::new(false));
-        let bank_forks = BankForks::new_rw_arc(bank);
-        let bank = bank_forks.read().unwrap().get(0).unwrap();
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let vote_tracker = VoteTracker::default();
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -6411,17 +6411,17 @@ pub(crate) mod tests {
         let stake = 10_000;
         let (bank_forks_arc, mut progress_map, _) =
             vote_simulator::initialize_state(&keypairs, stake);
-        let mut bank_forks = bank_forks_arc.write().unwrap();
 
-        let bank0 = bank_forks.get(0).unwrap();
-        bank_forks.insert(Bank::new_from_parent(
+        let bank0 = bank_forks_arc.read().unwrap().get(0).unwrap();
+        Bank::new_from_parent_with_bank_forks(
+            &bank_forks_arc,
             bank0.clone(),
             SlotLeader::default(),
             9,
-        ));
-        let bank9 = bank_forks.get(9).unwrap();
-        bank_forks.insert(Bank::new_from_parent(bank9, SlotLeader::default(), 10));
-        bank_forks.set_root(9, None, None);
+        );
+        let bank9 = bank_forks_arc.read().unwrap().get(9).unwrap();
+        Bank::new_from_parent_with_bank_forks(&bank_forks_arc, bank9, SlotLeader::default(), 10);
+        bank_forks_arc.write().unwrap().set_root(9, None, None);
         let total_epoch_stake = bank0.total_epoch_stake();
 
         // Insert new ForkProgress for slot 10 and its
@@ -6456,8 +6456,6 @@ pub(crate) mod tests {
         // Make sure is_propagated == false so that the propagation logic
         // runs in `update_propagation_status`
         assert!(!progress_map.get_leader_propagation_slot_must_exist(10).0);
-
-        drop(bank_forks);
 
         let vote_tracker = VoteTracker::default();
         vote_tracker.insert_vote(10, vote_pubkey);
@@ -6514,20 +6512,24 @@ pub(crate) mod tests {
         let stake_per_validator = 10_000;
         let (bank_forks_arc, mut progress_map, _) =
             vote_simulator::initialize_state(&keypairs, stake_per_validator);
-        let mut bank_forks = bank_forks_arc.write().unwrap();
         progress_map
             .get_propagated_stats_mut(0)
             .unwrap()
             .is_leader_slot = true;
-        bank_forks.set_root(0, None, None);
-        let total_epoch_stake = bank_forks.root_bank().total_epoch_stake();
+        bank_forks_arc.write().unwrap().set_root(0, None, None);
+        let total_epoch_stake = bank_forks_arc
+            .read()
+            .unwrap()
+            .root_bank()
+            .total_epoch_stake();
 
         // Insert new ForkProgress representing a slot for all slots 1..=num_banks. Only
         // make even numbered ones leader slots
         for i in 1..=10 {
-            let parent_bank = bank_forks.get(i - 1).unwrap().clone();
+            let parent_bank = bank_forks_arc.read().unwrap().get(i - 1).unwrap().clone();
             let prev_leader_slot = ((i - 1) / 2) * 2;
-            bank_forks.insert(Bank::new_from_parent(parent_bank, SlotLeader::default(), i));
+            let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), i);
+            bank_forks_arc.write().unwrap().insert(bank);
             progress_map.insert(
                 i,
                 ForkProgress::new(
@@ -6554,8 +6556,6 @@ pub(crate) mod tests {
             // Insert a vote for the last bank for each voter
             vote_tracker.insert_vote(10, *vote_pubkey);
         }
-
-        drop(bank_forks);
 
         // The last bank should reach propagation threshold, and propagate it all
         // the way back through earlier leader banks
@@ -6597,21 +6597,21 @@ pub(crate) mod tests {
         let stake_per_validator = 10_000;
         let (bank_forks_arc, mut progress_map, _) =
             vote_simulator::initialize_state(&keypairs, stake_per_validator);
-        let mut bank_forks = bank_forks_arc.write().unwrap();
         progress_map
             .get_propagated_stats_mut(0)
             .unwrap()
             .is_leader_slot = true;
-        bank_forks.set_root(0, None, None);
+        bank_forks_arc.write().unwrap().set_root(0, None, None);
 
         let total_epoch_stake = num_validators as u64 * stake_per_validator;
 
         // Insert new ForkProgress representing a slot for all slots 1..=num_banks. Only
         // make even numbered ones leader slots
         for i in 1..=10 {
-            let parent_bank = bank_forks.get(i - 1).unwrap().clone();
+            let parent_bank = bank_forks_arc.read().unwrap().get(i - 1).unwrap().clone();
             let prev_leader_slot = i - 1;
-            bank_forks.insert(Bank::new_from_parent(parent_bank, SlotLeader::default(), i));
+            let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), i);
+            bank_forks_arc.write().unwrap().insert(bank);
             let mut fork_progress = ForkProgress::new(
                 Hash::default(),
                 Some(prev_leader_slot),
@@ -6643,7 +6643,6 @@ pub(crate) mod tests {
         // Insert a new vote
         vote_tracker.insert_vote(10, vote_pubkeys[2]);
 
-        drop(bank_forks);
         // The last bank should reach propagation threshold, and propagate it all
         // the way back through earlier leader banks
         ReplayStage::update_propagation_status(
@@ -6755,17 +6754,13 @@ pub(crate) mod tests {
         let bank0 = Bank::new_for_tests(&genesis_config::create_genesis_config(10000).0);
         let parent_slot_bank =
             Bank::new_from_parent(Arc::new(bank0), SlotLeader::default(), parent_slot);
-        let bank_forks = BankForks::new_rw_arc(parent_slot_bank);
-        let mut bank_forks = bank_forks.write().unwrap();
-        let bank5 = Bank::new_from_parent(
-            bank_forks.get(parent_slot).unwrap(),
-            SlotLeader::default(),
-            5,
-        );
-        bank_forks.insert(bank5);
+        let bank_forks_arc = BankForks::new_rw_arc(parent_slot_bank);
+        let parent_bank = bank_forks_arc.read().unwrap().get(parent_slot).unwrap();
+        let bank5 = Bank::new_from_parent(parent_bank, SlotLeader::default(), 5);
+        bank_forks_arc.write().unwrap().insert(bank5);
 
         // Should purge only `previous_leader_slot` from the progress map
-        progress_map.handle_new_root(&bank_forks);
+        progress_map.handle_new_root(&bank_forks_arc.read().unwrap());
 
         // Should succeed
         assert!(ReplayStage::check_propagation_for_start_leader(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2450,6 +2450,7 @@ impl<'a> ProcessBlockStore<'a> {
     }
 }
 
+// `--warp-slot`: runs at startup only (before PoH/replay), so fork graph access is serial here.
 fn maybe_warp_slot(
     config: &ValidatorConfig,
     process_blockstore: &mut ProcessBlockStore,

--- a/gossip/src/epoch_specs.rs
+++ b/gossip/src/epoch_specs.rs
@@ -96,7 +96,8 @@ mod tests {
     #[test]
     fn test_get_epoch_duration() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let mut bank = Bank::new_for_tests(&genesis_config);
+        let (mut bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let epoch = 0;
         let num_slots = 32;
         assert_eq!(bank.epoch(), epoch);
@@ -106,7 +107,12 @@ mod tests {
             Duration::from_millis(num_slots * 400)
         );
         for slot in 1..32 {
-            bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::new_unique(), slot);
+            bank = Bank::new_from_parent_with_bank_forks(
+                bank_forks.as_ref(),
+                bank,
+                SlotLeader::new_unique(),
+                slot,
+            );
             assert_eq!(bank.epoch(), epoch);
             assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
             assert_eq!(
@@ -117,7 +123,12 @@ mod tests {
         let epoch = 1;
         let num_slots = 64;
         for slot in 32..32 + num_slots {
-            bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::new_unique(), slot);
+            bank = Bank::new_from_parent_with_bank_forks(
+                bank_forks.as_ref(),
+                bank,
+                SlotLeader::new_unique(),
+                slot,
+            );
             assert_eq!(bank.epoch(), epoch);
             assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
             assert_eq!(
@@ -128,7 +139,12 @@ mod tests {
         let epoch = 2;
         let num_slots = 128;
         for slot in 96..96 + num_slots {
-            bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::new_unique(), slot);
+            bank = Bank::new_from_parent_with_bank_forks(
+                bank_forks.as_ref(),
+                bank,
+                SlotLeader::new_unique(),
+                slot,
+            );
             assert_eq!(bank.epoch(), epoch);
             assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
             assert_eq!(

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -4587,7 +4587,8 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(1_000_000_000);
-        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let bank = Bank::new_for_tests(&genesis_config);
+        let (mut bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
 
         const NUM_TRANSFERS_PER_ENTRY: usize = 8;
         const NUM_TRANSFERS: usize = NUM_TRANSFERS_PER_ENTRY * 32;
@@ -5791,7 +5792,8 @@ pub mod tests {
 
         // Create a genesis bank (slot 0) with all features active.
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let parent_bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (parent_bank, _bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
         // Insert parent shreds at slot 0 so get_block_merkle_root returns the
         // parent's block ID.

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -543,7 +543,7 @@ mod tests {
             .write()
             .unwrap()
             .insert(Bank::new_from_parent(
-                bank,
+                bank.clone(),
                 SlotLeader::default(),
                 target_slot,
             ))
@@ -594,7 +594,7 @@ mod tests {
     #[test]
     fn test_schedule_for_unconfirmed_epoch() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         let cache = LeaderScheduleCache::new_from_bank(&bank);
 
         assert_eq!(cache.max_epoch.load(Ordering::Acquire), 1);
@@ -609,16 +609,21 @@ mod tests {
         assert_eq!(bank.get_epoch_and_slot_index(96).0, 2);
         assert!(cache.slot_leader_at(96, Some(&bank)).is_none());
 
-        let bank2 = Bank::new_from_parent(bank, SlotLeader::new_unique(), 95);
+        let bank2 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank,
+            SlotLeader::new_unique(),
+            95,
+        );
         assert!(bank2.epoch_vote_accounts(2).is_some());
 
         // Set root for a slot in epoch 1, so that epoch 2 is now confirmed
-        cache.set_root(&bank2);
+        cache.set_root(bank2.as_ref());
         assert_eq!(cache.max_epoch.load(Ordering::Acquire), 2);
-        assert!(cache.slot_leader_at(96, Some(&bank2)).is_some());
+        assert!(cache.slot_leader_at(96, Some(bank2.as_ref())).is_some());
         assert_eq!(bank2.get_epoch_and_slot_index(223).0, 2);
-        assert!(cache.slot_leader_at(223, Some(&bank2)).is_some());
+        assert!(cache.slot_leader_at(223, Some(bank2.as_ref())).is_some());
         assert_eq!(bank2.get_epoch_and_slot_index(224).0, 3);
-        assert!(cache.slot_leader_at(224, Some(&bank2)).is_none());
+        assert!(cache.slot_leader_at(224, Some(bank2.as_ref())).is_none());
     }
 }

--- a/poh/benches/transaction_recorder.rs
+++ b/poh/benches/transaction_recorder.rs
@@ -46,7 +46,8 @@ fn bench_record_transactions(c: &mut Criterion) {
         hashes_per_tick: Some(solana_clock::DEFAULT_HASHES_PER_TICK),
     };
     let exit = Arc::new(AtomicBool::new(false));
-    let mut bank = Arc::new(Bank::new_for_tests(&genesis_config_info.genesis_config));
+    let bank = Bank::new_for_tests(&genesis_config_info.genesis_config);
+    let (mut bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Arc::new(
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger"),

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -1288,7 +1288,8 @@ mod tests {
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let prev_hash = bank0.last_blockhash();
         let (mut poh_recorder, entry_receiver) = PohRecorder::new(
             0,
@@ -1303,8 +1304,12 @@ mod tests {
         );
 
         bank0.fill_bank_with_ticks_for_tests();
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
-
+        let bank1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0,
+            SlotLeader::default(),
+            1,
+        );
         // Set a working bank
         poh_recorder.set_bank_for_test(bank1.clone());
 
@@ -1392,7 +1397,8 @@ mod tests {
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let prev_hash = bank0.last_blockhash();
         let (mut poh_recorder, entry_receiver) = PohRecorder::new(
             0,
@@ -1407,7 +1413,12 @@ mod tests {
         );
 
         bank0.fill_bank_with_ticks_for_tests();
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
+        let bank1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0,
+            SlotLeader::default(),
+            1,
+        );
         poh_recorder.set_bank_for_test(bank1.clone());
         // Let poh_recorder tick up to bank1.tick_height() - 1
         for _ in 0..bank1.tick_height() - 1 {
@@ -1469,7 +1480,8 @@ mod tests {
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let prev_hash = bank0.last_blockhash();
         let (mut poh_recorder, entry_receiver) = PohRecorder::new(
             0,
@@ -1484,7 +1496,12 @@ mod tests {
         );
 
         bank0.fill_bank_with_ticks_for_tests();
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
+        let bank1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0,
+            SlotLeader::default(),
+            1,
+        );
         poh_recorder.set_bank_for_test(bank1.clone());
 
         // Record up to exactly min tick height
@@ -1561,7 +1578,8 @@ mod tests {
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let prev_hash = bank0.last_blockhash();
         let (mut poh_recorder, entry_receiver) = PohRecorder::new(
             0,
@@ -1576,7 +1594,12 @@ mod tests {
         );
 
         bank0.fill_bank_with_ticks_for_tests();
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
+        let bank1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0,
+            SlotLeader::default(),
+            1,
+        );
         poh_recorder.set_bank_for_test(bank1);
 
         // Check we can make two ticks without hitting min_tick_height
@@ -1843,7 +1866,8 @@ mod tests {
         } = create_genesis_config(2);
 
         // Setup start bank.
-        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (mut bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let prev_hash = bank.last_blockhash();
 
         // Setup leader schedule.
@@ -1941,7 +1965,12 @@ mod tests {
         // Reset onto Leader A's last slot.
         for _ in leader_a_start_slot + 1..leader_b_start_slot {
             let child_slot = bank.slot() + 1;
-            bank = Arc::new(Bank::new_from_parent(bank, leader_a, child_slot));
+            bank = Bank::new_from_parent_with_bank_forks(
+                bank_forks.as_ref(),
+                bank,
+                leader_a,
+                child_slot,
+            );
         }
         poh_recorder.reset(bank.clone(), Some((leader_b_start_slot, leader_b_end_slot)));
 
@@ -1963,7 +1992,8 @@ mod tests {
 
         // Simulate generating Leader B's second slot.
         let child_slot = bank.slot() + 1;
-        bank = Arc::new(Bank::new_from_parent(bank, leader_b, child_slot));
+        bank =
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, leader_b, child_slot);
 
         // Reset PoH targeting Leader D's slots.
         poh_recorder.reset(bank, Some((leader_d_start_slot, leader_d_end_slot)));
@@ -2011,7 +2041,8 @@ mod tests {
             validator_pubkey,
             ..
         } = create_genesis_config(2);
-        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let prev_hash = bank0.last_blockhash();
         let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
             0,
@@ -2072,7 +2103,12 @@ mod tests {
         );
 
         // reset poh now. we should immediately be leader
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
+        let bank1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0.clone(),
+            SlotLeader::default(),
+            1,
+        );
         assert_eq!(bank1.slot(), 1);
         poh_recorder.reset(bank1.clone(), Some((2, 2)));
         assert_eq!(
@@ -2123,11 +2159,12 @@ mod tests {
 
         // Let's test that correct grace ticks are reported
         // Set the leader slot one slot down
-        let bank2 = Arc::new(Bank::new_from_parent(
+        let bank2 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
             bank1.clone(),
             SlotLeader::default(),
             2,
-        ));
+        );
         poh_recorder.reset(bank2.clone(), Some((4, 4)));
 
         // send ticks for a slot
@@ -2140,7 +2177,12 @@ mod tests {
             poh_recorder.reached_leader_slot(&test_validator_pubkey),
             PohLeaderStatus::NotReached
         );
-        let bank3 = Arc::new(Bank::new_from_parent(bank2, SlotLeader::default(), 3));
+        let bank3 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank2.clone(),
+            SlotLeader::default(),
+            3,
+        );
         assert_eq!(bank3.slot(), 3);
         poh_recorder.reset(bank3.clone(), Some((4, 4)));
 
@@ -2156,7 +2198,12 @@ mod tests {
         // Let's test that if a node overshoots the ticks for its target
         // leader slot, reached_leader_slot() will return true, because it's overdue
         // Set the leader slot one slot down
-        let bank4 = Arc::new(Bank::new_from_parent(bank3, SlotLeader::default(), 4));
+        let bank4 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank3.clone(),
+            SlotLeader::default(),
+            4,
+        );
         poh_recorder.reset(bank4.clone(), Some((5, 5)));
 
         // Overshoot ticks for the slot
@@ -2236,7 +2283,8 @@ mod tests {
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let prev_hash = bank.last_blockhash();
         let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
             0,
@@ -2271,8 +2319,12 @@ mod tests {
         assert!(!poh_recorder.would_be_leader(2 * bank.ticks_per_slot()));
 
         // Move the bank up a slot (so that max_tick_height > slot 0's tick_height)
-        let bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::default(), 1));
-        // If we set the working bank, the node should be leader within next 2 slots
+        let bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank,
+            SlotLeader::default(),
+            1,
+        ); // If we set the working bank, the node should be leader within next 2 slots
         poh_recorder.set_bank_for_test(bank.clone());
         assert!(poh_recorder.would_be_leader(2 * bank.ticks_per_slot()));
     }
@@ -2284,7 +2336,8 @@ mod tests {
         let blockstore = Blockstore::open(ledger_path.path())
             .expect("Expected to be able to open database ledger");
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let genesis_hash = bank.last_blockhash();
 
         let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
@@ -2299,8 +2352,12 @@ mod tests {
             Arc::new(AtomicBool::default()),
         );
         //create a new bank
-        let bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::default(), 2));
-        // add virtual ticks into poh for slots 0, 1, and 2
+        let bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank,
+            SlotLeader::default(),
+            2,
+        ); // add virtual ticks into poh for slots 0, 1, and 2
         for _ in 0..(bank.ticks_per_slot() * 3) {
             poh_recorder.tick();
         }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1022,17 +1022,21 @@ impl ProgramTest {
             bank.store_account(address, account);
         }
         bank.set_capitalization_for_tests(bank.calculate_capitalization_for_tests());
-        // Advance beyond slot 0 for a slightly more realistic test environment
-        let bank = {
-            let bank = Arc::new(bank);
-            bank.fill_bank_with_ticks_for_tests();
-            let bank = Bank::new_from_parent(bank.clone(), *bank.leader(), bank.slot() + 1);
-            debug!("Bank slot: {}", bank.slot());
-            bank
-        };
-        let slot = bank.slot();
-        let last_blockhash = bank.last_blockhash();
+        // Advance beyond slot 0 for a slightly more realistic test environment.
+        // Create BankForks from the genesis bank first so fork_graph is set before creating
+        // the child bank (required for ProgramCache::extract in new_from_parent).
+        bank.fill_bank_with_ticks_for_tests();
         let bank_forks = BankForks::new_rw_arc(bank);
+        let bank0 = bank_forks.read().unwrap().root_bank();
+        let bank1 = Bank::new_from_parent(bank0.clone(), *bank0.leader(), bank0.slot() + 1);
+        let bank1 = {
+            let mut bf = bank_forks.write().unwrap();
+            bf.insert(bank1);
+            bf.working_bank()
+        };
+        debug!("Bank slot: {}", bank1.slot());
+        let slot = bank1.slot();
+        let last_blockhash = bank1.last_blockhash();
         let block_commitment_cache = Arc::new(RwLock::new(
             BlockCommitmentCache::new_for_tests_with_slots(slot, slot),
         ));
@@ -1298,8 +1302,7 @@ impl ProgramTestContext {
 
     /// Force the working bank ahead to a new slot
     pub fn warp_to_slot(&mut self, warp_slot: Slot) -> Result<(), ProgramTestError> {
-        let mut bank_forks = self.bank_forks.write().unwrap();
-        let bank = bank_forks.working_bank();
+        let bank = self.bank_forks.read().unwrap().working_bank();
 
         // Fill ticks until a new blockhash is recorded, otherwise retried transactions will have
         // the same signature
@@ -1319,27 +1322,23 @@ impl ProgramTestContext {
             bank.freeze();
             bank
         } else {
-            bank_forks
-                .insert(Bank::warp_from_parent(
-                    bank,
-                    SlotLeader::default(),
-                    pre_warp_slot,
-                ))
+            let warped = Bank::warp_from_parent(bank, SlotLeader::default(), pre_warp_slot);
+            self.bank_forks
+                .write()
+                .unwrap()
+                .insert(warped)
                 .clone_without_scheduler()
         };
 
-        bank_forks.set_root(
+        self.bank_forks.write().unwrap().set_root(
             pre_warp_slot,
             None, // snapshots are disabled
             Some(pre_warp_slot),
         );
 
         // warp_bank is frozen so go forward to get unfrozen bank at warp_slot
-        bank_forks.insert(Bank::new_from_parent(
-            warp_bank,
-            SlotLeader::default(),
-            warp_slot,
-        ));
+        let bank_at_warp_slot = Bank::new_from_parent(warp_bank, SlotLeader::default(), warp_slot);
+        self.bank_forks.write().unwrap().insert(bank_at_warp_slot);
 
         // Update block commitment cache, otherwise banks server will poll at
         // the wrong slot
@@ -1350,7 +1349,7 @@ impl ProgramTestContext {
         // bank.
         w_block_commitment_cache.set_all_slots(warp_slot, warp_slot);
 
-        let bank = bank_forks.working_bank();
+        let bank = self.bank_forks.read().unwrap().working_bank();
         self.last_blockhash = bank.last_blockhash();
         Ok(())
     }
@@ -1365,15 +1364,14 @@ impl ProgramTestContext {
 
     /// warp forward one more slot and force reward interval end
     pub fn warp_forward_force_reward_interval_end(&mut self) -> Result<(), ProgramTestError> {
-        let mut bank_forks = self.bank_forks.write().unwrap();
-        let bank = bank_forks.working_bank();
+        let bank = self.bank_forks.read().unwrap().working_bank();
 
         // Fill ticks until a new blockhash is recorded, otherwise retried transactions will have
         // the same signature
         bank.fill_bank_with_ticks_for_tests();
         let pre_warp_slot = bank.slot();
 
-        bank_forks.set_root(
+        self.bank_forks.write().unwrap().set_root(
             pre_warp_slot,
             None, // snapshot_controller
             Some(pre_warp_slot),
@@ -1384,7 +1382,7 @@ impl ProgramTestContext {
         let mut warp_bank = Bank::new_from_parent(bank, SlotLeader::default(), warp_slot);
 
         warp_bank.force_reward_interval_end_for_tests();
-        bank_forks.insert(warp_bank);
+        self.bank_forks.write().unwrap().insert(warp_bank);
 
         // Update block commitment cache, otherwise banks server will poll at
         // the wrong slot
@@ -1395,7 +1393,7 @@ impl ProgramTestContext {
         // bank.
         w_block_commitment_cache.set_all_slots(warp_slot, warp_slot);
 
-        let bank = bank_forks.working_bank();
+        let bank = self.bank_forks.read().unwrap().working_bank();
         self.last_blockhash = bank.last_blockhash();
         Ok(())
     }

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -40,10 +40,9 @@ fn bench_accounts_create(bencher: &mut Bencher) {
 #[bench]
 fn bench_accounts_squash(bencher: &mut Bencher) {
     let (genesis_config, _) = create_genesis_config(100_000);
-    let mut prev_bank = Arc::new(Bank::new_with_paths_for_benches(
-        &genesis_config,
-        vec![PathBuf::from("bench_a1")],
-    ));
+    let prev_bank =
+        Bank::new_with_paths_for_benches(&genesis_config, vec![PathBuf::from("bench_a1")]);
+    let (mut prev_bank, _bank_forks) = prev_bank.wrap_with_bank_forks_for_tests();
     let mut pubkeys: Vec<Pubkey> = vec![];
     deposit_many(&prev_bank, &mut pubkeys, 250_000).unwrap();
     prev_bank.freeze();

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -793,7 +793,8 @@ mod test {
         let mut genesis_config_info = create_genesis_config(10);
         genesis_config_info.genesis_config.epoch_schedule =
             EpochSchedule::custom(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH, false);
-        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config_info.genesis_config));
+        let (mut bank, _bank_forks) = Bank::new_for_tests(&genesis_config_info.genesis_config)
+            .wrap_with_bank_forks_for_tests();
 
         // We need to get and set accounts-db's latest full snapshot slot to test
         // get_next_snapshot_request().  To workaround potential borrowing issues
@@ -918,7 +919,7 @@ mod test {
             pruned_banks_sender,
         ))));
 
-        let fork0_bank0 = Arc::new(bank);
+        let (fork0_bank0, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let fork0_bank1 = Arc::new(Bank::new_from_parent(
             fork0_bank0.clone(),
             SlotLeader::new_unique(),
@@ -963,6 +964,7 @@ mod test {
         drop(fork2_bank1);
         drop(fork0_bank1);
         drop(fork0_bank0);
+        drop(bank_forks);
         let num_banks_purged = pruned_banks_request_handler.handle_request(&fork0_bank3);
         assert_eq!(num_banks_purged, 7);
     }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -790,6 +790,7 @@ mod tests {
                 },
                 tests::create_genesis_config,
             },
+            bank_forks::BankForks,
             genesis_utils::{self, GenesisConfigInfo, deactivate_features},
             stake_account::StakeAccount,
             stake_utils,
@@ -819,7 +820,7 @@ mod tests {
         solana_vote_program::vote_state::{self, create_bls_proof_of_possession},
         std::{
             collections::HashSet,
-            sync::{Arc, RwLockReadGuard},
+            sync::{Arc, RwLock, RwLockReadGuard},
         },
         test_case::test_case,
     };
@@ -1068,7 +1069,11 @@ mod tests {
             .map(|(_, reward, _)| *reward)
     }
 
-    fn apply_epoch_operations(mut bank: Bank, op: EpochOperations) -> Bank {
+    fn apply_epoch_operations(
+        bank: Arc<Bank>,
+        bank_forks: &RwLock<BankForks>,
+        op: EpochOperations,
+    ) -> Arc<Bank> {
         assert_eq!(bank.epoch(), op.epoch);
         for (vote_address, vote_op) in &op.vote_operations {
             if let Some(balance) = &vote_op.create_with_balance {
@@ -1162,9 +1167,10 @@ mod tests {
         }
 
         // Advance bank to next epoch
-        let slot = bank.slot + SLOTS_PER_EPOCH;
-        let prev_bank = Arc::new(bank);
-        bank = Bank::new_from_parent(prev_bank.clone(), SlotLeader::new_unique(), slot);
+        let slot = bank.slot() + SLOTS_PER_EPOCH;
+        let prev_bank = bank.clone();
+        let bank =
+            Bank::new_from_parent_with_bank_forks(bank_forks, bank, SlotLeader::new_unique(), slot);
 
         for (vote_address, vote_op) in &op.vote_operations {
             let expected_commission = vote_op.expected_reward_commission;
@@ -1242,13 +1248,15 @@ mod tests {
             deactivate_features(&mut genesis_config, &vec![delay_commission_updates::id()]);
         }
 
-        let mut bank = Bank::new_for_tests(&genesis_config);
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let vote_address = Pubkey::new_unique();
 
         // No reward should be given in the epoch that a vote account is
         // delegated to for the first time
-        bank = apply_epoch_operations(
+        let mut bank = apply_epoch_operations(
             bank,
+            bank_forks.as_ref(),
             EpochOperations {
                 epoch: 0,
                 vote_operations: vec![(
@@ -1271,6 +1279,7 @@ mod tests {
             let expected_commission = if delay_commission_updates { 1 } else { 2 };
             apply_epoch_operations(
                 bank,
+                bank_forks.as_ref(),
                 EpochOperations {
                     epoch: 1,
                     vote_operations: vec![(
@@ -1289,6 +1298,7 @@ mod tests {
         let expected_commission = if delay_commission_updates { 1 } else { 3 };
         apply_epoch_operations(
             bank,
+            bank_forks.as_ref(),
             EpochOperations {
                 epoch: 2,
                 vote_operations: vec![(
@@ -1315,12 +1325,14 @@ mod tests {
         );
 
         genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
-        let mut bank = Bank::new_for_tests(&genesis_config);
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         assert!(bank.feature_set.is_active(&delay_commission_updates::id()));
 
         let vote_address = Pubkey::new_unique();
-        bank = apply_epoch_operations(
+        let mut bank = apply_epoch_operations(
             bank,
+            bank_forks.as_ref(),
             EpochOperations {
                 epoch: 0,
                 vote_operations: vec![(
@@ -1338,6 +1350,7 @@ mod tests {
         // commission falls back to the latest commission rate for that epoch
         bank = apply_epoch_operations(
             bank,
+            bank_forks.as_ref(),
             EpochOperations {
                 epoch: 1,
                 vote_operations: vec![(
@@ -1358,6 +1371,7 @@ mod tests {
         // previous epoch
         bank = apply_epoch_operations(
             bank,
+            bank_forks.as_ref(),
             EpochOperations {
                 epoch: 2,
                 vote_operations: vec![(
@@ -1374,6 +1388,7 @@ mod tests {
 
         apply_epoch_operations(
             bank,
+            bank_forks.as_ref(),
             EpochOperations {
                 epoch: 3,
                 vote_operations: vec![(
@@ -1402,15 +1417,17 @@ mod tests {
         );
 
         genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
-        let mut bank = Bank::new_for_tests(&genesis_config);
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         assert!(bank.feature_set.is_active(&delay_commission_updates::id()));
 
         let genesis_vote_address = voting_keypair.pubkey();
 
         // Check that staked genesis vote accounts use the initial commission
         // rate for the first reward epoch
-        bank = apply_epoch_operations(
+        let mut bank = apply_epoch_operations(
             bank,
+            bank_forks.as_ref(),
             EpochOperations {
                 epoch: 0,
                 vote_operations: vec![(
@@ -1429,6 +1446,7 @@ mod tests {
         // rate for the second reward epoch too.
         bank = apply_epoch_operations(
             bank,
+            bank_forks.as_ref(),
             EpochOperations {
                 epoch: 1,
                 vote_operations: vec![(
@@ -1445,6 +1463,7 @@ mod tests {
 
         bank = apply_epoch_operations(
             bank,
+            bank_forks.as_ref(),
             EpochOperations {
                 epoch: 2,
                 vote_operations: vec![(
@@ -1460,6 +1479,7 @@ mod tests {
 
         bank = apply_epoch_operations(
             bank,
+            bank_forks.as_ref(),
             EpochOperations {
                 epoch: 3,
                 vote_operations: vec![(
@@ -1475,6 +1495,7 @@ mod tests {
 
         apply_epoch_operations(
             bank,
+            bank_forks.as_ref(),
             EpochOperations {
                 epoch: 4,
                 vote_operations: vec![(
@@ -1600,7 +1621,7 @@ mod tests {
         let expected_num_delegations = 4;
         let num_rewards_per_block = 2;
         // Distribute 4 rewards over 2 blocks
-        let (RewardBank { bank, .. }, _) = create_reward_bank(
+        let (RewardBank { bank, .. }, bank_forks) = create_reward_bank(
             expected_num_delegations,
             num_rewards_per_block,
             SLOTS_PER_EPOCH,
@@ -1659,7 +1680,12 @@ mod tests {
         // boundary; slot is advanced 2 to demonstrate that distribution works
         // on block-height, not slot
         let new_slot = bank.slot() + 2;
-        let bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::default(), new_slot));
+        let bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank,
+            SlotLeader::default(),
+            new_slot,
+        );
 
         let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
         let (_, recalculated_rewards, recalculated_partition_indices) =
@@ -1692,7 +1718,12 @@ mod tests {
 
         // Advance to last distribution slot
         let new_slot = bank.slot() + 1;
-        let bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::default(), new_slot));
+        let bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank,
+            SlotLeader::default(),
+            new_slot,
+        );
 
         let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
         assert!(!epoch_rewards_sysvar.active);
@@ -1774,7 +1805,7 @@ mod tests {
         let mut stakes = vec![2_000_000_000; expected_num_delegations];
         // Add stake large enough to be affected by total-rewards discrepancy
         stakes.push(40_000_000_000);
-        let (RewardBank { bank, .. }, _) = create_reward_bank_with_specific_stakes(
+        let (RewardBank { bank, .. }, _bank_forks) = create_reward_bank_with_specific_stakes(
             stakes,
             num_rewards_per_block,
             SLOTS_PER_EPOCH - 1,
@@ -1848,7 +1879,7 @@ mod tests {
         let sysvar = bank.get_epoch_rewards_sysvar();
         assert_eq!(point_value.rewards, sysvar.total_rewards);
 
-        // Advance to first distribution slot
+        // Advance to first distribution slot (bank_forks kept in scope so parent has fork_graph)
         let mut bank =
             Bank::new_from_parent(Arc::new(bank), SlotLeader::default(), SLOTS_PER_EPOCH + 1);
 
@@ -1909,13 +1940,13 @@ mod tests {
             3_000_000_000, // valid delegation
             4_000_000_000, // valid delegation
         ];
-        let (RewardBank { bank, .. }, _) = create_reward_bank_with_specific_stakes(
+        let (RewardBank { bank, .. }, bank_forks) = create_reward_bank_with_specific_stakes(
             stakes,
             num_rewards_per_block,
             SLOTS_PER_EPOCH - 1,
         );
 
-        // Advance to next epoch boundary
+        // Advance to next epoch boundary (bank_forks kept in scope so parent has fork_graph)
         let new_slot = bank.slot() + 1;
         let mut bank = Bank::new_from_parent(bank, SlotLeader::default(), new_slot);
 
@@ -1951,6 +1982,7 @@ mod tests {
             calculation_status.all_stake_rewards.num_rewards(),
             expected_num_stake_rewards
         );
+        let _ = &bank_forks; // Keep in scope so parent banks retain fork_graph
     }
 
     #[test]
@@ -2111,8 +2143,9 @@ mod tests {
                 .insert(stake_pubkey, stake_account.into());
         }
 
-        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-        let next_epoch_slot = bank.get_slots_in_epoch(bank.epoch);
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        let next_epoch_slot = bank.get_slots_in_epoch(bank.epoch());
         {
             let cache = bank.epoch_rewards_calculation_cache.lock().unwrap();
             assert!(
@@ -2121,8 +2154,12 @@ mod tests {
             );
         }
 
-        let bank_fork1 =
-            Bank::new_from_parent(Arc::clone(&bank), SlotLeader::default(), next_epoch_slot);
+        let bank_fork1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank.clone(),
+            SlotLeader::default(),
+            next_epoch_slot,
+        );
         {
             let cache = bank_fork1.epoch_rewards_calculation_cache.lock().unwrap();
             assert!(
@@ -2131,7 +2168,12 @@ mod tests {
             );
         }
 
-        let bank_fork2 = Bank::new_from_parent(bank, SlotLeader::default(), next_epoch_slot);
+        // Use new_from_parent (not _with_bank_forks) - we can't insert two banks at same slot
+        let bank_fork2 = Arc::new(Bank::new_from_parent(
+            bank.clone(),
+            SlotLeader::default(),
+            next_epoch_slot,
+        ));
         {
             let cache = bank_fork2.epoch_rewards_calculation_cache.lock().unwrap();
             assert!(

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -1127,7 +1127,7 @@ mod tests {
         let starting_slot = SLOTS_PER_EPOCH - 1;
         let num_rewards = 100;
         let stake_account_stores_per_block = 50;
-        let (RewardBank { bank, .. }, _) =
+        let (RewardBank { bank, .. }, bank_forks) =
             create_reward_bank(num_rewards, stake_account_stores_per_block, starting_slot);
 
         // Slot before the epoch boundary contains empty rewards (since fees are
@@ -1140,11 +1140,12 @@ mod tests {
             }
         );
 
-        let epoch_boundary_bank = Arc::new(Bank::new_from_parent(
+        let epoch_boundary_bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
             bank,
             SlotLeader::default(),
             SLOTS_PER_EPOCH,
-        ));
+        );
         // Slot at the epoch boundary contains voting rewards only, as well as partition data
         let KeyedRewardsAndNumPartitions {
             keyed_rewards,
@@ -1161,11 +1162,12 @@ mod tests {
 
         let mut total_staking_rewards = 0;
 
-        let partition0_bank = Arc::new(Bank::new_from_parent(
+        let partition0_bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
             epoch_boundary_bank,
             SlotLeader::default(),
             SLOTS_PER_EPOCH + 1,
-        ));
+        );
         // Slot after the epoch boundary contains first partition of staking
         // rewards, and no partitions because not at the epoch boundary
         let KeyedRewardsAndNumPartitions {
@@ -1178,11 +1180,12 @@ mod tests {
         total_staking_rewards += keyed_rewards.len();
         assert_eq!(num_partitions, None);
 
-        let partition1_bank = Arc::new(Bank::new_from_parent(
+        let partition1_bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
             partition0_bank,
             SlotLeader::default(),
             SLOTS_PER_EPOCH + 2,
-        ));
+        );
         // Slot 2 after the epoch boundary contains second partition of staking
         // rewards, and no partitions because not at the epoch boundary
         let KeyedRewardsAndNumPartitions {

--- a/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
@@ -110,7 +110,6 @@ mod tests {
         solana_account::ReadableAccount,
         solana_epoch_schedule::EpochSchedule,
         solana_native_token::LAMPORTS_PER_SOL,
-        std::sync::Arc,
     };
 
     /// Test `EpochRewards` sysvar creation, distribution, and burning.
@@ -121,7 +120,8 @@ mod tests {
         let (mut genesis_config, _mint_keypair) =
             create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
         genesis_config.epoch_schedule = EpochSchedule::custom(432000, 432000, false);
-        let bank = Bank::new_for_tests(&genesis_config);
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
         let total_rewards = 1_000_000_000;
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
@@ -159,7 +159,12 @@ mod tests {
         // Create a child bank to test parent_blockhash
         let parent_blockhash = bank.last_blockhash();
         let parent_slot = bank.slot();
-        let bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::default(), parent_slot + 1);
+        let bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank,
+            SlotLeader::default(),
+            parent_slot + 1,
+        );
         // Also note that running `create_epoch_rewards_sysvar()` against a bank
         // with an existing EpochRewards sysvar clobbers the previous values
         bank.create_epoch_rewards_sysvar(10, 42, num_partitions, &point_value);

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -88,16 +88,28 @@ mod tests {
             mut genesis_config, ..
         } = create_genesis_config_with_leader(500, &leader_id, LAMPORTS_PER_SOL);
         genesis_config.epoch_schedule = EpochSchedule::custom(400, 400, false);
-        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let deposit_amount = bank0.get_minimum_balance_for_rent_exemption(0);
-        let bank1 = Bank::new_from_parent(bank0.clone(), *bank0.leader(), 1);
+        let bank1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0.clone(),
+            *bank0.leader(),
+            1,
+        );
 
         // Create an account on a non-root fork
         let key1 = Pubkey::new_unique();
         bank_test_utils::deposit(&bank1, &key1, deposit_amount).unwrap();
 
         let bank2_slot = 2;
-        let bank2 = Bank::new_from_parent(bank0.clone(), *bank0.leader(), bank2_slot);
+        let bank0_leader = *bank0.leader();
+        let bank2 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0,
+            bank0_leader,
+            bank2_slot,
+        );
 
         // Test new account
         let key2 = Pubkey::new_unique();
@@ -178,7 +190,7 @@ mod tests {
             expected_accounts_lt_hash,
         );
         assert_eq!(dbank.get_bank_hash_stats(), bank2.get_bank_hash_stats());
-        assert_eq!(dbank, bank2);
+        assert_eq!(&dbank, bank2.as_ref());
     }
 
     fn add_root_and_flush_write_cache(bank: &Bank) {
@@ -194,7 +206,8 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } =
             create_genesis_config_with_leader(500, &leader_id, LAMPORTS_PER_SOL);
 
-        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank0, _bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         bank0.squash();
         let mut bank = Bank::new_from_parent(bank0.clone(), *bank0.leader(), 1);
         bank.set_block_id(Some(Hash::default()));
@@ -277,8 +290,10 @@ mod tests {
         } = create_genesis_config_with_leader(500, &leader_id, LAMPORTS_PER_SOL);
         activate_all_features(&mut genesis_config);
 
-        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
-        let mut bank = Bank::new_from_parent(bank0.clone(), *bank0.leader(), 1);
+        let (bank0, _bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        let bank0_leader = *bank0.leader();
+        let mut bank = Bank::new_from_parent(bank0, bank0_leader, 1);
         while !bank.is_complete() {
             bank.fill_bank_with_ticks_for_tests();
         }

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -6,14 +6,15 @@ mod tests {
     use {
         super::*, crate::inflation_rewards::points::PointValue,
         solana_genesis_config::create_genesis_config, solana_leader_schedule::SlotLeader,
-        solana_sysvar::epoch_rewards::EpochRewards, std::sync::Arc,
+        solana_sysvar::epoch_rewards::EpochRewards,
     };
 
     #[test]
     #[allow(deprecated)]
     fn test_sysvar_cache_initialization() {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
-        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
         let bank0_sysvar_cache = bank0.transaction_processor.sysvar_cache();
         let bank0_cached_clock = bank0_sysvar_cache.get_clock();
@@ -27,11 +28,12 @@ mod tests {
         assert!(bank0_sysvar_cache.get_epoch_rewards().is_err()); // partitioned epoch reward feature is not enabled
 
         let bank1_slot = bank0.slot() + 1;
-        let bank1 = Arc::new(Bank::new_from_parent(
+        let bank1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
             bank0.clone(),
             SlotLeader::default(),
             bank1_slot,
-        ));
+        );
 
         let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache();
         let bank1_cached_clock = bank1_sysvar_cache.get_clock();
@@ -49,7 +51,12 @@ mod tests {
         assert_eq!(bank0_cached_rent, bank1_cached_rent);
 
         let bank2_slot = bank1.slot() + 1;
-        let bank2 = Bank::new_from_parent(bank1.clone(), SlotLeader::default(), bank2_slot);
+        let bank2 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank1.clone(),
+            SlotLeader::default(),
+            bank2_slot,
+        );
 
         let bank2_sysvar_cache = bank2.transaction_processor.sysvar_cache();
         let bank2_cached_clock = bank2_sysvar_cache.get_clock();
@@ -75,9 +82,15 @@ mod tests {
     #[allow(deprecated)]
     fn test_reset_and_fill_sysvar_cache() {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
-        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let bank1_slot = bank0.slot() + 1;
-        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), bank1_slot);
+        let bank1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0,
+            SlotLeader::default(),
+            bank1_slot,
+        );
 
         let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache();
         let bank1_cached_clock = bank1_sysvar_cache.get_clock();
@@ -129,7 +142,7 @@ mod tests {
 
         bank1
             .transaction_processor
-            .fill_missing_sysvar_cache_entries(&bank1);
+            .fill_missing_sysvar_cache_entries(&*bank1);
 
         let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache();
         assert_eq!(bank1_sysvar_cache.get_clock(), bank1_cached_clock);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -266,7 +266,8 @@ impl Bank {
 #[test]
 fn test_bank_unix_timestamp_from_genesis() {
     let (genesis_config, _mint_keypair) = create_genesis_config(1);
-    let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (mut bank, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
     assert_eq!(
         genesis_config.creation_time,
@@ -419,7 +420,7 @@ fn bank2_sysvar_delta() -> u64 {
 
 #[test]
 fn test_bank_capitalization() {
-    let bank0 = Arc::new(Bank::new_for_tests(&GenesisConfig {
+    let (bank0, _bank_forks) = Bank::new_for_tests(&GenesisConfig {
         accounts: (0..42)
             .map(|_| {
                 (
@@ -430,7 +431,8 @@ fn test_bank_capitalization() {
             .collect(),
         cluster_type: ClusterType::MainnetBeta,
         ..GenesisConfig::default()
-    }));
+    })
+    .wrap_with_bank_forks_for_tests();
 
     assert_eq!(
         bank0.capitalization(),
@@ -732,7 +734,7 @@ where
     agave_logger::setup();
 
     // create a bank that ticks really slowly...
-    let bank0 = Arc::new(Bank::new_for_tests(&GenesisConfig {
+    let bank0 = Bank::new_for_tests(&GenesisConfig {
         accounts: (0..42)
             .map(|_| {
                 (
@@ -752,7 +754,8 @@ where
         cluster_type: ClusterType::MainnetBeta,
 
         ..GenesisConfig::default()
-    }));
+    });
+    let (bank0, _bank_forks) = bank0.wrap_with_bank_forks_for_tests();
 
     assert_eq!(
         bank0.capitalization(),
@@ -884,7 +887,7 @@ where
 
 fn do_test_bank_update_rewards_determinism() -> u64 {
     // create a bank that ticks really slowly...
-    let bank = Arc::new(Bank::new_for_tests(&GenesisConfig {
+    let (bank, _bank_forks) = Bank::new_for_tests(&GenesisConfig {
         accounts: (0..42)
             .map(|_| {
                 (
@@ -904,7 +907,8 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
         cluster_type: ClusterType::MainnetBeta,
 
         ..GenesisConfig::default()
-    }));
+    })
+    .wrap_with_bank_forks_for_tests();
 
     assert_eq!(
         bank.capitalization(),
@@ -1684,9 +1688,9 @@ fn test_readonly_accounts(relax_intrabatch_account_locks: bool) {
         bank.deactivate_feature(&feature_set::relax_intrabatch_account_locks::id());
     }
 
-    let next_slot = bank.slot() + 1;
-    let bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::default(), next_slot);
     let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
+    let next_slot = bank.slot() + 1;
+    let bank = Bank::new_from_parent(bank, SlotLeader::default(), next_slot);
 
     let vote_pubkey0 = solana_pubkey::new_rand();
     let vote_pubkey1 = solana_pubkey::new_rand();
@@ -2172,7 +2176,8 @@ fn new_from_parent_with_fork_next_slot(parent: Arc<Bank>, fork: &RwLock<BankFork
 #[test]
 fn test_bank_parents() {
     let (genesis_config, _) = create_genesis_config(1);
-    let parent = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (parent, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
     let bank = new_from_parent(parent.clone());
     assert!(Arc::ptr_eq(&bank.parents()[0], &parent));
@@ -2477,7 +2482,8 @@ fn test_hash_internal_state_error() {
 
 #[test]
 fn test_bank_hash_internal_state_squash() {
-    let bank0 = Arc::new(Bank::new_for_tests(&create_genesis_config(10).0));
+    let (bank0, _bank_forks) =
+        Bank::new_for_tests(&create_genesis_config(10).0).wrap_with_bank_forks_for_tests();
     let hash0 = bank0.hash_internal_state();
     // save hash0 because new_from_parent
     // updates sysvar entries
@@ -2722,7 +2728,8 @@ fn test_bank_update_sysvar_account() {
         for feature_id in FeatureSet::default().inactive() {
             activate_feature(&mut genesis_config, *feature_id);
         }
-        let bank1 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank1, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         if pass == 0 {
             add_root_and_flush_write_cache(&bank1);
             assert_eq!(
@@ -2793,11 +2800,12 @@ fn test_bank_update_sysvar_account() {
         }
 
         // Updating should increment the clock's slot
-        let bank2 = Arc::new(Bank::new_from_parent(
+        let bank2 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
             bank1.clone(),
             SlotLeader::default(),
             1,
-        ));
+        );
         add_root_and_flush_write_cache(&bank1);
         assert_capitalization_diff(
             &bank2,
@@ -2883,7 +2891,8 @@ fn test_bank_epoch_vote_accounts() {
     genesis_config.epoch_schedule =
         EpochSchedule::custom(SLOTS_PER_EPOCH, LEADER_SCHEDULE_SLOT_OFFSET, false);
 
-    let parent = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (parent, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
     let mut leader_vote_stake: Vec<_> = parent
         .epoch_vote_accounts(0)
         .map(|accounts| {
@@ -3115,7 +3124,8 @@ fn test_bank_inherit_fee_rate_governor() {
         .fee_rate_governor
         .target_lamports_per_signature = 123;
 
-    let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank0, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
     let bank1 = Arc::new(new_from_parent(bank0.clone()));
     assert_eq!(
         bank0.fee_rate_governor.target_lamports_per_signature / 2,
@@ -3304,7 +3314,8 @@ fn test_is_delta_with_no_committables() {
 #[test]
 fn test_bank_get_program_accounts() {
     let (genesis_config, mint_keypair) = create_genesis_config(500);
-    let parent = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (parent, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
     let genesis_accounts: Vec<_> = parent.get_all_accounts(false).unwrap();
     assert!(
@@ -3421,10 +3432,8 @@ fn test_get_filtered_indexed_accounts() {
             ..ACCOUNTS_DB_CONFIG_FOR_TESTING
         },
     };
-    let bank = Arc::new(Bank::new_with_config_for_tests(
-        &genesis_config,
-        bank_config,
-    ));
+    let (bank, bank_forks) = Bank::new_with_config_for_tests(&genesis_config, bank_config)
+        .wrap_with_bank_forks_for_tests();
 
     let address = Pubkey::new_unique();
     let program_id = Pubkey::new_unique();
@@ -3447,7 +3456,12 @@ fn test_get_filtered_indexed_accounts() {
     // demonstrates the need for a redundant post-processing filter.
     let another_program_id = Pubkey::new_unique();
     let new_account = AccountSharedData::new(1, 0, &another_program_id);
-    let bank = Arc::new(new_from_parent(bank));
+    let bank = Bank::new_from_parent_with_bank_forks(
+        bank_forks.as_ref(),
+        bank.clone(),
+        SlotLeader::default(),
+        bank.slot() + 1,
+    );
     bank.store_account(&address, &new_account);
     let indexed_accounts = bank
         .get_filtered_indexed_accounts(
@@ -3764,7 +3778,8 @@ fn test_blockhash_queue_sysvar_consistency() {
 #[test]
 fn test_hash_internal_state_unchanged() {
     let (genesis_config, _) = create_genesis_config(500);
-    let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank0, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
     bank0.freeze();
     let bank0_hash = bank0.hash();
     let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
@@ -3777,7 +3792,7 @@ fn test_hash_internal_state_unchanged() {
 #[test]
 fn test_hash_internal_state_unchanged_with_ticks() {
     let (genesis_config, _) = create_genesis_config(500);
-    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank, _bank_forks) = Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
     let bank1 = new_from_parent(bank);
     let hash1 = bank1.hash_internal_state();
     // ticks don't change its state even if a slot boundary is crossed
@@ -5238,7 +5253,7 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
         feature_set.deactivate(&feature_set::deprecate_rent_exemption_threshold::id());
     }
 
-    let mut bank = Arc::new(Bank::new_from_genesis(
+    let (mut bank, _bank_forks) = Bank::new_from_genesis(
         &genesis_config,
         Arc::new(RuntimeConfig::default()),
         vec![],
@@ -5252,7 +5267,8 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
         Arc::default(),
         None,
         Some(feature_set),
-    ));
+    )
+    .wrap_with_bank_forks_for_tests();
     loop {
         goto_end_of_slot(Arc::clone(&bank));
         if bank.slot == 0 {
@@ -5342,10 +5358,9 @@ fn test_shrink_candidate_slots_cached() {
     let pubkey2 = solana_pubkey::new_rand();
 
     // Set root for bank 0, with caching enabled
-    let bank0 = Arc::new(Bank::new_with_config_for_tests(
-        &genesis_config,
-        BankTestConfig::default(),
-    ));
+    let (bank0, bank_forks) =
+        Bank::new_with_config_for_tests(&genesis_config, BankTestConfig::default())
+            .wrap_with_bank_forks_for_tests();
 
     // Make pubkey0 large so any slot containing it is a candidate for shrinking
     let pubkey0_size = 100_000;
@@ -5362,7 +5377,12 @@ fn test_shrink_candidate_slots_cached() {
 
     // Store some lamports in bank 1
     let some_lamports = 123;
-    let bank1 = Arc::new(new_from_parent(bank0));
+    let bank1 = Bank::new_from_parent_with_bank_forks(
+        bank_forks.as_ref(),
+        bank0.clone(),
+        SlotLeader::default(),
+        bank0.slot() + 1,
+    );
     test_utils::deposit(&bank1, &pubkey1, some_lamports).unwrap();
     test_utils::deposit(&bank1, &pubkey2, some_lamports).unwrap();
     goto_end_of_slot(bank1.clone());
@@ -5373,7 +5393,12 @@ fn test_shrink_candidate_slots_cached() {
     bank1.force_flush_accounts_cache();
 
     // Store some lamports for pubkey1 in bank 2, root bank 2
-    let bank2 = Arc::new(new_from_parent(bank1));
+    let bank2 = Bank::new_from_parent_with_bank_forks(
+        bank_forks.as_ref(),
+        bank1.clone(),
+        SlotLeader::default(),
+        bank1.slot() + 1,
+    );
     test_utils::deposit(&bank2, &pubkey1, some_lamports).unwrap();
     bank2.store_account(&pubkey0, &account0);
     goto_end_of_slot(bank2.clone());
@@ -5465,11 +5490,14 @@ fn test_add_builtin_account() {
         // The account at program_id will be created initially with just 1 lamport.
         let program_id = Pubkey::new_from_array([0xFF; 32]);
 
-        let bank = Arc::new(Bank::new_from_parent(
-            Arc::new(Bank::new_for_tests(&genesis_config)),
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        let bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0.clone(),
             SlotLeader::default(),
             slot,
-        ));
+        );
         add_root_and_flush_write_cache(&bank.parent().unwrap());
         assert_eq!(bank.get_account_modified_slot(&program_id), None);
 
@@ -5639,11 +5667,14 @@ fn test_add_precompiled_account() {
         let slot = 123;
         let program_id = solana_pubkey::new_rand();
 
-        let bank = Arc::new(Bank::new_from_parent(
-            Arc::new(Bank::new_for_tests(&genesis_config)),
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        let bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0.clone(),
             SlotLeader::default(),
             slot,
-        ));
+        );
         add_root_and_flush_write_cache(&bank.parent().unwrap());
         assert_eq!(bank.get_account_modified_slot(&program_id), None);
 
@@ -7011,9 +7042,10 @@ fn test_update_clock_timestamp() {
         voting_keypair,
         ..
     } = create_genesis_config_with_leader(5, &leader_pubkey, 3);
-    let mut bank = Bank::new_for_tests(&genesis_config);
+    let (bank0, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
     // Advance past slot 0, which has special handling.
-    bank = new_from_parent(Arc::new(bank));
+    let mut bank = new_from_parent(bank0.clone());
     bank = new_from_parent(Arc::new(bank));
     assert_eq!(
         bank.clock().unix_timestamp,
@@ -7112,7 +7144,8 @@ fn test_timestamp_slow() {
     } = create_genesis_config_with_leader(5, &leader_pubkey, 3);
     let slots_in_epoch = 32;
     genesis_config.epoch_schedule = EpochSchedule::new(slots_in_epoch);
-    let mut bank = Bank::new_for_tests(&genesis_config);
+    let (mut bank, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
     let slot_duration = Duration::from_nanos(bank.ns_per_slot as u64);
 
     let recent_timestamp: UnixTimestamp = bank.unix_timestamp_from_genesis();
@@ -7130,7 +7163,7 @@ fn test_timestamp_slow() {
     // additional_secs greater than MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2 for an epoch
     // timestamp bounded to 150% deviation
     for _ in 0..31 {
-        bank = new_from_parent(Arc::new(bank));
+        bank = Arc::new(new_from_parent(bank));
         assert_eq!(
             bank.clock().unix_timestamp,
             bank.clock().epoch_start_timestamp
@@ -7156,7 +7189,8 @@ fn test_timestamp_fast() {
     } = create_genesis_config_with_leader(5, &leader_pubkey, 3);
     let slots_in_epoch = 32;
     genesis_config.epoch_schedule = EpochSchedule::new(slots_in_epoch);
-    let mut bank = Bank::new_for_tests(&genesis_config);
+    let (mut bank, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
     let recent_timestamp: UnixTimestamp = bank.unix_timestamp_from_genesis();
     let additional_secs = 5; // Greater than MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST for full epoch
@@ -7172,7 +7206,7 @@ fn test_timestamp_fast() {
     // additional_secs greater than MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST for an epoch
     // timestamp bounded to 25% deviation
     for _ in 0..31 {
-        bank = new_from_parent(Arc::new(bank));
+        bank = Arc::new(new_from_parent(bank));
         assert_eq!(
             bank.clock().unix_timestamp,
             bank.clock().epoch_start_timestamp
@@ -7275,10 +7309,7 @@ fn test_store_scan_consistency<F>(
         create_genesis_config_with_leader(10, &solana_pubkey::new_rand(), 374_999_998_287_840)
             .genesis_config;
     genesis_config.rent = Rent::free();
-    let bank0 = Arc::new(Bank::new_with_config_for_tests(
-        &genesis_config,
-        BankTestConfig::default(),
-    ));
+    let bank0 = Bank::new_with_config_for_tests(&genesis_config, BankTestConfig::default());
     bank0.set_callback(drop_callback);
 
     // Set up pubkeys to write to
@@ -7295,6 +7326,9 @@ fn test_store_scan_consistency<F>(
     for key in &all_pubkeys {
         bank0.store_account(key, &starting_account);
     }
+
+    let bank_forks = BankForks::new_rw_arc(bank0);
+    let bank0 = bank_forks.read().unwrap().root_bank();
 
     // Set aside a subset of accounts to modify
     let pubkeys_to_modify: Arc<HashSet<Pubkey>> = Arc::new(
@@ -7819,10 +7853,11 @@ fn test_get_inflation_start_slot_devnet_testnet() {
         genesis_config.accounts.remove(&pair.enable_id).unwrap();
     }
 
-    let bank = Bank::new_for_tests(&genesis_config);
+    let (bank0, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
     // Advance slot
-    let mut bank = new_from_parent(Arc::new(bank));
+    let mut bank = new_from_parent(bank0.clone());
     bank = new_from_parent(Arc::new(bank));
     assert_eq!(bank.get_inflation_start_slot(), 0);
     assert_eq!(bank.slot(), 2);
@@ -7900,10 +7935,11 @@ fn test_get_inflation_start_slot_mainnet() {
         genesis_config.accounts.remove(&pair.enable_id).unwrap();
     }
 
-    let bank = Bank::new_for_tests(&genesis_config);
+    let (bank0, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
     // Advance slot
-    let mut bank = new_from_parent(Arc::new(bank));
+    let mut bank = new_from_parent(bank0.clone());
     bank = new_from_parent(Arc::new(bank));
     assert_eq!(bank.get_inflation_start_slot(), 0);
     assert_eq!(bank.slot(), 2);
@@ -7987,9 +8023,11 @@ fn test_get_inflation_num_slots_with_activations() {
         genesis_config.accounts.remove(&pair.enable_id).unwrap();
     }
 
-    let mut bank = Bank::new_for_tests(&genesis_config);
+    let (bank0, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+    let mut bank = new_from_parent(bank0);
     assert_eq!(bank.get_inflation_num_slots(), 0);
-    for _ in 0..2 * slots_per_epoch {
+    for _ in 0..2 * slots_per_epoch - 1 {
         bank = new_from_parent(Arc::new(bank));
     }
     assert_eq!(bank.get_inflation_num_slots(), 2 * slots_per_epoch);
@@ -8038,9 +8076,11 @@ fn test_get_inflation_num_slots_already_activated() {
     } = create_genesis_config_with_leader(42, &solana_pubkey::new_rand(), 42);
     let slots_per_epoch = 32;
     genesis_config.epoch_schedule = EpochSchedule::new(slots_per_epoch);
-    let mut bank = Bank::new_for_tests(&genesis_config);
+    let (bank0, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+    let mut bank = new_from_parent(bank0);
     assert_eq!(bank.get_inflation_num_slots(), 0);
-    for _ in 0..slots_per_epoch {
+    for _ in 0..slots_per_epoch - 1 {
         bank = new_from_parent(Arc::new(bank));
     }
     assert_eq!(bank.get_inflation_num_slots(), slots_per_epoch);
@@ -9101,8 +9141,9 @@ fn test_verify_transactions_accounts_limit(simd_406_enabled: bool) {
 #[test]
 fn test_check_reserved_keys() {
     let (genesis_config, _mint_keypair) = create_genesis_config(1);
-    let bank = Bank::new_for_tests(&genesis_config);
-    let mut bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::new_unique(), 1);
+    let (bank0, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+    let mut bank = Bank::new_from_parent(bank0, SlotLeader::new_unique(), 1);
 
     let transaction =
         SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
@@ -11200,7 +11241,8 @@ fn test_register_hard_fork() {
     }
 
     let (genesis_config, _mint_keypair) = create_genesis_config(10);
-    let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank0, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
     let bank7 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 7);
     bank7.register_hard_fork(6);
@@ -11244,7 +11286,8 @@ fn test_last_restart_slot() {
     let GenesisConfigInfo { genesis_config, .. } =
         create_genesis_config_with_leader(mint_lamports, &leader_pubkey, validator_stake_lamports);
 
-    let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank0, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
     // Register a hard fork in the future so last restart slot will update
     bank0.register_hard_fork(3);
     assert!(last_restart_slot_dirty(&bank0));
@@ -11821,7 +11864,8 @@ fn test_loader_v3_to_v4_migration() {
 #[test]
 fn test_blockhash_last_valid_block_height() {
     let genesis_config = GenesisConfig::default();
-    let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (mut bank, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
     // valid until MAX_PROCESSING_AGE
     let last_blockhash = bank.last_blockhash();
@@ -11880,7 +11924,8 @@ fn test_bank_epoch_stakes() {
     let GenesisConfigInfo { genesis_config, .. } =
         create_genesis_config_with_vote_accounts(1_000_000_000, &voting_keypairs, stakes.clone());
 
-    let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank0, _bank_forks) =
+        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
     let mut bank1 = Bank::new_from_parent(
         bank0.clone(),
         SlotLeader::default(),
@@ -12149,7 +12194,8 @@ fn test_genesis_deprecate_rent_exemption_disabled() {
 fn test_parent_block_id() {
     // Setup parent bank and populate block ID.
     let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
-    let parent_bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let parent_bank = Bank::new_for_tests(&genesis_config);
+    let (parent_bank, _bank_forks) = parent_bank.wrap_with_bank_forks_for_tests();
     let parent_block_id = Some(Hash::new_unique());
     parent_bank.set_block_id(parent_block_id);
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -800,10 +800,11 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
-        let mut bank_forks = bank_forks.write().unwrap();
-        let child_bank = Bank::new_from_parent(bank_forks[0].clone(), SlotLeader::default(), 1);
+        let bank0 = bank_forks.read().unwrap()[0].clone();
+        let child_bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
         child_bank.register_default_tick_for_test();
-        bank_forks.insert(child_bank);
+        bank_forks.write().unwrap().insert(child_bank);
+        let bank_forks = bank_forks.read().unwrap();
         assert_eq!(bank_forks[1u64].tick_height(), 1);
         assert_eq!(bank_forks.working_bank().tick_height(), 1);
     }
@@ -947,12 +948,12 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
-        let mut bank_forks = bank_forks.write().unwrap();
-        let bank0 = bank_forks[0].clone();
-        let bank = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
-        bank_forks.insert(bank);
-        let bank = Bank::new_from_parent(bank0, SlotLeader::default(), 2);
-        bank_forks.insert(bank);
+        let bank0 = bank_forks.read().unwrap()[0].clone();
+        let bank1 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
+        bank_forks.write().unwrap().insert(bank1);
+        let bank2 = Bank::new_from_parent(bank0, SlotLeader::default(), 2);
+        bank_forks.write().unwrap().insert(bank2);
+        let bank_forks = bank_forks.read().unwrap();
         let descendants = bank_forks.descendants();
         let children: HashSet<u64> = [1u64, 2u64].iter().copied().collect();
         assert_eq!(children, *descendants.get(&0).unwrap());
@@ -965,12 +966,12 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
-        let mut bank_forks = bank_forks.write().unwrap();
-        let bank0 = bank_forks[0].clone();
-        let bank = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
-        bank_forks.insert(bank);
-        let bank = Bank::new_from_parent(bank0, SlotLeader::default(), 2);
-        bank_forks.insert(bank);
+        let bank0 = bank_forks.read().unwrap()[0].clone();
+        let bank1 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
+        bank_forks.write().unwrap().insert(bank1);
+        let bank2 = Bank::new_from_parent(bank0, SlotLeader::default(), 2);
+        bank_forks.write().unwrap().insert(bank2);
+        let bank_forks = bank_forks.read().unwrap();
         let ancestors = bank_forks.ancestors();
         assert!(ancestors[&0].is_empty());
         let parents: Vec<u64> = ancestors[&1].iter().cloned().collect();
@@ -984,12 +985,13 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
-        let mut bank_forks = bank_forks.write().unwrap();
-        let bank0 = bank_forks[0].clone();
+        let bank0 = bank_forks.read().unwrap()[0].clone();
         let child_bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
-        bank_forks.insert(child_bank);
+        bank_forks.write().unwrap().insert(child_bank);
 
         let frozen_slots: HashSet<Slot> = bank_forks
+            .read()
+            .unwrap()
             .frozen_banks()
             .map(|(slot, _bank)| slot)
             .collect();
@@ -1002,11 +1004,10 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
-        let mut bank_forks = bank_forks.write().unwrap();
-        let bank0 = bank_forks[0].clone();
+        let bank0 = bank_forks.read().unwrap()[0].clone();
         let child_bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
-        bank_forks.insert(child_bank);
-        assert_eq!(bank_forks.active_bank_slots(), vec![1]);
+        bank_forks.write().unwrap().insert(child_bank);
+        assert_eq!(bank_forks.read().unwrap().active_bank_slots(), vec![1]);
     }
 
     #[test]
@@ -1023,12 +1024,10 @@ mod tests {
 
         let bank0 = Bank::new_for_tests(&genesis_config);
         let bank_forks0 = BankForks::new_rw_arc(bank0);
-        let mut bank_forks0 = bank_forks0.write().unwrap();
-        bank_forks0.set_root(0, None, None);
+        bank_forks0.write().unwrap().set_root(0, None, None);
 
         let bank1 = Bank::new_for_tests(&genesis_config);
         let bank_forks1 = BankForks::new_rw_arc(bank1);
-        let mut bank_forks1 = bank_forks1.write().unwrap();
 
         let additional_timestamp_secs = 2;
 
@@ -1038,10 +1037,16 @@ mod tests {
             // Clock::unix_timestamp from Bank::unix_timestamp_from_genesis()
             let update_timestamp_case = slot == slots_in_epoch;
 
-            let child1 =
-                Bank::new_from_parent(bank_forks0[slot - 1].clone(), SlotLeader::default(), slot);
-            let child2 =
-                Bank::new_from_parent(bank_forks1[slot - 1].clone(), SlotLeader::default(), slot);
+            let child1 = Bank::new_from_parent(
+                bank_forks0.read().unwrap()[slot - 1].clone(),
+                SlotLeader::default(),
+                slot,
+            );
+            let child2 = Bank::new_from_parent(
+                bank_forks1.read().unwrap()[slot - 1].clone(),
+                SlotLeader::default(),
+                slot,
+            );
 
             if update_timestamp_case {
                 for child in &[&child1, &child2] {
@@ -1058,14 +1063,16 @@ mod tests {
             }
 
             // Set root in bank_forks0 to truncate the ancestor history
-            bank_forks0.insert(child1);
-            bank_forks0.set_root(slot, None, None);
+            let mut bf0 = bank_forks0.write().unwrap();
+            bf0.insert(child1);
+            bf0.set_root(slot, None, None);
+            drop(bf0);
 
             // Don't set root in bank_forks1 to keep the ancestor history
-            bank_forks1.insert(child2);
+            bank_forks1.write().unwrap().insert(child2);
         }
-        let child1 = &bank_forks0.working_bank();
-        let child2 = &bank_forks1.working_bank();
+        let child1 = bank_forks0.read().unwrap().working_bank();
+        let child2 = bank_forks1.read().unwrap().working_bank();
 
         child1.freeze();
         child2.freeze();

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -389,32 +389,38 @@ mod tests {
         super::*,
         crate::{
             bank::{Bank, SlotLeader},
+            bank_forks::BankForks,
             genesis_utils::{activate_all_features_alpenglow, create_genesis_config},
         },
         solana_entry::block_component::{
             BlockFooterV1, BlockHeaderV1, UpdateParentV1, VersionedUpdateParent,
         },
         solana_hash::Hash,
-        std::sync::Arc,
+        std::sync::{Arc, RwLock},
     };
 
-    fn create_test_bank() -> Arc<Bank> {
+    fn create_test_bank() -> (Arc<Bank>, Arc<RwLock<BankForks>>) {
         let genesis_config_info = create_genesis_config(10_000);
-        Arc::new(Bank::new_for_tests(&genesis_config_info.genesis_config))
+        Bank::new_with_bank_forks_for_tests(&genesis_config_info.genesis_config)
     }
 
-    fn create_test_bank_alpenglow() -> Arc<Bank> {
+    fn create_test_bank_alpenglow() -> (Arc<Bank>, Arc<RwLock<BankForks>>) {
         let mut genesis_config_info = create_genesis_config(10_000);
         activate_all_features_alpenglow(&mut genesis_config_info.genesis_config);
-        Arc::new(Bank::new_for_tests(&genesis_config_info.genesis_config))
+        Bank::new_with_bank_forks_for_tests(&genesis_config_info.genesis_config)
     }
 
-    fn create_child_bank(parent: &Arc<Bank>, slot: u64) -> Arc<Bank> {
-        Arc::new(Bank::new_from_parent(
+    fn create_child_bank(
+        bank_forks: &Arc<RwLock<BankForks>>,
+        parent: &Arc<Bank>,
+        slot: u64,
+    ) -> Arc<Bank> {
+        Bank::new_from_parent_with_bank_forks(
+            bank_forks,
             parent.clone(),
             SlotLeader::new_unique(),
             slot,
-        ))
+        )
     }
 
     // TODO(ksn): re-enable once broadcast stage produces block headers
@@ -476,8 +482,8 @@ mod tests {
             ..Default::default()
         };
 
-        let parent = create_test_bank();
-        let bank = create_child_bank(&parent, 1);
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
 
         // Calculate valid timestamp based on parent's time
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
@@ -514,8 +520,8 @@ mod tests {
             ..Default::default()
         };
 
-        let parent = create_test_bank();
-        let bank = create_child_bank(&parent, 1);
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
 
         // Calculate valid timestamp based on parent's time
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
@@ -562,8 +568,8 @@ mod tests {
             parent_block_id: Hash::default(),
         });
 
-        let parent = create_test_bank();
-        let bank = create_child_bank(&parent, 1);
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
 
         processor
             .on_marker(bank, parent, marker, None, &migration_status)
@@ -579,8 +585,8 @@ mod tests {
             ..Default::default()
         };
 
-        let parent = create_test_bank();
-        let bank = create_child_bank(&parent, 1);
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
 
         // Calculate valid timestamp based on parent's time
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
@@ -609,8 +615,8 @@ mod tests {
     fn test_complete_workflow_success() {
         let migration_status = MigrationStatus::post_migration_status();
         let mut processor = BlockComponentProcessor::default();
-        let parent = create_test_bank();
-        let bank = create_child_bank(&parent, 1);
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
 
         // Calculate valid timestamp based on parent's time
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
@@ -652,8 +658,8 @@ mod tests {
     fn test_block_marker_detected_pre_migration() {
         let migration_status = MigrationStatus::default();
         let mut processor = BlockComponentProcessor::default();
-        let parent = create_test_bank();
-        let bank = create_child_bank(&parent, 1);
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
 
         // Try to process a block header marker pre-migration - should fail
         let marker = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
@@ -671,8 +677,8 @@ mod tests {
     #[test]
     fn test_footer_and_update_parent_rejected_pre_migration() {
         let migration_status = MigrationStatus::default();
-        let parent = create_test_bank();
-        let bank = create_child_bank(&parent, 1);
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
 
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
         let footer_marker = VersionedBlockMarker::new_block_footer(BlockFooterV1 {
@@ -726,8 +732,8 @@ mod tests {
     fn test_complete_workflow_post_migration() {
         let migration_status = MigrationStatus::post_migration_status();
         let mut processor = BlockComponentProcessor::default();
-        let parent = create_test_bank();
-        let bank = create_child_bank(&parent, 1);
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
 
         // Process header marker
         let header_marker = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
@@ -776,8 +782,8 @@ mod tests {
     #[test]
     fn test_footer_without_header_errors() {
         let mut processor = BlockComponentProcessor::default();
-        let parent = create_test_bank();
-        let bank = create_child_bank(&parent, 1);
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
 
         let footer = VersionedBlockFooter::V1(BlockFooterV1 {
             bank_hash: Hash::new_unique(),
@@ -800,8 +806,8 @@ mod tests {
     fn test_marker_with_footer_at_slot_full() {
         let migration_status = MigrationStatus::post_migration_status();
         let mut processor = BlockComponentProcessor::default();
-        let parent = create_test_bank();
-        let bank = create_child_bank(&parent, 1);
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
 
         // Process header first
         processor.has_header = true;
@@ -853,7 +859,8 @@ mod tests {
 
         // Create genesis bank
         let genesis_config_info = create_genesis_config(10_000);
-        let genesis_bank = Arc::new(Bank::new_for_tests(&genesis_config_info.genesis_config));
+        let (genesis_bank, bank_forks) =
+            Bank::new_with_bank_forks_for_tests(&genesis_config_info.genesis_config);
 
         // Get epoch schedule to find first slot of next epoch
         let epoch_schedule = genesis_bank.epoch_schedule();
@@ -862,11 +869,11 @@ mod tests {
         // Create parent bank at last slot of epoch 0
         let mut parent = genesis_bank.clone();
         for slot in 1..first_slot_in_epoch_1 {
-            parent = create_child_bank(&parent, slot);
+            parent = create_child_bank(&bank_forks, &parent, slot);
         }
 
         // Create bank at first slot of epoch 1
-        let bank = create_child_bank(&parent, first_slot_in_epoch_1);
+        let bank = create_child_bank(&bank_forks, &parent, first_slot_in_epoch_1);
 
         // Verify we're in epoch 1
         assert_eq!(bank.epoch(), 1);
@@ -916,13 +923,13 @@ mod tests {
             ..Default::default()
         };
 
-        let parent = create_test_bank_alpenglow();
+        let (parent, bank_forks) = create_test_bank_alpenglow();
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
 
         // Set up clock on parent so validation doesn't skip bounds checking
         parent.update_clock_from_footer(parent_time_nanos);
 
-        let bank = create_child_bank(&parent, slot_gap);
+        let bank = create_child_bank(&bank_forks, &parent, slot_gap);
 
         let (lower_bound, upper_bound) =
             BlockComponentProcessor::nanosecond_time_bounds(0, parent_time_nanos, slot_gap);
@@ -1111,8 +1118,8 @@ mod tests {
     fn test_workflow_with_update_parent() {
         let migration_status = MigrationStatus::post_migration_status();
         let mut processor = BlockComponentProcessor::default();
-        let parent = create_test_bank();
-        let bank = create_child_bank(&parent, 1);
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
 
         processor
             .on_update_parent(&VersionedUpdateParent::V1(UpdateParentV1 {

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -227,9 +227,17 @@ mod tests {
         std::{collections::BTreeMap, sync::Arc},
     };
 
-    fn new_from_parent(parent: Arc<Bank>) -> Bank {
+    fn new_from_parent(
+        parent: Arc<Bank>,
+        bank_forks: &std::sync::Arc<std::sync::RwLock<crate::bank_forks::BankForks>>,
+    ) -> Arc<Bank> {
         let slot = parent.slot() + 1;
-        Bank::new_from_parent(parent, SlotLeader::default(), slot)
+        Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            parent,
+            SlotLeader::default(),
+            slot,
+        )
     }
 
     #[test]
@@ -277,7 +285,9 @@ mod tests {
             cluster_type: ClusterType::MainnetBeta,
             ..GenesisConfig::default()
         };
-        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        let mut bank = bank0;
         assert_eq!(
             bank.capitalization(),
             (num_genesis_accounts + num_non_circulating_accounts + num_stake_accounts) * balance
@@ -294,7 +304,7 @@ mod tests {
             num_non_circulating_accounts as usize + num_stake_accounts as usize
         );
 
-        bank = Arc::new(new_from_parent(bank));
+        bank = new_from_parent(bank, &bank_forks);
         let new_balance = 11;
         for key in non_circulating_accounts {
             bank.store_account(
@@ -314,7 +324,7 @@ mod tests {
 
         // Advance bank an epoch, which should unlock stakes
         for _ in 0..slots_per_epoch {
-            bank = Arc::new(new_from_parent(bank));
+            bank = new_from_parent(bank, &bank_forks);
         }
         assert_eq!(bank.epoch(), 1);
         let non_circulating_supply = calculate_non_circulating_supply(&bank).unwrap();

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -869,11 +869,18 @@ mod tests {
         bank_snapshots_dir: impl AsRef<Path>,
         num_total: usize,
         should_flush_and_hard_link_storages: bool,
-    ) -> Bank {
-        let mut bank = Arc::new(Bank::new_for_tests(genesis_config));
+    ) -> Arc<Bank> {
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(genesis_config).wrap_with_bank_forks_for_tests();
+        let mut bank = bank0;
         for _i in 0..num_total {
             let slot = bank.slot() + 1;
-            bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::new_unique(), slot));
+            bank = Bank::new_from_parent_with_bank_forks(
+                bank_forks.as_ref(),
+                bank,
+                SlotLeader::new_unique(),
+                slot,
+            );
             bank.fill_bank_with_ticks_for_tests();
             bank.set_block_id(Some(Hash::default()));
 
@@ -886,7 +893,7 @@ mod tests {
             .unwrap();
         }
 
-        Arc::into_inner(bank).unwrap()
+        bank
     }
 
     /// Creates a bank snapshot from a bank, regardless of state. The Bank will be frozen during

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -180,15 +180,19 @@ mod tests {
     fn create_banks(num_banks: u64) -> Vec<Arc<Bank>> {
         let mut banks = vec![];
         let (genesis_config, _) = create_genesis_config(1_000_000);
-        let mut parent_bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        let mut parent_bank = bank0;
         banks.push(parent_bank.clone());
 
         for _ in 1..=num_banks {
-            let new_bank = Arc::new(Bank::new_from_parent(
+            let slot = parent_bank.slot() + 1;
+            let new_bank = Bank::new_from_parent_with_bank_forks(
+                bank_forks.as_ref(),
                 parent_bank.clone(),
                 SlotLeader::default(),
-                parent_bank.slot() + 1,
-            ));
+                slot,
+            );
             parent_bank = new_bank;
             banks.push(parent_bank.clone());
         }

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -155,7 +155,7 @@ mod tests {
         solana_hash::Hash,
         solana_leader_schedule::SlotLeader,
         solana_signer_store::encode_base2,
-        std::{collections::HashMap, sync::Arc},
+        std::collections::HashMap,
     };
 
     fn new_vote(vote: Vote, rank: usize, keypair: &BlsKeypair) -> VoteMessage {
@@ -209,7 +209,8 @@ mod tests {
             &validator_keypairs,
             vec![100; validator_keypairs.len()],
         );
-        let bank = Arc::new(Bank::new_for_tests(&genesis.genesis_config));
+        let (bank, _bank_forks) =
+            Bank::new_for_tests(&genesis.genesis_config).wrap_with_bank_forks_for_tests();
         let bank = Bank::new_from_parent(bank, SlotLeader::default(), bank_slot);
 
         let rank_map = bank

--- a/svm-timings/src/lib.rs
+++ b/svm-timings/src/lib.rs
@@ -43,7 +43,7 @@ impl ProgramTiming {
 }
 
 /// Used as an index for `Metrics`.
-#[derive(Debug, Sequence)]
+#[derive(Debug, Copy, Clone, Sequence)]
 pub enum ExecuteTimingType {
     CheckUs,
     ValidateFeesUs,

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -226,13 +226,19 @@ mod tests {
         solana_transaction::Transaction,
     };
 
-    fn setup_test() -> (GenesisConfig, Arc<Bank>, Transaction) {
+    fn setup_test() -> (
+        GenesisConfig,
+        Arc<Bank>,
+        Arc<std::sync::RwLock<solana_runtime::bank_forks::BankForks>>,
+        Transaction,
+    ) {
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
             ..
         } = create_genesis_config(2);
-        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let tx = system_transaction::transfer(
             &mint_keypair,
             &solana_pubkey::new_rand(),
@@ -240,7 +246,7 @@ mod tests {
             genesis_config.hash(),
         );
 
-        (genesis_config, bank0, tx)
+        (genesis_config, bank0, bank_forks, tx)
     }
 
     const LAST_TICK_HEIGHT: u64 = 1;
@@ -248,9 +254,14 @@ mod tests {
 
     #[test]
     fn test_recv_slot_entries_1() {
-        let (genesis_config, bank0, tx) = setup_test();
+        let (genesis_config, bank0, bank_forks, tx) = setup_test();
 
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
+        let bank1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0,
+            SlotLeader::default(),
+            1,
+        );
         let (s, r) = unbounded();
         let mut last_hash = genesis_config.hash();
 
@@ -278,14 +289,20 @@ mod tests {
 
     #[test]
     fn test_recv_slot_entries_2() {
-        let (genesis_config, bank0, tx) = setup_test();
+        let (genesis_config, bank0, bank_forks, tx) = setup_test();
 
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
-        let bank2 = Arc::new(Bank::new_from_parent(
+        let bank1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0,
+            SlotLeader::default(),
+            1,
+        );
+        let bank2 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
             bank1.clone(),
             SlotLeader::default(),
             2,
-        ));
+        );
         let (s, r) = unbounded();
 
         let mut last_hash = genesis_config.hash();

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -3696,31 +3696,34 @@ mod tests {
     fn test_scheduler_install_into_bank() {
         agave_logger::setup();
 
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-        let child_bank = Bank::new_from_parent(bank, SlotLeader::default(), 1);
-
         let pool = DefaultSchedulerPool::new_dyn_for_verification(None, None, None, None, None);
 
-        let bank = Bank::default_for_tests();
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
-        let mut bank_forks = bank_forks.write().unwrap();
+        let bank = bank_forks.read().unwrap().root_bank();
 
         // existing banks in bank_forks shouldn't process transactions anymore in general, so
         // shouldn't be touched
-        assert!(
-            !bank_forks
-                .working_bank_with_scheduler()
-                .has_installed_scheduler()
-        );
-        bank_forks.install_scheduler_pool(pool);
-        assert!(
-            !bank_forks
-                .working_bank_with_scheduler()
-                .has_installed_scheduler()
-        );
+        {
+            let mut bank_forks_w = bank_forks.write().unwrap();
+            assert!(
+                !bank_forks_w
+                    .working_bank_with_scheduler()
+                    .has_installed_scheduler()
+            );
+            bank_forks_w.install_scheduler_pool(pool);
+            assert!(
+                !bank_forks_w
+                    .working_bank_with_scheduler()
+                    .has_installed_scheduler()
+            );
+        }
 
-        let mut child_bank = bank_forks.insert(child_bank);
+        // child_bank inserted after pool so it gets a scheduler
+        Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, SlotLeader::default(), 1);
+        let mut bank_forks = bank_forks.write().unwrap();
+        let mut child_bank = bank_forks.get_with_scheduler(1).unwrap();
         assert!(child_bank.has_installed_scheduler());
         bank_forks.remove(child_bank.slot());
         child_bank.drop_scheduler();
@@ -4321,7 +4324,7 @@ mod tests {
 
         // Create two banks for two contexts
         let bank0 = Bank::new_for_tests(&genesis_config);
-        let bank0 = setup_dummy_fork_graph(bank0).0;
+        let (bank0, _bank_forks) = setup_dummy_fork_graph(bank0);
         let bank1 = Arc::new(Bank::new_from_parent(
             bank0.clone(),
             SlotLeader::default(),
@@ -4541,18 +4544,18 @@ mod tests {
                 2,
                 genesis_config.hash(),
             ));
-        let mut bank = Bank::new_for_tests(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let (mut bank, _bank_forks) = setup_dummy_fork_graph(bank);
         for _ in 0..bank.max_processing_age() {
             bank.fill_bank_with_ticks_for_tests();
             bank.freeze();
             let slot = bank.slot();
-            bank = Bank::new_from_parent(
-                Arc::new(bank),
+            bank = Arc::new(Bank::new_from_parent(
+                bank,
                 SlotLeader::default(),
                 slot.checked_add(1).unwrap(),
-            );
+            ));
         }
-        let (bank, _bank_forks) = setup_dummy_fork_graph(bank);
         let context = SchedulingContext::for_verification(bank.clone());
 
         let pool =

--- a/votor/src/consensus_rewards/entry.rs
+++ b/votor/src/consensus_rewards/entry.rs
@@ -173,8 +173,14 @@ mod tests {
         )
         .genesis_config;
         genesis_config.epoch_schedule = EpochSchedule::without_warmup();
-        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-        let bank = Bank::new_from_parent(bank, SlotLeader::default(), slot);
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        let bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank,
+            SlotLeader::default(),
+            slot,
+        );
         let rank_map = bank.get_rank_map(slot).unwrap().clone();
         let signing_keys = (0..max_validators)
             .map(|index| {

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -350,6 +350,19 @@ mod tests {
         validator_keypairs: &[ValidatorVoteKeypairs],
         my_index: usize,
     ) -> VotingContext {
+        let (voting_context, _) = setup_voting_context_and_bank_forks_with_forks(
+            own_vote_sender,
+            validator_keypairs,
+            my_index,
+        );
+        voting_context
+    }
+
+    fn setup_voting_context_and_bank_forks_with_forks(
+        own_vote_sender: Sender<Vec<ConsensusMessage>>,
+        validator_keypairs: &[ValidatorVoteKeypairs],
+        my_index: usize,
+    ) -> (VotingContext, Arc<RwLock<BankForks>>) {
         // Can't have stake of 0, so start at 1 and go to 10. In descending order, so 0 has largest stake.
         let stakes: Vec<u64> = (1u64..=10).rev().map(|x| x.saturating_mul(100)).collect();
         let genesis = create_genesis_config_with_alpenglow_vote_accounts(
@@ -365,7 +378,7 @@ mod tests {
         let bls_sender = unbounded().0;
         let commitment_sender = unbounded().0;
         let consensus_metrics_sender = unbounded().0;
-        VotingContext {
+        let voting_context = VotingContext {
             vote_history: VoteHistory::new(my_keys.node_keypair.pubkey(), 0),
             vote_account_pubkey: my_keys.vote_keypair.pubkey(),
             identity_keypair: Arc::new(my_keys.node_keypair.insecure_clone()),
@@ -380,7 +393,8 @@ mod tests {
             wait_to_vote_slot: None,
             sharable_banks,
             consensus_metrics_sender,
-        }
+        };
+        (voting_context, bank_forks)
     }
 
     #[test]
@@ -606,8 +620,11 @@ mod tests {
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
             .collect::<Vec<_>>();
         let my_index = 0;
-        let mut voting_context =
-            setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
+        let (mut voting_context, bank_forks) = setup_voting_context_and_bank_forks_with_forks(
+            own_vote_sender,
+            &validator_keypairs,
+            my_index,
+        );
 
         // Set the stake of my_index to 0 in epoch 2
         // For epoch 2, make validator my_index to be zero stake, others have stake in ascending order, 1 < 2 < ... < 9
@@ -635,7 +652,8 @@ mod tests {
         new_bank.set_epoch_stakes_for_test(2, epoch2_epoch_stakes);
         assert!(new_bank.epoch_stakes(2).is_some());
         new_bank.freeze();
-        let bank_forks = BankForks::new_rw_arc(new_bank);
+        bank_forks.write().unwrap().insert(new_bank);
+        bank_forks.write().unwrap().set_root(1, None, None);
         voting_context.sharable_banks = bank_forks.read().unwrap().sharable_banks();
 
         // If we try to vote for a slot in epoch 1, it should succeed


### PR DESCRIPTION
- updates tests across 36 files to create banks with a proper fork graph via `wrap_with_bank_forks_for_tests()` / `new_from_parent_with_bank_forks`.
- fixes lock patterns to avoid holding a write lock on `BankForks` during `Bank::new_from_parent` (which needs the fork graph for `ProgramCache::extract`).
- prerequisite for #10591 (builtin cache optimization), broken out to simplify review.