### PR TITLE
accounts-db: Add `SlotCache::len`, avoid calling `DashMap::len`

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -85,7 +85,7 @@ impl Drop for SlotCache {
 
 impl SlotCache {
     pub fn len(&self) -> usize {
-        self.accounts_count.load(Ordering::Relaxed) as usize
+        self.accounts_count.load(Ordering::Acquire) as usize
     }
 
     pub fn report_slot_store_metrics(&self) {
@@ -147,7 +147,7 @@ impl SlotCache {
             self.total_size.fetch_add(data_len, Ordering::Relaxed);
             self.unique_account_writes_size
                 .fetch_add(data_len, Ordering::Relaxed);
-            self.accounts_count.fetch_add(1, Ordering::Relaxed);
+            self.accounts_count.fetch_add(1, Ordering::Release);
             self.total_accounts_count.fetch_add(1, Ordering::Relaxed);
             true
         };

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -84,6 +84,10 @@ impl Drop for SlotCache {
 }
 
 impl SlotCache {
+    pub fn len(&self) -> usize {
+        self.accounts_count.load(Ordering::Relaxed) as usize
+    }
+
     pub fn report_slot_store_metrics(&self) {
         datapoint_info!(
             "slot_repeated_writes",
@@ -529,6 +533,36 @@ mod tests {
         cache.slot_cache(inserted_slot).unwrap().mark_slot_frozen();
         // If the cache is told the size limit is 0, it should return the one frozen slot
         assert_eq!(cache.cached_frozen_slots(), vec![inserted_slot]);
+    }
+
+    #[test]
+    fn test_slot_cache_len_tracks_unique_accounts() {
+        let cache = AccountsCache::default();
+        let slot = 0;
+        let pubkey = Pubkey::new_unique();
+        let other_pubkey = Pubkey::new_unique();
+
+        cache.store(
+            slot,
+            &pubkey,
+            AccountSharedData::new(1, 0, &Pubkey::default()),
+        );
+        let slot_cache = cache.slot_cache(slot).unwrap();
+        assert_eq!(slot_cache.len(), 1);
+
+        cache.store(
+            slot,
+            &pubkey,
+            AccountSharedData::new(2, 0, &Pubkey::default()),
+        );
+        assert_eq!(slot_cache.len(), 1);
+
+        cache.store(
+            slot,
+            &other_pubkey,
+            AccountSharedData::new(3, 0, &Pubkey::default()),
+        );
+        assert_eq!(slot_cache.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

`DashMap::len` (that `SlotCache` ends up calling through a `Deref` implementation with `DashMap` as a target) iterates over all shards to retrieve their length, which results in acquiring locks.

Times spent during `Bank::new_from_parent()` to pre-populate the bank’s `cache_for_accounts_lt_hash` with the
pubkeys of accounts modified in the new slot retrieved by `AccountsDb::get_pubkeys_for_slot`, that ends up calling `SlotCache::len`:

```
populate_cache_for_accounts_lt_hash_us=7i
populate_cache_for_accounts_lt_hash_us=5i
populate_cache_for_accounts_lt_hash_us=7i
populate_cache_for_accounts_lt_hash_us=6i
populate_cache_for_accounts_lt_hash_us=5i
populate_cache_for_accounts_lt_hash_us=7i
populate_cache_for_accounts_lt_hash_us=10i
populate_cache_for_accounts_lt_hash_us=5i
populate_cache_for_accounts_lt_hash_us=5i
populate_cache_for_accounts_lt_hash_us=7i
```

#### Summary of Changes

We already track the number of accounts in the `accounts_count` field. Provide an explicit implementation of `SlotCache::len` which uses that field.

That improves the times mentioned above:

```
populate_cache_for_accounts_lt_hash_us=5i
populate_cache_for_accounts_lt_hash_us=6i
populate_cache_for_accounts_lt_hash_us=4i
populate_cache_for_accounts_lt_hash_us=5i
populate_cache_for_accounts_lt_hash_us=4i
populate_cache_for_accounts_lt_hash_us=4i
populate_cache_for_accounts_lt_hash_us=5i
populate_cache_for_accounts_lt_hash_us=6i
populate_cache_for_accounts_lt_hash_us=4i
populate_cache_for_accounts_lt_hash_us=4i
```

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
