### PR TITLE
cost tracker data limit dimension

### DIFF
--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -679,11 +679,12 @@ mod tests {
             std::iter::repeat(Ok(())),
         );
 
-        // set cost tracker limit to fit 1 transfer tx and 1 vote tx
+        // set cost tracker limit to bare minimum that will fit 1 transfer tx
+        // and 1 vote tx
         let cost_limit = transfer_tx_cost + vote_tx_cost;
         bank.write_cost_tracker()
             .unwrap()
-            .set_limits(cost_limit, cost_limit, cost_limit);
+            .set_limits(cost_limit, cost_limit, cost_limit, 0);
         let (results, num_selected) =
             qos_service.select_transactions_per_cost(txs.iter(), txs_costs.into_iter(), &bank);
         assert_eq!(num_selected, 2);

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -73,6 +73,7 @@ pub struct CostTracker {
     account_cost_limit: u64,
     block_cost_limit: u64,
     vote_cost_limit: u64,
+    account_data_size_limit: u64,
     cost_by_writable_accounts: HashMap<Pubkey, u64, ahash::RandomState>,
     block_cost: SharedBlockCost,
     vote_cost: u64,
@@ -97,6 +98,7 @@ impl Default for CostTracker {
             account_cost_limit: MAX_WRITABLE_ACCOUNT_UNITS,
             block_cost_limit: MAX_BLOCK_UNITS,
             vote_cost_limit: MAX_VOTE_UNITS,
+            account_data_size_limit: MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA,
             cost_by_writable_accounts: HashMap::with_capacity_and_hasher(
                 WRITABLE_ACCOUNTS_PER_BLOCK,
                 ahash::RandomState::new(),
@@ -121,6 +123,7 @@ impl CostTracker {
             self.account_cost_limit,
             self.block_cost_limit,
             self.vote_cost_limit,
+            self.account_data_size_limit,
         );
         new
     }
@@ -140,20 +143,27 @@ impl CostTracker {
         self.vote_cost_limit
     }
 
+    /// Get the overall allocated account data size limit.
+    pub fn get_account_data_size_limit(&self) -> u64 {
+        self.account_data_size_limit
+    }
+
     /// allows to adjust limits initiated during construction
     pub fn set_limits(
         &mut self,
         account_cost_limit: u64,
         block_cost_limit: u64,
         vote_cost_limit: u64,
+        account_data_size_limit: u64,
     ) {
         self.account_cost_limit = account_cost_limit;
         self.block_cost_limit = block_cost_limit;
         self.vote_cost_limit = vote_cost_limit;
+        self.account_data_size_limit = account_data_size_limit;
     }
 
     pub fn set_limits_max(&mut self) {
-        self.set_limits(u64::MAX, u64::MAX, u64::MAX);
+        self.set_limits(u64::MAX, u64::MAX, u64::MAX, u64::MAX);
     }
 
     pub fn in_flight_transaction_count(&self) -> usize {
@@ -336,7 +346,7 @@ impl CostTracker {
         let allocated_accounts_data_size =
             self.allocated_accounts_data_size + Saturating(tx_cost.allocated_accounts_data_size());
 
-        if allocated_accounts_data_size.0 > MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA {
+        if allocated_accounts_data_size.0 > self.account_data_size_limit {
             return Err(CostTrackerError::WouldExceedAccountDataBlockLimit);
         }
 
@@ -791,6 +801,30 @@ mod tests {
         // data is too big
         assert_eq!(
             testee.would_fit(&tx_cost2),
+            Err(CostTrackerError::WouldExceedAccountDataBlockLimit),
+        );
+    }
+
+    #[test]
+    fn test_cost_tracker_respects_custom_account_data_size_limit() {
+        // Setup transaction that allocates 2 bytes.
+        let mint_keypair = test_setup();
+        let tx = build_simple_transaction(&mint_keypair);
+        let mut tx_cost = simple_transaction_cost(&tx, 5);
+        if let TransactionCost::Transaction(ref mut usage_cost) = tx_cost {
+            usage_cost.allocated_accounts_data_size = 2;
+        } else {
+            unreachable!();
+        }
+
+        // Transaction fits with default limit.
+        let mut testee = CostTracker::new(u64::MAX, u64::MAX, u64::MAX);
+        assert_eq!(testee.would_fit(&tx_cost), Ok(()),);
+
+        // Transaction does not fit with 1B limit.
+        testee.account_data_size_limit = 1;
+        assert_eq!(
+            testee.would_fit(&tx_cost),
             Err(CostTrackerError::WouldExceedAccountDataBlockLimit),
         );
     }

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -73,7 +73,8 @@ pub struct CostTracker {
     account_cost_limit: u64,
     block_cost_limit: u64,
     vote_cost_limit: u64,
-    account_data_size_limit: u64,
+    // Maximum new account allocation data per block in bytes.
+    allocated_data_size_limit: u64,
     cost_by_writable_accounts: HashMap<Pubkey, u64, ahash::RandomState>,
     block_cost: SharedBlockCost,
     vote_cost: u64,
@@ -98,7 +99,7 @@ impl Default for CostTracker {
             account_cost_limit: MAX_WRITABLE_ACCOUNT_UNITS,
             block_cost_limit: MAX_BLOCK_UNITS,
             vote_cost_limit: MAX_VOTE_UNITS,
-            account_data_size_limit: MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA,
+            allocated_data_size_limit: MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA,
             cost_by_writable_accounts: HashMap::with_capacity_and_hasher(
                 WRITABLE_ACCOUNTS_PER_BLOCK,
                 ahash::RandomState::new(),
@@ -123,7 +124,7 @@ impl CostTracker {
             self.account_cost_limit,
             self.block_cost_limit,
             self.vote_cost_limit,
-            self.account_data_size_limit,
+            self.allocated_data_size_limit,
         );
         new
     }
@@ -144,8 +145,8 @@ impl CostTracker {
     }
 
     /// Get the overall allocated account data size limit.
-    pub fn get_account_data_size_limit(&self) -> u64 {
-        self.account_data_size_limit
+    pub fn get_allocated_data_size_limit(&self) -> u64 {
+        self.allocated_data_size_limit
     }
 
     /// allows to adjust limits initiated during construction
@@ -154,12 +155,12 @@ impl CostTracker {
         account_cost_limit: u64,
         block_cost_limit: u64,
         vote_cost_limit: u64,
-        account_data_size_limit: u64,
+        allocated_data_size_limit: u64,
     ) {
         self.account_cost_limit = account_cost_limit;
         self.block_cost_limit = block_cost_limit;
         self.vote_cost_limit = vote_cost_limit;
-        self.account_data_size_limit = account_data_size_limit;
+        self.allocated_data_size_limit = allocated_data_size_limit;
     }
 
     pub fn set_limits_max(&mut self) {
@@ -346,7 +347,7 @@ impl CostTracker {
         let allocated_accounts_data_size =
             self.allocated_accounts_data_size + Saturating(tx_cost.allocated_accounts_data_size());
 
-        if allocated_accounts_data_size.0 > self.account_data_size_limit {
+        if allocated_accounts_data_size.0 > self.allocated_data_size_limit {
             return Err(CostTrackerError::WouldExceedAccountDataBlockLimit);
         }
 
@@ -806,7 +807,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cost_tracker_respects_custom_account_data_size_limit() {
+    fn test_cost_tracker_respects_custom_allocated_data_size_limit() {
         // Setup transaction that allocates 2 bytes.
         let mint_keypair = test_setup();
         let tx = build_simple_transaction(&mint_keypair);
@@ -822,7 +823,7 @@ mod tests {
         assert_eq!(testee.would_fit(&tx_cost), Ok(()),);
 
         // Transaction does not fit with 1B limit.
-        testee.account_data_size_limit = 1;
+        testee.allocated_data_size_limit = 1;
         assert_eq!(
             testee.would_fit(&tx_cost),
             Err(CostTrackerError::WouldExceedAccountDataBlockLimit),

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -5743,7 +5743,7 @@ pub mod tests {
         let block_limit = tx_cost.sum();
         bank.write_cost_tracker()
             .unwrap()
-            .set_limits(u64::MAX, block_limit, u64::MAX);
+            .set_limits(u64::MAX, block_limit, u64::MAX, u64::MAX);
 
         let tx_costs = vec![None, Some(tx_cost), None];
         // The transaction will fit when added the first time

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4419,12 +4419,12 @@ impl Bank {
             let mut cost_tracker = self.write_cost_tracker().unwrap();
             let account_cost_limit = block_cost_limit.saturating_mul(40).saturating_div(100);
             let vote_cost_limit = cost_tracker.get_vote_limit();
-            let account_data_size_limit = cost_tracker.get_account_data_size_limit();
+            let allocated_data_size_limit = cost_tracker.get_allocated_data_size_limit();
             cost_tracker.set_limits(
                 account_cost_limit,
                 block_cost_limit,
                 vote_cost_limit,
-                account_data_size_limit,
+                allocated_data_size_limit,
             );
         }
 
@@ -5652,12 +5652,12 @@ impl Bank {
             let mut cost_tracker = self.write_cost_tracker().unwrap();
             let account_cost_limit = block_cost_limit.saturating_mul(40).saturating_div(100);
             let vote_cost_limit = cost_tracker.get_vote_limit();
-            let account_data_size_limit = cost_tracker.get_account_data_size_limit();
+            let allocated_data_size_limit = cost_tracker.get_allocated_data_size_limit();
             cost_tracker.set_limits(
                 account_cost_limit,
                 block_cost_limit,
                 vote_cost_limit,
-                account_data_size_limit,
+                allocated_data_size_limit,
             );
         }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4419,7 +4419,13 @@ impl Bank {
             let mut cost_tracker = self.write_cost_tracker().unwrap();
             let account_cost_limit = block_cost_limit.saturating_mul(40).saturating_div(100);
             let vote_cost_limit = cost_tracker.get_vote_limit();
-            cost_tracker.set_limits(account_cost_limit, block_cost_limit, vote_cost_limit);
+            let account_data_size_limit = cost_tracker.get_account_data_size_limit();
+            cost_tracker.set_limits(
+                account_cost_limit,
+                block_cost_limit,
+                vote_cost_limit,
+                account_data_size_limit,
+            );
         }
 
         self.apply_simd_0339_invoke_cost_changes();
@@ -5646,7 +5652,13 @@ impl Bank {
             let mut cost_tracker = self.write_cost_tracker().unwrap();
             let account_cost_limit = block_cost_limit.saturating_mul(40).saturating_div(100);
             let vote_cost_limit = cost_tracker.get_vote_limit();
-            cost_tracker.set_limits(account_cost_limit, block_cost_limit, vote_cost_limit);
+            let account_data_size_limit = cost_tracker.get_account_data_size_limit();
+            cost_tracker.set_limits(
+                account_cost_limit,
+                block_cost_limit,
+                vote_cost_limit,
+                account_data_size_limit,
+            );
         }
 
         if new_feature_activations.contains(&feature_set::vote_state_v4::id()) {

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -4248,7 +4248,7 @@ mod tests {
             bank.slot().checked_add(1).unwrap(),
         ));
         // Immediately trigger WouldExceedMaxBlockCostLimit by setting all cost limits to 0
-        bank.write_cost_tracker().unwrap().set_limits(0, 0, 0);
+        bank.write_cost_tracker().unwrap().set_limits(0, 0, 0, 0);
 
         let context = SchedulingContext::for_production(bank.clone());
         let scheduler = pool.take_scheduler(context).unwrap();


### PR DESCRIPTION
#### Problem
Cost tracker currently uses `MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA` directly to limit amount of account data that can be added per block. If we want to change this, e.g. if we change slot times, we'll need some plumbing.

#### Summary of Changes
Add cost tracker dimension for `allocated_data_size_limit`. This enables us to tie into existing `set_limits` plumbing if we want to feature gate change this.

Add test to make sure it works.