### PR TITLE
runtime: Implement rent-adjusted stake delegations for amended SIMD-0392 (formerly SIMD-0488)

### DIFF
--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -139,6 +139,57 @@ impl StakeReward {
         }
     }
 
+    pub fn new_with_pre_stake_account(
+        reward_lamports: i64,
+        stake_lamports: u64,
+        rent: &Rent,
+    ) -> (AccountSharedData, Self) {
+        let vote_pubkey = Pubkey::new_unique();
+        let vote_account = vote_state::create_v4_account_with_authorized(
+            &Pubkey::new_unique(),
+            &vote_pubkey,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
+            &vote_pubkey,
+            1000,
+            &vote_pubkey,
+            0,
+            &vote_pubkey,
+            stake_lamports,
+        );
+
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let stake_pubkey = Pubkey::new_unique();
+        let pre_stake_account = create_stake_account(
+            &stake_pubkey,
+            &vote_pubkey,
+            &vote_account,
+            rent,
+            rent_exempt_reserve + stake_lamports,
+        );
+        let post_stake_account = create_stake_account(
+            &stake_pubkey,
+            &vote_pubkey,
+            &vote_account,
+            rent,
+            rent_exempt_reserve + stake_lamports + reward_lamports as u64,
+        );
+
+        (
+            pre_stake_account,
+            Self {
+                stake_pubkey,
+                stake_reward_info: StakeRewardInfo {
+                    reward_type: solana_reward_info::RewardType::Staking,
+                    lamports: reward_lamports,
+                    post_balance: 0,         /* unused atm */
+                    commission_bps: Some(0), /* unused but tests require some value */
+                },
+
+                stake_account: post_stake_account,
+            },
+        )
+    }
+
     pub fn credit(&mut self, amount: u64) {
         self.stake_reward_info.lamports = amount as i64;
         self.stake_reward_info.post_balance += amount;
@@ -160,6 +211,7 @@ fn create_stake_account(
     let vote_state =
         vote_state::VoteStateV4::deserialize(vote_account.data(), voter_pubkey).unwrap();
     let credits_observed = vote_state.credits();
+    let last_epoch = vote_state.epoch_credits.last().map(|c| c.0).unwrap_or(0);
 
     let rent_exempt_reserve = rent.minimum_balance(stake_account.data().len());
     let stake_amount = lamports
@@ -172,10 +224,14 @@ fn create_stake_account(
         ..Meta::default()
     };
 
-    let stake = Stake {
+    let mut stake = Stake {
         delegation: Delegation::new(voter_pubkey, stake_amount, Epoch::MAX),
         credits_observed,
     };
+
+    if stake_amount == 0 {
+        stake.delegation.deactivation_epoch = last_epoch;
+    }
 
     stake_account
         .set_state(&StakeStateV2::Stake(meta, stake, StakeFlags::empty()))

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1495,6 +1495,10 @@ pub mod block_revenue_sharing {
     solana_pubkey::declare_id!("B1ockRevenueSharing111111111111111111111111");
 }
 
+pub mod rent_adjusted_delegations {
+    solana_pubkey::declare_id!("7MYx95UBiJufqnumyN7HfskJ9vKdcGMmhreVguqrE97K");
+}
+
 pub mod vote_account_initialize_v2 {
     solana_pubkey::declare_id!("VoteAccount1nitia1izeV211111111111111111111");
 }
@@ -2558,6 +2562,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             upgrade_bpf_stake_program_to_v5::id(),
             "SIMD-0490: Upgrade BPF Stake Program to v5.0.0",
+        ),
+        (
+            rent_adjusted_delegations::id(),
+            "SIMD-0488: Rent-adjusted delegations",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
         /***** ADD NEW FEATURE BOOL TO `FeatureSnapshot` *****/

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -782,7 +782,9 @@ impl JsonRpcRequestProcessor {
                 &addresses,
                 &|reward_type| -> bool {
                     reward_type == RewardType::Voting
-                        || (!epoch_has_partitioned_rewards && reward_type == RewardType::Staking)
+                        || (!epoch_has_partitioned_rewards
+                            && (reward_type == RewardType::Staking
+                                || reward_type == RewardType::DeactivatedStake))
                 },
             )
             .collect()
@@ -862,7 +864,10 @@ impl JsonRpcRequestProcessor {
                     block.rewards,
                     slot,
                     addresses,
-                    &|reward_type| -> bool { reward_type == RewardType::Staking },
+                    &|reward_type| -> bool {
+                        reward_type == RewardType::Staking
+                            || reward_type == RewardType::DeactivatedStake
+                    },
                 );
                 reward_map.extend(index_reward_map);
             }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -432,6 +432,7 @@ impl Bank {
         new_rate_activation_epoch: Option<Epoch>,
         delay_commission_updates: bool,
         commission_rate_in_basis_points: bool,
+        adjust_delegations_for_rent: bool,
     ) -> Option<DelegationRewards> {
         // curry closure to add the contextual stake_pubkey
         let reward_calc_tracer = reward_calc_tracer.as_ref().map(|outer| {
@@ -455,6 +456,12 @@ impl Bank {
         };
         let vote_state = vote_account.vote_state_view();
         let stake_state = stake_account.stake_state();
+
+        let current_lamports = stake_account.lamports();
+        let minimum_lamports = self
+            .rent_collector
+            .rent
+            .minimum_balance(stake_account.data_len());
 
         // Fetch the voter commission from past epochs to attempt to
         // delay the effect of commission updates by at least one
@@ -489,9 +496,11 @@ impl Bank {
                 stake_history,
                 new_rate_activation_epoch,
                 commission_rate_in_basis_points,
+                adjust_delegations_for_rent,
             },
             reward_calc_tracer,
-            stake_account.lamports(),
+            current_lamports,
+            minimum_lamports,
         ) {
             Ok((stake_reward, commission_lamports, stake)) => {
                 let stake_reward = PartitionedStakeReward {
@@ -536,6 +545,9 @@ impl Bank {
         let feature_snapshot = self.feature_set.snapshot();
         let delay_commission_updates = feature_snapshot.delay_commission_updates;
         let commission_rate_in_basis_points = feature_snapshot.commission_rate_in_basis_points;
+        let adjust_delegations_for_rent = self
+            .feature_set
+            .is_active(&agave_feature_set::rent_adjusted_delegations::id());
 
         let mut measure_redeem_rewards = Measure::start("redeem-rewards");
         // For N stake delegations, where N is >1,000,000, we produce:
@@ -567,6 +579,7 @@ impl Bank {
                                 new_warmup_cooldown_rate_epoch,
                                 delay_commission_updates,
                                 commission_rate_in_basis_points,
+                                adjust_delegations_for_rent,
                             )
                         });
                     let (stake_reward, maybe_reward_record) = match maybe_reward_record {

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -14,10 +14,15 @@ use {
     serde::{Deserialize, Serialize},
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut},
     solana_accounts_db::stake_rewards::{StakeReward, StakeRewardInfo},
+    solana_clock::Epoch,
     solana_measure::measure_us,
     solana_pubkey::Pubkey,
+    solana_rent::Rent,
     solana_reward_info::RewardType,
-    solana_stake_interface::state::{Delegation, StakeStateV2},
+    solana_stake_interface::{
+        stake_history::StakeHistory,
+        state::{Delegation, StakeStateV2},
+    },
     std::sync::{Arc, atomic::Ordering::Relaxed},
     thiserror::Error,
 };
@@ -190,8 +195,13 @@ impl Bank {
     }
 
     fn build_updated_stake_reward(
+        distribution_epoch: u64,
+        stake_history: &StakeHistory,
+        new_warmup_cooldown_rate_epoch: Option<Epoch>,
         stakes_cache_accounts: &im::HashMap<Pubkey, StakeAccount<Delegation>>,
         partitioned_stake_reward: &PartitionedStakeReward,
+        rent: &Rent,
+        adjust_delegations_for_rent: bool,
     ) -> Result<StakeReward, DistributionError> {
         let stake_account = stakes_cache_accounts
             .get(&partitioned_stake_reward.stake_pubkey)
@@ -209,13 +219,21 @@ impl Bank {
         account
             .checked_add_lamports(partitioned_stake_reward.stake_reward)
             .map_err(|_| DistributionError::ArithmeticOverflow)?;
-        assert_eq!(
-            stake
-                .delegation
-                .stake
-                .saturating_add(partitioned_stake_reward.stake_reward),
-            partitioned_stake_reward.stake.delegation.stake
-        );
+        if adjust_delegations_for_rent {
+            let minimum_balance = rent.minimum_balance(account.data().len());
+            assert!(
+                partitioned_stake_reward.stake.delegation.stake
+                    <= account.lamports().saturating_sub(minimum_balance),
+            );
+        } else {
+            assert_eq!(
+                stake
+                    .delegation
+                    .stake
+                    .saturating_add(partitioned_stake_reward.stake_reward),
+                partitioned_stake_reward.stake.delegation.stake
+            );
+        }
         account
             .set_state(&StakeStateV2::Stake(
                 meta,
@@ -223,10 +241,21 @@ impl Bank {
                 flags,
             ))
             .map_err(|_| DistributionError::UnableToSetState)?;
+
+        let reward_type = if partitioned_stake_reward.stake.delegation.stake(
+            distribution_epoch,
+            stake_history,
+            new_warmup_cooldown_rate_epoch,
+        ) == 0
+        {
+            RewardType::DeactivatedStake
+        } else {
+            RewardType::Staking
+        };
         Ok(StakeReward {
             stake_pubkey: partitioned_stake_reward.stake_pubkey,
             stake_reward_info: StakeRewardInfo {
-                reward_type: RewardType::Staking,
+                reward_type,
                 lamports: i64::try_from(partitioned_stake_reward.stake_reward).unwrap(),
                 post_balance: account.lamports(),
                 commission_bps: Some(partitioned_stake_reward.commission_bps),
@@ -263,6 +292,12 @@ impl Bank {
         let mut updated_stake_rewards = Vec::with_capacity(indices.len());
         let stakes_cache = self.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
+        let stake_history = stakes_cache.history();
+        let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
+        let rent = &self.rent_collector.rent;
+        let adjust_delegations_for_rent = self
+            .feature_set
+            .is_active(&agave_feature_set::rent_adjusted_delegations::id());
         for index in indices {
             let partitioned_stake_reward = partition_rewards
                 .all_stake_rewards
@@ -279,8 +314,15 @@ impl Bank {
                 });
             let stake_pubkey = partitioned_stake_reward.stake_pubkey;
             let reward_amount = partitioned_stake_reward.stake_reward;
-            match Self::build_updated_stake_reward(stakes_cache_accounts, partitioned_stake_reward)
-            {
+            match Self::build_updated_stake_reward(
+                self.epoch,
+                stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                partitioned_stake_reward,
+                rent,
+                adjust_delegations_for_rent,
+            ) {
                 Ok(stake_reward) => {
                     lamports_distributed += reward_amount;
                     updated_stake_rewards.push(stake_reward);
@@ -329,12 +371,14 @@ mod tests {
         solana_reward_info::RewardType,
         solana_stake_interface::{
             stake_flags::StakeFlags,
+            stake_history::StakeHistoryEntry,
             state::{Meta, Stake},
         },
         solana_sysvar as sysvar,
         solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
         solana_vote_program::vote_state,
         std::sync::Arc,
+        test_case::test_case,
     };
 
     #[test]
@@ -618,10 +662,31 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_build_updated_stake_reward() {
+    #[test_case(true; "adjust_delegations_for_rent")]
+    #[test_case(false; "no_adjust_delegations_for_rent")]
+    fn test_build_updated_stake_reward(adjust_delegations_for_rent: bool) {
         let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
         let bank = Bank::new_for_tests(&genesis_config);
+        // add an entry so we can get full deactivation one epoch later
+        let mut stake_history = StakeHistory::default();
+        stake_history.add(
+            0,
+            StakeHistoryEntry {
+                effective: 1_000_000 * LAMPORTS_PER_SOL,
+                activating: LAMPORTS_PER_SOL,
+                deactivating: LAMPORTS_PER_SOL,
+            },
+        );
+
+        let distribution_epoch = bank.epoch + 1;
+        let new_warmup_cooldown_rate_epoch = bank.new_warmup_cooldown_rate_epoch();
+        let mut rent = bank.rent_collector.rent.clone();
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+
+        // Adjust rent down, no impact at all
+        if adjust_delegations_for_rent {
+            rent.lamports_per_byte /= 2;
+        }
 
         let voter_pubkey = Pubkey::new_unique();
         let new_stake = Stake {
@@ -645,13 +710,19 @@ mod tests {
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
         assert_eq!(
-            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward,)
-                .unwrap_err(),
+            Bank::build_updated_stake_reward(
+                distribution_epoch,
+                &stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                &partitioned_stake_reward,
+                &rent,
+                adjust_delegations_for_rent,
+            )
+            .unwrap_err(),
             DistributionError::AccountNotFound
         );
         drop(stakes_cache);
-
-        let rent_exempt_reserve = 2_282_880;
 
         let overflowing_account = Pubkey::new_unique();
         let mut stake_account = AccountSharedData::new(
@@ -676,8 +747,16 @@ mod tests {
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
         assert_eq!(
-            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward,)
-                .unwrap_err(),
+            Bank::build_updated_stake_reward(
+                distribution_epoch,
+                &stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                &partitioned_stake_reward,
+                &rent,
+                adjust_delegations_for_rent,
+            )
+            .unwrap_err(),
             DistributionError::ArithmeticOverflow
         );
         drop(stakes_cache);
@@ -739,8 +818,97 @@ mod tests {
             },
         };
         assert_eq!(
-            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward,)
-                .unwrap(),
+            Bank::build_updated_stake_reward(
+                distribution_epoch,
+                &stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                &partitioned_stake_reward,
+                &rent,
+                adjust_delegations_for_rent,
+            )
+            .unwrap(),
+            expected_stake_reward
+        );
+        drop(stakes_cache);
+
+        let deactivating_account = Pubkey::new_unique();
+        let deactivating_stake = Stake {
+            delegation: Delegation {
+                voter_pubkey,
+                stake: 55_555,
+                deactivation_epoch: bank.epoch,
+                ..Delegation::default()
+            },
+            credits_observed: 42,
+        };
+        let starting_stake = deactivating_stake.delegation.stake - stake_reward;
+        let starting_lamports = rent_exempt_reserve + starting_stake;
+        let mut stake_account = AccountSharedData::new(
+            starting_lamports,
+            StakeStateV2::size_of(),
+            &solana_stake_interface::program::id(),
+        );
+        let other_stake = Stake {
+            delegation: Delegation {
+                voter_pubkey,
+                stake: starting_stake,
+                deactivation_epoch: bank.epoch,
+                ..Delegation::default()
+            },
+            credits_observed: 11,
+        };
+        stake_account
+            .set_state(&StakeStateV2::Stake(
+                Meta::default(),
+                other_stake,
+                StakeFlags::default(),
+            ))
+            .unwrap();
+        bank.store_account(&deactivating_account, &stake_account);
+        let partitioned_stake_reward = PartitionedStakeReward {
+            stake_pubkey: successful_account,
+            stake: deactivating_stake,
+            stake_reward,
+            commission_bps,
+        };
+        let stakes_cache = bank.stakes_cache.stakes();
+        let stakes_cache_accounts = stakes_cache.stake_delegations();
+        let expected_lamports = starting_lamports + stake_reward;
+        let mut expected_stake_account = AccountSharedData::new(
+            expected_lamports,
+            StakeStateV2::size_of(),
+            &solana_stake_interface::program::id(),
+        );
+        expected_stake_account
+            .set_state(&StakeStateV2::Stake(
+                Meta::default(),
+                deactivating_stake,
+                StakeFlags::default(),
+            ))
+            .unwrap();
+
+        let expected_stake_reward = StakeReward {
+            stake_pubkey: successful_account,
+            stake_account: expected_stake_account,
+            stake_reward_info: StakeRewardInfo {
+                reward_type: RewardType::DeactivatedStake,
+                lamports: stake_reward as i64,
+                post_balance: expected_lamports,
+                commission_bps: Some(commission_bps),
+            },
+        };
+        assert_eq!(
+            Bank::build_updated_stake_reward(
+                distribution_epoch,
+                &stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                &partitioned_stake_reward,
+                &rent,
+                adjust_delegations_for_rent,
+            )
+            .unwrap(),
             expected_stake_reward
         );
         drop(stakes_cache);
@@ -807,5 +975,100 @@ mod tests {
             ..
         } = bank.store_stake_accounts_in_partition(&partitioned_rewards, 0);
         assert_eq!(expected_total, lamports_distributed);
+    }
+
+    #[test]
+    fn test_distribute_with_increased_rent() {
+        let (mut genesis_config, _mint_keypair) =
+            create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        genesis_config.epoch_schedule = EpochSchedule::custom(432000, 432000, false);
+        let bank = Bank::new_for_tests(&genesis_config);
+
+        // Set up epoch_rewards sysvar with rewards with 10e9 lamports to distribute.
+        let total_rewards = 10 * LAMPORTS_PER_SOL;
+        let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
+        let total_points = (total_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
+        bank.create_epoch_rewards_sysvar(
+            0,
+            42,
+            num_partitions,
+            &PointValue {
+                rewards: total_rewards,
+                points: total_points,
+            },
+        );
+        let pre_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
+        let expected_balance =
+            bank.get_minimum_balance_for_rent_exemption(pre_epoch_rewards_account.data().len());
+        // Expected balance is the sysvar rent-exempt balance
+        assert_eq!(pre_epoch_rewards_account.lamports(), expected_balance);
+
+        // Use lower lamports per byte for creating, bank has higher amount
+        let mut lower_rent = bank.rent_collector.rent.clone();
+        lower_rent.lamports_per_byte /= 10;
+        let higher_rent = &bank.rent_collector.rent;
+
+        // Set up a partition of rewards to distribute
+        let stake_rewards = [
+            // Zero stake -> destaked
+            StakeReward::new_with_pre_stake_account(0, 0, &lower_rent),
+            // Below new minimum, small reward -> destaked
+            StakeReward::new_with_pre_stake_account(1, 1, &lower_rent),
+            // Below new minimum, no reward -> delegation modified
+            StakeReward::new_with_pre_stake_account(0, LAMPORTS_PER_SOL, &lower_rent),
+            // Below new minimum, small reward -> delegation modified
+            StakeReward::new_with_pre_stake_account(1, LAMPORTS_PER_SOL, &lower_rent),
+            // Below new minimum, big reward -> delegation modified
+            StakeReward::new_with_pre_stake_account(
+                LAMPORTS_PER_SOL as i64,
+                LAMPORTS_PER_SOL,
+                &lower_rent,
+            ),
+            // Above new minimum, small reward -> delegation capped
+            StakeReward::new_with_pre_stake_account(1, LAMPORTS_PER_SOL, higher_rent),
+            // Above new minimum, big reward -> delegation capped
+            StakeReward::new_with_pre_stake_account(
+                LAMPORTS_PER_SOL as i64,
+                LAMPORTS_PER_SOL,
+                higher_rent,
+            ),
+        ]
+        .into_iter()
+        .map(|r| {
+            bank.store_account(&r.1.stake_pubkey, &r.0);
+            r.1
+        })
+        .collect::<Vec<_>>();
+
+        let expected_num = stake_rewards.len();
+        let rewards_to_distribute = stake_rewards
+            .iter()
+            .map(|stake_reward| stake_reward.stake_reward_info.lamports)
+            .sum::<i64>() as u64;
+        let all_rewards = convert_rewards(stake_rewards);
+
+        let partitioned_rewards = StartBlockHeightAndPartitionedRewards {
+            distribution_starting_block_height: bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
+            all_stake_rewards: Arc::new(all_rewards),
+            partition_indices: vec![(0..expected_num).collect::<Vec<_>>()],
+        };
+
+        // Distribute rewards
+        let pre_cap = bank.capitalization();
+        bank.distribute_epoch_rewards_in_partition(&partitioned_rewards, 0);
+        let post_cap = bank.capitalization();
+        let post_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
+
+        // Assert that epoch rewards sysvar lamports balance does not change
+        assert_eq!(post_epoch_rewards_account.lamports(), expected_balance);
+
+        let epoch_rewards: sysvar::epoch_rewards::EpochRewards =
+            from_account(&post_epoch_rewards_account).unwrap();
+        assert_eq!(epoch_rewards.total_rewards, total_rewards);
+        assert_eq!(epoch_rewards.distributed_rewards, rewards_to_distribute,);
+
+        // Assert that the bank total capital changed by the amount of rewards
+        // distributed
+        assert_eq!(pre_cap + rewards_to_distribute, post_cap);
     }
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -995,7 +995,10 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
     let rewards = bank2.rewards.read().unwrap();
     rewards
         .iter()
-        .find(|(_address, reward)| reward.reward_type == RewardType::Staking)
+        .find(|(_address, reward)| {
+            reward.reward_type == RewardType::Staking
+                || reward.reward_type == RewardType::DeactivatedStake
+        })
         .unwrap();
 
     bank1.capitalization()

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -33,7 +33,8 @@ pub(crate) fn redeem_rewards<'a>(
     vote_state: DelegatedVoteState,
     calculation_environment: CalculationEnvironment<'a>,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
-    stake_account_lamports_for_trace: u64,
+    current_lamports: u64,
+    minimum_lamports: u64,
 ) -> Result<(u64, u64, Stake), InstructionError> {
     if let StakeStateV2::Stake(_meta, stake, _stake_flags) = stake_state {
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
@@ -52,7 +53,7 @@ pub(crate) fn redeem_rewards<'a>(
                 )),
             );
             inflation_point_calc_tracer(&InflationPointCalculationEvent::PriorTotalLamports(
-                stake_account_lamports_for_trace,
+                current_lamports,
             ));
             // Choose which trace to emit based on the `commission_rate_in_basis_points` feature.
             if commission_rate_in_basis_points {
@@ -73,6 +74,8 @@ pub(crate) fn redeem_rewards<'a>(
             vote_state,
             calculation_environment,
             inflation_point_calc_tracer,
+            current_lamports,
+            minimum_lamports,
         ) {
             Ok((stakers_reward, voters_reward, stake))
         } else {
@@ -89,6 +92,8 @@ fn redeem_stake_rewards<'a>(
     vote_state: DelegatedVoteState,
     calculation_environment: CalculationEnvironment<'a>,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
+    current_lamports: u64,
+    minimum_lamports: u64,
 ) -> Option<(u64, u64)> {
     if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
         inflation_point_calc_tracer(&InflationPointCalculationEvent::CreditsObserved(
@@ -96,7 +101,10 @@ fn redeem_stake_rewards<'a>(
             None,
         ));
     }
-    calculate_stake_rewards(
+
+    let rewarded_epoch = calculation_environment.rewarded_epoch;
+    let adjust_delegations_for_rent = calculation_environment.adjust_delegations_for_rent;
+    let maybe_rewards = calculate_stake_rewards(
         stake,
         voter_commission_bps,
         vote_state,
@@ -111,12 +119,39 @@ fn redeem_stake_rewards<'a>(
             ));
         }
         stake.credits_observed = calculated_stake_rewards.new_credits_observed;
-        stake.delegation.stake += calculated_stake_rewards.staker_rewards;
         (
             calculated_stake_rewards.staker_rewards,
             calculated_stake_rewards.voter_rewards,
         )
-    })
+    });
+
+    let staker_rewards = maybe_rewards.map(|x| x.0).unwrap_or(0);
+    if adjust_delegations_for_rent {
+        let new_delegation = std::cmp::min(
+            stake.delegation.stake.saturating_add(staker_rewards),
+            current_lamports
+                .saturating_add(staker_rewards)
+                .saturating_sub(minimum_lamports),
+        );
+        // If `maybe_rewards.is_some()`, need to drive forward credits, even
+        // if rewards are zero
+        if new_delegation != stake.delegation.stake || maybe_rewards.is_some() {
+            stake.delegation.stake = new_delegation;
+            // Deactivate stake if needed. This deactivation is immediate,
+            // unlike a requested deactivation which happens at the next epoch
+            // boundary
+            if new_delegation == 0 {
+                stake.delegation.deactivation_epoch = rewarded_epoch;
+            }
+            let voter_rewards = maybe_rewards.map(|x| x.1).unwrap_or(0);
+            Some((staker_rewards, voter_rewards))
+        } else {
+            None
+        }
+    } else {
+        stake.delegation.stake += staker_rewards;
+        maybe_rewards
+    }
 }
 
 /// for a given stake and vote_state, calculate what distributions and what updates should be made
@@ -278,6 +313,7 @@ mod tests {
         solana_clock::Epoch,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_pubkey::Pubkey,
+        solana_rent::Rent,
         solana_stake_interface::{stake_history::StakeHistory, state::Delegation},
         solana_vote_program::vote_state::{VoteStateV4, handler::VoteStateHandle},
         test_case::test_case,
@@ -295,8 +331,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_stake_state_redeem_rewards() {
+    #[test_case(true; "adjust_delegations_for_rent")]
+    #[test_case(false; "no_adjust_delegations_for_rent")]
+    fn test_stake_state_redeem_rewards(adjust_delegations_for_rent: bool) {
         let mut vote_state = VoteStateV4::default();
         // assume stake.stake() is right
         // bootstrap means fully-vested stake at epoch 0
@@ -305,6 +342,15 @@ mod tests {
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
+
+        let mut rent = Rent::default();
+        let minimum_balance = rent.minimum_balance(StakeStateV2::size_of());
+
+        // Adjust rent down, no impact
+        if adjust_delegations_for_rent {
+            rent.lamports_per_byte /= 2;
+        }
+        let new_minimum_balance = rent.minimum_balance(StakeStateV2::size_of());
 
         // this one can't collect now, credits_observed == vote_state.credits()
         assert_eq!(
@@ -322,8 +368,11 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
+                stake_lamports + minimum_balance,
+                new_minimum_balance,
             )
         );
 
@@ -347,8 +396,11 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
+                stake_lamports + minimum_balance,
+                new_minimum_balance,
             )
         );
 
@@ -369,6 +421,7 @@ mod tests {
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
+        let adjust_delegations_for_rent = true;
 
         // this one can't collect now, credits_observed == vote_state.credits()
         assert_eq!(
@@ -386,6 +439,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -415,6 +469,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -441,6 +496,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -470,6 +526,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -497,6 +554,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -526,6 +584,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -549,6 +608,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -569,6 +629,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -596,6 +657,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -623,6 +685,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -701,6 +764,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -729,9 +793,274 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
+        );
+    }
+
+    fn check_rent_adjusted_stake_delegation(
+        rewarded_epoch: u64,
+        mut pre_stake: Stake,
+        pre_lamports: u64,
+        new_minimum_balance: u64,
+        total_rewards: u64,
+        post_stake: Stake,
+        staker_rewards: Option<u64>,
+    ) {
+        let mut vote_state = VoteStateV4::default();
+        // put 1 credit to create rewards
+        vote_state.increment_credits(rewarded_epoch, 1);
+        let stake_history = &StakeHistory::default();
+        let new_rate_activation_epoch = None;
+        let commission_rate_in_basis_points = true;
+        let adjust_delegations_for_rent = true;
+
+        let maybe_rewards = redeem_stake_rewards(
+            &mut pre_stake,
+            vote_state.inflation_rewards_commission_bps,
+            DelegatedVoteState::from(&vote_state),
+            CalculationEnvironment {
+                rewarded_epoch,
+                point_value: &PointValue {
+                    rewards: total_rewards,
+                    points: 1,
+                },
+                stake_history,
+                new_rate_activation_epoch,
+                commission_rate_in_basis_points,
+                adjust_delegations_for_rent,
+            },
+            null_tracer(),
+            pre_lamports,
+            new_minimum_balance,
+        );
+        assert_eq!(pre_stake, post_stake);
+        assert_eq!(maybe_rewards.map(|x| x.0), staker_rewards)
+    }
+
+    #[test]
+    fn rent_adjusted_stake_delegation_calculations() {
+        let old_minimum_balance = 8;
+        let new_minimum_balance = 9;
+        let rewarded_epoch = 1;
+
+        // No rewards at all -> updated (all stakes get driven forward if
+        // inflation is disabled)
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            new_minimum_balance + 1,
+            new_minimum_balance,
+            0,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(0),
+        );
+
+        // Stake receives no rewards or delegation adjustment -> no update
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            new_minimum_balance + 1,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            None,
+        );
+
+        // Already destaked -> no update
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 0,
+                    deactivation_epoch: 0,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            old_minimum_balance - 1,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 0,
+                    deactivation_epoch: 0,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            None,
+        );
+
+        // Staked, already below minimum, go further below minimum
+        // -> destaked, still one lamport of rewards though
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            old_minimum_balance - 1,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 0,
+                    deactivation_epoch: rewarded_epoch,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(1),
+        );
+
+        // Delegation hits exactly 0 -> destaked, no rewards
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance,
+            new_minimum_balance,
+            0,
+            Stake {
+                delegation: Delegation {
+                    stake: 0,
+                    deactivation_epoch: rewarded_epoch,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(0),
+        );
+
+        // Delegation decreases to 1 -> still staked
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 2,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance + 1,
+            new_minimum_balance,
+            0,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(0),
+        );
+
+        // Rewards partially cover minimum balance change
+        // -> decrease stake
+        // This case is confusing because it pays out 2 lamports in rewards,
+        // so we adjust minimum up so that even with 2 lamports in rewards, the
+        // delegation goegs down.
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 2,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance,
+            new_minimum_balance + 1,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(2),
+        );
+
+        // Rewards cover minimum balance change -> no change in stake
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(1),
+        );
+
+        // Well above new minimum balance -> delegation change capped to rewards
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance + 2,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 2,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(1),
         );
     }
 
@@ -747,6 +1076,7 @@ mod tests {
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
+        let adjust_delegations_for_rent = true;
 
         calculate_stake_rewards(
             &stake,
@@ -758,6 +1088,7 @@ mod tests {
                 stake_history,
                 new_rate_activation_epoch,
                 commission_rate_in_basis_points,
+                adjust_delegations_for_rent,
             },
             null_tracer(),
         );
@@ -778,6 +1109,7 @@ mod tests {
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
+        let adjust_delegations_for_rent = true;
 
         // this one can't collect now, credits_observed == vote_state.credits()
         assert_eq!(
@@ -795,6 +1127,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -36,6 +36,7 @@ pub(crate) struct CalculationEnvironment<'a> {
     pub(crate) stake_history: &'a StakeHistory,
     pub(crate) new_rate_activation_epoch: Option<Epoch>,
     pub(crate) commission_rate_in_basis_points: bool,
+    pub(crate) adjust_delegations_for_rent: bool,
 }
 
 #[derive(Debug)]

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -43,6 +43,11 @@ impl<T> StakeAccount<T> {
     pub(crate) fn stake_state(&self) -> &StakeStateV2 {
         &self.stake_state
     }
+
+    #[inline]
+    pub(crate) fn data_len(&self) -> usize {
+        self.account.data().len()
+    }
 }
 
 impl StakeAccount<Delegation> {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -1356,6 +1356,10 @@ mod test {
         reward.reward_type = Some(RewardType::Staking);
         let gen_reward: generated::Reward = reward.clone().into();
         assert_eq!(reward, gen_reward.into());
+
+        reward.reward_type = Some(RewardType::DeactivatedStake);
+        let gen_reward: generated::Reward = reward.clone().into();
+        assert_eq!(reward, gen_reward.into());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

As described in [SIMD-0488](https://github.com/solana-foundation/solana-improvement-documents/pull/488), we need a mechanism for adjusting stake delegations during epoch rewards payout.

#### Summary of Changes

Implement the new calculation logic. The commits can be read in order:

* add the feature gate
* adjust the calculation
* tweak existing tests, add calculation test
* add distribution test

Note: leaving this in draft until the SIMD goes through, there's still one more open question about respecting the minimum SOL delegation amount