### PR TITLE
blockstore: mark CMR conflicts as dead under validate_chained_block_id

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -118,8 +118,8 @@ fn run_check_duplicate(
             root_bank = bank_forks.read().unwrap().root_bank();
         }
         let shred_slot = shred.slot();
-        let chained_merkle_conflict_duplicate_proofs = cluster_nodes::check_feature_activation(
-            &feature_set::chained_merkle_conflict_duplicate_proofs::id(),
+        let validate_chained_block_id = cluster_nodes::check_feature_activation(
+            &feature_set::validate_chained_block_id::id(),
             shred_slot,
             &root_bank,
         );
@@ -127,23 +127,13 @@ fn run_check_duplicate(
             PossibleDuplicateShred::LastIndexConflict(shred, conflict)
             | PossibleDuplicateShred::ErasureConflict(shred, conflict)
             | PossibleDuplicateShred::MerkleRootConflict(shred, conflict) => (shred, conflict),
-            PossibleDuplicateShred::ChainedMerkleRootConflict(shred, conflict) => {
-                if chained_merkle_conflict_duplicate_proofs {
-                    // Although this proof can be immediately stored on detection, we wait until
-                    // here in order to check the feature flag, as storage in blockstore can
-                    // preclude the detection of other duplicate proofs in this slot
-                    if blockstore.has_duplicate_shreds_in_slot(shred_slot) {
-                        return Ok(());
-                    }
-                    blockstore.store_duplicate_slot(
-                        shred_slot,
-                        conflict.clone(),
-                        shred.clone().into_payload(),
-                    )?;
-                    (shred, conflict)
-                } else {
-                    return Ok(());
+            PossibleDuplicateShred::ChainedMerkleRootConflict(_shred, _conflict) => {
+                if validate_chained_block_id {
+                    // Although chained merkle roots are not necessary for agave duplicate resolution protocols,
+                    // We still need to mark the block as dead for other client teams.
+                    blockstore.set_dead_slot(shred_slot)?;
                 }
+                return Ok(());
             }
             PossibleDuplicateShred::Exists(shred) => {
                 // Unlike the other cases we have to wait until here to decide to handle the duplicate and store

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1494,7 +1494,7 @@ pub mod vote_account_initialize_v2 {
 }
 
 pub mod validate_chained_block_id {
-    solana_pubkey::declare_id!("vbiddkDHTSHSvL8B21AetWvTBLxxUZ1FmU6DFjztyRn");
+    solana_pubkey::declare_id!("vcmrbYbiMVKaq1snKP6eCacNDcr6qZvpCNUjmk6gxvZ");
 }
 
 pub mod validator_admission_ticket {


### PR DESCRIPTION
#### Problem
The feature `chained_merkle_conflict_duplicate_proofs` was designed pre `enforce_fixed_fec_set` in order to notice duplicate blocks when there were undersized FEC sets.

With `enforce_fixed_fec_set` this feature is no longer needed and has been abandoned.

However FD requires that the CMR is correct across FEC sets. We *do not* need to mark the block as duplicate or send some sort of duplicate proofs via gossip, just mark the block as dead.

#### Summary of Changes
As part of SIMD-0340, mark the block as dead instead. In a follow up we'll remove the abandoned feature.
We wish to backport this PR as SIMD-0340 is critical for FD and needs to be activated in 4.0

See the amendment 
https://github.com/solana-foundation/solana-improvement-documents/pull/502