### PR TITLE
fix(fs): align write size to 4096 to support all NVMEs

### DIFF
--- a/fs/src/io_uring/file_creator.rs
+++ b/fs/src/io_uring/file_creator.rs
@@ -33,9 +33,10 @@ use {
 // 32 pages (Maximum Data Transfer Size) * page size (MPSMIN = Memory Page Size) = 128KiB.
 pub const DEFAULT_WRITE_SIZE: IoSize = 512 * 1024;
 
-// Write size and file offset alignment for use with direct IO - all modern file systems
-// effectively use this constant.
-const DIRECT_IO_WRITE_LEN_ALIGNMENT: IoSize = 512;
+// O_DIRECT requires I/O length, offset, and buffer address to be aligned to the device's logical
+// block size: 512 bytes on most block devices, but 4096 on some NVMes. Use 4096 to avoid
+// per-device detection at runtime.
+const DIRECT_IO_WRITE_LEN_ALIGNMENT: IoSize = 4096;
 
 // Status flags (updatable on file-descriptor) used as default upon file creation.
 const DEFAULT_STATUS_FLAGS: libc::c_int = O_NOATIME;


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/9856 ended up with 512 alignment for direct I/O writes, but it fails for some NVMEs. As reported in FD tests:
```
Archive error: failed to unpack "accounts/316628658.54075": IO error: Invalid argument (os error 22)
```

The used hardware spec:
```
Node                  Generic               SN                   Model                                    Namespace  Usage                      Format           FW Rev
--------------------- --------------------- -------------------- ---------------------------------------- ---------- -------------------------- ---------------- --------
..
/dev/nvme1n1          /dev/ng1n1            KND7N5364I1308G1S    DELL NVME ISE PE8110 RI U.2 960GB        0x1        960.20  GB / 960.20  GB      4 KiB +  0 B   1.1.0
```

indicates the NVME sector size of 4KiB, which ends up as required alignment for `O_DIRECT`

independently there were failures noticed on some CI workers where disks are
```
$ lsblk -o NAME,SIZE,LOG-SEC,PHY-SEC,MOUNTPOINT
NAME          SIZE LOG-SEC PHY-SEC MOUNTPOINT
nvme2n1       3.5T    4096    4096
└─vg01-lv01   7.4T    4096    4096 /var/lib/buildkite-agent
nvme0n1     447.1G     512    4096
├─nvme0n1p1     1M     512    4096
└─nvme0n1p2 447.1G     512    4096 /
nvme3n1       3.5T    4096    4096
└─vg01-lv01   7.4T    4096    4096 /var/lib/buildkite-agent
nvme1n1     447.1G    4096    4096
└─vg01-lv01   7.4T    4096    4096 /var/lib/buildkite-agent
```

Again: `LOG-SEC` column showing 4096 makes it the most likely culprit.

#### Summary of Changes
Bump constant used for alignment of writes to `4096` and update comment.
