### PR TITLE
chore: Remove outdate instruction from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,3 @@
 
 
 Fixes #
-<!-- OPTIONAL: Feature Gate Issue: # -->
-<!-- Don't forget to add the "feature-gate" label -->


### PR DESCRIPTION
#### Problem
Feature gates are no longer tracked with issues in this repo

#### Summary of Changes
Remove dated instructions from PR template