### PR TITLE
blockstore: Remove Result<> from infallible functions

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1779,8 +1779,9 @@ impl Blockstore {
             &shred,
             write_batch,
             shred_source,
-        )?;
+        );
         newly_completed_data_sets.extend(completed_data_sets);
+
         merkle_root_metas
             .entry(erasure_set)
             .or_insert(WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
@@ -1817,7 +1818,7 @@ impl Blockstore {
         // Commit step: commit all changes to the mutable structures at once, or none at all.
         // We don't want only a subset of these changes going through.
         self.code_shred_cf
-            .put_bytes_in_batch(write_batch, (slot, shred_index), shred.payload())?;
+            .put_bytes_in_batch(write_batch, (slot, shred_index), shred.payload());
         index_meta.coding_mut().insert(shred_index);
 
         Ok(())
@@ -2264,7 +2265,7 @@ impl Blockstore {
         shred: &Shred,
         write_batch: &mut WriteBatch,
         shred_source: ShredSource,
-    ) -> Result<impl Iterator<Item = CompletedDataSetInfo> + 'a + use<'a>> {
+    ) -> impl Iterator<Item = CompletedDataSetInfo> + 'a + use<'a> {
         let slot = shred.slot();
         let index = u64::from(shred.index());
 
@@ -2299,7 +2300,7 @@ impl Blockstore {
         // Commit step: commit all changes to the mutable structures at once, or none at all.
         // We don't want only a subset of these changes going through.
         self.data_shred_cf
-            .put_bytes_in_batch(write_batch, (slot, index), shred.payload())?;
+            .put_bytes_in_batch(write_batch, (slot, index), shred.payload());
         data_index.insert(index);
         let newly_completed_data_sets = update_slot_meta(
             last_in_slot,
@@ -2321,7 +2322,7 @@ impl Blockstore {
 
         trace!("inserted shred into slot {slot:?} and index {index:?}");
 
-        Ok(newly_completed_data_sets)
+        newly_completed_data_sets
     }
 
     pub fn get_data_shred(&self, slot: Slot, index: u64) -> Result<Option<Vec<u8>>> {
@@ -4540,7 +4541,7 @@ impl Blockstore {
 
             // At this point this slot has received a parent, so it's no longer an orphan
             if was_orphan_slot {
-                self.orphans_cf.delete_in_batch(write_batch, slot)?;
+                self.orphans_cf.delete_in_batch(write_batch, slot);
             }
         }
 
@@ -11514,8 +11515,7 @@ pub mod tests {
         let mut write_batch = blockstore.get_write_batch().unwrap();
         blockstore
             .merkle_root_meta_cf
-            .delete_range_in_batch(&mut write_batch, slot, slot)
-            .unwrap();
+            .delete_range_in_batch(&mut write_batch, slot, slot);
         blockstore.write_batch(write_batch).unwrap();
         assert!(
             blockstore
@@ -11588,8 +11588,7 @@ pub mod tests {
         let mut write_batch = blockstore.get_write_batch().unwrap();
         blockstore
             .merkle_root_meta_cf
-            .delete_range_in_batch(&mut write_batch, slot, slot)
-            .unwrap();
+            .delete_range_in_batch(&mut write_batch, slot, slot);
         blockstore.write_batch(write_batch).unwrap();
         assert!(
             blockstore

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -243,37 +243,37 @@ impl Blockstore {
         purge_type: PurgeType,
     ) -> Result<()> {
         self.meta_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.bank_hash_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.roots_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.data_shred_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.code_shred_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.dead_slots_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.duplicate_slots_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.erasure_meta_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.orphans_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.index_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.rewards_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.blocktime_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.perf_samples_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.block_height_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.optimistic_slots_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.merkle_root_meta_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot)?;
+            .delete_range_in_batch(write_batch, from_slot, to_slot);
 
         match purge_type {
             PurgeType::Exact => self.purge_special_columns_exact(write_batch, from_slot, to_slot),
@@ -380,16 +380,16 @@ impl Blockstore {
             for (i, transaction) in transactions.enumerate() {
                 if let Some(&signature) = transaction.signatures.first() {
                     self.transaction_status_cf
-                        .delete_in_batch(batch, (signature, slot))?;
+                        .delete_in_batch(batch, (signature, slot));
                     self.transaction_memos_cf
-                        .delete_in_batch(batch, (signature, slot))?;
+                        .delete_in_batch(batch, (signature, slot));
                     if !primary_indexes.is_empty() {
                         self.transaction_memos_cf
-                            .delete_deprecated_in_batch(batch, signature)?;
+                            .delete_deprecated_in_batch(batch, signature);
                     }
                     for primary_index in &primary_indexes {
                         self.transaction_status_cf
-                            .delete_deprecated_in_batch(batch, (*primary_index, signature, slot))?;
+                            .delete_deprecated_in_batch(batch, (*primary_index, signature, slot));
                     }
 
                     let meta = self.read_transaction_status((signature, slot))?;
@@ -402,15 +402,13 @@ impl Blockstore {
                     let transaction_index =
                         u32::try_from(i).map_err(|_| BlockstoreError::TransactionIndexOverflow)?;
                     for pubkey in account_keys.iter() {
-                        self.address_signatures_cf.delete_in_batch(
-                            batch,
-                            (*pubkey, slot, transaction_index, signature),
-                        )?;
+                        self.address_signatures_cf
+                            .delete_in_batch(batch, (*pubkey, slot, transaction_index, signature));
                         for primary_index in &primary_indexes {
                             self.address_signatures_cf.delete_deprecated_in_batch(
                                 batch,
                                 (*primary_index, *pubkey, slot, signature),
-                            )?;
+                            );
                         }
                     }
                 }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -558,19 +558,16 @@ impl AsRef<[u8]> for BlockstoreByteReference<'_> {
 }
 
 impl WriteBatch {
-    fn put_cf<K: AsRef<[u8]>>(&mut self, cf: &ColumnFamily, key: K, value: &[u8]) -> Result<()> {
+    fn put_cf<K: AsRef<[u8]>>(&mut self, cf: &ColumnFamily, key: K, value: &[u8]) {
         self.write_batch.put_cf(cf, key, value);
-        Ok(())
     }
 
-    fn delete_cf<K: AsRef<[u8]>>(&mut self, cf: &ColumnFamily, key: K) -> Result<()> {
+    fn delete_cf<K: AsRef<[u8]>>(&mut self, cf: &ColumnFamily, key: K) {
         self.write_batch.delete_cf(cf, key);
-        Ok(())
     }
 
-    fn delete_range_cf<K: AsRef<[u8]>>(&mut self, cf: &ColumnFamily, from: K, to: K) -> Result<()> {
+    fn delete_range_cf<K: AsRef<[u8]>>(&mut self, cf: &ColumnFamily, from: K, to: K) {
         self.write_batch.delete_range_cf(cf, from, to);
-        Ok(())
     }
 }
 
@@ -709,14 +706,9 @@ where
         result
     }
 
-    pub fn put_bytes_in_batch(
-        &self,
-        batch: &mut WriteBatch,
-        index: C::Index,
-        value: &[u8],
-    ) -> Result<()> {
+    pub fn put_bytes_in_batch(&self, batch: &mut WriteBatch, index: C::Index, value: &[u8]) {
         let key = <C as Column>::key(&index);
-        batch.put_cf(self.handle(), key, value)
+        batch.put_cf(self.handle(), key, value);
     }
 
     /// Retrieves the specified RocksDB integer property of the current
@@ -748,15 +740,15 @@ where
         result
     }
 
-    pub fn delete_in_batch(&self, batch: &mut WriteBatch, index: C::Index) -> Result<()> {
+    pub fn delete_in_batch(&self, batch: &mut WriteBatch, index: C::Index) {
         let key = <C as Column>::key(&index);
-        batch.delete_cf(self.handle(), key)
+        batch.delete_cf(self.handle(), key);
     }
 
     /// Adds a \[`from`, `to`\] range that deletes all entries between the `from` slot
     /// and `to` slot inclusively.  If `from` slot and `to` slot are the same, then all
     /// entries in that slot will be removed.
-    pub fn delete_range_in_batch(&self, batch: &mut WriteBatch, from: Slot, to: Slot) -> Result<()>
+    pub fn delete_range_in_batch(&self, batch: &mut WriteBatch, from: Slot, to: Slot)
     where
         C: Column + ColumnName,
     {
@@ -767,7 +759,7 @@ where
         // adjusting the `to` slot range by 1.
         let from_key = <C as Column>::key(&C::as_index(from));
         let to_key = <C as Column>::key(&C::as_index(to.saturating_add(1)));
-        batch.delete_range_cf(self.handle(), from_key, to_key)
+        batch.delete_range_cf(self.handle(), from_key, to_key);
     }
 
     /// Delete files whose slot range is within \[`from`, `to`\].
@@ -872,7 +864,8 @@ where
     ) -> Result<()> {
         let key = <C as Column>::key(&index);
         let serialized_value = C::serialize(value)?;
-        batch.put_cf(self.handle(), key, &serialized_value)
+        batch.put_cf(self.handle(), key, &serialized_value);
+        Ok(())
     }
 }
 
@@ -1019,9 +1012,9 @@ where
         &self,
         batch: &mut WriteBatch,
         index: C::DeprecatedIndex,
-    ) -> Result<()> {
+    ) {
         let key = C::deprecated_key(index);
-        batch.delete_cf(self.handle(), &key)
+        batch.delete_cf(self.handle(), &key);
     }
 }
 


### PR DESCRIPTION
#### Problem
Several Blockstore and related functions currently return a `Result<>`, but have no underlying calls or logic that can bubble up a `Result<>`

#### Summary of Changes
So, remove the Result from the return type to simplify callers and avoid useless error handling