### PR TITLE
Fix ledger-tool program run --trace not creating trace file

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -161,6 +161,7 @@ and the following fields are required
                 )
                 .arg(&load_genesis_config_arg)
                 .args(&snapshot_config_args)
+                .args(&accounts_db_args())
                 .arg(
                     Arg::with_name("mode")
                         .help(
@@ -542,42 +543,28 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     let (instruction_count, result) = vm.execute_program(&verified_executable, &mut execution_mode);
     let duration = Instant::now() - start_time;
     if let Some(trace_option) = matches.value_of("trace") {
-        vm.context_object_pointer.iterate_vm_traces(
-            &|instruction_context: InstructionContext, executable, register_trace| {
-                let mut analysis = LazyAnalysis::new(executable);
-                if trace_option == "stdout" {
-                    writeln!(
-                        &mut std::io::stdout(),
-                        "TX Instruction {} Program {:?}",
-                        instruction_context.get_index_in_trace(),
-                        instruction_context.get_program_key(),
-                    )
-                    .unwrap();
-                    analysis
-                        .analyze()
-                        .disassemble_register_trace(&mut std::io::stdout(), register_trace)
-                        .unwrap();
-                } else {
-                    let filename = format!(
-                        "{}.{}",
-                        trace_option,
-                        instruction_context.get_index_in_trace()
-                    );
-                    let mut fd = File::create(filename).unwrap();
-                    writeln!(
-                        &fd,
-                        "TX Instruction {} Program {:?}",
-                        instruction_context.get_index_in_trace(),
-                        instruction_context.get_program_key(),
-                    )
-                    .unwrap();
-                    analysis
-                        .analyze()
-                        .disassemble_register_trace(&mut fd, register_trace)
-                        .unwrap();
-                }
-            },
-        );
+        let register_trace = vm.register_trace.as_slice();
+        let mut analysis = LazyAnalysis::new(&verified_executable);
+        if trace_option == "stdout" {
+            writeln!(
+                &mut std::io::stdout(),
+                "TX Instruction 0 Program {:?}",
+                program_id,
+            )
+            .unwrap();
+            analysis
+                .analyze()
+                .disassemble_register_trace(&mut std::io::stdout(), register_trace)
+                .unwrap();
+        } else {
+            let filename = format!("{}.0", trace_option);
+            let mut fd = File::create(filename).unwrap();
+            writeln!(&fd, "TX Instruction 0 Program {:?}", program_id,).unwrap();
+            analysis
+                .analyze()
+                .disassemble_register_trace(&mut fd, register_trace)
+                .unwrap();
+        }
     }
     drop(vm);
 


### PR DESCRIPTION
     Issue #11343  

     agave-ledger-tool program run --trace <file> --mode interpreter
     silently produces no output and no trace file is created.
     
      Proposed Changes
     
     - Add accounts_db_args() to the run subcommand so 
     accounts_index_limit is registered and parse_process_options
     does not exit early

     - Read vm.register_trace directly after execution and use 
     verified_executable for disassembly, instead of going through 
     iterate_vm_traces which depends on the program being in 
     program_cache_for_tx_batch (it is not, as it is loaded from disk)
     
      Testing
     
     Tested manually with:
     agave-ledger-tool program run target/deploy/<program>.so \
       --limit 200000 --trace trace.txt \
       --ledger test-ledger --input instructions.json \
       --mode interpreter

     Verified `trace.txt.0` is created and contains disassembly output.
     