### PR TITLE
replay: validate chained block id on parallel replay path as well

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3173,6 +3173,28 @@ impl ReplayStage {
                     let replay_progress = bank_progress.replay_progress.clone();
                     drop(progress_lock);
 
+                    // Check if the child block's chained merkle root chains to the parent's block id.
+                    // It's important that we do this here (after we have a bank) rather than failing
+                    // in generate_new_bank_forks, as we need a bank to mark as dead in order to kick off
+                    // ancestor hashes service / duplicate block repair.
+                    match check_chained_block_id(blockstore, &bank) {
+                        ChainedBlockIdCheck::Inactive | ChainedBlockIdCheck::Pass => (),
+                        ChainedBlockIdCheck::Unavailable => {
+                            // Missing shred 0, can't replay anyway
+                            return replay_result;
+                        }
+                        ChainedBlockIdCheck::Mismatch => {
+                            // Mismatch, mark dead and don't replay
+                            replay_result.is_slot_dead = true;
+                            replay_result.replay_result =
+                                Some(Err(BlockstoreProcessorError::ChainedBlockIdFailure(
+                                    bank.slot(),
+                                    bank.parent_slot(),
+                                )));
+                            return replay_result;
+                        }
+                    }
+
                     if bank.leader_id() != my_pubkey {
                         let mut replay_blockstore_time =
                             Measure::start("replay_blockstore_into_bank");


### PR DESCRIPTION
#### Problem
This feature was only being checked on the serial fork replay path.

Some validators use parallel fork replay and thus this can lead to a divergence.

#### Summary of Changes
Copy the check over here as well (original check https://github.com/anza-xyz/agave/blob/5b3a87444445f1c93338383bf3c53ccffe72eb35/core/src/replay_stage.rs#L3270)

There is a large amount of code duplication between `replay_active_banks_concurrently` and `replay_active_bank` that could probably be moved into a helper fn including this new check. Will address in a follow up to keep this backport small
