### PR TITLE
Bump to wincode 0.4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13155,9 +13155,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.4.5"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a7bf870d59e16860de785358c89e75cffd171c04fb5f93fba029a167cb0263"
+checksum = "dc91ddd8c932a38bbec58ed536d9e93ce9cd01b6af9b6de3c501132cf98ddec6"
 dependencies = [
  "pastey",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -616,7 +616,7 @@ uriparse = "0.6.4"
 url = "2.5.8"
 wasm-bindgen = "0.2"
 winapi = "0.3.8"
-wincode = { version = "0.4.5", features = ["derive", "solana-short-vec"] }
+wincode = { version = "0.4.8", features = ["derive", "solana-short-vec"] }
 winreg = "0.55"
 x509-parser = "0.18.1"
 zstd = "0.13.3"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -10951,9 +10951,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.4.5"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a7bf870d59e16860de785358c89e75cffd171c04fb5f93fba029a167cb0263"
+checksum = "dc91ddd8c932a38bbec58ed536d9e93ce9cd01b6af9b6de3c501132cf98ddec6"
 dependencies = [
  "pastey",
  "proc-macro2",

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -145,12 +145,22 @@ use {
     wincode::{
         ReadResult, SchemaRead, SchemaWrite, WriteResult,
         config::{Config, DefaultConfig},
-        containers::{Pod, Vec as WincodeVec},
+        containers::Vec as WincodeVec,
         error::write_length_encoding_overflow,
         io::{Reader, Writer},
         len::{BincodeLen, FixIntLen},
+        pod_wrapper,
     },
 };
+
+pod_wrapper! {
+    // Use `BLSSignature` directly once `BLSSignature` wincode support
+    // is released in solana-sdk.
+    unsafe struct PodBLSSignature(BLSSignature);
+    // Use `BLSSignatureCompressed` directly once `BLSSignature` wincode support
+    // is released in solana-sdk.
+    unsafe struct PodBLSSignatureCompressed(BLSSignatureCompressed);
+}
 
 /// Wraps a value with a u16 length prefix for TLV-style serialization.
 ///
@@ -222,7 +232,7 @@ pub struct UpdateParentV1 {
 pub struct GenesisCertificate {
     pub slot: Slot,
     pub block_id: Hash,
-    #[wincode(with = "Pod<BLSSignature>")]
+    #[wincode(with = "PodBLSSignature")]
     pub bls_signature: BLSSignature,
     #[wincode(with = "WincodeVec<u8, BincodeLen>")]
     pub bitmap: Vec<u8>,
@@ -291,7 +301,7 @@ impl FinalCertificate {
 
 #[derive(Clone, PartialEq, Eq, Debug, SchemaRead, SchemaWrite)]
 pub struct VotesAggregate {
-    #[wincode(with = "Pod<BLSSignatureCompressed>")]
+    #[wincode(with = "PodBLSSignatureCompressed")]
     signature: BLSSignatureCompressed,
     #[wincode(with = "WincodeVec<u8, FixIntLen<u16>>")]
     bitmap: Vec<u8>,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -69,8 +69,8 @@ use {
     thiserror::Error,
     wincode::{
         SchemaRead, SchemaWrite, TypeMeta,
-        containers::Pod,
         io::{Reader, Writer},
+        pod_wrapper,
     },
 };
 pub use {
@@ -148,6 +148,10 @@ bitflags! {
         const DATA_COMPLETE_SHRED       = 0b0100_0000;
         const LAST_SHRED_IN_SLOT        = 0b1100_0000;
     }
+}
+
+pod_wrapper! {
+    unsafe struct PodShredFlags(ShredFlags);
 }
 
 impl ShredFlags {
@@ -266,7 +270,7 @@ struct ShredCommonHeader {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 struct DataShredHeader {
     parent_offset: u16,
-    #[wincode(with = "Pod<_>")]
+    #[wincode(with = "PodShredFlags")]
     flags: ShredFlags,
     size: u16, // common shred header + data shred header + data
 }
@@ -1813,33 +1817,33 @@ mod tests {
     fn test_shred_flags_serde() {
         use wincode::{Deserialize as _, Serialize as _};
 
-        let flags = Pod::<ShredFlags>::deserialize(&[0b0001_0101]).unwrap();
+        let flags = PodShredFlags::deserialize(&[0b0001_0101]).unwrap();
         assert_eq!(flags, ShredFlags::from_bits(0b0001_0101).unwrap());
         assert!(!flags.contains(ShredFlags::DATA_COMPLETE_SHRED));
         assert!(!flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
         assert_eq!((flags & ShredFlags::SHRED_TICK_REFERENCE_MASK).bits(), 21u8);
-        assert_eq!(Pod::<ShredFlags>::serialize(&flags).unwrap(), [0b0001_0101]);
+        assert_eq!(PodShredFlags::serialize(&flags).unwrap(), [0b0001_0101]);
 
-        let flags = Pod::<ShredFlags>::deserialize(&[0b0111_0001]).unwrap();
+        let flags = PodShredFlags::deserialize(&[0b0111_0001]).unwrap();
         assert_eq!(flags, ShredFlags::from_bits(0b0111_0001).unwrap());
         assert!(flags.contains(ShredFlags::DATA_COMPLETE_SHRED));
         assert!(!flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
         assert_eq!((flags & ShredFlags::SHRED_TICK_REFERENCE_MASK).bits(), 49u8);
-        assert_eq!(Pod::<ShredFlags>::serialize(&flags).unwrap(), [0b0111_0001]);
+        assert_eq!(PodShredFlags::serialize(&flags).unwrap(), [0b0111_0001]);
 
-        let flags = Pod::<ShredFlags>::deserialize(&[0b1110_0101]).unwrap();
+        let flags = PodShredFlags::deserialize(&[0b1110_0101]).unwrap();
         assert_eq!(flags, ShredFlags::from_bits(0b1110_0101).unwrap());
         assert!(flags.contains(ShredFlags::DATA_COMPLETE_SHRED));
         assert!(flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
         assert_eq!((flags & ShredFlags::SHRED_TICK_REFERENCE_MASK).bits(), 37u8);
-        assert_eq!(Pod::<ShredFlags>::serialize(&flags).unwrap(), [0b1110_0101]);
+        assert_eq!(PodShredFlags::serialize(&flags).unwrap(), [0b1110_0101]);
 
-        let flags = Pod::<ShredFlags>::deserialize(&[0b1011_1101]).unwrap();
+        let flags = PodShredFlags::deserialize(&[0b1011_1101]).unwrap();
         assert_eq!(flags, ShredFlags::from_bits(0b1011_1101).unwrap());
         assert!(!flags.contains(ShredFlags::DATA_COMPLETE_SHRED));
         assert!(!flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
         assert_eq!((flags & ShredFlags::SHRED_TICK_REFERENCE_MASK).bits(), 61u8);
-        assert_eq!(Pod::<ShredFlags>::serialize(&flags).unwrap(), [0b1011_1101]);
+        assert_eq!(PodShredFlags::serialize(&flags).unwrap(), [0b1011_1101]);
     }
 
     // Verifies that LAST_SHRED_IN_SLOT also implies DATA_COMPLETE_SHRED.
@@ -1861,7 +1865,7 @@ mod tests {
         assert!(flags.contains(ShredFlags::DATA_COMPLETE_SHRED));
         assert!(flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
 
-        let mut flags = Pod::<ShredFlags>::deserialize(&[0b1011_1111]).unwrap();
+        let mut flags = PodShredFlags::deserialize(&[0b1011_1111]).unwrap();
         assert!(!flags.contains(ShredFlags::DATA_COMPLETE_SHRED));
         assert!(!flags.contains(ShredFlags::LAST_SHRED_IN_SLOT));
         flags.insert(ShredFlags::LAST_SHRED_IN_SLOT);

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -11577,9 +11577,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.4.5"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a7bf870d59e16860de785358c89e75cffd171c04fb5f93fba029a167cb0263"
+checksum = "dc91ddd8c932a38bbec58ed536d9e93ce9cd01b6af9b6de3c501132cf98ddec6"
 dependencies = [
  "pastey",
  "proc-macro2",

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -9,8 +9,14 @@ use {
     solana_bls_signatures::Signature as BLSSignature,
     solana_clock::Slot,
     solana_hash::Hash,
-    wincode::{SchemaRead, SchemaWrite, containers::Pod},
+    wincode::{SchemaRead, SchemaWrite, pod_wrapper},
 };
+
+// Use `BLSSignature` directly once `BLSSignature` wincode support
+// is released in solana-sdk.
+pod_wrapper! {
+    unsafe struct PodBLSSignature(BLSSignature);
+}
 
 /// The seed used to derive the BLS keypair
 pub const BLS_KEYPAIR_DERIVE_SEED: &[u8; 9] = b"alpenglow";
@@ -28,7 +34,7 @@ pub struct VoteMessage {
     /// The type of the vote.
     pub vote: Vote,
     /// The signature.
-    #[wincode(with = "Pod<BLSSignature>")]
+    #[wincode(with = "PodBLSSignature")]
     pub signature: BLSSignature,
     /// The rank of the validator.
     pub rank: u16,
@@ -214,7 +220,7 @@ pub struct Certificate {
     /// The certificate type.
     pub cert_type: CertificateType,
     /// The aggregate signature.
-    #[wincode(with = "Pod<BLSSignature>")]
+    #[wincode(with = "PodBLSSignature")]
     pub signature: BLSSignature,
     /// A rank bitmap for validators' signatures included in the aggregate.
     /// See solana-signer-store for encoding format.

--- a/votor-messages/src/reward_certificate.rs
+++ b/votor-messages/src/reward_certificate.rs
@@ -8,12 +8,14 @@ use {
     solana_pubkey::Pubkey,
     solana_signer_store::EncodeError,
     thiserror::Error,
-    wincode::{
-        SchemaRead, SchemaWrite,
-        containers::{Pod, Vec as WincodeVec},
-        len::ShortU16,
-    },
+    wincode::{SchemaRead, SchemaWrite, containers::Vec as WincodeVec, len::ShortU16, pod_wrapper},
 };
+
+// Use `BLSSignatureCompressed` directly once `BLSSignature` wincode support
+// is released in solana-sdk.
+pod_wrapper! {
+    unsafe struct PodBLSSignatureCompressed(BLSSignatureCompressed);
+}
 
 /// Number of slots in the past that the the current leader is responsible for producing the reward certificates.
 pub const NUM_SLOTS_FOR_REWARD: u64 = 8;
@@ -34,7 +36,7 @@ pub struct SkipRewardCertificate {
     /// The slot the certificate is for.
     pub slot: Slot,
     /// The signature.
-    #[wincode(with = "Pod<BLSSignatureCompressed>")]
+    #[wincode(with = "PodBLSSignatureCompressed")]
     pub signature: BLSSignatureCompressed,
     /// The bitmap for validators, see solana-signer-store for encoding format.
     #[wincode(with = "WincodeVec<u8, ShortU16>")]
@@ -77,7 +79,7 @@ pub struct NotarRewardCertificate {
     /// The block id the certificate is for.
     pub block_id: Hash,
     /// The signature.
-    #[wincode(with = "Pod<BLSSignatureCompressed>")]
+    #[wincode(with = "PodBLSSignatureCompressed")]
     pub signature: BLSSignatureCompressed,
     /// The bitmap for validators, see solana-signer-store for encoding format.
     #[wincode(with = "WincodeVec<u8, ShortU16>")]


### PR DESCRIPTION
Updates wincode dependency to `0.4.8`.

Notably, the `Pod` struct has been deprecated due to it allowing unsound behavior in safe code. This PR updates usage of `Pod` to use the `pod_wrapper` macro. See https://github.com/anza-xyz/wincode/issues/89 for more information.

wincode support has already been merged in the `solana-bls-signatures` crate https://github.com/anza-xyz/solana-sdk/pull/624. So those types can be used directly once a release is created.