### PR TITLE
Serializes block_id into snapshot

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2485,12 +2485,17 @@ fn maybe_warp_slot(
             SlotLeader::default(),
             warp_slot,
         ));
+        // The bank must have a block id set to take a snapshot.
+        // Also must be set before calling set_root() just incase the warp slot triggers a
+        // snapshot request based on the snapshot config inside snapshot_controller.
+        let warp_bank = bank_forks.get(warp_slot).unwrap();
+        Bank::calculate_and_set_block_id_for_dcou(&warp_bank);
         bank_forks.set_root(warp_slot, Some(snapshot_controller), Some(warp_slot));
-        leader_schedule_cache.set_root(&bank_forks.root_bank());
+        leader_schedule_cache.set_root(&warp_bank);
 
         let full_snapshot_archive_info = match snapshot_bank_utils::bank_to_full_snapshot_archive(
             ledger_path,
-            &bank_forks.root_bank(),
+            &warp_bank,
             None,
             &config.snapshot_config.full_snapshot_archives_dir,
             &config.snapshot_config.incremental_snapshot_archives_dir,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -14,6 +14,7 @@ use {
     solana_core::snapshot_packager_service::SnapshotPackagerService,
     solana_genesis_config::GenesisConfig,
     solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
+    solana_hash::Hash,
     solana_keypair::Keypair,
     solana_net_utils::SocketAddrSpace,
     solana_runtime::{
@@ -193,6 +194,9 @@ where
         if slot % set_root_interval == 0 || slot == last_slot {
             if !bank.is_complete() {
                 bank.fill_bank_with_ticks_for_tests();
+            }
+            if bank.block_id().is_none() {
+                bank.set_block_id(Some(Hash::default()));
             }
             bank_forks.read().unwrap().prune_program_cache(bank.slot());
             // set_root should send a snapshot request
@@ -439,6 +443,7 @@ fn test_bank_forks_incremental_snapshot() {
             assert_eq!(bank.process_transaction(&tx), Ok(()));
 
             bank.fill_bank_with_ticks_for_tests();
+            bank.set_block_id(Some(Hash::default()));
 
             bank_scheduler
         };
@@ -503,6 +508,8 @@ fn make_full_snapshot_archive(
         "Making full snapshot archive from bank at slot: {}",
         bank.slot(),
     );
+    // The bank must have a block id set to take a snapshot.
+    Bank::calculate_and_set_block_id_for_dcou(bank);
     snapshot_bank_utils::bank_to_full_snapshot_archive(
         &snapshot_config.bank_snapshots_dir,
         bank,
@@ -524,6 +531,8 @@ fn make_incremental_snapshot_archive(
         bank.slot(),
         incremental_snapshot_base_slot,
     );
+    // The bank must have a block id set to take a snapshot.
+    Bank::calculate_and_set_block_id_for_dcou(bank);
     snapshot_bank_utils::bank_to_incremental_snapshot_archive(
         &snapshot_config.bank_snapshots_dir,
         bank,
@@ -680,6 +689,7 @@ fn test_snapshots_with_background_services() {
             assert_eq!(bank.process_transaction(&tx), Ok(()));
 
             bank.fill_bank_with_ticks_for_tests();
+            bank.set_block_id(Some(Hash::default()));
         }
 
         // Call `BankForks::set_root()` to cause snapshots to be taken
@@ -839,6 +849,7 @@ fn test_fastboot_snapshots_teardown(exit_backpressure: bool) {
         assert_eq!(bank.process_transaction(&tx), Ok(()));
 
         bank.fill_bank_with_ticks_for_tests();
+        bank.set_block_id(Some(Hash::default()));
 
         // Inject a fastboot snapshot at a specific slot
         if slot % FASTBOOT_SNAPSHOT_INTERVAL_SLOTS == 0 {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2529,6 +2529,9 @@ fn main() {
                         bank.slot(),
                     );
 
+                    // The bank must have a block id set to take a snapshot.
+                    Bank::calculate_and_set_block_id_for_dcou(&bank);
+
                     if is_incremental {
                         if starting_snapshot_hashes.is_none() {
                             eprintln!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -488,6 +488,7 @@ pub struct BankFieldsToDeserialize {
     pub(crate) accounts_data_len: u64,
     pub(crate) accounts_lt_hash: AccountsLtHash,
     pub(crate) bank_hash_stats: BankHashStats,
+    pub(crate) block_id: Option<Hash>, // Option wrapper can be removed in version after v4.1
 }
 
 /// Bank's common fields shared by all supported snapshot versions for serialization.
@@ -526,6 +527,7 @@ pub struct BankFieldsToSerialize {
     pub accounts_data_len: u64,
     pub versioned_epoch_stakes: HashMap<u64, VersionedEpochStakes>,
     pub accounts_lt_hash: AccountsLtHash,
+    pub block_id: Hash,
 }
 
 // Can't derive PartialEq because RwLock doesn't implement PartialEq
@@ -677,6 +679,7 @@ impl BankFieldsToSerialize {
             accounts_data_len: u64::default(),
             versioned_epoch_stakes: HashMap::default(),
             accounts_lt_hash: AccountsLtHash(LtHash([0x7E57; LtHash::NUM_ELEMENTS])),
+            block_id: Hash::default(),
         }
     }
 }
@@ -2020,7 +2023,7 @@ impl Bank {
             accounts_lt_hash: Mutex::new(fields.accounts_lt_hash),
             cache_for_accounts_lt_hash: DashMap::default(),
             stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
-            block_id: RwLock::new(None),
+            block_id: RwLock::new(fields.block_id),
             bank_hash_stats: AtomicBankHashStats::new(&fields.bank_hash_stats),
             epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
             expected_bank_hash: RwLock::new(None),
@@ -2128,6 +2131,7 @@ impl Bank {
             accounts_data_len: self.load_accounts_data_size(),
             versioned_epoch_stakes: self.epoch_stakes.clone(),
             accounts_lt_hash: self.accounts_lt_hash.lock().unwrap().clone(),
+            block_id: self.block_id().expect("block id must be set"),
         }
     }
 
@@ -6161,6 +6165,45 @@ impl Bank {
         } else {
             self.stakes_cache.stakes().clone()
         }
+    }
+
+    /// Calculates and sets block id for `bank`.
+    ///
+    /// This fn operates recursively. Since calculating the block id requires
+    /// the bank's parent's block id, if the bank's parent's block id is unset,
+    /// it will be calculated and set first.
+    ///
+    /// Note this fn will also freeze `bank`.
+    ///
+    /// Only to be called from dev contexts.
+    /// Couldn't make the fn actually DCOU, since it is called by
+    /// Validator::new() when warping a slot.
+    pub fn calculate_and_set_block_id_for_dcou(bank: &Bank) {
+        if bank.block_id().is_some() {
+            // done!
+            return;
+        }
+
+        let Some(parent) = bank.parent() else {
+            // If bank doesn't have a parent, then use bank hash for block id,
+            // as parent's block id is not available for the calculation below.
+            // Must freeze() to ensure bank hash has been calculated.
+            bank.freeze();
+            bank.set_block_id(Some(bank.hash()));
+            return;
+        };
+
+        let parent_block_id = parent.block_id().unwrap_or_else(|| {
+            // if the parent's block id isn't set, we recurse so it gets set
+            Self::calculate_and_set_block_id_for_dcou(&parent);
+            parent.block_id().unwrap()
+        });
+
+        // must freeze() to ensure bank hash has been calculated
+        bank.freeze();
+        let block_id =
+            solana_sha256_hasher::hashv(&[parent_block_id.as_ref(), bank.hash().as_ref()]);
+        bank.set_block_id(Some(block_id));
     }
 }
 

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -883,6 +883,7 @@ mod tests {
             bank.squash();
             bank.force_flush_accounts_cache();
         }
+        bank.set_block_id(Some(Hash::default()));
 
         // verification happens at startup, so mimic the behavior by loading from a snapshot
         let snapshot_config = SnapshotConfig::default();
@@ -991,6 +992,7 @@ mod tests {
             bank.squash();
             bank.force_flush_accounts_cache();
         }
+        bank.set_block_id(Some(Hash::default()));
 
         let snapshot_config = SnapshotConfig::default();
         let bank_snapshots_dir = TempDir::new().unwrap();

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -2150,6 +2150,7 @@ pub(crate) mod tests {
         test_context.run_program_checks(&bank, upgrade_slot);
 
         bank.fill_bank_with_ticks_for_tests();
+        bank.set_block_id(Some(Hash::default()));
         // Force flush the bank to create the account storage entry
         bank.squash();
         bank.force_flush_accounts_cache();

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -25,6 +25,7 @@ mod tests {
             accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
         },
         solana_epoch_schedule::EpochSchedule,
+        solana_hash::Hash,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_pubkey::Pubkey,
         solana_stake_interface::state::Stake,
@@ -108,6 +109,7 @@ mod tests {
 
         let accounts_db = &bank2.rc.accounts.accounts_db;
 
+        bank2.set_block_id(Some(Hash::default()));
         bank2.squash();
         bank2.force_flush_accounts_cache();
 
@@ -120,6 +122,7 @@ mod tests {
             let mut bank_fields = bank2.get_fields_to_serialize();
             let versioned_epoch_stakes = mem::take(&mut bank_fields.versioned_epoch_stakes);
             let accounts_lt_hash = Some(bank_fields.accounts_lt_hash.clone().into());
+            let block_id = Some(bank_fields.block_id);
             serde_snapshot::serialize_bank_snapshot_into(
                 &mut writer,
                 bank_fields,
@@ -131,6 +134,7 @@ mod tests {
                     unused_epoch_accounts_hash: None,
                     versioned_epoch_stakes,
                     accounts_lt_hash,
+                    block_id,
                 },
             )
             .unwrap();
@@ -193,6 +197,7 @@ mod tests {
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         bank0.squash();
         let mut bank = Bank::new_from_parent(bank0.clone(), *bank0.leader(), 1);
+        bank.set_block_id(Some(Hash::default()));
         bank.freeze();
         add_root_and_flush_write_cache(&bank0);
 
@@ -277,6 +282,7 @@ mod tests {
         while !bank.is_complete() {
             bank.fill_bank_with_ticks_for_tests();
         }
+        bank.set_block_id(Some(Hash::default()));
 
         // Set extra field
         bank.fee_rate_governor.lamports_per_signature = 7000;
@@ -356,7 +362,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "7NL9Sugo2js3PtueK7izqSwX5dGWKDMDVnjo6MirVPWE")
+            frozen_abi(digest = "ELfWa1ABrJu9sQABjieyqnWioDaHNykbmYqsQr7yYYBb")
         )]
         #[derive(serde::Serialize)]
         pub struct BankAbiTestWrapper {
@@ -369,6 +375,7 @@ mod tests {
             S: serde::Serializer,
         {
             let bank = Bank::default_for_tests();
+            bank.set_block_id(Some(Hash::default()));
             let snapshot_storages = AccountsDb::example().get_storages(0..1).0;
             // ensure there is at least one snapshot storage example for ABI digesting
             assert!(!snapshot_storages.is_empty());
@@ -394,6 +401,7 @@ mod tests {
                     unused_epoch_accounts_hash: Some(Hash::new_unique()),
                     versioned_epoch_stakes,
                     accounts_lt_hash: Some(AccountsLtHash(LtHash::identity()).into()),
+                    block_id: Some(Hash::new_unique()),
                 },
             )
         }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12469,6 +12469,7 @@ fn test_new_from_snapshot_uses_rent_from_sysvar() {
 
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.rent_collector.rent = wrong_rent.clone();
+    bank.set_block_id(Some(Hash::default()));
 
     // Serialize bank to snapshot
     let snapshot_storages = bank.get_snapshot_storages(None);
@@ -12507,4 +12508,71 @@ fn test_new_from_snapshot_uses_rent_from_sysvar() {
     // Verify the bank's rent matches the sysvar, NOT the corrupted fields
     assert_eq!(new_bank.rent_collector.rent, expected_rent);
     assert_ne!(new_bank.rent_collector.rent, wrong_rent);
+}
+
+#[test]
+fn test_calculate_and_set_block_id_for_dcou() {
+    // scenario 1: block id already set
+    {
+        let bank = create_simple_test_bank(123);
+        let block_id = Hash::new_unique();
+        bank.set_block_id(Some(block_id));
+        Bank::calculate_and_set_block_id_for_dcou(&bank);
+        assert_eq!(bank.block_id(), Some(block_id));
+    }
+
+    // scenario 2: block id unset
+    {
+        let bank1 = Arc::new(create_simple_test_bank(123));
+        let block_id1 = Hash::new_unique();
+        // oldest ancestor must have block_id set
+        bank1.set_block_id(Some(block_id1));
+        bank1.fill_bank_with_ticks_for_tests();
+
+        let bank2 = new_from_parent(bank1);
+        Bank::calculate_and_set_block_id_for_dcou(&bank2);
+
+        // ensure expected block_id is correct
+        assert_eq!(
+            bank2.block_id(),
+            Some(hashv(&[block_id1.as_ref(), bank2.hash().as_ref()])),
+        );
+    }
+
+    // scenario 3: block id unset, multiple parents
+    {
+        let mut bank = Arc::new(create_simple_test_bank(123));
+        // oldest ancestor must have block id set
+        bank.set_block_id(Some(Hash::new_unique()));
+        for _ in 0..7 {
+            bank.fill_bank_with_ticks_for_tests();
+            bank = new_from_parent(bank).into();
+        }
+
+        Bank::calculate_and_set_block_id_for_dcou(&bank);
+
+        // we don't calculate the expected parent block id
+        // out-of-band, since scenario 2 covers that
+        assert_eq!(
+            bank.block_id(),
+            Some(hashv(&[
+                bank.parent_block_id().unwrap().as_ref(),
+                bank.hash().as_ref(),
+            ])),
+        );
+    }
+
+    // scenario 4: no parent
+    {
+        let bank = create_simple_test_bank(123);
+        assert!(bank.parent().is_none());
+        assert!(bank.block_id().is_none());
+
+        // must freeze() to ensure bank hash is calculated
+        bank.freeze();
+        let expected_block_id = bank.hash();
+
+        Bank::calculate_and_set_block_id_for_dcou(&bank);
+        assert_eq!(bank.block_id(), Some(expected_block_id));
+    }
 }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -220,6 +220,7 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             versioned_epoch_stakes: vec![], // populated from ExtraFieldsToDeserialize
             accounts_lt_hash: AccountsLtHash(LT_HASH_CANARY), // populated from ExtraFieldsToDeserialize
             bank_hash_stats: BankHashStats::default(),        // populated from AccountsDbFields
+            block_id: None, // populated from ExtraFieldsToDeserialize
         }
     }
 }
@@ -423,14 +424,6 @@ struct ExtraFieldsToDeserialize {
     versioned_epoch_stakes: Vec<(u64, DeserializableVersionedEpochStakes)>,
     #[serde(deserialize_with = "default_on_eof")]
     accounts_lt_hash: Option<SerdeAccountsLtHash>,
-    /// In order to maintain snapshot compatibility between adjacent versions
-    /// (edge <-> beta, and beta <-> stable), we must be able to deserialize
-    /// (and ignore) this new field (block id) in adjacent versions *before*
-    /// we serialize the new field into snapshots.
-    /// Hence the annotation to allow dead code.
-    /// This code is not truly dead though, as it enables newer versions to
-    /// populate this field and have older versions still load the snapshot.
-    #[expect(dead_code)]
     #[serde(deserialize_with = "default_on_eof")]
     block_id: Option<Hash>,
 }
@@ -450,6 +443,7 @@ pub struct ExtraFieldsToSerialize {
     pub unused_epoch_accounts_hash: Option<Hash>,
     pub versioned_epoch_stakes: HashMap<u64, VersionedEpochStakes>,
     pub accounts_lt_hash: Option<SerdeAccountsLtHash>,
+    pub block_id: Option<Hash>,
 }
 
 fn deserialize_bank_fields<R>(
@@ -481,7 +475,7 @@ where
         _unused_epoch_accounts_hash,
         versioned_epoch_stakes,
         accounts_lt_hash,
-        block_id: _,
+        block_id,
     } = extra_fields;
 
     bank_fields.fee_rate_governor = bank_fields
@@ -491,6 +485,7 @@ where
     bank_fields.accounts_lt_hash = accounts_lt_hash
         .expect("snapshot must have accounts_lt_hash")
         .into();
+    bank_fields.block_id = block_id;
 
     Ok((bank_fields, accounts_db_fields))
 }
@@ -666,6 +661,7 @@ impl Serialize for SerializableBankAndStorage<'_> {
         let lamports_per_signature = bank_fields.fee_rate_governor.lamports_per_signature;
         let versioned_epoch_stakes = std::mem::take(&mut bank_fields.versioned_epoch_stakes);
         let accounts_lt_hash = Some(bank_fields.accounts_lt_hash.clone().into());
+        let block_id = Some(bank_fields.block_id);
         let bank_fields_to_serialize = (
             SerializableVersionedBank::from(bank_fields),
             SerializableAccountsDb::<'_> {
@@ -679,6 +675,7 @@ impl Serialize for SerializableBankAndStorage<'_> {
                 unused_epoch_accounts_hash: None,
                 versioned_epoch_stakes,
                 accounts_lt_hash,
+                block_id,
             },
         );
         bank_fields_to_serialize.serialize(serializer)

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -682,6 +682,7 @@ fn _verify_epoch_stakes(
 ///
 /// Requires:
 ///     - `bank` is complete
+///     - `bank`'s block id is set
 pub fn bank_to_full_snapshot_archive(
     bank_snapshots_dir: impl AsRef<Path>,
     bank: &Bank,
@@ -694,6 +695,7 @@ pub fn bank_to_full_snapshot_archive(
     let bank_snapshots_dir = tempfile::tempdir_in(&bank_snapshots_dir)?;
 
     assert!(bank.is_complete());
+    assert!(bank.block_id().is_some());
     // set accounts-db's latest full snapshot slot here to ensure zero lamport
     // accounts are handled properly.
     bank.rc
@@ -751,6 +753,7 @@ pub fn bank_to_full_snapshot_archive(
 ///
 /// Requires:
 ///     - `bank` is complete
+///     - `bank`'s block id is set
 ///     - `bank`'s slot is greater than `full_snapshot_slot`
 pub fn bank_to_incremental_snapshot_archive(
     bank_snapshots_dir: impl AsRef<Path>,
@@ -764,6 +767,7 @@ pub fn bank_to_incremental_snapshot_archive(
     let snapshot_version = snapshot_version.unwrap_or_default();
 
     assert!(bank.is_complete());
+    assert!(bank.block_id().is_some());
     assert!(bank.slot() > full_snapshot_slot);
     // set accounts-db's latest full snapshot slot here to ensure zero lamport
     // accounts are handled properly.
@@ -846,6 +850,7 @@ mod tests {
         solana_accounts_db::{
             accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING, accounts_file::StorageAccess,
         },
+        solana_hash::Hash,
         solana_keypair::Keypair,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_pubkey::Pubkey,
@@ -870,6 +875,7 @@ mod tests {
             let slot = bank.slot() + 1;
             bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::new_unique(), slot));
             bank.fill_bank_with_ticks_for_tests();
+            bank.set_block_id(Some(Hash::default()));
 
             create_bank_snapshot_from_bank(
                 &bank_snapshots_dir,
@@ -889,6 +895,7 @@ mod tests {
     ///
     /// Requires:
     ///     - `bank` is complete
+    ///     - `bank`'s block id is set
     fn create_bank_snapshot_from_bank(
         bank_snapshots_dir: impl AsRef<Path>,
         bank: &Bank,
@@ -896,6 +903,7 @@ mod tests {
         should_flush_and_hard_link_storages: bool,
     ) -> agave_snapshots::Result<()> {
         assert!(bank.is_complete());
+        assert!(bank.block_id().is_some());
 
         bank.squash(); // Bank may not be a root
         bank.rehash(); // Bank may have been manually modified by the caller
@@ -929,6 +937,7 @@ mod tests {
         let original_bank = Bank::new_for_tests(&genesis_config);
 
         original_bank.fill_bank_with_ticks_for_tests();
+        original_bank.set_block_id(Some(Hash::default()));
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
@@ -1013,6 +1022,7 @@ mod tests {
             .unwrap();
 
         bank1.fill_bank_with_ticks_for_tests();
+        bank1.set_block_id(Some(Hash::default()));
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
@@ -1116,6 +1126,7 @@ mod tests {
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
         bank4.fill_bank_with_ticks_for_tests();
+        bank4.set_block_id(Some(Hash::default()));
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
@@ -1205,6 +1216,7 @@ mod tests {
             .transfer(5 * LAMPORTS_PER_SOL, &mint_keypair, &key5.pubkey())
             .unwrap();
         bank1.fill_bank_with_ticks_for_tests();
+        bank1.set_block_id(Some(Hash::default()));
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
@@ -1243,6 +1255,7 @@ mod tests {
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
         bank4.fill_bank_with_ticks_for_tests();
+        bank4.set_block_id(Some(Hash::default()));
 
         let incremental_snapshot_archive_info = bank_to_incremental_snapshot_archive(
             bank_snapshots_dir.path(),
@@ -1317,6 +1330,7 @@ mod tests {
             .transfer(3 * LAMPORTS_PER_SOL, &mint_keypair, &key3.pubkey())
             .unwrap();
         bank1.fill_bank_with_ticks_for_tests();
+        bank1.set_block_id(Some(Hash::default()));
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
@@ -1355,6 +1369,7 @@ mod tests {
             .transfer(3 * LAMPORTS_PER_SOL, &mint_keypair, &key3.pubkey())
             .unwrap();
         bank4.fill_bank_with_ticks_for_tests();
+        bank4.set_block_id(Some(Hash::default()));
 
         bank_to_incremental_snapshot_archive(
             &bank_snapshots_dir,
@@ -1393,6 +1408,7 @@ mod tests {
         let genesis_config = GenesisConfig::default();
         let bank = Bank::new_for_tests(&genesis_config);
         bank.fill_bank_with_ticks_for_tests();
+        bank.set_block_id(Some(Hash::default()));
 
         // freeze the bank before mucking with capitalization, since
         // freezing also changes capitalization (fees, incinerator, etc).
@@ -1510,6 +1526,7 @@ mod tests {
             .transfer(lamports_to_transfer, &key2, &key1.pubkey())
             .unwrap();
         bank1.fill_bank_with_ticks_for_tests();
+        bank1.set_block_id(Some(Hash::default()));
 
         let full_snapshot_slot = slot;
         let full_snapshot_archive_info = bank_to_full_snapshot_archive(
@@ -1545,6 +1562,7 @@ mod tests {
             "Ensure Account1's balance is zero"
         );
         bank2.fill_bank_with_ticks_for_tests();
+        bank2.set_block_id(Some(Hash::default()));
 
         // Take an incremental snapshot and then do a roundtrip on the bank and ensure it
         // deserializes correctly.
@@ -1600,6 +1618,7 @@ mod tests {
             bank4.get_account_modified_slot(&key1.pubkey()).is_none(),
             "Ensure Account1 has been cleaned and purged from AccountsDb"
         );
+        bank4.set_block_id(Some(Hash::default()));
 
         // Take an incremental snapshot and then do a roundtrip on the bank and ensure it
         // deserializes correctly
@@ -1665,6 +1684,7 @@ mod tests {
         let slot = 1;
         let bank1 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, leader, slot);
         bank1.fill_bank_with_ticks_for_tests();
+        bank1.set_block_id(Some(Hash::default()));
 
         let all_snapshots_dir = tempfile::TempDir::new().unwrap();
         let snapshot_archive_format = SnapshotConfig::default().archive_format;
@@ -1686,6 +1706,7 @@ mod tests {
             .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key1.pubkey())
             .unwrap();
         bank2.fill_bank_with_ticks_for_tests();
+        bank2.set_block_id(Some(Hash::default()));
 
         bank_to_incremental_snapshot_archive(
             &all_snapshots_dir,
@@ -1715,6 +1736,7 @@ mod tests {
     fn test_bank_snapshot_dir_accounts_hardlinks() {
         let bank = Bank::new_for_tests(&GenesisConfig::default());
         bank.fill_bank_with_ticks_for_tests();
+        bank.set_block_id(Some(Hash::default()));
 
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         create_bank_snapshot_from_bank(
@@ -2033,6 +2055,7 @@ mod tests {
             .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
             .unwrap();
         bank3.fill_bank_with_ticks_for_tests();
+        bank3.set_block_id(Some(Hash::default()));
 
         assert!(
             bank3.get_account_modified_slot(&key1.pubkey()).is_none(),
@@ -2140,6 +2163,7 @@ mod tests {
         let bank2 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, leader, slot);
         bank2.transfer(lamports * 2, &key2, &mint.pubkey()).unwrap();
         bank2.fill_bank_with_ticks_for_tests();
+        bank2.set_block_id(Some(Hash::default()));
         assert_eq!(bank2.get_balance(&key2.pubkey()), 0);
 
         // Take a bank snapshot, passing `true` for `should_flush_and_hard_link_storages`.
@@ -2224,6 +2248,7 @@ mod tests {
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let bank = Bank::new_for_tests(&genesis_config);
         bank.fill_bank_with_ticks_for_tests();
+        bank.set_block_id(Some(Hash::default()));
 
         // Take a bank snapshot, passing `true` for `should_flush_and_hard_link_storages`.
         // This ensures that `serialize_snapshot` performs all necessary steps to create
@@ -2280,6 +2305,7 @@ mod tests {
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let bank = Bank::new_for_tests(&genesis_config);
         bank.fill_bank_with_ticks_for_tests();
+        bank.set_block_id(Some(Hash::default()));
 
         // freeze the bank before mucking with capitalization, since
         // freezing also changes capitalization (fees, incinerator, etc).

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -365,6 +365,7 @@ mod tests {
         solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
         solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
         solana_genesis_config::create_genesis_config,
+        solana_hash::Hash,
         solana_loader_v3_interface::state::UpgradeableLoaderState,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_pubkey::Pubkey,
@@ -621,6 +622,7 @@ mod tests {
         )
         .unwrap();
         bank.fill_bank_with_ticks_for_tests();
+        bank.set_block_id(Some(Hash::default()));
         bank.squash();
         bank.force_flush_accounts_cache();
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -532,6 +532,7 @@ pub fn serialize_snapshot(
                 unused_epoch_accounts_hash: None,
                 versioned_epoch_stakes,
                 accounts_lt_hash: Some(bank_fields.accounts_lt_hash.clone().into()),
+                block_id: Some(bank_fields.block_id),
             };
             serde_snapshot::serialize_bank_snapshot_into(
                 stream,


### PR DESCRIPTION
#### Problem

`block_id` is not serialized into the snapshot.

Deserialization support was added in https://github.com/anza-xyz/agave/pull/9644, which is in v4.0. It is now safe to serialize block id here, in v4.1.

This is for SIMD-333[^1].

[^1]: https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0333-snapshot-include-block-id.md


#### Summary of Changes

Serialize block_id into snapshot.

Note that the block_id is required to Some when writing into the snapshot now. As such, many tests needed to be updated to set the bank's block_id field before taking a snapshot. If preferred, I could pull out the code that sets block_id into a separate PR. I didn't do that here since setting block_id isn't necessary without the snapshot changes.


#### Additional Testing

I ran this commit on a dev box, created snapshots, then restarted on v4.0. The node was successfully able to load the snapshot and startup.