### PR TITLE
Buffered io uring writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7869,6 +7869,7 @@ dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-bls-cert-verify",
  "agave-feature-set",
+ "agave-fs",
  "agave-logger",
  "agave-math-utils",
  "agave-reserved-account-keys",
@@ -9024,6 +9025,7 @@ name = "solana-local-cluster"
 version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-fs",
  "agave-logger",
  "agave-snapshots",
  "agave-votor",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -43,6 +43,7 @@ frozen-abi = [
 agave-banking-stage-ingress-types = { workspace = true }
 agave-bls-cert-verify = { workspace = true }
 agave-feature-set = { workspace = true }
+agave-fs = { workspace = true }
 agave-logger = { workspace = true }
 agave-math-utils = { workspace = true }
 agave-scheduler-bindings = { workspace = true }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,5 +1,6 @@
 mod snapshot_gossip_manager;
 use {
+    agave_fs::io_setup::IoSetupState,
     agave_snapshots::{
         SnapshotKind, paths as snapshot_paths, snapshot_config::SnapshotConfig,
         snapshot_hash::StartingSnapshotHashes,
@@ -45,6 +46,7 @@ impl SnapshotPackagerService {
         snapshot_controller: Arc<SnapshotController>,
         enable_gossip_push: bool,
         niceness_adj: i8,
+        io_setup: IoSetupState,
     ) -> Self {
         let t_snapshot_packager = Builder::new()
             .name("solSnapshotPkgr".to_string())
@@ -66,6 +68,7 @@ impl SnapshotPackagerService {
                             let (_, dur) = meas_dur!(Self::teardown(
                                 teardown_state,
                                 snapshot_controller.snapshot_config(),
+                                &io_setup,
                             ));
                             info!("Teardown completed in {dur:?}.");
                         }
@@ -125,6 +128,7 @@ impl SnapshotPackagerService {
                         &snapshot_config.bank_snapshots_dir,
                         snapshot_config.snapshot_version,
                         snapshot_package.bank_snapshot_package,
+                        &io_setup,
                         snapshot_package.snapshot_storages.as_slice(),
                         exit_backpressure.is_none(),
                     );
@@ -151,6 +155,7 @@ impl SnapshotPackagerService {
                             &bank_snapshot_info.snapshot_dir,
                             snapshot_package.snapshot_storages,
                             snapshot_config,
+                            &io_setup,
                         ) {
                             error!(
                                 "Stopping {}! Fatal error while archiving snapshot package: {err}",
@@ -223,7 +228,7 @@ impl SnapshotPackagerService {
     }
 
     /// Performs final operations before gracefully shutting down
-    fn teardown(state: TeardownState, snapshot_config: &SnapshotConfig) {
+    fn teardown(state: TeardownState, snapshot_config: &SnapshotConfig, io_setup: &IoSetupState) {
         let TeardownState {
             snapshot_slot,
             snapshot_storages,
@@ -237,6 +242,7 @@ impl SnapshotPackagerService {
                 &snapshot_config.bank_snapshots_dir,
                 snapshot_config.snapshot_version,
                 bank_snapshot_package,
+                io_setup,
                 snapshot_storages.as_slice(),
                 false,
             );
@@ -295,6 +301,7 @@ impl SnapshotPackagerService {
         let start = Instant::now();
         let result = snapshot_utils::write_obsolete_accounts_to_snapshot(
             &bank_snapshot_dir,
+            io_setup,
             &snapshot_storages,
             snapshot_slot,
         );

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -33,6 +33,7 @@ use {
         tpu::{Tpu, TpuSockets},
         tvu::{AlpenglowInitializationState, Tvu, TvuConfig, TvuSockets},
     },
+    agave_fs::io_setup::IoSetupState,
     agave_snapshots::{
         SnapshotInterval, snapshot_archive_info::SnapshotArchiveInfoGetter as _,
         snapshot_config::SnapshotConfig, snapshot_hash::StartingSnapshotHashes,
@@ -998,6 +999,10 @@ impl Validator {
             .get(SnapshotPackagerService::NAME)
             .cloned();
         let enable_gossip_push = true;
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()?
+            .with_buffers_registered(config.accounts_db_config.use_registered_io_uring_buffers)
+            .with_direct_io(config.accounts_db_config.snapshots_use_direct_io);
         let snapshot_packager_service = SnapshotPackagerService::new(
             pending_snapshot_packages.clone(),
             starting_snapshot_hashes,
@@ -1007,6 +1012,7 @@ impl Validator {
             snapshot_controller.clone(),
             enable_gossip_push,
             config.snapshot_packager_niceness_adj,
+            io_setup,
         );
         let snapshot_request_handler = SnapshotRequestHandler {
             snapshot_controller: snapshot_controller.clone(),
@@ -2488,6 +2494,12 @@ fn maybe_warp_slot(
         bank_forks.set_root(warp_slot, Some(snapshot_controller), Some(warp_slot));
         leader_schedule_cache.set_root(&bank_forks.root_bank());
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .map_err(|e| format!("Could not enable sqpoll: {e}"))?
+            .with_buffers_registered(config.accounts_db_config.use_registered_io_uring_buffers)
+            .with_direct_io(config.accounts_db_config.snapshots_use_direct_io);
+
         let full_snapshot_archive_info = match snapshot_bank_utils::bank_to_full_snapshot_archive(
             ledger_path,
             &bank_forks.root_bank(),
@@ -2495,6 +2507,7 @@ fn maybe_warp_slot(
             &config.snapshot_config.full_snapshot_archives_dir,
             &config.snapshot_config.incremental_snapshot_archives_dir,
             config.snapshot_config.archive_format,
+            &io_setup,
         ) {
             Ok(archive_info) => archive_info,
             Err(e) => return Err(format!("Unable to create snapshot: {e}")),

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -2,6 +2,7 @@
 
 use {
     crate::snapshot_utils::create_tmp_accounts_dir_for_tests,
+    agave_fs::io_setup::IoSetupState,
     agave_snapshots::{
         SnapshotInterval, SnapshotKind, paths as snapshot_paths,
         snapshot_archive_info::FullSnapshotArchiveInfo, snapshot_config::SnapshotConfig,
@@ -157,8 +158,12 @@ fn restore_from_snapshot(
 // also marks each bank as root and generates snapshots
 // finally tries to restore from the last bank's snapshot and compares the restored bank to the
 // `last_slot` bank
-fn run_bank_forks_snapshot_n<F>(last_slot: Slot, f: F, set_root_interval: u64)
-where
+fn run_bank_forks_snapshot_n<F>(
+    last_slot: Slot,
+    f: F,
+    set_root_interval: u64,
+    io_setup: &IoSetupState,
+) where
     F: Fn(&Bank, &Keypair),
 {
     agave_logger::setup();
@@ -218,6 +223,7 @@ where
         &snapshot_config.full_snapshot_archives_dir,
         &snapshot_config.incremental_snapshot_archives_dir,
         snapshot_config.archive_format,
+        io_setup,
     )
     .unwrap();
 
@@ -236,6 +242,11 @@ where
 
 #[test]
 fn test_bank_forks_snapshot() {
+    let io_setup = IoSetupState::default()
+        .with_shared_sqpoll()
+        .unwrap()
+        .with_buffers_registered(true)
+        .with_direct_io(true);
     // create banks up to slot 4 and create 1 new account in each bank. test that bank 4 snapshots
     // and restores correctly
     run_bank_forks_snapshot_n(
@@ -250,6 +261,7 @@ fn test_bank_forks_snapshot() {
             assert_eq!(bank.process_transaction(&tx), Ok(()));
         },
         1,
+        &io_setup,
     );
 }
 
@@ -326,6 +338,11 @@ fn test_slots_to_snapshot() {
 
 #[test]
 fn test_bank_forks_status_cache_snapshot() {
+    let io_setup = IoSetupState::default()
+        .with_shared_sqpoll()
+        .unwrap()
+        .with_buffers_registered(true)
+        .with_direct_io(true);
     // create banks up to slot (MAX_CACHE_ENTRIES * 2) + 1 while transferring 1 lamport into 2 different accounts each time
     // this is done to ensure the AccountStorageEntries keep getting cleaned up as the root moves
     // ahead. Also tests the status_cache purge and status cache snapshotting.
@@ -353,6 +370,7 @@ fn test_bank_forks_status_cache_snapshot() {
                 goto_end_of_slot(bank);
             },
             *set_root_interval,
+            &io_setup,
         );
     }
 }
@@ -394,6 +412,12 @@ fn test_bank_forks_incremental_snapshot() {
             .path()
             .display()
     );
+
+    let io_setup = IoSetupState::default()
+        .with_shared_sqpoll()
+        .unwrap()
+        .with_buffers_registered(true)
+        .with_direct_io(true);
 
     let bank_forks = snapshot_test_config.bank_forks.clone();
     let mint_keypair = &snapshot_test_config.genesis_config_info.mint_keypair;
@@ -449,7 +473,8 @@ fn test_bank_forks_incremental_snapshot() {
         // Since AccountsBackgroundService isn't running, manually make a full snapshot archive
         // at the right interval
         if snapshot_utils::should_take_full_snapshot(slot, FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS) {
-            make_full_snapshot_archive(&bank, snapshot_controller.snapshot_config()).unwrap();
+            make_full_snapshot_archive(&bank, snapshot_controller.snapshot_config(), &io_setup)
+                .unwrap();
             latest_full_snapshot_slot = Some(slot);
         }
         // Similarly, make an incremental snapshot archive at the right interval, but only if
@@ -467,6 +492,7 @@ fn test_bank_forks_incremental_snapshot() {
                 &bank,
                 latest_full_snapshot_slot.unwrap(),
                 snapshot_controller.snapshot_config(),
+                &io_setup,
             )
             .unwrap();
 
@@ -488,6 +514,7 @@ fn test_bank_forks_incremental_snapshot() {
 fn make_full_snapshot_archive(
     bank: &Bank,
     snapshot_config: &SnapshotConfig,
+    io_setup: &IoSetupState,
 ) -> agave_snapshots::Result<()> {
     info!(
         "Making full snapshot archive from bank at slot: {}",
@@ -500,6 +527,7 @@ fn make_full_snapshot_archive(
         &snapshot_config.full_snapshot_archives_dir,
         &snapshot_config.incremental_snapshot_archives_dir,
         snapshot_config.archive_format,
+        io_setup,
     )?;
     Ok(())
 }
@@ -508,6 +536,7 @@ fn make_incremental_snapshot_archive(
     bank: &Bank,
     incremental_snapshot_base_slot: Slot,
     snapshot_config: &SnapshotConfig,
+    io_setup: &IoSetupState,
 ) -> agave_snapshots::Result<()> {
     info!(
         "Making incremental snapshot archive from bank at slot: {}, and base slot: {}",
@@ -522,6 +551,7 @@ fn make_incremental_snapshot_archive(
         &snapshot_config.full_snapshot_archives_dir,
         &snapshot_config.incremental_snapshot_archives_dir,
         snapshot_config.archive_format,
+        io_setup,
     )?;
     Ok(())
 }
@@ -631,6 +661,11 @@ fn test_snapshots_with_background_services() {
         snapshot_request_handler,
         pruned_banks_request_handler,
     };
+    let io_setup = IoSetupState::default()
+        .with_shared_sqpoll()
+        .unwrap()
+        .with_buffers_registered(true)
+        .with_direct_io(true);
 
     let exit = Arc::new(AtomicBool::new(false));
     let snapshot_packager_service = SnapshotPackagerService::new(
@@ -642,6 +677,7 @@ fn test_snapshots_with_background_services() {
         snapshot_controller.clone(),
         false,
         0,
+        io_setup,
     );
 
     let accounts_background_service =
@@ -797,6 +833,12 @@ fn test_fastboot_snapshots_teardown(exit_backpressure: bool) {
     // Enable or disable backpressure based on the test case parameter
     let exit_backpressure = exit_backpressure.then(|| Arc::new(AtomicBool::new(false)));
 
+    let io_setup = IoSetupState::default()
+        .with_shared_sqpoll()
+        .unwrap()
+        .with_buffers_registered(true)
+        .with_direct_io(true);
+
     let exit = Arc::new(AtomicBool::new(false));
     let snapshot_packager_service = SnapshotPackagerService::new(
         pending_snapshot_packages.clone(),
@@ -807,6 +849,7 @@ fn test_fastboot_snapshots_teardown(exit_backpressure: bool) {
         snapshot_controller.clone(),
         false,
         0,
+        io_setup,
     );
 
     let mint_keypair = &snapshot_test_config.genesis_config_info.mint_keypair;

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -143,6 +143,7 @@ name = "agave-ledger-tool"
 version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-fs",
  "agave-logger",
  "agave-reserved-account-keys",
  "agave-snapshots",
@@ -6539,6 +6540,7 @@ dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-bls-cert-verify",
  "agave-feature-set",
+ "agave-fs",
  "agave-logger",
  "agave-math-utils",
  "agave-scheduler-bindings",
@@ -7461,6 +7463,7 @@ name = "solana-local-cluster"
 version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-fs",
  "agave-logger",
  "agave-snapshots",
  "agave-votor",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -45,6 +45,7 @@ used_underscore_binding = "deny"
 [workspace.dependencies]
 agave-banking-stage-ingress-types = { path = "../banking-stage-ingress-types", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-feature-set = { path = "../feature-set", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+agave-fs = { path = "../fs", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-logger = { path = "../logger", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "../reserved-account-keys", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-snapshots = { path = "../snapshots", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }

--- a/fs/src/buffered_writer.rs
+++ b/fs/src/buffered_writer.rs
@@ -1,24 +1,33 @@
 use {
-    crate::FileSize,
+    crate::{
+        FileSize, IoSize,
+        file_io::FileCreator,
+        io_uring::{
+            file_creator::{DEFAULT_WRITE_SIZE, IoUringFileCreator, IoUringFileCreatorBuilder},
+            memory::IoBufferChunk,
+        },
+    },
     std::{
         fs,
-        io::{self, BufWriter},
-        path::Path,
+        io::{self, Result},
+        path::PathBuf,
+        sync::Arc,
     },
 };
-
-/// Default buffer size for writing large files to disks. Since current implementation does not do
-/// background writing, this size is set above minimum reasonable SSD write sizes to also reduce
-/// number of syscalls.
-const DEFAULT_BUFFER_SIZE: usize = 2 * 1024 * 1024;
 
 /// Return a buffered writer for creating a new file at `path`
 ///
 /// The returned writer is using a buffer size tuned for writing large files to disks.
-pub fn large_file_buf_writer(path: impl AsRef<Path>) -> io::Result<impl io::Write> {
-    let file = fs::File::create(path)?;
+pub fn large_file_buf_writer(path: PathBuf) -> io::Result<impl io::Write> {
+    let mut io_uring_file_creator = IoUringFileCreatorBuilder::new()
+        .build((DEFAULT_WRITE_SIZE as usize).strict_mul(4), |_| None)?;
+    let parent_dir_handle = Arc::new(fs::File::open(path.parent().ok_or(io::Error::new(
+        io::ErrorKind::NotADirectory,
+        "large file buf writer expected the file path to have a parent directory",
+    ))?)?);
+    let file_key = io_uring_file_creator.open(path, 0o644, parent_dir_handle)?;
 
-    Ok(BufWriter::with_capacity(DEFAULT_BUFFER_SIZE, file))
+    Ok(IoUringFileWriter::new(io_uring_file_creator, file_key))
 }
 
 /// A writer that enforces a hard byte-count limit on the wrapped writer.
@@ -68,6 +77,91 @@ impl<W: io::Write> io::Write for SizeLimitedWriter<W> {
     }
     fn flush(&mut self) -> io::Result<()> {
         self.inner.flush()
+    }
+}
+
+pub struct IoUringFileWriter<'a> {
+    inner: IoUringFileCreator<'a>,
+    // Safety: the IoBufferChunk is safe to use as long as the inner IoUringFileCreator is still alive
+    current_buffer: Option<IoBufferChunk>,
+    current_buffer_offset: IoSize,
+    file_offset: u64,
+    file_key: usize,
+}
+
+impl<'a> IoUringFileWriter<'a> {
+    pub fn new(file_creator: IoUringFileCreator<'a>, file_key: usize) -> Self {
+        Self {
+            inner: file_creator,
+            current_buffer: None,
+            current_buffer_offset: 0,
+            file_key,
+            file_offset: 0,
+        }
+    }
+
+    fn write_current_buffer(&mut self, is_final_write: bool) -> Result<()> {
+        // Replace `self.current_buffer` with None. The next write will have to wait for a free buffer.
+        if let Some(buf) = self.current_buffer.take() {
+            self.inner.schedule_write(
+                self.file_key,
+                self.file_offset,
+                is_final_write,
+                buf,
+                self.current_buffer_offset,
+            )?;
+            self.file_offset = self
+                .file_offset
+                .strict_add(self.current_buffer_offset as u64);
+            self.current_buffer_offset = 0;
+        }
+
+        Ok(())
+    }
+}
+
+impl io::Write for IoUringFileWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        // buffer was filled and queued to write, fetch a new buffer
+        if self.current_buffer.is_none() {
+            self.current_buffer_offset = 0;
+            self.current_buffer = Some(self.inner.wait_free_buf()?);
+        }
+
+        // unwrap the buffer. we just ensured that it is not `None`
+        let current_buffer = self.current_buffer.as_ref().unwrap();
+        let mut dst = unsafe {
+            std::slice::from_raw_parts_mut(
+                current_buffer.as_mut_ptr(),
+                current_buffer.len() as usize,
+            )
+        };
+        dst = &mut dst[self.current_buffer_offset as usize..];
+
+        // copy as many bytes as we can into the buffer
+        let bytes_copied =
+            (current_buffer.len().strict_sub(self.current_buffer_offset)).min(buf.len() as u32);
+        dst.copy_from_slice(&buf[..bytes_copied as usize]);
+        self.current_buffer_offset = self
+            .current_buffer_offset
+            .strict_add(bytes_copied as IoSize);
+
+        // check if the buffer is full. if it is, schedule a write
+        if self.current_buffer_offset == current_buffer.len() {
+            self.write_current_buffer(false)?;
+        }
+
+        Ok(bytes_copied as usize)
+    }
+
+    /// Flush is only expected to be called once.
+    fn flush(&mut self) -> Result<()> {
+        // flush the current buffer if necessary
+        if self.current_buffer_offset != 0 {
+            self.write_current_buffer(true)?;
+        }
+        // wait for all the fs ops to drain and then return
+        self.inner.drain()
     }
 }
 

--- a/fs/src/buffered_writer.rs
+++ b/fs/src/buffered_writer.rs
@@ -2,32 +2,55 @@ use {
     crate::{
         FileSize, IoSize,
         file_io::FileCreator,
-        io_uring::{
-            file_creator::{DEFAULT_WRITE_SIZE, IoUringFileCreator, IoUringFileCreatorBuilder},
-            memory::IoBufferChunk,
-        },
+        io_setup::IoSetupState,
+        io_uring::{file_creator::IoUringFileCreator, memory::IoBufferChunk},
     },
     std::{
         fs,
-        io::{self, Result},
+        io::{self, BufWriter, Result},
         path::PathBuf,
         sync::Arc,
     },
 };
 
+/// Default buffer size for writing large files to disks. Since current implementation does not do
+/// background writing, this size is set above minimum reasonable SSD write sizes to also reduce
+/// number of syscalls.
+const DEFAULT_BUFFER_SIZE: usize = 2 * 1024 * 1024;
+
 /// Return a buffered writer for creating a new file at `path`
 ///
 /// The returned writer is using a buffer size tuned for writing large files to disks.
-pub fn large_file_buf_writer(path: PathBuf) -> io::Result<impl io::Write> {
-    let mut io_uring_file_creator = IoUringFileCreatorBuilder::new()
-        .build((DEFAULT_WRITE_SIZE as usize).strict_mul(4), |_| None)?;
-    let parent_dir_handle = Arc::new(fs::File::open(path.parent().ok_or(io::Error::new(
-        io::ErrorKind::NotADirectory,
-        "large file buf writer expected the file path to have a parent directory",
-    ))?)?);
-    let file_key = io_uring_file_creator.open(path, 0o644, parent_dir_handle)?;
+pub fn large_file_buf_writer(
+    path: PathBuf,
+    io_setup: &IoSetupState,
+) -> io::Result<Box<dyn io::Write>> {
+    #[cfg(target_os = "linux")]
+    if agave_io_uring::io_uring_supported() {
+        use crate::io_uring::file_creator::{DEFAULT_WRITE_SIZE, IoUringFileCreatorBuilder};
 
-    Ok(IoUringFileWriter::new(io_uring_file_creator, file_key))
+        let mut io_uring_file_creator = IoUringFileCreatorBuilder::new()
+            .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
+            .write_with_direct_io(io_setup.use_direct_io)
+            .shared_sqpoll(io_setup.shared_sqpoll_fd())
+            .build((DEFAULT_WRITE_SIZE as usize).strict_mul(4), |_| None)?;
+        let parent_dir_handle = Arc::new(fs::File::open(path.parent().ok_or(io::Error::new(
+            io::ErrorKind::NotADirectory,
+            "large file buf writer expected the file path to have a parent directory",
+        ))?)?);
+        let file_key = io_uring_file_creator.open(path, 0o644, parent_dir_handle)?;
+
+        return Ok(Box::new(IoUringFileWriter::new(
+            io_uring_file_creator,
+            file_key,
+        )));
+    }
+
+    let file = fs::File::create(path)?;
+    Ok(Box::new(BufWriter::with_capacity(
+        DEFAULT_BUFFER_SIZE,
+        file,
+    )))
 }
 
 /// A writer that enforces a hard byte-count limit on the wrapped writer.

--- a/fs/src/io_uring/file_creator.rs
+++ b/fs/src/io_uring/file_creator.rs
@@ -240,7 +240,12 @@ impl IoUringFileCreator<'_> {
     /// Schedule opening file at `path` with `mode` permissions.
     ///
     /// Returns key that can be used for scheduling writes for it.
-    fn open(&mut self, path: PathBuf, mode: u32, dir_handle: Arc<File>) -> io::Result<usize> {
+    pub(crate) fn open(
+        &mut self,
+        path: PathBuf,
+        mode: u32,
+        dir_handle: Arc<File>,
+    ) -> io::Result<usize> {
         let file = PendingFile::from_path(path);
         let path_cstring = Pin::new(file.path_cstring());
 
@@ -297,7 +302,7 @@ impl IoUringFileCreator<'_> {
     /// buffer size.
     ///
     /// Write operation can be immediately added to ring or put into file state for future execution.
-    fn schedule_write(
+    pub(crate) fn schedule_write(
         &mut self,
         file_key: usize,
         file_offset: FileSize,
@@ -366,7 +371,7 @@ impl IoUringFileCreator<'_> {
         Ok(())
     }
 
-    fn wait_free_buf(&mut self) -> io::Result<IoBufferChunk> {
+    pub(crate) fn wait_free_buf(&mut self) -> io::Result<IoBufferChunk> {
         loop {
             self.ring.process_completions()?;
             let state = self.ring.context_mut();

--- a/fs/src/io_uring/memory.rs
+++ b/fs/src/io_uring/memory.rs
@@ -173,7 +173,7 @@ impl DerefMut for PageAlignedMemory {
 ///
 /// Stored `ptr` and `size` are used as an unsafe (no lifetime tracking) equivalent of `&mut [u8]`.
 #[derive(Debug)]
-pub(super) struct IoBufferChunk {
+pub(crate) struct IoBufferChunk {
     ptr: *mut u8,
     size: IoSize,
     /// IO buffer index identifying part of the underlying buffer if it was registered in `io_uring`.

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -21,6 +21,7 @@ frozen-abi = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-fs = { workspace = true }
 agave-logger = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 agave-snapshots = { workspace = true }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -13,6 +13,7 @@ use {
         program::*,
     },
     agave_feature_set::{self as feature_set, FeatureSet},
+    agave_fs::io_setup::IoSetupState,
     agave_reserved_account_keys::ReservedAccountKeys,
     agave_snapshots::{
         ArchiveFormat, DEFAULT_ARCHIVE_COMPRESSION, SUPPORTED_ARCHIVE_COMPRESSION, SnapshotVersion,
@@ -1525,6 +1526,18 @@ fn main() {
                             "correct misassigned owner and data on testnet ed25519 precompile \
                              account deployment",
                         ),
+                )
+                .arg(
+                    Arg::with_name("direct_io")
+                        .long("direct_io")
+                        .takes_value(false)
+                        .help("Enable direct io when creating the snapshot."),
+                )
+                .arg(
+                    Arg::with_name("registered_io_uring_buffers")
+                        .long("registered_io_uring_buffers")
+                        .takes_value(false)
+                        .help("Use registered buffers when creating the snapshot."),
                 ),
         )
         .subcommand(
@@ -2146,6 +2159,15 @@ fn main() {
                         ""
                     };
 
+                    let direct_io = arg_matches.is_present("direct_io");
+                    let registered_io_uring_buffers =
+                        arg_matches.is_present("registered_io_uring_buffers");
+                    let io_setup = IoSetupState::default()
+                        .with_shared_sqpoll()
+                        .unwrap()
+                        .with_direct_io(direct_io)
+                        .with_buffers_registered(registered_io_uring_buffers);
+
                     info!(
                         "Creating {}snapshot of slot {} in {}",
                         snapshot_type_str,
@@ -2557,6 +2579,7 @@ fn main() {
                                 output_directory.clone(),
                                 output_directory,
                                 snapshot_archive_format,
+                                &io_setup,
                             )
                             .unwrap_or_else(|err| {
                                 eprintln!("Unable to create incremental snapshot: {err}");
@@ -2580,6 +2603,7 @@ fn main() {
                                 output_directory.clone(),
                                 output_directory,
                                 snapshot_archive_format,
+                                &io_setup,
                             )
                             .unwrap_or_else(|err| {
                                 eprintln!("Unable to create snapshot: {err}");

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -22,6 +22,7 @@ dev-context-only-utils = [
 
 [dependencies]
 agave-feature-set = { workspace = true }
+agave-fs = { workspace = true }
 agave-logger = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-votor = { workspace = true }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
+    agave_fs::io_setup::IoSetupState,
     agave_snapshots::{
         SnapshotArchiveKind, SnapshotInterval, paths as snapshot_paths,
         snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_config::SnapshotConfig,
@@ -2240,6 +2241,7 @@ fn create_snapshot_to_hard_fork(
     blockstore: &Blockstore,
     snapshot_slot: Slot,
     hard_forks: Vec<Slot>,
+    io_setup: &IoSetupState,
 ) {
     let process_options = ProcessOptions {
         halt_at_slot: Some(snapshot_slot),
@@ -2287,6 +2289,7 @@ fn create_snapshot_to_hard_fork(
         ledger_path,
         ledger_path,
         snapshot_config.archive_format,
+        io_setup,
     )
     .unwrap();
     info!(
@@ -2379,7 +2382,17 @@ fn test_hard_fork_with_gap_in_roots() {
     let genesis_slot = 0;
     {
         let blockstore_a = Blockstore::open(&val_a_ledger_path).unwrap();
-        create_snapshot_to_hard_fork(&blockstore_a, hard_fork_slot, vec![hard_fork_slot]);
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_buffers_registered(true)
+            .with_direct_io(true);
+        create_snapshot_to_hard_fork(
+            &blockstore_a,
+            hard_fork_slot,
+            vec![hard_fork_slot],
+            &io_setup,
+        );
 
         // Intentionally make agave-validator unbootable by replaying blocks from the genesis to
         // ensure the hard-forked snapshot is used always.  Otherwise, we couldn't create a gap

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6452,6 +6452,7 @@ dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-bls-cert-verify",
  "agave-feature-set",
+ "agave-fs",
  "agave-logger",
  "agave-math-utils",
  "agave-scheduler-bindings",

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -390,6 +390,7 @@ mod tests {
     use {
         super::*,
         crate::{runtime_config::RuntimeConfig, snapshot_bank_utils, snapshot_utils},
+        agave_fs::io_setup::IoSetupState,
         agave_snapshots::snapshot_config::SnapshotConfig,
         solana_account::{ReadableAccount as _, WritableAccount as _},
         solana_accounts_db::{
@@ -855,6 +856,11 @@ mod tests {
         let snapshot_config = SnapshotConfig::default();
         let bank_snapshots_dir = TempDir::new().unwrap();
         let snapshot_archives_dir = TempDir::new().unwrap();
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         let snapshot = snapshot_bank_utils::bank_to_full_snapshot_archive(
             &bank_snapshots_dir,
             &bank,
@@ -862,6 +868,7 @@ mod tests {
             &snapshot_archives_dir,
             &snapshot_archives_dir,
             snapshot_config.archive_format,
+            &io_setup,
         )
         .unwrap();
         let (_accounts_tempdir, accounts_dir) = snapshot_utils::create_tmp_accounts_dir_for_tests();
@@ -960,6 +967,11 @@ mod tests {
         let snapshot_config = SnapshotConfig::default();
         let bank_snapshots_dir = TempDir::new().unwrap();
         let snapshot_archives_dir = TempDir::new().unwrap();
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         let snapshot = snapshot_bank_utils::bank_to_full_snapshot_archive(
             &bank_snapshots_dir,
             &bank,
@@ -967,6 +979,7 @@ mod tests {
             &snapshot_archives_dir,
             &snapshot_archives_dir,
             snapshot_config.archive_format,
+            &io_setup,
         )
         .unwrap();
         let (_accounts_tempdir, accounts_dir) = snapshot_utils::create_tmp_accounts_dir_for_tests();

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -509,6 +509,7 @@ pub(crate) mod tests {
             snapshot_utils::create_tmp_accounts_dir_for_tests,
         },
         agave_feature_set::FeatureSet,
+        agave_fs::io_setup::IoSetupState,
         agave_snapshots::snapshot_config::SnapshotConfig,
         assert_matches::assert_matches,
         solana_account::{
@@ -2148,6 +2149,12 @@ pub(crate) mod tests {
         let snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let snapshot_archive_format = SnapshotConfig::default().archive_format;
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         let full_snapshot_archive_info = bank_to_full_snapshot_archive(
             bank_snapshots_dir.path(),
             &bank,
@@ -2155,6 +2162,7 @@ pub(crate) mod tests {
             snapshot_archives_dir.path(),
             snapshot_archives_dir.path(),
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
 

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -11,6 +11,7 @@ mod tests {
             snapshot_utils::{StorageAndNextAccountsFileId, create_tmp_accounts_dir_for_tests},
             stakes::{SerdeStakesToStakeFormat, Stakes},
         },
+        agave_fs::io_setup::IoSetupState,
         agave_snapshots::snapshot_config::SnapshotConfig,
         solana_accounts_db::{
             ObsoleteAccounts,
@@ -275,6 +276,11 @@ mod tests {
         let bank_snapshots_dir = TempDir::new().unwrap();
         let full_snapshot_archives_dir = TempDir::new().unwrap();
         let incremental_snapshot_archives_dir = TempDir::new().unwrap();
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
 
         // Serialize
         let snapshot_archive_info = snapshot_bank_utils::bank_to_full_snapshot_archive(
@@ -284,6 +290,7 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             SnapshotConfig::default().archive_format,
+            &io_setup,
         )
         .unwrap();
 

--- a/runtime/src/serde_snapshot/status_cache.rs
+++ b/runtime/src/serde_snapshot/status_cache.rs
@@ -6,6 +6,7 @@ use shuttle::sync::Mutex;
 use std::sync::Mutex;
 use {
     crate::{bank::BankSlotDelta, snapshot_utils, status_cache::KeySlice},
+    agave_fs::io_setup::IoSetupState,
     bincode::{self, Options as _},
     serde::{Deserialize, Serialize},
     solana_clock::Slot,
@@ -29,8 +30,9 @@ type SerdeStatus<T> = ahash::HashMap<Hash, (usize, Vec<(KeySlice, T)>)>;
 pub fn serialize_status_cache(
     slot_deltas: &[BankSlotDelta],
     status_cache_path: &Path,
+    io_setup: &IoSetupState,
 ) -> agave_snapshots::Result<u64> {
-    snapshot_utils::serialize_snapshot_data_file(status_cache_path, |stream| {
+    snapshot_utils::serialize_snapshot_data_file(status_cache_path, io_setup, |stream| {
         let snapshot_slot_deltas = slot_deltas
             .iter()
             .map(|slot_delta| {

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -25,7 +25,7 @@ use {
         },
         status_cache,
     },
-    agave_fs::dirs,
+    agave_fs::{dirs, io_setup::IoSetupState},
     agave_snapshots::{
         ArchiveFormat, SnapshotArchiveKind, SnapshotKind, SnapshotVersion,
         error::{
@@ -676,6 +676,7 @@ pub fn bank_to_full_snapshot_archive(
     full_snapshot_archives_dir: impl AsRef<Path>,
     incremental_snapshot_archives_dir: impl AsRef<Path>,
     archive_format: ArchiveFormat,
+    io_setup: &IoSetupState,
 ) -> agave_snapshots::Result<FullSnapshotArchiveInfo> {
     let snapshot_version = snapshot_version.unwrap_or_default();
     let bank_snapshots_dir = tempfile::tempdir_in(&bank_snapshots_dir)?;
@@ -716,6 +717,7 @@ pub fn bank_to_full_snapshot_archive(
         &snapshot_config.bank_snapshots_dir,
         snapshot_config.snapshot_version,
         snapshot_package.bank_snapshot_package,
+        io_setup,
         snapshot_storages.as_slice(),
         false, // we do not intend to fastboot, so skip flushing and hard linking the storages
     )?;
@@ -727,6 +729,7 @@ pub fn bank_to_full_snapshot_archive(
         bank_snapshot_info.snapshot_dir,
         snapshot_storages,
         &snapshot_config,
+        io_setup,
     )?;
 
     Ok(FullSnapshotArchiveInfo::new(snapshot_archive_info))
@@ -747,6 +750,7 @@ pub fn bank_to_incremental_snapshot_archive(
     full_snapshot_archives_dir: impl AsRef<Path>,
     incremental_snapshot_archives_dir: impl AsRef<Path>,
     archive_format: ArchiveFormat,
+    io_setup: &IoSetupState,
 ) -> agave_snapshots::Result<IncrementalSnapshotArchiveInfo> {
     let snapshot_version = snapshot_version.unwrap_or_default();
 
@@ -791,6 +795,7 @@ pub fn bank_to_incremental_snapshot_archive(
         &snapshot_config.bank_snapshots_dir,
         snapshot_config.snapshot_version,
         snapshot_package.bank_snapshot_package,
+        io_setup,
         snapshot_storages.as_slice(),
         false, // we do not intend to fastboot, so skip flushing and hard linking the storages
     )?;
@@ -802,6 +807,7 @@ pub fn bank_to_incremental_snapshot_archive(
         bank_snapshot_info.snapshot_dir,
         snapshot_storages,
         &snapshot_config,
+        io_setup,
     )?;
 
     Ok(IncrementalSnapshotArchiveInfo::new(
@@ -850,6 +856,7 @@ mod tests {
         bank_snapshots_dir: impl AsRef<Path>,
         num_total: usize,
         should_flush_and_hard_link_storages: bool,
+        io_setup: &IoSetupState,
     ) -> Bank {
         let mut bank = Arc::new(Bank::new_for_tests(genesis_config));
         for _i in 0..num_total {
@@ -862,6 +869,7 @@ mod tests {
                 &bank,
                 SnapshotVersion::default(),
                 should_flush_and_hard_link_storages,
+                io_setup,
             )
             .unwrap();
         }
@@ -880,6 +888,7 @@ mod tests {
         bank: &Bank,
         snapshot_version: SnapshotVersion,
         should_flush_and_hard_link_storages: bool,
+        io_setup: &IoSetupState,
     ) -> agave_snapshots::Result<()> {
         assert!(bank.is_complete());
 
@@ -900,6 +909,7 @@ mod tests {
             bank_snapshots_dir.as_ref(),
             snapshot_version,
             bank_snapshot_package,
+            io_setup,
             snapshot_storages.as_slice(),
             should_flush_and_hard_link_storages,
         )?;
@@ -922,6 +932,12 @@ mod tests {
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let snapshot_archive_format = SnapshotConfig::default().archive_format;
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         let snapshot_archive_info = bank_to_full_snapshot_archive(
             &bank_snapshots_dir,
             &original_bank,
@@ -929,6 +945,7 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
 
@@ -997,6 +1014,12 @@ mod tests {
         let snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let snapshot_archive_format = SnapshotConfig::default().archive_format;
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         let full_snapshot_archive_info = bank_to_full_snapshot_archive(
             bank_snapshots_dir.path(),
             &bank1,
@@ -1004,6 +1027,7 @@ mod tests {
             snapshot_archives_dir.path(),
             snapshot_archives_dir.path(),
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
 
@@ -1096,6 +1120,12 @@ mod tests {
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let snapshot_archive_format = SnapshotConfig::default().archive_format;
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         let full_snapshot_archive_info = bank_to_full_snapshot_archive(
             bank_snapshots_dir.path(),
             &bank4,
@@ -1103,6 +1133,7 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
 
@@ -1177,6 +1208,12 @@ mod tests {
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let snapshot_archive_format = SnapshotConfig::default().archive_format;
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         let full_snapshot_slot = slot;
         let full_snapshot_archive_info = bank_to_full_snapshot_archive(
             bank_snapshots_dir.path(),
@@ -1185,6 +1222,7 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
 
@@ -1212,6 +1250,12 @@ mod tests {
             .unwrap();
         bank4.fill_bank_with_ticks_for_tests();
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         let incremental_snapshot_archive_info = bank_to_incremental_snapshot_archive(
             bank_snapshots_dir.path(),
             &bank4,
@@ -1220,6 +1264,7 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
 
@@ -1284,6 +1329,12 @@ mod tests {
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let snapshot_archive_format = SnapshotConfig::default().archive_format;
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         let full_snapshot_slot = slot;
         bank_to_full_snapshot_archive(
             &bank_snapshots_dir,
@@ -1292,6 +1343,7 @@ mod tests {
             &full_snapshot_archives_dir,
             &incremental_snapshot_archives_dir,
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
 
@@ -1319,6 +1371,12 @@ mod tests {
             .unwrap();
         bank4.fill_bank_with_ticks_for_tests();
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         bank_to_incremental_snapshot_archive(
             &bank_snapshots_dir,
             &bank4,
@@ -1327,6 +1385,7 @@ mod tests {
             &full_snapshot_archives_dir,
             &incremental_snapshot_archives_dir,
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
 
@@ -1365,6 +1424,12 @@ mod tests {
         let bad_capitalization = good_capitalization + 1;
         bank.set_capitalization_for_tests(bad_capitalization);
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         let snapshot_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archive_info = bank_to_full_snapshot_archive(
             &snapshot_dir,
@@ -1373,6 +1438,7 @@ mod tests {
             &snapshot_dir,
             &snapshot_dir,
             SnapshotConfig::default().archive_format,
+            &io_setup,
         )
         .unwrap();
 
@@ -1441,6 +1507,12 @@ mod tests {
         let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let snapshot_archive_format = SnapshotConfig::default().archive_format;
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         let (mut genesis_config, mint_keypair) =
             create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
         // test expects 0 transaction fee
@@ -1475,6 +1547,7 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
 
@@ -1513,6 +1586,7 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
         let deserialized_bank = bank_from_snapshot_archives(
@@ -1569,6 +1643,7 @@ mod tests {
             full_snapshot_archives_dir.path(),
             incremental_snapshot_archives_dir.path(),
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
 
@@ -1619,6 +1694,12 @@ mod tests {
         let all_snapshots_dir = tempfile::TempDir::new().unwrap();
         let snapshot_archive_format = SnapshotConfig::default().archive_format;
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         let full_snapshot_slot = slot;
         bank_to_full_snapshot_archive(
             &all_snapshots_dir,
@@ -1627,6 +1708,7 @@ mod tests {
             &all_snapshots_dir,
             &all_snapshots_dir,
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
 
@@ -1646,6 +1728,7 @@ mod tests {
             &all_snapshots_dir,
             &all_snapshots_dir,
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
 
@@ -1668,11 +1751,17 @@ mod tests {
         bank.fill_bank_with_ticks_for_tests();
 
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         create_bank_snapshot_from_bank(
             &bank_snapshots_dir,
             &bank,
             SnapshotVersion::default(),
             true,
+            &io_setup,
         )
         .unwrap();
 
@@ -1704,7 +1793,18 @@ mod tests {
     fn test_fastboot_versioning() {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
-        let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 3, true);
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+        let _bank = create_snapshot_dirs_for_tests(
+            &genesis_config,
+            &bank_snapshots_dir,
+            3,
+            true,
+            &io_setup,
+        );
 
         let snapshot_config = SnapshotConfig {
             bank_snapshots_dir: bank_snapshots_dir.as_ref().to_path_buf(),
@@ -1758,11 +1858,17 @@ mod tests {
     fn test_get_highest_bank_snapshot(should_flush_and_hard_link_storages: bool) {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         let _bank = create_snapshot_dirs_for_tests(
             &genesis_config,
             &bank_snapshots_dir,
             4,
             should_flush_and_hard_link_storages,
+            &io_setup,
         );
 
         let snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
@@ -1797,7 +1903,18 @@ mod tests {
     fn test_clean_orphaned_account_snapshot_dirs() {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
-        let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 2, true);
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+        let _bank = create_snapshot_dirs_for_tests(
+            &genesis_config,
+            &bank_snapshots_dir,
+            2,
+            true,
+            &io_setup,
+        );
 
         let snapshot_dir_slot_2 = bank_snapshots_dir.path().join("2");
         let accounts_link_dir_slot_2 =
@@ -1844,7 +1961,18 @@ mod tests {
     fn test_clean_orphaned_account_snapshot_dirs_no_hard_link() {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
-        let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 2, false);
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+        let _bank = create_snapshot_dirs_for_tests(
+            &genesis_config,
+            &bank_snapshots_dir,
+            2,
+            false,
+            &io_setup,
+        );
 
         // Ensure the bank snapshot dir does exist.
         let bank_snapshot_dir = get_bank_snapshot_dir(&bank_snapshots_dir, 2);
@@ -1865,11 +1993,17 @@ mod tests {
     fn test_purge_incomplete_bank_snapshots(should_flush_and_hard_link_storages: bool) {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         let _bank = create_snapshot_dirs_for_tests(
             &genesis_config,
             &bank_snapshots_dir,
             2,
             should_flush_and_hard_link_storages,
+            &io_setup,
         );
 
         // remove the "version" files so the snapshots will be purged
@@ -1911,6 +2045,12 @@ mod tests {
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
         let snapshot_archive_format = SnapshotConfig::default().archive_format;
+
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
 
         let (genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
 
@@ -1994,6 +2134,7 @@ mod tests {
             full_snapshot_archives_dir.path(),
             full_snapshot_archives_dir.path(),
             snapshot_archive_format,
+            &io_setup,
         )
         .unwrap();
 
@@ -2050,6 +2191,12 @@ mod tests {
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let (mut genesis_config, mint) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         // Disable fees so fees don't need to be calculated
         genesis_config.fee_rate_governor = solana_fee_calculator::FeeRateGovernor::new(0, 0);
 
@@ -2089,6 +2236,7 @@ mod tests {
             &bank2,
             SnapshotVersion::default(),
             true,
+            &io_setup,
         )
         .unwrap();
 
@@ -2124,7 +2272,20 @@ mod tests {
     fn test_fastboot_missing_obsolete_accounts() {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
-        let bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 3, true);
+
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
+        let bank = create_snapshot_dirs_for_tests(
+            &genesis_config,
+            &bank_snapshots_dir,
+            3,
+            true,
+            &io_setup,
+        );
 
         let account_paths = &bank.rc.accounts.accounts_db.paths;
         let bank_snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
@@ -2158,6 +2319,12 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         bank.fill_bank_with_ticks_for_tests();
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         // Take a bank snapshot, passing `true` for `should_flush_and_hard_link_storages`.
         // This ensures that `serialize_snapshot` performs all necessary steps to create
         // a snapshot that supports fastbooting.
@@ -2166,6 +2333,7 @@ mod tests {
             &bank,
             SnapshotVersion::default(),
             true,
+            &io_setup,
         )
         .unwrap();
 
@@ -2213,6 +2381,12 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         bank.fill_bank_with_ticks_for_tests();
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         // freeze the bank before mucking with capitalization, since
         // freezing also changes capitalization (fees, incinerator, etc).
         bank.freeze();
@@ -2226,6 +2400,7 @@ mod tests {
             &bank,
             SnapshotVersion::default(),
             true,
+            &io_setup,
         )
         .unwrap();
 
@@ -2261,11 +2436,18 @@ mod tests {
     fn test_purge_all_bank_snapshots(should_flush_and_hard_link_storages: bool) {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         let _bank = create_snapshot_dirs_for_tests(
             &genesis_config,
             &bank_snapshots_dir,
             10,
             should_flush_and_hard_link_storages,
+            &io_setup,
         );
         // Keep bank in this scope so that its account_paths tmp dirs are not released, and purge_all_bank_snapshots
         // can clear the account hardlinks correctly.
@@ -2280,11 +2462,19 @@ mod tests {
     fn test_purge_old_bank_snapshots(should_flush_and_hard_link_storages: bool) {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         let _bank = create_snapshot_dirs_for_tests(
             &genesis_config,
             &bank_snapshots_dir,
             10,
             should_flush_and_hard_link_storages,
+            &io_setup,
         );
         // Keep bank in this scope so that its account_paths tmp dirs are not released, and purge_old_bank_snapshots
         // can clear the account hardlinks correctly.
@@ -2308,12 +2498,19 @@ mod tests {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         // The bank must stay in scope to ensure the temp dirs that it holds are not dropped
         let _bank = create_snapshot_dirs_for_tests(
             &genesis_config,
             &bank_snapshots_dir,
             9,
             should_flush_and_hard_link_storages,
+            &io_setup,
         );
         let bank_snapshots_before = get_bank_snapshots(&bank_snapshots_dir);
 
@@ -2341,12 +2538,19 @@ mod tests {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         // The bank must stay in scope to ensure the temp dirs that it holds are not dropped
         let _bank = create_snapshot_dirs_for_tests(
             &genesis_config,
             &bank_snapshots_dir,
             9,
             should_flush_and_hard_link_storages,
+            &io_setup,
         );
 
         purge_old_bank_snapshots_at_startup(&bank_snapshots_dir);
@@ -2593,6 +2797,12 @@ mod tests {
             .maximum_full_snapshot_archives_to_retain
             .get();
 
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
+
         // Take some snapshots. Do not flush or hard link storages so that get highest loadable
         // can be tested when the snapshot has not been marked loadable
         let _bank = create_snapshot_dirs_for_tests(
@@ -2600,6 +2810,7 @@ mod tests {
             &snapshot_config.bank_snapshots_dir,
             num_snapshots_to_create,
             false,
+            &io_setup,
         );
 
         let highest_bank_snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -363,6 +363,7 @@ mod tests {
             snapshot_minimizer::SnapshotMinimizer,
             snapshot_utils,
         },
+        agave_fs::io_setup::IoSetupState,
         agave_snapshots::snapshot_config::SnapshotConfig,
         dashmap::DashSet,
         solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
@@ -631,6 +632,11 @@ mod tests {
         let snapshot_config = SnapshotConfig::default();
         let bank_snapshots_dir = TempDir::new().unwrap();
         let snapshot_archives_dir = TempDir::new().unwrap();
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         let snapshot = snapshot_bank_utils::bank_to_full_snapshot_archive(
             &bank_snapshots_dir,
             &bank,
@@ -638,6 +644,7 @@ mod tests {
             &snapshot_archives_dir,
             &snapshot_archives_dir,
             snapshot_config.archive_format,
+            &io_setup,
         )
         .unwrap();
         let (_accounts_tempdir, accounts_dir) = snapshot_utils::create_tmp_accounts_dir_for_tests();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -703,7 +703,7 @@ fn serialize_obsolete_accounts(
         .as_ref()
         .join(snapshot_paths::SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME);
     let mut file_stream = SizeLimitedWriter::new(
-        large_file_buf_writer(&obsolete_accounts_path)?,
+        large_file_buf_writer(obsolete_accounts_path.clone())?,
         maximum_obsolete_accounts_file_size,
     );
 
@@ -795,8 +795,10 @@ fn serialize_snapshot_data_file_capped<F>(
 where
     F: FnOnce(&mut dyn Write) -> Result<()>,
 {
-    let mut data_file_stream =
-        SizeLimitedWriter::new(large_file_buf_writer(data_file_path)?, maximum_file_size);
+    let mut data_file_stream = SizeLimitedWriter::new(
+        large_file_buf_writer(data_file_path.into())?,
+        maximum_file_size,
+    );
     serializer(&mut data_file_stream).map_err(|err| {
         IoError::other(format!(
             "unable to serialize snapshot data to file '{}': {err}",

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -451,6 +451,7 @@ pub fn archive_snapshot_package(
     bank_snapshot_dir: impl AsRef<Path>,
     mut snapshot_storages: Vec<Arc<AccountStorageEntry>>,
     snapshot_config: &SnapshotConfig,
+    io_setup: &IoSetupState,
 ) -> Result<SnapshotArchiveInfo> {
     let snapshot_archive_path = match snapshot_archive_kind {
         SnapshotArchiveKind::Full => snapshot_paths::build_full_snapshot_archive_path(
@@ -481,6 +482,7 @@ pub fn archive_snapshot_package(
         &bank_snapshot_dir,
         snapshot_archive_path,
         snapshot_config.archive_format,
+        io_setup,
     )?;
 
     Ok(snapshot_archive_info)
@@ -491,6 +493,7 @@ pub fn serialize_snapshot(
     bank_snapshots_dir: impl AsRef<Path>,
     snapshot_version: SnapshotVersion,
     bank_snapshot_package: BankSnapshotPackage,
+    io_setup: &IoSetupState,
     snapshot_storages: &[Arc<AccountStorageEntry>],
     should_flush_and_hard_link_storages: bool,
 ) -> Result<BankSnapshotInfo> {
@@ -543,7 +546,7 @@ pub fn serialize_snapshot(
             Ok(())
         };
         let (bank_snapshot_consumed_size, bank_serialize) = measure_time!(
-            serialize_snapshot_data_file(&bank_snapshot_path, bank_snapshot_serializer)
+            serialize_snapshot_data_file(&bank_snapshot_path, io_setup, bank_snapshot_serializer)
                 .map_err(|err| AddBankSnapshotError::SerializeBank(Box::new(err)))?,
             "bank serialize"
         );
@@ -551,8 +554,12 @@ pub fn serialize_snapshot(
         let status_cache_path =
             bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_STATUS_CACHE_FILENAME);
         let (status_cache_consumed_size, status_cache_serialize_us) = measure_us!(
-            serde_snapshot::serialize_status_cache(status_cache_slot_deltas, &status_cache_path)
-                .map_err(|err| AddBankSnapshotError::SerializeStatusCache(Box::new(err)))?
+            serde_snapshot::serialize_status_cache(
+                status_cache_slot_deltas,
+                &status_cache_path,
+                io_setup
+            )
+            .map_err(|err| AddBankSnapshotError::SerializeStatusCache(Box::new(err)))?
         );
 
         let version_path = bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_VERSION_FILENAME);
@@ -576,10 +583,13 @@ pub fn serialize_snapshot(
                 );
 
                 let (_, serialize_obsolete_accounts_us) = measure_us!({
-                    write_obsolete_accounts_to_snapshot(&bank_snapshot_dir, snapshot_storages, slot)
-                        .map_err(|err| {
-                            AddBankSnapshotError::SerializeObsoleteAccounts(Box::new(err))
-                        })?
+                    write_obsolete_accounts_to_snapshot(
+                        &bank_snapshot_dir,
+                        io_setup,
+                        snapshot_storages,
+                        slot,
+                    )
+                    .map_err(|err| AddBankSnapshotError::SerializeObsoleteAccounts(Box::new(err)))?
                 });
 
                 mark_bank_snapshot_as_loadable(&bank_snapshot_dir)
@@ -682,6 +692,7 @@ fn do_get_highest_bank_snapshot(
 
 pub fn write_obsolete_accounts_to_snapshot(
     bank_snapshot_dir: impl AsRef<Path>,
+    io_setup: &IoSetupState,
     snapshot_storages: &[Arc<AccountStorageEntry>],
     snapshot_slot: Slot,
 ) -> Result<u64> {
@@ -689,6 +700,7 @@ pub fn write_obsolete_accounts_to_snapshot(
         SerdeObsoleteAccountsMap::new_from_storages(snapshot_storages, snapshot_slot);
     serialize_obsolete_accounts(
         bank_snapshot_dir,
+        io_setup,
         &obsolete_accounts,
         MAX_OBSOLETE_ACCOUNTS_FILE_SIZE,
     )
@@ -696,6 +708,7 @@ pub fn write_obsolete_accounts_to_snapshot(
 
 fn serialize_obsolete_accounts(
     bank_snapshot_dir: impl AsRef<Path>,
+    io_setup: &IoSetupState,
     obsolete_accounts_map: &SerdeObsoleteAccountsMap,
     maximum_obsolete_accounts_file_size: u64,
 ) -> Result<u64> {
@@ -703,7 +716,7 @@ fn serialize_obsolete_accounts(
         .as_ref()
         .join(snapshot_paths::SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME);
     let mut file_stream = SizeLimitedWriter::new(
-        large_file_buf_writer(obsolete_accounts_path.clone())?,
+        large_file_buf_writer(obsolete_accounts_path.clone(), io_setup)?,
         maximum_obsolete_accounts_file_size,
     );
 
@@ -745,12 +758,17 @@ fn deserialize_obsolete_accounts(
     Ok(obsolete_accounts)
 }
 
-pub fn serialize_snapshot_data_file<F>(data_file_path: &Path, serializer: F) -> Result<u64>
+pub fn serialize_snapshot_data_file<F>(
+    data_file_path: &Path,
+    io_setup: &IoSetupState,
+    serializer: F,
+) -> Result<u64>
 where
     F: FnOnce(&mut dyn Write) -> Result<()>,
 {
     serialize_snapshot_data_file_capped::<F>(
         data_file_path,
+        io_setup,
         MAX_SNAPSHOT_DATA_FILE_SIZE,
         serializer,
     )
@@ -789,6 +807,7 @@ pub fn deserialize_snapshot_data_files<T: Sized>(
 
 fn serialize_snapshot_data_file_capped<F>(
     data_file_path: &Path,
+    io_setup: &IoSetupState,
     maximum_file_size: u64,
     serializer: F,
 ) -> Result<u64>
@@ -796,7 +815,7 @@ where
     F: FnOnce(&mut dyn Write) -> Result<()>,
 {
     let mut data_file_stream = SizeLimitedWriter::new(
-        large_file_buf_writer(data_file_path.into())?,
+        large_file_buf_writer(data_file_path.into(), io_setup)?,
         maximum_file_size,
     );
     serializer(&mut data_file_stream).map_err(|err| {
@@ -1807,10 +1826,16 @@ mod tests {
 
     #[test]
     fn test_serialize_snapshot_data_file_under_limit() {
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         let temp_dir = tempfile::TempDir::new().unwrap();
         let expected_consumed_size = size_of::<u32>() as u64;
         let consumed_size = serialize_snapshot_data_file_capped(
             &temp_dir.path().join("data-file"),
+            &io_setup,
             expected_consumed_size,
             |stream| {
                 serialize_into(stream, &2323_u32)?;
@@ -1823,10 +1848,16 @@ mod tests {
 
     #[test]
     fn test_serialize_snapshot_data_file_over_limit() {
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         let temp_dir = tempfile::TempDir::new().unwrap();
         let expected_consumed_size = size_of::<u32>() as u64;
         let result = serialize_snapshot_data_file_capped(
             &temp_dir.path().join("data-file"),
+            &io_setup,
             expected_consumed_size - 1,
             |stream| {
                 serialize_into(stream, &2323_u32)?;
@@ -1838,12 +1869,18 @@ mod tests {
 
     #[test]
     fn test_deserialize_snapshot_data_file_under_limit() {
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         let expected_data = 2323_u32;
         let expected_consumed_size = size_of::<u32>() as u64;
 
         let temp_dir = tempfile::TempDir::new().unwrap();
         serialize_snapshot_data_file_capped(
             &temp_dir.path().join("data-file"),
+            &io_setup,
             expected_consumed_size,
             |stream| {
                 serialize_into(stream, &expected_data)?;
@@ -1872,12 +1909,18 @@ mod tests {
 
     #[test]
     fn test_deserialize_snapshot_data_file_over_limit() {
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         let expected_data = 2323_u32;
         let expected_consumed_size = size_of::<u32>() as u64;
 
         let temp_dir = tempfile::TempDir::new().unwrap();
         serialize_snapshot_data_file_capped(
             &temp_dir.path().join("data-file"),
+            &io_setup,
             expected_consumed_size,
             |stream| {
                 serialize_into(stream, &expected_data)?;
@@ -1905,12 +1948,18 @@ mod tests {
 
     #[test]
     fn test_deserialize_snapshot_data_file_extra_data() {
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         let expected_data = 2323_u32;
         let expected_consumed_size = size_of::<u32>() as u64;
 
         let temp_dir = tempfile::TempDir::new().unwrap();
         serialize_snapshot_data_file_capped(
             &temp_dir.path().join("data-file"),
+            &io_setup,
             expected_consumed_size * 2,
             |stream| {
                 serialize_into(&mut *stream, &expected_data)?;
@@ -2624,6 +2673,11 @@ mod tests {
     #[test_case(1)]
     #[test_case(10)]
     fn test_serialize_deserialize_account_storage_entries(num_storages: u64) {
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         let temp_dir = tempfile::tempdir().unwrap();
         let bank_snapshot_dir = temp_dir.path();
         let snapshot_slot = num_storages + 1 as Slot;
@@ -2643,8 +2697,13 @@ mod tests {
         }
 
         // write obsolete accounts to snapshot
-        write_obsolete_accounts_to_snapshot(bank_snapshot_dir, &snapshot_storages, snapshot_slot)
-            .unwrap();
+        write_obsolete_accounts_to_snapshot(
+            bank_snapshot_dir,
+            &io_setup,
+            &snapshot_storages,
+            snapshot_slot,
+        )
+        .unwrap();
 
         // Deserialize
         let deserialized_accounts =
@@ -2660,6 +2719,11 @@ mod tests {
     #[test]
     #[should_panic(expected = "bytes would exceed limit of 100")]
     fn test_serialize_obsolete_accounts_too_large_file() {
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         let temp_dir = tempfile::tempdir().unwrap();
         let bank_snapshot_dir = temp_dir.path();
         let num_storages = 10;
@@ -2684,12 +2748,17 @@ mod tests {
             SerdeObsoleteAccountsMap::new_from_storages(&snapshot_storages, snapshot_slot);
 
         // Limit the file size to something low for the test
-        serialize_obsolete_accounts(bank_snapshot_dir, &obsolete_accounts, 100).unwrap();
+        serialize_obsolete_accounts(bank_snapshot_dir, &io_setup, &obsolete_accounts, 100).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "too large obsolete accounts file to deserialize")]
     fn test_deserialize_obsolete_accounts_too_large_file() {
+        let io_setup = IoSetupState::default()
+            .with_shared_sqpoll()
+            .unwrap()
+            .with_direct_io(true)
+            .with_buffers_registered(true);
         let temp_dir = tempfile::tempdir().unwrap();
         let bank_snapshot_dir = temp_dir.path();
         let num_storages = 10;
@@ -2710,8 +2779,13 @@ mod tests {
         }
 
         // Write obsolete accounts to snapshot
-        write_obsolete_accounts_to_snapshot(bank_snapshot_dir, &snapshot_storages, snapshot_slot)
-            .unwrap();
+        write_obsolete_accounts_to_snapshot(
+            bank_snapshot_dir,
+            &io_setup,
+            &snapshot_storages,
+            snapshot_slot,
+        )
+        .unwrap();
 
         // Set a very low maximum file size for deserialization
         // This should panic

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -88,7 +88,7 @@ pub fn archive_snapshot(
     ));
 
     {
-        let archive_writer = large_file_buf_writer(&staging_archive_path)
+        let archive_writer = large_file_buf_writer(staging_archive_path.clone())
             .map_err(|err| E::CreateArchiveFile(err, staging_archive_path.clone()))?;
 
         let do_archive_files = |encoder: &mut dyn Write| -> std::result::Result<(), E> {

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -3,7 +3,7 @@ use {
         ArchiveFormat, Result, SnapshotArchiveKind, error::ArchiveSnapshotPackageError, paths,
         snapshot_archive_info::SnapshotArchiveInfo, snapshot_hash::SnapshotHash,
     },
-    agave_fs::buffered_writer::large_file_buf_writer,
+    agave_fs::{buffered_writer::large_file_buf_writer, io_setup::IoSetupState},
     log::info,
     solana_accounts_db::{
         account_storage::AccountStoragesOrderer, account_storage_entry::AccountStorageEntry,
@@ -29,6 +29,7 @@ pub fn archive_snapshot(
     bank_snapshot_dir: impl AsRef<Path>,
     archive_path: impl AsRef<Path>,
     archive_format: ArchiveFormat,
+    io_setup: &IoSetupState,
 ) -> Result<SnapshotArchiveInfo> {
     use ArchiveSnapshotPackageError as E;
     const ACCOUNTS_DIR: &str = "accounts";
@@ -88,7 +89,7 @@ pub fn archive_snapshot(
     ));
 
     {
-        let archive_writer = large_file_buf_writer(staging_archive_path.clone())
+        let archive_writer = large_file_buf_writer(staging_archive_path.clone(), io_setup)
             .map_err(|err| E::CreateArchiveFile(err, staging_archive_path.clone()))?;
 
         let do_archive_files = |encoder: &mut dyn Write| -> std::result::Result<(), E> {


### PR DESCRIPTION
#### Problem


#### Summary of Changes
Use changes made in #10157 to implement a buffered writer.

Fixes #


## Notes:
1. This design assumes `flush` is only called once because of how the underlying `IoUringFileCreator` handles final writes.
2. Huge delta to add `IoSetupState` everywhere.
3. Some unsafe code introduced.