### PR TITLE
[syscalls] Remove `fix_alt_bn128_pairing_length_check` feature

### DIFF
--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2195,14 +2195,7 @@ declare_builtin_function!(
                 )
             }
             ALT_BN128_PAIRING_BE => {
-                let version = if invoke_context
-                    .get_feature_set()
-                    .fix_alt_bn128_pairing_length_check {
-                    VersionedPairing::V1
-                } else {
-                    VersionedPairing::V0
-                };
-                alt_bn128_versioned_pairing(version, input, Endianness::BE)
+                alt_bn128_versioned_pairing(VersionedPairing::V1, input, Endianness::BE)
             }
             ALT_BN128_PAIRING_LE => {
                 alt_bn128_versioned_pairing(VersionedPairing::V1, input, Endianness::LE)


### PR DESCRIPTION
#### Problem

the `fix_alt_bn128_pairing_length_check` feature has been activated on all clusters (https://github.com/anza-xyz/feature-gate-tracker/issues/106#event-23633474617).

#### Summary of Changes

Clean up the feature gate logic.

Fixes #
