### PR TITLE
fix(net-utils): harden ip echo client response parsing

### DIFF
--- a/net-utils/src/ip_echo_client.rs
+++ b/net-utils/src/ip_echo_client.rs
@@ -108,9 +108,7 @@ fn parse_response(
                 ))
             })?;
     let payload = match response_header {
-        [0, 0, 0, 0] => {
-            bincode::deserialize(&response[HEADER_LENGTH..IP_ECHO_SERVER_RESPONSE_LENGTH])?
-        }
+        [0, 0, 0, 0] => bincode::deserialize(body)?,
         [b'H', b'T', b'T', b'P'] => {
             let http_response = std::str::from_utf8(body);
             match http_response {


### PR DESCRIPTION
#### Problem
ip echo client makes incorrect assumptions about the response payload

#### Summary of Changes
we know where the body starts. use it directly