### PR TITLE
Improves `ConsensusPool` tests

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -695,6 +695,64 @@ mod tests {
         test_case::test_case,
     };
 
+    struct TestContext {
+        validators: Vec<ValidatorVoteKeypairs>,
+        bank_forks: Arc<RwLock<BankForks>>,
+        pool: ConsensusPool,
+    }
+
+    impl TestContext {
+        fn new() -> Self {
+            let num_validators = 10;
+            let validator_keypairs = (0..num_validators)
+                .map(|_| ValidatorVoteKeypairs::new_rand())
+                .collect::<Vec<_>>();
+            let bank_forks = create_bank_forks(&validator_keypairs);
+            let root_bank = bank_forks.read().unwrap().root_bank();
+            Self {
+                validators: validator_keypairs,
+                pool: ConsensusPool::new_from_root_bank(Pubkey::new_unique(), &root_bank),
+                bank_forks,
+            }
+        }
+
+        fn add_certificate(&mut self, vote: Vote) {
+            let root_bank = self.bank_forks.read().unwrap().root_bank();
+            for rank in 0..6 {
+                self.pool
+                    .add_message(
+                        root_bank.epoch_schedule(),
+                        root_bank.epoch_stakes_map(),
+                        root_bank.slot(),
+                        &Pubkey::new_unique(),
+                        dummy_vote_message(&self.validators, &vote, rank),
+                        &mut vec![],
+                    )
+                    .unwrap();
+            }
+            self.pool
+                .add_message(
+                    root_bank.epoch_schedule(),
+                    root_bank.epoch_stakes_map(),
+                    root_bank.slot(),
+                    &Pubkey::new_unique(),
+                    dummy_vote_message(&self.validators, &vote, 6),
+                    &mut vec![],
+                )
+                .unwrap();
+            match vote {
+                Vote::Notarize(vote) => assert_eq!(self.pool.highest_notarized_slot(), vote.slot),
+                Vote::NotarizeFallback(vote) => {
+                    assert_eq!(self.pool.highest_notarized_slot(), vote.slot)
+                }
+                Vote::Skip(vote) => assert_eq!(self.pool.highest_skip_slot(), vote.slot),
+                Vote::SkipFallback(vote) => assert_eq!(self.pool.highest_skip_slot(), vote.slot),
+                Vote::Finalize(vote) => assert_eq!(self.pool.highest_finalized_slot(), vote.slot),
+                Vote::Genesis(_genesis_vote) => (),
+            }
+        }
+    }
+
     fn dummy_vote_message(
         keypairs: &[ValidatorVoteKeypairs],
         vote: &Vote,
@@ -723,64 +781,6 @@ mod tests {
         BankForks::new_rw_arc(bank0)
     }
 
-    fn create_initial_state() -> (
-        Vec<ValidatorVoteKeypairs>,
-        ConsensusPool,
-        Arc<RwLock<BankForks>>,
-    ) {
-        // Create 10 node validatorvotekeypairs vec
-        let validator_keypairs = (0..10)
-            .map(|_| ValidatorVoteKeypairs::new_rand())
-            .collect::<Vec<_>>();
-        let bank_forks = create_bank_forks(&validator_keypairs);
-        let root_bank = bank_forks.read().unwrap().root_bank();
-        (
-            validator_keypairs,
-            ConsensusPool::new_from_root_bank(Pubkey::new_unique(), &root_bank),
-            bank_forks,
-        )
-    }
-
-    fn add_certificate(
-        pool: &mut ConsensusPool,
-        bank: &Bank,
-        validator_keypairs: &[ValidatorVoteKeypairs],
-        vote: Vote,
-    ) {
-        for rank in 0..6 {
-            assert!(
-                pool.add_message(
-                    bank.epoch_schedule(),
-                    bank.epoch_stakes_map(),
-                    bank.slot(),
-                    &Pubkey::new_unique(),
-                    dummy_vote_message(validator_keypairs, &vote, rank),
-                    &mut vec![]
-                )
-                .is_ok()
-            );
-        }
-        assert!(
-            pool.add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(validator_keypairs, &vote, 6),
-                &mut vec![]
-            )
-            .is_ok()
-        );
-        match vote {
-            Vote::Notarize(vote) => assert_eq!(pool.highest_notarized_slot(), vote.slot),
-            Vote::NotarizeFallback(vote) => assert_eq!(pool.highest_notarized_slot(), vote.slot),
-            Vote::Skip(vote) => assert_eq!(pool.highest_skip_slot(), vote.slot),
-            Vote::SkipFallback(vote) => assert_eq!(pool.highest_skip_slot(), vote.slot),
-            Vote::Finalize(vote) => assert_eq!(pool.highest_finalized_slot(), vote.slot),
-            Vote::Genesis(_genesis_vote) => (),
-        }
-    }
-
     fn add_skip_vote_range(
         pool: &mut ConsensusPool,
         root_bank: &Bank,
@@ -791,30 +791,29 @@ mod tests {
     ) {
         for slot in start..=end {
             let vote = Vote::new_skip_vote(slot);
-            assert!(
-                pool.add_message(
-                    root_bank.epoch_schedule(),
-                    root_bank.epoch_stakes_map(),
-                    root_bank.slot(),
-                    &Pubkey::new_unique(),
-                    dummy_vote_message(keypairs, &vote, rank),
-                    &mut vec![]
-                )
-                .is_ok()
-            );
+            pool.add_message(
+                root_bank.epoch_schedule(),
+                root_bank.epoch_stakes_map(),
+                root_bank.slot(),
+                &Pubkey::new_unique(),
+                dummy_vote_message(keypairs, &vote, rank),
+                &mut vec![],
+            )
+            .unwrap();
         }
     }
 
     #[test]
     fn test_make_decision_leader_does_not_start_if_notarization_missing() {
-        let (_, pool, _) = create_initial_state();
+        let ctx = TestContext::new();
 
         // No notarization set, pool is default
         let parent_slot = 2;
         let my_leader_slot = 3;
         let first_alpenglow_slot = 0;
         let decision =
-            pool.make_start_leader_decision(my_leader_slot, parent_slot, first_alpenglow_slot);
+            ctx.pool
+                .make_start_leader_decision(my_leader_slot, parent_slot, first_alpenglow_slot);
         assert!(
             !decision,
             "Leader should not be allowed to start without notarization"
@@ -823,19 +822,23 @@ mod tests {
 
     #[test]
     fn test_make_decision_first_alpenglow_slot_edge_case_1() {
-        let (_, pool, _) = create_initial_state();
+        let ctx = TestContext::new();
 
         // If parent_slot == 0, you don't need a notarization certificate
         // Because leader_slot == parent_slot + 1, you don't need a skip certificate
         let parent_slot = 0;
         let my_leader_slot = 1;
         let first_alpenglow_slot = 0;
-        assert!(pool.make_start_leader_decision(my_leader_slot, parent_slot, first_alpenglow_slot));
+        assert!(ctx.pool.make_start_leader_decision(
+            my_leader_slot,
+            parent_slot,
+            first_alpenglow_slot
+        ));
     }
 
     #[test]
     fn test_make_decision_first_alpenglow_slot_edge_case_2() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
 
         // If parent_slot < first_alpenglow_slot, and parent_slot > 0
         // no notarization certificate is required, but a skip
@@ -844,31 +847,30 @@ mod tests {
         let my_leader_slot = 3;
         let first_alpenglow_slot = 2;
 
-        assert!(!pool.make_start_leader_decision(
+        assert!(!ctx.pool.make_start_leader_decision(
             my_leader_slot,
             parent_slot,
             first_alpenglow_slot,
         ));
 
-        add_certificate(
-            &mut pool,
-            &bank_forks.read().unwrap().root_bank(),
-            &validator_keypairs,
-            Vote::new_skip_vote(first_alpenglow_slot),
-        );
+        ctx.add_certificate(Vote::new_skip_vote(first_alpenglow_slot));
 
-        assert!(pool.make_start_leader_decision(my_leader_slot, parent_slot, first_alpenglow_slot));
+        assert!(ctx.pool.make_start_leader_decision(
+            my_leader_slot,
+            parent_slot,
+            first_alpenglow_slot
+        ));
     }
 
     #[test]
     fn test_make_decision_first_alpenglow_slot_edge_case_3() {
-        let (_, pool, _) = create_initial_state();
+        let ctx = TestContext::new();
         // If parent_slot == first_alpenglow_slot, and
         // first_alpenglow_slot > 0, you need a notarization certificate
         let parent_slot = 2;
         let my_leader_slot = 3;
         let first_alpenglow_slot = 2;
-        assert!(!pool.make_start_leader_decision(
+        assert!(!ctx.pool.make_start_leader_decision(
             my_leader_slot,
             parent_slot,
             first_alpenglow_slot,
@@ -877,7 +879,7 @@ mod tests {
 
     #[test]
     fn test_make_decision_first_alpenglow_slot_edge_case_4() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
 
         // If parent_slot < first_alpenglow_slot, and parent_slot == 0,
         // no notarization certificate is required, but a skip certificate will
@@ -886,89 +888,82 @@ mod tests {
         let my_leader_slot = 2;
         let first_alpenglow_slot = 1;
 
-        assert!(!pool.make_start_leader_decision(
+        assert!(!ctx.pool.make_start_leader_decision(
             my_leader_slot,
             parent_slot,
             first_alpenglow_slot,
         ));
 
-        add_certificate(
-            &mut pool,
-            &bank_forks.read().unwrap().root_bank(),
-            &validator_keypairs,
-            Vote::new_skip_vote(first_alpenglow_slot),
-        );
-        assert!(pool.make_start_leader_decision(my_leader_slot, parent_slot, first_alpenglow_slot));
+        ctx.add_certificate(Vote::new_skip_vote(first_alpenglow_slot));
+        assert!(ctx.pool.make_start_leader_decision(
+            my_leader_slot,
+            parent_slot,
+            first_alpenglow_slot
+        ));
     }
 
     #[test]
     fn test_make_decision_first_alpenglow_slot_edge_case_5() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
 
         // Valid skip certificate for 1-9 exists
         for slot in 1..=9 {
-            add_certificate(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
-                &validator_keypairs,
-                Vote::new_skip_vote(slot),
-            );
+            ctx.add_certificate(Vote::new_skip_vote(slot));
         }
 
         // Parent slot is equal to 0, so no notarization certificate required
         let my_leader_slot = 10;
         let parent_slot = 0;
         let first_alpenglow_slot = 0;
-        assert!(pool.make_start_leader_decision(my_leader_slot, parent_slot, first_alpenglow_slot));
+        assert!(ctx.pool.make_start_leader_decision(
+            my_leader_slot,
+            parent_slot,
+            first_alpenglow_slot
+        ));
     }
 
     #[test]
     fn test_make_decision_first_alpenglow_slot_edge_case_6() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
 
         // Valid skip certificate for 1-9 exists
         for slot in 1..=9 {
-            add_certificate(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
-                &validator_keypairs,
-                Vote::new_skip_vote(slot),
-            );
+            ctx.add_certificate(Vote::new_skip_vote(slot));
         }
         // Parent slot is less than first_alpenglow_slot, so no notarization certificate required
         let my_leader_slot = 10;
         let parent_slot = 4;
         let first_alpenglow_slot = 5;
-        assert!(pool.make_start_leader_decision(my_leader_slot, parent_slot, first_alpenglow_slot));
+        assert!(ctx.pool.make_start_leader_decision(
+            my_leader_slot,
+            parent_slot,
+            first_alpenglow_slot
+        ));
     }
 
     #[test]
     fn test_make_decision_leader_does_not_start_if_skip_certificate_missing() {
-        let (validator_keypairs, mut pool, _) = create_initial_state();
+        let mut ctx = TestContext::new();
 
-        let bank_forks = create_bank_forks(&validator_keypairs);
-        let my_pubkey = validator_keypairs[0].vote_keypair.pubkey();
+        let bank_forks = create_bank_forks(&ctx.validators);
+        let my_pubkey = ctx.validators[0].vote_keypair.pubkey();
 
         // Create bank 5
         let bank = create_bank(5, bank_forks.read().unwrap().get(0).unwrap(), &my_pubkey);
         bank.freeze();
-        bank_forks.write().unwrap().insert(bank);
+        ctx.bank_forks.write().unwrap().insert(bank);
 
         // Notarize slot 5
-        add_certificate(
-            &mut pool,
-            &bank_forks.read().unwrap().root_bank(),
-            &validator_keypairs,
-            Vote::new_notarization_vote(5, Hash::default()),
-        );
-        assert_eq!(pool.highest_notarized_slot(), 5);
+        ctx.add_certificate(Vote::new_notarization_vote(5, Hash::default()));
+        assert_eq!(ctx.pool.highest_notarized_slot(), 5);
 
         // No skip certificate for 6-10
         let my_leader_slot = 10;
         let parent_slot = 5;
         let first_alpenglow_slot = 0;
         let decision =
-            pool.make_start_leader_decision(my_leader_slot, parent_slot, first_alpenglow_slot);
+            ctx.pool
+                .make_start_leader_decision(my_leader_slot, parent_slot, first_alpenglow_slot);
         assert!(
             !decision,
             "Leader should not be allowed to start if a skip certificate is missing"
@@ -977,82 +972,69 @@ mod tests {
 
     #[test]
     fn test_make_decision_leader_starts_when_no_skip_required() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
 
         // Notarize slot 5
-        add_certificate(
-            &mut pool,
-            &bank_forks.read().unwrap().root_bank(),
-            &validator_keypairs,
-            Vote::new_notarization_vote(5, Hash::default()),
-        );
-        assert_eq!(pool.highest_notarized_slot(), 5);
+        ctx.add_certificate(Vote::new_notarization_vote(5, Hash::default()));
+        assert_eq!(ctx.pool.highest_notarized_slot(), 5);
 
         // Leader slot is just +1 from notarized slot (no skip needed)
         let my_leader_slot = 6;
         let parent_slot = 5;
         let first_alpenglow_slot = 0;
-        assert!(pool.make_start_leader_decision(my_leader_slot, parent_slot, first_alpenglow_slot));
+        assert!(ctx.pool.make_start_leader_decision(
+            my_leader_slot,
+            parent_slot,
+            first_alpenglow_slot
+        ));
     }
 
     #[test]
     fn test_make_decision_leader_starts_if_notarized_and_skips_valid() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
 
         // Notarize slot 5
-        add_certificate(
-            &mut pool,
-            &bank_forks.read().unwrap().root_bank(),
-            &validator_keypairs,
-            Vote::new_notarization_vote(5, Hash::default()),
-        );
-        assert_eq!(pool.highest_notarized_slot(), 5);
+        ctx.add_certificate(Vote::new_notarization_vote(5, Hash::default()));
+        assert_eq!(ctx.pool.highest_notarized_slot(), 5);
 
         // Valid skip certificate for 6-9 exists
         for slot in 6..=9 {
-            add_certificate(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
-                &validator_keypairs,
-                Vote::new_skip_vote(slot),
-            );
+            ctx.add_certificate(Vote::new_skip_vote(slot));
         }
 
         let my_leader_slot = 10;
         let parent_slot = 5;
         let first_alpenglow_slot = 0;
-        assert!(pool.make_start_leader_decision(my_leader_slot, parent_slot, first_alpenglow_slot));
+        assert!(ctx.pool.make_start_leader_decision(
+            my_leader_slot,
+            parent_slot,
+            first_alpenglow_slot
+        ));
     }
 
     #[test]
     fn test_make_decision_leader_starts_if_skip_range_superset() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
 
         // Notarize slot 5
-        add_certificate(
-            &mut pool,
-            &bank_forks.read().unwrap().root_bank(),
-            &validator_keypairs,
-            Vote::new_notarization_vote(5, Hash::default()),
-        );
-        assert_eq!(pool.highest_notarized_slot(), 5);
+        ctx.add_certificate(Vote::new_notarization_vote(5, Hash::default()));
+        assert_eq!(ctx.pool.highest_notarized_slot(), 5);
 
         // Valid skip certificate for 4-9 exists
         // Should start leader block even if the beginning of the range is from
         // before your last notarized slot
         for slot in 4..=9 {
-            add_certificate(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
-                &validator_keypairs,
-                Vote::new_skip_fallback_vote(slot),
-            );
+            ctx.add_certificate(Vote::new_skip_fallback_vote(slot));
         }
 
         let my_leader_slot = 10;
         let parent_slot = 5;
         let first_alpenglow_slot = 0;
-        assert!(pool.make_start_leader_decision(my_leader_slot, parent_slot, first_alpenglow_slot));
+        assert!(ctx.pool.make_start_leader_decision(
+            my_leader_slot,
+            parent_slot,
+            first_alpenglow_slot
+        ));
     }
 
     #[test_case(Vote::new_finalization_vote(5), vec![CertificateType::Finalize(5)])]
@@ -1064,7 +1046,7 @@ mod tests {
         vote: Vote,
         expected_cert_types: Vec<CertificateType>,
     ) {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
         let my_validator_ix = 5;
         let highest_slot_fn = match &vote {
             Vote::Finalize(_) => |pool: &ConsensusPool| pool.highest_finalized_slot(),
@@ -1074,55 +1056,53 @@ mod tests {
             Vote::SkipFallback(_) => |pool: &ConsensusPool| pool.highest_skip_slot(),
             Vote::Genesis(_genesis_vote) => |_pool: &ConsensusPool| 0,
         };
-        let bank = bank_forks.read().unwrap().root_bank();
-        assert!(
-            pool.add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, my_validator_ix),
-                &mut vec![]
-            )
-            .is_ok()
-        );
-        let slot = vote.slot();
-        assert!(highest_slot_fn(&pool) < slot);
-        // Same key voting again shouldn't make a certificate
-        assert!(
-            pool.add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, my_validator_ix),
-                &mut vec![]
-            )
-            .is_ok()
-        );
-        assert!(highest_slot_fn(&pool) < slot);
-        for rank in 0..4 {
-            assert!(
-                pool.add_message(
-                    bank.epoch_schedule(),
-                    bank.epoch_stakes_map(),
-                    bank.slot(),
-                    &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, rank),
-                    &mut vec![]
-                )
-                .is_ok()
-            );
-        }
-        assert!(highest_slot_fn(&pool) < slot);
-        let new_validator_ix = 6;
-        let (new_finalized_slot, certs_to_send) = pool
+        let bank = ctx.bank_forks.read().unwrap().root_bank();
+        ctx.pool
             .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, new_validator_ix),
+                dummy_vote_message(&ctx.validators, &vote, my_validator_ix),
+                &mut vec![],
+            )
+            .unwrap();
+        let slot = vote.slot();
+        assert!(highest_slot_fn(&ctx.pool) < slot);
+        // Same key voting again shouldn't make a certificate
+        ctx.pool
+            .add_message(
+                bank.epoch_schedule(),
+                bank.epoch_stakes_map(),
+                bank.slot(),
+                &Pubkey::new_unique(),
+                dummy_vote_message(&ctx.validators, &vote, my_validator_ix),
+                &mut vec![],
+            )
+            .unwrap();
+        assert!(highest_slot_fn(&ctx.pool) < slot);
+        for rank in 0..4 {
+            ctx.pool
+                .add_message(
+                    bank.epoch_schedule(),
+                    bank.epoch_stakes_map(),
+                    bank.slot(),
+                    &Pubkey::new_unique(),
+                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    &mut vec![],
+                )
+                .unwrap();
+        }
+        assert!(highest_slot_fn(&ctx.pool) < slot);
+        let new_validator_ix = 6;
+        let (new_finalized_slot, certs_to_send) = ctx
+            .pool
+            .add_message(
+                bank.epoch_schedule(),
+                bank.epoch_stakes_map(),
+                bank.slot(),
+                &Pubkey::new_unique(),
+                dummy_vote_message(&ctx.validators, &vote, new_validator_ix),
                 &mut vec![],
             )
             .unwrap();
@@ -1137,10 +1117,11 @@ mod tests {
                 cert.cert_type == expected_cert_type && cert.cert_type.slot() == slot
             }));
         }
-        assert_eq!(highest_slot_fn(&pool), slot);
+        assert_eq!(highest_slot_fn(&ctx.pool), slot);
         // Now add the same certificate again, this should silently exit.
         for cert in certs_to_send {
-            let (new_finalized_slot, certs_to_send) = pool
+            let (new_finalized_slot, certs_to_send) = ctx
+                .pool
                 .add_message(
                     bank.epoch_schedule(),
                     bank.epoch_stakes_map(),
@@ -1170,17 +1151,18 @@ mod tests {
     )]
     #[test_case(CertificateType::Skip(8), Vote::new_skip_vote(8))]
     fn test_add_certificate_with_types(cert_type: CertificateType, vote: Vote) {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
 
         let cert = Certificate {
             cert_type,
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        let bank = bank_forks.read().unwrap().root_bank();
+        let bank = ctx.bank_forks.read().unwrap().root_bank();
         let message = ConsensusMessage::Certificate(cert.clone());
         // Add the certificate to the pool
-        let (new_finalized_slot, certs_to_send) = pool
+        let (new_finalized_slot, certs_to_send) = ctx
+            .pool
             .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
@@ -1202,7 +1184,8 @@ mod tests {
         assert_eq!(*certs_to_send[0], cert);
 
         // Adding the cert again will not trigger another send
-        let (new_finalized_slot, certs_to_send) = pool
+        let (new_finalized_slot, certs_to_send) = ctx
+            .pool
             .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
@@ -1216,14 +1199,15 @@ mod tests {
         assert_eq!(certs_to_send, []);
 
         // Now add the vote from everyone else, this will not trigger a certificate send
-        for rank in 0..validator_keypairs.len() {
-            let (_, certs_to_send) = pool
+        for rank in 0..ctx.validators.len() {
+            let (_, certs_to_send) = ctx
+                .pool
                 .add_message(
                     bank.epoch_schedule(),
                     bank.epoch_stakes_map(),
                     bank.slot(),
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, rank),
+                    dummy_vote_message(&ctx.validators, &vote, rank),
                     &mut vec![],
                 )
                 .unwrap();
@@ -1237,10 +1221,10 @@ mod tests {
 
     #[test]
     fn test_add_vote_zero_stake() {
-        let (_, mut pool, bank_forks) = create_initial_state();
-        let bank = bank_forks.read().unwrap().root_bank();
+        let mut ctx = TestContext::new();
+        let bank = ctx.bank_forks.read().unwrap().root_bank();
         assert_eq!(
-            pool.add_message(
+            ctx.pool.add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
@@ -1268,341 +1252,330 @@ mod tests {
 
     #[test]
     fn test_consecutive_slots() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
 
-        add_certificate(
-            &mut pool,
-            &bank_forks.read().unwrap().root_bank(),
-            &validator_keypairs,
-            Vote::new_skip_vote(15),
-        );
-        assert_eq!(pool.highest_skip_slot(), 15);
+        ctx.add_certificate(Vote::new_skip_vote(15));
+        assert_eq!(ctx.pool.highest_skip_slot(), 15);
 
-        let bank = bank_forks.read().unwrap().root_bank();
-        for i in 0..validator_keypairs.len() {
+        let bank = ctx.bank_forks.read().unwrap().root_bank();
+        for i in 0..ctx.validators.len() {
             let slot = (i as u64).saturating_add(16);
             let vote = Vote::new_skip_vote(slot);
             // These should not extend the skip range
-            assert!(
-                pool.add_message(
+            ctx.pool
+                .add_message(
                     bank.epoch_schedule(),
                     bank.epoch_stakes_map(),
                     bank.slot(),
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, i),
-                    &mut vec![]
+                    dummy_vote_message(&ctx.validators, &vote, i),
+                    &mut vec![],
                 )
-                .is_ok()
-            );
+                .unwrap();
         }
 
-        assert_single_certificate_range(&pool, 15, 15);
+        assert_single_certificate_range(&ctx.pool, 15, 15);
     }
 
     #[test]
     fn test_multi_skip_cert() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
 
         // We have 10 validators, 40% voted for (5, 15)
         for rank in 0..4 {
             add_skip_vote_range(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
+                &mut ctx.pool,
+                &ctx.bank_forks.read().unwrap().root_bank(),
                 5,
                 15,
-                &validator_keypairs,
+                &ctx.validators,
                 rank,
             );
         }
         // 30% voted for (5, 8)
         for rank in 4..7 {
             add_skip_vote_range(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
+                &mut ctx.pool,
+                &ctx.bank_forks.read().unwrap().root_bank(),
                 5,
                 8,
-                &validator_keypairs,
+                &ctx.validators,
                 rank,
             );
         }
         // The rest voted for (11, 15)
         for rank in 7..10 {
             add_skip_vote_range(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
+                &mut ctx.pool,
+                &ctx.bank_forks.read().unwrap().root_bank(),
                 11,
                 15,
-                &validator_keypairs,
+                &ctx.validators,
                 rank,
             );
         }
         // Test slots from 5 to 15, [5, 8] and [11, 15] should be certified, the others aren't
         for slot in 5..9 {
-            assert!(pool.skip_certified(slot));
+            assert!(ctx.pool.skip_certified(slot));
         }
         for slot in 9..11 {
-            assert!(!pool.skip_certified(slot));
+            assert!(!ctx.pool.skip_certified(slot));
         }
         for slot in 11..=15 {
-            assert!(pool.skip_certified(slot));
+            assert!(ctx.pool.skip_certified(slot));
         }
     }
 
     #[test]
     fn test_add_multiple_votes() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
 
         // 10 validators, half vote for (5, 15), the other (20, 30)
         for rank in 0..5 {
             add_skip_vote_range(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
+                &mut ctx.pool,
+                &ctx.bank_forks.read().unwrap().root_bank(),
                 5,
                 15,
-                &validator_keypairs,
+                &ctx.validators,
                 rank,
             );
         }
         for rank in 5..10 {
             add_skip_vote_range(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
+                &mut ctx.pool,
+                &ctx.bank_forks.read().unwrap().root_bank(),
                 20,
                 30,
-                &validator_keypairs,
+                &ctx.validators,
                 rank,
             );
         }
-        assert_eq!(pool.highest_skip_slot(), 0);
+        assert_eq!(ctx.pool.highest_skip_slot(), 0);
 
         // Now the first half vote for (5, 30)
         for rank in 0..5 {
             add_skip_vote_range(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
+                &mut ctx.pool,
+                &ctx.bank_forks.read().unwrap().root_bank(),
                 5,
                 30,
-                &validator_keypairs,
+                &ctx.validators,
                 rank,
             );
         }
-        assert_single_certificate_range(&pool, 20, 30);
+        assert_single_certificate_range(&ctx.pool, 20, 30);
     }
 
     #[test]
     fn test_add_multiple_disjoint_votes() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
         // 50% of the validators vote for (1, 10)
         for rank in 0..5 {
             add_skip_vote_range(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
+                &mut ctx.pool,
+                &ctx.bank_forks.read().unwrap().root_bank(),
                 1,
                 10,
-                &validator_keypairs,
+                &ctx.validators,
                 rank,
             );
         }
-        let bank = bank_forks.read().unwrap().root_bank();
+        let bank = ctx.bank_forks.read().unwrap().root_bank();
         // 10% vote for skip 2
         let vote = Vote::new_skip_vote(2);
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, 6),
-                &mut vec![]
+                dummy_vote_message(&ctx.validators, &vote, 6),
+                &mut vec![],
             )
-            .is_ok()
-        );
-        assert_eq!(pool.highest_skip_slot(), 2);
+            .unwrap();
+        assert_eq!(ctx.pool.highest_skip_slot(), 2);
 
-        assert_single_certificate_range(&pool, 2, 2);
+        assert_single_certificate_range(&ctx.pool, 2, 2);
         // 10% vote for skip 4
         let vote = Vote::new_skip_vote(4);
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, 7),
-                &mut vec![]
+                dummy_vote_message(&ctx.validators, &vote, 7),
+                &mut vec![],
             )
-            .is_ok()
-        );
-        assert_eq!(pool.highest_skip_slot(), 4);
+            .unwrap();
+        assert_eq!(ctx.pool.highest_skip_slot(), 4);
 
-        assert_single_certificate_range(&pool, 2, 2);
-        assert_single_certificate_range(&pool, 4, 4);
+        assert_single_certificate_range(&ctx.pool, 2, 2);
+        assert_single_certificate_range(&ctx.pool, 4, 4);
         // 10% vote for skip 3
         let vote = Vote::new_skip_vote(3);
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, 8),
-                &mut vec![]
+                dummy_vote_message(&ctx.validators, &vote, 8),
+                &mut vec![],
             )
-            .is_ok()
-        );
-        assert_eq!(pool.highest_skip_slot(), 4);
-        assert_single_certificate_range(&pool, 2, 4);
-        assert!(pool.skip_certified(3));
+            .unwrap();
+        assert_eq!(ctx.pool.highest_skip_slot(), 4);
+        assert_single_certificate_range(&ctx.pool, 2, 4);
+        assert!(ctx.pool.skip_certified(3));
         // Let the last 10% vote for (3, 10) now
         add_skip_vote_range(
-            &mut pool,
-            &bank_forks.read().unwrap().root_bank(),
+            &mut ctx.pool,
+            &ctx.bank_forks.read().unwrap().root_bank(),
             3,
             10,
-            &validator_keypairs,
+            &ctx.validators,
             8,
         );
-        assert_eq!(pool.highest_skip_slot(), 10);
-        assert_single_certificate_range(&pool, 2, 10);
-        assert!(pool.skip_certified(7));
+        assert_eq!(ctx.pool.highest_skip_slot(), 10);
+        assert_single_certificate_range(&ctx.pool, 2, 10);
+        assert!(ctx.pool.skip_certified(7));
     }
 
     #[test]
     fn test_update_existing_singleton_vote() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
         // 50% voted on (1, 6)
         for rank in 0..5 {
             add_skip_vote_range(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
+                &mut ctx.pool,
+                &ctx.bank_forks.read().unwrap().root_bank(),
                 1,
                 6,
-                &validator_keypairs,
+                &ctx.validators,
                 rank,
             );
         }
-        let bank = bank_forks.read().unwrap().root_bank();
+        let bank = ctx.bank_forks.read().unwrap().root_bank();
         // Range expansion on a singleton vote should be ok
         let vote = Vote::new_skip_vote(1);
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, 6),
-                &mut vec![]
+                dummy_vote_message(&ctx.validators, &vote, 6),
+                &mut vec![],
             )
-            .is_ok()
-        );
-        assert_eq!(pool.highest_skip_slot(), 1);
+            .unwrap();
+        assert_eq!(ctx.pool.highest_skip_slot(), 1);
         add_skip_vote_range(
-            &mut pool,
-            &bank_forks.read().unwrap().root_bank(),
+            &mut ctx.pool,
+            &ctx.bank_forks.read().unwrap().root_bank(),
             1,
             6,
-            &validator_keypairs,
+            &ctx.validators,
             6,
         );
-        assert_eq!(pool.highest_skip_slot(), 6);
-        assert_single_certificate_range(&pool, 1, 6);
+        assert_eq!(ctx.pool.highest_skip_slot(), 6);
+        assert_single_certificate_range(&ctx.pool, 1, 6);
     }
 
     #[test]
     fn test_update_existing_vote() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
-        let bank = bank_forks.read().unwrap().root_bank();
+        let mut ctx = TestContext::new();
+        let bank = ctx.bank_forks.read().unwrap().root_bank();
         // 50% voted for (10, 25)
         for rank in 0..5 {
-            add_skip_vote_range(&mut pool, &bank, 10, 25, &validator_keypairs, rank);
+            add_skip_vote_range(&mut ctx.pool, &bank, 10, 25, &ctx.validators, rank);
         }
 
-        add_skip_vote_range(&mut pool, &bank, 10, 20, &validator_keypairs, 6);
-        assert_eq!(pool.highest_skip_slot(), 20);
-        assert_single_certificate_range(&pool, 10, 20);
+        add_skip_vote_range(&mut ctx.pool, &bank, 10, 20, &ctx.validators, 6);
+        assert_eq!(ctx.pool.highest_skip_slot(), 20);
+        assert_single_certificate_range(&ctx.pool, 10, 20);
 
         // AlreadyExists, silently fail
         let vote = Vote::new_skip_vote(20);
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, 6),
-                &mut vec![]
+                dummy_vote_message(&ctx.validators, &vote, 6),
+                &mut vec![],
             )
-            .is_ok()
-        );
+            .unwrap();
     }
 
     #[test]
     fn test_threshold_not_reached() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
         // half voted (5, 15) and the other half voted (20, 30)
         for rank in 0..5 {
             add_skip_vote_range(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
+                &mut ctx.pool,
+                &ctx.bank_forks.read().unwrap().root_bank(),
                 5,
                 15,
-                &validator_keypairs,
+                &ctx.validators,
                 rank,
             );
         }
         for rank in 5..10 {
             add_skip_vote_range(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
+                &mut ctx.pool,
+                &ctx.bank_forks.read().unwrap().root_bank(),
                 20,
                 30,
-                &validator_keypairs,
+                &ctx.validators,
                 rank,
             );
         }
         for slot in 5..31 {
-            assert!(!pool.skip_certified(slot));
+            assert!(!ctx.pool.skip_certified(slot));
         }
     }
 
     #[test]
     fn test_update_and_skip_range_certify() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
         // half voted (5, 15) and the other half voted (10, 30)
         for rank in 0..5 {
             add_skip_vote_range(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
+                &mut ctx.pool,
+                &ctx.bank_forks.read().unwrap().root_bank(),
                 5,
                 15,
-                &validator_keypairs,
+                &ctx.validators,
                 rank,
             );
         }
         for rank in 5..10 {
             add_skip_vote_range(
-                &mut pool,
-                &bank_forks.read().unwrap().root_bank(),
+                &mut ctx.pool,
+                &ctx.bank_forks.read().unwrap().root_bank(),
                 10,
                 30,
-                &validator_keypairs,
+                &ctx.validators,
                 rank,
             );
         }
         for slot in 5..10 {
-            assert!(!pool.skip_certified(slot));
+            assert!(!ctx.pool.skip_certified(slot));
         }
         for slot in 16..31 {
-            assert!(!pool.skip_certified(slot));
+            assert!(!ctx.pool.skip_certified(slot));
         }
-        assert_single_certificate_range(&pool, 10, 15);
+        assert_single_certificate_range(&ctx.pool, 10, 15);
     }
 
     #[test]
     fn test_safe_to_notar() {
         agave_logger::setup();
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
-        let bank = bank_forks.read().unwrap().root_bank();
+        let mut ctx = TestContext::new();
+        let bank = ctx.bank_forks.read().unwrap().root_bank();
         let (my_vote_key, _, _) =
             get_key_and_stakes(bank.epoch_schedule(), bank.epoch_stakes_map(), 0, 0).unwrap();
 
@@ -1613,33 +1586,31 @@ mod tests {
         // Add a skip from myself.
         let vote = Vote::new_skip_vote(2);
         let mut new_events = vec![];
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &my_vote_key,
-                dummy_vote_message(&validator_keypairs, &vote, 0),
-                &mut new_events
+                dummy_vote_message(&ctx.validators, &vote, 0),
+                &mut new_events,
             )
-            .is_ok()
-        );
+            .unwrap();
         assert!(new_events.is_empty());
 
         // 40% notarized, should succeed
         for rank in 1..5 {
             let vote = Vote::new_notarization_vote(2, block_id);
-            assert!(
-                pool.add_message(
+            ctx.pool
+                .add_message(
                     bank.epoch_schedule(),
                     bank.epoch_stakes_map(),
                     bank.slot(),
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, rank),
-                    &mut new_events
+                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    &mut new_events,
                 )
-                .is_ok()
-            );
+                .unwrap();
         }
         assert_eq!(new_events.len(), 1);
         if let VotorEvent::SafeToNotar((event_slot, event_block_id)) = new_events[0] {
@@ -1657,50 +1628,47 @@ mod tests {
         // Add 20% notarize, but no vote from myself, should fail
         for rank in 1..3 {
             let vote = Vote::new_notarization_vote(3, block_id);
-            assert!(
-                pool.add_message(
+            ctx.pool
+                .add_message(
                     bank.epoch_schedule(),
                     bank.epoch_stakes_map(),
                     bank.slot(),
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, rank),
-                    &mut new_events
+                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    &mut new_events,
                 )
-                .is_ok()
-            );
+                .unwrap();
         }
         assert!(new_events.is_empty());
 
         // Add a notarize from myself for some other block, but still not enough notar or skip, should fail.
         let vote = Vote::new_notarization_vote(3, Hash::new_unique());
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &my_vote_key,
-                dummy_vote_message(&validator_keypairs, &vote, 0),
-                &mut new_events
+                dummy_vote_message(&ctx.validators, &vote, 0),
+                &mut new_events,
             )
-            .is_ok()
-        );
+            .unwrap();
         assert!(new_events.is_empty());
 
         // Now add 40% skip, should succeed
         // Funny thing is in this case we will also get SafeToSkip(3)
         for rank in 3..7 {
             let vote = Vote::new_skip_vote(3);
-            assert!(
-                pool.add_message(
+            ctx.pool
+                .add_message(
                     bank.epoch_schedule(),
                     bank.epoch_stakes_map(),
                     bank.slot(),
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, rank),
-                    &mut new_events
+                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    &mut new_events,
                 )
-                .is_ok()
-            );
+                .unwrap();
         }
         assert_eq!(new_events.len(), 2);
         if let VotorEvent::SafeToSkip(event_slot) = new_events[0] {
@@ -1721,17 +1689,16 @@ mod tests {
         let duplicate_block_id = Hash::new_unique();
         for rank in 7..9 {
             let vote = Vote::new_notarization_vote(3, duplicate_block_id);
-            assert!(
-                pool.add_message(
+            ctx.pool
+                .add_message(
                     bank.epoch_schedule(),
                     bank.epoch_stakes_map(),
                     bank.slot(),
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, rank),
-                    &mut new_events
+                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    &mut new_events,
                 )
-                .is_ok()
-            );
+                .unwrap();
         }
 
         assert_eq!(new_events.len(), 1);
@@ -1745,8 +1712,8 @@ mod tests {
 
     #[test]
     fn test_safe_to_skip() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
-        let bank = bank_forks.read().unwrap().root_bank();
+        let mut ctx = TestContext::new();
+        let bank = ctx.bank_forks.read().unwrap().root_bank();
         let (my_vote_key, _, _) =
             get_key_and_stakes(bank.epoch_schedule(), bank.epoch_stakes_map(), 0, 0).unwrap();
         let slot = 2;
@@ -1755,33 +1722,31 @@ mod tests {
         // Add a notarize from myself.
         let block_id = Hash::new_unique();
         let vote = Vote::new_notarization_vote(2, block_id);
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &my_vote_key,
-                dummy_vote_message(&validator_keypairs, &vote, 0),
-                &mut new_events
+                dummy_vote_message(&ctx.validators, &vote, 0),
+                &mut new_events,
             )
-            .is_ok()
-        );
+            .unwrap();
         // Should still fail because there are no other votes.
         assert!(new_events.is_empty());
         // Add 50% skip, should succeed
         for rank in 1..6 {
             let vote = Vote::new_skip_vote(2);
-            assert!(
-                pool.add_message(
+            ctx.pool
+                .add_message(
                     bank.epoch_schedule(),
                     bank.epoch_stakes_map(),
                     bank.slot(),
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&validator_keypairs, &vote, rank),
-                    &mut new_events
+                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    &mut new_events,
                 )
-                .is_ok()
-            );
+                .unwrap();
         }
         assert_eq!(new_events.len(), 1);
         if let VotorEvent::SafeToSkip(event_slot) = new_events[0] {
@@ -1792,17 +1757,16 @@ mod tests {
         new_events.clear();
         // Add 10% more notarize, will not send new SafeToSkip because the event was already sent
         let vote = Vote::new_notarization_vote(2, block_id);
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, 6),
-                &mut new_events
+                dummy_vote_message(&ctx.validators, &vote, 6),
+                &mut new_events,
             )
-            .is_ok()
-        );
+            .unwrap();
         assert!(new_events.is_empty());
     }
 
@@ -1822,40 +1786,36 @@ mod tests {
     fn test_reject_conflicting_vote(
         pool: &mut ConsensusPool,
         bank: &Bank,
-        validator_keypairs: &[ValidatorVoteKeypairs],
+        validators: &[ValidatorVoteKeypairs],
         vote_type_1: VoteType,
         vote_type_2: VoteType,
         slot: Slot,
     ) {
         let vote_1 = create_new_vote(vote_type_1, slot);
         let vote_2 = create_new_vote(vote_type_2, slot);
-        assert!(
-            pool.add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(validator_keypairs, &vote_1, 0),
-                &mut vec![]
-            )
-            .is_ok()
-        );
-        assert!(
-            pool.add_message(
-                bank.epoch_schedule(),
-                bank.epoch_stakes_map(),
-                bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(validator_keypairs, &vote_2, 0),
-                &mut vec![]
-            )
-            .is_err()
-        );
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            dummy_vote_message(validators, &vote_1, 0),
+            &mut vec![],
+        )
+        .unwrap();
+        pool.add_message(
+            bank.epoch_schedule(),
+            bank.epoch_stakes_map(),
+            bank.slot(),
+            &Pubkey::new_unique(),
+            dummy_vote_message(validators, &vote_2, 0),
+            &mut vec![],
+        )
+        .unwrap_err();
     }
 
     #[test]
     fn test_reject_conflicting_votes_with_type() {
-        let (validator_keypairs, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
         let mut slot = 2;
         for vote_type_1 in [
             VoteType::Finalize,
@@ -1867,9 +1827,9 @@ mod tests {
             let conflicting_vote_types = conflicting_types(vote_type_1);
             for vote_type_2 in conflicting_vote_types {
                 test_reject_conflicting_vote(
-                    &mut pool,
-                    &bank_forks.read().unwrap().root_bank(),
-                    &validator_keypairs,
+                    &mut ctx.pool,
+                    &ctx.bank_forks.read().unwrap().root_bank(),
+                    &ctx.validators,
                     vote_type_1,
                     *vote_type_2,
                     slot,
@@ -1881,74 +1841,66 @@ mod tests {
 
     #[test]
     fn test_handle_new_root() {
-        let validator_keypairs = (0..10)
-            .map(|_| ValidatorVoteKeypairs::new_rand())
-            .collect::<Vec<_>>();
-        let bank_forks = create_bank_forks(&validator_keypairs);
-        let mut pool = ConsensusPool::new_from_root_bank(
-            Pubkey::new_unique(),
-            &bank_forks.read().unwrap().root_bank(),
-        );
+        let mut ctx = TestContext::new();
 
-        let root_bank = bank_forks.read().unwrap().root_bank();
+        let root_bank = ctx.bank_forks.read().unwrap().root_bank();
         // Add a skip cert on slot 1 and finalize cert on slot 2
         let cert_1 = Certificate {
             cert_type: CertificateType::Skip(1),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 root_bank.epoch_schedule(),
                 root_bank.epoch_stakes_map(),
                 root_bank.slot(),
                 &Pubkey::new_unique(),
                 ConsensusMessage::Certificate(cert_1),
-                &mut vec![]
+                &mut vec![],
             )
-            .is_ok()
-        );
+            .unwrap();
         let cert_2 = Certificate {
             cert_type: CertificateType::FinalizeFast(2, Hash::new_unique()),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 root_bank.epoch_schedule(),
                 root_bank.epoch_stakes_map(),
                 root_bank.slot(),
                 &Pubkey::new_unique(),
                 ConsensusMessage::Certificate(cert_2),
-                &mut vec![]
+                &mut vec![],
             )
-            .is_ok()
-        );
-        assert!(pool.skip_certified(1));
-        assert!(pool.is_finalized(2));
+            .unwrap();
+        assert!(ctx.pool.skip_certified(1));
+        assert!(ctx.pool.is_finalized(2));
 
         let new_bank = Arc::new(create_bank(2, root_bank, &Pubkey::new_unique()));
-        pool.prune_old_state(new_bank.slot());
+        ctx.pool.prune_old_state(new_bank.slot());
         // Check that cert for 1 is gone, but cert for 2 is still there
-        assert!(!pool.skip_certified(1));
-        assert!(pool.is_finalized(2));
+        assert!(!ctx.pool.skip_certified(1));
+        assert!(ctx.pool.is_finalized(2));
         let new_bank = Arc::new(create_bank(3, new_bank, &Pubkey::new_unique()));
-        pool.prune_old_state(new_bank.slot());
+        ctx.pool.prune_old_state(new_bank.slot());
         // Now both certs should be gone
-        assert!(!pool.skip_certified(1));
-        assert!(!pool.is_finalized(2));
+        assert!(!ctx.pool.skip_certified(1));
+        assert!(!ctx.pool.is_finalized(2));
         // Send a vote on slot 1, it should be rejected
         let vote = Vote::new_skip_vote(1);
         assert!(
-            pool.add_message(
-                new_bank.epoch_schedule(),
-                new_bank.epoch_stakes_map(),
-                new_bank.slot(),
-                &Pubkey::new_unique(),
-                dummy_vote_message(&validator_keypairs, &vote, 0),
-                &mut vec![]
-            )
-            .is_err()
+            ctx.pool
+                .add_message(
+                    new_bank.epoch_schedule(),
+                    new_bank.epoch_stakes_map(),
+                    new_bank.slot(),
+                    &Pubkey::new_unique(),
+                    dummy_vote_message(&ctx.validators, &vote, 0),
+                    &mut vec![]
+                )
+                .is_err()
         );
 
         // Send a cert on slot 2, it should be rejected
@@ -1959,24 +1911,25 @@ mod tests {
             bitmap: Vec::new(),
         });
         assert!(
-            pool.add_message(
-                new_bank.epoch_schedule(),
-                new_bank.epoch_stakes_map(),
-                new_bank.slot(),
-                &Pubkey::new_unique(),
-                cert,
-                &mut vec![]
-            )
-            .is_err()
+            ctx.pool
+                .add_message(
+                    new_bank.epoch_schedule(),
+                    new_bank.epoch_stakes_map(),
+                    new_bank.slot(),
+                    &Pubkey::new_unique(),
+                    cert,
+                    &mut vec![]
+                )
+                .is_err()
         );
     }
 
     #[test]
     fn test_get_certs_for_standstill() {
-        let (_, mut pool, bank_forks) = create_initial_state();
+        let mut ctx = TestContext::new();
 
         // Should return empty vector if no certificates
-        assert!(pool.get_certs_for_standstill().is_empty());
+        assert!(ctx.pool.get_certs_for_standstill().is_empty());
 
         // Add notar-fallback cert on 3 and finalize cert on 4
         let cert_3 = Certificate {
@@ -1984,36 +1937,34 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        let bank = bank_forks.read().unwrap().root_bank();
-        assert!(
-            pool.add_message(
+        let bank = ctx.bank_forks.read().unwrap().root_bank();
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
                 ConsensusMessage::Certificate(cert_3),
-                &mut vec![]
+                &mut vec![],
             )
-            .is_ok()
-        );
+            .unwrap();
         let cert_4 = Certificate {
             cert_type: CertificateType::Finalize(4),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
                 ConsensusMessage::Certificate(cert_4),
-                &mut vec![]
+                &mut vec![],
             )
-            .is_ok()
-        );
+            .unwrap();
         // Should return both certificates
-        let certs = pool.get_certs_for_standstill();
+        let certs = ctx.pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 2);
         assert!(certs.iter().any(|cert| cert.cert_type.slot() == 3
             && matches!(cert.cert_type, CertificateType::NotarizeFallback(_, _))));
@@ -2026,17 +1977,16 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
                 ConsensusMessage::Certificate(cert_5),
-                &mut vec![]
+                &mut vec![],
             )
-            .is_ok()
-        );
+            .unwrap();
 
         // Add Finalize cert on 5
         let cert_5_finalize = Certificate {
@@ -2044,17 +1994,16 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
                 ConsensusMessage::Certificate(cert_5_finalize),
-                &mut vec![]
+                &mut vec![],
             )
-            .is_ok()
-        );
+            .unwrap();
 
         // Add FinalizeFast cert on 5
         let cert_5 = Certificate {
@@ -2062,19 +2011,18 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
                 ConsensusMessage::Certificate(cert_5),
-                &mut vec![]
+                &mut vec![],
             )
-            .is_ok()
-        );
+            .unwrap();
         // Should return only FinalizeFast cert on 5
-        let certs = pool.get_certs_for_standstill();
+        let certs = ctx.pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 1);
         assert!(
             certs[0].cert_type.slot() == 5
@@ -2087,19 +2035,18 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
                 ConsensusMessage::Certificate(cert_6),
-                &mut vec![]
+                &mut vec![],
             )
-            .is_ok()
-        );
+            .unwrap();
         // Should return certs on 5 and 6
-        let certs = pool.get_certs_for_standstill();
+        let certs = ctx.pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 2);
         assert!(certs.iter().any(|cert| cert.cert_type.slot() == 5
             && matches!(cert.cert_type, CertificateType::FinalizeFast(_, _))));
@@ -2112,37 +2059,35 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
                 ConsensusMessage::Certificate(cert_6_finalize),
-                &mut vec![]
+                &mut vec![],
             )
-            .is_ok()
-        );
+            .unwrap();
         // Add a NotarizeFallback cert on 6
         let cert_6_notarize_fallback = Certificate {
             cert_type: CertificateType::NotarizeFallback(6, Hash::new_unique()),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
                 ConsensusMessage::Certificate(cert_6_notarize_fallback),
-                &mut vec![]
+                &mut vec![],
             )
-            .is_ok()
-        );
+            .unwrap();
         // This should not be returned because 6 is the current highest finalized slot
         // only Notarize/Finalze/FinalizeFast should be returned
-        let certs = pool.get_certs_for_standstill();
+        let certs = ctx.pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 2);
         assert!(certs.iter().any(|cert| cert.cert_type.slot() == 6
             && matches!(cert.cert_type, CertificateType::Finalize(_))));
@@ -2155,19 +2100,18 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
                 ConsensusMessage::Certificate(cert_7),
-                &mut vec![]
+                &mut vec![],
             )
-            .is_ok()
-        );
+            .unwrap();
         // Should return certs on 6 and 7
-        let certs = pool.get_certs_for_standstill();
+        let certs = ctx.pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 3);
         assert!(certs.iter().any(|cert| cert.cert_type.slot() == 6
             && matches!(cert.cert_type, CertificateType::Finalize(_))));
@@ -2184,36 +2128,34 @@ mod tests {
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
                 ConsensusMessage::Certificate(cert_8_finalize),
-                &mut vec![]
+                &mut vec![],
             )
-            .is_ok()
-        );
+            .unwrap();
         let cert_8_notarize = Certificate {
             cert_type: CertificateType::Notarize(8, Hash::new_unique()),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
                 &Pubkey::new_unique(),
                 ConsensusMessage::Certificate(cert_8_notarize),
-                &mut vec![]
+                &mut vec![],
             )
-            .is_ok()
-        );
+            .unwrap();
 
         // Should only return certs on 8 now
-        let certs = pool.get_certs_for_standstill();
+        let certs = ctx.pool.get_certs_for_standstill();
         assert_eq!(certs.len(), 2);
         assert!(certs.iter().any(|cert| cert.cert_type.slot() == 8
             && matches!(cert.cert_type, CertificateType::Finalize(_))));
@@ -2223,8 +2165,8 @@ mod tests {
 
     #[test]
     fn test_new_parent_ready_with_certificates() {
-        let (_, mut pool, bank_forks) = create_initial_state();
-        let bank = bank_forks.read().unwrap().root_bank();
+        let mut ctx = TestContext::new();
+        let bank = ctx.bank_forks.read().unwrap().root_bank();
         let mut events = vec![];
 
         // Add a notarization cert on slot 1 to 3
@@ -2235,8 +2177,8 @@ mod tests {
                 signature: BLSSignature::default(),
                 bitmap: Vec::new(),
             };
-            assert!(
-                pool.add_message(
+            ctx.pool
+                .add_message(
                     bank.epoch_schedule(),
                     bank.epoch_stakes_map(),
                     bank.slot(),
@@ -2244,8 +2186,7 @@ mod tests {
                     ConsensusMessage::Certificate(cert),
                     &mut events,
                 )
-                .is_ok()
-            );
+                .unwrap();
         }
         // events should now contain ParentReady for slot 4
         error!("Events: {events:?}");
@@ -2266,8 +2207,8 @@ mod tests {
                 signature: BLSSignature::default(),
                 bitmap: Vec::new(),
             };
-            assert!(
-                pool.add_message(
+            ctx.pool
+                .add_message(
                     bank.epoch_schedule(),
                     bank.epoch_stakes_map(),
                     bank.slot(),
@@ -2275,8 +2216,7 @@ mod tests {
                     ConsensusMessage::Certificate(cert),
                     &mut events,
                 )
-                .is_ok()
-            );
+                .unwrap();
         }
         // events should now contain ParentReady for slot 8
         error!("Events: {events:?}");
@@ -2297,8 +2237,8 @@ mod tests {
                 signature: BLSSignature::default(),
                 bitmap: Vec::new(),
             };
-            assert!(
-                pool.add_message(
+            ctx.pool
+                .add_message(
                     bank.epoch_schedule(),
                     bank.epoch_stakes_map(),
                     bank.slot(),
@@ -2306,16 +2246,15 @@ mod tests {
                     ConsensusMessage::Certificate(cert),
                     &mut events,
                 )
-                .is_ok()
-            );
+                .unwrap();
         }
         let cert = Certificate {
             cert_type: CertificateType::FinalizeFast(11, hash),
             signature: BLSSignature::default(),
             bitmap: Vec::new(),
         };
-        assert!(
-            pool.add_message(
+        ctx.pool
+            .add_message(
                 bank.epoch_schedule(),
                 bank.epoch_stakes_map(),
                 bank.slot(),
@@ -2323,8 +2262,7 @@ mod tests {
                 ConsensusMessage::Certificate(cert),
                 &mut events,
             )
-            .is_ok()
-        );
+            .unwrap();
         // events should now contain ParentReady for slot 12
         error!("Events: {events:?}");
         assert!(
@@ -2339,16 +2277,16 @@ mod tests {
 
     #[test]
     fn test_vote_message_signature_verification() {
-        let (validator_keypairs, _, _) = create_initial_state();
+        let ctx = TestContext::new();
         let rank_to_test = 3;
         let vote = Vote::new_notarization_vote(42, Hash::new_unique());
 
-        let consensus_message = dummy_vote_message(&validator_keypairs, &vote, rank_to_test);
+        let consensus_message = dummy_vote_message(&ctx.validators, &vote, rank_to_test);
         let ConsensusMessage::Vote(vote_message) = consensus_message else {
             panic!("Expected Vote message")
         };
 
-        let validator_vote_keypair = &validator_keypairs[rank_to_test].vote_keypair;
+        let validator_vote_keypair = &ctx.validators[rank_to_test].vote_keypair;
         let bls_keypair =
             BLSKeypair::derive_from_signer(validator_vote_keypair, BLS_KEYPAIR_DERIVE_SEED)
                 .unwrap();
@@ -2356,24 +2294,21 @@ mod tests {
 
         let signed_message = bincode::serialize(&vote).unwrap();
 
-        assert!(
-            vote_message
-                .signature
-                .verify(&bls_pubkey, &signed_message)
-                .is_ok(),
-            "BLS signature verification failed for VoteMessage"
-        );
+        vote_message
+            .signature
+            .verify(&bls_pubkey, &signed_message)
+            .unwrap();
     }
 
     #[test]
     fn test_update_pubkey() {
         let new_pubkey = Pubkey::new_unique();
-        let (_, mut pool, _) = create_initial_state();
-        let old_pubkey = pool.my_pubkey();
-        assert_eq!(pool.parent_ready_tracker.my_pubkey(), old_pubkey);
+        let mut ctx = TestContext::new();
+        let old_pubkey = ctx.pool.my_pubkey();
+        assert_eq!(ctx.pool.parent_ready_tracker.my_pubkey(), old_pubkey);
         assert_ne!(old_pubkey, new_pubkey);
-        pool.update_pubkey(new_pubkey);
-        assert_eq!(pool.my_pubkey(), new_pubkey);
-        assert_eq!(pool.parent_ready_tracker.my_pubkey(), new_pubkey);
+        ctx.pool.update_pubkey(new_pubkey);
+        assert_eq!(ctx.pool.my_pubkey(), new_pubkey);
+        assert_eq!(ctx.pool.parent_ready_tracker.my_pubkey(), new_pubkey);
     }
 }


### PR DESCRIPTION
#### Problem

Two main problems:
- adding new arguments to consensus pool's constructor would require changing all the tests
- a bunch of tests are using `Result::is_ok` and if the tests fail, we do not get any further information on what the error variant was and have to modify the tests and rerun them.


#### Summary of Changes

- first problem is addressed by introducing `TestContext`.  This will be help in adding tests for https://github.com/anza-xyz/agave/pull/11302.
- Second problem is addressed by replacing `is_ok` with `unwrap`
