### PR TITLE
clippy(rpc): allow large JsonRpcRequestProcessor result error

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1295,6 +1295,7 @@ impl JsonRpcRequestProcessor {
         }
     }
 
+    #[allow(clippy::result_large_err)]
     pub async fn get_block(
         &self,
         slot: Slot,
@@ -2209,6 +2210,7 @@ impl JsonRpcRequestProcessor {
     }
 
     /// Use a set of filters to get an iterator of keyed program accounts from a bank
+    #[allow(clippy::result_large_err)]
     async fn get_filtered_program_accounts(
         &self,
         bank: Arc<Bank>,


### PR DESCRIPTION
#### Problem
Clippy in Rust toolchain 1.94 marks the `RpcCustomError::SendTransactionPreflightFailure` error variant as too large.

#### Summary of Changes
Allow the lint to pass. Since rpc is going to be removed from validator, there is not much incentive to change the error's internals.
