### PR TITLE
builtins-default-costs: Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7341,17 +7341,9 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
- "log",
  "qualifier_attr",
- "rand 0.9.2",
- "solana-bpf-loader-program",
- "solana-compute-budget-program",
- "solana-frozen-abi",
- "solana-loader-v4-program",
  "solana-pubkey 4.1.0",
  "solana-sdk-ids",
- "solana-system-program",
- "solana-vote-program",
  "static_assertions",
 ]
 

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -19,27 +19,16 @@ name = "solana_builtins_default_costs"
 
 [features]
 agave-unstable-api = []
-frozen-abi = ["dep:solana-frozen-abi", "solana-vote-program/frozen-abi"]
 dev-context-only-utils = ["dep:qualifier_attr"]
 
 [dependencies]
 agave-feature-set = { workspace = true }
 ahash = { workspace = true }
-log = { workspace = true }
 qualifier_attr = { workspace = true, optional = true }
-solana-bpf-loader-program = { workspace = true }
-solana-compute-budget-program = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
-] }
-solana-loader-v4-program = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
-solana-system-program = { workspace = true }
-solana-vote-program = { workspace = true }
 
 [dev-dependencies]
-rand = { workspace = true }
 static_assertions = { workspace = true }
 
 [lints]

--- a/builtins-default-costs/src/lib.rs
+++ b/builtins-default-costs/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "agave-unstable-api")]
-#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 
 #[cfg(feature = "dev-context-only-utils")]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6571,14 +6571,8 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
- "log",
- "solana-bpf-loader-program",
- "solana-compute-budget-program",
- "solana-loader-v4-program",
  "solana-pubkey 4.1.0",
  "solana-sdk-ids",
- "solana-system-program",
- "solana-vote-program",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6219,14 +6219,8 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
- "log",
- "solana-bpf-loader-program",
- "solana-compute-budget-program",
- "solana-loader-v4-program",
  "solana-pubkey 4.1.0",
  "solana-sdk-ids",
- "solana-system-program",
- "solana-vote-program",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
There are some unused dependencies in `builtins-default-costs`. Also, `frozen-abi` feature is not used.

#### Summary of Changes
Remove