### PR TITLE
Add helper to check transaction version from wire bytes

### DIFF
--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -485,7 +485,7 @@ mod tests {
         let tx = simple_transfer();
         let mut bytes = bincode::serialize(&tx).unwrap();
         // Set the number of signatures to u16::MAX except the MSB of
-        // first byte, which version bit.
+        // first byte, which is the version bit.
         bytes[0] = 0x7f;
         bytes[1] = 0xff;
         bytes[2] = 0xff;

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -34,6 +34,11 @@ impl TransactionFrame {
     /// Parse a serialized transaction and verify basic structure.
     /// The `bytes` parameter must have no trailing data.
     pub(crate) fn try_new(bytes: &[u8]) -> Result<Self> {
+        assert!(matches!(
+            Self::is_wire_transaction_legacy_or_v0(bytes),
+            Ok(true) | Err(_)
+        ));
+
         let mut offset = 0;
         let signature = SignatureFrame::try_new(bytes, &mut offset)?;
         let message_header = MessageHeaderFrame::try_new(bytes, &mut offset)?;
@@ -69,6 +74,16 @@ impl TransactionFrame {
             instructions,
             address_table_lookup,
         })
+    }
+
+    fn is_wire_transaction_legacy_or_v0(bytes: &[u8]) -> Result<bool> {
+        let first_byte = *bytes.first().ok_or(TransactionViewError::ParseError)?;
+
+        // In wire format:
+        // - legacy/v0 transactions start with signatures (compact-u16 count),
+        //   whose first byte always has MSB = 0 in practice.
+        // - v1 transactions start with a version byte with MSB = 1.
+        Ok((first_byte & solana_message::MESSAGE_VERSION_PREFIX) == 0)
     }
 
     /// Return the number of signatures in the transaction.
@@ -469,8 +484,9 @@ mod tests {
     fn test_signature_overflow() {
         let tx = simple_transfer();
         let mut bytes = bincode::serialize(&tx).unwrap();
-        // Set the number of signatures to u16::MAX
-        bytes[0] = 0xff;
+        // Set the number of signatures to u16::MAX except the MSB of
+        // first byte, which version bit.
+        bytes[0] = 0x7f;
         bytes[1] = 0xff;
         bytes[2] = 0xff;
         assert!(TransactionFrame::try_new(&bytes).is_err());
@@ -670,5 +686,38 @@ mod tests {
 
             assert!(iter.next().is_none());
         }
+    }
+
+    #[test]
+    fn test_is_wire_transaction_legacy_or_v0_errors_on_empty_bytes() {
+        let bytes = [];
+        assert_eq!(
+            TransactionFrame::is_wire_transaction_legacy_or_v0(&bytes),
+            Err(TransactionViewError::ParseError)
+        );
+    }
+
+    #[test]
+    fn test_is_wire_transaction_legacy_or_v0_true_when_first_byte_has_no_version_prefix() {
+        assert!(TransactionFrame::is_wire_transaction_legacy_or_v0(&[0x00]).unwrap());
+        assert!(TransactionFrame::is_wire_transaction_legacy_or_v0(&[0x01]).unwrap());
+        assert!(TransactionFrame::is_wire_transaction_legacy_or_v0(&[0x7f]).unwrap());
+    }
+
+    #[test]
+    fn test_is_wire_transaction_legacy_or_v0_false_when_first_byte_has_version_prefix() {
+        assert!(
+            !TransactionFrame::is_wire_transaction_legacy_or_v0(&[
+                solana_message::MESSAGE_VERSION_PREFIX
+            ])
+            .unwrap()
+        );
+        assert!(
+            !TransactionFrame::is_wire_transaction_legacy_or_v0(&[
+                solana_message::MESSAGE_VERSION_PREFIX | 1
+            ])
+            .unwrap()
+        );
+        assert!(!TransactionFrame::is_wire_transaction_legacy_or_v0(&[0xff]).unwrap());
     }
 }

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -80,8 +80,9 @@ impl TransactionFrame {
         let first_byte = *bytes.first().ok_or(TransactionViewError::ParseError)?;
 
         // In wire format:
-        // - legacy/v0 transactions start with signatures (compact-u16 count),
-        //   whose first byte always has MSB = 0 in practice.
+        // - Legacy/v0 transactions start with signatures (compact-u16 count).
+        //   Packet size limits keep the signature count well below 128, so the
+        //   first byte never has MSB set.
         // - v1 transactions start with a version byte with MSB = 1.
         Ok((first_byte & solana_message::MESSAGE_VERSION_PREFIX) == 0)
     }


### PR DESCRIPTION
#### Problem

In wire format:
- legacy/v0 transactions start with signatures (compact-u16 count), whose first byte always has MSB = 0 in practice.
 - v1 transactions start with a version byte with MSB = 1.

#### Summary of Changes
- Add helper function implements that to quickly identify tx version

Fixes #
