### PR TITLE
build: fix `cargo test -p agave-transaction-view`

### DIFF
--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -35,7 +35,7 @@ solana-message = { workspace = true, features = ["serde"] }
 solana-signature = { workspace = true, features = ["serde"] }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true, features = ["bincode"] }
-solana-transaction = { workspace = true, features = ["wincode"] }
+solana-transaction = { workspace = true, features = ["serde", "wincode"] }
 
 [[bench]]
 name = "bytes"


### PR DESCRIPTION
#### Problem

- `cargo test -p agave-transaction-view` fails due to solana-transaction missing serde feature.

#### Summary of Changes

- Enable solana-transaction serde feature in `agave-transaction-view` dev dependencies.