### PR TITLE
vote: when alpenglow migration is complete, disallow Tower vote ixs

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -147,6 +147,7 @@ impl BpfAllocator {
 pub struct EnvironmentConfig<'a> {
     pub blockhash: Hash,
     pub blockhash_lamports_per_signature: u64,
+    alpenglow_migration_succeeded: bool,
     epoch_stake_callback: &'a dyn InvokeContextCallback,
     feature_set: &'a SVMFeatureSet,
     pub program_runtime_environment_for_execution: &'a ProgramRuntimeEnvironment,
@@ -157,6 +158,7 @@ impl<'a> EnvironmentConfig<'a> {
     pub fn new(
         blockhash: Hash,
         blockhash_lamports_per_signature: u64,
+        alpenglow_migration_succeeded: bool,
         epoch_stake_callback: &'a dyn InvokeContextCallback,
         feature_set: &'a SVMFeatureSet,
         program_runtime_environment_for_execution: &'a ProgramRuntimeEnvironment,
@@ -166,6 +168,7 @@ impl<'a> EnvironmentConfig<'a> {
         Self {
             blockhash,
             blockhash_lamports_per_signature,
+            alpenglow_migration_succeeded,
             epoch_stake_callback,
             feature_set,
             program_runtime_environment_for_execution,
@@ -654,6 +657,11 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         *self.compute_meter.borrow_mut() = remaining;
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn set_alpenglow_migration_succeeded_for_tests(&mut self, succeeded: bool) {
+        self.environment_config.alpenglow_migration_succeeded = succeeded;
+    }
+
     /// Get this invocation's compute budget
     pub fn get_compute_budget(&self) -> &SVMTransactionExecutionBudget {
         &self.compute_budget
@@ -678,6 +686,10 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         self.environment_config
             .feature_set
             .deprecate_legacy_vote_ixs
+    }
+
+    pub fn is_alpenglow_migration_succeeded(&self) -> bool {
+        self.environment_config.alpenglow_migration_succeeded
     }
 
     /// Get cached sysvars
@@ -833,6 +845,7 @@ macro_rules! with_mock_invoke_context_with_feature_set {
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
+            false,
             &MockInvokeContextCallback {},
             $feature_set,
             &program_runtime_environment,

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -75,6 +75,11 @@ fn is_vote_authorize_with_bls_enabled(invoke_context: &InvokeContext) -> bool {
     feature_set.vote_state_v4 && feature_set.bls_pubkey_management_in_vote_account
 }
 
+fn should_reject_legacy_vote_instructions(invoke_context: &InvokeContext) -> bool {
+    invoke_context.is_deprecate_legacy_vote_ixs_active()
+        || invoke_context.is_alpenglow_migration_succeeded()
+}
+
 // Citing `runtime/src/block_cost_limit.rs`, vote has statically defined 2100
 // units; can consume based on instructions in the future like `bpf_loader` does.
 pub const DEFAULT_COMPUTE_UNITS: u64 = 2_100;
@@ -201,7 +206,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         VoteInstruction::Vote(vote) | VoteInstruction::VoteSwitch(vote, _) => {
-            if invoke_context.is_deprecate_legacy_vote_ixs_active() {
+            if should_reject_legacy_vote_instructions(invoke_context) {
                 return Err(InstructionError::InvalidInstructionData);
             }
             let slot_hashes = get_sysvar_with_account_check::slot_hashes(
@@ -222,7 +227,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
         }
         VoteInstruction::UpdateVoteState(vote_state_update)
         | VoteInstruction::UpdateVoteStateSwitch(vote_state_update, _) => {
-            if invoke_context.is_deprecate_legacy_vote_ixs_active() {
+            if should_reject_legacy_vote_instructions(invoke_context) {
                 return Err(InstructionError::InvalidInstructionData);
             }
             let sysvar_cache = invoke_context.get_sysvar_cache();
@@ -239,7 +244,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
         }
         VoteInstruction::CompactUpdateVoteState(vote_state_update)
         | VoteInstruction::CompactUpdateVoteStateSwitch(vote_state_update, _) => {
-            if invoke_context.is_deprecate_legacy_vote_ixs_active() {
+            if should_reject_legacy_vote_instructions(invoke_context) {
                 return Err(InstructionError::InvalidInstructionData);
             }
             let sysvar_cache = invoke_context.get_sysvar_cache();
@@ -256,6 +261,9 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
         }
         VoteInstruction::TowerSync(tower_sync)
         | VoteInstruction::TowerSyncSwitch(tower_sync, _) => {
+            if invoke_context.is_alpenglow_migration_succeeded() {
+                return Err(InstructionError::InvalidInstructionData);
+            }
             let sysvar_cache = invoke_context.get_sysvar_cache();
             let slot_hashes = sysvar_cache.get_slot_hashes()?;
             let clock = sysvar_cache.get_clock()?;
@@ -491,6 +499,7 @@ mod tests {
         custom_commission_collector: bool,
         block_revenue_sharing: bool,
         vote_account_initialize_v2: bool,
+        alpenglow_migration_succeeded: bool,
     }
 
     impl VoteProgramFeatures {
@@ -502,6 +511,7 @@ mod tests {
                 custom_commission_collector: true,
                 block_revenue_sharing: true,
                 vote_account_initialize_v2: true,
+                alpenglow_migration_succeeded: false,
             }
         }
     }
@@ -538,6 +548,7 @@ mod tests {
             custom_commission_collector,
             block_revenue_sharing,
             vote_account_initialize_v2,
+            alpenglow_migration_succeeded,
         } = features;
         let cu_consumed = RefCell::new(0u64);
         let accounts = mock_process_instruction_with_feature_set(
@@ -548,6 +559,8 @@ mod tests {
             expected_result,
             Entrypoint::register,
             |invoke_context| {
+                invoke_context
+                    .set_alpenglow_migration_succeeded_for_tests(alpenglow_migration_succeeded);
                 // Register system program for CPI support.
                 invoke_context.program_cache_for_tx_batch.replenish(
                     solana_sdk_ids::system_program::id(),
@@ -943,6 +956,7 @@ mod tests {
             custom_commission_collector,
             block_revenue_sharing,
             vote_account_initialize_v2,
+            alpenglow_migration_succeeded: false,
         };
 
         let accounts = process_instruction(
@@ -1075,6 +1089,7 @@ mod tests {
             custom_commission_collector,
             block_revenue_sharing,
             vote_account_initialize_v2,
+            alpenglow_migration_succeeded: false,
         };
 
         let all_v2_features_enabled = vote_state_v4
@@ -4025,6 +4040,30 @@ mod tests {
                 &Pubkey::new_unique(),
             ),
             Err(InstructionError::InvalidAccountData),
+        );
+    }
+
+    #[test]
+    fn test_tower_sync_rejected_after_alpenglow_migration_succeeds() {
+        let features = VoteProgramFeatures {
+            alpenglow_migration_succeeded: true,
+            ..Default::default()
+        };
+
+        process_instruction_as_one_arg(
+            features,
+            &tower_sync(&Pubkey::default(), &Pubkey::default(), TowerSync::default()),
+            Err(InstructionError::InvalidInstructionData),
+        );
+        process_instruction_as_one_arg(
+            features,
+            &tower_sync_switch(
+                &Pubkey::default(),
+                &Pubkey::default(),
+                TowerSync::default(),
+                Hash::default(),
+            ),
+            Err(InstructionError::InvalidInstructionData),
         );
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3602,6 +3602,7 @@ impl Bank {
         let processing_environment = TransactionProcessingEnvironment {
             blockhash,
             blockhash_lamports_per_signature,
+            alpenglow_migration_succeeded: self.get_alpenglow_genesis_certificate().is_some(),
             epoch_total_stake: self.get_current_epoch_total_stake(),
             feature_set: self.feature_set.runtime_features(),
             program_runtime_environment_for_execution: self

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -174,6 +174,7 @@ impl Bank {
                 EnvironmentConfig::new(
                     Hash::default(),
                     0,
+                    false,
                     &MockCallback {},
                     &feature_set,
                     &program_runtime_environment,

--- a/svm-test-harness/instr/src/harness.rs
+++ b/svm-test-harness/instr/src/harness.rs
@@ -95,6 +95,7 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
             EnvironmentConfig::new(
                 blockhash,
                 blockhash_lamports_per_signature,
+                false,
                 callback,
                 &feature_set,
                 &program_runtime_environment,

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -222,6 +222,7 @@ mod tests {
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
+            false,
             &MockCallback {},
             &feature_set,
             &program_runtime_environment,
@@ -278,6 +279,7 @@ mod tests {
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
+            false,
             &MockCallback {},
             &feature_set,
             &program_runtime_environment,
@@ -326,6 +328,7 @@ mod tests {
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
+            false,
             &MockCallback {},
             &feature_set,
             &program_runtime_environment,
@@ -462,6 +465,7 @@ mod tests {
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
+            false,
             &MockCallback {},
             &feature_set,
             &program_runtime_environment,
@@ -503,6 +507,7 @@ mod tests {
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
+            false,
             &MockCallback {},
             &feature_set,
             &program_runtime_environment,
@@ -543,6 +548,7 @@ mod tests {
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
+            false,
             &MockCallback {},
             &feature_set,
             &program_runtime_environment,
@@ -704,6 +710,7 @@ mod tests {
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
+            false,
             &MockCallback {},
             &feature_set,
             &program_runtime_environment,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -148,6 +148,8 @@ pub struct TransactionProcessingEnvironment {
     /// change transaction fees. For this reason, it is recommended to use the
     /// `fee_per_signature` field to adjust transaction fees.
     pub blockhash_lamports_per_signature: u64,
+    /// Whether the alpenglow migration has completed for this bank context.
+    pub alpenglow_migration_succeeded: bool,
     /// The total stake for the current epoch.
     pub epoch_total_stake: u64,
     /// Runtime feature set to use for the transaction batch.
@@ -166,6 +168,7 @@ pub fn get_mock_transaction_processing_environment() -> TransactionProcessingEnv
     TransactionProcessingEnvironment {
         blockhash: Hash::default(),
         blockhash_lamports_per_signature: 0,
+        alpenglow_migration_succeeded: false,
         epoch_total_stake: 0,
         feature_set: SVMFeatureSet::default(),
         program_runtime_environment_for_execution: get_mock_program_runtime_environment(),
@@ -972,6 +975,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             EnvironmentConfig::new(
                 environment.blockhash,
                 environment.blockhash_lamports_per_signature,
+                environment.alpenglow_migration_succeeded,
                 callback,
                 &environment.feature_set,
                 &environment.program_runtime_environment_for_execution,

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -161,6 +161,7 @@ impl SvmTestEnvironment<'_> {
         let processing_environment = TransactionProcessingEnvironment {
             blockhash: LAST_BLOCKHASH,
             blockhash_lamports_per_signature: LAMPORTS_PER_SIGNATURE,
+            alpenglow_migration_succeeded: false,
             epoch_total_stake: 0,
             feature_set: test_entry.feature_set,
             program_runtime_environment_for_execution: batch_processor

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -6018,6 +6018,7 @@ mod tests {
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
+            false,
             &MockCallback {},
             &feature_set,
             &program_runtime_environment,
@@ -6084,6 +6085,7 @@ mod tests {
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
+            false,
             &MockCallback {},
             &feature_set,
             &program_runtime_environment,


### PR DESCRIPTION
#### Problem
When the alpenglow migration has succeeded, it is imperative that we reject TowerBFT vote instructions.

Not only is it a waste of compute as consensus no longer consumes the result of these instructions, it opens up an attack to gain more inflationary rewards:
- Validator sends both towerbft votes and alpenglow votes for a block
- vote program increments the validator's credits when processing the tower bft vote
- runtime increments the validator's credits when processing the alpenglow rewards certificate
- validator earns double inflation rewards

#### Summary of Changes
When the alpenglow migration has succeeded, reject all tower bft vote instructions.

Migration success is monitored by a special off curve account https://github.com/anza-xyz/agave/blob/a8c364c77bfb94b760a1089edba602c04fac6365/votor-messages/src/migration.rs#L88-L89
Unlike a typical feature flag activation, the migration happens over a dynamic # of slots:
```
slot S     | feature activated
s + 5000   | migration process starts
s + ?      | migration succeeds and GENESIS_CERTIFICATE_ACCOUNT is populated
```

Thus we have to plug in `bank.get_alpenglow_genesis_certificate().is_some()` into the invoke context.