### PR TITLE
Remove warp_slot in validator

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -97,10 +97,6 @@ filter = 'package(solana-core) & test(/^test_snapshots_have_expected_epoch_accou
 slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-cli) & test(/^test_stake_delegation_force/)'
-slow-timeout = { period = "60s", terminate-after = 3 }
-
-[[profile.ci.overrides]]
 filter = 'package(solana-client-test) & test(/^test_send_and_confirm_transactions_in_parallel_with_tpu_client/)'
 slow-timeout = { period = "60s", terminate-after = 3 }
 

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -97,6 +97,10 @@ filter = 'package(solana-core) & test(/^test_snapshots_have_expected_epoch_accou
 slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.ci.overrides]]
+filter = 'package(solana-cli) & test(/^test_stake_delegation_force/)'
+slow-timeout = { period = "60s", terminate-after = 3 }
+
+[[profile.ci.overrides]]
 filter = 'package(solana-client-test) & test(/^test_send_and_confirm_transactions_in_parallel_with_tpu_client/)'
 slow-timeout = { period = "60s", terminate-after = 3 }
 

--- a/cli/src/test_utils.rs
+++ b/cli/src/test_utils.rs
@@ -50,6 +50,16 @@ pub async fn wait_n_slots(rpc_client: &RpcClient, n: u64) -> u64 {
     }
 }
 
+pub async fn wait_for_min_slot(rpc_client: &RpcClient, min_slot: u64) {
+    loop {
+        let slot = rpc_client.get_slot().await.unwrap();
+        if slot >= min_slot {
+            return;
+        }
+        sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT));
+    }
+}
+
 pub async fn wait_for_next_epoch_plus_n_slots(rpc_client: &RpcClient, n: u64) -> (Epoch, u64) {
     let current_epoch = rpc_client.get_epoch_info().await.unwrap().epoch;
     let next_epoch = current_epoch.saturating_add(1);

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -41,6 +41,9 @@ async fn test_stake_delegation_force() {
     let faucet_addr = run_local_faucet_with_unique_port_for_tests(mint_keypair.insecure_clone());
     let slots_per_epoch = 32;
     let test_validator = TestValidatorGenesis::default()
+        // Reduce test time by making slots shorter. 8 was selected as it is the largest value that
+        // impact test time.
+        .ticks_per_slot(8)
         .fee_rate_governor(FeeRateGovernor::new(0, 0))
         .rent(Rent {
             lamports_per_byte: 1,

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -7,7 +7,7 @@ use {
         cli::{CliCommand, CliConfig, process_command, request_and_confirm_airdrop},
         spend_utils::SpendAmount,
         stake::StakeAuthorizationIndexed,
-        test_utils::{check_ready, wait_for_next_epoch_plus_n_slots},
+        test_utils::{check_ready, wait_for_min_slot},
     },
     solana_cli_output::{OutputFormat, parse_sign_only_reply_string},
     solana_client::nonblocking::blockhash_query::{BlockhashQuery, Source},
@@ -52,7 +52,6 @@ async fn test_stake_delegation_force() {
             /* enable_warmup_epochs = */ false,
         ))
         .faucet_addr(Some(faucet_addr))
-        .warp_slot(DELINQUENT_VALIDATOR_SLOT_DISTANCE * 2) // get out in front of the cli voter delinquency check
         .start_async_with_mint_address(&mint_keypair, SocketAddrSpace::Unspecified)
         .await
         .expect("validator start failed");
@@ -164,7 +163,8 @@ async fn test_stake_delegation_force() {
     };
     process_command(&config).await.unwrap();
 
-    wait_for_next_epoch_plus_n_slots(&rpc_client, 1).await;
+    // Wait until slot exceeds the delinquent threshold
+    wait_for_min_slot(&rpc_client, DELINQUENT_VALIDATOR_SLOT_DISTANCE + 1).await;
 
     // Delegate stake2 fails because voter has not voted, but is now staked
     config.signers = vec![&default_signer];

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -77,7 +77,7 @@ use {
     solana_hard_forks::HardForks,
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_leader_schedule::{FixedSchedule, SlotLeader},
+    solana_leader_schedule::FixedSchedule,
     solana_ledger::{
         bank_forks_utils,
         blockstore::{

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -34,8 +34,7 @@ use {
         tvu::{AlpenglowInitializationState, Tvu, TvuConfig, TvuSockets},
     },
     agave_snapshots::{
-        SnapshotInterval, snapshot_archive_info::SnapshotArchiveInfoGetter as _,
-        snapshot_config::SnapshotConfig, snapshot_hash::StartingSnapshotHashes,
+        SnapshotInterval, snapshot_config::SnapshotConfig, snapshot_hash::StartingSnapshotHashes,
     },
     agave_votor::{
         vote_history::VoteHistory,
@@ -129,7 +128,6 @@ use {
         dependency_tracker::DependencyTracker,
         prioritization_fee_cache::PrioritizationFeeCache,
         runtime_config::RuntimeConfig,
-        snapshot_bank_utils,
         snapshot_controller::SnapshotController,
         snapshot_utils::{self, clean_orphaned_account_snapshot_dirs},
     },
@@ -355,7 +353,6 @@ pub struct ValidatorConfig {
     pub poh_hashes_per_batch: u64,
     pub process_ledger_before_services: bool,
     pub accounts_db_config: AccountsDbConfig,
-    pub warp_slot: Option<Slot>,
     pub accounts_db_skip_shrink: bool,
     pub accounts_db_force_initial_clean: bool,
     pub staked_nodes_overrides: Arc<RwLock<HashMap<Pubkey, u64>>>,
@@ -433,7 +430,6 @@ impl ValidatorConfig {
             poh_pinned_cpu_core: poh_service::DEFAULT_PINNED_CPU_CORE,
             poh_hashes_per_batch: poh_service::DEFAULT_HASHES_PER_BATCH,
             process_ledger_before_services: false,
-            warp_slot: None,
             accounts_db_skip_shrink: false,
             accounts_db_force_initial_clean: false,
             staked_nodes_overrides: Arc::new(RwLock::new(HashMap::new())),
@@ -1121,16 +1117,6 @@ impl Validator {
             &snapshot_controller,
             config,
         );
-
-        maybe_warp_slot(
-            config,
-            &mut process_blockstore,
-            ledger_path,
-            &bank_forks,
-            &leader_schedule_cache,
-            &snapshot_controller,
-        )
-        .map_err(ValidatorError::Other)?;
 
         if config.process_ledger_before_services {
             process_blockstore
@@ -2093,13 +2079,6 @@ fn post_process_restored_tower(
             ));
         }
 
-        if let Some(warp_slot) = config.warp_slot {
-            // unconditionally relax tower requirement so that we can always restore tower
-            // from root bank after the warp
-            should_require_tower = false;
-            return Err(crate::consensus::TowerError::HardFork(warp_slot));
-        }
-
         tower
     });
 
@@ -2448,68 +2427,6 @@ impl<'a> ProcessBlockStore<'a> {
         self.process()?;
         Ok(self.tower.unwrap())
     }
-}
-
-fn maybe_warp_slot(
-    config: &ValidatorConfig,
-    process_blockstore: &mut ProcessBlockStore,
-    ledger_path: &Path,
-    bank_forks: &RwLock<BankForks>,
-    leader_schedule_cache: &LeaderScheduleCache,
-    snapshot_controller: &SnapshotController,
-) -> Result<(), String> {
-    if let Some(warp_slot) = config.warp_slot {
-        let mut bank_forks = bank_forks.write().unwrap();
-
-        let working_bank = bank_forks.working_bank();
-
-        if warp_slot <= working_bank.slot() {
-            return Err(format!(
-                "warp slot ({}) cannot be less than the working bank slot ({})",
-                warp_slot,
-                working_bank.slot()
-            ));
-        }
-        info!("warping to slot {warp_slot}");
-
-        let root_bank = bank_forks.root_bank();
-
-        // An accounts hash calculation from storages will occur in warp_from_parent() below.  This
-        // requires that the accounts cache has been flushed, which requires the parent slot to be
-        // rooted.
-        root_bank.squash();
-        root_bank.force_flush_accounts_cache();
-
-        bank_forks.insert(Bank::warp_from_parent(
-            root_bank,
-            SlotLeader::default(),
-            warp_slot,
-        ));
-        bank_forks.set_root(warp_slot, Some(snapshot_controller), Some(warp_slot));
-        leader_schedule_cache.set_root(&bank_forks.root_bank());
-
-        let full_snapshot_archive_info = match snapshot_bank_utils::bank_to_full_snapshot_archive(
-            ledger_path,
-            &bank_forks.root_bank(),
-            None,
-            &config.snapshot_config.full_snapshot_archives_dir,
-            &config.snapshot_config.incremental_snapshot_archives_dir,
-            config.snapshot_config.archive_format,
-        ) {
-            Ok(archive_info) => archive_info,
-            Err(e) => return Err(format!("Unable to create snapshot: {e}")),
-        };
-        info!(
-            "created snapshot: {}",
-            full_snapshot_archive_info.path().display()
-        );
-
-        drop(bank_forks);
-        // Process blockstore after warping bank forks to make sure tower and
-        // bank forks are in sync.
-        process_blockstore.process()?;
-    }
-    Ok(())
 }
 
 /// Returns the starting slot at which the blockstore should be scanned for

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -46,7 +46,6 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         no_os_disk_stats_reporting: config.no_os_disk_stats_reporting,
         enforce_ulimit_nofile: config.enforce_ulimit_nofile,
         poh_pinned_cpu_core: config.poh_pinned_cpu_core,
-        warp_slot: config.warp_slot,
         accounts_db_skip_shrink: config.accounts_db_skip_shrink,
         accounts_db_force_initial_clean: config.accounts_db_force_initial_clean,
         staked_nodes_overrides: config.staked_nodes_overrides.clone(),

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -16,7 +16,7 @@ use {
         utils::create_accounts_run_and_snapshot_dirs,
     },
     solana_cli_output::CliAccount,
-    solana_clock::{DEFAULT_MS_PER_SLOT, Slot},
+    solana_clock::DEFAULT_MS_PER_SLOT,
     solana_commitment_config::CommitmentConfig,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_core::{
@@ -128,7 +128,6 @@ pub struct TestValidatorGenesis {
     rpc_config: JsonRpcConfig,
     pubsub_config: PubSubConfig,
     rpc_ports: Option<(u16, u16)>, // (JsonRpc, JsonRpcPubSub), None == random ports
-    warp_slot: Option<Slot>,
     accounts: HashMap<Pubkey, AccountSharedData>,
     upgradeable_programs: Vec<UpgradeableProgramInfo>,
     ticks_per_slot: Option<u64>,
@@ -163,7 +162,6 @@ impl Default for TestValidatorGenesis {
             rpc_config: JsonRpcConfig::default_for_test(),
             pubsub_config: PubSubConfig::default(),
             rpc_ports: Option::<(u16, u16)>::default(),
-            warp_slot: Option::<Slot>::default(),
             accounts: HashMap::<Pubkey, AccountSharedData>::default(),
             upgradeable_programs: Vec::<UpgradeableProgramInfo>::default(),
             ticks_per_slot: Option::<u64>::default(),
@@ -290,11 +288,6 @@ impl TestValidatorGenesis {
 
     pub fn faucet_addr(&mut self, faucet_addr: Option<SocketAddr>) -> &mut Self {
         self.rpc_config.faucet_addr = faucet_addr;
-        self
-    }
-
-    pub fn warp_slot(&mut self, warp_slot: Slot) -> &mut Self {
-        self.warp_slot = Some(warp_slot);
         self
     }
 
@@ -1215,7 +1208,6 @@ impl TestValidator {
                 incremental_snapshot_archives_dir: ledger_path.to_path_buf(),
                 ..SnapshotConfig::default()
             },
-            warp_slot: config.warp_slot,
             validator_exit: config.validator_exit.clone(),
             max_ledger_shreds: config.max_ledger_shreds,
             no_wait_for_vote_to_start_leader: true,

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -297,28 +297,6 @@ fn main() {
 
     let clone_feature_set = matches.is_present("clone_feature_set");
 
-    let warp_slot = if matches.is_present("warp_slot") {
-        Some(match matches.value_of("warp_slot") {
-            Some(_) => value_t_or_exit!(matches, "warp_slot", Slot),
-            None => cluster_rpc_client
-                .as_ref()
-                .unwrap_or_else(|_| {
-                    println!(
-                        "The --url argument must be provided if --warp-slot/-w is used without an \
-                         explicit slot"
-                    );
-                    exit(1);
-                })
-                .get_slot()
-                .unwrap_or_else(|err| {
-                    println!("Unable to get current cluster slot: {err}");
-                    exit(1);
-                }),
-        })
-    } else {
-        None
-    };
-
     let faucet_lamports = matches
         .value_of("faucet_sol")
         .and_then(sol_str_to_lamports)
@@ -552,10 +530,6 @@ fn main() {
             println!("Error: clone_feature_set failed: {e}");
             exit(1);
         }
-    }
-
-    if let Some(warp_slot) = warp_slot {
-        genesis.warp_slot(warp_slot);
     }
 
     if let Some(ticks_per_slot) = ticks_per_slot {

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -16,9 +16,7 @@ use {
     },
     solana_clap_utils::{
         hidden_unless_forced,
-        input_validators::{
-            is_parsable, is_pubkey, is_pubkey_or_keypair, is_slot, is_url_or_moniker,
-        },
+        input_validators::{is_parsable, is_pubkey, is_pubkey_or_keypair, is_url_or_moniker},
     },
     solana_clock::Slot,
     solana_core::banking_trace::BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT,
@@ -690,22 +688,6 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                     "Copy an upgradeable program and its executable data from the cluster \
                      referenced by the --url argument the genesis configuration. If the ledger \
                      already exists then this parameter is silently ignored",
-                ),
-        )
-        .arg(
-            Arg::with_name("warp_slot")
-                .required(false)
-                .long("warp-slot")
-                .short("w")
-                .takes_value(true)
-                .value_name("WARP_SLOT")
-                .validator(is_slot)
-                .min_values(0)
-                .max_values(1)
-                .help(
-                    "Warp the ledger to WARP_SLOT after starting the validator. If no slot is \
-                     provided then the current slot of the cluster referenced by the --url \
-                     argument will be used",
                 ),
         )
         .arg(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -809,7 +809,6 @@ pub fn execute(
         blockstore_options: run_args.blockstore_options,
         run_verification: !matches.is_present("skip_startup_ledger_verification"),
         debug_keys,
-        warp_slot: None,
         generator_config: None,
         contact_debug_interval,
         contact_save_interval: DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS,


### PR DESCRIPTION
#### Problem
Warp slot should only be run from the ledger tool, not the validator

#### Summary of Changes
- Remove warp slot from the validator.
- Remove hookup in the test validator
- Open: Do test validator hooks need to go through the deprecation flow? 

I verified that warp slot CLI arg doesn't show up on a regular validator. 
Fixes #
