### PR TITLE
leader-schedule: Change the type of `len` and `repeat` to `usize`

### DIFF
--- a/leader-schedule/src/lib.rs
+++ b/leader-schedule/src/lib.rs
@@ -8,12 +8,16 @@ use {
     rand_chacha::{ChaChaRng, rand_core::SeedableRng},
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
-    std::sync::Arc,
+    std::{num::NonZeroUsize, sync::Arc},
 };
 
 mod vote_keyed;
 /// Stake-weighted leader schedule for one epoch.
 pub use vote_keyed::LeaderSchedule;
+
+/// Number of consecutive slots assigned to the same leader before the schedule
+/// advances to the next validator.
+pub const NUM_CONSECUTIVE_LEADER_SLOTS: NonZeroUsize = NonZeroUsize::new(4).unwrap();
 
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
 pub struct SlotLeader {
@@ -40,9 +44,10 @@ pub struct FixedSchedule {
 fn stake_weighted_slot_leaders(
     mut slot_leader_stakes: Vec<(SlotLeader, u64)>,
     epoch: Epoch,
-    len: u64,
-    repeat: u64,
+    len: usize,
+    repeat: NonZeroUsize,
 ) -> Vec<SlotLeader> {
+    let repeat = repeat.get();
     debug_assert!(
         len.is_multiple_of(repeat),
         "expected `len` {len} to be divisible by `repeat` {repeat}"
@@ -86,6 +91,9 @@ fn sort_stakes(stakes: &mut Vec<(SlotLeader, u64)>) {
 #[cfg(test)]
 mod tests {
     use {super::*, itertools::Itertools, rand::Rng, std::iter::repeat_with, test_case::test_case};
+
+    const NZ_1: NonZeroUsize = NonZeroUsize::new(1).unwrap();
+    const NZ_2: NonZeroUsize = NonZeroUsize::new(2).unwrap();
 
     #[test]
     fn test_get_leader_upcoming_slots() {
@@ -151,32 +159,32 @@ mod tests {
         Pubkey::new_from_array(bytes)
     }
 
-    #[test_case(1, &[10, 20, 30], 12, 1, &[1, 1, 2, 1, 1, 0, 0, 1, 2, 1, 0, 1])]
-    #[test_case(1, &[10, 20, 30], 12, 2, &[1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 0, 0])]
-    #[test_case(1, &[30, 10, 20], 12, 1, &[2, 2, 0, 2, 2, 1, 1, 2, 0, 2, 1, 2])]
-    #[test_case(1, &[30, 10, 20], 12, 2, &[2, 2, 2, 2, 0, 0, 2, 2, 2, 2, 1,1])]
-    #[test_case(1, &[10, 20, 25, 30], 12, 1, &[2, 2, 3, 1, 2, 0, 1, 1, 3, 2, 1, 2])]
-    #[test_case(1, &[10, 20, 25, 30, 35, 40, 100], 15, 1,
+    #[test_case(1, &[10, 20, 30], 12, NZ_1, &[1, 1, 2, 1, 1, 0, 0, 1, 2, 1, 0, 1])]
+    #[test_case(1, &[10, 20, 30], 12, NZ_2, &[1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 0, 0])]
+    #[test_case(1, &[30, 10, 20], 12, NZ_1, &[2, 2, 0, 2, 2, 1, 1, 2, 0, 2, 1, 2])]
+    #[test_case(1, &[30, 10, 20], 12, NZ_2, &[2, 2, 2, 2, 0, 0, 2, 2, 2, 2, 1, 1])]
+    #[test_case(1, &[10, 20, 25, 30], 12, NZ_1, &[2, 2, 3, 1, 2, 0, 1, 1, 3, 2, 1, 2])]
+    #[test_case(1, &[10, 20, 25, 30, 35, 40, 100], 15, NZ_1,
                 &[4, 5, 6, 3, 4, 1, 2, 3, 6, 4, 2, 4, 5, 6, 6])]
-    #[test_case(1, &[10, 20, 25, 30, 35, 40, 100, 1000], 15, 1,
+    #[test_case(1, &[10, 20, 25, 30, 35, 40, 100, 1000], 15, NZ_1,
                 &[7, 7, 7, 7, 7, 4, 6, 7, 7, 7, 6, 7, 7, 7, 7])]
-    #[test_case(1, &[10, 20, 25, 30, 35, 40, 100, 1000, 10_000], 20, 1,
+    #[test_case(1, &[10, 20, 25, 30, 35, 40, 100, 1000, 10_000], 20, NZ_1,
                 &[8, 8, 8, 8, 8, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 7])]
-    #[test_case(1, &[10, 20, 25, 30, 35, 40, 100, 1000, 10_000], 25, 1,
+    #[test_case(1, &[10, 20, 25, 30, 35, 40, 100, 1000, 10_000], 25, NZ_1,
                 &[8, 8, 8, 8, 8, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 7, 8, 8, 8, 8, 8])]
-    #[test_case(457468, &[10, 20, 30], 12, 1, &[2, 2, 0, 1, 0, 2, 1, 2, 1, 2, 2, 2])]
-    #[test_case(457468, &[10, 20, 30], 12, 2, &[2, 2, 2, 2, 0, 0, 1, 1, 0, 0, 2, 2])]
-    #[test_case(457469, &[10, 20, 30], 12, 1, &[1, 2, 2, 2, 2, 2, 2, 1, 0, 2, 2, 0])]
-    #[test_case(457470, &[10, 20, 30], 12, 1, &[2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 0, 2])]
-    #[test_case(3466545, &[10, 20, 30], 12, 1, &[2, 2, 0, 0, 2, 1, 1, 1, 0, 0, 2, 2])]
-    #[test_case(3466545, &[10, 20, 30], 13, 1, &[2, 2, 0, 0, 2, 1, 1, 1, 0, 0, 2, 2, 1])]
-    #[test_case(3466545, &[10, 20, 30], 14, 1, &[2, 2, 0, 0, 2, 1, 1, 1, 0, 0, 2, 2, 1, 2])]
-    #[test_case(3466545, &[10, 20, 30], 14, 2, &[2, 2, 2, 2, 0, 0, 0, 0, 2, 2, 1, 1, 1, 1])]
+    #[test_case(457468, &[10, 20, 30], 12, NZ_1, &[2, 2, 0, 1, 0, 2, 1, 2, 1, 2, 2, 2])]
+    #[test_case(457468, &[10, 20, 30], 12, NZ_2, &[2, 2, 2, 2, 0, 0, 1, 1, 0, 0, 2, 2])]
+    #[test_case(457469, &[10, 20, 30], 12, NZ_1, &[1, 2, 2, 2, 2, 2, 2, 1, 0, 2, 2, 0])]
+    #[test_case(457470, &[10, 20, 30], 12, NZ_1, &[2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 0, 2])]
+    #[test_case(3466545, &[10, 20, 30], 12, NZ_1, &[2, 2, 0, 0, 2, 1, 1, 1, 0, 0, 2, 2])]
+    #[test_case(3466545, &[10, 20, 30], 13, NZ_1, &[2, 2, 0, 0, 2, 1, 1, 1, 0, 0, 2, 2, 1])]
+    #[test_case(3466545, &[10, 20, 30], 14, NZ_1, &[2, 2, 0, 0, 2, 1, 1, 1, 0, 0, 2, 2, 1, 2])]
+    #[test_case(3466545, &[10, 20, 30], 14, NZ_2, &[2, 2, 2, 2, 0, 0, 0, 0, 2, 2, 1, 1, 1, 1])]
     fn test_stake_leader_schedule_exact_order(
         epoch: u64,
         stakes: &[u64],
-        len: u64,
-        repeat: u64,
+        len: usize,
+        repeat: NonZeroUsize,
         expected_order: &[usize],
     ) {
         let slot_leaders: Vec<_> = (0..stakes.len() as u16)
@@ -218,7 +226,7 @@ mod tests {
     #[test_case(454357, 10_000, 3, "E9XL5BLhCJ4Emyfs8jTUsQetfA8QZj78LcnN63dPp7jJ")]
     fn test_long_leader_schedule_hashed(
         epoch: Epoch,
-        len: u64,
+        len: usize,
         stake_pow: u32,
         expected_hash: &str,
     ) {
@@ -242,7 +250,8 @@ mod tests {
             .enumerate()
             .map(|(i, slot_leader)| (slot_leader, i.pow(stake_pow) as u64))
             .collect();
-        let schedule = stake_weighted_slot_leaders(stakes, epoch, len, 1);
+        let schedule =
+            stake_weighted_slot_leaders(stakes, epoch, len, NonZeroUsize::new(1).unwrap());
         assert_eq!(hash_slot_leader_vote_addresses(&schedule), expected_hash);
     }
 
@@ -262,7 +271,7 @@ mod tests {
             vec![(SlotLeader::new_unique(), 0), (SlotLeader::new_unique(), 0)],
             0,
             5,
-            1,
+            NonZeroUsize::new(1).unwrap(),
         );
     }
 }

--- a/leader-schedule/src/lib.rs
+++ b/leader-schedule/src/lib.rs
@@ -250,8 +250,7 @@ mod tests {
             .enumerate()
             .map(|(i, slot_leader)| (slot_leader, i.pow(stake_pow) as u64))
             .collect();
-        let schedule =
-            stake_weighted_slot_leaders(stakes, epoch, len, NonZeroUsize::new(1).unwrap());
+        let schedule = stake_weighted_slot_leaders(stakes, epoch, len, NZ_1);
         assert_eq!(hash_slot_leader_vote_addresses(&schedule), expected_hash);
     }
 
@@ -271,7 +270,7 @@ mod tests {
             vec![(SlotLeader::new_unique(), 0), (SlotLeader::new_unique(), 0)],
             0,
             5,
-            NonZeroUsize::new(1).unwrap(),
+            NZ_1,
         );
     }
 }

--- a/leader-schedule/src/vote_keyed.rs
+++ b/leader-schedule/src/vote_keyed.rs
@@ -4,7 +4,7 @@ use {
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
     solana_vote::vote_account::VoteAccountsHashMap,
-    std::{collections::HashMap, iter, ops::Index},
+    std::{collections::HashMap, iter, num::NonZeroUsize, ops::Index},
 };
 
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
@@ -19,8 +19,8 @@ impl LeaderSchedule {
     pub fn new(
         vote_accounts_map: &VoteAccountsHashMap,
         epoch: Epoch,
-        len: u64,
-        repeat: u64,
+        len: usize,
+        repeat: NonZeroUsize,
     ) -> Self {
         let slot_leader_stakes: Vec<_> = vote_accounts_map
             .iter()
@@ -146,14 +146,20 @@ mod tests {
     fn test_leader_schedule_basic() {
         let num_keys = 10;
         let vote_accounts_map: HashMap<_, _> = (0..num_keys)
-            .map(|i| (solana_pubkey::new_rand(), (i, VoteAccount::new_random())))
+            .map(|i| {
+                (
+                    solana_pubkey::new_rand(),
+                    (i as u64, VoteAccount::new_random()),
+                )
+            })
             .collect();
 
         let epoch: Epoch = rand::random();
         let len = num_keys * 10;
-        let leader_schedule = LeaderSchedule::new(&vote_accounts_map, epoch, len, 1);
-        let leader_schedule2 = LeaderSchedule::new(&vote_accounts_map, epoch, len, 1);
-        assert_eq!(leader_schedule.num_slots() as u64, len);
+        let repeat = NonZeroUsize::new(1).unwrap();
+        let leader_schedule = LeaderSchedule::new(&vote_accounts_map, epoch, len, repeat);
+        let leader_schedule2 = LeaderSchedule::new(&vote_accounts_map, epoch, len, repeat);
+        assert_eq!(leader_schedule.num_slots(), len);
         // Check that the same schedule is reproducibly generated
         assert_eq!(leader_schedule, leader_schedule2);
     }
@@ -162,17 +168,22 @@ mod tests {
     fn test_repeated_leader_schedule() {
         let num_keys = 10;
         let vote_accounts_map: HashMap<_, _> = (0..num_keys)
-            .map(|i| (solana_pubkey::new_rand(), (i, VoteAccount::new_random())))
+            .map(|i| {
+                (
+                    solana_pubkey::new_rand(),
+                    (i as u64, VoteAccount::new_random()),
+                )
+            })
             .collect();
 
         let epoch = rand::random::<Epoch>();
-        let repeat = 8;
-        let len = num_keys * repeat;
+        let repeat = NonZeroUsize::new(8).unwrap();
+        let len = num_keys * repeat.get();
         let leader_schedule = LeaderSchedule::new(&vote_accounts_map, epoch, len, repeat);
-        assert_eq!(leader_schedule.num_slots() as u64, len);
+        assert_eq!(leader_schedule.num_slots(), len);
         let mut leader_node = SlotLeader::default();
         for (i, node) in leader_schedule.get_slot_leaders().iter().enumerate() {
-            if i % repeat as usize == 0 {
+            if i % repeat.get() == 0 {
                 leader_node = *node;
             } else {
                 assert_eq!(leader_node, *node);
@@ -202,14 +213,24 @@ mod tests {
         let epoch = 0;
         let len = 8;
         // What the schedule looks like without any repeats
-        let leaders1 = LeaderSchedule::new(&vote_accounts_map, epoch, len, 1)
-            .get_slot_leaders()
-            .to_vec();
+        let leaders1 = LeaderSchedule::new(
+            &vote_accounts_map,
+            epoch,
+            len,
+            NonZeroUsize::new(1).unwrap(),
+        )
+        .get_slot_leaders()
+        .to_vec();
 
         // What the schedule looks like with repeats
-        let leaders2 = LeaderSchedule::new(&vote_accounts_map, epoch, len, 2)
-            .get_slot_leaders()
-            .to_vec();
+        let leaders2 = LeaderSchedule::new(
+            &vote_accounts_map,
+            epoch,
+            len,
+            NonZeroUsize::new(2).unwrap(),
+        )
+        .get_slot_leaders()
+        .to_vec();
         assert_eq!(leaders1.len(), leaders2.len());
 
         let leaders1_expected = vec![

--- a/runtime/src/leader_schedule_utils.rs
+++ b/runtime/src/leader_schedule_utils.rs
@@ -28,7 +28,10 @@ pub fn leader_schedule_from_vote_accounts(
     Some(LeaderSchedule::new(
         epoch_vote_accounts,
         epoch,
-        epoch_schedule.get_slots_in_epoch(epoch) as usize,
+        epoch_schedule
+            .get_slots_in_epoch(epoch)
+            .try_into()
+            .expect("number of slots in epoch must fit in usize"),
         NUM_CONSECUTIVE_LEADER_SLOTS,
     ))
 }

--- a/runtime/src/leader_schedule_utils.rs
+++ b/runtime/src/leader_schedule_utils.rs
@@ -1,8 +1,8 @@
 use {
     crate::bank::Bank,
-    solana_clock::{Epoch, NUM_CONSECUTIVE_LEADER_SLOTS, Slot},
+    solana_clock::{Epoch, Slot},
     solana_epoch_schedule::EpochSchedule,
-    solana_leader_schedule::LeaderSchedule,
+    solana_leader_schedule::{LeaderSchedule, NUM_CONSECUTIVE_LEADER_SLOTS},
     solana_pubkey::Pubkey,
     solana_vote::vote_account::VoteAccountsHashMap,
     std::collections::HashMap,
@@ -28,7 +28,7 @@ pub fn leader_schedule_from_vote_accounts(
     Some(LeaderSchedule::new(
         epoch_vote_accounts,
         epoch,
-        epoch_schedule.get_slots_in_epoch(epoch),
+        epoch_schedule.get_slots_in_epoch(epoch) as usize,
         NUM_CONSECUTIVE_LEADER_SLOTS,
     ))
 }
@@ -68,27 +68,29 @@ pub fn num_ticks_left_in_slot(bank: &Bank, tick_height: u64) -> u64 {
 }
 
 pub fn first_of_consecutive_leader_slots(slot: Slot) -> Slot {
-    (slot / NUM_CONSECUTIVE_LEADER_SLOTS) * NUM_CONSECUTIVE_LEADER_SLOTS
+    let num_consecutive_leader_slots = NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64;
+    (slot / num_consecutive_leader_slots) * num_consecutive_leader_slots
 }
 
 /// Returns the last slot in the leader window that contains `slot`
 #[inline]
 pub fn last_of_consecutive_leader_slots(slot: Slot) -> Slot {
-    first_of_consecutive_leader_slots(slot) + NUM_CONSECUTIVE_LEADER_SLOTS - 1
+    first_of_consecutive_leader_slots(slot) + NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64 - 1
 }
 
 /// Returns the index within the leader slot range that contains `slot`
 #[inline]
 pub fn leader_slot_index(slot: Slot) -> usize {
-    (slot % NUM_CONSECUTIVE_LEADER_SLOTS) as usize
+    slot as usize % NUM_CONSECUTIVE_LEADER_SLOTS
 }
 
 /// Returns the number of slots left after `slot` in the leader window
 /// that contains `slot`
 #[inline]
-pub fn remaining_slots_in_window(slot: Slot) -> u64 {
+pub fn remaining_slots_in_window(slot: Slot) -> usize {
     NUM_CONSECUTIVE_LEADER_SLOTS
-        .checked_sub(leader_slot_index(slot) as u64)
+        .get()
+        .checked_sub(leader_slot_index(slot))
         .unwrap()
 }
 
@@ -130,7 +132,7 @@ mod tests {
     fn test_leader_span_math() {
         // All of the test cases assume a 4 slot leader span and need to be
         // adjusted if it changes.
-        assert_eq!(NUM_CONSECUTIVE_LEADER_SLOTS, 4);
+        assert_eq!(NUM_CONSECUTIVE_LEADER_SLOTS.get(), 4);
 
         assert_eq!(first_of_consecutive_leader_slots(0), 0);
         assert_eq!(first_of_consecutive_leader_slots(1), 0);


### PR DESCRIPTION
#### Problem

Using `u64` as type for `len` and `repeat` is not correct.

#### Summary of Changes

Use `usize` for `len` and `NonZeroUsize` for `repeat`.