### PR TITLE
perf(deps): enable wincode for solana-nonce-account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8300,6 +8300,7 @@ dependencies = [
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "wincode",
 ]
 
 [[package]]
@@ -9132,6 +9133,7 @@ dependencies = [
  "solana-hash 4.2.0",
  "solana-pubkey 4.1.0",
  "solana-sha256-hasher",
+ "wincode",
 ]
 
 [[package]]
@@ -9144,6 +9146,7 @@ dependencies = [
  "solana-hash 4.2.0",
  "solana-nonce",
  "solana-sdk-ids",
+ "wincode",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -125,7 +125,6 @@ solana-metrics = { workspace = true }
 solana-native-token = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-nonce = { workspace = true }
-solana-nonce-account = { workspace = true }
 solana-packet = { workspace = true }
 solana-perf = { workspace = true }
 solana-poh = { workspace = true }
@@ -206,6 +205,7 @@ solana-cost-model = { path = "../cost-model", features = ["agave-unstable-api", 
 solana-keypair = { workspace = true }
 solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-poh = { path = "../poh", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
 solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api", "metrics"] }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6906,7 +6906,6 @@ dependencies = [
  "solana-native-token",
  "solana-net-utils",
  "solana-nonce",
- "solana-nonce-account",
  "solana-packet 4.1.0",
  "solana-perf",
  "solana-poh",
@@ -7221,6 +7220,7 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -7907,6 +7907,7 @@ dependencies = [
  "solana-hash 4.2.0",
  "solana-pubkey 4.1.0",
  "solana-sha256-hasher",
+ "wincode",
 ]
 
 [[package]]
@@ -7919,6 +7920,7 @@ dependencies = [
  "solana-hash 4.2.0",
  "solana-nonce",
  "solana-sdk-ids",
+ "wincode",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6554,7 +6554,6 @@ dependencies = [
  "solana-native-token",
  "solana-net-utils",
  "solana-nonce",
- "solana-nonce-account",
  "solana-packet 4.1.0",
  "solana-perf",
  "solana-poh",
@@ -6902,6 +6901,7 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -7475,6 +7475,7 @@ dependencies = [
  "solana-hash 4.2.0",
  "solana-pubkey 4.1.0",
  "solana-sha256-hasher",
+ "wincode",
 ]
 
 [[package]]
@@ -7487,6 +7488,7 @@ dependencies = [
  "solana-hash 4.2.0",
  "solana-nonce",
  "solana-sdk-ids",
+ "wincode",
 ]
 
 [[package]]

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -27,7 +27,7 @@ solana-bincode = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-instruction = { workspace = true }
 solana-nonce = { workspace = true, features = ["serde"] }
-solana-nonce-account = { workspace = true }
+solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-packet = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true, features = ["sha2"] }
@@ -42,7 +42,6 @@ assert_matches = { workspace = true }
 criterion = { workspace = true }
 solana-compute-budget = { path = "../../compute-budget", features = ["agave-unstable-api"] }
 solana-hash = { workspace = true }
-solana-nonce-account = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-rent = { workspace = true }
 solana-sha256-hasher = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -133,7 +133,7 @@ solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-native-token = { workspace = true }
 solana-nonce = { workspace = true }
-solana-nonce-account = { workspace = true }
+solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-packet = { workspace = true }
 solana-perf = { workspace = true }
 solana-poh-config = { workspace = true }

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -26,7 +26,7 @@ solana-keypair = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-net-utils = { workspace = true, optional = true }
-solana-nonce-account = { workspace = true }
+solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-pubkey = { workspace = true }
 solana-runtime = { workspace = true }
 solana-signature = { workspace = true }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -62,7 +62,7 @@ solana-loader-v4-interface = { workspace = true }
 solana-loader-v4-program = { workspace = true }
 solana-message = { workspace = true }
 solana-nonce = { workspace = true }
-solana-nonce-account = { workspace = true }
+solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-program-entrypoint = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-program-runtime = { workspace = true }


### PR DESCRIPTION
#### Problem
Verifying nonce account uses bincode to deserialize it. A wincode based deserialization to verify nonce was implemented in https://github.com/anza-xyz/solana-sdk/pull/553 gated with `wincode` feature on `solana-nonce-account` (enables transitive `wincode` feature on `nonce` and `fee-calculator` deps).

#### Summary of Changes
Enable `wincode` feature on `solana-nonce-account` in crates that use `verify_nonce_account`.
