### PR TITLE
program-runtime: couple environments with ProgramRuntimeEnvironments

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -14,6 +14,7 @@ use {
         execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
         loaded_programs::{
             ProgramCacheEntryType, ProgramCacheForTxBatch, ProgramRuntimeEnvironment,
+            ProgramRuntimeEnvironments,
         },
         stable_log,
         sysvar_cache::SysvarCache,
@@ -149,8 +150,7 @@ pub struct EnvironmentConfig<'a> {
     pub blockhash_lamports_per_signature: u64,
     epoch_stake_callback: &'a dyn InvokeContextCallback,
     feature_set: &'a SVMFeatureSet,
-    pub program_runtime_environment_for_execution: &'a ProgramRuntimeEnvironment,
-    pub program_runtime_environment_for_deployment: &'a ProgramRuntimeEnvironment,
+    program_runtime_environments: &'a ProgramRuntimeEnvironments,
     sysvar_cache: &'a SysvarCache,
 }
 impl<'a> EnvironmentConfig<'a> {
@@ -159,8 +159,7 @@ impl<'a> EnvironmentConfig<'a> {
         blockhash_lamports_per_signature: u64,
         epoch_stake_callback: &'a dyn InvokeContextCallback,
         feature_set: &'a SVMFeatureSet,
-        program_runtime_environment_for_execution: &'a ProgramRuntimeEnvironment,
-        program_runtime_environment_for_deployment: &'a ProgramRuntimeEnvironment,
+        program_runtime_environments: &'a ProgramRuntimeEnvironments,
         sysvar_cache: &'a SysvarCache,
     ) -> Self {
         Self {
@@ -168,8 +167,7 @@ impl<'a> EnvironmentConfig<'a> {
             blockhash_lamports_per_signature,
             epoch_stake_callback,
             feature_set,
-            program_runtime_environment_for_execution,
-            program_runtime_environment_for_deployment,
+            program_runtime_environments,
             sysvar_cache,
         }
     }
@@ -587,7 +585,8 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             Arc::clone(
                 &**self
                     .environment_config
-                    .program_runtime_environment_for_execution,
+                    .program_runtime_environments
+                    .get_env_for_execution(),
             ),
             SBPFVersion::V0,
             // Removes lifetime tracking
@@ -671,7 +670,8 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
 
     pub fn get_program_runtime_environment_for_deployment(&self) -> &ProgramRuntimeEnvironment {
         self.environment_config
-            .program_runtime_environment_for_deployment
+            .program_runtime_environments
+            .get_env_for_deployment()
     }
 
     pub fn is_deprecate_legacy_vote_ixs_active(&self) -> bool {
@@ -803,7 +803,7 @@ macro_rules! with_mock_invoke_context_with_feature_set {
                 __private::{Hash, ReadableAccount, Rent, TransactionContext},
                 execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
                 invoke_context::{EnvironmentConfig, InvokeContext},
-                loaded_programs::{ProgramCacheForTxBatch, get_mock_program_runtime_environment},
+                loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments},
                 sysvar_cache::SysvarCache,
             },
         };
@@ -829,14 +829,13 @@ macro_rules! with_mock_invoke_context_with_feature_set {
             compute_budget.max_instruction_trace_length,
             $top_level_instructions,
         );
-        let program_runtime_environment = get_mock_program_runtime_environment();
+        let program_runtime_environments = ProgramRuntimeEnvironments::mock();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockInvokeContextCallback {},
             $feature_set,
-            &program_runtime_environment,
-            &program_runtime_environment,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -58,6 +58,55 @@ impl ProgramRuntimeEnvironment {
         unsafe { std::mem::transmute(inner) }
     }
 }
+
+/// Paired execution and deployment environments.
+///
+/// Registered functions within each program runtime environment (syscalls)
+/// depend on per-epoch feature gate statuses. In most cases, the list of
+/// registered functions in the two environments will be the same. However,
+/// it's possible that the effective epoch of deployment could be in the
+/// *next epoch*.
+pub struct ProgramRuntimeEnvironments {
+    /// Environment compiled for the current epoch in which programs are
+    /// executing.
+    execution: ProgramRuntimeEnvironment,
+    /// Environment compiled for the epoch of the next slot at which a program
+    /// deployed in the current slot will execute.
+    deployment: ProgramRuntimeEnvironment,
+}
+
+impl ProgramRuntimeEnvironments {
+    /// Create a new ProgramRuntimeEnvironments from an `execution` and
+    /// `deployment` environment.
+    pub fn new(
+        execution: ProgramRuntimeEnvironment,
+        deployment: ProgramRuntimeEnvironment,
+    ) -> Self {
+        Self {
+            execution,
+            deployment,
+        }
+    }
+
+    /// Get the program runtime environment for execution.
+    pub fn get_env_for_execution(&self) -> &ProgramRuntimeEnvironment {
+        &self.execution
+    }
+
+    /// Get the program runtime environment for deployment.
+    pub fn get_env_for_deployment(&self) -> &ProgramRuntimeEnvironment {
+        &self.deployment
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn mock() -> Self {
+        Self {
+            execution: get_mock_program_runtime_environment(),
+            deployment: get_mock_program_runtime_environment(),
+        }
+    }
+}
+
 #[cfg(feature = "dev-context-only-utils")]
 pub fn get_mock_program_runtime_environment() -> ProgramRuntimeEnvironment {
     static MOCK_ENVIRONMENT: std::sync::OnceLock<ProgramRuntimeEnvironment> =

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -128,7 +128,9 @@ use {
     solana_precompile_error::PrecompileError,
     solana_program_runtime::{
         invoke_context::BuiltinFunctionRegisterer,
-        loaded_programs::{ProgramCacheEntry, ProgramRuntimeEnvironment},
+        loaded_programs::{
+            ProgramCacheEntry, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
+        },
     },
     solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_rent::Rent,
@@ -3604,13 +3606,13 @@ impl Bank {
             blockhash_lamports_per_signature,
             epoch_total_stake: self.get_current_epoch_total_stake(),
             feature_set: self.feature_set.runtime_features(),
-            program_runtime_environment_for_execution: self
-                .transaction_processor
-                .program_runtime_environment
-                .clone(),
-            program_runtime_environment_for_deployment: self
-                .transaction_processor
-                .program_runtime_environment_for_epoch(effective_epoch_of_deployments),
+            program_runtime_environments: ProgramRuntimeEnvironments::new(
+                self.transaction_processor
+                    .program_runtime_environment
+                    .clone(),
+                self.transaction_processor
+                    .program_runtime_environment_for_epoch(effective_epoch_of_deployments),
+            ),
             rent: self.rent_collector.rent.clone(),
         };
 

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -17,7 +17,10 @@ use {
     solana_program_runtime::{
         deploy::deploy_program,
         invoke_context::{EnvironmentConfig, InvokeContext},
-        loaded_programs::{LoadProgramMetrics, ProgramCacheForTxBatch, ProgramRuntimeEnvironment},
+        loaded_programs::{
+            LoadProgramMetrics, ProgramCacheForTxBatch, ProgramRuntimeEnvironment,
+            ProgramRuntimeEnvironments,
+        },
         sysvar_cache::SysvarCache,
     },
     solana_pubkey::Pubkey,
@@ -168,6 +171,10 @@ impl Bank {
             struct MockCallback {}
             impl InvokeContextCallback for MockCallback {}
             let feature_set = self.feature_set.runtime_features();
+            let program_runtime_environments = ProgramRuntimeEnvironments::new(
+                ProgramRuntimeEnvironment::clone(&program_runtime_environment),
+                ProgramRuntimeEnvironment::clone(&program_runtime_environment),
+            );
             let mut dummy_invoke_context = InvokeContext::new(
                 &mut dummy_transaction_context,
                 &mut program_cache_for_tx_batch,
@@ -176,8 +183,7 @@ impl Bank {
                     0,
                     &MockCallback {},
                     &feature_set,
-                    &program_runtime_environment,
-                    &program_runtime_environment,
+                    &program_runtime_environments,
                     &sysvar_cache,
                 ),
                 None,

--- a/svm-test-harness/instr/src/harness.rs
+++ b/svm-test-harness/instr/src/harness.rs
@@ -7,7 +7,9 @@ use {
     solana_instruction_error::InstructionError,
     solana_program_runtime::{
         invoke_context::{EnvironmentConfig, InvokeContext, mock_compile_message},
-        loaded_programs::ProgramCacheForTxBatch,
+        loaded_programs::{
+            ProgramCacheForTxBatch, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
+        },
         sysvar_cache::SysvarCache,
     },
     solana_pubkey::Pubkey,
@@ -89,6 +91,10 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
             .map(|x| (x.blockhash, x.fee_calculator.lamports_per_signature))
             .unwrap_or_default();
 
+        let program_runtime_environments = ProgramRuntimeEnvironments::new(
+            ProgramRuntimeEnvironment::clone(&program_runtime_environment),
+            program_runtime_environment,
+        );
         let mut invoke_context = InvokeContext::new(
             &mut transaction_context,
             program_cache,
@@ -97,8 +103,7 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
                 blockhash_lamports_per_signature,
                 callback,
                 &feature_set,
-                &program_runtime_environment,
-                &program_runtime_environment,
+                &program_runtime_environments,
                 sysvar_cache,
             ),
             Some(log_collector.clone()),

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -88,7 +88,7 @@ mod tests {
             execution_budget::{SVMTransactionExecutionBudget, SVMTransactionExecutionCost},
             invoke_context::EnvironmentConfig,
             loaded_programs::{
-                ProgramCacheEntry, ProgramCacheForTxBatch, get_mock_program_runtime_environment,
+                ProgramCacheEntry, ProgramCacheForTxBatch, ProgramRuntimeEnvironments,
             },
             sysvar_cache::SysvarCache,
         },
@@ -218,14 +218,13 @@ mod tests {
         ));
         let sysvar_cache = SysvarCache::default();
         let feature_set = SVMFeatureSet::all_enabled();
-        let program_runtime_environment = get_mock_program_runtime_environment();
+        let program_runtime_environments = ProgramRuntimeEnvironments::mock();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
-            &program_runtime_environment,
-            &program_runtime_environment,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -274,14 +273,13 @@ mod tests {
                 ),
             ]),
         ));
-        let program_runtime_environment = get_mock_program_runtime_environment();
+        let program_runtime_environments = ProgramRuntimeEnvironments::mock();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
-            &program_runtime_environment,
-            &program_runtime_environment,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut transaction_context =
@@ -322,14 +320,13 @@ mod tests {
                 ),
             ]),
         ));
-        let program_runtime_environment = get_mock_program_runtime_environment();
+        let program_runtime_environments = ProgramRuntimeEnvironments::mock();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
-            &program_runtime_environment,
-            &program_runtime_environment,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3, 1);
@@ -458,14 +455,13 @@ mod tests {
         ));
         let sysvar_cache = SysvarCache::default();
         let feature_set = SVMFeatureSet::all_enabled();
-        let program_runtime_environment = get_mock_program_runtime_environment();
+        let program_runtime_environments = ProgramRuntimeEnvironments::mock();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
-            &program_runtime_environment,
-            &program_runtime_environment,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(
@@ -499,14 +495,13 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
-        let program_runtime_environment = get_mock_program_runtime_environment();
+        let program_runtime_environments = ProgramRuntimeEnvironments::mock();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
-            &program_runtime_environment,
-            &program_runtime_environment,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut transaction_context =
@@ -539,14 +534,13 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0).unwrap()),
         ));
-        let program_runtime_environment = get_mock_program_runtime_environment();
+        let program_runtime_environments = ProgramRuntimeEnvironments::mock();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
-            &program_runtime_environment,
-            &program_runtime_environment,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut transaction_context = TransactionContext::new(accounts, Rent::default(), 1, 3, 1);
@@ -700,14 +694,13 @@ mod tests {
             }
         }
         let feature_set = SVMFeatureSet::all_enabled();
-        let program_runtime_environment = get_mock_program_runtime_environment();
+        let program_runtime_environments = ProgramRuntimeEnvironments::mock();
         let environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
-            &program_runtime_environment,
-            &program_runtime_environment,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         let mut invoke_context = InvokeContext::new(

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -40,6 +40,7 @@ use {
         loaded_programs::{
             EpochBoundaryPreparation, ForkGraph, ProgramCache, ProgramCacheEntry,
             ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
+            ProgramRuntimeEnvironments,
         },
         solana_sbpf::{program::BuiltinProgram, vm::Config as VmConfig},
         sysvar_cache::SysvarCache,
@@ -64,7 +65,6 @@ use {
 #[cfg(feature = "dev-context-only-utils")]
 use {
     qualifier_attr::{field_qualifiers, qualifiers},
-    solana_program_runtime::loaded_programs::get_mock_program_runtime_environment,
     std::sync::Weak,
 };
 
@@ -152,11 +152,8 @@ pub struct TransactionProcessingEnvironment {
     pub epoch_total_stake: u64,
     /// Runtime feature set to use for the transaction batch.
     pub feature_set: SVMFeatureSet,
-    /// The current ProgramRuntimeEnvironment derived from the SVMFeatureSet.
-    pub program_runtime_environment_for_execution: ProgramRuntimeEnvironment,
-    /// Depending on the next slot this is either the current or the upcoming
-    /// ProgramRuntimeEnvironment.
-    pub program_runtime_environment_for_deployment: ProgramRuntimeEnvironment,
+    /// Program runtime environments for execution and deployment.
+    pub program_runtime_environments: ProgramRuntimeEnvironments,
     /// Rent calculator to use for the transaction batch.
     pub rent: Rent,
 }
@@ -168,8 +165,7 @@ pub fn get_mock_transaction_processing_environment() -> TransactionProcessingEnv
         blockhash_lamports_per_signature: 0,
         epoch_total_stake: 0,
         feature_set: SVMFeatureSet::default(),
-        program_runtime_environment_for_execution: get_mock_program_runtime_environment(),
-        program_runtime_environment_for_deployment: get_mock_program_runtime_environment(),
+        program_runtime_environments: ProgramRuntimeEnvironments::mock(),
         rent: Rent::default(),
     }
 }
@@ -409,7 +405,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             self.replenish_program_cache(
                 &account_loader,
                 &builtins,
-                &environment.program_runtime_environment_for_execution,
+                environment
+                    .program_runtime_environments
+                    .get_env_for_execution(),
                 &mut program_cache_for_tx_batch,
                 &mut execute_timings,
                 config.check_program_deployment_slot,
@@ -499,7 +497,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         self.replenish_program_cache(
                             &account_loader,
                             &program_accounts_set,
-                            &environment.program_runtime_environment_for_execution,
+                            environment
+                                .program_runtime_environments
+                                .get_env_for_execution(),
                             &mut program_cache_for_tx_batch,
                             &mut execute_timings,
                             config.check_program_deployment_slot,
@@ -974,8 +974,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 environment.blockhash_lamports_per_signature,
                 callback,
                 &environment.feature_set,
-                &environment.program_runtime_environment_for_execution,
-                &environment.program_runtime_environment_for_deployment,
+                &environment.program_runtime_environments,
                 sysvar_cache,
             ),
             log_collector.clone(),

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -14,7 +14,9 @@ use {
     solana_instruction::{AccountMeta, Instruction},
     solana_program_runtime::{
         execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
-        loaded_programs::{ProgramCacheEntryType, ProgramCacheForTxBatch},
+        loaded_programs::{
+            ProgramCacheEntryType, ProgramCacheForTxBatch, ProgramRuntimeEnvironments,
+        },
     },
     solana_pubkey::Pubkey,
     solana_svm::{
@@ -264,9 +266,10 @@ fn svm_concurrent() {
                     &th_txs,
                     check_results,
                     &TransactionProcessingEnvironment {
-                        program_runtime_environment_for_execution: local_batch
-                            .program_runtime_environment
-                            .clone(),
+                        program_runtime_environments: ProgramRuntimeEnvironments::new(
+                            local_batch.program_runtime_environment.clone(),
+                            local_batch.program_runtime_environment.clone(),
+                        ),
                         ..get_mock_transaction_processing_environment()
                     },
                     &processing_config,

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -22,8 +22,11 @@ use {
     solana_native_token::LAMPORTS_PER_SOL,
     solana_nonce::{self as nonce, state::DurableNonce},
     solana_program_entrypoint::MAX_PERMITTED_DATA_INCREASE,
-    solana_program_runtime::execution_budget::{
-        MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES, SVMTransactionExecutionAndFeeBudgetLimits,
+    solana_program_runtime::{
+        execution_budget::{
+            MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES, SVMTransactionExecutionAndFeeBudgetLimits,
+        },
+        loaded_programs::ProgramRuntimeEnvironments,
     },
     solana_pubkey::Pubkey,
     solana_sdk_ids::{bpf_loader_upgradeable, compute_budget, native_loader},
@@ -163,10 +166,10 @@ impl SvmTestEnvironment<'_> {
             blockhash_lamports_per_signature: LAMPORTS_PER_SIGNATURE,
             epoch_total_stake: 0,
             feature_set: test_entry.feature_set,
-            program_runtime_environment_for_execution: batch_processor
-                .program_runtime_environment_for_epoch(EXECUTION_EPOCH),
-            program_runtime_environment_for_deployment: batch_processor
-                .program_runtime_environment_for_epoch(EXECUTION_EPOCH),
+            program_runtime_environments: ProgramRuntimeEnvironments::new(
+                batch_processor.program_runtime_environment_for_epoch(EXECUTION_EPOCH),
+                batch_processor.program_runtime_environment_for_epoch(EXECUTION_EPOCH),
+            ),
             rent: test_entry.rent.clone(),
         };
 

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -6014,14 +6014,13 @@ mod tests {
 
         with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
         let feature_set = SVMFeatureSet::default();
-        let program_runtime_environment = get_mock_program_runtime_environment();
+        let program_runtime_environments = ProgramRuntimeEnvironments::mock();
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
-            &program_runtime_environment,
-            &program_runtime_environment,
+            &program_runtime_environments,
             &sysvar_cache,
         );
         invoke_context.mock_set_remaining(compute_budget.compute_unit_limit);
@@ -6080,14 +6079,13 @@ mod tests {
 
         with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
         let feature_set = SVMFeatureSet::default();
-        let program_runtime_environment = get_mock_program_runtime_environment();
+        let program_runtime_environments = ProgramRuntimeEnvironments::mock();
         invoke_context.environment_config = EnvironmentConfig::new(
             Hash::default(),
             0,
             &MockCallback {},
             &feature_set,
-            &program_runtime_environment,
-            &program_runtime_environment,
+            &program_runtime_environments,
             &sysvar_cache,
         );
 


### PR DESCRIPTION
#### Problem
We plumb both the execution and deployment program runtime environments throughout the InvokeContext and the deployment pipeline. These could just use a struct instead to unify their transport.

#### Summary of Changes
Couple the environments together in a `ProgramRuntimeEnvironments` struct.
