### PR TITLE
Buffered io uring file writer

### DIFF
--- a/fs/src/buffered_writer.rs
+++ b/fs/src/buffered_writer.rs
@@ -1,24 +1,65 @@
 use {
     crate::FileSize,
-    std::{
-        fs,
-        io::{self, BufWriter},
-        path::Path,
-    },
+    std::{fs, io, path::Path},
 };
 
-/// Default buffer size for writing large files to disks. Since current implementation does not do
+/// Default buffer size for IO uring. This is a multiple of the default write size to allow
+/// multiple writes to be in flight at the same time.
+#[cfg(target_os = "linux")]
+const DEFAULT_IO_URING_BUFFER_SIZE: usize =
+    4 * crate::io_uring::file_creator::DEFAULT_WRITE_SIZE as usize;
+
+/// Default buffer size for writing large files to disks with `BufWriter`. Since `BufWriter` does not do
 /// background writing, this size is set above minimum reasonable SSD write sizes to also reduce
 /// number of syscalls.
-const DEFAULT_BUFFER_SIZE: usize = 2 * 1024 * 1024;
+#[cfg(not(target_os = "linux"))]
+const DEFAULT_BUF_WRITER_BUFFER_SIZE: usize = 2 * 1024 * 1024;
 
 /// Return a buffered writer for creating a new file at `path`
 ///
 /// The returned writer is using a buffer size tuned for writing large files to disks.
 pub fn large_file_buf_writer(path: impl AsRef<Path>) -> io::Result<impl io::Write> {
-    let file = fs::File::create(path)?;
+    #[cfg(target_os = "linux")]
+    {
+        assert!(agave_io_uring::io_uring_supported());
+        use {
+            crate::{
+                io_setup::IoSetupState,
+                io_uring::{
+                    file_creator::IoUringFileCreatorBuilder, file_writer::IoUringFileWriter,
+                },
+            },
+            std::sync::Arc,
+        };
 
-    Ok(BufWriter::with_capacity(DEFAULT_BUFFER_SIZE, file))
+        let io_setup = IoSetupState::default();
+        let file_creator = IoUringFileCreatorBuilder::new()
+            .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
+            .write_with_direct_io(io_setup.use_direct_io)
+            .build(DEFAULT_IO_URING_BUFFER_SIZE, |_| None)?;
+
+        IoUringFileWriter::new(
+            file_creator,
+            path.as_ref().to_path_buf(),
+            0o666,
+            Arc::new(fs::File::open(path.as_ref().parent().ok_or(
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "expected path to an output file that has a parent directory",
+                ),
+            )?)?),
+        )
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let file = fs::File::create(path)?;
+
+        Ok(io::BufWriter::with_capacity(
+            DEFAULT_BUF_WRITER_BUFFER_SIZE,
+            file,
+        ))
+    }
 }
 
 /// A writer that enforces a hard byte-count limit on the wrapped writer.

--- a/fs/src/io_uring/file_creator.rs
+++ b/fs/src/io_uring/file_creator.rs
@@ -36,7 +36,7 @@ pub const DEFAULT_WRITE_SIZE: IoSize = 512 * 1024;
 // O_DIRECT requires I/O length, offset, and buffer address to be aligned to the device's logical
 // block size: 512 bytes on most block devices, but 4096 on some NVMes. Use 4096 to avoid
 // per-device detection at runtime.
-const DIRECT_IO_WRITE_LEN_ALIGNMENT: IoSize = 4096;
+pub(super) const DIRECT_IO_WRITE_LEN_ALIGNMENT: IoSize = 4096;
 
 // Status flags (updatable on file-descriptor) used as default upon file creation.
 const DEFAULT_STATUS_FLAGS: libc::c_int = O_NOATIME;
@@ -241,7 +241,12 @@ impl IoUringFileCreator<'_> {
     /// Schedule opening file at `path` with `mode` permissions.
     ///
     /// Returns key that can be used for scheduling writes for it.
-    fn open(&mut self, path: PathBuf, mode: u32, dir_handle: Arc<File>) -> io::Result<usize> {
+    pub(super) fn open(
+        &mut self,
+        path: PathBuf,
+        mode: u32,
+        dir_handle: Arc<File>,
+    ) -> io::Result<usize> {
         let file = PendingFile::from_path(path);
         let path_cstring = Pin::new(file.path_cstring());
 
@@ -298,7 +303,7 @@ impl IoUringFileCreator<'_> {
     /// buffer size.
     ///
     /// Write operation can be immediately added to ring or put into file state for future execution.
-    fn schedule_write(
+    pub(super) fn schedule_write(
         &mut self,
         file_key: usize,
         file_offset: FileSize,
@@ -367,7 +372,7 @@ impl IoUringFileCreator<'_> {
         Ok(())
     }
 
-    fn wait_free_buf(&mut self) -> io::Result<IoBufferChunk> {
+    pub(super) fn wait_free_buf(&mut self) -> io::Result<IoBufferChunk> {
         loop {
             self.ring.process_completions()?;
             let state = self.ring.context_mut();

--- a/fs/src/io_uring/file_writer.rs
+++ b/fs/src/io_uring/file_writer.rs
@@ -48,7 +48,6 @@ impl<'a> IoUringFileWriter<'a> {
     /// Writes the current buffer and sets `self.current_buffer` to `None`
     fn write_current_buffer(&mut self, is_final_write: bool) -> Result<()> {
         debug_assert!(self.current_buffer.is_some());
-        debug_assert!(!self.finalized);
 
         if let Some(current_buffer) = self.current_buffer.take() {
             self.inner.schedule_write(

--- a/fs/src/io_uring/file_writer.rs
+++ b/fs/src/io_uring/file_writer.rs
@@ -24,7 +24,7 @@ pub struct IoUringFileWriter<'a> {
     current_buffer_offset: IoSize,
     file_offset: FileSize,
     file_key: usize,
-    flushed: bool,
+    finalized: bool,
 }
 
 impl<'a> IoUringFileWriter<'a> {
@@ -41,14 +41,14 @@ impl<'a> IoUringFileWriter<'a> {
             current_buffer_offset: 0,
             file_key,
             file_offset: 0,
-            flushed: false,
+            finalized: false,
         })
     }
 
     /// Writes the current buffer and sets `self.current_buffer` to `None`
     fn write_current_buffer(&mut self, is_final_write: bool) -> Result<()> {
         debug_assert!(self.current_buffer.is_some());
-        debug_assert!(!self.flushed);
+        debug_assert!(!self.finalized);
 
         if let Some(current_buffer) = self.current_buffer.take() {
             self.inner.schedule_write(
@@ -71,10 +71,10 @@ impl Write for IoUringFileWriter<'_> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         // @TODO -- once file creator supports multiple partial writes we
         // can support multiple flushes
-        if self.flushed {
+        if self.finalized {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
-                "file writer has already been flushed",
+                "file writer has already been finalized by flush",
             ));
         }
 
@@ -105,10 +105,10 @@ impl Write for IoUringFileWriter<'_> {
     fn flush(&mut self) -> Result<()> {
         // @TODO -- once file creator supports multiple partial writes we
         // can support multiple flushes
-        if self.flushed {
+        if self.finalized {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
-                "file writer has already been flushed",
+                "file writer has already been finalized by flush",
             ));
         }
 
@@ -121,7 +121,7 @@ impl Write for IoUringFileWriter<'_> {
         }
 
         // Flush the current buffer
-        self.flushed = true;
+        self.finalized = true;
         self.write_current_buffer(true)?;
 
         // Wait for all the fs ops to drain and then return
@@ -131,7 +131,7 @@ impl Write for IoUringFileWriter<'_> {
 
 impl Drop for IoUringFileWriter<'_> {
     fn drop(&mut self) {
-        if !self.flushed {
+        if !self.finalized {
             let flush_res = self.flush();
             debug_assert!(flush_res.is_ok());
         }

--- a/fs/src/io_uring/file_writer.rs
+++ b/fs/src/io_uring/file_writer.rs
@@ -1,0 +1,222 @@
+use {
+    crate::{
+        FileSize, IoSize,
+        file_io::FileCreator,
+        io_uring::{file_creator::IoUringFileCreator, memory::IoBufferChunk},
+    },
+    std::{
+        fs::File,
+        io::{self, Result, Write},
+        path::PathBuf,
+        sync::Arc,
+    },
+};
+
+pub struct IoUringFileWriter<'a> {
+    /// Write buffer, acquired on demand during writes.
+    /// `None` initially and after each full buffer is submitted to io_uring.
+    ///
+    /// # Safety
+    /// `IoBufferChunk` borrows memory owned by `inner`. This is safe because Rust drops
+    /// fields in declaration order, so `current_buffer` is always dropped before `inner`.
+    current_buffer: Option<IoBufferChunk>,
+    inner: IoUringFileCreator<'a>,
+    current_buffer_offset: IoSize,
+    file_offset: FileSize,
+    file_key: usize,
+    flushed: bool,
+}
+
+impl<'a> IoUringFileWriter<'a> {
+    pub fn new(
+        mut file_creator: IoUringFileCreator<'a>,
+        path: PathBuf,
+        mode: u32,
+        dir_handle: Arc<File>,
+    ) -> Result<Self> {
+        let file_key = file_creator.open(path, mode, dir_handle)?;
+        Ok(Self {
+            inner: file_creator,
+            current_buffer: None,
+            current_buffer_offset: 0,
+            file_key,
+            file_offset: 0,
+            flushed: false,
+        })
+    }
+
+    /// Writes the current buffer and sets `self.current_buffer` to `None`
+    fn write_current_buffer(&mut self, is_final_write: bool) -> Result<()> {
+        debug_assert!(self.current_buffer.is_some());
+        if let Some(current_buffer) = self.current_buffer.take() {
+            self.inner.schedule_write(
+                self.file_key,
+                self.file_offset,
+                is_final_write,
+                current_buffer,
+                self.current_buffer_offset,
+            )?;
+            self.file_offset = self
+                .file_offset
+                .strict_add(self.current_buffer_offset as FileSize);
+            self.current_buffer_offset = 0;
+        }
+        Ok(())
+    }
+}
+
+impl Write for IoUringFileWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        // Get a new buffer if we need to
+        let current_buffer = if let Some(buf) = self.current_buffer.as_mut() {
+            buf
+        } else {
+            self.current_buffer.insert(self.inner.wait_free_buf()?)
+        };
+
+        let remaining_buf_len =
+            current_buffer.len().strict_sub(self.current_buffer_offset) as usize;
+        if remaining_buf_len <= buf.len() {
+            // Copy as many bytes as we can into the buffer and then send it to the io uring
+            current_buffer.copy_from_slice(&buf[..remaining_buf_len], self.current_buffer_offset);
+            self.current_buffer_offset = current_buffer.len();
+            self.write_current_buffer(false)?;
+            Ok(remaining_buf_len)
+        } else {
+            current_buffer.copy_from_slice(buf, self.current_buffer_offset);
+            self.current_buffer_offset = self.current_buffer_offset.strict_add(buf.len() as IoSize);
+            Ok(buf.len())
+        }
+    }
+
+    /// Flush can only be called once.
+    /// Flush will close the underlying file.
+    fn flush(&mut self) -> Result<()> {
+        // @TODO -- once file creator supports multiple partial writes we
+        // can support multiple flushes
+        if self.flushed {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "file writer has already been flushed",
+            ));
+        }
+
+        // Handle the case where we are flushing after the buffer has already been dispatched during a write.
+        // This would mean that `self.current_buffer = None`, but we still need to fetch a new buffer
+        // just to do a zero byte write that will close the file.
+        if self.current_buffer.is_none() {
+            debug_assert_eq!(self.current_buffer_offset, 0);
+            self.current_buffer = Some(self.inner.wait_free_buf()?);
+        }
+
+        // Flush the current buffer
+        self.flushed = true;
+        self.write_current_buffer(true)?;
+
+        // Wait for all the fs ops to drain and then return
+        self.inner.drain()
+    }
+}
+
+impl Drop for IoUringFileWriter<'_> {
+    fn drop(&mut self) {
+        if !self.flushed {
+            debug_assert!(self.flush().is_ok());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        crate::{
+            FileSize, IoSize,
+            io_uring::{
+                file_creator::{DIRECT_IO_WRITE_LEN_ALIGNMENT, IoUringFileCreatorBuilder},
+                file_writer::IoUringFileWriter,
+            },
+        },
+        std::{
+            fs::File,
+            io::{Read, Write},
+            sync::{
+                Arc,
+                atomic::{AtomicBool, Ordering},
+            },
+        },
+        test_case::test_case,
+    };
+
+    // Check several edge cases:
+    // * creating empty file
+    // * file content is a multiple of write size
+    // * buffer holds single write size (1 internal buffer is used)
+    // * negations and combinations of above
+    #[test_case(0, 2u32.strict_mul(DIRECT_IO_WRITE_LEN_ALIGNMENT), DIRECT_IO_WRITE_LEN_ALIGNMENT)]
+    #[test_case(DIRECT_IO_WRITE_LEN_ALIGNMENT as u64, DIRECT_IO_WRITE_LEN_ALIGNMENT, DIRECT_IO_WRITE_LEN_ALIGNMENT)]
+    #[test_case(2u64.strict_mul(DIRECT_IO_WRITE_LEN_ALIGNMENT as u64), DIRECT_IO_WRITE_LEN_ALIGNMENT, DIRECT_IO_WRITE_LEN_ALIGNMENT)]
+    #[test_case(4u64.strict_mul(DIRECT_IO_WRITE_LEN_ALIGNMENT as u64), 2u32.strict_mul(DIRECT_IO_WRITE_LEN_ALIGNMENT), DIRECT_IO_WRITE_LEN_ALIGNMENT)]
+    #[test_case(9u64.strict_mul(DIRECT_IO_WRITE_LEN_ALIGNMENT as u64), DIRECT_IO_WRITE_LEN_ALIGNMENT, DIRECT_IO_WRITE_LEN_ALIGNMENT)]
+    #[test_case(9u64.strict_mul(DIRECT_IO_WRITE_LEN_ALIGNMENT as u64), 2u32.strict_mul(DIRECT_IO_WRITE_LEN_ALIGNMENT), DIRECT_IO_WRITE_LEN_ALIGNMENT)]
+    #[test_case(2u64.strict_mul(DIRECT_IO_WRITE_LEN_ALIGNMENT as u64).strict_add(1), 2u32.strict_mul(DIRECT_IO_WRITE_LEN_ALIGNMENT), DIRECT_IO_WRITE_LEN_ALIGNMENT)]
+    #[test_case((DIRECT_IO_WRITE_LEN_ALIGNMENT as u64).strict_sub(1), 2u32.strict_mul(DIRECT_IO_WRITE_LEN_ALIGNMENT), DIRECT_IO_WRITE_LEN_ALIGNMENT)]
+    fn test_write_chunked_content(file_size: FileSize, buf_size: IoSize, write_size: IoSize) {
+        // test with and without direct io
+        write_and_verify(file_size, buf_size, write_size, true);
+        write_and_verify(file_size, buf_size, write_size, false);
+    }
+
+    fn write_and_verify(
+        file_size: FileSize,
+        buf_size: IoSize,
+        write_size: IoSize,
+        use_direct_io: bool,
+    ) {
+        let original_contents = (0..file_size).map(|i| i as u8).collect::<Vec<_>>();
+        let (contents_a, contents_b) = original_contents.split_at(file_size as usize / 3);
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dir = Arc::new(File::open(temp_dir.path()).unwrap());
+        let file_path = temp_dir.path().join("test.txt");
+        let file_closed = Arc::new(AtomicBool::new(false));
+        let io_uring_file_creator = IoUringFileCreatorBuilder::new()
+            .write_with_direct_io(use_direct_io)
+            .write_capacity(write_size)
+            .build(buf_size as usize, |file_info| {
+                assert_eq!(file_info.size, original_contents.len() as FileSize);
+                file_closed.store(true, Ordering::Relaxed);
+                Some(file_info.file)
+            })
+            .unwrap();
+
+        let mut io_uring_file_writer =
+            IoUringFileWriter::new(io_uring_file_creator, file_path.clone(), 0o666, dir).unwrap();
+
+        io_uring_file_writer.write_all(contents_a).unwrap();
+        io_uring_file_writer.write_all(contents_b).unwrap();
+        io_uring_file_writer.flush().unwrap();
+        drop(io_uring_file_writer);
+        assert!(file_closed.load(Ordering::Relaxed));
+
+        let mut current_contents = Vec::new();
+        File::open(&file_path)
+            .unwrap()
+            .read_to_end(&mut current_contents)
+            .unwrap();
+        assert_eq!(current_contents, original_contents,);
+    }
+
+    #[test]
+    fn test_double_flush() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dir = Arc::new(File::open(temp_dir.path()).unwrap());
+        let file_path = temp_dir.path().join("test.txt");
+        let io_uring_file_creator = IoUringFileCreatorBuilder::new()
+            .build(4096, |_| None)
+            .unwrap();
+
+        let mut io_uring_file_writer =
+            IoUringFileWriter::new(io_uring_file_creator, file_path.clone(), 0o666, dir).unwrap();
+        io_uring_file_writer.flush().unwrap();
+        assert!(io_uring_file_writer.flush().is_err());
+    }
+}

--- a/fs/src/io_uring/file_writer.rs
+++ b/fs/src/io_uring/file_writer.rs
@@ -48,6 +48,8 @@ impl<'a> IoUringFileWriter<'a> {
     /// Writes the current buffer and sets `self.current_buffer` to `None`
     fn write_current_buffer(&mut self, is_final_write: bool) -> Result<()> {
         debug_assert!(self.current_buffer.is_some());
+        debug_assert!(!self.flushed);
+
         if let Some(current_buffer) = self.current_buffer.take() {
             self.inner.schedule_write(
                 self.file_key,
@@ -67,6 +69,15 @@ impl<'a> IoUringFileWriter<'a> {
 
 impl Write for IoUringFileWriter<'_> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        // @TODO -- once file creator supports multiple partial writes we
+        // can support multiple flushes
+        if self.flushed {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "file writer has already been flushed",
+            ));
+        }
+
         // Get a new buffer if we need to
         let current_buffer = if let Some(buf) = self.current_buffer.as_mut() {
             buf
@@ -121,7 +132,8 @@ impl Write for IoUringFileWriter<'_> {
 impl Drop for IoUringFileWriter<'_> {
     fn drop(&mut self) {
         if !self.flushed {
-            debug_assert!(self.flush().is_ok());
+            let flush_res = self.flush();
+            debug_assert!(flush_res.is_ok());
         }
     }
 }
@@ -206,7 +218,7 @@ mod tests {
     }
 
     #[test]
-    fn test_double_flush() {
+    fn test_allow_only_one_flush() {
         let temp_dir = tempfile::tempdir().unwrap();
         let dir = Arc::new(File::open(temp_dir.path()).unwrap());
         let file_path = temp_dir.path().join("test.txt");
@@ -217,6 +229,7 @@ mod tests {
         let mut io_uring_file_writer =
             IoUringFileWriter::new(io_uring_file_creator, file_path.clone(), 0o666, dir).unwrap();
         io_uring_file_writer.flush().unwrap();
+        assert!(io_uring_file_writer.write(&[0]).is_err());
         assert!(io_uring_file_writer.flush().is_err());
     }
 }

--- a/fs/src/io_uring/memory.rs
+++ b/fs/src/io_uring/memory.rs
@@ -256,6 +256,17 @@ impl IoBufferChunk {
         }
     }
 
+    /// Copy bytes from `buf` into the buffer at the provided offset.
+    pub fn copy_from_slice(&mut self, buf: &[u8], offset: IoSize) {
+        let offset = offset as usize;
+        let end = offset.strict_add(buf.len());
+        assert!(end <= self.len() as usize);
+        // Safety: caller owns the &mut buffer indicating that it is not used by io-uring op,
+        // `end` is checked above to ensure the buffer is large enough
+        let dst = unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), end) };
+        dst[offset..].copy_from_slice(buf);
+    }
+
     /// Register provided buffer as fixed buffer in `io_uring`.
     pub unsafe fn register<S, E: RingOp<S>>(
         buffer: &mut [u8],

--- a/fs/src/io_uring/mod.rs
+++ b/fs/src/io_uring/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod dir_remover;
 pub mod file_creator;
+pub mod file_writer;
 pub mod memory;
 pub mod sequential_file_reader;
 pub(crate) mod sqpoll;


### PR DESCRIPTION
#### Problem
Currently Agave uses `std::io::BufWriter` to write snapshots. This is slower than using an async io backend and also blocks us from enabling direct io.

#### Summary of Changes
Adds a buffered file writer built ontop of `IoUringFileCreator`.

Fixes #
