### PR TITLE
Remove the unused range argument in accounts index scan

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -33,7 +33,6 @@ use {
         collections::{HashSet, btree_map::BTreeMap},
         fmt::Debug,
         num::NonZeroUsize,
-        ops::{Bound, Range, RangeBounds},
         path::PathBuf,
         sync::{
             Arc, Mutex, RwLock,
@@ -224,8 +223,8 @@ pub enum ScanError {
     Aborted(String),
 }
 
-enum ScanTypes<R: RangeBounds<Pubkey>> {
-    Unindexed(Option<R>),
+enum ScanTypes {
+    Unindexed,
     Indexed(IndexKey),
 }
 
@@ -380,54 +379,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         }
     }
 
-    /// return the bin index for a given pubkey
-    fn bin_from_pubkey(&self, pubkey: &Pubkey) -> usize {
-        self.bin_calculator.bin_from_pubkey(pubkey)
-    }
-
-    /// returns the start bin and the end bin (inclusive) to scan.
-    ///
-    /// Note that start_bin maybe larger than highest bin index. Therefore, the
-    /// caller should not assume that start_bin is a valid bin index. So don't
-    /// index into `account_maps` with start_bin. Use `start_bin..=end_bin` to
-    /// iterate over the bins.
-    fn bin_start_end_inclusive<R>(&self, range: &R) -> (usize, usize)
-    where
-        R: RangeBounds<Pubkey>,
-    {
-        let start_bin = match range.start_bound() {
-            Bound::Included(start) => self.bin_from_pubkey(start),
-            Bound::Excluded(start) => {
-                // check if start == self.account_maps[start_bin].highest_pubkey(), then
-                // we should return start_bin + 1
-                let start_bin = self.bin_from_pubkey(start);
-                if start == &self.account_maps[start_bin].highest_pubkey {
-                    start_bin + 1
-                } else {
-                    start_bin
-                }
-            }
-            Bound::Unbounded => 0,
-        };
-
-        let end_bin_inclusive = match range.end_bound() {
-            Bound::Included(end) => self.bin_from_pubkey(end),
-            Bound::Excluded(end) => {
-                // check if end == self.account_maps[end_bin].lowest_pubkey(), then
-                // we should return end_bin - 1
-                let end_bin = self.bin_from_pubkey(end);
-                if end == &self.account_maps[end_bin].lowest_pubkey {
-                    end_bin.saturating_sub(1)
-                } else {
-                    end_bin
-                }
-            }
-            Bound::Unbounded => self.account_maps.len().saturating_sub(1),
-        };
-
-        (start_bin, end_bin_inclusive)
-    }
-
     #[allow(clippy::type_complexity)]
     fn allocate_accounts_index(
         config: &AccountsIndexConfig,
@@ -448,15 +399,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         (account_maps, bin_calculator, storage)
     }
 
-    fn iter<'a, R>(
+    fn iter<'a>(
         &'a self,
-        range: Option<&'a R>,
         iter_order: AccountsIndexPubkeyIterOrder,
-    ) -> AccountsIndexPubkeyIterator<'a, T, U>
-    where
-        R: RangeBounds<Pubkey>,
-    {
-        AccountsIndexPubkeyIterator::new(self, range, iter_order)
+    ) -> AccountsIndexPubkeyIterator<'a, T, U> {
+        AccountsIndexPubkeyIterator::new(self, iter_order)
     }
 
     /// is the accounts index using disk as a backing store
@@ -468,18 +415,17 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         ongoing_scan_roots.keys().next().cloned()
     }
 
-    fn do_checked_scan_accounts<F, R>(
+    fn do_checked_scan_accounts<F>(
         &self,
         metric_name: &'static str,
         ancestors: &Ancestors,
         scan_bank_id: BankId,
         func: F,
-        scan_type: ScanTypes<R>,
+        scan_type: ScanTypes,
         config: &ScanConfig,
     ) -> Result<(), ScanError>
     where
         F: FnMut(&Pubkey, (&T, Slot)),
-        R: RangeBounds<Pubkey> + std::fmt::Debug,
     {
         {
             let locked_removed_bank_ids = self.removed_bank_ids.lock().unwrap();
@@ -636,9 +582,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         assert!() justification in AccountsDb::retry_to_get_account_accessor)
         */
         match scan_type {
-            ScanTypes::Unindexed(range) => {
+            ScanTypes::Unindexed => {
                 // Pass "" not to log metrics, so RPC doesn't get spammy
-                self.do_scan_accounts(metric_name, ancestors, func, range, Some(max_root), config);
+                self.do_scan_accounts(metric_name, ancestors, func, Some(max_root), config);
             }
             ScanTypes::Indexed(IndexKey::ProgramId(program_id)) => {
                 self.do_scan_secondary_index(
@@ -703,17 +649,15 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     // Scan accounts and return latest version of each account that is either:
     // 1) rooted or
     // 2) present in ancestors
-    fn do_scan_accounts<F, R>(
+    fn do_scan_accounts<F>(
         &self,
         metric_name: &'static str,
         ancestors: &Ancestors,
         mut func: F,
-        range: Option<R>,
         max_root: Option<Slot>,
         config: &ScanConfig,
     ) where
         F: FnMut(&Pubkey, (&T, Slot)),
-        R: RangeBounds<Pubkey> + std::fmt::Debug,
     {
         let returns_items = match config.scan_order {
             ScanOrder::Unsorted => AccountsIndexPubkeyIterOrder::Unsorted,
@@ -730,7 +674,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         let mut iterator_elapsed = 0;
         let mut iterator_timer = Measure::start("iterator_elapsed");
 
-        for pubkeys in self.iter(range.as_ref(), returns_items) {
+        for pubkeys in self.iter(returns_items) {
             iterator_timer.stop();
             iterator_elapsed += iterator_timer.as_us();
             for pubkey in pubkeys {
@@ -913,7 +857,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             ancestors,
             scan_bank_id,
             func,
-            ScanTypes::Unindexed(None::<Range<Pubkey>>),
+            ScanTypes::Unindexed,
             config,
         )
     }
@@ -936,7 +880,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             ancestors,
             scan_bank_id,
             func,
-            ScanTypes::<Range<Pubkey>>::Indexed(index_key),
+            ScanTypes::Indexed(index_key),
             config,
         )
     }
@@ -1812,10 +1756,6 @@ mod tests {
         solana_account::AccountSharedData,
         solana_pubkey::PUBKEY_BYTES,
         spl_generic_token::{spl_token_ids, token::SPL_TOKEN_ACCOUNT_OWNER_OFFSET},
-        std::ops::{
-            Bound::{Excluded, Included, Unbounded},
-            RangeInclusive,
-        },
         test_case::test_matrix,
     };
 
@@ -4140,50 +4080,6 @@ mod tests {
             index.handle_dead_keys(&[key], &AccountSecondaryIndexes::default()),
             vec![key].into_iter().collect::<HashSet<_>>()
         );
-    }
-
-    #[test]
-    fn test_start_end_bin() {
-        let index = AccountsIndex::<bool, bool>::default_for_tests();
-        assert_eq!(index.bins(), BINS_FOR_TESTING);
-
-        let range = (Unbounded::<Pubkey>, Unbounded);
-        let (start, end) = index.bin_start_end_inclusive(&range);
-        assert_eq!(start, 0); // no range, so 0
-        assert_eq!(end, BINS_FOR_TESTING - 1); // no range, so last bin
-
-        let key = Pubkey::from([0; 32]);
-        let range = RangeInclusive::new(key, key);
-        let (start, end) = index.bin_start_end_inclusive(&range);
-        assert_eq!(start, 0); // start at pubkey 0, so 0
-        assert_eq!(end, 0); // end at pubkey 0, so 0
-
-        let range = (Included(key), Excluded(key));
-        let (start, end) = index.bin_start_end_inclusive(&range);
-        assert_eq!(start, 0); // start at pubkey 0, so 0
-        assert_eq!(end, 0); // end at pubkey 0, so 0
-
-        let range = (Excluded(key), Excluded(key));
-        let (start, end) = index.bin_start_end_inclusive(&range);
-        assert_eq!(start, 0); // start at pubkey 0, so 0
-        assert_eq!(end, 0); // end at pubkey 0, so 0
-
-        let key = Pubkey::from([0xff; 32]);
-        let range = RangeInclusive::new(key, key);
-        let (start, end) = index.bin_start_end_inclusive(&range);
-        let bins = index.bins();
-        assert_eq!(start, bins - 1); // start at highest possible pubkey, so bins - 1
-        assert_eq!(end, bins - 1);
-
-        let range = (Included(key), Excluded(key));
-        let (start, end) = index.bin_start_end_inclusive(&range);
-        assert_eq!(start, bins - 1); // start at highest possible pubkey, so bins - 1
-        assert_eq!(end, bins - 1);
-
-        let range = (Excluded(key), Excluded(key));
-        let (start, end) = index.bin_start_end_inclusive(&range);
-        assert_eq!(start, bins); // Exclude the highest possible pubkey, so start should be "bins"
-        assert_eq!(end, bins - 1); // End should be the last bin index
     }
 
     #[test]

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -8,7 +8,6 @@ use {
         bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
         stats::Stats,
     },
-    crate::pubkey_bins::PubkeyBinCalculator24,
     rand::{Rng, rng},
     solana_bucket_map::bucket_api::BucketApi,
     solana_clock::Slot,
@@ -40,8 +39,6 @@ pub struct InMemAccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<
     map_internal: RwLock<HashMap<Pubkey, Box<AccountMapEntry<T>>, ahash::RandomState>>,
     storage: Arc<BucketMapHolder<T, U>>,
     _bin: usize,
-    pub(crate) lowest_pubkey: Pubkey,
-    pub(crate) highest_pubkey: Pubkey,
 
     bucket: Option<Arc<BucketApi<(Slot, U)>>>,
 
@@ -116,9 +113,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         num_initial_accounts: Option<usize>,
     ) -> Self {
         let num_ages_to_distribute_flushes = Age::MAX - storage.ages_to_stay_in_cache;
-        let bin_calc = PubkeyBinCalculator24::new(storage.bins);
-        let lowest_pubkey = bin_calc.lowest_pubkey_from_bin(bin);
-        let highest_pubkey = bin_calc.highest_pubkey_from_bin(bin);
 
         let map_internal = if let Some(num_initial_accounts) = num_initial_accounts {
             let capacity_per_bin = num_initial_accounts / storage.bins;
@@ -134,8 +128,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             map_internal,
             storage: Arc::clone(storage),
             _bin: bin,
-            lowest_pubkey,
-            highest_pubkey,
             bucket: storage
                 .disk
                 .as_ref()

--- a/accounts-db/src/accounts_index/iter.rs
+++ b/accounts-db/src/accounts_index/iter.rs
@@ -1,20 +1,14 @@
 use {
     super::{AccountsIndex, DiskIndexValue, IndexValue, in_mem_accounts_index::InMemAccountsIndex},
     solana_pubkey::Pubkey,
-    std::{
-        ops::{Bound, RangeBounds},
-        sync::Arc,
-    },
+    std::sync::Arc,
 };
 
 pub const ITER_BATCH_SIZE: usize = 1000;
 
 pub struct AccountsIndexPubkeyIterator<'a, T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
     account_maps: &'a [Arc<InMemAccountsIndex<T, U>>],
-    start_bound: Bound<&'a Pubkey>,
-    end_bound: Bound<&'a Pubkey>,
-    start_bin: usize,
-    end_bin_inclusive: usize,
+    current_bin: usize,
     items: Vec<Pubkey>,
     iter_order: AccountsIndexPubkeyIterOrder,
 }
@@ -22,36 +16,12 @@ pub struct AccountsIndexPubkeyIterator<'a, T: IndexValue, U: DiskIndexValue + Fr
 impl<'a, T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     AccountsIndexPubkeyIterator<'a, T, U>
 {
-    pub fn new<R>(
-        index: &'a AccountsIndex<T, U>,
-        range: Option<&'a R>,
-        iter_order: AccountsIndexPubkeyIterOrder,
-    ) -> Self
-    where
-        R: RangeBounds<Pubkey>,
-    {
-        match range {
-            Some(range) => {
-                let (start_bin, end_bin_inclusive) = index.bin_start_end_inclusive(range);
-                Self {
-                    account_maps: &index.account_maps,
-                    start_bound: range.start_bound(),
-                    end_bound: range.end_bound(),
-                    start_bin,
-                    end_bin_inclusive,
-                    items: Vec::new(),
-                    iter_order,
-                }
-            }
-            None => Self {
-                account_maps: &index.account_maps,
-                start_bound: Bound::Unbounded,
-                end_bound: Bound::Unbounded,
-                start_bin: 0,
-                end_bin_inclusive: index.account_maps.len().saturating_sub(1),
-                items: Vec::new(),
-                iter_order,
-            },
+    pub fn new(index: &'a AccountsIndex<T, U>, iter_order: AccountsIndexPubkeyIterOrder) -> Self {
+        Self {
+            account_maps: &index.account_maps,
+            current_bin: 0,
+            items: Vec::new(),
+            iter_order,
         }
     }
 }
@@ -62,23 +32,18 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Iterator
 {
     type Item = Vec<Pubkey>;
     fn next(&mut self) -> Option<Self::Item> {
-        let range = (self.start_bound, self.end_bound);
         while self.items.len() < ITER_BATCH_SIZE {
-            if self.start_bin > self.end_bin_inclusive {
+            if self.current_bin >= self.account_maps.len() {
                 break;
             }
 
-            let bin = self.start_bin;
-            let map = &self.account_maps[bin];
+            let map = &self.account_maps[self.current_bin];
             let mut items = map.keys();
-            if !(self.start_bound == Bound::Unbounded && self.end_bound == Bound::Unbounded) {
-                items.retain(|k| range.contains(k));
-            }
             if self.iter_order == AccountsIndexPubkeyIterOrder::Sorted {
                 items.sort_unstable();
             }
             self.items.append(&mut items);
-            self.start_bin += 1;
+            self.current_bin += 1;
         }
 
         (!self.items.is_empty()).then(|| std::mem::take(&mut self.items))
@@ -106,7 +71,6 @@ mod tests {
         },
         crate::accounts_index::ReclaimsSlotList,
         solana_account::AccountSharedData,
-        std::ops::Range,
     };
 
     #[test]
@@ -140,7 +104,7 @@ mod tests {
             AccountsIndexPubkeyIterOrder::Unsorted,
         ] {
             // Create a sorted iterator for the whole pubkey range.
-            let mut iter = index.iter(None::<&Range<Pubkey>>, iter_order);
+            let mut iter = index.iter(iter_order);
             // First iter.next() should return the first batch of 2000 pubkeys in the first bin.
             let x = iter.next().unwrap();
             assert_eq!(x.len(), 2 * ITER_BATCH_SIZE);
@@ -159,7 +123,7 @@ mod tests {
     fn test_accounts_iter_finished() {
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         index.add_root(0);
-        let mut iter = index.iter(None::<&Range<Pubkey>>, AccountsIndexPubkeyIterOrder::Sorted);
+        let mut iter = index.iter(AccountsIndexPubkeyIterOrder::Sorted);
         assert!(iter.next().is_none());
         let mut gc = ReclaimsSlotList::new();
         index.upsert(

--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -44,89 +44,34 @@ impl PubkeyBinCalculator24 {
         (((as_ref[0] as usize) << 16) | ((as_ref[1] as usize) << 8) | (as_ref[2] as usize))
             >> self.shift_bits
     }
-
-    pub(crate) fn lowest_pubkey_from_bin(&self, mut bin: usize) -> Pubkey {
-        assert!(bin < self.bins());
-        bin <<= self.shift_bits;
-        let mut pubkey = Pubkey::from([0; 32]);
-        pubkey.as_mut()[0] = ((bin / 256 / 256) & 0xff) as u8;
-        pubkey.as_mut()[1] = ((bin / 256) & 0xff) as u8;
-        pubkey.as_mut()[2] = (bin & 0xff) as u8;
-        pubkey
-    }
-
-    pub(crate) fn highest_pubkey_from_bin(&self, mut bin: usize) -> Pubkey {
-        assert!(bin < self.bins());
-        let mask = (1 << self.shift_bits) - 1;
-        bin <<= self.shift_bits;
-        bin |= mask;
-        let mut pubkey = Pubkey::from([0xff; 32]);
-        pubkey.as_mut()[0] = ((bin / 256 / 256) & 0xff) as u8;
-        pubkey.as_mut()[1] = ((bin / 256) & 0xff) as u8;
-        pubkey.as_mut()[2] = (bin & 0xff) as u8;
-        pubkey
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_pubkey_lowest_highest_bin4() {
-        let calc = PubkeyBinCalculator24::new(4);
+    impl PubkeyBinCalculator24 {
+        fn lowest_pubkey_from_bin(&self, mut bin: usize) -> Pubkey {
+            assert!(bin < self.bins());
+            bin <<= self.shift_bits;
+            let mut pubkey = Pubkey::from([0; 32]);
+            pubkey.as_mut()[0] = ((bin / 256 / 256) & 0xff) as u8;
+            pubkey.as_mut()[1] = ((bin / 256) & 0xff) as u8;
+            pubkey.as_mut()[2] = (bin & 0xff) as u8;
+            pubkey
+        }
 
-        // bin 0
-        let expected_lowest = Pubkey::from([
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0,
-        ]);
-        let expected_highest = Pubkey::from([
-            0x3F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-            0xFF, 0xFF, 0xFF, 0xFF,
-        ]);
-        assert_eq!(calc.lowest_pubkey_from_bin(0), expected_lowest);
-        assert_eq!(calc.highest_pubkey_from_bin(0), expected_highest);
-
-        // bin 1
-        let expected_lowest = Pubkey::from([
-            0x40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0,
-        ]);
-        let expected_highest = Pubkey::from([
-            0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-            0xFF, 0xFF, 0xFF, 0xFF,
-        ]);
-        assert_eq!(calc.lowest_pubkey_from_bin(1), expected_lowest,);
-        assert_eq!(calc.highest_pubkey_from_bin(1), expected_highest);
-
-        // bin 2
-        let expected_lowest = Pubkey::from([
-            0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0,
-        ]);
-        let expected_highest = Pubkey::from([
-            0xBF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-            0xFF, 0xFF, 0xFF, 0xFF,
-        ]);
-        assert_eq!(calc.lowest_pubkey_from_bin(2), expected_lowest);
-        assert_eq!(calc.highest_pubkey_from_bin(2), expected_highest);
-
-        // bin 3
-        let expected_lowest = Pubkey::from([
-            0xC0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0,
-        ]);
-        let expected_highest = Pubkey::from([
-            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-            0xFF, 0xFF, 0xFF, 0xFF,
-        ]);
-        assert_eq!(calc.lowest_pubkey_from_bin(3), expected_lowest);
-        assert_eq!(calc.highest_pubkey_from_bin(3), expected_highest);
+        fn highest_pubkey_from_bin(&self, mut bin: usize) -> Pubkey {
+            assert!(bin < self.bins());
+            let mask = (1 << self.shift_bits) - 1;
+            bin <<= self.shift_bits;
+            bin |= mask;
+            let mut pubkey = Pubkey::from([0xff; 32]);
+            pubkey.as_mut()[0] = ((bin / 256 / 256) & 0xff) as u8;
+            pubkey.as_mut()[1] = ((bin / 256) & 0xff) as u8;
+            pubkey.as_mut()[2] = (bin & 0xff) as u8;
+            pubkey
+        }
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Range in Accounts scan is actually unused. I think it is left over from rent collection days. 

#### Summary of Changes
- Remove it and all the unused code that follows

Fixes #
