### PR TITLE
Fleshes out more of paying vote rewards for Alpenglow

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -43,7 +43,10 @@ use {
             },
         },
         bank_forks::BankForks,
-        block_component_processor::{BlockComponentProcessor, vote_reward::VoteRewardAccountState},
+        block_component_processor::{
+            BlockComponentProcessor,
+            vote_reward::epoch_inflation_account_state::EpochInflationAccountState,
+        },
         epoch_stakes::{
             BLSPubkeyToRankMap, DeserializableVersionedEpochStakes, NodeVoteAccounts,
             VersionedEpochStakes,
@@ -1764,7 +1767,7 @@ impl Bank {
         // the vote reward account state should be created at the epoch boundary in which we
         // activate alpenglow as it will need info from the previous epoch.
         if self.feature_set.snapshot().alpenglow {
-            VoteRewardAccountState::new_epoch_update_account(
+            EpochInflationAccountState::new_epoch_update_account(
                 self,
                 parent_epoch,
                 parent_capitalization,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5249,9 +5249,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "CJJZGTf9hSxCa54aw6koyLsixsVzN6vqQsRBDDmq2xPZ"
+                    "Gqd3QevNuGLvzL91YbUa86FCcPFCi3GsSDqrhbq2gjX7"
                 } else {
-                    "GAcpLy2beH4eyygZaprWWzn4geSCd3xvLvnn2tudvhy1"
+                    "HV9Wr7XVke8YYYxMnsQWYf8GnBC5PPKJyGX52raDvev8"
                 },
             );
         }
@@ -5260,9 +5260,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "D1fVqmYoLjX8YRDKdfxdyvjUGZJQuPkczgb45ska2MAQ"
+                    "Gdes9UEi7nxJyytpnAPM8wRMpZ39W8G3tqJSHUj49GQk"
                 } else {
-                    "EKG6nQZnUHiv56HpYfxGSkXpn2uo8ea9bJfR6uYvKBR1"
+                    "5Gp1HpKChMPo1t34WHCFM2mhWxy5s8QYFkf3FnxEAmku"
                 },
             );
             break;

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -1,7 +1,10 @@
 use {
     crate::{
         bank::Bank,
-        validated_block_finalization::ValidatedBlockFinalizationCert,
+        block_component_processor::vote_reward::calculate_and_pay_voting_reward_and_update_vote_state,
+        validated_block_finalization::{
+            BlockFinalizationCertError, ValidatedBlockFinalizationCert,
+        },
         validated_reward_certificate::{Error as ValidatedRewardCertError, ValidatedRewardCert},
     },
     agave_votor_messages::{
@@ -16,10 +19,10 @@ use {
         BlockFooterV1, BlockMarkerV1, GenesisCertificate, VersionedBlockFooter,
         VersionedBlockHeader, VersionedBlockMarker, VersionedUpdateParent,
     },
+    solana_hash::Hash,
     solana_pubkey::Pubkey,
     std::{num::NonZeroU64, sync::Arc},
     thiserror::Error,
-    vote_reward::calculate_and_pay_voting_reward,
 };
 
 pub(crate) mod vote_reward;
@@ -36,8 +39,8 @@ pub enum BlockComponentProcessorError {
     GenesisCertificateOnNonChild,
     #[error("GenesisCertificate was invalid and failed to verify")]
     GenesisCertificateFailedVerification,
-    #[error("FinalizationCertificate was invalid or failed to verify")]
-    InvalidFinalizationCertificate,
+    #[error("FinalizationCertificate was invalid or failed to verify {0}")]
+    InvalidFinalizationCertificate(#[from] BlockFinalizationCertError),
     #[error("Missing block footer")]
     MissingBlockFooter,
     #[error("Missing parent marker (neither a header nor an update parent was present)")]
@@ -248,25 +251,38 @@ impl BlockComponentProcessor {
 
         Self::enforce_nanosecond_clock_bounds(&bank, &parent_bank, &footer)?;
 
-        let reward_slot_and_validators = match ValidatedRewardCert::try_new(
+        let BlockFooterV1 {
+            bank_hash,
+            block_producer_time_nanos,
+            block_user_agent: _,
+            final_cert,
+            skip_reward_cert,
+            notar_reward_cert,
+        } = footer;
+
+        let reward_slot_and_validators =
+            match ValidatedRewardCert::try_new(&bank, &skip_reward_cert, &notar_reward_cert) {
+                Ok(c) => Some(c.into_parts()),
+                Err(ValidatedRewardCertError::Empty) => None,
+                Err(e) => return Err(e.into()),
+            };
+        let validated_final_cert = final_cert
+            .map(|final_cert| {
+                ValidatedBlockFinalizationCert::try_from_footer(final_cert, &bank)
+                    .map_err(BlockComponentProcessorError::InvalidFinalizationCertificate)
+            })
+            .transpose()?;
+
+        Self::update_bank_with_footer_fields(
             &bank,
-            &footer.skip_reward_cert,
-            &footer.notar_reward_cert,
-        ) {
-            Ok(c) => Some(c.into_parts()),
-            Err(ValidatedRewardCertError::Empty) => None,
-            Err(e) => return Err(e.into()),
-        };
-        Self::update_bank_with_footer(&bank, &footer, reward_slot_and_validators);
+            block_producer_time_nanos as i64,
+            bank_hash,
+            reward_slot_and_validators,
+            validated_final_cert.as_ref(),
+        );
 
-        // Verify finalization certificate and send to consensus pool
-        if let Some(final_cert) = footer.final_cert {
-            let validated = ValidatedBlockFinalizationCert::try_from_footer(final_cert, &bank)
-                .map_err(|e| {
-                    warn!("Failed to validate finalization certificate: {e}");
-                    BlockComponentProcessorError::InvalidFinalizationCertificate
-                })?;
-
+        // Send finalization cert(s) to consensus pool
+        if let Some(validated) = validated_final_cert {
             if let Some(sender) = finalization_cert_sender {
                 let (finalize_cert, notarize_cert) = validated.into_certificates();
                 if let Some(notarize_cert) = notarize_cert {
@@ -369,17 +385,24 @@ impl BlockComponentProcessor {
         (min_working_bank_time, max_working_bank_time)
     }
 
-    pub fn update_bank_with_footer(
+    pub fn update_bank_with_footer_fields(
         bank: &Bank,
-        footer: &BlockFooterV1,
+        block_producer_time_nanos: i64,
+        bank_hash: Hash,
         reward_slot_and_validators: Option<(Slot, Vec<Pubkey>)>,
+        final_cert: Option<&ValidatedBlockFinalizationCert>,
     ) {
         // Update clock sysvar
-        bank.update_clock_from_footer(footer.block_producer_time_nanos as i64);
+        bank.update_clock_from_footer(block_producer_time_nanos);
 
-        calculate_and_pay_voting_reward(bank, reward_slot_and_validators).unwrap();
+        calculate_and_pay_voting_reward_and_update_vote_state(
+            bank,
+            reward_slot_and_validators,
+            final_cert,
+        )
+        .unwrap();
         // Record expected bank hash from footer for later verification when the bank is frozen.
-        bank.set_expected_bank_hash(footer.bank_hash);
+        bank.set_expected_bank_hash(bank_hash);
     }
 }
 

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -1,158 +1,189 @@
 use {
-    crate::bank::Bank,
+    crate::{bank::Bank, validated_block_finalization::ValidatedBlockFinalizationCert},
+    epoch_inflation_account_state::{EpochInflationAccountState, EpochInflationState},
+    log::info,
     solana_account::{AccountSharedData, ReadableAccount},
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
-    solana_system_interface::program as system_program,
-    std::sync::LazyLock,
+    solana_vote::vote_account::VoteAccount,
+    solana_vote_interface::state::{
+        LandedVote, Lockout, MAX_EPOCH_CREDITS_HISTORY, VoteStateV4, VoteStateVersions,
+    },
+    std::collections::VecDeque,
     thiserror::Error,
-    wincode::{SchemaRead, SchemaWrite},
 };
 
-/// The account address for the off curve account used to store metadata for calculating and
-/// paying voting rewards.
-static VOTE_REWARD_ACCOUNT_ADDR: LazyLock<Pubkey> = LazyLock::new(|| {
-    let (pubkey, _) = Pubkey::find_program_address(
-        &[b"vote_reward_account"],
-        &agave_feature_set::alpenglow::id(),
-    );
-    pubkey
-});
-
-/// The state stored in the off curve account used to store metadata for calculating and paying
-/// voting rewards.
-#[derive(Debug, Default, PartialEq, Eq, SchemaWrite, SchemaRead)]
-pub(crate) struct VoteRewardAccountState {
-    /// The rewards (in lamports) that would be paid to a validator whose stake is equal to the
-    /// capitalization and it voted in every slot in the epoch.  This is also the epoch inflation.
-    epoch_validator_rewards_lamports: u64,
-}
-
-impl VoteRewardAccountState {
-    /// Returns the deserialized [`Self`] from the accounts in the [`Bank`].
-    ///
-    /// If the function determines that the account has not been legitimately created yet, it will
-    /// set a dummy `Self` in the bank and return the default state.  This state can be used for the
-    /// epoch in which Alpenglow is activated.
-    fn new_from_bank(bank: &Bank) -> Self {
-        bank.get_account(&VOTE_REWARD_ACCOUNT_ADDR)
-            .and_then(|a| wincode::deserialize::<Self>(a.data()).ok())
-            .unwrap_or_else(|| {
-                let state = Self::default();
-                state.set_state(bank);
-                state
-            })
-    }
-
-    /// Serializes and updates [`Self`] into the accounts in the [`Bank`].
-    fn set_state(&self, bank: &Bank) {
-        let data = wincode::serialize(&self).unwrap();
-        let lamports = bank.rent_collector().rent.minimum_balance(data.len());
-        let mut account = AccountSharedData::new(lamports, data.len(), &system_program::ID);
-        account.set_data_from_slice(&data);
-        bank.store_account_and_update_capitalization(&VOTE_REWARD_ACCOUNT_ADDR, &account);
-    }
-
-    /// Calculates and serializes a new version of [`Self`] into the accounts in the [`Bank`]
-    /// when  a new epoch starts.   At the start of a new epoch, over several slots we pay the
-    /// inflation rewards from the  previous epoch.  This is called Partitioned Epoch Rewards
-    /// (PER).  As such, the capitalization keeps increasing in the first slots of the epoch.
-    /// Vote rewards are calculated as a function of the capitalization and we do not want
-    /// voting in the initial slots  to earn less rewards than voting in the later rewards.  As
-    /// such this function is called with [`additional_validator_rewards`] which should be the
-    /// total rewards that will be paid by PER and we use the capitalization from the previous
-    /// epoch plus this value to compute the vote rewards.
-    pub(crate) fn new_epoch_update_account(
-        bank: &Bank,
-        prev_epoch: Epoch,
-        prev_epoch_capitalization: u64,
-        additional_validator_rewards: u64,
-    ) {
-        let epoch_validator_rewards_lamports = bank.calculate_epoch_inflation_rewards(
-            prev_epoch_capitalization + additional_validator_rewards,
-            prev_epoch,
-        );
-        let state = Self {
-            epoch_validator_rewards_lamports,
-        };
-        state.set_state(bank);
-    }
-
-    /// Returns the amount of lamports needed to store this account.
-    #[allow(dead_code)] // TODO(akhi): caller not yet upstreamed
-    #[cfg(test)]
-    pub(crate) fn rent_needed_for_account(bank: &Bank) -> u64 {
-        let state = Self {
-            epoch_validator_rewards_lamports: 0,
-        };
-        let account_size = wincode::serialized_size(&state).unwrap();
-        bank.rent_collector()
-            .rent
-            .minimum_balance(account_size as usize)
-    }
-}
+pub mod epoch_inflation_account_state;
 
 /// Different types of errors that can happen when calculating and paying voting reward.
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum PayVoteRewardError {
-    #[error("missing epoch stakes")]
-    MissingEpochStakes,
-    #[error("missing validator")]
-    MissingValidator,
+    #[error("missing EpochInflationAccountState for current slot {current_slot}")]
+    MissingEpochInflationAccountState { current_slot: Slot },
+    #[error("missing epoch stakes for reward_slot {reward_slot} in current_slot {current_slot}")]
+    MissingEpochStakes {
+        reward_slot: Slot,
+        current_slot: Slot,
+    },
+    #[error(
+        "validator {pubkey} missing in current slot {current_slot} for reward slot {reward_slot}"
+    )]
+    MissingRewardSlotValidator {
+        pubkey: Pubkey,
+        reward_slot: Slot,
+        current_slot: Slot,
+    },
+    #[error(
+        "missing validator stake info for reward epoch {reward_epoch} in current_slot \
+         {current_slot}"
+    )]
+    NoEpochValidatorStake {
+        reward_epoch: Epoch,
+        current_slot: Slot,
+    },
 }
 
-/// Calculates and pays voting reward.
+/// Calculates voting rewards and updates vote state fields for rewarded validators.
 ///
 /// This is a NOP if [`reward_slot_and_validators`] is [`None`].
 ///
-/// TODO: currently this function is just calculating rewards and not actually paying them.
-pub(super) fn calculate_and_pay_voting_reward(
+/// The reward slot is in the past relative to the current slot and hence might be in a different
+/// epoch than the current epoch and may have different validator sets and stakes, etc.
+/// This function must compute rewards using the stakes in the reward slot and pay them using the
+/// stakes in the current slot.
+///
+/// Additionally we also update vote-state `votes` and `root_slot` fields from the footer
+/// reward and finalization certificate
+pub(super) fn calculate_and_pay_voting_reward_and_update_vote_state(
     bank: &Bank,
     reward_slot_and_validators: Option<(Slot, Vec<Pubkey>)>,
+    final_cert: Option<&ValidatedBlockFinalizationCert>,
 ) -> Result<(), PayVoteRewardError> {
-    let Some((reward_slot, validators)) = reward_slot_and_validators else {
+    let Some((reward_slot, validators_to_reward)) = reward_slot_and_validators else {
         return Ok(());
     };
 
-    let (vote_accounts, total_stake_lamports) = {
-        let epoch_stakes = bank
-            .epoch_stakes_from_slot(reward_slot)
-            .ok_or(PayVoteRewardError::MissingEpochStakes)?;
+    let current_slot = bank.slot();
+    let (reward_slot_accounts, reward_slot_total_stake) = {
+        let epoch_stakes = bank.epoch_stakes_from_slot(reward_slot).ok_or(
+            PayVoteRewardError::MissingEpochStakes {
+                reward_slot,
+                current_slot,
+            },
+        )?;
         (
             epoch_stakes.stakes().vote_accounts().as_ref(),
             epoch_stakes.total_stake(),
         )
     };
-    let epoch_validator_rewards_lamports =
-        VoteRewardAccountState::new_from_bank(bank).epoch_validator_rewards_lamports;
 
-    let mut total_leader_reward_lamports = 0u64;
-    for validator in validators {
-        let (validator_stake_lamports, _) = vote_accounts
-            .get(&validator)
-            .ok_or(PayVoteRewardError::MissingValidator)?;
-        let reward_lamports = calculate_voting_reward(
-            bank.epoch_schedule().slots_per_epoch,
-            epoch_validator_rewards_lamports,
-            total_stake_lamports,
-            *validator_stake_lamports,
+    // This assumes that if the epoch_schedule ever changes, the new schedule will maintain correct
+    // info about older slots as well.
+    let reward_epoch = bank.epoch_schedule.get_epoch(reward_slot);
+    let epoch_state = {
+        let epoch_inflation_account_state = EpochInflationAccountState::new_from_bank(bank);
+        // This function should only be called after alpenglow is active and the slot in the the epoch
+        // that activated Alpenglow should have created the account.
+        debug_assert!(epoch_inflation_account_state.is_some());
+        epoch_inflation_account_state
+            .ok_or(PayVoteRewardError::MissingEpochInflationAccountState { current_slot })?
+            .get_epoch_state(reward_epoch)
+            .ok_or(PayVoteRewardError::NoEpochValidatorStake {
+                reward_epoch,
+                current_slot,
+            })?
+    };
+
+    let current_vote_accounts = bank.vote_accounts();
+    let current_slot_leader_vote_pubkey = bank.leader().vote_address;
+    // Adding 1 to capacity in case the current leader was not in the aggregate and paying it
+    // triggers a reallocation.
+    let mut paid_vote_accounts = Vec::with_capacity(validators_to_reward.len().saturating_add(1));
+    let mut total_leader_reward = 0u64;
+    let current_epoch = bank.epoch();
+    for validator_to_reward in validators_to_reward {
+        let (reward_slot_validator_stake, _) = reward_slot_accounts
+            .get(&validator_to_reward)
+            .ok_or(PayVoteRewardError::MissingRewardSlotValidator {
+                pubkey: validator_to_reward,
+                reward_slot,
+                current_slot,
+            })?;
+        let (validator_reward, add_leader_reward) = calculate_reward(
+            &epoch_state,
+            reward_slot_total_stake,
+            *reward_slot_validator_stake,
         );
-        // As per the Alpenglow SIMD, the rewards are split equally between the validators and the leader.
-        let validator_reward_lamports = reward_lamports / 2;
-        let leader_reward_lamports = reward_lamports - validator_reward_lamports;
-        total_leader_reward_lamports =
-            total_leader_reward_lamports.saturating_add(leader_reward_lamports);
+        total_leader_reward = total_leader_reward.saturating_add(add_leader_reward);
+
+        if current_slot_leader_vote_pubkey == validator_to_reward {
+            // Current slot's leader's node pubkey is associated with exactly one vote
+            // pubkey and this reward is for this vote pubkey.  The reward will be paid.
+            // However, we haven't finished calculating the total rewards for the leader yet.
+            // `total_leader_reward` be paid at the end of the function.
+            total_leader_reward = total_leader_reward.saturating_add(validator_reward);
+            continue;
+        }
+
+        // The reward was not for a vote pubkey associated with the current slot's leader's node pubkey.
+        // We can pay it into the vote account immediately.
+        let Some((_, current_slot_account)) = current_vote_accounts.get(&validator_to_reward)
+        else {
+            info!(
+                "validator {validator_to_reward} was present for reward_slot {reward_slot} but is \
+                 absent for current_slot {current_slot}"
+            );
+            continue;
+        };
+        if let Some(account_data) = pay_reward_update_vote_state(
+            current_epoch,
+            reward_slot,
+            current_slot_account,
+            validator_to_reward,
+            validator_reward,
+            final_cert,
+        ) {
+            paid_vote_accounts.push((validator_to_reward, account_data));
+        }
     }
+
+    // We have computed the final `total_leader_rewards` now.  We can pay it into the leader's
+    // vote account.
+    if total_leader_reward != 0 {
+        match current_vote_accounts.get(&current_slot_leader_vote_pubkey) {
+            Some((_, leader_account)) => {
+                if let Some(account_data) = pay_reward_update_vote_state(
+                    current_epoch,
+                    reward_slot,
+                    leader_account,
+                    current_slot_leader_vote_pubkey,
+                    total_leader_reward,
+                    final_cert,
+                ) {
+                    paid_vote_accounts.push((current_slot_leader_vote_pubkey, account_data));
+                }
+            }
+            None => {
+                info!(
+                    "Current slot {current_slot}'s leader's account \
+                     {current_slot_leader_vote_pubkey} not found.  It will not be paid."
+                )
+            }
+        }
+    }
+
+    bank.store_accounts((current_slot, paid_vote_accounts.as_slice()));
     Ok(())
 }
 
 /// Computes the voting reward in Lamports.
-fn calculate_voting_reward(
-    slots_per_epoch: u64,
-    epoch_validator_rewards_lamports: u64,
+///
+/// Returns `(validator rewards, leader rewards)`.
+fn calculate_reward(
+    epoch_state: &EpochInflationState,
     total_stake_lamports: u64,
     validator_stake_lamports: u64,
-) -> u64 {
+) -> (u64, u64) {
     // Rewards are computed as following:
     // per_slot_inflation = epoch_validator_rewards_lamports / slots_per_epoch
     // fractional_stake = validator_stake / total_stake_lamports
@@ -160,12 +191,123 @@ fn calculate_voting_reward(
     //
     // The code below is equivalent but changes the order of operations to maintain precision
 
-    let numerator = epoch_validator_rewards_lamports as u128 * validator_stake_lamports as u128;
-    let denominator = slots_per_epoch as u128 * total_stake_lamports as u128;
+    let numerator =
+        epoch_state.max_possible_validator_reward as u128 * validator_stake_lamports as u128;
+    let denominator = epoch_state.slots_per_epoch as u128 * total_stake_lamports as u128;
 
     // SAFETY: the result should fit in u64 because we do not expect the inflation in a single
     // epoch to exceed u64::MAX.
-    (numerator / denominator).try_into().unwrap()
+    let reward_lamports: u64 = (numerator / denominator).try_into().unwrap();
+    // As per the Alpenglow SIMD, the rewards are split equally between the validators and the leader.
+    let validator_reward_lamports = reward_lamports / 2;
+    let leader_reward_lamports = reward_lamports - validator_reward_lamports;
+    (validator_reward_lamports, leader_reward_lamports)
+}
+
+/// Deserializes `VoteState` from `account`; pays `reward` in `current_epoch` to the `epoch_credits` field;
+/// and updates the `votes` and `root_slot` fields in the vote state deserialized from the `account`.
+///
+/// TODO: this is using VoteStateV4 explicitly.  When we upstream, we will use VoteStateHandle API.
+fn pay_reward_update_vote_state(
+    current_epoch: Epoch,
+    reward_slot: Slot,
+    account: &VoteAccount,
+    validator_vote_pubkey: Pubkey,
+    reward: u64,
+    final_cert: Option<&ValidatedBlockFinalizationCert>,
+) -> Option<AccountSharedData> {
+    let data = account.account().data();
+    let Ok(vote_state_versions) = bincode::deserialize(data) else {
+        return None;
+    };
+    match vote_state_versions {
+        VoteStateVersions::V4(mut vote_state) => {
+            increment_credits(&mut vote_state, current_epoch, reward);
+            update_vote_state(
+                &mut vote_state,
+                reward_slot,
+                validator_vote_pubkey,
+                final_cert,
+            );
+            let mut paid_account = AccountSharedData::new(
+                account.lamports(),
+                account.account().data().len(),
+                account.owner(),
+            );
+            paid_account
+                .serialize_data(&VoteStateVersions::V4(vote_state))
+                .ok()?;
+            Some(paid_account)
+        }
+        _ => None,
+    }
+}
+
+/// Stores rewards as credits in the current vote state.
+///
+/// TODO: this is using VoteStateV4 explicitly.  When we upstream, we will use VoteStateHandle API.
+fn increment_credits(vote_state: &mut VoteStateV4, epoch: Epoch, credits: u64) {
+    // never seen a credit
+    if vote_state.epoch_credits.is_empty() {
+        vote_state.epoch_credits.push((epoch, 0, 0));
+    } else if epoch != vote_state.epoch_credits.last().unwrap().0 {
+        let (_, credits, prev_credits) = *vote_state.epoch_credits.last().unwrap();
+
+        if credits != prev_credits {
+            // if credits were earned previous epoch
+            // append entry at end of list for the new epoch
+            vote_state.epoch_credits.push((epoch, credits, credits));
+        } else {
+            // else just move the current epoch
+            vote_state.epoch_credits.last_mut().unwrap().0 = epoch;
+        }
+
+        // Remove too old epoch_credits
+        if vote_state.epoch_credits.len() > MAX_EPOCH_CREDITS_HISTORY {
+            vote_state.epoch_credits.remove(0);
+        }
+    }
+
+    vote_state.epoch_credits.last_mut().unwrap().1 = vote_state
+        .epoch_credits
+        .last()
+        .unwrap()
+        .1
+        .saturating_add(credits);
+}
+
+/// Updates `root_slot` and `votes` in vote state using the rewards and finalization certificates from the footer
+///
+/// Downstream tooling expects these fields to be be set:
+/// - `root_slot`, a validator's latest finalized & replayed slot
+/// - `votes`, a validator's latest vote
+///
+/// `votes` is consumed for health monitoring, we require it to be within `DELINQUENT_VALIDATOR_SLOT_DISTANCE`
+/// of the tip of the chain to be considered healthy.
+///
+/// `root_slot` is similarly used by various tooling (e.g. stake delegation) to determine whether the validator
+/// is healthy to interact with  and also is required to be within `DELINQUENT_VALIDATOR_SLOT_DISTANCE` of the tip.
+///
+/// Until we overhaul vote state we continue populating these two fields similar to TowerBFT:
+/// - `root_slot` is populated from the footer finalization certificate
+/// - `votes` is populated from the footer rewards aggregate
+fn update_vote_state(
+    vote_state: &mut VoteStateV4,
+    reward_slot: Slot,
+    validator_vote_pubkey: Pubkey,
+    final_cert: Option<&ValidatedBlockFinalizationCert>,
+) {
+    if let Some(final_cert) = final_cert {
+        if final_cert.was_signed_by(&validator_vote_pubkey) {
+            vote_state.root_slot = Some(final_cert.slot());
+        }
+    }
+
+    let latest_root_or_reward = vote_state.root_slot.unwrap_or(reward_slot).max(reward_slot);
+    vote_state.votes = VecDeque::from([LandedVote {
+        lockout: Lockout::new(latest_root_or_reward),
+        latency: 0,
+    }]);
 }
 
 #[cfg(test)]
@@ -174,11 +316,63 @@ mod tests {
         super::*,
         crate::{
             bank_forks::BankForks,
-            genesis_utils::{GenesisConfigInfo, create_genesis_config},
+            genesis_utils::{
+                ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
+            },
+            test_utils::new_rand_vote_account,
+            validated_block_finalization::ValidatedBlockFinalizationCert,
         },
+        agave_votor_messages::{
+            consensus_message::{Certificate, CertificateType},
+            reward_certificate::NUM_SLOTS_FOR_REWARD,
+        },
+        bitvec::prelude::*,
+        rand::seq::IndexedRandom,
+        solana_account::ReadableAccount,
+        solana_bls_signatures::Signature as BLSSignature,
+        solana_epoch_schedule::EpochSchedule,
         solana_genesis_config::GenesisConfig,
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_leader_schedule::SlotLeader,
         solana_native_token::LAMPORTS_PER_SOL,
+        solana_rent::Rent,
+        solana_signer::Signer,
+        solana_signer_store::encode_base2,
     };
+
+    fn get_vote_state_v4(bank: &Bank, vote_pubkey: &Pubkey) -> VoteStateV4 {
+        let vote_accounts = bank.vote_accounts();
+        let (_, vote_account) = vote_accounts.get(vote_pubkey).unwrap();
+        let vote_state_versions: VoteStateVersions =
+            bincode::deserialize(vote_account.account().data()).unwrap();
+        let VoteStateVersions::V4(vote_state) = vote_state_versions else {
+            panic!("unexpected vote state version");
+        };
+        *vote_state
+    }
+
+    fn build_fast_finalization_cert(
+        bank: &Bank,
+        signing_ranks: &[usize],
+    ) -> ValidatedBlockFinalizationCert {
+        let slot = bank.slot();
+        let block_id = Hash::new_unique();
+        let cert_type = CertificateType::FinalizeFast(slot, block_id);
+        let max_rank = signing_ranks.iter().copied().max().unwrap_or(0);
+        let mut bitvec = BitVec::<u8, Lsb0>::repeat(false, max_rank.saturating_add(1));
+        for &rank in signing_ranks {
+            bitvec.set(rank, true);
+        }
+        let bitmap = encode_base2(&bitvec).unwrap();
+
+        let cert = Certificate {
+            cert_type,
+            signature: BLSSignature::default(),
+            bitmap,
+        };
+        ValidatedBlockFinalizationCert::from_validated_fast(cert, bank)
+    }
 
     #[test]
     fn calculate_voting_reward_does_not_panic() {
@@ -186,72 +380,323 @@ mod tests {
         // it is staked by a single validator.
         let circulating_supply = 566_000_000 * LAMPORTS_PER_SOL;
 
-        let bank = Bank::new_for_tests(&GenesisConfig::default());
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&GenesisConfig::default()));
+        let bank = bank_forks.read().unwrap().root_bank();
         let validator_rewards_lamports =
             bank.calculate_epoch_inflation_rewards(circulating_supply, 1);
 
-        calculate_voting_reward(
-            bank.epoch_schedule().slots_per_epoch,
-            validator_rewards_lamports,
-            circulating_supply,
-            circulating_supply,
-        );
-    }
-
-    #[test]
-    fn serialization_works() {
-        let bank = Bank::new_for_tests(&GenesisConfig::default());
-        let state = VoteRewardAccountState {
-            epoch_validator_rewards_lamports: 1234,
+        let epoch_state = EpochInflationState {
+            slots_per_epoch: bank.epoch_schedule.slots_per_epoch,
+            max_possible_validator_reward: validator_rewards_lamports,
+            epoch: 1234,
         };
-        state.set_state(&bank);
-        let deserialized = VoteRewardAccountState::new_from_bank(&bank);
-        assert_eq!(state, deserialized);
+
+        calculate_reward(&epoch_state, circulating_supply, circulating_supply);
     }
 
     #[test]
-    fn epoch_update_works() {
-        let bank = Bank::new_for_tests(&GenesisConfig::default());
-        let prev_epoch = 1;
-        let prev_epoch_capitalization = 12345;
-        let additional_validator_rewards = 6789;
-        VoteRewardAccountState::new_epoch_update_account(
-            &bank,
-            prev_epoch,
-            prev_epoch_capitalization,
-            additional_validator_rewards,
-        );
-        let VoteRewardAccountState {
-            epoch_validator_rewards_lamports,
-        } = VoteRewardAccountState::new_from_bank(&bank);
-        let validator_rewards_lamports = bank.calculate_epoch_inflation_rewards(
-            prev_epoch_capitalization + additional_validator_rewards,
-            prev_epoch,
-        );
-        assert_eq!(epoch_validator_rewards_lamports, validator_rewards_lamports);
+    fn increment_credits_works() {
+        let mut vote_state = VoteStateV4::default();
+        let epoch = 1234;
+        let credits = 543432;
+        increment_credits(&mut vote_state, epoch, credits);
+        assert_eq!(credits, vote_state.epoch_credits.last().unwrap().1);
     }
 
     #[test]
-    fn handles_prefunded_account() {
-        let GenesisConfigInfo {
-            genesis_config,
-            mint_keypair,
-            ..
-        } = create_genesis_config(10_000);
+    fn pay_reward_works() {
+        let account =
+            VoteAccount::try_from(new_rand_vote_account(&mut rand::rng(), None, true)).unwrap();
+        let epoch = 1234;
+        let reward = 3453423;
+        let account_shared_data =
+            pay_reward_update_vote_state(epoch, 0, &account, Pubkey::default(), reward, None)
+                .unwrap();
+        let vote_state_versions: VoteStateVersions =
+            bincode::deserialize(&account_shared_data.data_clone()).unwrap();
+        let VoteStateVersions::V4(vote_state) = vote_state_versions else {
+            panic!("unexpected state version: {vote_state_versions:?}");
+        };
+        assert_eq!(reward, vote_state.epoch_credits.last().unwrap().1);
+    }
+
+    fn calc_reward_for_test(
+        prev_bank: &Bank,
+        bank: &Bank,
+        total_stake: u64,
+        stake_voted: u64,
+    ) -> u64 {
+        let epoch_inflation =
+            bank.calculate_epoch_inflation_rewards(prev_bank.capitalization(), prev_bank.epoch());
+        let numerator = epoch_inflation as u128 * stake_voted as u128;
+        let denominator = bank.epoch_schedule.slots_per_epoch as u128 * total_stake as u128;
+        let reward: u64 = (numerator / denominator).try_into().unwrap();
+        reward / 2
+    }
+
+    #[test]
+    fn calculate_and_pay_works() {
+        let num_validators = 100;
+        let per_validator_stake = LAMPORTS_PER_SOL * 100;
+        let num_validators_to_reward = 10;
+
+        let validator_keypairs = (0..num_validators)
+            .map(|_| ValidatorVoteKeypairs::new_rand())
+            .collect::<Vec<_>>();
+        let mut genesis_config = create_genesis_config_with_alpenglow_vote_accounts(
+            1_000_000_000,
+            &validator_keypairs,
+            vec![per_validator_stake; validator_keypairs.len()],
+        )
+        .genesis_config;
+        genesis_config.epoch_schedule = EpochSchedule::without_warmup();
+        genesis_config.rent = Rent::default();
+
+        let validator_keypairs_to_reward = validator_keypairs
+            .choose_multiple(&mut rand::rng(), num_validators_to_reward as usize)
+            .collect::<Vec<_>>();
+
+        let validator_pubkeys_to_reward = validator_keypairs_to_reward
+            .iter()
+            .map(|v| v.vote_keypair.pubkey())
+            .collect::<Vec<_>>();
+        let leader_vote_pubkey = validator_keypairs_to_reward[0].vote_keypair.pubkey();
+        let leader_node_pubkey = validator_keypairs_to_reward[0].node_keypair.pubkey();
+        let slot_leader = SlotLeader {
+            id: leader_node_pubkey,
+            vote_address: leader_vote_pubkey,
+        };
+
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
-        let root_bank = bank_forks.read().unwrap().root_bank();
+        let prev_bank = bank_forks.read().unwrap().root_bank();
+        let current_slot = prev_bank
+            .epoch_schedule
+            .get_first_slot_in_epoch(prev_bank.epoch() + 1)
+            + NUM_SLOTS_FOR_REWARD;
+        let bank = Bank::new_from_parent(prev_bank.clone(), slot_leader, current_slot);
+        let reward_slot = current_slot - NUM_SLOTS_FOR_REWARD;
 
-        let prefund_lamports = 100;
-        root_bank
-            .transfer(prefund_lamports, &mint_keypair, &VOTE_REWARD_ACCOUNT_ADDR)
-            .unwrap();
+        calculate_and_pay_voting_reward_and_update_vote_state(
+            &bank,
+            Some((reward_slot, validator_pubkeys_to_reward.clone())),
+            None,
+        )
+        .unwrap();
 
-        assert!(root_bank.get_account(&VOTE_REWARD_ACCOUNT_ADDR).is_some());
+        let vote_accounts = bank.vote_accounts();
+        let rewards = validator_pubkeys_to_reward
+            .iter()
+            .map(|validator| {
+                let (_, vote_account) = vote_accounts.get(validator).unwrap();
+                let data = vote_account.account().data();
+                let vote_state_versions = bincode::deserialize(data).unwrap();
+                let VoteStateVersions::V4(vote_state) = vote_state_versions else {
+                    panic!();
+                };
+                assert_eq!(vote_state.epoch_credits.len(), 1);
+                let got_reward = vote_state.epoch_credits[0].1;
+                let total_stake = bank
+                    .epoch_stakes_from_slot(reward_slot)
+                    .unwrap()
+                    .total_stake();
+                let expected_validator_reward =
+                    calc_reward_for_test(&prev_bank, &bank, total_stake, per_validator_stake);
+                if *validator != leader_vote_pubkey {
+                    assert_eq!(got_reward, expected_validator_reward);
+                }
+                got_reward
+            })
+            .collect::<Vec<_>>();
+        let expected_leader_reward = rewards.last().unwrap()
+            * validator_pubkeys_to_reward.len() as u64
+            + rewards.last().unwrap();
+        assert_eq!(expected_leader_reward, rewards[0]);
+    }
+
+    #[test]
+    fn calculate_and_pay_sets_root_slot_for_signer_in_final_cert() {
+        let validator_keypairs = (0..4)
+            .map(|_| ValidatorVoteKeypairs::new_rand())
+            .collect::<Vec<_>>();
+        let per_validator_stake = LAMPORTS_PER_SOL * 100;
+        let mut genesis_config = create_genesis_config_with_alpenglow_vote_accounts(
+            1_000_000_000,
+            &validator_keypairs,
+            vec![per_validator_stake; validator_keypairs.len()],
+        )
+        .genesis_config;
+        genesis_config.epoch_schedule = EpochSchedule::without_warmup();
+        genesis_config.rent = Rent::default();
+
+        let leader_vote_pubkey = validator_keypairs[0].vote_keypair.pubkey();
+        let leader_node_pubkey = validator_keypairs[0].node_keypair.pubkey();
+        let slot_leader = SlotLeader {
+            id: leader_node_pubkey,
+            vote_address: leader_vote_pubkey,
+        };
+        let target_vote_pubkey = validator_keypairs[1].vote_keypair.pubkey();
+
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let prev_bank = bank_forks.read().unwrap().root_bank();
+        let current_slot = prev_bank
+            .epoch_schedule
+            .get_first_slot_in_epoch(prev_bank.epoch() + 1)
+            + NUM_SLOTS_FOR_REWARD;
+        let bank = Bank::new_from_parent(prev_bank.clone(), slot_leader, current_slot);
+        let reward_slot = current_slot - NUM_SLOTS_FOR_REWARD;
+
+        let cert_rank = {
+            let rank_map = bank
+                .epoch_stakes_from_slot(bank.slot())
+                .unwrap()
+                .bls_pubkey_to_rank_map();
+            (0..rank_map.len())
+                .find_map(|rank| {
+                    rank_map
+                        .get_pubkey_stake_entry(rank)
+                        .and_then(|entry| (entry.pubkey == target_vote_pubkey).then_some(rank))
+                })
+                .unwrap()
+        };
+        let final_cert = build_fast_finalization_cert(&bank, &[cert_rank]);
+
+        calculate_and_pay_voting_reward_and_update_vote_state(
+            &bank,
+            Some((reward_slot, vec![target_vote_pubkey])),
+            Some(&final_cert),
+        )
+        .unwrap();
+
+        let vote_state = get_vote_state_v4(&bank, &target_vote_pubkey);
+        assert_eq!(vote_state.root_slot, Some(final_cert.slot()));
+        assert_eq!(vote_state.votes.len(), 1);
         assert_eq!(
-            root_bank.get_balance(&VOTE_REWARD_ACCOUNT_ADDR),
-            prefund_lamports,
+            vote_state.votes.front().unwrap().lockout.slot(),
+            final_cert.slot().max(reward_slot)
         );
-        let state = VoteRewardAccountState::new_from_bank(&root_bank);
-        assert_eq!(state, VoteRewardAccountState::default());
+    }
+
+    #[test]
+    fn calculate_and_pay_uses_reward_slot_vote_when_signer_absent_from_final_cert() {
+        let validator_keypairs = (0..4)
+            .map(|_| ValidatorVoteKeypairs::new_rand())
+            .collect::<Vec<_>>();
+        let per_validator_stake = LAMPORTS_PER_SOL * 100;
+        let mut genesis_config = create_genesis_config_with_alpenglow_vote_accounts(
+            1_000_000_000,
+            &validator_keypairs,
+            vec![per_validator_stake; validator_keypairs.len()],
+        )
+        .genesis_config;
+        genesis_config.epoch_schedule = EpochSchedule::without_warmup();
+        genesis_config.rent = Rent::default();
+
+        let leader_node_pubkey = validator_keypairs[0].node_keypair.pubkey();
+        let leader_vote_pubkey = validator_keypairs[0].vote_keypair.pubkey();
+        let target_vote_pubkey = validator_keypairs[1].vote_keypair.pubkey();
+        let slot_leader = SlotLeader {
+            id: leader_node_pubkey,
+            vote_address: leader_vote_pubkey,
+        };
+        let non_target_vote_pubkey = validator_keypairs[2].vote_keypair.pubkey();
+
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let prev_bank = bank_forks.read().unwrap().root_bank();
+        let current_slot = prev_bank
+            .epoch_schedule
+            .get_first_slot_in_epoch(prev_bank.epoch() + 1)
+            + NUM_SLOTS_FOR_REWARD;
+        let bank = Bank::new_from_parent(prev_bank.clone(), slot_leader, current_slot);
+        let reward_slot = current_slot - NUM_SLOTS_FOR_REWARD;
+
+        let cert_rank = {
+            let rank_map = bank
+                .epoch_stakes_from_slot(bank.slot())
+                .unwrap()
+                .bls_pubkey_to_rank_map();
+            (0..rank_map.len())
+                .find_map(|rank| {
+                    rank_map
+                        .get_pubkey_stake_entry(rank)
+                        .and_then(|entry| (entry.pubkey == non_target_vote_pubkey).then_some(rank))
+                })
+                .unwrap()
+        };
+        let final_cert = build_fast_finalization_cert(&bank, &[cert_rank]);
+
+        calculate_and_pay_voting_reward_and_update_vote_state(
+            &bank,
+            Some((reward_slot, vec![target_vote_pubkey])),
+            Some(&final_cert),
+        )
+        .unwrap();
+
+        let vote_state = get_vote_state_v4(&bank, &target_vote_pubkey);
+        assert_eq!(vote_state.root_slot, None);
+        assert_eq!(vote_state.votes.len(), 1);
+        assert_eq!(
+            vote_state.votes.front().unwrap().lockout.slot(),
+            reward_slot
+        );
+    }
+
+    #[test]
+    fn leader_with_multiple_vote_accounts_not_paid() {
+        let num_validators = 5;
+        let per_validator_stake = LAMPORTS_PER_SOL * 100;
+        let node_keypair = Keypair::new();
+
+        let validator_keypairs = (0..num_validators)
+            .map(|_| {
+                ValidatorVoteKeypairs::new(
+                    node_keypair.insecure_clone(),
+                    Keypair::new(),
+                    Keypair::new(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut genesis_config = create_genesis_config_with_alpenglow_vote_accounts(
+            1_000_000_000,
+            &validator_keypairs,
+            vec![per_validator_stake; validator_keypairs.len()],
+        )
+        .genesis_config;
+        genesis_config.epoch_schedule = EpochSchedule::without_warmup();
+        genesis_config.rent = Rent::default();
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let prev_bank = bank_forks.read().unwrap().root_bank();
+        let current_slot = prev_bank
+            .epoch_schedule
+            .get_first_slot_in_epoch(prev_bank.epoch() + 1)
+            + NUM_SLOTS_FOR_REWARD;
+
+        let node_pubkey = node_keypair.pubkey();
+        let vote_pubkey = validator_keypairs[0].vote_keypair.pubkey();
+        let slot_leader = SlotLeader {
+            id: node_pubkey,
+            vote_address: vote_pubkey,
+        };
+        let bank = Bank::new_from_parent(prev_bank.clone(), slot_leader, current_slot);
+        let reward_slot = current_slot - NUM_SLOTS_FOR_REWARD;
+
+        calculate_and_pay_voting_reward_and_update_vote_state(
+            &bank,
+            Some((reward_slot, vec![vote_pubkey])),
+            None,
+        )
+        .unwrap();
+        let vote_accounts = bank.vote_accounts();
+        for (add, (_, vote_account)) in vote_accounts.iter() {
+            let data = vote_account.account().data();
+            let vote_state_versions = bincode::deserialize(data).unwrap();
+            let VoteStateVersions::V4(vote_state) = vote_state_versions else {
+                panic!();
+            };
+            if add == &vote_pubkey {
+                assert!(!vote_state.epoch_credits.is_empty());
+            } else {
+                assert!(vote_state.epoch_credits.is_empty());
+            }
+        }
     }
 }

--- a/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
+++ b/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
@@ -1,0 +1,264 @@
+use {
+    crate::bank::Bank,
+    serde::{Deserialize, Serialize},
+    solana_account::{Account, AccountSharedData, ReadableAccount},
+    solana_clock::Epoch,
+    solana_genesis_config::GenesisConfig,
+    solana_pubkey::Pubkey,
+    solana_rent::Rent,
+    solana_system_interface::program as system_program,
+    std::sync::LazyLock,
+    wincode::{SchemaRead, SchemaWrite},
+};
+
+/// The account address for the off curve account used to store metadata for calculating and
+/// paying voting rewards.
+static VOTE_REWARD_ACCOUNT_ADDR: LazyLock<Pubkey> = LazyLock::new(|| {
+    let (pubkey, _) = Pubkey::find_program_address(
+        &[b"vote_reward_account"],
+        &agave_feature_set::alpenglow::id(),
+    );
+    pubkey
+});
+
+/// The per epoch info stored in the off curve account.
+#[derive(Debug, Clone, PartialEq, Eq, SchemaRead, SchemaWrite, Deserialize, Serialize)]
+pub(super) struct EpochInflationState {
+    /// The rewards (in lamports) that would be paid to a validator whose stake is equal to the
+    /// capitalization and it voted in every slot in the epoch.  This is also the
+    /// epoch inflation.
+    pub(super) max_possible_validator_reward: u64,
+    /// Number of slots in the epoch.
+    pub(super) slots_per_epoch: u64,
+    /// The epoch number for this state.
+    pub(super) epoch: Epoch,
+}
+
+impl EpochInflationState {
+    fn new_from_bank(
+        bank: &Bank,
+        prev_epoch: Epoch,
+        prev_epoch_capitalization: u64,
+        additional_validator_rewards: u64,
+    ) -> Self {
+        let max_possible_validator_reward = bank.calculate_epoch_inflation_rewards(
+            prev_epoch_capitalization + additional_validator_rewards,
+            prev_epoch,
+        );
+        EpochInflationState {
+            max_possible_validator_reward,
+            slots_per_epoch: bank.epoch_schedule.slots_per_epoch,
+            epoch: bank.epoch(),
+        }
+    }
+}
+
+/// The state stored in the off curve account used to store metadata for calculating and paying
+/// voting rewards.
+///
+/// Info for the previous and the current epoch is stored.
+#[derive(Debug, PartialEq, Eq, SchemaWrite, SchemaRead, Serialize, Deserialize)]
+pub struct EpochInflationAccountState {
+    /// [`EpochInflationState`] for the current epoch.
+    pub(super) current: EpochInflationState,
+    /// [`EpochInflationState`] for the previous epoch.  This is needed for scenarios when the
+    /// reward slot is in a previous epoch relative to the current slot.
+    ///
+    /// Stored in an `Option` because in the first epoch when Alpenglow is enabled, we will not
+    /// have any state for the previous epoch.
+    pub(super) prev: Option<EpochInflationState>,
+}
+
+impl EpochInflationAccountState {
+    /// Returns the deserialized [`Self`] from the accounts in the [`Bank`].
+    ///
+    /// Returns `None` if the `bank` does not contain the account or the account state is not of
+    /// the expected size.
+    pub(crate) fn new_from_bank(bank: &Bank) -> Option<Self> {
+        bank.get_account(&VOTE_REWARD_ACCOUNT_ADDR)
+            .and_then(|acct| wincode::deserialize(acct.data()).ok())
+    }
+
+    /// Serializes and updates [`Self`] into the accounts in the [`Bank`].
+    pub(super) fn set_state(&self, bank: &Bank) {
+        let data = wincode::serialize(&self).unwrap();
+        let lamports = bank.get_minimum_balance_for_rent_exemption(data.len());
+        let mut account = AccountSharedData::new(lamports, data.len(), &system_program::ID);
+        account.set_data_from_slice(&data);
+        bank.store_account_and_update_capitalization(&VOTE_REWARD_ACCOUNT_ADDR, &account);
+    }
+
+    /// Inserts a dummy account for [`Self`] into the `genesis_config` to aid local cluster testing.
+    pub(crate) fn insert_into_genesis_config(genesis_config: &mut GenesisConfig) {
+        let current = EpochInflationState {
+            max_possible_validator_reward: 0,
+            slots_per_epoch: genesis_config.epoch_schedule.slots_per_epoch,
+            epoch: 0,
+        };
+        let account = Self {
+            current,
+            prev: None,
+        };
+        let account_size = wincode::serialized_size(&account).unwrap();
+        let lamports = Rent::default()
+            .minimum_balance(account_size.try_into().unwrap())
+            .max(1);
+        let account = Account::new_data(lamports, &account, &system_program::ID).unwrap();
+        genesis_config
+            .accounts
+            .insert(*VOTE_REWARD_ACCOUNT_ADDR, account);
+    }
+
+    /// Computes a new version of `Self` for `bank.epoch` and serializes it into accounts in the `bank`.
+    ///
+    /// At the start of a new epoch, over several slots we pay the inflation rewards from the
+    /// previous epoch.  This is called Partitioned Epoch Rewards (PER).  As such, the
+    /// capitalization keeps increasing in the first slots of the epoch.  Vote rewards are
+    /// calculated as a function of the capitalization and we do not want voting in the initial
+    /// slots to earn less rewards than voting in the later rewards.  As such this function is
+    /// called with [`additional_validator_rewards`] which should be the total rewards that will
+    /// be paid by PER and we use the capitalization from the previous epoch plus this value to
+    /// compute the vote rewards.
+    pub(crate) fn new_epoch_update_account(
+        bank: &Bank,
+        prev_epoch: Epoch,
+        prev_epoch_capitalization: u64,
+        additional_validator_rewards: u64,
+    ) {
+        let prev = Self::new_from_bank(bank).map(|s| s.current);
+        let current = EpochInflationState::new_from_bank(
+            bank,
+            prev_epoch,
+            prev_epoch_capitalization,
+            additional_validator_rewards,
+        );
+        let state = Self { prev, current };
+        state.set_state(bank);
+    }
+
+    /// Returns the [`EpochState`] corresponding to the given `epoch`.
+    pub(super) fn get_epoch_state(self, epoch: Epoch) -> Option<EpochInflationState> {
+        if self.current.epoch == epoch {
+            return Some(self.current);
+        }
+        if let Some(prev) = self.prev {
+            if prev.epoch == epoch {
+                return Some(prev);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            bank_forks::BankForks,
+            genesis_utils::{
+                GenesisConfigInfo, ValidatorVoteKeypairs, create_genesis_config,
+                create_genesis_config_with_alpenglow_vote_accounts,
+            },
+        },
+        rand::Rng,
+        solana_genesis_config::GenesisConfig,
+        solana_leader_schedule::SlotLeader,
+        std::sync::Arc,
+    };
+
+    fn get_rand_state() -> EpochInflationAccountState {
+        let mut rng = rand::rng();
+        EpochInflationAccountState {
+            prev: None,
+            current: EpochInflationState {
+                max_possible_validator_reward: rng.random(),
+                slots_per_epoch: rng.random(),
+                epoch: rng.random(),
+            },
+        }
+    }
+
+    #[test]
+    fn set_state_works() {
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&GenesisConfig::default()));
+        let bank = bank_forks.read().unwrap().root_bank();
+        let state = get_rand_state();
+        state.set_state(&bank);
+        let deserialized = EpochInflationAccountState::new_from_bank(&bank).unwrap();
+        assert_eq!(state, deserialized);
+    }
+
+    #[test]
+    fn new_epoch_update_account_works() {
+        let (bank_epoch_0, bank_epoch_1, bank_epoch_2) = {
+            let validator_keypairs = (0..10)
+                .map(|_| ValidatorVoteKeypairs::new_rand())
+                .collect::<Vec<_>>();
+            let genesis = create_genesis_config_with_alpenglow_vote_accounts(
+                1_000_000_000,
+                &validator_keypairs,
+                vec![100; validator_keypairs.len()],
+            );
+            let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis.genesis_config));
+            let bank_epoch_0 = bank_forks.read().unwrap().root_bank();
+            let first_slot_in_epoch_1 = bank_epoch_0.epoch_schedule().get_first_slot_in_epoch(1);
+            let bank_epoch_1 = Arc::new(Bank::new_from_parent(
+                bank_epoch_0.clone(),
+                SlotLeader::new_unique(),
+                first_slot_in_epoch_1,
+            ));
+            assert_eq!(bank_epoch_1.epoch(), 1);
+            let first_slot_in_epoch_2 = bank_epoch_1.epoch_schedule().get_first_slot_in_epoch(2);
+            let bank_epoch_2 = Arc::new(Bank::new_from_parent(
+                bank_epoch_1.clone(),
+                SlotLeader::new_unique(),
+                first_slot_in_epoch_2,
+            ));
+            (bank_epoch_0, bank_epoch_1, bank_epoch_2)
+        };
+        assert_eq!(bank_epoch_0.epoch(), 0);
+        assert_eq!(bank_epoch_1.epoch(), 1);
+        assert_eq!(bank_epoch_2.epoch(), 2);
+
+        let expected_prev = EpochInflationState::new_from_bank(
+            &bank_epoch_1,
+            bank_epoch_0.epoch(),
+            bank_epoch_0.capitalization(),
+            0,
+        );
+        let expected_current = EpochInflationState::new_from_bank(
+            &bank_epoch_2,
+            bank_epoch_1.epoch(),
+            bank_epoch_1.capitalization(),
+            0,
+        );
+        let EpochInflationAccountState { current, prev } =
+            EpochInflationAccountState::new_from_bank(&bank_epoch_2).unwrap();
+        assert_eq!(current, expected_current);
+        assert_eq!(prev.unwrap(), expected_prev);
+    }
+
+    #[test]
+    fn handles_prefunded_account() {
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(10_000);
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let root_bank = bank_forks.read().unwrap().root_bank();
+
+        let prefund_lamports = 100;
+        root_bank
+            .transfer(prefund_lamports, &mint_keypair, &VOTE_REWARD_ACCOUNT_ADDR)
+            .unwrap();
+
+        assert!(root_bank.get_account(&VOTE_REWARD_ACCOUNT_ADDR).is_some());
+        assert_eq!(
+            root_bank.get_balance(&VOTE_REWARD_ACCOUNT_ADDR),
+            prefund_lamports,
+        );
+        assert_eq!(EpochInflationAccountState::new_from_bank(&root_bank), None);
+    }
+}

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -1,7 +1,11 @@
 #[expect(deprecated)]
 use solana_stake_interface::config::Config as StakeConfig;
 use {
-    crate::{bank::VAT_TO_BURN_PER_EPOCH, stake_utils},
+    crate::{
+        bank::VAT_TO_BURN_PER_EPOCH,
+        block_component_processor::vote_reward::epoch_inflation_account_state::EpochInflationAccountState,
+        stake_utils,
+    },
     agave_feature_set::{FEATURE_NAMES, FeatureSet},
     agave_votor_messages::{
         self,
@@ -355,6 +359,7 @@ pub fn activate_all_features_alpenglow(genesis_config: &mut GenesisConfig) {
     genesis_config
         .accounts
         .insert(*GENESIS_CERTIFICATE_ACCOUNT, certificate_account);
+    EpochInflationAccountState::insert_into_genesis_config(genesis_config);
 }
 
 pub fn activate_all_features(genesis_config: &mut GenesisConfig) {


### PR DESCRIPTION
#### Problem

Previously, we were just calculating the vote rewards but not actually paying them.  This PR fleshes out more of paying vote rewards.  More specifically, we pay the vote rewards into the vote accounts and also update account state to aid delinquency monitoring.


#### Summary of Changes

- Fleshes out the data we need to store in the off curve account.  In particular, we need to store info for 2 epochs and additional information on top of validator rewards.
- We pay the vote rewards in the vote accounts and additionally update the delinquency list based on which validators signed the final cert.
- Increases the test coverage 