### PR TITLE
Introduces the ability to create random `VoteAccount` that can be used for Alpenglow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11335,6 +11335,7 @@ dependencies = [
  "serde",
  "solana-account 4.1.0",
  "solana-bincode",
+ "solana-bls-signatures",
  "solana-clock",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9702,6 +9702,7 @@ dependencies = [
  "serde",
  "solana-account 4.1.0",
  "solana-bincode",
+ "solana-bls-signatures",
  "solana-clock",
  "solana-hash 4.2.0",
  "solana-instruction",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10005,6 +10005,7 @@ dependencies = [
  "serde",
  "solana-account 4.1.0",
  "solana-bincode",
+ "solana-bls-signatures",
  "solana-clock",
  "solana-hash 4.2.0",
  "solana-instruction",

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -18,7 +18,7 @@ name = "solana_vote"
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = ["dep:rand", "dep:bincode"]
+dev-context-only-utils = ["dep:rand", "dep:bincode", "solana-bls-signatures"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
@@ -32,6 +32,7 @@ rand = { version = "0.9.2", optional = true }
 serde = { workspace = true, features = ["rc"] }
 solana-account = { workspace = true, features = ["bincode"] }
 solana-bincode = { workspace = true }
+solana-bls-signatures = { workspace = true, features = ["bytemuck"], optional = true }
 solana-clock = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -19,6 +19,19 @@ use {
     },
     thiserror::Error,
 };
+#[cfg(feature = "dev-context-only-utils")]
+use {
+    rand::Rng as _,
+    solana_account::WritableAccount,
+    solana_bls_signatures::{
+        keypair::Keypair as BLSKeypair, pubkey::PubkeyCompressed as BLSPubkeyCompressed,
+    },
+    solana_clock::Clock,
+    solana_vote_interface::{
+        authorized_voters::AuthorizedVoters,
+        state::{VoteInit, VoteStateV4, VoteStateVersions},
+    },
+};
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Clone, Debug, PartialEq)]
@@ -94,12 +107,6 @@ impl VoteAccount {
 
     #[cfg(feature = "dev-context-only-utils")]
     pub fn new_random() -> VoteAccount {
-        use {
-            rand::Rng as _,
-            solana_clock::Clock,
-            solana_vote_interface::state::{VoteInit, VoteStateV4, VoteStateVersions},
-        };
-
         let mut rng = rand::rng();
         let vote_pubkey = Pubkey::new_unique();
 
@@ -125,6 +132,31 @@ impl VoteAccount {
         .unwrap();
 
         VoteAccount::try_from(account).unwrap()
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn new_random_alpenglow() -> VoteAccount {
+        let lamports = 100;
+        let owner = solana_sdk_ids::vote::id();
+        let mut vote_account = AccountSharedData::new(lamports, VoteStateV4::size_of(), &owner);
+
+        let bls_pubkey_compressed: BLSPubkeyCompressed = BLSKeypair::new().public.into();
+        let bls_pubkey_compressed_buffer = bincode::serialize(&bls_pubkey_compressed).unwrap();
+        let vote_state = VoteStateV4 {
+            node_pubkey: Pubkey::new_unique(),
+            authorized_voters: AuthorizedVoters::new(0, Pubkey::new_unique()),
+            authorized_withdrawer: Pubkey::new_unique(),
+            bls_pubkey_compressed: Some(bls_pubkey_compressed_buffer.try_into().unwrap()),
+            ..VoteStateV4::default()
+        };
+
+        VoteStateV4::serialize(
+            &VoteStateVersions::V4(Box::new(vote_state)),
+            vote_account.data_as_mut_slice(),
+        )
+        .unwrap();
+
+        VoteAccount::try_from(vote_account).unwrap()
     }
 }
 


### PR DESCRIPTION
#### Problem

When we upstream the vote reward paying logic from the alpenglow repo to the agave repo, we will need to be able to create tests with `VoteAccount`s that are compatible for alpenglow.  Currently we do not have this mechanism.


#### Summary of Changes

This PR introduces `VoteAccount::new_random_alpenglow()` which creates a random `VoteAccount` that is compatible for Alpenglow.
