### PR TITLE
Replace STACK_FRAME_SIZE with get_stack_frame_size for configurability

### DIFF
--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [features]
 agave-unstable-api = []
+conf-stack-frame-size = ["solana-program-runtime/conf-stack-frame-size"]
 dev-context-only-utils = []
 
 [dependencies]

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -1,6 +1,9 @@
-pub use solana_program_runtime::execution_budget::{
-    MAX_CALL_DEPTH, MAX_INSTRUCTION_STACK_DEPTH, STACK_FRAME_SIZE, SVMTransactionExecutionBudget,
-    SVMTransactionExecutionCost,
+pub use solana_program_runtime::{
+    execution_budget::{
+        MAX_CALL_DEPTH, MAX_INSTRUCTION_STACK_DEPTH, SVMTransactionExecutionBudget,
+        SVMTransactionExecutionCost,
+    },
+    solana_sbpf::vm::get_stack_frame_size,
 };
 use {
     solana_fee_structure::FeeDetails,

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -1,6 +1,6 @@
 pub use solana_program_runtime::execution_budget::{
-    MAX_CALL_DEPTH, MAX_INSTRUCTION_STACK_DEPTH, SVMTransactionExecutionBudget,
-    SVMTransactionExecutionCost, get_stack_frame_size,
+    MAX_CALL_DEPTH, MAX_INSTRUCTION_STACK_DEPTH, STACK_FRAME_SIZE, SVMTransactionExecutionBudget,
+    SVMTransactionExecutionCost,
 };
 use {
     solana_fee_structure::FeeDetails,

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -1,6 +1,6 @@
 pub use solana_program_runtime::execution_budget::{
-    MAX_CALL_DEPTH, MAX_INSTRUCTION_STACK_DEPTH, STACK_FRAME_SIZE, SVMTransactionExecutionBudget,
-    SVMTransactionExecutionCost,
+    MAX_CALL_DEPTH, MAX_INSTRUCTION_STACK_DEPTH, SVMTransactionExecutionBudget,
+    SVMTransactionExecutionCost, get_stack_frame_size,
 };
 use {
     solana_fee_structure::FeeDetails,

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -18,6 +18,7 @@ name = "solana_program_runtime"
 
 [features]
 agave-unstable-api = []
+conf-stack-frame-size = ["solana-sbpf/conf-stack-frame-size"]
 dev-context-only-utils = ["dep:solana-message"]
 dummy-for-ci-check = ["metrics"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
@@ -25,7 +26,6 @@ metrics = []
 sbpf-debugger = ["solana-sbpf/debugger"]
 shuttle-test = ["solana-sbpf/shuttle-test", "solana-svm-type-overrides/shuttle-test"]
 svm-internal = ["dep:qualifier_attr"]
-conf-stack-frame-size = ["solana-sbpf/conf-stack-frame-size"]
 
 [dependencies]
 base64 = { workspace = true }

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -25,6 +25,7 @@ metrics = []
 sbpf-debugger = ["solana-sbpf/debugger"]
 shuttle-test = ["solana-sbpf/shuttle-test", "solana-svm-type-overrides/shuttle-test"]
 svm-internal = ["dep:qualifier_attr"]
+conf-stack-frame-size = ["solana-sbpf/conf-stack-frame-size"]
 
 [dependencies]
 base64 = { workspace = true }

--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -23,9 +23,6 @@ pub const DEFAULT_INVOCATION_COST: u64 = 946;
 /// Max call depth. This is the maximum nesting of SBF to SBF call that can happen within a program.
 pub const MAX_CALL_DEPTH: usize = 64;
 
-/// The size of one SBF stack frame.
-pub const STACK_FRAME_SIZE: usize = 4096;
-
 pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
 
 /// Roughly 0.5us/page, where page is 32K; given roughly 15CU/us, the
@@ -81,7 +78,7 @@ impl SVMTransactionExecutionBudget {
             max_instruction_trace_length: MAX_INSTRUCTION_TRACE_LENGTH,
             sha256_max_slices: 20_000,
             max_call_depth: MAX_CALL_DEPTH,
-            stack_frame_size: STACK_FRAME_SIZE,
+            stack_frame_size: solana_sbpf::vm::get_stack_frame_size(),
             heap_size: u32::try_from(solana_program_entrypoint::HEAP_LENGTH).unwrap(),
         }
     }

--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -23,37 +23,8 @@ pub const DEFAULT_INVOCATION_COST: u64 = 946;
 /// Max call depth. This is the maximum nesting of SBF to SBF call that can happen within a program.
 pub const MAX_CALL_DEPTH: usize = 64;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "dev-context-only-utils")] {
-        /// The size of one SBF stack frame.
-        /// Configurable via the `SBF_STACK_FRAME_SIZE` environment variable.
-        #[inline(always)]
-        pub fn get_stack_frame_size() -> usize {
-            const STACK_FRAME_SIZE: usize = 4096;
-            static STACK_FRAME_SIZE_CACHE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-            *STACK_FRAME_SIZE_CACHE.get_or_init(|| {
-                let size = std::env::var("SBF_STACK_FRAME_SIZE")
-                    .ok()
-                    .and_then(|v| v.parse::<usize>().ok())
-                    .unwrap_or(STACK_FRAME_SIZE);
-                if size != STACK_FRAME_SIZE {
-                    log::warn!(
-                        "SBF_STACK_FRAME_SIZE is set to {size} (default: {STACK_FRAME_SIZE}). This is a \
-                        development/debugging option and must not be used on validator nodes."
-                    );
-                }
-                size
-            })
-        }
-    } else {
-        /// The size of one SBF stack frame.
-        #[inline(always)]
-        pub fn get_stack_frame_size() -> usize {
-            const STACK_FRAME_SIZE: usize = 4096;
-            STACK_FRAME_SIZE
-        }
-    }
-}
+/// The size of one SBF stack frame.
+pub const STACK_FRAME_SIZE: usize = 4096;
 
 pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
 
@@ -110,7 +81,7 @@ impl SVMTransactionExecutionBudget {
             max_instruction_trace_length: MAX_INSTRUCTION_TRACE_LENGTH,
             sha256_max_slices: 20_000,
             max_call_depth: MAX_CALL_DEPTH,
-            stack_frame_size: get_stack_frame_size(),
+            stack_frame_size: STACK_FRAME_SIZE,
             heap_size: u32::try_from(solana_program_entrypoint::HEAP_LENGTH).unwrap(),
         }
     }

--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -23,25 +23,36 @@ pub const DEFAULT_INVOCATION_COST: u64 = 946;
 /// Max call depth. This is the maximum nesting of SBF to SBF call that can happen within a program.
 pub const MAX_CALL_DEPTH: usize = 64;
 
-/// The size of one SBF stack frame.
-/// Configurable via the `SBF_STACK_FRAME_SIZE` environment variable.
-#[inline(always)]
-pub fn get_stack_frame_size() -> usize {
-    const STACK_FRAME_SIZE: usize = 4096;
-    static STACK_FRAME_SIZE_CACHE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *STACK_FRAME_SIZE_CACHE.get_or_init(|| {
-        let size = std::env::var("SBF_STACK_FRAME_SIZE")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(STACK_FRAME_SIZE);
-        if size != STACK_FRAME_SIZE {
-            log::warn!(
-                "SBF_STACK_FRAME_SIZE is set to {size} (default: {STACK_FRAME_SIZE}). This is a \
-                 development/debugging option and must not be used on validator nodes."
-            );
+cfg_if::cfg_if! {
+    if #[cfg(feature = "dev-context-only-utils")] {
+        /// The size of one SBF stack frame.
+        /// Configurable via the `SBF_STACK_FRAME_SIZE` environment variable.
+        #[inline(always)]
+        pub fn get_stack_frame_size() -> usize {
+            const STACK_FRAME_SIZE: usize = 4096;
+            static STACK_FRAME_SIZE_CACHE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+            *STACK_FRAME_SIZE_CACHE.get_or_init(|| {
+                let size = std::env::var("SBF_STACK_FRAME_SIZE")
+                    .ok()
+                    .and_then(|v| v.parse::<usize>().ok())
+                    .unwrap_or(STACK_FRAME_SIZE);
+                if size != STACK_FRAME_SIZE {
+                    log::warn!(
+                        "SBF_STACK_FRAME_SIZE is set to {size} (default: {STACK_FRAME_SIZE}). This is a \
+                        development/debugging option and must not be used on validator nodes."
+                    );
+                }
+                size
+            })
         }
-        size
-    })
+    } else {
+        /// The size of one SBF stack frame.
+        #[inline(always)]
+        pub fn get_stack_frame_size() -> usize {
+            const STACK_FRAME_SIZE: usize = 4096;
+            STACK_FRAME_SIZE
+        }
+    }
 }
 
 pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;

--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -23,8 +23,28 @@ pub const DEFAULT_INVOCATION_COST: u64 = 946;
 /// Max call depth. This is the maximum nesting of SBF to SBF call that can happen within a program.
 pub const MAX_CALL_DEPTH: usize = 64;
 
-/// The size of one SBF stack frame.
-pub const STACK_FRAME_SIZE: usize = 4096;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "sbpf-debugger")] {
+        /// The size of one SBF stack frame.
+        pub fn get_stack_frame_size() -> usize {
+            const STACK_FRAME_SIZE: usize = 4096;
+            static STACK_FRAME_SIZE_CACHE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+            *STACK_FRAME_SIZE_CACHE.get_or_init(|| {
+                std::env::var("SBF_STACK_FRAME_SIZE")
+                    .ok()
+                    .and_then(|v| v.parse::<usize>().ok())
+                    .unwrap_or(STACK_FRAME_SIZE)
+            })
+        }
+    } else {
+        /// The size of one SBF stack frame.
+        #[inline(always)]
+        pub fn get_stack_frame_size() -> usize {
+            const STACK_FRAME_SIZE: usize = 4096;
+            STACK_FRAME_SIZE
+        }
+    }
+}
 
 pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
 
@@ -81,7 +101,7 @@ impl SVMTransactionExecutionBudget {
             max_instruction_trace_length: MAX_INSTRUCTION_TRACE_LENGTH,
             sha256_max_slices: 20_000,
             max_call_depth: MAX_CALL_DEPTH,
-            stack_frame_size: STACK_FRAME_SIZE,
+            stack_frame_size: get_stack_frame_size(),
             heap_size: u32::try_from(solana_program_entrypoint::HEAP_LENGTH).unwrap(),
         }
     }

--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -24,15 +24,23 @@ pub const DEFAULT_INVOCATION_COST: u64 = 946;
 pub const MAX_CALL_DEPTH: usize = 64;
 
 /// The size of one SBF stack frame.
+/// Configurable via the `SBF_STACK_FRAME_SIZE` environment variable.
 #[inline(always)]
 pub fn get_stack_frame_size() -> usize {
     const STACK_FRAME_SIZE: usize = 4096;
     static STACK_FRAME_SIZE_CACHE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *STACK_FRAME_SIZE_CACHE.get_or_init(|| {
-        std::env::var("SBF_STACK_FRAME_SIZE")
+        let size = std::env::var("SBF_STACK_FRAME_SIZE")
             .ok()
             .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(STACK_FRAME_SIZE)
+            .unwrap_or(STACK_FRAME_SIZE);
+        if size != STACK_FRAME_SIZE {
+            log::warn!(
+                "SBF_STACK_FRAME_SIZE is set to {size} (default: {STACK_FRAME_SIZE}). This is a \
+                 development/debugging option and must not be used on validator nodes."
+            );
+        }
+        size
     })
 }
 

--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -23,27 +23,17 @@ pub const DEFAULT_INVOCATION_COST: u64 = 946;
 /// Max call depth. This is the maximum nesting of SBF to SBF call that can happen within a program.
 pub const MAX_CALL_DEPTH: usize = 64;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "sbpf-debugger")] {
-        /// The size of one SBF stack frame.
-        pub fn get_stack_frame_size() -> usize {
-            const STACK_FRAME_SIZE: usize = 4096;
-            static STACK_FRAME_SIZE_CACHE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-            *STACK_FRAME_SIZE_CACHE.get_or_init(|| {
-                std::env::var("SBF_STACK_FRAME_SIZE")
-                    .ok()
-                    .and_then(|v| v.parse::<usize>().ok())
-                    .unwrap_or(STACK_FRAME_SIZE)
-            })
-        }
-    } else {
-        /// The size of one SBF stack frame.
-        #[inline(always)]
-        pub fn get_stack_frame_size() -> usize {
-            const STACK_FRAME_SIZE: usize = 4096;
-            STACK_FRAME_SIZE
-        }
-    }
+/// The size of one SBF stack frame.
+#[inline(always)]
+pub fn get_stack_frame_size() -> usize {
+    const STACK_FRAME_SIZE: usize = 4096;
+    static STACK_FRAME_SIZE_CACHE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *STACK_FRAME_SIZE_CACHE.get_or_init(|| {
+        std::env::var("SBF_STACK_FRAME_SIZE")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(STACK_FRAME_SIZE)
+    })
 }
 
 pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;

--- a/program-runtime/src/mem_pool.rs
+++ b/program-runtime/src/mem_pool.rs
@@ -1,7 +1,7 @@
 use {
     crate::execution_budget::{
         MAX_CALL_DEPTH, MAX_HEAP_FRAME_BYTES, MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268,
-        MIN_HEAP_FRAME_BYTES, STACK_FRAME_SIZE,
+        MIN_HEAP_FRAME_BYTES,
     },
     solana_sbpf::{aligned_memory::AlignedMemory, ebpf::HOST_ALIGN, vm::CallFrame},
     std::{
@@ -103,7 +103,8 @@ impl VmMemoryPool {
     pub fn new() -> Self {
         Self {
             stack: Pool::new(array::from_fn(|_| {
-                AlignedMemory::zero_filled(STACK_FRAME_SIZE * MAX_CALL_DEPTH)
+                #[allow(clippy::arithmetic_side_effects)]
+                AlignedMemory::zero_filled(solana_sbpf::vm::get_stack_frame_size() * MAX_CALL_DEPTH)
             })),
             heap: Pool::new(array::from_fn(|_| {
                 AlignedMemory::zero_filled(MAX_HEAP_FRAME_BYTES as usize)
@@ -120,8 +121,9 @@ impl VmMemoryPool {
         self.heap.len()
     }
 
+    #[allow(clippy::arithmetic_side_effects)]
     pub fn get_stack(&mut self, size: usize) -> AlignedMemory<{ HOST_ALIGN }> {
-        debug_assert!(size == STACK_FRAME_SIZE * MAX_CALL_DEPTH);
+        debug_assert!(size == solana_sbpf::vm::get_stack_frame_size() * MAX_CALL_DEPTH);
         self.stack
             .get()
             .unwrap_or_else(|| AlignedMemory::zero_filled(size))

--- a/program-runtime/src/mem_pool.rs
+++ b/program-runtime/src/mem_pool.rs
@@ -1,7 +1,7 @@
 use {
     crate::execution_budget::{
         MAX_CALL_DEPTH, MAX_HEAP_FRAME_BYTES, MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268,
-        MIN_HEAP_FRAME_BYTES, STACK_FRAME_SIZE,
+        MIN_HEAP_FRAME_BYTES, get_stack_frame_size,
     },
     solana_sbpf::{aligned_memory::AlignedMemory, ebpf::HOST_ALIGN, vm::CallFrame},
     std::{
@@ -103,7 +103,7 @@ impl VmMemoryPool {
     pub fn new() -> Self {
         Self {
             stack: Pool::new(array::from_fn(|_| {
-                AlignedMemory::zero_filled(STACK_FRAME_SIZE * MAX_CALL_DEPTH)
+                AlignedMemory::zero_filled(get_stack_frame_size() * MAX_CALL_DEPTH)
             })),
             heap: Pool::new(array::from_fn(|_| {
                 AlignedMemory::zero_filled(MAX_HEAP_FRAME_BYTES as usize)
@@ -121,7 +121,7 @@ impl VmMemoryPool {
     }
 
     pub fn get_stack(&mut self, size: usize) -> AlignedMemory<{ HOST_ALIGN }> {
-        debug_assert!(size == STACK_FRAME_SIZE * MAX_CALL_DEPTH);
+        debug_assert!(size == get_stack_frame_size() * MAX_CALL_DEPTH);
         self.stack
             .get()
             .unwrap_or_else(|| AlignedMemory::zero_filled(size))

--- a/program-runtime/src/mem_pool.rs
+++ b/program-runtime/src/mem_pool.rs
@@ -103,6 +103,7 @@ impl VmMemoryPool {
     pub fn new() -> Self {
         Self {
             stack: Pool::new(array::from_fn(|_| {
+                #[allow(clippy::arithmetic_side_effects)]
                 AlignedMemory::zero_filled(get_stack_frame_size() * MAX_CALL_DEPTH)
             })),
             heap: Pool::new(array::from_fn(|_| {
@@ -120,6 +121,7 @@ impl VmMemoryPool {
         self.heap.len()
     }
 
+    #[allow(clippy::arithmetic_side_effects)]
     pub fn get_stack(&mut self, size: usize) -> AlignedMemory<{ HOST_ALIGN }> {
         debug_assert!(size == get_stack_frame_size() * MAX_CALL_DEPTH);
         self.stack

--- a/program-runtime/src/mem_pool.rs
+++ b/program-runtime/src/mem_pool.rs
@@ -1,7 +1,7 @@
 use {
     crate::execution_budget::{
         MAX_CALL_DEPTH, MAX_HEAP_FRAME_BYTES, MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268,
-        MIN_HEAP_FRAME_BYTES, get_stack_frame_size,
+        MIN_HEAP_FRAME_BYTES, STACK_FRAME_SIZE,
     },
     solana_sbpf::{aligned_memory::AlignedMemory, ebpf::HOST_ALIGN, vm::CallFrame},
     std::{
@@ -103,8 +103,7 @@ impl VmMemoryPool {
     pub fn new() -> Self {
         Self {
             stack: Pool::new(array::from_fn(|_| {
-                #[allow(clippy::arithmetic_side_effects)]
-                AlignedMemory::zero_filled(get_stack_frame_size() * MAX_CALL_DEPTH)
+                AlignedMemory::zero_filled(STACK_FRAME_SIZE * MAX_CALL_DEPTH)
             })),
             heap: Pool::new(array::from_fn(|_| {
                 AlignedMemory::zero_filled(MAX_HEAP_FRAME_BYTES as usize)
@@ -121,9 +120,8 @@ impl VmMemoryPool {
         self.heap.len()
     }
 
-    #[allow(clippy::arithmetic_side_effects)]
     pub fn get_stack(&mut self, size: usize) -> AlignedMemory<{ HOST_ALIGN }> {
-        debug_assert!(size == get_stack_frame_size() * MAX_CALL_DEPTH);
+        debug_assert!(size == STACK_FRAME_SIZE * MAX_CALL_DEPTH);
         self.stack
             .get()
             .unwrap_or_else(|| AlignedMemory::zero_filled(size))

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -234,11 +234,7 @@ impl<FG: ForkGraph> Default for TransactionBatchProcessor<FG> {
             epoch_boundary_preparation: Arc::new(RwLock::new(EpochBoundaryPreparation::default())),
             global_program_cache: Arc::new(RwLock::new(ProgramCache::new(Slot::default()))),
             program_runtime_environment: ProgramRuntimeEnvironment::from(
-                BuiltinProgram::new_loader(VmConfig {
-                    stack_frame_size:
-                        solana_program_runtime::execution_budget::get_stack_frame_size(),
-                    ..VmConfig::default()
-                }),
+                BuiltinProgram::new_loader(VmConfig::default()),
             ),
             builtin_program_ids: RwLock::new(HashSet::new()),
             builtin_program_cache: RwLock::new(ProgramCacheForTxBatch::new(Slot::default())),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -234,7 +234,11 @@ impl<FG: ForkGraph> Default for TransactionBatchProcessor<FG> {
             epoch_boundary_preparation: Arc::new(RwLock::new(EpochBoundaryPreparation::default())),
             global_program_cache: Arc::new(RwLock::new(ProgramCache::new(Slot::default()))),
             program_runtime_environment: ProgramRuntimeEnvironment::from(
-                BuiltinProgram::new_loader(VmConfig::default()),
+                BuiltinProgram::new_loader(VmConfig {
+                    stack_frame_size:
+                        solana_program_runtime::execution_budget::get_stack_frame_size(),
+                    ..VmConfig::default()
+                }),
             ),
             builtin_program_ids: RwLock::new(HashSet::new()),
             builtin_program_cache: RwLock::new(ProgramCacheForTxBatch::new(Slot::default())),


### PR DESCRIPTION
## Problem

When debugging SBF programs, the stack frame size is hardcoded to 4096 bytes. There is no way to adjust it at runtime. This will be necessary in the near future because of https://github.com/solana-foundation/solana-improvement-documents/pull/500.

In the discussion (https://github.com/solana-foundation/solana-improvement-documents/pull/377#discussion_r2701326186) @Lichtso and @LucasSte have alluded to such a solution now that they'd removed dynamic stack frames from SBPFv3.

## Change

Added `conf-stack-frame-size` feature flag to `program-runtime`, forwarding to `solana-sbpf/conf-stack-frame-size`.

Takes advantage of https://github.com/anza-xyz/sbpf/pull/160 (now merged) to replace the `STACK_FRAME_SIZE` constant with `solana_sbpf::vm::get_stack_frame_size()` which reads the `SBF_STACK_FRAME_SIZE` env var once on first access (cached via `OnceLock`), falling back to 4096. Without the `conf-stack-frame-size` feature enabled, `get_stack_frame_size()` always returns the default 4096, ignoring the env var.

Updated call sites:
- `SVMTransactionExecutionBudget::new_with_defaults()`
- `VmMemoryPool` stack allocation and pool assertions
- `compute-budget` re-export - replaced `STACK_FRAME_SIZE` with `get_stack_frame_size` from `solana_sbpf::vm`

Note: without the feature, `get_stack_frame_size()` is a `const fn`; with the feature enabled it becomes a regular function (due to `OnceLock` usage). This means enabling the feature may break const contexts that call it - callers must account for this.