### PR TITLE
blockstore: Remove support for deprecated special columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Release channels have their own copy of this changelog:
 * `--public-tpu-address` and `--public-tpu-forwards-address` CLI arguments and `setPublicTpuForwardsAddress`, `setPublicTpuAddress` RPC methods now specify QUIC ports, not UDP.
 * Blockstore `PerfSamples` column legacy format removed.
   * The `PerfSamples` column format was updated in agave v1.15 to write `PerfSampleV2`. The old format, `PerfSampleV1`, will no longer be supported for fallback reads as of v4.0.
+* Blockstore transaction metadata column legacy format support removed.
+  * The `TransactionStatus`, `TransactionMemos`, and `AddressSignatures` columns
+  were updated in v1.18 to write a new key format. The old key format will no
+  no longer be supported for fallback reads as of v4.0
 #### Changes
 * Added `--enable-scheduler-bindings` which binds an IPC server at `<ledger-path>/scheduler_bindings.ipc` for external schedulers to connect to.
 * Added `clientId` field to each node in `getClusterNodes` response

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -125,7 +125,6 @@ fn analyze_storage(blockstore: &Blockstore) -> Result<()> {
     analyze_column(blockstore, TransactionStatus::NAME)?;
     analyze_column(blockstore, AddressSignatures::NAME)?;
     analyze_column(blockstore, TransactionMemos::NAME)?;
-    analyze_column(blockstore, TransactionStatusIndex::NAME)?;
     analyze_column(blockstore, Rewards::NAME)?;
     analyze_column(blockstore, Blocktime::NAME)?;
     analyze_column(blockstore, PerfSamples::NAME)?;
@@ -153,7 +152,6 @@ fn raw_key_to_slot(key: &[u8], column_name: &str) -> Option<Slot> {
             cf::AddressSignatures::index(key),
         )),
         cf::TransactionMemos::NAME => None, // does not implement slot()
-        cf::TransactionStatusIndex::NAME => None, // does not implement slot()
         cf::Rewards::NAME => Some(cf::Rewards::slot(cf::Rewards::index(key))),
         cf::Blocktime::NAME => Some(cf::Blocktime::slot(cf::Blocktime::index(key))),
         cf::PerfSamples::NAME => Some(cf::PerfSamples::slot(cf::PerfSamples::index(key))),

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7,7 +7,7 @@ use trees::{Tree, TreeWalk};
 use {
     crate::{
         ancestor_iterator::AncestorIterator,
-        blockstore::column::{Column, ColumnIndexDeprecation, TypedColumn, columns as cf},
+        blockstore::column::{Column, TypedColumn, columns as cf},
         blockstore_db::{IteratorDirection, IteratorMode, LedgerColumn, Rocks, WriteBatch},
         blockstore_meta::*,
         blockstore_options::{
@@ -276,11 +276,9 @@ pub struct Blockstore {
     rewards_cf: LedgerColumn<cf::Rewards>,
     transaction_status_cf: LedgerColumn<cf::TransactionStatus>,
     transaction_memos_cf: LedgerColumn<cf::TransactionMemos>,
-    transaction_status_index_cf: LedgerColumn<cf::TransactionStatusIndex>,
     address_signatures_cf: LedgerColumn<cf::AddressSignatures>,
     perf_samples_cf: LedgerColumn<cf::PerfSamples>,
 
-    highest_primary_index_slot: RwLock<Option<Slot>>,
     max_root: AtomicU64,
     insert_shreds_lock: Mutex<()>,
     new_shreds_signals: Mutex<Vec<Sender<bool>>>,
@@ -427,7 +425,6 @@ impl Blockstore {
         let rewards_cf = db.column();
         let transaction_status_cf = db.column();
         let transaction_memos_cf = db.column();
-        let transaction_status_index_cf = db.column();
         let address_signatures_cf = db.column();
         let perf_samples_cf = db.column();
 
@@ -463,13 +460,11 @@ impl Blockstore {
             roots_cf,
             transaction_memos_cf,
             transaction_status_cf,
-            transaction_status_index_cf,
             alt_meta_cf,
             alt_index_cf,
             alt_data_shred_cf,
             alt_merkle_root_meta_cf,
 
-            highest_primary_index_slot: RwLock::<Option<Slot>>::default(),
             new_shreds_signals: Mutex::default(),
             completed_slots_senders: Mutex::default(),
             insert_shreds_lock: Mutex::<()>::default(),
@@ -478,7 +473,6 @@ impl Blockstore {
             slots_stats: SlotsStats::default(),
         };
         blockstore.cleanup_old_entries()?;
-        blockstore.update_highest_primary_index_slot()?;
 
         Ok(blockstore)
     }
@@ -995,7 +989,6 @@ impl Blockstore {
         self.rewards_cf.submit_rocksdb_cf_metrics();
         self.transaction_status_cf.submit_rocksdb_cf_metrics();
         self.transaction_memos_cf.submit_rocksdb_cf_metrics();
-        self.transaction_status_index_cf.submit_rocksdb_cf_metrics();
         self.address_signatures_cf.submit_rocksdb_cf_metrics();
         self.perf_samples_cf.submit_rocksdb_cf_metrics();
     }
@@ -3141,16 +3134,6 @@ impl Blockstore {
             return Ok(());
         }
 
-        // Initialize TransactionStatusIndexMeta if they are not present already
-        if self.transaction_status_index_cf.get(0)?.is_none() {
-            self.transaction_status_index_cf
-                .put(0, &TransactionStatusIndexMeta::default())?;
-        }
-        if self.transaction_status_index_cf.get(1)?.is_none() {
-            self.transaction_status_index_cf
-                .put(1, &TransactionStatusIndexMeta::default())?;
-        }
-
         // If present, delete dummy entries inserted by old software
         // https://github.com/solana-labs/solana/blob/bc2b372/ledger/src/blockstore.rs#L2130-L2137
         let transaction_status_dummy_key = cf::TransactionStatus::as_index(2);
@@ -3175,80 +3158,14 @@ impl Blockstore {
         Ok(())
     }
 
-    fn get_highest_primary_index_slot(&self) -> Option<Slot> {
-        *self.highest_primary_index_slot.read().unwrap()
-    }
-
-    fn set_highest_primary_index_slot(&self, slot: Option<Slot>) {
-        *self.highest_primary_index_slot.write().unwrap() = slot;
-    }
-
-    fn update_highest_primary_index_slot(&self) -> Result<()> {
-        let iterator = self.transaction_status_index_cf.iter(IteratorMode::Start)?;
-        let mut highest_primary_index_slot = None;
-        for (_, data) in iterator {
-            let meta = cf::TransactionStatusIndex::deserialize(&data).unwrap();
-            if highest_primary_index_slot.is_none()
-                || highest_primary_index_slot.is_some_and(|slot| slot < meta.max_slot)
-            {
-                highest_primary_index_slot = Some(meta.max_slot);
-            }
-        }
-        if highest_primary_index_slot.is_some_and(|slot| slot != 0) {
-            self.set_highest_primary_index_slot(highest_primary_index_slot);
-        } else {
-            self.db.set_clean_slot_0(true);
-        }
-        Ok(())
-    }
-
-    fn maybe_cleanup_highest_primary_index_slot(&self, oldest_slot: Slot) -> Result<()> {
-        let mut w_highest_primary_index_slot = self.highest_primary_index_slot.write().unwrap();
-        if let Some(highest_primary_index_slot) = *w_highest_primary_index_slot {
-            if oldest_slot > highest_primary_index_slot {
-                *w_highest_primary_index_slot = None;
-                self.db.set_clean_slot_0(true);
-            }
-        }
-        Ok(())
-    }
-
-    fn read_deprecated_transaction_status(
-        &self,
-        index: (Signature, Slot),
-    ) -> Result<Option<TransactionStatusMeta>> {
-        let (signature, slot) = index;
-        let result = self
-            .transaction_status_cf
-            .get_raw_protobuf_or_bincode::<StoredTransactionStatusMeta>(
-                &cf::TransactionStatus::deprecated_key((0, signature, slot)),
-            )?;
-        if result.is_none() {
-            Ok(self
-                .transaction_status_cf
-                .get_raw_protobuf_or_bincode::<StoredTransactionStatusMeta>(
-                    &cf::TransactionStatus::deprecated_key((1, signature, slot)),
-                )?
-                .and_then(|meta| meta.try_into().ok()))
-        } else {
-            Ok(result.and_then(|meta| meta.try_into().ok()))
-        }
-    }
-
     pub fn read_transaction_status(
         &self,
         index: (Signature, Slot),
     ) -> Result<Option<TransactionStatusMeta>> {
-        let result = self.transaction_status_cf.get_protobuf(index)?;
-        if result.is_none()
-            && self
-                .get_highest_primary_index_slot()
-                .is_some_and(|highest_slot| highest_slot >= index.1)
-        {
-            self.read_deprecated_transaction_status(index)
-        } else {
-            Ok(result.and_then(|meta| meta.try_into().ok()))
-        }
+        Ok(self
+            .transaction_status_cf
+            .get_protobuf(index)?
+            .and_then(|meta| meta.try_into().ok()))
     }
 
     #[inline]
@@ -3330,17 +3247,7 @@ impl Blockstore {
         signature: Signature,
         slot: Slot,
     ) -> Result<Option<String>> {
-        let memos = self.transaction_memos_cf.get((signature, slot))?;
-        if memos.is_none()
-            && self
-                .get_highest_primary_index_slot()
-                .is_some_and(|highest_slot| highest_slot >= slot)
-        {
-            self.transaction_memos_cf
-                .get_raw(cf::TransactionMemos::deprecated_key(signature))
-        } else {
-            Ok(memos)
-        }
+        self.transaction_memos_cf.get((signature, slot))
     }
 
     pub fn write_transaction_memos(
@@ -3410,12 +3317,10 @@ impl Blockstore {
         let (lock, _) = self.ensure_lowest_cleanup_slot();
         let first_available_block = self.get_first_available_block()?;
 
-        let iterator =
-            self.transaction_status_cf
-                .iter_current_index_filtered(IteratorMode::From(
-                    (signature, first_available_block),
-                    IteratorDirection::Forward,
-                ))?;
+        let iterator = self.transaction_status_cf.iter(IteratorMode::From(
+            (signature, first_available_block),
+            IteratorDirection::Forward,
+        ))?;
 
         for ((sig, slot), _data) in iterator {
             counter += 1;
@@ -3433,40 +3338,7 @@ impl Blockstore {
             return Ok((status, counter));
         }
 
-        if self.get_highest_primary_index_slot().is_none() {
-            return Ok((None, counter));
-        }
-        for transaction_status_cf_primary_index in 0..=1 {
-            let index_iterator =
-                self.transaction_status_cf
-                    .iter_deprecated_index_filtered(IteratorMode::From(
-                        (
-                            transaction_status_cf_primary_index,
-                            signature,
-                            first_available_block,
-                        ),
-                        IteratorDirection::Forward,
-                    ))?;
-            for ((i, sig, slot), _data) in index_iterator {
-                counter += 1;
-                if i != transaction_status_cf_primary_index || sig != signature {
-                    break;
-                }
-                if !self.is_root(slot) && !confirmed_unrooted_slots.contains(&slot) {
-                    continue;
-                }
-                let status = self
-                    .transaction_status_cf
-                    .get_raw_protobuf_or_bincode::<StoredTransactionStatusMeta>(
-                        &cf::TransactionStatus::deprecated_key((i, signature, slot)),
-                    )?
-                    .and_then(|status| status.try_into().ok())
-                    .map(|status| (slot, status));
-                return Ok((status, counter));
-            }
-        }
         drop(lock);
-
         Ok((None, counter))
     }
 
@@ -3588,17 +3460,15 @@ impl Blockstore {
         if slot < lowest_available_slot {
             return Ok(signatures);
         }
-        let index_iterator =
-            self.address_signatures_cf
-                .iter_current_index_filtered(IteratorMode::From(
-                    (
-                        pubkey,
-                        slot.max(lowest_available_slot),
-                        0,
-                        Signature::default(),
-                    ),
-                    IteratorDirection::Forward,
-                ))?;
+        let index_iterator = self.address_signatures_cf.iter(IteratorMode::From(
+            (
+                pubkey,
+                slot.max(lowest_available_slot),
+                0,
+                Signature::default(),
+            ),
+            IteratorDirection::Forward,
+        ))?;
         for ((address, transaction_slot, transaction_index, signature), _) in index_iterator {
             if transaction_slot > slot || address != pubkey {
                 break;
@@ -3724,17 +3594,15 @@ impl Blockstore {
         get_initial_slot_timer.stop();
 
         let mut address_signatures_iter_timer = Measure::start("iter_timer");
-        let mut iterator =
-            self.address_signatures_cf
-                .iter_current_index_filtered(IteratorMode::From(
-                    // Regardless of whether a `before` signature is provided, the latest relevant
-                    // `slot` is queried directly with the `find_address_signatures_for_slot()`
-                    // call above. Thus, this iterator starts at the lowest entry of `address,
-                    // slot` and iterates backwards to continue reporting the next earliest
-                    // signatures.
-                    (address, slot, 0, Signature::default()),
-                    IteratorDirection::Reverse,
-                ))?;
+        let mut iterator = self.address_signatures_cf.iter(IteratorMode::From(
+            // Regardless of whether a `before` signature is provided, the latest relevant
+            // `slot` is queried directly with the `find_address_signatures_for_slot()`
+            // call above. Thus, this iterator starts at the lowest entry of `address,
+            // slot` and iterates backwards to continue reporting the next earliest
+            // signatures.
+            (address, slot, 0, Signature::default()),
+            IteratorDirection::Reverse,
+        ))?;
 
         // Iterate until limit is reached
         while address_signatures.len() < limit {
@@ -8674,79 +8542,6 @@ pub mod tests {
     }
 
     #[test]
-    fn test_read_transaction_status_with_old_data() {
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-        let signature = Signature::from([1; 64]);
-
-        let index0_slot = 2;
-        blockstore
-            .write_deprecated_transaction_status(
-                0,
-                index0_slot,
-                signature,
-                vec![&Pubkey::new_unique()],
-                vec![&Pubkey::new_unique()],
-                TransactionStatusMeta {
-                    fee: index0_slot * 1_000,
-                    ..TransactionStatusMeta::default()
-                },
-            )
-            .unwrap();
-
-        let index1_slot = 1;
-        blockstore
-            .write_deprecated_transaction_status(
-                1,
-                index1_slot,
-                signature,
-                vec![&Pubkey::new_unique()],
-                vec![&Pubkey::new_unique()],
-                TransactionStatusMeta {
-                    fee: index1_slot * 1_000,
-                    ..TransactionStatusMeta::default()
-                },
-            )
-            .unwrap();
-
-        let slot = 3;
-        blockstore
-            .write_transaction_status(
-                slot,
-                signature,
-                vec![
-                    (&Pubkey::new_unique(), true),
-                    (&Pubkey::new_unique(), false),
-                ]
-                .into_iter(),
-                TransactionStatusMeta {
-                    fee: slot * 1_000,
-                    ..TransactionStatusMeta::default()
-                },
-                0,
-            )
-            .unwrap();
-
-        let meta = blockstore
-            .read_transaction_status((signature, slot))
-            .unwrap()
-            .unwrap();
-        assert_eq!(meta.fee, slot * 1000);
-
-        let meta = blockstore
-            .read_transaction_status((signature, index0_slot))
-            .unwrap()
-            .unwrap();
-        assert_eq!(meta.fee, index0_slot * 1000);
-
-        let meta = blockstore
-            .read_transaction_status((signature, index1_slot))
-            .unwrap()
-            .unwrap();
-        assert_eq!(meta.fee, index1_slot * 1000);
-    }
-
-    #[test]
     fn test_get_transaction_status() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
@@ -8981,27 +8776,26 @@ pub mod tests {
         blockstore.set_roots([0, 2, 4].iter()).unwrap();
 
         // Initialize statuses:
-        //   signature1 in skipped slot and root (2), both index 1
-        //   signature2 in skipped slot and root (4), both index 0
-        //   signature3 in root
-        //   signature4 in non-root,
+        //   signature1 in skipped slot (1) and root (2)
+        //   signature2 in skipped slot (3) and root (4)
+        //   signature3 in root (4)
+        //   signature4 in non-root (5)
         //   signature5 extra entries
         transaction_status_cf
-            .put_deprecated_protobuf((1, signature1, 1), &status)
+            .put_protobuf((signature1, 1), &status)
             .unwrap();
 
         transaction_status_cf
-            .put_deprecated_protobuf((1, signature1, 2), &status)
+            .put_protobuf((signature1, 2), &status)
             .unwrap();
 
         transaction_status_cf
-            .put_deprecated_protobuf((0, signature2, 3), &status)
+            .put_protobuf((signature2, 3), &status)
             .unwrap();
 
         transaction_status_cf
-            .put_deprecated_protobuf((0, signature2, 4), &status)
+            .put_protobuf((signature2, 4), &status)
             .unwrap();
-        blockstore.set_highest_primary_index_slot(Some(4));
 
         transaction_status_cf
             .put_protobuf((signature3, 4), &status)
@@ -9015,39 +8809,43 @@ pub mod tests {
             .put_protobuf((signature5, 5), &status)
             .unwrap();
 
-        // Signature exists, root found in index 1
-        if let (Some((slot, _status)), counter) = blockstore
+        // Signature exists
+        let (status, counter) = blockstore
             .get_transaction_status_with_counter(signature1, &[].into())
-            .unwrap()
-        {
-            assert_eq!(slot, 2);
-            assert_eq!(counter, 4);
-        }
-
-        // Signature exists, root found in index 0
-        if let (Some((slot, _status)), counter) = blockstore
-            .get_transaction_status_with_counter(signature2, &[].into())
-            .unwrap()
-        {
-            assert_eq!(slot, 4);
-            assert_eq!(counter, 3);
-        }
+            .unwrap();
+        let (slot, _status) = status.unwrap();
+        assert_eq!(slot, 2);
+        assert_eq!(counter, 2);
 
         // Signature exists
-        if let (Some((slot, _status)), counter) = blockstore
+        let (status, counter) = blockstore
+            .get_transaction_status_with_counter(signature2, &[].into())
+            .unwrap();
+        let (slot, _status) = status.unwrap();
+        assert_eq!(slot, 4);
+        assert_eq!(counter, 2);
+
+        // Signature exists
+        let (status, counter) = blockstore
             .get_transaction_status_with_counter(signature3, &[].into())
-            .unwrap()
-        {
-            assert_eq!(slot, 4);
-            assert_eq!(counter, 1);
-        }
+            .unwrap();
+        let (slot, _status) = status.unwrap();
+        assert_eq!(slot, 4);
+        assert_eq!(counter, 1);
+
+        // Signature does not exist (in a rooted block)
+        let (status, counter) = blockstore
+            .get_transaction_status_with_counter(signature5, &[].into())
+            .unwrap();
+        assert_eq!(status, None);
+        assert_eq!(counter, 1);
 
         // Signature does not exist
         let (status, counter) = blockstore
             .get_transaction_status_with_counter(signature6, &[].into())
             .unwrap();
         assert_eq!(status, None);
-        assert_eq!(counter, 1);
+        assert_eq!(counter, 0);
     }
 
     fn do_test_lowest_cleanup_slot_and_special_cfs(simulate_blockstore_cleanup_service: bool) {
@@ -9440,41 +9238,6 @@ pub mod tests {
                 .unwrap(),
             None
         );
-    }
-
-    impl Blockstore {
-        pub(crate) fn write_deprecated_transaction_status(
-            &self,
-            primary_index: u64,
-            slot: Slot,
-            signature: Signature,
-            writable_keys: Vec<&Pubkey>,
-            readonly_keys: Vec<&Pubkey>,
-            status: TransactionStatusMeta,
-        ) -> Result<()> {
-            let status = status.into();
-            self.transaction_status_cf
-                .put_deprecated_protobuf((primary_index, signature, slot), &status)?;
-            for address in writable_keys {
-                self.address_signatures_cf.put_deprecated(
-                    (primary_index, *address, slot, signature),
-                    &AddressSignatureMeta { writeable: true },
-                )?;
-            }
-            for address in readonly_keys {
-                self.address_signatures_cf.put_deprecated(
-                    (primary_index, *address, slot, signature),
-                    &AddressSignatureMeta { writeable: false },
-                )?;
-            }
-            let mut w_highest_primary_index_slot = self.highest_primary_index_slot.write().unwrap();
-            if w_highest_primary_index_slot.is_none()
-                || w_highest_primary_index_slot.is_some_and(|highest_slot| highest_slot < slot)
-            {
-                *w_highest_primary_index_slot = Some(slot);
-            }
-            Ok(())
-        }
     }
 
     #[test]

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -1,8 +1,4 @@
-use {
-    super::*,
-    solana_message::AccountKeys,
-    std::{cmp::max, time::Instant},
-};
+use {super::*, solana_message::AccountKeys, std::time::Instant};
 
 #[derive(Default)]
 pub struct PurgeStats {
@@ -34,9 +30,9 @@ impl Blockstore {
     /// as it does not update the associated slot-meta entries that refer to
     /// the deleted entries.
     ///
-    /// For slot-id based column families, the purge is done by range deletion,
-    /// while the non-slot-id based column families, `cf::TransactionStatus`,
-    /// `AddressSignature`, and `cf::TransactionStatusIndex`, are cleaned-up
+    /// For slot-id based column families, the purge is done by range deletion.
+    /// The non-slot-id based column families, `cf::TransactionStatus`,
+    /// `cf::TransactionMemos`, and `cf::AddressSignatures`, are cleaned-up
     /// based on the `purge_type` setting.
     pub fn purge_slots(&self, from_slot: Slot, to_slot: Slot, purge_type: PurgeType) -> Result<()> {
         let mut purge_stats = PurgeStats::default();
@@ -75,10 +71,6 @@ impl Blockstore {
         // with Slot::default() for initial compaction filter behavior consistency
         let to_slot = to_slot.checked_add(1).unwrap();
         self.db.set_oldest_slot(to_slot);
-
-        if let Err(err) = self.maybe_cleanup_highest_primary_index_slot(to_slot) {
-            warn!("Could not clean up TransactionStatusIndex: {err:?}");
-        }
     }
 
     /// Ensures that the SlotMeta::next_slots vector for all slots contain no references in the
@@ -394,26 +386,7 @@ impl Blockstore {
             return Ok(());
         }
 
-        let mut index0 = self.transaction_status_index_cf.get(0)?.unwrap_or_default();
-        let mut index1 = self.transaction_status_index_cf.get(1)?.unwrap_or_default();
-        let highest_primary_index_slot = self.get_highest_primary_index_slot();
-        let slot_indexes = |slot: Slot| -> Vec<u64> {
-            let mut indexes = vec![];
-            if highest_primary_index_slot.is_none() {
-                return indexes;
-            }
-            if slot <= index0.max_slot && (index0.frozen || slot >= index1.max_slot) {
-                indexes.push(0);
-            }
-            if slot <= index1.max_slot && (index1.frozen || slot >= index0.max_slot) {
-                indexes.push(1);
-            }
-            indexes
-        };
-
         for slot in from_slot..=to_slot {
-            let primary_indexes = slot_indexes(slot);
-
             let (slot_entries, _, _) =
                 self.get_slot_entries_with_shred_info(slot, 0, true /* allow_dead_slots */)?;
             let transactions = slot_entries
@@ -425,14 +398,6 @@ impl Blockstore {
                         .delete_in_batch(batch, (signature, slot));
                     self.transaction_memos_cf
                         .delete_in_batch(batch, (signature, slot));
-                    if !primary_indexes.is_empty() {
-                        self.transaction_memos_cf
-                            .delete_deprecated_in_batch(batch, signature);
-                    }
-                    for primary_index in &primary_indexes {
-                        self.transaction_status_cf
-                            .delete_deprecated_in_batch(batch, (*primary_index, signature, slot));
-                    }
 
                     let meta = self.read_transaction_status((signature, slot))?;
                     let loaded_addresses = meta.map(|meta| meta.loaded_addresses);
@@ -446,32 +411,11 @@ impl Blockstore {
                     for pubkey in account_keys.iter() {
                         self.address_signatures_cf
                             .delete_in_batch(batch, (*pubkey, slot, transaction_index, signature));
-                        for primary_index in &primary_indexes {
-                            self.address_signatures_cf.delete_deprecated_in_batch(
-                                batch,
-                                (*primary_index, *pubkey, slot, signature),
-                            );
-                        }
                     }
                 }
             }
         }
-        let mut update_highest_primary_index_slot = false;
-        if index0.max_slot >= from_slot && index0.max_slot <= to_slot {
-            index0.max_slot = from_slot.saturating_sub(1);
-            self.transaction_status_index_cf
-                .put_in_batch(batch, 0, &index0)?;
-            update_highest_primary_index_slot = true;
-        }
-        if index1.max_slot >= from_slot && index1.max_slot <= to_slot {
-            index1.max_slot = from_slot.saturating_sub(1);
-            self.transaction_status_index_cf
-                .put_in_batch(batch, 1, &index1)?;
-            update_highest_primary_index_slot = true
-        }
-        if update_highest_primary_index_slot {
-            self.set_highest_primary_index_slot(Some(max(index0.max_slot, index1.max_slot)))
-        }
+
         Ok(())
     }
 }
@@ -592,43 +536,6 @@ pub mod tests {
                     .into_iter(),
                     TransactionStatusMeta::default(),
                     0,
-                )
-                .unwrap();
-        }
-    }
-
-    fn populate_deprecated_transaction_statuses_for_test(
-        blockstore: &Blockstore,
-        primary_index: u64,
-        min_slot: u64,
-        max_slot: u64,
-    ) {
-        for x in min_slot..=max_slot {
-            let entries = make_slot_entries_with_transactions(1);
-            let shreds = entries_to_test_shreds(
-                &entries,
-                x,                   // slot
-                x.saturating_sub(1), // parent_slot
-                true,                // is_full_slot
-                0,                   // version
-            );
-            blockstore.insert_shreds(shreds, None, false).unwrap();
-            let signature = entries
-                .iter()
-                .filter(|entry| !entry.is_tick())
-                .cloned()
-                .flat_map(|entry| entry.transactions)
-                .map(|transaction| transaction.signatures[0])
-                .collect::<Vec<Signature>>()[0];
-            let random_bytes: Vec<u8> = (0..64).map(|_| rand::random::<u8>()).collect();
-            blockstore
-                .write_deprecated_transaction_status(
-                    primary_index,
-                    x,
-                    signature,
-                    vec![&Pubkey::try_from(&random_bytes[..32]).unwrap()],
-                    vec![&Pubkey::try_from(&random_bytes[32..]).unwrap()],
-                    TransactionStatusMeta::default(),
                 )
                 .unwrap();
         }
@@ -763,47 +670,16 @@ pub mod tests {
 
     #[test_case(purge_exact; "exact")]
     #[test_case(purge_compaction_filter; "compaction_filter")]
-    fn test_purge_special_columns_with_old_data(purge: impl Fn(&Blockstore, Slot)) {
+    fn test_purge_special_columns(purge: impl Fn(&Blockstore, Slot)) {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let max_slot = 19;
 
-        populate_deprecated_transaction_statuses_for_test(&blockstore, 0, 0, 4);
-        populate_deprecated_transaction_statuses_for_test(&blockstore, 1, 5, 9);
-        populate_transaction_statuses_for_test(&blockstore, 10, 14);
+        populate_transaction_statuses_for_test(&blockstore, 0, max_slot);
 
-        let mut index0 = blockstore
-            .transaction_status_index_cf
-            .get(0)
-            .unwrap()
-            .unwrap_or_default();
-        index0.frozen = true;
-        index0.max_slot = 4;
-        blockstore
-            .transaction_status_index_cf
-            .put(0, &index0)
-            .unwrap();
-        let mut index1 = blockstore
-            .transaction_status_index_cf
-            .get(1)
-            .unwrap()
-            .unwrap_or_default();
-        index1.frozen = false;
-        index1.max_slot = 9;
-        blockstore
-            .transaction_status_index_cf
-            .put(1, &index1)
-            .unwrap();
-
-        let num_statuses = blockstore
-            .transaction_status_cf
-            .iter(IteratorMode::Start)
-            .unwrap()
-            .count();
-        assert_eq!(num_statuses, 15);
-
-        // Delete some of primary-index 0
         let oldest_slot = 3;
         purge(&blockstore, oldest_slot);
+
         let status_entry_iterator = blockstore
             .transaction_status_cf
             .iter(IteratorMode::Start)
@@ -813,11 +689,13 @@ pub mod tests {
             assert!(slot >= oldest_slot);
             count += 1;
         }
-        assert_eq!(count, 12);
+        assert_eq!(count, max_slot - (oldest_slot - 1));
 
-        // Delete the rest of primary-index 0
-        let oldest_slot = 5;
+        clear_and_repopulate_transaction_statuses_for_test(&blockstore, max_slot);
+
+        let oldest_slot = 12;
         purge(&blockstore, oldest_slot);
+
         let status_entry_iterator = blockstore
             .transaction_status_cf
             .iter(IteratorMode::Start)
@@ -827,58 +705,7 @@ pub mod tests {
             assert!(slot >= oldest_slot);
             count += 1;
         }
-        assert_eq!(count, 10);
-
-        // Delete some of primary-index 1
-        let oldest_slot = 8;
-        purge(&blockstore, oldest_slot);
-        let status_entry_iterator = blockstore
-            .transaction_status_cf
-            .iter(IteratorMode::Start)
-            .unwrap();
-        let mut count = 0;
-        for ((_signature, slot), _value) in status_entry_iterator {
-            assert!(slot >= oldest_slot);
-            count += 1;
-        }
-        assert_eq!(count, 7);
-
-        // Delete the rest of primary-index 1
-        let oldest_slot = 10;
-        purge(&blockstore, oldest_slot);
-        let status_entry_iterator = blockstore
-            .transaction_status_cf
-            .iter(IteratorMode::Start)
-            .unwrap();
-        let mut count = 0;
-        for ((_signature, slot), _value) in status_entry_iterator {
-            assert!(slot >= oldest_slot);
-            count += 1;
-        }
-        assert_eq!(count, 5);
-
-        // Delete some of new-style entries
-        let oldest_slot = 13;
-        purge(&blockstore, oldest_slot);
-        let status_entry_iterator = blockstore
-            .transaction_status_cf
-            .iter(IteratorMode::Start)
-            .unwrap();
-        let mut count = 0;
-        for ((_signature, slot), _value) in status_entry_iterator {
-            assert!(slot >= oldest_slot);
-            count += 1;
-        }
-        assert_eq!(count, 2);
-
-        // Delete the rest of the new-style entries
-        let oldest_slot = 20;
-        purge(&blockstore, oldest_slot);
-        let mut status_entry_iterator = blockstore
-            .transaction_status_cf
-            .iter(IteratorMode::Start)
-            .unwrap();
-        assert!(status_entry_iterator.next().is_none());
+        assert_eq!(count, max_slot - (oldest_slot - 1));
     }
 
     #[test]
@@ -911,47 +738,6 @@ pub mod tests {
     }
 
     #[test]
-    fn test_purge_special_columns_compaction_filter() {
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-        let max_slot = 19;
-
-        clear_and_repopulate_transaction_statuses_for_test(&blockstore, max_slot);
-
-        let oldest_slot = 3;
-        blockstore.db.set_oldest_slot(oldest_slot);
-        blockstore.transaction_status_cf.compact();
-
-        let status_entry_iterator = blockstore
-            .transaction_status_cf
-            .iter(IteratorMode::Start)
-            .unwrap();
-        let mut count = 0;
-        for ((_signature, slot), _value) in status_entry_iterator {
-            assert!(slot >= oldest_slot);
-            count += 1;
-        }
-        assert_eq!(count, max_slot - (oldest_slot - 1));
-
-        clear_and_repopulate_transaction_statuses_for_test(&blockstore, max_slot);
-
-        let oldest_slot = 12;
-        blockstore.db.set_oldest_slot(oldest_slot);
-        blockstore.transaction_status_cf.compact();
-
-        let status_entry_iterator = blockstore
-            .transaction_status_cf
-            .iter(IteratorMode::Start)
-            .unwrap();
-        let mut count = 0;
-        for ((_signature, slot), _value) in status_entry_iterator {
-            assert!(slot >= oldest_slot);
-            count += 1;
-        }
-        assert_eq!(count, max_slot - (oldest_slot - 1));
-    }
-
-    #[test]
     fn test_purge_transaction_memos_compaction_filter() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
@@ -965,19 +751,6 @@ pub mod tests {
             Signature::from(key)
         }
 
-        // Insert some deprecated TransactionMemos
-        blockstore
-            .transaction_memos_cf
-            .put_deprecated(random_signature(), &"this is a memo".to_string())
-            .unwrap();
-        blockstore
-            .transaction_memos_cf
-            .put_deprecated(random_signature(), &"another memo".to_string())
-            .unwrap();
-        // Set clean_slot_0 to false, since we have deprecated memos
-        blockstore.db.set_clean_slot_0(false);
-
-        // Insert some current TransactionMemos
         blockstore
             .transaction_memos_cf
             .put(
@@ -1001,7 +774,7 @@ pub mod tests {
             .iter(IteratorMode::Start)
             .unwrap()
             .count();
-        assert_eq!(num_memos, 4);
+        assert_eq!(num_memos, 2);
 
         // Purge at oldest_slot without clean_slot_0 only purges the current memo at slot 4
         blockstore.db.set_oldest_slot(oldest_slot);
@@ -1013,20 +786,6 @@ pub mod tests {
         let mut count = 0;
         for ((_signature, slot), _value) in memos_iterator {
             assert!(slot == 0 || slot >= oldest_slot);
-            count += 1;
-        }
-        assert_eq!(count, 3);
-
-        // Purge at oldest_slot with clean_slot_0 purges deprecated memos
-        blockstore.db.set_clean_slot_0(true);
-        blockstore.transaction_memos_cf.compact();
-        let memos_iterator = blockstore
-            .transaction_memos_cf
-            .iter(IteratorMode::Start)
-            .unwrap();
-        let mut count = 0;
-        for ((_signature, slot), _value) in memos_iterator {
-            assert!(slot >= oldest_slot);
             count += 1;
         }
         assert_eq!(count, 1);

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -14,6 +14,7 @@ use {
 };
 
 pub(crate) const DEPRECATED_PROGRAM_COSTS_COLUMN_NAME: &str = "program_costs";
+pub(crate) const DEPRECATED_TRANSACTION_STATUS_INDEX_NAME: &str = "transaction_status_index";
 
 // To add a new column, declare the type below and implement the applicable
 // traits for it. At the very least, Column and ColumnName will be necessary.
@@ -181,16 +182,9 @@ pub mod columns {
     #[derive(Debug)]
     /// The transaction memos column
     ///
-    /// * index type: [`Signature`]
+    /// * index type: `(`[`Signature`]`, `[`Slot`])`
     /// * value type: [`String`]
     pub struct TransactionMemos;
-
-    #[derive(Debug)]
-    /// The transaction status index column.
-    ///
-    /// * index type: `u64` (see [`SlotColumn`])
-    /// * value type: [`blockstore_meta::TransactionStatusIndexMeta`]
-    pub struct TransactionStatusIndex;
 
     #[derive(Debug)]
     /// The rewards column
@@ -325,42 +319,12 @@ pub enum IndexError {
     UnpackError,
 }
 
-/// Helper trait to transition primary indexes out from the columns that are using them.
-pub trait ColumnIndexDeprecation: Column {
-    const CURRENT_INDEX_LEN: usize;
-    type DeprecatedIndex;
-    type DeprecatedKey: AsRef<[u8]>;
-
-    fn deprecated_key(index: Self::DeprecatedIndex) -> Self::DeprecatedKey;
-    fn try_deprecated_index(key: &[u8]) -> std::result::Result<Self::DeprecatedIndex, IndexError>;
-
-    fn try_current_index(key: &[u8]) -> std::result::Result<Self::Index, IndexError>;
-    fn convert_index(deprecated_index: Self::DeprecatedIndex) -> Self::Index;
-
-    fn index(key: &[u8]) -> Self::Index {
-        if let Ok(index) = Self::try_current_index(key) {
-            index
-        } else if let Ok(index) = Self::try_deprecated_index(key) {
-            Self::convert_index(index)
-        } else {
-            // Way back in the day, we broke the TransactionStatus column key. This fallback
-            // preserves the existing logic for ancient keys, but realistically should never be
-            // executed.
-            Self::as_index(0)
-        }
-    }
-}
-
 impl TypedColumn for columns::AddressSignatures {
     type Type = blockstore_meta::AddressSignatureMeta;
 }
 
 impl TypedColumn for columns::TransactionMemos {
     type Type = String;
-}
-
-impl TypedColumn for columns::TransactionStatusIndex {
-    type Type = blockstore_meta::TransactionStatusIndexMeta;
 }
 
 impl<T: SlotColumn> Column for T {
@@ -400,7 +364,10 @@ impl Column for columns::TransactionStatus {
     }
 
     fn index(key: &[u8]) -> (Signature, Slot) {
-        <columns::TransactionStatus as ColumnIndexDeprecation>::index(key)
+        convert_column_key_bytes_to_index!(key,
+             0..64 => Signature::from,
+            64..72 => Slot::from_be_bytes,
+        )
     }
 
     fn slot(index: Self::Index) -> Slot {
@@ -418,46 +385,6 @@ impl ColumnName for columns::TransactionStatus {
 }
 impl ProtobufColumn for columns::TransactionStatus {
     type Type = generated::TransactionStatusMeta;
-}
-
-impl ColumnIndexDeprecation for columns::TransactionStatus {
-    const CURRENT_INDEX_LEN: usize = 72;
-    type DeprecatedIndex = (u64, Signature, Slot);
-    type DeprecatedKey = [u8; 80];
-
-    fn deprecated_key((index, signature, slot): Self::DeprecatedIndex) -> Self::DeprecatedKey {
-        convert_column_index_to_key_bytes!(DeprecatedKey,
-              ..8  => &index.to_be_bytes(),
-             8..72 => signature.as_ref(),
-            72..   => &slot.to_be_bytes(),
-        )
-    }
-
-    fn try_deprecated_index(key: &[u8]) -> std::result::Result<Self::DeprecatedIndex, IndexError> {
-        if key.len() != std::mem::size_of::<Self::DeprecatedKey>() {
-            return Err(IndexError::UnpackError);
-        }
-        Ok(convert_column_key_bytes_to_index!(key,
-             0..8  => u64::from_be_bytes,  // primary index
-             8..72 => Signature::from,
-            72..80 => Slot::from_be_bytes,
-        ))
-    }
-
-    fn try_current_index(key: &[u8]) -> std::result::Result<Self::Index, IndexError> {
-        if key.len() != Self::CURRENT_INDEX_LEN {
-            return Err(IndexError::UnpackError);
-        }
-        Ok(convert_column_key_bytes_to_index!(key,
-             0..64 => Signature::from,
-            64..72 => Slot::from_be_bytes,
-        ))
-    }
-
-    fn convert_index(deprecated_index: Self::DeprecatedIndex) -> Self::Index {
-        let (_primary_index, signature, slot) = deprecated_index;
-        (signature, slot)
-    }
 }
 
 impl Column for columns::AddressSignatures {
@@ -478,7 +405,12 @@ impl Column for columns::AddressSignatures {
     }
 
     fn index(key: &[u8]) -> Self::Index {
-        <columns::AddressSignatures as ColumnIndexDeprecation>::index(key)
+        convert_column_key_bytes_to_index!(key,
+             0..32  => Pubkey::from,
+            32..40  => Slot::from_be_bytes,
+            40..44  => u32::from_be_bytes,  // transaction index
+            44..108 => Signature::from,
+        )
     }
 
     fn slot(index: Self::Index) -> Slot {
@@ -495,52 +427,6 @@ impl ColumnName for columns::AddressSignatures {
     const NAME: &'static str = "address_signatures";
 }
 
-impl ColumnIndexDeprecation for columns::AddressSignatures {
-    const CURRENT_INDEX_LEN: usize = 108;
-    type DeprecatedIndex = (u64, Pubkey, Slot, Signature);
-    type DeprecatedKey = [u8; 112];
-
-    fn deprecated_key(
-        (primary_index, pubkey, slot, signature): Self::DeprecatedIndex,
-    ) -> Self::DeprecatedKey {
-        convert_column_index_to_key_bytes!(DeprecatedKey,
-              ..8  => &primary_index.to_be_bytes(),
-             8..40 => pubkey.as_ref(),
-            40..48 => &slot.to_be_bytes(),
-            48..   => signature.as_ref(),
-        )
-    }
-
-    fn try_deprecated_index(key: &[u8]) -> std::result::Result<Self::DeprecatedIndex, IndexError> {
-        if key.len() != std::mem::size_of::<Self::DeprecatedKey>() {
-            return Err(IndexError::UnpackError);
-        }
-        Ok(convert_column_key_bytes_to_index!(key,
-             0..8   => u64::from_be_bytes,  // primary index
-             8..40  => Pubkey::from,
-            40..48  => Slot::from_be_bytes,
-            48..112 => Signature::from,
-        ))
-    }
-
-    fn try_current_index(key: &[u8]) -> std::result::Result<Self::Index, IndexError> {
-        if key.len() != Self::CURRENT_INDEX_LEN {
-            return Err(IndexError::UnpackError);
-        }
-        Ok(convert_column_key_bytes_to_index!(key,
-             0..32  => Pubkey::from,
-            32..40  => Slot::from_be_bytes,
-            40..44  => u32::from_be_bytes,  // transaction index
-            44..108 => Signature::from,
-        ))
-    }
-
-    fn convert_index(deprecated_index: Self::DeprecatedIndex) -> Self::Index {
-        let (_primary_index, pubkey, slot, signature) = deprecated_index;
-        (pubkey, slot, 0, signature)
-    }
-}
-
 impl Column for columns::TransactionMemos {
     type Index = (Signature, Slot);
     type Key = [u8; SIGNATURE_BYTES + std::mem::size_of::<Slot>()];
@@ -554,7 +440,10 @@ impl Column for columns::TransactionMemos {
     }
 
     fn index(key: &[u8]) -> Self::Index {
-        <columns::TransactionMemos as ColumnIndexDeprecation>::index(key)
+        convert_column_key_bytes_to_index!(key,
+             0..64 => Signature::from,
+            64..72 => Slot::from_be_bytes,
+        )
     }
 
     fn slot(index: Self::Index) -> Slot {
@@ -567,59 +456,6 @@ impl Column for columns::TransactionMemos {
 }
 impl ColumnName for columns::TransactionMemos {
     const NAME: &'static str = "transaction_memos";
-}
-
-impl ColumnIndexDeprecation for columns::TransactionMemos {
-    const CURRENT_INDEX_LEN: usize = 72;
-    type DeprecatedIndex = Signature;
-    type DeprecatedKey = [u8; 64];
-
-    fn deprecated_key(signature: Self::DeprecatedIndex) -> Self::DeprecatedKey {
-        Self::DeprecatedKey::from(signature)
-    }
-
-    fn try_deprecated_index(key: &[u8]) -> std::result::Result<Self::DeprecatedIndex, IndexError> {
-        Signature::try_from(&key[..64]).map_err(|_| IndexError::UnpackError)
-    }
-
-    fn try_current_index(key: &[u8]) -> std::result::Result<Self::Index, IndexError> {
-        if key.len() != Self::CURRENT_INDEX_LEN {
-            return Err(IndexError::UnpackError);
-        }
-        Ok(convert_column_key_bytes_to_index!(key,
-             0..64 => Signature::from,
-            64..72 => Slot::from_be_bytes,
-        ))
-    }
-
-    fn convert_index(deprecated_index: Self::DeprecatedIndex) -> Self::Index {
-        (deprecated_index, 0)
-    }
-}
-
-impl Column for columns::TransactionStatusIndex {
-    type Index = u64;
-    type Key = [u8; std::mem::size_of::<u64>()];
-
-    #[inline]
-    fn key(index: &Self::Index) -> Self::Key {
-        index.to_be_bytes()
-    }
-
-    fn index(key: &[u8]) -> Self::Index {
-        convert_column_key_bytes_to_index!(key, 0..8 => u64::from_be_bytes)
-    }
-
-    fn slot(_index: Self::Index) -> Slot {
-        unimplemented!()
-    }
-
-    fn as_index(slot: u64) -> u64 {
-        slot
-    }
-}
-impl ColumnName for columns::TransactionStatusIndex {
-    const NAME: &'static str = "transaction_status_index";
 }
 
 impl SlotColumn for columns::Rewards {}

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -3,8 +3,8 @@ use {
     crate::{
         blockstore::{
             column::{
-                Column, ColumnIndexDeprecation, ColumnName, DEPRECATED_PROGRAM_COSTS_COLUMN_NAME,
-                ProtobufColumn, TypedColumn, columns,
+                Column, ColumnName, DEPRECATED_PROGRAM_COSTS_COLUMN_NAME,
+                DEPRECATED_TRANSACTION_STATUS_INDEX_NAME, ProtobufColumn, TypedColumn, columns,
             },
             error::{BlockstoreError, Result},
         },
@@ -38,7 +38,7 @@ use {
         path::{Path, PathBuf},
         sync::{
             Arc,
-            atomic::{AtomicBool, AtomicU64, Ordering},
+            atomic::{AtomicU64, Ordering},
         },
     },
 };
@@ -64,7 +64,6 @@ pub enum IteratorMode<Index> {
 #[derive(Default, Clone, Debug)]
 struct OldestSlot {
     slot: Arc<AtomicU64>,
-    clean_slot_0: Arc<AtomicBool>,
 }
 
 impl OldestSlot {
@@ -83,14 +82,6 @@ impl OldestSlot {
         // also eventual propagation (very Relaxed) load is Ok, because compaction by nature doesn't
         // require strictly synchronized semantics in this regard
         self.slot.load(Ordering::Relaxed)
-    }
-
-    pub(crate) fn set_clean_slot_0(&self, clean_slot_0: bool) {
-        self.clean_slot_0.store(clean_slot_0, Ordering::Relaxed);
-    }
-
-    pub(crate) fn get_clean_slot_0(&self) -> bool {
-        self.clean_slot_0.load(Ordering::Relaxed)
     }
 }
 
@@ -143,6 +134,13 @@ impl Rocks {
         if db.cf_handle(DEPRECATED_PROGRAM_COSTS_COLUMN_NAME).is_some() {
             db.drop_cf(DEPRECATED_PROGRAM_COSTS_COLUMN_NAME)?;
         }
+        // Delete the now unused transaction status index column if it is present
+        if db
+            .cf_handle(DEPRECATED_TRANSACTION_STATUS_INDEX_NAME)
+            .is_some()
+        {
+            db.drop_cf(DEPRECATED_TRANSACTION_STATUS_INDEX_NAME)?;
+        }
 
         let rocks = Rocks {
             db,
@@ -186,7 +184,6 @@ impl Rocks {
             new_cf_descriptor::<columns::TransactionStatus>(options, oldest_slot),
             new_cf_descriptor::<columns::AddressSignatures>(options, oldest_slot),
             new_cf_descriptor::<columns::TransactionMemos>(options, oldest_slot),
-            new_cf_descriptor::<columns::TransactionStatusIndex>(options, oldest_slot),
             new_cf_descriptor::<columns::Rewards>(options, oldest_slot),
             new_cf_descriptor::<columns::Blocktime>(options, oldest_slot),
             new_cf_descriptor::<columns::PerfSamples>(options, oldest_slot),
@@ -241,7 +238,7 @@ impl Rocks {
         cf_descriptors
     }
 
-    const fn columns() -> [&'static str; 24] {
+    const fn columns() -> [&'static str; 23] {
         [
             columns::ErasureMeta::NAME,
             columns::DeadSlots::NAME,
@@ -256,7 +253,6 @@ impl Rocks {
             columns::TransactionStatus::NAME,
             columns::AddressSignatures::NAME,
             columns::TransactionMemos::NAME,
-            columns::TransactionStatusIndex::NAME,
             columns::Rewards::NAME,
             columns::Blocktime::NAME,
             columns::PerfSamples::NAME,
@@ -462,10 +458,6 @@ impl Rocks {
 
     pub(crate) fn set_oldest_slot(&self, oldest_slot: Slot) {
         self.oldest_slot.set(oldest_slot);
-    }
-
-    pub(crate) fn set_clean_slot_0(&self, clean_slot_0: bool) {
-        self.oldest_slot.set_clean_slot_0(clean_slot_0);
     }
 }
 
@@ -968,72 +960,10 @@ where
     }
 }
 
-impl<C> LedgerColumn<C>
-where
-    C: ColumnIndexDeprecation + ColumnName,
-{
-    pub(crate) fn iter_current_index_filtered(
-        &self,
-        iterator_mode: IteratorMode<C::Index>,
-    ) -> Result<impl Iterator<Item = (C::Index, Box<[u8]>)> + '_> {
-        let start_key: <C as Column>::Key;
-        let iterator_mode = match iterator_mode {
-            IteratorMode::Start => RocksIteratorMode::Start,
-            IteratorMode::End => RocksIteratorMode::End,
-            IteratorMode::From(start, direction) => {
-                start_key = <C as Column>::key(&start);
-                RocksIteratorMode::From(start_key.as_ref(), direction)
-            }
-        };
-
-        let iter = self.backend.iterator_cf(self.handle(), iterator_mode);
-        Ok(iter.filter_map(|pair| {
-            let (key, value) = pair.unwrap();
-            C::try_current_index(&key).ok().map(|index| (index, value))
-        }))
-    }
-
-    pub(crate) fn iter_deprecated_index_filtered(
-        &self,
-        iterator_mode: IteratorMode<C::DeprecatedIndex>,
-    ) -> Result<impl Iterator<Item = (C::DeprecatedIndex, Box<[u8]>)> + '_> {
-        let start_key: <C as ColumnIndexDeprecation>::DeprecatedKey;
-        let iterator_mode = match iterator_mode {
-            IteratorMode::Start => RocksIteratorMode::Start,
-            IteratorMode::End => RocksIteratorMode::End,
-            IteratorMode::From(start_from, direction) => {
-                start_key = C::deprecated_key(start_from);
-                RocksIteratorMode::From(start_key.as_ref(), direction)
-            }
-        };
-
-        let iterator = self.backend.iterator_cf(self.handle(), iterator_mode);
-        Ok(iterator.filter_map(|pair| {
-            let (key, value) = pair.unwrap();
-            C::try_deprecated_index(&key)
-                .ok()
-                .map(|index| (index, value))
-        }))
-    }
-
-    pub(crate) fn delete_deprecated_in_batch(
-        &self,
-        batch: &mut WriteBatch,
-        index: C::DeprecatedIndex,
-    ) {
-        let key = C::deprecated_key(index);
-        batch.delete_cf(self.handle(), &key);
-    }
-}
-
 /// A CompactionFilter implementation to remove keys older than a given slot.
 struct PurgedSlotFilter<C: Column + ColumnName> {
     /// The oldest slot to keep; any slot < oldest_slot will be removed
     oldest_slot: Slot,
-    /// Whether to preserve keys that return slot 0, even when oldest_slot > 0.
-    // This is used to delete old column data that wasn't keyed with a Slot, and so always returns
-    // `C::slot() == 0`
-    clean_slot_0: bool,
     name: CString,
     _phantom: PhantomData<C>,
 }
@@ -1043,7 +973,7 @@ impl<C: Column + ColumnName> CompactionFilter for PurgedSlotFilter<C> {
         use rocksdb::CompactionDecision::*;
 
         let slot_in_key = C::slot(C::index(key));
-        if slot_in_key >= self.oldest_slot || (slot_in_key == 0 && !self.clean_slot_0) {
+        if slot_in_key >= self.oldest_slot {
             Keep
         } else {
             Remove
@@ -1066,10 +996,8 @@ impl<C: Column + ColumnName> CompactionFilterFactory for PurgedSlotFilterFactory
 
     fn create(&mut self, _context: CompactionFilterContext) -> Self::Filter {
         let copied_oldest_slot = self.oldest_slot.get();
-        let copied_clean_slot_0 = self.oldest_slot.get_clean_slot_0();
         PurgedSlotFilter::<C> {
             oldest_slot: copied_oldest_slot,
-            clean_slot_0: copied_clean_slot_0,
             name: CString::new(format!(
                 "purged_slot_filter({}, {:?})",
                 C::NAME,
@@ -1257,7 +1185,6 @@ pub mod tests {
             is_manual_compaction: true,
         };
         let oldest_slot = OldestSlot::default();
-        oldest_slot.set_clean_slot_0(true);
 
         let mut factory = PurgedSlotFilterFactory::<ShredData> {
             oldest_slot: oldest_slot.clone(),
@@ -1419,32 +1346,5 @@ pub mod tests {
 
         // The deprecated column should have been dropped by Rocks::open()
         assert!(!is_program_costs_column_present(db_path));
-    }
-
-    impl<C> LedgerColumn<C>
-    where
-        C: ColumnIndexDeprecation + ProtobufColumn + ColumnName,
-    {
-        pub fn put_deprecated_protobuf(
-            &self,
-            index: C::DeprecatedIndex,
-            value: &C::Type,
-        ) -> Result<()> {
-            let mut buf = Vec::with_capacity(value.encoded_len());
-            value.encode(&mut buf)?;
-            self.backend
-                .put_cf(self.handle(), C::deprecated_key(index), &buf)
-        }
-    }
-
-    impl<C> LedgerColumn<C>
-    where
-        C: ColumnIndexDeprecation + TypedColumn + ColumnName,
-    {
-        pub fn put_deprecated(&self, index: C::DeprecatedIndex, value: &C::Type) -> Result<()> {
-            let serialized_value = C::serialize(value)?;
-            self.backend
-                .put_cf(self.handle(), C::deprecated_key(index), &serialized_value)
-        }
     }
 }

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -607,12 +607,6 @@ impl DuplicateSlotProof {
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
-pub struct TransactionStatusIndexMeta {
-    pub max_slot: Slot,
-    pub frozen: bool,
-}
-
-#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct AddressSignatureMeta {
     pub writeable: bool,
 }


### PR DESCRIPTION
#### Problem
The TransactionStatus, TransactionMemos, and AddressSignatures columns use to have a u64 in their key format. That u64 was used for the cleaning (compaction) mechanism and pertained to an entry in the TransactionStatusIndex column.

When these columns were rekeyed to drop the u64, logic was added to find values with both the old and new key format in order to support the transition. But, the old format hasn't been written for years so it is reasonable to drop support for it now.

#### Summary of Changes
This change removes the TransactionStatusIndex column and drops support for reading the old key formats in the transaction metadata columns.

Reference PR's of interest:
- https://github.com/solana-labs/solana/pull/33419 introduced the new key format (v1.18)
- https://github.com/solana-labs/solana/pull/33678 introduced `clean_slot_0`

#### v4.0 Backport
I'd like to propose backporting this change to v4.0. While not critical (ie no key bugs fixed), we already have several breaking changes in v4.0 that will disallow v4.0 from reading old blockstores. It is nice to have all of those in one version IMO.

And while the line count is high, the PR is ~90% red lines