### PR TITLE
BlsSigverifier: also use slots to trigger reporting of stats

### DIFF
--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -116,12 +116,13 @@ impl SigVerifier {
             .thread_name(|i| format!("solSigVerBLS{i:02}"))
             .build()
             .unwrap();
+        let root_slot = sharable_banks.root().slot();
         Self {
             migration_status,
             banlist,
             channels,
             sharable_banks,
-            stats: SigVerifierStats::default(),
+            stats: SigVerifierStats::new(root_slot),
             verified_certs: HashSet::new(),
             last_checked_root_slot: 0,
             cluster_info,
@@ -150,9 +151,9 @@ impl SigVerifier {
                 error!("verify_and_send_batch() failed with {e}. Exiting.");
                 break;
             }
-            self.stats.maybe_report();
+            self.stats.maybe_report(self.sharable_banks.root().slot());
         }
-        self.stats.do_report();
+        self.stats.do_report(self.sharable_banks.root().slot());
     }
 
     fn verify_and_send_batches(&mut self, batches: Vec<PacketBatch>) -> Result<(), SigVerifyError> {
@@ -543,7 +544,7 @@ mod tests {
             vote_rank2,
         );
         let messages2 = vec![ConsensusMessage::Vote(vote_message2)];
-        ctx.verifier.stats = SigVerifierStats::default();
+        ctx.verifier.stats = SigVerifierStats::new(ctx.verifier.sharable_banks.root().slot());
         ctx.verifier
             .verify_and_send_batches(messages_to_batches(&messages2))
             .unwrap();
@@ -567,7 +568,7 @@ mod tests {
             vote_rank3,
         );
         let messages3 = vec![ConsensusMessage::Vote(vote_message3)];
-        ctx.verifier.stats = SigVerifierStats::default();
+        ctx.verifier.stats = SigVerifierStats::new(ctx.verifier.sharable_banks.root().slot());
         ctx.verifier
             .verify_and_send_batches(messages_to_batches(&messages3))
             .unwrap();
@@ -1377,7 +1378,7 @@ mod tests {
         let consensus_message2 = ConsensusMessage::Certificate(cert2);
         let packet_batches2 = messages_to_batches(&[consensus_message2]);
 
-        ctx.verifier.stats = SigVerifierStats::default();
+        ctx.verifier.stats = SigVerifierStats::new(ctx.verifier.sharable_banks.root().slot());
         ctx.verifier
             .verify_and_send_batches(packet_batches2)
             .unwrap();

--- a/core/src/bls_sigverify/stats.rs
+++ b/core/src/bls_sigverify/stats.rs
@@ -2,10 +2,37 @@
 use qualifier_attr::qualifiers;
 use {
     agave_math_utils::welford_stats::WelfordStats,
+    solana_clock::Slot,
     std::time::{Duration, Instant},
 };
 
-const STATS_INTERVAL_DURATION: Duration = Duration::from_secs(1);
+/// Max number of root slots to wait before triggering reporting of stats.  At 400ms slot times, this is 4s.
+const SLOTS_INTERVAL: Slot = 10;
+/// Max amount of seconds to wait before triggering reporting of stats.
+const DURATION_INTERVAL: Duration = Duration::from_secs(5);
+
+/// A struct to control when stats should be reported depending on how many slots or time has passed.
+#[derive(Debug)]
+pub(super) struct Reporting {
+    /// The last time when reporting was done.
+    time: Instant,
+    /// The last slot when reporting was done.
+    slot: Slot,
+}
+
+impl Reporting {
+    fn new(root_slot: Slot) -> Self {
+        Self {
+            time: Instant::now(),
+            slot: root_slot,
+        }
+    }
+
+    /// Returns `true` if reporting should be done else `false`.
+    fn should_report(&self, root_slot: Slot) -> bool {
+        self.slot + SLOTS_INTERVAL >= root_slot || self.time.elapsed() > DURATION_INTERVAL
+    }
+}
 
 /// Stats for the sigverifier.
 #[derive(Debug)]
@@ -37,11 +64,11 @@ pub(super) struct SigVerifierStats {
     /// Number of certs received that the node has already generated.
     pub(super) num_generated_certs_received: u64,
     /// Last time the stats were reported.
-    pub(super) last_report: Instant,
+    pub(super) last_report: Reporting,
 }
 
-impl Default for SigVerifierStats {
-    fn default() -> Self {
+impl SigVerifierStats {
+    pub(super) fn new(root_slot: Slot) -> Self {
         Self {
             vote_stats: SigVerifyVoteStats::default(),
             cert_stats: SigVerifyCertStats::default(),
@@ -56,25 +83,22 @@ impl Default for SigVerifierStats {
             num_verified_certs_received: 0,
             num_generated_certs_received: 0,
             verify_and_send_batch_us: WelfordStats::default(),
-            last_report: Instant::now(),
+            last_report: Reporting::new(root_slot),
         }
     }
-}
 
-impl SigVerifierStats {
     /// Reports stats if they have not been reported in some time.
     ///
     /// Also resets all stats.
-    pub(super) fn maybe_report(&mut self) {
-        if self.last_report.elapsed() < STATS_INTERVAL_DURATION {
-            return;
+    pub(super) fn maybe_report(&mut self, root_slot: Slot) {
+        if self.last_report.should_report(root_slot) {
+            self.do_report(root_slot);
+            *self = SigVerifierStats::new(root_slot);
         }
-        self.do_report();
-        *self = SigVerifierStats::default();
     }
 
     /// Reports stats regardless of when they were last reported.
-    pub(super) fn do_report(&mut self) {
+    pub(super) fn do_report(&mut self, root_slot: Slot) {
         let Self {
             vote_stats,
             cert_stats,
@@ -96,6 +120,7 @@ impl SigVerifierStats {
         cert_stats.report();
         datapoint_info!(
             "bls_sig_verifier_stats",
+            ("root_slot", root_slot, i64),
             (
                 "extract_and_verify_us_count",
                 extract_filter_msgs_us.count(),


### PR DESCRIPTION
#### Problem

Currently, we are reporting stats at arbitrary time boundaries.  Reporting them at slot boundaries can make it easier to reason about the collected metrics.


#### Summary of Changes

Stats will be reported after X root slots pass or Y time passes whichever happens first.


Fixes #11101