### PR TITLE
Marks AccountsDb::contains() as DCOU

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6648,6 +6648,7 @@ impl AccountsDb {
     }
 
     /// Is `pubkey` in the db?
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn contains(&self, pubkey: &Pubkey) -> bool {
         self.accounts_cache.contains_pubkey(pubkey) || self.accounts_index.contains(pubkey)
     }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -847,6 +847,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     }
 
     /// Is `pubkey` in the index?
+    #[cfg(feature = "dev-context-only-utils")]
     pub(crate) fn contains(&self, pubkey: &Pubkey) -> bool {
         self.get_and_then(pubkey, |entry| (false, entry.is_some()))
     }


### PR DESCRIPTION
#### Problem

`AccountsIndex::contains()` is only called in dev/test contexts, but isn't marked DCOU. So it emits warnings on builds[^1].

[^1]: See https://discord.com/channels/428295358100013066/838890116386521088/1484796390079991889.


#### Summary of Changes

Mark it DCOU.
