### PR TITLE
xdp: switch to lpm trie for routing

### DIFF
--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -12,6 +12,8 @@ pub mod device;
 #[cfg(target_os = "linux")]
 pub mod gre;
 #[cfg(target_os = "linux")]
+pub(crate) mod lpm;
+#[cfg(target_os = "linux")]
 pub mod netlink;
 #[cfg(target_os = "linux")]
 pub mod packet;

--- a/xdp/src/lpm.rs
+++ b/xdp/src/lpm.rs
@@ -1,0 +1,315 @@
+use {crate::route::Route, std::net::Ipv4Addr};
+
+const EMPTY_SLOT: u32 = u32::MAX;
+const ROOT_NODE_INDEX: u32 = 0;
+// these are for source code clarity, not because they can/should be changed
+const NIBBLE_BITS: u8 = 4;
+const IPV4_NIBBLES: usize = 8;
+const CHILDREN_PER_NODE: usize = 16;
+
+/// A longest-prefix-match lookup structure for IPv4 routes.
+///
+/// This is a nibble trie where each node has up to 16 children corresponding to
+/// the 16 possible values of a 4-bit nibble.
+#[derive(Clone, Debug)]
+pub(crate) struct Ipv4Lpm {
+    nodes: Vec<Node>,
+    children: Vec<u32>,
+}
+
+impl Ipv4Lpm {
+    /// Builds a lpm index from the given list of routes.
+    ///
+    /// If multiple routes share the same exact prefix, the first in the list wins. This means that
+    /// route priority can be implemented by sorting the routes before calling this function.
+    pub fn build(routes: &[Route<Ipv4Addr>]) -> Self {
+        assert!(
+            routes.len() < EMPTY_SLOT as usize,
+            "too many routes to index with 32 bits"
+        );
+        let mut builder = Builder::new();
+        for (route_idx, route) in routes.iter().enumerate() {
+            builder.insert_route(route_idx as u32, route);
+        }
+        builder.finish()
+    }
+
+    /// Returns the index of the default route.
+    pub fn default_route(&self) -> Option<u32> {
+        self.nodes
+            .get(ROOT_NODE_INDEX as usize)
+            .and_then(|root| (root.value_idx != EMPTY_SLOT).then_some(root.value_idx))
+    }
+
+    /// Looks up the given address.
+    ///
+    /// Returns the index of the best matching route, or None if no route matches.
+    pub fn lookup(&self, addr: Ipv4Addr) -> Option<u32> {
+        let mut node = self.nodes.get(ROOT_NODE_INDEX as usize)?;
+        let mut best = node.value_idx;
+        let addr_bits = u32::from(addr);
+
+        for depth in 0..IPV4_NIBBLES {
+            let nibble = nibble_at(addr_bits, depth);
+            // child_mask is a 16-bit bitfield where each bit corresponds to one of the 16 possible
+            // nibbles/children. When a bit is set it means the child exists.
+            let child_bit = 1u16 << nibble;
+            if node.child_mask & child_bit == 0 {
+                // no child for this nibble, stop
+                break;
+            }
+
+            // children for this node are stored at children[child_base..child_base +
+            // child_mask.count_ones()], which is to say the children are densely packed starting at
+            // child_base, children[child_base + 1] is the second child, etc
+            //
+            // To find the index of the current nibble, we count how many bits are set in child_mask
+            // that are to the left of child_bit.
+            #[allow(clippy::arithmetic_side_effects)]
+            let rank = (node.child_mask & (child_bit - 1)).count_ones();
+            #[allow(clippy::arithmetic_side_effects)]
+            let child_idx = self.children[(node.child_base + rank) as usize];
+
+            node = &self.nodes[child_idx as usize];
+            if node.value_idx != EMPTY_SLOT {
+                best = node.value_idx;
+            }
+        }
+
+        (best != EMPTY_SLOT).then_some(best)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Node {
+    // index of the route to use if this node is a match, or EMPTY_SLOT if no route matches at this node
+    value_idx: u32,
+    // index into the children array where this node's children start
+    child_base: u32,
+    // bitmask indicating which children exist
+    child_mask: u16,
+}
+
+// Builder for the Ipv4Lpm structure. This is used to incrementally build the trie before converting
+// it into the compact format used for lookup.
+#[derive(Clone)]
+struct BuilderNode {
+    value_idx: u32,
+    value_prefix_len: u8,
+    children: [u32; CHILDREN_PER_NODE],
+}
+
+impl BuilderNode {
+    fn new() -> Self {
+        Self {
+            value_idx: EMPTY_SLOT,
+            value_prefix_len: 0,
+            children: [EMPTY_SLOT; CHILDREN_PER_NODE],
+        }
+    }
+}
+
+struct Builder {
+    nodes: Vec<BuilderNode>,
+}
+
+impl Builder {
+    fn new() -> Self {
+        Self {
+            nodes: vec![BuilderNode::new()],
+        }
+    }
+
+    fn insert_route(&mut self, route_idx: u32, route: &Route<Ipv4Addr>) {
+        let network_bits = match route.destination {
+            None => 0,
+            Some(addr) => u32::from(addr),
+        };
+        let prefix_len = route.dst_len.min(32);
+
+        let full_nibbles = (prefix_len / NIBBLE_BITS) as usize;
+        let partial_bits = prefix_len % NIBBLE_BITS;
+        let mut node_idx = ROOT_NODE_INDEX;
+
+        for depth in 0..full_nibbles {
+            let nibble = nibble_at(network_bits, depth);
+            node_idx = self.child_or_insert(node_idx, nibble);
+        }
+
+        if partial_bits == 0 {
+            // The prefix ends on a nibble boundary, we can just set the value at this node
+            self.set_value(node_idx, route_idx, prefix_len);
+            return;
+        }
+
+        // We have a partial nibble at the end. We're going to insert multiple nodes to cover all
+        // possible values of the bits after the prefix. Eg if the prefix is 17 bits, then we have 1
+        // bit of the last nibble that is part of the prefix and 3 bits that are not. This means we
+        // need to insert nodes for all 8 possible values of those 3 bits so at lookup we match the
+        // prefix bits and then match any value for the remaining bits. This trades a bit more work
+        // at build time for faster lookup.
+        let base_nibble = nibble_at(network_bits, full_nibbles);
+        let fanout_bits = NIBBLE_BITS.saturating_sub(partial_bits);
+        let range_start = (base_nibble >> fanout_bits) << fanout_bits;
+        let range_len = 1usize << fanout_bits;
+        for nibble in range_start as usize..(range_start as usize).saturating_add(range_len) {
+            let child_idx = self.child_or_insert(node_idx, nibble as u8);
+            self.set_value(child_idx, route_idx, prefix_len);
+        }
+    }
+
+    fn child_or_insert(&mut self, node_idx: u32, nibble: u8) -> u32 {
+        let child_idx = self.nodes[node_idx as usize].children[nibble as usize];
+        if child_idx != EMPTY_SLOT {
+            return child_idx;
+        }
+
+        let child_idx = self.nodes.len() as u32;
+        self.nodes.push(BuilderNode::new());
+        self.nodes[node_idx as usize].children[nibble as usize] = child_idx;
+        child_idx
+    }
+
+    fn set_value(&mut self, node_idx: u32, route_idx: u32, prefix_len: u8) {
+        let node = &mut self.nodes[node_idx as usize];
+        // If there's already a route at this node, only replace it if the new one has longer
+        // prefix. This means that if there are multiple routes with the same prefix length, the
+        // first one wins.
+        if node.value_idx == EMPTY_SLOT || prefix_len > node.value_prefix_len {
+            node.value_idx = route_idx;
+            node.value_prefix_len = prefix_len;
+        }
+    }
+
+    fn finish(self) -> Ipv4Lpm {
+        let mut nodes = Vec::with_capacity(self.nodes.len());
+        let mut children = Vec::new();
+
+        for builder_node in self.nodes {
+            let child_base = children.len() as u32;
+            let mut child_mask = 0u16;
+
+            for (nibble, child_idx) in builder_node.children.into_iter().enumerate() {
+                if child_idx == EMPTY_SLOT {
+                    continue;
+                }
+                child_mask |= 1u16 << nibble;
+                children.push(child_idx);
+            }
+
+            // Convert from BuilderNode(s) where each node has a fixed array of 16 children, to the
+            // compact format where children are densely packed and we have a bitmask to indicate
+            // which children exist.
+            nodes.push(Node {
+                value_idx: builder_node.value_idx,
+                child_base,
+                child_mask,
+            });
+        }
+
+        Ipv4Lpm { nodes, children }
+    }
+}
+
+#[inline]
+fn nibble_at(addr_bits: u32, depth: usize) -> u8 {
+    // get the nibble at the given depth, where depth 0 is the most significant nibble
+    // eg with depth=0 and addr_bits=0x12345678, this returns 0x1
+    #[allow(clippy::arithmetic_side_effects)]
+    let shift = 28u32 - (depth as u32) * u32::from(NIBBLE_BITS);
+    ((addr_bits >> shift) & 0x0f) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::route::Route, std::net::Ipv4Addr};
+
+    fn route(destination: Option<Ipv4Addr>, dst_len: u8) -> Route<Ipv4Addr> {
+        Route {
+            destination,
+            gateway: None,
+            preferred_src: None,
+            out_if_index: Some(1),
+            priority: None,
+            type_: 0,
+            dst_len,
+        }
+    }
+
+    #[test]
+    fn test_default_route() {
+        let routes = vec![route(None, 0)];
+        let lpm = Ipv4Lpm::build(&routes);
+
+        assert_eq!(lpm.default_route(), Some(0));
+        assert_eq!(lpm.lookup(Ipv4Addr::new(10, 0, 0, 0)), Some(0));
+    }
+
+    #[test]
+    fn test_non_default_route() {
+        let routes = vec![route(None, 0), route(Some(Ipv4Addr::new(10, 0, 0, 1)), 24)];
+        let lpm = Ipv4Lpm::build(&routes);
+
+        assert_eq!(lpm.lookup(Ipv4Addr::new(10, 0, 0, 1)), Some(1));
+        assert_eq!(lpm.lookup(Ipv4Addr::new(10, 0, 1, 0)), Some(0));
+    }
+
+    #[test]
+    fn test_longer_prefix_wins_order_descending() {
+        let routes = vec![
+            route(None, 0),
+            route(Some(Ipv4Addr::new(10, 1, 1, 0)), 24),
+            route(Some(Ipv4Addr::new(10, 1, 0, 0)), 16),
+            route(Some(Ipv4Addr::new(10, 0, 0, 0)), 8),
+        ];
+        let lpm = Ipv4Lpm::build(&routes);
+
+        assert_eq!(lpm.lookup(Ipv4Addr::new(10, 1, 1, 0)), Some(1));
+        assert_eq!(lpm.lookup(Ipv4Addr::new(10, 1, 0, 0)), Some(2));
+        assert_eq!(lpm.lookup(Ipv4Addr::new(10, 0, 0, 0)), Some(3));
+        assert_eq!(lpm.lookup(Ipv4Addr::new(11, 0, 0, 0)), Some(0));
+    }
+
+    #[test]
+    fn test_longer_prefix_wins_order_ascending() {
+        let routes = vec![
+            route(None, 0),
+            route(Some(Ipv4Addr::new(10, 0, 0, 0)), 8),
+            route(Some(Ipv4Addr::new(10, 1, 0, 0)), 16),
+            route(Some(Ipv4Addr::new(10, 1, 1, 0)), 24),
+        ];
+        let lpm = Ipv4Lpm::build(&routes);
+
+        assert_eq!(lpm.lookup(Ipv4Addr::new(10, 1, 1, 0)), Some(3));
+        assert_eq!(lpm.lookup(Ipv4Addr::new(10, 1, 0, 0)), Some(2));
+        assert_eq!(lpm.lookup(Ipv4Addr::new(10, 0, 0, 0)), Some(1));
+        assert_eq!(lpm.lookup(Ipv4Addr::new(11, 0, 0, 0)), Some(0));
+    }
+
+    #[test]
+    fn test_partial_nibble_prefixes() {
+        let routes = vec![route(None, 0), route(Some(Ipv4Addr::new(10, 0, 0, 0)), 17)];
+        let lpm = Ipv4Lpm::build(&routes);
+
+        for i in 0x00..=0x7F {
+            let addr = Ipv4Addr::new(10, 0, i, 0);
+            assert_eq!(
+                lpm.lookup(addr),
+                Some(1),
+                "addr {addr} should match the /17 route"
+            );
+        }
+        assert_eq!(lpm.lookup(Ipv4Addr::new(10, 0, 0x80, 0)), Some(0));
+    }
+
+    #[test]
+    fn test_equal_len_prefixes_first_wins() {
+        let routes = vec![
+            route(Some(Ipv4Addr::new(10, 0, 0, 0)), 8),
+            route(Some(Ipv4Addr::new(10, 0, 0, 0)), 8),
+        ];
+        let lpm = Ipv4Lpm::build(&routes);
+
+        assert_eq!(lpm.lookup(Ipv4Addr::new(10, 0, 0, 0)), Some(0));
+    }
+}

--- a/xdp/src/netlink.rs
+++ b/xdp/src/netlink.rs
@@ -4,10 +4,10 @@ use {
     libc::{
         AF_INET, AF_INET6, AF_NETLINK, IFLA_INFO_DATA, IFLA_INFO_KIND, IFLA_LINKINFO, NDA_DST,
         NDA_LLADDR, NETLINK_EXT_ACK, NETLINK_ROUTE, NLA_ALIGNTO, NLA_TYPE_MASK, NLM_F_DUMP,
-        NLM_F_MULTI, NLM_F_REQUEST, NLMSG_DONE, NLMSG_ERROR, RT_TABLE_MAIN, RTA_DST, RTA_GATEWAY,
-        RTA_IIF, RTA_OIF, RTA_PREFSRC, RTA_PRIORITY, RTA_TABLE, RTM_GETLINK, RTM_GETNEIGH,
-        RTM_GETROUTE, RTM_NEWLINK, RTM_NEWNEIGH, RTM_NEWROUTE, SO_RCVBUF, SOCK_RAW, SOL_NETLINK,
-        SOL_SOCKET, nlattr, nlmsgerr, nlmsghdr, recv, send, setsockopt, sockaddr_nl, socket,
+        NLM_F_MULTI, NLM_F_REQUEST, NLMSG_DONE, NLMSG_ERROR, RTA_DST, RTA_GATEWAY, RTA_IIF,
+        RTA_OIF, RTA_PREFSRC, RTA_PRIORITY, RTA_TABLE, RTM_GETLINK, RTM_GETNEIGH, RTM_GETROUTE,
+        RTM_NEWLINK, RTM_NEWNEIGH, RTM_NEWROUTE, SO_RCVBUF, SOCK_RAW, SOL_NETLINK, SOL_SOCKET,
+        nlattr, nlmsgerr, nlmsghdr, recv, send, setsockopt, sockaddr_nl, socket,
     },
     std::{
         collections::HashMap,
@@ -651,15 +651,16 @@ fn parse_ip_address(data: &[u8], family: u8) -> Option<IpAddr> {
     }
 }
 
-pub fn netlink_get_routes(family: u8) -> Result<Vec<RouteEntry>, io::Error> {
+pub fn netlink_get_routes(family: u8, table: u32) -> Result<Vec<RouteEntry>, io::Error> {
     let sock = NetlinkSocket::open()?;
 
     // Safety: RouteRequest is POD
     let mut req = unsafe { mem::zeroed::<RouteRequest>() };
 
     let nlmsg_len = mem::size_of::<nlmsghdr>() + mem::size_of::<rtmsg>();
+    let table_attr_len = align_to(NLA_HDR_LEN + mem::size_of::<u32>(), NLA_ALIGNTO as usize);
     req.header = nlmsghdr {
-        nlmsg_len: nlmsg_len as u32,
+        nlmsg_len: (nlmsg_len + table_attr_len) as u32,
         nlmsg_flags: (NLM_F_REQUEST | NLM_F_DUMP) as u16,
         nlmsg_type: RTM_GETROUTE,
         nlmsg_pid: 0,
@@ -667,9 +668,10 @@ pub fn netlink_get_routes(family: u8) -> Result<Vec<RouteEntry>, io::Error> {
     };
 
     req.rtm.rtm_family = family;
-    req.rtm.rtm_table = RT_TABLE_MAIN;
 
-    sock.send(&bytes_of(&req)[..req.header.nlmsg_len as usize])?;
+    let mut req_buf = bytes_of(&req)[..nlmsg_len].to_vec();
+    push_nlattr(&mut req_buf, RTA_TABLE, &table);
+    sock.send(&req_buf)?;
 
     let mut routes = Vec::new();
 
@@ -683,7 +685,12 @@ pub fn netlink_get_routes(family: u8) -> Result<Vec<RouteEntry>, io::Error> {
         }
 
         if let Some(route) = parse_rtm_newroute(&msg) {
-            routes.push(route);
+            // for compatibility reasons, it turns out the kernel ignores the rtm_table filter in
+            // the request unless NETLINK_GET_STRICT_CHK is set. Filter manually for now until we
+            // add support for strict checking and do enough testing.
+            if route.table == Some(table) {
+                routes.push(route);
+            }
         }
     }
 
@@ -705,7 +712,7 @@ pub fn parse_rtm_newroute(msg: &NetlinkMessage) -> Option<RouteEntry> {
         out_if_index: None,
         in_if_index: None,
         priority: None,
-        table: None,
+        table: Some(u32::from(rt_msg.rtm_table)),
         protocol: rt_msg.rtm_protocol,
         scope: rt_msg.rtm_scope,
         type_: rt_msg.rtm_type,
@@ -741,4 +748,16 @@ pub fn parse_rtm_newroute(msg: &NetlinkMessage) -> Option<RouteEntry> {
         route.pref_src = parse_ip_address(prefsrc_attr.data, rt_msg.rtm_family);
     }
     Some(route)
+}
+
+fn push_nlattr<T>(buf: &mut Vec<u8>, attr_type: u16, value: &T) {
+    let attr_len = NLA_HDR_LEN + mem::size_of::<T>();
+    let aligned_len = align_to(attr_len, NLA_ALIGNTO as usize);
+    let attr = nlattr {
+        nla_len: attr_len as u16,
+        nla_type: attr_type,
+    };
+    buf.extend_from_slice(bytes_of(&attr));
+    buf.extend_from_slice(bytes_of(value));
+    buf.resize(buf.len() + (aligned_len - attr_len), 0);
 }

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -128,60 +128,25 @@ fn is_ipv6_match(addr: Ipv6Addr, network: Ipv6Addr, prefix_len: u8) -> bool {
     true
 }
 
-#[derive(Clone)]
-struct RouteTable {
-    routes: Vec<RouteEntry>,
-}
-
-impl RouteTable {
-    pub fn new() -> Result<Self, io::Error> {
-        let routes = netlink_get_routes(AF_INET as u8)?;
-        Ok(Self { routes })
-    }
-
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = &RouteEntry> {
-        self.routes.iter()
-    }
-
-    pub fn upsert(&mut self, new_route: RouteEntry) -> bool {
-        if let Some(existing) = self.routes.iter_mut().find(|old| old.same_key(&new_route)) {
-            if existing != &new_route {
-                *existing = new_route;
-                return true;
-            }
-            false
-        } else {
-            self.routes.push(new_route);
-            true
-        }
-    }
-
-    pub fn remove(&mut self, new_route: RouteEntry) -> bool {
-        if let Some(i) = self.routes.iter().position(|old| old.same_key(&new_route)) {
-            self.routes.swap_remove(i);
-            return true;
-        }
-        false
-    }
-}
-
 #[derive(Clone, Debug)]
-struct InterfaceTable {
+pub struct Interfaces {
     interfaces: Vec<InterfaceInfo>,
 }
 
-impl InterfaceTable {
-    pub fn new() -> Result<Self, io::Error> {
-        Ok(Self {
-            interfaces: netlink_get_interfaces(AF_INET as u8)?.into_iter().collect(),
-        })
+impl Interfaces {
+    pub fn new(interfaces: Vec<InterfaceInfo>) -> Self {
+        Self { interfaces }
+    }
+
+    pub fn from_netlink() -> Result<Self, io::Error> {
+        Ok(Self::new(netlink_get_interfaces(AF_INET as u8)?))
     }
 
     pub fn iter(&self) -> impl ExactSizeIterator<Item = &InterfaceInfo> {
         self.interfaces.iter()
     }
 
-    pub fn upsert(&mut self, new_interface: InterfaceInfo) -> bool {
+    fn upsert(&mut self, new_interface: InterfaceInfo) -> bool {
         if let Some(existing) = self
             .interfaces
             .iter_mut()
@@ -197,7 +162,7 @@ impl InterfaceTable {
         true
     }
 
-    pub fn remove(&mut self, if_index: u32) -> bool {
+    fn remove(&mut self, if_index: u32) -> bool {
         if let Some(i) = self
             .interfaces
             .iter()
@@ -211,10 +176,156 @@ impl InterfaceTable {
 }
 
 #[derive(Clone)]
+pub struct Neighbors {
+    neighbors: Vec<NeighborEntry>,
+}
+
+impl Neighbors {
+    pub fn new(neighbors: Vec<NeighborEntry>) -> Self {
+        Self { neighbors }
+    }
+
+    pub fn from_netlink() -> Result<Self, io::Error> {
+        Ok(Self::new(netlink_get_neighbors(None, AF_INET as u8)?))
+    }
+
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &NeighborEntry> {
+        self.neighbors.iter()
+    }
+
+    fn lookup(&self, ip: IpAddr, if_index: u32) -> Option<&MacAddress> {
+        self.neighbors
+            .iter()
+            .find(|n| n.ifindex == if_index as i32 && n.destination == Some(ip))
+            .and_then(|n| n.lladdr.as_ref())
+    }
+
+    fn upsert(&mut self, new_neighbor: NeighborEntry) -> bool {
+        let Some((ifidx, ip)) = new_neighbor.key() else {
+            return false;
+        };
+
+        if let Some(i) = self
+            .neighbors
+            .iter()
+            .position(|old| old.ifindex == ifidx && old.destination == Some(IpAddr::V4(ip)))
+        {
+            if self.neighbors[i] != new_neighbor {
+                self.neighbors[i] = new_neighbor;
+                return true;
+            }
+            false
+        } else {
+            self.neighbors.push(new_neighbor);
+            true
+        }
+    }
+
+    fn remove(&mut self, ip: Ipv4Addr, if_index: u32) -> bool {
+        if let Some(i) = self.neighbors.iter().position(|old| {
+            old.ifindex == if_index as i32 && old.destination == Some(IpAddr::V4(ip))
+        }) {
+            self.neighbors.swap_remove(i);
+            return true;
+        }
+        false
+    }
+}
+
+#[derive(Clone)]
+pub struct Routes {
+    routes: Vec<RouteEntry>,
+}
+
+impl Routes {
+    pub fn new(routes: Vec<RouteEntry>) -> Self {
+        Self { routes }
+    }
+
+    pub fn from_netlink() -> Result<Self, io::Error> {
+        Ok(Self::new(netlink_get_routes(AF_INET as u8)?))
+    }
+
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &RouteEntry> {
+        self.routes.iter()
+    }
+
+    fn upsert(&mut self, new_route: RouteEntry) -> bool {
+        if let Some(existing) = self.routes.iter_mut().find(|old| old.same_key(&new_route)) {
+            if existing != &new_route {
+                *existing = new_route;
+                return true;
+            }
+            false
+        } else {
+            self.routes.push(new_route);
+            true
+        }
+    }
+
+    fn remove(&mut self, new_route: RouteEntry) -> bool {
+        if let Some(i) = self.routes.iter().position(|old| old.same_key(&new_route)) {
+            self.routes.swap_remove(i);
+            return true;
+        }
+        false
+    }
+}
+
+#[derive(Clone)]
+pub struct RoutingTables {
+    routes: Routes,
+    neighbors: Neighbors,
+    interfaces: Interfaces,
+}
+
+impl RoutingTables {
+    pub fn new(routes: Routes, neighbors: Neighbors, interfaces: Interfaces) -> Self {
+        Self {
+            routes,
+            neighbors,
+            interfaces,
+        }
+    }
+
+    pub fn from_netlink() -> Result<Self, io::Error> {
+        Ok(Self::new(
+            Routes::from_netlink()?,
+            Neighbors::from_netlink()?,
+            Interfaces::from_netlink()?,
+        ))
+    }
+
+    pub fn upsert_route(&mut self, new_route: RouteEntry) -> bool {
+        self.routes.upsert(new_route)
+    }
+
+    pub fn remove_route(&mut self, new_route: RouteEntry) -> bool {
+        self.routes.remove(new_route)
+    }
+
+    pub fn upsert_neighbor(&mut self, new_neighbor: NeighborEntry) -> bool {
+        self.neighbors.upsert(new_neighbor)
+    }
+
+    pub fn remove_neighbor(&mut self, ip: Ipv4Addr, if_index: u32) -> bool {
+        self.neighbors.remove(ip, if_index)
+    }
+
+    pub fn upsert_interface(&mut self, new_interface: InterfaceInfo) -> bool {
+        self.interfaces.upsert(new_interface)
+    }
+
+    pub fn remove_interface(&mut self, if_index: u32) -> bool {
+        self.interfaces.remove(if_index)
+    }
+}
+
+#[derive(Clone)]
 pub struct Router {
-    arp_table: ArpTable,
-    route_table: RouteTable,
-    interface_table: InterfaceTable,
+    neighbors: Neighbors,
+    routes: Routes,
+    interfaces: Interfaces,
     // cache for the default route next hop so we can avoid arp table lookups on the common case
     cached_default_route: Option<NextHop>,
     // cache for gre route info keyed by interface index. This stays tiny in practice.
@@ -223,13 +334,38 @@ pub struct Router {
 
 impl Router {
     pub fn new() -> Result<Self, io::Error> {
-        Ok(Self {
-            arp_table: ArpTable::new()?,
-            route_table: RouteTable::new()?,
-            interface_table: InterfaceTable::new()?,
+        Self::from_tables(RoutingTables::from_netlink()?)
+    }
+
+    pub fn from_tables(tables: RoutingTables) -> Result<Self, io::Error> {
+        let mut router = Self {
+            neighbors: tables.neighbors,
+            routes: tables.routes,
+            interfaces: tables.interfaces,
             cached_default_route: None,
             cached_gre_info: Vec::new(),
-        })
+        };
+
+        let mut has_gre_interface = false;
+        for interface in router.interfaces.iter() {
+            if interface.gre_tunnel.is_some() {
+                has_gre_interface = true;
+                if let Some(gre) = router.interface_gre_route_info(interface) {
+                    router.cached_gre_info.push(gre);
+                }
+            }
+        }
+        if router.cached_gre_info.is_empty() && has_gre_interface {
+            warn!("GRE cache: GRE interface(s) present but none with valid remote resolved");
+        }
+
+        router.cached_default_route = match router.default_route() {
+            Ok(hop) => Some(hop),
+            Err(RouteError::NoRouteFound(_)) => None,
+            Err(e) => return Err(io::Error::other(e)),
+        };
+
+        Ok(router)
     }
 
     fn cached_gre_route_info(&self, if_index: u32) -> Option<&GreRouteInfo> {
@@ -244,7 +380,7 @@ impl Router {
         }
 
         let interface = self
-            .interface_table
+            .interfaces
             .iter()
             .find(|interface| interface.if_index == if_index)?;
         self.interface_gre_route_info(interface)
@@ -287,7 +423,7 @@ impl Router {
             });
         }
 
-        let mac_addr = self.arp_table.lookup(next_hop_ip, if_index).cloned();
+        let mac_addr = self.neighbors.lookup(next_hop_ip, if_index).cloned();
         Ok(NextHop {
             ip_addr: next_hop_ip,
             mac_addr,
@@ -299,7 +435,7 @@ impl Router {
 
     fn default_route(&self) -> Result<NextHop, RouteError> {
         let default_route = self
-            .route_table
+            .routes
             .iter()
             .find(|r| r.destination.is_none())
             .ok_or(RouteError::NoRouteFound(IpAddr::V4(Ipv4Addr::UNSPECIFIED)))?;
@@ -315,36 +451,9 @@ impl Router {
     }
 
     pub fn route(&self, dest_ip: IpAddr) -> Result<NextHop, RouteError> {
-        let route = lookup_route(self.route_table.iter(), dest_ip)
-            .ok_or(RouteError::NoRouteFound(dest_ip))?;
+        let route =
+            lookup_route(self.routes.iter(), dest_ip).ok_or(RouteError::NoRouteFound(dest_ip))?;
         self.resolve_next_hop(dest_ip, route)
-    }
-
-    // called to rebuild cached values after route/neigh/interface updates right
-    // before a new Router instance is published
-    pub fn build_caches(&mut self) -> Result<(), io::Error> {
-        self.cached_default_route = None;
-        self.cached_gre_info.clear();
-
-        let mut has_gre_interface = false;
-        for interface in self.interface_table.iter() {
-            if interface.gre_tunnel.is_some() {
-                has_gre_interface = true;
-                if let Some(gre) = self.interface_gre_route_info(interface) {
-                    self.cached_gre_info.push(gre);
-                }
-            }
-        }
-        if self.cached_gre_info.is_empty() && has_gre_interface {
-            warn!("GRE cache: GRE interface(s) present but none with valid remote resolved");
-        }
-        self.cached_default_route = match self.default_route() {
-            Ok(hop) => Some(hop),
-            Err(RouteError::NoRouteFound(_)) => None,
-            Err(e) => return Err(io::Error::other(e)),
-        };
-
-        Ok(())
     }
 
     fn interface_gre_route_info(&self, interface: &InterfaceInfo) -> Option<GreRouteInfo> {
@@ -357,10 +466,10 @@ impl Router {
             return None;
         }
 
-        let underlay_route = lookup_route(self.route_table.iter(), remote)?;
+        let underlay_route = lookup_route(self.routes.iter(), remote)?;
         let underlay_if_index = underlay_route.out_if_index? as u32;
         let underlay_interface = self
-            .interface_table
+            .interfaces
             .iter()
             .find(|candidate| candidate.if_index == underlay_if_index)?;
         if underlay_interface.is_gre() {
@@ -373,7 +482,7 @@ impl Router {
         }
         let underlay_next_hop_ip = underlay_route.gateway.unwrap_or(remote);
         let mac_addr = self
-            .arp_table
+            .neighbors
             .lookup(underlay_next_hop_ip, underlay_if_index)
             .copied()?;
 
@@ -382,80 +491,6 @@ impl Router {
             tunnel_info: tunnel_info.clone(),
             mac_addr,
         })
-    }
-
-    pub fn upsert_route(&mut self, new_route: RouteEntry) -> bool {
-        self.route_table.upsert(new_route)
-    }
-
-    pub fn remove_route(&mut self, new_route: RouteEntry) -> bool {
-        self.route_table.remove(new_route)
-    }
-
-    pub fn upsert_neighbor(&mut self, new_neighbor: NeighborEntry) -> bool {
-        self.arp_table.upsert(new_neighbor)
-    }
-
-    pub fn remove_neighbor(&mut self, ip: Ipv4Addr, if_index: u32) -> bool {
-        self.arp_table.remove(ip, if_index)
-    }
-
-    pub fn upsert_interface(&mut self, new_interface: InterfaceInfo) -> bool {
-        self.interface_table.upsert(new_interface)
-    }
-
-    pub fn remove_interface(&mut self, if_index: u32) -> bool {
-        self.interface_table.remove(if_index)
-    }
-}
-
-#[derive(Clone)]
-struct ArpTable {
-    neighbors: Vec<NeighborEntry>,
-}
-
-impl ArpTable {
-    pub fn new() -> Result<Self, io::Error> {
-        let neighbors = netlink_get_neighbors(None, AF_INET as u8)?;
-        Ok(Self { neighbors })
-    }
-
-    pub fn lookup(&self, ip: IpAddr, if_index: u32) -> Option<&MacAddress> {
-        self.neighbors
-            .iter()
-            .find(|n| n.ifindex == if_index as i32 && n.destination == Some(ip))
-            .and_then(|n| n.lladdr.as_ref())
-    }
-
-    pub fn upsert(&mut self, new_neighbor: NeighborEntry) -> bool {
-        let Some((ifidx, ip)) = new_neighbor.key() else {
-            return false;
-        };
-
-        if let Some(i) = self
-            .neighbors
-            .iter()
-            .position(|old| old.ifindex == ifidx && old.destination == Some(IpAddr::V4(ip)))
-        {
-            if self.neighbors[i] != new_neighbor {
-                self.neighbors[i] = new_neighbor;
-                return true;
-            }
-            false
-        } else {
-            self.neighbors.push(new_neighbor);
-            true
-        }
-    }
-
-    pub fn remove(&mut self, ip: Ipv4Addr, if_index: u32) -> bool {
-        if let Some(i) = self.neighbors.iter().position(|old| {
-            old.ifindex == if_index as i32 && old.destination == Some(IpAddr::V4(ip))
-        }) {
-            self.neighbors.swap_remove(i);
-            return true;
-        }
-        false
     }
 }
 
@@ -491,13 +526,20 @@ mod tests {
         routes: Vec<RouteEntry>,
         interfaces: Vec<InterfaceInfo>,
     ) -> Router {
-        Router {
-            arp_table: ArpTable { neighbors },
-            route_table: RouteTable { routes },
-            interface_table: InterfaceTable { interfaces },
-            cached_default_route: None,
-            cached_gre_info: Vec::new(),
-        }
+        let tables = RoutingTables::new(
+            Routes::new(routes),
+            Neighbors::new(neighbors),
+            Interfaces::new(interfaces),
+        );
+        Router::from_tables(tables).unwrap()
+    }
+
+    fn empty_tables() -> RoutingTables {
+        RoutingTables::new(
+            Routes::new(Vec::new()),
+            Neighbors::new(Vec::new()),
+            Interfaces::new(Vec::new()),
+        )
     }
 
     #[test]
@@ -556,11 +598,17 @@ mod tests {
 
     #[test]
     fn test_router() {
-        let mut router = Router::new().unwrap();
-        let next_hop = router.route("1.1.1.1".parse().unwrap()).unwrap();
-        eprintln!("{next_hop:?}");
+        let mut tables = empty_tables();
+        let before_routes_len = tables.routes.iter().len();
 
-        let before_routes_len = router.route_table.iter().len();
+        let gateway = Ipv4Addr::new(10, 255, 255, 1);
+        let neighbor = NeighborEntry {
+            destination: Some(IpAddr::V4(gateway)),
+            lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
+            ifindex: 1,
+            state: NUD_REACHABLE,
+        };
+        assert!(tables.upsert_neighbor(neighbor));
 
         // Create a unique, private IPv4 /32 route to avoid collisions
         let test_dst = Ipv4Addr::new(10, 255, 255, 123);
@@ -581,20 +629,25 @@ mod tests {
         };
 
         // Upsert new route and check that it was inserted and routes are dirty
-        assert!(router.upsert_route(route.clone()));
-        assert!(router.route_table.iter().any(|r| r == &route));
-        assert!(router.route_table.iter().len() >= before_routes_len);
+        assert!(tables.upsert_route(route.clone()));
+        assert!(tables.routes.iter().any(|r| r == &route));
+        assert!(tables.routes.iter().len() >= before_routes_len);
+
+        let router = Router::from_tables(tables.clone()).unwrap();
+        let next_hop = router.route(IpAddr::V4(test_dst)).unwrap();
+        assert_eq!(next_hop.if_index, 1);
+        assert_eq!(next_hop.ip_addr, IpAddr::V4(gateway));
 
         // Delete using same key should remove the route
-        assert!(router.remove_route(route.clone()));
-        assert!(router.route_table.iter().all(|r| r != &route));
-        assert_eq!(router.route_table.iter().len(), before_routes_len);
+        assert!(tables.remove_route(route.clone()));
+        assert!(tables.routes.iter().all(|r| r != &route));
+        assert_eq!(tables.routes.iter().len(), before_routes_len);
     }
 
     #[test]
-    fn test_arp_table() {
-        let mut router = Router::new().unwrap();
-        let before_neigh_len = router.arp_table.neighbors.len();
+    fn test_neighbors_table() {
+        let mut tables = empty_tables();
+        let before_neigh_len = tables.neighbors.iter().len();
 
         // Create a unique, private neighbor entry on a dummy ifindex
         let neigh_ip = Ipv4Addr::new(10, 255, 255, 77);
@@ -606,20 +659,20 @@ mod tests {
         };
 
         // Upsert new neighbor and check that it was inserted and neighbors are dirty
-        assert!(router.upsert_neighbor(entry.clone()));
-        assert!(router.arp_table.neighbors.iter().any(|n| n == &entry));
-        assert!(router.arp_table.neighbors.len() >= before_neigh_len);
+        assert!(tables.upsert_neighbor(entry.clone()));
+        assert!(tables.neighbors.iter().any(|n| n == &entry));
+        assert!(tables.neighbors.iter().len() >= before_neigh_len);
 
         // Delete neighbor and check that it was deleted
-        assert!(router.remove_neighbor(neigh_ip, 1));
-        assert!(router.arp_table.neighbors.iter().all(|n| n != &entry));
-        assert_eq!(router.arp_table.neighbors.len(), before_neigh_len);
+        assert!(tables.remove_neighbor(neigh_ip, 1));
+        assert!(tables.neighbors.iter().all(|n| n != &entry));
+        assert_eq!(tables.neighbors.iter().len(), before_neigh_len);
     }
 
     #[test]
     fn test_interface_table() {
-        let mut router = Router::new().unwrap();
-        let before_interface_len = router.interface_table.iter().len();
+        let mut tables = empty_tables();
+        let before_interface_len = tables.interfaces.iter().len();
 
         // Create a unique, private interface with a dummy ifindex
         let test_if_index = 99999;
@@ -629,12 +682,12 @@ mod tests {
         };
 
         // Upsert new interface and check that it was inserted
-        assert!(router.upsert_interface(interface.clone()));
-        assert!(router.interface_table.iter().any(|i| i == &interface));
-        assert!(router.interface_table.iter().len() >= before_interface_len);
+        assert!(tables.upsert_interface(interface.clone()));
+        assert!(tables.interfaces.iter().any(|i| i == &interface));
+        assert!(tables.interfaces.iter().len() >= before_interface_len);
 
         // Upsert same interface with no changes should return false
-        assert!(!router.upsert_interface(interface.clone()));
+        assert!(!tables.upsert_interface(interface.clone()));
 
         // Upsert with changes should return true
         let mut modified_interface = interface.clone();
@@ -645,24 +698,19 @@ mod tests {
             tos: 0,
             pmtudisc: 0,
         });
-        assert!(router.upsert_interface(modified_interface.clone()));
-        assert!(
-            router
-                .interface_table
-                .iter()
-                .any(|i| i == &modified_interface)
-        );
-        assert!(router.interface_table.iter().all(|i| i != &interface));
+        assert!(tables.upsert_interface(modified_interface.clone()));
+        assert!(tables.interfaces.iter().any(|i| i == &modified_interface));
+        assert!(tables.interfaces.iter().all(|i| i != &interface));
 
         // Delete interface and check that it was deleted
-        assert!(router.remove_interface(test_if_index));
+        assert!(tables.remove_interface(test_if_index));
         assert!(
-            router
-                .interface_table
+            tables
+                .interfaces
                 .iter()
                 .all(|i| i.if_index != test_if_index)
         );
-        assert_eq!(router.interface_table.iter().len(), before_interface_len);
+        assert_eq!(tables.interfaces.iter().len(), before_interface_len);
     }
 
     #[test]
@@ -726,39 +774,21 @@ mod tests {
             },
         ];
 
-        let mut router = router_from_tables(neighbors, routes, interfaces);
-        let uncached1 = router.route(IpAddr::V4(gre_dest1)).unwrap();
-        assert_eq!(uncached1.if_index, if_index_gre1 as u32);
-        assert_eq!(uncached1.mac_addr, Some(mac1));
+        let router = router_from_tables(neighbors, routes, interfaces);
+        let hop1 = router.route(IpAddr::V4(gre_dest1)).unwrap();
+        assert_eq!(hop1.if_index, if_index_gre1 as u32);
+        assert_eq!(hop1.mac_addr, Some(mac1));
         assert_eq!(
-            uncached1.gre.as_ref().map(|gre| gre.if_index),
+            hop1.gre.as_ref().map(|gre| gre.if_index),
             Some(if_index_gre1 as u32)
         );
 
-        let uncached2 = router.route(IpAddr::V4(gre_dest2)).unwrap();
-        assert_eq!(uncached2.if_index, if_index_gre2 as u32);
-        assert_eq!(uncached2.mac_addr, Some(mac2));
+        let hop2 = router.route(IpAddr::V4(gre_dest2)).unwrap();
+        assert_eq!(hop2.if_index, if_index_gre2 as u32);
+        assert_eq!(hop2.mac_addr, Some(mac2));
         assert_eq!(
-            uncached2.gre.as_ref().map(|gre| gre.if_index),
+            hop2.gre.as_ref().map(|gre| gre.if_index),
             Some(if_index_gre2 as u32)
-        );
-
-        router.build_caches().unwrap();
-
-        let cached1 = router.route(IpAddr::V4(gre_dest1)).unwrap();
-        assert_eq!(cached1.if_index, uncached1.if_index);
-        assert_eq!(cached1.mac_addr, uncached1.mac_addr);
-        assert_eq!(
-            cached1.gre.as_ref().map(|gre| gre.if_index),
-            uncached1.gre.as_ref().map(|gre| gre.if_index)
-        );
-
-        let cached2 = router.route(IpAddr::V4(gre_dest2)).unwrap();
-        assert_eq!(cached2.if_index, uncached2.if_index);
-        assert_eq!(cached2.mac_addr, uncached2.mac_addr);
-        assert_eq!(
-            cached2.gre.as_ref().map(|gre| gre.if_index),
-            uncached2.gre.as_ref().map(|gre| gre.if_index)
         );
     }
 
@@ -813,40 +843,22 @@ mod tests {
             },
         ];
 
-        let mut router = router_from_tables(neighbors, routes, interfaces);
+        let router = router_from_tables(neighbors, routes, interfaces);
 
-        let uncached_default = router.default().unwrap();
-        assert_eq!(uncached_default.if_index, if_index_gre as u32);
-        assert_eq!(uncached_default.mac_addr, Some(mac));
+        let hop_default = router.default().unwrap();
+        assert_eq!(hop_default.if_index, if_index_gre as u32);
+        assert_eq!(hop_default.mac_addr, Some(mac));
         assert_eq!(
-            uncached_default.gre.as_ref().map(|gre| gre.if_index),
+            hop_default.gre.as_ref().map(|gre| gre.if_index),
             Some(if_index_gre as u32)
         );
 
-        let uncached_route = router.route(IpAddr::V4(dest)).unwrap();
-        assert_eq!(uncached_route.if_index, if_index_gre as u32);
-        assert_eq!(uncached_route.mac_addr, Some(mac));
+        let hop_route = router.route(IpAddr::V4(dest)).unwrap();
+        assert_eq!(hop_route.if_index, if_index_gre as u32);
+        assert_eq!(hop_route.mac_addr, Some(mac));
         assert_eq!(
-            uncached_route.gre.as_ref().map(|gre| gre.if_index),
+            hop_route.gre.as_ref().map(|gre| gre.if_index),
             Some(if_index_gre as u32)
-        );
-
-        router.build_caches().unwrap();
-
-        let cached_default = router.default().unwrap();
-        assert_eq!(cached_default.if_index, uncached_default.if_index);
-        assert_eq!(cached_default.mac_addr, uncached_default.mac_addr);
-        assert_eq!(
-            cached_default.gre.as_ref().map(|gre| gre.if_index),
-            uncached_default.gre.as_ref().map(|gre| gre.if_index)
-        );
-
-        let cached_route = router.route(IpAddr::V4(dest)).unwrap();
-        assert_eq!(cached_route.if_index, uncached_route.if_index);
-        assert_eq!(cached_route.mac_addr, uncached_route.mac_addr);
-        assert_eq!(
-            cached_route.gre.as_ref().map(|gre| gre.if_index),
-            uncached_route.gre.as_ref().map(|gre| gre.if_index)
         );
     }
 }

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -1,11 +1,15 @@
 use {
-    crate::netlink::{
-        GreTunnelInfo, InterfaceInfo, MacAddress, NeighborEntry, RouteEntry,
-        netlink_get_interfaces, netlink_get_neighbors, netlink_get_routes,
+    crate::{
+        lpm::Ipv4Lpm,
+        netlink::{
+            GreTunnelInfo, InterfaceInfo, MacAddress, NeighborEntry, RouteEntry,
+            netlink_get_interfaces, netlink_get_neighbors, netlink_get_routes,
+        },
     },
     libc::AF_INET,
     log::warn,
     std::{
+        cmp::Ordering,
         io,
         net::{IpAddr, Ipv4Addr},
     },
@@ -49,12 +53,17 @@ pub struct Route<T> {
     pub gateway: Option<T>,
     pub preferred_src: Option<T>,
     pub out_if_index: Option<u32>,
+    pub priority: Option<u32>,
+    pub type_: u8,
     pub dst_len: u8,
 }
 
 impl<T: PartialEq> Route<T> {
-    fn same_prefix(&self, other: &Self) -> bool {
-        self.destination == other.destination && self.dst_len == other.dst_len
+    fn same_key(&self, other: &Self) -> bool {
+        self.destination == other.destination
+            && self.dst_len == other.dst_len
+            && self.priority == other.priority
+            && self.type_ == other.type_
     }
 }
 
@@ -92,51 +101,11 @@ impl TryFrom<RouteEntry> for Route<Ipv4Addr> {
             gateway,
             preferred_src,
             out_if_index,
+            priority: entry.priority,
+            type_: entry.type_,
             dst_len: entry.dst_len.min(32),
         })
     }
-}
-
-fn lookup_route<'a, I>(routes: I, dest: Ipv4Addr) -> Option<&'a Route<Ipv4Addr>>
-where
-    I: Iterator<Item = &'a Route<Ipv4Addr>>,
-{
-    let mut best_match = None;
-
-    for route in routes {
-        match route.destination {
-            // this is the default route
-            None => {
-                if best_match.is_none() {
-                    best_match = Some((route, 0));
-                }
-            }
-            Some(route_addr) => {
-                let prefix_len = route.dst_len;
-                if !is_ipv4_match(dest, route_addr, prefix_len) {
-                    continue;
-                }
-
-                if best_match.is_none() || prefix_len > best_match.unwrap().1 {
-                    best_match = Some((route, prefix_len));
-                }
-            }
-        }
-    }
-
-    best_match.map(|(route, _)| route)
-}
-
-fn is_ipv4_match(addr: Ipv4Addr, network: Ipv4Addr, prefix_len: u8) -> bool {
-    if prefix_len == 0 {
-        return true;
-    }
-
-    let mask = 0xFFFFFFFF << 32u32.saturating_sub(prefix_len as u32);
-    let addr_bits = u32::from(addr) & mask;
-    let network_bits = u32::from(network) & mask;
-
-    addr_bits == network_bits
 }
 
 #[derive(Clone, Debug)]
@@ -249,7 +218,8 @@ pub struct Routes {
 }
 
 impl Routes {
-    pub fn new(routes: Vec<Route<Ipv4Addr>>) -> Self {
+    pub fn new(mut routes: Vec<Route<Ipv4Addr>>) -> Self {
+        routes.sort_by(Self::compare_routes);
         Self { routes }
     }
 
@@ -262,8 +232,23 @@ impl Routes {
         ))
     }
 
+    fn compare_routes(left: &Route<Ipv4Addr>, right: &Route<Ipv4Addr>) -> Ordering {
+        right
+            .dst_len
+            .cmp(&left.dst_len)
+            .then_with(|| left.priority.unwrap_or(0).cmp(&right.priority.unwrap_or(0)))
+    }
+
     pub fn iter(&self) -> impl ExactSizeIterator<Item = &Route<Ipv4Addr>> {
         self.routes.iter()
+    }
+
+    fn get(&self, route_idx: usize) -> Option<&Route<Ipv4Addr>> {
+        self.routes.get(route_idx)
+    }
+
+    fn as_slice(&self) -> &[Route<Ipv4Addr>] {
+        &self.routes
     }
 
     fn upsert(&mut self, new_route: RouteEntry) -> bool {
@@ -271,18 +256,21 @@ impl Routes {
             return false;
         };
 
-        if let Some(existing) = self
-            .routes
-            .iter_mut()
-            .find(|old| old.same_prefix(&new_route))
-        {
+        if let Some(existing) = self.routes.iter_mut().find(|old| old.same_key(&new_route)) {
             if existing != &new_route {
                 *existing = new_route;
                 return true;
             }
             false
         } else {
-            self.routes.push(new_route);
+            let route = new_route;
+            let insert_at = self.routes.partition_point(|existing| {
+                matches!(
+                    Self::compare_routes(existing, &route),
+                    Ordering::Less | Ordering::Equal
+                )
+            });
+            self.routes.insert(insert_at, route);
             true
         }
     }
@@ -292,15 +280,12 @@ impl Routes {
             return false;
         };
 
-        if let Some(i) = self
-            .routes
-            .iter()
-            .position(|old| old.same_prefix(&new_route))
-        {
-            self.routes.swap_remove(i);
-            return true;
+        if let Some(i) = self.routes.iter().position(|old| old.same_key(&new_route)) {
+            self.routes.remove(i);
+            true
+        } else {
+            false
         }
-        false
     }
 }
 
@@ -357,6 +342,7 @@ impl RoutingTables {
 pub struct Router {
     neighbors: Neighbors,
     routes: Routes,
+    ipv4_lpm: Ipv4Lpm,
     interfaces: Interfaces,
     // cache for the default route next hop so we can avoid arp table lookups on the common case
     cached_default_route: Option<NextHop>,
@@ -370,9 +356,11 @@ impl Router {
     }
 
     pub fn from_tables(tables: RoutingTables) -> Result<Self, io::Error> {
+        let ipv4_lpm = Ipv4Lpm::build(tables.routes.as_slice());
         let mut router = Self {
             neighbors: tables.neighbors,
             routes: tables.routes,
+            ipv4_lpm,
             interfaces: tables.interfaces,
             cached_default_route: None,
             cached_gre_info: Vec::new(),
@@ -463,9 +451,9 @@ impl Router {
 
     fn default_route(&self) -> Result<NextHop, RouteError> {
         let default_route = self
-            .routes
-            .iter()
-            .find(|r| r.destination.is_none())
+            .ipv4_lpm
+            .default_route()
+            .and_then(|route_idx| self.routes.get(route_idx as usize))
             .ok_or(RouteError::NoRouteFound(IpAddr::V4(Ipv4Addr::UNSPECIFIED)))?;
         self.resolve_next_hop(Ipv4Addr::UNSPECIFIED, default_route)
     }
@@ -478,8 +466,15 @@ impl Router {
         }
     }
 
+    fn lookup_route_v4(&self, dest_ip: Ipv4Addr) -> Option<&Route<Ipv4Addr>> {
+        self.ipv4_lpm
+            .lookup(dest_ip)
+            .and_then(|route_idx| self.routes.get(route_idx as usize))
+    }
+
     pub fn route_v4(&self, dest_ip: Ipv4Addr) -> Result<NextHop, RouteError> {
-        let route = lookup_route(self.routes.iter(), dest_ip)
+        let route = self
+            .lookup_route_v4(dest_ip)
             .ok_or(RouteError::NoRouteFound(dest_ip.into()))?;
         self.resolve_next_hop(dest_ip, route)
     }
@@ -499,7 +494,7 @@ impl Router {
             return None;
         }
 
-        let underlay_route = lookup_route(self.routes.iter(), remote)?;
+        let underlay_route = self.lookup_route_v4(remote)?;
         let underlay_if_index = underlay_route.out_if_index?;
         let underlay_interface = self
             .interfaces
@@ -542,7 +537,32 @@ mod tests {
             gateway: None,
             preferred_src: None,
             out_if_index: Some(out_if_index),
+            priority: None,
+            type_: 0,
             dst_len: 32,
+        }
+    }
+
+    fn test_route_entry(
+        destination: Option<Ipv4Addr>,
+        gateway: Option<Ipv4Addr>,
+        out_if_index: u32,
+        dst_len: u8,
+    ) -> RouteEntry {
+        RouteEntry {
+            destination: destination.map(IpAddr::V4),
+            gateway: gateway.map(IpAddr::V4),
+            pref_src: None,
+            out_if_index: Some(out_if_index as i32),
+            in_if_index: None,
+            priority: None,
+            table: None,
+            protocol: 0,
+            scope: 0,
+            type_: 0,
+            family: AF_INET as u8,
+            dst_len,
+            flags: 0,
         }
     }
 
@@ -568,28 +588,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ipv4_match() {
-        assert!(is_ipv4_match(
-            Ipv4Addr::new(192, 168, 1, 10),
-            Ipv4Addr::new(192, 168, 1, 0),
-            24
-        ));
-
-        assert!(!is_ipv4_match(
-            Ipv4Addr::new(192, 168, 2, 10),
-            Ipv4Addr::new(192, 168, 1, 0),
-            24
-        ));
-
-        // Match with default route
-        assert!(is_ipv4_match(
-            Ipv4Addr::new(1, 2, 3, 4),
-            Ipv4Addr::new(0, 0, 0, 0),
-            0
-        ));
-    }
-
-    #[test]
     fn test_router() {
         let mut tables = empty_tables();
         let before_routes_len = tables.routes.iter().len();
@@ -607,7 +605,7 @@ mod tests {
         let test_dst = Ipv4Addr::new(10, 255, 255, 123);
         let route = RouteEntry {
             destination: Some(IpAddr::V4(test_dst)),
-            gateway: Some(IpAddr::V4(Ipv4Addr::new(10, 255, 255, 1))),
+            gateway: Some(IpAddr::V4(gateway)),
             pref_src: None,
             out_if_index: Some(1),
             in_if_index: None,
@@ -816,6 +814,8 @@ mod tests {
                 gateway: None,
                 preferred_src: None,
                 out_if_index: Some(if_index_gre as u32),
+                priority: None,
+                type_: 0,
                 dst_len: 0,
             },
         ];
@@ -869,22 +869,15 @@ mod tests {
             state: NUD_REACHABLE,
         }));
 
-        assert!(tables.upsert_route(test_route_entry(
-            None,
-            Some(default_gateway),
-            1,
-            0,
-            RouteTable::Main.as_u32(),
-        )));
-
+        assert!(tables.upsert_route(test_route_entry(None, Some(default_gateway), 1, 0,)));
         assert!(tables.upsert_route(RouteEntry {
             destination: Some(IpAddr::V4(blocked_dst)),
             gateway: None,
             pref_src: None,
-            out_if_index: None,
+            out_if_index: None, // missing output interface should block this route
             in_if_index: None,
             priority: None,
-            table: Some(RouteTable::Main.as_u32()),
+            table: None,
             protocol: 0,
             scope: 0,
             type_: 0,

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -3,11 +3,11 @@ use {
         GreTunnelInfo, InterfaceInfo, MacAddress, NeighborEntry, RouteEntry,
         netlink_get_interfaces, netlink_get_neighbors, netlink_get_routes,
     },
-    libc::{AF_INET, AF_INET6},
+    libc::AF_INET,
     log::warn,
     std::{
         io,
-        net::{IpAddr, Ipv4Addr, Ipv6Addr},
+        net::{IpAddr, Ipv4Addr},
     },
     thiserror::Error,
 };
@@ -43,29 +43,77 @@ pub struct NextHop {
     pub gre: Option<GreRouteInfo>,
 }
 
-fn lookup_route<'a, I>(routes: I, dest: IpAddr) -> Option<&'a RouteEntry>
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Route<T> {
+    pub destination: Option<T>,
+    pub gateway: Option<T>,
+    pub preferred_src: Option<T>,
+    pub out_if_index: Option<u32>,
+    pub dst_len: u8,
+}
+
+impl<T: PartialEq> Route<T> {
+    fn same_prefix(&self, other: &Self) -> bool {
+        self.destination == other.destination && self.dst_len == other.dst_len
+    }
+}
+
+impl TryFrom<RouteEntry> for Route<Ipv4Addr> {
+    type Error = ();
+
+    fn try_from(entry: RouteEntry) -> Result<Self, Self::Error> {
+        if entry.family != AF_INET as u8 {
+            return Err(());
+        }
+
+        let destination = match entry.destination {
+            Some(IpAddr::V4(addr)) => Some(addr),
+            Some(IpAddr::V6(_)) => return Err(()),
+            None => None,
+        };
+        let gateway = match entry.gateway {
+            Some(IpAddr::V4(addr)) => Some(addr),
+            Some(IpAddr::V6(_)) => return Err(()),
+            None => None,
+        };
+        let preferred_src = match entry.pref_src {
+            Some(IpAddr::V4(addr)) => Some(addr),
+            Some(IpAddr::V6(_)) => return Err(()),
+            None => None,
+        };
+        let out_if_index = entry
+            .out_if_index
+            .map(u32::try_from)
+            .transpose()
+            .map_err(|_| ())?;
+
+        Ok(Self {
+            destination,
+            gateway,
+            preferred_src,
+            out_if_index,
+            dst_len: entry.dst_len.min(32),
+        })
+    }
+}
+
+fn lookup_route<'a, I>(routes: I, dest: Ipv4Addr) -> Option<&'a Route<Ipv4Addr>>
 where
-    I: Iterator<Item = &'a RouteEntry>,
+    I: Iterator<Item = &'a Route<Ipv4Addr>>,
 {
     let mut best_match = None;
 
-    let family = match dest {
-        IpAddr::V4(_) => AF_INET as u8,
-        IpAddr::V6(_) => AF_INET6 as u8,
-    };
-
-    for route in routes.filter(|r| r.family == family) {
-        match (dest, route.destination) {
+    for route in routes {
+        match route.destination {
             // this is the default route
-            (_, None) => {
+            None => {
                 if best_match.is_none() {
                     best_match = Some((route, 0));
                 }
             }
-
-            (IpAddr::V4(dest_addr), Some(IpAddr::V4(route_addr))) => {
+            Some(route_addr) => {
                 let prefix_len = route.dst_len;
-                if !is_ipv4_match(dest_addr, route_addr, prefix_len) {
+                if !is_ipv4_match(dest, route_addr, prefix_len) {
                     continue;
                 }
 
@@ -73,20 +121,6 @@ where
                     best_match = Some((route, prefix_len));
                 }
             }
-
-            (IpAddr::V6(dest_addr), Some(IpAddr::V6(route_addr))) => {
-                let prefix_len = route.dst_len;
-                if !is_ipv6_match(dest_addr, route_addr, prefix_len) {
-                    continue;
-                }
-
-                if best_match.is_none() || prefix_len > best_match.unwrap().1 {
-                    best_match = Some((route, prefix_len));
-                }
-            }
-
-            // mixed address families - can't match
-            _ => continue,
         }
     }
 
@@ -103,29 +137,6 @@ fn is_ipv4_match(addr: Ipv4Addr, network: Ipv4Addr, prefix_len: u8) -> bool {
     let network_bits = u32::from(network) & mask;
 
     addr_bits == network_bits
-}
-
-fn is_ipv6_match(addr: Ipv6Addr, network: Ipv6Addr, prefix_len: u8) -> bool {
-    if prefix_len == 0 {
-        return true;
-    }
-
-    let addr_segments = addr.segments();
-    let network_segments = network.segments();
-
-    let full_segments = (prefix_len / 16) as usize;
-    if addr_segments[..full_segments] != network_segments[..full_segments] {
-        return false;
-    }
-
-    if let Some(remaining_bits) = prefix_len.checked_rem(16).filter(|&b| b != 0) {
-        let mask = 0xFFFF_u16 << 16u16.saturating_sub(remaining_bits as u16);
-        if (addr_segments[full_segments] & mask) != (network_segments[full_segments] & mask) {
-            return false;
-        }
-    }
-
-    true
 }
 
 #[derive(Clone, Debug)]
@@ -234,24 +245,37 @@ impl Neighbors {
 
 #[derive(Clone)]
 pub struct Routes {
-    routes: Vec<RouteEntry>,
+    routes: Vec<Route<Ipv4Addr>>,
 }
 
 impl Routes {
-    pub fn new(routes: Vec<RouteEntry>) -> Self {
+    pub fn new(routes: Vec<Route<Ipv4Addr>>) -> Self {
         Self { routes }
     }
 
     pub fn from_netlink() -> Result<Self, io::Error> {
-        Ok(Self::new(netlink_get_routes(AF_INET as u8)?))
+        Ok(Self::new(
+            netlink_get_routes(AF_INET as u8)?
+                .into_iter()
+                .filter_map(|entry| Route::try_from(entry).ok())
+                .collect(),
+        ))
     }
 
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = &RouteEntry> {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &Route<Ipv4Addr>> {
         self.routes.iter()
     }
 
     fn upsert(&mut self, new_route: RouteEntry) -> bool {
-        if let Some(existing) = self.routes.iter_mut().find(|old| old.same_key(&new_route)) {
+        let Ok(new_route) = Route::try_from(new_route) else {
+            return false;
+        };
+
+        if let Some(existing) = self
+            .routes
+            .iter_mut()
+            .find(|old| old.same_prefix(&new_route))
+        {
             if existing != &new_route {
                 *existing = new_route;
                 return true;
@@ -264,7 +288,15 @@ impl Routes {
     }
 
     fn remove(&mut self, new_route: RouteEntry) -> bool {
-        if let Some(i) = self.routes.iter().position(|old| old.same_key(&new_route)) {
+        let Ok(new_route) = Route::try_from(new_route) else {
+            return false;
+        };
+
+        if let Some(i) = self
+            .routes
+            .iter()
+            .position(|old| old.same_prefix(&new_route))
+        {
             self.routes.swap_remove(i);
             return true;
         }
@@ -388,18 +420,14 @@ impl Router {
 
     fn resolve_next_hop(
         &self,
-        route_ip: IpAddr,
-        route: &RouteEntry,
+        route_ip: Ipv4Addr,
+        route: &Route<Ipv4Addr>,
     ) -> Result<NextHop, RouteError> {
         let if_index = route
             .out_if_index
-            .ok_or(RouteError::MissingOutputInterface)? as u32;
-
-        let next_hop_ip = route.gateway.unwrap_or(route_ip);
-        let preferred_src_ip = match route.pref_src {
-            Some(IpAddr::V4(v4)) => Some(v4),
-            _ => None,
-        };
+            .ok_or(RouteError::MissingOutputInterface)?;
+        let next_hop_ip = IpAddr::V4(route.gateway.unwrap_or(route_ip));
+        let preferred_src_ip = route.preferred_src;
 
         if let Some(default_route) = &self.cached_default_route {
             if default_route.ip_addr == next_hop_ip && default_route.if_index == if_index {
@@ -439,7 +467,7 @@ impl Router {
             .iter()
             .find(|r| r.destination.is_none())
             .ok_or(RouteError::NoRouteFound(IpAddr::V4(Ipv4Addr::UNSPECIFIED)))?;
-        self.resolve_next_hop(IpAddr::V4(Ipv4Addr::UNSPECIFIED), default_route)
+        self.resolve_next_hop(Ipv4Addr::UNSPECIFIED, default_route)
     }
 
     pub fn default(&self) -> Result<NextHop, RouteError> {
@@ -450,24 +478,29 @@ impl Router {
         }
     }
 
-    pub fn route(&self, dest_ip: IpAddr) -> Result<NextHop, RouteError> {
-        let route =
-            lookup_route(self.routes.iter(), dest_ip).ok_or(RouteError::NoRouteFound(dest_ip))?;
+    pub fn route_v4(&self, dest_ip: Ipv4Addr) -> Result<NextHop, RouteError> {
+        let route = lookup_route(self.routes.iter(), dest_ip)
+            .ok_or(RouteError::NoRouteFound(dest_ip.into()))?;
         self.resolve_next_hop(dest_ip, route)
     }
 
     fn interface_gre_route_info(&self, interface: &InterfaceInfo) -> Option<GreRouteInfo> {
         let tunnel_info = interface.gre_tunnel.as_ref()?;
-        let remote = tunnel_info.remote;
-        let local = tunnel_info.local;
+        let remote = match tunnel_info.remote {
+            IpAddr::V4(remote) => remote,
+            IpAddr::V6(_) => return None,
+        };
+        let local = match tunnel_info.local {
+            IpAddr::V4(local) => local,
+            IpAddr::V6(_) => return None,
+        };
         // Skip unconfigured tunnels (remote/local 0.0.0.0)
-        if remote == IpAddr::V4(Ipv4Addr::UNSPECIFIED) || local == IpAddr::V4(Ipv4Addr::UNSPECIFIED)
-        {
+        if remote == Ipv4Addr::UNSPECIFIED || local == Ipv4Addr::UNSPECIFIED {
             return None;
         }
 
         let underlay_route = lookup_route(self.routes.iter(), remote)?;
-        let underlay_if_index = underlay_route.out_if_index? as u32;
+        let underlay_if_index = underlay_route.out_if_index?;
         let underlay_interface = self
             .interfaces
             .iter()
@@ -476,11 +509,11 @@ impl Router {
             warn!(
                 "GRE interface {} has remote {} that routes via another GRE interface {}. \
                  gre-over-gre is not supported.",
-                interface.if_index, remote, underlay_interface.if_index
+                interface.if_index, tunnel_info.remote, underlay_interface.if_index
             );
             return None;
         }
-        let underlay_next_hop_ip = underlay_route.gateway.unwrap_or(remote);
+        let underlay_next_hop_ip = IpAddr::V4(underlay_route.gateway.unwrap_or(remote));
         let mac_addr = self
             .neighbors
             .lookup(underlay_next_hop_ip, underlay_if_index)
@@ -503,27 +536,19 @@ mod tests {
         std::net::{IpAddr, Ipv4Addr},
     };
 
-    fn route_entry(destination: Option<IpAddr>, out_if_index: i32) -> RouteEntry {
-        RouteEntry {
+    fn test_route(destination: Option<Ipv4Addr>, out_if_index: u32) -> Route<Ipv4Addr> {
+        Route {
             destination,
             gateway: None,
-            pref_src: None,
+            preferred_src: None,
             out_if_index: Some(out_if_index),
-            in_if_index: None,
-            priority: None,
-            table: None,
-            protocol: 0,
-            scope: 0,
-            type_: 0,
-            family: AF_INET as u8,
             dst_len: 32,
-            flags: 0,
         }
     }
 
     fn router_from_tables(
         neighbors: Vec<NeighborEntry>,
-        routes: Vec<RouteEntry>,
+        routes: Vec<Route<Ipv4Addr>>,
         interfaces: Vec<InterfaceInfo>,
     ) -> Router {
         let tables = RoutingTables::new(
@@ -565,38 +590,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ipv6_match() {
-        assert!(is_ipv6_match(
-            Ipv6Addr::new(
-                0x2001, 0xdb8, 0x1234, 0x5678, 0xabcd, 0xef01, 0x2345, 0x6789
-            ),
-            Ipv6Addr::new(0x2001, 0xdb8, 0x1234, 0x5678, 0, 0, 0, 0),
-            64
-        ));
-
-        assert!(!is_ipv6_match(
-            Ipv6Addr::new(
-                0x2001, 0xdb8, 0x1235, 0x5678, 0xabcd, 0xef01, 0x2345, 0x6789
-            ),
-            Ipv6Addr::new(0x2001, 0xdb8, 0x1234, 0x5678, 0, 0, 0, 0),
-            64
-        ));
-
-        // Match with partial segment
-        assert!(is_ipv6_match(
-            Ipv6Addr::new(0x2001, 0xdb8, 0x1234, 0x6700, 0, 0, 0, 0),
-            Ipv6Addr::new(0x2001, 0xdb8, 0x1234, 0x6600, 0, 0, 0, 0),
-            52
-        ));
-
-        assert!(!is_ipv6_match(
-            Ipv6Addr::new(0x2001, 0xdb8, 0x1234, 0x6700, 0, 0, 0, 0),
-            Ipv6Addr::new(0x2001, 0xdb8, 0x1234, 0x5600, 0, 0, 0, 0),
-            52
-        ));
-    }
-
-    #[test]
     fn test_router() {
         let mut tables = empty_tables();
         let before_routes_len = tables.routes.iter().len();
@@ -630,17 +623,26 @@ mod tests {
 
         // Upsert new route and check that it was inserted and routes are dirty
         assert!(tables.upsert_route(route.clone()));
-        assert!(tables.routes.iter().any(|r| r == &route));
+        assert!(tables.routes.iter().any(|r| {
+            r.destination == Some(test_dst)
+                && r.gateway == Some(gateway)
+                && r.out_if_index == Some(1)
+        }));
         assert!(tables.routes.iter().len() >= before_routes_len);
 
         let router = Router::from_tables(tables.clone()).unwrap();
-        let next_hop = router.route(IpAddr::V4(test_dst)).unwrap();
+        let next_hop = router.route_v4(test_dst).unwrap();
         assert_eq!(next_hop.if_index, 1);
         assert_eq!(next_hop.ip_addr, IpAddr::V4(gateway));
 
         // Delete using same key should remove the route
         assert!(tables.remove_route(route.clone()));
-        assert!(tables.routes.iter().all(|r| r != &route));
+        assert!(
+            tables
+                .routes
+                .iter()
+                .all(|r| r.destination != Some(test_dst))
+        );
         assert_eq!(tables.routes.iter().len(), before_routes_len);
     }
 
@@ -741,10 +743,10 @@ mod tests {
         ];
 
         let routes = vec![
-            route_entry(Some(IpAddr::V4(remote1)), if_index_underlay),
-            route_entry(Some(IpAddr::V4(remote2)), if_index_underlay),
-            route_entry(Some(IpAddr::V4(gre_dest1)), if_index_gre1),
-            route_entry(Some(IpAddr::V4(gre_dest2)), if_index_gre2),
+            test_route(Some(remote1), if_index_underlay as u32),
+            test_route(Some(remote2), if_index_underlay as u32),
+            test_route(Some(gre_dest1), if_index_gre1 as u32),
+            test_route(Some(gre_dest2), if_index_gre2 as u32),
         ];
 
         let interfaces = vec![
@@ -775,7 +777,7 @@ mod tests {
         ];
 
         let router = router_from_tables(neighbors, routes, interfaces);
-        let hop1 = router.route(IpAddr::V4(gre_dest1)).unwrap();
+        let hop1 = router.route_v4(gre_dest1).unwrap();
         assert_eq!(hop1.if_index, if_index_gre1 as u32);
         assert_eq!(hop1.mac_addr, Some(mac1));
         assert_eq!(
@@ -783,7 +785,7 @@ mod tests {
             Some(if_index_gre1 as u32)
         );
 
-        let hop2 = router.route(IpAddr::V4(gre_dest2)).unwrap();
+        let hop2 = router.route_v4(gre_dest2).unwrap();
         assert_eq!(hop2.if_index, if_index_gre2 as u32);
         assert_eq!(hop2.mac_addr, Some(mac2));
         assert_eq!(
@@ -808,21 +810,13 @@ mod tests {
         }];
 
         let routes = vec![
-            route_entry(Some(IpAddr::V4(remote)), if_index_underlay),
-            RouteEntry {
+            test_route(Some(remote), if_index_underlay as u32),
+            Route {
                 destination: None,
                 gateway: None,
-                pref_src: None,
-                out_if_index: Some(if_index_gre),
-                in_if_index: None,
-                priority: None,
-                table: None,
-                protocol: 0,
-                scope: 0,
-                type_: 0,
-                family: AF_INET as u8,
+                preferred_src: None,
+                out_if_index: Some(if_index_gre as u32),
                 dst_len: 0,
-                flags: 0,
             },
         ];
 
@@ -853,12 +847,56 @@ mod tests {
             Some(if_index_gre as u32)
         );
 
-        let hop_route = router.route(IpAddr::V4(dest)).unwrap();
+        let hop_route = router.route_v4(dest).unwrap();
         assert_eq!(hop_route.if_index, if_index_gre as u32);
         assert_eq!(hop_route.mac_addr, Some(mac));
         assert_eq!(
             hop_route.gre.as_ref().map(|gre| gre.if_index),
             Some(if_index_gre as u32)
         );
+    }
+
+    #[test]
+    fn test_missing_output_interface_blocks_fallback_route() {
+        let blocked_dst = Ipv4Addr::new(10, 0, 0, 2);
+        let default_gateway = Ipv4Addr::new(10, 0, 0, 1);
+
+        let mut tables = empty_tables();
+        assert!(tables.upsert_neighbor(NeighborEntry {
+            destination: Some(IpAddr::V4(default_gateway)),
+            lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
+            ifindex: 1,
+            state: NUD_REACHABLE,
+        }));
+
+        assert!(tables.upsert_route(test_route_entry(
+            None,
+            Some(default_gateway),
+            1,
+            0,
+            RouteTable::Main.as_u32(),
+        )));
+
+        assert!(tables.upsert_route(RouteEntry {
+            destination: Some(IpAddr::V4(blocked_dst)),
+            gateway: None,
+            pref_src: None,
+            out_if_index: None,
+            in_if_index: None,
+            priority: None,
+            table: Some(RouteTable::Main.as_u32()),
+            protocol: 0,
+            scope: 0,
+            type_: 0,
+            family: AF_INET as u8,
+            dst_len: 32,
+            flags: 0,
+        }));
+
+        let router = Router::from_tables(tables).unwrap();
+        assert!(matches!(
+            router.route_v4(blocked_dst),
+            Err(RouteError::MissingOutputInterface)
+        ));
     }
 }

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -6,7 +6,7 @@ use {
             netlink_get_interfaces, netlink_get_neighbors, netlink_get_routes,
         },
     },
-    libc::AF_INET,
+    libc::{AF_INET, RT_TABLE_DEFAULT, RT_TABLE_LOCAL, RT_TABLE_MAIN},
     log::warn,
     std::{
         cmp::Ordering,
@@ -45,6 +45,36 @@ pub struct NextHop {
     pub if_index: u32,
     pub preferred_src_ip: Option<Ipv4Addr>,
     pub gre: Option<GreRouteInfo>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteTable {
+    Default,
+    Local,
+    Main,
+    Other(u32),
+}
+
+impl From<RouteTable> for u32 {
+    fn from(table: RouteTable) -> Self {
+        match table {
+            RouteTable::Default => u32::from(RT_TABLE_DEFAULT),
+            RouteTable::Local => u32::from(RT_TABLE_LOCAL),
+            RouteTable::Main => u32::from(RT_TABLE_MAIN),
+            RouteTable::Other(table) => table,
+        }
+    }
+}
+
+impl From<u32> for RouteTable {
+    fn from(table: u32) -> Self {
+        match table {
+            table if table == u32::from(RT_TABLE_DEFAULT) => Self::Default,
+            table if table == u32::from(RT_TABLE_LOCAL) => Self::Local,
+            table if table == u32::from(RT_TABLE_MAIN) => Self::Main,
+            table => Self::Other(table),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -214,22 +244,22 @@ impl Neighbors {
 
 #[derive(Clone)]
 pub struct Routes {
+    pub(crate) table: RouteTable,
     routes: Vec<Route<Ipv4Addr>>,
 }
 
 impl Routes {
-    pub fn new(mut routes: Vec<Route<Ipv4Addr>>) -> Self {
+    pub fn new(table: RouteTable, mut routes: Vec<Route<Ipv4Addr>>) -> Self {
         routes.sort_by(Self::compare_routes);
-        Self { routes }
+        Self { table, routes }
     }
 
-    pub fn from_netlink() -> Result<Self, io::Error> {
-        Ok(Self::new(
-            netlink_get_routes(AF_INET as u8)?
-                .into_iter()
-                .filter_map(|entry| Route::try_from(entry).ok())
-                .collect(),
-        ))
+    pub fn from_netlink(table: RouteTable) -> Result<Self, io::Error> {
+        let routes = netlink_get_routes(AF_INET as u8, u32::from(table))?
+            .into_iter()
+            .filter_map(|entry| Route::try_from(entry).ok())
+            .collect();
+        Ok(Self::new(table, routes))
     }
 
     fn compare_routes(left: &Route<Ipv4Addr>, right: &Route<Ipv4Addr>) -> Ordering {
@@ -252,6 +282,13 @@ impl Routes {
     }
 
     fn upsert(&mut self, new_route: RouteEntry) -> bool {
+        if !new_route
+            .table
+            .is_some_and(|table| self.table == RouteTable::from(table))
+        {
+            return false;
+        }
+
         let Ok(new_route) = Route::try_from(new_route) else {
             return false;
         };
@@ -276,6 +313,13 @@ impl Routes {
     }
 
     fn remove(&mut self, new_route: RouteEntry) -> bool {
+        if !new_route
+            .table
+            .is_some_and(|table| self.table == RouteTable::from(table))
+        {
+            return false;
+        }
+
         let Ok(new_route) = Route::try_from(new_route) else {
             return false;
         };
@@ -291,7 +335,7 @@ impl Routes {
 
 #[derive(Clone)]
 pub struct RoutingTables {
-    routes: Routes,
+    pub(crate) routes: Routes,
     neighbors: Neighbors,
     interfaces: Interfaces,
 }
@@ -305,9 +349,9 @@ impl RoutingTables {
         }
     }
 
-    pub fn from_netlink() -> Result<Self, io::Error> {
+    pub fn from_netlink(table: RouteTable) -> Result<Self, io::Error> {
         Ok(Self::new(
-            Routes::from_netlink()?,
+            Routes::from_netlink(table)?,
             Neighbors::from_netlink()?,
             Interfaces::from_netlink()?,
         ))
@@ -352,7 +396,7 @@ pub struct Router {
 
 impl Router {
     pub fn new() -> Result<Self, io::Error> {
-        Self::from_tables(RoutingTables::from_netlink()?)
+        Self::from_tables(RoutingTables::from_netlink(RouteTable::Main)?)
     }
 
     pub fn from_tables(tables: RoutingTables) -> Result<Self, io::Error> {
@@ -548,6 +592,18 @@ mod tests {
         gateway: Option<Ipv4Addr>,
         out_if_index: u32,
         dst_len: u8,
+        table: u32,
+    ) -> RouteEntry {
+        test_route_entry_with_priority(destination, gateway, out_if_index, dst_len, table, None)
+    }
+
+    fn test_route_entry_with_priority(
+        destination: Option<Ipv4Addr>,
+        gateway: Option<Ipv4Addr>,
+        out_if_index: u32,
+        dst_len: u8,
+        table: u32,
+        priority: Option<u32>,
     ) -> RouteEntry {
         RouteEntry {
             destination: destination.map(IpAddr::V4),
@@ -555,8 +611,8 @@ mod tests {
             pref_src: None,
             out_if_index: Some(out_if_index as i32),
             in_if_index: None,
-            priority: None,
-            table: None,
+            priority,
+            table: Some(table),
             protocol: 0,
             scope: 0,
             type_: 0,
@@ -572,7 +628,7 @@ mod tests {
         interfaces: Vec<InterfaceInfo>,
     ) -> Router {
         let tables = RoutingTables::new(
-            Routes::new(routes),
+            Routes::new(RouteTable::Main, routes),
             Neighbors::new(neighbors),
             Interfaces::new(interfaces),
         );
@@ -581,10 +637,43 @@ mod tests {
 
     fn empty_tables() -> RoutingTables {
         RoutingTables::new(
-            Routes::new(Vec::new()),
+            Routes::new(RouteTable::Main, Vec::new()),
             Neighbors::new(Vec::new()),
             Interfaces::new(Vec::new()),
         )
+    }
+
+    fn dual_default_tables(primary_gateway: Ipv4Addr, backup_gateway: Ipv4Addr) -> RoutingTables {
+        let mut tables = empty_tables();
+        assert!(tables.upsert_neighbor(NeighborEntry {
+            destination: Some(IpAddr::V4(primary_gateway)),
+            lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
+            ifindex: 1,
+            state: NUD_REACHABLE,
+        }));
+        assert!(tables.upsert_neighbor(NeighborEntry {
+            destination: Some(IpAddr::V4(backup_gateway)),
+            lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x02])),
+            ifindex: 2,
+            state: NUD_REACHABLE,
+        }));
+        assert!(tables.upsert_route(test_route_entry_with_priority(
+            None,
+            Some(backup_gateway),
+            2,
+            0,
+            u32::from(RouteTable::Main),
+            Some(200),
+        )));
+        assert!(tables.upsert_route(test_route_entry_with_priority(
+            None,
+            Some(primary_gateway),
+            1,
+            0,
+            u32::from(RouteTable::Main),
+            Some(100),
+        )));
+        tables
     }
 
     #[test]
@@ -610,7 +699,7 @@ mod tests {
             out_if_index: Some(1),
             in_if_index: None,
             priority: None,
-            table: None,
+            table: Some(u32::from(RouteTable::Main)),
             protocol: 0,
             scope: 0,
             type_: 0,
@@ -711,6 +800,77 @@ mod tests {
                 .all(|i| i.if_index != test_if_index)
         );
         assert_eq!(tables.interfaces.iter().len(), before_interface_len);
+    }
+
+    #[test]
+    fn test_routes_ignore_other_table_updates() {
+        let test_dst = Ipv4Addr::new(10, 0, 0, 1);
+        let main_gateway = Ipv4Addr::new(10, 0, 0, 2);
+        let other_gateway = Ipv4Addr::new(10, 0, 0, 3);
+        let main_table = u32::from(RouteTable::Main);
+
+        let mut tables = empty_tables();
+        assert!(tables.upsert_neighbor(NeighborEntry {
+            destination: Some(IpAddr::V4(main_gateway)),
+            lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
+            ifindex: 1,
+            state: NUD_REACHABLE,
+        }));
+        assert!(tables.upsert_route(test_route_entry(
+            Some(test_dst),
+            Some(main_gateway),
+            1,
+            32,
+            main_table,
+        )));
+
+        assert!(!tables.upsert_route(test_route_entry(
+            Some(test_dst),
+            Some(other_gateway),
+            2,
+            32,
+            100,
+        )));
+
+        let router = Router::from_tables(tables).unwrap();
+        let next_hop = router.route_v4(test_dst).unwrap();
+        assert_eq!(next_hop.if_index, 1);
+        assert_eq!(next_hop.ip_addr, IpAddr::V4(main_gateway));
+    }
+
+    #[test]
+    fn test_routes_ignore_other_table_deletes() {
+        let test_dst = Ipv4Addr::new(10, 0, 0, 1);
+        let main_gateway = Ipv4Addr::new(10, 0, 0, 2);
+        let main_table = u32::from(RouteTable::Main);
+
+        let mut tables = empty_tables();
+        assert!(tables.upsert_neighbor(NeighborEntry {
+            destination: Some(IpAddr::V4(main_gateway)),
+            lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
+            ifindex: 1,
+            state: NUD_REACHABLE,
+        }));
+        assert!(tables.upsert_route(test_route_entry(
+            Some(test_dst),
+            Some(main_gateway),
+            1,
+            32,
+            main_table,
+        )));
+
+        assert!(!tables.remove_route(test_route_entry(
+            Some(test_dst),
+            Some(Ipv4Addr::new(10, 0, 0, 3)),
+            2,
+            32,
+            100,
+        )));
+
+        let router = Router::from_tables(tables).unwrap();
+        let next_hop = router.route_v4(test_dst).unwrap();
+        assert_eq!(next_hop.if_index, 1);
+        assert_eq!(next_hop.ip_addr, IpAddr::V4(main_gateway));
     }
 
     #[test]
@@ -869,7 +1029,14 @@ mod tests {
             state: NUD_REACHABLE,
         }));
 
-        assert!(tables.upsert_route(test_route_entry(None, Some(default_gateway), 1, 0,)));
+        assert!(tables.upsert_route(test_route_entry(
+            None,
+            Some(default_gateway),
+            1,
+            0,
+            u32::from(RouteTable::Main),
+        )));
+
         assert!(tables.upsert_route(RouteEntry {
             destination: Some(IpAddr::V4(blocked_dst)),
             gateway: None,
@@ -877,7 +1044,7 @@ mod tests {
             out_if_index: None, // missing output interface should block this route
             in_if_index: None,
             priority: None,
-            table: None,
+            table: Some(u32::from(RouteTable::Main)),
             protocol: 0,
             scope: 0,
             type_: 0,
@@ -891,5 +1058,49 @@ mod tests {
             router.route_v4(blocked_dst),
             Err(RouteError::MissingOutputInterface)
         ));
+    }
+
+    #[test]
+    fn test_same_prefix_diff_priority() {
+        let primary = Ipv4Addr::new(10, 0, 0, 1);
+        let backup = Ipv4Addr::new(10, 0, 0, 2);
+        let tables = dual_default_tables(primary, backup);
+
+        let router = Router::from_tables(tables.clone()).unwrap();
+        let next_hop = router.default().unwrap();
+        assert_eq!(next_hop.if_index, 1);
+        assert_eq!(next_hop.ip_addr, IpAddr::V4(primary));
+
+        {
+            let mut tables = tables.clone();
+            assert!(tables.remove_route(test_route_entry_with_priority(
+                None,
+                Some(backup),
+                2,
+                0,
+                u32::from(RouteTable::Main),
+                Some(200),
+            )));
+
+            let router = Router::from_tables(tables).unwrap();
+            let next_hop = router.default().unwrap();
+            assert_eq!(next_hop.if_index, 1);
+            assert_eq!(next_hop.ip_addr, IpAddr::V4(primary));
+        }
+
+        let mut tables = tables;
+        assert!(tables.remove_route(test_route_entry_with_priority(
+            None,
+            Some(primary),
+            1,
+            0,
+            u32::from(RouteTable::Main),
+            Some(100),
+        )));
+
+        let router = Router::from_tables(tables).unwrap();
+        let next_hop = router.default().unwrap();
+        assert_eq!(next_hop.if_index, 2);
+        assert_eq!(next_hop.ip_addr, IpAddr::V4(backup));
     }
 }

--- a/xdp/src/route_monitor.rs
+++ b/xdp/src/route_monitor.rs
@@ -4,7 +4,7 @@ use {
             NetlinkMessage, NetlinkSocket, parse_rtm_ifinfomsg, parse_rtm_newneigh,
             parse_rtm_newroute,
         },
-        route::Router,
+        route::{Router, RoutingTables},
     },
     arc_swap::ArcSwap,
     libc::{
@@ -24,6 +24,7 @@ use {
         time::{Duration, Instant},
     },
 };
+
 pub struct RouteMonitor;
 
 impl RouteMonitor {
@@ -32,6 +33,7 @@ impl RouteMonitor {
     /// Publishes the updated routing table every `update_interval` if needed
     pub fn start<F: FnOnce() + Send + Sync + 'static>(
         atomic_router: Arc<ArcSwap<Router>>,
+        tables: RoutingTables,
         exit: Arc<AtomicBool>,
         update_interval: Duration,
         on_thread_start: F,
@@ -42,8 +44,7 @@ impl RouteMonitor {
                 // MUST remain first to run here
                 on_thread_start();
 
-                let mut state =
-                    RouteMonitorState::new(Router::new().expect("error creating Router"));
+                let mut state = RouteMonitorState::new(tables);
 
                 let timeout = Duration::from_millis(10);
                 while !exit.load(Ordering::Relaxed) {
@@ -83,7 +84,7 @@ impl RouteMonitor {
                     // Drain channel
                     match state.sock.recv() {
                         Ok(msgs) => {
-                            state.dirty |= Self::process_netlink_updates(&mut state.router, &msgs);
+                            state.dirty |= Self::process_netlink_updates(&mut state.tables, &msgs);
                         }
                         Err(e) => {
                             error!("netlink recv error: {e}");
@@ -97,42 +98,42 @@ impl RouteMonitor {
     }
 
     #[inline]
-    fn process_netlink_updates(router: &mut Router, msgs: &[NetlinkMessage]) -> bool {
+    fn process_netlink_updates(tables: &mut RoutingTables, msgs: &[NetlinkMessage]) -> bool {
         let mut dirty = false;
         for m in msgs {
             match m.header.nlmsg_type {
                 RTM_NEWROUTE => {
                     if let Some(r) = parse_rtm_newroute(m) {
-                        dirty |= router.upsert_route(r);
+                        dirty |= tables.upsert_route(r);
                     }
                 }
                 RTM_DELROUTE => {
                     if let Some(r) = parse_rtm_newroute(m) {
-                        dirty |= router.remove_route(r);
+                        dirty |= tables.remove_route(r);
                     }
                 }
                 RTM_NEWNEIGH => {
                     if let Some(n) = parse_rtm_newneigh(m, None) {
                         if let Some(IpAddr::V4(_)) = n.destination {
-                            dirty |= router.upsert_neighbor(n);
+                            dirty |= tables.upsert_neighbor(n);
                         }
                     }
                 }
                 RTM_DELNEIGH => {
                     if let Some(n) = parse_rtm_newneigh(m, None) {
                         if let Some(IpAddr::V4(ip)) = n.destination {
-                            dirty |= router.remove_neighbor(ip, n.ifindex as u32);
+                            dirty |= tables.remove_neighbor(ip, n.ifindex as u32);
                         }
                     }
                 }
                 RTM_NEWLINK => {
                     if let Some(interface_info) = parse_rtm_ifinfomsg(m) {
-                        dirty |= router.upsert_interface(interface_info);
+                        dirty |= tables.upsert_interface(interface_info);
                     }
                 }
                 RTM_DELLINK => {
                     if let Some(interface_info) = parse_rtm_ifinfomsg(m) {
-                        dirty |= router.remove_interface(interface_info.if_index);
+                        dirty |= tables.remove_interface(interface_info.if_index);
                     }
                 }
                 _ => {}
@@ -144,18 +145,18 @@ impl RouteMonitor {
 
 struct RouteMonitorState {
     sock: NetlinkSocket,
-    router: Router,
+    tables: RoutingTables,
     dirty: bool,
     last_publish: Instant,
 }
 
 impl RouteMonitorState {
     /// Creates a new RouteMonitorState with a bounded netlink socket
-    fn new(router: Router) -> Self {
+    fn new(tables: RoutingTables) -> Self {
         Self {
             sock: NetlinkSocket::bind((RTMGRP_IPV4_ROUTE | RTMGRP_NEIGH | RTMGRP_LINK) as u32)
                 .expect("error creating netlink socket"),
-            router,
+            tables,
             dirty: false,
             last_publish: Instant::now(),
         }
@@ -164,12 +165,10 @@ impl RouteMonitorState {
     /// Resets the route monitor state by creating a new router and reinitializing
     /// the netlink socket. Used when errors occur to recover to a clean state
     fn reset(&mut self, atomic_router: &Arc<ArcSwap<Router>>) {
-        let mut router = Router::new().expect("error creating Router");
-        if let Err(e) = router.build_caches() {
-            log::warn!("failed to build router caches on reset: {e:?}");
-        }
+        let tables = RoutingTables::from_netlink().expect("error creating RoutingTables");
+        let router = Router::from_tables(tables.clone()).expect("error creating Router");
         atomic_router.store(Arc::new(router));
-        *self = Self::new(Arc::unwrap_or_clone(atomic_router.load_full()));
+        *self = Self::new(tables);
     }
 
     /// Publishes the updated router if there are new route/neighbor updates
@@ -180,11 +179,10 @@ impl RouteMonitorState {
         update_interval: Duration,
     ) {
         if self.dirty && self.last_publish.elapsed() >= update_interval {
-            let mut router = self.router.clone();
-            if let Err(e) = router.build_caches() {
-                log::warn!("failed to build router caches before publish: {e:?}");
+            match Router::from_tables(self.tables.clone()) {
+                Ok(router) => atomic_router.store(Arc::new(router)),
+                Err(e) => log::warn!("failed to build router before publish: {e:?}"),
             }
-            atomic_router.store(Arc::new(router));
             self.last_publish = Instant::now();
             self.dirty = false;
         }

--- a/xdp/src/route_monitor.rs
+++ b/xdp/src/route_monitor.rs
@@ -165,7 +165,8 @@ impl RouteMonitorState {
     /// Resets the route monitor state by creating a new router and reinitializing
     /// the netlink socket. Used when errors occur to recover to a clean state
     fn reset(&mut self, atomic_router: &Arc<ArcSwap<Router>>) {
-        let tables = RoutingTables::from_netlink().expect("error creating RoutingTables");
+        let tables = RoutingTables::from_netlink(self.tables.routes.table)
+            .expect("error creating RoutingTables");
         let router = Router::from_tables(tables.clone()).expect("error creating Router");
         atomic_router.store(Arc::new(router));
         *self = Self::new(tables);

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -3,7 +3,7 @@ use {
     crate::{
         device::{NetworkDevice, QueueId},
         load_xdp_program,
-        route::{Router, RoutingTables},
+        route::{RouteTable, Router, RoutingTables},
         route_monitor::RouteMonitor,
         set_cpu_affinity,
         tx_loop::TxPacket,
@@ -269,7 +269,7 @@ impl TransmitterBuilder {
             .map(|tx_loop_builder| tx_loop_builder.build())
             .collect::<Vec<_>>();
 
-        let tables_result = RoutingTables::from_netlink();
+        let tables_result = RoutingTables::from_netlink(RouteTable::Main);
 
         caps::drop(None, CapSet::Effective, CAP_NET_RAW).expect("drop CAP_NET_RAW capability");
         caps::drop(None, CapSet::Effective, CAP_NET_ADMIN).expect("drop CAP_NET_ADMIN capability");

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -14,7 +14,11 @@ use {
     aya::Ebpf,
     crossbeam_channel::TryRecvError,
     log::info,
-    std::{net::Ipv4Addr, thread::Builder, time::Duration},
+    std::{
+        net::{IpAddr, Ipv4Addr},
+        thread::Builder,
+        time::Duration,
+    },
 };
 use {
     bytes::Bytes,
@@ -357,7 +361,10 @@ impl TransmitterBuilder {
                     .spawn(move || {
                         tx_loop.run(receiver, drop_sender, move |ip| {
                             let r = atomic_router.load();
-                            r.route(*ip).ok()
+                            match ip {
+                                IpAddr::V4(ip) => r.route_v4(*ip).ok(),
+                                IpAddr::V6(_) => None,
+                            }
                         })
                     })
                     .unwrap(),

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -3,7 +3,7 @@ use {
     crate::{
         device::{NetworkDevice, QueueId},
         load_xdp_program,
-        route::Router,
+        route::{Router, RoutingTables},
         route_monitor::RouteMonitor,
         set_cpu_affinity,
         tx_loop::TxPacket,
@@ -265,18 +265,19 @@ impl TransmitterBuilder {
             .map(|tx_loop_builder| tx_loop_builder.build())
             .collect::<Vec<_>>();
 
-        let router_result = Router::new();
+        let tables_result = RoutingTables::from_netlink();
 
         caps::drop(None, CapSet::Effective, CAP_NET_RAW).expect("drop CAP_NET_RAW capability");
         caps::drop(None, CapSet::Effective, CAP_NET_ADMIN).expect("drop CAP_NET_ADMIN capability");
 
-        let mut router = router_result?;
-        router.build_caches()?;
+        let tables = tables_result?;
+        let router = Router::from_tables(tables.clone())?;
 
         // Use ArcSwap for lock-free updates of the routing table
         let atomic_router = Arc::new(ArcSwap::from_pointee(router));
         let route_monitor_handle = RouteMonitor::start(
             Arc::clone(&atomic_router),
+            tables,
             exit.clone(),
             ROUTE_MONITOR_UPDATE_INTERVAL,
             || {


### PR DESCRIPTION
The initial routing implementation in agave-xdp assumed a static routing table with only a handful of entries (one per interface + default).

DZ breaks that assumption by installing hundreds of routes (~550 on mnb today).  The result is that routing when DZ is on doesn't work at all, the XDP thread is pegged at 100% cpu routing, which leads to skipped blocks and the XDP channel filling up. 

This PR fixes the issue by reworking routing and implementing a 4-bit (nibble) trie for lookups.

before

<img width="2056" height="1080" alt="Screenshot 2026-03-22 at 9 28 12 pm" src="https://github.com/user-attachments/assets/1edb917e-35cb-4fec-ae7f-bf8037394433" />


after

<img width="2051" height="982" alt="Screenshot 2026-03-22 at 9 26 38 pm" src="https://github.com/user-attachments/assets/5b6cc600-ad97-45af-ae3a-6246c1ff1858" />
