### PR TITLE
ci: run sanity tests in docker

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -308,7 +308,7 @@ EOF
 }
 
 pull_or_push_steps() {
-  command_step sanity "ci/test-sanity.sh" 5 default
+  command_step sanity "ci/docker-run-default-image.sh ci/test-sanity.sh" 5 default
   wait_step
 
   # Check for any .sh file changes


### PR DESCRIPTION
#### Problem

iirc I encountered some issues when I tried to migrate the sanity tests to docker. looks like the issue has been resolved now 🤔 

#### Summary of Changes

run sanity tests in docker

--- 

highlight this for future reference: https://github.com/anza-xyz/agave/pull/11469#issuecomment-4116335374

```
the motivation is that

align with the other steps
more focus on maintaining the ci image rather than the machine configuration
and after this PR, I plan to move some fast checks happening earlier like fmt and sort
```