### PR TITLE
unkey loader v4

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -841,7 +841,7 @@ pub mod remaining_compute_units_syscall_enabled {
 }
 
 pub mod enable_loader_v4 {
-    solana_pubkey::declare_id!("2aQJYqER2aKyb3cZw22v4SL2xMX7vwXBRWfvS4pTrtED");
+    solana_pubkey::declare_id!("LoaderV4Wi11BeDe1eted1111111111111111111111");
 }
 
 pub mod require_rent_exempt_split_destination {


### PR DESCRIPTION
#### Problem
As per [RFC-0423](https://github.com/solana-foundation/solana-improvement-documents/discussions/423), Loader V4 will be redesigned and reintroduced as an on-chain BPF program. While I work through the churn on #10396 to properly delete the builtin implementation, we should un-key the feature, obviously, to let onlookers know this program will not make it to any network in its current form.

#### Summary of Changes
Swap the `enable_loader_v4` feature gate with a dummy.