### PR TITLE
ConsumeWorker - remove min_max prioritization metric

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1827,6 +1827,7 @@ impl ConsumeWorkerMetrics {
     }
 }
 
+#[derive(Default)]
 struct ConsumeWorkerCountMetrics {
     max_queue_len: AtomicU64,
     num_messages_processed: AtomicU64,
@@ -1836,25 +1837,6 @@ struct ConsumeWorkerCountMetrics {
     retryable_transaction_count: AtomicUsize,
     retryable_expired_bank_count: AtomicUsize,
     cost_model_throttled_transactions_count: AtomicU64,
-    min_prioritization_fees: AtomicU64,
-    max_prioritization_fees: AtomicU64,
-}
-
-impl Default for ConsumeWorkerCountMetrics {
-    fn default() -> Self {
-        Self {
-            max_queue_len: AtomicU64::default(),
-            num_messages_processed: AtomicU64::default(),
-            transactions_attempted_processing_count: AtomicU64::default(),
-            processed_transactions_count: AtomicU64::default(),
-            processed_with_successful_result_count: AtomicU64::default(),
-            retryable_transaction_count: AtomicUsize::default(),
-            retryable_expired_bank_count: AtomicUsize::default(),
-            cost_model_throttled_transactions_count: AtomicU64::default(),
-            min_prioritization_fees: AtomicU64::new(u64::MAX),
-            max_prioritization_fees: AtomicU64::default(),
-        }
-    }
 }
 
 impl ConsumeWorkerCountMetrics {
@@ -1899,17 +1881,6 @@ impl ConsumeWorkerCountMetrics {
                 "cost_model_throttled_transactions_count",
                 self.cost_model_throttled_transactions_count
                     .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "min_prioritization_fees",
-                self.min_prioritization_fees
-                    .swap(u64::MAX, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "max_prioritization_fees",
-                self.max_prioritization_fees.swap(0, Ordering::Relaxed),
                 i64
             ),
         );

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1658,8 +1658,6 @@ impl ConsumeWorkerMetrics {
             retryable_transaction_indexes,
             execute_and_commit_timings,
             error_counters,
-            min_prioritization_fees,
-            max_prioritization_fees,
             ..
         }: &ExecuteAndCommitTransactionsOutput,
     ) {
@@ -1681,20 +1679,6 @@ impl ConsumeWorkerMetrics {
         self.count_metrics
             .retryable_transaction_count
             .fetch_add(retryable_transaction_indexes.len(), Ordering::Relaxed);
-        let min_prioritization_fees = self
-            .count_metrics
-            .min_prioritization_fees
-            .fetch_min(*min_prioritization_fees, Ordering::Relaxed);
-        let max_prioritization_fees = self
-            .count_metrics
-            .max_prioritization_fees
-            .fetch_max(*max_prioritization_fees, Ordering::Relaxed);
-        self.count_metrics
-            .min_prioritization_fees
-            .swap(min_prioritization_fees, Ordering::Relaxed);
-        self.count_metrics
-            .max_prioritization_fees
-            .swap(max_prioritization_fees, Ordering::Relaxed);
         self.update_on_execute_and_commit_timings(execute_and_commit_timings);
         self.update_on_error_counters(error_counters);
     }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -85,8 +85,6 @@ pub struct ExecuteAndCommitTransactionsOutput {
     pub commit_transactions_result: Result<Vec<CommitTransactionDetails>, PohRecorderError>,
     pub(crate) execute_and_commit_timings: LeaderExecuteAndCommitTimings,
     pub(crate) error_counters: TransactionErrorMetrics,
-    pub(crate) min_prioritization_fees: u64,
-    pub(crate) max_prioritization_fees: u64,
 }
 
 #[derive(Debug, Default, PartialEq)]
@@ -266,20 +264,6 @@ impl Consumer {
         let transaction_status_sender_enabled = self.committer.transaction_status_sender_enabled();
         let mut execute_and_commit_timings = LeaderExecuteAndCommitTimings::default();
 
-        let min_max = batch
-            .sanitized_transactions()
-            .iter()
-            .filter_map(|transaction| {
-                transaction
-                    .compute_budget_instruction_details()
-                    .sanitize_and_convert_to_compute_budget_limits(&bank.feature_set)
-                    .ok()
-                    .map(|limits| limits.compute_unit_price)
-            })
-            .minmax();
-        let (min_prioritization_fees, max_prioritization_fees) =
-            min_max.into_option().unwrap_or_default();
-
         let mut error_counters = TransactionErrorMetrics::default();
         let mut retryable_transaction_indexes: Vec<_> = batch
             .lock_results()
@@ -440,8 +424,6 @@ impl Consumer {
                 commit_transactions_result: Err(recorder_err),
                 execute_and_commit_timings,
                 error_counters,
-                min_prioritization_fees,
-                max_prioritization_fees,
             };
         }
 
@@ -496,8 +478,6 @@ impl Consumer {
             commit_transactions_result: Ok(commit_transaction_statuses),
             execute_and_commit_timings,
             error_counters,
-            min_prioritization_fees,
-            max_prioritization_fees,
         }
     }
 


### PR DESCRIPTION
#### Problem
- The min/max priority metric is useless on consume worker side

#### Summary of Changes
- Remove the metric

Fixes #
