### PR TITLE
BlsSigverifier: count number of unnecessary certs verified

### DIFF
--- a/core/src/bls_sigverify/bls_cert_sigverify.rs
+++ b/core/src/bls_sigverify/bls_cert_sigverify.rs
@@ -112,7 +112,9 @@ fn verify_certs(
         .filter_map(|(cert_payload, res)| match res {
             Ok(()) => {
                 let cert = cert_payload.cert;
-                verified_certs_set.insert(cert.cert_type);
+                if !verified_certs_set.insert(cert.cert_type) {
+                    stats.unnecessary_certs_verified += 1;
+                }
                 Some(ConsensusMessage::Certificate(cert))
             }
             Err(e) => {

--- a/core/src/bls_sigverify/stats.rs
+++ b/core/src/bls_sigverify/stats.rs
@@ -180,6 +180,9 @@ pub(super) struct SigVerifyCertStats {
     pub(super) certs_to_sig_verify: u64,
     /// Number of certs [`verify_and_send_certificates`] successfully verified the signature of.
     pub(super) sig_verified_certs: u64,
+    /// Number of certs that were verified unnecessarily because another cert of the same
+    /// `CertificateType` was already verified.
+    pub(super) unnecessary_certs_verified: u64,
 
     /// Number of times stake verification failed on a cert.
     pub(super) stake_verification_failed: u64,
@@ -202,6 +205,7 @@ impl SigVerifyCertStats {
         let Self {
             certs_to_sig_verify,
             sig_verified_certs,
+            unnecessary_certs_verified,
             stake_verification_failed,
             signature_verification_failed,
             too_far_in_future,
@@ -211,6 +215,7 @@ impl SigVerifyCertStats {
         } = other;
         self.certs_to_sig_verify += certs_to_sig_verify;
         self.sig_verified_certs += sig_verified_certs;
+        self.unnecessary_certs_verified += unnecessary_certs_verified;
         self.stake_verification_failed += stake_verification_failed;
         self.signature_verification_failed += signature_verification_failed;
         self.too_far_in_future += too_far_in_future;
@@ -224,6 +229,7 @@ impl SigVerifyCertStats {
         let Self {
             certs_to_sig_verify,
             sig_verified_certs,
+            unnecessary_certs_verified,
             stake_verification_failed,
             signature_verification_failed,
             too_far_in_future,
@@ -235,6 +241,11 @@ impl SigVerifyCertStats {
             "bls_cert_sigverify_stats",
             ("certs_to_sig_verify", *certs_to_sig_verify, i64),
             ("sig_verified_certs", *sig_verified_certs, i64),
+            (
+                "unnecessary_certs_verified",
+                *unnecessary_certs_verified,
+                i64
+            ),
             ("stake_verification_failed", *stake_verification_failed, i64),
             (
                 "signature_verification_failed",


### PR DESCRIPTION
#### Problem

Under normal conditions, the Bls Sigverifier will receive multiple certs of the same `CertificateType`.  Once we have received and verified a single valid cert, we do not need to verify the rest.  Currently, if we get multiple such certs in a single batch, we will verify all of them and some of this might be unnecessary work.

#### Summary of Changes

This PR adds a new metric `unnecessary_certs_verified` to count how often this is happening.  Once, we have the code running under more realistic workloads, we can measure how often this is happening and consider mechanisms to prevent this wasted work.

One idea would be to ask each worker thread to handle all certs of a single `CertificateType` and as soon as it finds one valid one, it can drop the rest of the certs.