### PR TITLE
accounts-db: Use Acquire/Release ordering in `SlotCache::accounts_count`

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -143,7 +143,7 @@ impl SlotCache {
             self.total_size.fetch_add(data_len, Ordering::Relaxed);
             self.unique_account_writes_size
                 .fetch_add(data_len, Ordering::Relaxed);
-            self.accounts_count.fetch_add(1, Ordering::Relaxed);
+            self.accounts_count.fetch_add(1, Ordering::Release);
             self.total_accounts_count.fetch_add(1, Ordering::Relaxed);
             true
         };
@@ -165,6 +165,10 @@ impl SlotCache {
 
     pub fn is_frozen(&self) -> bool {
         self.is_frozen.load(Ordering::Acquire)
+    }
+
+    pub fn len(&self) -> usize {
+        self.accounts_count.load(Ordering::Acquire) as usize
     }
 
     pub fn total_bytes(&self) -> u64 {


### PR DESCRIPTION
#### Problem

We are planning to use it not only in metrics (see #11320). 

#### Summary of Changes

Use stronger atomic ordering.
