### PR TITLE
ci: increase timeout limit for crate publishing tests

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -308,7 +308,7 @@ EOF
 
   # crate publish test
   if [[ -z $CI_PULL_REQUEST ]]; then
-    command_step crate-publish-test "cargo xtask publish test" 30 default
+    command_step crate-publish-test "cargo xtask publish test" 45 default
   fi
 }
 


### PR DESCRIPTION
#### Problem

some of our ci agents do not have sufficient capacity to finish crate publish tests within 30 mins: https://buildkite.com/anza/agave/builds/44490#019d1aec-7f2d-4cc2-9dbf-24576446c75d

#### Summary of Changes

increase timeout limit