### PR TITLE
ci: update xtask-shared version

### DIFF
--- a/ci/xtask/Cargo.lock
+++ b/ci/xtask/Cargo.lock
@@ -832,13 +832,13 @@ dependencies = [
  "env_logger",
  "log",
  "tokio",
- "xtask 0.1.0 (git+https://github.com/anza-xyz/xtask?rev=391661c1cf8823f60e1b3bd05038744edd49099d)",
+ "xtask 0.1.0 (git+https://github.com/anza-xyz/xtask?rev=a9b0cf5facf85eb11458bbefc651132722c18dae)",
 ]
 
 [[package]]
 name = "xtask"
 version = "0.1.0"
-source = "git+https://github.com/anza-xyz/xtask?rev=391661c1cf8823f60e1b3bd05038744edd49099d#391661c1cf8823f60e1b3bd05038744edd49099d"
+source = "git+https://github.com/anza-xyz/xtask?rev=a9b0cf5facf85eb11458bbefc651132722c18dae#a9b0cf5facf85eb11458bbefc651132722c18dae"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -23,7 +23,7 @@ clap = { version = "4.6.0", features = ["derive"] }
 env_logger = "0.11.9"
 log = "0.4.28"
 tokio = { version = "1.50.0", features = ["full"] }
-xtask_shared = { package = "xtask", git = "https://github.com/anza-xyz/xtask", rev = "391661c1cf8823f60e1b3bd05038744edd49099d" }
+xtask_shared = { package = "xtask", git = "https://github.com/anza-xyz/xtask", rev = "a9b0cf5facf85eb11458bbefc651132722c18dae" }
 
 [profile.dev]
 debug = "line-tables-only"


### PR DESCRIPTION
#### Summary of Changes

update xtask-shared to `a9b0cf5facf85eb11458bbefc651132722c18dae`

includes:

- add env to buildkite's command step https://www.github.com/anza-xyz/xtask/pull/24
- add --rm to publish test docker command https://www.github.com/anza-xyz/xtask/pull/25