### PR TITLE
Revert "net: add multicast TTL support to SocketConfiguration (#10700)"

### DIFF
--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -56,20 +56,6 @@ pub struct Node {
 }
 
 impl Node {
-    /// Returns the UDP config for broadcast/retransmit egress sockets.
-    fn retransmit_and_broadcast_udp_config(socket_configs: &SocketConfigs) -> SocketConfig {
-        if cfg!(target_os = "linux") {
-            // Agave does not currently support multicast.
-            // This sets a socket option for these egress sockets only.
-            const MULTICAST_TTL: u32 = 64;
-            socket_configs
-                .primarily_write_udp
-                .multicast_ttl(MULTICAST_TTL)
-        } else {
-            socket_configs.primarily_write_udp
-        }
-    }
-
     /// Creates socket configurations for different socket usage patterns.
     ///
     /// In Agave, many sockets are primarily read heavy or write heavy.
@@ -160,8 +146,6 @@ impl Node {
         }
 
         let socket_configs = Self::create_socket_configs();
-        let retransmit_broadcast_udp_config =
-            Self::retransmit_and_broadcast_udp_config(&socket_configs);
 
         let (tvu_port, mut tvu_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
@@ -267,7 +251,7 @@ impl Node {
         let (tvu_retransmit_port, mut retransmit_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
-            retransmit_broadcast_udp_config,
+            socket_configs.primarily_write_udp,
             num_tvu_retransmit_sockets.get(),
         )
         .expect("tvu retransmit multi_bind");
@@ -277,7 +261,7 @@ impl Node {
                 &bind_ip_addrs,
                 tvu_retransmit_port,
                 num_tvu_retransmit_sockets.get(),
-                retransmit_broadcast_udp_config,
+                socket_configs.primarily_write_udp,
             )
             .expect("Secondary bind TVU retransmit"),
         );
@@ -299,7 +283,7 @@ impl Node {
         let (broadcast_port, mut broadcast) = multi_bind_in_range_with_config(
             bind_ip_addr,
             port_range,
-            retransmit_broadcast_udp_config,
+            socket_configs.primarily_write_udp,
             4,
         )
         .expect("broadcast multi_bind");
@@ -309,7 +293,7 @@ impl Node {
                 &bind_ip_addrs,
                 broadcast_port,
                 4,
-                retransmit_broadcast_udp_config,
+                socket_configs.primarily_write_udp,
             )
             .expect("Secondary bind broadcast"),
         );

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -94,7 +94,6 @@ pub struct SocketConfiguration {
     recv_buffer_size: Option<usize>,
     send_buffer_size: Option<usize>,
     non_blocking: bool,
-    multicast_ttl: Option<u32>,
 }
 
 impl SocketConfiguration {
@@ -125,11 +124,6 @@ impl SocketConfiguration {
         self.non_blocking = non_blocking;
         self
     }
-
-    pub fn multicast_ttl(mut self, ttl: u32) -> Self {
-        self.multicast_ttl = Some(ttl);
-        self
-    }
 }
 
 #[cfg(any(windows, target_os = "ios"))]
@@ -153,7 +147,6 @@ pub(crate) fn udp_socket_with_config(config: SocketConfiguration) -> io::Result<
         recv_buffer_size,
         send_buffer_size,
         non_blocking,
-        multicast_ttl,
     } = config;
     let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
     if PLATFORM_SUPPORTS_SOCKET_CONFIGS {
@@ -163,9 +156,6 @@ pub(crate) fn udp_socket_with_config(config: SocketConfiguration) -> io::Result<
         }
         if let Some(send_buffer_size) = send_buffer_size {
             sock.set_send_buffer_size(send_buffer_size)?;
-        }
-        if let Some(multicast_ttl) = multicast_ttl {
-            sock.set_multicast_ttl_v4(multicast_ttl)?;
         }
 
         if reuseport {
@@ -636,17 +626,6 @@ mod tests {
             tcp_listeners,
         ));
         assert!(verify_all_reachable_udp(&ip_echo_server_addr, &socket_refs));
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn test_multicast_ttl() {
-        let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let port = unique_port_range_for_tests(1).start;
-        let config = SocketConfiguration::default().multicast_ttl(64);
-        let socket = bind_to_with_config(ip_addr, port, config).unwrap();
-        let sock2 = socket2::Socket::from(socket);
-        assert_eq!(sock2.multicast_ttl_v4().unwrap(), 64);
     }
 
     // This test is gated for non-macOS platforms because it requires binding to 127.0.0.2,


### PR DESCRIPTION
This reverts commit 20c6f05b7b2e0acc8c1291fb50f46fe002839075.

#### Problem
Anza is in communication with DZ regarding DZ/multicast support in Agave.
Anza is waiting for a holistic design doc from DZ. We can't have one off PRs in Agave without understanding the full scope of the goals/intended changes.

#### Summary of Changes
Revert multicast TTL support for SocketConfiguration