### PR TITLE
ci: Fix deny warnings when checking feature combinations

### DIFF
--- a/ci/feature-check/test-feature.sh
+++ b/ci/feature-check/test-feature.sh
@@ -22,9 +22,10 @@ exclude_features=(
 	ebpf
 )
 
+export RUSTFLAGS="-D warnings"
+
 cargo +"$rust_nightly" hack check \
 	--each-feature \
 	--exclude-features "$(IFS=,; echo "${exclude_features[*]}")" \
 	--exclude-all-features \
-	--partition "$partition" \
-	--config build.rustflags='"--deny=warnings"'
+	--partition "$partition"


### PR DESCRIPTION
#### Problem
PR #11111 attempted to add deny warnings to `test-feature.sh` by adding `config`. However, it does not work this way, and CI still does not fail on warnings (example #11463). `RUSTFLAGS` should be set.

#### Summary of Changes
Set `RUSTFLAGS` to deny warnings.