### PR TITLE
v4.0: address rustsec-2026-0049

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6265,7 +6265,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.6",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -6315,7 +6315,7 @@ dependencies = [
  "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.6",
+ "rustls-webpki 0.103.10",
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -6340,9 +6340,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -55,6 +55,17 @@ cargo_audit_ignores=(
   # URL:       https://rustsec.org/advisories/RUSTSEC-2024-0376
   # Solution:  Upgrade to >=0.12.3
   --ignore RUSTSEC-2024-0376
+
+  # Crate:     rustls-webpki
+  # Version:   0.101.7
+  # Title:     CRLs not considered authoritative by Distribution Point due to faulty matching logic
+  # Date:      2026-03-20
+  # ID:        RUSTSEC-2026-0049
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0049
+  # Solution:  Upgrade to >=0.103.10
+  #
+  # NOTE: we took the fix for 0.103.6 dependents. here we ignore for those on incompatible 0.101.7
+  --ignore RUSTSEC-2026-0049
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem
https://rustsec.org/advisories/RUSTSEC-2026-0049

#### Summary of Changes
* bump rustls-webpki@0.103.6 to 0.103.10 to pickup the upstream patch
* ignore the advisory for rustls-webpki@0.101.7 due to extensive dependent tree