### PR TITLE
fixup clock test

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7101,6 +7101,7 @@ fn test_update_clock_timestamp() {
     );
 
     // Timestamp cannot go backward from ancestor Bank to child
+    let parent_timestamp = bank.clock().unix_timestamp;
     bank = new_from_parent(Arc::new(bank));
     update_vote_account_timestamp(
         BlockTimestamp {
@@ -7111,10 +7112,7 @@ fn test_update_clock_timestamp() {
         &voting_keypair.pubkey(),
     );
     bank.update_clock(None);
-    assert_eq!(
-        bank.clock().unix_timestamp,
-        bank.unix_timestamp_from_genesis()
-    );
+    assert_eq!(bank.clock().unix_timestamp, parent_timestamp);
 }
 
 fn poh_estimate_offset(bank: &Bank) -> Duration {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7106,7 +7106,7 @@ fn test_update_clock_timestamp() {
     update_vote_account_timestamp(
         BlockTimestamp {
             slot: bank.slot(),
-            timestamp: bank.unix_timestamp_from_genesis() - 1,
+            timestamp: parent_timestamp - 1,
         },
         &bank,
         &voting_keypair.pubkey(),


### PR DESCRIPTION
#### Problem
`test_update_clock_timestamp` is broken but we haven't noticed because of the coarse granularity.

`bank.clock().unix_timestamp` returns the bank value, which is adopted from the parent bank in most cases.

`bank.unix_timestamp_from_genesis()` returns `genesis timestamp + slot * slot time` with a granularity of seconds. 

For the last check in the test, the child bank inherits from a parent that has been set to genesis time + 1, so `bank.clock().unix_timestamp` return `genesis time + 1`.

It also uses a slot of 3, and with a slot time of 400ms, this will come out to 1 second having passed since genesis, so `bank.unix_timestamp_from_genesis()` returns `genesis time + 1`

But if we change to some different slot time, for example 200ms, slot 3 will round down to 0 seconds having passed and the assert check fails.

#### Summary of Changes
Snapshot the parent clock timestamp for setting vote account and comparing w/ child