### PR TITLE
fix: use a more appropriate version string when reserving crates

### DIFF
--- a/scripts/reserve-cratesio-package-name.sh
+++ b/scripts/reserve-cratesio-package-name.sh
@@ -101,7 +101,7 @@ if pushd "${tmpdir}" &>/dev/null; then
   cat <<EOF > "Cargo.toml"
 [package]
 name = "${package_name}"
-version = "0.0.0"
+version = "0.0.1-reserved"
 description = "reserved for future use"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"


### PR DESCRIPTION
#### Problem
the version reservation uses what could be a valid release version for initial claim

#### Summary of Changes
use a prerelease tagged version instead