### PR TITLE
ledger-tool: Uses default scan order for get_program_accounts()

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -26,7 +26,7 @@ use {
     log::*,
     serde::Serialize,
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut},
-    solana_accounts_db::accounts_index::{ScanConfig, ScanOrder},
+    solana_accounts_db::accounts_index::ScanConfig,
     solana_clap_utils::{
         input_parsers::{cluster_type_of, pubkey_of, pubkeys_of},
         input_validators::{
@@ -2258,10 +2258,7 @@ fn main() {
 
                     if remove_stake_accounts {
                         for (address, mut account) in bank
-                            .get_program_accounts(
-                                &stake::program::id(),
-                                &ScanConfig::new(ScanOrder::Sorted),
-                            )
+                            .get_program_accounts(&stake::program::id(), &ScanConfig::default())
                             .unwrap()
                             .into_iter()
                         {
@@ -2285,10 +2282,7 @@ fn main() {
 
                     if !vote_accounts_to_destake.is_empty() {
                         for (address, mut account) in bank
-                            .get_program_accounts(
-                                &stake::program::id(),
-                                &ScanConfig::new(ScanOrder::Sorted),
-                            )
+                            .get_program_accounts(&stake::program::id(), &ScanConfig::default())
                             .unwrap()
                             .into_iter()
                         {
@@ -2370,7 +2364,7 @@ fn main() {
                         for (address, mut account) in bank
                             .get_program_accounts(
                                 &solana_vote_program::id(),
-                                &ScanConfig::new(ScanOrder::Sorted),
+                                &ScanConfig::default(),
                             )
                             .unwrap()
                             .into_iter()


### PR DESCRIPTION
#### Problem

`ledger-tool create-snapshot` has the ability to remove/destake accounts. It calls `get_program_accounts()` to get the list of vote/stake accounts. Currently it specifies that the pubkeys should be sorted, but there is no need.

The underlying impl in accounts-db to have a sorted scan order is very expensive, and should be avoided unless necessary.


#### Summary of Changes

Use default scan order in ledger-tool create-snapshot.