### PR TITLE
ledger-tool: Uses unsorted scan order for output

### DIFF
--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -11,10 +11,7 @@ use {
         ser::{Impossible, SerializeSeq, SerializeStruct, Serializer},
     },
     solana_account::{AccountSharedData, ReadableAccount},
-    solana_accounts_db::{
-        accounts_index::{ScanConfig, ScanOrder},
-        is_loadable::IsLoadable as _,
-    },
+    solana_accounts_db::{accounts_index::ScanConfig, is_loadable::IsLoadable as _},
     solana_cli_output::{
         CliAccount, CliAccountNewConfig, OutputFormat, QuietDisplay, VerboseDisplay,
         display::{build_balance_message, writeln_transaction},
@@ -908,7 +905,7 @@ impl AccountsScanner {
 
         match &self.config.mode {
             AccountsOutputMode::All => {
-                self.bank.scan_all_accounts(scan_func, true).unwrap();
+                self.bank.scan_all_accounts(scan_func, false).unwrap();
             }
             AccountsOutputMode::Individual(pubkeys) => pubkeys.iter().for_each(|pubkey| {
                 if let Some((account, _slot)) = self
@@ -922,7 +919,7 @@ impl AccountsScanner {
             }),
             AccountsOutputMode::Program(program_pubkey) => self
                 .bank
-                .get_program_accounts(program_pubkey, &ScanConfig::new(ScanOrder::Sorted))
+                .get_program_accounts(program_pubkey, &ScanConfig::default())
                 .unwrap()
                 .iter()
                 .filter(|(_, account)| self.should_process_account(account))


### PR DESCRIPTION
#### Problem

`ledger-tool` can list all accounts. To do so, it ends up calling into accounts-db `scan_accounts()`. Currently it specifies that the addresses should be sorted, but this is very expensive and should be avoided.

Instead, a user can post-process the results and sort easily.

(Having scan_accounts() support sorted order artificially constrains how the accounts index can/is implemented. I'm working to remove these constraints to ibrl accounts-db.)


#### Summary of Changes

Use unsorted scan order in ledger-tool output.