### PR TITLE
bank: fix slot leader sanity check when loading a snapshot for slot 0

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1912,27 +1912,29 @@ impl Bank {
             "should be populated (from fields.versioned_epoch_stakes)"
         );
 
-        // Compute and validate the slot leader from epoch stakes
-        let leader: SlotLeader;
-        #[cfg(not(feature = "dev-context-only-utils"))]
-        {
-            _ = leader_for_tests;
-            leader = Self::slot_leader_from_epoch_stakes(
-                fields.slot,
-                &fields.epoch_schedule,
-                &epoch_stakes,
-            );
-        }
-        #[cfg(feature = "dev-context-only-utils")]
-        {
-            leader = leader_for_tests.unwrap_or_else(|| {
+        // Compute and validate the slot leader from epoch stakes.
+        let compute_leader = || {
+            if slot == 0 {
+                // Genesis snapshot has no leader for the genesis block.
+                // Instead the leader is set to the maximum delegated vote account.
+                stakes
+                    .highest_staked_node()
+                    .expect("genesis snapshot should contain at least one staked vote account")
+            } else {
                 Self::slot_leader_from_epoch_stakes(
                     fields.slot,
                     &fields.epoch_schedule,
                     &epoch_stakes,
                 )
-            });
-        }
+            }
+        };
+        #[cfg(not(feature = "dev-context-only-utils"))]
+        let leader = {
+            _ = leader_for_tests;
+            compute_leader()
+        };
+        #[cfg(feature = "dev-context-only-utils")]
+        let leader = leader_for_tests.unwrap_or_else(compute_leader);
         assert_eq!(
             fields.leader_id, leader.id,
             "snapshot leader_id does not match computed slot leader"

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -259,7 +259,7 @@ impl VoteAccounts {
     }
 
     pub fn find_max_by_delegated_stake(&self) -> Option<(&Pubkey, &VoteAccount)> {
-        let key = |(_pubkey, (stake, _vote_account)): &(_, &(u64, _))| *stake;
+        let key = |(pubkey, (stake, _vote_account)): &(_, &(u64, _))| (*stake, *pubkey);
         let (vote_address, (_stake, vote_account)) = self.vote_accounts.iter().max_by_key(key)?;
         Some((vote_address, vote_account))
     }


### PR DESCRIPTION
#### Problem
When loading a genesis config, we create bank 0 with leader set to the highest staked node 
https://github.com/anza-xyz/agave/blob/5d52acc9f108f2adcd0f5dfb3f2b4aba62b5c4af/runtime/src/bank.rs#L2878
If we snapshot this bank, the snapshot has the leader set to the highest staked node.

When loading the snapshot we recompute the slot leader using epoch stakes:
https://github.com/anza-xyz/agave/blob/5d52acc9f108f2adcd0f5dfb3f2b4aba62b5c4af/runtime/src/bank.rs#L1915-L1925 

Depending on the cluster setup, the leader from epoch stakes for bank 0 might not be the highest staked node. This causes us to panic on the sanity check here :

https://github.com/anza-xyz/agave/blob/5d52acc9f108f2adcd0f5dfb3f2b4aba62b5c4af/runtime/src/bank.rs#L1936-L1939

#### Summary of Changes
When loading a snapshot for slot 0, special case the sanity check to use the highest staked node

### bonus bug
because `HashMap` iteration order is non-deterministic `fn highest_staked_node()` could produce different results if there was a tie for the highest. fixed to break ties by pubkey.