### PR TITLE
Removes AccountsIndexPubkeyIterOrder

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -17,7 +17,7 @@ use {
     in_mem_accounts_index::{
         ExistedLocation, InMemAccountsIndex, InsertNewEntryResults, StartupStats,
     },
-    iter::{AccountsIndexPubkeyIterOrder, AccountsIndexPubkeyIterator},
+    iter::AccountsIndexPubkeyIterator,
     log::*,
     rand::{Rng, rng},
     rayon::iter::{IntoParallelIterator, ParallelIterator},
@@ -367,11 +367,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         (account_maps, bin_calculator, storage)
     }
 
-    fn iter<'a>(
-        &'a self,
-        iter_order: AccountsIndexPubkeyIterOrder,
-    ) -> AccountsIndexPubkeyIterator<'a, T, U> {
-        AccountsIndexPubkeyIterator::new(self, iter_order)
+    fn iter<'a>(&'a self) -> AccountsIndexPubkeyIterator<'a, T, U> {
+        AccountsIndexPubkeyIterator::new(self)
     }
 
     /// is the accounts index using disk as a backing store
@@ -637,7 +634,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         let mut iterator_elapsed = 0;
         let mut iterator_timer = Measure::start("iterator_elapsed");
 
-        for pubkeys in self.iter(AccountsIndexPubkeyIterOrder::Unsorted) {
+        for pubkeys in self.iter() {
             iterator_timer.stop();
             iterator_elapsed += iterator_timer.as_us();
             for pubkey in pubkeys {

--- a/accounts-db/src/accounts_index/iter.rs
+++ b/accounts-db/src/accounts_index/iter.rs
@@ -10,18 +10,16 @@ pub struct AccountsIndexPubkeyIterator<'a, T: IndexValue, U: DiskIndexValue + Fr
     account_maps: &'a [Arc<InMemAccountsIndex<T, U>>],
     current_bin: usize,
     items: Vec<Pubkey>,
-    iter_order: AccountsIndexPubkeyIterOrder,
 }
 
 impl<'a, T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     AccountsIndexPubkeyIterator<'a, T, U>
 {
-    pub fn new(index: &'a AccountsIndex<T, U>, iter_order: AccountsIndexPubkeyIterOrder) -> Self {
+    pub fn new(index: &'a AccountsIndex<T, U>) -> Self {
         Self {
             account_maps: &index.account_maps,
             current_bin: 0,
             items: Vec::new(),
-            iter_order,
         }
     }
 }
@@ -39,27 +37,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Iterator
 
             let map = &self.account_maps[self.current_bin];
             let mut items = map.keys();
-            if self.iter_order == AccountsIndexPubkeyIterOrder::Sorted {
-                items.sort_unstable();
-            }
             self.items.append(&mut items);
             self.current_bin += 1;
         }
 
         (!self.items.is_empty()).then(|| std::mem::take(&mut self.items))
     }
-}
-
-/// Specify how the accounts index pubkey iterator should return pubkeys
-///
-/// Users should prefer `Unsorted`, unless required otherwise,
-/// as sorting incurs additional runtime cost.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum AccountsIndexPubkeyIterOrder {
-    /// Returns pubkeys *not* sorted
-    Unsorted,
-    /// Returns pubkeys *sorted*
-    Sorted,
 }
 
 #[cfg(test)]
@@ -99,31 +82,22 @@ mod tests {
             );
         }
 
-        for iter_order in [
-            AccountsIndexPubkeyIterOrder::Sorted,
-            AccountsIndexPubkeyIterOrder::Unsorted,
-        ] {
-            // Create a sorted iterator for the whole pubkey range.
-            let mut iter = index.iter(iter_order);
-            // First iter.next() should return the first batch of 2000 pubkeys in the first bin.
-            let x = iter.next().unwrap();
-            assert_eq!(x.len(), 2 * ITER_BATCH_SIZE);
-            assert_eq!(
-                x.is_sorted(),
-                iter_order == AccountsIndexPubkeyIterOrder::Sorted
-            );
-            assert_eq!(iter.items.len(), 0); // should be empty.
+        // Create an iterator for the whole pubkey range.
+        let mut iter = index.iter();
+        // First iter.next() should return the first batch of 2000 pubkeys in the first bin.
+        let x = iter.next().unwrap();
+        assert_eq!(x.len(), 2 * ITER_BATCH_SIZE);
+        assert_eq!(iter.items.len(), 0); // should be empty.
 
-            // Then iter.next() should return None.
-            assert!(iter.next().is_none());
-        }
+        // Then iter.next() should return None.
+        assert!(iter.next().is_none());
     }
 
     #[test]
     fn test_accounts_iter_finished() {
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         index.add_root(0);
-        let mut iter = index.iter(AccountsIndexPubkeyIterOrder::Sorted);
+        let mut iter = index.iter();
         assert!(iter.next().is_none());
         let mut gc = ReclaimsSlotList::new();
         index.upsert(


### PR DESCRIPTION
#### Problem

The accounts-db functions that support scanning accounts and providing sorted results constrains accounts-db's design. Let's remove those constraints.

For this PR, we target `AccountsIndexPubkeyIterOrder`, which is no longer used.


#### Summary of Changes

Remove `AccountsIndexPubkeyIterOrder`.