### PR TITLE
v3.1: address rustsec-2026-0049

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6525,8 +6525,7 @@ dependencies = [
 [[package]]
 name = "rustls-webpki"
 version = "0.103.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+source = "git+https://github.com/anza-xyz/rustls-webpki?tag=anza-rustsec-2026-0049-0.103.6#aea57bff30e8085466e72ccaab42678100a92005"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -688,3 +688,4 @@ crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d
 # There is a similar override in `programs/sbf/Cargo.toml`.  Please keep both
 # comments and the overrides in sync.
 solana-curve25519 = { path = "curves/curve25519" }
+rustls-webpki = { git = "https://github.com/anza-xyz/rustls-webpki", tag = "anza-rustsec-2026-0049-0.103.6" }

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -90,6 +90,19 @@ cargo_audit_ignores=(
   #
   # AGAVE OK: we backported the fix to 0.11.13 vendored
   --ignore RUSTSEC-2026-0037
+
+
+  # Crate:     rustls-webpki
+  # Version:   0.101.7
+  # Title:     CRLs not considered authoritative by Distribution Point due to faulty matching logic
+  # Date:      2026-03-20
+  # ID:        RUSTSEC-2026-0049
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0049
+  # Solution:  Upgrade to >=0.103.10
+  #
+  # AGAVE OK: we patched the 0.103.6 release tag for corresponding dependents. here we
+  # ignore for those on incompatible 0.101.7
+  --ignore RUSTSEC-2026-0049
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem
https://rustsec.org/advisories/RUSTSEC-2026-0049

#### Summary of Changes
* point at our patched 0.103.6
* ignore for 0.101.7 dependents