### PR TITLE
Remove BankForks atomic shared root

### DIFF
--- a/gossip/src/epoch_specs.rs
+++ b/gossip/src/epoch_specs.rs
@@ -4,7 +4,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank,
-        bank_forks::{BankForks, ReadOnlyAtomicSlot},
+        bank_forks::{BankForks, SharableBanks},
     },
     std::{
         collections::HashMap,
@@ -18,8 +18,7 @@ use {
 pub struct EpochSpecs {
     epoch: Epoch, // when fields were last updated.
     epoch_schedule: EpochSchedule,
-    root: ReadOnlyAtomicSlot, // updated by bank-forks.
-    bank_forks: Arc<RwLock<BankForks>>,
+    sharable_banks: SharableBanks, // updated by bank-forks.
     current_epoch_staked_nodes: Arc<HashMap<Pubkey, /*stake:*/ u64>>,
     epoch_duration: Duration,
 }
@@ -39,10 +38,10 @@ impl EpochSpecs {
 
     // Updates fields if root bank has moved to a new epoch.
     fn maybe_refresh(&mut self) {
-        if self.epoch_schedule.get_epoch(self.root.get()) == self.epoch {
+        let root_bank = self.sharable_banks.root();
+        if root_bank.epoch() == self.epoch {
             return; // still same epoch. nothing to update.
         }
-        let root_bank = self.bank_forks.read().unwrap().root_bank();
         debug_assert_eq!(
             self.epoch_schedule.get_epoch(root_bank.slot()),
             root_bank.epoch()
@@ -56,21 +55,28 @@ impl EpochSpecs {
 
 impl Clone for EpochSpecs {
     fn clone(&self) -> Self {
-        Self::from(self.bank_forks.clone())
+        Self {
+            epoch: self.epoch,
+            epoch_schedule: self.epoch_schedule.clone(),
+            sharable_banks: self.sharable_banks.clone(),
+            current_epoch_staked_nodes: self.current_epoch_staked_nodes.clone(),
+            epoch_duration: self.epoch_duration,
+        }
     }
 }
 
 impl From<Arc<RwLock<BankForks>>> for EpochSpecs {
     fn from(bank_forks: Arc<RwLock<BankForks>>) -> Self {
-        let (root, root_bank) = {
+        let (sharable_banks, root_bank) = {
             let bank_forks = bank_forks.read().unwrap();
-            (bank_forks.get_atomic_root(), bank_forks.root_bank())
+            let sharable_banks = bank_forks.sharable_banks();
+            let root_bank = sharable_banks.root();
+            (sharable_banks, root_bank)
         };
         Self {
             epoch: root_bank.epoch(),
             epoch_schedule: root_bank.epoch_schedule().clone(),
-            root,
-            bank_forks,
+            sharable_banks,
             current_epoch_staked_nodes: root_bank.current_epoch_staked_nodes(),
             epoch_duration: get_epoch_duration(&root_bank),
         }
@@ -169,7 +175,7 @@ mod tests {
         assert_eq!(root_bank.epoch(), epoch);
         assert_eq!(epoch_specs.epoch, epoch);
         assert_eq!(&epoch_specs.epoch_schedule, root_bank.epoch_schedule());
-        assert_eq!(epoch_specs.root.get(), slot);
+        assert_eq!(epoch_specs.sharable_banks.root().slot(), slot);
     }
 
     #[test]

--- a/gossip/src/epoch_specs.rs
+++ b/gossip/src/epoch_specs.rs
@@ -53,18 +53,6 @@ impl EpochSpecs {
     }
 }
 
-impl Clone for EpochSpecs {
-    fn clone(&self) -> Self {
-        Self {
-            epoch: self.epoch,
-            epoch_schedule: self.epoch_schedule.clone(),
-            sharable_banks: self.sharable_banks.clone(),
-            current_epoch_staked_nodes: self.current_epoch_staked_nodes.clone(),
-            epoch_duration: self.epoch_duration,
-        }
-    }
-}
-
 impl From<Arc<RwLock<BankForks>>> for EpochSpecs {
     fn from(bank_forks: Arc<RwLock<BankForks>>) -> Self {
         let (sharable_banks, root_bank) = {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -29,19 +29,6 @@ use {
 };
 
 pub type AtomicSlot = AtomicU64;
-#[derive(Clone)]
-pub struct ReadOnlyAtomicSlot {
-    slot: Arc<AtomicSlot>,
-}
-
-impl ReadOnlyAtomicSlot {
-    pub fn get(&self) -> Slot {
-        // The expectation is that an instance `ReadOnlyAtomicSlot` is on a different thread than
-        // BankForks *and* this instance is being accessed *without* locking BankForks first.
-        // Thus, to ensure atomic ordering correctness, we must use Acquire-Release semantics.
-        self.slot.load(Ordering::Acquire)
-    }
-}
 
 /// Convenience type since often root/working banks are fetched together.
 #[derive(Clone)]
@@ -424,9 +411,8 @@ impl BankForks {
             .get(root)
             .expect("root bank didn't exist in bank_forks");
 
-        // To support `RootBankCache` (via `ReadOnlyAtomicSlot`) accessing `root` *without* locking
-        // BankForks first *and* from a different thread, this store *must* be at least Release to
-        // ensure atomic ordering correctness.
+        // Readers may observe root changes from other threads without taking the BankForks lock,
+        // so this store must remain at least Release.
         self.root.store(root, Ordering::Release);
         self.sharable_banks.root_bank.store(Arc::clone(root_bank));
 
@@ -606,13 +592,6 @@ impl BankForks {
 
     pub fn root(&self) -> Slot {
         self.root.load(Ordering::Relaxed)
-    }
-
-    /// Gets a read-only wrapper to an atomic slot holding the root slot.
-    pub fn get_atomic_root(&self) -> ReadOnlyAtomicSlot {
-        ReadOnlyAtomicSlot {
-            slot: self.root.clone(),
-        }
     }
 
     /// After setting a new root, prune the banks that are no longer on rooted paths

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -20,15 +20,10 @@ use {
     std::{
         collections::{HashMap, HashSet, hash_map::Entry},
         ops::Index,
-        sync::{
-            Arc, RwLock,
-            atomic::{AtomicU64, Ordering},
-        },
+        sync::{Arc, RwLock},
         time::Instant,
     },
 };
-
-pub type AtomicSlot = AtomicU64;
 
 /// Convenience type since often root/working banks are fetched together.
 #[derive(Clone)]
@@ -81,7 +76,7 @@ struct SetRootTimings {
 pub struct BankForks {
     banks: HashMap<Slot, BankWithScheduler>,
     descendants: HashMap<Slot, HashSet<Slot>>,
-    root: Arc<AtomicSlot>,
+    root: Slot,
     working_slot: Slot,
     sharable_banks: SharableBanks,
     highest_slot_at_startup: Slot,
@@ -132,7 +127,7 @@ impl BankForks {
         let migration_status = Arc::new(Self::initialize_migration_status(&root_bank));
 
         let bank_forks = Arc::new(RwLock::new(Self {
-            root: Arc::new(AtomicSlot::new(root_slot)),
+            root: root_slot,
             working_slot: root_slot,
             sharable_banks: SharableBanks {
                 root_bank: Arc::new(ArcSwap::from(root_bank.clone())),
@@ -261,7 +256,7 @@ impl BankForks {
         mode: SchedulingMode,
         mut bank: Bank,
     ) -> BankWithScheduler {
-        if self.root.load(Ordering::Relaxed) < self.highest_slot_at_startup {
+        if self.root < self.highest_slot_at_startup {
             bank.set_check_program_deployment_slot(true);
         }
 
@@ -411,9 +406,7 @@ impl BankForks {
             .get(root)
             .expect("root bank didn't exist in bank_forks");
 
-        // Readers may observe root changes from other threads without taking the BankForks lock,
-        // so this store must remain at least Release.
-        self.root.store(root, Ordering::Release);
+        self.root = root;
         self.sharable_banks.root_bank.store(Arc::clone(root_bank));
 
         let new_epoch = root_bank.epoch();
@@ -591,7 +584,7 @@ impl BankForks {
     }
 
     pub fn root(&self) -> Slot {
-        self.root.load(Ordering::Relaxed)
+        self.root
     }
 
     /// After setting a new root, prune the banks that are no longer on rooted paths


### PR DESCRIPTION
#### Problem
- BankForks maintains an atomic root that is exposed via `ReadOnlyAtomicSlot`
- We have similar logic via `SharableBanks`
- There is only a single user of `ReadOnlyAtomicSlot` - `EpochSpecs`
    - It immediately uses the atomic root to load the root bank anyway

#### Summary of Changes
- Use `SharableBanks` to get root in `EpochSpecs`
- Make BankForks::root a simple `Slot`

Fixes #
