### PR TITLE
Remove MAX_ROOT_DISTANCE_FOR_VOTE_ONLY

### DIFF
--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -28,7 +28,6 @@ use {
     },
 };
 
-pub const MAX_ROOT_DISTANCE_FOR_VOTE_ONLY: Slot = 400;
 pub type AtomicSlot = AtomicU64;
 #[derive(Clone)]
 pub struct ReadOnlyAtomicSlot {


### PR DESCRIPTION
#### Problem
- Unused constant
- Vote Only mode is *only* a concept for alpenglow transition now, and has no relationship to root distance

#### Summary of Changes
- Remove it

Fixes #
