### PR TITLE
bloom: fix benchmarks by enabling hash atomic feature

### DIFF
--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -42,7 +42,7 @@ solana-time-utils = { workspace = true }
 bencher = { workspace = true }
 rayon = { workspace = true }
 solana-bloom = { path = ".", features = ["agave-unstable-api"] }
-solana-hash = { workspace = true }
+solana-hash = { workspace = true, features = ["atomic"] }
 solana-sha256-hasher = { workspace = true }
 solana-signature = { workspace = true, features = ["std"] }
 


### PR DESCRIPTION
#### Problem

```
error[E0599]: no function or associated item named `new_unique` found for struct `solana_hash::Hash` in the current scope
  --> bloom/benches/bloom.rs:90:60
   |
90 |     let hash_values: Vec<_> = std::iter::repeat_with(Hash::new_unique)
   |                                                            ^^^^^^^^^^ function or associated item not found in `solana_hash::Hash`

error[E0599]: no function or associated item named `new_unique` found for struct `solana_hash::Hash` in the current scope
   --> bloom/benches/bloom.rs:109:60
    |
109 |     let hash_values: Vec<_> = std::iter::repeat_with(Hash::new_unique)
    |                                                            ^^^^^^^^^^ function or associated item not found in `solana_hash::Hash`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `solana-bloom` (bench "bloom") due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```

#### Summary of Changes
- Enabled `atomic` feature to get back `Hash::new_unique()` used in benchmarks