### PR TITLE
ci: pin cargo-sort to 2.0.2 in docker image

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -83,7 +83,7 @@ RUN \
   rustup target add wasm32-unknown-unknown && \
   cargo install cargo-audit && \
   cargo install cargo-hack && \
-  cargo install cargo-sort@^2 && \
+  cargo install cargo-sort@2.0.2 && \
   cargo install mdbook && \
   cargo install mdbook-linkcheck && \
   cargo install svgbob_cli && \


### PR DESCRIPTION
#### Problem

`cargo-sort` "fixed" some sorting issues in 2.1.x. however, the changes break our ci. using `@^2` seems a bad idea. let's pin to a specific version so we have a better control

#### Summary of Changes

pin cargo-sort to 2.0.2 in ci docker image


(more context: https://anza-xyz.slack.com/archives/C08D0FL5Q4T/p1773305624660589?thread_ts=1773241661.955819&cid=C08D0FL5Q4T)