### PR TITLE
Improves tests for AccountsIndexPubkeyIterator

### DIFF
--- a/accounts-db/src/accounts_index/iter.rs
+++ b/accounts-db/src/accounts_index/iter.rs
@@ -54,15 +54,20 @@ mod tests {
         },
         crate::accounts_index::ReclaimsSlotList,
         solana_account::AccountSharedData,
+        std::iter,
     };
 
+    /// Ensure that when there are fewer than ITER_BATCH_SIZE items in a bin that `next()`
+    /// will correctly get items from the next bin, in a loop, until the iterator has
+    /// collected at least ITER_BATCH_SIZE items, or it has visited all the bins.
     #[test]
-    fn test_account_index_iter_batched() {
+    fn test_accounts_index_iter_batched_small() {
         let index = AccountsIndex::<bool, bool>::default_for_tests();
-        // Setup an account index for test.
-        // Two bins. First bin has 2000 accounts, second bin has 0 accounts.
-        let num_pubkeys = 2 * ITER_BATCH_SIZE;
-        let pubkeys = std::iter::repeat_with(Pubkey::new_unique)
+        // this test requires the index to have more than one bin
+        assert!(index.bins() > 1);
+        // ensure each bin ends up with fewer than ITER_BATCH_SIZE items
+        let num_pubkeys = ITER_BATCH_SIZE;
+        let pubkeys = iter::repeat_with(solana_pubkey::new_rand)
             .take(num_pubkeys)
             .collect::<Vec<_>>();
 
@@ -84,12 +89,61 @@ mod tests {
 
         // Create an iterator for the whole pubkey range.
         let mut iter = index.iter();
-        // First iter.next() should return the first batch of 2000 pubkeys in the first bin.
+        // First iter.next() should return all the pubkeys
         let x = iter.next().unwrap();
-        assert_eq!(x.len(), 2 * ITER_BATCH_SIZE);
+        assert_eq!(x.len(), num_pubkeys);
         assert_eq!(iter.items.len(), 0); // should be empty.
 
         // Then iter.next() should return None.
+        assert!(iter.next().is_none());
+    }
+
+    /// Ensure that when there are at least ITER_BATCH_SIZE items in a bin that `next()`
+    /// will return those items immediately and *not* visit the next bin.
+    #[test]
+    fn test_accounts_index_iter_batched_large() {
+        let index = AccountsIndex::<bool, bool>::default_for_tests();
+        // this test requires the index to have two bins
+        assert_eq!(index.bins(), 2);
+        // ensure each bin ends up with more than ITER_BATCH_SIZE items
+        let num_pubkeys = ITER_BATCH_SIZE * (index.bins() + 1);
+        let pubkeys = iter::repeat_with(solana_pubkey::new_rand)
+            .take(num_pubkeys)
+            .collect::<Vec<_>>();
+
+        for key in pubkeys {
+            let slot = 0;
+            let value = true;
+            let mut gc = ReclaimsSlotList::new();
+            index.upsert(
+                slot,
+                slot,
+                &key,
+                &AccountSharedData::default(),
+                &AccountSecondaryIndexes::default(),
+                value,
+                &mut gc,
+                UpsertReclaim::PopulateReclaims,
+            );
+        }
+
+        // Create an iterator for the whole pubkey range.
+        let mut iter = index.iter();
+        // First iter.next() should return the whole first bin.
+        let x = iter.next().unwrap();
+        let (len0, _) = index.account_maps[0].len_and_cap_for_startup();
+        assert_eq!(x.len(), len0);
+        assert_eq!(iter.items.len(), 0); // should be empty.
+
+        // Second iter.next() should return all the remaining
+        let num_remaining = num_pubkeys - len0;
+        let y = iter.next().unwrap();
+        let (len1, _) = index.account_maps[1].len_and_cap_for_startup();
+        assert_eq!(y.len(), num_remaining);
+        assert_eq!(y.len(), len1);
+        assert_eq!(iter.items.len(), 0); // should be empty.
+
+        // Third iter.next() should return None.
         assert!(iter.next().is_none());
     }
 


### PR DESCRIPTION
#### Problem

Tests for AccountsIndexPubkeyIterator do not cover both cases where an index bin has less than or more than ITER_BATCH_SIZE number of accounts.


#### Summary of Changes

Add/improve tests to cover both cases.