### PR TITLE
Randomizes accounts index binning (v1)

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -12,7 +12,7 @@ use {
         ancestors::Ancestors,
         contains::Contains,
         is_zero_lamport::IsZeroLamport,
-        pubkey_bins::PubkeyBinCalculator24,
+        pubkey_bins::{PubkeyBinCalculator, PubkeyBinCalculatorBuilder},
         rolling_bit_field::RollingBitField,
     },
     account_map_entry::{AccountMapEntry, PreAllocatedAccountMapEntry, SlotListWriteGuard},
@@ -234,7 +234,7 @@ pub enum AccountsIndexScanResult {
 /// U: account info type to be persisted to disk
 pub struct AccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
     pub account_maps: Box<[Arc<InMemAccountsIndex<T, U>>]>,
-    pub bin_calculator: PubkeyBinCalculator24,
+    pub bin_calculator: PubkeyBinCalculator,
     program_id_index: SecondaryIndex<RwLockSecondaryIndexEntry>,
     spl_token_mint_index: SecondaryIndex<RwLockSecondaryIndexEntry>,
     spl_token_owner_index: SecondaryIndex<RwLockSecondaryIndexEntry>,
@@ -258,6 +258,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
 
     pub fn new(config: &AccountsIndexConfig, exit: Arc<AtomicBool>) -> Self {
         let (account_maps, bin_calculator, storage) = Self::allocate_accounts_index(config, exit);
+        info!("AccountsIndex bin calculator: {bin_calculator:?}");
         Self {
             purge_older_root_entries_one_slot_list: AtomicUsize::default(),
             account_maps,
@@ -285,12 +286,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         exit: Arc<AtomicBool>,
     ) -> (
         Box<[Arc<InMemAccountsIndex<T, U>>]>,
-        PubkeyBinCalculator24,
+        PubkeyBinCalculator,
         AccountsIndexStorage<T, U>,
     ) {
         let bins = config.bins.unwrap_or(BINS_DEFAULT);
         // create bin_calculator early to verify # bins is reasonable
-        let bin_calculator = PubkeyBinCalculator24::new(bins);
+        let bin_calculator = PubkeyBinCalculatorBuilder::with_bins(
+            NonZeroUsize::new(bins).expect("bins is non-zero"),
+        );
         let storage = AccountsIndexStorage::new(bins, config, exit);
 
         let account_maps: Box<_> = (0..bins)
@@ -1051,7 +1054,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         // lock contention.
         let bins = self.bins();
         let random_bin_offset = rng().random_range(0..bins);
-        let bin_calc = self.bin_calculator;
+        let bin_calc = &self.bin_calculator;
         items.sort_unstable_by(|(pubkey_a, _), (pubkey_b, _)| {
             ((bin_calc.bin_from_pubkey(pubkey_a) + random_bin_offset) % bins)
                 .cmp(&((bin_calc.bin_from_pubkey(pubkey_b) + random_bin_offset) % bins))
@@ -3852,14 +3855,5 @@ mod tests {
             index.handle_dead_keys(&[key], &AccountSecondaryIndexes::default()),
             vec![key].into_iter().collect::<HashSet<_>>()
         );
-    }
-
-    #[test]
-    #[should_panic(expected = "bins.is_power_of_two()")]
-    #[allow(clippy::field_reassign_with_default)]
-    fn test_illegal_bins() {
-        let mut config = AccountsIndexConfig::default();
-        config.bins = Some(3);
-        AccountsIndex::<bool, bool>::new(&config, Arc::default());
     }
 }

--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -1,48 +1,87 @@
 use {
-    solana_pubkey::Pubkey,
-    std::num::{NonZeroU32, NonZeroUsize},
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
+    std::{fmt, hash::BuildHasher as _, num::NonZeroUsize},
 };
 
-#[derive(Clone, Copy, Debug)]
-pub struct PubkeyBinCalculator24 {
-    // how many bits from the first 3 bytes to shift away to ignore when calculating bin
-    shift_bits: u32,
+/// Used to calculate which bin a pubkey maps to.
+///
+/// This struct may be cloned, and will retain the same pubkey -> bin results.
+///
+/// To instantiate, use `PubkeyBinCalculatorBuilder::with_bins(num_bins)`.
+#[derive(Clone)]
+pub struct PubkeyBinCalculator {
+    mask: u64,
+    hasher_builder: PubkeyHasherBuilder,
 }
 
-impl PubkeyBinCalculator24 {
-    const MAX_BITS: u32 = 24;
-    const MAX_BINS: usize = 1_usize << Self::MAX_BITS;
+impl PubkeyBinCalculator {
+    /// Calculates the bin that `pubkey` maps to.
+    #[inline]
+    pub fn bin_from_pubkey(&self, pubkey: &Pubkey) -> usize {
+        let hash = self.hash_from_pubkey(pubkey);
+        (hash & self.mask) as usize
+    }
 
-    /// Creates a new PubkeyBinCalculator24
+    /// Calculates the hash of `pubkey`.
+    #[inline]
+    fn hash_from_pubkey(&self, pubkey: &Pubkey) -> u64 {
+        self.hasher_builder.hash_one(pubkey)
+    }
+}
+
+impl fmt::Debug for PubkeyBinCalculator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PubkeyBinCalculator")
+            .field("num_bins", &(self.mask + 1))
+            .field("offset", &(self.hasher_builder.offset()))
+            .finish_non_exhaustive()
+    }
+}
+
+/// Used to build unique instances of `PubkeyBinCalculator'.
+#[derive(Debug)]
+pub struct PubkeyBinCalculatorBuilder;
+
+impl PubkeyBinCalculatorBuilder {
+    /// Builds a `PubkeyBinCalculator` with `num_bins`.
+    ///
+    /// The returned bin calculator will produce *unique* mappings
+    /// compared to other bin calculators!
     ///
     /// # Panics
     ///
     /// This function will panic if the following conditions are not met:
-    /// * `bins` must be greater than zero
-    /// * `bins` must be a power of two
-    /// * `bins` must be less than or equal to 2^24
-    pub fn new(bins: usize) -> Self {
-        // SAFETY: Caller must guarantee `bins` is non-zero.
-        let bins = NonZeroUsize::new(bins).expect("bins is non-zero");
-        assert!(bins.is_power_of_two());
-        assert!(bins.get() <= Self::MAX_BINS);
-        // SAFETY: `bins` was already non-zero, and we just asserted it fits in 24 bits.
-        let bins = unsafe { NonZeroU32::new_unchecked(bins.get() as u32) };
-        let bits = bins.ilog2();
-        Self {
-            shift_bits: Self::MAX_BITS - bits,
+    /// * `num_bins` must be a power of two
+    pub fn with_bins(num_bins: NonZeroUsize) -> PubkeyBinCalculator {
+        Self::build(num_bins, PubkeyHasherBuilder::default())
+    }
+
+    /// Builds a `PubkeyBinCalculator` with `num_bins` and `offset`.
+    ///
+    /// The `offset` is used to instantiate a specific PubkeyHasher for the bin calculator.
+    /// Prefer `with_bins()` whenever possible.
+    ///
+    /// The returned bin calculator will produce *identical* mappings
+    /// compared to other bin calculators with the same num_bins and offset.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the following conditions are not met:
+    /// * `num_bins` must be a power of two
+    pub fn with_bins_and_offset(num_bins: NonZeroUsize, offset: usize) -> PubkeyBinCalculator {
+        Self::build(num_bins, PubkeyHasherBuilder::with_offset(offset))
+    }
+
+    /// Internal helper for building a `PubkeyBinCalculator`.
+    ///
+    /// Only intended to be called by the public build methods.
+    fn build(num_bins: NonZeroUsize, hasher_builder: PubkeyHasherBuilder) -> PubkeyBinCalculator {
+        assert!(num_bins.is_power_of_two());
+        let num_bins_mask = num_bins.get() - 1;
+        PubkeyBinCalculator {
+            mask: num_bins_mask as u64,
+            hasher_builder,
         }
-    }
-
-    pub fn bins(&self) -> usize {
-        1 << (Self::MAX_BITS - self.shift_bits)
-    }
-
-    #[inline]
-    pub fn bin_from_pubkey(&self, pubkey: &Pubkey) -> usize {
-        let as_ref = pubkey.as_ref();
-        (((as_ref[0] as usize) << 16) | ((as_ref[1] as usize) << 8) | (as_ref[2] as usize))
-            >> self.shift_bits
     }
 }
 
@@ -50,174 +89,63 @@ impl PubkeyBinCalculator24 {
 mod tests {
     use super::*;
 
-    impl PubkeyBinCalculator24 {
-        fn lowest_pubkey_from_bin(&self, mut bin: usize) -> Pubkey {
-            assert!(bin < self.bins());
-            bin <<= self.shift_bits;
-            let mut pubkey = Pubkey::from([0; 32]);
-            pubkey.as_mut()[0] = ((bin / 256 / 256) & 0xff) as u8;
-            pubkey.as_mut()[1] = ((bin / 256) & 0xff) as u8;
-            pubkey.as_mut()[2] = (bin & 0xff) as u8;
-            pubkey
-        }
-
-        fn highest_pubkey_from_bin(&self, mut bin: usize) -> Pubkey {
-            assert!(bin < self.bins());
-            let mask = (1 << self.shift_bits) - 1;
-            bin <<= self.shift_bits;
-            bin |= mask;
-            let mut pubkey = Pubkey::from([0xff; 32]);
-            pubkey.as_mut()[0] = ((bin / 256 / 256) & 0xff) as u8;
-            pubkey.as_mut()[1] = ((bin / 256) & 0xff) as u8;
-            pubkey.as_mut()[2] = (bin & 0xff) as u8;
-            pubkey
-        }
-    }
-
+    /// Ensure that bin calculation is deterministic.
     #[test]
-    fn test_pubkey_bins() {
-        for i in 0..=24 {
-            let bins = 2u32.pow(i);
-            let calc = PubkeyBinCalculator24::new(bins as usize);
-            assert_eq!(calc.shift_bits, 24 - i, "i: {i}");
-            for bin in 0..bins {
-                assert_eq!(
-                    bin as usize,
-                    calc.bin_from_pubkey(&calc.lowest_pubkey_from_bin(bin as usize))
-                );
-
-                assert_eq!(
-                    bin as usize,
-                    calc.bin_from_pubkey(&calc.highest_pubkey_from_bin(bin as usize))
-                );
-
-                assert_eq!(calc.bins(), bins as usize);
-            }
-        }
-    }
-
-    #[test]
-    fn test_pubkey_bins_pubkeys() {
-        let mut pk = Pubkey::from([0; 32]);
-        for i in 0..=8 {
-            let bins = 2usize.pow(i);
-            let calc = PubkeyBinCalculator24::new(bins);
-
-            let shift_bits = calc.shift_bits - 16; // we are only dealing with first byte
-
-            pk.as_mut()[0] = 0;
-            assert_eq!(0, calc.bin_from_pubkey(&pk));
-            pk.as_mut()[0] = 0xff;
-            assert_eq!(bins - 1, calc.bin_from_pubkey(&pk));
-
-            for bin in 0..bins {
-                pk.as_mut()[0] = (bin << shift_bits) as u8;
-                assert_eq!(
-                    bin,
-                    calc.bin_from_pubkey(&pk),
-                    "bin: {}/{}, shift_bits: {}, val: {}",
-                    bin,
-                    bins,
-                    shift_bits,
-                    pk.as_ref()[0]
-                );
-                if bin > 0 {
-                    pk.as_mut()[0] = ((bin << shift_bits) - 1) as u8;
-                    assert_eq!(bin - 1, calc.bin_from_pubkey(&pk));
+    fn test_bin_from_pubkey_is_deterministic() {
+        for num_bins in [1 << 10, 1 << 14, 1 << 19] {
+            let bin_calculator1 =
+                PubkeyBinCalculatorBuilder::with_bins(NonZeroUsize::new(num_bins).unwrap());
+            // second bin calculator that exercies Calculator::clone()
+            let bin_calculator2 = bin_calculator1.clone();
+            for i_pubkey in 0..1_000 {
+                let pubkey = Pubkey::new_unique();
+                let expected_bin = bin_calculator1.bin_from_pubkey(&pubkey);
+                for i_calculation in 0..10 {
+                    let actual_bin = bin_calculator1.bin_from_pubkey(&pubkey);
+                    assert_eq!(
+                        actual_bin, expected_bin,
+                        "num_bins: {num_bins}, i_pubkey: {i_pubkey}, i_calculation: \
+                         {i_calculation}, pubkey: {pubkey}",
+                    );
                 }
-            }
-        }
-
-        for i in 9..=16 {
-            let mut pk = Pubkey::from([0; 32]);
-            let bins = 2usize.pow(i);
-            let calc = PubkeyBinCalculator24::new(bins);
-
-            let shift_bits = calc.shift_bits - 8;
-
-            pk.as_mut()[1] = 0;
-            assert_eq!(0, calc.bin_from_pubkey(&pk));
-            pk.as_mut()[0] = 0xff;
-            pk.as_mut()[1] = 0xff;
-            assert_eq!(bins - 1, calc.bin_from_pubkey(&pk));
-
-            let mut pk = Pubkey::from([0; 32]);
-            for bin in 0..bins {
-                let mut target = (bin << shift_bits) as u16;
-                pk.as_mut()[0] = (target / 256) as u8;
-                pk.as_mut()[1] = (target % 256) as u8;
-                assert_eq!(
-                    bin,
-                    calc.bin_from_pubkey(&pk),
-                    "bin: {}/{}, shift_bits: {}, val: {}",
-                    bin,
-                    bins,
-                    shift_bits,
-                    pk.as_ref()[0]
-                );
-                if bin > 0 {
-                    target -= 1;
-                    pk.as_mut()[0] = (target / 256) as u8;
-                    pk.as_mut()[1] = (target % 256) as u8;
-                    assert_eq!(bin - 1, calc.bin_from_pubkey(&pk));
-                }
-            }
-        }
-
-        for i in 17..=24 {
-            let mut pk = Pubkey::from([0; 32]);
-            let bins = 2usize.pow(i);
-            let calc = PubkeyBinCalculator24::new(bins);
-
-            let shift_bits = calc.shift_bits;
-
-            pk.as_mut()[1] = 0;
-            assert_eq!(0, calc.bin_from_pubkey(&pk));
-            pk.as_mut()[0] = 0xff;
-            pk.as_mut()[1] = 0xff;
-            pk.as_mut()[2] = 0xff;
-            assert_eq!(bins - 1, calc.bin_from_pubkey(&pk));
-
-            let mut pk = Pubkey::from([0; 32]);
-            for bin in 0..bins {
-                let mut target = (bin << shift_bits) as u32;
-                pk.as_mut()[0] = (target / 256 / 256) as u8;
-                pk.as_mut()[1] = ((target / 256) % 256) as u8;
-                pk.as_mut()[2] = (target % 256) as u8;
-                assert_eq!(
-                    bin,
-                    calc.bin_from_pubkey(&pk),
-                    "bin: {}/{}, shift_bits: {}, val: {:?}",
-                    bin,
-                    bins,
-                    shift_bits,
-                    &pk.as_ref()[0..3],
-                );
-                if bin > 0 {
-                    target -= 1;
-                    pk.as_mut()[0] = (target / 256 / 256) as u8;
-                    pk.as_mut()[1] = ((target / 256) % 256) as u8;
-                    pk.as_mut()[2] = (target % 256) as u8;
-                    assert_eq!(bin - 1, calc.bin_from_pubkey(&pk));
-                }
+                assert_eq!(expected_bin, bin_calculator2.bin_from_pubkey(&pubkey));
             }
         }
     }
 
+    /// Ensure that bin calculators from *different* builders produce different hashes.
     #[test]
-    #[should_panic(expected = "bins.is_power_of_two()")]
-    fn test_pubkey_bins_bad_non_pow2() {
-        PubkeyBinCalculator24::new(3);
+    fn test_builders_produces_unique_instances() {
+        let num_bins = NonZeroUsize::new(1).unwrap();
+        let bin_calculator1 = PubkeyBinCalculatorBuilder::with_bins(num_bins);
+        let bin_calculator2 = PubkeyBinCalculatorBuilder::with_bins(num_bins);
+        let pubkey = Pubkey::new_unique();
+        assert_ne!(
+            bin_calculator1.hash_from_pubkey(&pubkey),
+            bin_calculator2.hash_from_pubkey(&pubkey),
+        );
     }
 
+    /// Ensure that bin calculators from different builders, but with the
+    /// same num_bins and offset, produce *identical* hashes.
     #[test]
-    #[should_panic(expected = "bins.get() <= Self::MAX_BINS")]
-    fn test_pubkey_bins_bad_too_large() {
-        PubkeyBinCalculator24::new(1 << (PubkeyBinCalculator24::MAX_BITS + 1));
+    fn test_builders_with_same_offset_produce_identical_instances() {
+        let num_bins = NonZeroUsize::new(1).unwrap();
+        let offset = 0;
+        let bin_calculator1 = PubkeyBinCalculatorBuilder::with_bins_and_offset(num_bins, offset);
+        let bin_calculator2 = PubkeyBinCalculatorBuilder::with_bins_and_offset(num_bins, offset);
+        let pubkey = Pubkey::new_unique();
+        assert_eq!(
+            bin_calculator1.hash_from_pubkey(&pubkey),
+            bin_calculator2.hash_from_pubkey(&pubkey),
+        );
     }
+
+    /// Ensure non-power-of-two number of bins is not allowed.
     #[test]
-    #[should_panic(expected = "bins is non-zero")]
-    fn test_pubkey_bins_bad_is_zero() {
-        PubkeyBinCalculator24::new(0);
+    #[should_panic(expected = "num_bins.is_power_of_two()")]
+    fn test_num_bins_not_power_of_two_should_panic() {
+        let num_bins = NonZeroUsize::new(3).unwrap();
+        PubkeyBinCalculatorBuilder::with_bins(num_bins);
     }
 }


### PR DESCRIPTION
### Problem

Binning in the accounts index is a fixed mapping. This is non-ideal as it doesn't facilitate node diversity.

Here's the number of entries per bin, with the entries sorted in descending order, for all the bins:

<img width="594" height="370" alt="Screenshot 2026-03-26 at 10 40 37 AM" src="https://github.com/user-attachments/assets/92fed707-3095-4e8b-8525-028cf4784508" />

And here's just the top 10 bins:

<img width="597" height="370" alt="Screenshot 2026-03-26 at 10 40 43 AM" src="https://github.com/user-attachments/assets/fd995d6f-67be-4113-98ba-26efd0cc4353" />

We can see the first bin is significantly larger than the rest.

This is also bad for performance when needing to lookup or insert a pubkey in that bin, as it'll take longer than the smaller bins.


### Summary of Changes

Randomize account index binning.





### Results

#### Entries per Bin

The current binning strategy in master ends up with a very large single bin, more than twice as large as the next largest. This PR flattens the curve.

| branch | min | max | diff |
|--------|--------|--------|--------|
| master | 133,444 | 311,782 | 178,338 |
| pr | 133,575 | 136,298 | 2,723 |



Here's the number of entries per bin, for all the bins:

<img width="632" height="390" alt="Screenshot 2026-03-26 at 10 42 44 AM" src="https://github.com/user-attachments/assets/648af2aa-8bf7-4447-b1ed-4c3ff4d8f750" />

And here's the top 10:

<img width="632" height="389" alt="Screenshot 2026-03-26 at 10 42 43 AM" src="https://github.com/user-attachments/assets/7377ed31-9a3e-4436-b146-fd366489f785" />


And here's a comparison of the top 10 between master and this PR:

<img width="630" height="390" alt="Screenshot 2026-03-26 at 10 48 16 AM" src="https://github.com/user-attachments/assets/7307f0c5-ad77-48fc-b9c3-a4db4157904e" />


#### Index Generation Time

Generating the index has to map all the accounts into index bins. Here's the runtime of generating the index on mnb running on my dev node, which was restarting every 20ish minutes to get this data.

On the left side is master, the middle is randomized binning (this PR), and the right side is randomized binning and requiring a pow2 requirement for number of bins. What I see is that index generation takes a bit over 3 seconds longer.

<img width="918" height="441" alt="Screenshot 2026-03-26 at 2 27 41 PM" src="https://github.com/user-attachments/assets/77b72a4a-f27d-44e9-bc17-b1f9c3032be8" />


#### A/B Testing

I ran two nodes on mnb, one with master and one with this pr, and then switched their builds and restarted. 

`3XU` started with this pr (left side is pr, right side is master)
`BtJ` started with master (left side is master, right size is pr)

Here's replay time for loading accounts (mean and p99). I don't see a difference. (I wasn't expecting one, as most loads are hitting in the account caches.)

<img width="919" height="886" alt="replay load" src="https://github.com/user-attachments/assets/721bcc41-b570-4128-accb-4879ca1401ed" />

Next is updating the index during store unfrozen (mean and max). I think I see a small slow down. (Looking at slowlana profiles, I do that that the PubkeyHasher has an additional bounds check, which is safe to skip. I'm planning to remove that from the SDK.)

<img width="919" height="881" alt="store unfrozen" src="https://github.com/user-attachments/assets/3fa81ff6-dc7b-4fb0-a927-df003cb87c3c" />

Here's store frozen (mean and max). The big spikes are when squash runs. I don't see a difference here.

<img width="921" height="875" alt="store frozen" src="https://github.com/user-attachments/assets/f434aba3-c016-4a6d-a18a-1652d238f234" />

Lastly, here's the time (mean and max) spent loading from the index. Note this is over 10 seconds, whereas the store unfrozen/frozen were only over 1 second. I don't see a difference here. Also note this metric is the load time from inside the index bin. So it doesn't include any time spent calculating the bin from pubkey. This hopefully helps show that the bins themselves are not made any worse.

<img width="919" height="884" alt="in mem load" src="https://github.com/user-attachments/assets/3d557dbb-0b42-4606-90d6-5c17af5836c5" />