### PR TITLE
Include deleted accounts when calculating account data delta

### DIFF
--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -188,6 +188,7 @@ mod tests {
         status: Result<()>,
         loaded_transaction: LoadedTransaction,
     ) -> TransactionProcessingResult {
+        let accounts_data_len_delta = status.as_ref().ok().map(|_| 0);
         Ok(ProcessedTransaction::Executed(Box::new(
             ExecutedTransaction {
                 execution_details: TransactionExecutionDetails {
@@ -196,7 +197,7 @@ mod tests {
                     inner_instructions: None,
                     return_data: None,
                     executed_units: 0,
-                    accounts_data_len_delta: 0,
+                    accounts_data_len_delta,
                 },
                 loaded_transaction,
                 programs_modified_by_tx: HashMap::new(),

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -164,7 +164,9 @@ mod tests {
         solana_signer::{Signer, signers::Signers},
         solana_svm::{
             account_loader::{FeesOnlyTransaction, LoadedTransaction},
-            transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
+            transaction_execution_result::{
+                AccountsDeltas, ExecutedTransaction, TransactionExecutionDetails,
+            },
         },
         solana_system_interface::{instruction as system_instruction, program as system_program},
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
@@ -188,7 +190,10 @@ mod tests {
         status: Result<()>,
         loaded_transaction: LoadedTransaction,
     ) -> TransactionProcessingResult {
-        let accounts_data_len_delta = status.as_ref().is_ok().then_some(0);
+        let accounts_deltas = status.as_ref().is_ok().then_some(AccountsDeltas {
+            accounts_resize_delta: 0,
+            accounts_uninitialized_size: 0,
+        });
         Ok(ProcessedTransaction::Executed(Box::new(
             ExecutedTransaction {
                 execution_details: TransactionExecutionDetails {
@@ -197,7 +202,7 @@ mod tests {
                     inner_instructions: None,
                     return_data: None,
                     executed_units: 0,
-                    accounts_data_len_delta,
+                    accounts_deltas,
                 },
                 loaded_transaction,
                 programs_modified_by_tx: HashMap::new(),

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -188,7 +188,7 @@ mod tests {
         status: Result<()>,
         loaded_transaction: LoadedTransaction,
     ) -> TransactionProcessingResult {
-        let accounts_data_len_delta = status.as_ref().ok().map(|_| 0);
+        let accounts_data_len_delta = status.as_ref().is_ok().then_some(0);
         Ok(ProcessedTransaction::Executed(Box::new(
             ExecutedTransaction {
                 execution_details: TransactionExecutionDetails {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4051,7 +4051,12 @@ impl Bank {
             .iter()
             .filter_map(|processing_result| processing_result.processed_transaction())
             .filter_map(|processed_tx| processed_tx.execution_details())
-            .filter_map(|details| details.accounts_data_len_delta)
+            .filter_map(|details| details.accounts_deltas.as_ref())
+            .map(|deltas| {
+                deltas
+                    .accounts_resize_delta
+                    .saturating_sub_unsigned(deltas.accounts_uninitialized_size)
+            })
             .sum();
         self.update_accounts_data_size_delta_on_chain(accounts_data_len_delta);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4051,12 +4051,7 @@ impl Bank {
             .iter()
             .filter_map(|processing_result| processing_result.processed_transaction())
             .filter_map(|processed_tx| processed_tx.execution_details())
-            .filter_map(|details| {
-                details
-                    .status
-                    .is_ok()
-                    .then_some(details.accounts_data_len_delta)
-            })
+            .filter_map(|details| details.accounts_data_len_delta)
             .sum();
         self.update_accounts_data_size_delta_on_chain(accounts_data_len_delta);
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -238,7 +238,7 @@ fn new_executed_processing_result(
     status: Result<()>,
     fee_details: FeeDetails,
 ) -> TransactionProcessingResult {
-    let accounts_data_len_delta = status.as_ref().ok().map(|_| 0);
+    let accounts_data_len_delta = status.as_ref().is_ok().then_some(0);
     Ok(ProcessedTransaction::Executed(Box::new(
         ExecutedTransaction {
             loaded_transaction: LoadedTransaction {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9601,6 +9601,50 @@ fn create_mock_transfer(
 }
 
 #[test]
+fn test_accounts_data_size_delta_on_chain_with_deleted_account_transaction() {
+    let GenesisConfigInfo {
+        mut genesis_config,
+        mint_keypair,
+        ..
+    } = create_genesis_config_with_leader(100 * LAMPORTS_PER_SOL, &Pubkey::new_unique(), 42);
+    genesis_config.rent = Rent::default();
+
+    let mock_program_id = Pubkey::new_unique();
+    let account_data_size = 100usize;
+    let deleted_account = Keypair::new();
+    let deleted_account_balance = genesis_config.rent.minimum_balance(account_data_size) + 1;
+    genesis_config.accounts.insert(
+        deleted_account.pubkey(),
+        Account::new(deleted_account_balance, account_data_size, &mock_program_id),
+    );
+
+    let (bank, _bank_forks) = Bank::new_with_mockup_builtin_for_tests(
+        &genesis_config,
+        mock_program_id,
+        MockTransferBuiltin::register,
+    );
+    let recent_blockhash = bank.last_blockhash();
+
+    let accounts_data_size_delta_on_chain_before = bank.load_accounts_data_size_delta_on_chain();
+    let tx = create_mock_transfer(
+        &mint_keypair,
+        &deleted_account,
+        &mint_keypair,
+        deleted_account_balance,
+        mock_program_id,
+        recent_blockhash,
+    );
+    bank.process_transaction(&tx).unwrap();
+    let accounts_data_size_delta_on_chain_after = bank.load_accounts_data_size_delta_on_chain();
+
+    assert!(bank.get_account(&deleted_account.pubkey()).is_none());
+    assert_eq!(
+        accounts_data_size_delta_on_chain_after - accounts_data_size_delta_on_chain_before,
+        -(account_data_size as i64),
+    );
+}
+
+#[test]
 fn test_invalid_rent_state_changes_existing_accounts() {
     let GenesisConfigInfo {
         mut genesis_config,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -238,6 +238,7 @@ fn new_executed_processing_result(
     status: Result<()>,
     fee_details: FeeDetails,
 ) -> TransactionProcessingResult {
+    let accounts_data_len_delta = status.as_ref().ok().map(|_| 0);
     Ok(ProcessedTransaction::Executed(Box::new(
         ExecutedTransaction {
             loaded_transaction: LoadedTransaction {
@@ -250,7 +251,7 @@ fn new_executed_processing_result(
                 inner_instructions: None,
                 return_data: None,
                 executed_units: 0,
-                accounts_data_len_delta: 0,
+                accounts_data_len_delta,
             },
             programs_modified_by_tx: HashMap::new(),
         },

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -103,7 +103,7 @@ use {
         account_loader::{FeesOnlyTransaction, LoadedTransaction, TRANSACTION_ACCOUNT_BASE_SIZE},
         rollback_accounts::RollbackAccounts,
         transaction_commit_result::TransactionCommitResultExtensions,
-        transaction_execution_result::ExecutedTransaction,
+        transaction_execution_result::{AccountsDeltas, ExecutedTransaction},
     },
     solana_svm_timings::ExecuteTimings,
     solana_svm_transaction::svm_message::SVMMessage,
@@ -238,7 +238,10 @@ fn new_executed_processing_result(
     status: Result<()>,
     fee_details: FeeDetails,
 ) -> TransactionProcessingResult {
-    let accounts_data_len_delta = status.as_ref().is_ok().then_some(0);
+    let accounts_deltas = status.as_ref().is_ok().then_some(AccountsDeltas {
+        accounts_resize_delta: 0,
+        accounts_uninitialized_size: 0,
+    });
     Ok(ProcessedTransaction::Executed(Box::new(
         ExecutedTransaction {
             loaded_transaction: LoadedTransaction {
@@ -251,7 +254,7 @@ fn new_executed_processing_result(
                 inner_instructions: None,
                 return_data: None,
                 executed_units: 0,
-                accounts_data_len_delta,
+                accounts_deltas,
             },
             programs_modified_by_tx: HashMap::new(),
         },

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9602,46 +9602,112 @@ fn create_mock_transfer(
 
 #[test]
 fn test_accounts_data_size_delta_on_chain_with_deleted_account_transaction() {
-    let GenesisConfigInfo {
-        mut genesis_config,
-        mint_keypair,
-        ..
-    } = create_genesis_config_with_leader(100 * LAMPORTS_PER_SOL, &Pubkey::new_unique(), 42);
-    genesis_config.rent = Rent::default();
+    #[derive(Clone, Copy)]
+    enum PreExecState {
+        RentExempt,
+        RentPaying,
+        Uninitialized,
+    }
 
-    let mock_program_id = Pubkey::new_unique();
-    let account_data_size = 100usize;
-    let deleted_account = Keypair::new();
-    let deleted_account_balance = genesis_config.rent.minimum_balance(account_data_size) + 1;
-    genesis_config.accounts.insert(
-        deleted_account.pubkey(),
-        Account::new(deleted_account_balance, account_data_size, &mock_program_id),
-    );
+    let account_data_size = 100;
 
-    let (bank, _bank_forks) = Bank::new_with_mockup_builtin_for_tests(
-        &genesis_config,
-        mock_program_id,
-        MockTransferBuiltin::register,
-    );
-    let recent_blockhash = bank.last_blockhash();
+    for pre_exec_state in [
+        PreExecState::RentExempt,
+        PreExecState::RentPaying,
+        PreExecState::Uninitialized,
+    ] {
+        let (mut genesis_config, mint_keypair) = create_genesis_config(100 * LAMPORTS_PER_SOL);
+        genesis_config.rent = Rent::default();
+        let mock_program_id = Pubkey::new_unique();
+        let rent_exempt_minimum = genesis_config.rent.minimum_balance(account_data_size);
+        let deleted_account = Keypair::new();
 
-    let accounts_data_size_delta_on_chain_before = bank.load_accounts_data_size_delta_on_chain();
-    let tx = create_mock_transfer(
-        &mint_keypair,
-        &deleted_account,
-        &mint_keypair,
-        deleted_account_balance,
-        mock_program_id,
-        recent_blockhash,
-    );
-    bank.process_transaction(&tx).unwrap();
-    let accounts_data_size_delta_on_chain_after = bank.load_accounts_data_size_delta_on_chain();
+        // Cases 1 and 2 begin with an existing account. Case 3 creates and
+        // drains the account within the same transaction.
+        let balance = match pre_exec_state {
+            PreExecState::RentExempt => {
+                let balance = rent_exempt_minimum + 1;
+                genesis_config.accounts.insert(
+                    deleted_account.pubkey(),
+                    Account::new(balance, account_data_size, &mock_program_id),
+                );
+                balance
+            }
+            PreExecState::RentPaying => {
+                let balance = rent_exempt_minimum - 1;
+                genesis_config.accounts.insert(
+                    deleted_account.pubkey(),
+                    Account::new_rent_epoch(
+                        balance,
+                        account_data_size,
+                        &mock_program_id,
+                        INITIAL_RENT_EPOCH + 1,
+                    ),
+                );
+                balance
+            }
+            PreExecState::Uninitialized => 0,
+        };
 
-    assert!(bank.get_account(&deleted_account.pubkey()).is_none());
-    assert_eq!(
-        accounts_data_size_delta_on_chain_after - accounts_data_size_delta_on_chain_before,
-        -(account_data_size as i64),
-    );
+        let (bank, _bank_forks) = Bank::new_with_mockup_builtin_for_tests(
+            &genesis_config,
+            mock_program_id,
+            MockTransferBuiltin::register,
+        );
+        let recent_blockhash = bank.last_blockhash();
+
+        let accounts_data_size_delta_on_chain_before =
+            bank.load_accounts_data_size_delta_on_chain();
+        let tx = match pre_exec_state {
+            // Existing rent-exempt/rent-paying account is fully drained and deleted.
+            PreExecState::RentExempt | PreExecState::RentPaying => create_mock_transfer(
+                &mint_keypair,
+                &deleted_account,
+                &mint_keypair,
+                balance,
+                mock_program_id,
+                recent_blockhash,
+            ),
+            // The account starts uninitialized, is created, then immediately drained.
+            PreExecState::Uninitialized => {
+                let create_instruction = system_instruction::create_account(
+                    &mint_keypair.pubkey(),
+                    &deleted_account.pubkey(),
+                    rent_exempt_minimum,
+                    account_data_size as u64,
+                    &mock_program_id,
+                );
+                let transfer_from_instruction = Instruction::new_with_bincode(
+                    mock_program_id,
+                    &MockTransferInstruction::Transfer(rent_exempt_minimum),
+                    vec![
+                        AccountMeta::new(mint_keypair.pubkey(), true),
+                        AccountMeta::new(deleted_account.pubkey(), true),
+                        AccountMeta::new(mint_keypair.pubkey(), false),
+                    ],
+                );
+                Transaction::new_signed_with_payer(
+                    &[create_instruction, transfer_from_instruction],
+                    Some(&mint_keypair.pubkey()),
+                    &[&mint_keypair, &deleted_account],
+                    recent_blockhash,
+                )
+            }
+        };
+        bank.process_transaction(&tx).unwrap();
+        let accounts_data_size_delta_on_chain_after = bank.load_accounts_data_size_delta_on_chain();
+
+        assert!(bank.get_account(&deleted_account.pubkey()).is_none());
+        assert_eq!(
+            accounts_data_size_delta_on_chain_after - accounts_data_size_delta_on_chain_before,
+            match pre_exec_state {
+                PreExecState::RentExempt | PreExecState::RentPaying => {
+                    -(account_data_size as i64)
+                }
+                PreExecState::Uninitialized => 0,
+            },
+        );
+    }
 }
 
 #[test]

--- a/svm/src/rent_calculator.rs
+++ b/svm/src/rent_calculator.rs
@@ -34,22 +34,20 @@ pub enum RentState {
 /// This method has a default implementation that calls into
 /// `check_rent_state_with_account`.
 pub fn check_rent_state(
-    pre_rent_state: Option<&RentState>,
-    post_rent_state: Option<&RentState>,
+    pre_rent_state: &RentState,
+    post_rent_state: &RentState,
     transaction_context: &TransactionContext,
     index: IndexOfAccount,
 ) -> TransactionResult<()> {
-    if let Some((pre_rent_state, post_rent_state)) = pre_rent_state.zip(post_rent_state) {
-        let expect_msg = "account must exist at TransactionContext index if rent-states are Some";
-        check_rent_state_with_account(
-            pre_rent_state,
-            post_rent_state,
-            transaction_context
-                .get_key_of_account_at_index(index)
-                .expect(expect_msg),
-            index,
-        )?;
-    }
+    let expect_msg = "account must exist at TransactionContext index";
+    check_rent_state_with_account(
+        pre_rent_state,
+        post_rent_state,
+        transaction_context
+            .get_key_of_account_at_index(index)
+            .expect(expect_msg),
+        index,
+    )?;
     Ok(())
 }
 

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -15,12 +15,6 @@ pub struct WritableTransactionAccountStateInfo {
 }
 
 #[derive(PartialEq, Debug)]
-pub(crate) struct AccountDeltas {
-    pub num_delta: i64,
-    pub data_size_delta: i64,
-}
-
-#[derive(PartialEq, Debug)]
 pub(crate) struct TransactionAccountStateInfo {
     info: Option<WritableTransactionAccountStateInfo>, // None: readonly account
 }
@@ -82,7 +76,7 @@ impl TransactionAccountStateInfo {
     }
 }
 
-// Returns delta for num_accounts and account_size given the pre and post state infos.
+// Returns account data size delta for a given transaction execution
 pub(crate) fn get_account_data_len_delta(
     pre: &[TransactionAccountStateInfo],
     post: &[TransactionAccountStateInfo],
@@ -90,13 +84,14 @@ pub(crate) fn get_account_data_len_delta(
 ) -> i64 {
     // accounts_resize_delta accounts doesn't account for deleted accounts, so the overall
     // state delta is computed by subtracting the data size of every deleted account.
-    let data_size_delta = pre.iter().zip(post).fold(
+    pre.iter().zip(post).fold(
         accounts_resize_delta,
         |data_size_delta, (pre_info, post_info)| {
             match (&pre_info.info, &post_info.info) {
                 (Some(pre), Some(post)) => {
                     match (&pre.rent_state, &post.rent_state) {
-                        // deleted
+                        // deleted: post data size is used because pre_size - post_size is already
+                        // accounted for in the accounts_resize_delta.
                         (RentState::RentExempt, RentState::Uninitialized) => {
                             data_size_delta - post.data_size as i64
                         }
@@ -108,8 +103,7 @@ pub(crate) fn get_account_data_len_delta(
                 _ => data_size_delta,
             }
         },
-    );
-    data_size_delta
+    )
 }
 
 #[cfg(test)]
@@ -304,5 +298,51 @@ mod test {
             result.err(),
             Some(TransactionError::InsufficientFundsForRent { account_index: 0 })
         );
+    }
+
+    #[test]
+    fn test_get_account_data_len_delta_with_deleted_account() {
+        // Test that deleted accounts (RentExempt -> Uninitialized) are correctly subtracted from delta
+        let pre_state_infos = vec![
+            TransactionAccountStateInfo {
+                info: Some(WritableTransactionAccountStateInfo {
+                    rent_state: RentState::RentExempt,
+                    balance: 1000,
+                    data_size: 100,
+                }),
+            },
+            TransactionAccountStateInfo {
+                info: Some(WritableTransactionAccountStateInfo {
+                    rent_state: RentState::Uninitialized,
+                    balance: 0,
+                    data_size: 0,
+                }),
+            },
+        ];
+
+        let post_state_infos = vec![
+            TransactionAccountStateInfo {
+                info: Some(WritableTransactionAccountStateInfo {
+                    rent_state: RentState::Uninitialized,
+                    balance: 0,
+                    data_size: 50, // This was 100 before deletion
+                }),
+            },
+            TransactionAccountStateInfo {
+                info: Some(WritableTransactionAccountStateInfo {
+                    rent_state: RentState::RentExempt,
+                    balance: 2000,
+                    data_size: 50,
+                }),
+            },
+        ];
+
+        // accounts_resize_delta starts at 50 - 50 = 0
+        let accounts_resize_delta = 0i64;
+        let delta =
+            get_account_data_len_delta(&pre_state_infos, &post_state_infos, accounts_resize_delta);
+
+        // The deleted account (first one) should subtract its remaining data size (50) from the delta, resulting in -50
+        assert_eq!(delta, -50);
     }
 }

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -82,32 +82,26 @@ impl TransactionAccountStateInfo {
 
 // Returns account data size delta for a given transaction execution
 pub(crate) fn get_account_data_len_delta(
-    pre: &[TransactionAccountStateInfo],
     post: &[TransactionAccountStateInfo],
     accounts_resize_delta: i64,
 ) -> i64 {
     // accounts_resize_delta accounts doesn't account for deleted accounts, so the overall
     // state delta is computed by subtracting the data size of every deleted account.
-    pre.iter().zip(post).fold(
-        accounts_resize_delta,
-        |data_size_delta, (pre_info, post_info)| {
-            match (&pre_info.info, &post_info.info) {
-                (Some(pre), Some(post)) => {
-                    match (&pre.rent_state, &post.rent_state) {
-                        // deleted: post data size is used because pre_size - post_size is already
-                        // accounted for in the accounts_resize_delta.
-                        (RentState::RentExempt, RentState::Uninitialized) => {
-                            data_size_delta - post.data_size as i64
-                        }
-                        // ephemeral account, existing account realloc, or new account creation
-                        _ => data_size_delta,
-                    }
+    post.iter()
+        .fold(accounts_resize_delta, |data_size_delta, post_info| {
+            if let Some(post) = &post_info.info {
+                match &post.rent_state {
+                    // deleted: post-exec data size is used because `post_size - pre_size` is already
+                    // accounted for in accounts_resize_delta.
+                    RentState::Uninitialized => data_size_delta - post.data_size as i64,
+                    // existing account or new account creation
+                    _ => data_size_delta,
                 }
+            } else {
                 // None indicates non write-locked accounts -> no change
-                _ => data_size_delta,
+                data_size_delta
             }
-        },
-    )
+        })
 }
 
 #[cfg(test)]
@@ -306,47 +300,41 @@ mod test {
 
     #[test]
     fn test_get_account_data_len_delta_with_deleted_account() {
-        // Test that deleted accounts (RentExempt -> Uninitialized) are correctly subtracted from delta
-        let pre_state_infos = vec![
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::RentExempt,
-                    balance: 1000,
-                    data_size: 100,
-                }),
-            },
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::Uninitialized,
-                    balance: 0,
-                    data_size: 0,
-                }),
-            },
-        ];
-
         let post_state_infos = vec![
             TransactionAccountStateInfo {
                 info: Some(WritableTransactionAccountStateInfo {
                     rent_state: RentState::Uninitialized,
                     balance: 0,
-                    data_size: 50, // This was 100 before deletion
+                    data_size: 50,
+                }),
+            },
+            TransactionAccountStateInfo {
+                info: Some(WritableTransactionAccountStateInfo {
+                    rent_state: RentState::Uninitialized,
+                    balance: 0,
+                    data_size: 50,
+                }),
+            },
+            TransactionAccountStateInfo {
+                info: Some(WritableTransactionAccountStateInfo {
+                    rent_state: RentState::Uninitialized,
+                    balance: 0,
+                    data_size: 50,
                 }),
             },
             TransactionAccountStateInfo {
                 info: Some(WritableTransactionAccountStateInfo {
                     rent_state: RentState::RentExempt,
-                    balance: 2000,
+                    balance: 10000,
                     data_size: 50,
                 }),
             },
         ];
 
-        // accounts_resize_delta starts at 50 - 50 = 0
-        let accounts_resize_delta = 0i64;
-        let delta =
-            get_account_data_len_delta(&pre_state_infos, &post_state_infos, accounts_resize_delta);
+        let accounts_resize_delta = 0;
+        let delta = get_account_data_len_delta(&post_state_infos, accounts_resize_delta);
 
-        // The deleted account (first one) should subtract its remaining data size (50) from the delta, resulting in -50
-        assert_eq!(delta, -50);
+        // 3 deleted accounts should contribute 3 * (-50) = -150 to the delta
+        assert_eq!(delta, -150);
     }
 }

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -8,8 +8,21 @@ use {
 };
 
 #[derive(PartialEq, Debug)]
+pub struct WritableTransactionAccountStateInfo {
+    rent_state: RentState,
+    balance: u64,
+    data_size: usize,
+}
+
+#[derive(PartialEq, Debug)]
+pub(crate) struct AccountDeltas {
+    pub num_delta: i64,
+    pub data_size_delta: i64,
+}
+
+#[derive(PartialEq, Debug)]
 pub(crate) struct TransactionAccountStateInfo {
-    rent_state: Option<RentState>, // None: readonly account
+    info: Option<WritableTransactionAccountStateInfo>, // None: readonly account
 }
 
 impl TransactionAccountStateInfo {
@@ -20,49 +33,83 @@ impl TransactionAccountStateInfo {
     ) -> Vec<Self> {
         (0..message.account_keys().len())
             .map(|i| {
-                let rent_state = if message.is_writable(i) {
-                    let state = if let Ok(account) = transaction_context
+                let info = if message.is_writable(i) {
+                    if let Ok(account) = transaction_context
                         .accounts()
                         .try_borrow(i as IndexOfAccount)
                     {
-                        Some(get_account_rent_state(
-                            rent,
-                            account.lamports(),
-                            account.data().len(),
-                        ))
+                        let rent_state =
+                            get_account_rent_state(rent, account.lamports(), account.data().len());
+                        let balance = account.lamports();
+                        let data_size = account.data().len();
+                        Some(WritableTransactionAccountStateInfo {
+                            rent_state,
+                            balance,
+                            data_size,
+                        })
                     } else {
+                        debug_assert!(false, "message and transaction context out of sync, fatal");
                         None
-                    };
-                    debug_assert!(
-                        state.is_some(),
-                        "message and transaction context out of sync, fatal"
-                    );
-                    state
+                    }
                 } else {
                     None
                 };
-                Self { rent_state }
+                Self { info }
             })
             .collect()
     }
 
     pub(crate) fn verify_changes(
-        pre_state_infos: &[Self],
-        post_state_infos: &[Self],
+        pre_state_infos: &[TransactionAccountStateInfo],
+        post_state_infos: &[TransactionAccountStateInfo],
         transaction_context: &TransactionContext,
     ) -> Result<()> {
         for (i, (pre_state_info, post_state_info)) in
             pre_state_infos.iter().zip(post_state_infos).enumerate()
         {
-            check_rent_state(
-                pre_state_info.rent_state.as_ref(),
-                post_state_info.rent_state.as_ref(),
-                transaction_context,
-                i as IndexOfAccount,
-            )?;
+            if let (Some(pre_state_info), Some(post_state_info)) =
+                (pre_state_info.info.as_ref(), post_state_info.info.as_ref())
+            {
+                check_rent_state(
+                    Some(&pre_state_info.rent_state),
+                    Some(&post_state_info.rent_state),
+                    transaction_context,
+                    i as IndexOfAccount,
+                )?;
+            }
         }
         Ok(())
     }
+}
+
+// Returns delta for num_accounts and account_size given the pre and post state infos.
+pub(crate) fn get_account_data_len_delta(
+    pre: &[TransactionAccountStateInfo],
+    post: &[TransactionAccountStateInfo],
+    accounts_resize_delta: i64,
+) -> i64 {
+    // accounts_resize_delta accounts doesn't account for deleted accounts, so the overall
+    // state delta is computed by subtracting the data size of every deleted account.
+    let data_size_delta = pre.iter().zip(post).fold(
+        accounts_resize_delta,
+        |data_size_delta, (pre_info, post_info)| {
+            match (&pre_info.info, &post_info.info) {
+                (Some(pre), Some(post)) => {
+                    match (&pre.rent_state, &post.rent_state) {
+                        // deleted
+                        (RentState::RentExempt, RentState::Uninitialized) => {
+                            data_size_delta - post.data_size as i64
+                        }
+                        // ephemeral account, existing account realloc, or new account creation
+                        _ => data_size_delta,
+                    }
+                }
+                // None indicates non write-locked accounts -> no change
+                _ => data_size_delta,
+            }
+        },
+    );
+    data_size_delta
 }
 
 #[cfg(test)]
@@ -124,11 +171,19 @@ mod test {
             result,
             vec![
                 TransactionAccountStateInfo {
-                    rent_state: Some(RentState::Uninitialized)
+                    info: Some(WritableTransactionAccountStateInfo {
+                        rent_state: RentState::Uninitialized,
+                        balance: 0,
+                        data_size: 0,
+                    })
                 },
-                TransactionAccountStateInfo { rent_state: None },
+                TransactionAccountStateInfo { info: None },
                 TransactionAccountStateInfo {
-                    rent_state: Some(RentState::Uninitialized)
+                    info: Some(WritableTransactionAccountStateInfo {
+                        rent_state: RentState::Uninitialized,
+                        balance: 0,
+                        data_size: 0,
+                    })
                 }
             ]
         );
@@ -180,14 +235,26 @@ mod test {
         let key2 = Keypair::new();
         let pre_rent_state = vec![
             TransactionAccountStateInfo {
-                rent_state: Some(RentState::Uninitialized),
+                info: Some(WritableTransactionAccountStateInfo {
+                    rent_state: RentState::Uninitialized,
+                    balance: 0,
+                    data_size: 0,
+                }),
             },
             TransactionAccountStateInfo {
-                rent_state: Some(RentState::Uninitialized),
+                info: Some(WritableTransactionAccountStateInfo {
+                    rent_state: RentState::Uninitialized,
+                    balance: 0,
+                    data_size: 0,
+                }),
             },
         ];
         let post_rent_state = vec![TransactionAccountStateInfo {
-            rent_state: Some(RentState::Uninitialized),
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state: RentState::Uninitialized,
+                balance: 0,
+                data_size: 0,
+            }),
         }];
 
         let transaction_accounts = vec![
@@ -205,12 +272,20 @@ mod test {
         assert!(result.is_ok());
 
         let pre_rent_state = vec![TransactionAccountStateInfo {
-            rent_state: Some(RentState::Uninitialized),
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state: RentState::Uninitialized,
+                balance: 0,
+                data_size: 0,
+            }),
         }];
         let post_rent_state = vec![TransactionAccountStateInfo {
-            rent_state: Some(RentState::RentPaying {
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state: RentState::RentPaying {
+                    data_size: 2,
+                    lamports: 5,
+                },
+                balance: 5,
                 data_size: 2,
-                lamports: 5,
             }),
         }];
 

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -12,12 +12,6 @@ pub(crate) struct TransactionAccountStateInfo {
     info: Option<WritableTransactionAccountStateInfo>, // None: readonly account
 }
 
-#[derive(PartialEq, Debug)]
-pub struct WritableTransactionAccountStateInfo {
-    rent_state: RentState,
-    data_size: usize,
-}
-
 impl TransactionAccountStateInfo {
     pub(crate) fn new(
         transaction_context: &TransactionContext,
@@ -75,6 +69,12 @@ impl TransactionAccountStateInfo {
         }
         Ok(())
     }
+}
+
+#[derive(PartialEq, Debug)]
+struct WritableTransactionAccountStateInfo {
+    rent_state: RentState,
+    data_size: usize,
 }
 
 // Returns account data size delta for a given transaction execution

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -28,7 +28,7 @@ impl TransactionAccountStateInfo {
         (0..message.account_keys().len())
             .map(|i| {
                 let info = if message.is_writable(i) {
-                    if let Ok(account) = transaction_context
+                    let state = if let Ok(account) = transaction_context
                         .accounts()
                         .try_borrow(i as IndexOfAccount)
                     {
@@ -42,9 +42,13 @@ impl TransactionAccountStateInfo {
                             data_size,
                         })
                     } else {
-                        debug_assert!(false, "message and transaction context out of sync, fatal");
                         None
-                    }
+                    };
+                    debug_assert!(
+                        state.is_some(),
+                        "message and transaction context out of sync, fatal"
+                    );
+                    state
                 } else {
                     None
                 };
@@ -54,8 +58,8 @@ impl TransactionAccountStateInfo {
     }
 
     pub(crate) fn verify_changes(
-        pre_state_infos: &[TransactionAccountStateInfo],
-        post_state_infos: &[TransactionAccountStateInfo],
+        pre_state_infos: &[Self],
+        post_state_infos: &[Self],
         transaction_context: &TransactionContext,
     ) -> Result<()> {
         for (i, (pre_state_info, post_state_info)) in
@@ -65,8 +69,8 @@ impl TransactionAccountStateInfo {
                 (pre_state_info.info.as_ref(), post_state_info.info.as_ref())
             {
                 check_rent_state(
-                    Some(&pre_state_info.rent_state),
-                    Some(&post_state_info.rent_state),
+                    &pre_state_info.rent_state,
+                    &post_state_info.rent_state,
                     transaction_context,
                     i as IndexOfAccount,
                 )?;

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -77,28 +77,22 @@ struct WritableTransactionAccountStateInfo {
     data_size: usize,
 }
 
-// Returns account data size delta for a given transaction execution
-pub(crate) fn get_account_data_len_delta(
-    post: &[TransactionAccountStateInfo],
-    accounts_resize_delta: i64,
-) -> i64 {
-    // accounts_resize_delta accounts doesn't account for deleted accounts, so the overall
-    // state delta is computed by subtracting the data size of every deleted account.
+// Returns the cumulative size of all post-exec uninitialized accounts
+pub(crate) fn get_uninitialized_accounts_size(post: &[TransactionAccountStateInfo]) -> u64 {
     post.iter()
-        .fold(accounts_resize_delta, |data_size_delta, post_info| {
+        .map(|post_info| {
             if let Some(post) = &post_info.info {
                 match &post.rent_state {
-                    // deleted: post-exec data size is used because `post_size - pre_size` is already
-                    // accounted for in accounts_resize_delta.
-                    RentState::Uninitialized => data_size_delta - post.data_size as i64,
-                    // existing account or new account creation
-                    _ => data_size_delta,
+                    RentState::Uninitialized => post.data_size as u64,
+                    _ => 0,
                 }
             } else {
-                // None indicates non write-locked accounts -> no change
-                data_size_delta
+                // None indicates non write-locked account, which could not have
+                // become uninitialized during transaction execution
+                0
             }
         })
+        .sum()
 }
 
 #[cfg(test)]
@@ -289,7 +283,7 @@ mod test {
     }
 
     #[test]
-    fn test_get_account_data_len_delta_with_deleted_account() {
+    fn test_get_uninitialized_accounts_size_with_deleted_accounts() {
         let post_state_infos = vec![
             TransactionAccountStateInfo {
                 info: Some(WritableTransactionAccountStateInfo {
@@ -317,10 +311,7 @@ mod test {
             },
         ];
 
-        let accounts_resize_delta = 0;
-        let delta = get_account_data_len_delta(&post_state_infos, accounts_resize_delta);
-
-        // 3 deleted accounts should contribute 3 * (-50) = -150 to the delta
-        assert_eq!(delta, -150);
+        // 3 deleted accounts should contribute 3 * (50) = 150 to the count
+        assert_eq!(get_uninitialized_accounts_size(&post_state_infos), 150);
     }
 }

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -80,17 +80,9 @@ struct WritableTransactionAccountStateInfo {
 // Returns the cumulative size of all post-exec uninitialized accounts
 pub(crate) fn get_uninitialized_accounts_size(post: &[TransactionAccountStateInfo]) -> u64 {
     post.iter()
-        .map(|post_info| {
-            if let Some(post) = &post_info.info {
-                match &post.rent_state {
-                    RentState::Uninitialized => post.data_size as u64,
-                    _ => 0,
-                }
-            } else {
-                // None indicates non write-locked account, which could not have
-                // become uninitialized during transaction execution
-                0
-            }
+        .filter_map(|post_info| post_info.info.as_ref())
+        .filter_map(|post| {
+            matches!(&post.rent_state, RentState::Uninitialized).then_some(post.data_size as u64)
         })
         .sum()
 }

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -8,15 +8,14 @@ use {
 };
 
 #[derive(PartialEq, Debug)]
-pub struct WritableTransactionAccountStateInfo {
-    rent_state: RentState,
-    balance: u64,
-    data_size: usize,
+pub(crate) struct TransactionAccountStateInfo {
+    info: Option<WritableTransactionAccountStateInfo>, // None: readonly account
 }
 
 #[derive(PartialEq, Debug)]
-pub(crate) struct TransactionAccountStateInfo {
-    info: Option<WritableTransactionAccountStateInfo>, // None: readonly account
+pub struct WritableTransactionAccountStateInfo {
+    rent_state: RentState,
+    data_size: usize,
 }
 
 impl TransactionAccountStateInfo {
@@ -32,13 +31,11 @@ impl TransactionAccountStateInfo {
                         .accounts()
                         .try_borrow(i as IndexOfAccount)
                     {
-                        let rent_state =
-                            get_account_rent_state(rent, account.lamports(), account.data().len());
                         let balance = account.lamports();
                         let data_size = account.data().len();
+                        let rent_state = get_account_rent_state(rent, balance, data_size);
                         Some(WritableTransactionAccountStateInfo {
                             rent_state,
-                            balance,
                             data_size,
                         })
                     } else {
@@ -165,7 +162,6 @@ mod test {
                 TransactionAccountStateInfo {
                     info: Some(WritableTransactionAccountStateInfo {
                         rent_state: RentState::Uninitialized,
-                        balance: 0,
                         data_size: 0,
                     })
                 },
@@ -173,7 +169,6 @@ mod test {
                 TransactionAccountStateInfo {
                     info: Some(WritableTransactionAccountStateInfo {
                         rent_state: RentState::Uninitialized,
-                        balance: 0,
                         data_size: 0,
                     })
                 }
@@ -229,14 +224,12 @@ mod test {
             TransactionAccountStateInfo {
                 info: Some(WritableTransactionAccountStateInfo {
                     rent_state: RentState::Uninitialized,
-                    balance: 0,
                     data_size: 0,
                 }),
             },
             TransactionAccountStateInfo {
                 info: Some(WritableTransactionAccountStateInfo {
                     rent_state: RentState::Uninitialized,
-                    balance: 0,
                     data_size: 0,
                 }),
             },
@@ -244,7 +237,6 @@ mod test {
         let post_rent_state = vec![TransactionAccountStateInfo {
             info: Some(WritableTransactionAccountStateInfo {
                 rent_state: RentState::Uninitialized,
-                balance: 0,
                 data_size: 0,
             }),
         }];
@@ -266,7 +258,6 @@ mod test {
         let pre_rent_state = vec![TransactionAccountStateInfo {
             info: Some(WritableTransactionAccountStateInfo {
                 rent_state: RentState::Uninitialized,
-                balance: 0,
                 data_size: 0,
             }),
         }];
@@ -276,7 +267,6 @@ mod test {
                     data_size: 2,
                     lamports: 5,
                 },
-                balance: 5,
                 data_size: 2,
             }),
         }];
@@ -304,28 +294,24 @@ mod test {
             TransactionAccountStateInfo {
                 info: Some(WritableTransactionAccountStateInfo {
                     rent_state: RentState::Uninitialized,
-                    balance: 0,
                     data_size: 50,
                 }),
             },
             TransactionAccountStateInfo {
                 info: Some(WritableTransactionAccountStateInfo {
                     rent_state: RentState::Uninitialized,
-                    balance: 0,
                     data_size: 50,
                 }),
             },
             TransactionAccountStateInfo {
                 info: Some(WritableTransactionAccountStateInfo {
                     rent_state: RentState::Uninitialized,
-                    balance: 0,
                     data_size: 50,
                 }),
             },
             TransactionAccountStateInfo {
                 info: Some(WritableTransactionAccountStateInfo {
                     rent_state: RentState::RentExempt,
-                    balance: 10000,
                     data_size: 50,
                 }),
             },

--- a/svm/src/transaction_execution_result.rs
+++ b/svm/src/transaction_execution_result.rs
@@ -47,6 +47,8 @@ impl TransactionExecutionDetails {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AccountsDeltas {
-    pub accounts_resize_delta: i64, // aggregate resize delta across all accounts touched by the transaction
-    pub accounts_uninitialized_size: u64, // aggregate size of all accounts that were uninitialized by this transaction
+    /// aggregate resize delta across all accounts touched by the transaction
+    pub accounts_resize_delta: i64,
+    /// aggregate size of all accounts that were uninitialized by this transaction
+    pub accounts_uninitialized_size: u64,
 }

--- a/svm/src/transaction_execution_result.rs
+++ b/svm/src/transaction_execution_result.rs
@@ -34,13 +34,19 @@ pub struct TransactionExecutionDetails {
     pub inner_instructions: Option<InnerInstructionsList>,
     pub return_data: Option<TransactionReturnData>,
     pub executed_units: u64,
-    /// The change in accounts data len for this transaction.
+    /// deltas related to total account data size changes for this transaction.
     /// NOTE: set to None IFF `status` is not `Ok`.
-    pub accounts_data_len_delta: Option<i64>,
+    pub accounts_deltas: Option<AccountsDeltas>,
 }
 
 impl TransactionExecutionDetails {
     pub fn was_successful(&self) -> bool {
         self.status.is_ok()
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccountsDeltas {
+    pub accounts_resize_delta: i64, // aggregate resize delta across all accounts touched by the transaction
+    pub accounts_uninitialized_size: u64, // aggregate size of all accounts that were uninitialized by this transaction
 }

--- a/svm/src/transaction_execution_result.rs
+++ b/svm/src/transaction_execution_result.rs
@@ -35,8 +35,8 @@ pub struct TransactionExecutionDetails {
     pub return_data: Option<TransactionReturnData>,
     pub executed_units: u64,
     /// The change in accounts data len for this transaction.
-    /// NOTE: This value is valid IFF `status` is `Ok`.
-    pub accounts_data_len_delta: i64,
+    /// NOTE: set to None IFF `status` is not `Ok`.
+    pub accounts_data_len_delta: Option<i64>,
 }
 
 impl TransactionExecutionDetails {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -10,7 +10,7 @@ use {
         nonce_info::NonceInfo,
         program_loader::{get_program_deployment_slot, load_program_with_pubkey},
         rollback_accounts::RollbackAccounts,
-        transaction_account_state_info::TransactionAccountStateInfo,
+        transaction_account_state_info::{TransactionAccountStateInfo, get_account_data_len_delta},
         transaction_balances::{BalanceCollectionRoutines, BalanceCollector},
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
@@ -1011,7 +1011,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     &post_account_state_info,
                     &transaction_context,
                 )
-                .map(|_| info)
+                .map(|_| post_account_state_info)
             })
             .map_err(|err| {
                 match err {
@@ -1045,7 +1045,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             accounts,
             return_data,
             touched_account_count,
-            accounts_resize_delta: accounts_data_len_delta,
+            accounts_resize_delta,
         } = execution_record;
 
         if status.is_ok()
@@ -1055,7 +1055,12 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         {
             status = Err(TransactionError::UnbalancedTransaction);
         }
-        let status = status.map(|_| ());
+
+        let post_account_state_info = status;
+        let status = match &post_account_state_info {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err.clone()),
+        };
 
         loaded_transaction.accounts = accounts;
         execute_timings.details.total_account_count += loaded_transaction.accounts.len() as u64;
@@ -1067,6 +1072,16 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             Some(return_data)
         } else {
             None
+        };
+
+        let accounts_data_len_delta = if let Ok(post_state_info) = post_account_state_info {
+            get_account_data_len_delta(
+                &pre_account_state_info,
+                &post_state_info,
+                accounts_resize_delta,
+            )
+        } else {
+            0
         };
 
         ExecutedTransaction {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -10,10 +10,14 @@ use {
         nonce_info::NonceInfo,
         program_loader::{get_program_deployment_slot, load_program_with_pubkey},
         rollback_accounts::RollbackAccounts,
-        transaction_account_state_info::{TransactionAccountStateInfo, get_account_data_len_delta},
+        transaction_account_state_info::{
+            TransactionAccountStateInfo, get_uninitialized_accounts_size,
+        },
         transaction_balances::{BalanceCollectionRoutines, BalanceCollector},
         transaction_error_metrics::TransactionErrorMetrics,
-        transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
+        transaction_execution_result::{
+            AccountsDeltas, ExecutedTransaction, TransactionExecutionDetails,
+        },
         transaction_processing_result::{ProcessedTransaction, TransactionProcessingResult},
     },
     log::debug,
@@ -1056,14 +1060,18 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             post_account_state_info_result = Err(TransactionError::UnbalancedTransaction);
         }
 
-        let (status, accounts_data_len_delta) = post_account_state_info_result
+        // accounts_resize_delta and accounts_uninitialized_size must be set to None
+        // in the result if status is an error
+        let (status, accounts_deltas) = post_account_state_info_result
             .map(|post_state_info| {
                 (
                     Ok(()),
-                    Some(get_account_data_len_delta(
-                        &post_state_info,
+                    Some(AccountsDeltas {
                         accounts_resize_delta,
-                    )),
+                        accounts_uninitialized_size: get_uninitialized_accounts_size(
+                            &post_state_info,
+                        ),
+                    }),
                 )
             })
             .unwrap_or_else(|err| (Err(err), None));
@@ -1087,7 +1095,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 inner_instructions,
                 return_data,
                 executed_units,
-                accounts_data_len_delta,
+                accounts_deltas,
             },
             loaded_transaction,
             programs_modified_by_tx: program_cache_for_tx_batch.drain_modified_entries(),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1056,10 +1056,17 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             post_account_state_info_result = Err(TransactionError::UnbalancedTransaction);
         }
 
-        let status = match &post_account_state_info_result {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err.clone()),
-        };
+        let (status, accounts_data_len_delta) = post_account_state_info_result
+            .map(|post_state_info| {
+                (
+                    Ok(()),
+                    Some(get_account_data_len_delta(
+                        &post_state_info,
+                        accounts_resize_delta,
+                    )),
+                )
+            })
+            .unwrap_or_else(|err| (Err(err), None));
 
         loaded_transaction.accounts = accounts;
         execute_timings.details.total_account_count += loaded_transaction.accounts.len() as u64;
@@ -1071,13 +1078,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             Some(return_data)
         } else {
             None
-        };
-
-        let accounts_data_len_delta = if let Ok(post_state_info) = post_account_state_info_result {
-            get_account_data_len_delta(&post_state_info, accounts_resize_delta)
-        } else {
-            // If transaction execution failed, no delta is expected
-            0
         };
 
         ExecutedTransaction {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1074,11 +1074,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         };
 
         let accounts_data_len_delta = if let Ok(post_state_info) = post_account_state_info_result {
-            get_account_data_len_delta(
-                &pre_account_state_info,
-                &post_state_info,
-                accounts_resize_delta,
-            )
+            get_account_data_len_delta(&post_state_info, accounts_resize_delta)
         } else {
             // If transaction execution failed, no delta is expected
             0

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1002,8 +1002,8 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         execute_timings.execute_accessories.process_message_us += process_message_time.as_us();
 
-        let mut status = process_result
-            .and_then(|info| {
+        let mut post_account_state_info_result = process_result
+            .and_then(|_| {
                 let post_account_state_info =
                     TransactionAccountStateInfo::new(&transaction_context, tx, &environment.rent);
                 TransactionAccountStateInfo::verify_changes(
@@ -1048,16 +1048,15 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             accounts_resize_delta,
         } = execution_record;
 
-        if status.is_ok()
+        if post_account_state_info_result.is_ok()
             && transaction_accounts_lamports_sum(&accounts)
                 .filter(|lamports_after_tx| lamports_before_tx == *lamports_after_tx)
                 .is_none()
         {
-            status = Err(TransactionError::UnbalancedTransaction);
+            post_account_state_info_result = Err(TransactionError::UnbalancedTransaction);
         }
 
-        let post_account_state_info = status;
-        let status = match &post_account_state_info {
+        let status = match &post_account_state_info_result {
             Ok(_) => Ok(()),
             Err(err) => Err(err.clone()),
         };
@@ -1074,13 +1073,14 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             None
         };
 
-        let accounts_data_len_delta = if let Ok(post_state_info) = post_account_state_info {
+        let accounts_data_len_delta = if let Ok(post_state_info) = post_account_state_info_result {
             get_account_data_len_delta(
                 &pre_account_state_info,
                 &post_state_info,
                 accounts_resize_delta,
             )
         } else {
+            // If transaction execution failed, no delta is expected
             0
         };
 


### PR DESCRIPTION
#### Problem

`bank.accounts_data_size_delta_on_chain` doesn't consider the size of deleted/zero-lamport accounts, which leads to reported bank metrics that overshoot the actual total account data size.

#### Summary of Changes

- rather than directly using `accounts_resize_delta`, `execute_loaded_transaction()` also subtracts the size of deleted accounts to produce the correct value for `accounts_data_len_delta`.
- unit tests: the new test added to `bank/tests.rs` fails on master
