### PR TITLE
Deprecates --account-shrink-path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Release channels have their own copy of this changelog:
 #### Breaking
 #### Deprecations
 * Using `minimal` for `--accounts-index-limit` is now deprecated.
+* `--account-shrink-path` is now deprecated.
 #### Changes
 
 ## 4.0.0

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -128,6 +128,15 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
     }
 
     add_arg!(
+        // deprecated in v4.1.0
+        Arg::with_name("account_shrink_path")
+            .long("account-shrink-path")
+            .value_name("PATH")
+            .takes_value(true)
+            .multiple(true)
+            .help("Path to accounts shrink path which can hold a compacted account set."),
+    );
+    add_arg!(
         // deprecated in v4.0.0
         Arg::with_name("enable_accounts_disk_index")
             .long("enable-accounts-disk-index")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -254,14 +254,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("account_shrink_path")
-            .long("account-shrink-path")
-            .value_name("PATH")
-            .takes_value(true)
-            .multiple(true)
-            .help("Path to accounts shrink path which can hold a compacted account set."),
-    )
-    .arg(
         Arg::with_name("snapshots")
             .long("snapshots")
             .value_name("DIR")


### PR DESCRIPTION
#### Problem

`--account-shrink-path` was originally added in https://github.com/solana-labs/solana/pull/14238, back in Dec 2020. Back then, account storage files were recommended to be kept in ram on tmpfs. The account-shrink-path was a way to take old account data and move it from ram to disk.

We haven't put account storage files on tmpfs is a loooooong time (and we have the accounts write cache now too), so there's no difference between the normal account paths and the shrink paths. It's unnecessary code to support and work around.


#### Summary of Changes

Deprecate `--account-shrink-path`.