### PR TITLE
Decouple platform tools sdk from CI

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -77,7 +77,7 @@ test-stable-sbf)
   "$cargo_build_sbf" --version
 
   # Install the platform tools
-  _ platform-tools-sdk/sbf/scripts/install.sh
+  _ programs/sbf/install.sh
 
   # SBPFv0 program tests
   _ make -C programs/sbf test-v0

--- a/programs/sbf/Makefile
+++ b/programs/sbf/Makefile
@@ -1,4 +1,3 @@
-SBF_SDK_PATH := ../../platform-tools-sdk/sbf
 SRC_DIR := c/src
 OUT_DIR := target/deploy
 TOOLCHAIN := 1.89.0-sbpf-solana-v1.54
@@ -41,4 +40,4 @@ rust-new:
 
 .PHONY: test-v0
 
-include $(SBF_SDK_PATH)/c/sbf.mk
+include c/sbf.mk

--- a/programs/sbf/c/inc/deserialize_deprecated.h
+++ b/programs/sbf/c/inc/deserialize_deprecated.h
@@ -1,0 +1,1 @@
+#include <sol/deserialize_deprecated.h>

--- a/programs/sbf/c/inc/sol/alt_bn128.h
+++ b/programs/sbf/c/inc/sol/alt_bn128.h
@@ -1,0 +1,71 @@
+#pragma once
+/**
+ * @brief Solana bn128 elliptic curve addition, multiplication, and pairing
+**/
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Output length for the add operation.
+ */
+#define ALT_BN128_ADDITION_OUTPUT_LEN 64
+
+/**
+ * Output length for the multiplication operation.
+ */
+#define ALT_BN128_MULTIPLICATION_OUTPUT_LEN 64
+
+/**
+ * Output length for pairing operation.
+ */
+#define ALT_BN128_PAIRING_OUTPUT_LEN 32
+
+/**
+ * Add operation.
+ */
+#define ALT_BN128_ADD 0
+
+/**
+ * Subtraction operation.
+ */
+#define ALT_BN128_SUB 1
+
+/**
+ * Multiplication operation.
+ */
+#define ALT_BN128_MUL 2
+
+/**
+ * Pairing operation.
+ */
+#define ALT_BN128_PAIRING 3
+
+/**
+ * Addition on elliptic curves alt_bn128
+ *
+ * @param group_op ...
+ * @param input ...
+ * @param input_size ...
+ * @param result 64 byte array to hold the result. ...
+ * @return 0 if executed successfully
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/alt_bn128.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+uint64_t sol_alt_bn128_group_op(const uint64_t, const uint8_t *, const uint64_t, uint8_t *);
+#else
+typedef uint64_t(*sol_alt_bn128_group_op_pointer_type)(const uint64_t, const uint8_t *, const uint64_t, uint8_t *);
+static uint64_t sol_alt_bn128_group_op(const uint64_t arg1, const uint8_t * arg2, const uint64_t arg3, uint8_t * arg4) {
+  sol_alt_bn128_group_op_pointer_type sol_alt_bn128_group_op_pointer = (sol_alt_bn128_group_op_pointer_type) 2920034699;
+  return sol_alt_bn128_group_op_pointer(arg1, arg2, arg3, arg4);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/alt_bn128_compression.h
+++ b/programs/sbf/c/inc/sol/alt_bn128_compression.h
@@ -1,0 +1,91 @@
+#pragma once
+/**
+ * @brief Solana bn128 elliptic curve compression and decompression
+**/
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Output length for the g1 compress operation.
+ */
+#define ALT_BN128_COMPRESSION_G1_COMPRESS_OUTPUT_LEN 32
+
+/**
+ * Output length for the g1 decompress operation.
+ */
+#define ALT_BN128_COMPRESSION_G1_DECOMPRESS_OUTPUT_LEN 64
+
+/**
+ * Output length for the g1 compress operation.
+ */
+#define ALT_BN128_COMPRESSION_G2_COMPRESS_OUTPUT_LEN 64
+
+/**
+ * Output length for the g2 decompress operation.
+ */
+#define ALT_BN128_COMPRESSION_G2_DECOMPRESS_OUTPUT_LEN 128
+
+/**
+ * G1 compression operation.
+ */
+#define ALT_BN128_G1_COMPRESS 0
+
+/**
+ * G1 decompression operation.
+ */
+#define ALT_BN128_G1_DECOMPRESS 1
+
+/**
+ * G2 compression operation.
+ */
+#define ALT_BN128_G2_COMPRESS 2
+
+/**
+ * G2 decompression operation.
+ */
+#define ALT_BN128_G2_DECOMPRESS 3
+
+/**
+ * Compression of alt_bn128 g1 and g2 points
+ *
+ * @param op ...
+ * @param input ...
+ * @param input_size ...
+ * @param result 64 byte array to hold the result. ...
+ * @return 0 if executed successfully
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/alt_bn128_compression.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+uint64_t sol_alt_bn128_compression(
+        const uint64_t op,
+        const uint8_t *input,
+        const uint64_t input_size,
+        uint8_t *result
+);
+#else
+typedef uint64_t(*sol_alt_bn128_compression_pointer_type)(
+        const uint64_t op,
+        const uint8_t *input,
+        const uint64_t input_size,
+        uint8_t *result
+);
+static uint64_t sol_alt_bn128_compression(
+        const uint64_t op arg1,
+        const uint8_t *input arg2,
+        const uint64_t input_size arg3,
+        uint8_t *result
+ arg4) {
+  sol_alt_bn128_compression_pointer_type sol_alt_bn128_compression_pointer = (sol_alt_bn128_compression_pointer_type) 860870125;
+  return sol_alt_bn128_compression_pointer(arg1, arg2, arg3, arg4);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/assert.h
+++ b/programs/sbf/c/inc/sol/assert.h
@@ -1,0 +1,56 @@
+#pragma once
+/**
+ * @brief Solana assert and panic utilities
+ */
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * Panics
+ *
+ * Prints the line number where the panic occurred and then causes
+ * the SBF VM to immediately halt execution. No accounts' data are updated
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/assert.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+void sol_panic_(const char *, uint64_t, uint64_t, uint64_t);
+#else
+typedef void(*sol_panic__pointer_type)(const char *, uint64_t, uint64_t, uint64_t);
+static void sol_panic_(const char * arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4) {
+  sol_panic__pointer_type sol_panic__pointer = (sol_panic__pointer_type) 1751159739;
+  sol_panic__pointer(arg1, arg2, arg3, arg4);
+}
+#endif
+#define sol_panic() sol_panic_(__FILE__, sizeof(__FILE__), __LINE__, 0)
+
+/**
+ * Asserts
+ */
+#define sol_assert(expr)  \
+if (!(expr)) {          \
+  sol_panic(); \
+}
+
+#ifdef SOL_TEST
+/**
+ * Stub functions when building tests
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+void sol_panic_(const char *file, uint64_t len, uint64_t line, uint64_t column) {
+  printf("Panic in %s at %d:%d\n", file, line, column);
+  abort();
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/big_mod_exp.h
+++ b/programs/sbf/c/inc/sol/big_mod_exp.h
@@ -1,0 +1,32 @@
+#pragma once
+/**
+ * @brief Solana big_mod_exp system call
+**/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Big integer modular exponentiation
+ *
+ * @param bytes Pointer to BigModExpParam struct
+ * @param result 32 byte array to hold the result
+ * @return 0 if executed successfully
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/big_mod_exp.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+uint64_t sol_big_mod_exp(const uint8_t *, uint8_t *);
+#else
+typedef uint64_t(*sol_big_mod_exp_pointer_type)(const uint8_t *, uint8_t *);
+static uint64_t sol_big_mod_exp(const uint8_t * arg1, uint8_t * arg2) {
+  sol_big_mod_exp_pointer_type sol_big_mod_exp_pointer = (sol_big_mod_exp_pointer_type) 2014202901;
+  return sol_big_mod_exp_pointer(arg1, arg2);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/blake3.h
+++ b/programs/sbf/c/inc/sol/blake3.h
@@ -1,0 +1,39 @@
+#pragma once
+/**
+ * @brief Solana Blake3 system call
+ */
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Length of a Blake3 hash result
+ */
+#define BLAKE3_RESULT_LENGTH 32
+
+/**
+ * Blake3
+ *
+ * @param bytes Array of byte arrays
+ * @param bytes_len Number of byte arrays
+ * @param result 32 byte array to hold the result
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/blake3.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+uint64_t sol_blake3(const SolBytes *, int, const uint8_t *);
+#else
+typedef uint64_t(*sol_blake3_pointer_type)(const SolBytes *, int, const uint8_t *);
+static uint64_t sol_blake3(const SolBytes * arg1, int arg2, const uint8_t * arg3) {
+  sol_blake3_pointer_type sol_blake3_pointer = (sol_blake3_pointer_type) 390877474;
+  return sol_blake3_pointer(arg1, arg2, arg3);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/compute_units.h
+++ b/programs/sbf/c/inc/sol/compute_units.h
@@ -1,0 +1,42 @@
+#pragma once
+/**
+ * @brief Solana logging utilities
+ */
+
+#include <sol/types.h>
+#include <sol/string.h>
+#include <sol/entrypoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Prints a string to stdout
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/compute_units.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+uint64_t sol_remaining_compute_units();
+#else
+typedef uint64_t(*sol_remaining_compute_units_pointer_type)();
+static uint64_t sol_remaining_compute_units() {
+  sol_remaining_compute_units_pointer_type sol_remaining_compute_units_pointer = (sol_remaining_compute_units_pointer_type) 3991886574;
+  return sol_remaining_compute_units_pointer();
+}
+#endif
+
+#ifdef SOL_TEST
+/**
+ * Stub functions when building tests
+ */
+
+uint64_t sol_remaining_compute_units() {
+  return UINT64_MAX;
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/constants.h
+++ b/programs/sbf/c/inc/sol/constants.h
@@ -1,0 +1,18 @@
+#pragma once
+/**
+ * @brief Solana constants
+ */
+
+/**
+ * The Solana runtime provides a memory region that is available to programs at
+ * a fixed virtual address and length. The builtin functions `sol_calloc` and
+ * `sol_free` call into the Solana runtime to allocate from this memory region
+ * for heap operations.  Because the memory region is directly available to
+ * programs another option is a program can implement their own heap directly on
+ * top of that region.  If a program chooses to implement their own heap they
+ * should not call the builtin heap functions because they will conflict.
+ * `HEAP_START_ADDRESS` and `HEAP_LENGTH` specify the memory region's start
+ * virtual address and length.
+ */
+#define HEAP_START_ADDRESS (uint64_t)0x300000000
+#define HEAP_LENGTH (uint64_t)(32 * 1024)

--- a/programs/sbf/c/inc/sol/cpi.h
+++ b/programs/sbf/c/inc/sol/cpi.h
@@ -1,0 +1,138 @@
+#pragma once
+/**
+ * @brief Solana Cross-Program Invocation
+ */
+
+#include <sol/types.h>
+#include <sol/pubkey.h>
+#include <sol/entrypoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Maximum CPI instruction data size. 10 KiB was chosen to ensure that CPI
+ * instructions are not more limited than transaction instructions if the size
+ * of transactions is doubled in the future.
+ */
+static const uint64_t MAX_CPI_INSTRUCTION_DATA_LEN = 10240;
+
+/**
+ * Maximum CPI instruction accounts. 255 was chosen to ensure that instruction
+ * accounts are always within the maximum instruction account limit for SBF
+ * program instructions.
+ */
+static const uint8_t MAX_CPI_INSTRUCTION_ACCOUNTS = 255;
+
+/**
+ * Maximum number of account info structs that can be used in a single CPI
+ * invocation. A limit on account info structs is effectively the same as
+ * limiting the number of unique accounts. 128 was chosen to match the max
+ * number of locked accounts per transaction (MAX_TX_ACCOUNT_LOCKS).
+ */
+static const uint16_t MAX_CPI_ACCOUNT_INFOS = 128;
+
+/**
+ * Account Meta
+ */
+typedef struct {
+  SolPubkey *pubkey; /** An account's public key */
+  bool is_writable; /** True if the `pubkey` can be loaded as a read-write account */
+  bool is_signer; /** True if an Instruction requires a Transaction signature matching `pubkey` */
+} SolAccountMeta;
+
+/**
+ * Instruction
+ */
+typedef struct {
+  SolPubkey *program_id; /** Pubkey of the instruction processor that executes this instruction */
+  SolAccountMeta *accounts; /** Metadata for what accounts should be passed to the instruction processor */
+  uint64_t account_len; /** Number of SolAccountMetas */
+  uint8_t *data; /** Opaque data passed to the instruction processor */
+  uint64_t data_len; /** Length of the data in bytes */
+} SolInstruction;
+
+/**
+ * Internal cross-program invocation function
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/cpi.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+uint64_t sol_invoke_signed_c(
+  const SolInstruction *,
+  const SolAccountInfo *,
+  int,
+  const SolSignerSeeds *,
+  int
+);
+#else
+typedef uint64_t(*sol_invoke_signed_c_pointer_type)(
+  const SolInstruction *,
+  const SolAccountInfo *,
+  int,
+  const SolSignerSeeds *,
+  int
+);
+static uint64_t sol_invoke_signed_c(
+  const SolInstruction * arg1,
+  const SolAccountInfo * arg2,
+  int arg3,
+  const SolSignerSeeds * arg4,
+  int
+ arg5) {
+  sol_invoke_signed_c_pointer_type sol_invoke_signed_c_pointer = (sol_invoke_signed_c_pointer_type) 2720767109;
+  return sol_invoke_signed_c_pointer(arg1, arg2, arg3, arg4, arg5);
+}
+#endif
+
+/**
+ * Invoke another program and sign for some of the keys
+ *
+ * @param instruction Instruction to process
+ * @param account_infos Accounts used by instruction
+ * @param account_infos_len Length of account_infos array
+ * @param seeds Seed bytes used to sign program accounts
+ * @param seeds_len Length of the seeds array
+ */
+static uint64_t sol_invoke_signed(
+    const SolInstruction *instruction,
+    const SolAccountInfo *account_infos,
+    int account_infos_len,
+    const SolSignerSeeds *signers_seeds,
+    int signers_seeds_len
+) {
+  return sol_invoke_signed_c(
+    instruction,
+    account_infos,
+    account_infos_len,
+    signers_seeds,
+    signers_seeds_len
+  );
+}
+/**
+ * Invoke another program
+ *
+ * @param instruction Instruction to process
+ * @param account_infos Accounts used by instruction
+ * @param account_infos_len Length of account_infos array
+*/
+static uint64_t sol_invoke(
+    const SolInstruction *instruction,
+    const SolAccountInfo *account_infos,
+    int account_infos_len
+) {
+  const SolSignerSeeds signers_seeds[] = {{}};
+  return sol_invoke_signed(
+    instruction,
+    account_infos,
+    account_infos_len,
+    signers_seeds,
+    0
+  );
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/deserialize.h
+++ b/programs/sbf/c/inc/sol/deserialize.h
@@ -1,0 +1,140 @@
+#pragma once
+/**
+ * @brief Solana SBF loader deserializer to be used when deploying
+ * a program with `SBFLoader2111111111111111111111111111111111` or
+ * `SBFLoaderUpgradeab1e11111111111111111111111`
+ */
+
+#include <sol/types.h>
+#include <sol/pubkey.h>
+#include <sol/entrypoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Maximum number of bytes a program may add to an account during a single realloc
+ */
+#define MAX_PERMITTED_DATA_INCREASE (1024 * 10)
+
+/**
+ * De-serializes the input parameters into usable types
+ *
+ * Use this function to deserialize the buffer passed to the program entrypoint
+ * into usable types.  This function does not perform copy deserialization,
+ * instead it populates the pointers and lengths in SolAccountInfo and data so
+ * that any modification to lamports or account data take place on the original
+ * buffer.  Doing so also eliminates the need to serialize back into the buffer
+ * at the end of the program.
+ *
+ * @param input Source buffer containing serialized input parameters
+ * @param params Pointer to a SolParameters structure
+ * @return Boolean true if successful.
+ */
+static bool sol_deserialize(
+  const uint8_t *input,
+  SolParameters *params,
+  uint64_t ka_num
+) {
+  if (NULL == input || NULL == params) {
+    return false;
+  }
+  params->ka_num = *(uint64_t *) input;
+  input += sizeof(uint64_t);
+
+  for (int i = 0; i < params->ka_num; i++) {
+    uint8_t dup_info = input[0];
+    input += sizeof(uint8_t);
+
+    if (i >= ka_num) {
+      if (dup_info == UINT8_MAX) {
+        input += sizeof(uint8_t);
+        input += sizeof(uint8_t);
+        input += sizeof(uint8_t);
+        input += 4; // padding
+        input += sizeof(SolPubkey);
+        input += sizeof(SolPubkey);
+        input += sizeof(uint64_t);
+        uint64_t data_len = *(uint64_t *) input;
+        input += sizeof(uint64_t);
+        input += data_len;
+        input += MAX_PERMITTED_DATA_INCREASE;
+        input = (uint8_t*)(((uint64_t)input + 8 - 1) & ~(8 - 1)); // padding
+        input += sizeof(uint64_t);
+      } else {
+        input += 7; // padding
+      }
+      continue;
+    }
+    if (dup_info == UINT8_MAX) {
+      // is signer?
+      params->ka[i].is_signer = *(uint8_t *) input != 0;
+      input += sizeof(uint8_t);
+
+      // is writable?
+      params->ka[i].is_writable = *(uint8_t *) input != 0;
+      input += sizeof(uint8_t);
+
+      // executable?
+      params->ka[i].executable = *(uint8_t *) input;
+      input += sizeof(uint8_t);
+
+      input += 4; // padding
+
+      // key
+      params->ka[i].key = (SolPubkey *) input;
+      input += sizeof(SolPubkey);
+
+      // owner
+      params->ka[i].owner = (SolPubkey *) input;
+      input += sizeof(SolPubkey);
+
+      // lamports
+      params->ka[i].lamports = (uint64_t *) input;
+      input += sizeof(uint64_t);
+
+      // account data
+      params->ka[i].data_len = *(uint64_t *) input;
+      input += sizeof(uint64_t);
+      params->ka[i].data = (uint8_t *) input;
+      input += params->ka[i].data_len;
+      input += MAX_PERMITTED_DATA_INCREASE;
+      input = (uint8_t*)(((uint64_t)input + 8 - 1) & ~(8 - 1)); // padding
+
+      // rent epoch
+      params->ka[i].rent_epoch = *(uint64_t *) input;
+      input += sizeof(uint64_t);
+    } else {
+      params->ka[i].is_signer = params->ka[dup_info].is_signer;
+      params->ka[i].is_writable = params->ka[dup_info].is_writable;
+      params->ka[i].executable = params->ka[dup_info].executable;
+      params->ka[i].key = params->ka[dup_info].key;
+      params->ka[i].owner = params->ka[dup_info].owner;
+      params->ka[i].lamports = params->ka[dup_info].lamports;
+      params->ka[i].data_len = params->ka[dup_info].data_len;
+      params->ka[i].data = params->ka[dup_info].data;
+      params->ka[i].rent_epoch = params->ka[dup_info].rent_epoch;
+      input += 7; // padding
+    }
+  }
+
+  params->data_len = *(uint64_t *) input;
+  input += sizeof(uint64_t);
+  params->data = input;
+  input += params->data_len;
+
+  params->program_id = (SolPubkey *) input;
+  input += sizeof(SolPubkey);
+  if (params->ka_num > ka_num) {
+    params->ka_num = ka_num;
+  }
+
+  return true;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/deserialize_deprecated.h
+++ b/programs/sbf/c/inc/sol/deserialize_deprecated.h
@@ -1,0 +1,119 @@
+#pragma once
+/**
+ * @brief Solana deprecated SBF loader deserializer to be used when deploying
+ * a program with `SBFLoader1111111111111111111111111111111111`
+ */
+
+ #include <sol/types.h>
+ #include <sol/pubkey.h>
+ #include <sol/entrypoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * De-serializes the input parameters into usable types
+ *
+ * Use this function to deserialize the buffer passed to the program entrypoint
+ * into usable types.  This function does not perform copy deserialization,
+ * instead it populates the pointers and lengths in SolAccountInfo and data so
+ * that any modification to lamports or account data take place on the original
+ * buffer.  Doing so also eliminates the need to serialize back into the buffer
+ * at the end of the program.
+ *
+ * @param input Source buffer containing serialized input parameters
+ * @param params Pointer to a SolParameters structure
+ * @return Boolean true if successful.
+ */
+static bool sol_deserialize_deprecated(
+  const uint8_t *input,
+  SolParameters *params,
+  uint64_t ka_num
+) {
+  if (NULL == input || NULL == params) {
+    return false;
+  }
+  params->ka_num = *(uint64_t *) input;
+  input += sizeof(uint64_t);
+
+  for (int i = 0; i < params->ka_num; i++) {
+    uint8_t dup_info = input[0];
+    input += sizeof(uint8_t);
+
+    if (i >= ka_num) {
+      if (dup_info == UINT8_MAX) {
+        input += sizeof(uint8_t);
+        input += sizeof(uint8_t);
+        input += sizeof(SolPubkey);
+        input += sizeof(uint64_t);
+        input += *(uint64_t *) input;
+        input += sizeof(uint64_t);
+        input += sizeof(SolPubkey);
+        input += sizeof(uint8_t);
+        input += sizeof(uint64_t);
+      }
+      continue;
+    }
+    if (dup_info == UINT8_MAX) {
+      // is signer?
+      params->ka[i].is_signer = *(uint8_t *) input != 0;
+      input += sizeof(uint8_t);
+
+      // is writable?
+      params->ka[i].is_writable = *(uint8_t *) input != 0;
+      input += sizeof(uint8_t);
+
+      // key
+      params->ka[i].key = (SolPubkey *) input;
+      input += sizeof(SolPubkey);
+
+      // lamports
+      params->ka[i].lamports = (uint64_t *) input;
+      input += sizeof(uint64_t);
+
+      // account data
+      params->ka[i].data_len = *(uint64_t *) input;
+      input += sizeof(uint64_t);
+      params->ka[i].data = (uint8_t *) input;
+      input += params->ka[i].data_len;
+
+      // owner
+      params->ka[i].owner = (SolPubkey *) input;
+      input += sizeof(SolPubkey);
+
+      // executable?
+      params->ka[i].executable = *(uint8_t *) input;
+      input += sizeof(uint8_t);
+
+      // rent epoch
+      params->ka[i].rent_epoch = *(uint64_t *) input;
+      input += sizeof(uint64_t);
+    } else {
+      params->ka[i].is_signer = params->ka[dup_info].is_signer;
+      params->ka[i].key = params->ka[dup_info].key;
+      params->ka[i].lamports = params->ka[dup_info].lamports;
+      params->ka[i].data_len = params->ka[dup_info].data_len;
+      params->ka[i].data = params->ka[dup_info].data;
+      params->ka[i].owner = params->ka[dup_info].owner;
+      params->ka[i].executable = params->ka[dup_info].executable;
+      params->ka[i].rent_epoch = params->ka[dup_info].rent_epoch;
+    }
+  }
+
+  params->data_len = *(uint64_t *) input;
+  input += sizeof(uint64_t);
+  params->data = input;
+  input += params->data_len;
+
+  params->program_id = (SolPubkey *) input;
+  input += sizeof(SolPubkey);
+
+  return true;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/entrypoint.h
+++ b/programs/sbf/c/inc/sol/entrypoint.h
@@ -1,0 +1,53 @@
+#pragma once
+/**
+ * @brief Solana program entrypoint
+ */
+
+#include <sol/constants.h>
+#include <sol/types.h>
+#include <sol/pubkey.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Keyed Account
+ */
+typedef struct {
+  SolPubkey *key;      /** Public key of the account */
+  uint64_t *lamports;  /** Number of lamports owned by this account */
+  uint64_t data_len;   /** Length of data in bytes */
+  uint8_t *data;       /** On-chain data within this account */
+  SolPubkey *owner;    /** Program that owns this account */
+  uint64_t rent_epoch; /** The epoch at which this account will next owe rent */
+  bool is_signer;      /** Transaction was signed by this account's key? */
+  bool is_writable;    /** Is the account writable? */
+  bool executable;     /** This account's data contains a loaded program (and is now read-only) */
+} SolAccountInfo;
+
+/**
+ * Structure that the program's entrypoint input data is deserialized into.
+ */
+typedef struct {
+  SolAccountInfo* ka; /** Pointer to an array of SolAccountInfo, must already
+                          point to an array of SolAccountInfos */
+  uint64_t ka_num; /** Number of SolAccountInfo entries in `ka` */
+  const uint8_t *data; /** pointer to the instruction data */
+  uint64_t data_len; /** Length in bytes of the instruction data */
+  const SolPubkey *program_id; /** program_id of the currently executing program */
+} SolParameters;
+
+/**
+ * Program instruction entrypoint
+ *
+ * @param input Buffer of serialized input parameters.  Use sol_deserialize() to decode
+ * @return 0 if the instruction executed successfully
+ */
+uint64_t entrypoint(const uint8_t *input);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/alt_bn128.inc
+++ b/programs/sbf/c/inc/sol/inc/alt_bn128.inc
@@ -1,0 +1,62 @@
+#pragma once
+/**
+ * @brief Solana bn128 elliptic curve addition, multiplication, and pairing
+**/
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Output length for the add operation.
+ */
+#define ALT_BN128_ADDITION_OUTPUT_LEN 64
+
+/**
+ * Output length for the multiplication operation.
+ */
+#define ALT_BN128_MULTIPLICATION_OUTPUT_LEN 64
+
+/**
+ * Output length for pairing operation.
+ */
+#define ALT_BN128_PAIRING_OUTPUT_LEN 32
+
+/**
+ * Add operation.
+ */
+#define ALT_BN128_ADD 0
+
+/**
+ * Subtraction operation.
+ */
+#define ALT_BN128_SUB 1
+
+/**
+ * Multiplication operation.
+ */
+#define ALT_BN128_MUL 2
+
+/**
+ * Pairing operation.
+ */
+#define ALT_BN128_PAIRING 3
+
+/**
+ * Addition on elliptic curves alt_bn128
+ *
+ * @param group_op ...
+ * @param input ...
+ * @param input_size ...
+ * @param result 64 byte array to hold the result. ...
+ * @return 0 if executed successfully
+ */
+@SYSCALL uint64_t sol_alt_bn128_group_op(const uint64_t, const uint8_t *, const uint64_t, uint8_t *);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/alt_bn128_compression.inc
+++ b/programs/sbf/c/inc/sol/inc/alt_bn128_compression.inc
@@ -1,0 +1,72 @@
+#pragma once
+/**
+ * @brief Solana bn128 elliptic curve compression and decompression
+**/
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Output length for the g1 compress operation.
+ */
+#define ALT_BN128_COMPRESSION_G1_COMPRESS_OUTPUT_LEN 32
+
+/**
+ * Output length for the g1 decompress operation.
+ */
+#define ALT_BN128_COMPRESSION_G1_DECOMPRESS_OUTPUT_LEN 64
+
+/**
+ * Output length for the g1 compress operation.
+ */
+#define ALT_BN128_COMPRESSION_G2_COMPRESS_OUTPUT_LEN 64
+
+/**
+ * Output length for the g2 decompress operation.
+ */
+#define ALT_BN128_COMPRESSION_G2_DECOMPRESS_OUTPUT_LEN 128
+
+/**
+ * G1 compression operation.
+ */
+#define ALT_BN128_G1_COMPRESS 0
+
+/**
+ * G1 decompression operation.
+ */
+#define ALT_BN128_G1_DECOMPRESS 1
+
+/**
+ * G2 compression operation.
+ */
+#define ALT_BN128_G2_COMPRESS 2
+
+/**
+ * G2 decompression operation.
+ */
+#define ALT_BN128_G2_DECOMPRESS 3
+
+/**
+ * Compression of alt_bn128 g1 and g2 points
+ *
+ * @param op ...
+ * @param input ...
+ * @param input_size ...
+ * @param result 64 byte array to hold the result. ...
+ * @return 0 if executed successfully
+ */
+@SYSCALL uint64_t sol_alt_bn128_compression(
+        const uint64_t op,
+        const uint8_t *input,
+        const uint64_t input_size,
+        uint8_t *result
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/assert.inc
+++ b/programs/sbf/c/inc/sol/inc/assert.inc
@@ -1,0 +1,47 @@
+#pragma once
+/**
+ * @brief Solana assert and panic utilities
+ */
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * Panics
+ *
+ * Prints the line number where the panic occurred and then causes
+ * the SBF VM to immediately halt execution. No accounts' data are updated
+ */
+@SYSCALL void sol_panic_(const char *, uint64_t, uint64_t, uint64_t);
+#define sol_panic() sol_panic_(__FILE__, sizeof(__FILE__), __LINE__, 0)
+
+/**
+ * Asserts
+ */
+#define sol_assert(expr)  \
+if (!(expr)) {          \
+  sol_panic(); \
+}
+
+#ifdef SOL_TEST
+/**
+ * Stub functions when building tests
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+void sol_panic_(const char *file, uint64_t len, uint64_t line, uint64_t column) {
+  printf("Panic in %s at %d:%d\n", file, line, column);
+  abort();
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/big_mod_exp.inc
+++ b/programs/sbf/c/inc/sol/inc/big_mod_exp.inc
@@ -1,0 +1,23 @@
+#pragma once
+/**
+ * @brief Solana big_mod_exp system call
+**/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Big integer modular exponentiation
+ *
+ * @param bytes Pointer to BigModExpParam struct
+ * @param result 32 byte array to hold the result
+ * @return 0 if executed successfully
+ */
+@SYSCALL uint64_t sol_big_mod_exp(const uint8_t *, uint8_t *);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/blake3.inc
+++ b/programs/sbf/c/inc/sol/inc/blake3.inc
@@ -1,0 +1,30 @@
+#pragma once
+/**
+ * @brief Solana Blake3 system call
+ */
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Length of a Blake3 hash result
+ */
+#define BLAKE3_RESULT_LENGTH 32
+
+/**
+ * Blake3
+ *
+ * @param bytes Array of byte arrays
+ * @param bytes_len Number of byte arrays
+ * @param result 32 byte array to hold the result
+ */
+@SYSCALL uint64_t sol_blake3(const SolBytes *, int, const uint8_t *);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/compute_units.inc
+++ b/programs/sbf/c/inc/sol/inc/compute_units.inc
@@ -1,0 +1,33 @@
+#pragma once
+/**
+ * @brief Solana logging utilities
+ */
+
+#include <sol/types.h>
+#include <sol/string.h>
+#include <sol/entrypoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Prints a string to stdout
+ */
+@SYSCALL uint64_t sol_remaining_compute_units();
+
+#ifdef SOL_TEST
+/**
+ * Stub functions when building tests
+ */
+
+uint64_t sol_remaining_compute_units() {
+  return UINT64_MAX;
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/cpi.inc
+++ b/programs/sbf/c/inc/sol/inc/cpi.inc
@@ -1,0 +1,117 @@
+#pragma once
+/**
+ * @brief Solana Cross-Program Invocation
+ */
+
+#include <sol/types.h>
+#include <sol/pubkey.h>
+#include <sol/entrypoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Maximum CPI instruction data size. 10 KiB was chosen to ensure that CPI
+ * instructions are not more limited than transaction instructions if the size
+ * of transactions is doubled in the future.
+ */
+static const uint64_t MAX_CPI_INSTRUCTION_DATA_LEN = 10240;
+
+/**
+ * Maximum CPI instruction accounts. 255 was chosen to ensure that instruction
+ * accounts are always within the maximum instruction account limit for SBF
+ * program instructions.
+ */
+static const uint8_t MAX_CPI_INSTRUCTION_ACCOUNTS = 255;
+
+/**
+ * Maximum number of account info structs that can be used in a single CPI
+ * invocation. A limit on account info structs is effectively the same as
+ * limiting the number of unique accounts. 128 was chosen to match the max
+ * number of locked accounts per transaction (MAX_TX_ACCOUNT_LOCKS).
+ */
+static const uint16_t MAX_CPI_ACCOUNT_INFOS = 128;
+
+/**
+ * Account Meta
+ */
+typedef struct {
+  SolPubkey *pubkey; /** An account's public key */
+  bool is_writable; /** True if the `pubkey` can be loaded as a read-write account */
+  bool is_signer; /** True if an Instruction requires a Transaction signature matching `pubkey` */
+} SolAccountMeta;
+
+/**
+ * Instruction
+ */
+typedef struct {
+  SolPubkey *program_id; /** Pubkey of the instruction processor that executes this instruction */
+  SolAccountMeta *accounts; /** Metadata for what accounts should be passed to the instruction processor */
+  uint64_t account_len; /** Number of SolAccountMetas */
+  uint8_t *data; /** Opaque data passed to the instruction processor */
+  uint64_t data_len; /** Length of the data in bytes */
+} SolInstruction;
+
+/**
+ * Internal cross-program invocation function
+ */
+@SYSCALL uint64_t sol_invoke_signed_c(
+  const SolInstruction *,
+  const SolAccountInfo *,
+  int,
+  const SolSignerSeeds *,
+  int
+);
+
+/**
+ * Invoke another program and sign for some of the keys
+ *
+ * @param instruction Instruction to process
+ * @param account_infos Accounts used by instruction
+ * @param account_infos_len Length of account_infos array
+ * @param seeds Seed bytes used to sign program accounts
+ * @param seeds_len Length of the seeds array
+ */
+static uint64_t sol_invoke_signed(
+    const SolInstruction *instruction,
+    const SolAccountInfo *account_infos,
+    int account_infos_len,
+    const SolSignerSeeds *signers_seeds,
+    int signers_seeds_len
+) {
+  return sol_invoke_signed_c(
+    instruction,
+    account_infos,
+    account_infos_len,
+    signers_seeds,
+    signers_seeds_len
+  );
+}
+/**
+ * Invoke another program
+ *
+ * @param instruction Instruction to process
+ * @param account_infos Accounts used by instruction
+ * @param account_infos_len Length of account_infos array
+*/
+static uint64_t sol_invoke(
+    const SolInstruction *instruction,
+    const SolAccountInfo *account_infos,
+    int account_infos_len
+) {
+  const SolSignerSeeds signers_seeds[] = {{}};
+  return sol_invoke_signed(
+    instruction,
+    account_infos,
+    account_infos_len,
+    signers_seeds,
+    0
+  );
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/keccak.inc
+++ b/programs/sbf/c/inc/sol/inc/keccak.inc
@@ -1,0 +1,30 @@
+#pragma once
+/**
+ * @brief Solana keccak system call
+**/
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Length of a Keccak hash result
+ */
+#define KECCAK_RESULT_LENGTH 32
+
+/**
+ * Keccak
+ *
+ * @param bytes Array of byte arrays
+ * @param bytes_len Number of byte arrays
+ * @param result 32 byte array to hold the result
+ */
+@SYSCALL uint64_t sol_keccak256(const SolBytes *, int, uint8_t *);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/last_restart_slot.inc
+++ b/programs/sbf/c/inc/sol/inc/last_restart_slot.inc
@@ -1,0 +1,21 @@
+#pragma once
+/**
+ * @brief Solana Last Restart Slot system call
+ */
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Get Last Restart Slot
+ */
+@SYSCALL u64 sol_get_last_restart_slot(uint8_t *result);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/log.inc
+++ b/programs/sbf/c/inc/sol/inc/log.inc
@@ -1,0 +1,103 @@
+#pragma once
+/**
+ * @brief Solana logging utilities
+ */
+
+#include <sol/types.h>
+#include <sol/string.h>
+#include <sol/entrypoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Prints a string to stdout
+ */
+@SYSCALL void sol_log_(const char *, uint64_t);
+#define sol_log(message) sol_log_(message, sol_strlen(message))
+
+/**
+ * Prints a 64 bit values represented in hexadecimal to stdout
+ */
+@SYSCALL void sol_log_64_(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+#define sol_log_64 sol_log_64_
+
+/**
+ * Prints the current compute unit consumption to stdout
+ */
+@SYSCALL void sol_log_compute_units_();
+#define sol_log_compute_units() sol_log_compute_units_()
+
+/**
+ * Prints the hexadecimal representation of an array
+ *
+ * @param array The array to print
+ */
+static void sol_log_array(const uint8_t *array, int len) {
+  for (int j = 0; j < len; j++) {
+    sol_log_64(0, 0, 0, j, array[j]);
+  }
+}
+
+/**
+ * Print the base64 representation of some arrays.
+ */
+@SYSCALL void sol_log_data(SolBytes *, uint64_t);
+
+/**
+ * Prints the program's input parameters
+ *
+ * @param params Pointer to a SolParameters structure
+ */
+static void sol_log_params(const SolParameters *params) {
+  sol_log("- Program identifier:");
+  sol_log_pubkey(params->program_id);
+
+  sol_log("- Number of KeyedAccounts");
+  sol_log_64(0, 0, 0, 0, params->ka_num);
+  for (int i = 0; i < params->ka_num; i++) {
+    sol_log("  - Is signer");
+    sol_log_64(0, 0, 0, 0, params->ka[i].is_signer);
+    sol_log("  - Is writable");
+    sol_log_64(0, 0, 0, 0, params->ka[i].is_writable);
+    sol_log("  - Key");
+    sol_log_pubkey(params->ka[i].key);
+    sol_log("  - Lamports");
+    sol_log_64(0, 0, 0, 0, *params->ka[i].lamports);
+    sol_log("  - data");
+    sol_log_array(params->ka[i].data, params->ka[i].data_len);
+    sol_log("  - Owner");
+    sol_log_pubkey(params->ka[i].owner);
+    sol_log("  - Executable");
+    sol_log_64(0, 0, 0, 0, params->ka[i].executable);
+    sol_log("  - Rent Epoch");
+    sol_log_64(0, 0, 0, 0, params->ka[i].rent_epoch);
+  }
+  sol_log("- Instruction data\0");
+  sol_log_array(params->data, params->data_len);
+}
+
+#ifdef SOL_TEST
+/**
+ * Stub functions when building tests
+ */
+#include <stdio.h>
+
+void sol_log_(const char *s, uint64_t len) {
+  printf("Program log: %s\n", s);
+}
+void sol_log_64(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4, uint64_t arg5) {
+  printf("Program log: %llu, %llu, %llu, %llu, %llu\n", arg1, arg2, arg3, arg4, arg5);
+}
+
+void sol_log_compute_units_() {
+  printf("Program consumption: __ units remaining\n");
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/poseidon.inc
+++ b/programs/sbf/c/inc/sol/inc/poseidon.inc
@@ -1,0 +1,62 @@
+#pragma once
+/**
+ * @brief Solana poseidon system call
+**/
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Length of a Poseidon hash result
+ */
+#define POSEIDON_RESULT_LENGTH 32
+
+/**
+ * Configuration using the Barreto–Naehrig curve with an embedding degree of
+ * 12, defined over a 254-bit prime field.
+ *
+ * Configuration Details:
+ * - S-Box: x^5
+ * - Width: 2 <= t <= 13
+ * - Inputs: 1 <= n <= 12
+ * - Full rounds: 8
+ * - Partial rounds: Depending on width: [56, 57, 56, 60, 60, 63, 64, 63,
+ *   60, 66, 60, 65]
+ */
+#define POSEIDON_PARAMETERS_BN254_X5 0
+
+/**
+ * Big-endian inputs and output
+ */
+#define POSEIDON_ENDIANNESS_BIG_ENDIAN 0
+
+/**
+ * Little-endian inputs and output
+ */
+#define POSEIDON_ENDIANNESS_LITTLE_ENDIAN 1
+
+/**
+ * Poseidon
+ *
+ * @param parameters Configuration parameters for the hash function
+ * @param endianness Endianness of inputs and result
+ * @param bytes Array of byte arrays
+ * @param bytes_len Number of byte arrays
+ * @param result 32 byte array to hold the result
+ */
+@SYSCALL uint64_t sol_poseidon(
+  const uint64_t parameters,
+  const uint64_t endianness,
+  const SolBytes *bytes,
+  const uint64_t bytes_len,
+  uint8_t *result
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/pubkey.inc
+++ b/programs/sbf/c/inc/sol/inc/pubkey.inc
@@ -1,0 +1,107 @@
+#pragma once
+/**
+ * @brief Solana Public key
+ */
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Size of Public key in bytes
+ */
+#define SIZE_PUBKEY 32
+
+/**
+ * Public key
+ */
+typedef struct {
+  uint8_t x[SIZE_PUBKEY];
+} SolPubkey;
+
+/**
+ * Prints the hexadecimal representation of a public key
+ *
+ * @param key The public key to print
+ */
+@SYSCALL void sol_log_pubkey(const SolPubkey *);
+
+/**
+ * Compares two public keys
+ *
+ * @param one First public key
+ * @param two Second public key
+ * @return true if the same
+ */
+static bool SolPubkey_same(const SolPubkey *one, const SolPubkey *two) {
+  for (int i = 0; i < sizeof(*one); i++) {
+    if (one->x[i] != two->x[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Seed used to create a program address or passed to sol_invoke_signed
+ */
+typedef struct {
+  const uint8_t *addr; /** Seed bytes */
+  uint64_t len; /** Length of the seed bytes */
+} SolSignerSeed;
+
+/**
+ * Seeds used by a signer to create a program address or passed to
+ * sol_invoke_signed
+ */
+typedef struct {
+  const SolSignerSeed *addr; /** An array of a signer's seeds */
+  uint64_t len; /** Number of seeds */
+} SolSignerSeeds;
+
+/**
+ * Create a program address
+ *
+ * @param seeds Seed bytes used to sign program accounts
+ * @param seeds_len Length of the seeds array
+ * @param program_id Program id of the signer
+ * @param program_address Program address created, filled on return
+ */
+@SYSCALL uint64_t sol_create_program_address(const SolSignerSeed *, int, const SolPubkey *, SolPubkey *);
+
+/**
+ * Try to find a program address and return corresponding bump seed
+ *
+ * @param seeds Seed bytes used to sign program accounts
+ * @param seeds_len Length of the seeds array
+ * @param program_id Program id of the signer
+ * @param program_address Program address created, filled on return
+ * @param bump_seed Bump seed required to create a valid program address
+ */
+@SYSCALL uint64_t sol_try_find_program_address(const SolSignerSeed *, int, const SolPubkey *, SolPubkey *, uint8_t *);
+
+#ifdef SOL_TEST
+/**
+ * Stub functions when building tests
+ */
+#include <stdio.h>
+
+void sol_log_pubkey(
+  const SolPubkey *pubkey
+) {
+  printf("Program log: ");
+  for (int i = 0; i < SIZE_PUBKEY; i++) {
+    printf("%02 ", pubkey->x[i]);
+  }
+  printf("\n");
+}
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/return_data.inc
+++ b/programs/sbf/c/inc/sol/inc/return_data.inc
@@ -1,0 +1,41 @@
+#pragma once
+/**
+ * @brief Solana return data system calls
+**/
+
+#include <sol/types.h>
+#include <sol/pubkey.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * Maximum size of return data
+ */
+#define MAX_RETURN_DATA 1024
+
+/**
+ * Set the return data
+ *
+ * @param bytes byte array to set
+ * @param bytes_len length of byte array. This may not exceed MAX_RETURN_DATA.
+ */
+@SYSCALL void sol_set_return_data(const uint8_t *, uint64_t);
+
+/**
+ * Get the return data
+ *
+ * @param bytes byte buffer
+ * @param bytes_len maximum length of buffer
+ * @param program_id the program_id which set the return data. Only set if there was some return data (the function returns non-zero).
+ * @param result length of return data (may exceed bytes_len if the return data is longer)
+ */
+@SYSCALL uint64_t sol_get_return_data(uint8_t *, uint64_t, SolPubkey *);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/secp256k1.inc
+++ b/programs/sbf/c/inc/sol/inc/secp256k1.inc
@@ -1,0 +1,41 @@
+#pragma once
+/**
+ * @brief Solana secp256k1 system call
+ */
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Length of a secp256k1 recover input hash */
+#define SECP256K1_RECOVER_HASH_LENGTH 32
+/** Length of a secp256k1 input signature */
+#define SECP256K1_RECOVER_SIGNATURE_LENGTH 64
+/** Length of a secp256k1 recover result */
+#define SECP256K1_RECOVER_RESULT_LENGTH 64
+
+/** The hash provided to a sol_secp256k1_recover is invalid */
+#define SECP256K1_RECOVER_ERROR_INVALID_HASH 1
+/** The recovery_id provided to a sol_secp256k1_recover is invalid */
+#define SECP256K1_RECOVER_ERROR_INVALID_RECOVERY_ID 2
+/** The signature provided to a sol_secp256k1_recover is invalid */
+#define SECP256K1_RECOVER_ERROR_INVALID_SIGNATURE 3
+
+/**
+ * Recover public key from a signed message.
+ *
+ * @param hash Hashed message
+ * @param recovery_id Tag used for public key recovery from signatures. Can be 0 or 1
+ * @param signature An ECDSA signature
+ * @param result 64 byte array to hold the result. A recovered public key
+ * @return 0 if executed successfully
+ */
+@SYSCALL uint64_t sol_secp256k1_recover(const uint8_t *, uint64_t, const uint8_t *, uint8_t *);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/inc/sha.inc
+++ b/programs/sbf/c/inc/sol/inc/sha.inc
@@ -1,0 +1,30 @@
+#pragma once
+/**
+ * @brief Solana sha system call
+ */
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Length of a sha256 hash result
+ */
+#define SHA256_RESULT_LENGTH 32
+
+/**
+ * Sha256
+ *
+ * @param bytes Array of byte arrays
+ * @param bytes_len Number of byte arrays
+ * @param result 32 byte array to hold the result
+ */
+@SYSCALL uint64_t sol_sha256(const SolBytes *, int, uint8_t *);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/keccak.h
+++ b/programs/sbf/c/inc/sol/keccak.h
@@ -1,0 +1,39 @@
+#pragma once
+/**
+ * @brief Solana keccak system call
+**/
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Length of a Keccak hash result
+ */
+#define KECCAK_RESULT_LENGTH 32
+
+/**
+ * Keccak
+ *
+ * @param bytes Array of byte arrays
+ * @param bytes_len Number of byte arrays
+ * @param result 32 byte array to hold the result
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/keccak.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+uint64_t sol_keccak256(const SolBytes *, int, uint8_t *);
+#else
+typedef uint64_t(*sol_keccak256_pointer_type)(const SolBytes *, int, uint8_t *);
+static uint64_t sol_keccak256(const SolBytes * arg1, int arg2, uint8_t * arg3) {
+  sol_keccak256_pointer_type sol_keccak256_pointer = (sol_keccak256_pointer_type) 3615046331;
+  return sol_keccak256_pointer(arg1, arg2, arg3);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/last_restart_slot.h
+++ b/programs/sbf/c/inc/sol/last_restart_slot.h
@@ -1,0 +1,30 @@
+#pragma once
+/**
+ * @brief Solana Last Restart Slot system call
+ */
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Get Last Restart Slot
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/last_restart_slot.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+u64 sol_get_last_restart_slot(uint8_t *result);
+#else
+typedef u64(*sol_get_last_restart_slot_pointer_type)(uint8_t *result);
+static u64 sol_get_last_restart_slot(uint8_t *result arg1) {
+  sol_get_last_restart_slot_pointer_type sol_get_last_restart_slot_pointer = (sol_get_last_restart_slot_pointer_type) 411697201;
+  return sol_get_last_restart_slot_pointer(arg1);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/log.h
+++ b/programs/sbf/c/inc/sol/log.h
@@ -1,0 +1,139 @@
+#pragma once
+/**
+ * @brief Solana logging utilities
+ */
+
+#include <sol/types.h>
+#include <sol/string.h>
+#include <sol/entrypoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Prints a string to stdout
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/log.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+void sol_log_(const char *, uint64_t);
+#else
+typedef void(*sol_log__pointer_type)(const char *, uint64_t);
+static void sol_log_(const char * arg1, uint64_t arg2) {
+  sol_log__pointer_type sol_log__pointer = (sol_log__pointer_type) 544561597;
+  sol_log__pointer(arg1, arg2);
+}
+#endif
+#define sol_log(message) sol_log_(message, sol_strlen(message))
+
+/**
+ * Prints a 64 bit values represented in hexadecimal to stdout
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/log.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+void sol_log_64_(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+#else
+typedef void(*sol_log_64__pointer_type)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+static void sol_log_64_(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4, uint64_t arg5) {
+  sol_log_64__pointer_type sol_log_64__pointer = (sol_log_64__pointer_type) 1546269048;
+  sol_log_64__pointer(arg1, arg2, arg3, arg4, arg5);
+}
+#endif
+#define sol_log_64 sol_log_64_
+
+/**
+ * Prints the current compute unit consumption to stdout
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/log.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+void sol_log_compute_units_();
+#else
+typedef void(*sol_log_compute_units__pointer_type)();
+static void sol_log_compute_units_() {
+  sol_log_compute_units__pointer_type sol_log_compute_units__pointer = (sol_log_compute_units__pointer_type) 1387942038;
+  sol_log_compute_units__pointer();
+}
+#endif
+#define sol_log_compute_units() sol_log_compute_units_()
+
+/**
+ * Prints the hexadecimal representation of an array
+ *
+ * @param array The array to print
+ */
+static void sol_log_array(const uint8_t *array, int len) {
+  for (int j = 0; j < len; j++) {
+    sol_log_64(0, 0, 0, j, array[j]);
+  }
+}
+
+/**
+ * Print the base64 representation of some arrays.
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/log.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+void sol_log_data(SolBytes *, uint64_t);
+#else
+typedef void(*sol_log_data_pointer_type)(SolBytes *, uint64_t);
+static void sol_log_data(SolBytes * arg1, uint64_t arg2) {
+  sol_log_data_pointer_type sol_log_data_pointer = (sol_log_data_pointer_type) 1930933300;
+  sol_log_data_pointer(arg1, arg2);
+}
+#endif
+
+/**
+ * Prints the program's input parameters
+ *
+ * @param params Pointer to a SolParameters structure
+ */
+static void sol_log_params(const SolParameters *params) {
+  sol_log("- Program identifier:");
+  sol_log_pubkey(params->program_id);
+
+  sol_log("- Number of KeyedAccounts");
+  sol_log_64(0, 0, 0, 0, params->ka_num);
+  for (int i = 0; i < params->ka_num; i++) {
+    sol_log("  - Is signer");
+    sol_log_64(0, 0, 0, 0, params->ka[i].is_signer);
+    sol_log("  - Is writable");
+    sol_log_64(0, 0, 0, 0, params->ka[i].is_writable);
+    sol_log("  - Key");
+    sol_log_pubkey(params->ka[i].key);
+    sol_log("  - Lamports");
+    sol_log_64(0, 0, 0, 0, *params->ka[i].lamports);
+    sol_log("  - data");
+    sol_log_array(params->ka[i].data, params->ka[i].data_len);
+    sol_log("  - Owner");
+    sol_log_pubkey(params->ka[i].owner);
+    sol_log("  - Executable");
+    sol_log_64(0, 0, 0, 0, params->ka[i].executable);
+    sol_log("  - Rent Epoch");
+    sol_log_64(0, 0, 0, 0, params->ka[i].rent_epoch);
+  }
+  sol_log("- Instruction data\0");
+  sol_log_array(params->data, params->data_len);
+}
+
+#ifdef SOL_TEST
+/**
+ * Stub functions when building tests
+ */
+#include <stdio.h>
+
+void sol_log_(const char *s, uint64_t len) {
+  printf("Program log: %s\n", s);
+}
+void sol_log_64(uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4, uint64_t arg5) {
+  printf("Program log: %llu, %llu, %llu, %llu, %llu\n", arg1, arg2, arg3, arg4, arg5);
+}
+
+void sol_log_compute_units_() {
+  printf("Program consumption: __ units remaining\n");
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/poseidon.h
+++ b/programs/sbf/c/inc/sol/poseidon.h
@@ -1,0 +1,83 @@
+#pragma once
+/**
+ * @brief Solana poseidon system call
+**/
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Length of a Poseidon hash result
+ */
+#define POSEIDON_RESULT_LENGTH 32
+
+/**
+ * Configuration using the Barreto–Naehrig curve with an embedding degree of
+ * 12, defined over a 254-bit prime field.
+ *
+ * Configuration Details:
+ * - S-Box: x^5
+ * - Width: 2 <= t <= 13
+ * - Inputs: 1 <= n <= 12
+ * - Full rounds: 8
+ * - Partial rounds: Depending on width: [56, 57, 56, 60, 60, 63, 64, 63,
+ *   60, 66, 60, 65]
+ */
+#define POSEIDON_PARAMETERS_BN254_X5 0
+
+/**
+ * Big-endian inputs and output
+ */
+#define POSEIDON_ENDIANNESS_BIG_ENDIAN 0
+
+/**
+ * Little-endian inputs and output
+ */
+#define POSEIDON_ENDIANNESS_LITTLE_ENDIAN 1
+
+/**
+ * Poseidon
+ *
+ * @param parameters Configuration parameters for the hash function
+ * @param endianness Endianness of inputs and result
+ * @param bytes Array of byte arrays
+ * @param bytes_len Number of byte arrays
+ * @param result 32 byte array to hold the result
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/poseidon.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+uint64_t sol_poseidon(
+  const uint64_t parameters,
+  const uint64_t endianness,
+  const SolBytes *bytes,
+  const uint64_t bytes_len,
+  uint8_t *result
+);
+#else
+typedef uint64_t(*sol_poseidon_pointer_type)(
+  const uint64_t parameters,
+  const uint64_t endianness,
+  const SolBytes *bytes,
+  const uint64_t bytes_len,
+  uint8_t *result
+);
+static uint64_t sol_poseidon(
+  const uint64_t parameters arg1,
+  const uint64_t endianness arg2,
+  const SolBytes *bytes arg3,
+  const uint64_t bytes_len arg4,
+  uint8_t *result
+ arg5) {
+  sol_poseidon_pointer_type sol_poseidon_pointer = (sol_poseidon_pointer_type) 3298065441;
+  return sol_poseidon_pointer(arg1, arg2, arg3, arg4, arg5);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/pubkey.h
+++ b/programs/sbf/c/inc/sol/pubkey.h
@@ -1,0 +1,134 @@
+#pragma once
+/**
+ * @brief Solana Public key
+ */
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Size of Public key in bytes
+ */
+#define SIZE_PUBKEY 32
+
+/**
+ * Public key
+ */
+typedef struct {
+  uint8_t x[SIZE_PUBKEY];
+} SolPubkey;
+
+/**
+ * Prints the hexadecimal representation of a public key
+ *
+ * @param key The public key to print
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/pubkey.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+void sol_log_pubkey(const SolPubkey *);
+#else
+typedef void(*sol_log_pubkey_pointer_type)(const SolPubkey *);
+static void sol_log_pubkey(const SolPubkey * arg1) {
+  sol_log_pubkey_pointer_type sol_log_pubkey_pointer = (sol_log_pubkey_pointer_type) 2129692874;
+  sol_log_pubkey_pointer(arg1);
+}
+#endif
+
+/**
+ * Compares two public keys
+ *
+ * @param one First public key
+ * @param two Second public key
+ * @return true if the same
+ */
+static bool SolPubkey_same(const SolPubkey *one, const SolPubkey *two) {
+  for (int i = 0; i < sizeof(*one); i++) {
+    if (one->x[i] != two->x[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Seed used to create a program address or passed to sol_invoke_signed
+ */
+typedef struct {
+  const uint8_t *addr; /** Seed bytes */
+  uint64_t len; /** Length of the seed bytes */
+} SolSignerSeed;
+
+/**
+ * Seeds used by a signer to create a program address or passed to
+ * sol_invoke_signed
+ */
+typedef struct {
+  const SolSignerSeed *addr; /** An array of a signer's seeds */
+  uint64_t len; /** Number of seeds */
+} SolSignerSeeds;
+
+/**
+ * Create a program address
+ *
+ * @param seeds Seed bytes used to sign program accounts
+ * @param seeds_len Length of the seeds array
+ * @param program_id Program id of the signer
+ * @param program_address Program address created, filled on return
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/pubkey.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+uint64_t sol_create_program_address(const SolSignerSeed *, int, const SolPubkey *, SolPubkey *);
+#else
+typedef uint64_t(*sol_create_program_address_pointer_type)(const SolSignerSeed *, int, const SolPubkey *, SolPubkey *);
+static uint64_t sol_create_program_address(const SolSignerSeed * arg1, int arg2, const SolPubkey * arg3, SolPubkey * arg4) {
+  sol_create_program_address_pointer_type sol_create_program_address_pointer = (sol_create_program_address_pointer_type) 2474062396;
+  return sol_create_program_address_pointer(arg1, arg2, arg3, arg4);
+}
+#endif
+
+/**
+ * Try to find a program address and return corresponding bump seed
+ *
+ * @param seeds Seed bytes used to sign program accounts
+ * @param seeds_len Length of the seeds array
+ * @param program_id Program id of the signer
+ * @param program_address Program address created, filled on return
+ * @param bump_seed Bump seed required to create a valid program address
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/pubkey.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+uint64_t sol_try_find_program_address(const SolSignerSeed *, int, const SolPubkey *, SolPubkey *, uint8_t *);
+#else
+typedef uint64_t(*sol_try_find_program_address_pointer_type)(const SolSignerSeed *, int, const SolPubkey *, SolPubkey *, uint8_t *);
+static uint64_t sol_try_find_program_address(const SolSignerSeed * arg1, int arg2, const SolPubkey * arg3, SolPubkey * arg4, uint8_t * arg5) {
+  sol_try_find_program_address_pointer_type sol_try_find_program_address_pointer = (sol_try_find_program_address_pointer_type) 1213221432;
+  return sol_try_find_program_address_pointer(arg1, arg2, arg3, arg4, arg5);
+}
+#endif
+
+#ifdef SOL_TEST
+/**
+ * Stub functions when building tests
+ */
+#include <stdio.h>
+
+void sol_log_pubkey(
+  const SolPubkey *pubkey
+) {
+  printf("Program log: ");
+  for (int i = 0; i < SIZE_PUBKEY; i++) {
+    printf("%02 ", pubkey->x[i]);
+  }
+  printf("\n");
+}
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/return_data.h
+++ b/programs/sbf/c/inc/sol/return_data.h
@@ -1,0 +1,59 @@
+#pragma once
+/**
+ * @brief Solana return data system calls
+**/
+
+#include <sol/types.h>
+#include <sol/pubkey.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * Maximum size of return data
+ */
+#define MAX_RETURN_DATA 1024
+
+/**
+ * Set the return data
+ *
+ * @param bytes byte array to set
+ * @param bytes_len length of byte array. This may not exceed MAX_RETURN_DATA.
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/return_data.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+void sol_set_return_data(const uint8_t *, uint64_t);
+#else
+typedef void(*sol_set_return_data_pointer_type)(const uint8_t *, uint64_t);
+static void sol_set_return_data(const uint8_t * arg1, uint64_t arg2) {
+  sol_set_return_data_pointer_type sol_set_return_data_pointer = (sol_set_return_data_pointer_type) 2720453611;
+  sol_set_return_data_pointer(arg1, arg2);
+}
+#endif
+
+/**
+ * Get the return data
+ *
+ * @param bytes byte buffer
+ * @param bytes_len maximum length of buffer
+ * @param program_id the program_id which set the return data. Only set if there was some return data (the function returns non-zero).
+ * @param result length of return data (may exceed bytes_len if the return data is longer)
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/return_data.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+uint64_t sol_get_return_data(uint8_t *, uint64_t, SolPubkey *);
+#else
+typedef uint64_t(*sol_get_return_data_pointer_type)(uint8_t *, uint64_t, SolPubkey *);
+static uint64_t sol_get_return_data(uint8_t * arg1, uint64_t arg2, SolPubkey * arg3) {
+  sol_get_return_data_pointer_type sol_get_return_data_pointer = (sol_get_return_data_pointer_type) 1562527204;
+  return sol_get_return_data_pointer(arg1, arg2, arg3);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/secp256k1.h
+++ b/programs/sbf/c/inc/sol/secp256k1.h
@@ -1,0 +1,50 @@
+#pragma once
+/**
+ * @brief Solana secp256k1 system call
+ */
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Length of a secp256k1 recover input hash */
+#define SECP256K1_RECOVER_HASH_LENGTH 32
+/** Length of a secp256k1 input signature */
+#define SECP256K1_RECOVER_SIGNATURE_LENGTH 64
+/** Length of a secp256k1 recover result */
+#define SECP256K1_RECOVER_RESULT_LENGTH 64
+
+/** The hash provided to a sol_secp256k1_recover is invalid */
+#define SECP256K1_RECOVER_ERROR_INVALID_HASH 1
+/** The recovery_id provided to a sol_secp256k1_recover is invalid */
+#define SECP256K1_RECOVER_ERROR_INVALID_RECOVERY_ID 2
+/** The signature provided to a sol_secp256k1_recover is invalid */
+#define SECP256K1_RECOVER_ERROR_INVALID_SIGNATURE 3
+
+/**
+ * Recover public key from a signed message.
+ *
+ * @param hash Hashed message
+ * @param recovery_id Tag used for public key recovery from signatures. Can be 0 or 1
+ * @param signature An ECDSA signature
+ * @param result 64 byte array to hold the result. A recovered public key
+ * @return 0 if executed successfully
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/secp256k1.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+uint64_t sol_secp256k1_recover(const uint8_t *, uint64_t, const uint8_t *, uint8_t *);
+#else
+typedef uint64_t(*sol_secp256k1_recover_pointer_type)(const uint8_t *, uint64_t, const uint8_t *, uint8_t *);
+static uint64_t sol_secp256k1_recover(const uint8_t * arg1, uint64_t arg2, const uint8_t * arg3, uint8_t * arg4) {
+  sol_secp256k1_recover_pointer_type sol_secp256k1_recover_pointer = (sol_secp256k1_recover_pointer_type) 400819024;
+  return sol_secp256k1_recover_pointer(arg1, arg2, arg3, arg4);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/sha.h
+++ b/programs/sbf/c/inc/sol/sha.h
@@ -1,0 +1,39 @@
+#pragma once
+/**
+ * @brief Solana sha system call
+ */
+
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Length of a sha256 hash result
+ */
+#define SHA256_RESULT_LENGTH 32
+
+/**
+ * Sha256
+ *
+ * @param bytes Array of byte arrays
+ * @param bytes_len Number of byte arrays
+ * @param result 32 byte array to hold the result
+ */
+/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE platform-tools-sdk/sbf/c/inc/sol/inc/sha.inc AND RUN `cargo run --bin gen-headers` */
+#ifndef SOL_SBPFV3
+uint64_t sol_sha256(const SolBytes *, int, uint8_t *);
+#else
+typedef uint64_t(*sol_sha256_pointer_type)(const SolBytes *, int, uint8_t *);
+static uint64_t sol_sha256(const SolBytes * arg1, int arg2, uint8_t * arg3) {
+  sol_sha256_pointer_type sol_sha256_pointer = (sol_sha256_pointer_type) 301243782;
+  return sol_sha256_pointer(arg1, arg2, arg3);
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/string.h
+++ b/programs/sbf/c/inc/sol/string.h
@@ -1,0 +1,116 @@
+#pragma once
+/**
+ * @brief Solana string and memory system calls and utilities
+ */
+
+#include <sol/constants.h>
+#include <sol/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Copies memory
+ */
+static void *sol_memcpy(void *dst, const void *src, int len) {
+  for (int i = 0; i < len; i++) {
+    *((uint8_t *)dst + i) = *((const uint8_t *)src + i);
+  }
+  return dst;
+}
+
+/**
+ * Compares memory
+ */
+static int sol_memcmp(const void *s1, const void *s2, int n) {
+  for (int i = 0; i < n; i++) {
+    uint8_t diff = *((uint8_t *)s1 + i) - *((const uint8_t *)s2 + i);
+    if (diff) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Fill a byte string with a byte value
+ */
+static void *sol_memset(void *b, int c, size_t len) {
+  uint8_t *a = (uint8_t *) b;
+  while (len > 0) {
+    *a = c;
+    a++;
+    len--;
+  }
+  return b;
+}
+
+/**
+ * Find length of string
+ */
+static size_t sol_strlen(const char *s) {
+  size_t len = 0;
+  while (*s) {
+    len++;
+    s++;
+  }
+  return len;
+}
+
+/**
+ * Alloc zero-initialized memory
+ */
+static void *sol_calloc(size_t nitems, size_t size) {
+  // Bump allocator
+  uint64_t* pos_ptr = (uint64_t*)HEAP_START_ADDRESS;
+
+  uint64_t pos = *pos_ptr;
+  if (pos == 0) {
+      /** First time, set starting position */
+      pos = HEAP_START_ADDRESS + HEAP_LENGTH;
+  }
+
+  uint64_t bytes = (uint64_t)(nitems * size);
+  if (size == 0 ||
+      !(nitems == 0 || size == 0) &&
+      !(nitems == bytes / size)) {
+    /** Overflow */
+    return NULL;
+  }
+  if (pos < bytes) {
+    /** Saturated */
+    pos = 0;
+  } else {
+    pos -= bytes;
+  }
+
+  uint64_t align = size;
+  align--;
+  align |= align >> 1;
+  align |= align >> 2;
+  align |= align >> 4;
+  align |= align >> 8;
+  align |= align >> 16;
+  align |= align >> 32;
+  align++;
+  pos &= ~(align - 1);
+  if (pos < HEAP_START_ADDRESS + sizeof(uint8_t*)) {
+      return NULL;
+  }
+  *pos_ptr = pos;
+  return (void*)pos;
+}
+
+/**
+ * Deallocates the memory previously allocated by sol_calloc
+ */
+static void sol_free(void *ptr) {
+  // I'm a bump allocator, I don't free
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/sol/types.h
+++ b/programs/sbf/c/inc/sol/types.h
@@ -1,0 +1,141 @@
+#pragma once
+/**
+ * @brief Solana types for SBF programs
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Pick up static_assert if C11 or greater
+ *
+ * Inlined here until <assert.h> is available
+ */
+#if (defined _ISOC11_SOURCE || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 201112L)) && !defined (__cplusplus)
+#undef static_assert
+#define static_assert _Static_assert
+#endif
+
+/**
+ * Numeric types
+ */
+#ifndef __LP64__
+#error LP64 data model required
+#endif
+
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef signed short int16_t;
+typedef unsigned short uint16_t;
+typedef signed int int32_t;
+typedef unsigned int uint32_t;
+typedef signed long int int64_t;
+typedef unsigned long int uint64_t;
+typedef int64_t ssize_t;
+typedef uint64_t size_t;
+
+#if defined (__cplusplus) || defined(static_assert)
+static_assert(sizeof(int8_t) == 1);
+static_assert(sizeof(uint8_t) == 1);
+static_assert(sizeof(int16_t) == 2);
+static_assert(sizeof(uint16_t) == 2);
+static_assert(sizeof(int32_t) == 4);
+static_assert(sizeof(uint32_t) == 4);
+static_assert(sizeof(int64_t) == 8);
+static_assert(sizeof(uint64_t) == 8);
+#endif
+
+/**
+ * Minimum of signed integral types
+ */
+#define INT8_MIN   (-128)
+#define INT16_MIN  (-32767-1)
+#define INT32_MIN  (-2147483647-1)
+#define INT64_MIN  (-9223372036854775807L-1)
+
+/**
+ * Maximum of signed integral types
+ */
+#define INT8_MAX   (127)
+#define INT16_MAX  (32767)
+#define INT32_MAX  (2147483647)
+#define INT64_MAX  (9223372036854775807L)
+
+/**
+ * Maximum of unsigned integral types
+ */
+#define UINT8_MAX   (255)
+#define UINT16_MAX  (65535)
+#define UINT32_MAX  (4294967295U)
+#define UINT64_MAX  (18446744073709551615UL)
+
+/**
+ * NULL
+ */
+#define NULL 0
+
+/** Indicates the instruction was processed successfully */
+#define SUCCESS 0
+
+/**
+ * Builtin program status values occupy the upper 32 bits of the program return
+ * value.  Programs may define their own error values but they must be confined
+ * to the lower 32 bits.
+ */
+#define TO_BUILTIN(error) ((uint64_t)(error) << 32)
+
+/** Note: Not applicable to program written in C */
+#define ERROR_CUSTOM_ZERO TO_BUILTIN(1)
+/** The arguments provided to a program instruction where invalid */
+#define ERROR_INVALID_ARGUMENT TO_BUILTIN(2)
+/** An instruction's data contents was invalid */
+#define ERROR_INVALID_INSTRUCTION_DATA TO_BUILTIN(3)
+/** An account's data contents was invalid */
+#define ERROR_INVALID_ACCOUNT_DATA TO_BUILTIN(4)
+/** An account's data was too small */
+#define ERROR_ACCOUNT_DATA_TOO_SMALL TO_BUILTIN(5)
+/** An account's balance was too small to complete the instruction */
+#define ERROR_INSUFFICIENT_FUNDS TO_BUILTIN(6)
+/** The account did not have the expected program id */
+#define ERROR_INCORRECT_PROGRAM_ID TO_BUILTIN(7)
+/** A signature was required but not found */
+#define ERROR_MISSING_REQUIRED_SIGNATURES TO_BUILTIN(8)
+/** An initialize instruction was sent to an account that has already been initialized */
+#define ERROR_ACCOUNT_ALREADY_INITIALIZED TO_BUILTIN(9)
+/** An attempt to operate on an account that hasn't been initialized */
+#define ERROR_UNINITIALIZED_ACCOUNT TO_BUILTIN(10)
+/** The instruction expected additional account keys */
+#define ERROR_NOT_ENOUGH_ACCOUNT_KEYS TO_BUILTIN(11)
+/** Note: Not applicable to program written in C */
+#define ERROR_ACCOUNT_BORROW_FAILED TO_BUILTIN(12)
+/** The length of the seed is too long for address generation */
+#define MAX_SEED_LENGTH_EXCEEDED TO_BUILTIN(13)
+/** Provided seeds do not result in a valid address */
+#define INVALID_SEEDS TO_BUILTIN(14)
+
+/**
+ * Boolean type
+ */
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
+/**
+ * Computes the number of elements in an array
+ */
+#define SOL_ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+
+/**
+ * Byte array pointer and string
+ */
+typedef struct {
+  const uint8_t *addr; /** bytes */
+  uint64_t len; /** number of bytes*/
+} SolBytes;
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/programs/sbf/c/inc/solana_sdk.h
+++ b/programs/sbf/c/inc/solana_sdk.h
@@ -1,0 +1,23 @@
+#pragma once
+/**
+ * @brief Solana C-based SBF program types and utility functions
+ */
+
+#include <sol/assert.h>
+#include <sol/big_mod_exp.h>
+#include <sol/blake3.h>
+#include <sol/compute_units.h>
+#include <sol/cpi.h>
+#include <sol/deserialize.h>
+#include <sol/deserialize_deprecated.h>
+#include <sol/entrypoint.h>
+#include <sol/keccak.h>
+#include <sol/log.h>
+#include <sol/pubkey.h>
+#include <sol/return_data.h>
+#include <sol/secp256k1.h>
+#include <sol/sha.h>
+#include <sol/string.h>
+#include <sol/types.h>
+
+/**@}*/

--- a/programs/sbf/c/inc/stdio.h
+++ b/programs/sbf/c/inc/stdio.h
@@ -1,0 +1,4 @@
+#pragma once
+typedef void *FILE;
+
+int printf(const char * restrictformat, ... );

--- a/programs/sbf/c/inc/stdlib.h
+++ b/programs/sbf/c/inc/stdlib.h
@@ -1,0 +1,2 @@
+#pragma once
+#include <solana_sdk.h>

--- a/programs/sbf/c/inc/string.h
+++ b/programs/sbf/c/inc/string.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <solana_sdk.h>
+
+#define memcpy sol_memcpy
+#define memset sol_memset
+#define strlen sol_strlen

--- a/programs/sbf/c/inc/sys/param.h
+++ b/programs/sbf/c/inc/sys/param.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/programs/sbf/c/inc/wchar.h
+++ b/programs/sbf/c/inc/wchar.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/programs/sbf/c/sbf.ld
+++ b/programs/sbf/c/sbf.ld
@@ -1,0 +1,24 @@
+PHDRS
+{
+  text PT_LOAD  ;
+  rodata PT_LOAD ;
+  data PT_LOAD ;
+  dynamic PT_DYNAMIC ;
+}
+
+SECTIONS
+{
+  . = SIZEOF_HEADERS;
+  .text : { *(.text*) } :text
+  .rodata : { *(.rodata*) } :rodata
+  .data.rel.ro : { *(.data.rel.ro*) } :rodata
+  .dynamic : { *(.dynamic) } :dynamic
+  .dynsym : { *(.dynsym) } :data
+  .dynstr : { *(.dynstr) } :data
+  .rel.dyn : { *(.rel.dyn) } :data
+  /DISCARD/ : {
+      *(.eh_frame*)
+      *(.gnu.hash*)
+      *(.hash*)
+    }
+}

--- a/programs/sbf/c/sbf.mk
+++ b/programs/sbf/c/sbf.mk
@@ -1,0 +1,340 @@
+LOCAL_PATH := $(dir $(lastword $(MAKEFILE_LIST)))
+INSTALL_SH := $(abspath $(LOCAL_PATH)/../install.sh)
+
+all:
+.PHONY: help all clean
+
+ifneq ($(V),1)
+_@ :=@
+endif
+
+TOOLS_VERSION=v1.54
+INC_DIRS ?=
+SRC_DIR ?= ./src
+TEST_PREFIX ?= test_
+OUT_DIR ?= ./out
+SBPF_CPU ?= v0
+OS := $(shell uname)
+
+PLATFORM_TOOLS_FOLDER=$(HOME)/.cache/solana/$(TOOLS_VERSION)/platform-tools
+LLVM_DIR = $(PLATFORM_TOOLS_FOLDER)/llvm
+LLVM_SYSTEM_INC_DIRS := $(LLVM_DIR)/lib/clang/20/include
+
+ifeq "$(SBPF_CPU)" "v1"
+TARGET_NAME := sbpfv1
+else ifeq "$(SBPF_CPU)" "v2"
+TARGET_NAME := sbpfv2
+else
+TARGET_NAME := sbpf
+endif
+
+LLVM_TARGET := $(TARGET_NAME)-solana-solana
+
+COMPILER_RT_DIR = $(PLATFORM_TOOLS_FOLDER)/rust/lib/rustlib/$(LLVM_TARGET)/lib
+STD_INC_DIRS := $(LLVM_DIR)/$(TARGET_NAME)/include
+STD_LIB_DIRS := $(LLVM_DIR)/lib/$(TARGET_NAME)
+ifdef LLVM_DIR
+CC := $(LLVM_DIR)/bin/clang
+CXX := $(LLVM_DIR)/bin/clang++
+LLD := $(LLVM_DIR)/bin/ld.lld
+OBJ_DUMP := $(LLVM_DIR)/bin/llvm-objdump
+READ_ELF := $(LLVM_DIR)/bin/llvm-readelf
+endif
+
+SYSTEM_INC_DIRS := \
+  $(LOCAL_PATH)inc \
+  $(LLVM_SYSTEM_INC_DIRS) \
+
+C_FLAGS := \
+  -Werror \
+  -O2 \
+  -fno-builtin \
+  -std=c17 \
+  $(addprefix -isystem,$(SYSTEM_INC_DIRS)) \
+  $(addprefix -I,$(STD_INC_DIRS)) \
+  $(addprefix -I,$(INC_DIRS)) \
+
+ifeq ($(SOL_SBPFV3),1)
+C_FLAGS := \
+  $(C_FLAGS) \
+  -DSOL_SBPFV3=1
+endif
+
+CXX_FLAGS := \
+  $(C_FLAGS) \
+  -std=c++17 \
+
+SBF_C_FLAGS := \
+  $(C_FLAGS) \
+  -target sbf \
+  -fPIC
+
+SBF_CXX_FLAGS := \
+  $(CXX_FLAGS) \
+  -target sbf \
+  -fPIC \
+  -fomit-frame-pointer \
+  -fno-exceptions \
+  -fno-asynchronous-unwind-tables \
+  -fno-unwind-tables
+
+ifeq "$(SBPF_CPU)" "v1"
+SBF_C_FLAGS := \
+  $(SBF_C_FLAGS) \
+  -mcpu=v1
+
+SBF_CXX_FLAGS := \
+  $(SBF_CXX_FLAGS) \
+  -mcpu=v1
+else ifeq "$(SBPF_CPU)" "v2"
+SBF_C_FLAGS := \
+  $(SBF_C_FLAGS) \
+  -mcpu=v2
+
+SBF_CXX_FLAGS := \
+  $(SBF_CXX_FLAGS) \
+  -mcpu=v2
+endif
+
+SBF_LLD_FLAGS := \
+  -z notext \
+  -shared \
+  --Bdynamic \
+  $(LOCAL_PATH)sbf.ld \
+  --entry entrypoint \
+  -L $(STD_LIB_DIRS) \
+  -z max-page-size=4096 \
+  -lc \
+
+OBJ_DUMP_FLAGS := \
+  --source \
+  --disassemble \
+
+READ_ELF_FLAGS := \
+  --all \
+
+CRITERION_FOLDER=$(HOME)/.cache/solana/v2.3.2/criterion
+TESTFRAMEWORK_RPATH := $(abspath $(CRITERION_FOLDER)/lib)
+TESTFRAMEWORK_FLAGS := \
+  -DSOL_TEST \
+  -isystem $(CRITERION_FOLDER)/include \
+  -L $(CRITERION_FOLDER)/lib \
+  -rpath $(TESTFRAMEWORK_RPATH) \
+  -lcriterion \
+
+MACOS_ADJUST_TEST_DYLIB := \
+$(if $(filter $(OS),Darwin),\
+ $(_@)install_name_tool -change libcriterion.3.dylib $(TESTFRAMEWORK_RPATH)/libcriterion.3.dylib, \
+ : \
+)
+
+TEST_C_FLAGS := \
+  $(C_FLAGS) \
+  $(TESTFRAMEWORK_FLAGS) \
+
+TEST_CXX_FLAGS := \
+  $(CXX_FLAGS) \
+  $(TESTFRAMEWORK_FLAGS) \
+
+help:
+	@echo ''
+	@echo 'Solana VM Program makefile'
+	@echo ''
+	@echo 'This makefile will build Solana Programs from C or C++ source files into ELFs'
+	@echo ''
+	@echo 'Assumptions:'
+	@echo '  - Programs are located in the source directory: $(SRC_DIR)/<program name>'
+	@echo '  - Programs are named by their directory name (eg. directory name:src/foo/ -> program name:foo)'
+	@echo '  - Tests are located in their corresponding program directory and must being with "test_"'
+	@echo '  - Output files will be placed in the directory: $(OUT_DIR)'
+	@echo ''
+	@echo 'User settings'
+	@echo '  - The following setting are overridable on the command line, default values shown:'
+	@echo '    - Show commands while building: V=1'
+	@echo '      V=$(V)'
+	@echo '    - List of include directories:'
+	@echo '      INC_DIRS=$(INC_DIRS)'
+	@echo '    - List of system include directories:'
+	@echo '      SYSTEM_INC_DIRS=$(SYSTEM_INC_DIRS)'
+	@echo '    - List of standard library include directories:'
+	@echo '      STD_INC_DIRS=$(STD_INC_DIRS)'
+	@echo '    - List of standard library archive directories:'
+	@echo '      STD_LIB_DIRS=$(STD_LIB_DIRS)'
+	@echo '    - Location of source directories:'
+	@echo '      SRC_DIR=$(SRC_DIR)'
+	@echo '    - Location to place output files:'
+	@echo '      OUT_DIR=$(OUT_DIR)'
+	@echo '    - Location of LLVM:'
+	@echo '      LLVM_DIR=$(LLVM_DIR)'
+	@echo '    - Version of SBPF (v0, v1 or v2):'
+	@echo '      SBPF_CPU=$(SBPF_CPU)'
+	@echo ''
+	@echo 'Usage:'
+	@echo '  - make help - This help message'
+	@echo '  - make all - Build all the programs and tests, run the tests'
+	@echo '  - make programs - Build all the programs'
+	@echo '  - make tests - Build and run all tests'
+	@echo '  - make dump_<program name> - Dump the contents of the program to stdout'
+	@echo '  - make readelf_<program name> - Display information about the ELF binary'
+	@echo '  - make <program name> - Build a single program by name'
+	@echo '  - make <test name> - Build and run a single test by name'
+	@echo ''
+	@echo 'Available programs:'
+	$(foreach name, $(PROGRAM_NAMES), @echo '  - $(name)'$(\n))
+	@echo ''
+	@echo 'Available tests:'
+	$(foreach name, $(TEST_NAMES), @echo '  - $(name)'$(\n))
+	@echo ''
+	@echo 'Example:'
+	@echo '  - Assuming a program named foo (src/foo/foo.c)'
+	@echo '    - make foo'
+	@echo '    - make dump_foo'
+	@echo ''
+
+define C_RULE
+$1: $2
+	@echo "[cc] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(CC) $(SBF_C_FLAGS) -o $1 -c $2
+endef
+
+define CC_RULE
+$1: $2
+	@echo "[cxx] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(CXX) $(SBF_CXX_FLAGS) -o $1 -c $2
+endef
+
+define D_RULE
+$1: $2 $(LOCAL_PATH)/sbf.mk
+	@echo "[GEN] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(CC) -M -MT '$(basename $1).o' $(SBF_C_FLAGS) $2 | sed 's,\($(basename $1)\)\.o[ :]*,\1.o $1 : ,g' > $1
+endef
+
+define DXX_RULE
+$1: $2 $(LOCAL_PATH)/sbf.mk
+	@echo "[GEN] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(CXX) -M -MT '$(basename $1).o' $(SBF_CXX_FLAGS) $2 | sed 's,\($(basename $1)\)\.o[ :]*,\1.o $1 : ,g' > $1
+endef
+
+define O_RULE
+$1: $2
+	@echo "[llc] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(LLC) $(SBF_LLC_FLAGS) -o $1 $2
+endef
+
+define SO_RULE
+$1: $2
+	@echo "[lld] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(LLD) $(SBF_LLD_FLAGS) -o $1 $2 $(COMPILER_RT_DIR)/libcompiler_builtins-*.rlib
+ifeq (,$(wildcard $(subst .so,-keypair.json,$1)))
+	$(_@)solana-keygen new --no-passphrase --silent -o $(subst .so,-keypair.json,$1)
+endif
+	@echo To deploy this program:
+	@echo $$$$ solana program deploy $(abspath $1)
+endef
+
+define TEST_C_RULE
+$1: $2
+	@echo "[test cc] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(CC) $(TEST_C_FLAGS) -o $1 $2
+	$(_@)$(MACOS_ADJUST_TEST_DYLIB) $1
+endef
+
+define TEST_CC_RULE
+$1: $2
+	@echo "[test cxx] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(CXX) $(TEST_CXX_FLAGS) -o $1 $2
+	$(_@)$(MACOS_ADJUST_TEST_DYLIB) $1
+endef
+
+define TEST_D_RULE
+$1: $2 $(LOCAL_PATH)/sbf.mk
+	@echo "[GEN] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(CC) -M -MT '$(basename $1)' $(TEST_C_FLAGS) $2 | sed 's,\($(basename $1)\)[ :]*,\1 $1 : ,g' > $1
+endef
+
+define TEST_DXX_RULE
+$1: $2 $(LOCAL_PATH)/sbf.mk
+	@echo "[GEN] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(CXX) -M -MT '$(basename $1)' $(TEST_CXX_FLAGS) $2 | sed 's,\($(basename $1)\)[ :]*,\1 $1 : ,g' > $1
+endef
+
+define TEST_EXEC_RULE
+$1: $2
+	LD_LIBRARY_PATH=$(TESTFRAMEWORK_RPATH) \
+	$2$(\n)
+endef
+
+.PHONY: $(INSTALL_SH)
+$(INSTALL_SH):
+	$(_@)$(INSTALL_SH)
+
+PROGRAM_NAMES := $(notdir $(basename $(wildcard $(SRC_DIR)/*)))
+
+define \n
+
+
+endef
+
+all: programs tests
+
+$(foreach PROGRAM, $(PROGRAM_NAMES), \
+  $(eval -include $(wildcard $(OUT_DIR)/$(PROGRAM)/*.d)) \
+  \
+  $(eval $(PROGRAM): %: $(addprefix $(OUT_DIR)/, %.so)) \
+  $(eval $(PROGRAM)_SRCS := \
+    $(addprefix $(SRC_DIR)/$(PROGRAM)/, \
+    $(filter-out $(TEST_PREFIX)%,$(notdir $(wildcard $(SRC_DIR)/$(PROGRAM)/*.c $(SRC_DIR)/$(PROGRAM)/*.cc))))) \
+  $(eval $(PROGRAM)_OBJS := $(subst $(SRC_DIR), $(OUT_DIR), \
+    $(patsubst %.c,%.o, \
+    $(patsubst %.cc,%.o,$($(PROGRAM)_SRCS))))) \
+	$(eval $($(PROGRAM)_SRCS): $(INSTALL_SH)) \
+  $(eval $(call SO_RULE,$(OUT_DIR)/$(PROGRAM).so,$($(PROGRAM)_OBJS))) \
+  $(foreach _,$(filter %.c,$($(PROGRAM)_SRCS)), \
+    $(eval $(call D_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.c=%.d)),$_)) \
+    $(eval $(call C_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.c=%.o)),$_))) \
+  $(foreach _,$(filter %.cc,$($(PROGRAM)_SRCS)), \
+    $(eval $(call DXX_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.cc=%.d)),$_)) \
+    $(eval $(call CC_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.cc=%.o)),$_))) \
+  \
+  $(eval TESTS := $(notdir $(basename $(wildcard $(SRC_DIR)/$(PROGRAM)/$(TEST_PREFIX)*.c)))) \
+  $(eval $(TESTS) : %: $(addprefix $(OUT_DIR)/$(PROGRAM)/, %)) \
+  $(eval TEST_NAMES := $(TEST_NAMES) $(TESTS)) \
+  $(foreach TEST, $(TESTS), \
+    $(eval $(TEST)_SRCS := \
+      $(addprefix $(SRC_DIR)/$(PROGRAM)/, \
+      $(notdir $(wildcard $(SRC_DIR)/$(PROGRAM)/$(TEST).c $(SRC_DIR)/$(PROGRAM)/$(TEST).cc)))) \
+		$(eval $($(TEST)_SRCS): $(INSTALL_SH)) \
+    $(foreach _,$(filter %.c,$($(TEST)_SRCS)), \
+      $(eval $(call TEST_D_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.c=%.d)),$_)) \
+      $(eval $(call TEST_C_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.c=%)),$_))) \
+    $(foreach _,$(filter %.cc, $($(TEST)_SRCS)), \
+      $(eval $(call TEST_DXX_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.cc=%.d)),$_)) \
+      $(eval $(call TEST_CC_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.cc=%)),$_))) \
+    $(eval $(call TEST_EXEC_RULE,$(TEST),$(addprefix $(OUT_DIR)/$(PROGRAM)/, $(TEST)))) \
+   ) \
+)
+
+.PHONY: $(PROGRAM_NAMES)
+programs: $(PROGRAM_NAMES)
+
+.PHONY: $(TEST_NAMES)
+tests: $(TEST_NAMES)
+
+dump_%: %
+	$(_@)$(OBJ_DUMP) $(OBJ_DUMP_FLAGS) $(addprefix $(OUT_DIR)/, $(addsuffix .so, $<))
+
+readelf_%: %
+	$(_@)$(READ_ELF) $(READ_ELF_FLAGS) $(addprefix $(OUT_DIR)/, $(addsuffix .so, $<))
+
+clean:
+	rm -rf $(OUT_DIR)

--- a/programs/sbf/c/sbf.mk
+++ b/programs/sbf/c/sbf.mk
@@ -113,7 +113,14 @@ OBJ_DUMP_FLAGS := \
 READ_ELF_FLAGS := \
   --all \
 
-CRITERION_FOLDER=$(HOME)/.cache/solana/v2.3.2/criterion
+OS := $(shell uname -s)
+ifeq ($(OS),Linux)
+    CRITERION_VERSION=v2.3.3
+else
+    CRITERION_VERSION=v2.3.2
+endif
+
+CRITERION_FOLDER=$(HOME)/.cache/solana/$(CRITERION_VERSION)/criterion
 TESTFRAMEWORK_RPATH := $(abspath $(CRITERION_FOLDER)/lib)
 TESTFRAMEWORK_FLAGS := \
   -DSOL_TEST \

--- a/programs/sbf/install.sh
+++ b/programs/sbf/install.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+
+unameOut="$(uname -s)"
+case "${unameOut}" in
+  Linux*)
+    criterion_suffix=
+    machine=linux;;
+  Darwin*)
+    criterion_suffix=
+    machine=osx;;
+  MINGW*)
+    criterion_suffix=-mingw
+    machine=windows;;
+  *)
+    criterion_suffix=
+    machine=linux
+esac
+unameOut="$(uname -m)"
+case "${unameOut}" in
+  arm64*)
+    arch=aarch64;;
+  *)
+    arch=x86_64
+esac
+
+download() {
+  declare url="$1/$2/$3"
+  declare filename=$3
+  declare wget_args=(
+    "$url" -O "$filename"
+    "--progress=dot:giga"
+    "--retry-connrefused"
+    "--read-timeout=30"
+  )
+  declare curl_args=(
+    -L "$url" -o "$filename"
+  )
+  if hash wget 2>/dev/null; then
+    wget_or_curl="wget ${wget_args[*]}"
+  elif hash curl 2>/dev/null; then
+    wget_or_curl="curl ${curl_args[*]}"
+  else
+    echo "Error: Neither curl nor wget were found" >&2
+    return 1
+  fi
+
+  set -x
+  if $wget_or_curl; then
+    tar --strip-components 1 -jxf "$filename" || return 1
+    { set +x; } 2>/dev/null
+    rm -rf "$filename"
+    return 0
+  fi
+  return 1
+}
+
+get() {
+  declare version=$1
+  declare dirname=$2
+  declare job=$3
+  declare cache_root=~/.cache/solana
+  declare cache_dirname="$cache_root/$version/$dirname"
+  declare cache_partial_dirname="$cache_dirname"_partial
+
+  if [[ -r $cache_dirname ]]; then
+    return 0
+  fi
+
+  rm -rf "$cache_partial_dirname" || return 1
+  mkdir -p "$cache_partial_dirname" || return 1
+  pushd "$cache_partial_dirname"
+
+  if $job; then
+    popd
+    return 0
+  fi
+  popd
+  return 1
+}
+
+# Install Criterion
+if [[ $machine == "linux" ]]; then
+  version=v2.3.3
+else
+  version=v2.3.2
+fi
+if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
+  (
+    set -e
+    rm -rf criterion*
+    job="download \
+           https://github.com/Snaipe/Criterion/releases/download \
+           $version \
+           criterion-$version-$machine$criterion_suffix-x86_64.tar.bz2 \
+           criterion"
+    get $version criterion "$job"
+  )
+  exitcode=$?
+  if [[ $exitcode -ne 0 ]]; then
+    exit 1
+  fi
+fi
+
+# Install platform tools
+tools_version=v1.54
+rust_version=1.89.0
+tools_folder="$HOME"/.cache/solana
+if [[ ! -e platform-tools-$tools_version.md || ! -e platform-tools ]]; then
+  (
+    set -e
+    rm -rf platform-tools*
+    job="download \
+           https://github.com/anza-xyz/platform-tools/releases/download \
+           $tools_version \
+           platform-tools-${machine}-${arch}.tar.bz2 \
+           platform-tools"
+    get $tools_version platform-tools "$job"
+  )
+  exitcode=$?
+  if [[ $exitcode -ne 0 ]]; then
+    exit 1
+  fi
+
+  set -ex
+  rust_folder="${tools_folder}"/"${tools_version}"/platform-tools/rust
+
+  "${rust_folder}"/bin/rustc --version
+  "${rust_folder}"/bin/rustc --print sysroot
+
+  if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+    # MacOS has an outdated version of bash and does not support the safer 'mapfile' alternative
+    toolchains=()
+    while IFS='' read -r line; do toolchains+=("$line"); done < <(rustup toolchain list)
+  else
+    mapfile -t toolchains < <(rustup toolchain list)
+  fi
+
+  set +e
+  for item in "${toolchains[@]}"
+  do
+    if [[ $item == *"solana"* ]]; then
+      rustup toolchain uninstall "$item"
+    fi
+  done
+  set -e
+
+  rustup toolchain link "$rust_version-sbpf-solana-$tools_version" "${rust_folder}"
+fi
+
+exit 0

--- a/programs/sbf/install.sh
+++ b/programs/sbf/install.sh
@@ -72,6 +72,7 @@ get() {
 
   if $job; then
     popd
+    mv "$cache_partial_dirname" "$cache_dirname" || return 1
     return 0
   fi
   popd


### PR DESCRIPTION
#### Problem

We want to move `platform-tools-sdk` out of the monorepo, but the `platform-tools-sdk/sbf` folder is still coupled to CI.

#### Summary of Changes

I copied over the necessary files to build C programs from `platform-tools-sdk/sbf` and adjusted the Makefile and `install.sh` in `programs/sbf` accordingly.

This is an intermediate step until we can have all the files in the separate repository and download them from there for CI.