### PR TITLE
build: upgrade to rts-alloc 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6017,11 +6017,12 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d46bfcacc6e65b67c547e5083ffd549fe80dee8ec337507dd7f01d26763f4"
+checksum = "53ced2d9fa1303e8c6814fe3fceb6599951e17622088df430ed6de039930cb9b"
 dependencies = [
  "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -355,7 +355,7 @@ reqwest = { version = "0.12.28", default-features = false }
 reqwest-middleware = "0.4.2"
 rolling-file = "0.2.0"
 rpassword = "7.4"
-rts-alloc = { version = "2.0.0" }
+rts-alloc = { version = "3.0.0" }
 rustls = { version = "0.23.37", features = ["std"], default-features = false }
 scopeguard = "1.2.0"
 semver = "1.0.27"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -5421,11 +5421,12 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d46bfcacc6e65b67c547e5083ffd549fe80dee8ec337507dd7f01d26763f4"
+checksum = "53ced2d9fa1303e8c6814fe3fceb6599951e17622088df430ed6de039930cb9b"
 dependencies = [
  "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5178,11 +5178,12 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d46bfcacc6e65b67c547e5083ffd549fe80dee8ec337507dd7f01d26763f4"
+checksum = "53ced2d9fa1303e8c6814fe3fceb6599951e17622088df430ed6de039930cb9b"
 dependencies = [
  "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/scheduling-utils/src/handshake/client.rs
+++ b/scheduling-utils/src/handshake/client.rs
@@ -1,7 +1,7 @@
 use {
     crate::handshake::{
         ClientLogon,
-        shared::{GLOBAL_ALLOCATORS, LOGON_FAILURE, MAX_WORKERS, VERSION},
+        shared::{LOGON_FAILURE, MAX_WORKERS, VERSION},
     },
     agave_scheduler_bindings::{
         PackToWorkerMessage, ProgressMessage, TpuToPackMessage, WorkerToPackMessage,
@@ -151,17 +151,7 @@ pub fn setup_session(
 
     // Setup requested allocators.
     let allocators = (0..logon.allocator_handles)
-        .map(|offset| {
-            // NB: Server validates all requested counts are within expected bands so this should
-            // never panic.
-            let id = GLOBAL_ALLOCATORS
-                .checked_add(logon.worker_count)
-                .unwrap()
-                .checked_add(offset)
-                .unwrap();
-
-            unsafe { Allocator::join(allocator_file, u32::try_from(id).unwrap()) }
-        })
+        .map(|_| Allocator::join(allocator_file))
         .collect::<Result<Vec<_>, _>>()?;
 
     // Ensure worker file count matches expectations.

--- a/scheduling-utils/src/handshake/server.rs
+++ b/scheduling-utils/src/handshake/server.rs
@@ -161,13 +161,8 @@ impl Server {
         // Setup the worker sessions.
         let (worker_files, workers) = (0..logon.worker_count).try_fold(
             (Vec::default(), Vec::default()),
-            |(mut fds, mut workers), offset| {
-                // NB: Server validates all requested counts are within expected bands so this
-                // should never panic.
-                let worker_index = GLOBAL_ALLOCATORS.checked_add(offset).unwrap();
-                let worker_index = u32::try_from(worker_index).unwrap();
-                // SAFETY: Worker index is guaranteed to be unique.
-                let allocator = unsafe { Allocator::join(&allocator_file, worker_index) }?;
+            |(mut fds, mut workers), _| {
+                let allocator = Allocator::join(&allocator_file)?;
 
                 let (pack_to_worker_file, pack_to_worker) =
                     Self::create_consumer(logon.pack_to_worker_capacity)?;
@@ -213,13 +208,15 @@ impl Server {
             let allocator_file = Self::create_shmem(huge)?;
             let allocator_file_size = Self::align_file_size(logon.allocator_size, huge);
 
-            Allocator::create(
-                &allocator_file,
-                allocator_file_size,
-                u32::try_from(allocator_count).unwrap(),
-                2 * 1024 * 1024,
-                0,
-            )
+            // SAFETY: We just created this file and thus can uniquely initialize it.
+            unsafe {
+                Allocator::create(
+                    &allocator_file,
+                    allocator_file_size,
+                    u32::try_from(allocator_count).unwrap(),
+                    2 * 1024 * 1024,
+                )
+            }
             .map(|allocator| (allocator_file, allocator))
         };
 


### PR DESCRIPTION
#### Problem

- We need windows support and various features from rts-alloc 3.0.0.

#### Summary of Changes

- Upgrade rts-alloc to 3.0.0.
