### PR TITLE
Moving RPC index scan limit to RPC

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -59,7 +59,6 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndex
     drives: None,
     index_limit: IndexLimit::InMemOnly,
     ages_to_stay_in_cache: None,
-    scan_results_limit_bytes: None,
     num_initial_accounts: None,
 };
 pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIndexConfig {
@@ -68,7 +67,6 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
     drives: None,
     index_limit: IndexLimit::InMemOnly,
     ages_to_stay_in_cache: None,
-    scan_results_limit_bytes: None,
     num_initial_accounts: None,
 };
 pub type ScanResult<T> = Result<T, ScanError>;
@@ -225,7 +223,6 @@ pub struct AccountsIndexConfig {
     pub drives: Option<Vec<PathBuf>>,
     pub index_limit: IndexLimit,
     pub ages_to_stay_in_cache: Option<Age>,
-    pub scan_results_limit_bytes: Option<usize>,
     /// Initial number of accounts, used to pre-allocate HashMap capacity at startup.
     pub num_initial_accounts: Option<usize>,
 }
@@ -238,7 +235,6 @@ impl Default for AccountsIndexConfig {
             drives: None,
             index_limit: IndexLimit::InMemOnly,
             ages_to_stay_in_cache: None,
-            scan_results_limit_bytes: None,
             num_initial_accounts: None,
         }
     }
@@ -318,9 +314,6 @@ pub struct AccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
 
     storage: AccountsIndexStorage<T, U>,
 
-    /// when a scan's accumulated data exceeds this limit, abort the scan
-    pub scan_results_limit_bytes: Option<usize>,
-
     pub purge_older_root_entries_one_slot_list: AtomicUsize,
 
     /// # roots added since last check
@@ -335,7 +328,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     }
 
     pub fn new(config: &AccountsIndexConfig, exit: Arc<AtomicBool>) -> Self {
-        let scan_results_limit_bytes = config.scan_results_limit_bytes;
         let (account_maps, bin_calculator, storage) = Self::allocate_accounts_index(config, exit);
         Self {
             purge_older_root_entries_one_slot_list: AtomicUsize::default(),
@@ -353,7 +345,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             roots_tracker: RwLock::<RootsTracker>::default(),
             scan_tracker: ScanTracker::default(),
             storage,
-            scan_results_limit_bytes,
             roots_added: AtomicUsize::default(),
             roots_removed: AtomicUsize::default(),
         }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -171,6 +171,8 @@ pub struct JsonRpcConfig {
     pub full_api: bool,
     pub rpc_scan_and_fix_roots: bool,
     pub max_request_body_size: Option<usize>,
+    /// If set, abort index scans whose accumulated results exceed this many bytes.
+    pub scan_results_limit_bytes: Option<usize>,
     /// Disable the health check, used for tests and TestValidator
     pub disable_health_check: bool,
 }
@@ -192,6 +194,7 @@ impl Default for JsonRpcConfig {
             full_api: Default::default(),
             rpc_scan_and_fix_roots: Default::default(),
             max_request_body_size: Option::default(),
+            scan_results_limit_bytes: Option::default(),
             disable_health_check: Default::default(),
         }
     }
@@ -310,6 +313,7 @@ impl JsonRpcRequestProcessor {
         let bank = Arc::clone(bank);
         let index_key = index_key.to_owned();
         let program_id = program_id.to_owned();
+        let byte_limit_for_scans = self.config.scan_results_limit_bytes;
         let mut accounts = self
             .runtime
             .spawn_blocking(move || {
@@ -326,7 +330,7 @@ impl JsonRpcRequestProcessor {
                                 .iter()
                                 .all(|filter_type| filter_allows(filter_type, account))
                     },
-                    bank.byte_limit_for_scans(),
+                    byte_limit_for_scans,
                 )
             })
             .await

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1804,14 +1804,6 @@ impl Bank {
             .set_program_runtime_environment(program_runtime_environment);
     }
 
-    pub fn byte_limit_for_scans(&self) -> Option<usize> {
-        self.rc
-            .accounts
-            .accounts_db
-            .accounts_index
-            .scan_results_limit_bytes
-    }
-
     pub fn proper_ancestors_set(&self) -> HashSet<Slot> {
         HashSet::from_iter(self.proper_ancestors())
     }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1018,17 +1018,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
-        Arg::with_name("accounts_index_scan_results_limit_mb")
-            .long("accounts-index-scan-results-limit-mb")
-            .value_name("MEGABYTES")
-            .validator(is_parsable::<usize>)
-            .takes_value(true)
-            .help(
-                "How large accumulated results from an accounts index scan can become. If this is \
-                 exceeded, the scan aborts.",
-            ),
-    )
-    .arg(
         Arg::with_name("accounts_index_bins")
             .long("accounts-index-bins")
             .value_name("BINS")

--- a/validator/src/commands/run/args/json_rpc_config.rs
+++ b/validator/src/commands/run/args/json_rpc_config.rs
@@ -18,6 +18,7 @@ static DEFAULT_RPC_BLOCKING_THREADS: LazyLock<String> =
 const DEFAULT_RPC_NICENESS_ADJ: &str = "0";
 static DEFAULT_RPC_MAX_REQUEST_BODY_SIZE: LazyLock<String> =
     LazyLock::new(|| solana_rpc::rpc::MAX_REQUEST_BODY_SIZE.to_string());
+const MB: usize = 1_024 * 1_024;
 
 impl FromClapArgMatches for JsonRpcConfig {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
@@ -54,6 +55,13 @@ impl FromClapArgMatches for JsonRpcConfig {
             full_api: matches.is_present("full_rpc_api"),
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
             max_request_body_size: Some(value_t!(matches, "rpc_max_request_body_size", usize)?),
+            scan_results_limit_bytes: value_t!(
+                matches,
+                "accounts_index_scan_results_limit_mb",
+                usize
+            )
+            .ok()
+            .map(|mb| mb * MB),
             disable_health_check: false,
         })
     }
@@ -168,6 +176,15 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .validator(is_parsable::<usize>)
             .default_value(&DEFAULT_RPC_MAX_REQUEST_BODY_SIZE)
             .help("The maximum request body size accepted by rpc service"),
+        Arg::with_name("accounts_index_scan_results_limit_mb")
+            .long("accounts-index-scan-results-limit-mb")
+            .value_name("MEGABYTES")
+            .validator(is_parsable::<usize>)
+            .takes_value(true)
+            .help(
+                "How large accumulated results from an accounts index scan can become. If this is \
+                 exceeded, the scan aborts.",
+            ),
     ]
 }
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -618,10 +618,6 @@ pub fn execute(
     }
 
     const MB: usize = 1_024 * 1_024;
-    accounts_index_config.scan_results_limit_bytes =
-        value_t!(matches, "accounts_index_scan_results_limit_mb", usize)
-            .ok()
-            .map(|mb| mb * MB);
 
     let account_shrink_paths: Option<Vec<PathBuf>> =
         values_t!(matches, "account_shrink_path", String)


### PR DESCRIPTION
#### Problem
RPC limit on scan size is parsed from the CLI and then stored in the accounts index. The only user is the RPC library which then passes it down to the accounts_index as a limit for scan size on scans

#### Summary of Changes
- Move it to the RPC_Config


#### Testing

I checked the CLI with this change, and found that the CLI was identical: --accounts-index-scan-results-limit-mb was present with this change, and in the same location in the args list. 



Alternatively it could be used to abort scans in the accounts_index, but that would be an effective change to the API, as the scan_index would effect more RPC methods than it does currently.

Fixes #
