### PR TITLE
tests: program-runtime: harden cpi stack height test

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1085,7 +1085,10 @@ pub fn mock_process_instruction<F: FnMut(&mut InvokeContext), G: FnMut(&mut Invo
 mod tests {
     use {
         super::*,
-        crate::execution_budget::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
+        crate::execution_budget::{
+            DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT, MAX_INSTRUCTION_STACK_DEPTH,
+            MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268,
+        },
         serde::{Deserialize, Serialize},
         solana_account::Account,
         solana_keypair::Keypair,
@@ -1093,6 +1096,7 @@ mod tests {
         solana_sbpf::program::BuiltinFunctionDefinition,
         solana_sdk_ids::system_program,
         solana_signer::Signer,
+        solana_svm_feature_set::SVMFeatureSet,
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         solana_transaction_context::MAX_ACCOUNTS_PER_INSTRUCTION,
         test_case::test_case,
@@ -1218,18 +1222,32 @@ mod tests {
     #[test_case(false; "SIMD-0268 disabled")]
     #[test_case(true; "SIMD-0268 enabled")]
     fn test_instruction_stack_height(simd_0268_active: bool) {
-        let one_more_than_max_depth =
-            SVMTransactionExecutionBudget::new_with_defaults(simd_0268_active)
-                .max_instruction_stack_depth
-                .saturating_add(1);
+        let feature_set = &SVMFeatureSet {
+            raise_cpi_nesting_limit_to_8: simd_0268_active,
+            ..SVMFeatureSet::all_enabled()
+        };
+        let max_depth = SVMTransactionExecutionBudget::new_with_defaults(simd_0268_active)
+            .max_instruction_stack_depth;
+        assert_eq!(
+            max_depth,
+            if simd_0268_active {
+                MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268
+            } else {
+                MAX_INSTRUCTION_STACK_DEPTH
+            },
+        );
+
+        // Set up max_depth + 1 accounts (one extra to trigger the failing push)
+        // and a matching program account for each.
         let mut invoke_stack = vec![];
         let mut transaction_accounts = vec![];
         let mut instruction_accounts = vec![];
-        for index in 0..one_more_than_max_depth {
-            invoke_stack.push(solana_pubkey::new_rand());
+        for index in 0..max_depth.saturating_add(1) {
+            let program_id = solana_pubkey::new_rand();
+            invoke_stack.push(program_id);
             transaction_accounts.push((
                 solana_pubkey::new_rand(),
-                AccountSharedData::new(index as u64, 1, invoke_stack.get(index).unwrap()),
+                AccountSharedData::new(1, 1, &program_id),
             ));
             instruction_accounts.push(InstructionAccount::new(
                 index as IndexOfAccount,
@@ -1237,6 +1255,10 @@ mod tests {
                 true,
             ));
         }
+
+        // Append program accounts after the regular accounts so that
+        // `first_program_account + depth` indexes the right program.
+        let first_program_account = transaction_accounts.len();
         for (index, program_id) in invoke_stack.iter().enumerate() {
             transaction_accounts.push((
                 *program_id,
@@ -1248,26 +1270,44 @@ mod tests {
                 false,
             ));
         }
-        with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
+        with_mock_invoke_context_with_feature_set!(
+            invoke_context,
+            transaction_context,
+            feature_set,
+            transaction_accounts,
+        );
 
-        // Check call depth increases and has a limit
-        let mut depth_reached: usize = 0;
-        for _ in 0..invoke_stack.len() {
+        // Each push must succeed and the stack height must track.
+        for depth in 0..max_depth {
+            assert_eq!(invoke_context.get_stack_height(), depth);
             invoke_context
                 .transaction_context
                 .configure_top_level_instruction_for_tests(
-                    one_more_than_max_depth.saturating_add(depth_reached) as IndexOfAccount,
+                    (first_program_account.saturating_add(depth)) as IndexOfAccount,
                     instruction_accounts.clone(),
                     vec![],
                 )
                 .unwrap();
-            if Err(InstructionError::CallDepth) == invoke_context.push() {
-                break;
-            }
-            depth_reached = depth_reached.saturating_add(1);
+            assert!(
+                invoke_context.push().is_ok(),
+                "push at depth {depth} should succeed (max_depth={max_depth})",
+            );
         }
-        assert_ne!(depth_reached, 0);
-        assert!(depth_reached < one_more_than_max_depth);
+
+        // At exactly max_depth, one more push must fail with CallDepth.
+        assert_eq!(invoke_context.get_stack_height(), max_depth);
+        invoke_context
+            .transaction_context
+            .configure_top_level_instruction_for_tests(
+                (first_program_account.saturating_add(max_depth)) as IndexOfAccount,
+                instruction_accounts.clone(),
+                vec![],
+            )
+            .unwrap();
+        assert_eq!(invoke_context.push(), Err(InstructionError::CallDepth),);
+
+        // Stack height must not have changed after the rejected push.
+        assert_eq!(invoke_context.get_stack_height(), max_depth);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
This test for CPI stack height is broken for SIMD-0268 coverage.

Make this change to the test:

```diff
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1266,8 +1266,7 @@ mod tests {
             }
             depth_reached = depth_reached.saturating_add(1);
         }
-        assert_ne!(depth_reached, 0);
-        assert!(depth_reached < one_more_than_max_depth);
+        assert_eq!(depth_reached, one_more_than_max_depth.saturating_sub(1));
     }
```

Get:

```
running 2 tests
test invoke_context::tests::test_instruction_stack_height::simd_0268_disabled ... ok
test invoke_context::tests::test_instruction_stack_height::simd_0268_enabled ... FAILED

failures:

---- invoke_context::tests::test_instruction_stack_height::simd_0268_enabled stdout ----

thread 'invoke_context::tests::test_instruction_stack_height::simd_0268_enabled' (2206831) panicked at program-runtime/src/invoke_context.rs:1269:9:
assertion `left == right` failed
  left: 5
 right: 9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

#### Summary of Changes
Fix the test, and also harden it to use more precise values and be a little clearer to follow.

Now that the test uses two dedicated loops - one for allowed frames and one for the violation - the assertion provided above is implicitly part of the test.