### PR TITLE
program-runtime: size VmMemoryPool to SIMD-0268 max depth (9)

### DIFF
--- a/program-runtime/src/mem_pool.rs
+++ b/program-runtime/src/mem_pool.rs
@@ -1,7 +1,7 @@
 use {
     crate::execution_budget::{
-        MAX_CALL_DEPTH, MAX_HEAP_FRAME_BYTES, MAX_INSTRUCTION_STACK_DEPTH, MIN_HEAP_FRAME_BYTES,
-        STACK_FRAME_SIZE,
+        MAX_CALL_DEPTH, MAX_HEAP_FRAME_BYTES, MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268,
+        MIN_HEAP_FRAME_BYTES, STACK_FRAME_SIZE,
     },
     solana_sbpf::{aligned_memory::AlignedMemory, ebpf::HOST_ALIGN},
     std::array,
@@ -58,8 +58,8 @@ impl Reset for AlignedMemory<{ HOST_ALIGN }> {
 }
 
 pub struct VmMemoryPool {
-    stack: Pool<AlignedMemory<{ HOST_ALIGN }>, MAX_INSTRUCTION_STACK_DEPTH>,
-    heap: Pool<AlignedMemory<{ HOST_ALIGN }>, MAX_INSTRUCTION_STACK_DEPTH>,
+    stack: Pool<AlignedMemory<{ HOST_ALIGN }>, MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268>,
+    heap: Pool<AlignedMemory<{ HOST_ALIGN }>, MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268>,
 }
 
 impl VmMemoryPool {

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -4,7 +4,7 @@
 use qualifier_attr::qualifiers;
 use {
     crate::{
-        execution_budget::MAX_INSTRUCTION_STACK_DEPTH,
+        execution_budget::MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268,
         invoke_context::{BpfAllocator, InvokeContext, SerializedAccountMetadata, SyscallContext},
         loaded_programs::ProgramCacheEntry,
         mem_pool::VmMemoryPool,
@@ -267,8 +267,8 @@ pub fn execute<'a, 'b: 'a>(
         MEMORY_POOL.with_borrow_mut(|memory_pool| {
             memory_pool.put_stack(stack);
             memory_pool.put_heap(heap);
-            debug_assert!(memory_pool.stack_len() <= MAX_INSTRUCTION_STACK_DEPTH);
-            debug_assert!(memory_pool.heap_len() <= MAX_INSTRUCTION_STACK_DEPTH);
+            debug_assert!(memory_pool.stack_len() <= MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268);
+            debug_assert!(memory_pool.heap_len() <= MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268);
         });
         drop(vm);
         invoke_context.insert_register_trace(register_trace);


### PR DESCRIPTION
#### Problem
When SIMD-0268 is activated (in Agave 4.1), we want the VM memory pool to be allocating enough for the maximum possible stack size. We can't gate this static pool on a runtime feature gate, so we felt it was best to just increase the pool size in the 4.1 release by default.

Since this is an implementation detail specific to Agave, there's no need for a re-key of SIMD-0268 and we are also not considering backporting to 4.0 at this time.

#### Summary of Changes
Update the `VmMemoryPool` to allocate space for 9 instruction stack frames instead of 5, to prepare for SIMD-0268.