### PR TITLE
BlsSigverifier: Collects metrics for when we try to ban a pubkey that is already banned

### DIFF
--- a/core/src/bls_sigverify/bls_cert_sigverify.rs
+++ b/core/src/bls_sigverify/bls_cert_sigverify.rs
@@ -118,7 +118,9 @@ fn verify_certs(
                 Some(ConsensusMessage::Certificate(cert))
             }
             Err(e) => {
-                banlist.ban(cert_payload.remote_pubkey, BAN_TIMEOUT);
+                if banlist.ban(cert_payload.remote_pubkey, BAN_TIMEOUT) {
+                    stats.already_banned += 1;
+                }
 
                 match e {
                     CertVerifyError::NotEnoughStake { .. } => {

--- a/core/src/bls_sigverify/bls_vote_sigverify.rs
+++ b/core/src/bls_sigverify/bls_vote_sigverify.rs
@@ -192,7 +192,9 @@ fn verify_votes(
     let ((verified_votes, invalid_remote_pubkeys), time_us) =
         measure_us!(verify_individual_votes(votes_to_verify, thread_pool));
     for remote_pubkey in invalid_remote_pubkeys {
-        banlist.ban(remote_pubkey, BAN_TIMEOUT);
+        if banlist.ban(remote_pubkey, BAN_TIMEOUT) {
+            stats.already_banned += 1;
+        };
     }
     stats.fn_verify_individual_votes_stats.add_sample(time_us);
 

--- a/core/src/bls_sigverify/stats.rs
+++ b/core/src/bls_sigverify/stats.rs
@@ -183,6 +183,8 @@ pub(super) struct SigVerifyCertStats {
     /// Number of certs that were verified unnecessarily because another cert of the same
     /// `CertificateType` was already verified.
     pub(super) unnecessary_certs_verified: u64,
+    /// Number of times we are banning a validator that was already banned.
+    pub(super) already_banned: u64,
 
     /// Number of times stake verification failed on a cert.
     pub(super) stake_verification_failed: u64,
@@ -206,6 +208,7 @@ impl SigVerifyCertStats {
             certs_to_sig_verify,
             sig_verified_certs,
             unnecessary_certs_verified,
+            already_banned,
             stake_verification_failed,
             signature_verification_failed,
             too_far_in_future,
@@ -216,6 +219,7 @@ impl SigVerifyCertStats {
         self.certs_to_sig_verify += certs_to_sig_verify;
         self.sig_verified_certs += sig_verified_certs;
         self.unnecessary_certs_verified += unnecessary_certs_verified;
+        self.already_banned += already_banned;
         self.stake_verification_failed += stake_verification_failed;
         self.signature_verification_failed += signature_verification_failed;
         self.too_far_in_future += too_far_in_future;
@@ -230,6 +234,7 @@ impl SigVerifyCertStats {
             certs_to_sig_verify,
             sig_verified_certs,
             unnecessary_certs_verified,
+            already_banned,
             stake_verification_failed,
             signature_verification_failed,
             too_far_in_future,
@@ -246,6 +251,7 @@ impl SigVerifyCertStats {
                 *unnecessary_certs_verified,
                 i64
             ),
+            ("already_banned", *already_banned, i64),
             ("stake_verification_failed", *stake_verification_failed, i64),
             (
                 "signature_verification_failed",
@@ -280,6 +286,8 @@ pub(super) struct SigVerifyVoteStats {
 
     /// Number of times the cert was too far in the future and discarded.
     pub(super) too_far_in_future: u64,
+    /// Number of times we are banning a validator that was already banned.
+    pub(super) already_banned: u64,
 
     /// Number of votes sent successfully over the channel to metrics.
     pub(super) metrics_sent: u64,
@@ -315,6 +323,7 @@ impl SigVerifyVoteStats {
             votes_to_sig_verify,
             sig_verified_votes,
             too_far_in_future,
+            already_banned,
             metrics_sent,
             metrics_channel_full,
             rewards_sent,
@@ -331,6 +340,7 @@ impl SigVerifyVoteStats {
         self.votes_to_sig_verify += votes_to_sig_verify;
         self.sig_verified_votes += sig_verified_votes;
         self.too_far_in_future += too_far_in_future;
+        self.already_banned += already_banned;
         self.metrics_sent += metrics_sent;
         self.metrics_channel_full += metrics_channel_full;
         self.rewards_sent += rewards_sent;
@@ -353,6 +363,7 @@ impl SigVerifyVoteStats {
             votes_to_sig_verify,
             sig_verified_votes,
             too_far_in_future,
+            already_banned,
             metrics_sent,
             metrics_channel_full,
             rewards_sent,
@@ -371,6 +382,7 @@ impl SigVerifyVoteStats {
             ("votes_to_sig_verify", *votes_to_sig_verify, i64),
             ("sig_verified_votes", *sig_verified_votes, i64),
             ("too_far_in_future", *too_far_in_future, i64),
+            ("already_banned", *already_banned, i64),
             ("metrics_sent", *metrics_sent, i64),
             ("metrics_channel_full", *metrics_channel_full, i64),
             ("rewards_sent", *rewards_sent, i64),

--- a/net-utils/src/banlist.rs
+++ b/net-utils/src/banlist.rs
@@ -14,13 +14,17 @@ pub struct Banlist<T> {
 
 impl<T: Eq + Hash> Banlist<T> {
     /// Ban the `id` for the specified `timeout`
-    pub fn ban(&self, id: T, timeout: Duration) {
+    ///
+    /// Returns `true` if the `id` was already banned else `false`.
+    pub fn ban(&self, id: T, timeout: Duration) -> bool {
         debug_assert!(!timeout.is_zero());
+        debug_assert!(Instant::now().checked_add(timeout).is_some());
         let Some(expires_at) = Instant::now().checked_add(timeout) else {
-            return;
+            return false;
         };
         let prev = self.banned.write().unwrap().insert(id, expires_at);
         debug_assert!(prev < Some(expires_at));
+        prev.is_some()
     }
 
     /// Check if `id` is banned using the current time.

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -63,8 +63,11 @@ impl SimpleQosBanlist {
         )
     }
 
-    pub fn ban(&self, pubkey: Pubkey, timeout: Duration) {
-        self.banlist.ban(pubkey, timeout);
+    /// Ban the `pubkey` for the specified `timeout`
+    ///
+    /// Returns `true` if the `id` was already banned else `false`.
+    pub fn ban(&self, pubkey: Pubkey, timeout: Duration) -> bool {
+        let ret = self.banlist.ban(pubkey, timeout);
         match self.eviction_sender.try_send(pubkey) {
             Ok(()) => {}
             Err(TrySendError::Full(pubkey)) => {
@@ -80,6 +83,7 @@ impl SimpleQosBanlist {
                 );
             }
         }
+        ret
     }
 
     pub fn is_banned(&self, pubkey: &Pubkey) -> bool {


### PR DESCRIPTION
#### Problem

When verifying a vote or a cert fails, the validator bans the sender.  However, it may have already received messages from the banned sender that it will still process.  This could be a hypothetical problem.  We do not know to what extend this could be a problem though.

#### Summary of Changes

This PR adds metrics where we count how often we banned an already banned sender.  This metrics can be used to gauge the severity of the problem and then we can figure out if we need to come up with solutions to address the problem.
