### PR TITLE
ci: sanitize input and fix bot-conditions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -9,7 +9,7 @@ jobs:
   dependabot:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
-    if: github.triggering_actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: checkout
         uses: actions/checkout@v6
@@ -18,8 +18,10 @@ jobs:
           token: ${{ secrets.PAT }}
 
       - name: update code
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          input="${{ github.event.pull_request.title }}"
+          input="$PR_TITLE"
 
           regex='[Bb]ump (.+) from ([^ ]+) to ([^ ]+)( in .*)?'
           if [[ ! "$input" =~ $regex ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,16 @@ jobs:
     steps:
       - name: Create Release
         uses: actions/github-script@v8
+        env:
+          REF_NAME: ${{ github.ref_name }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: '${{ github.ref_name }}',
-              name: 'Release ${{ github.ref_name }}',
+              tag_name: process.env.REF_NAME,
+              name: `Release ${process.env.REF_NAME}`,
               body: '🚧',
               draft: false,
               prerelease: true
@@ -66,6 +68,8 @@ jobs:
 
       - name: Process
         id: process
+        env:
+          BASE_REF: ${{ github.event.base_ref }}
         run: |
           xtask bump-version patch-or-pre-release
 
@@ -77,19 +81,21 @@ jobs:
 
           echo "new_version=$new_version" | tee -a $GITHUB_OUTPUT
 
-          base_ref="${{ github.event.base_ref }}"
-          target_branch="${base_ref##*/}"
+          target_branch="${BASE_REF##*/}"
           echo "target_branch=$target_branch" | tee -a $GITHUB_OUTPUT
 
       - name: Create PR
         uses: actions/github-script@v8
+        env:
+          NEW_VERSION: ${{ steps.process.outputs.new_version }}
+          TARGET_BRANCH: ${{ steps.process.outputs.target_branch }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'Bump version to ${{ steps.process.outputs.new_version }}',
-              head: 'version-bump-${{ steps.process.outputs.new_version }}',
-              base: '${{ steps.process.outputs.target_branch }}'
+              title: `Bump version to ${process.env.NEW_VERSION}`,
+              head: `version-bump-${process.env.NEW_VERSION}`,
+              base: process.env.TARGET_BRANCH
             })


### PR DESCRIPTION
#### Problem

Move untrusted context values out of inline scripts and into `env:` blocks so they are treated as data rather than code.

#### Summary of Changes

**dependabot-pr.yml**
- Replace `github.triggering_actor` with `github.event.pull_request.user.login` so the bot check is bound to the PR author and cannot be bypassed by re-running the workflow as a different actor
- Sanitize `github.event.pull_request.title` by passing it through `env:` instead of interpolating it directly into the shell script

**release.yml**
- Sanitize `github.ref_name`, `github.event.base_ref`, and `steps.process.outputs.*` by passing them through `env:` and reading via `process.env` / shell variables instead of inline `${{ }}` expansion
