### PR TITLE
Fix - equality and identity checks in `TransactionBatchProcessor::set_program_runtime_environment()`

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1253,6 +1253,7 @@ mod tests {
             loaded_programs::{BlockRelation, ProgramCacheEntryType},
         },
         solana_rent::Rent,
+        solana_sbpf::vm,
         solana_sdk_ids::{bpf_loader, loader_v4, system_program, sysvar},
         solana_signature::Signature,
         solana_svm_callback::{AccountState, InvokeContextCallback},
@@ -2670,6 +2671,57 @@ mod tests {
         assert_eq!(
             actual_inspected_accounts.as_slice(),
             &[(fee_payer_address, vec![(Some(fee_payer_account), true)])],
+        );
+    }
+
+    #[test]
+    fn test_set_program_runtime_environment() {
+        let mut transaction_processor = TransactionBatchProcessor::<TestForkGraph>::default();
+        let current_environment =
+            ProgramRuntimeEnvironment::clone(&transaction_processor.program_runtime_environment);
+        let new_environment = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
+        let config = vm::Config {
+            enable_symbol_and_section_labels: true,
+            ..vm::Config::default()
+        };
+        let new_environment2 = ProgramRuntimeEnvironment::from(BuiltinProgram::new_loader(config));
+        assert_ne!(current_environment, new_environment);
+        assert_ne!(current_environment, new_environment2);
+        assert_ne!(new_environment, new_environment2);
+        // Assign an equal and identical environment: No changes
+        transaction_processor.set_program_runtime_environment(ProgramRuntimeEnvironment::clone(
+            &current_environment,
+        ));
+        assert_eq!(
+            transaction_processor.program_runtime_environment,
+            current_environment,
+        );
+        // Assign an equal but not identical environment: No changes
+        transaction_processor
+            .set_program_runtime_environment(ProgramRuntimeEnvironment::clone(&new_environment));
+        assert_eq!(
+            transaction_processor.program_runtime_environment,
+            current_environment,
+        );
+        // Assign a different and not identical environment: Overwritten
+        transaction_processor
+            .set_program_runtime_environment(ProgramRuntimeEnvironment::clone(&new_environment2));
+        assert_eq!(
+            transaction_processor.program_runtime_environment,
+            new_environment2,
+        );
+        // Assign an environment which is equal to the upcoming_environment: Overwritten
+        transaction_processor
+            .epoch_boundary_preparation
+            .write()
+            .unwrap()
+            .upcoming_environment = Some(ProgramRuntimeEnvironment::clone(&new_environment));
+        transaction_processor.set_program_runtime_environment(ProgramRuntimeEnvironment::clone(
+            &current_environment,
+        ));
+        assert_eq!(
+            transaction_processor.program_runtime_environment,
+            new_environment,
         );
     }
 }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -345,19 +345,20 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
     /// Updates the environments when entering a new Epoch.
     pub fn set_program_runtime_environment(&mut self, new_environment: ProgramRuntimeEnvironment) {
-        // First update the parts of the environments which changed
-        if self.program_runtime_environment != new_environment {
+        // First update the environment only if it is different
+        if *self.program_runtime_environment != *new_environment {
             self.program_runtime_environment = new_environment;
         }
-        // Then try to consolidate with the upcoming environments (to reuse their address)
+        // Then try to consolidate with the upcoming environment (to reuse the address)
         if let Some(upcoming_environment) = &self
             .epoch_boundary_preparation
             .read()
             .unwrap()
             .upcoming_environment
-            && &self.program_runtime_environment == upcoming_environment
-            && &self.program_runtime_environment != upcoming_environment
+            && *self.program_runtime_environment == **upcoming_environment
+            && self.program_runtime_environment != *upcoming_environment
         {
+            // Use the prediction if equal but not identical
             self.program_runtime_environment = upcoming_environment.clone();
         }
     }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -355,11 +355,14 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .read()
             .unwrap()
             .upcoming_environment
-            && *self.program_runtime_environment == **upcoming_environment
-            && self.program_runtime_environment != *upcoming_environment
         {
-            // Use the prediction if equal but not identical
-            self.program_runtime_environment = upcoming_environment.clone();
+            let upcoming_environment = ProgramRuntimeEnvironment::clone(upcoming_environment);
+            if self.program_runtime_environment != upcoming_environment
+                && *self.program_runtime_environment == *upcoming_environment
+            {
+                // Use the prediction if equal but not identical
+                self.program_runtime_environment = upcoming_environment;
+            }
         }
     }
 


### PR DESCRIPTION
#### Problem

#11257 accidentally messed up a performance optimization which should have deduplicate equivalient environments but instead kept producing a new one for every epoch.

#### Summary of Changes

Reverts the logic back in https://github.com/anza-xyz/agave/pull/11257/changes#diff-9cdf3f551fba4b8b92dbdd58af9c878564da6720db0beffd6e64ec3f36de375aL332.