### PR TITLE
support scheduler bindings for windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
  "libc",
  "nix",
  "rts-alloc",
+ "sha2 0.10.9",
  "shaq",
  "slotmap",
  "solana-fee",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "wincode",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "solana-pubkey 4.1.0",
  "solana-transaction-error",
  "thiserror 2.0.18",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "solana-pubkey 4.1.0",
  "solana-transaction-error",
  "thiserror 2.0.18",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/scheduling-utils/Cargo.toml
+++ b/scheduling-utils/Cargo.toml
@@ -32,6 +32,13 @@ wincode = { workspace = true, optional = true }
 libc = { workspace = true }
 nix = { workspace = true, features = ["socket", "uio"] }
 
+[target."cfg(windows)".dependencies]
+windows-sys = { version = "0.59.0", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Pipes",
+] }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/scheduling-utils/Cargo.toml
+++ b/scheduling-utils/Cargo.toml
@@ -33,6 +33,7 @@ libc = { workspace = true }
 nix = { workspace = true, features = ["socket", "uio"] }
 
 [target."cfg(windows)".dependencies]
+sha2 = { workspace = true }
 windows-sys = { version = "0.59.0", features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",

--- a/scheduling-utils/src/handshake/client.rs
+++ b/scheduling-utils/src/handshake/client.rs
@@ -1,14 +1,14 @@
 use {
+    super::shared::MAX_WORKERS,
     crate::handshake::{
-        ClientHandshakeError, ClientLogon, ClientSession, ClientWorkerSession,
-        shared::{LOGON_FAILURE, MAX_WORKERS, VERSION},
+        ClientHandshakeError, ClientLogon, ClientSession,
+        shared::{GLOBAL_SHMEM, HANDSHAKE_BUFFER_SIZE, LOGON_FAILURE, join_session, send_logon},
     },
     libc::CMSG_LEN,
     nix::sys::socket::{self, ControlMessageOwned, MsgFlags, UnixAddr},
-    rts_alloc::Allocator,
     std::{
         fs::File,
-        io::{IoSliceMut, Write},
+        io::IoSliceMut,
         os::{
             fd::{AsRawFd, FromRawFd},
             unix::net::UnixStream,
@@ -17,9 +17,6 @@ use {
         time::Duration,
     },
 };
-
-/// Number of global shared memory objects (in addition to per worker objects).
-const GLOBAL_SHMEM: usize = 3;
 
 /// The maximum size in bytes of the control message containing the queues assuming [`MAX_WORKERS`]
 /// is respected.
@@ -69,31 +66,14 @@ fn connect_path(
     let files = recv_response(&mut stream)?;
 
     // Join the shared memory regions.
-    let session = setup_session(&logon, files)?;
+    let session = join_session(&logon, files)?;
 
     Ok(session)
 }
 
-fn send_logon(stream: &mut UnixStream, logon: ClientLogon) -> Result<(), ClientHandshakeError> {
-    // Send the logon message.
-    let mut buf = [0; 1024];
-    buf[..8].copy_from_slice(&VERSION.to_le_bytes());
-    const LOGON_END: usize = 8 + core::mem::size_of::<ClientLogon>();
-    let ptr = buf[8..LOGON_END].as_mut_ptr().cast::<ClientLogon>();
-    // SAFETY:
-    // - `buf` is valid for writes.
-    // - `buf.len()` has enough space for logon's size in memory.
-    unsafe {
-        core::ptr::write_unaligned(ptr, logon);
-    }
-    stream.write_all(&buf)?;
-
-    Ok(())
-}
-
 fn recv_response(stream: &mut UnixStream) -> Result<Vec<File>, ClientHandshakeError> {
     // Receive the requested FDs.
-    let mut buf = [0; 1024];
+    let mut buf = [0; HANDSHAKE_BUFFER_SIZE];
     let mut iov = [IoSliceMut::new(&mut buf)];
     // SAFETY: CMSG_LEN is always safe (const expression).
     let mut cmsgs = [0u8; unsafe { CMSG_LEN(CMSG_MAX_SIZE as u32) as usize }];
@@ -134,52 +114,7 @@ pub fn setup_session(
     logon: &ClientLogon,
     files: Vec<File>,
 ) -> Result<ClientSession, ClientHandshakeError> {
-    if files.len() < GLOBAL_SHMEM {
-        return Err(ClientHandshakeError::ProtocolViolation);
-    }
-    let (global_files, worker_files) = files.split_at(GLOBAL_SHMEM);
-    let [allocator_file, tpu_to_pack_file, progress_tracker_file] = global_files else {
-        unreachable!();
-    };
-
-    // Setup requested allocators.
-    let allocators = (0..logon.allocator_handles)
-        .map(|_| Allocator::join(allocator_file))
-        .collect::<Result<Vec<_>, _>>()?;
-
-    // Ensure worker file count matches expectations.
-    if worker_files.is_empty()
-        || !worker_files.len().is_multiple_of(2)
-        || worker_files.len() / 2 != logon.worker_count
-    {
-        return Err(ClientHandshakeError::ProtocolViolation);
-    }
-
-    // NB: After creating & mapping the queues we are fine to drop the files as mmap will keep the
-    // underlying object alive until process exit or munmap.
-    let session = ClientSession {
-        allocators,
-        tpu_to_pack: unsafe { shaq::spsc::Consumer::join(tpu_to_pack_file)? },
-        progress_tracker: unsafe { shaq::spsc::Consumer::join(progress_tracker_file)? },
-        workers: worker_files
-            .chunks(2)
-            .map(|window| {
-                let [pack_to_worker, worker_to_pack] = window else {
-                    panic!();
-                };
-
-                Ok(ClientWorkerSession {
-                    pack_to_worker: unsafe { shaq::spsc::Producer::join(pack_to_worker)? },
-                    worker_to_pack: unsafe { shaq::spsc::Consumer::join(worker_to_pack)? },
-                })
-            })
-            .collect::<Result<_, ClientHandshakeError>>()?,
-    };
-
-    // Drop the file handles now that mmaps are completed.
-    drop(files);
-
-    Ok(session)
+    join_session(logon, files)
 }
 
 impl From<nix::Error> for ClientHandshakeError {

--- a/scheduling-utils/src/handshake/client_windows.rs
+++ b/scheduling-utils/src/handshake/client_windows.rs
@@ -1,0 +1,168 @@
+use {
+    crate::handshake::{
+        ClientHandshakeError, ClientLogon, ClientSession,
+        shared::{HANDSHAKE_BUFFER_SIZE, LOGON_FAILURE, join_session, send_logon},
+    },
+    std::{
+        ffi::OsString,
+        fs::{File, OpenOptions},
+        io::Read,
+        os::windows::{
+            ffi::OsStringExt,
+            fs::OpenOptionsExt,
+            io::{FromRawHandle, RawHandle},
+        },
+        path::{Path, PathBuf},
+        time::{Duration, Instant},
+    },
+    windows_sys::Win32::{
+        Foundation::{ERROR_PIPE_BUSY, INVALID_HANDLE_VALUE},
+        Storage::FileSystem::{
+            CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_DELETE, FILE_SHARE_READ,
+            FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE, OPEN_EXISTING,
+        },
+        System::Pipes::WaitNamedPipeW,
+    },
+};
+
+pub fn connect(
+    path: impl AsRef<Path>,
+    logon: ClientLogon,
+    timeout: Duration,
+) -> Result<ClientSession, ClientHandshakeError> {
+    connect_path(path.as_ref(), logon, timeout)
+}
+
+fn connect_path(
+    path: &Path,
+    logon: ClientLogon,
+    timeout: Duration,
+) -> Result<ClientSession, ClientHandshakeError> {
+    let mut stream = connect_pipe(path, timeout)?;
+    send_logon(&mut stream, logon)?;
+    let files = recv_response(&mut stream)?;
+    join_session(&logon, files)
+}
+
+pub fn setup_session(
+    logon: &ClientLogon,
+    files: Vec<File>,
+) -> Result<ClientSession, ClientHandshakeError> {
+    join_session(logon, files)
+}
+
+fn connect_pipe(path: &Path, timeout: Duration) -> Result<File, ClientHandshakeError> {
+    let pipe_name = pipe_name(path);
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .unwrap_or_else(Instant::now);
+
+    loop {
+        let handle = unsafe {
+            CreateFileW(
+                pipe_name.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                core::ptr::null(),
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                0,
+            )
+        };
+
+        if handle != INVALID_HANDLE_VALUE {
+            return Ok(unsafe { File::from_raw_handle(handle as RawHandle) });
+        }
+
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() != Some(ERROR_PIPE_BUSY as i32) {
+            return Err(err.into());
+        }
+
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(ClientHandshakeError::TimedOut);
+        }
+
+        let remaining = deadline.saturating_duration_since(now).as_millis();
+        let wait_ms = u32::try_from(remaining).unwrap_or(u32::MAX);
+        let waited = unsafe { WaitNamedPipeW(pipe_name.as_ptr(), wait_ms) };
+        if waited == 0 {
+            let err = std::io::Error::last_os_error();
+            if Instant::now() >= deadline {
+                return Err(ClientHandshakeError::TimedOut);
+            }
+            return Err(err.into());
+        }
+    }
+}
+
+fn recv_response(stream: &mut File) -> Result<Vec<File>, ClientHandshakeError> {
+    let mut marker = [0; 1];
+    stream.read_exact(&mut marker)?;
+
+    if marker[0] == LOGON_FAILURE {
+        let mut reason_len = [0; 1];
+        stream.read_exact(&mut reason_len)?;
+        let mut reason = vec![0; usize::from(reason_len[0])];
+        stream.read_exact(&mut reason)?;
+        let reason =
+            String::from_utf8(reason).map_err(|_| ClientHandshakeError::ProtocolViolation)?;
+        return Err(ClientHandshakeError::Rejected(reason));
+    }
+
+    let mut count_bytes = [0; 4];
+    stream.read_exact(&mut count_bytes)?;
+    let count = u32::from_le_bytes(count_bytes);
+    let mut files = Vec::with_capacity(count as usize);
+
+    for _ in 0..count {
+        let path = read_path(stream)?;
+        files.push(open_region_file(&path)?);
+    }
+
+    Ok(files)
+}
+
+fn read_path(stream: &mut File) -> Result<PathBuf, ClientHandshakeError> {
+    let mut len_bytes = [0; 4];
+    stream.read_exact(&mut len_bytes)?;
+    let byte_len = u32::from_le_bytes(len_bytes) as usize;
+    if !byte_len.is_multiple_of(2) || byte_len > HANDSHAKE_BUFFER_SIZE * 64 {
+        return Err(ClientHandshakeError::ProtocolViolation);
+    }
+
+    let mut bytes = vec![0; byte_len];
+    stream.read_exact(&mut bytes)?;
+    let wide = bytes
+        .chunks_exact(2)
+        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+        .collect::<Vec<_>>();
+    Ok(PathBuf::from(OsString::from_wide(&wide)))
+}
+
+fn open_region_file(path: &Path) -> Result<File, ClientHandshakeError> {
+    let mut open_options = OpenOptions::new();
+    open_options.read(true).write(true);
+    open_options.share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE);
+    open_options.open(path).map_err(Into::into)
+}
+
+fn pipe_name(path: &Path) -> Vec<u16> {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+        os::windows::ffi::OsStrExt,
+    };
+
+    let mut hasher = DefaultHasher::new();
+    path.as_os_str().hash(&mut hasher);
+    let pipe_name = format!(
+        r"\\.\pipe\agave-scheduler-bindings-{:016x}",
+        hasher.finish()
+    );
+    std::ffi::OsStr::new(&pipe_name)
+        .encode_wide()
+        .chain(core::iter::once(0))
+        .collect()
+}

--- a/scheduling-utils/src/handshake/client_windows.rs
+++ b/scheduling-utils/src/handshake/client_windows.rs
@@ -1,6 +1,7 @@
 use {
     crate::handshake::{
         ClientHandshakeError, ClientLogon, ClientSession,
+        pipe_windows::pipe_name,
         shared::{HANDSHAKE_BUFFER_SIZE, LOGON_FAILURE, join_session, send_logon},
     },
     std::{
@@ -146,23 +147,4 @@ fn open_region_file(path: &Path) -> Result<File, ClientHandshakeError> {
     open_options.read(true).write(true);
     open_options.share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE);
     open_options.open(path).map_err(Into::into)
-}
-
-fn pipe_name(path: &Path) -> Vec<u16> {
-    use std::{
-        collections::hash_map::DefaultHasher,
-        hash::{Hash, Hasher},
-        os::windows::ffi::OsStrExt,
-    };
-
-    let mut hasher = DefaultHasher::new();
-    path.as_os_str().hash(&mut hasher);
-    let pipe_name = format!(
-        r"\\.\pipe\agave-scheduler-bindings-{:016x}",
-        hasher.finish()
-    );
-    std::ffi::OsStr::new(&pipe_name)
-        .encode_wide()
-        .chain(core::iter::once(0))
-        .collect()
 }

--- a/scheduling-utils/src/handshake/mod.rs
+++ b/scheduling-utils/src/handshake/mod.rs
@@ -1,6 +1,12 @@
 #[cfg(unix)]
 pub mod client;
+#[cfg(windows)]
+#[path = "client_windows.rs"]
+pub mod client;
 #[cfg(unix)]
+pub mod server;
+#[cfg(windows)]
+#[path = "server_windows.rs"]
 pub mod server;
 mod shared;
 #[cfg(test)]

--- a/scheduling-utils/src/handshake/mod.rs
+++ b/scheduling-utils/src/handshake/mod.rs
@@ -3,6 +3,8 @@ pub mod client;
 #[cfg(windows)]
 #[path = "client_windows.rs"]
 pub mod client;
+#[cfg(windows)]
+mod pipe_windows;
 #[cfg(unix)]
 pub mod server;
 #[cfg(windows)]

--- a/scheduling-utils/src/handshake/pipe_windows.rs
+++ b/scheduling-utils/src/handshake/pipe_windows.rs
@@ -1,0 +1,40 @@
+use {
+    sha2::{Digest, Sha256},
+    std::{ffi::OsStr, os::windows::ffi::OsStrExt, path::Path},
+};
+
+pub(super) fn pipe_name(path: &Path) -> Vec<u16> {
+    let mut hasher = Sha256::new();
+    for unit in path.as_os_str().encode_wide() {
+        hasher.update(unit.to_le_bytes());
+    }
+
+    let digest = hasher.finalize();
+    let pipe_name = format!(r"\\.\pipe\agave-scheduler-bindings-{digest:x}");
+
+    OsStr::new(&pipe_name)
+        .encode_wide()
+        .chain(core::iter::once(0))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pipe_name;
+    use std::path::Path;
+
+    #[test]
+    fn pipe_name_is_deterministic_for_same_path() {
+        let path = Path::new(r"C:\tmp\agave.sock");
+
+        assert_eq!(pipe_name(path), pipe_name(path));
+    }
+
+    #[test]
+    fn pipe_name_changes_with_path() {
+        assert_ne!(
+            pipe_name(Path::new(r"C:\tmp\agave-a.sock")),
+            pipe_name(Path::new(r"C:\tmp\agave-b.sock"))
+        );
+    }
+}

--- a/scheduling-utils/src/handshake/server.rs
+++ b/scheduling-utils/src/handshake/server.rs
@@ -2,8 +2,8 @@ use {
     crate::handshake::{
         AgaveHandshakeError, AgaveTpuToPackSession, AgaveWorkerSession, ClientLogon,
         shared::{
-            AgaveSession, GLOBAL_ALLOCATORS, LOGON_FAILURE, LOGON_SUCCESS, MAX_ALLOCATOR_HANDLES,
-            MAX_WORKERS, VERSION,
+            AgaveSession, GLOBAL_ALLOCATORS, HANDSHAKE_BUFFER_SIZE, LOGON_FAILURE, LOGON_SUCCESS,
+            recv_logon,
         },
     },
     agave_scheduler_bindings::PackToWorkerMessage,
@@ -12,13 +12,13 @@ use {
     std::{
         ffi::CStr,
         fs::File,
-        io::{IoSlice, Read, Write},
+        io::{IoSlice, Write},
         os::{
             fd::{AsRawFd, FromRawFd},
             unix::net::{UnixListener, UnixStream},
         },
         path::Path,
-        time::{Duration, Instant},
+        time::Duration,
     },
 };
 
@@ -41,7 +41,7 @@ impl Server {
 
         Ok(Self {
             listener,
-            buffer: [0; 1024],
+            buffer: [0; HANDSHAKE_BUFFER_SIZE],
         })
     }
 
@@ -95,51 +95,7 @@ impl Server {
     }
 
     fn recv_logon(&mut self, stream: &mut UnixStream) -> Result<ClientLogon, AgaveHandshakeError> {
-        // Read the logon message.
-        let handshake_start = Instant::now();
-        let mut buffer_len = 0;
-        while buffer_len < self.buffer.len() {
-            let read = stream.read(&mut self.buffer[buffer_len..])?;
-            if read == 0 {
-                return Err(AgaveHandshakeError::EofDuringHandshake);
-            }
-
-            // SAFETY: We cannot read a value greater than buffer.len() which itself is a usize.
-            buffer_len = buffer_len.checked_add(read).unwrap();
-
-            if handshake_start.elapsed() > HANDSHAKE_TIMEOUT {
-                return Err(AgaveHandshakeError::Timeout);
-            }
-        }
-
-        // Ensure exact version match, version will be bumped any time a backwards incompatible
-        // change is made to handshake/shared memory objects.
-        let version = u64::from_le_bytes(self.buffer[..8].try_into().unwrap());
-        if version != VERSION {
-            return Err(AgaveHandshakeError::Version {
-                server: VERSION,
-                client: version,
-            });
-        }
-
-        // Read the logon message, cannot panic as we ensure the correct buf size at compile time
-        // (hence the const just below).
-        const LOGON_END: usize = 8 + core::mem::size_of::<ClientLogon>();
-        let logon = ClientLogon::try_from_bytes(&self.buffer[8..LOGON_END]).unwrap();
-
-        // Put a hard limit of 64 worker threads for now.
-        if !(1..=MAX_WORKERS).contains(&logon.worker_count) {
-            return Err(AgaveHandshakeError::WorkerCount(logon.worker_count));
-        }
-
-        // Hard limit allocator handles to 128.
-        if !(1..=MAX_ALLOCATOR_HANDLES).contains(&logon.allocator_handles) {
-            return Err(AgaveHandshakeError::AllocatorHandles(
-                logon.allocator_handles,
-            ));
-        }
-
-        Ok(logon)
+        recv_logon(stream, &mut self.buffer)
     }
 
     pub fn setup_session(

--- a/scheduling-utils/src/handshake/server_windows.rs
+++ b/scheduling-utils/src/handshake/server_windows.rs
@@ -1,6 +1,7 @@
 use {
     crate::handshake::{
         AgaveHandshakeError, AgaveTpuToPackSession, AgaveWorkerSession, ClientLogon,
+        pipe_windows::pipe_name,
         shared::{
             AgaveSession, GLOBAL_ALLOCATORS, HANDSHAKE_BUFFER_SIZE, LOGON_FAILURE, LOGON_SUCCESS,
             recv_logon,
@@ -287,24 +288,6 @@ fn unique_region_path() -> PathBuf {
     let id = COUNTER.fetch_add(1, Ordering::Relaxed);
     let pid = std::process::id();
     std::env::temp_dir().join(format!("agave-scheduler-bindings-{pid}-{id}.shmem"))
-}
-
-fn pipe_name(path: &Path) -> Vec<u16> {
-    use std::{
-        collections::hash_map::DefaultHasher,
-        hash::{Hash, Hasher},
-    };
-
-    let mut hasher = DefaultHasher::new();
-    path.as_os_str().hash(&mut hasher);
-    let pipe_name = format!(
-        r"\\.\pipe\agave-scheduler-bindings-{:016x}",
-        hasher.finish()
-    );
-    OsStr::new(&pipe_name)
-        .encode_wide()
-        .chain(core::iter::once(0))
-        .collect()
 }
 
 fn timeout_ms(timeout: Duration) -> u32 {

--- a/scheduling-utils/src/handshake/server_windows.rs
+++ b/scheduling-utils/src/handshake/server_windows.rs
@@ -1,0 +1,312 @@
+use {
+    crate::handshake::{
+        AgaveHandshakeError, AgaveTpuToPackSession, AgaveWorkerSession, ClientLogon,
+        shared::{
+            AgaveSession, GLOBAL_ALLOCATORS, HANDSHAKE_BUFFER_SIZE, LOGON_FAILURE, LOGON_SUCCESS,
+            recv_logon,
+        },
+    },
+    agave_scheduler_bindings::PackToWorkerMessage,
+    rts_alloc::Allocator,
+    std::{
+        ffi::OsStr,
+        fs::{File, OpenOptions},
+        io::Write,
+        os::windows::{
+            ffi::OsStrExt,
+            fs::OpenOptionsExt,
+            io::{FromRawHandle, RawHandle},
+        },
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicU64, Ordering},
+        time::Duration,
+    },
+    windows_sys::Win32::{
+        Foundation::{CloseHandle, ERROR_PIPE_CONNECTED, HANDLE, INVALID_HANDLE_VALUE},
+        Storage::FileSystem::{
+            FILE_ATTRIBUTE_TEMPORARY, FILE_FLAG_DELETE_ON_CLOSE, FILE_SHARE_DELETE,
+            FILE_SHARE_READ, FILE_SHARE_WRITE,
+        },
+        System::Pipes::{
+            ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, PIPE_ACCESS_DUPLEX,
+            PIPE_READMODE_BYTE, PIPE_TYPE_BYTE, PIPE_WAIT,
+        },
+    },
+};
+
+type ShaqError = shaq::error::Error;
+type RtsAllocError = rts_alloc::error::Error;
+
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(1);
+
+pub struct Server {
+    pipe_name: Vec<u16>,
+    buffer: [u8; HANDSHAKE_BUFFER_SIZE],
+}
+
+struct RegionFile {
+    file: File,
+    path: PathBuf,
+}
+
+impl Server {
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, std::io::Error> {
+        Ok(Self {
+            pipe_name: pipe_name(path.as_ref()),
+            buffer: [0; HANDSHAKE_BUFFER_SIZE],
+        })
+    }
+
+    pub fn accept(&mut self) -> Result<AgaveSession, AgaveHandshakeError> {
+        let handle = unsafe {
+            CreateNamedPipeW(
+                self.pipe_name.as_ptr(),
+                PIPE_ACCESS_DUPLEX,
+                PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                1,
+                HANDSHAKE_BUFFER_SIZE as u32,
+                HANDSHAKE_BUFFER_SIZE as u32,
+                timeout_ms(HANDSHAKE_TIMEOUT),
+                core::ptr::null(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(std::io::Error::last_os_error().into());
+        }
+
+        let connected = unsafe { ConnectNamedPipe(handle, core::ptr::null_mut()) };
+        if connected == 0 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() != Some(ERROR_PIPE_CONNECTED as i32) {
+                unsafe {
+                    CloseHandle(handle);
+                }
+                return Err(err.into());
+            }
+        }
+
+        let mut stream = unsafe { File::from_raw_handle(handle as RawHandle) };
+        let result = match self.handle_logon(&mut stream) {
+            Ok(session) => Ok(session),
+            Err(err) => {
+                let reason = err.to_string();
+                let reason_len = u8::try_from(reason.len()).unwrap_or(u8::MAX);
+
+                let mut buffer = [0; HANDSHAKE_BUFFER_SIZE];
+                let buffer_len = 2usize.checked_add(usize::from(reason_len)).unwrap();
+                buffer[0] = LOGON_FAILURE;
+                buffer[1] = reason_len;
+                buffer[2..buffer_len]
+                    .copy_from_slice(&reason.as_bytes()[..usize::from(reason_len)]);
+
+                let _ = stream.write_all(&buffer[..buffer_len]);
+                Err(err)
+            }
+        };
+
+        unsafe {
+            DisconnectNamedPipe(handle);
+        }
+
+        result
+    }
+
+    fn handle_logon(&mut self, stream: &mut File) -> Result<AgaveSession, AgaveHandshakeError> {
+        let logon = recv_logon(stream, &mut self.buffer)?;
+        let (session, files) = Self::setup_session_regions(logon)?;
+        write_success_response(stream, &files)?;
+        Ok(session)
+    }
+
+    pub fn setup_session(
+        logon: ClientLogon,
+    ) -> Result<(AgaveSession, Vec<File>), AgaveHandshakeError> {
+        let (session, files) = Self::setup_session_regions(logon)?;
+        Ok((session, files.into_iter().map(|file| file.file).collect()))
+    }
+
+    fn setup_session_regions(
+        logon: ClientLogon,
+    ) -> Result<(AgaveSession, Vec<RegionFile>), AgaveHandshakeError> {
+        let (allocator_file, tpu_to_pack_allocator) = Self::create_allocator(&logon)?;
+        let (tpu_to_pack_file, tpu_to_pack_queue) =
+            Self::create_producer(logon.tpu_to_pack_capacity, true)?;
+        let (progress_tracker_file, progress_tracker) =
+            Self::create_producer(logon.progress_tracker_capacity, false)?;
+
+        let (worker_files, workers) = (0..logon.worker_count).try_fold(
+            (Vec::default(), Vec::default()),
+            |(mut files, mut workers), _| {
+                let allocator = Allocator::join(&allocator_file.file)?;
+
+                let (pack_to_worker_file, pack_to_worker) =
+                    Self::create_consumer(logon.pack_to_worker_capacity)?;
+                let (worker_to_pack_file, worker_to_pack) =
+                    Self::create_producer(logon.worker_to_pack_capacity, true)?;
+
+                files.extend([pack_to_worker_file, worker_to_pack_file]);
+                workers.push(AgaveWorkerSession {
+                    allocator,
+                    pack_to_worker,
+                    worker_to_pack,
+                });
+
+                Ok::<_, AgaveHandshakeError>((files, workers))
+            },
+        )?;
+
+        Ok((
+            AgaveSession {
+                flags: logon.flags,
+                tpu_to_pack: AgaveTpuToPackSession {
+                    allocator: tpu_to_pack_allocator,
+                    producer: tpu_to_pack_queue,
+                },
+                progress_tracker,
+                workers,
+            },
+            [allocator_file, tpu_to_pack_file, progress_tracker_file]
+                .into_iter()
+                .chain(worker_files)
+                .collect(),
+        ))
+    }
+
+    fn create_allocator(logon: &ClientLogon) -> Result<(RegionFile, Allocator), RtsAllocError> {
+        let allocator_count = GLOBAL_ALLOCATORS
+            .checked_add(logon.worker_count)
+            .unwrap()
+            .checked_add(logon.allocator_handles)
+            .unwrap();
+
+        let create = |huge: bool| {
+            let allocator_file = Self::create_shmem(huge)?;
+            let allocator_file_size = Self::align_file_size(logon.allocator_size, huge);
+
+            unsafe {
+                Allocator::create(
+                    &allocator_file.file,
+                    allocator_file_size,
+                    u32::try_from(allocator_count).unwrap(),
+                    2 * 1024 * 1024,
+                )
+            }
+            .map(|allocator| (allocator_file, allocator))
+        };
+
+        create(true).or_else(|_| create(false))
+    }
+
+    fn create_producer<T>(
+        capacity: usize,
+        huge: bool,
+    ) -> Result<(RegionFile, shaq::spsc::Producer<T>), ShaqError> {
+        let create = |huge: bool| {
+            let file = Self::create_shmem(huge)?;
+            let minimum_file_size = shaq::spsc::minimum_file_size::<T>(capacity);
+            let file_size = Self::align_file_size(minimum_file_size, huge);
+
+            unsafe { shaq::spsc::Producer::create(&file.file, file_size) }
+                .map(|producer| (file, producer))
+        };
+
+        match huge {
+            true => create(true).or_else(|_| create(false)),
+            false => create(false),
+        }
+    }
+
+    fn create_consumer(
+        capacity: usize,
+    ) -> Result<(RegionFile, shaq::spsc::Consumer<PackToWorkerMessage>), ShaqError> {
+        let create = |huge: bool| {
+            let file = Self::create_shmem(huge)?;
+            let minimum_file_size = shaq::spsc::minimum_file_size::<PackToWorkerMessage>(capacity);
+            let file_size = Self::align_file_size(minimum_file_size, huge);
+
+            unsafe { shaq::spsc::Consumer::create(&file.file, file_size) }
+                .map(|producer| (file, producer))
+        };
+
+        create(true).or_else(|_| create(false))
+    }
+
+    fn create_shmem(huge: bool) -> Result<RegionFile, std::io::Error> {
+        if huge {
+            return Err(std::io::ErrorKind::Unsupported.into());
+        }
+
+        let path = unique_region_path();
+        let mut open_options = OpenOptions::new();
+        open_options.read(true).write(true).create_new(true);
+        open_options.share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE);
+        open_options.attributes(FILE_ATTRIBUTE_TEMPORARY);
+        open_options.custom_flags(FILE_FLAG_DELETE_ON_CLOSE);
+        let file = open_options.open(&path)?;
+
+        Ok(RegionFile { file, path })
+    }
+
+    fn align_file_size(size: usize, huge: bool) -> usize {
+        match huge {
+            true => size.next_multiple_of(2 * 1024 * 1024),
+            false => size.next_multiple_of(4096),
+        }
+    }
+}
+
+fn write_success_response(
+    stream: &mut File,
+    files: &[RegionFile],
+) -> Result<(), AgaveHandshakeError> {
+    stream.write_all(&[LOGON_SUCCESS])?;
+    stream.write_all(&(u32::try_from(files.len()).unwrap()).to_le_bytes())?;
+    for file in files {
+        write_path(stream, &file.path)?;
+    }
+    Ok(())
+}
+
+fn write_path(stream: &mut File, path: &Path) -> Result<(), AgaveHandshakeError> {
+    let wide = path.as_os_str().encode_wide().collect::<Vec<_>>();
+    let byte_len = wide
+        .len()
+        .checked_mul(2)
+        .and_then(|len| u32::try_from(len).ok())
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::InvalidData))?;
+    stream.write_all(&byte_len.to_le_bytes())?;
+    for unit in wide {
+        stream.write_all(&unit.to_le_bytes())?;
+    }
+    Ok(())
+}
+
+fn unique_region_path() -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("agave-scheduler-bindings-{pid}-{id}.shmem"))
+}
+
+fn pipe_name(path: &Path) -> Vec<u16> {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+    };
+
+    let mut hasher = DefaultHasher::new();
+    path.as_os_str().hash(&mut hasher);
+    let pipe_name = format!(
+        r"\\.\pipe\agave-scheduler-bindings-{:016x}",
+        hasher.finish()
+    );
+    OsStr::new(&pipe_name)
+        .encode_wide()
+        .chain(core::iter::once(0))
+        .collect()
+}
+
+fn timeout_ms(timeout: Duration) -> u32 {
+    u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX)
+}

--- a/scheduling-utils/src/handshake/shared.rs
+++ b/scheduling-utils/src/handshake/shared.rs
@@ -3,6 +3,10 @@ use {
         PackToWorkerMessage, ProgressMessage, TpuToPackMessage, WorkerToPackMessage,
     },
     rts_alloc::Allocator,
+    std::{
+        fs::File,
+        io::{Read, Write},
+    },
     thiserror::Error,
 };
 
@@ -17,6 +21,8 @@ pub(crate) const LOGON_SUCCESS: u8 = 0x01;
 pub(crate) const LOGON_FAILURE: u8 = 0x02;
 pub(crate) const MAX_ALLOCATOR_HANDLES: usize = 128;
 pub(crate) const GLOBAL_ALLOCATORS: usize = 1;
+pub(crate) const GLOBAL_SHMEM: usize = 3;
+pub(crate) const HANDSHAKE_BUFFER_SIZE: usize = 1024;
 
 /// The logon message sent by the client to the server.
 #[derive(Debug, Default, Clone, Copy)]
@@ -57,6 +63,102 @@ impl ClientLogon {
         // - `Self` is valid for any byte pattern
         Some(unsafe { core::ptr::read_unaligned(buffer.as_ptr().cast()) })
     }
+}
+
+pub(crate) fn send_logon<W: Write>(
+    stream: &mut W,
+    logon: ClientLogon,
+) -> Result<(), ClientHandshakeError> {
+    let mut buf = [0; HANDSHAKE_BUFFER_SIZE];
+    buf[..8].copy_from_slice(&VERSION.to_le_bytes());
+    const LOGON_END: usize = 8 + core::mem::size_of::<ClientLogon>();
+    let ptr = buf[8..LOGON_END].as_mut_ptr().cast::<ClientLogon>();
+    // SAFETY:
+    // - `buf` is valid for writes.
+    // - `buf.len()` has enough space for logon's size in memory.
+    unsafe {
+        core::ptr::write_unaligned(ptr, logon);
+    }
+    stream.write_all(&buf)?;
+
+    Ok(())
+}
+
+pub(crate) fn recv_logon<R: Read>(
+    stream: &mut R,
+    buffer: &mut [u8; HANDSHAKE_BUFFER_SIZE],
+) -> Result<ClientLogon, AgaveHandshakeError> {
+    stream.read_exact(buffer)?;
+
+    let version = u64::from_le_bytes(buffer[..8].try_into().unwrap());
+    if version != VERSION {
+        return Err(AgaveHandshakeError::Version {
+            server: VERSION,
+            client: version,
+        });
+    }
+
+    const LOGON_END: usize = 8 + core::mem::size_of::<ClientLogon>();
+    let logon = ClientLogon::try_from_bytes(&buffer[8..LOGON_END]).unwrap();
+
+    if !(1..=MAX_WORKERS).contains(&logon.worker_count) {
+        return Err(AgaveHandshakeError::WorkerCount(logon.worker_count));
+    }
+
+    if !(1..=MAX_ALLOCATOR_HANDLES).contains(&logon.allocator_handles) {
+        return Err(AgaveHandshakeError::AllocatorHandles(
+            logon.allocator_handles,
+        ));
+    }
+
+    Ok(logon)
+}
+
+pub(crate) fn join_session(
+    logon: &ClientLogon,
+    files: Vec<File>,
+) -> Result<ClientSession, ClientHandshakeError> {
+    if files.len() < GLOBAL_SHMEM {
+        return Err(ClientHandshakeError::ProtocolViolation);
+    }
+    let (global_files, worker_files) = files.split_at(GLOBAL_SHMEM);
+    let [allocator_file, tpu_to_pack_file, progress_tracker_file] = global_files else {
+        unreachable!();
+    };
+
+    let allocators = (0..logon.allocator_handles)
+        .map(|_| Allocator::join(allocator_file))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if worker_files.is_empty()
+        || !worker_files.len().is_multiple_of(2)
+        || worker_files.len() / 2 != logon.worker_count
+    {
+        return Err(ClientHandshakeError::ProtocolViolation);
+    }
+
+    let session = ClientSession {
+        allocators,
+        tpu_to_pack: unsafe { shaq::spsc::Consumer::join(tpu_to_pack_file)? },
+        progress_tracker: unsafe { shaq::spsc::Consumer::join(progress_tracker_file)? },
+        workers: worker_files
+            .chunks(2)
+            .map(|window| {
+                let [pack_to_worker, worker_to_pack] = window else {
+                    panic!();
+                };
+
+                Ok(ClientWorkerSession {
+                    pack_to_worker: unsafe { shaq::spsc::Producer::join(pack_to_worker)? },
+                    worker_to_pack: unsafe { shaq::spsc::Consumer::join(worker_to_pack)? },
+                })
+            })
+            .collect::<Result<_, ClientHandshakeError>>()?,
+    };
+
+    drop(files);
+
+    Ok(session)
 }
 
 pub mod logon_flags {}

--- a/scheduling-utils/src/handshake/tests.rs
+++ b/scheduling-utils/src/handshake/tests.rs
@@ -12,11 +12,18 @@ use {
     tempfile::NamedTempFile,
 };
 
+fn new_ipc_path() -> std::path::PathBuf {
+    let ipc = NamedTempFile::new().unwrap();
+    let path = ipc.path().to_path_buf();
+    #[cfg(unix)]
+    std::fs::remove_file(&path).unwrap();
+    path
+}
+
 #[test]
 fn message_passing_on_all_queues() {
-    let ipc = NamedTempFile::new().unwrap();
-    std::fs::remove_file(ipc.path()).unwrap();
-    let mut server = Server::new(ipc.path()).unwrap();
+    let ipc = new_ipc_path();
+    let mut server = Server::new(&ipc).unwrap();
 
     // Test messages.
     let tpu_to_pack = TpuToPackMessage {
@@ -176,9 +183,8 @@ fn message_passing_on_all_queues() {
 
 #[test]
 fn accept_worker_count_max() {
-    let ipc = NamedTempFile::new().unwrap();
-    std::fs::remove_file(ipc.path()).unwrap();
-    let mut server = Server::new(ipc.path()).unwrap();
+    let ipc = new_ipc_path();
+    let mut server = Server::new(&ipc).unwrap();
 
     let server_handle = std::thread::spawn(move || {
         let res = server.accept();
@@ -208,9 +214,8 @@ fn accept_worker_count_max() {
 
 #[test]
 fn reject_worker_count_low() {
-    let ipc = NamedTempFile::new().unwrap();
-    std::fs::remove_file(ipc.path()).unwrap();
-    let mut server = Server::new(ipc.path()).unwrap();
+    let ipc = new_ipc_path();
+    let mut server = Server::new(&ipc).unwrap();
 
     let server_handle = std::thread::spawn(move || {
         let res = server.accept();
@@ -246,9 +251,8 @@ fn reject_worker_count_low() {
 
 #[test]
 fn reject_worker_count_high() {
-    let ipc = NamedTempFile::new().unwrap();
-    std::fs::remove_file(ipc.path()).unwrap();
-    let mut server = Server::new(ipc.path()).unwrap();
+    let ipc = new_ipc_path();
+    let mut server = Server::new(&ipc).unwrap();
 
     let server_handle = std::thread::spawn(move || {
         let res = server.accept();


### PR DESCRIPTION
#### Problem
- UDS preventing scheduler-bindings from being used in windows
- Cannot commit fully to process managment w/ files passed if we have no support for windows (yet)

#### Summary of Changes
- Add abstraction around UDS so that we can support external process connecting in windows.

Fixes #
