### PR TITLE
docs(votor): add comment for staked validators cache target size

### DIFF
--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -23,6 +23,9 @@ use {
 };
 
 const STAKED_VALIDATORS_CACHE_TTL_S: u64 = 5;
+/// Target number of epochs to keep in the staked validators cache. Due to lazy-lru eviction
+/// semantics, the cache may hold up to `2 * STAKED_VALIDATORS_CACHE_NUM_EPOCH_TARGET` entries
+/// before evicting down to this target.
 const STAKED_VALIDATORS_CACHE_NUM_EPOCH_TARGET: usize = 3;
 
 #[derive(Debug)]


### PR DESCRIPTION
#### Problem
Follow-up to https://github.com/anza-xyz/agave/pull/11157 the constant used for sizing epoch cache could use comment describing lazy-lru capacity behavior.

#### Summary of Changes
Add comment to the constant `STAKED_VALIDATORS_CACHE_NUM_EPOCH_TARGET`
