### PR TITLE
Removes `EpochInflationRewards`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -989,18 +989,6 @@ impl Default for BankTestConfig {
     }
 }
 
-/// Data returned from [`Bank::calculate_epoch_inflation_rewards()`].
-pub(crate) struct EpochInflationRewards {
-    /// Amount of rewards a validator should get if it voted in every slot in
-    /// the epoch and its stake is equal to the network capitalization i.e.
-    /// the total supply.
-    pub(crate) validator_rewards_lamports: u64,
-    /// The current inflation rate for the validators.
-    pub(crate) validator_rate: f64,
-    /// The current inflation rate for the foundation.
-    pub(crate) foundation_rate: f64,
-}
-
 #[derive(Debug, Default, PartialEq)]
 pub struct ProcessedTransactionCounts {
     pub processed_transactions_count: u64,
@@ -2565,30 +2553,17 @@ impl Bank {
         num_slots as f64 / self.slots_per_year
     }
 
-    /// For a given [`capitalization`] (total_supply in lamports) and [`epoch`], calculates various inflation related info.
+    /// For a given `capitalization` (total_supply in lamports) and `epoch`, returns the
+    /// `epoch inflation rewards` in lamports.
     pub(crate) fn calculate_epoch_inflation_rewards(
         &self,
         capitalization: u64,
         epoch: Epoch,
-    ) -> EpochInflationRewards {
+    ) -> u64 {
         let slot_in_year = self.slot_in_year_for_inflation();
-        let (validator_rate, foundation_rate) = {
-            let inflation = self.inflation.read().unwrap();
-            (
-                (*inflation).validator(slot_in_year),
-                (*inflation).foundation(slot_in_year),
-            )
-        };
-
+        let validator_rate = self.inflation.read().unwrap().validator(slot_in_year);
         let epoch_duration_in_years = self.epoch_duration_in_years(epoch);
-        let validator_rewards_lamports =
-            (validator_rate * capitalization as f64 * epoch_duration_in_years) as u64;
-
-        EpochInflationRewards {
-            validator_rewards_lamports,
-            validator_rate,
-            foundation_rate,
-        }
+        (validator_rate * capitalization as f64 * epoch_duration_in_years) as u64
     }
 
     /// Convert computed RewardCommissions to RewardCommissionAccounts for storing.

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -8,8 +8,8 @@ use {
     },
     crate::{
         bank::{
-            EpochInflationRewards, RewardCalcTracer, RewardCalculationEvent, RewardCommission,
-            RewardCommissions, RewardsMetrics, null_tracer,
+            RewardCalcTracer, RewardCalculationEvent, RewardCommission, RewardCommissions,
+            RewardsMetrics, null_tracer,
         },
         inflation_rewards::{
             points::{DelegatedVoteState, PointValue, calculate_points},
@@ -211,8 +211,6 @@ impl Bank {
         let PartitionedRewardsCalculation {
             reward_commission_accounts,
             stake_rewards,
-            validator_rate,
-            foundation_rate,
             capitalization,
             point_value,
             ..
@@ -256,8 +254,6 @@ impl Bank {
             "epoch_rewards",
             ("slot", self.slot, i64),
             ("epoch", prev_epoch, i64),
-            ("validator_rate", *validator_rate, f64),
-            ("foundation_rate", *foundation_rate, f64),
             ("validator_rewards", total_reward_commissions, i64),
             ("active_stake", active_stake, i64),
             ("pre_capitalization", *capitalization, i64),
@@ -297,11 +293,8 @@ impl Bank {
         metrics: &mut RewardsMetrics,
     ) -> PartitionedRewardsCalculation {
         let capitalization = self.capitalization();
-        let EpochInflationRewards {
-            validator_rewards_lamports,
-            validator_rate,
-            foundation_rate,
-        } = self.calculate_epoch_inflation_rewards(capitalization, rewarded_epoch);
+        let validator_rewards_lamports =
+            self.calculate_epoch_inflation_rewards(capitalization, rewarded_epoch);
 
         let CalculateValidatorRewardsResult {
             reward_commission_accounts,
@@ -328,8 +321,6 @@ impl Bank {
         PartitionedRewardsCalculation {
             reward_commission_accounts,
             stake_rewards,
-            validator_rate,
-            foundation_rate,
             capitalization,
             point_value,
         }

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -309,11 +309,9 @@ pub(super) struct EpochRewardCalculateParamInfo<'a> {
 /// side effects.
 #[derive(Debug)]
 pub(super) struct PartitionedRewardsCalculation {
-    pub(super) reward_commission_accounts: RewardCommissionAccounts,
-    pub(super) stake_rewards: StakeRewardCalculation,
-    pub(super) validator_rate: f64,
-    pub(super) foundation_rate: f64,
-    pub(super) capitalization: u64,
+    reward_commission_accounts: RewardCommissionAccounts,
+    stake_rewards: StakeRewardCalculation,
+    capitalization: u64,
     point_value: PointValue,
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -843,10 +843,8 @@ where
         - bank2_sysvar_delta();
 
     // this assumes that no new builtins or precompiles were activated in bank1 or bank2
-    let EpochInflationRewards {
-        validator_rewards_lamports,
-        ..
-    } = bank2.calculate_epoch_inflation_rewards(bank0.capitalization(), bank0.epoch());
+    let validator_rewards_lamports =
+        bank2.calculate_epoch_inflation_rewards(bank0.capitalization(), bank0.epoch());
 
     // verify the stake and vote accounts are the right size
     assert!(

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -1,5 +1,5 @@
 use {
-    crate::bank::{Bank, EpochInflationRewards},
+    crate::bank::Bank,
     solana_account::{AccountSharedData, ReadableAccount},
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
@@ -68,16 +68,12 @@ impl VoteRewardAccountState {
         prev_epoch_capitalization: u64,
         additional_validator_rewards: u64,
     ) {
-        let EpochInflationRewards {
-            validator_rewards_lamports,
-            validator_rate: _,
-            foundation_rate: _,
-        } = bank.calculate_epoch_inflation_rewards(
+        let epoch_validator_rewards_lamports = bank.calculate_epoch_inflation_rewards(
             prev_epoch_capitalization + additional_validator_rewards,
             prev_epoch,
         );
         let state = Self {
-            epoch_validator_rewards_lamports: validator_rewards_lamports,
+            epoch_validator_rewards_lamports,
         };
         state.set_state(bank);
     }
@@ -191,10 +187,8 @@ mod tests {
         let circulating_supply = 566_000_000 * LAMPORTS_PER_SOL;
 
         let bank = Bank::new_for_tests(&GenesisConfig::default());
-        let EpochInflationRewards {
-            validator_rewards_lamports,
-            ..
-        } = bank.calculate_epoch_inflation_rewards(circulating_supply, 1);
+        let validator_rewards_lamports =
+            bank.calculate_epoch_inflation_rewards(circulating_supply, 1);
 
         calculate_voting_reward(
             bank.epoch_schedule().slots_per_epoch,
@@ -230,10 +224,7 @@ mod tests {
         let VoteRewardAccountState {
             epoch_validator_rewards_lamports,
         } = VoteRewardAccountState::new_from_bank(&bank);
-        let EpochInflationRewards {
-            validator_rewards_lamports,
-            ..
-        } = bank.calculate_epoch_inflation_rewards(
+        let validator_rewards_lamports = bank.calculate_epoch_inflation_rewards(
             prev_epoch_capitalization + additional_validator_rewards,
             prev_epoch,
         );


### PR DESCRIPTION
#### Problem

Currently `EpochInflationRewards` is returning the validator_rate and the foundation_rate.  These fields are not really being used anywhere.  They are used in just one place to record metrics which I believe are not so relevant anymore.


#### Summary of Changes

- Removes these fields from `EpochInflationRewards` and since `EpochInflationRewards` then only contains a single field, removes the struct itself.
- Removes handling of these fields in downstream structs and functions.
