### PR TITLE
Reduce Visibility of ScanConfig

### DIFF
--- a/accounts-db/benches/accounts.rs
+++ b/accounts-db/benches/accounts.rs
@@ -12,7 +12,6 @@ use {
         account_info::{AccountInfo, StorageLocation},
         accounts::{AccountAddressFilter, Accounts},
         accounts_db::{ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, AccountFromStorage, AccountsDb},
-        accounts_index::ScanConfig,
         ancestors::Ancestors,
     },
     solana_hash::Hash,
@@ -137,7 +136,6 @@ fn bench_concurrent_scan_write(bencher: &mut Bencher) {
                         &Ancestors::default(),
                         0,
                         AccountSharedData::default().owner(),
-                        &ScanConfig::default(),
                     )
                     .unwrap(),
             );

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -318,7 +318,6 @@ impl Accounts {
         ancestors: &Ancestors,
         bank_id: BankId,
         program_id: &Pubkey,
-        config: &ScanConfig,
     ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         let mut collector = Vec::new();
         self.accounts_db
@@ -330,7 +329,7 @@ impl Accounts {
                         account.owner() == program_id
                     })
                 },
-                config,
+                &ScanConfig::default(),
             )
             .map(|_| collector)
     }
@@ -341,7 +340,6 @@ impl Accounts {
         bank_id: BankId,
         program_id: &Pubkey,
         filter: F,
-        config: &ScanConfig,
     ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         let mut collector = Vec::new();
         self.accounts_db
@@ -353,7 +351,7 @@ impl Accounts {
                         account.owner() == program_id && filter(account)
                     })
                 },
-                config,
+                &ScanConfig::default(),
             )
             .map(|_| collector)
     }
@@ -400,11 +398,10 @@ impl Accounts {
         bank_id: BankId,
         index_key: &IndexKey,
         filter: F,
-        config: &ScanConfig,
         byte_limit_for_scan: Option<usize>,
     ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         let sum = AtomicUsize::default();
-        let config = config.recreate_with_abort();
+        let config = ScanConfig::default().recreate_with_abort();
         let mut collector = Vec::new();
         let result = self
             .accounts_db

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3371,7 +3371,7 @@ impl AccountsDb {
         }
     }
 
-    pub fn scan_accounts<F>(
+    pub(crate) fn scan_accounts<F>(
         &self,
         ancestors: &Ancestors,
         bank_id: BankId,
@@ -3403,7 +3403,7 @@ impl AccountsDb {
         Ok(())
     }
 
-    pub fn index_scan_accounts<F>(
+    pub(crate) fn index_scan_accounts<F>(
         &self,
         ancestors: &Ancestors,
         bank_id: BankId,

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -138,28 +138,28 @@ pub enum UpsertReclaim {
 }
 
 #[derive(Debug, Default)]
-pub struct ScanConfig {
+pub(crate) struct ScanConfig {
     /// checked by the scan. When true, abort scan.
-    pub abort: Option<Arc<AtomicBool>>,
+    pub(crate) abort: Option<Arc<AtomicBool>>,
 }
 
 impl ScanConfig {
     /// mark the scan as aborted
-    pub fn abort(&self) {
+    pub(crate) fn abort(&self) {
         if let Some(abort) = self.abort.as_ref() {
             abort.store(true, Ordering::Relaxed)
         }
     }
 
     /// use existing 'abort' if available, otherwise allocate one
-    pub fn recreate_with_abort(&self) -> Self {
+    pub(crate) fn recreate_with_abort(&self) -> Self {
         ScanConfig {
             abort: Some(self.abort.clone().unwrap_or_default()),
         }
     }
 
     /// true if scan should abort
-    pub fn is_aborted(&self) -> bool {
+    pub(crate) fn is_aborted(&self) -> bool {
         if let Some(abort) = self.abort.as_ref() {
             abort.load(Ordering::Relaxed)
         } else {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -26,7 +26,6 @@ use {
     log::*,
     serde::Serialize,
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut},
-    solana_accounts_db::accounts_index::ScanConfig,
     solana_clap_utils::{
         input_parsers::{cluster_type_of, pubkey_of, pubkeys_of},
         input_validators::{
@@ -2258,7 +2257,7 @@ fn main() {
 
                     if remove_stake_accounts {
                         for (address, mut account) in bank
-                            .get_program_accounts(&stake::program::id(), &ScanConfig::default())
+                            .get_program_accounts(&stake::program::id())
                             .unwrap()
                             .into_iter()
                         {
@@ -2282,7 +2281,7 @@ fn main() {
 
                     if !vote_accounts_to_destake.is_empty() {
                         for (address, mut account) in bank
-                            .get_program_accounts(&stake::program::id(), &ScanConfig::default())
+                            .get_program_accounts(&stake::program::id())
                             .unwrap()
                             .into_iter()
                         {
@@ -2362,10 +2361,7 @@ fn main() {
 
                         // Delete existing vote accounts
                         for (address, mut account) in bank
-                            .get_program_accounts(
-                                &solana_vote_program::id(),
-                                &ScanConfig::default(),
-                            )
+                            .get_program_accounts(&solana_vote_program::id())
                             .unwrap()
                             .into_iter()
                         {

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -11,7 +11,7 @@ use {
         ser::{Impossible, SerializeSeq, SerializeStruct, Serializer},
     },
     solana_account::{AccountSharedData, ReadableAccount},
-    solana_accounts_db::{accounts_index::ScanConfig, is_loadable::IsLoadable as _},
+    solana_accounts_db::is_loadable::IsLoadable as _,
     solana_cli_output::{
         CliAccount, CliAccountNewConfig, OutputFormat, QuietDisplay, VerboseDisplay,
         display::{build_balance_message, writeln_transaction},
@@ -919,7 +919,7 @@ impl AccountsScanner {
             }),
             AccountsOutputMode::Program(program_pubkey) => self
                 .bank
-                .get_program_accounts(program_pubkey, &ScanConfig::default())
+                .get_program_accounts(program_pubkey)
                 .unwrap()
                 .iter()
                 .filter(|(_, account)| self.should_process_account(account))

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -25,7 +25,7 @@ use {
     },
     solana_accounts_db::{
         accounts::AccountAddressFilter,
-        accounts_index::{AccountIndex, AccountSecondaryIndexes, IndexKey, ScanConfig, ScanResult},
+        accounts_index::{AccountIndex, AccountSecondaryIndexes, IndexKey, ScanResult},
     },
     solana_client::connection_cache::Protocol,
     solana_clock::{Slot, UnixTimestamp},
@@ -326,7 +326,6 @@ impl JsonRpcRequestProcessor {
                                 .iter()
                                 .all(|filter_type| filter_allows(filter_type, account))
                     },
-                    &ScanConfig::default(),
                     bank.byte_limit_for_scans(),
                 )
             })
@@ -2256,7 +2255,6 @@ impl JsonRpcRequestProcessor {
                                 .iter()
                                 .all(|filter_type| filter_allows(filter_type, account))
                         },
-                        &ScanConfig::default(),
                     )
                     .map_err(|e| RpcCustomError::ScanError {
                         message: e.to_string(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -89,7 +89,7 @@ use {
         accounts::{AccountAddressFilter, Accounts, PubkeyAccountSlot},
         accounts_db::{AccountsDb, AccountsDbConfig},
         accounts_hash::AccountsLtHash,
-        accounts_index::{IndexKey, ScanConfig, ScanResult},
+        accounts_index::{IndexKey, ScanResult},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         ancestors::Ancestors,
         blockhash_queue::BlockhashQueue,
@@ -4633,25 +4633,22 @@ impl Bank {
     pub fn get_program_accounts(
         &self,
         program_id: &Pubkey,
-        config: &ScanConfig,
     ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         self.rc
             .accounts
-            .load_by_program(&self.ancestors, self.bank_id, program_id, config)
+            .load_by_program(&self.ancestors, self.bank_id, program_id)
     }
 
     pub fn get_filtered_program_accounts<F: Fn(&AccountSharedData) -> bool>(
         &self,
         program_id: &Pubkey,
         filter: F,
-        config: &ScanConfig,
     ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         self.rc.accounts.load_by_program_with_filter(
             &self.ancestors,
             self.bank_id,
             program_id,
             filter,
-            config,
         )
     }
 
@@ -4659,7 +4656,6 @@ impl Bank {
         &self,
         index_key: &IndexKey,
         filter: F,
-        config: &ScanConfig,
         byte_limit_for_scan: Option<usize>,
     ) -> ScanResult<Vec<KeyedAccountSharedData>> {
         self.rc.accounts.load_by_index_key_with_filter(
@@ -4667,7 +4663,6 @@ impl Bank {
             self.bank_id,
             index_key,
             filter,
-            config,
             byte_limit_for_scan,
         )
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -40,7 +40,7 @@ use {
     solana_account_info::MAX_PERMITTED_DATA_INCREASE,
     solana_accounts_db::{
         accounts::AccountAddressFilter,
-        accounts_index::{AccountIndex, AccountSecondaryIndexes, IndexKey, ScanConfig, ScanError},
+        accounts_index::{AccountIndex, AccountSecondaryIndexes, IndexKey, ScanError},
         ancestors::Ancestors,
     },
     solana_client_traits::SyncClient,
@@ -3342,15 +3342,11 @@ fn test_bank_get_program_accounts() {
     let bank1 = Arc::new(new_from_parent(bank0.clone()));
     bank1.squash();
     assert_eq!(
-        bank0
-            .get_program_accounts(&program_id, &ScanConfig::default(),)
-            .unwrap(),
+        bank0.get_program_accounts(&program_id).unwrap(),
         vec![(pubkey0, account0.clone())]
     );
     assert_eq!(
-        bank1
-            .get_program_accounts(&program_id, &ScanConfig::default(),)
-            .unwrap(),
+        bank1.get_program_accounts(&program_id).unwrap(),
         vec![(pubkey0, account0)]
     );
     assert_eq!(
@@ -3369,20 +3365,8 @@ fn test_bank_get_program_accounts() {
 
     let bank3 = Arc::new(new_from_parent(bank2));
     bank3.squash();
-    assert_eq!(
-        bank1
-            .get_program_accounts(&program_id, &ScanConfig::default(),)
-            .unwrap()
-            .len(),
-        2
-    );
-    assert_eq!(
-        bank3
-            .get_program_accounts(&program_id, &ScanConfig::default(),)
-            .unwrap()
-            .len(),
-        2
-    );
+    assert_eq!(bank1.get_program_accounts(&program_id).unwrap().len(), 2);
+    assert_eq!(bank3.get_program_accounts(&program_id).unwrap().len(), 2);
 }
 
 #[test]
@@ -3411,7 +3395,6 @@ fn test_get_filtered_indexed_accounts_limit_exceeded() {
         bank.get_filtered_indexed_accounts(
             &IndexKey::ProgramId(program_id),
             |_| true,
-            &ScanConfig::default(),
             Some(limit), // limit here will be exceeded, resulting in aborted scan
         )
         .is_err()
@@ -3438,12 +3421,7 @@ fn test_get_filtered_indexed_accounts() {
     bank.store_account(&address, &account);
 
     let indexed_accounts = bank
-        .get_filtered_indexed_accounts(
-            &IndexKey::ProgramId(program_id),
-            |_| true,
-            &ScanConfig::default(),
-            None,
-        )
+        .get_filtered_indexed_accounts(&IndexKey::ProgramId(program_id), |_| true, None)
         .unwrap();
     assert_eq!(indexed_accounts.len(), 1);
     assert_eq!(indexed_accounts[0], (address, account));
@@ -3461,22 +3439,12 @@ fn test_get_filtered_indexed_accounts() {
     );
     bank.store_account(&address, &new_account);
     let indexed_accounts = bank
-        .get_filtered_indexed_accounts(
-            &IndexKey::ProgramId(program_id),
-            |_| true,
-            &ScanConfig::default(),
-            None,
-        )
+        .get_filtered_indexed_accounts(&IndexKey::ProgramId(program_id), |_| true, None)
         .unwrap();
     assert_eq!(indexed_accounts.len(), 1);
     assert_eq!(indexed_accounts[0], (address, new_account.clone()));
     let indexed_accounts = bank
-        .get_filtered_indexed_accounts(
-            &IndexKey::ProgramId(another_program_id),
-            |_| true,
-            &ScanConfig::default(),
-            None,
-        )
+        .get_filtered_indexed_accounts(&IndexKey::ProgramId(another_program_id), |_| true, None)
         .unwrap();
     assert_eq!(indexed_accounts.len(), 1);
     assert_eq!(indexed_accounts[0], (address, new_account.clone()));
@@ -3486,7 +3454,6 @@ fn test_get_filtered_indexed_accounts() {
         .get_filtered_indexed_accounts(
             &IndexKey::ProgramId(program_id),
             |account| account.owner() == &program_id,
-            &ScanConfig::default(),
             None,
         )
         .unwrap();
@@ -3495,7 +3462,6 @@ fn test_get_filtered_indexed_accounts() {
         .get_filtered_indexed_accounts(
             &IndexKey::ProgramId(another_program_id),
             |account| account.owner() == &another_program_id,
-            &ScanConfig::default(),
             None,
         )
         .unwrap();
@@ -7346,8 +7312,7 @@ fn test_store_scan_consistency<F>(
                         bank_to_scan_receiver.recv_timeout(Duration::from_millis(10))
                     {
                         info!("scanning program accounts for slot {}", bank_to_scan.slot());
-                        let accounts_result =
-                            bank_to_scan.get_program_accounts(&program_id, &ScanConfig::default());
+                        let accounts_result = bank_to_scan.get_program_accounts(&program_id);
                         let _ = scan_finished_sender.send(bank_to_scan.bank_id());
                         num_banks_scanned.fetch_add(1, Relaxed);
                         match (&acceptable_scan_results, accounts_result.is_err()) {

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -2,7 +2,7 @@ use {
     crate::bank::Bank,
     log::*,
     solana_account::ReadableAccount,
-    solana_accounts_db::accounts_index::{AccountIndex, IndexKey, ScanConfig, ScanResult},
+    solana_accounts_db::accounts_index::{AccountIndex, IndexKey, ScanResult},
     solana_pubkey::Pubkey,
     solana_stake_interface::{self as stake, state::StakeStateV2},
     std::collections::HashSet,
@@ -23,7 +23,6 @@ pub fn calculate_non_circulating_supply(bank: &Bank) -> ScanResult<NonCirculatin
     let withdraw_authority_list = withdraw_authority();
 
     let clock = bank.clock();
-    let config = &ScanConfig::default();
     let stake_accounts = if bank
         .rc
         .accounts
@@ -38,11 +37,10 @@ pub fn calculate_non_circulating_supply(bank: &Bank) -> ScanResult<NonCirculatin
             // zero-lamport Account::Default() after being wiped and reinitialized in later
             // updates. We include the redundant filter here to avoid returning these accounts.
             |account| account.owner() == &stake::program::id(),
-            config,
             None,
         )?
     } else {
-        bank.get_program_accounts(&stake::program::id(), config)?
+        bank.get_program_accounts(&stake::program::id())?
     };
 
     for (pubkey, account) in stake_accounts.iter() {


### PR DESCRIPTION
#### Problem
ScanConfig is only used in default configuration outside of accounts_db. This actually does nothing

#### Summary of Changes
- Reduce visibility of scan config to accounts-db

Fixes #
