### PR TITLE
build: align test validator shutdown sequence

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -132,6 +132,9 @@ fn main() {
         None
     };
     agave_logger::initialize_logging(logfile);
+    // NB: This hook is used to shutdown the validator, so don't remove it even if you
+    // don't want metrics.
+    solana_metrics::set_panic_hook("solana-test-validator", None);
 
     info!("{} {}", crate_name!(), solana_version::version!());
     info!("Starting validator with: {:#?}", std::env::args_os());

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -133,9 +133,13 @@ fn main() {
     };
     agave_logger::initialize_logging(logfile);
     // NB: Align with agave to abort.
+    let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(|info| {
-        eprintln!("{info}");
-        std::process::abort();
+        // Call the default hook.
+        default_hook(info);
+
+        // Force a process exit (no stack unwind).
+        std::process::exit(1);
     }));
 
     info!("{} {}", crate_name!(), solana_version::version!());

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -132,9 +132,11 @@ fn main() {
         None
     };
     agave_logger::initialize_logging(logfile);
-    // NB: This hook is used to shutdown the validator, so don't remove it even if you
-    // don't want metrics.
-    solana_metrics::set_panic_hook("solana-test-validator", None);
+    // NB: Align with agave to abort.
+    std::panic::set_hook(Box::new(|info| {
+        eprintln!("{info}");
+        std::process::abort();
+    }));
 
     info!("{} {}", crate_name!(), solana_version::version!());
     info!("Starting validator with: {:#?}", std::env::args_os());

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -132,9 +132,9 @@ fn main() {
         None
     };
     agave_logger::initialize_logging(logfile);
-    // NB: Align with agave to abort.
+    // NB: Align with agave to exit if any thread panics.
     let default_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(|info| {
+    std::panic::set_hook(Box::new(move |info| {
         // Call the default hook.
         default_hook(info);
 


### PR DESCRIPTION
#### Problem

- `solana-test-validator` will ignore panics and continue running in a half dead state (unlike the regular agave which will force a process exit).

#### Solution

- Install panic hook to force process exit (this seemed better than install the metrics hook).