### PR TITLE
refactor: serialize DuplicateSlotProof in gossip with wincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8468,6 +8468,7 @@ dependencies = [
  "static_assertions",
  "test-case",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -12965,6 +12966,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "657690780ce23e6f66576a782ffd88eb353512381817029cc1d7a99154bb6d1f"
 dependencies = [
+ "bytes",
  "pastey",
  "proc-macro2",
  "quote",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7365,6 +7365,7 @@ dependencies = [
  "solana-vote-program",
  "static_assertions",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -11299,6 +11300,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "657690780ce23e6f66576a782ffd88eb353512381817029cc1d7a99154bb6d1f"
 dependencies = [
+ "bytes",
  "pastey",
  "proc-macro2",
  "quote",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -89,6 +89,7 @@ solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -83,8 +83,10 @@ pub enum Error {
     NumChunksMismatch,
     #[error("missing data chunk")]
     MissingDataChunk,
-    #[error("(de)serialization error")]
-    SerializationError(#[from] bincode::Error),
+    #[error("wincode deserialization error")]
+    WincodeReadError(#[from] wincode::ReadError),
+    #[error("wincode serialization error")]
+    WincodeWriteError(#[from] wincode::WriteError),
     #[error("shred type mismatch")]
     ShredTypeMismatch,
     #[error("slot mismatch")]
@@ -115,7 +117,8 @@ impl Error {
             | Self::InvalidShred(_)
             | Self::NumChunksMismatch
             | Self::MissingDataChunk
-            | Self::SerializationError(_)
+            | Self::WincodeReadError(_)
+            | Self::WincodeWriteError(_)
             | Self::TryFromIntError(_)
             | Self::UnknownSlotLeader(_) => false,
         }
@@ -229,7 +232,7 @@ where
         shred1: shred.into_payload(),
         shred2: other_shred.into_payload(),
     };
-    let data = bincode::serialize(&proof)?;
+    let data = wincode::serialize(&proof)?;
     let chunk_size = if DUPLICATE_SHRED_HEADER_SIZE < max_size {
         max_size - DUPLICATE_SHRED_HEADER_SIZE
     } else {
@@ -306,7 +309,7 @@ pub(crate) fn into_shreds(
         return Err(Error::MissingDataChunk);
     }
     let data = (0..num_chunks).map(|k| data.remove(&k).unwrap()).concat();
-    let proof: DuplicateSlotProof = bincode::deserialize(&data)?;
+    let proof: DuplicateSlotProof = wincode::deserialize(&data)?;
     if proof.shred1 == proof.shred2 {
         return Err(Error::InvalidDuplicateSlotProof);
     }
@@ -478,7 +481,7 @@ pub(crate) mod tests {
             shred1: shred.into_payload(),
             shred2: other_shred.into_payload(),
         };
-        let data = bincode::serialize(&proof)?;
+        let data = wincode::serialize(&proof)?;
         let chunk_size = max_size - DUPLICATE_SHRED_HEADER_SIZE;
         let chunks: Vec<_> = data.chunks(chunk_size).map(Vec::from).collect();
         let num_chunks = u8::try_from(chunks.len())?;

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -120,7 +120,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
 trees = { workspace = true }
-wincode = { workspace = true }
+wincode = { workspace = true, features = ["bytes"] }
 
 [dependencies.rocksdb]
 # Avoid the vendored bzip2 within rocksdb-sys that can cause linker conflicts

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -11,6 +11,7 @@ use {
         fmt::Display,
         ops::{Range, RangeBounds},
     },
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 bitflags! {
@@ -275,7 +276,7 @@ pub struct MerkleRootMeta {
     first_received_shred_type: ShredType,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, SchemaRead, SchemaWrite)]
 pub struct DuplicateSlotProof {
     #[serde(with = "shred::serde_bytes_payload")]
     pub shred1: shred::Payload,

--- a/ledger/src/shred/payload.rs
+++ b/ledger/src/shred/payload.rs
@@ -10,9 +10,10 @@ use {
         ops::{Bound, Deref, DerefMut, RangeBounds, RangeFull},
         slice::SliceIndex,
     },
+    wincode::{SchemaRead, SchemaWrite},
 };
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Debug, Eq, SchemaRead, SchemaWrite)]
 pub struct Payload {
     pub bytes: Bytes,
 }
@@ -315,5 +316,28 @@ mod test {
             .expect("valid packet and nonce");
         assert_eq!(bytes, shred.payload().as_ref());
         assert_eq!(got, Some(nonce));
+    }
+
+    #[test]
+    fn test_payload_wincode_serde_bytes_compat() {
+        // Verify that wincode serializes Payload with the same bytes as bincode does via
+        // serde_bytes_payload, ensuring on-disk compatibility during migration.
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct AsSerdeBytesPayload(#[serde(with = "super::serde_bytes_payload")] Payload);
+
+        for example in [vec![], vec![44], vec![0u8, 1, 2, 3, 100, 255]] {
+            let payload = Payload::from(example);
+
+            let wincode_bytes = wincode::serialize(&payload).unwrap();
+            let bincode_bytes = bincode::serialize(&AsSerdeBytesPayload(payload.clone())).unwrap();
+
+            assert_eq!(wincode_bytes, bincode_bytes);
+
+            let wincode_payload: Payload = wincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(*wincode_payload, *payload);
+            let bincode_payload: AsSerdeBytesPayload =
+                bincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(*wincode_payload, *bincode_payload.0);
+        }
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7023,6 +7023,7 @@ dependencies = [
  "solana-vote-program",
  "static_assertions",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -11592,6 +11593,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "657690780ce23e6f66576a782ffd88eb353512381817029cc1d7a99154bb6d1f"
 dependencies = [
+ "bytes",
  "pastey",
  "proc-macro2",
  "quote",


### PR DESCRIPTION
#### Problem
Newest wincode release supports `Bytes` encoding with `wincode`, code relying on `serde_bytes_payload`, i.e. `DuplicateSlotProof` can now use wincode serialize and deserialize functions.

#### Summary of Changes
* add test for compatibility of serde_bytes_payload with wincode
* annotate `DuplicateSlotProof` with wincode derives
* switch gossip `duplicate_shred.rs` to use wincode for serialize and deserialize
