### PR TITLE
chore(toolchain): bump to Rust 1.94.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.94.1"


### PR DESCRIPTION
#### Problem
Patch release [1.94.1](https://blog.rust-lang.org/2026/03/26/1.94.1-release/) mentions:
```
Fix std::thread::spawn on wasm32-wasip1-threads
Clippy: fix ICE in match_same_arms
Cargo: downgrade curl-sys to 0.4.83

And a security fix:
Cargo: Update tar to 0.4.45
```

#### Summary of Changes
Update stable toolchain, do not change nightly.
