### PR TITLE
bloom: enable sha2 feature in dev dependencies (tests fix)

### DIFF
--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -43,7 +43,7 @@ bencher = { workspace = true }
 rayon = { workspace = true }
 solana-bloom = { path = ".", features = ["agave-unstable-api"] }
 solana-hash = { workspace = true, features = ["atomic"] }
-solana-sha256-hasher = { workspace = true }
+solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-signature = { workspace = true, features = ["std"] }
 
 [[bench]]


### PR DESCRIPTION
#### Problem

```
running 7 tests
test bloom::test::test_add_contains ... FAILED
test bloom::test::test_filter_math ... ok
test bloom::test::test_debug ... FAILED
test bloom::test::test_bloom_filter ... ok
test bloom::test::test_random ... ok
test bloom::test::test_atomic_bloom ... ok
test bloom::test::test_atomic_bloom_round_trip ... ok

failures:

---- bloom::test::test_add_contains stdout ----

thread 'bloom::test::test_add_contains' (498352) panicked at /home/redrum/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/solana-sha256-hasher-3.1.0/src/lib.rs:58:13:
hashv is only available on target `solana` or with the `sha2` feature enabled on this crate
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- bloom::test::test_debug stdout ----

thread 'bloom::test::test_debug' (498356) panicked at /home/redrum/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/solana-sha256-hasher-3.1.0/src/lib.rs:58:13:
hashv is only available on target `solana` or with the `sha2` feature enabled on this crate
```
    
    
#### Summary of Changes
- Enabled `sha2` feature for dev-dependency `solana-sha256-hasher`
