### PR TITLE
Uses `VoteStateHandler` API in `vote_reward.rs`

### DIFF
--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -208,6 +208,7 @@ impl VoteStateHandler {
         }
     }
 
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn votes(&self) -> &VecDeque<LandedVote> {
         match &self.target_state {
             TargetVoteState::V4(v4) => &v4.votes,
@@ -220,7 +221,7 @@ impl VoteStateHandler {
         }
     }
 
-    pub(crate) fn set_votes(&mut self, votes: VecDeque<LandedVote>) {
+    pub fn set_votes(&mut self, votes: VecDeque<LandedVote>) {
         match &mut self.target_state {
             TargetVoteState::V4(v4) => v4.votes = votes,
         }
@@ -245,13 +246,13 @@ impl VoteStateHandler {
         self.last_lockout().map(|v| v.slot())
     }
 
-    pub(crate) fn root_slot(&self) -> Option<Slot> {
+    pub fn root_slot(&self) -> Option<Slot> {
         match &self.target_state {
             TargetVoteState::V4(v4) => v4.root_slot,
         }
     }
 
-    pub(crate) fn set_root_slot(&mut self, root_slot: Option<Slot>) {
+    pub fn set_root_slot(&mut self, root_slot: Option<Slot>) {
         match &mut self.target_state {
             TargetVoteState::V4(v4) => v4.root_slot = root_slot,
         }
@@ -269,6 +270,7 @@ impl VoteStateHandler {
         }
     }
 
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)> {
         match &self.target_state {
             TargetVoteState::V4(v4) => &v4.epoch_credits,
@@ -420,8 +422,7 @@ impl VoteStateHandler {
         }
     }
 
-    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-    pub(crate) fn increment_credits(&mut self, epoch: Epoch, credits: u64) {
+    pub fn increment_credits(&mut self, epoch: Epoch, credits: u64) {
         // increment credits, record by epoch
 
         // never seen a credit
@@ -560,6 +561,21 @@ impl VoteStateHandler {
         }
     }
 
+    /// Constructs a `VoteStateHandler` of the same version as the input `VoteStateVersions`.
+    ///
+    /// Returns `Err(InstructionError::InvalidAccountData)` if the version of the input
+    /// `VoteStateVersions` is not supported by `VoteStateHandler`.
+    pub fn try_new_from_vote_state_versions(
+        versions: VoteStateVersions,
+    ) -> Result<Self, InstructionError> {
+        match versions {
+            VoteStateVersions::V4(state) => Ok(Self::new_v4(*state)),
+            VoteStateVersions::V3(_)
+            | VoteStateVersions::V1_14_11(_)
+            | VoteStateVersions::Uninitialized => Err(InstructionError::InvalidAccountData),
+        }
+    }
+
     #[cfg(any(test, feature = "dev-context-only-utils"))]
     pub fn default_v4() -> Self {
         Self::new_v4(VoteStateV4::default())
@@ -579,16 +595,24 @@ impl VoteStateHandler {
         }
     }
 
-    #[cfg(test)]
-    pub fn serialize(self) -> Vec<u8> {
+    /// Serializes `self` into the provided `data` buffer.
+    ///
+    /// Returns `Err(InstructionError::InvalidAccountData)` if serialization fails.
+    pub fn serialize_into(self, data: &mut [u8]) -> Result<(), InstructionError> {
         match self.target_state {
             TargetVoteState::V4(v4) => {
-                let mut data = vec![0; VoteStateV4::size_of()];
                 let versioned = VoteStateVersions::V4(Box::new(v4));
-                bincode::serialize_into(&mut data[..], &versioned).unwrap();
-                data
+                bincode::serialize_into(data, &versioned)
+                    .map_err(|_e| InstructionError::InvalidAccountData)
             }
         }
+    }
+
+    #[cfg(test)]
+    pub fn serialize(self) -> Vec<u8> {
+        let mut data = vec![0; VoteStateV4::size_of()];
+        self.serialize_into(&mut data).unwrap();
+        data
     }
 }
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1,10 +1,7 @@
 //! Vote state, vote program
 //! Receive and processes votes from validators
 
-#[cfg(feature = "dev-context-only-utils")]
 pub mod handler;
-#[cfg(not(feature = "dev-context-only-utils"))]
-pub(crate) mod handler;
 
 pub use solana_vote_interface::state::{vote_state_versions::*, *};
 use {

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -2,13 +2,12 @@ use {
     crate::{bank::Bank, validated_block_finalization::ValidatedBlockFinalizationCert},
     epoch_inflation_account_state::{EpochInflationAccountState, EpochInflationState},
     log::info,
-    solana_account::{AccountSharedData, ReadableAccount},
+    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
     solana_vote::vote_account::VoteAccount,
-    solana_vote_interface::state::{
-        LandedVote, Lockout, MAX_EPOCH_CREDITS_HISTORY, VoteStateV4, VoteStateVersions,
-    },
+    solana_vote_interface::state::{LandedVote, Lockout},
+    solana_vote_program::vote_state::handler::VoteStateHandler,
     std::collections::VecDeque,
     thiserror::Error,
 };
@@ -135,7 +134,7 @@ pub(super) fn calculate_and_pay_voting_reward_and_update_vote_state(
             );
             continue;
         };
-        if let Some(account_data) = pay_reward_update_vote_state(
+        if let Some(account_data) = update_vote_account(
             current_epoch,
             reward_slot,
             current_slot_account,
@@ -152,7 +151,7 @@ pub(super) fn calculate_and_pay_voting_reward_and_update_vote_state(
     if total_leader_reward != 0 {
         match current_vote_accounts.get(&current_slot_leader_vote_pubkey) {
             Some((_, leader_account)) => {
-                if let Some(account_data) = pay_reward_update_vote_state(
+                if let Some(account_data) = update_vote_account(
                     current_epoch,
                     reward_slot,
                     leader_account,
@@ -204,11 +203,10 @@ fn calculate_reward(
     (validator_reward_lamports, leader_reward_lamports)
 }
 
-/// Deserializes `VoteState` from `account`; pays `reward` in `current_epoch` to the `epoch_credits` field;
-/// and updates the `votes` and `root_slot` fields in the vote state deserialized from the `account`.
+/// Deserializes the state from the `account` and updates various fields in it.
 ///
-/// TODO: this is using VoteStateV4 explicitly.  When we upstream, we will use VoteStateHandle API.
-fn pay_reward_update_vote_state(
+/// If successful, returns the `AccountSharedData` that can be stored back into a `Bank`.
+fn update_vote_account(
     current_epoch: Epoch,
     reward_slot: Slot,
     account: &VoteAccount,
@@ -216,67 +214,31 @@ fn pay_reward_update_vote_state(
     reward: u64,
     final_cert: Option<&ValidatedBlockFinalizationCert>,
 ) -> Option<AccountSharedData> {
-    let data = account.account().data();
-    let Ok(vote_state_versions) = bincode::deserialize(data) else {
-        return None;
-    };
-    match vote_state_versions {
-        VoteStateVersions::V4(mut vote_state) => {
-            increment_credits(&mut vote_state, current_epoch, reward);
-            update_vote_state(
-                &mut vote_state,
-                reward_slot,
-                validator_vote_pubkey,
-                final_cert,
-            );
-            let mut paid_account = AccountSharedData::new(
-                account.lamports(),
-                account.account().data().len(),
-                account.owner(),
-            );
-            paid_account
-                .serialize_data(&VoteStateVersions::V4(vote_state))
-                .ok()?;
-            Some(paid_account)
-        }
-        _ => None,
-    }
+    let versions = bincode::deserialize(account.account().data()).ok()?;
+    let mut handle = VoteStateHandler::try_new_from_vote_state_versions(versions).ok()?;
+    update_vote_state(
+        &mut handle,
+        reward_slot,
+        current_epoch,
+        reward,
+        validator_vote_pubkey,
+        final_cert,
+    );
+    let mut paid_account = AccountSharedData::new(
+        account.lamports(),
+        account.account().data().len(),
+        account.owner(),
+    );
+    handle
+        .serialize_into(paid_account.data_as_mut_slice())
+        .ok()?;
+    Some(paid_account)
 }
 
-/// Stores rewards as credits in the current vote state.
+/// Updates `epoch_credits`, `root_slot`, and `votes` in vote state using the rewards and finalization
+/// certificates from the footer.
 ///
-/// TODO: this is using VoteStateV4 explicitly.  When we upstream, we will use VoteStateHandle API.
-fn increment_credits(vote_state: &mut VoteStateV4, epoch: Epoch, credits: u64) {
-    // never seen a credit
-    if vote_state.epoch_credits.is_empty() {
-        vote_state.epoch_credits.push((epoch, 0, 0));
-    } else if epoch != vote_state.epoch_credits.last().unwrap().0 {
-        let (_, credits, prev_credits) = *vote_state.epoch_credits.last().unwrap();
-
-        if credits != prev_credits {
-            // if credits were earned previous epoch
-            // append entry at end of list for the new epoch
-            vote_state.epoch_credits.push((epoch, credits, credits));
-        } else {
-            // else just move the current epoch
-            vote_state.epoch_credits.last_mut().unwrap().0 = epoch;
-        }
-
-        // Remove too old epoch_credits
-        if vote_state.epoch_credits.len() > MAX_EPOCH_CREDITS_HISTORY {
-            vote_state.epoch_credits.remove(0);
-        }
-    }
-
-    vote_state.epoch_credits.last_mut().unwrap().1 = vote_state
-        .epoch_credits
-        .last()
-        .unwrap()
-        .1
-        .saturating_add(credits);
-}
-
-/// Updates `root_slot` and `votes` in vote state using the rewards and finalization certificates from the footer
+/// `epoch_credits` are updated to record the rewards that the vote account has earned.
 ///
 /// Downstream tooling expects these fields to be be set:
 /// - `root_slot`, a validator's latest finalized & replayed slot
@@ -292,22 +254,25 @@ fn increment_credits(vote_state: &mut VoteStateV4, epoch: Epoch, credits: u64) {
 /// - `root_slot` is populated from the footer finalization certificate
 /// - `votes` is populated from the footer rewards aggregate
 fn update_vote_state(
-    vote_state: &mut VoteStateV4,
+    handle: &mut VoteStateHandler,
     reward_slot: Slot,
+    reward_epoch: Epoch,
+    reward: u64,
     validator_vote_pubkey: Pubkey,
     final_cert: Option<&ValidatedBlockFinalizationCert>,
 ) {
+    handle.increment_credits(reward_epoch, reward);
     if let Some(final_cert) = final_cert {
         if final_cert.was_signed_by(&validator_vote_pubkey) {
-            vote_state.root_slot = Some(final_cert.slot());
+            handle.set_root_slot(Some(final_cert.slot()));
         }
     }
 
-    let latest_root_or_reward = vote_state.root_slot.unwrap_or(reward_slot).max(reward_slot);
-    vote_state.votes = VecDeque::from([LandedVote {
+    let latest_root_or_reward = handle.root_slot().unwrap_or(reward_slot).max(reward_slot);
+    handle.set_votes(VecDeque::from([LandedVote {
         lockout: Lockout::new(latest_root_or_reward),
         latency: 0,
-    }]);
+    }]));
 }
 
 #[cfg(test)]
@@ -339,17 +304,14 @@ mod tests {
         solana_rent::Rent,
         solana_signer::Signer,
         solana_signer_store::encode_base2,
+        solana_vote_interface::state::VoteStateVersions,
     };
 
-    fn get_vote_state_v4(bank: &Bank, vote_pubkey: &Pubkey) -> VoteStateV4 {
+    fn get_vote_state_handler(bank: &Bank, vote_pubkey: &Pubkey) -> VoteStateHandler {
         let vote_accounts = bank.vote_accounts();
         let (_, vote_account) = vote_accounts.get(vote_pubkey).unwrap();
-        let vote_state_versions: VoteStateVersions =
-            bincode::deserialize(vote_account.account().data()).unwrap();
-        let VoteStateVersions::V4(vote_state) = vote_state_versions else {
-            panic!("unexpected vote state version");
-        };
-        *vote_state
+        let versions = bincode::deserialize(vote_account.account().data()).unwrap();
+        VoteStateHandler::try_new_from_vote_state_versions(versions).unwrap()
     }
 
     fn build_fast_finalization_cert(
@@ -396,11 +358,15 @@ mod tests {
 
     #[test]
     fn increment_credits_works() {
-        let mut vote_state = VoteStateV4::default();
+        let mut handle = VoteStateHandler::default_v4();
         let epoch = 1234;
         let credits = 543432;
-        increment_credits(&mut vote_state, epoch, credits);
-        assert_eq!(credits, vote_state.epoch_credits.last().unwrap().1);
+        handle.increment_credits(epoch, credits);
+        let (got_epoch, got_final_credits, got_initial_credits) =
+            *handle.epoch_credits().last().unwrap();
+        assert_eq!(got_epoch, epoch);
+        assert_eq!(got_final_credits, credits);
+        assert_eq!(got_initial_credits, 0);
     }
 
     #[test]
@@ -410,8 +376,7 @@ mod tests {
         let epoch = 1234;
         let reward = 3453423;
         let account_shared_data =
-            pay_reward_update_vote_state(epoch, 0, &account, Pubkey::default(), reward, None)
-                .unwrap();
+            update_vote_account(epoch, 0, &account, Pubkey::default(), reward, None).unwrap();
         let vote_state_versions: VoteStateVersions =
             bincode::deserialize(&account_shared_data.data_clone()).unwrap();
         let VoteStateVersions::V4(vote_state) = vote_state_versions else {
@@ -567,11 +532,11 @@ mod tests {
         )
         .unwrap();
 
-        let vote_state = get_vote_state_v4(&bank, &target_vote_pubkey);
-        assert_eq!(vote_state.root_slot, Some(final_cert.slot()));
-        assert_eq!(vote_state.votes.len(), 1);
+        let handle = get_vote_state_handler(&bank, &target_vote_pubkey);
+        assert_eq!(handle.root_slot(), Some(final_cert.slot()));
+        assert_eq!(handle.votes().len(), 1);
         assert_eq!(
-            vote_state.votes.front().unwrap().lockout.slot(),
+            handle.votes().front().unwrap().lockout.slot(),
             final_cert.slot().max(reward_slot)
         );
     }
@@ -631,11 +596,11 @@ mod tests {
         )
         .unwrap();
 
-        let vote_state = get_vote_state_v4(&bank, &target_vote_pubkey);
-        assert_eq!(vote_state.root_slot, None);
-        assert_eq!(vote_state.votes.len(), 1);
+        let vote_state = get_vote_state_handler(&bank, &target_vote_pubkey);
+        assert_eq!(vote_state.root_slot(), None);
+        assert_eq!(vote_state.votes().len(), 1);
         assert_eq!(
-            vote_state.votes.front().unwrap().lockout.slot(),
+            vote_state.votes().front().unwrap().lockout.slot(),
             reward_slot
         );
     }


### PR DESCRIPTION
#### Problem

Currently, `vote_reward.rs` knows about `VoteStateV4`.  This means that when we introduce new vote states, we will have to update this module as well.  This is not ideal.

We want to use the `VoteStateHandler` API in `vote_reward.rs` so that `vote_rewar in particular so that we do not need to reimplement `increment_credits` and we are using the abstraction instead of `VoteStateV4` directly.  Which means it should be easier to port if and when we introduce new vote states.


#### Summary of Changes

This PR exposes the `VoteStateHandler` struct publicly which abstracts away different vote state versions and uses that in `vote_reward.rs`.

Fixes #11585 
