### PR TITLE
Move zero lamport check for flush to sub function

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5579,6 +5579,28 @@ impl AccountsDb {
         }
     }
 
+    /// Returns whether `pubkey` is a zero-lamport account, or `None` if the account doesn't exist.
+    /// When `ancestors` is `Some`, the lamport balance is checked against the most recent ancestor.
+    /// When `ancestors` is `None`, only key existence is tested and `Some(false)` is always returned for present accounts.
+    fn is_zero_lamport(&self, pubkey: &Pubkey, ancestors: Option<&Ancestors>) -> Option<bool> {
+        // With ancestors, find the most recent ancestor and check the account balance
+        // If the account doesn't exist return None
+        if let Some(ancestors) = ancestors {
+            return self.accounts_index.get_with_and_then(
+                pubkey,
+                ancestors,
+                true,
+                |(_, account)| account.is_zero_lamport(),
+            );
+        }
+
+        // Without ancestors, only whether the account exists in the index or not can be checked.
+        // If present, return (Some(false)); if missing, None.
+        self.accounts_index
+            .get_and_then(pubkey, |account| (true, account.is_some()))
+            .then_some(false)
+    }
+
     // Stores accounts in the write cache. If an account is zero-lamport and not present in the
     // index, there is no need to store it in the write cache as it will not effect the accounts
     // hash. The function returns a BitVec indicating whether each account was stored in the cache.
@@ -5609,27 +5631,16 @@ impl AccountsDb {
                     return;
                 }
                 if account.is_zero_lamport() {
-                    if let Some(ancestors) = ancestors {
-                        if let Some(is_zero_lamport) = self.accounts_index.get_with_and_then(
-                            pubkey,
-                            ancestors,
-                            true,
-                            |(_, account)| account.is_zero_lamport(),
-                        ) {
-                            if is_zero_lamport {
-                                stats.num_ancestors_zero_lamport_skipped += 1;
-                                return;
-                            }
-                        } else {
+                    match self.is_zero_lamport(pubkey, ancestors) {
+                        None => {
                             stats.num_ephemeral_accounts_skipped += 1;
                             return;
                         }
-                    } else if self
-                        .accounts_index
-                        .get_and_then(pubkey, |account| (true, account.is_none()))
-                    {
-                        stats.num_ephemeral_accounts_skipped += 1;
-                        return;
+                        Some(true) => {
+                            stats.num_ancestors_zero_lamport_skipped += 1;
+                            return;
+                        }
+                        Some(false) => {}
                     }
                 }
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6447,3 +6447,33 @@ fn test_index_scan_accounts_excludes_roots_added_during_scan() {
     // slot 3 was rooted after the scan guard's max_root (= 2) was established.
     assert!(!found_pubkeys.contains(&pubkey_new));
 }
+
+#[test_case(Some(42), Some(false); "nonzero_lamports")]
+#[test_case(Some(0),  Some(true);  "zero_lamports")]
+#[test_case(None,     None;        "missing")]
+fn test_is_zero_lamport_with_ancestors(lamports: Option<u64>, expected: Option<bool>) {
+    let db = AccountsDb::new_single_for_tests();
+    let pubkey = Pubkey::new_unique();
+    let ancestors = Ancestors::from(vec![0]);
+    if let Some(lamports) = lamports {
+        let account = AccountSharedData::new(lamports, 0, &Pubkey::default());
+        db.store_for_tests((0, [(&pubkey, &account)].as_slice()));
+        db.add_root_and_flush_write_cache(0);
+    }
+    assert_eq!(db.is_zero_lamport(&pubkey, Some(&ancestors)), expected);
+}
+
+#[test_case(true,  Some(false); "present")]
+#[test_case(false, None;        "missing")]
+fn test_is_zero_lamport_no_ancestors(stored: bool, expected: Option<bool>) {
+    let db = AccountsDb::new_single_for_tests();
+    let pubkey = Pubkey::new_unique();
+    if stored {
+        // Set the account to zero lamports. Since no ancestors are provided, the lamport count is
+        // is not checked, only the existance of the account.
+        let account = AccountSharedData::new(0, 0, &Pubkey::default());
+        db.store_for_tests((0, [(&pubkey, &account)].as_slice()));
+        db.add_root_and_flush_write_cache(0);
+    }
+    assert_eq!(db.is_zero_lamport(&pubkey, None), expected);
+}


### PR DESCRIPTION
#### Problem
Zero lamport check will need to check write cache items (next PR). This will add complexity to the is zero lamport check

#### Summary of Changes
- Move zero lamport check to sub function.
- Clean up logic
- Add some unit tests

Fixes #
