### PR TITLE
blockstore: upstream population of DoubleMerkleRootMeta

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -19,6 +19,7 @@ use {
         shred::{
             self, DATA_SHREDS_PER_FEC_BLOCK, ErasureSetId, ProcessShredsStats, ReedSolomonCache,
             Shred, ShredId, ShredType, Shredder,
+            merkle_tree::{MerkleTree, SIZE_OF_MERKLE_PROOF_ENTRY, get_proof_size},
         },
         slot_stats::{ShredSource, SlotsStats},
         transaction_address_lookup_table_scanner::scan_transaction,
@@ -33,6 +34,7 @@ use {
     rand::Rng,
     rayon::iter::{IntoParallelIterator, ParallelIterator},
     rocksdb::{DBRawIterator, LiveFile},
+    serde_bytes::ByteBuf,
     solana_account::ReadableAccount,
     solana_address_lookup_table_interface::state::AddressLookupTable,
     solana_clock::{DEFAULT_TICKS_PER_SECOND, Slot, UnixTimestamp},
@@ -41,12 +43,13 @@ use {
         entry::{Entry, MaxDataShredsLen, create_ticks},
     },
     solana_genesis_config::{DEFAULT_GENESIS_ARCHIVE, DEFAULT_GENESIS_FILE, GenesisConfig},
-    solana_hash::Hash,
+    solana_hash::{HASH_BYTES, Hash},
     solana_keypair::Keypair,
     solana_measure::measure::Measure,
     solana_metrics::datapoint_error,
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
+    solana_sha256_hasher::hashv,
     solana_signature::Signature,
     solana_signer::Signer,
     solana_storage_proto::{StoredExtendedRewards, StoredTransactionStatusMeta},
@@ -257,6 +260,7 @@ pub struct Blockstore {
     index_cf: LedgerColumn<cf::Index>,
     erasure_meta_cf: LedgerColumn<cf::ErasureMeta>,
     merkle_root_meta_cf: LedgerColumn<cf::MerkleRootMeta>,
+    double_merkle_meta_cf: LedgerColumn<cf::DoubleMerkleMeta>,
     orphans_cf: LedgerColumn<cf::Orphans>,
     duplicate_slots_cf: LedgerColumn<cf::DuplicateSlots>,
 
@@ -410,6 +414,7 @@ impl Blockstore {
         let index_cf = db.column();
         let erasure_meta_cf = db.column();
         let merkle_root_meta_cf = db.column();
+        let double_merkle_meta_cf = db.column();
         let orphans_cf = db.column();
         let duplicate_slots_cf = db.column();
 
@@ -456,6 +461,7 @@ impl Blockstore {
             erasure_meta_cf,
             index_cf,
             merkle_root_meta_cf,
+            double_merkle_meta_cf,
             meta_cf,
             optimistic_slots_cf,
             perf_samples_cf,
@@ -571,6 +577,21 @@ impl Blockstore {
         // Database::destroy() fails if the root directory doesn't exist
         fs::create_dir_all(ledger_path)?;
         Rocks::destroy(&Path::new(ledger_path).join(BLOCKSTORE_DIRECTORY_ROCKS_LEVEL))
+    }
+
+    /// Checks all available block versions, if we have a *complete* block for
+    /// `block_id`, returns the location where it is stored
+    #[allow(dead_code)]
+    pub fn get_block_location(&self, slot: Slot, block_id: Hash) -> Result<Option<BlockLocation>> {
+        for location in [
+            BlockLocation::Original,
+            BlockLocation::Alternate { block_id },
+        ] {
+            if self.get_double_merkle_root(slot, location)? == Some(block_id) {
+                return Ok(Some(location));
+            }
+        }
+        Ok(None)
     }
 
     /// Returns the SlotMeta of the specified slot.
@@ -756,6 +777,50 @@ impl Blockstore {
                 merkle_root_meta,
             ),
         }
+    }
+
+    /// Gets the double merkle meta for the given block.
+    /// If the meta is present but the proofs have not yet been populated - generate and store them
+    /// and return the updated double merkle meta
+    pub fn get_double_merkle_meta_maybe_populate_proofs(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+    ) -> Result<Option<DoubleMerkleMeta>> {
+        let Some(mut double_merkle_meta) = self.double_merkle_meta_cf.get((slot, location))? else {
+            return Ok(None);
+        };
+
+        if double_merkle_meta.proofs.is_empty() {
+            self.populate_double_merkle_meta_proofs(slot, location, &mut double_merkle_meta)?;
+            self.double_merkle_meta_cf
+                .put((slot, location), &double_merkle_meta)?;
+        }
+
+        Ok(Some(double_merkle_meta))
+    }
+
+    /// Gets the double merkle root for the block in the given location.
+    /// Returns `None` if the block is not full.
+    /// DoubleMerkleMeta is computed atomically during shred insertion when a slot becomes full.
+    pub fn get_double_merkle_root(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+    ) -> Result<Option<Hash>> {
+        let Some(double_merkle_meta_bytes) =
+            self.double_merkle_meta_cf.get_slice((slot, location))?
+        else {
+            debug_assert!(
+                self.meta_from_location(slot, location)
+                    .unwrap()
+                    .is_none_or(|meta| !meta.is_full())
+            );
+            return Ok(None);
+        };
+
+        let dmr: Hash = wincode::deserialize(&double_merkle_meta_bytes[0..HASH_BYTES])?;
+        Ok(Some(dmr))
     }
 
     /// Check whether the specified slot is an orphan slot which does not
@@ -1260,13 +1325,148 @@ impl Blockstore {
         }
     }
 
+    /// Computes and adds DoubleMerkleMeta to the write_batch for any newly completed slots.
+    fn compute_double_merkle_meta_for_newly_completed_slots(
+        &self,
+        shred_insertion_tracker: &mut ShredInsertionTracker,
+    ) -> Result<()> {
+        for (&(location, slot), slot_meta_entry) in
+            shred_insertion_tracker.slot_meta_working_set.iter()
+        {
+            let meta = RefCell::borrow(&*slot_meta_entry.new_slot_meta);
+            if !is_newly_completed_slot(&meta, &slot_meta_entry.old_slot_meta) {
+                continue;
+            }
+
+            self.build_double_merkle_meta_in_batch(
+                slot,
+                location,
+                meta.last_index.expect("Slot is full"),
+                &shred_insertion_tracker.slot_meta_working_set,
+                &shred_insertion_tracker.merkle_root_metas,
+                &mut shred_insertion_tracker.write_batch,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Builds DoubleMerkleMeta for a completed slot and adds it to the write batch.
+    /// Expects the block to be full
+    fn build_double_merkle_meta_in_batch(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+        last_index: u64,
+        slot_metas: &HashMap<(BlockLocation, Slot), SlotMetaWorkingSetEntry>,
+        merkle_root_metas: &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
+        write_batch: &mut WriteBatch,
+    ) -> Result<()> {
+        let fec_set_count = (last_index / (DATA_SHREDS_PER_FEC_BLOCK as u64) + 1) as usize;
+        let merkle_tree = self.build_double_merkle_tree(
+            slot,
+            location,
+            fec_set_count,
+            Some(slot_metas),
+            Some(merkle_root_metas),
+        )?;
+
+        let double_merkle_root = *merkle_tree.root();
+        // We don't build the proofs here as they are only needed to serve repair requests.
+        // These will be built later when calling `get_double_merkle_meta_maybe_populate_proofs`
+        let proofs = ByteBuf::new();
+
+        // Create and add DoubleMerkleMeta to write batch
+        let double_merkle_meta = DoubleMerkleMeta {
+            double_merkle_root,
+            fec_set_count,
+            proofs,
+        };
+
+        self.double_merkle_meta_cf
+            .put_in_batch(write_batch, (slot, location), &double_merkle_meta)
+    }
+
+    /// Builds the double merkle tree for a completed block (expects the block to be full)
+    fn build_double_merkle_tree(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+        fec_set_count: usize,
+        slot_metas: Option<&HashMap<(BlockLocation, Slot), SlotMetaWorkingSetEntry>>,
+        merkle_root_metas: Option<
+            &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
+        >,
+    ) -> Result<MerkleTree> {
+        // Get the parent info from tracker if specified first, then fall back to db
+        let Some((Some(parent_slot), parent_block_id)) =
+            self.get_parent_info_from_tracker_or_db(slot, location, slot_metas)?
+        else {
+            // Something has gone wrong here - the block is full yet the slot meta/parent slot info was missing!
+            error!(
+                "slot {slot} location {location} was full, yet the slot meta is missing / \
+                 incomplete"
+            );
+            return Err(BlockstoreError::ParentInfoUnavailable(slot, location));
+        };
+
+        // Collect merkle roots for each FEC set
+        let merkle_tree_leaves = (0..fec_set_count)
+            .map(|i| {
+                let fec_set_index = (i * DATA_SHREDS_PER_FEC_BLOCK) as u32;
+                let erasure_set = ErasureSetId::new(slot, fec_set_index);
+                self.get_merkle_root_from_tracker_or_db(location, erasure_set, merkle_root_metas)
+                    .map_err(|_| shred::Error::InvalidMerkleRoot)
+                    .and_then(|mr| mr.ok_or(shred::Error::InvalidMerkleRoot))
+            })
+            // Add parent info as the last leaf
+            .chain(std::iter::once(Ok(hashv(&[
+                &parent_slot.to_le_bytes(),
+                parent_block_id.as_ref(),
+            ]))));
+
+        MerkleTree::try_new_with_len(merkle_tree_leaves, fec_set_count + 1)
+            .map_err(|_| BlockstoreError::MerkleTreeConstructionFailure(slot, location))
+    }
+
+    /// Populates the proofs for the block at `slot` `location` into the `double_merkle_meta`
+    fn populate_double_merkle_meta_proofs(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+        double_merkle_meta: &mut DoubleMerkleMeta,
+    ) -> Result<()> {
+        let merkle_tree = self.build_double_merkle_tree(
+            slot,
+            location,
+            double_merkle_meta.fec_set_count,
+            None,
+            None,
+        )?;
+        let tree_size = double_merkle_meta.fec_set_count + 1;
+        let proof_len_bytes = get_proof_size(tree_size) as usize * SIZE_OF_MERKLE_PROOF_ENTRY;
+        let mut proofs = ByteBuf::with_capacity(tree_size * proof_len_bytes);
+
+        for leaf_index in 0..tree_size {
+            for proof_entry in merkle_tree.make_merkle_proof(leaf_index, tree_size) {
+                let proof_entry = proof_entry
+                    .map_err(|_| BlockstoreError::MerkleProofConstructionFailure(slot, location))?;
+                proofs.extend_from_slice(proof_entry);
+            }
+        }
+
+        double_merkle_meta.proofs = proofs;
+
+        Ok(())
+    }
+
     /// Gets the merkle root from the tracker if available, otherwise from the db.
-    #[allow(dead_code)]
     fn get_merkle_root_from_tracker_or_db(
         &self,
         location: BlockLocation,
         erasure_set: ErasureSetId,
-        merkle_root_metas: &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
+        merkle_root_metas: Option<
+            &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
+        >,
     ) -> Result<Option<Hash>> {
         let err = || {
             BlockstoreError::MissingMerkleRoot(
@@ -1274,8 +1474,10 @@ impl Blockstore {
                 erasure_set.fec_set_index() as u64,
             )
         };
-        // First check the tracker
-        if let Some(working_entry) = merkle_root_metas.get(&(location, erasure_set)) {
+        // First check the tracker if available
+        if let Some(working_entry) =
+            merkle_root_metas.and_then(|mm| mm.get(&(location, erasure_set)))
+        {
             return Ok(Some(working_entry.as_ref().merkle_root().ok_or_else(err)?));
         }
 
@@ -1286,6 +1488,25 @@ impl Blockstore {
                     .map(|meta| meta.merkle_root().ok_or_else(err))
                     .transpose()
             })
+    }
+
+    /// Gets the parent info for this block using the slot meta from the tracker if available, otherwise from the db
+    fn get_parent_info_from_tracker_or_db(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+        slot_metas: Option<&HashMap<(BlockLocation, Slot), SlotMetaWorkingSetEntry>>,
+    ) -> Result<Option<(Option<Slot>, Hash)>> {
+        if let Some(working_entry) = slot_metas.and_then(|sm| sm.get(&(location, slot))) {
+            // First check the tracker if available
+            let parent_slot = RefCell::borrow(&*working_entry.new_slot_meta).parent_slot;
+            Ok(Some((parent_slot, Hash::default())))
+        } else if let Some(meta) = self.meta_from_location(slot, location)? {
+            // Fall back to DB
+            Ok(Some((meta.parent_slot, Hash::default())))
+        } else {
+            Ok(None)
+        }
     }
 
     fn commit_updates_to_write_batch(
@@ -1458,6 +1679,9 @@ impl Blockstore {
         )?;
 
         self.check_chained_merkle_root_consistency(&mut shred_insertion_tracker);
+
+        // Compute DoubleMerkleMeta for any newly completed slots so it's committed atomically
+        self.compute_double_merkle_meta_for_newly_completed_slots(&mut shred_insertion_tracker)?;
 
         let (should_signal, newly_completed_slots) =
             self.commit_updates_to_write_batch(&mut shred_insertion_tracker, metrics)?;
@@ -5624,7 +5848,12 @@ pub mod tests {
         super::*,
         crate::{
             genesis_utils::{GenesisConfigInfo, create_genesis_config},
-            shred::max_ticks_per_n_shreds,
+            shred::{
+                max_ticks_per_n_shreds,
+                merkle_tree::{
+                    MerkleProofEntry, SIZE_OF_MERKLE_PROOF_ENTRY, get_merkle_root, get_proof_size,
+                },
+            },
         },
         assert_matches::assert_matches,
         crossbeam_channel::unbounded,
@@ -5650,6 +5879,7 @@ pub mod tests {
             InnerInstruction, InnerInstructions, Reward, Rewards, TransactionTokenBalance,
         },
         std::{cmp::Ordering, num::NonZeroUsize, time::Duration},
+        test_case::test_case,
     };
 
     // used for tests only
@@ -12105,6 +12335,168 @@ pub mod tests {
         assert_eq!(
             tx_status2.status,
             Err(TransactionError::InsufficientFundsForFee)
+        );
+    }
+
+    #[test_case(false ; "original_location")]
+    #[test_case(true ; "alternate_location")]
+    fn test_get_double_merkle_root(use_alternate_location: bool) {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let parent_slot = 990;
+        let parent_block_id = Hash::default();
+        let slot = 1000;
+        let num_entries = 200;
+
+        // Create a set of shreds for a complete block
+        let (data_shreds, _, leader_schedule) =
+            setup_erasure_shreds(slot, parent_slot, num_entries);
+
+        // Collect FEC set merkle roots for verification
+        let mut fec_set_roots = [Hash::default(); 3];
+        for shred in data_shreds.iter() {
+            if shred.index() % (DATA_SHREDS_PER_FEC_BLOCK as u32) == 0 {
+                fec_set_roots[(shred.index() as usize) / DATA_SHREDS_PER_FEC_BLOCK] =
+                    shred.merkle_root().unwrap();
+            }
+        }
+
+        let parent_info_hash = hashv(&[&parent_slot.to_le_bytes(), parent_block_id.as_ref()]);
+        let merkle_tree_leaves: Vec<_> = fec_set_roots
+            .iter()
+            .copied()
+            .chain(std::iter::once(parent_info_hash))
+            .map(Ok)
+            .collect();
+        let merkle_tree = MerkleTree::try_new(merkle_tree_leaves.into_iter()).unwrap();
+        let expected_double_merkle_root = *merkle_tree.root();
+
+        let block_location = if use_alternate_location {
+            BlockLocation::Alternate {
+                block_id: expected_double_merkle_root,
+            }
+        } else {
+            BlockLocation::Original
+        };
+
+        // Insert shreds into blockstore at the specified location
+        let shreds = data_shreds
+            .iter()
+            .map(|shred| (Cow::Borrowed(shred), use_alternate_location, block_location));
+        let insert_results = blockstore
+            .do_insert_shreds(
+                shreds,
+                Some(&leader_schedule),
+                false,
+                None,
+                &mut BlockstoreInsertionMetrics::default(),
+            )
+            .unwrap();
+        assert!(insert_results.duplicate_shreds.is_empty());
+
+        let slot_meta = blockstore
+            .meta_from_location(slot, block_location)
+            .unwrap()
+            .unwrap();
+        assert!(slot_meta.is_full());
+
+        // Test getting the double merkle root
+        let double_merkle_root = blockstore
+            .get_double_merkle_root(slot, block_location)
+            .unwrap()
+            .unwrap();
+
+        let double_merkle_meta = blockstore
+            .double_merkle_meta_cf
+            .get((slot, block_location))
+            .unwrap()
+            .unwrap();
+
+        // Verify the double merkle root matches our pre-computed value
+        assert_eq!(double_merkle_root, expected_double_merkle_root);
+        assert_eq!(double_merkle_meta.double_merkle_root, double_merkle_root);
+        assert_eq!(double_merkle_meta.fec_set_count, 3); // With 200 entries, we should have 3 FEC sets
+        // Proofs are empty
+        assert_eq!(double_merkle_meta.proofs.len(), 0);
+
+        // Generate the proofs
+        let double_merkle_meta = blockstore
+            .get_double_merkle_meta_maybe_populate_proofs(slot, block_location)
+            .unwrap()
+            .unwrap();
+        let proof_size = get_proof_size(double_merkle_meta.fec_set_count + 1) as usize;
+        assert_eq!(
+            double_merkle_meta.proofs.len(),
+            4 * proof_size * SIZE_OF_MERKLE_PROOF_ENTRY
+        ); // 3 FEC sets + 1 parent info
+
+        // Verify the proofs
+        // FEC sets
+        for (fec_set, root) in fec_set_roots.iter().enumerate() {
+            let proof: Vec<_> = double_merkle_meta
+                .get_fec_set_proof(fec_set)
+                .unwrap()
+                .chunks(SIZE_OF_MERKLE_PROOF_ENTRY)
+                .map(<&MerkleProofEntry>::try_from)
+                .map(std::result::Result::unwrap)
+                .collect();
+            assert_eq!(proof_size, proof.len());
+
+            let verified_root = get_merkle_root(fec_set, *root, proof).unwrap();
+            assert_eq!(double_merkle_meta.double_merkle_root, verified_root);
+        }
+
+        // Parent info - final proof
+        let parent_info_proof: Vec<_> = double_merkle_meta
+            .get_parent_info_proof()
+            .unwrap()
+            .chunks(SIZE_OF_MERKLE_PROOF_ENTRY)
+            .map(<&MerkleProofEntry>::try_from)
+            .map(std::result::Result::unwrap)
+            .collect();
+        assert_eq!(proof_size, parent_info_proof.len());
+
+        let verified_root = get_merkle_root(
+            double_merkle_meta.fec_set_count,
+            parent_info_hash,
+            parent_info_proof,
+        )
+        .unwrap();
+        assert_eq!(double_merkle_meta.double_merkle_root, verified_root);
+
+        // Slot not full should return None
+        let incomplete_slot = 1001;
+        let (partial_shreds, _, leader_schedule) =
+            setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot(
+                incomplete_slot,
+                slot, // parent is 1000
+                5,
+                0,
+                Hash::new_from_array(rand::random()),
+                false, // not last in slot
+            );
+
+        let shreds = partial_shreds
+            .iter()
+            .take(3)
+            .map(|shred| (Cow::Borrowed(shred), use_alternate_location, block_location));
+        let insert_results = blockstore
+            .do_insert_shreds(
+                shreds,
+                Some(&leader_schedule),
+                false,
+                None,
+                &mut BlockstoreInsertionMetrics::default(),
+            )
+            .unwrap();
+        assert!(insert_results.duplicate_shreds.is_empty());
+
+        assert!(
+            blockstore
+                .get_double_merkle_root(incomplete_slot, block_location)
+                .unwrap()
+                .is_none()
         );
     }
 }

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -301,6 +301,19 @@ impl Blockstore {
                 .delete_range_in_batch(write_batch, from_slot, to_slot);
             self.alt_merkle_root_meta_cf
                 .delete_range_in_batch(write_batch, from_slot, to_slot);
+            // This column stores information for both the original and alternate
+            // columns. When `purge_alt_columns` is specified we delete the
+            // entire column.
+            self.double_merkle_meta_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot);
+        } else {
+            // This column stores information for both the original and alternate
+            // locations. When `purge_alt_columns` is not specified we only delete the
+            // data associated with the original column.
+            for slot in from_slot..=to_slot {
+                self.double_merkle_meta_cf
+                    .delete_in_batch(write_batch, (slot, BlockLocation::Original));
+            }
         }
 
         match purge_type {
@@ -346,6 +359,8 @@ impl Blockstore {
         self.alt_data_shred_cf
             .delete_file_in_range(from_slot, to_slot)?;
         self.alt_merkle_root_meta_cf
+            .delete_file_in_range(from_slot, to_slot)?;
+        self.double_merkle_meta_cf
             .delete_file_in_range(from_slot, to_slot)
     }
 

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -2,7 +2,7 @@
 use {
     crate::{
         blockstore::error::Result,
-        blockstore_meta::{self, PerfSample},
+        blockstore_meta::{self, BlockLocation, PerfSample},
     },
     bincode::Options as BincodeOptions,
     serde::{Serialize, de::DeserializeOwned},
@@ -243,6 +243,16 @@ pub mod columns {
     /// * index type: `(slot: u64, fec_set_index: u32, block_id: Hash)`
     /// * value type: [`blockstore_meta::MerkleRootMeta`]
     pub struct AlternateMerkleRootMeta;
+
+    #[derive(Debug)]
+    /// The double merkle root metadata column
+    ///
+    /// This column stores details about the double merkle root of a block.
+    /// We update this column when we finish ingesting all the shreds of the block.
+    ///
+    /// * index type: `(Slot, BlockLocation)`
+    /// * value type: [`blockstore_meta::DoubleMerkleMeta`]
+    pub struct DoubleMerkleMeta;
 }
 
 macro_rules! convert_column_index_to_key_bytes {
@@ -820,6 +830,45 @@ impl ColumnName for columns::AlternateMerkleRootMeta {
 }
 impl TypedColumn for columns::AlternateMerkleRootMeta {
     type Type = blockstore_meta::MerkleRootMeta;
+}
+
+impl Column for columns::DoubleMerkleMeta {
+    type Index = (Slot, BlockLocation);
+    // Key size: Slot (8 bytes) + Hash (32 bytes)
+    // When BlockLocation::Original, the hash is Hash::default().
+    type Key = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
+
+    #[inline]
+    fn key((slot, location): &Self::Index) -> Self::Key {
+        debug_assert_eq!(std::mem::size_of::<Slot>(), 8);
+        convert_column_index_to_key_bytes!(Key,
+            ..8 => &slot.to_be_bytes(),
+            8.. => &location.as_bytes()
+        )
+    }
+
+    fn index(key: &[u8]) -> Self::Index {
+        convert_column_key_bytes_to_index!(key,
+            0..8 => Slot::from_be_bytes,
+            8..40 => BlockLocation::from_bytes,
+        )
+    }
+
+    fn as_index(slot: Slot) -> Self::Index {
+        (slot, BlockLocation::Original)
+    }
+
+    fn slot((slot, _location): Self::Index) -> Slot {
+        slot
+    }
+}
+
+impl ColumnName for columns::DoubleMerkleMeta {
+    const NAME: &'static str = "double_merkle_meta";
+}
+
+impl TypedColumn for columns::DoubleMerkleMeta {
+    type Type = blockstore_meta::DoubleMerkleMeta;
 }
 
 #[cfg(test)]

--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -1,8 +1,8 @@
 //! The error that can be produced from Blockstore operations.
 
 use {
-    super::PurgeType, agave_snapshots::hardened_unpack::UnpackError, solana_clock::Slot,
-    thiserror::Error,
+    super::PurgeType, crate::blockstore_meta::BlockLocation,
+    agave_snapshots::hardened_unpack::UnpackError, solana_clock::Slot, thiserror::Error,
 };
 
 #[derive(Error, Debug)]
@@ -19,6 +19,8 @@ pub enum BlockstoreError {
     DeadSlot,
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("deserialization error: {0}")]
+    Deserialize(#[from] wincode::ReadError),
     #[error("serialization error: {0}")]
     Serialize(#[from] bincode::Error),
     #[error("fs extra error: {0}")]
@@ -39,6 +41,12 @@ pub enum BlockstoreError {
     ProtobufDecodeError(#[from] prost::DecodeError),
     #[error("parent entries unavailable")]
     ParentEntriesUnavailable,
+    #[error("parent info unavailable: slot {0} location {1}")]
+    ParentInfoUnavailable(Slot, BlockLocation),
+    #[error("merkle tree construction failure: slot {0} location {1}")]
+    MerkleTreeConstructionFailure(Slot, BlockLocation),
+    #[error("merkle proof construction failure: slot {0} location {1}")]
+    MerkleProofConstructionFailure(Slot, BlockLocation),
     #[error("slot unavailable")]
     SlotUnavailable,
     #[error("unsupported transaction version")]

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -194,6 +194,7 @@ impl Rocks {
             new_cf_descriptor::<columns::AlternateIndex>(options, oldest_slot),
             new_cf_descriptor::<columns::AlternateShredData>(options, oldest_slot),
             new_cf_descriptor::<columns::AlternateMerkleRootMeta>(options, oldest_slot),
+            new_cf_descriptor::<columns::DoubleMerkleMeta>(options, oldest_slot),
         ];
 
         // When remaining columns are optional we can just return immediately here.
@@ -238,7 +239,7 @@ impl Rocks {
         cf_descriptors
     }
 
-    const fn columns() -> [&'static str; 23] {
+    const fn columns() -> [&'static str; 24] {
         [
             columns::ErasureMeta::NAME,
             columns::DeadSlots::NAME,
@@ -263,6 +264,7 @@ impl Rocks {
             columns::AlternateIndex::NAME,
             columns::AlternateShredData::NAME,
             columns::AlternateMerkleRootMeta::NAME,
+            columns::DoubleMerkleMeta::NAME,
         ]
     }
 
@@ -583,6 +585,26 @@ where
 
         let key = <C as Column>::key(&index);
         let result = self.backend.get_cf(self.handle(), key);
+
+        if let Some(op_start_instant) = is_perf_enabled {
+            report_rocksdb_read_perf(
+                C::NAME,
+                PERF_METRIC_OP_NAME_GET,
+                &op_start_instant.elapsed(),
+                &self.column_options,
+            );
+        }
+        result
+    }
+
+    pub fn get_slice(&self, index: C::Index) -> Result<Option<DBPinnableSlice<'_>>> {
+        let is_perf_enabled = maybe_enable_rocksdb_perf(
+            self.column_options.rocks_perf_sample_interval,
+            &self.read_perf_status,
+        );
+
+        let key = <C as Column>::key(&index);
+        let result = self.backend.get_pinned_cf(self.handle(), key);
 
         if let Some(op_start_instant) = is_perf_enabled {
             report_rocksdb_read_perf(

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -1,12 +1,16 @@
 use {
     crate::{
         bit_vec::BitVec,
-        shred::{self, DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, Shred, ShredType},
+        shred::{
+            self, DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, Shred, ShredType,
+            merkle_tree::{SIZE_OF_MERKLE_PROOF_ENTRY, get_proof_size},
+        },
     },
     bitflags::bitflags,
     serde::{Deserialize, Deserializer, Serialize, Serializer},
+    serde_bytes::ByteBuf,
     solana_clock::{Slot, UnixTimestamp},
-    solana_hash::Hash,
+    solana_hash::{HASH_BYTES, Hash},
     std::{
         fmt::Display,
         ops::{Range, RangeBounds},
@@ -289,6 +293,24 @@ pub struct DuplicateSlotProof {
 pub enum BlockLocation {
     Original,
     Alternate { block_id: Hash },
+}
+
+impl BlockLocation {
+    pub(crate) fn from_bytes(bytes: [u8; HASH_BYTES]) -> Self {
+        let block_id = Hash::new_from_array(bytes);
+        if block_id == Hash::default() {
+            Self::Original
+        } else {
+            Self::Alternate { block_id }
+        }
+    }
+
+    pub(crate) fn as_bytes(&self) -> [u8; HASH_BYTES] {
+        match self {
+            BlockLocation::Original => Hash::default().to_bytes(),
+            BlockLocation::Alternate { block_id } => block_id.to_bytes(),
+        }
+    }
 }
 
 impl Display for BlockLocation {
@@ -695,6 +717,55 @@ impl OptimisticSlotMetaVersioned {
         match self {
             OptimisticSlotMetaVersioned::V0(meta) => meta.timestamp,
         }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DoubleMerkleMeta {
+    /// The double merkle root computed as the root of the merkle tree
+    /// containing the merkle roots of each fec set + the parent info (parent_slot, parent_double_merkle_root)
+    pub(crate) double_merkle_root: Hash,
+
+    /// The number of fec sets in this block
+    pub(crate) fec_set_count: usize,
+
+    /// The merkle proofs.
+    /// Each proof is of size `get_proof_size(fec_set_count + 1)`
+    /// This `ByteBuf` contains the concatenated proofs for all the fec set leaves and the parent info leaf
+    ///
+    /// The size of this vec is `(fec_set_count + 1) * get_proof_size(fec_set_count + 1) * SIZE_OF_MERKLE_PROOF_ENTRY`
+    /// To access the proof for the i-th leaf:
+    ///   `proofs[i * get_proof_size(fec_set_count + 1) * SIZE_OF_MERKLE_PROOF_ENTRY
+    ///      ..(i + 1) * get_proof_size(fec_set_count + 1) * SIZE_OF_MERKLE_PROOF_ENTRY]`
+    pub(crate) proofs: ByteBuf,
+}
+
+impl DoubleMerkleMeta {
+    /// Return the proof associated with the leaf of fec set `fec_set_index`
+    /// Returns `None` if the proofs are yet to be populated or `fec_set_index` is out of bounds
+    pub fn get_fec_set_proof(&self, fec_set_index: usize) -> Option<&[u8]> {
+        if fec_set_index >= self.fec_set_count {
+            return None;
+        }
+        if self.proofs.is_empty() {
+            return None;
+        }
+
+        let proof_size =
+            usize::from(get_proof_size(self.fec_set_count + 1)) * SIZE_OF_MERKLE_PROOF_ENTRY;
+        Some(&self.proofs[fec_set_index * proof_size..(fec_set_index + 1) * proof_size])
+    }
+
+    /// Return the proof associated with the parent info leaf
+    /// Returns `None` if the proofs are yet to be populated
+    pub fn get_parent_info_proof(&self) -> Option<&[u8]> {
+        if self.proofs.is_empty() {
+            return None;
+        }
+
+        let proof_size =
+            usize::from(get_proof_size(self.fec_set_count + 1)) * SIZE_OF_MERKLE_PROOF_ENTRY;
+        Some(&self.proofs[self.fec_set_count * proof_size..])
     }
 }
 

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -86,7 +86,7 @@ use {solana_keypair::Keypair, solana_perf::packet::Packet, solana_signer::Signer
 
 mod common;
 pub mod merkle;
-mod merkle_tree;
+pub(crate) mod merkle_tree;
 mod payload;
 mod shred_code;
 pub(crate) mod shred_data;

--- a/ledger/src/shred/merkle_tree.rs
+++ b/ledger/src/shred/merkle_tree.rs
@@ -41,12 +41,19 @@ impl MerkleTree {
             return Err(Error::EmptyIterator);
         }
         let num_shreds = shreds.len();
-        let capacity = get_merkle_tree_size(num_shreds);
+        Self::try_new_with_len(shreds, num_shreds)
+    }
+
+    pub(crate) fn try_new_with_len(
+        shreds: impl Iterator<Item = Result<Hash, Error>>,
+        len: usize,
+    ) -> Result<MerkleTree, Error> {
+        let capacity = get_merkle_tree_size(len);
         let mut nodes = Vec::with_capacity(capacity);
         for shred in shreds {
             nodes.push(shred?);
         }
-        let init = (num_shreds > 1).then_some(num_shreds);
+        let init = (len > 1).then_some(len);
         for size in successors(init, |&k| (k > 2).then_some((k + 1) >> 1)) {
             let offset = nodes.len() - size;
             for index in (offset..offset + size).step_by(2) {
@@ -130,7 +137,6 @@ pub fn get_merkle_tree_size(num_shreds: usize) -> usize {
 }
 
 // Maps number of (code + data) shreds to merkle_proof.len().
-#[cfg(test)]
 pub(crate) const fn get_proof_size(num_shreds: usize) -> u8 {
     let bits = usize::BITS - num_shreds.leading_zeros();
     let proof_size = if num_shreds.is_power_of_two() {


### PR DESCRIPTION
Upstreams:
- blockstore: compute and populate DoubleMerkleRootMeta (#[613](https://github.com/anza-xyz/alpenglow/pull/613))
- blockid: move DMR computation to shred insert (#[675](https://github.com/anza-xyz/alpenglow/pull/675))

#### Problem
In alpenglow we use the Double Merkle Root as the block identifier - not the chained merkle root.
This block id is used to vote on a block, and to refer to the block during duplicate block handling.

We wish to maintain a blockstore column to store and keep track of this value.

#### Summary of Changes
When a block becomes newly full, compute and insert the DoubleMerkleMeta. We maintain the invariant that `slot_meta.is_full() <=> double_merkle_meta.is_some()`.

The double merkle meta stores the root which is will be used in `bank.set_block_id` by replay in a future upstream.
Additionally it stores the relevant proofs which will be served through alpenglow repair in a future upstream