### PR TITLE
replay: do not set block_id for leader_blocks

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3555,7 +3555,11 @@ impl ReplayStage {
                 } else {
                     None
                 };
-                bank.set_block_id(block_id);
+
+                if block_id.is_some() {
+                    bank.set_block_id(block_id);
+                }
+
                 // Freeze the bank before sending to any auxiliary threads
                 // that may expect to be operating on a frozen bank
                 bank.freeze();


### PR DESCRIPTION
#### Problem
For leader banks, broadcast is responsible for setting the `block_id` once the block has finished shredding:
https://github.com/anza-xyz/agave/blob/a7c8d68de87f4ff567e70ae49b78622e10c729a0/turbine/src/broadcast_stage/broadcast_utils.rs#L200-L209

In replay we accidentally set the `None` block id for leader blocks
https://github.com/anza-xyz/agave/blob/fb1208f7bd8098b5078bf6509a3b24437b6303b2/core/src/replay_stage.rs#L3525-L3558

In rare cases, shredding can complete before bank freeze on a leader block. This will lead to:
- broadcast setting `Some(block_id)`
- replay setting `block_id` back to `None`

#### Summary of Changes
Do not set `block_id` in replay for leader blocks.

This was found and correctly addressed in the alpenglow repo - just didn't fix it here

https://github.com/anza-xyz/alpenglow/blob/8a139cd8c68b7ee9582b55f6f9c472cb9444917b/core/src/replay_stage.rs#L3689-L3690