### PR TITLE
bank: account for VAT burned in PER post calculation state

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -51,7 +51,7 @@ struct RewardsAccumulator {
 
 #[derive(Error, Debug, PartialEq, Eq)]
 enum RefreshError {
-    #[error("Commission account {0} laports would overflow current = {1}, new commission = {2}")]
+    #[error("Commission account {0} lamports would overflow current = {1}, new commission = {2}")]
     CommissionAccountOverflow(Pubkey, u64, u64),
     #[error("Commission account is missing: {0}")]
     MissingCommissionAccount(Pubkey),

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -24,6 +24,7 @@ use {
         ThreadPool,
         iter::{IndexedParallelIterator, ParallelIterator},
     },
+    solana_account::{ReadableAccount, WritableAccount},
     solana_clock::{Epoch, Slot},
     solana_measure::{measure::Measure, measure_us},
     solana_native_token::LAMPORTS_PER_SOL,
@@ -216,9 +217,11 @@ impl Bank {
             ..
         } = rewards_calculation;
 
+        let reward_commission_accounts =
+            self.refresh_reward_commission_accounts(reward_commission_accounts);
         let total_reward_commissions = reward_commission_accounts.total_reward_commission_lamports;
-        self.store_commission_accounts_partitioned(reward_commission_accounts, rewards_metrics);
-        self.update_reward_commissions(reward_commission_accounts);
+        self.store_commission_accounts_partitioned(&reward_commission_accounts, rewards_metrics);
+        self.update_reward_commissions(&reward_commission_accounts);
 
         let StakeRewardCalculation {
             total_stake_rewards_lamports,
@@ -261,6 +264,56 @@ impl Bank {
             ("num_stake_accounts", num_stake_accounts, i64),
             ("num_vote_accounts", num_vote_accounts, i64),
         );
+    }
+
+    /// Rebuild reward commission account updates against the latest account state.
+    ///
+    /// Reward commission calculations happen before epoch-boundary account updates
+    /// (for example VAT burns). Refreshing here ensures commission writes compose
+    /// with those updates instead of overwriting them with stale snapshots.
+    fn refresh_reward_commission_accounts(
+        &self,
+        reward_commission_accounts: &RewardCommissionAccounts,
+    ) -> RewardCommissionAccounts {
+        let mut refreshed = RewardCommissionAccounts {
+            accounts_with_rewards: Vec::with_capacity(
+                reward_commission_accounts.accounts_with_rewards.len(),
+            ),
+            total_reward_commission_lamports: 0,
+        };
+
+        for (commission_pubkey, reward_info, fallback_account) in
+            &reward_commission_accounts.accounts_with_rewards
+        {
+            let Ok(commission_lamports) = u64::try_from(reward_info.lamports) else {
+                debug!(
+                    "reward redemption failed for {commission_pubkey}: invalid negative reward \
+                     lamports {}",
+                    reward_info.lamports
+                );
+                continue;
+            };
+            let mut commission_account = self
+                .get_account(commission_pubkey)
+                .unwrap_or_else(|| fallback_account.clone());
+            if let Err(err) = commission_account.checked_add_lamports(commission_lamports) {
+                debug!("reward redemption failed for {commission_pubkey}: {err:?}");
+                continue;
+            }
+
+            let mut reward_info = *reward_info;
+            reward_info.post_balance = commission_account.lamports();
+            refreshed.accounts_with_rewards.push((
+                *commission_pubkey,
+                reward_info,
+                commission_account,
+            ));
+            refreshed.total_reward_commission_lamports = refreshed
+                .total_reward_commission_lamports
+                .saturating_add(commission_lamports);
+        }
+
+        refreshed
     }
 
     fn store_commission_accounts_partitioned(

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -32,6 +32,7 @@ use {
     solana_stake_interface::{stake_history::StakeHistory, state::Delegation},
     solana_sysvar::epoch_rewards::EpochRewards,
     std::sync::{Arc, atomic::Ordering::Relaxed},
+    thiserror::Error,
 };
 
 #[derive(Debug)]
@@ -46,6 +47,18 @@ struct RewardsAccumulator {
     reward_commissions: RewardCommissions,
     num_stake_rewards: usize,
     total_stake_rewards_lamports: u64,
+}
+
+#[derive(Error, Debug, PartialEq, Eq)]
+enum RefreshError {
+    #[error("Commission account {0} laports would overflow current = {1}, new commission = {2}")]
+    CommissionAccountOverflow(Pubkey, u64, u64),
+    #[error("Commission account is missing: {0}")]
+    MissingCommissionAccount(Pubkey),
+    #[error("Rewards lamports are negative: {0}")]
+    NegativeLamports(i64),
+    #[error("Total commission lamports would overflow current = {0}, new commission = {1}")]
+    TotalCommissionOverflow(u64, u64),
 }
 
 impl RewardsAccumulator {
@@ -217,8 +230,11 @@ impl Bank {
             ..
         } = rewards_calculation;
 
-        let reward_commission_accounts =
-            self.refresh_reward_commission_accounts(reward_commission_accounts);
+        let reward_commission_accounts = self
+            .refresh_reward_commission_accounts(reward_commission_accounts)
+            .unwrap_or_else(|error| {
+                panic!("failed to refresh reward commission accounts: {error}")
+            });
         let total_reward_commissions = reward_commission_accounts.total_reward_commission_lamports;
         self.store_commission_accounts_partitioned(&reward_commission_accounts, rewards_metrics);
         self.update_reward_commissions(&reward_commission_accounts);
@@ -274,7 +290,7 @@ impl Bank {
     fn refresh_reward_commission_accounts(
         &self,
         reward_commission_accounts: &RewardCommissionAccounts,
-    ) -> RewardCommissionAccounts {
+    ) -> Result<RewardCommissionAccounts, RefreshError> {
         let mut refreshed = RewardCommissionAccounts {
             accounts_with_rewards: Vec::with_capacity(
                 reward_commission_accounts.accounts_with_rewards.len(),
@@ -282,24 +298,22 @@ impl Bank {
             total_reward_commission_lamports: 0,
         };
 
-        for (commission_pubkey, reward_info, fallback_account) in
-            &reward_commission_accounts.accounts_with_rewards
+        for (commission_pubkey, reward_info, _) in &reward_commission_accounts.accounts_with_rewards
         {
-            let Ok(commission_lamports) = u64::try_from(reward_info.lamports) else {
-                debug!(
-                    "reward redemption failed for {commission_pubkey}: invalid negative reward \
-                     lamports {}",
-                    reward_info.lamports
-                );
-                continue;
-            };
+            let commission_lamports = u64::try_from(reward_info.lamports)
+                .map_err(|_| RefreshError::NegativeLamports(reward_info.lamports))?;
             let mut commission_account = self
                 .get_account(commission_pubkey)
-                .unwrap_or_else(|| fallback_account.clone());
-            if let Err(err) = commission_account.checked_add_lamports(commission_lamports) {
-                debug!("reward redemption failed for {commission_pubkey}: {err:?}");
-                continue;
-            }
+                .ok_or(RefreshError::MissingCommissionAccount(*commission_pubkey))?;
+            commission_account
+                .checked_add_lamports(commission_lamports)
+                .map_err(|_| {
+                    RefreshError::CommissionAccountOverflow(
+                        *commission_pubkey,
+                        commission_account.lamports(),
+                        commission_lamports,
+                    )
+                })?;
 
             let mut reward_info = *reward_info;
             reward_info.post_balance = commission_account.lamports();
@@ -310,10 +324,14 @@ impl Bank {
             ));
             refreshed.total_reward_commission_lamports = refreshed
                 .total_reward_commission_lamports
-                .saturating_add(commission_lamports);
+                .checked_add(commission_lamports)
+                .ok_or(RefreshError::TotalCommissionOverflow(
+                    refreshed.total_reward_commission_lamports,
+                    commission_lamports,
+                ))?;
         }
 
-        refreshed
+        Ok(refreshed)
     }
 
     fn store_commission_accounts_partitioned(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13,8 +13,8 @@ use {
             self, GenesisConfigInfo, ValidatorVoteKeypairs, activate_all_features,
             activate_feature, bootstrap_validator_stake_lamports,
             create_genesis_config_with_leader, create_genesis_config_with_vote_accounts,
-            create_lockup_stake_account, genesis_sysvar_and_builtin_program_lamports,
-            minimum_vote_account_balance_for_vat,
+            create_lockup_stake_account, deactivate_features,
+            genesis_sysvar_and_builtin_program_lamports, minimum_vote_account_balance_for_vat,
         },
         runtime_config::RuntimeConfig,
         serde_snapshot::fields_from_stream,
@@ -22,7 +22,7 @@ use {
         stake_utils,
         stakes::InvalidCacheEntryReason,
     },
-    agave_feature_set::{self as feature_set, FeatureSet},
+    agave_feature_set::{self as feature_set, FeatureSet, delay_commission_updates},
     agave_reserved_account_keys::ReservedAccount,
     agave_transaction_view::static_account_keys_frame::MAX_STATIC_ACCOUNTS_PER_PACKET,
     ahash::AHashMap,
@@ -320,6 +320,90 @@ fn test_bank_new() {
     assert_eq!(rent.burn_percent, Rent::default().burn_percent);
     assert_eq!(rent.exemption_threshold, 1.0f64.to_le_bytes());
     assert_eq!(rent.lamports_per_byte, 6);
+}
+
+#[test]
+fn test_process_new_epoch_vat_burn() {
+    let GenesisConfigInfo {
+        mut genesis_config,
+        voting_keypair,
+        ..
+    } = create_genesis_config_with_leader(
+        1_000_000 * LAMPORTS_PER_SOL,
+        &Pubkey::new_unique(),
+        42 * LAMPORTS_PER_SOL,
+    );
+    genesis_config.epoch_schedule = EpochSchedule::new(MINIMUM_SLOTS_PER_EPOCH);
+    activate_feature(&mut genesis_config, agave_feature_set::alpenglow::id());
+    deactivate_features(&mut genesis_config, &vec![delay_commission_updates::id()]);
+
+    let bank = Bank::new_for_tests(&genesis_config);
+    let vote_address = voting_keypair.pubkey();
+    assert!(
+        bank.feature_set
+            .is_active(&agave_feature_set::validator_admission_ticket::id())
+    );
+
+    let mut vote_account = bank.get_account(&vote_address).unwrap();
+    let vote_state_versions = vote_account
+        .deserialize_data::<VoteStateVersions>()
+        .unwrap();
+    let VoteStateVersions::V4(mut vote_state) = vote_state_versions else {
+        panic!("unexpected vote state version");
+    };
+    vote_state.inflation_rewards_commission_bps = 10_000;
+    let last_credits = vote_state
+        .epoch_credits
+        .last()
+        .map(|(_epoch, credits, _)| *credits)
+        .unwrap_or(0);
+    vote_state
+        .epoch_credits
+        .push((bank.epoch(), last_credits + 1_000, last_credits));
+    vote_account
+        .serialize_data(&VoteStateVersions::V4(vote_state))
+        .unwrap();
+    bank.store_account(&vote_address, &vote_account);
+
+    let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+    let before_vote_balance = bank.get_balance(&vote_address);
+    let before_incinerator_balance = bank.get_balance(&incinerator::id());
+    let next_epoch_slot = bank.slot() + bank.epoch_schedule().get_slots_in_epoch(bank.epoch());
+
+    let bank = Bank::new_from_parent_with_bank_forks(
+        &bank_forks,
+        bank,
+        SlotLeader::new_unique(),
+        next_epoch_slot,
+    );
+
+    let after_vote_balance = bank.get_balance(&vote_address);
+    let after_incinerator_balance = bank.get_balance(&incinerator::id());
+    let reward_lamports = bank
+        .rewards
+        .read()
+        .unwrap()
+        .iter()
+        .rev()
+        .find(|(address, reward)| {
+            address == &vote_address && reward.reward_type == RewardType::Voting
+        })
+        .map(|(_, reward)| u64::try_from(reward.lamports).unwrap())
+        .expect("expected voting reward entry");
+
+    assert!(reward_lamports > 0, "must receive voting reward");
+    assert_eq!(
+        after_incinerator_balance - before_incinerator_balance,
+        VAT_TO_BURN_PER_EPOCH,
+        "VAT burn moved lamports into the incinerator"
+    );
+    assert_eq!(
+        after_vote_balance,
+        before_vote_balance
+            .saturating_add(reward_lamports)
+            .saturating_sub(VAT_TO_BURN_PER_EPOCH),
+        "vote account balance should receive rewards and burn the VAT"
+    );
 }
 
 pub(crate) fn create_simple_test_bank(lamports: u64) -> Bank {


### PR DESCRIPTION
#### Problem
Audit has revealed an issue in the VAT burn interaction with PER:
> In [#10576](https://github.com/anza-xyz/agave/pull/10576/), the rewards are computed [here](https://github.com/anza-xyz/agave/blob/7fb0847a9e4741245b5fe35cf95ccc89ef35735b/runtime/src/bank.rs#L1730-L1741), then update_epoch_stakes is called [here](https://github.com/anza-xyz/agave/blob/45ee107606cf44a36ff623fc120727393d0171ec/runtime/src/bank.rs#L1767), which eventually then triggers maybe_burn_vat_from_staked_accounts. The problem is, the rewards that are distributed [here](https://github.com/anza-xyz/agave/blob/7fb0847a9e4741245b5fe35cf95ccc89ef35735b/runtime/src/bank.rs#L1751-L1759) also updates vote account balance using the rewards amount pre- VAT burn, causing the incinerator to get the burned VAT, while the vote account's balance only receives the commission with VAT not burned

Essentially:
1) PER snapshot is taken - we store the vote account's final lamport balance after applying commission if the validator had earned rewards this epoch
2) we create the new epoch stakes and burn the VAT
3) PER comission is distributed, if the vote account had earned rewards, it is stored using the account from the snapshot in (1) - overwriting the VAT burn.

VAT burning was only tested in the Alpenglow repo prior to our implementation of rewards, so we missed this 😓 

#### Summary of Changes
Between steps (2) and (3) refresh the account balance to account for VAT burn

Note: burning is only active when alpenglow is active, so no reason to backport this PR
