### PR TITLE
Uses unstable sort in remove_uncleaned_slots_up_to_slot_and_move_pubkeys()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1448,11 +1448,8 @@ impl AccountsDb {
             {
                 // Sort all keys by bin index so that we can insert
                 // them in `candidates` more efficiently.
-                removed_pubkeys.sort_by(|a, b| {
-                    self.accounts_index
-                        .bin_calculator
-                        .bin_from_pubkey(a)
-                        .cmp(&self.accounts_index.bin_calculator.bin_from_pubkey(b))
+                removed_pubkeys.sort_unstable_by_key(|pubkey| {
+                    self.accounts_index.bin_calculator.bin_from_pubkey(pubkey)
                 });
                 if let Some(first_removed_pubkey) = removed_pubkeys.first() {
                     let mut prev_bin = self


### PR DESCRIPTION
#### Problem

`remove_uncleaned_slots_up_to_slot_and_move_pubkeys()` sorts pubkeys by bin with *stable* sort. Order is not necessary though.


#### Summary of Changes

Use unstable sort.