### PR TITLE
feat(alpenglow): deserialize `BlockComponent`s only on alpenglow feature activation

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2708,13 +2708,17 @@ pub mod tests {
             genesis_utils::{
                 GenesisConfigInfo, create_genesis_config, create_genesis_config_with_leader,
             },
+            shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
         },
         assert_matches::assert_matches,
         rand::{Rng, rng},
         rayon::ThreadPoolBuilder,
         solana_account::{AccountSharedData, WritableAccount},
         solana_cost_model::transaction_cost::TransactionCost,
-        solana_entry::entry::{create_ticks, next_entry, next_entry_mut},
+        solana_entry::{
+            block_component::{BlockComponent, BlockFooterV1, BlockHeaderV1, VersionedBlockMarker},
+            entry::{create_ticks, next_entry, next_entry_mut},
+        },
         solana_epoch_schedule::EpochSchedule,
         solana_hash::Hash,
         solana_instruction::{Instruction, error::InstructionError},
@@ -5807,13 +5811,6 @@ pub mod tests {
 
     fn confirm_slot_with_block_markers_common()
     -> (Blockstore, GenesisConfig, tempfile::TempDir, ThreadPool) {
-        use {
-            crate::shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
-            solana_entry::block_component::{
-                BlockComponent, BlockFooterV1, BlockHeaderV1, VersionedBlockMarker,
-            },
-        };
-
         let GenesisConfigInfo {
             mut genesis_config, ..
         } = create_genesis_config(100 * LAMPORTS_PER_SOL);
@@ -5963,7 +5960,7 @@ pub mod tests {
                 &replay_tx_thread_pool,
                 &mut ConfirmationTiming::default(),
                 &mut ConfirmationProgress::new(bank0.last_blockhash()),
-                true, // skip_verification: alpenglow banks have different tick expectations
+                true,
                 None,
                 None,
                 None,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1626,6 +1626,107 @@ pub fn confirm_slot(
     prioritization_fee_cache: Option<&PrioritizationFeeCache>,
     migration_status: &MigrationStatus,
 ) -> result::Result<(), BlockstoreProcessorError> {
+    match bank
+        .feature_set
+        .is_active(&agave_feature_set::alpenglow::id())
+    {
+        true => confirm_slot_with_components(
+            blockstore,
+            bank,
+            replay_tx_thread_pool,
+            timing,
+            progress,
+            skip_verification,
+            transaction_status_sender,
+            entry_notification_sender,
+            replay_vote_sender,
+            allow_dead_slots,
+            log_messages_bytes_limit,
+            prioritization_fee_cache,
+            migration_status,
+        ),
+        false => confirm_slot_with_entries(
+            blockstore,
+            bank,
+            replay_tx_thread_pool,
+            timing,
+            progress,
+            skip_verification,
+            transaction_status_sender,
+            entry_notification_sender,
+            replay_vote_sender,
+            allow_dead_slots,
+            log_messages_bytes_limit,
+            prioritization_fee_cache,
+            migration_status,
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn confirm_slot_with_entries(
+    blockstore: &Blockstore,
+    bank: &BankWithScheduler,
+    replay_tx_thread_pool: &ThreadPool,
+    timing: &mut ConfirmationTiming,
+    progress: &mut ConfirmationProgress,
+    skip_verification: bool,
+    transaction_status_sender: Option<&TransactionStatusSender>,
+    entry_notification_sender: Option<&EntryNotifierSender>,
+    replay_vote_sender: Option<&ReplayVoteSender>,
+    allow_dead_slots: bool,
+    log_messages_bytes_limit: Option<usize>,
+    prioritization_fee_cache: Option<&PrioritizationFeeCache>,
+    migration_status: &MigrationStatus,
+) -> result::Result<(), BlockstoreProcessorError> {
+    let slot = bank.slot();
+
+    let slot_entries_load_result = {
+        let mut load_elapsed = Measure::start("load_elapsed");
+        let load_result = blockstore
+            .get_slot_entries_with_shred_info(slot, progress.num_shreds, allow_dead_slots)
+            .map_err(BlockstoreProcessorError::FailedToLoadEntries);
+        load_elapsed.stop();
+        if load_result.is_err() {
+            timing.fetch_fail_elapsed += load_elapsed.as_us();
+        } else {
+            timing.fetch_elapsed += load_elapsed.as_us();
+        }
+        load_result
+    }?;
+
+    confirm_slot_entries(
+        bank,
+        replay_tx_thread_pool,
+        slot_entries_load_result,
+        timing,
+        progress,
+        skip_verification,
+        transaction_status_sender,
+        entry_notification_sender,
+        replay_vote_sender,
+        log_messages_bytes_limit,
+        prioritization_fee_cache,
+        migration_status,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn confirm_slot_with_components(
+    blockstore: &Blockstore,
+    bank: &BankWithScheduler,
+    replay_tx_thread_pool: &ThreadPool,
+    timing: &mut ConfirmationTiming,
+    progress: &mut ConfirmationProgress,
+    skip_verification: bool,
+    transaction_status_sender: Option<&TransactionStatusSender>,
+    entry_notification_sender: Option<&EntryNotifierSender>,
+    replay_vote_sender: Option<&ReplayVoteSender>,
+    allow_dead_slots: bool,
+    log_messages_bytes_limit: Option<usize>,
+    prioritization_fee_cache: Option<&PrioritizationFeeCache>,
+    migration_status: &MigrationStatus,
+) -> result::Result<(), BlockstoreProcessorError> {
     let slot = bank.slot();
 
     let (slot_components, completed_ranges, slot_full) = {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -5807,9 +5807,11 @@ pub mod tests {
 
     fn confirm_slot_with_block_markers_common()
     -> (Blockstore, GenesisConfig, tempfile::TempDir, ThreadPool) {
-        use crate::shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder};
-        use solana_entry::block_component::{
-            BlockComponent, BlockFooterV1, BlockHeaderV1, VersionedBlockMarker,
+        use {
+            crate::shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
+            solana_entry::block_component::{
+                BlockComponent, BlockFooterV1, BlockHeaderV1, VersionedBlockMarker,
+            },
         };
 
         let GenesisConfigInfo {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -5805,6 +5805,175 @@ pub mod tests {
         }
     }
 
+    fn confirm_slot_with_block_markers_common()
+    -> (Blockstore, GenesisConfig, tempfile::TempDir, ThreadPool) {
+        use crate::shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder};
+        use solana_entry::block_component::{
+            BlockComponent, BlockFooterV1, BlockHeaderV1, VersionedBlockMarker,
+        };
+
+        let GenesisConfigInfo {
+            mut genesis_config, ..
+        } = create_genesis_config(100 * LAMPORTS_PER_SOL);
+
+        let ticks_per_slot = 1;
+        genesis_config.ticks_per_slot = ticks_per_slot;
+
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let keypair = Arc::new(Keypair::new());
+        let reed_solomon_cache = ReedSolomonCache::default();
+
+        let header = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+            parent_slot: 0,
+            parent_block_id: Hash::default(),
+        });
+        let header_component = BlockComponent::new_block_marker(header);
+
+        let footer = VersionedBlockMarker::new_block_footer(BlockFooterV1 {
+            bank_hash: Hash::new_unique(),
+            block_producer_time_nanos: 1_000_000_000,
+            block_user_agent: b"test".to_vec(),
+            final_cert: None,
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        });
+        let footer_component = BlockComponent::new_block_marker(footer);
+
+        let shredder = Shredder::new(1, 0, 0, 0).unwrap();
+        let mut next_shred_index = 0u32;
+
+        let header_shreds: Vec<Shred> = shredder
+            .make_merkle_shreds_from_component(
+                &keypair,
+                &header_component,
+                false,
+                Hash::default(),
+                next_shred_index,
+                0,
+                &reed_solomon_cache,
+                &mut ProcessShredsStats::default(),
+            )
+            .filter(Shred::is_data)
+            .collect();
+        next_shred_index = header_shreds.last().unwrap().index() + 1;
+
+        let entries = create_ticks(ticks_per_slot, 0, genesis_config.hash());
+        let entry_shreds: Vec<Shred> = shredder
+            .make_merkle_shreds_from_entries(
+                &keypair,
+                &entries,
+                false,
+                Hash::default(),
+                next_shred_index,
+                0,
+                &reed_solomon_cache,
+                &mut ProcessShredsStats::default(),
+            )
+            .filter(Shred::is_data)
+            .collect();
+        next_shred_index = entry_shreds.last().unwrap().index() + 1;
+
+        let footer_shreds: Vec<Shred> = shredder
+            .make_merkle_shreds_from_component(
+                &keypair,
+                &footer_component,
+                true, // last in slot
+                Hash::default(),
+                next_shred_index,
+                0,
+                &reed_solomon_cache,
+                &mut ProcessShredsStats::default(),
+            )
+            .filter(Shred::is_data)
+            .collect();
+
+        let mut all_shreds = header_shreds;
+        all_shreds.extend(entry_shreds);
+        all_shreds.extend(footer_shreds);
+        blockstore.insert_shreds(all_shreds, None, true).unwrap();
+
+        let replay_tx_thread_pool = create_thread_pool(1);
+
+        (
+            blockstore,
+            genesis_config,
+            ledger_path,
+            replay_tx_thread_pool,
+        )
+    }
+
+    #[test]
+    fn test_confirm_slot_block_with_markers_fails_without_alpenglow() {
+        let (blockstore, genesis_config, _ledger_path, replay_tx_thread_pool) =
+            confirm_slot_with_block_markers_common();
+
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+        let bank1 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
+        assert!(
+            !bank1
+                .feature_set
+                .is_active(&agave_feature_set::alpenglow::id())
+        );
+        let bank1 = bank_forks.write().unwrap().insert(bank1);
+
+        assert!(
+            confirm_slot(
+                &blockstore,
+                &bank1,
+                &replay_tx_thread_pool,
+                &mut ConfirmationTiming::default(),
+                &mut ConfirmationProgress::new(bank0.last_blockhash()),
+                false,
+                None,
+                None,
+                None,
+                false,
+                None,
+                None,
+                &MigrationStatus::default(),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_confirm_slot_block_with_markers_succeeds_with_alpenglow() {
+        let (blockstore, genesis_config, _ledger_path, replay_tx_thread_pool) =
+            confirm_slot_with_block_markers_common();
+
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+        let mut bank1 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
+        bank1.activate_feature(&agave_feature_set::alpenglow::id());
+        assert!(
+            bank1
+                .feature_set
+                .is_active(&agave_feature_set::alpenglow::id())
+        );
+        let bank1 = bank_forks.write().unwrap().insert(bank1);
+
+        assert!(
+            confirm_slot(
+                &blockstore,
+                &bank1,
+                &replay_tx_thread_pool,
+                &mut ConfirmationTiming::default(),
+                &mut ConfirmationProgress::new(bank0.last_blockhash()),
+                true, // skip_verification: alpenglow banks have different tick expectations
+                None,
+                None,
+                None,
+                false,
+                None,
+                None,
+                &MigrationStatus::post_migration_status(),
+            )
+            .is_ok()
+        );
+    }
+
     #[test]
     fn test_check_block_cost_limit() {
         let dummy_leader_pubkey = solana_pubkey::new_rand();


### PR DESCRIPTION
#### Problem and Summary of Changes
See https://github.com/anza-xyz/agave/issues/11590 for more detail.

**Background**
[SIMD-0307](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0307-add-block-footer.md) introduces the notion of `BlockMarker`s.

A block's contents used to be a sequence of `Vec<Entry>`. With Alpenglow, we instead want to have this be a sequence of `BlockComponent`, where `BlockComponent` can either be an `EntryBatch`, i.e., a `Vec<Entry>`, or `BlockMarker`. To make things backwards compatible, we use the first 8 bytes as a discriminator.

Our thought was that - empty entry batches should never occur, so the thinking was: if the first 8 bytes are all zeros, then we've got a block marker; otherwise, we've got an entry batch. We enforced this rule in 4.1, but this rule wasn't explicitly enforced pre-4.1; there was no need to, since `0x00 00 00 00 00 00 00 00` resolves to an empty entry batch, which didn't seem fundamentally incorrect pre-4.1.

**Problem**
Here's the block in question in #11590 :

```
range  0:  29800 bytes → 272 entries
range  1:  57350 bytes →  12 entries
range  2:  56496 bytes →  11 entries
range  3:  56184 bytes →  12 entries
range  4:  56200 bytes →  10 entries
range  5:  30264 bytes →   7 entries
range  6:  29311 bytes →  66 entries
range  7:  30299 bytes →  69 entries
range  8:  29358 bytes →  42 entries
range  9:  29344 bytes →  61 entries
range 10:  29481 bytes →  66 entries
range 11:   8226 bytes →  15 entries
range 12:      8 bytes → 0x00 00 00 00 00 00 00 00  ← empty entry batch (count=0, nothing else)
```

As a result of this, pre-4.1 nodes (v3.1 and v4.0) mark this slot as dead for `TooFewTicks` (the block was abandoned midway), which is expected. However, v4.1 nodes mark it as dead due to a `BlockComponent` deserialization failure on range 12, treating the `0x00...` bytes as a `BlockMarker` and failing with `FailedToLoadEntries(InvalidShredData(Custom("could not reconstruct block component: Io(ReadSizeLimit(2))")))`. If a leader had completed such a block properly (with enough ticks), pre-4.1 nodes would have accepted it, but 4.1 nodes would still reject it, leading to divergence in the cluster.

**Proposed Fix**
We feature gate `BlockComponent` deserialization on the `alpenglow` feature gate.

There's no chicken-and-egg problem for the migration block component with Alpenglow. Notably, the alpenglow feature flag being active != alpenglow consensus being active. In particular, when alpenglow's feature flag activates at the beginning of an epoch, there's a 5000 slot window during which we still continue with TowerBFT. This allows the leader to construct the migration block component, which in turn can then be successfully parsed.

Fixes #11590