### PR TITLE
Explicitly forbid ipv6 addresses in parse_host and, hence, in `--bind-address`

### DIFF
--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -205,6 +205,10 @@ pub fn parse_port_range(port_range: &str) -> Option<PortRange> {
 }
 
 pub fn parse_host(host: &str) -> Result<IpAddr, String> {
+    if let Ok(IpAddr::V6(_)) = host.parse::<IpAddr>() {
+        return Err(format!("IPv6 addresses are not supported: {host}"));
+    }
+
     // First, check if the host syntax is valid. This check is needed because addresses
     // such as `("localhost:1234", 0)` will resolve to IPs on some networks.
     let parsed_url = Url::parse(&format!("http://{host}")).map_err(|e| e.to_string())?;
@@ -386,6 +390,7 @@ mod tests {
         parse_host("localhost").unwrap();
         parse_host("127.0.0.0:1234").unwrap_err();
         parse_host("127.0.0.0").unwrap();
+        parse_host("2001:db8:abcd:42::dead:beef").unwrap_err();
     }
 
     #[test]

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -616,7 +616,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .validator(solana_net_utils::is_host)
                 .default_value("127.0.0.1")
                 .help(
-                    "IP address to bind the validator ports. Can be repeated. The first \
+                    "IPv4 address to bind the validator ports. Can be repeated. The first \
                      --bind-address MUST be your public internet address. ALL protocols (gossip, \
                      repair, IP echo, TVU, TPU, etc.) bind to this address on startup. Additional \
                      --bind-address values enable multihoming for Gossip/TVU/TPU - these \


### PR DESCRIPTION
We don't support IPv6 bind-address: it is not parsed correctly in `parse_host`, it doesn't work well with our network code. This PR makes this restriction to be explicit, informing user that IPv6 is not supported for `--bind-address` validator cla. While currently the error is "invalid port number" because it fails parsing formed url.
