### PR TITLE
XDP ebpf program must be aligned by 8 bytes

### DIFF
--- a/xdp-ebpf/src/lib.rs
+++ b/xdp-ebpf/src/lib.rs
@@ -8,7 +8,7 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 #![no_std]
 
-#[repr(C, align(4))]
+#[repr(C, align(8))]
 pub struct Aligned<Bytes: ?Sized>(Bytes);
 
 impl<Bytes: ?Sized> core::ops::Deref for Aligned<Bytes> {


### PR DESCRIPTION
#### Problem

`object::File::parse` reads ELF header to detect alignment and the data must be properly aligned (8 byte because it happens to be ELFCLASS64). 
We currently align by 4, which leads to panic during validator launch:

```
> readelf -h xdp-ebpf/agave-xdp-prog                                                  ✭ ✱
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00
  Class:                             ELF64
```

1. The error message comes from aya-obj crate, obj.rs:

```rust
pub enum ParseError {
    #[error("error parsing ELF data")]
    ElfError(object::read::Error),
 ```
 
 2. This error is wrapping underlying object crate parsing error, which happen when we call `object::read::File::parse(data).map_err(ParseError::ElfError)?`
 
 3. There we get the `FileKind` (Elf64 or Elf32) by looking into Magic. The magic in our case is "7f 45 4c 46 02". 
 
This decodes to:
 
 7f 45 4c 46 = (0x7f 'E' 'L' 'F')
02 = EI_CLASS = ELFCLASS64 (64-bit)
01 = EI_DATA = ELFDATA2LSB (little-endian)
01 = EI_VERSION = EV_CURRENT
00 = EI_OSABI = System V
00 = EI_ABIVERSION
remaining 00 ... 00 = padding
 
 4. The important part is `02 = EI_CLASS = ELFCLASS64 (64-bit)`.

#### Summary of Changes

Hence, read using 8bytes alignment. Even if ELF32 will be ever used, it is safe to use larger alignment.

Fixes: https://github.com/anza-xyz/agave/pull/10952
