### PR TITLE
refactor(ledger): switch blockstore to wincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8620,6 +8620,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-program-error",
+ "wincode",
 ]
 
 [[package]]
@@ -8779,7 +8780,6 @@ dependencies = [
  "rocksdb",
  "scopeguard",
  "serde",
- "serde_bytes",
  "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-accounts-db",
@@ -9676,6 +9676,7 @@ checksum = "dc553b782111862cd6c56bdeba696dcba9722a42154ef1248c5a06ca1d983797"
 dependencies = [
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -10508,6 +10509,7 @@ dependencies = [
  "solana-transaction-status",
  "test-case",
  "tonic-prost-build",
+ "wincode",
 ]
 
 [[package]]
@@ -11129,6 +11131,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-instruction-error",
  "solana-sanitize",
+ "wincode",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11195,6 +11195,7 @@ dependencies = [
  "solana-transaction-error",
  "test-case",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7513,6 +7513,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-program-error",
+ "wincode",
 ]
 
 [[package]]
@@ -7635,7 +7636,6 @@ dependencies = [
  "rocksdb",
  "scopeguard",
  "serde",
- "serde_bytes",
  "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-accounts-db",
@@ -8375,6 +8375,7 @@ checksum = "dc553b782111862cd6c56bdeba696dcba9722a42154ef1248c5a06ca1d983797"
 dependencies = [
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -9036,6 +9037,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-prost-build",
+ "wincode",
 ]
 
 [[package]]
@@ -9568,6 +9570,7 @@ dependencies = [
  "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
+ "wincode",
 ]
 
 [[package]]
@@ -9580,6 +9583,7 @@ dependencies = [
  "serde_derive",
  "solana-instruction-error",
  "solana-sanitize",
+ "wincode",
 ]
 
 [[package]]
@@ -9641,6 +9645,7 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -33,10 +33,10 @@ agave-votor-messages = { workspace = true }
 anyhow = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
-bitflags = { workspace = true, features = ["serde"] }
+bitflags = { workspace = true }
 bytes = { workspace = true }
 bzip2 = { workspace = true }
-chrono = { workspace = true, features = ["default", "serde"] }
+chrono = { workspace = true, features = ["default"] }
 chrono-humanize = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api"] }
@@ -58,7 +58,6 @@ rayon = { workspace = true }
 reed-solomon-erasure = { workspace = true, features = ["simd-accel"] }
 scopeguard = { workspace = true }
 serde = { workspace = true }
-serde_bytes = { workspace = true }
 solana-account = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-accounts-db = { workspace = true }
@@ -88,7 +87,7 @@ solana-nohash-hasher = { workspace = true }
 solana-packet = { workspace = true }
 solana-perf = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["wincode"] }
 solana-rayon-threadlimit = { workspace = true }
 solana-runtime = { workspace = true }
 solana-runtime-transaction = { workspace = true }

--- a/ledger/src/bit_vec.rs
+++ b/ledger/src/bit_vec.rs
@@ -1,11 +1,15 @@
 use {
-    serde::{Deserialize, Serialize},
     std::{
         iter::Enumerate,
+        mem::MaybeUninit,
         ops::{Bound, RangeBounds},
         slice::Iter,
     },
     thiserror::Error,
+    wincode::{
+        ReadError, ReadResult, SchemaRead, SchemaWrite, config::Config, io::Reader,
+        len::SeqLen as _,
+    },
 };
 
 type Word = u8;
@@ -24,10 +28,8 @@ const BITS_PER_WORD: usize = std::mem::size_of::<Word>() * 8;
 /// assert_eq!(bit_vec.range(..2).iter_ones().collect::<Vec<_>>(), [0, 1]);
 /// assert_eq!(bit_vec.range(1..).count_ones(), 1);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq, SchemaWrite)]
 pub struct BitVec<const NUM_BITS: usize> {
-    #[serde(with = "serde_bytes")]
     words: Box<[Word]>,
 }
 
@@ -39,28 +41,32 @@ impl<const NUM_BITS: usize> Default for BitVec<NUM_BITS> {
     }
 }
 
-// Note: serde_bytes' default `Deserialize` would construct a variable-length buffer,
+// Note: bincode/wincode would construct a variable-length buffer,
 // which violates `BitVec`'s invariant that its backing vector length (in words)
 // is exactly `NUM_WORDS`. Bounds checks and performance rely on this fixed size.
 //
 // `BitVec` is normally constructed via `Default`, which initializes with
-// `vec![0; Self::NUM_WORDS]`. This custom `Deserialize` preserves the invariant by
+// `vec![0; Self::NUM_WORDS]`. This custom `SchemaRead` preserves the invariant by
 // allocating exactly `NUM_WORDS` and populating from the serialized data, zero-filling
 // any missing words. This is required for the `SlotMetaV1` -> `SlotMetaV2` migration,
 // where `completed_data_indexes` was encoded as a variable-length `BTreeSet<u32>`.
-impl<'de, const NUM_BITS: usize> Deserialize<'de> for BitVec<NUM_BITS> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let bytes = <&serde_bytes::Bytes as Deserialize>::deserialize(deserializer)?;
-        let mut words = Vec::with_capacity(Self::NUM_WORDS);
-        words.extend_from_slice(bytes);
-        words.resize(Self::NUM_WORDS, 0);
+unsafe impl<'de, const NUM_BITS: usize, C: Config> SchemaRead<'de, C> for BitVec<NUM_BITS> {
+    type Dst = Self;
 
-        Ok(Self {
-            words: words.into_boxed_slice(),
-        })
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let bytes_len = C::LengthEncoding::read(reader.by_ref())?;
+        if bytes_len > Self::NUM_WORDS {
+            return Err(ReadError::LengthEncodingOverflow("bit_vec len too large"));
+        }
+        let mut words = Box::new_uninit_slice(Self::NUM_WORDS);
+        let (to_read, to_zero) = words.split_at_mut(bytes_len);
+        reader.copy_into_slice(&mut to_read[..bytes_len])?;
+        to_zero.fill(MaybeUninit::zeroed());
+        // Safety: copy_into_slice ensures that the slice of `bytes_len` length is initialized,
+        // other are zeroed out.
+        let words = unsafe { words.assume_init() };
+        dst.write(Self { words });
+        Ok(())
     }
 }
 
@@ -601,16 +607,14 @@ mod tests {
             let mut expected = BitVec::<NUM_BITS>::default();
             expected.words[..data.len()].copy_from_slice(&data);
 
-            #[derive(Serialize)]
-            #[serde(transparent)]
+            #[derive(SchemaWrite)]
             struct Source {
-                #[serde(with = "serde_bytes")]
                 data: Vec<u8>,
             }
-            let serialized = bincode::serialize(&Source { data }).unwrap();
+            let serialized = wincode::serialize(&Source { data }).unwrap();
             // Deserializing should always result in a BitVec with exactly NUM_WORDS words,
             // adding zeroed bits that are not present in the serialized data.
-            let deserialized: BitVec<NUM_BITS> = bincode::deserialize(&serialized).unwrap();
+            let deserialized: BitVec<NUM_BITS> = wincode::deserialize(&serialized).unwrap();
             prop_assert_eq!(deserialized, expected);
         }
 
@@ -618,8 +622,8 @@ mod tests {
         fn serialize_roundtrip(range in rand_range(0..1024_usize)) {
             const NUM_BITS: usize = 1024;
             let bit_vec = range.into_iter().collect::<BitVec<NUM_BITS>>();
-            let serialized = bincode::serialize(&bit_vec).unwrap();
-            let deserialized: BitVec<NUM_BITS> = bincode::deserialize(&serialized).unwrap();
+            let serialized = wincode::serialize(&bit_vec).unwrap();
+            let deserialized: BitVec<NUM_BITS> = wincode::deserialize(&serialized).unwrap();
             prop_assert_eq!(deserialized, bit_vec);
         }
     }

--- a/ledger/src/bit_vec.rs
+++ b/ledger/src/bit_vec.rs
@@ -6,10 +6,7 @@ use {
         slice::Iter,
     },
     thiserror::Error,
-    wincode::{
-        ReadError, ReadResult, SchemaRead, SchemaWrite, config::Config, io::Reader,
-        len::SeqLen as _,
-    },
+    wincode::{ReadResult, SchemaRead, SchemaWrite, config::Config, io::Reader},
 };
 
 type Word = u8;
@@ -47,25 +44,17 @@ impl<const NUM_BITS: usize> Default for BitVec<NUM_BITS> {
 //
 // `BitVec` is normally constructed via `Default`, which initializes with
 // `vec![0; Self::NUM_WORDS]`. This custom `SchemaRead` preserves the invariant by
-// allocating exactly `NUM_WORDS` and populating from the serialized data, zero-filling
-// any missing words. This is required for the `SlotMetaV1` -> `SlotMetaV2` migration,
-// where `completed_data_indexes` was encoded as a variable-length `BTreeSet<u32>`.
+// forcing returned instance to have exactly `NUM_WORDS` - populating from the serialized data
+// and zero-filling any missing words or truncating any excess words.
 unsafe impl<'de, const NUM_BITS: usize, C: Config> SchemaRead<'de, C> for BitVec<NUM_BITS> {
     type Dst = Self;
 
     fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let bytes_len = C::LengthEncoding::read(reader.by_ref())?;
-        if bytes_len > Self::NUM_WORDS {
-            return Err(ReadError::LengthEncodingOverflow("bit_vec len too large"));
-        }
-        let mut words = Box::new_uninit_slice(Self::NUM_WORDS);
-        let (to_read, to_zero) = words.split_at_mut(bytes_len);
-        reader.copy_into_slice(&mut to_read[..bytes_len])?;
-        to_zero.fill(MaybeUninit::zeroed());
-        // Safety: copy_into_slice ensures that the slice of `bytes_len` length is initialized,
-        // other are zeroed out.
-        let words = unsafe { words.assume_init() };
-        dst.write(Self { words });
+        let mut vec = <Vec<u8> as SchemaRead<C>>::get(reader.by_ref())?;
+        vec.resize(Self::NUM_WORDS, 0);
+        dst.write(Self {
+            words: vec.into_boxed_slice(),
+        });
         Ok(())
     }
 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -645,8 +645,8 @@ impl Blockstore {
         use crate::blockstore_meta::DoubleMerkleMeta;
         let meta = DoubleMerkleMeta {
             double_merkle_root,
-            fec_set_count: 1,       // Minimal valid value
-            proofs: ByteBuf::new(), // Empty proofs for testing
+            fec_set_count: 1,   // Minimal valid value
+            proofs: Vec::new(), // Empty proofs for testing
         };
         self.double_merkle_meta_cf
             .put((slot, block_location), &meta)

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -33,7 +33,6 @@ use {
     rand::Rng,
     rayon::iter::{IntoParallelIterator, ParallelIterator},
     rocksdb::{DBRawIterator, LiveFile},
-    serde_bytes::ByteBuf,
     solana_account::ReadableAccount,
     solana_address_lookup_table_interface::state::AddressLookupTable,
     solana_clock::{DEFAULT_TICKS_PER_SECOND, Slot, UnixTimestamp},
@@ -675,7 +674,7 @@ impl Blockstore {
         let (slot, fec_set_index) = erasure_set.store_key();
         self.erasure_meta_cf.put_bytes(
             (slot, u64::from(fec_set_index)),
-            &bincode::serialize(erasure_meta).unwrap(),
+            &wincode::serialize(erasure_meta).unwrap(),
         )
     }
 
@@ -1460,7 +1459,7 @@ impl Blockstore {
         let double_merkle_root = *merkle_tree.root();
         // We don't build the proofs here as they are only needed to serve repair requests.
         // These will be built later when calling `get_double_merkle_meta_maybe_populate_proofs`
-        let proofs = ByteBuf::new();
+        let proofs = Vec::new();
 
         // Create and add DoubleMerkleMeta to write batch
         let double_merkle_meta = DoubleMerkleMeta {
@@ -1531,7 +1530,7 @@ impl Blockstore {
         )?;
         let tree_size = double_merkle_meta.fec_set_count as usize + 1;
         let proof_len_bytes = get_proof_size(tree_size) as usize * SIZE_OF_MERKLE_PROOF_ENTRY;
-        let mut proofs = ByteBuf::with_capacity(tree_size * proof_len_bytes);
+        let mut proofs = Vec::with_capacity(tree_size * proof_len_bytes);
 
         for leaf_index in 0..tree_size {
             for proof_entry in merkle_tree.make_merkle_proof(leaf_index, tree_size) {
@@ -3057,9 +3056,9 @@ impl Blockstore {
 
         for bytes in shred_bytes_iter {
             let shred = Shred::new_from_serialized_shred(Vec::from(bytes)).map_err(|err| {
-                BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(format!(
-                    "Could not reconstruct shred from shred payload: {err:?}"
-                ))))
+                BlockstoreError::InvalidShredData(format!(
+                    "Could not reconstruct shred from shred payload: {err}"
+                ))
             })?;
             shreds.push(shred);
         }
@@ -3537,7 +3536,7 @@ impl Blockstore {
 
         let (rewards, num_partitions) = self
             .rewards_cf
-            .get_protobuf_or_bincode::<StoredExtendedRewards>(slot)?
+            .get_protobuf_or_wincode::<StoredExtendedRewards>(slot)?
             .unwrap_or_default()
             .into();
 
@@ -3591,7 +3590,7 @@ impl Blockstore {
         let transaction_status_dummy_key = cf::TransactionStatus::as_index(2);
         if self
             .transaction_status_cf
-            .get_protobuf_or_bincode::<StoredTransactionStatusMeta>(transaction_status_dummy_key)?
+            .get_protobuf_or_wincode::<StoredTransactionStatusMeta>(transaction_status_dummy_key)?
             .is_some()
         {
             self.transaction_status_cf
@@ -4117,7 +4116,7 @@ impl Blockstore {
 
     pub fn read_rewards(&self, index: Slot) -> Result<Option<Rewards>> {
         self.rewards_cf
-            .get_protobuf_or_bincode::<Rewards>(index)
+            .get_protobuf_or_wincode::<Rewards>(index)
             .map(|result| result.map(|option| option.into()))
     }
 
@@ -4379,9 +4378,9 @@ impl Blockstore {
                     .take(num_shreds as usize)
                     .process_results(|shreds| Shredder::deshred(shreds))?
                     .map_err(|e| {
-                        BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(
-                            format!("could not reconstruct data buffer from shreds: {e:?}"),
-                        )))
+                        BlockstoreError::InvalidShredData(format!(
+                            "could not reconstruct data buffer from shreds: {e}"
+                        ))
                     })
                     .and_then(&mut deserialize)
             })
@@ -4401,9 +4400,9 @@ impl Blockstore {
             wincode::deserialize(&payload)
                 .map(|component| vec![component])
                 .map_err(|e| {
-                    BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(
-                        format!("could not reconstruct block component: {e:?}"),
-                    )))
+                    BlockstoreError::InvalidShredData(format!(
+                        "could not reconstruct block component: {e}"
+                    ))
                 })
         })
     }
@@ -4417,9 +4416,7 @@ impl Blockstore {
     ) -> Result<Vec<Entry>> {
         self.get_slot_data_in_block(slot, completed_ranges, slot_meta, |payload| {
             <WincodeVec<Entry, MaxDataShredsLen>>::deserialize(&payload).map_err(|e| {
-                BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(format!(
-                    "could not reconstruct entries: {e:?}"
-                ))))
+                BlockstoreError::InvalidShredData(format!("could not reconstruct entries: {e}"))
             })
         })
     }
@@ -10849,7 +10846,7 @@ pub mod tests {
             assert_eq!(
                 blockstore
                     .rewards_cf
-                    .get_protobuf_or_bincode::<StoredExtendedRewards>(slot)
+                    .get_protobuf_or_wincode::<StoredExtendedRewards>(slot)
                     .unwrap()
                     .unwrap(),
                 protobuf_rewards
@@ -10933,7 +10930,7 @@ pub mod tests {
             assert_eq!(
                 blockstore
                     .transaction_status_cf
-                    .get_protobuf_or_bincode::<StoredTransactionStatusMeta>((
+                    .get_protobuf_or_wincode::<StoredTransactionStatusMeta>((
                         Signature::default(),
                         slot
                     ))

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -4,13 +4,14 @@ use {
         blockstore::error::Result,
         blockstore_meta::{self, BlockLocation, PerfSample},
     },
-    bincode::Options as BincodeOptions,
-    serde::{Serialize, de::DeserializeOwned},
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::{HASH_BYTES, Hash},
     solana_pubkey::{PUBKEY_BYTES, Pubkey},
     solana_signature::{SIGNATURE_BYTES, Signature},
     solana_storage_proto::convert::generated,
+    wincode::{
+        ReadError, SchemaRead, SchemaReadOwned, SchemaWrite, config::DefaultConfig, io::Reader,
+    },
 };
 
 pub(crate) const DEPRECATED_PROGRAM_COSTS_COLUMN_NAME: &str = "program_costs";
@@ -270,12 +271,18 @@ macro_rules! convert_column_key_bytes_to_index {
     }};
 }
 
-fn deserialize_fixint_reject_trailing<T: DeserializeOwned>(data: &[u8]) -> Result<T> {
-    let config = bincode::DefaultOptions::new()
-        // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
-        .with_fixint_encoding()
-        .reject_trailing_bytes();
-    Ok(config.deserialize(data)?)
+// TODO: replace with dedicated wincode API on wincode>=0.5.1
+fn deserialize_reject_trailing<'de, T>(src: &'de [u8]) -> Result<T>
+where
+    T: SchemaRead<'de, DefaultConfig, Dst = T>,
+{
+    let mut reader = src;
+    let value = <T as SchemaRead<'de, DefaultConfig>>::get(reader.by_ref())?;
+    if reader.is_empty() {
+        Ok(value)
+    } else {
+        Err(ReadError::Custom("trailing bytes").into())
+    }
 }
 
 pub trait Column {
@@ -301,14 +308,15 @@ pub trait ColumnName {
 
 // Columns that serialize data on insertion and deserialize on fetch
 pub trait TypedColumn: Column {
-    type Type: Serialize + DeserializeOwned;
+    type Type: SchemaWrite<DefaultConfig, Src = Self::Type>
+        + SchemaReadOwned<DefaultConfig, Dst = Self::Type>;
 
     fn deserialize(data: &[u8]) -> Result<Self::Type> {
-        Ok(bincode::deserialize(data)?)
+        Ok(wincode::deserialize(data)?)
     }
 
     fn serialize(data: &Self::Type) -> Result<Vec<u8>> {
-        Ok(bincode::serialize(data)?)
+        Ok(wincode::serialize(data)?)
     }
 }
 
@@ -599,7 +607,7 @@ impl TypedColumn for columns::Index {
     type Type = blockstore_meta::Index;
 
     fn deserialize(data: &[u8]) -> Result<Self::Type> {
-        deserialize_fixint_reject_trailing(data)
+        deserialize_reject_trailing(data)
     }
 }
 
@@ -877,6 +885,7 @@ mod tests {
         super::*,
         crate::blockstore_meta::{ConnectedFlags, SlotMetaV3},
         solana_hash::Hash,
+        wincode,
     };
 
     #[test]
@@ -900,8 +909,6 @@ mod tests {
 
     #[test]
     fn test_slot_meta_column_deserialize_v2_from_v3_bytes() {
-        use bincode::Options;
-
         let meta_v3 = SlotMetaV3 {
             slot: 42,
             consumed: 10,
@@ -915,18 +922,11 @@ mod tests {
             parent_block_id: Hash::new_unique(),
             replay_fec_set_index: 7,
         };
-        let v3_bytes = bincode::serialize(&meta_v3).unwrap();
+        let v3_bytes = wincode::serialize(&meta_v3).unwrap();
 
         let expected = blockstore_meta::SlotMeta::from(meta_v3);
 
-        let config = bincode::DefaultOptions::new()
-            .with_fixint_encoding()
-            .reject_trailing_bytes();
-        assert!(
-            config
-                .deserialize::<blockstore_meta::SlotMeta>(&v3_bytes)
-                .is_err()
-        );
+        assert!(deserialize_reject_trailing::<blockstore_meta::SlotMeta>(&v3_bytes).is_err());
 
         let deserialized = <columns::SlotMeta as TypedColumn>::deserialize(&v3_bytes).unwrap();
         assert_eq!(expected, deserialized);

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -311,10 +311,12 @@ pub trait TypedColumn: Column {
     type Type: SchemaWrite<DefaultConfig, Src = Self::Type>
         + SchemaReadOwned<DefaultConfig, Dst = Self::Type>;
 
+    #[inline]
     fn deserialize(data: &[u8]) -> Result<Self::Type> {
         Ok(wincode::deserialize(data)?)
     }
 
+    #[inline]
     fn serialize(data: &Self::Type) -> Result<Vec<u8>> {
         Ok(wincode::serialize(data)?)
     }

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -606,6 +606,7 @@ impl ColumnName for columns::Index {
 impl TypedColumn for columns::Index {
     type Type = blockstore_meta::Index;
 
+    #[inline]
     fn deserialize(data: &[u8]) -> Result<Self::Type> {
         deserialize_reject_trailing(data)
     }

--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -9,8 +9,8 @@ use {
 pub enum BlockstoreError {
     #[error("shred for index exists")]
     ShredForIndexExists,
-    #[error("invalid shred data")]
-    InvalidShredData(bincode::Error),
+    #[error("invalid shred data: {0}")]
+    InvalidShredData(String),
     #[error("RocksDB error: {0}")]
     RocksDb(#[from] rocksdb::Error),
     #[error("slot is not rooted")]
@@ -21,10 +21,10 @@ pub enum BlockstoreError {
     DeadSlot,
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("deserialization error: {0}")]
-    Deserialize(#[from] wincode::ReadError),
-    #[error("serialization error: {0}")]
-    Serialize(#[from] bincode::Error),
+    #[error("deserialization wincode error: {0}")]
+    WincodeRead(#[from] wincode::ReadError),
+    #[error("serialization wincode error: {0}")]
+    WincodeWrite(#[from] wincode::WriteError),
     #[error("fs extra error: {0}")]
     FsExtraError(#[from] fs_extra::error::Error),
     #[error("slot cleaned up")]

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -16,7 +16,6 @@ use {
         },
         blockstore_options::{AccessType, BlockstoreOptions, LedgerColumnOptions},
     },
-    bincode::deserialize,
     log::*,
     prost::Message,
     rocksdb::{
@@ -27,7 +26,6 @@ use {
         compaction_filter_factory::{CompactionFilterContext, CompactionFilterFactory},
         properties as RocksProperties,
     },
-    serde::de::DeserializeOwned,
     solana_clock::Slot,
     std::{
         collections::HashSet,
@@ -41,6 +39,7 @@ use {
             atomic::{AtomicU64, Ordering},
         },
     },
+    wincode::{SchemaReadOwned, deserialize},
 };
 
 const BLOCKSTORE_METRICS_ERROR: i64 = -1;
@@ -889,15 +888,19 @@ impl<C> LedgerColumn<C>
 where
     C: ProtobufColumn + ColumnName,
 {
-    pub fn get_protobuf_or_bincode<T: DeserializeOwned + Into<C::Type>>(
+    pub fn get_protobuf_or_wincode<
+        T: SchemaReadOwned<wincode::config::DefaultConfig, Dst = T> + Into<C::Type>,
+    >(
         &self,
         index: C::Index,
     ) -> Result<Option<C::Type>> {
         let key = <C as Column>::key(&index);
-        self.get_raw_protobuf_or_bincode::<T>(key)
+        self.get_raw_protobuf_or_wincode::<T>(key)
     }
 
-    pub(crate) fn get_raw_protobuf_or_bincode<T: DeserializeOwned + Into<C::Type>>(
+    pub(crate) fn get_raw_protobuf_or_wincode<
+        T: SchemaReadOwned<wincode::config::DefaultConfig, Dst = T> + Into<C::Type>,
+    >(
         &self,
         key: impl AsRef<[u8]>,
     ) -> Result<Option<C::Type>> {

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -207,6 +207,9 @@ mod wincode_compat {
     unsafe impl<'de, C: ConfigCore> SchemaRead<'de, C> for OptionCompat {
         type Dst = Option<Slot>;
 
+        const TYPE_META: wincode::TypeMeta =
+            <Slot as SchemaRead<'de, C>>::TYPE_META.keep_zero_copy(false);
+
         fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
             let val = <Slot as SchemaRead<'de, C>>::get(reader)?;
             dst.write((val != Slot::MAX).then_some(val));
@@ -215,6 +218,9 @@ mod wincode_compat {
     }
     unsafe impl<C: ConfigCore> SchemaWrite<C> for OptionCompat {
         type Src = Option<Slot>;
+
+        const TYPE_META: wincode::TypeMeta =
+            <Slot as SchemaWrite<C>>::TYPE_META.keep_zero_copy(false);
 
         fn size_of(src: &Self::Src) -> WriteResult<usize> {
             <Slot as SchemaWrite<C>>::size_of(&src.unwrap_or(Slot::MAX))
@@ -266,6 +272,8 @@ mod wincode_compat_cast {
     unsafe impl<'de, C: ConfigCore> SchemaRead<'de, C> for U32AsU64 {
         type Dst = u32;
 
+        const TYPE_META: wincode::TypeMeta = <u64 as SchemaRead<'de, C>>::TYPE_META;
+
         fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
             let val = <u64 as SchemaRead<'de, C>>::get(reader)?;
             dst.write(val as u32);
@@ -274,6 +282,8 @@ mod wincode_compat_cast {
     }
     unsafe impl<C: ConfigCore> SchemaWrite<C> for U32AsU64 {
         type Src = u32;
+
+        const TYPE_META: wincode::TypeMeta = <u64 as SchemaWrite<C>>::TYPE_META;
 
         fn size_of(src: &Self::Src) -> WriteResult<usize> {
             <u64 as SchemaWrite<C>>::size_of(&u64::from(*src))

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -272,7 +272,8 @@ mod wincode_compat_cast {
     unsafe impl<'de, C: ConfigCore> SchemaRead<'de, C> for U32AsU64 {
         type Dst = u32;
 
-        const TYPE_META: wincode::TypeMeta = <u64 as SchemaRead<'de, C>>::TYPE_META;
+        const TYPE_META: wincode::TypeMeta =
+            <u64 as SchemaRead<'de, C>>::TYPE_META.keep_zero_copy(false);
 
         fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
             let val = <u64 as SchemaRead<'de, C>>::get(reader)?;
@@ -283,7 +284,8 @@ mod wincode_compat_cast {
     unsafe impl<C: ConfigCore> SchemaWrite<C> for U32AsU64 {
         type Src = u32;
 
-        const TYPE_META: wincode::TypeMeta = <u64 as SchemaWrite<C>>::TYPE_META;
+        const TYPE_META: wincode::TypeMeta =
+            <u64 as SchemaWrite<C>>::TYPE_META.keep_zero_copy(false);
 
         fn size_of(src: &Self::Src) -> WriteResult<usize> {
             <u64 as SchemaWrite<C>>::size_of(&u64::from(*src))
@@ -714,6 +716,7 @@ pub struct AddressSignatureMeta {
 
 /// Performance information about validator execution during a time slice.
 ///
+#[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct PerfSample {
     // `PerfSampleV1` part
@@ -725,6 +728,7 @@ pub struct PerfSample {
     pub num_non_vote_transactions: u64,
 }
 
+#[repr(C)]
 #[derive(Clone, Debug, Default, SchemaRead, SchemaWrite, PartialEq, Eq)]
 pub struct OptimisticSlotMetaV0 {
     pub hash: Hash,

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -7,8 +7,6 @@ use {
         },
     },
     bitflags::bitflags,
-    serde::{Deserialize, Deserializer, Serialize, Serializer},
-    serde_bytes::ByteBuf,
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::{HASH_BYTES, Hash},
     std::{
@@ -19,7 +17,7 @@ use {
 };
 
 bitflags! {
-    #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     /// Flags to indicate whether a slot is a descendant of a slot on the main fork
     pub struct ConnectedFlags:u8 {
         // A slot S should be considered to be connected if:
@@ -48,6 +46,10 @@ bitflags! {
     }
 }
 
+wincode::pod_wrapper! {
+    unsafe struct PodConnectedFlags(ConnectedFlags);
+}
+
 impl Default for ConnectedFlags {
     fn default() -> Self {
         ConnectedFlags::empty()
@@ -55,8 +57,7 @@ impl Default for ConnectedFlags {
 }
 
 /// A fixed size BitVec offers fast lookup and fast de/serialization.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(transparent)]
+#[derive(Clone, PartialEq, Eq, Default, SchemaRead, SchemaWrite)]
 pub struct CompletedDataIndexes {
     index: BitVec<MAX_DATA_SHREDS_PER_SLOT>,
 }
@@ -101,14 +102,14 @@ impl FromIterator<u32> for CompletedDataIndexes {
     }
 }
 
-// Manually implement Debut to display indices indices instead of raw u8's
+// Manually implement Debug to display indices instead of raw u8's
 impl Debug for CompletedDataIndexes {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.iter().collect::<Vec<_>>())
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, SchemaRead, SchemaWrite, Eq, PartialEq)]
 /// The Meta column family
 pub struct SlotMetaBase<T> {
     /// The number of slots above the root (the genesis block). The first
@@ -126,16 +127,17 @@ pub struct SlotMetaBase<T> {
     pub first_shred_timestamp: u64,
     /// The index of the shred that is flagged as the last shred for this slot.
     /// None until the shred with LAST_SHRED_IN_SLOT flag is received.
-    #[serde(with = "serde_compat")]
+    #[wincode(with = "wincode_compat::OptionCompat")]
     pub last_index: Option<u64>,
     /// The slot height of the block this one derives from.
     /// The parent slot of the head of a detached chain of slots is None.
-    #[serde(with = "serde_compat")]
+    #[wincode(with = "wincode_compat::OptionCompat")]
     pub parent_slot: Option<Slot>,
     /// The list of slots, each of which contains a block that derives
     /// from this one.
     pub next_slots: Vec<Slot>,
     /// Connected status flags of this slot
+    #[wincode(with = "PodConnectedFlags")]
     pub connected_flags: ConnectedFlags,
     /// Shreds indices which are marked data complete.  That is, those that have the
     /// [`ShredFlags::DATA_COMPLETE_SHRED`][`crate::shred::ShredFlags::DATA_COMPLETE_SHRED`] set.
@@ -150,17 +152,18 @@ pub type SlotMeta = SlotMetaBase<CompletedDataIndexes>;
 /// converted into a SlotMeta. The logic to read and convert SlotMetaV3 to
 /// SlotMeta enables this software to read a Blockstore modified by a future
 /// version where the SlotMetaV3 format is persisted.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, SchemaRead, SchemaWrite, Eq, PartialEq)]
 pub(crate) struct SlotMetaV3 {
     pub slot: Slot,
     pub consumed: u64,
     pub received: u64,
     pub first_shred_timestamp: u64,
-    #[serde(with = "serde_compat")]
+    #[wincode(with = "wincode_compat::OptionCompat")]
     pub last_index: Option<u64>,
-    #[serde(with = "serde_compat")]
+    #[wincode(with = "wincode_compat::OptionCompat")]
     pub parent_slot: Option<Slot>,
     pub next_slots: Vec<Slot>,
+    #[wincode(with = "PodConnectedFlags")]
     pub connected_flags: ConnectedFlags,
     pub completed_data_indexes: CompletedDataIndexes,
     /// The block id of the parent block.
@@ -187,42 +190,54 @@ impl From<SlotMetaV3> for SlotMeta {
     }
 }
 
-// Serde implementation of serialize and deserialize for Option<u64>
+// Wincode implementation of serialize and deserialize for Option<u64>
 // where None is represented as u64::MAX; for backward compatibility.
-mod serde_compat {
-    use super::*;
+mod wincode_compat {
+    use {
+        super::*,
+        std::mem::MaybeUninit,
+        wincode::{
+            ReadResult, WriteResult,
+            config::ConfigCore,
+            io::{Reader, Writer},
+        },
+    };
 
-    pub(super) fn serialize<S>(val: &Option<u64>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        val.unwrap_or(u64::MAX).serialize(serializer)
+    pub(crate) struct OptionCompat;
+    unsafe impl<'de, C: ConfigCore> SchemaRead<'de, C> for OptionCompat {
+        type Dst = Option<Slot>;
+
+        fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+            let val = <Slot as SchemaRead<'de, C>>::get(reader)?;
+            dst.write((val != Slot::MAX).then_some(val));
+            Ok(())
+        }
     }
+    unsafe impl<C: ConfigCore> SchemaWrite<C> for OptionCompat {
+        type Src = Option<Slot>;
 
-    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let val = u64::deserialize(deserializer)?;
-        Ok((val != u64::MAX).then_some(val))
+        fn size_of(src: &Self::Src) -> WriteResult<usize> {
+            <Slot as SchemaWrite<C>>::size_of(&src.unwrap_or(Slot::MAX))
+        }
+
+        fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+            <Slot as SchemaWrite<C>>::write(writer, &src.unwrap_or(Slot::MAX))
+        }
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, SchemaRead, SchemaWrite, PartialEq, Eq)]
 pub struct Index {
     pub slot: Slot,
     data: ShredIndex,
     coding: ShredIndex,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, SchemaRead, SchemaWrite, Eq, PartialEq)]
 /// Erasure coding information
 pub struct ErasureMeta {
     /// Which erasure set in the slot this is
-    #[serde(
-        serialize_with = "serde_compat_cast::serialize::<_, u64, _>",
-        deserialize_with = "serde_compat_cast::deserialize::<_, u64, _>"
-    )]
+    #[wincode(with = "wincode_compat_cast::U32AsU64")]
     fec_set_index: u32,
     /// First coding index in the FEC set
     first_coding_index: u64,
@@ -232,40 +247,45 @@ pub struct ErasureMeta {
     config: ErasureConfig,
 }
 
-// Helper module to serde values by type-casting to an intermediate
+// Helper module to serialize values by type-casting to an intermediate
 // type for backward compatibility.
-mod serde_compat_cast {
-    use super::*;
+mod wincode_compat_cast {
+    use {
+        super::*,
+        std::mem::MaybeUninit,
+        wincode::{
+            ReadResult, WriteResult,
+            config::ConfigCore,
+            io::{Reader, Writer},
+        },
+    };
 
-    // Serializes a value of type T by first type-casting to type R.
-    pub(super) fn serialize<S: Serializer, R, T: Copy>(
-        &val: &T,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        R: TryFrom<T> + Serialize,
-        <R as TryFrom<T>>::Error: std::fmt::Display,
-    {
-        R::try_from(val)
-            .map_err(serde::ser::Error::custom)?
-            .serialize(serializer)
+    /// Serializes a `u32` as `u64` for backward compatibility with on-disk data
+    /// that stored the field with 8-byte width.
+    pub(super) struct U32AsU64;
+    unsafe impl<'de, C: ConfigCore> SchemaRead<'de, C> for U32AsU64 {
+        type Dst = u32;
+
+        fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+            let val = <u64 as SchemaRead<'de, C>>::get(reader)?;
+            dst.write(val as u32);
+            Ok(())
+        }
     }
+    unsafe impl<C: ConfigCore> SchemaWrite<C> for U32AsU64 {
+        type Src = u32;
 
-    // Deserializes a value of type R and type-casts it to type T.
-    pub(super) fn deserialize<'de, D, R, T>(deserializer: D) -> Result<T, D::Error>
-    where
-        D: Deserializer<'de>,
-        R: Deserialize<'de>,
-        T: TryFrom<R>,
-        <T as TryFrom<R>>::Error: std::fmt::Display,
-    {
-        R::deserialize(deserializer)
-            .map(T::try_from)?
-            .map_err(serde::de::Error::custom)
+        fn size_of(src: &Self::Src) -> WriteResult<usize> {
+            <u64 as SchemaWrite<C>>::size_of(&u64::from(*src))
+        }
+
+        fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+            <u64 as SchemaWrite<C>>::write(writer, &u64::from(*src))
+        }
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, SchemaRead, SchemaWrite)]
 pub(crate) struct ErasureConfig {
     pub(crate) num_data: usize,
     pub(crate) num_coding: usize,
@@ -277,7 +297,7 @@ impl ErasureConfig {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, SchemaRead, SchemaWrite)]
 pub struct MerkleRootMeta {
     /// The merkle root, `None` for legacy shreds
     merkle_root: Option<Hash>,
@@ -287,11 +307,9 @@ pub struct MerkleRootMeta {
     first_received_shred_type: ShredType,
 }
 
-#[derive(Deserialize, Serialize, SchemaRead, SchemaWrite)]
+#[derive(SchemaRead, SchemaWrite)]
 pub struct DuplicateSlotProof {
-    #[serde(with = "shred::serde_bytes_payload")]
     pub shred1: shred::Payload,
-    #[serde(with = "shred::serde_bytes_payload")]
     pub shred2: shred::Payload,
 }
 
@@ -329,7 +347,7 @@ impl Display for BlockLocation {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[derive(SchemaRead, SchemaWrite, Debug, PartialEq, Eq)]
 pub enum FrozenHashVersioned {
     Current(FrozenHashStatus),
 }
@@ -350,7 +368,7 @@ impl FrozenHashVersioned {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[derive(SchemaRead, SchemaWrite, Debug, PartialEq, Eq)]
 pub struct FrozenHashStatus {
     pub frozen_hash: Hash,
     pub is_duplicate_confirmed: bool,
@@ -389,7 +407,7 @@ impl Index {
 ///   requested range, avoiding unnecessary traversal.
 /// - **Simplified Serialization**: The contiguous memory layout allows for efficient
 ///   serialization/deserialization without tree reconstruction.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, SchemaRead, SchemaWrite, Default)]
 pub struct ShredIndex {
     index: BitVec<MAX_DATA_SHREDS_PER_SLOT>,
     num_shreds: usize,
@@ -679,15 +697,14 @@ impl DuplicateSlotProof {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Default, SchemaRead, SchemaWrite, PartialEq, Eq)]
 pub struct AddressSignatureMeta {
     pub writeable: bool,
 }
 
 /// Performance information about validator execution during a time slice.
 ///
-/// Version of the [`PerfSample`] introduced in 1.15.x.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct PerfSample {
     // `PerfSampleV1` part
     pub num_transactions: u64,
@@ -698,13 +715,13 @@ pub struct PerfSample {
     pub num_non_vote_transactions: u64,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, SchemaRead, SchemaWrite, PartialEq, Eq)]
 pub struct OptimisticSlotMetaV0 {
     pub hash: Hash,
     pub timestamp: UnixTimestamp,
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[derive(SchemaRead, SchemaWrite, Debug, PartialEq, Eq)]
 pub enum OptimisticSlotMetaVersioned {
     V0(OptimisticSlotMetaV0),
 }
@@ -727,7 +744,7 @@ impl OptimisticSlotMetaVersioned {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct DoubleMerkleMeta {
     /// The double merkle root computed as the root of the merkle tree
     /// containing the merkle roots of each fec set + the parent info (parent_slot, parent_double_merkle_root)
@@ -738,13 +755,13 @@ pub struct DoubleMerkleMeta {
 
     /// The merkle proofs.
     /// Each proof is of size `get_proof_size(fec_set_count + 1)`
-    /// This `ByteBuf` contains the concatenated proofs for all the fec set leaves and the parent info leaf
+    /// This `Vec<u8>` contains the concatenated proofs for all the fec set leaves and the parent info leaf
     ///
     /// The size of this vec is `(fec_set_count + 1) * get_proof_size(fec_set_count + 1) * SIZE_OF_MERKLE_PROOF_ENTRY`
     /// To access the proof for the i-th leaf:
     ///   `proofs[i * get_proof_size(fec_set_count + 1) * SIZE_OF_MERKLE_PROOF_ENTRY
     ///      ..(i + 1) * get_proof_size(fec_set_count + 1) * SIZE_OF_MERKLE_PROOF_ENTRY]`
-    pub(crate) proofs: ByteBuf,
+    pub(crate) proofs: Vec<u8>,
 }
 
 impl DoubleMerkleMeta {
@@ -982,14 +999,15 @@ mod test {
         // Define a couple structs with bool and ConnectedFlags to illustrate
         // that that ConnectedFlags can be deserialized into a bool if the
         // PARENT_CONNECTED bit is NOT set
-        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        #[derive(Debug, PartialEq, SchemaRead, SchemaWrite)]
         struct WithBool {
             slot: Slot,
             connected: bool,
         }
-        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        #[derive(Debug, PartialEq, SchemaRead, SchemaWrite)]
         struct WithFlags {
             slot: Slot,
+            #[wincode(with = "PodConnectedFlags")]
             connected: ConnectedFlags,
         }
 
@@ -1005,40 +1023,40 @@ mod test {
 
         // Confirm that serialized byte arrays are same length
         assert_eq!(
-            bincode::serialized_size(&with_bool).unwrap(),
-            bincode::serialized_size(&with_flags).unwrap()
+            wincode::serialized_size(&with_bool).unwrap(),
+            wincode::serialized_size(&with_flags).unwrap()
         );
 
         // Confirm that connected=false equivalent to ConnectedFlags::default()
         assert_eq!(
-            bincode::serialize(&with_bool).unwrap(),
-            bincode::serialize(&with_flags).unwrap()
+            wincode::serialize(&with_bool).unwrap(),
+            wincode::serialize(&with_flags).unwrap()
         );
 
         // Set connected in WithBool and confirm inequality
         with_bool.connected = true;
         assert_ne!(
-            bincode::serialize(&with_bool).unwrap(),
-            bincode::serialize(&with_flags).unwrap()
+            wincode::serialize(&with_bool).unwrap(),
+            wincode::serialize(&with_flags).unwrap()
         );
 
         // Set connected in WithFlags and confirm equality regained
         with_flags.connected.set(ConnectedFlags::CONNECTED, true);
         assert_eq!(
-            bincode::serialize(&with_bool).unwrap(),
-            bincode::serialize(&with_flags).unwrap()
+            wincode::serialize(&with_bool).unwrap(),
+            wincode::serialize(&with_flags).unwrap()
         );
 
         // Deserializing WithBool into WithFlags succeeds
         assert_eq!(
             with_flags,
-            bincode::deserialize::<WithFlags>(&bincode::serialize(&with_bool).unwrap()).unwrap()
+            wincode::deserialize::<WithFlags>(&wincode::serialize(&with_bool).unwrap()).unwrap()
         );
 
         // Deserializing WithFlags into WithBool succeeds
         assert_eq!(
             with_bool,
-            bincode::deserialize::<WithBool>(&bincode::serialize(&with_flags).unwrap()).unwrap()
+            wincode::deserialize::<WithBool>(&wincode::serialize(&with_flags).unwrap()).unwrap()
         );
 
         // Deserializing WithFlags with extra bit set into WithBool fails
@@ -1046,7 +1064,7 @@ mod test {
             .connected
             .set(ConnectedFlags::PARENT_CONNECTED, true);
         assert!(
-            bincode::deserialize::<WithBool>(&bincode::serialize(&with_flags).unwrap()).is_err()
+            wincode::deserialize::<WithBool>(&wincode::serialize(&with_flags).unwrap()).is_err()
         );
     }
 
@@ -1065,11 +1083,10 @@ mod test {
 
     #[test]
     fn test_erasure_meta_transition() {
-        #[derive(Debug, Deserialize, PartialEq, Serialize)]
+        #[derive(Debug, PartialEq, SchemaRead, SchemaWrite)]
         struct OldErasureMeta {
             set_index: u64,
             first_coding_index: u64,
-            #[serde(rename = "size")]
             __unused_size: usize,
             config: ErasureConfig,
         }
@@ -1093,12 +1110,12 @@ mod test {
         };
 
         assert_eq!(
-            bincode::serialized_size(&old_erasure_meta).unwrap(),
-            bincode::serialized_size(&new_erasure_meta).unwrap(),
+            wincode::serialized_size(&old_erasure_meta).unwrap(),
+            wincode::serialized_size(&new_erasure_meta).unwrap(),
         );
 
         assert_eq!(
-            bincode::deserialize::<ErasureMeta>(&bincode::serialize(&old_erasure_meta).unwrap())
+            wincode::deserialize::<ErasureMeta>(&wincode::serialize(&old_erasure_meta).unwrap())
                 .unwrap(),
             new_erasure_meta
         );
@@ -1107,7 +1124,7 @@ mod test {
         old_erasure_meta.__unused_size = usize::try_from(u32::MAX).unwrap();
 
         assert_eq!(
-            bincode::deserialize::<OldErasureMeta>(&bincode::serialize(&new_erasure_meta).unwrap())
+            wincode::deserialize::<OldErasureMeta>(&wincode::serialize(&new_erasure_meta).unwrap())
                 .unwrap(),
             old_erasure_meta
         );

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -49,7 +49,7 @@
 //! So, given a) - c), we must restrict data shred's payload length such that the entire coding
 //! payload can fit into one coding shred / packet.
 
-pub(crate) use self::{merkle_tree::PROOF_ENTRIES_FOR_32_32_BATCH, payload::serde_bytes_payload};
+pub(crate) use self::merkle_tree::PROOF_ENTRIES_FOR_32_32_BATCH;
 use {
     self::traits::{Shred as _, ShredData as _},
     crate::blockstore::{self},
@@ -229,14 +229,12 @@ pub enum Error {
     Eq,
     Hash,
     PartialEq,
-    Deserialize,
     IntoPrimitive,
     Serialize,
     TryFromPrimitive,
     SchemaWrite,
     SchemaRead,
 )]
-#[serde(into = "u8", try_from = "u8")]
 #[wincode(tag_encoding = "u8")]
 pub enum ShredType {
     #[wincode(tag = 0b1010_0101)]

--- a/ledger/src/shred/payload.rs
+++ b/ledger/src/shred/payload.rs
@@ -99,30 +99,6 @@ impl Payload {
     }
 }
 
-pub(crate) mod serde_bytes_payload {
-    use {
-        super::Payload,
-        serde::{Deserialize, Deserializer, Serializer},
-        serde_bytes::ByteBuf,
-    };
-
-    pub(crate) fn serialize<S: Serializer>(
-        payload: &Payload,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error> {
-        serializer.serialize_bytes(payload)
-    }
-
-    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Payload, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Deserialize::deserialize(deserializer)
-            .map(ByteBuf::into_vec)
-            .map(Payload::from)
-    }
-}
-
 impl PartialEq for Payload {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -316,28 +292,5 @@ mod test {
             .expect("valid packet and nonce");
         assert_eq!(bytes, shred.payload().as_ref());
         assert_eq!(got, Some(nonce));
-    }
-
-    #[test]
-    fn test_payload_wincode_serde_bytes_compat() {
-        // Verify that wincode serializes Payload with the same bytes as bincode does via
-        // serde_bytes_payload, ensuring on-disk compatibility during migration.
-        #[derive(serde::Serialize, serde::Deserialize)]
-        struct AsSerdeBytesPayload(#[serde(with = "super::serde_bytes_payload")] Payload);
-
-        for example in [vec![], vec![44], vec![0u8, 1, 2, 3, 100, 255]] {
-            let payload = Payload::from(example);
-
-            let wincode_bytes = wincode::serialize(&payload).unwrap();
-            let bincode_bytes = bincode::serialize(&AsSerdeBytesPayload(payload.clone())).unwrap();
-
-            assert_eq!(wincode_bytes, bincode_bytes);
-
-            let wincode_payload: Payload = wincode::deserialize(&wincode_bytes).unwrap();
-            assert_eq!(*wincode_payload, *payload);
-            let bincode_payload: AsSerdeBytesPayload =
-                bincode::deserialize(&bincode_bytes).unwrap();
-            assert_eq!(*wincode_payload, *bincode_payload.0);
-        }
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7172,6 +7172,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-program-error",
+ "wincode",
 ]
 
 [[package]]
@@ -7294,7 +7295,6 @@ dependencies = [
  "rocksdb",
  "scopeguard",
  "serde",
- "serde_bytes",
  "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-accounts-db",
@@ -8007,6 +8007,7 @@ checksum = "dc553b782111862cd6c56bdeba696dcba9722a42154ef1248c5a06ca1d983797"
 dependencies = [
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -9394,6 +9395,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status",
  "tonic-prost-build",
+ "wincode",
 ]
 
 [[package]]
@@ -9880,6 +9882,7 @@ dependencies = [
  "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
+ "wincode",
 ]
 
 [[package]]
@@ -9892,6 +9895,7 @@ dependencies = [
  "serde_derive",
  "solana-instruction-error",
  "solana-sanitize",
+ "wincode",
 ]
 
 [[package]]
@@ -9953,6 +9957,7 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -32,9 +32,10 @@ solana-pubkey = { workspace = true }
 solana-serde = { workspace = true }
 solana-signature = { workspace = true, features = ["std"] }
 solana-transaction = { workspace = true }
-solana-transaction-context = { workspace = true, features = ["serde"] }
-solana-transaction-error = { workspace = true }
+solana-transaction-context = { workspace = true, features = ["serde", "wincode"] }
+solana-transaction-error = { workspace = true, features = ["wincode"] }
 solana-transaction-status = { workspace = true }
+wincode = { workspace = true }
 
 [build-dependencies]
 tonic-prost-build = { workspace = true }

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -7,6 +7,7 @@ use {
     },
     solana_message::v0::LoadedAddresses,
     solana_serde::default_on_eof,
+    solana_transaction::{SchemaRead, SchemaWrite},
     solana_transaction_context::transaction::TransactionReturnData,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     solana_transaction_status::{
@@ -19,7 +20,7 @@ pub mod convert;
 
 pub type StoredExtendedRewards = Vec<StoredExtendedReward>;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, SchemaRead, SchemaWrite)]
 pub struct StoredExtendedReward {
     pubkey: String,
     lamports: i64,
@@ -75,7 +76,7 @@ impl From<Reward> for StoredExtendedReward {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, SchemaRead, SchemaWrite)]
 pub struct StoredTokenAmount {
     pub ui_amount: f64,
     pub decimals: u8,
@@ -132,7 +133,7 @@ impl From<TransactionError> for StoredTransactionError {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, SchemaRead, SchemaWrite)]
 pub struct StoredTransactionTokenBalance {
     pub account_index: u8,
     pub mint: String,
@@ -181,7 +182,7 @@ impl From<TransactionTokenBalance> for StoredTransactionTokenBalance {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, SchemaRead, SchemaWrite)]
 pub struct StoredTransactionStatusMeta {
     pub status: Result<()>,
     pub fee: u64,

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -22,31 +22,31 @@ mod wincode_compat {
     use {
         std::{marker::PhantomData, mem::MaybeUninit},
         wincode::{
-            ReadError, SchemaRead, SchemaWrite,
+            ReadError, ReadResult, SchemaRead, SchemaWrite, WriteResult,
             config::Config,
             io::{ReadError as IoReadError, Reader, Writer},
         },
     };
 
-    /// Deserializes `T` normally, but returns `T::default()` if the reader is
+    /// Deserializes using `T` normally, but returns `T::Dst::default()` if the reader is
     /// exhausted (EOF), for backward compatibility when new fields are appended
     /// to a struct. Equivalent to `#[serde(deserialize_with = "default_on_eof")]`.
     pub(super) struct DefaultOnEmptyRead<T>(PhantomData<T>);
 
+    // Note: TYPE_META is left dynamic, since during reading both 0-size or non-0-size reads are
+    // allowed, so trusted readers can't rely on encoding to be static sized.
     unsafe impl<'de, C: Config, T> SchemaRead<'de, C> for DefaultOnEmptyRead<T>
     where
-        T: SchemaRead<'de, C, Dst = T> + Default,
+        T: SchemaRead<'de, C>,
+        T::Dst: Default,
     {
-        type Dst = T;
+        type Dst = T::Dst;
 
-        fn read(
-            reader: impl Reader<'de>,
-            dst: &mut MaybeUninit<Self::Dst>,
-        ) -> wincode::ReadResult<()> {
+        fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
             match <T as SchemaRead<'de, C>>::read(reader, dst) {
                 Ok(()) => Ok(()),
                 Err(ReadError::Io(IoReadError::ReadSizeLimit(_))) => {
-                    dst.write(T::default());
+                    dst.write(Self::Dst::default());
                     Ok(())
                 }
                 Err(e) => Err(e),
@@ -56,15 +56,17 @@ mod wincode_compat {
 
     unsafe impl<C: Config, T> SchemaWrite<C> for DefaultOnEmptyRead<T>
     where
-        T: SchemaWrite<C, Src = T>,
+        T: SchemaWrite<C>,
     {
-        type Src = T;
+        type Src = T::Src;
 
-        fn size_of(src: &Self::Src) -> wincode::WriteResult<usize> {
+        const TYPE_META: wincode::TypeMeta = T::TYPE_META;
+
+        fn size_of(src: &Self::Src) -> WriteResult<usize> {
             <T as SchemaWrite<C>>::size_of(src)
         }
 
-        fn write(writer: impl Writer, src: &Self::Src) -> wincode::WriteResult<()> {
+        fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
             <T as SchemaWrite<C>>::write(writer, src)
         }
     }

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -18,6 +18,58 @@ use {
 
 pub mod convert;
 
+mod wincode_compat {
+    use {
+        std::{marker::PhantomData, mem::MaybeUninit},
+        wincode::{
+            ReadError, SchemaRead, SchemaWrite,
+            config::Config,
+            io::{ReadError as IoReadError, Reader, Writer},
+        },
+    };
+
+    /// Deserializes `T` normally, but returns `T::default()` if the reader is
+    /// exhausted (EOF), for backward compatibility when new fields are appended
+    /// to a struct. Equivalent to `#[serde(deserialize_with = "default_on_eof")]`.
+    pub(super) struct DefaultOnEmptyRead<T>(PhantomData<T>);
+
+    unsafe impl<'de, C: Config, T> SchemaRead<'de, C> for DefaultOnEmptyRead<T>
+    where
+        T: SchemaRead<'de, C, Dst = T> + Default,
+    {
+        type Dst = T;
+
+        fn read(
+            reader: impl Reader<'de>,
+            dst: &mut MaybeUninit<Self::Dst>,
+        ) -> wincode::ReadResult<()> {
+            match <T as SchemaRead<'de, C>>::read(reader, dst) {
+                Ok(()) => Ok(()),
+                Err(ReadError::Io(IoReadError::ReadSizeLimit(_))) => {
+                    dst.write(T::default());
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    unsafe impl<C: Config, T> SchemaWrite<C> for DefaultOnEmptyRead<T>
+    where
+        T: SchemaWrite<C, Src = T>,
+    {
+        type Src = T;
+
+        fn size_of(src: &Self::Src) -> wincode::WriteResult<usize> {
+            <T as SchemaWrite<C>>::size_of(src)
+        }
+
+        fn write(writer: impl Writer, src: &Self::Src) -> wincode::WriteResult<()> {
+            <T as SchemaWrite<C>>::write(writer, src)
+        }
+    }
+}
+
 pub type StoredExtendedRewards = Vec<StoredExtendedReward>;
 
 #[derive(Serialize, Deserialize, SchemaRead, SchemaWrite)]
@@ -25,12 +77,16 @@ pub struct StoredExtendedReward {
     pubkey: String,
     lamports: i64,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<u64>")]
     post_balance: u64,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<RewardType>>")]
     reward_type: Option<RewardType>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<u8>>")]
     commission: Option<u8>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<u16>>")]
     commission_bps: Option<u16>,
 }
 
@@ -139,8 +195,10 @@ pub struct StoredTransactionTokenBalance {
     pub mint: String,
     pub ui_token_amount: StoredTokenAmount,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<String>")]
     pub owner: String,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<String>")]
     pub program_id: String,
 }
 
@@ -189,20 +247,32 @@ pub struct StoredTransactionStatusMeta {
     pub pre_balances: Vec<u64>,
     pub post_balances: Vec<u64>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<Vec<InnerInstructions>>>")]
     pub inner_instructions: Option<Vec<InnerInstructions>>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<Vec<String>>>")]
     pub log_messages: Option<Vec<String>>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(
+        with = "wincode_compat::DefaultOnEmptyRead<Option<Vec<StoredTransactionTokenBalance>>>"
+    )]
     pub pre_token_balances: Option<Vec<StoredTransactionTokenBalance>>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(
+        with = "wincode_compat::DefaultOnEmptyRead<Option<Vec<StoredTransactionTokenBalance>>>"
+    )]
     pub post_token_balances: Option<Vec<StoredTransactionTokenBalance>>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<Vec<StoredExtendedReward>>>")]
     pub rewards: Option<Vec<StoredExtendedReward>>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<TransactionReturnData>>")]
     pub return_data: Option<TransactionReturnData>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<u64>>")]
     pub compute_units_consumed: Option<u64>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<u64>>")]
     pub cost_units: Option<u64>,
 }
 

--- a/transaction-status-client-types/Cargo.toml
+++ b/transaction-status-client-types/Cargo.toml
@@ -24,13 +24,14 @@ serde_json = { workspace = true }
 solana-account-decoder-client-types = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-instruction = { workspace = true }
-solana-message = { workspace = true }
-solana-reward-info = { workspace = true, features = ["serde"] }
+solana-message = { workspace = true, features = ["wincode"] }
+solana-reward-info = { workspace = true, features = ["serde", "wincode"] }
 solana-signature = { workspace = true, default-features = false }
-solana-transaction = { workspace = true, features = ["serde"] }
+solana-transaction = { workspace = true, features = ["serde", "wincode"] }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -20,7 +20,10 @@ use {
     },
     solana_reward_info::RewardType,
     solana_signature::Signature,
-    solana_transaction::versioned::{TransactionVersion, VersionedTransaction},
+    solana_transaction::{
+        SchemaRead, SchemaWrite,
+        versioned::{TransactionVersion, VersionedTransaction},
+    },
     solana_transaction_context::transaction::TransactionReturnData,
     solana_transaction_error::{TransactionError, TransactionResult},
     thiserror::Error,
@@ -199,7 +202,7 @@ pub struct EncodedTransactionWithStatusMeta {
     pub version: Option<TransactionVersion>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SchemaRead, SchemaWrite)]
 #[serde(rename_all = "camelCase")]
 pub struct Reward {
     pub pubkey: String,
@@ -642,7 +645,7 @@ impl From<InnerInstructions> for UiInnerInstructions {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SchemaRead, SchemaWrite)]
 pub struct InnerInstructions {
     /// Transaction instruction index
     pub index: u8,
@@ -650,7 +653,7 @@ pub struct InnerInstructions {
     pub instructions: Vec<InnerInstruction>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SchemaRead, SchemaWrite)]
 pub struct InnerInstruction {
     /// Compiled instruction
     pub instruction: CompiledInstruction,

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -34,7 +34,7 @@ solana-loader-v3-interface = { workspace = true, features = ["bincode"] }
 solana-message = { workspace = true }
 solana-program-option = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-reward-info = { workspace = true }
+solana-reward-info = { workspace = true, features = ["wincode"] }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true }
 solana-stake-interface = { workspace = true }


### PR DESCRIPTION
#### Problem
Blockstore data is serialized with bincode, which can be replaced by wincode serialization to improve performance.

#### Summary of Changes
* add wincode schema annotations / impl
* remove unused serde annotations / impl from `ledger/`

Note, the whole `ledger` crate can almost get rid of `bincode`, except for a small change (outside of blockstore) depending on https://github.com/anza-xyz/solana-sdk/pull/649, so it is left out for follow-up PR.