### PR TITLE
cleanup(ledger-tool): don't implement Deserialize for CliDuplicateSlotProof

### DIFF
--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -304,7 +304,7 @@ impl fmt::Display for CliBlockWithEntries {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CliDuplicateSlotProof {
     shred1: CliDuplicateShred,
@@ -354,7 +354,7 @@ impl From<DuplicateSlotProof> for CliDuplicateSlotProof {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CliDuplicateShred {
     fec_set_index: u32,


### PR DESCRIPTION
#### Problem
`CliDuplicateSlotProof` and `CliDuplicateShred` have `Deserialize` derive, but it is not used. We only need `Serialize` for cli output formatting.
This derive forces embedded fields to support `Deserialize`, which could otherwise be converted to wincode-only deserialization.

#### Summary of Changes
Remove unnecessary derive.
