### PR TITLE
feat(transaction-context): support wincode schema in TransactionReturnData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11067,6 +11067,7 @@ dependencies = [
  "solana-system-interface 3.1.0",
  "solana-transaction-context",
  "static_assertions",
+ "wincode",
 ]
 
 [[package]]

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -19,12 +19,14 @@ agave-unstable-api = []
 bincode = ["dep:bincode", "serde", "solana-account/bincode"]
 dev-context-only-utils = ["bincode", "solana-account/dev-context-only-utils", "dep:qualifier_attr"]
 serde = ["serde/derive", "solana-pubkey/serde"]
+wincode = ["dep:wincode", "solana-pubkey/wincode"]
 
 [dependencies]
 solana-account = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-instructions-sysvar = { workspace = true }
 solana-pubkey = { workspace = true }
+wincode = { workspace = true, optional = true }
 
 [target.'cfg(not(any(target_arch = "sbf", target_arch = "bpf")))'.dependencies]
 bincode = { workspace = true, optional = true }

--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -600,6 +600,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
 /// Return data at the end of a transaction
 #[cfg(not(any(target_arch = "bpf", target_arch = "sbf")))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaRead, wincode::SchemaWrite))]
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TransactionReturnData {
     pub program_id: Pubkey,


### PR DESCRIPTION
#### Problem
`TransactionReturnData` is serialized in `storage-proto` / `ledger::blockstore` and doing so with `wincode` require appropriate derived API.

#### Summary of Changes
* add `wincode` feature to `transaction-context` (note this is not yet full `wincode` support for this crate, since using it in `BorrowedInstructionAccount` requires a couple of sdk crates to add wincode support)
* annotate `TransactionReturnData` with wincode derives
