### PR TITLE
[leader-schedule, random] Remove sha2 from dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8670,13 +8670,12 @@ name = "solana-leader-schedule"
 version = "4.1.0-alpha.0"
 dependencies = [
  "agave-random",
- "bs58",
  "itertools 0.14.0",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
- "sha2 0.10.9",
  "solana-clock",
  "solana-pubkey 4.1.0",
+ "solana-sha256-hasher",
  "solana-vote",
  "test-case",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
  "bs58",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
- "sha2 0.10.9",
+ "solana-sha256-hasher",
  "test-case",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,9 +224,9 @@ name = "agave-random"
 version = "4.1.0-alpha.0"
 dependencies = [
  "assert_matches",
- "bs58",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
+ "solana-hash 4.2.0",
  "solana-sha256-hasher",
  "test-case",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -347,7 +347,6 @@ serde_json = "1.0.149"
 serde_with = { version = "3.18.0", default-features = false }
 serde_yaml = "0.9.34"
 serial_test = "3.4.0"
-sha2 = "0.10.9"
 shaq = { version = "2.0.0" }
 shuttle = "0.7.1"
 signal-hook = "0.4.3"

--- a/leader-schedule/Cargo.toml
+++ b/leader-schedule/Cargo.toml
@@ -28,9 +28,8 @@ solana-pubkey = { workspace = true, features = ["rand"] }
 solana-vote = { workspace = true }
 
 [dev-dependencies]
-bs58 = { workspace = true, features = ["alloc"] }
 rand = { workspace = true }
-sha2 = { workspace = true }
+solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-vote = { path = "../vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
 test-case = { workspace = true }
 

--- a/leader-schedule/src/lib.rs
+++ b/leader-schedule/src/lib.rs
@@ -225,12 +225,15 @@ mod tests {
         expected_hash: &str,
     ) {
         fn hash_slot_leader_vote_addresses(v: &[SlotLeader]) -> String {
-            use sha2::{Digest, Sha256};
+            use solana_sha256_hasher::Hasher;
 
-            let hasher = v.iter().fold(Sha256::new(), |hasher, slot_leader| {
-                hasher.chain_update(slot_leader.vote_address.to_bytes())
-            });
-            bs58::encode(hasher.finalize()).into_string()
+            let mut hasher = Hasher::default();
+
+            for slot_leader in v {
+                hasher.hash(&slot_leader.vote_address.to_bytes());
+            }
+
+            hasher.result().to_string()
         }
         let slot_leaders: Vec<_> = (0..=u16::MAX)
             .map(|seed| SlotLeader {

--- a/random/Cargo.toml
+++ b/random/Cargo.toml
@@ -26,5 +26,5 @@ rand = { workspace = true }
 assert_matches = { workspace = true }
 bs58 = { workspace = true, features = ["alloc"] }
 rand_chacha = { workspace = true }
-sha2 = { workspace = true }
+solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 test-case = { workspace = true }

--- a/random/Cargo.toml
+++ b/random/Cargo.toml
@@ -24,7 +24,7 @@ rand = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-bs58 = { workspace = true, features = ["alloc"] }
 rand_chacha = { workspace = true }
+solana-hash = { workspace = true, features = ["decode"] }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 test-case = { workspace = true }

--- a/random/src/range.rs
+++ b/random/src/range.rs
@@ -138,7 +138,7 @@ mod tests {
             let compat = sampler_compat.sample(&mut rng_compat);
             hash.hash(&compat.to_le_bytes());
         });
-        assert_eq!(bs58::encode(hash.result()).into_string(), expected_hash);
+        assert_eq!(hash.result().to_string(), expected_hash);
     }
 
     #[test]
@@ -169,7 +169,7 @@ mod tests {
             let compat = sampler_compat.sample(&mut rng_compat);
             hash.hash(&compat.to_le_bytes());
         });
-        assert_eq!(bs58::encode(hash.result()).into_string(), expected_hash);
+        assert_eq!(hash.result().to_string(), expected_hash);
     }
 
     #[test_case(0..100, &[95, 2, 28, 92, 17, 78, 72, 72, 21, 65])]
@@ -212,7 +212,7 @@ mod tests {
             let compat = random_u64_range(&mut rng_compat, range.clone());
             hash.hash(&compat.to_le_bytes());
         });
-        assert_eq!(bs58::encode(hash.result()).into_string(), expected_hash);
+        assert_eq!(hash.result().to_string(), expected_hash);
     }
 
     #[test]

--- a/random/src/range.rs
+++ b/random/src/range.rs
@@ -102,7 +102,7 @@ mod tests {
         super::*,
         rand::SeedableRng as _,
         rand_chacha::ChaChaRng,
-        sha2::{Digest, Sha256},
+        solana_sha256_hasher::Hasher,
         std::{array, ops::Range},
         test_case::test_case,
     };
@@ -133,12 +133,12 @@ mod tests {
         let sampler_compat =
             UniformU64Sampler::new_like_instance_sample(NonZero::new(range_end).unwrap());
 
-        let mut hash = Sha256::new();
+        let mut hash = Hasher::default();
         (0..600_000).for_each(|_| {
             let compat = sampler_compat.sample(&mut rng_compat);
-            hash.update(compat.to_le_bytes());
+            hash.hash(&compat.to_le_bytes());
         });
-        assert_eq!(bs58::encode(hash.finalize()).into_string(), expected_hash);
+        assert_eq!(bs58::encode(hash.result()).into_string(), expected_hash);
     }
 
     #[test]
@@ -164,12 +164,12 @@ mod tests {
         let sampler_compat =
             UniformU64Sampler::new_like_trait_sample(NonZero::new(range_end).unwrap());
 
-        let mut hash = Sha256::new();
+        let mut hash = Hasher::default();
         (0..1_000).for_each(|_| {
             let compat = sampler_compat.sample(&mut rng_compat);
-            hash.update(compat.to_le_bytes());
+            hash.hash(&compat.to_le_bytes());
         });
-        assert_eq!(bs58::encode(hash.finalize()).into_string(), expected_hash);
+        assert_eq!(bs58::encode(hash.result()).into_string(), expected_hash);
     }
 
     #[test_case(0..100, &[95, 2, 28, 92, 17, 78, 72, 72, 21, 65])]
@@ -207,12 +207,13 @@ mod tests {
     fn test_random_range_reproducibility(range: Range<u64>, expected_hash: &str) {
         let mut rng_compat = ChaChaRng::from_seed(CHACHA_SEED);
 
-        let mut hash = Sha256::new();
+        let mut hash = Hasher::default();
         (0..10_000).for_each(|_| {
             let compat = random_u64_range(&mut rng_compat, range.clone());
-            hash.update(compat.to_le_bytes());
+            hash.hash(&compat.to_le_bytes());
         });
-        assert_eq!(bs58::encode(hash.finalize()).into_string(), expected_hash);
+        assert_eq!(bs58::encode(hash.result()).into_string(), expected_hash);
+
     }
 
     #[test]

--- a/random/src/range.rs
+++ b/random/src/range.rs
@@ -213,7 +213,6 @@ mod tests {
             hash.hash(&compat.to_le_bytes());
         });
         assert_eq!(bs58::encode(hash.result()).into_string(), expected_hash);
-
     }
 
     #[test]

--- a/random/src/weighted.rs
+++ b/random/src/weighted.rs
@@ -90,7 +90,7 @@ mod tests {
             let compat = index_compat.sample(&mut rng_compat);
             hash.hash(&compat.to_le_bytes());
         });
-        assert_eq!(bs58::encode(hash.result()).into_string(), expected_hash);
+        assert_eq!(hash.result().to_string(), expected_hash);
     }
 
     #[test]

--- a/random/src/weighted.rs
+++ b/random/src/weighted.rs
@@ -53,13 +53,8 @@ impl WeightedU64Index {
 #[cfg(test)]
 mod tests {
     use {
-        super::*,
-        assert_matches::assert_matches,
-        rand::SeedableRng as _,
-        rand_chacha::ChaChaRng,
-        solana_sha256_hasher::Hasher,
-        std::array,
-        test_case::test_case,
+        super::*, assert_matches::assert_matches, rand::SeedableRng as _, rand_chacha::ChaChaRng,
+        solana_sha256_hasher::Hasher, std::array, test_case::test_case,
     };
 
     const CHACHA_SEED: [u8; 32] = [16; 32];

--- a/random/src/weighted.rs
+++ b/random/src/weighted.rs
@@ -57,7 +57,7 @@ mod tests {
         assert_matches::assert_matches,
         rand::SeedableRng as _,
         rand_chacha::ChaChaRng,
-        sha2::{Digest, Sha256},
+        solana_sha256_hasher::Hasher,
         std::array,
         test_case::test_case,
     };
@@ -90,12 +90,12 @@ mod tests {
         let mut rng_compat = ChaChaRng::from_seed(CHACHA_SEED);
         let index_compat = WeightedU64Index::new(weights).expect("non empty and non zero is ok");
 
-        let mut hash = Sha256::new();
+        let mut hash = Hasher::default();
         (0..len).for_each(|_| {
             let compat = index_compat.sample(&mut rng_compat);
-            hash.update(compat.to_le_bytes());
+            hash.hash(&compat.to_le_bytes());
         });
-        assert_eq!(&bs58::encode(hash.finalize()).into_string(), expected_hash);
+        assert_eq!(bs58::encode(hash.result()).into_string(), expected_hash);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

The `sha2` crate is only used as a dev-dependency for simple unit tests in the `solana-leader-schedule` and `solana-random` crates. It is possible to replace the test logic with the `solana-sha256-hasher` instead and remove the `sha2` dependency in the repo to reduce the burden on crate maintenance (e.g. https://github.com/anza-xyz/agave/pull/11591).

#### Summary of Changes

Replaced `sha2` crate with `solana-sha256-hasher` in the `solana-leader-schedule` and `solana-random` dev-dependency. The crate `bs58` is also not used in `leader-schedule`, but it was specified as a dev-dependency, so I removed this.

Fixes #
