### PR TITLE
fix(ci): checkout target commit before installing deps in publish-windows-tarball

### DIFF
--- a/.github/workflows/publish-windows-tarball.yml
+++ b/.github/workflows/publish-windows-tarball.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: master
+          ref: ${{ github.event.inputs.commit }}
           fetch-depth: 0
 
       # took the workaround from https://github.com/sfackler/rust-openssl/issues/2149
@@ -35,14 +35,6 @@ jobs:
         run: |
           # install all deps
           source .github/scripts/install-all-deps.sh ${{ runner.os }}
-
-          # checkout the commit
-          if [[ -z ${{ env.COMMIT }} ]]; then
-            echo "Required parameter env.COMMIT is empty."
-            exit 1
-          fi
-
-          git checkout ${{ env.COMMIT }}
 
           source ci/env.sh
           echo "tag=$CI_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
#### Problem

The checkout step was hardcoded to `ref: master`, causing `install-all-deps.sh` and subsequent build scripts (`ci/env.sh`, `ci/channel-info.sh`, `ci/publish-tarball.sh`) to run against master rather than the requested commit. Changed `ref` to use the `commit` input directly so the correct tree is checked out from the start.


#### Summary of Changes

Removed the now-redundant `git checkout $COMMIT` call and the manual emptiness guard; the latter is unnecessary since the `commit` input is already marked `required: true`.
