### PR TITLE
Remove C SDK from the release tarball

### DIFF
--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -49,20 +49,9 @@ scripts/create-release-tarball.sh --build-dir "$RELEASE_BASENAME" \
                                   --target "$TARGET" \
                                   --tarball-basename "$TARBALL_BASENAME"
 
-# Maybe tarballs are platform agnostic, only publish them from the Linux build
-MAYBE_TARBALLS=
-if [[ $TARGET == *linux* ]]; then
-  (
-    set -x
-    platform-tools-sdk/sbf/scripts/package.sh
-    [[ -f sbf-sdk.tar.bz2 ]]
-  )
-  MAYBE_TARBALLS="sbf-sdk.tar.bz2"
-fi
-
 source ci/upload-ci-artifact.sh
 
-for file in "${TARBALL_BASENAME}"-$TARGET.tar.bz2 "${TARBALL_BASENAME}"-$TARGET.yml agave-install-init-"$TARGET"* $MAYBE_TARBALLS; do
+for file in "${TARBALL_BASENAME}"-$TARGET.tar.bz2 "${TARBALL_BASENAME}"-$TARGET.yml agave-install-init-"$TARGET"*; do
   if [[ -n $DO_NOT_PUBLISH_TAR ]]; then
     upload-ci-artifact "$file"
     echo "Skipped $file due to DO_NOT_PUBLISH_TAR"


### PR DESCRIPTION
#### Problem

`platform-tools-sdk` will be moved to a new repository `cargo-build-sbf` (maybe we'll rename it to something more telling), and C SDK releases will be managed there.

#### Summary of Changes

Remove `sbd-sdk.tar.bz2` from the Agave release.