### PR TITLE
feat(storage-proto): bump reward-info to 6.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9622,9 +9622,9 @@ dependencies = [
 
 [[package]]
 name = "solana-reward-info"
-version = "5.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f4c5c5b5599e640c15ead65be499d60f6ee62a5ba7aa7e23f5b0537046ed49"
+checksum = "8044bc87e5b9a22f543fae851e1aae5b082bbe469a20480ee9f6b35ca920a969"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -471,7 +471,7 @@ solana-quic-client = { path = "quic-client", version = "=4.1.0-alpha.0", feature
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-remote-wallet = { path = "remote-wallet", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-rent = "4.1.0"
-solana-reward-info = "5.0.0"
+solana-reward-info = "6.1.0"
 solana-rpc = { path = "rpc", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-rpc-client = { path = "rpc-client", version = "=4.1.0-alpha.0", default-features = false }
 solana-rpc-client-api = { path = "rpc-client-api", version = "=4.1.0-alpha.0" }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -4779,7 +4779,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
@@ -8292,9 +8292,9 @@ dependencies = [
 
 [[package]]
 name = "solana-reward-info"
-version = "5.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f4c5c5b5599e640c15ead65be499d60f6ee62a5ba7aa7e23f5b0537046ed49"
+checksum = "8044bc87e5b9a22f543fae851e1aae5b082bbe469a20480ee9f6b35ca920a969"
 dependencies = [
  "serde",
  "serde_derive",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7934,9 +7934,9 @@ dependencies = [
 
 [[package]]
 name = "solana-reward-info"
-version = "5.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f4c5c5b5599e640c15ead65be499d60f6ee62a5ba7aa7e23f5b0537046ed49"
+checksum = "8044bc87e5b9a22f543fae851e1aae5b082bbe469a20480ee9f6b35ca920a969"
 dependencies = [
  "serde",
  "serde_derive",

--- a/storage-proto/proto/confirmed_block.proto
+++ b/storage-proto/proto/confirmed_block.proto
@@ -129,6 +129,7 @@ enum RewardType {
     Rent = 2;
     Staking = 3;
     Voting = 4;
+    DeactivatedStake = 5;
 }
 
 message Reward {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -120,6 +120,7 @@ impl From<Reward> for generated::Reward {
                 Some(RewardType::Rent) => generated::RewardType::Rent,
                 Some(RewardType::Staking) => generated::RewardType::Staking,
                 Some(RewardType::Voting) => generated::RewardType::Voting,
+                Some(RewardType::DeactivatedStake) => generated::RewardType::DeactivatedStake,
             } as i32,
             commission: reward.commission.map(|c| c.to_string()).unwrap_or_default(),
             commission_bps: reward

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -143,6 +143,7 @@ impl From<generated::Reward> for Reward {
                 2 => Some(RewardType::Rent),
                 3 => Some(RewardType::Staking),
                 4 => Some(RewardType::Voting),
+                5 => Some(RewardType::DeactivatedStake),
                 _ => None,
             },
             commission: reward.commission.parse::<u8>().ok(),


### PR DESCRIPTION
#### Problem
Moving from raward-info 5 to 6 bring new enum variant.

#### Summary of Changes
* bump `solana-reward-info` to `6.1.0`
* update conversion code to handle `DeactivatedStake`
