### PR TITLE
clippy(svm): rm unnecessary into_iter and nested match if

### DIFF
--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -416,9 +416,8 @@ fn deserialize_parameters_for_abiv0<I: IntoIterator<Item = usize>>(
     account_lengths: I,
 ) -> Result<(), InstructionError> {
     let mut start = size_of::<u64>(); // number of accounts
-    for (instruction_account_index, pre_len) in (0..instruction_context
-        .get_number_of_instruction_accounts())
-        .zip(account_lengths.into_iter())
+    for (instruction_account_index, pre_len) in
+        (0..instruction_context.get_number_of_instruction_accounts()).zip(account_lengths)
     {
         let duplicate =
             instruction_context.is_instruction_account_duplicate(instruction_account_index)?;
@@ -599,9 +598,8 @@ fn deserialize_parameters_for_abiv1<I: IntoIterator<Item = usize>>(
     account_lengths: I,
 ) -> Result<(), InstructionError> {
     let mut start = size_of::<u64>(); // number of accounts
-    for (instruction_account_index, pre_len) in (0..instruction_context
-        .get_number_of_instruction_accounts())
-        .zip(account_lengths.into_iter())
+    for (instruction_account_index, pre_len) in
+        (0..instruction_context.get_number_of_instruction_accounts()).zip(account_lengths)
     {
         let duplicate =
             instruction_context.is_instruction_account_duplicate(instruction_account_index)?;

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -473,10 +473,8 @@ pub fn process_new_vote_state(
     }
 
     match (new_root, vote_state.root_slot()) {
-        (Some(new_root), Some(current_root)) => {
-            if new_root < current_root {
-                return Err(VoteError::RootRollBack);
-            }
+        (Some(new_root), Some(current_root)) if new_root < current_root => {
+            return Err(VoteError::RootRollBack);
         }
         (None, Some(_)) => {
             return Err(VoteError::RootRollBack);

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1116,7 +1116,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 vec![Vec::new(); top_level_ixs_num];
             for (cpi_num, ((ix_in_trace, ix_data), ix_accounts)) in ix_trace
                 .into_iter()
-                .zip(ix_data_trace.into_iter())
+                .zip(ix_data_trace)
                 .zip(accounts)
                 .skip(top_level_ixs_num)
                 .enumerate()


### PR DESCRIPTION
#### Problem
Clippy for 1.95 rust toolchain signals code improvements

#### Summary of Changes
* collapse if into match case in process_new_vote_state
* remove unnecessary into_iter calls