### PR TITLE
clippy(votor): use keys() instead of iter() when values are unused

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -518,8 +518,8 @@ impl ConsensusPool {
     fn highest_notarized_slot(&self) -> Slot {
         // Return the max of CertificateType::Notarize and CertificateType::NotarizeFallback
         self.completed_certificates
-            .iter()
-            .filter_map(|(cert_type, _)| match cert_type {
+            .keys()
+            .filter_map(|cert_type| match cert_type {
                 CertificateType::Notarize(s, _) => Some(s),
                 CertificateType::NotarizeFallback(s, _) => Some(s),
                 _ => None,
@@ -532,8 +532,8 @@ impl ConsensusPool {
     #[cfg(test)]
     fn highest_skip_slot(&self) -> Slot {
         self.completed_certificates
-            .iter()
-            .filter_map(|(cert_type, _)| match cert_type {
+            .keys()
+            .filter_map(|cert_type| match cert_type {
                 CertificateType::Skip(s) => Some(s),
                 _ => None,
             })
@@ -544,8 +544,8 @@ impl ConsensusPool {
 
     pub(crate) fn highest_finalized_slot(&self) -> Slot {
         self.completed_certificates
-            .iter()
-            .filter_map(|(cert_type, _)| match cert_type {
+            .keys()
+            .filter_map(|cert_type| match cert_type {
                 CertificateType::Finalize(s) => Some(s),
                 CertificateType::FinalizeFast(s, _) => Some(s),
                 _ => None,


### PR DESCRIPTION
#### Problem
Clippy for 1.95 rust toolchain signals code improvements

#### Summary of Changes
Use `.keys().filter_map(|k| ..` instead of `.iter().filter_map(|(k, _)| ..` 