### PR TITLE
validator: Add support for manually purging Blockstore

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -5,6 +5,7 @@ use {
         repair::{outstanding_requests::OutstandingRequests, serve_repair::ShredRepairType},
     },
     solana_gossip::{cluster_info::ClusterInfo, node::NodeMultihoming},
+    solana_ledger::blockstore::Blockstore,
     solana_pubkey::Pubkey,
     solana_runtime::{bank_forks::BankForks, snapshot_controller::SnapshotController},
     solana_tls_utils::NotifyKeyUpdate,
@@ -87,4 +88,5 @@ pub struct AdminRpcRequestMetadataPostInit {
     pub node: Option<Arc<NodeMultihoming>>,
     pub banking_control_sender: mpsc::Sender<BankingControlMsg>,
     pub snapshot_controller: Arc<SnapshotController>,
+    pub blockstore: Arc<Blockstore>,
 }

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -101,7 +101,7 @@ pub struct Tvu {
     window_service: WindowService,
     cluster_slots_service: ClusterSlotsService,
     replay_stage: ReplayStage,
-    blockstore_cleanup_service: Option<BlockstoreCleanupService>,
+    blockstore_cleanup_service: BlockstoreCleanupService,
     cost_update_service: CostUpdateService,
     voting_service: VotingService,
     bls_voting_service: BLSVotingService,
@@ -579,9 +579,11 @@ impl Tvu {
 
         let replay_stage = ReplayStage::new(replay_stage_config, replay_senders, replay_receivers)?;
 
-        let blockstore_cleanup_service = tvu_config.max_ledger_shreds.map(|max_ledger_shreds| {
-            BlockstoreCleanupService::new(blockstore.clone(), max_ledger_shreds, exit.clone())
-        });
+        let blockstore_cleanup_service = BlockstoreCleanupService::new(
+            blockstore.clone(),
+            tvu_config.max_ledger_shreds,
+            exit.clone(),
+        );
 
         let duplicate_shred_listener = DuplicateShredListener::new(
             exit,
@@ -628,9 +630,7 @@ impl Tvu {
         self.cluster_slots_service.join()?;
         self.fetch_stage.join()?;
         self.shred_sigverify.join()?;
-        if let Some(cleanup_service) = self.blockstore_cleanup_service {
-            cleanup_service.join()?;
-        }
+        self.blockstore_cleanup_service.join()?;
         self.replay_stage.join()?;
         self.cost_update_service.join()?;
         self.voting_service.join()?;

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1786,6 +1786,7 @@ impl Validator {
             node: Some(node_multihoming),
             banking_control_sender,
             snapshot_controller,
+            blockstore: blockstore.clone(),
         });
 
         Ok(Self {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -290,6 +290,9 @@ pub struct Blockstore {
     new_shreds_signals: Mutex<Vec<Sender<bool>>>,
     completed_slots_senders: Mutex<Vec<CompletedSlotsSender>>,
     pub lowest_cleanup_slot: RwLock<Slot>,
+    // A sender that feeds into the BlockstoreCleanupService request channel
+    // to enable manual Blockstore purge requests to be issued
+    pub(crate) manual_purge_request_sender: Mutex<Option<Sender<Slot>>>,
     pub slots_stats: SlotsStats,
 }
 
@@ -479,6 +482,7 @@ impl Blockstore {
             insert_shreds_lock: Mutex::<()>::default(),
             max_root,
             lowest_cleanup_slot: RwLock::<Slot>::default(),
+            manual_purge_request_sender: Mutex::default(),
             slots_stats: SlotsStats::default(),
         };
         blockstore.cleanup_old_entries()?;
@@ -4719,10 +4723,6 @@ impl Blockstore {
 
     pub fn lowest_cleanup_slot(&self) -> Slot {
         *self.lowest_cleanup_slot.read().unwrap()
-    }
-
-    pub fn storage_size(&self) -> Result<u64> {
-        self.db.storage_size()
     }
 
     /// Returns the total physical storage size contributed by all data shreds.

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -1,4 +1,7 @@
-use {super::*, solana_message::AccountKeys, std::time::Instant};
+use {
+    super::*, crate::blockstore::error::BlockstoreManualPurgeError, crossbeam_channel::Sender,
+    solana_message::AccountKeys, std::time::Instant,
+};
 
 #[derive(Default)]
 pub struct PurgeStats {
@@ -433,6 +436,38 @@ impl Blockstore {
 
         Ok(())
     }
+
+    pub(crate) fn register_manual_purge_request_sender(&self, sender: Sender<Slot>) {
+        *self.manual_purge_request_sender.lock().unwrap() = Some(sender);
+    }
+
+    /// Send a purge request to the BlockstoreCleanupService request channel
+    pub fn send_manual_purge_request(&self, max_slot_to_delete: Slot) -> Result<()> {
+        // Deleting data newer than the latest root is likely to interfere
+        // with replay so save any callers from themself
+        let max_root = self.max_root();
+        if max_slot_to_delete > max_root {
+            return Err(BlockstoreError::ManualPurge(
+                BlockstoreManualPurgeError::SlotNewerThanRoot {
+                    request_slot: max_slot_to_delete,
+                    max_root,
+                },
+            ));
+        }
+
+        let sender_guard = self.manual_purge_request_sender.lock().unwrap();
+        let Some(ref sender) = *sender_guard else {
+            return Err(BlockstoreError::ManualPurge(
+                BlockstoreManualPurgeError::SenderUnavailable,
+            ));
+        };
+        sender
+            .try_send(max_slot_to_delete)
+            .map_err(BlockstoreManualPurgeError::from)
+            .map_err(BlockstoreError::ManualPurge)?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -851,5 +886,31 @@ pub mod tests {
 
         let child_slot_meta = blockstore.meta(12).unwrap().unwrap();
         assert_eq!(child_slot_meta.parent_slot.unwrap(), 5);
+    }
+
+    #[test]
+    fn test_send_manual_purge_request() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let (sender, receiver) = bounded(1);
+
+        blockstore.set_roots(std::iter::once(&10)).unwrap();
+
+        // Request before sender has been registered fails
+        assert!(blockstore.send_manual_purge_request(5).is_err());
+
+        blockstore.register_manual_purge_request_sender(sender.clone());
+
+        // Request slot > max root fails
+        assert!(blockstore.send_manual_purge_request(15).is_err());
+        // Request slot < max root succeeds
+        blockstore.send_manual_purge_request(5).unwrap();
+        // Request to full channel fails
+        assert!(blockstore.send_manual_purge_request(5).is_err());
+
+        // Drain + drop the channel so next send fails but does not panic
+        let _ = receiver.try_recv().unwrap();
+        drop(receiver);
+        assert!(blockstore.send_manual_purge_request(7).is_err());
     }
 }

--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -73,5 +73,25 @@ pub enum BlockstoreError {
         #[source]
         inner: Box<BlockstoreError>,
     },
+    #[error(transparent)]
+    ManualPurge(#[from] BlockstoreManualPurgeError),
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
+
+#[derive(Error, Debug)]
+pub enum BlockstoreManualPurgeError {
+    #[error("purge request sender is unavailable")]
+    SenderUnavailable,
+
+    #[error("purge request for slot {request_slot} is newer than the latest root {max_root}")]
+    SlotNewerThanRoot { request_slot: Slot, max_root: Slot },
+
+    #[error("purge request try send error")]
+    TrySend,
+}
+
+impl<T> std::convert::From<crossbeam_channel::TrySendError<T>> for BlockstoreManualPurgeError {
+    fn from(_e: crossbeam_channel::TrySendError<T>) -> BlockstoreManualPurgeError {
+        BlockstoreManualPurgeError::TrySend
+    }
+}

--- a/ledger/src/blockstore_cleanup_service.rs
+++ b/ledger/src/blockstore_cleanup_service.rs
@@ -6,9 +6,10 @@
 
 use {
     crate::blockstore::{
-        self, Blockstore, PurgeType,
+        Blockstore, PurgeType,
         column::{ColumnName, columns},
     },
+    crossbeam_channel::{Receiver, Sender, TrySendError, bounded},
     solana_clock::Slot,
     solana_measure::measure::Measure,
     std::{
@@ -48,17 +49,29 @@ pub struct BlockstoreCleanupService {
 }
 
 impl BlockstoreCleanupService {
-    pub fn new(blockstore: Arc<Blockstore>, max_ledger_shreds: u64, exit: Arc<AtomicBool>) -> Self {
+    pub fn new(
+        blockstore: Arc<Blockstore>,
+        max_ledger_shreds: Option<u64>,
+        exit: Arc<AtomicBool>,
+    ) -> Self {
         let mut last_purge_slot = 0;
         let mut last_check_time = Instant::now();
 
         let t_cleanup = Builder::new()
             .name("solBstoreClean".to_string())
             .spawn(move || {
+                let (cleanup_request_sender, cleanup_request_receiver) = bounded(1);
+                blockstore.register_manual_purge_request_sender(cleanup_request_sender.clone());
+
                 info!(
-                    "BlockstoreCleanupService has started with max ledger \
-                     shreds={max_ledger_shreds}",
+                    "BlockstoreCleanupService has started with {}",
+                    if let Some(max_shreds) = max_ledger_shreds {
+                        format!("max shred limit {max_shreds}")
+                    } else {
+                        "no shred limit, automatic cleanup is disabled".to_string()
+                    }
                 );
+
                 loop {
                     if exit.load(Ordering::Relaxed) {
                         break;
@@ -67,6 +80,8 @@ impl BlockstoreCleanupService {
                     if last_check_time.elapsed() > CHECK_FOR_CLEANUP_INTERVAL {
                         Self::cleanup_ledger(
                             &blockstore,
+                            &cleanup_request_sender,
+                            &cleanup_request_receiver,
                             max_ledger_shreds,
                             &mut last_purge_slot,
                             DEFAULT_CLEANUP_SLOT_INTERVAL,
@@ -80,6 +95,7 @@ impl BlockstoreCleanupService {
                     // in a timely manner
                     thread::sleep(Duration::from_secs(1));
                 }
+
                 info!("BlockstoreCleanupService has stopped");
             })
             .unwrap();
@@ -87,27 +103,38 @@ impl BlockstoreCleanupService {
         Self { t_cleanup }
     }
 
-    /// A helper function to `cleanup_ledger` which returns a tuple of the
-    /// following four elements suggesting whether to clean up the ledger:
-    ///
-    /// Return value (bool, Slot, u64):
-    /// - `slots_to_clean` (bool): a boolean value indicating whether there
-    ///   are any slots to clean.  If true, then `cleanup_ledger` function
-    ///   will then proceed with the ledger cleanup.
-    /// - `lowest_slot_to_purge` (Slot): the lowest slot to purge.  Any
-    ///   slot which is older or equal to `lowest_slot_to_purge` will be
-    ///   cleaned up.
-    /// - `total_shreds` (u64): the total estimated number of shreds before the
-    ///   `root`.
-    fn find_slots_to_clean(
+    /// Push a cleanup request into `cleanup_request_sender` if an automatic
+    /// cleanup is due
+    fn maybe_generate_automatic_cleanup_request(
         blockstore: &Blockstore,
-        root: Slot,
-        max_ledger_shreds: u64,
-    ) -> (bool, Slot, u64) {
+        cleanup_request_sender: &Sender<Slot>,
+        max_ledger_shreds: Option<u64>,
+        last_purge_slot: &mut u64,
+        purge_interval: u64,
+    ) {
+        let Some(max_ledger_shreds) = max_ledger_shreds else {
+            // Automatic blockstore cleanup is disabled
+            return;
+        };
+
+        if cleanup_request_sender.is_full() {
+            // An unprocessed cleanup request already exists so bail now
+            return;
+        }
+
+        let root = blockstore.max_root();
+        if root - *last_purge_slot <= purge_interval {
+            // Not enough roots have passed since the last cleanup so bail now
+            return;
+        }
+        *last_purge_slot = root;
+
+        info!("Looking for Blockstore data to cleanup, latest root: {root}");
+
         let live_files = blockstore
             .live_files_metadata()
             .expect("Blockstore::live_files_metadata()");
-        let num_shreds = live_files
+        let num_shreds: u64 = live_files
             .iter()
             .filter(|live_file| live_file.column_family_name == columns::ShredData::NAME)
             .map(|file_meta| file_meta.num_entries)
@@ -142,7 +169,7 @@ impl BlockstoreCleanupService {
                 "Skipping Blockstore cleanup: highest slot {highest_slot} < lowest slot \
                  {lowest_slot}",
             );
-            return (false, 0, num_shreds);
+            return;
         }
         // The + 1 ensures we count the correct number of slots. Additionally,
         // it guarantees num_slots >= 1 for the subsequent division.
@@ -154,62 +181,61 @@ impl BlockstoreCleanupService {
         );
 
         if num_shreds <= max_ledger_shreds {
-            return (false, 0, num_shreds);
+            // Cleanup is not necessary at this time
+            return;
         }
 
         // Add an extra (mean_shreds_per_slot - 1) in the numerator
         // so that our integer division rounds up
         let num_slots_to_clean = (num_shreds - max_ledger_shreds + mean_shreds_per_slot - 1)
             .checked_div(mean_shreds_per_slot);
+        let Some(num_slots_to_clean) = num_slots_to_clean else {
+            error!("Skipping Blockstore automatic cleanup: calculated mean of 0 shreds per slot");
+            return;
+        };
 
-        if let Some(num_slots_to_clean) = num_slots_to_clean {
-            // Ensure we don't cleanup anything past the last root we saw
-            let lowest_cleanup_slot = std::cmp::min(lowest_slot + num_slots_to_clean - 1, root);
-            (true, lowest_cleanup_slot, num_shreds)
-        } else {
-            error!("Skipping Blockstore cleanup: calculated mean of 0 shreds per slot");
-            (false, 0, num_shreds)
-        }
+        // Ensure we don't cleanup anything past the last root we saw
+        let lowest_cleanup_slot = std::cmp::min(lowest_slot + num_slots_to_clean - 1, root);
+
+        match cleanup_request_sender.try_send(lowest_cleanup_slot) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                info!("Dropping Blockstore automatic cleanup request: a pending request exists");
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                unreachable!(
+                    "Channel disconnected while this thread holds both ends of the channel"
+                );
+            }
+        };
     }
 
-    /// Checks for new roots and initiates a cleanup if the last cleanup was at
-    /// least `purge_interval` slots ago. A cleanup will no-op if the ledger
-    /// already has fewer than `max_ledger_shreds`; otherwise, the cleanup will
-    /// purge enough slots to get the ledger size below `max_ledger_shreds`.
-    ///
-    /// # Arguments
-    ///
-    /// - `max_ledger_shreds`: the number of shreds to keep since the new root.
-    /// - `last_purge_slot`: an both an input and output parameter indicating
-    ///   the id of the last purged slot.  As an input parameter, it works
-    ///   together with `purge_interval` on whether it is too early to perform
-    ///   ledger cleanup.  As an output parameter, it will be updated if this
-    ///   function actually performs the ledger cleanup.
-    /// - `purge_interval`: the minimum slot interval between two ledger
-    ///   cleanup.  When the max root fetched from the Blockstore minus
-    ///   `last_purge_slot` is fewer than `purge_interval`, the function will
-    ///   simply return `Ok` without actually running the ledger cleanup.
-    ///   In this case, `purge_interval` will remain unchanged.
-    ///
-    /// Also see `blockstore::purge_slot`.
+    /// Cleanup the ledger if a cleanup request is present. Cleanup requests may
+    /// be automatically created given the configuration options, or they may
+    /// come from an external caller who holds a Blockstore
     pub fn cleanup_ledger(
-        blockstore: &Arc<Blockstore>,
-        max_ledger_shreds: u64,
+        blockstore: &Blockstore,
+        cleanup_request_sender: &Sender<Slot>,
+        cleanup_request_receiver: &Receiver<Slot>,
+        max_ledger_shreds: Option<u64>,
         last_purge_slot: &mut u64,
         purge_interval: u64,
     ) {
-        let root = blockstore.max_root();
-        if root - *last_purge_slot <= purge_interval {
-            return;
-        }
-        *last_purge_slot = root;
-        info!("Looking for Blockstore data to cleanup, latest root: {root}");
+        Self::maybe_generate_automatic_cleanup_request(
+            blockstore,
+            cleanup_request_sender,
+            max_ledger_shreds,
+            last_purge_slot,
+            purge_interval,
+        );
 
-        let disk_utilization_pre = blockstore.storage_size();
-        let (slots_to_clean, lowest_cleanup_slot, total_shreds) =
-            Self::find_slots_to_clean(blockstore, root, max_ledger_shreds);
+        // `Receiver::try_recv()` will error if the channel is disconnected or
+        // empty. Both sides of the channel are passed in so it is impossible
+        // for the channel to be disconnected. If the channel is empty, there
+        // is nothing to do and `ok()` will convert to an `Option` for us
+        let lowest_cleanup_slot = cleanup_request_receiver.try_recv().ok();
 
-        if slots_to_clean {
+        if let Some(lowest_cleanup_slot) = lowest_cleanup_slot {
             *blockstore.lowest_cleanup_slot.write().unwrap() = lowest_cleanup_slot;
 
             let mut purge_time = Measure::start("purge_slots()");
@@ -234,25 +260,6 @@ impl BlockstoreCleanupService {
             purge_time.stop();
             info!("Cleaned up Blockstore data older than slot {lowest_cleanup_slot}. {purge_time}");
         }
-
-        let disk_utilization_post = blockstore.storage_size();
-        Self::report_disk_metrics(disk_utilization_pre, disk_utilization_post, total_shreds);
-    }
-
-    fn report_disk_metrics(
-        pre: blockstore::Result<u64>,
-        post: blockstore::Result<u64>,
-        total_shreds: u64,
-    ) {
-        if let (Ok(pre), Ok(post)) = (pre, post) {
-            datapoint_info!(
-                "ledger_disk_utilization",
-                ("disk_utilization_pre", pre as i64, i64),
-                ("disk_utilization_post", post as i64, i64),
-                ("disk_utilization_delta", (pre as i64 - post as i64), i64),
-                ("total_shreds", total_shreds, i64),
-            );
-        }
     }
 
     pub fn join(self) -> thread::Result<()> {
@@ -264,10 +271,10 @@ mod tests {
     use {super::*, crate::blockstore::make_many_slot_entries};
 
     fn flush_blockstore_contents_to_disk(blockstore: Blockstore) -> Blockstore {
-        // The find_slots_to_clean() routine uses a method that queries data
-        // from RocksDB SST files. On a running validator, these are created
-        // fairly regularly as new data is coming in and contents of memory are
-        // pushed to disk. In a unit test environment, we aren't pushing nearly
+        // The maybe_generate_automatic_cleanup_request() routine uses a method
+        // that queries data from RocksDB SST files. On a running validator,
+        // these are created fairly regularly as new data comes in and older
+        // data is pushed to disk. In these unit tests, we aren't pushing nearly
         // enough data for this to happen organically. So, instead open and
         // close the Blockstore which will perform the flush to SSTs.
         let ledger_path = blockstore.ledger_path().clone();
@@ -276,17 +283,19 @@ mod tests {
     }
 
     #[test]
-    fn test_find_slots_to_clean() {
-        // BlockstoreCleanupService::find_slots_to_clean() does not modify the
-        // Blockstore, so we can make repeated calls on the same slots
+    fn test_maybe_generate_automatic_cleanup_request() {
+        // maybe_generate_automatic_cleanup_request() does not modify Blockstore
+        // state so multiple calls can be made on the same range of slots
         agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let (sender, receiver) = bounded(1);
 
         // Construct and build some shreds for slots [1, 10]
         let num_slots: u64 = 10;
         let num_entries = 200;
         let (shreds, _) = make_many_slot_entries(1, num_slots, num_entries);
+        let total_num_shreds = shreds.len() as u64;
         let shreds_per_slot = (shreds.len() / num_slots as usize) as u64;
         assert!(shreds_per_slot > 1);
         blockstore.insert_shreds(shreds, None, false).unwrap();
@@ -294,59 +303,107 @@ mod tests {
         // Initiate a flush so inserted shreds found by find_slots_to_clean()
         let blockstore = Arc::new(flush_blockstore_contents_to_disk(blockstore));
 
-        // Ensure no cleaning of slots > last_root
-        let last_root = 0;
-        let max_ledger_shreds = 0;
-        let (should_clean, lowest_purged, _) = BlockstoreCleanupService::find_slots_to_clean(
-            &blockstore,
-            last_root,
-            max_ledger_shreds,
-        );
-        // Slot 0 will exist in blockstore with zero shreds since it is slot
-        // 1's parent. Thus, slot 0 will be identified for clean.
-        assert!(should_clean && lowest_purged == 0);
-        // Now, set max_ledger_shreds to 1, slot 0 still eligible for clean
-        let max_ledger_shreds = 1;
-        let (should_clean, lowest_purged, _) = BlockstoreCleanupService::find_slots_to_clean(
-            &blockstore,
-            last_root,
-            max_ledger_shreds,
-        );
-        assert!(should_clean && lowest_purged == 0);
+        // Note that last_purge_slot gets updated after a couple basic checks to
+        // avoid rescanning all the Blockstore SST files again. This is good for
+        // production but our unit test will reset the value after each step
+        let mut last_purge_slot = 0;
+        // Keep purge_interval at 0 to keep math in our unit test easy
+        let purge_interval = 0;
 
-        // Ensure no cleaning if blockstore contains fewer than max_ledger_shreds
-        let last_root = num_slots;
-        let max_ledger_shreds = (shreds_per_slot * num_slots) + 1;
-        let (should_clean, lowest_purged, _) = BlockstoreCleanupService::find_slots_to_clean(
+        // Start with 1 as the latest root
+        let mut latest_root = 1;
+        blockstore.set_roots(std::iter::once(&latest_root)).unwrap();
+        // Auto clean will select slot 1 (latest_root) as min clean slot
+        let max_ledger_shreds = Some(1);
+        BlockstoreCleanupService::maybe_generate_automatic_cleanup_request(
             &blockstore,
-            last_root,
+            &sender,
             max_ledger_shreds,
+            &mut last_purge_slot,
+            purge_interval,
         );
-        assert!(!should_clean && lowest_purged == 0);
+        assert_eq!(receiver.try_recv().unwrap(), latest_root);
+
+        // Reset last_purge_slot
+        assert_eq!(last_purge_slot, 1);
+        last_purge_slot = 0;
+        BlockstoreCleanupService::maybe_generate_automatic_cleanup_request(
+            &blockstore,
+            &sender,
+            max_ledger_shreds,
+            &mut last_purge_slot,
+            purge_interval,
+        );
+        assert_eq!(receiver.try_recv().unwrap(), latest_root);
+        // Reset last_purge_slot
+        assert_eq!(last_purge_slot, 1);
+        last_purge_slot = 0;
+
+        // The auto clean request dropped when a request already exists
+        sender.try_send(100).unwrap();
+        BlockstoreCleanupService::maybe_generate_automatic_cleanup_request(
+            &blockstore,
+            &sender,
+            max_ledger_shreds,
+            &mut last_purge_slot,
+            purge_interval,
+        );
+        assert_eq!(receiver.try_recv().unwrap(), 100);
+        assert!(receiver.is_empty());
+
+        // No auto clean request when max_ledger_shreds is None
+        let max_ledger_shreds = None;
+        BlockstoreCleanupService::maybe_generate_automatic_cleanup_request(
+            &blockstore,
+            &sender,
+            max_ledger_shreds,
+            &mut last_purge_slot,
+            purge_interval,
+        );
+        assert!(receiver.is_empty());
+
+        // No auto clean request when max_ledger_shreds exceeds blockstore load
+        let max_ledger_shreds = Some(total_num_shreds + 1);
+        BlockstoreCleanupService::maybe_generate_automatic_cleanup_request(
+            &blockstore,
+            &sender,
+            max_ledger_shreds,
+            &mut last_purge_slot,
+            purge_interval,
+        );
+        assert!(receiver.is_empty());
+        // Reset last_purge_slot
+        assert_eq!(last_purge_slot, 1);
+        last_purge_slot = 0;
+
+        // Auto clean can once again clean up to latest_root
+        let max_ledger_shreds = Some(total_num_shreds - 1);
+        BlockstoreCleanupService::maybe_generate_automatic_cleanup_request(
+            &blockstore,
+            &sender,
+            max_ledger_shreds,
+            &mut last_purge_slot,
+            purge_interval,
+        );
+        assert_eq!(receiver.try_recv().unwrap(), latest_root);
+        // Reset last_purge_slot
+        assert_eq!(last_purge_slot, 1);
+        last_purge_slot = 0;
 
         for slot in 1..=num_slots {
             // Set last_root to make slots <= slot eligible for cleaning
-            let last_root = slot;
+            latest_root = slot;
+            blockstore.set_roots(std::iter::once(&latest_root)).unwrap();
             // Set max_ledger_shreds to 0 so that all eligible slots are cleaned
-            let max_ledger_shreds = 0;
-            let (should_clean, lowest_purged, _) = BlockstoreCleanupService::find_slots_to_clean(
+            let max_ledger_shreds = Some(0);
+            BlockstoreCleanupService::maybe_generate_automatic_cleanup_request(
                 &blockstore,
-                last_root,
+                &sender,
                 max_ledger_shreds,
+                &mut last_purge_slot,
+                purge_interval,
             );
-            assert!(should_clean && lowest_purged == slot);
-
-            // Set last_root to make all slots eligible for cleaning
-            let last_root = num_slots + 1;
-            // Set max_ledger_shreds to the number of shreds in slots > slot.
-            // This will make it so that slots [1, slot] are cleaned
-            let max_ledger_shreds = shreds_per_slot * (num_slots - slot);
-            let (should_clean, lowest_purged, _) = BlockstoreCleanupService::find_slots_to_clean(
-                &blockstore,
-                last_root,
-                max_ledger_shreds,
-            );
-            assert!(should_clean && lowest_purged == slot);
+            assert_eq!(receiver.try_recv().unwrap(), latest_root);
         }
     }
 
@@ -355,67 +412,37 @@ mod tests {
         agave_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let (sender, receiver) = bounded(1);
+
         let (shreds, _) = make_many_slot_entries(0, 50, 5);
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
-        // Initiate a flush so inserted shreds found by find_slots_to_clean()
+        // Initiate a flush so inserted shreds found by maybe_generate_automatic_cleanup_request()
         let blockstore = Arc::new(flush_blockstore_contents_to_disk(blockstore));
 
-        // Mark 50 as a root to kill all but 5 shreds, which will be in the newest slots
-        let mut last_purge_slot = 0;
-        blockstore.set_roots([50].iter()).unwrap();
-        BlockstoreCleanupService::cleanup_ledger(&blockstore, 5, &mut last_purge_slot, 10);
-        assert_eq!(last_purge_slot, 50);
+        // Mark 40 as a root to cleanup all older slots
+        let root = 40;
+        blockstore.set_roots(std::iter::once(&root)).unwrap();
 
-        //check that 0-40 don't exist
+        let mut last_purge_slot = 0;
+        let max_ledger_shreds = Some(5);
+        let purge_interval = 10;
+        BlockstoreCleanupService::cleanup_ledger(
+            &blockstore,
+            &sender,
+            &receiver,
+            max_ledger_shreds,
+            &mut last_purge_slot,
+            purge_interval,
+        );
+        assert_eq!(last_purge_slot, root);
+        // A request will be generated and consumed so channel should be empty
+        assert!(receiver.is_empty());
+
+        // Ensure that slots 0-40 are not present
         blockstore
             .slot_meta_iterator(0)
             .unwrap()
             .for_each(|(slot, _)| assert!(slot > 40));
-    }
-
-    #[test]
-    fn test_cleanup_speed() {
-        agave_logger::setup();
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-
-        let mut first_insert = Measure::start("first_insert");
-        let initial_slots = 50;
-        let initial_entries = 5;
-        let (shreds, _) = make_many_slot_entries(0, initial_slots, initial_entries);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
-        first_insert.stop();
-        info!("{first_insert}");
-
-        let mut last_purge_slot = 0;
-        let mut slot = initial_slots;
-        let mut num_slots = 6;
-        for _ in 0..5 {
-            let mut insert_time = Measure::start("insert time");
-            let batch_size = 2;
-            let batches = num_slots / batch_size;
-            for i in 0..batches {
-                let (shreds, _) = make_many_slot_entries(slot + i * batch_size, batch_size, 5);
-                blockstore.insert_shreds(shreds, None, false).unwrap();
-                if i % 100 == 0 {
-                    info!("inserting..{i} of {batches}");
-                }
-            }
-            insert_time.stop();
-
-            let mut time = Measure::start("purge time");
-            blockstore.set_roots([slot + num_slots].iter()).unwrap();
-            BlockstoreCleanupService::cleanup_ledger(
-                &blockstore,
-                initial_slots,
-                &mut last_purge_slot,
-                10,
-            );
-            time.stop();
-            info!("slot: {slot} size: {num_slots} {insert_time} {time}");
-            slot += num_slots;
-            num_slots *= 2;
-        }
     }
 }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -88,7 +88,6 @@ impl OldestSlot {
 #[derive(Debug)]
 pub(crate) struct Rocks {
     db: rocksdb::DB,
-    path: PathBuf,
     access_type: AccessType,
     oldest_slot: OldestSlot,
     column_options: Arc<LedgerColumnOptions>,
@@ -144,7 +143,6 @@ impl Rocks {
 
         let rocks = Rocks {
             db,
-            path,
             access_type: options.access_type,
             oldest_slot,
             column_options,
@@ -452,10 +450,6 @@ impl Rocks {
             Ok(live_files) => Ok(live_files),
             Err(e) => Err(BlockstoreError::RocksDb(e)),
         }
-    }
-
-    pub(crate) fn storage_size(&self) -> Result<u64> {
-        Ok(fs_extra::dir::get_size(&self.path)?)
     }
 
     pub(crate) fn set_oldest_slot(&self, oldest_slot: Slot) {

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -8,6 +8,7 @@ use {
     },
     log::*,
     serde::{Deserialize, Serialize, de::Deserializer},
+    solana_clock::Slot,
     solana_core::{
         admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         banking_stage::{
@@ -284,6 +285,9 @@ pub trait AdminRpc {
 
     #[rpc(meta, name = "isGeneratingSnapshots")]
     fn is_generating_snapshots(&self, meta: Self::Metadata) -> Result<bool>;
+
+    #[rpc(meta, name = "blockstorePurge")]
+    fn blockstore_purge(&self, meta: Self::Metadata, maximum_purge_slot: Slot) -> Result<()>;
 }
 
 pub struct AdminRpcImpl;
@@ -836,6 +840,19 @@ impl AdminRpc for AdminRpcImpl {
             ))
         }
     }
+
+    fn blockstore_purge(&self, meta: Self::Metadata, maximum_purge_slot: Slot) -> Result<()> {
+        meta.with_post_init(|post_init| {
+            post_init
+                .blockstore
+                .send_manual_purge_request(maximum_purge_slot)
+                .map_err(|err| jsonrpc_core::Error {
+                    code: ErrorCode::InvalidRequest,
+                    message: format!("{err}"),
+                    data: None,
+                })
+        })
+    }
 }
 
 impl AdminRpcImpl {
@@ -1040,10 +1057,12 @@ mod tests {
         },
         solana_gossip::{cluster_info::ClusterInfo, node::Node},
         solana_ledger::{
+            blockstore::Blockstore,
             create_new_tmp_ledger,
             genesis_utils::{
                 GenesisConfigInfo, create_genesis_config, create_genesis_config_with_leader,
             },
+            get_tmp_ledger_path_auto_delete,
         },
         solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
         solana_rpc::rpc::create_validator_exit,
@@ -1097,6 +1116,9 @@ mod tests {
                 bank_forks.read().unwrap().root(),
             ));
 
+            let ledger_path = get_tmp_ledger_path_auto_delete!();
+            let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+
             let vote_account = vote_keypair.pubkey();
             let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
             let repair_whitelist = Arc::new(RwLock::new(HashSet::new()));
@@ -1124,6 +1146,7 @@ mod tests {
                     node: None,
                     banking_control_sender: mpsc::channel(1).0,
                     snapshot_controller,
+                    blockstore,
                 }))),
                 staked_nodes_overrides: Arc::new(RwLock::new(HashMap::new())),
                 rpc_to_plugin_manager_sender: None,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -75,7 +75,8 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .subcommand(commands::staked_nodes_overrides::command())
         .subcommand(commands::wait_for_restart_window::command())
         .subcommand(commands::set_public_address::command())
-        .subcommand(commands::manage_block_production::command(default_args));
+        .subcommand(commands::manage_block_production::command(default_args))
+        .subcommand(commands::blockstore::command());
 
     commands::run::add_args(app, default_args)
         .args(&thread_args(&default_args.thread_args))

--- a/validator/src/commands/blockstore/mod.rs
+++ b/validator/src/commands/blockstore/mod.rs
@@ -1,0 +1,71 @@
+use {
+    crate::{
+        admin_rpc_service,
+        commands::{FromClapArgMatches, Result},
+    },
+    clap::{App, AppSettings, Arg, ArgMatches, SubCommand, value_t},
+    solana_clap_utils::input_validators::is_parsable,
+    solana_clock::Slot,
+    std::path::Path,
+};
+
+const COMMAND: &str = "blockstore";
+
+#[derive(Debug, PartialEq)]
+#[cfg_attr(test, derive(Default))]
+pub struct BlockstorePurgeArgs {
+    pub maximum_purge_slot: Slot,
+}
+
+impl FromClapArgMatches for BlockstorePurgeArgs {
+    fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        Ok(BlockstorePurgeArgs {
+            maximum_purge_slot: value_t!(matches, "maximum_purge_slot", Slot)?,
+        })
+    }
+}
+
+pub fn command<'a>() -> App<'a, 'a> {
+    SubCommand::with_name(COMMAND)
+        .about("Interact with the validator's Blockstore")
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .setting(AppSettings::InferSubcommands)
+        .setting(AppSettings::Hidden)
+        .subcommand(
+            SubCommand::with_name("purge")
+                .about("Delete blocks from the Blockstore")
+                .arg(
+                    Arg::with_name("maximum_purge_slot")
+                        .long("maximum-purge-slot")
+                        .value_name("MAXIMUM_PURGE_SLOT")
+                        .index(1)
+                        .takes_value(true)
+                        .required(true)
+                        .validator(is_parsable::<Slot>)
+                        .help(
+                            "The maximum slot to purge from the Blockstore. All slots up to and \
+                             including MAXIMUM_PURGE_SLOT will be purged",
+                        ),
+                ),
+        )
+}
+
+pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
+    match matches.subcommand() {
+        ("purge", Some(subcommand_matches)) => {
+            let BlockstorePurgeArgs { maximum_purge_slot } =
+                BlockstorePurgeArgs::from_clap_arg_match(subcommand_matches)?;
+
+            let admin_client = admin_rpc_service::connect(ledger_path);
+            admin_rpc_service::runtime().block_on(async move {
+                admin_client
+                    .await?
+                    .blockstore_purge(maximum_purge_slot)
+                    .await
+            })?;
+        }
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}

--- a/validator/src/commands/mod.rs
+++ b/validator/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod authorized_voter;
+pub mod blockstore;
 pub mod contact_info;
 pub mod exit;
 pub mod manage_block_production;

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -97,6 +97,9 @@ pub fn main() {
         ("manage-block-production", Some(subcommand_matches)) => {
             commands::manage_block_production::execute(subcommand_matches, &ledger_path)
         }
+        ("blockstore", Some(subcommand_matches)) => {
+            commands::blockstore::execute(subcommand_matches, &ledger_path)
+        }
         _ => unreachable!(),
     }
     .unwrap_or_else(|err| {


### PR DESCRIPTION
#### Problem
Currently, the `--limit-ledger-size` argument is optional.
- When this flag is passed, `BlockstoreCleanupService` is created to automatically delete the oldest Blockstore data to keep the Blockstore within the specified limit
- When the flag is NOT passed, the Blockstore is allowed to grow unbounded

One limitation / annoyance with `--limit-ledger-size` is that the unit is in shreds. One might hope for the unit to be slots, but chain activity variation means that the number of shreds per slot varies slot to slot.

So, if an operator is trying to retain data for the last epoch (such as our warehouse nodes), they don't really have any options  to purge the data (since only a single process can hold write access for rocksdb). This leads to clunky solutions like our warehouse nodes that stop & restart every epoch.

#### Summary of Changes
This PR looks to improve the ergonomics here by adding a validator admin RPC interface command to manually purge the Blockstore. The hook to initiate purges allows operators the option to implement their own logic for purging the Blockstore. It also provides an "emergency option" to clear space without having to stop the validator

This is accomplished by:
- Ensuring that `BlockstoreCleanupService` is created unconditionally (first commit)
- Making `BlockstoreCleanupService` utilize a channel internally so that there is a hook to insert additional/external cleanup requests with the existing automatic "requests" (second commit) 
- Register the channel with Blockstore + add a subcommand to `agave-validator` to enable cleaning like below third comit):
```
agave-validator blockstore purge SLOT
```

#### Backport Intentions
I would like to backport this to v4.0. I've been meaning to land this change sooner but have been occupied with other things. This change is pretty fairly isolated and the unit test should show that existing behavior is not broken. Rather, new behavior will for operators who opt in and who were previously running without `--limit-ledger-size`; I assume this is a very small group.

There is some more cleanup to be done in this file. For example, I thought about creating a `Context` struct for all the config options / state and writing up nice comments for them. I'm happy to do that immediately after this PR lands, but I skipped it for now for the purpose of keeping the diff smaller

#### Future Work
I could see potentially adding an additional command or two that would mirror `ledger-tool` functionality in future PR's. I'm not dead set on this, but the purge command introduced by this PR is legitimately "must have" due to the one-process-with-write-per-rocksdb limitation.