### PR TITLE
clippy: lint fixes for rust 1.95

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -455,7 +455,8 @@ impl Accounts {
             &ScanConfig::default(),
         )?;
         if sort_results {
-            collector.sort_unstable_by_key(|(addr, _, _)| *addr);
+            // Avoid copying pubkeys (using Ord::cmp(a, b) silences clippy::unnecessary_sort_by).
+            collector.sort_unstable_by(|(addr_a, _, _), (addr_b, _, _)| Ord::cmp(addr_a, addr_b));
         }
         Ok(collector)
     }

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -455,7 +455,7 @@ impl Accounts {
             &ScanConfig::default(),
         )?;
         if sort_results {
-            collector.sort_unstable_by(|(a_addr, _, _), (b_addr, _, _)| a_addr.cmp(b_addr));
+            collector.sort_unstable_by_key(|(addr, _, _)| *addr);
         }
         Ok(collector)
     }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1682,10 +1682,8 @@ mod tests {
                             .map(|store| db.get_unique_accounts_from_storage(store))
                             .collect::<Vec<_>>();
 
-                        let mut accounts_per_storage = infos
-                            .iter()
-                            .zip(original_results.into_iter())
-                            .collect::<Vec<_>>();
+                        let mut accounts_per_storage =
+                            infos.iter().zip(original_results).collect::<Vec<_>>();
 
                         let accounts_to_combine = db.calc_accounts_to_combine(
                             &mut accounts_per_storage,
@@ -1815,10 +1813,8 @@ mod tests {
                                     .map(|store| db.get_unique_accounts_from_storage(store))
                                     .collect::<Vec<_>>();
 
-                                let mut accounts_per_storage = infos
-                                    .iter()
-                                    .zip(original_results.into_iter())
-                                    .collect::<Vec<_>>();
+                                let mut accounts_per_storage =
+                                    infos.iter().zip(original_results).collect::<Vec<_>>();
 
                                 let accounts_to_combine = db.calc_accounts_to_combine(
                                     &mut accounts_per_storage,
@@ -2015,10 +2011,7 @@ mod tests {
                 .map(|store| db.get_unique_accounts_from_storage(store))
                 .collect::<Vec<_>>();
             assert_eq!(original_results.first().unwrap().stored_accounts.len(), 2);
-            let mut accounts_per_storage = infos
-                .iter()
-                .zip(original_results.into_iter())
-                .collect::<Vec<_>>();
+            let mut accounts_per_storage = infos.iter().zip(original_results).collect::<Vec<_>>();
 
             let accounts_to_combine = db.calc_accounts_to_combine(
                 &mut accounts_per_storage,
@@ -2210,10 +2203,7 @@ mod tests {
                 .map(|store| db.get_unique_accounts_from_storage(store))
                 .collect::<Vec<_>>();
             assert_eq!(original_results.first().unwrap().stored_accounts.len(), 2);
-            let mut accounts_per_storage = infos
-                .iter()
-                .zip(original_results.into_iter())
-                .collect::<Vec<_>>();
+            let mut accounts_per_storage = infos.iter().zip(original_results).collect::<Vec<_>>();
 
             let accounts_to_combine = db.calc_accounts_to_combine(
                 &mut accounts_per_storage,

--- a/bench-tps/src/send_batch.rs
+++ b/bench-tps/src/send_batch.rs
@@ -79,7 +79,7 @@ pub fn fund_keys<T: 'static + TpsClient + Send + Sync + ?Sized>(
             let dests: Vec<_> = not_funded.drain(start..).collect();
             let spends: Vec<_> = dests.iter().map(|k| (k.pubkey(), to_lamports)).collect();
             to_fund.push((f, spends));
-            new_funded.extend(dests.into_iter());
+            new_funded.extend(dests);
         }
 
         to_fund.chunks(FUND_CHUNK_LEN).for_each(|chunk| {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1672,39 +1672,36 @@ pub async fn process_show_stakes(
         );
         if let Ok(stake_state) = stake_account.state() {
             match stake_state {
-                StakeStateV2::Initialized(_) => {
-                    if vote_account_pubkeys.is_empty() {
-                        stake_accounts.push(CliKeyedStakeState {
-                            stake_pubkey: stake_pubkey.to_string(),
-                            stake_state: build_stake_state(
-                                stake_account.lamports,
-                                &stake_state,
-                                use_lamports_unit,
-                                &stake_history,
-                                &clock,
-                                new_rate_activation_epoch,
-                                false,
-                            ),
-                        });
-                    }
+                StakeStateV2::Initialized(_) if vote_account_pubkeys.is_empty() => {
+                    stake_accounts.push(CliKeyedStakeState {
+                        stake_pubkey: stake_pubkey.to_string(),
+                        stake_state: build_stake_state(
+                            stake_account.lamports,
+                            &stake_state,
+                            use_lamports_unit,
+                            &stake_history,
+                            &clock,
+                            new_rate_activation_epoch,
+                            false,
+                        ),
+                    });
                 }
-                StakeStateV2::Stake(_, stake, _) => {
+                StakeStateV2::Stake(_, stake, _)
                     if vote_account_pubkeys.is_empty()
-                        || vote_account_pubkeys.contains(&stake.delegation.voter_pubkey)
-                    {
-                        stake_accounts.push(CliKeyedStakeState {
-                            stake_pubkey: stake_pubkey.to_string(),
-                            stake_state: build_stake_state(
-                                stake_account.lamports,
-                                &stake_state,
-                                use_lamports_unit,
-                                &stake_history,
-                                &clock,
-                                new_rate_activation_epoch,
-                                false,
-                            ),
-                        });
-                    }
+                        || vote_account_pubkeys.contains(&stake.delegation.voter_pubkey) =>
+                {
+                    stake_accounts.push(CliKeyedStakeState {
+                        stake_pubkey: stake_pubkey.to_string(),
+                        stake_state: build_stake_state(
+                            stake_account.lamports,
+                            &stake_state,
+                            use_lamports_unit,
+                            &stake_history,
+                            &clock,
+                            new_rate_activation_epoch,
+                            false,
+                        ),
+                    });
                 }
                 _ => {}
             }

--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -135,7 +135,7 @@ fn create_transaction_confirmation_task(
                 {
                     if let Ok(result) = rpc_client.get_signature_statuses(signatures).await {
                         let statuses = result.value;
-                        for (signature, status) in signatures.iter().zip(statuses.into_iter()) {
+                        for (signature, status) in signatures.iter().zip(statuses) {
                             if let Some((status, data)) = status
                                 .filter(|status| {
                                     status.satisfies_commitment(rpc_client.commitment())

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -445,11 +445,12 @@ impl SchedulingDetails {
         let now = Instant::now();
         if now.duration_since(self.last_report) > REPORT_INTERVAL {
             self.last_report = now;
-            if self.num_schedule_calls > 0 {
-                let avg_starting_queue_size =
-                    self.sum_starting_queue_size / self.num_schedule_calls;
-                let avg_starting_buffer_size =
-                    self.sum_starting_buffer_size / self.num_schedule_calls;
+            if let (Some(avg_starting_queue_size), Some(avg_starting_buffer_size)) = (
+                self.sum_starting_queue_size
+                    .checked_div(self.num_schedule_calls),
+                self.sum_starting_buffer_size
+                    .checked_div(self.num_schedule_calls),
+            ) {
                 let datapoint = create_datapoint!(
                     @point "scheduling_details",
                     ("num_schedule_calls", self.num_schedule_calls, i64),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1482,8 +1482,8 @@ impl ReplayStage {
             .read()
             .unwrap()
             .banks()
-            .iter()
-            .filter_map(|(slot, _)| (*slot > genesis_slot).then_some(*slot))
+            .keys()
+            .filter_map(|slot| (*slot > genesis_slot).then_some(*slot))
             .collect();
         for slot in slots_to_purge.into_iter() {
             info!("{my_pubkey} Alpenglow migration: Purging poh block in slot {slot}");
@@ -2270,9 +2270,7 @@ impl ReplayStage {
 
             (r_bank_forks.root(), bank_hashes)
         };
-        for (duplicate_slot, bank_hash) in
-            new_duplicate_slots.into_iter().zip(bank_hashes.into_iter())
-        {
+        for (duplicate_slot, bank_hash) in new_duplicate_slots.into_iter().zip(bank_hashes) {
             // WindowService should only send the signal once per slot
             let duplicate_state = DuplicateState::new_from_state(
                 duplicate_slot,

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -351,7 +351,7 @@ async fn shreds(
                     let parent_blockhash = Hash::from_str(&block.previous_blockhash)?;
                     let virtual_ticks_entries =
                         create_ticks(num_virtual_ticks, num_hashes_per_tick, parent_blockhash);
-                    entries.extend(virtual_ticks_entries.into_iter());
+                    entries.extend(virtual_ticks_entries);
                 }
 
                 // Create transaction entries
@@ -362,7 +362,7 @@ async fn shreds(
                     hash: Hash::default(),
                     transactions: vec![tx_with_meta.get_transaction()],
                 });
-                entries.extend(transaction_entries.into_iter());
+                entries.extend(transaction_entries);
 
                 // Create the tick entries for this slot
                 //
@@ -383,7 +383,7 @@ async fn shreds(
                         transactions: vec![],
                     }
                 });
-                entries.extend(tick_entries.into_iter());
+                entries.extend(tick_entries);
 
                 entries
             }

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -203,8 +203,7 @@ pub async fn upload_confirmed_blocks(
     let mut failures = 0;
     use futures::stream::StreamExt;
 
-    let mut stream =
-        tokio_stream::iter(receiver.into_iter()).chunks(config.num_blocks_to_upload_in_parallel);
+    let mut stream = tokio_stream::iter(receiver).chunks(config.num_blocks_to_upload_in_parallel);
 
     while let Some(blocks) = stream.next().await {
         if exit.load(Ordering::Relaxed) {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5132,7 +5132,7 @@ fn send_signals(
 
         slots.push(newly_completed_slots);
 
-        for (signal, slots) in completed_slots_senders.iter().zip(slots.into_iter()) {
+        for (signal, slots) in completed_slots_senders.iter().zip(slots) {
             let res = signal.try_send(slots);
             if let Err(TrySendError::Full(_)) = res {
                 datapoint_error!(

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1648,10 +1648,8 @@ pub fn confirm_slot(
         .iter()
         .rposition(|bc| matches!(bc, BlockComponent::EntryBatch(_)));
 
-    for (ix, (completed_range, component)) in completed_ranges
-        .iter()
-        .zip(slot_components.into_iter())
-        .enumerate()
+    for (ix, (completed_range, component)) in
+        completed_ranges.iter().zip(slot_components).enumerate()
     {
         let num_shreds = completed_range.end - completed_range.start;
         let is_final = slot_full && ix == completed_ranges.len() - 1;

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -336,7 +336,7 @@ impl JsonRpcRequestProcessor {
             .await
             .expect("Failed to spawn blocking task")?;
         if sort_results {
-            accounts.sort_unstable_by(|(a_addr, _), (b_addr, _)| a_addr.cmp(b_addr));
+            accounts.sort_unstable_by_key(|(addr, _)| *addr);
         }
         Ok(accounts)
     }
@@ -2281,7 +2281,7 @@ impl JsonRpcRequestProcessor {
                 .await
                 .expect("Failed to spawn blocking task")?;
             if sort_results {
-                accounts.sort_unstable_by(|(a_addr, _), (b_addr, _)| a_addr.cmp(b_addr));
+                accounts.sort_unstable_by_key(|(addr, _)| *addr);
             }
             Ok(accounts)
         }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -336,7 +336,8 @@ impl JsonRpcRequestProcessor {
             .await
             .expect("Failed to spawn blocking task")?;
         if sort_results {
-            accounts.sort_unstable_by_key(|(addr, _)| *addr);
+            // Avoid copying pubkeys (using Ord::cmp(a, b) silences clippy::unnecessary_sort_by).
+            accounts.sort_unstable_by(|(addr_a, _), (addr_b, _)| Ord::cmp(addr_a, addr_b));
         }
         Ok(accounts)
     }
@@ -2281,7 +2282,8 @@ impl JsonRpcRequestProcessor {
                 .await
                 .expect("Failed to spawn blocking task")?;
             if sort_results {
-                accounts.sort_unstable_by_key(|(addr, _)| *addr);
+                // Avoid copying pubkeys (using Ord::cmp(a, b) silences clippy::unnecessary_sort_by).
+                accounts.sort_unstable_by(|(addr_a, _), (addr_b, _)| Ord::cmp(addr_a, addr_b));
             }
             Ok(accounts)
         }

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -406,8 +406,8 @@ pub(crate) mod tests {
             new_vote_accounts(num_nodes, num_vote_accounts_per_node, is_alpenglow);
 
         let expected_authorized_voters: HashMap<_, _> = vote_accounts_map
-            .iter()
-            .flat_map(|(_, vote_accounts)| {
+            .values()
+            .flat_map(|vote_accounts| {
                 vote_accounts
                     .iter()
                     .map(|v| (v.vote_account, v.authorized_voter))

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -48,19 +48,17 @@ pub fn calculate_non_circulating_supply(bank: &Bank) -> ScanResult<NonCirculatin
             .deserialize_data::<StakeStateV2>()
             .unwrap_or_default();
         match stake_account {
-            StakeStateV2::Initialized(meta) => {
-                if meta.lockup.is_in_force(&clock, None)
-                    || withdraw_authority_list.contains(&meta.authorized.withdrawer)
-                {
-                    non_circulating_accounts_set.insert(*pubkey);
-                }
+            StakeStateV2::Initialized(meta)
+                if (meta.lockup.is_in_force(&clock, None)
+                    || withdraw_authority_list.contains(&meta.authorized.withdrawer)) =>
+            {
+                non_circulating_accounts_set.insert(*pubkey);
             }
-            StakeStateV2::Stake(meta, _stake, _stake_flags) => {
-                if meta.lockup.is_in_force(&clock, None)
-                    || withdraw_authority_list.contains(&meta.authorized.withdrawer)
-                {
-                    non_circulating_accounts_set.insert(*pubkey);
-                }
+            StakeStateV2::Stake(meta, _stake, _stake_flags)
+                if (meta.lockup.is_in_force(&clock, None)
+                    || withdraw_authority_list.contains(&meta.authorized.withdrawer)) =>
+            {
+                non_circulating_accounts_set.insert(*pubkey);
             }
             _ => {}
         }

--- a/snapshots/src/archive_format.rs
+++ b/snapshots/src/archive_format.rs
@@ -173,7 +173,7 @@ mod tests {
             Some(ArchiveFormat::TarLz4),
         ];
 
-        for (arg, expected) in zip(SUPPORTED_ARCHIVE_COMPRESSION.iter(), golden.into_iter()) {
+        for (arg, expected) in zip(SUPPORTED_ARCHIVE_COMPRESSION.iter(), golden) {
             assert_eq!(ArchiveFormat::from_cli_arg(arg), expected);
         }
 

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -754,8 +754,7 @@ fn update_finalized_transactions(
         statuses.extend(
             client
                 .get_signature_statuses(unconfirmed_signatures_chunk)?
-                .value
-                .into_iter(),
+                .value,
         );
     }
 
@@ -781,9 +780,8 @@ fn log_transaction_confirmations(
     confirmations: &mut Option<usize>,
 ) -> Result<(), Error> {
     let finalized_block_height = client.get_block_height()?;
-    for ((transaction, last_valid_block_height), opt_transaction_status) in unconfirmed_transactions
-        .into_iter()
-        .zip(statuses.into_iter())
+    for ((transaction, last_valid_block_height), opt_transaction_status) in
+        unconfirmed_transactions.into_iter().zip(statuses)
     {
         match db::update_finalized_transaction(
             db,

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -648,9 +648,7 @@ where
                         .await
                     {
                         let statuses = result.value;
-                        for (signature, status) in
-                            pending_signatures_chunk.iter().zip(statuses.into_iter())
-                        {
+                        for (signature, status) in pending_signatures_chunk.iter().zip(statuses) {
                             if let Some(status) = status {
                                 if status.satisfies_commitment(self.rpc_client.commitment()) {
                                     if let Some((i, _)) = pending_transactions.remove(signature) {


### PR DESCRIPTION
#### Problem
Rust 1.95 toolchain clippy signals new lint warnings.

#### Summary of Changes
Addresses clippy lints across several crate:
- **Remove redundant `.into_iter()` calls** (`accounts-db`, `bench-tps`, `client`, `ledger`, `ledger-tool`, `runtime`, `snapshots`, `tokens`, `tpu-client`): Removes explicit `.into_iter()` calls in iterator chains and `extend()`/`zip()` contexts where the type already implements `IntoIterator` and coercion is automatic.
- **Collapse `if` into match guards** (`cli`, `runtime`): Converts `match` arms that immediately `if`-guard their body into proper `Pattern if condition =>` match guards, reducing nesting.
- Update **Use `sort_unstable_by`** (`accounts-db`, `rpc`): Use `sort_unstable_by(|(a, ..), (b, ..)| Ord::cmp(a, b))` to avoid `clippy::unnecessary_sort_by` warning.
- **Use `values()` instead of `iter()` when only values are needed** (`core`, `runtime`): Replaces `.iter().flat_map(|(_, v)| ...)` / `.iter().filter_map(|(_, v)| ...)` with `.values().flat_map(|v| ...)`.
- **Use `checked_div` for integer division** (`core`): Replaces a manual `if divisor > 0` guard around integer division with `checked_div`, returning `Option` and matching on it.
