### PR TITLE
svm: tests: delete loader v4

### DIFF
--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -314,66 +314,6 @@ mod tests {
     }
 
     #[test]
-    fn test_load_program_accounts_loader_v4() {
-        let key = Pubkey::new_unique();
-        let mock_bank = MockBankCallback::default();
-        let mut account_data = AccountSharedData::default();
-        account_data.set_owner(loader_v4::id());
-        mock_bank
-            .account_shared_data
-            .borrow_mut()
-            .insert(key, (account_data.clone(), 0));
-
-        let result = load_program_accounts(&mock_bank, &key);
-        assert!(matches!(
-            result,
-            Some((ProgramAccountLoadResult::InvalidAccountData(_), _))
-        ));
-
-        account_data.set_data(vec![0; 64]);
-        mock_bank
-            .account_shared_data
-            .borrow_mut()
-            .insert(key, (account_data.clone(), 0));
-        let result = load_program_accounts(&mock_bank, &key);
-        assert!(matches!(
-            result,
-            Some((ProgramAccountLoadResult::InvalidAccountData(_), _))
-        ));
-
-        let loader_data = LoaderV4State {
-            slot: 25,
-            authority_address_or_next_version: Pubkey::new_unique(),
-            status: LoaderV4Status::Deployed,
-        };
-        let encoded = unsafe {
-            std::mem::transmute::<&LoaderV4State, &[u8; LoaderV4State::program_data_offset()]>(
-                &loader_data,
-            )
-        };
-        account_data.set_data(encoded.to_vec());
-        mock_bank
-            .account_shared_data
-            .borrow_mut()
-            .insert(key, (account_data.clone(), 25));
-
-        let result = load_program_accounts(&mock_bank, &key);
-
-        match result {
-            Some((
-                ProgramAccountLoadResult::ProgramOfLoaderV4(data, deployment_slot),
-                last_modification_slot,
-            )) => {
-                assert_eq!(data, account_data);
-                assert_eq!(deployment_slot, 25);
-                assert_eq!(last_modification_slot, 25);
-            }
-
-            _ => panic!("Invalid result"),
-        }
-    }
-
-    #[test]
     fn test_load_program_accounts_loader_v1_or_v2() {
         let key = Pubkey::new_unique();
         let mock_bank = MockBankCallback::default();
@@ -500,7 +440,7 @@ mod tests {
         let key = Pubkey::new_unique();
         let mock_bank = MockBankCallback::default();
         let mut account_data = AccountSharedData::default();
-        account_data.set_owner(loader_v4::id());
+        account_data.set_owner(bpf_loader_upgradeable::id());
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         mock_bank
             .account_shared_data
@@ -517,7 +457,7 @@ mod tests {
 
         let loaded_program = ProgramCacheEntry::new_tombstone(
             0, // Slot 0
-            ProgramCacheEntryOwner::LoaderV4,
+            ProgramCacheEntryOwner::LoaderV3,
             ProgramCacheEntryType::FailedVerification(
                 batch_processor.program_runtime_environment_for_epoch(20),
             ),
@@ -677,89 +617,6 @@ mod tests {
     }
 
     #[test]
-    fn test_load_program_of_loader_v4() {
-        let key = Pubkey::new_unique();
-        let mock_bank = MockBankCallback::default();
-        let mut account_data = AccountSharedData::default();
-        account_data.set_owner(loader_v4::id());
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-
-        let loader_data = LoaderV4State {
-            slot: 0,
-            authority_address_or_next_version: Pubkey::new_unique(),
-            status: LoaderV4Status::Deployed,
-        };
-        let encoded = unsafe {
-            std::mem::transmute::<&LoaderV4State, &[u8; LoaderV4State::program_data_offset()]>(
-                &loader_data,
-            )
-        };
-        account_data.set_data(encoded.to_vec());
-        mock_bank
-            .account_shared_data
-            .borrow_mut()
-            .insert(key, (account_data.clone(), 0));
-
-        let result = load_program_with_pubkey(
-            &mock_bank,
-            &batch_processor.program_runtime_environment_for_epoch(0),
-            &key,
-            0,
-            &mut ExecuteTimings::default(),
-        );
-        let loaded_program = ProgramCacheEntry::new_tombstone(
-            0,
-            ProgramCacheEntryOwner::LoaderV4,
-            ProgramCacheEntryType::FailedVerification(
-                batch_processor.program_runtime_environment_for_epoch(0),
-            ),
-        );
-        assert_eq!(result.unwrap(), (Arc::new(loaded_program), 0));
-
-        let mut header = account_data.data().to_vec();
-        let mut complement =
-            vec![0; std::cmp::max(0, LoaderV4State::program_data_offset() - header.len())];
-        header.append(&mut complement);
-
-        let mut buffer = load_test_program();
-        header.append(&mut buffer);
-
-        account_data.set_data(header);
-        mock_bank
-            .account_shared_data
-            .borrow_mut()
-            .insert(key, (account_data.clone(), 0));
-
-        let result = load_program_with_pubkey(
-            &mock_bank,
-            &batch_processor.program_runtime_environment_for_epoch(20),
-            &key,
-            200,
-            &mut ExecuteTimings::default(),
-        );
-
-        let data = account_data.data()[LoaderV4State::program_data_offset()..].to_vec();
-        account_data.set_data(data);
-        mock_bank
-            .account_shared_data
-            .borrow_mut()
-            .insert(key, (account_data.clone(), 0));
-
-        let program_runtime_environment = get_mock_program_runtime_environment();
-        let expected = ProgramCacheEntry::new(
-            account_data.owner(),
-            ProgramRuntimeEnvironment::clone(&program_runtime_environment),
-            0,
-            DELAY_VISIBILITY_SLOT_OFFSET,
-            account_data.data(),
-            account_data.data().len(),
-            #[cfg(feature = "metrics")]
-            &mut LoadProgramMetrics::default(),
-        );
-        assert_eq!(result.unwrap(), (Arc::new(expected.unwrap()), 0));
-    }
-
-    #[test]
     fn test_load_program_environment() {
         let key = Pubkey::new_unique();
         let mock_bank = MockBankCallback::default();
@@ -829,15 +686,6 @@ mod tests {
 
         let result = get_program_deployment_slot(&mock_bank, &key);
         assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
-
-        account_data.set_owner(loader_v4::id());
-        mock_bank
-            .account_shared_data
-            .borrow_mut()
-            .insert(key, (account_data, 0));
-
-        let result = get_program_deployment_slot(&mock_bank, &key);
-        assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
     }
 
     #[test]
@@ -860,7 +708,7 @@ mod tests {
             .borrow_mut()
             .insert(key1, (account_data, 0));
 
-        let account_data = AccountSharedData::new_data(
+        let mut account_data = AccountSharedData::new_data(
             100,
             &UpgradeableLoaderState::ProgramData {
                 slot: 77,
@@ -872,30 +720,10 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key2, (account_data, 0));
+            .insert(key2, (account_data.clone(), 0));
 
         let result = get_program_deployment_slot(&mock_bank, &key1);
         assert_eq!(result.unwrap(), 77);
-
-        let state = LoaderV4State {
-            slot: 58,
-            authority_address_or_next_version: Pubkey::new_unique(),
-            status: LoaderV4Status::Deployed,
-        };
-        let encoded = unsafe {
-            std::mem::transmute::<&LoaderV4State, &[u8; LoaderV4State::program_data_offset()]>(
-                &state,
-            )
-        };
-        let mut account_data = AccountSharedData::new(100, encoded.len(), &loader_v4::id());
-        account_data.set_data(encoded.to_vec());
-        mock_bank
-            .account_shared_data
-            .borrow_mut()
-            .insert(key1, (account_data.clone(), 0));
-
-        let result = get_program_deployment_slot(&mock_bank, &key1);
-        assert_eq!(result.unwrap(), 58);
 
         account_data.set_owner(Pubkey::new_unique());
         mock_bank

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1257,7 +1257,7 @@ mod tests {
         },
         solana_rent::Rent,
         solana_sbpf::vm,
-        solana_sdk_ids::{bpf_loader, loader_v4, system_program, sysvar},
+        solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, system_program, sysvar},
         solana_signature::Signature,
         solana_svm_callback::{AccountState, InvokeContextCallback},
         solana_system_interface::instruction as system_instruction,
@@ -1770,7 +1770,7 @@ mod tests {
         let key1 = Pubkey::new_unique();
         let owner1 = bpf_loader::id();
         let key2 = Pubkey::new_unique();
-        let owner2 = loader_v4::id();
+        let owner2 = bpf_loader_upgradeable::id();
 
         let mut data1 = AccountSharedData::default();
         data1.set_owner(owner1);
@@ -1830,7 +1830,7 @@ mod tests {
         let non_program_pubkey1 = Pubkey::new_unique();
         let non_program_pubkey2 = Pubkey::new_unique();
         let program1_pubkey = bpf_loader::id();
-        let program2_pubkey = loader_v4::id();
+        let program2_pubkey = bpf_loader_upgradeable::id();
         let account1_pubkey = Pubkey::new_unique();
         let account2_pubkey = Pubkey::new_unique();
         let account3_pubkey = Pubkey::new_unique();

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -151,7 +151,7 @@ fn svm_concurrent() {
 
     mock_bank.configure_sysvars();
     batch_processor.fill_missing_sysvar_cache_entries(&*mock_bank);
-    register_builtins(&mock_bank, &batch_processor, false);
+    register_builtins(&mock_bank, &batch_processor);
 
     let program_id = deploy_program("transfer-from-account".to_string(), 0, &mock_bank);
 

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -7,7 +7,7 @@ use {
         create_custom_loader, deploy_program_with_upgrade_authority, load_program, program_address,
         program_data_size, register_builtins,
     },
-    solana_account::{AccountSharedData, PROGRAM_OWNERS, ReadableAccount, WritableAccount},
+    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_clock::Slot,
     solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_compute_budget_interface::ComputeBudgetInstruction,
@@ -29,7 +29,9 @@ use {
         loaded_programs::ProgramRuntimeEnvironments,
     },
     solana_pubkey::Pubkey,
-    solana_sdk_ids::{bpf_loader_upgradeable, compute_budget, native_loader},
+    solana_sdk_ids::{
+        bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, compute_budget, native_loader,
+    },
     solana_signer::Signer,
     solana_svm::{
         account_loader::{CheckedTransactionDetails, TransactionCheckResult},
@@ -147,7 +149,7 @@ impl SvmTestEnvironment<'_> {
         // The sysvars must be put in the cache
         mock_bank.configure_sysvars();
         batch_processor.fill_missing_sysvar_cache_entries(&mock_bank);
-        register_builtins(&mock_bank, &batch_processor, test_entry.with_loader_v4);
+        register_builtins(&mock_bank, &batch_processor);
 
         let processing_config = TransactionProcessingConfig {
             recording_config: ExecutionRecordingConfig {
@@ -369,9 +371,6 @@ pub struct SvmTestEntry {
     // features configuration for this test
     pub feature_set: SVMFeatureSet,
 
-    // until LoaderV4 is live on mainnet, we default to omitting it, but can also test it
-    pub with_loader_v4: bool,
-
     // enables drop on failure processing (transactions without Ok status have no state effect)
     pub drop_on_failure: bool,
 
@@ -398,7 +397,6 @@ impl Default for SvmTestEntry {
     fn default() -> Self {
         Self {
             feature_set: SVMFeatureSet::all_enabled(),
-            with_loader_v4: false,
             all_or_nothing: false,
             drop_on_failure: false,
             initial_programs: Vec::new(),
@@ -411,13 +409,6 @@ impl Default for SvmTestEntry {
 }
 
 impl SvmTestEntry {
-    pub fn with_loader_v4() -> Self {
-        Self {
-            with_loader_v4: true,
-            ..Self::default()
-        }
-    }
-
     pub fn set_rent_params(&mut self, rent: Rent) {
         self.rent = rent;
     }
@@ -2578,8 +2569,13 @@ fn svm_integration(test_entries: Vec<SvmTestEntry>) {
 
 #[test]
 fn program_cache_create_account() {
-    for loader_id in PROGRAM_OWNERS {
-        let mut test_entry = SvmTestEntry::with_loader_v4();
+    let supported_loaders = [
+        bpf_loader_upgradeable::id(),
+        bpf_loader::id(),
+        bpf_loader_deprecated::id(),
+    ];
+    for loader_id in &supported_loaders {
+        let mut test_entry = SvmTestEntry::default();
 
         let fee_payer_keypair = Keypair::new();
         let fee_payer = fee_payer_keypair.pubkey();

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -13,14 +13,13 @@ use {
         invoke_context::InvokeContext,
         loaded_programs::{BlockRelation, ForkGraph, ProgramCacheEntry, ProgramRuntimeEnvironment},
         solana_sbpf::{
-            program::{BuiltinProgram, SBPFVersion},
+            program::{BuiltinFunctionDefinition, BuiltinProgram, SBPFVersion},
             vm::Config,
         },
     },
     solana_pubkey::Pubkey,
     solana_rent::Rent,
-    solana_sbpf::program::BuiltinFunctionDefinition,
-    solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, compute_budget, loader_v4},
+    solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, compute_budget},
     solana_svm::transaction_processor::TransactionBatchProcessor,
     solana_svm_callback::{AccountState, InvokeContextCallback, TransactionProcessingCallback},
     solana_svm_feature_set::SVMFeatureSet,
@@ -273,7 +272,6 @@ pub fn deploy_program_with_upgrade_authority(
 pub fn register_builtins(
     mock_bank: &MockBankCallback,
     batch_processor: &TransactionBatchProcessor<MockForkGraph>,
-    with_loader_v4: bool,
 ) {
     const DEPLOYMENT_SLOT: u64 = 0;
     // We must register LoaderV3 as a loadable account, otherwise programs won't execute.
@@ -313,20 +311,6 @@ pub fn register_builtins(
             solana_bpf_loader_program::Entrypoint::register,
         ),
     );
-
-    if with_loader_v4 {
-        let loader_v4_name = "solana_loader_v4_program";
-        mock_bank.add_builtin(
-            batch_processor,
-            loader_v4::id(),
-            loader_v4_name,
-            ProgramCacheEntry::new_builtin(
-                DEPLOYMENT_SLOT,
-                loader_v4_name.len(),
-                solana_loader_v4_program::Entrypoint::register,
-            ),
-        );
-    }
 
     // In order to perform a transference of native tokens using the system instruction,
     // the system program builtin must be registered.


### PR DESCRIPTION
#### Problem
As per [RFC-0423](https://github.com/solana-foundation/solana-improvement-documents/discussions/423), Loader V4 will be redesigned and reintroduced as an on-chain program. The builtin implementation should be removed.

#### Summary of Changes
Convert all tests in `svm` to use Loader V3 instead of Loader V4.

Broken off https://github.com/anza-xyz/agave/pull/10396