### PR TITLE
compute-budget-instruction: tests: delete loader v4

### DIFF
--- a/compute-budget-instruction/benches/process_compute_budget_instructions.rs
+++ b/compute-budget-instruction/benches/process_compute_budget_instructions.rs
@@ -126,7 +126,11 @@ fn bench_process_compute_budget_instructions_builtins(c: &mut Criterion) {
                         &(),
                         vec![],
                     ),
-                    Instruction::new_with_bincode(solana_sdk_ids::loader_v4::id(), &(), vec![]),
+                    Instruction::new_with_bincode(
+                        solana_sdk_ids::bpf_loader_upgradeable::id(),
+                        &(),
+                        vec![],
+                    ),
                 ];
                 let tx = build_sanitized_transaction(&Keypair::new(), &ixs);
                 bencher.iter(|| {

--- a/compute-budget-instruction/src/builtin_programs_filter.rs
+++ b/compute-budget-instruction/src/builtin_programs_filter.rs
@@ -93,14 +93,14 @@ mod test {
         // lookup same `index` will return cached data, will not lookup `program_id`
         // again
         assert_eq!(
-            test_store.get_program_kind(index, &solana_sdk_ids::loader_v4::id()),
+            test_store.get_program_kind(index, &solana_sdk_ids::bpf_loader_upgradeable::id()),
             ProgramKind::NotBuiltin
         );
 
         // not-migrating builtin
         index += 1;
         assert_eq!(
-            test_store.get_program_kind(index, &solana_sdk_ids::loader_v4::id()),
+            test_store.get_program_kind(index, &solana_sdk_ids::bpf_loader_upgradeable::id()),
             ProgramKind::Builtin,
         );
 


### PR DESCRIPTION
#### Problem
As per [RFC-0423](https://github.com/solana-foundation/solana-improvement-documents/discussions/423), Loader V4 will be redesigned and reintroduced as an on-chain program. The builtin implementation should be removed.

#### Summary of Changes
Convert all tests in `compute-budget-instruction` to use Loader V3 instead of Loader V4.

Broken off https://github.com/anza-xyz/agave/pull/10396