### PR TITLE
Fix index out of bounds panic in ancient storage compaction

### DIFF
--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -295,9 +295,12 @@ impl<'a> StorableAccountsBySlot<'a> {
     /// on the starting_offsets based on the assumption that the
     /// starting_offsets are always sorted.
     fn find_internal_index(&self, index: usize) -> (usize, usize) {
-        // special case for when there is only one slot - just return the first index without searching.
+        // special case for when there is only one entry - just return the first index without searching.
         // This happens when we are just shrinking a single slot storage, which happens very often.
-        if !self.contains_multiple_slots {
+        // Note: we check the actual number of entries, not just whether slots differ,
+        // because multiple entries can have the same slot value (e.g., when packing
+        // many_refs_newest and one_ref accounts from the same source slot).
+        if self.slots_and_accounts.len() <= 1 {
             return (0, index);
         }
         let upper_bound = self


### PR DESCRIPTION
Summary

Fix a panic in find_internal_index() in StorableAccountsBySlot during ancient storage compaction when pack() combines many_refs_newest and one_ref accounts from the same source slot.

Problem

find_internal_index() has a fast path checking !self.contains_multiple_slots. However, contains_multiple_slots only checks whether slot values differ — not whether there are multiple entries.

When pack() chains many_refs_newest and one_ref accounts (both from the same source slot), it produces multiple entries with the same slot value:


slots_and_accounts = [
    (slot_X, &many_refs_accounts[0..3]),  // 3 accounts
    (slot_X, &one_ref_accounts[0..4]),    // 4 accounts
]
contains_multiple_slots = false (same slot)
len = 7, but fast path returns (0, index) for any index
When index >= 3 → out of bounds on first slice

thread 'solAcctsDbBg00' panicked at accounts-db/src/storable_accounts.rs:335:9:
index out of bounds: the len is 6 but the index is 6
Root Cause

Triggers on networks with low account diversity (private/test networks with few validators), where the same accounts are updated every slot, causing high ref_count and many "unpackable" accounts during ancient compaction. On mainnet, account updates are distributed across millions of accounts, making this extremely unlikely.

Fix


// Before:
if !self.contains_multiple_slots {
// After:
if self.slots_and_accounts.len() <= 1 {