### PR TITLE
program_runtime: split out loading task code into a separate module

### DIFF
--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -9,6 +9,7 @@ pub mod deploy;
 pub mod execution_budget;
 pub mod invoke_context;
 pub mod loaded_programs;
+pub mod loading_task;
 pub mod mem_pool;
 pub mod memory;
 pub mod program_metrics;

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -3,6 +3,7 @@ use crate::program_metrics::LoadProgramMetrics;
 use {
     crate::{
         invoke_context::{BuiltinFunctionRegisterer, InvokeContext},
+        loading_task::LoadingTaskWaiter,
         program_metrics::{EMA_SCALE, ProgramCacheStats, ProgramStatistics},
     },
     log::error,
@@ -17,7 +18,7 @@ use {
     solana_svm_type_overrides::{
         rand::{Rng, rng},
         sync::{
-            Arc, Condvar, Mutex, RwLock,
+            Arc, Mutex, RwLock,
             atomic::{AtomicU64, Ordering},
         },
         thread,
@@ -593,54 +594,6 @@ impl EpochBoundaryPreparation {
         }
 
         None
-    }
-}
-
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-pub struct LoadingTaskCookie(u64);
-
-impl LoadingTaskCookie {
-    fn new() -> Self {
-        Self(0)
-    }
-
-    fn update(&mut self) {
-        let LoadingTaskCookie(cookie) = self;
-        *cookie = cookie.wrapping_add(1);
-    }
-}
-
-/// Suspends the thread in case no cooprative loading task was assigned
-#[derive(Debug, Default)]
-pub struct LoadingTaskWaiter {
-    cookie: Mutex<LoadingTaskCookie>,
-    cond: Condvar,
-}
-
-impl LoadingTaskWaiter {
-    pub fn new() -> Self {
-        Self {
-            cookie: Mutex::new(LoadingTaskCookie::new()),
-            cond: Condvar::new(),
-        }
-    }
-
-    pub fn cookie(&self) -> LoadingTaskCookie {
-        *self.cookie.lock().unwrap()
-    }
-
-    pub fn notify(&self) {
-        let mut cookie = self.cookie.lock().unwrap();
-        cookie.update();
-        self.cond.notify_all();
-    }
-
-    pub fn wait(&self, cookie: LoadingTaskCookie) -> LoadingTaskCookie {
-        let cookie_guard = self.cookie.lock().unwrap();
-        *self
-            .cond
-            .wait_while(cookie_guard, |current_cookie| *current_cookie == cookie)
-            .unwrap()
     }
 }
 

--- a/program-runtime/src/loading_task.rs
+++ b/program-runtime/src/loading_task.rs
@@ -1,0 +1,49 @@
+use solana_svm_type_overrides::sync::{Condvar, Mutex};
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct LoadingTaskCookie(u64);
+
+impl LoadingTaskCookie {
+    fn new() -> Self {
+        Self(0)
+    }
+
+    fn update(&mut self) {
+        let LoadingTaskCookie(cookie) = self;
+        *cookie = cookie.wrapping_add(1);
+    }
+}
+
+/// Suspends the thread in case no cooprative loading task was assigned
+#[derive(Debug, Default)]
+pub struct LoadingTaskWaiter {
+    cookie: Mutex<LoadingTaskCookie>,
+    cond: Condvar,
+}
+
+impl LoadingTaskWaiter {
+    pub fn new() -> Self {
+        Self {
+            cookie: Mutex::new(LoadingTaskCookie::new()),
+            cond: Condvar::new(),
+        }
+    }
+
+    pub fn cookie(&self) -> LoadingTaskCookie {
+        *self.cookie.lock().unwrap()
+    }
+
+    pub fn notify(&self) {
+        let mut cookie = self.cookie.lock().unwrap();
+        cookie.update();
+        self.cond.notify_all();
+    }
+
+    pub fn wait(&self, cookie: LoadingTaskCookie) -> LoadingTaskCookie {
+        let cookie_guard = self.cookie.lock().unwrap();
+        *self
+            .cond
+            .wait_while(cookie_guard, |current_cookie| *current_cookie == cookie)
+            .unwrap()
+    }
+}


### PR DESCRIPTION
#### Problem

loaded_programs.rs is humongous.

#### Summary of Changes

Splits out 50 lines of self-contained code into its own module/file.