### PR TITLE
Moved Scan Guard to Accounts Database

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -50,7 +50,7 @@ use {
             AccountsIndexScanResult, IndexKey, IsCached, ReclaimsSlotList, RefCount, ScanFilter,
             SlotList, Startup, UpsertReclaim, in_mem_accounts_index::StartupStats,
         },
-        accounts_scan::{ScanConfig, ScanResult},
+        accounts_scan::{ScanConfig, ScanError, ScanGuard, ScanResult},
         accounts_update_notifier_interface::{AccountForGeyser, AccountsUpdateNotifier},
         active_stats::{ActiveStatItem, ActiveStats},
         ancestors::Ancestors,
@@ -3351,10 +3351,26 @@ impl AccountsDb {
     where
         F: FnMut(Option<(&Pubkey, AccountSharedData, Slot)>),
     {
-        // This can error out if the slots being scanned over are aborted
+        // Register this scan so that slots needed by the scan are not cleaned out from under us.
+        let scan_guard = ScanGuard::try_new(&self.accounts_index.scan_tracker, bank_id, || {
+            self.accounts_index.max_root_inclusive()
+        })
+        .ok_or(ScanError::SlotRemoved {
+            slot: ancestors.max_slot(),
+            bank_id,
+        })?;
+
+        // If the scan's ancestors are all rooted, drop them and scan roots only
+        let empty_ancestors = Ancestors::default();
+        let ancestors = if scan_guard.should_use_ancestors(ancestors) {
+            ancestors
+        } else {
+            &empty_ancestors
+        };
+
         self.accounts_index.scan_accounts(
             ancestors,
-            bank_id,
+            scan_guard.max_root(),
             |pubkey, (account_info, slot)| {
                 let mut account_accessor =
                     self.get_account_accessor(slot, pubkey, &account_info.storage_location());
@@ -3368,8 +3384,15 @@ impl AccountsDb {
                 scan_func(account_slot)
             },
             config,
-        )?;
+        );
 
+        // Check whether the bank was removed while the scan was in progress.
+        if scan_guard.was_scan_corrupted() {
+            return Err(ScanError::SlotRemoved {
+                slot: ancestors.max_slot(),
+                bank_id,
+            });
+        }
         Ok(())
     }
 
@@ -3396,9 +3419,26 @@ impl AccountsDb {
             return Ok(used_index);
         }
 
+        // Register this scan so that slots needed by the scan are not cleaned out from under us.
+        let scan_guard = ScanGuard::try_new(&self.accounts_index.scan_tracker, bank_id, || {
+            self.accounts_index.max_root_inclusive()
+        })
+        .ok_or(ScanError::SlotRemoved {
+            slot: ancestors.max_slot(),
+            bank_id,
+        })?;
+
+        // If the scan's ancestors are all rooted, drop them and scan roots only
+        let empty_ancestors = Ancestors::default();
+        let ancestors = if scan_guard.should_use_ancestors(ancestors) {
+            ancestors
+        } else {
+            &empty_ancestors
+        };
+
         self.accounts_index.index_scan_accounts(
             ancestors,
-            bank_id,
+            scan_guard.max_root(),
             index_key,
             |pubkey, (account_info, slot)| {
                 let account_slot = self
@@ -3409,7 +3449,15 @@ impl AccountsDb {
                 scan_func(account_slot)
             },
             config,
-        )?;
+        );
+
+        // Check whether the bank was removed while the scan was in progress.
+        if scan_guard.was_scan_corrupted() {
+            return Err(ScanError::SlotRemoved {
+                slot: ancestors.max_slot(),
+                bank_id,
+            });
+        }
         let used_index = true;
         Ok(used_index)
     }
@@ -3843,7 +3891,7 @@ impl AccountsDb {
                             // retry_to_get_account_accessor() must outlive the Arc<Bank> (and its all
                             // ancestors) over this fn invocation, guaranteeing the prevention of being purged,
                             // first of all.
-                            // For details, see the comment in AccountIndex::do_checked_scan_accounts(),
+                            // For details, see the comment in ScanGuard::should_use_ancestors(),
                             // which is referring back here.
                             panic!("{message}");
                         });

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1357,18 +1357,15 @@ fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
     let mut found_accounts = HashSet::new();
     let index_key = IndexKey::SplTokenMint(mint_key);
     let bank_id = 0;
-    accounts
-        .accounts_index
-        .index_scan_accounts(
-            &Ancestors::default(),
-            bank_id,
-            index_key,
-            |key, _| {
-                found_accounts.insert(*key);
-            },
-            &ScanConfig::default(),
-        )
-        .unwrap();
+    accounts.accounts_index.index_scan_accounts(
+        &Ancestors::default(),
+        accounts.accounts_index.max_root_inclusive(),
+        index_key,
+        |key, _| {
+            found_accounts.insert(*key);
+        },
+        &ScanConfig::default(),
+    );
     assert_eq!(found_accounts.len(), 2);
     assert!(found_accounts.contains(&pubkey1));
     assert!(found_accounts.contains(&pubkey2));
@@ -1435,16 +1432,13 @@ fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
 
     // Secondary index should have purged `pubkey1` as well
     let mut found_accounts = vec![];
-    accounts
-        .accounts_index
-        .index_scan_accounts(
-            &Ancestors::default(),
-            bank_id,
-            IndexKey::SplTokenMint(mint_key),
-            |key, _| found_accounts.push(*key),
-            &ScanConfig::default(),
-        )
-        .unwrap();
+    accounts.accounts_index.index_scan_accounts(
+        &Ancestors::default(),
+        accounts.accounts_index.max_root_inclusive(),
+        IndexKey::SplTokenMint(mint_key),
+        |key, _| found_accounts.push(*key),
+        &ScanConfig::default(),
+    );
     assert_eq!(found_accounts, vec![pubkey2]);
 }
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1357,15 +1357,17 @@ fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
     let mut found_accounts = HashSet::new();
     let index_key = IndexKey::SplTokenMint(mint_key);
     let bank_id = 0;
-    accounts.accounts_index.index_scan_accounts(
-        &Ancestors::default(),
-        accounts.accounts_index.max_root_inclusive(),
-        index_key,
-        |key, _| {
-            found_accounts.insert(*key);
-        },
-        &ScanConfig::default(),
-    );
+    accounts
+        .index_scan_accounts(
+            &Ancestors::default(),
+            bank_id,
+            index_key,
+            |account| {
+                found_accounts.insert(*account.unwrap().0);
+            },
+            &ScanConfig::default(),
+        )
+        .unwrap();
     assert_eq!(found_accounts.len(), 2);
     assert!(found_accounts.contains(&pubkey1));
     assert!(found_accounts.contains(&pubkey2));
@@ -1432,13 +1434,17 @@ fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
 
     // Secondary index should have purged `pubkey1` as well
     let mut found_accounts = vec![];
-    accounts.accounts_index.index_scan_accounts(
-        &Ancestors::default(),
-        accounts.accounts_index.max_root_inclusive(),
-        IndexKey::SplTokenMint(mint_key),
-        |key, _| found_accounts.push(*key),
-        &ScanConfig::default(),
-    );
+    accounts
+        .index_scan_accounts(
+            &Ancestors::default(),
+            bank_id,
+            IndexKey::SplTokenMint(mint_key),
+            |account| {
+                found_accounts.push(*account.unwrap().0);
+            },
+            &ScanConfig::default(),
+        )
+        .unwrap();
     assert_eq!(found_accounts, vec![pubkey2]);
 }
 

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -8,7 +8,7 @@ mod secondary;
 mod stats;
 use {
     crate::{
-        accounts_scan::{ScanConfig, ScanError, ScanGuard, ScanTracker},
+        accounts_scan::{ScanConfig, ScanTracker},
         ancestors::Ancestors,
         contains::Contains,
         is_zero_lamport::IsZeroLamport,
@@ -29,7 +29,7 @@ use {
     secondary::{RwLockSecondaryIndexEntry, SecondaryIndex, SecondaryIndexEntry},
     smallvec::SmallVec,
     solana_account::ReadableAccount,
-    solana_clock::{BankId, Slot},
+    solana_clock::Slot,
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
     stats::Stats,
@@ -312,70 +312,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         &self,
         metric_name: &'static str,
         ancestors: &Ancestors,
-        scan_bank_id: BankId,
+        max_root: Slot,
         func: F,
         scan_type: ScanTypes,
         config: &ScanConfig,
-    ) -> Result<(), ScanError>
-    where
+    ) where
         F: FnMut(&Pubkey, (&T, Slot)),
     {
-        let ancestors_max_slot = ancestors.max_slot();
-        let scan_guard = ScanGuard::try_new(&self.scan_tracker, scan_bank_id, || {
-            self.max_root_inclusive()
-        })
-        .ok_or(ScanError::SlotRemoved {
-            slot: ancestors_max_slot,
-            bank_id: scan_bank_id,
-        })?;
-        let max_root = scan_guard.max_root();
-        let use_ancestors = scan_guard.should_use_ancestors(ancestors);
-        let empty_ancestors = Ancestors::default();
-        let ancestors = if use_ancestors {
-            ancestors
-        } else {
-            &empty_ancestors
-        };
-
-        /*
-        Now there are two cases, either `ancestors` is empty or nonempty
-        (see `ScanGuard::should_use_ancestors` for the proof and edge-case diagrams):
-
-        1) If ancestors is empty, then this is the same as a scan on a rooted bank,
-        and `ongoing_scan_roots` provides protection against cleanup of roots necessary
-        for the scan, and  passing `Some(max_root)` to `do_scan_accounts()` ensures newer
-        roots don't appear in the scan.
-
-        2) If ancestors is non-empty, then from `should_use_ancestors` we know
-        that the fork structure must look something like:
-
-        Diagram 2:
-
-                Build fork structure:
-                        slot 0
-                          |
-                    slot 1 (max_root)
-                    /            \
-             slot 2              |
-                |            slot 3 (potential newer max root)
-              slot 4
-                |
-             slot 5 (scan)
-
-        Consider both types of ancestors, ancestor <= `max_root` and
-        ancestor > `max_root`, where `max_root == 1` as illustrated above.
-
-        a) The set of `ancestors <= max_root` are all rooted, which means their state
-        is protected by the same guarantees as 1).
-
-        b) As for the `ancestors > max_root`, those banks have at least one reference discoverable
-        through the chain of `Bank::BankRc::parent` starting from the calling bank. For instance
-        bank 5's parent reference keeps bank 4 alive, which will prevent the `Bank::drop()` from
-        running and cleaning up bank 4. Furthermore, no cleans can happen past the saved max_root == 1,
-        so a potential newer max root at 3 will not clean up any of the ancestors > 1, so slot 4
-        will not be cleaned in the middle of the scan either. (NOTE similar reasoning is employed for
-        assert!() justification in AccountsDb::retry_to_get_account_accessor)
-        */
         match scan_type {
             ScanTypes::Unindexed => {
                 // Pass "" not to log metrics, so RPC doesn't get spammy
@@ -412,14 +355,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                 );
             }
         }
-
-        if scan_guard.was_scan_corrupted() {
-            return Err(ScanError::SlotRemoved {
-                slot: ancestors.max_slot(),
-                bank_id: scan_bank_id,
-            });
-        }
-        Ok(())
     }
 
     // Scan accounts and return latest version of each account that is either:
@@ -616,41 +551,32 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     pub(crate) fn scan_accounts<F>(
         &self,
         ancestors: &Ancestors,
-        scan_bank_id: BankId,
+        max_root: Slot,
         func: F,
         config: &ScanConfig,
-    ) -> Result<(), ScanError>
-    where
+    ) where
         F: FnMut(&Pubkey, (&T, Slot)),
     {
         // Pass "" not to log metrics, so RPC doesn't get spammy
-        self.do_checked_scan_accounts(
-            "",
-            ancestors,
-            scan_bank_id,
-            func,
-            ScanTypes::Unindexed,
-            config,
-        )
+        self.do_checked_scan_accounts("", ancestors, max_root, func, ScanTypes::Unindexed, config)
     }
 
     /// call func with every pubkey and index visible from a given set of ancestors
     pub(crate) fn index_scan_accounts<F>(
         &self,
         ancestors: &Ancestors,
-        scan_bank_id: BankId,
+        max_root: Slot,
         index_key: IndexKey,
         func: F,
         config: &ScanConfig,
-    ) -> Result<(), ScanError>
-    where
+    ) where
         F: FnMut(&Pubkey, (&T, Slot)),
     {
         // Pass "" not to log metrics, so RPC doesn't get spammy
         self.do_checked_scan_accounts(
             "",
             ancestors,
-            scan_bank_id,
+            max_root,
             func,
             ScanTypes::Indexed(index_key),
             config,
@@ -1571,14 +1497,12 @@ mod tests {
         assert!(!index.contains_with(key, None, None));
 
         let mut num = 0;
-        index
-            .scan_accounts(
-                &ancestors,
-                0,
-                |_pubkey, _index| num += 1,
-                &ScanConfig::default(),
-            )
-            .expect("scan should succeed");
+        index.scan_accounts(
+            &ancestors,
+            index.max_root_inclusive(),
+            |_pubkey, _index| num += 1,
+            &ScanConfig::default(),
+        );
         assert_eq!(num, 0);
     }
 
@@ -1651,14 +1575,12 @@ mod tests {
         assert!(!index.contains_with(&key, None, None));
 
         let mut num = 0;
-        index
-            .scan_accounts(
-                &ancestors,
-                0,
-                |_pubkey, _index| num += 1,
-                &ScanConfig::default(),
-            )
-            .expect("scan should succeed");
+        index.scan_accounts(
+            &ancestors,
+            index.max_root_inclusive(),
+            |_pubkey, _index| num += 1,
+            &ScanConfig::default(),
+        );
         assert_eq!(num, 0);
     }
 
@@ -1715,26 +1637,22 @@ mod tests {
         assert!(!index.contains_with(pubkey, None, None));
 
         let mut num = 0;
-        index
-            .scan_accounts(
-                &ancestors,
-                0,
-                |_pubkey, _index| num += 1,
-                &ScanConfig::default(),
-            )
-            .expect("scan should succeed");
+        index.scan_accounts(
+            &ancestors,
+            index.max_root_inclusive(),
+            |_pubkey, _index| num += 1,
+            &ScanConfig::default(),
+        );
         assert_eq!(num, 0);
         ancestors.insert(slot);
         assert!(index.contains_with(pubkey, Some(&ancestors), None));
         assert_eq!(index.ref_count_from_storage(pubkey), 1);
-        index
-            .scan_accounts(
-                &ancestors,
-                0,
-                |_pubkey, _index| num += 1,
-                &ScanConfig::default(),
-            )
-            .expect("scan should succeed");
+        index.scan_accounts(
+            &ancestors,
+            index.max_root_inclusive(),
+            |_pubkey, _index| num += 1,
+            &ScanConfig::default(),
+        );
         assert_eq!(num, 1);
 
         // not zero lamports
@@ -1752,26 +1670,22 @@ mod tests {
         assert!(!index.contains_with(pubkey, None, None));
 
         let mut num = 0;
-        index
-            .scan_accounts(
-                &ancestors,
-                0,
-                |_pubkey, _index| num += 1,
-                &ScanConfig::default(),
-            )
-            .expect("scan should succeed");
+        index.scan_accounts(
+            &ancestors,
+            index.max_root_inclusive(),
+            |_pubkey, _index| num += 1,
+            &ScanConfig::default(),
+        );
         assert_eq!(num, 0);
         ancestors.insert(slot);
         assert!(index.contains_with(pubkey, Some(&ancestors), None));
         assert_eq!(index.ref_count_from_storage(pubkey), 1);
-        index
-            .scan_accounts(
-                &ancestors,
-                0,
-                |_pubkey, _index| num += 1,
-                &ScanConfig::default(),
-            )
-            .expect("scan should succeed");
+        index.scan_accounts(
+            &ancestors,
+            index.max_root_inclusive(),
+            |_pubkey, _index| num += 1,
+            &ScanConfig::default(),
+        );
         assert_eq!(num, 1);
     }
 
@@ -2171,25 +2085,21 @@ mod tests {
         });
 
         let mut num = 0;
-        index
-            .scan_accounts(
-                &ancestors,
-                0,
-                |_pubkey, _index| num += 1,
-                &ScanConfig::default(),
-            )
-            .expect("scan should succeed");
+        index.scan_accounts(
+            &ancestors,
+            index.max_root_inclusive(),
+            |_pubkey, _index| num += 1,
+            &ScanConfig::default(),
+        );
         assert_eq!(num, 0);
         ancestors.insert(slot);
         assert!(index.contains_with(&key, Some(&ancestors), None));
-        index
-            .scan_accounts(
-                &ancestors,
-                0,
-                |_pubkey, _index| num += 1,
-                &ScanConfig::default(),
-            )
-            .expect("scan should succeed");
+        index.scan_accounts(
+            &ancestors,
+            index.max_root_inclusive(),
+            |_pubkey, _index| num += 1,
+            &ScanConfig::default(),
+        );
         assert_eq!(num, 1);
     }
 
@@ -2214,14 +2124,12 @@ mod tests {
         assert!(!index.contains_with(&key, Some(&ancestors), None));
 
         let mut num = 0;
-        index
-            .scan_accounts(
-                &ancestors,
-                0,
-                |_pubkey, _index| num += 1,
-                &ScanConfig::default(),
-            )
-            .expect("scan should succeed");
+        index.scan_accounts(
+            &ancestors,
+            index.max_root_inclusive(),
+            |_pubkey, _index| num += 1,
+            &ScanConfig::default(),
+        );
         assert_eq!(num, 0);
     }
     #[test]
@@ -2352,19 +2260,17 @@ mod tests {
 
         let mut num = 0;
         let mut found_key = false;
-        index
-            .scan_accounts(
-                &ancestors,
-                0,
-                |pubkey, _index| {
-                    if pubkey == &key {
-                        found_key = true
-                    };
-                    num += 1
-                },
-                &ScanConfig::default(),
-            )
-            .expect("scan should succeed");
+        index.scan_accounts(
+            &ancestors,
+            index.max_root_inclusive(),
+            |pubkey, _index| {
+                if pubkey == &key {
+                    found_key = true
+                };
+                num += 1
+            },
+            &ScanConfig::default(),
+        );
 
         assert_eq!(num, 1);
         assert!(found_key);
@@ -2414,16 +2320,14 @@ mod tests {
         let (index, _) = setup_accounts_index_keys(num_pubkeys);
 
         let mut scanned_keys = HashSet::new();
-        index
-            .scan_accounts(
-                &Ancestors::default(),
-                0,
-                |pubkey, _index| {
-                    scanned_keys.insert(*pubkey);
-                },
-                &ScanConfig::default(),
-            )
-            .expect("scan should succeed");
+        index.scan_accounts(
+            &Ancestors::default(),
+            index.max_root_inclusive(),
+            |pubkey, _index| {
+                scanned_keys.insert(*pubkey);
+            },
+            &ScanConfig::default(),
+        );
         assert_eq!(scanned_keys.len(), num_pubkeys);
     }
 
@@ -2675,20 +2579,18 @@ mod tests {
 
         let mut num = 0;
         let mut found_key = false;
-        index
-            .scan_accounts(
-                &Ancestors::default(),
-                0,
-                |pubkey, index| {
-                    if pubkey == &key {
-                        found_key = true;
-                        assert_eq!(index, (&true, 3));
-                    };
-                    num += 1
-                },
-                &ScanConfig::default(),
-            )
-            .expect("scan should succeed");
+        index.scan_accounts(
+            &Ancestors::default(),
+            index.max_root_inclusive(),
+            |pubkey, index| {
+                if pubkey == &key {
+                    found_key = true;
+                    assert_eq!(index, (&true, 3));
+                };
+                num += 1
+            },
+            &ScanConfig::default(),
+        );
         assert_eq!(num, 1);
         assert!(found_key);
     }

--- a/accounts-db/src/accounts_scan.rs
+++ b/accounts-db/src/accounts_scan.rs
@@ -193,10 +193,43 @@ impl<'a> ScanGuard<'a> {
     /// when bank 4 was frozen, so we default to a scan on the latest roots by
     /// removing all `ancestors`.
     ///
-    /// When ancestors **is** used:
-    /// - Ancestors <= `max_root` are all rooted, protected by `ongoing_scan_roots`.
-    /// - Ancestors > `max_root` are kept alive by the `Bank::parent` reference
-    ///   chain, so they cannot be cleaned mid-scan.
+    /// After calling this, there are two cases:
+    ///
+    /// 1) **Ancestors is empty** (this method returned `false`): the scan behaves
+    ///    like a scan on a rooted bank. `ongoing_scan_roots` protects the roots
+    ///    needed by the scan, and passing `max_root` to the scan ensures newer
+    ///    roots don't appear in the results.
+    ///
+    /// 2) **Ancestors is non-empty** (this method returned `true`): the fork
+    ///    structure must look something like:
+    ///
+    /// ```text
+    ///            slot 0
+    ///              |
+    ///        slot 1 (max_root)
+    ///        /            \
+    ///   slot 2              |
+    ///      |            slot 3 (potential newer max root)
+    ///    slot 4
+    ///      |
+    ///   slot 5 (scan)
+    /// ```
+    ///
+    ///    Consider both types of ancestors, `ancestor <= max_root` and
+    ///    `ancestor > max_root`, where `max_root == 1` as illustrated above.
+    ///
+    ///    a) The set of `ancestors <= max_root` are all rooted, which means their
+    ///       state is protected by the same guarantees as case 1.
+    ///
+    ///    b) The `ancestors > max_root` have at least one reference discoverable
+    ///       through the chain of `Bank::BankRc::parent` starting from the calling
+    ///       bank. For instance bank 5's parent reference keeps bank 4 alive, which
+    ///       prevents `Bank::drop()` from running and cleaning up bank 4.
+    ///       Furthermore, no cleans can happen past the saved `max_root == 1`, so a
+    ///       potential newer max root at slot 3 will not clean up any of the
+    ///       ancestors > 1, and slot 4 will not be cleaned in the middle of the
+    ///       scan either. (NOTE: similar reasoning is employed for the `assert!()`
+    ///       justification in `AccountsDb::retry_to_get_account_accessor`.)
     pub(crate) fn should_use_ancestors(&self, ancestors: &Ancestors) -> bool {
         ancestors.contains_key(&self.max_root)
     }


### PR DESCRIPTION
#### Problem
Scan will need to look at the accounts_cache in the future when cached accounts are removed from the write cache. Move the scan guards out of the index in and into the database

#### Summary of Changes
- Move the scan guards out of the index and into the database. 

Fixes #
