### PR TITLE
ci: adding dependabot config + min 7 day npm package age 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,20 @@ updates:
       timezone: Etc/UTC
     open-pull-requests-limit: 6
 
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: weekly
+      time: "08:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+    groups:
+      docs-dependencies:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=10080


### PR DESCRIPTION
#### Problem

Adds Dependabot tracking for the docs JS dependencies, which were not being monitored before. Updates are grouped into a single weekly PR to avoid noise, with a 7-day cooldown, so freshly published packages don't get proposed immediately, so we can let them bake for supply chain issues. The same 7-day minimum is enforced locally via .npmrc so pnpm install also rejects packages that haven't aged out yet. Security updates bypass the cooldown and still come through immediately