### PR TITLE
bank: add proper VAT filtering to stakes cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9440,6 +9440,7 @@ dependencies = [
  "solana-account 4.1.0",
  "solana-account-info",
  "solana-accounts-db",
+ "solana-address 2.5.0",
  "solana-banks-client",
  "solana-banks-interface",
  "solana-banks-server",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8138,6 +8138,7 @@ dependencies = [
  "solana-account 4.1.0",
  "solana-account-info",
  "solana-accounts-db",
+ "solana-address 2.5.0",
  "solana-banks-client",
  "solana-banks-interface",
  "solana-banks-server",

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1506,7 +1506,7 @@ pub mod validate_chained_block_id {
 }
 
 pub mod validator_admission_ticket {
-    solana_pubkey::declare_id!("VATtb1DepUwdPh5bFVasdtkbeDNsftZSRzr2aKpKWJA");
+    solana_pubkey::declare_id!("VAT9huvhPjRN9cyrPytq9rwvEJ3J4ADtjdncgZRyANJ");
 }
 
 pub mod direct_account_pointers_in_program_input {

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -24,6 +24,7 @@ serde = { workspace = true }
 solana-account = { workspace = true }
 solana-account-info = { workspace = true }
 solana-accounts-db = { workspace = true }
+solana-address = { workspace = true }
 solana-banks-client = { workspace = true }
 solana-banks-interface = { workspace = true }
 solana-banks-server = { workspace = true }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -16,6 +16,7 @@ use {
     },
     solana_account_info::AccountInfo,
     solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING,
+    solana_address::Address,
     solana_banks_client::start_client,
     solana_banks_server::banks_server::start_local_server,
     solana_clock::{Clock, Epoch, Slot},
@@ -1218,6 +1219,15 @@ impl ProgramTestContext {
 
     pub fn genesis_config(&self) -> &GenesisConfig {
         &self.genesis_config
+    }
+
+    pub fn is_active(&self, feature: &Address) -> bool {
+        self.bank_forks
+            .read()
+            .unwrap()
+            .root_bank()
+            .feature_set
+            .is_active(feature)
     }
 
     /// Manually increment vote credits for the current epoch in the specified vote account to simulate validator voting activity

--- a/program-test/tests/setup.rs
+++ b/program-test/tests/setup.rs
@@ -3,6 +3,7 @@ use {
     solana_program_test::ProgramTestContext,
     solana_pubkey::Pubkey,
     solana_rent::Rent,
+    solana_runtime::genesis_utils::minimum_vote_account_balance_for_vat,
     solana_signer::Signer,
     solana_stake_interface::{
         instruction as stake_instruction,
@@ -12,7 +13,10 @@ use {
     solana_transaction::Transaction,
     solana_vote_program::{
         vote_instruction,
-        vote_state::{self, VoteInit, VoteStateV4},
+        vote_state::{
+            self, VoteAuthorize, VoteInit, VoteStateV4, VoterWithBLSArgs,
+            create_bls_pubkey_and_proof_of_possession,
+        },
     },
 };
 
@@ -54,15 +58,20 @@ pub async fn setup_vote(context: &mut ProgramTestContext) -> Pubkey {
         0,
         &system_program::id(),
     ));
-    let vote_lamports = Rent::default().minimum_balance(VoteStateV4::size_of());
+    let vote_lamports = if context.is_active(&agave_feature_set::validator_admission_ticket::id()) {
+        // Fund vote accounts above VAT admission threshold
+        minimum_vote_account_balance_for_vat(10)
+    } else {
+        Rent::default().minimum_balance(VoteStateV4::size_of())
+    };
+
     let vote_keypair = Keypair::new();
-    let user_keypair = Keypair::new();
     instructions.append(&mut vote_instruction::create_account_with_config(
         &context.payer.pubkey(),
         &vote_keypair.pubkey(),
         &VoteInit {
             node_pubkey: validator_keypair.pubkey(),
-            authorized_voter: user_keypair.pubkey(),
+            authorized_voter: vote_keypair.pubkey(),
             ..VoteInit::default()
         },
         vote_lamports,
@@ -83,6 +92,30 @@ pub async fn setup_vote(context: &mut ProgramTestContext) -> Pubkey {
         .process_transaction(transaction)
         .await
         .unwrap();
+
+    if context.is_active(&agave_feature_set::bls_pubkey_management_in_vote_account::id()) {
+        let (bls_pubkey, bls_proof_of_possession) =
+            create_bls_pubkey_and_proof_of_possession(&vote_keypair.pubkey());
+        let bls_transaction = Transaction::new_signed_with_payer(
+            &[vote_instruction::authorize(
+                &vote_keypair.pubkey(),
+                &vote_keypair.pubkey(),
+                &vote_keypair.pubkey(),
+                VoteAuthorize::VoterWithBLS(VoterWithBLSArgs {
+                    bls_pubkey,
+                    bls_proof_of_possession,
+                }),
+            )],
+            Some(&context.payer.pubkey()),
+            &vec![&context.payer, &vote_keypair],
+            context.last_blockhash,
+        );
+        context
+            .banks_client
+            .process_transaction(bls_transaction)
+            .await
+            .unwrap();
+    }
 
     vote_keypair.pubkey()
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7771,6 +7771,7 @@ dependencies = [
  "solana-account 4.1.0",
  "solana-account-info",
  "solana-accounts-db",
+ "solana-address 2.5.0",
  "solana-banks-client",
  "solana-banks-interface",
  "solana-banks-server",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1689,8 +1689,12 @@ impl Bank {
                 &stake_delegations
             ));
 
-        // Apply stake rewards and commission using new snapshots.
-        let cached_vote_accounts = self.get_cached_vote_accounts(rewarded_epoch, &vote_accounts);
+        // Apply stake rewards and commission using the distribution vote-account
+        // snapshot that matches VAT admission filtering when enabled.
+        let distribution_epoch_vote_accounts =
+            self.maybe_filter_vote_accounts_for_vat(&vote_accounts);
+        let cached_vote_accounts =
+            self.get_cached_vote_accounts(rewarded_epoch, &distribution_epoch_vote_accounts);
         let (rewards_calculation, update_rewards_with_thread_pool_time_us) =
             measure_us!(self.calculate_rewards(
                 &stake_history,
@@ -6072,6 +6076,28 @@ impl Bank {
     /// Return total transaction fee collected
     pub fn get_collector_fee_details(&self) -> CollectorFeeDetails {
         self.collector_fee_details.read().unwrap().clone()
+    }
+
+    fn maybe_filter_vote_accounts_for_vat(&self, vote_accounts: &VoteAccounts) -> VoteAccounts {
+        if self.feature_set.snapshot().validator_admission_ticket {
+            let vote_account_rent_exempt_minimum = self
+                .rent_collector
+                .rent
+                .minimum_balance(VoteStateV4::size_of());
+            let minimum_vote_account_balance = if self.feature_set.snapshot().alpenglow {
+                // When alpenglow is active the minimum required balance is
+                // VAT + rent-exempt minimum for vote account.
+                vote_account_rent_exempt_minimum + VAT_TO_BURN_PER_EPOCH
+            } else {
+                // If alpenglow is not active, the minimum required balance is
+                // rent-exempt minimum.
+                vote_account_rent_exempt_minimum
+            };
+            vote_accounts
+                .clone_and_filter_for_vat(MAX_ALPENGLOW_VOTE_ACCOUNTS, minimum_vote_account_balance)
+        } else {
+            vote_accounts.clone()
+        }
     }
 
     /// If the VAT feature is active, returns the `Stakes` as filtered by SIMD-0357

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -234,9 +234,11 @@ impl Bank {
 
         let (num_stake_accounts, num_vote_accounts) = {
             let stakes = self.stakes_cache.stakes();
+            let filtered_vote_accounts =
+                self.maybe_filter_vote_accounts_for_vat(stakes.vote_accounts());
             (
                 stakes.stake_delegations().len(),
-                stakes.vote_accounts().len(),
+                filtered_vote_accounts.len(),
             )
         };
         self.capitalization
@@ -398,8 +400,9 @@ impl Bank {
         let stake_delegations = stakes.stake_delegations_vec();
         let stake_delegations = self.filter_stake_delegations(stake_delegations);
 
-        // Vote account state from the end of the rewarded epoch / beginning of the
-        // distribution epoch.
+        // Use the vote-account snapshot from epoch_stakes, which is VAT-filtered
+        // when admission filtering is enabled. Recalculation should match the
+        // vote-account admission policy used for distribution.
         let leader_schedule_epoch = self.epoch_schedule().get_leader_schedule_epoch(self.slot());
         let distribution_epoch_vote_accounts = self
             .epoch_stakes(leader_schedule_epoch)
@@ -1900,6 +1903,105 @@ mod tests {
         assert_eq!(
             calculation_status.all_stake_rewards.num_rewards(),
             expected_num_stake_rewards
+        );
+        let _ = &bank_forks; // Keep in scope so parent banks retain fork_graph
+    }
+
+    #[test]
+    fn test_initialize_after_snapshot_restore_preserves_vat_filtered_rewards() {
+        let num_validators = crate::bank::MAX_ALPENGLOW_VOTE_ACCOUNTS + 1;
+        let num_rewards_per_block = 64;
+        // Use unique stakes so VAT filtering deterministically excludes exactly
+        // the lowest-staked validator instead of dropping an entire tie group.
+        let stakes = (0..num_validators)
+            .map(|index| 2_000_000_000 + (num_validators - index) as u64)
+            .collect::<Vec<_>>();
+        let (
+            RewardBank {
+                bank,
+                voters,
+                stakers,
+            },
+            bank_forks,
+        ) = create_reward_bank_with_specific_stakes(
+            stakes,
+            num_rewards_per_block,
+            SLOTS_PER_EPOCH - 1,
+        );
+
+        let filtered_vote_pubkey = *voters.last().unwrap();
+        let filtered_stake_pubkey = *stakers.last().unwrap();
+
+        // Advance to the epoch boundary, which computes the original in-memory
+        // reward list and updates EpochStakes for the new epoch.
+        let new_slot = bank.slot() + 1;
+        let mut bank = Bank::new_from_parent(bank, SlotLeader::default(), new_slot);
+
+        let leader_schedule_epoch = bank.epoch_schedule().get_leader_schedule_epoch(bank.slot());
+        let filtered_epoch_vote_accounts = bank
+            .epoch_stakes(leader_schedule_epoch)
+            .unwrap()
+            .stakes()
+            .vote_accounts();
+        assert_eq!(
+            bank.stakes_cache.stakes().vote_accounts().len(),
+            num_validators
+        );
+        assert_eq!(
+            filtered_epoch_vote_accounts.len(),
+            crate::bank::MAX_ALPENGLOW_VOTE_ACCOUNTS
+        );
+        assert!(
+            filtered_epoch_vote_accounts
+                .get(&filtered_vote_pubkey)
+                .is_none()
+        );
+
+        let EpochRewardStatus::Active(EpochRewardPhase::Calculation(calculation_status)) =
+            bank.epoch_reward_status.clone()
+        else {
+            panic!("{:?} not active calculation", bank.epoch_reward_status);
+        };
+        assert_eq!(
+            calculation_status.all_stake_rewards.num_rewards(),
+            crate::bank::MAX_ALPENGLOW_VOTE_ACCOUNTS
+        );
+        assert!(
+            calculation_status
+                .all_stake_rewards
+                .enumerated_rewards_iter()
+                .all(|(_, reward)| reward.stake_pubkey != filtered_stake_pubkey)
+        );
+
+        // Simulate snapshot restore: re-apply features from accounts and
+        // rebuild epoch_reward_status from snapshot-stable state.
+        bank.feature_set = Arc::new(FeatureSet::default());
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+        bank.initialize_after_snapshot_restore(|| &thread_pool);
+
+        let EpochRewardStatus::Active(EpochRewardPhase::Distribution(distribution_status)) =
+            bank.epoch_reward_status.clone()
+        else {
+            panic!("{:?} not active distribution", bank.epoch_reward_status);
+        };
+        assert_eq!(
+            distribution_status.all_stake_rewards.num_rewards(),
+            crate::bank::MAX_ALPENGLOW_VOTE_ACCOUNTS
+        );
+        assert!(
+            distribution_status
+                .all_stake_rewards
+                .enumerated_rewards_iter()
+                .all(|(_, reward)| reward.stake_pubkey != filtered_stake_pubkey)
+        );
+
+        assert_eq!(
+            calculation_status.distribution_starting_block_height,
+            distribution_status.distribution_starting_block_height
+        );
+        assert_eq!(
+            calculation_status.all_stake_rewards,
+            distribution_status.all_stake_rewards
         );
         let _ = &bank_forks; // Keep in scope so parent banks retain fork_graph
     }


### PR DESCRIPTION
Reintroduces https://github.com/anza-xyz/agave/pull/11529 w/ a rekey of the feature gate to `VAT9huvhPjRN9cyrPytq9rwvEJ3J4ADtjdncgZRyANJ`

#### Problem

Audit has revealed a  bug in the VAT interaction with the stakes cache

> In [#10576](https://github.com/anza-xyz/agave/pull/10576), there is a correctness issue if a validator is starting from a snapshot where epoch rewards period is active, which can cause the rewards for no longer part of the top-2000 validator set validators to be excluded on the snapshot-booting validator. During a normal validator run validator set is [non-filtered](https://github.com/anza-xyz/agave/blob/5517ccc7703de128529d249ff6a05b4beeccb4ba/runtime/src/bank.rs#L1690) whereas when booting from a snapshot uses [epoch_stakes](https://github.com/anza-xyz/agave/blob/5816bd0a5cca4e097881306aede3ead2c2134bde/runtime/src/bank/partitioned_epoch_rewards/calculation.rs#L415-L419), which is a filtered set of validators. This will cause a mismatch during [redeem_delegation_rewards](https://github.com/anza-xyz/agave/blob/5816bd0a5cca4e097881306aede3ead2c2134bde/runtime/src/bank/partitioned_epoch_rewards/calculation.rs#L460-L463)

#### Summary of Changes
Apply the VAT filtering on the  stakes cache during distribution and after snapshot restore when caching the vote accounts

Note: This is crucial if we want to activate VAT in v4.0 pre alpenglow, so suggesting we backport