### PR TITLE
Add pre/post account sizes to the TransactionStatusMeta

### DIFF
--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -816,6 +816,8 @@ mod test {
             }),
             compute_units_consumed: Some(1234u64),
             cost_units: Some(5678),
+            pre_acc_sizes: None,
+            post_acc_sizes: None,
         };
 
         let output = {
@@ -897,6 +899,8 @@ Rewards:
             }),
             compute_units_consumed: Some(2345u64),
             cost_units: Some(5678),
+            pre_acc_sizes: None,
+            post_acc_sizes: None,
         };
 
         let output = {

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -4,7 +4,7 @@ use {
     solana_cost_model::cost_model::CostModel,
     solana_ledger::{
         blockstore_processor::TransactionStatusSender,
-        transaction_balances::compile_collected_balances,
+        transaction_balances::compile_collected_tx_status_meta,
     },
     solana_measure::measure_us,
     solana_runtime::{
@@ -16,9 +16,9 @@ use {
     },
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_svm::{
-        transaction_balances::BalanceCollector,
         transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
         transaction_processing_result::TransactionProcessingResult,
+        transaction_status_meta_collector::TxStatusMetaCollector,
     },
     solana_transaction_error::TransactionError,
     std::{num::Saturating, sync::Arc},
@@ -65,7 +65,7 @@ impl Committer {
         processing_results: Vec<TransactionProcessingResult>,
         starting_transaction_index: Option<usize>,
         bank: &Bank,
-        balance_collector: Option<BalanceCollector>,
+        tx_status_meta_collector: Option<TxStatusMetaCollector>,
         execute_and_commit_timings: &mut LeaderExecuteAndCommitTimings,
         processed_counts: &ProcessedTransactionCounts,
     ) -> (u64, Vec<CommitTransactionDetails>) {
@@ -115,7 +115,7 @@ impl Committer {
                 commit_results,
                 bank,
                 batch,
-                balance_collector,
+                tx_status_meta_collector,
                 starting_transaction_index,
             );
         });
@@ -128,7 +128,7 @@ impl Committer {
         commit_results: Vec<TransactionCommitResult>,
         bank: &Bank,
         batch: &TransactionBatch<impl TransactionWithMeta>,
-        balance_collector: Option<BalanceCollector>,
+        tx_status_meta_collector: Option<TxStatusMetaCollector>,
         starting_transaction_index: Option<usize>,
     ) {
         if let Some(transaction_status_sender) = &self.transaction_status_sender {
@@ -166,17 +166,17 @@ impl Committer {
                 })
                 .unzip();
 
-            // There are two cases where balance_collector could be None:
+            // There are two cases where tx_status_meta_collector could be None:
             // * Balance recording is disabled. If that were the case, there would
             //   be no TransactionStatusSender, and we would not be in this branch.
             // * The batch was aborted in its entirety in SVM. In that case, there
             //   would be zero processed transactions, and commit_transactions()
             //   would not have been called at all.
             // Therefore this should always be true.
-            debug_assert!(balance_collector.is_some());
+            debug_assert!(tx_status_meta_collector.is_some());
 
-            let (balances, token_balances) =
-                compile_collected_balances(balance_collector.unwrap_or_default());
+            let (balances, account_sizes, token_balances) =
+                compile_collected_tx_status_meta(tx_status_meta_collector.unwrap_or_default());
 
             transaction_status_sender.send_transaction_status_batch(
                 bank.slot(),
@@ -184,6 +184,7 @@ impl Committer {
                 commit_results,
                 balances,
                 token_balances,
+                account_sizes,
                 tx_costs,
                 batch_transaction_indexes,
             );

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -340,7 +340,7 @@ impl Consumer {
         let LoadAndExecuteTransactionsOutput {
             processing_results,
             processed_counts,
-            balance_collector,
+            tx_status_meta_collector,
         } = load_and_execute_transactions_output;
 
         let actual_execute_time = execute_and_commit_timings
@@ -434,7 +434,7 @@ impl Consumer {
                     processing_results,
                     starting_transaction_index,
                     bank,
-                    balance_collector,
+                    tx_status_meta_collector,
                     &mut execute_and_commit_timings,
                     &processed_counts,
                 )

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -8586,6 +8586,8 @@ pub mod tests {
                     return_data: Some(TransactionReturnData::default()),
                     compute_units_consumed,
                     cost_units,
+                    pre_acc_sizes: None,
+                    post_acc_sizes: None,
                 }
                 .into();
                 blockstore
@@ -8606,6 +8608,8 @@ pub mod tests {
                     return_data: Some(TransactionReturnData::default()),
                     compute_units_consumed,
                     cost_units,
+                    pre_acc_sizes: None,
+                    post_acc_sizes: None,
                 }
                 .into();
                 blockstore
@@ -8626,6 +8630,8 @@ pub mod tests {
                     return_data: Some(TransactionReturnData::default()),
                     compute_units_consumed,
                     cost_units,
+                    pre_acc_sizes: None,
+                    post_acc_sizes: None,
                 }
                 .into();
                 blockstore
@@ -8648,6 +8654,8 @@ pub mod tests {
                         return_data: Some(TransactionReturnData::default()),
                         compute_units_consumed,
                         cost_units,
+                        pre_acc_sizes: None,
+                        post_acc_sizes: None,
                     },
                 }
             })
@@ -8800,6 +8808,8 @@ pub mod tests {
             return_data: Some(test_return_data.clone()),
             compute_units_consumed: compute_units_consumed_1,
             cost_units: cost_units_1,
+            pre_acc_sizes: None,
+            post_acc_sizes: None,
         }
         .into();
         assert!(
@@ -8823,6 +8833,8 @@ pub mod tests {
             return_data,
             compute_units_consumed,
             cost_units,
+            pre_acc_sizes,
+            post_acc_sizes,
         } = transaction_status_cf
             .get_protobuf((Signature::default(), 0))
             .unwrap()
@@ -8842,6 +8854,8 @@ pub mod tests {
         assert_eq!(return_data.unwrap(), test_return_data);
         assert_eq!(compute_units_consumed, compute_units_consumed_1);
         assert_eq!(cost_units, cost_units_1);
+        assert_eq!(pre_acc_sizes, None);
+        assert_eq!(post_acc_sizes, None);
 
         // insert value
         let status = TransactionStatusMeta {
@@ -8858,6 +8872,8 @@ pub mod tests {
             return_data: Some(test_return_data.clone()),
             compute_units_consumed: compute_units_consumed_2,
             cost_units: cost_units_2,
+            pre_acc_sizes: None,
+            post_acc_sizes: None,
         }
         .into();
         assert!(
@@ -8881,6 +8897,8 @@ pub mod tests {
             return_data,
             compute_units_consumed,
             cost_units,
+            pre_acc_sizes,
+            post_acc_sizes,
         } = transaction_status_cf
             .get_protobuf((Signature::from([2u8; 64]), 9))
             .unwrap()
@@ -8902,6 +8920,8 @@ pub mod tests {
         assert_eq!(return_data.unwrap(), test_return_data);
         assert_eq!(compute_units_consumed, compute_units_consumed_2);
         assert_eq!(cost_units, cost_units_2);
+        assert_eq!(pre_acc_sizes, None);
+        assert_eq!(post_acc_sizes, None);
     }
 
     #[test]
@@ -8926,6 +8946,8 @@ pub mod tests {
             return_data: Some(TransactionReturnData::default()),
             compute_units_consumed: Some(42u64),
             cost_units: Some(1234),
+            pre_acc_sizes: None,
+            post_acc_sizes: None,
         }
         .into();
 
@@ -9103,6 +9125,8 @@ pub mod tests {
             return_data: Some(TransactionReturnData::default()),
             compute_units_consumed: Some(42u64),
             cost_units: Some(1234),
+            pre_acc_sizes: None,
+            post_acc_sizes: None,
         }
         .into();
 
@@ -9234,6 +9258,8 @@ pub mod tests {
             return_data: Some(TransactionReturnData::default()),
             compute_units_consumed: Some(42u64),
             cost_units: Some(1234),
+            pre_acc_sizes: None,
+            post_acc_sizes: None,
         }
         .into();
 
@@ -9405,6 +9431,8 @@ pub mod tests {
                     return_data: return_data.clone(),
                     compute_units_consumed: Some(42),
                     cost_units: Some(1234),
+                    pre_acc_sizes: None,
+                    post_acc_sizes: None,
                 }
                 .into();
                 blockstore
@@ -9427,6 +9455,8 @@ pub mod tests {
                         return_data,
                         compute_units_consumed: Some(42),
                         cost_units: Some(1234),
+                        pre_acc_sizes: None,
+                        post_acc_sizes: None,
                     },
                 }
             })
@@ -9530,6 +9560,8 @@ pub mod tests {
                     return_data: return_data.clone(),
                     compute_units_consumed: Some(42u64),
                     cost_units: Some(1234),
+                    pre_acc_sizes: None,
+                    post_acc_sizes: None,
                 }
                 .into();
                 blockstore
@@ -9552,6 +9584,8 @@ pub mod tests {
                         return_data,
                         compute_units_consumed: Some(42u64),
                         cost_units: Some(1234),
+                        pre_acc_sizes: None,
+                        post_acc_sizes: None,
                     },
                 }
             })
@@ -10202,6 +10236,8 @@ pub mod tests {
                 return_data: Some(TransactionReturnData::default()),
                 compute_units_consumed: None,
                 cost_units: None,
+                pre_acc_sizes: None,
+                post_acc_sizes: None,
             }
             .into();
             transaction_status_cf
@@ -10904,6 +10940,8 @@ pub mod tests {
             }),
             compute_units_consumed: Some(23456),
             cost_units: Some(5678),
+            pre_acc_sizes: None,
+            post_acc_sizes: None,
         };
         let deprecated_status: StoredTransactionStatusMeta = status.clone().try_into().unwrap();
         let protobuf_status: generated::TransactionStatusMeta = status.into();

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -5,7 +5,7 @@ use {
         blockstore_meta::SlotMeta,
         entry_notifier_service::{EntryNotification, EntryNotifierSender},
         leader_schedule_cache::LeaderScheduleCache,
-        transaction_balances::compile_collected_balances,
+        transaction_balances::compile_collected_tx_status_meta,
         use_snapshot_archives_at_startup::UseSnapshotArchivesAtStartup,
     },
     ExecuteTimingType::{NumExecuteBatches, TotalBatchesLen},
@@ -61,7 +61,9 @@ use {
         versioned::VersionedTransaction,
     },
     solana_transaction_error::{TransactionError, TransactionResult as Result},
-    solana_transaction_status::token_balances::TransactionTokenBalancesSet,
+    solana_transaction_status::{
+        account_sizes::TransactionAccountSizesSet, token_balances::TransactionTokenBalancesSet,
+    },
     solana_vote::{vote_account::VoteAccountsHashMap, vote_parser::is_valid_vote_only_transaction},
     std::{
         borrow::Cow,
@@ -247,7 +249,7 @@ pub fn execute_batch<'a>(
         }
     };
 
-    let (commit_results, balance_collector) = batch
+    let (commit_results, tx_status_meta_collector) = batch
         .bank()
         .load_execute_and_commit_transactions_with_pre_commit_callback(
             batch,
@@ -304,16 +306,16 @@ pub fn execute_batch<'a>(
             .map(|tx| tx.as_sanitized_transaction().into_owned())
             .collect();
 
-        // There are two cases where balance_collector could be None:
+        // There are two cases where tx_status_meta_collector could be None:
         // * Balance recording is disabled. If that were the case, there would
         //   be no TransactionStatusSender, and we would not be in this branch.
         // * The batch was aborted in its entirety in SVM. In that case, nothing
         //   would have been committed.
         // Therefore this should always be true.
-        debug_assert!(balance_collector.is_some());
+        debug_assert!(tx_status_meta_collector.is_some());
 
-        let (balances, token_balances) =
-            compile_collected_balances(balance_collector.unwrap_or_default());
+        let (balances, account_sizes, token_balances) =
+            compile_collected_tx_status_meta(tx_status_meta_collector.unwrap_or_default());
 
         // The length of costs vector needs to be consistent with all other
         // vectors that are sent over (such as `transactions`). So, replace the
@@ -329,6 +331,7 @@ pub fn execute_batch<'a>(
             commit_results,
             balances,
             token_balances,
+            account_sizes,
             tx_costs,
             transaction_indexes.into_owned(),
         );
@@ -2613,6 +2616,7 @@ pub struct TransactionStatusBatch {
     pub commit_results: Vec<TransactionCommitResult>,
     pub balances: TransactionBalancesSet,
     pub token_balances: TransactionTokenBalancesSet,
+    pub account_sizes: TransactionAccountSizesSet,
     pub costs: Vec<Option<u64>>,
     pub transaction_indexes: Vec<usize>,
 }
@@ -2631,6 +2635,7 @@ impl TransactionStatusSender {
         commit_results: Vec<TransactionCommitResult>,
         balances: TransactionBalancesSet,
         token_balances: TransactionTokenBalancesSet,
+        account_sizes: TransactionAccountSizesSet,
         costs: Vec<Option<u64>>,
         transaction_indexes: Vec<usize>,
     ) {
@@ -2646,6 +2651,7 @@ impl TransactionStatusSender {
                 commit_results,
                 balances,
                 token_balances,
+                account_sizes,
                 costs,
                 transaction_indexes,
             },

--- a/ledger/src/transaction_balances.rs
+++ b/ledger/src/transaction_balances.rs
@@ -3,25 +3,32 @@ use {
         parse_account_data::SplTokenAdditionalDataV2, parse_token::token_amount_to_ui_amount_v3,
     },
     solana_runtime::bank::TransactionBalancesSet,
-    solana_svm::transaction_balances::{BalanceCollector, SvmTokenInfo},
+    solana_svm::transaction_status_meta_collector::{SvmTokenInfo, TxStatusMetaCollector},
     solana_transaction_status::{
-        TransactionTokenBalance, token_balances::TransactionTokenBalancesSet,
+        TransactionTokenBalance, account_sizes::TransactionAccountSizesSet,
+        token_balances::TransactionTokenBalancesSet,
     },
 };
 
-// decompose the contents of BalanceCollector into the two structs required by TransactionStatusSender
-pub fn compile_collected_balances(
-    balance_collector: BalanceCollector,
-) -> (TransactionBalancesSet, TransactionTokenBalancesSet) {
-    let (native_pre, native_post, token_pre, token_post) = balance_collector.into_vecs();
+// Decompose the SVM collector into status-writer transport structs.
+pub fn compile_collected_tx_status_meta(
+    tx_status_meta_collector: TxStatusMetaCollector,
+) -> (
+    TransactionBalancesSet,
+    TransactionAccountSizesSet,
+    TransactionTokenBalancesSet,
+) {
+    let (native_pre, native_post, acc_size_pre, acc_size_post, token_pre, token_post) =
+        tx_status_meta_collector.into_vecs();
 
     let native_balances = TransactionBalancesSet::new(native_pre, native_post);
+    let account_sizes = TransactionAccountSizesSet::new(acc_size_pre, acc_size_post);
     let token_balances = TransactionTokenBalancesSet::new(
         collected_token_infos_to_token_balances(token_pre),
         collected_token_infos_to_token_balances(token_post),
     );
 
-    (native_balances, token_balances)
+    (native_balances, account_sizes, token_balances)
 }
 
 fn collected_token_infos_to_token_balances(
@@ -131,23 +138,32 @@ mod tests {
             program_id: token_2022::id().to_string(),
         };
 
+        let acc_size_pre = vec![vec![10, 20, 30], vec![40, 50, 60]];
+        let acc_size_post = vec![vec![11, 21, 31], vec![41, 51, 61]];
         let expected_native = TransactionBalancesSet::new(native_pre.clone(), native_post.clone());
+        let expected_sizes =
+            TransactionAccountSizesSet::new(acc_size_pre.clone(), acc_size_post.clone());
         let expected_token = TransactionTokenBalancesSet::new(
             vec![vec![token_balance_before], vec![]],
             vec![vec![token_balance_after], vec![]],
         );
 
-        let balance_collector = BalanceCollector {
+        let tx_status_meta_collector = TxStatusMetaCollector {
             native_pre,
             native_post,
+            acc_size_pre,
+            acc_size_post,
             token_pre,
             token_post,
         };
 
-        let (actual_native, actual_token) = compile_collected_balances(balance_collector);
+        let (actual_native, actual_sizes, actual_token) =
+            compile_collected_tx_status_meta(tx_status_meta_collector);
 
         assert_eq!(expected_native.pre_balances, actual_native.pre_balances);
         assert_eq!(expected_native.post_balances, actual_native.post_balances);
+        assert_eq!(expected_sizes.pre_acc_sizes, actual_sizes.pre_acc_sizes);
+        assert_eq!(expected_sizes.post_acc_sizes, actual_sizes.post_acc_sizes);
 
         assert_eq!(
             expected_token.pre_token_balances,

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -238,6 +238,8 @@ impl RpcSender for MockSender {
                             fee: 0,
                             pre_balances: vec![499999999999999950, 50, 1],
                             post_balances: vec![499999999999999950, 50, 1],
+                            pre_acc_sizes: OptionSerializer::Skip,
+                            post_acc_sizes: OptionSerializer::Skip,
                             inner_instructions: OptionSerializer::None,
                             log_messages: OptionSerializer::None,
                             pre_token_balances: OptionSerializer::None,

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -2738,7 +2738,9 @@ pub(crate) mod tests {
         let bank2 = Bank::new_from_parent(bank0, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
 
-        let alice = Keypair::from_base58_string("sfLnS4rZ5a8gXke3aGxCgM6usFAVPxLUaBSRdssGY9uS5eoiEWQ41CqDcpXbcekpKsie8Lyy3LNFdhEvjUE1wd9");
+        let alice = Keypair::from_base58_string(
+            "sfLnS4rZ5a8gXke3aGxCgM6usFAVPxLUaBSRdssGY9uS5eoiEWQ41CqDcpXbcekpKsie8Lyy3LNFdhEvjUE1wd9",
+        );
 
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -135,6 +135,7 @@ impl TransactionStatusService {
                     transactions,
                     commit_results,
                     balances,
+                    account_sizes,
                     token_balances,
                     costs,
                     transaction_indexes,
@@ -154,6 +155,8 @@ impl TransactionStatusService {
                     post_balances,
                     pre_token_balances,
                     post_token_balances,
+                    pre_acc_sizes,
+                    post_acc_sizes,
                     cost,
                     transaction_index,
                 ) in izip!(
@@ -163,6 +166,8 @@ impl TransactionStatusService {
                     balances.post_balances,
                     token_balances.pre_token_balances,
                     token_balances.post_token_balances,
+                    account_sizes.pre_acc_sizes,
+                    account_sizes.post_acc_sizes,
                     costs,
                     transaction_indexes,
                 ) {
@@ -203,6 +208,8 @@ impl TransactionStatusService {
                         return_data,
                         compute_units_consumed: Some(executed_units),
                         cost_units: cost,
+                        pre_acc_sizes: Some(pre_acc_sizes),
+                        post_acc_sizes: Some(post_acc_sizes),
                     };
 
                     if let Some(transaction_notifier) = transaction_notifier.as_ref() {
@@ -376,7 +383,7 @@ pub(crate) mod tests {
         },
         solana_transaction_status::{
             TransactionStatusMeta, TransactionTokenBalance,
-            token_balances::TransactionTokenBalancesSet,
+            account_sizes::TransactionAccountSizesSet, token_balances::TransactionTokenBalancesSet,
         },
         std::sync::{Arc, atomic::AtomicBool},
     };
@@ -485,6 +492,10 @@ pub(crate) mod tests {
             pre_balances: vec![vec![123456]],
             post_balances: vec![vec![234567]],
         };
+        let account_sizes = TransactionAccountSizesSet {
+            pre_acc_sizes: vec![vec![32]],
+            post_acc_sizes: vec![vec![64]],
+        };
 
         let owner = Pubkey::new_unique().to_string();
         let token_program_id = Pubkey::new_unique().to_string();
@@ -523,6 +534,7 @@ pub(crate) mod tests {
             transactions: vec![transaction],
             commit_results: vec![commit_result],
             balances,
+            account_sizes,
             token_balances,
             costs: vec![Some(123)],
             transaction_indexes: vec![transaction_index],
@@ -616,6 +628,10 @@ pub(crate) mod tests {
             pre_balances: vec![vec![123456], vec![234567]],
             post_balances: vec![vec![234567], vec![345678]],
         };
+        let account_sizes = TransactionAccountSizesSet {
+            pre_acc_sizes: vec![vec![32], vec![128]],
+            post_acc_sizes: vec![vec![64], vec![256]],
+        };
 
         let token_balances = TransactionTokenBalancesSet {
             pre_token_balances: vec![vec![], vec![]],
@@ -631,6 +647,7 @@ pub(crate) mod tests {
             transactions: vec![transaction1, transaction2],
             commit_results: vec![commit_result.clone(), commit_result],
             balances: balances.clone(),
+            account_sizes,
             token_balances,
             costs: vec![Some(123), Some(456)],
             transaction_indexes: vec![transaction_index1, transaction_index2],

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -149,7 +149,6 @@ use {
         account_loader::LoadedTransaction,
         account_overrides::AccountOverrides,
         program_loader::load_program_with_pubkey,
-        transaction_balances::{BalanceCollector, SvmTokenInfo},
         transaction_commit_result::{CommittedTransaction, TransactionCommitResult},
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_execution_result::{
@@ -163,6 +162,7 @@ use {
             ExecutionRecordingConfig, TransactionBatchProcessor, TransactionLogMessages,
             TransactionProcessingConfig, TransactionProcessingEnvironment,
         },
+        transaction_status_meta_collector::{SvmTokenInfo, TxStatusMetaCollector},
     },
     solana_svm_callback::{AccountState, InvokeContextCallback, TransactionProcessingCallback},
     solana_svm_timings::{ExecuteTimingType, ExecuteTimings},
@@ -344,7 +344,7 @@ pub struct LoadAndExecuteTransactionsOutput {
     pub processed_counts: ProcessedTransactionCounts,
     // Balances accumulated for TransactionStatusSender when transaction
     // balance recording is enabled.
-    pub balance_collector: Option<BalanceCollector>,
+    pub tx_status_meta_collector: Option<TxStatusMetaCollector>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -397,6 +397,7 @@ impl TransactionBalancesSet {
         }
     }
 }
+
 pub type TransactionBalances = Vec<Vec<u64>>;
 
 pub type PreCommitResult<'a> = Result<Option<RwLockReadGuard<'a, Hash>>>;
@@ -3434,7 +3435,7 @@ impl Bank {
 
         let LoadAndExecuteTransactionsOutput {
             mut processing_results,
-            balance_collector,
+            tx_status_meta_collector,
             ..
         } = self.load_and_execute_transactions(
             &batch,
@@ -3516,21 +3517,35 @@ impl Bank {
         };
         let logs = logs.unwrap_or_default();
 
-        let (pre_balances, post_balances, pre_token_balances, post_token_balances) =
-            match balance_collector {
-                Some(balance_collector) => {
-                    let (mut native_pre, mut native_post, mut token_pre, mut token_post) =
-                        balance_collector.into_vecs();
+        let (
+            pre_balances,
+            post_balances,
+            _pre_acc_sizes,
+            _post_acc_sizes,
+            pre_token_balances,
+            post_token_balances,
+        ) = match tx_status_meta_collector {
+            Some(tx_status_meta_collector) => {
+                let (
+                    mut native_pre,
+                    mut native_post,
+                    mut acc_size_pre,
+                    mut acc_size_post,
+                    mut token_pre,
+                    mut token_post,
+                ) = tx_status_meta_collector.into_vecs();
 
-                    (
-                        native_pre.pop(),
-                        native_post.pop(),
-                        token_pre.pop(),
-                        token_post.pop(),
-                    )
-                }
-                None => (None, None, None, None),
-            };
+                (
+                    native_pre.pop(),
+                    native_post.pop(),
+                    acc_size_pre.pop(),
+                    acc_size_post.pop(),
+                    token_pre.pop(),
+                    token_post.pop(),
+                )
+            }
+            None => (None, None, None, None, None, None),
+        };
 
         TransactionSimulationResult {
             result,
@@ -3713,7 +3728,7 @@ impl Bank {
         LoadAndExecuteTransactionsOutput {
             processing_results: sanitized_output.processing_results,
             processed_counts,
-            balance_collector: sanitized_output.balance_collector,
+            tx_status_meta_collector: sanitized_output.tx_status_meta_collector,
         }
     }
 
@@ -4135,7 +4150,7 @@ impl Bank {
         recording_config: ExecutionRecordingConfig,
         timings: &mut ExecuteTimings,
         log_messages_bytes_limit: Option<usize>,
-    ) -> (Vec<TransactionCommitResult>, Option<BalanceCollector>) {
+    ) -> (Vec<TransactionCommitResult>, Option<TxStatusMetaCollector>) {
         self.do_load_execute_and_commit_transactions_with_pre_commit_callback(
             batch,
             recording_config,
@@ -4156,7 +4171,7 @@ impl Bank {
             &mut ExecuteTimings,
             &[TransactionProcessingResult],
         ) -> PreCommitResult<'a>,
-    ) -> Result<(Vec<TransactionCommitResult>, Option<BalanceCollector>)> {
+    ) -> Result<(Vec<TransactionCommitResult>, Option<TxStatusMetaCollector>)> {
         self.do_load_execute_and_commit_transactions_with_pre_commit_callback(
             batch,
             recording_config,
@@ -4175,11 +4190,11 @@ impl Bank {
         pre_commit_callback: Option<
             impl FnOnce(&mut ExecuteTimings, &[TransactionProcessingResult]) -> PreCommitResult<'a>,
         >,
-    ) -> Result<(Vec<TransactionCommitResult>, Option<BalanceCollector>)> {
+    ) -> Result<(Vec<TransactionCommitResult>, Option<TxStatusMetaCollector>)> {
         let LoadAndExecuteTransactionsOutput {
             processing_results,
             processed_counts,
-            balance_collector,
+            tx_status_meta_collector,
         } = self.load_and_execute_transactions(
             batch,
             self.max_processing_age(),
@@ -4212,7 +4227,7 @@ impl Bank {
             timings,
         );
         drop(freeze_lock);
-        Ok((commit_results, balance_collector))
+        Ok((commit_results, tx_status_meta_collector))
     }
 
     /// Process a Transaction. This is used for unit tests and simply calls the vector

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4677,7 +4677,8 @@ fn test_pre_post_transaction_balances() {
         None,
     );
 
-    let (native_pre, native_post, _, _) = balance_collector.unwrap().into_vecs();
+    let (native_pre, native_post, _acc_size_pre, _acc_size_post, _, _) =
+        balance_collector.unwrap().into_vecs();
     let transaction_balances_set = TransactionBalancesSet::new(native_pre, native_post);
 
     assert_eq!(transaction_balances_set.pre_balances.len(), 3);

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -1068,6 +1068,8 @@ mod tests {
                 return_data: Some(TransactionReturnData::default()),
                 compute_units_consumed: Some(1234),
                 cost_units: Some(5678),
+                pre_acc_sizes: None,
+                post_acc_sizes: None,
             },
         });
         let expected_block = ConfirmedBlock {

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -257,6 +257,8 @@ impl From<StoredConfirmedBlockTransactionStatusMeta> for TransactionStatusMeta {
             return_data: None,
             compute_units_consumed: None,
             cost_units: None,
+            pre_acc_sizes: None,
+            post_acc_sizes: None,
         }
     }
 }

--- a/storage-proto/proto/confirmed_block.proto
+++ b/storage-proto/proto/confirmed_block.proto
@@ -75,6 +75,12 @@ message TransactionStatusMeta {
     optional uint64 compute_units_consumed = 16;
     // Total transaction cost
     optional uint64 cost_units = 17;
+    // Per-account data sizes before transaction execution.
+    repeated uint64 pre_acc_sizes = 18;
+    // Per-account data sizes after transaction execution.
+    repeated uint64 post_acc_sizes = 19;
+    bool pre_acc_sizes_none = 20;
+    bool post_acc_sizes_none = 21;
 }
 
 message TransactionError {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -466,7 +466,21 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             return_data,
             compute_units_consumed,
             cost_units,
+            pre_acc_sizes,
+            post_acc_sizes,
         } = value;
+        let pre_acc_sizes_none = pre_acc_sizes.is_none();
+        let pre_acc_sizes = pre_acc_sizes
+            .unwrap_or_default()
+            .into_iter()
+            .map(|account_size| u64::try_from(account_size).expect("account data size fits in u64"))
+            .collect();
+        let post_acc_sizes_none = post_acc_sizes.is_none();
+        let post_acc_sizes = post_acc_sizes
+            .unwrap_or_default()
+            .into_iter()
+            .map(|account_size| u64::try_from(account_size).expect("account data size fits in u64"))
+            .collect();
         let err = match status {
             Ok(()) => None,
             Err(err) => Some(generated::TransactionError {
@@ -527,6 +541,10 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             return_data_none,
             compute_units_consumed,
             cost_units,
+            pre_acc_sizes,
+            pre_acc_sizes_none,
+            post_acc_sizes,
+            post_acc_sizes_none,
         }
     }
 }
@@ -560,6 +578,10 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             return_data_none,
             compute_units_consumed,
             cost_units,
+            pre_acc_sizes,
+            pre_acc_sizes_none,
+            post_acc_sizes,
+            post_acc_sizes_none,
         } = value;
         let status = match &err {
             None => Ok(()),
@@ -579,6 +601,30 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             None
         } else {
             Some(log_messages)
+        };
+        let pre_acc_sizes = if pre_acc_sizes_none {
+            None
+        } else {
+            Some(
+                pre_acc_sizes
+                    .into_iter()
+                    .map(|account_size| {
+                        usize::try_from(account_size).expect("account data size fits in usize")
+                    })
+                    .collect(),
+            )
+        };
+        let post_acc_sizes = if post_acc_sizes_none {
+            None
+        } else {
+            Some(
+                post_acc_sizes
+                    .into_iter()
+                    .map(|account_size| {
+                        usize::try_from(account_size).expect("account data size fits in usize")
+                    })
+                    .collect(),
+            )
         };
         let pre_token_balances = Some(
             pre_token_balances
@@ -630,6 +676,8 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             return_data,
             compute_units_consumed,
             cost_units,
+            pre_acc_sizes,
+            post_acc_sizes,
         })
     }
 }

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -203,6 +203,10 @@ pub struct StoredTransactionStatusMeta {
     pub compute_units_consumed: Option<u64>,
     #[serde(deserialize_with = "default_on_eof")]
     pub cost_units: Option<u64>,
+    #[serde(deserialize_with = "default_on_eof")]
+    pub pre_acc_sizes: Option<Vec<usize>>,
+    #[serde(deserialize_with = "default_on_eof")]
+    pub post_acc_sizes: Option<Vec<usize>>,
 }
 
 impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
@@ -220,6 +224,8 @@ impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
             return_data,
             compute_units_consumed,
             cost_units,
+            pre_acc_sizes,
+            post_acc_sizes,
         } = value;
         Self {
             status,
@@ -238,6 +244,8 @@ impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
             return_data,
             compute_units_consumed,
             cost_units,
+            pre_acc_sizes,
+            post_acc_sizes,
         }
     }
 }
@@ -259,6 +267,8 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
             return_data,
             compute_units_consumed,
             cost_units,
+            pre_acc_sizes,
+            post_acc_sizes,
         } = value;
 
         if !loaded_addresses.is_empty() {
@@ -285,6 +295,8 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
             return_data,
             compute_units_consumed,
             cost_units,
+            pre_acc_sizes,
+            post_acc_sizes,
         })
     }
 }

--- a/svm/src/lib.rs
+++ b/svm/src/lib.rs
@@ -10,13 +10,13 @@ pub mod program_loader;
 pub mod rent_calculator;
 pub mod rollback_accounts;
 pub mod transaction_account_state_info;
-pub mod transaction_balances;
 pub mod transaction_commit_result;
 pub mod transaction_error_metrics;
 pub mod transaction_execution_result;
 pub mod transaction_processing_callback;
 pub mod transaction_processing_result;
 pub mod transaction_processor;
+pub mod transaction_status_meta_collector;
 
 #[cfg_attr(feature = "frozen-abi", macro_use)]
 #[cfg(feature = "frozen-abi")]

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -13,12 +13,14 @@ use {
         transaction_account_state_info::{
             TransactionAccountStateInfo, get_uninitialized_accounts_size,
         },
-        transaction_balances::{BalanceCollectionRoutines, BalanceCollector},
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_execution_result::{
             AccountsDeltas, ExecutedTransaction, TransactionExecutionDetails,
         },
         transaction_processing_result::{ProcessedTransaction, TransactionProcessingResult},
+        transaction_status_meta_collector::{
+            TxStatusMetaCollectionRoutines, TxStatusMetaCollector,
+        },
     },
     log::debug,
     percentage::Percentage,
@@ -86,9 +88,9 @@ pub struct LoadAndExecuteSanitizedTransactionsOutput {
     /// could not be processed. Note processed transactions can still have a
     /// failure result meaning that the transaction will be rolled back.
     pub processing_results: Vec<TransactionProcessingResult>,
-    /// Balances accumulated for TransactionStatusSender when
-    /// transaction balance recording is enabled.
-    pub balance_collector: Option<BalanceCollector>,
+    /// Transaction status metadata accumulated for TransactionStatusSender
+    /// when transaction recording is enabled.
+    pub tx_status_meta_collector: Option<TxStatusMetaCollector>,
 }
 
 /// Configuration of the recording capabilities for transaction execution
@@ -421,11 +423,11 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             account_keys_in_batch,
         );
 
-        // Create the transaction balance collector if recording is enabled.
-        let mut balance_collector = config
+        // Create the transaction status metadata collector if recording is enabled.
+        let mut tx_status_meta_collector = config
             .recording_config
             .enable_transaction_balance_recording
-            .then(|| BalanceCollector::new_with_transaction_count(sanitized_txs.len()));
+            .then(|| TxStatusMetaCollector::new_with_transaction_count(sanitized_txs.len()));
 
         // Clone the batch-local program cache (builtins already populated in new_from()).
         // User-deployed programs are loaded per-transaction via replenish_program_cache
@@ -441,7 +443,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     .collect(),
                 // If we abort the batch and balance recording is enabled, no balances should be
                 // collected. If this is a leader thread, no batch will be committed.
-                balance_collector: None,
+                tx_status_meta_collector: None,
             };
         }
 
@@ -476,8 +478,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             ));
             load_us = load_us.saturating_add(single_load_us);
 
-            let ((), collect_balances_us) =
-                measure_us!(balance_collector.collect_pre_balances(&mut account_loader, tx));
+            let ((), collect_balances_us) = measure_us!(
+                tx_status_meta_collector.collect_pre_status_meta(&mut account_loader, tx)
+            );
             execute_timings
                 .saturating_add_in_place(ExecuteTimingType::CollectBalancesUs, collect_balances_us);
 
@@ -535,7 +538,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                                 .collect(),
                             // If we abort the batch and balance recording is enabled, no balances should be
                             // collected. If this is a leader thread, no batch will be committed.
-                            balance_collector: None,
+                            tx_status_meta_collector: None,
                         };
                     }
 
@@ -586,8 +589,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             });
             execution_us = execution_us.saturating_add(single_execution_us);
 
-            let ((), collect_balances_us) =
-                measure_us!(balance_collector.collect_post_balances(&mut account_loader, tx));
+            let ((), collect_balances_us) = measure_us!(
+                tx_status_meta_collector.collect_post_status_meta(&mut account_loader, tx)
+            );
             execute_timings
                 .saturating_add_in_place(ExecuteTimingType::CollectBalancesUs, collect_balances_us);
 
@@ -614,7 +618,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     processing_results,
                     // If we abort the batch and balance recording is enabled, no balances should be
                     // collected. If this is a leader thread, no batch will be committed.
-                    balance_collector: None,
+                    tx_status_meta_collector: None,
                 };
             }
 
@@ -645,15 +649,15 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         execute_timings.saturating_add_in_place(ExecuteTimingType::LoadUs, load_us);
         execute_timings.saturating_add_in_place(ExecuteTimingType::ExecuteUs, execution_us);
 
-        if let Some(ref balance_collector) = balance_collector {
-            debug_assert!(balance_collector.lengths_match_expected(sanitized_txs.len()));
+        if let Some(ref tx_status_meta_collector) = tx_status_meta_collector {
+            debug_assert!(tx_status_meta_collector.lengths_match_expected(sanitized_txs.len()));
         }
 
         LoadAndExecuteSanitizedTransactionsOutput {
             error_metrics,
             execute_timings,
             processing_results,
-            balance_collector,
+            tx_status_meta_collector,
         }
     }
 

--- a/svm/src/transaction_status_meta_collector.rs
+++ b/svm/src/transaction_status_meta_collector.rs
@@ -13,19 +13,22 @@ use {
 
 // we use internal aliases for clarity, the external type aliases are often confusing
 type TxNativeBalances = Vec<u64>;
+type TxAccountSizes = Vec<usize>;
 type TxTokenBalances = Vec<SvmTokenInfo>;
 type BatchNativeBalances = Vec<TxNativeBalances>;
+type BatchAccountSizes = Vec<TxAccountSizes>;
 type BatchTokenBalances = Vec<TxTokenBalances>;
 
-// to operate cleanly over Option<BalanceCollector> we use a trait impled on the outer and inner type
-pub(crate) trait BalanceCollectionRoutines {
-    fn collect_pre_balances<CB: TransactionProcessingCallback>(
+// to operate cleanly over Option<TxStatusMetaCollector> we use a trait impled on the
+// outer and inner type
+pub(crate) trait TxStatusMetaCollectionRoutines {
+    fn collect_pre_status_meta<CB: TransactionProcessingCallback>(
         &mut self,
         account_loader: &mut AccountLoader<CB>,
         transaction: &impl SVMTransaction,
     );
 
-    fn collect_post_balances<CB: TransactionProcessingCallback>(
+    fn collect_post_status_meta<CB: TransactionProcessingCallback>(
         &mut self,
         account_loader: &mut AccountLoader<CB>,
         transaction: &impl SVMTransaction,
@@ -35,52 +38,68 @@ pub(crate) trait BalanceCollectionRoutines {
 #[derive(Debug, Default)]
 #[cfg_attr(
     feature = "dev-context-only-utils",
-    field_qualifiers(native_pre(pub), native_post(pub), token_pre(pub), token_post(pub),)
+    field_qualifiers(
+        native_pre(pub),
+        native_post(pub),
+        token_pre(pub),
+        token_post(pub),
+        acc_size_pre(pub),
+        acc_size_post(pub),
+    )
 )]
-pub struct BalanceCollector {
+pub struct TxStatusMetaCollector {
     native_pre: BatchNativeBalances,
     native_post: BatchNativeBalances,
     token_pre: BatchTokenBalances,
     token_post: BatchTokenBalances,
+    acc_size_pre: BatchAccountSizes,
+    acc_size_post: BatchAccountSizes,
 }
 
-impl BalanceCollector {
+impl TxStatusMetaCollector {
     // we always provide one vec for every transaction, even if the vecs are empty
     pub(crate) fn new_with_transaction_count(transaction_count: usize) -> Self {
         Self {
             native_pre: Vec::with_capacity(transaction_count),
             native_post: Vec::with_capacity(transaction_count),
+            acc_size_pre: Vec::with_capacity(transaction_count),
+            acc_size_post: Vec::with_capacity(transaction_count),
             token_pre: Vec::with_capacity(transaction_count),
             token_post: Vec::with_capacity(transaction_count),
         }
     }
 
-    // we use this pattern to prevent anything outside svm mutating BalanceCollector internals
+    // we use this pattern to prevent anything outside svm mutating collector internals
     // with no public constructor, and only private fields, non-svm code can only disassemble the struct
     pub fn into_vecs(
         self,
     ) -> (
         BatchNativeBalances,
         BatchNativeBalances,
+        BatchAccountSizes,
+        BatchAccountSizes,
         BatchTokenBalances,
         BatchTokenBalances,
     ) {
         (
             self.native_pre,
             self.native_post,
+            self.acc_size_pre,
+            self.acc_size_post,
             self.token_pre,
             self.token_post,
         )
     }
 
-    // gather native lamport balances for all accounts
-    // and token balances for valid, initialized token accounts with valid, initialized mints
-    fn collect_balances<CB: TransactionProcessingCallback>(
+    // Gather per-account metadata needed for transaction status: lamports, data sizes, and token
+    // balance info for valid token accounts when the transaction touches a token program.
+    fn collect_transaction_status_meta<CB: TransactionProcessingCallback>(
         &mut self,
         account_loader: &mut AccountLoader<CB>,
         transaction: &impl SVMTransaction,
-    ) -> (TxNativeBalances, TxTokenBalances) {
+    ) -> (TxNativeBalances, TxAccountSizes, TxTokenBalances) {
         let mut native_balances = Vec::with_capacity(transaction.account_keys().len());
+        let mut account_sizes = Vec::with_capacity(transaction.account_keys().len());
         let mut token_balances = vec![];
 
         let has_token_program = transaction.account_keys().iter().any(is_known_spl_token_id);
@@ -88,10 +107,12 @@ impl BalanceCollector {
         for (index, key) in transaction.account_keys().iter().enumerate() {
             let Some(account) = account_loader.load_account(key) else {
                 native_balances.push(0);
+                account_sizes.push(0);
                 continue;
             };
 
             native_balances.push(account.lamports());
+            account_sizes.push(account.data().len());
 
             if has_token_program
                 && !transaction.is_invoked(index)
@@ -104,57 +125,63 @@ impl BalanceCollector {
             }
         }
 
-        (native_balances, token_balances)
+        (native_balances, account_sizes, token_balances)
     }
 
     pub(crate) fn lengths_match_expected(&self, expected_len: usize) -> bool {
         self.native_pre.len() == expected_len
             && self.native_post.len() == expected_len
+            && self.acc_size_pre.len() == expected_len
+            && self.acc_size_post.len() == expected_len
             && self.token_pre.len() == expected_len
             && self.token_post.len() == expected_len
     }
 }
 
-impl BalanceCollectionRoutines for BalanceCollector {
-    fn collect_pre_balances<CB: TransactionProcessingCallback>(
+impl TxStatusMetaCollectionRoutines for TxStatusMetaCollector {
+    fn collect_pre_status_meta<CB: TransactionProcessingCallback>(
         &mut self,
         account_loader: &mut AccountLoader<CB>,
         transaction: &impl SVMTransaction,
     ) {
-        let (native_balances, token_balances) = self.collect_balances(account_loader, transaction);
+        let (native_balances, account_sizes, token_balances) =
+            self.collect_transaction_status_meta(account_loader, transaction);
         self.native_pre.push(native_balances);
+        self.acc_size_pre.push(account_sizes);
         self.token_pre.push(token_balances);
     }
 
-    fn collect_post_balances<CB: TransactionProcessingCallback>(
+    fn collect_post_status_meta<CB: TransactionProcessingCallback>(
         &mut self,
         account_loader: &mut AccountLoader<CB>,
         transaction: &impl SVMTransaction,
     ) {
-        let (native_balances, token_balances) = self.collect_balances(account_loader, transaction);
+        let (native_balances, account_sizes, token_balances) =
+            self.collect_transaction_status_meta(account_loader, transaction);
         self.native_post.push(native_balances);
+        self.acc_size_post.push(account_sizes);
         self.token_post.push(token_balances);
     }
 }
 
-impl BalanceCollectionRoutines for Option<BalanceCollector> {
-    fn collect_pre_balances<CB: TransactionProcessingCallback>(
+impl TxStatusMetaCollectionRoutines for Option<TxStatusMetaCollector> {
+    fn collect_pre_status_meta<CB: TransactionProcessingCallback>(
         &mut self,
         account_loader: &mut AccountLoader<CB>,
         transaction: &impl SVMTransaction,
     ) {
         if let Some(inner) = self {
-            inner.collect_pre_balances(account_loader, transaction)
+            inner.collect_pre_status_meta(account_loader, transaction)
         }
     }
 
-    fn collect_post_balances<CB: TransactionProcessingCallback>(
+    fn collect_post_status_meta<CB: TransactionProcessingCallback>(
         &mut self,
         account_loader: &mut AccountLoader<CB>,
         transaction: &impl SVMTransaction,
     ) {
         if let Some(inner) = self {
-            inner.collect_post_balances(account_loader, transaction)
+            inner.collect_post_status_meta(account_loader, transaction)
         }
     }
 }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -3454,7 +3454,7 @@ fn svm_metrics_accumulation() {
 }
 
 // NOTE this could be moved to its own file in the future, but it requires a total refactor of the test runner
-mod balance_collector {
+mod tx_status_meta_collector {
     use {
         super::*,
         rand::prelude::*,
@@ -3761,8 +3761,14 @@ mod balance_collector {
                 .enable_transaction_balance_recording = true;
 
             let batch_output = env.execute();
-            let (pre_lamport_vecs, post_lamport_vecs, pre_token_vecs, post_token_vecs) =
-                batch_output.balance_collector.unwrap().into_vecs();
+            let (
+                pre_lamport_vecs,
+                post_lamport_vecs,
+                pre_account_sizes,
+                post_account_sizes,
+                pre_token_vecs,
+                post_token_vecs,
+            ) = batch_output.tx_status_meta_collector.unwrap().into_vecs();
 
             // first test the fee-payer balances
             let mut running_fee_payer_balance = STARTING_BALANCE;
@@ -3785,6 +3791,28 @@ mod balance_collector {
                 assert_eq!(post_bal, expected_post_balance);
 
                 running_fee_payer_balance = expected_post_balance;
+            }
+
+            let expected_user_account_size = if use_tokens {
+                TokenAccount::get_packed_len()
+            } else {
+                0
+            };
+
+            for ((pre_balances, post_balances), (pre_sizes, post_sizes)) in pre_lamport_vecs
+                .iter()
+                .zip(post_lamport_vecs.iter())
+                .zip(pre_account_sizes.iter().zip(post_account_sizes.iter()))
+            {
+                assert_eq!(pre_sizes.len(), pre_balances.len());
+                assert_eq!(post_sizes.len(), post_balances.len());
+
+                assert_eq!(pre_sizes[0], 0);
+                assert_eq!(post_sizes[0], 0);
+                assert_eq!(pre_sizes[1], expected_user_account_size);
+                assert_eq!(post_sizes[1], expected_user_account_size);
+                assert_eq!(pre_sizes[2], expected_user_account_size);
+                assert_eq!(post_sizes[2], expected_user_account_size);
             }
 
             // thanks to execute() we know user_balances is correct

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -397,6 +397,16 @@ pub struct UiTransactionStatusMeta {
         skip_serializing_if = "OptionSerializer::should_skip"
     )]
     pub cost_units: OptionSerializer<u64>,
+    #[serde(
+        default = "OptionSerializer::skip",
+        skip_serializing_if = "OptionSerializer::should_skip"
+    )]
+    pub pre_acc_sizes: OptionSerializer<Vec<usize>>,
+    #[serde(
+        default = "OptionSerializer::skip",
+        skip_serializing_if = "OptionSerializer::should_skip"
+    )]
+    pub post_acc_sizes: OptionSerializer<Vec<usize>>,
 }
 
 impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
@@ -427,6 +437,8 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
             ),
             compute_units_consumed: OptionSerializer::or_skip(meta.compute_units_consumed),
             cost_units: OptionSerializer::or_skip(meta.cost_units),
+            pre_acc_sizes: OptionSerializer::or_skip(meta.pre_acc_sizes),
+            post_acc_sizes: OptionSerializer::or_skip(meta.post_acc_sizes),
         }
     }
 }
@@ -673,6 +685,8 @@ pub struct TransactionStatusMeta {
     pub return_data: Option<TransactionReturnData>,
     pub compute_units_consumed: Option<u64>,
     pub cost_units: Option<u64>,
+    pub pre_acc_sizes: Option<Vec<usize>>,
+    pub post_acc_sizes: Option<Vec<usize>>,
 }
 
 impl Default for TransactionStatusMeta {
@@ -691,6 +705,8 @@ impl Default for TransactionStatusMeta {
             return_data: None,
             compute_units_consumed: None,
             cost_units: None,
+            pre_acc_sizes: None,
+            post_acc_sizes: None,
         }
     }
 }

--- a/transaction-status/src/account_sizes.rs
+++ b/transaction-status/src/account_sizes.rs
@@ -1,0 +1,20 @@
+pub type TransactionAccountSizes = Vec<Vec<usize>>;
+
+#[derive(Debug)]
+pub struct TransactionAccountSizesSet {
+    pub pre_acc_sizes: TransactionAccountSizes,
+    pub post_acc_sizes: TransactionAccountSizes,
+}
+
+impl TransactionAccountSizesSet {
+    pub fn new(
+        pre_acc_sizes: TransactionAccountSizes,
+        post_acc_sizes: TransactionAccountSizes,
+    ) -> Self {
+        assert_eq!(pre_acc_sizes.len(), post_acc_sizes.len());
+        Self {
+            pre_acc_sizes,
+            post_acc_sizes,
+        }
+    }
+}

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -48,6 +48,7 @@ use {
     thiserror::Error,
 };
 
+pub mod account_sizes;
 pub mod extract_memos;
 pub mod parse_accounts;
 pub mod parse_address_lookup_table;
@@ -189,6 +190,8 @@ fn build_simple_ui_transaction_status_meta(
         return_data: OptionSerializer::Skip,
         compute_units_consumed: OptionSerializer::Skip,
         cost_units: OptionSerializer::Skip,
+        pre_acc_sizes: OptionSerializer::or_skip(meta.pre_acc_sizes),
+        post_acc_sizes: OptionSerializer::or_skip(meta.post_acc_sizes),
     }
 }
 
@@ -204,6 +207,8 @@ fn parse_ui_transaction_status_meta(
         fee: meta.fee,
         pre_balances: meta.pre_balances,
         post_balances: meta.post_balances,
+        pre_acc_sizes: OptionSerializer::or_skip(meta.pre_acc_sizes),
+        post_acc_sizes: OptionSerializer::or_skip(meta.post_acc_sizes),
         inner_instructions: meta
             .inner_instructions
             .map(|ixs| {
@@ -961,6 +966,8 @@ mod test {
             return_data: None,
             compute_units_consumed: None,
             cost_units: None,
+            pre_acc_sizes: None,
+            post_acc_sizes: None,
         };
         #[rustfmt::skip]
         let expected_json_output_value: serde_json::Value = serde_json::from_str(
@@ -1055,6 +1062,8 @@ mod test {
             return_data: None,
             compute_units_consumed: None,
             cost_units: None,
+            pre_acc_sizes: None,
+            post_acc_sizes: None,
         };
 
         let confirmed_tx = ConfirmedTransactionWithStatusMeta {


### PR DESCRIPTION
#### Problem

Unlike with native/token balances, it's difficult to get reliable information on the data size of accounts and how they change over time without fully executed transactions.

#### Summary of Changes

Add account data size to the `TransactionStatusMeta`:

- As with native balances (but in contrast to token balances), the transaction meta collector captures pre/post execution account sizes for every account. Because of this, no account index is stored. The ordering of the collected sizes corresponds to the account ordering in `transaction.account_keys()`.
- Accounts that don't exist pre-exec are stored with size 0. To distinguish this from an existing account with a zero-sized data field, the native balance can be checked.
  - Post-exec zero-lamport accounts on the other hand may have a non-zero size stored.
- Basic renaming/refactoring

Fixes #
