### PR TITLE
Rename `SyscallContext` to `MemoryContext`

### DIFF
--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1045,7 +1045,7 @@ where
     // unwrapping here is fine: we're in a syscall and the method below fails
     // only outside syscalls
     let accounts_metadata = &invoke_context
-        .get_syscall_context()
+        .get_memory_context()
         .unwrap()
         .accounts_metadata;
 
@@ -1957,7 +1957,7 @@ mod tests {
         );
 
         invoke_context
-            .set_syscall_context(MemoryContext {
+            .set_memory_context(MemoryContext {
                 allocator: BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
                 accounts_metadata: vec![account_metadata],
             })

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1391,7 +1391,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            invoke_context::{BpfAllocator, SerializedAccountMetadata, SyscallContext},
+            invoke_context::{BpfAllocator, MemoryContext, SerializedAccountMetadata},
             memory::translate_type,
             with_mock_invoke_context_with_feature_set,
         },
@@ -1957,7 +1957,7 @@ mod tests {
         );
 
         invoke_context
-            .set_syscall_context(SyscallContext {
+            .set_syscall_context(MemoryContext {
                 allocator: BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
                 accounts_metadata: vec![account_metadata],
             })

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -733,19 +733,19 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             .unwrap_or(true)
     }
 
-    // Set this instruction syscall context
+    // Set this instruction memory context
     pub fn set_memory_context(
         &mut self,
-        syscall_context: MemoryContext,
+        memory_context: MemoryContext,
     ) -> Result<(), InstructionError> {
         *self
             .memory_context
             .last_mut()
-            .ok_or(InstructionError::CallDepth)? = Some(syscall_context);
+            .ok_or(InstructionError::CallDepth)? = Some(memory_context);
         Ok(())
     }
 
-    // Get this instruction's SyscallContext
+    // Get this instruction's MemoryContext
     pub fn get_memory_context(&self) -> Result<&MemoryContext, InstructionError> {
         self.memory_context
             .last()
@@ -753,11 +753,11 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             .ok_or(InstructionError::CallDepth)
     }
 
-    // Get this instruction's SyscallContext
+    // Get this instruction's MemoryContext
     pub fn get_memory_context_mut(&mut self) -> Result<&mut MemoryContext, InstructionError> {
         self.memory_context
             .last_mut()
-            .and_then(|syscall_context| syscall_context.as_mut())
+            .and_then(|memory_context| memory_context.as_mut())
             .ok_or(InstructionError::CallDepth)
     }
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -212,7 +212,7 @@ pub struct InvokeContext<'a, 'ix_data> {
     /// Time spent so far executing nested program calls.
     pub total_nested_exec_time: Duration,
     pub timings: ExecuteDetailsTimings,
-    pub syscall_context: Vec<Option<MemoryContext>>,
+    pub memory_context: Vec<Option<MemoryContext>>,
     /// Pairs of index in TX instruction trace and VM register trace
     register_traces: Vec<(usize, Vec<[u64; 12]>)>,
     /// Debug port to use for this executing transaction.
@@ -239,7 +239,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             compute_meter: RefCell::new(compute_budget.compute_unit_limit),
             total_nested_exec_time: Duration::ZERO,
             timings: ExecuteDetailsTimings::default(),
-            syscall_context: Vec::new(),
+            memory_context: Vec::new(),
             register_traces: Vec::new(),
             #[cfg(feature = "sbpf-debugger")]
             debug_port: None,
@@ -273,13 +273,13 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             }
         }
 
-        self.syscall_context.push(None);
+        self.memory_context.push(None);
         self.transaction_context.push()
     }
 
     /// Pop a stack frame from the invocation stack
     pub(crate) fn pop(&mut self) -> Result<(), InstructionError> {
-        self.syscall_context.pop();
+        self.memory_context.pop();
         self.transaction_context.pop()
     }
 
@@ -734,28 +734,28 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
     }
 
     // Set this instruction syscall context
-    pub fn set_syscall_context(
+    pub fn set_memory_context(
         &mut self,
         syscall_context: MemoryContext,
     ) -> Result<(), InstructionError> {
         *self
-            .syscall_context
+            .memory_context
             .last_mut()
             .ok_or(InstructionError::CallDepth)? = Some(syscall_context);
         Ok(())
     }
 
     // Get this instruction's SyscallContext
-    pub fn get_syscall_context(&self) -> Result<&MemoryContext, InstructionError> {
-        self.syscall_context
+    pub fn get_memory_context(&self) -> Result<&MemoryContext, InstructionError> {
+        self.memory_context
             .last()
             .and_then(std::option::Option::as_ref)
             .ok_or(InstructionError::CallDepth)
     }
 
     // Get this instruction's SyscallContext
-    pub fn get_syscall_context_mut(&mut self) -> Result<&mut MemoryContext, InstructionError> {
-        self.syscall_context
+    pub fn get_memory_context_mut(&mut self) -> Result<&mut MemoryContext, InstructionError> {
+        self.memory_context
             .last_mut()
             .and_then(|syscall_context| syscall_context.as_mut())
             .ok_or(InstructionError::CallDepth)

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -178,7 +178,7 @@ impl<'a> EnvironmentConfig<'a> {
 }
 
 /// This structure contains metadata about the memory for each instruction under execution.
-/// The BpfAllcoation, accounts addresses in the guest and the memory mapping (future).
+/// The BpfAllocator, accounts addresses in the guest and the memory mapping (future).
 pub struct MemoryContext {
     pub allocator: BpfAllocator,
     pub accounts_metadata: Vec<SerializedAccountMetadata>,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -177,7 +177,9 @@ impl<'a> EnvironmentConfig<'a> {
     }
 }
 
-pub struct SyscallContext {
+/// This structure contains metadata about the memory for each instruction under execution.
+/// The BpfAllcoation, accounts addresses in the guest and the memory mapping (future).
+pub struct MemoryContext {
     pub allocator: BpfAllocator,
     pub accounts_metadata: Vec<SerializedAccountMetadata>,
 }
@@ -210,7 +212,7 @@ pub struct InvokeContext<'a, 'ix_data> {
     /// Time spent so far executing nested program calls.
     pub total_nested_exec_time: Duration,
     pub timings: ExecuteDetailsTimings,
-    pub syscall_context: Vec<Option<SyscallContext>>,
+    pub syscall_context: Vec<Option<MemoryContext>>,
     /// Pairs of index in TX instruction trace and VM register trace
     register_traces: Vec<(usize, Vec<[u64; 12]>)>,
     /// Debug port to use for this executing transaction.
@@ -734,7 +736,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
     // Set this instruction syscall context
     pub fn set_syscall_context(
         &mut self,
-        syscall_context: SyscallContext,
+        syscall_context: MemoryContext,
     ) -> Result<(), InstructionError> {
         *self
             .syscall_context
@@ -744,7 +746,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
     }
 
     // Get this instruction's SyscallContext
-    pub fn get_syscall_context(&self) -> Result<&SyscallContext, InstructionError> {
+    pub fn get_syscall_context(&self) -> Result<&MemoryContext, InstructionError> {
         self.syscall_context
             .last()
             .and_then(std::option::Option::as_ref)
@@ -752,7 +754,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
     }
 
     // Get this instruction's SyscallContext
-    pub fn get_syscall_context_mut(&mut self) -> Result<&mut SyscallContext, InstructionError> {
+    pub fn get_syscall_context_mut(&mut self) -> Result<&mut MemoryContext, InstructionError> {
         self.syscall_context
             .last_mut()
             .and_then(|syscall_context| syscall_context.as_mut())

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -5,7 +5,7 @@ use qualifier_attr::qualifiers;
 use {
     crate::{
         execution_budget::MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268,
-        invoke_context::{BpfAllocator, InvokeContext, SerializedAccountMetadata, SyscallContext},
+        invoke_context::{BpfAllocator, InvokeContext, MemoryContext, SerializedAccountMetadata},
         mem_pool::VmMemoryPool,
         program_cache_entry::ProgramCacheEntry,
         serialization, stable_log,
@@ -67,7 +67,7 @@ pub fn create_vm<'a, 'b>(
             .virtual_address_space_adjustments,
         invoke_context.get_feature_set().account_data_direct_mapping,
     )?;
-    invoke_context.set_syscall_context(SyscallContext {
+    invoke_context.set_syscall_context(MemoryContext {
         allocator: BpfAllocator::new(heap_size as u64),
         accounts_metadata,
     })?;

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -67,7 +67,7 @@ pub fn create_vm<'a, 'b>(
             .virtual_address_space_adjustments,
         invoke_context.get_feature_set().account_data_direct_mapping,
     )?;
-    invoke_context.set_syscall_context(MemoryContext {
+    invoke_context.set_memory_context(MemoryContext {
         allocator: BpfAllocator::new(heap_size as u64),
         accounts_metadata,
     })?;
@@ -414,7 +414,7 @@ pub fn execute<'a, 'b: 'a>(
             virtual_address_space_adjustments,
             account_data_direct_mapping,
             parameter_bytes,
-            &invoke_context.get_syscall_context()?.accounts_metadata,
+            &invoke_context.get_memory_context()?.accounts_metadata,
         )
     }
 

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -749,7 +749,7 @@ declare_builtin_function!(
         let Ok(layout) = Layout::from_size_align(size as usize, align) else {
             return Ok(0);
         };
-        let allocator = &mut invoke_context.get_syscall_context_mut()?.allocator;
+        let allocator = &mut invoke_context.get_memory_context_mut()?.allocator;
         if free_addr == 0 {
             match allocator.alloc(layout) {
                 Ok(addr) => Ok(addr),
@@ -3153,7 +3153,7 @@ mod tests {
         ($invoke_context:ident, $memory_mapping:ident, $heap:ident) => {
             prepare_mockup!($invoke_context, program_id, bpf_loader::id());
             $invoke_context
-                .set_syscall_context(MemoryContext {
+                .set_memory_context(MemoryContext {
                     allocator: BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
                     accounts_metadata: Vec::new(),
                 })

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2670,7 +2670,7 @@ mod tests {
         solana_program::program::check_type_assumptions,
         solana_program_runtime::{
             execution_budget::MAX_HEAP_FRAME_BYTES,
-            invoke_context::{BpfAllocator, InvokeContext, SyscallContext},
+            invoke_context::{BpfAllocator, InvokeContext, MemoryContext},
             memory::address_is_aligned,
             with_mock_invoke_context, with_mock_invoke_context_with_feature_set,
         },
@@ -3153,7 +3153,7 @@ mod tests {
         ($invoke_context:ident, $memory_mapping:ident, $heap:ident) => {
             prepare_mockup!($invoke_context, program_id, bpf_loader::id());
             $invoke_context
-                .set_syscall_context(SyscallContext {
+                .set_syscall_context(MemoryContext {
                     allocator: BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
                     accounts_metadata: Vec::new(),
                 })


### PR DESCRIPTION
#### Problem

`SyscallContext` will be used in the near future to own the MemoryMapping for each instruction, so we'll rename it to `MemoryContext`.

#### Summary of Changes

Rename the struct and related usages.
