### PR TITLE
runtime: Bundle parameters in reward calculation functions

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -12,7 +12,7 @@ use {
             RewardsMetrics, null_tracer,
         },
         inflation_rewards::{
-            points::{DelegatedVoteState, PointValue, calculate_points},
+            points::{CalculationEnvironment, DelegatedVoteState, PointValue, calculate_points},
             redeem_rewards,
         },
         stake_account::StakeAccount,
@@ -480,15 +480,17 @@ impl Bank {
         };
 
         match redeem_rewards(
-            rewarded_epoch,
             stake_state,
             commission_bps,
             DelegatedVoteState::from(vote_state),
-            point_value,
-            stake_history,
+            CalculationEnvironment {
+                rewarded_epoch,
+                point_value,
+                stake_history,
+                new_rate_activation_epoch,
+                commission_rate_in_basis_points,
+            },
             reward_calc_tracer,
-            new_rate_activation_epoch,
-            commission_rate_in_basis_points,
             stake_account.lamports(),
         ) {
             Ok((stake_reward, commission_lamports, stake)) => {

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -2,14 +2,12 @@
 
 use {
     self::points::{
-        CalculatedStakePoints, DelegatedVoteState, InflationPointCalculationEvent, PointValue,
-        SkippedReason, calculate_stake_points_and_credits,
+        CalculatedStakePoints, CalculationEnvironment, DelegatedVoteState,
+        InflationPointCalculationEvent, SkippedReason, calculate_stake_points_and_credits,
     },
-    solana_clock::Epoch,
     solana_instruction::error::InstructionError,
     solana_stake_interface::{
         error::StakeError,
-        stake_history::StakeHistory,
         state::{Stake, StakeStateV2},
     },
 };
@@ -29,32 +27,28 @@ struct CalculatedStakeRewards {
 /// * Voters reward
 /// * Updated stake information
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn redeem_rewards(
-    rewarded_epoch: Epoch,
+pub(crate) fn redeem_rewards<'a>(
     stake_state: &StakeStateV2,
     voter_commission_bps: u16,
     vote_state: DelegatedVoteState,
-    point_value: &PointValue,
-    stake_history: &StakeHistory,
+    calculation_environment: CalculationEnvironment<'a>,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
-    new_rate_activation_epoch: Option<Epoch>,
-    commission_rate_in_basis_points: bool,
     stake_account_lamports_for_trace: u64,
 ) -> Result<(u64, u64, Stake), InstructionError> {
     if let StakeStateV2::Stake(_meta, stake, _stake_flags) = stake_state {
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
             inflation_point_calc_tracer(
                 &InflationPointCalculationEvent::EffectiveStakeAtRewardedEpoch(stake.stake(
-                    rewarded_epoch,
-                    stake_history,
-                    new_rate_activation_epoch,
+                    calculation_environment.rewarded_epoch,
+                    calculation_environment.stake_history,
+                    calculation_environment.new_rate_activation_epoch,
                 )),
             );
             inflation_point_calc_tracer(&InflationPointCalculationEvent::PriorTotalLamports(
                 stake_account_lamports_for_trace,
             ));
             // Choose which trace to emit based on the `commission_rate_in_basis_points` feature.
-            if commission_rate_in_basis_points {
+            if calculation_environment.commission_rate_in_basis_points {
                 inflation_point_calc_tracer(&InflationPointCalculationEvent::CommissionBps(
                     voter_commission_bps,
                 ));
@@ -67,14 +61,11 @@ pub(crate) fn redeem_rewards(
 
         let mut stake = *stake;
         if let Some((stakers_reward, voters_reward)) = redeem_stake_rewards(
-            rewarded_epoch,
             &mut stake,
-            point_value,
             voter_commission_bps,
             vote_state,
-            stake_history,
+            calculation_environment,
             inflation_point_calc_tracer,
-            new_rate_activation_epoch,
         ) {
             Ok((stakers_reward, voters_reward, stake))
         } else {
@@ -85,15 +76,12 @@ pub(crate) fn redeem_rewards(
     }
 }
 
-fn redeem_stake_rewards(
-    rewarded_epoch: Epoch,
+fn redeem_stake_rewards<'a>(
     stake: &mut Stake,
-    point_value: &PointValue,
     voter_commission_bps: u16,
     vote_state: DelegatedVoteState,
-    stake_history: &StakeHistory,
+    calculation_environment: CalculationEnvironment<'a>,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
-    new_rate_activation_epoch: Option<Epoch>,
 ) -> Option<(u64, u64)> {
     if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
         inflation_point_calc_tracer(&InflationPointCalculationEvent::CreditsObserved(
@@ -102,14 +90,11 @@ fn redeem_stake_rewards(
         ));
     }
     calculate_stake_rewards(
-        rewarded_epoch,
         stake,
-        point_value,
         voter_commission_bps,
         vote_state,
-        stake_history,
+        calculation_environment,
         inflation_point_calc_tracer.as_ref(),
-        new_rate_activation_epoch,
     )
     .map(|calculated_stake_rewards| {
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer {
@@ -134,15 +119,12 @@ fn redeem_stake_rewards(
 ///   * new value for credits_observed in the stake
 ///
 /// returns None if there's no payout or if any deserved payout is < 1 lamport
-fn calculate_stake_rewards(
-    rewarded_epoch: Epoch,
+fn calculate_stake_rewards<'a>(
     stake: &Stake,
-    point_value: &PointValue,
     voter_commission_bps: u16,
     vote_state: DelegatedVoteState,
-    stake_history: &StakeHistory,
+    calculation_environment: CalculationEnvironment<'a>,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
-    new_rate_activation_epoch: Option<Epoch>,
 ) -> Option<CalculatedStakeRewards> {
     // ensure to run to trigger (optional) inflation_point_calc_tracer
     let CalculatedStakePoints {
@@ -152,19 +134,19 @@ fn calculate_stake_rewards(
     } = calculate_stake_points_and_credits(
         stake,
         vote_state,
-        stake_history,
+        calculation_environment.stake_history,
         inflation_point_calc_tracer.as_ref(),
-        new_rate_activation_epoch,
+        calculation_environment.new_rate_activation_epoch,
     );
 
     // Drive credits_observed forward unconditionally when rewards are disabled
     // or when this is the stake's activation epoch
-    if point_value.rewards == 0 {
+    if calculation_environment.point_value.rewards == 0 {
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
             inflation_point_calc_tracer(&SkippedReason::DisabledInflation.into());
         }
         force_credits_update_with_skipped_reward = true;
-    } else if stake.delegation.activation_epoch == rewarded_epoch {
+    } else if stake.delegation.activation_epoch == calculation_environment.rewarded_epoch {
         // not assert!()-ed; but points should be zero
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
             inflation_point_calc_tracer(&SkippedReason::JustActivated.into());
@@ -186,7 +168,7 @@ fn calculate_stake_rewards(
         }
         return None;
     }
-    if point_value.points == 0 {
+    if calculation_environment.point_value.points == 0 {
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
             inflation_point_calc_tracer(&SkippedReason::ZeroPointValue.into());
         }
@@ -195,9 +177,9 @@ fn calculate_stake_rewards(
 
     // The final unwrap is safe, as points_value.points is guaranteed to be non zero above.
     let rewards = points
-        .checked_mul(u128::from(point_value.rewards))
+        .checked_mul(u128::from(calculation_environment.point_value.rewards))
         .expect("Rewards intermediate calculation should fit within u128")
-        .checked_div(point_value.points)
+        .checked_div(calculation_environment.point_value.points)
         .unwrap();
 
     let rewards = u64::try_from(rewards).expect("Rewards should fit within u64");
@@ -215,7 +197,7 @@ fn calculate_stake_rewards(
             rewards,
             voter_rewards,
             staker_rewards,
-            (*point_value).clone(),
+            calculation_environment.point_value.clone(),
         ));
     }
 
@@ -276,12 +258,13 @@ fn commission_split(commission_bps: u16, on: u64) -> (u64, u64, bool) {
 #[cfg(test)]
 mod tests {
     use {
-        self::points::null_tracer,
+        self::points::{PointValue, null_tracer},
         super::*,
         proptest::prelude::*,
+        solana_clock::Epoch,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_pubkey::Pubkey,
-        solana_stake_interface::state::Delegation,
+        solana_stake_interface::{stake_history::StakeHistory, state::Delegation},
         solana_vote_program::vote_state::{VoteStateV4, handler::VoteStateHandle},
         test_case::test_case,
     };
@@ -305,22 +288,28 @@ mod tests {
         // bootstrap means fully-vested stake at epoch 0
         let stake_lamports = 1;
         let mut stake = new_stake(stake_lamports, &Pubkey::default(), &vote_state, u64::MAX);
+        let stake_history = &StakeHistory::default();
+        let new_rate_activation_epoch = None;
+        let commission_rate_in_basis_points = true;
 
         // this one can't collect now, credits_observed == vote_state.credits()
         assert_eq!(
             None,
             redeem_stake_rewards(
-                0,
                 &mut stake,
-                &PointValue {
-                    rewards: 1_000_000_000,
-                    points: 1
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 0,
+                    point_value: &PointValue {
+                        rewards: 1_000_000_000,
+                        points: 1
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
 
@@ -332,17 +321,20 @@ mod tests {
         assert_eq!(
             Some((stake_lamports * 2, 0)),
             redeem_stake_rewards(
-                0,
                 &mut stake,
-                &PointValue {
-                    rewards: 1,
-                    points: 1
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 0,
+                    point_value: &PointValue {
+                        rewards: 1,
+                        points: 1
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
 
@@ -360,21 +352,28 @@ mod tests {
         // bootstrap means fully-vested stake at epoch 0
         let mut stake = new_stake(1, &Pubkey::default(), &vote_state, u64::MAX);
 
+        let stake_history = &StakeHistory::default();
+        let new_rate_activation_epoch = None;
+        let commission_rate_in_basis_points = true;
+
         // this one can't collect now, credits_observed == vote_state.credits()
         assert_eq!(
             None,
             calculate_stake_rewards(
-                0,
                 &stake,
-                &PointValue {
-                    rewards: 1_000_000_000,
-                    points: 1
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 0,
+                    point_value: &PointValue {
+                        rewards: 1_000_000_000,
+                        points: 1
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
 
@@ -390,17 +389,20 @@ mod tests {
                 new_credits_observed: 2,
             }),
             calculate_stake_rewards(
-                0,
                 &stake,
-                &PointValue {
-                    rewards: 2,
-                    points: 2 // all his
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 0,
+                    point_value: &PointValue {
+                        rewards: 2,
+                        points: 2 // all his
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
 
@@ -413,17 +415,20 @@ mod tests {
                 new_credits_observed: 2,
             }),
             calculate_stake_rewards(
-                0,
                 &stake,
-                &PointValue {
-                    rewards: 1,
-                    points: 1
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 0,
+                    point_value: &PointValue {
+                        rewards: 1,
+                        points: 1
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
 
@@ -439,17 +444,20 @@ mod tests {
                 new_credits_observed: 3,
             }),
             calculate_stake_rewards(
-                1,
                 &stake,
-                &PointValue {
-                    rewards: 2,
-                    points: 2
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 1,
+                    point_value: &PointValue {
+                        rewards: 2,
+                        points: 2
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
 
@@ -463,17 +471,20 @@ mod tests {
                 new_credits_observed: 4,
             }),
             calculate_stake_rewards(
-                2,
                 &stake,
-                &PointValue {
-                    rewards: 2,
-                    points: 2
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 2,
+                    point_value: &PointValue {
+                        rewards: 2,
+                        points: 2
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
 
@@ -489,17 +500,20 @@ mod tests {
                 new_credits_observed: 4,
             }),
             calculate_stake_rewards(
-                2,
                 &stake,
-                &PointValue {
-                    rewards: 4,
-                    points: 4
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 2,
+                    point_value: &PointValue {
+                        rewards: 4,
+                        points: 4
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
 
@@ -509,34 +523,40 @@ mod tests {
         assert_eq!(
             None, // would be Some((0, 2 * 1 + 1 * 2, 4)),
             calculate_stake_rewards(
-                2,
                 &stake,
-                &PointValue {
-                    rewards: 4,
-                    points: 4
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 2,
+                    point_value: &PointValue {
+                        rewards: 4,
+                        points: 4
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
         vote_state.inflation_rewards_commission_bps = 9900;
         assert_eq!(
             None, // would be Some((0, 2 * 1 + 1 * 2, 4)),
             calculate_stake_rewards(
-                2,
                 &stake,
-                &PointValue {
-                    rewards: 4,
-                    points: 4
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 2,
+                    point_value: &PointValue {
+                        rewards: 4,
+                        points: 4
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
 
@@ -550,17 +570,20 @@ mod tests {
                 new_credits_observed: 4,
             }),
             calculate_stake_rewards(
-                2,
                 &stake,
-                &PointValue {
-                    rewards: 0,
-                    points: 4
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 2,
+                    point_value: &PointValue {
+                        rewards: 0,
+                        points: 4
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
 
@@ -574,17 +597,20 @@ mod tests {
                 new_credits_observed: 4,
             }),
             calculate_stake_rewards(
-                2,
                 &stake,
-                &PointValue {
-                    rewards: 0,
-                    points: 4
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 2,
+                    point_value: &PointValue {
+                        rewards: 0,
+                        points: 4
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
 
@@ -649,17 +675,20 @@ mod tests {
                 new_credits_observed: 4,
             }),
             calculate_stake_rewards(
-                2,
                 &stake,
-                &PointValue {
-                    rewards: 1,
-                    points: 1
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 2,
+                    point_value: &PointValue {
+                        rewards: 1,
+                        points: 1
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
 
@@ -674,17 +703,20 @@ mod tests {
                 new_credits_observed: 4,
             }),
             calculate_stake_rewards(
-                2,
                 &stake,
-                &PointValue {
-                    rewards: 1,
-                    points: 1
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 2,
+                    point_value: &PointValue {
+                        rewards: 1,
+                        points: 1
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
     }
@@ -698,15 +730,22 @@ mod tests {
 
         vote_state.increment_credits(0, credits);
 
+        let stake_history = &StakeHistory::default();
+        let new_rate_activation_epoch = None;
+        let commission_rate_in_basis_points = true;
+
         calculate_stake_rewards(
-            0,
             &stake,
-            &PointValue { rewards, points: 1 },
             vote_state.inflation_rewards_commission_bps,
             DelegatedVoteState::from(&vote_state),
-            &StakeHistory::default(),
+            CalculationEnvironment {
+                rewarded_epoch: 0,
+                point_value: &PointValue { rewards, points: 1 },
+                stake_history,
+                new_rate_activation_epoch,
+                commission_rate_in_basis_points,
+            },
             null_tracer(),
-            None,
         );
     }
 
@@ -722,22 +761,28 @@ mod tests {
             &vote_state,
             u64::MAX,
         );
+        let stake_history = &StakeHistory::default();
+        let new_rate_activation_epoch = None;
+        let commission_rate_in_basis_points = true;
 
         // this one can't collect now, credits_observed == vote_state.credits()
         assert_eq!(
             None,
             calculate_stake_rewards(
-                0,
                 &stake,
-                &PointValue {
-                    rewards: 1_000_000_000,
-                    points: 1
-                },
                 vote_state.inflation_rewards_commission_bps,
                 DelegatedVoteState::from(&vote_state),
-                &StakeHistory::default(),
+                CalculationEnvironment {
+                    rewarded_epoch: 0,
+                    point_value: &PointValue {
+                        rewards: 1_000_000_000,
+                        points: 1
+                    },
+                    stake_history,
+                    new_rate_activation_epoch,
+                    commission_rate_in_basis_points,
+                },
                 null_tracer(),
-                None,
             )
         );
     }

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -37,18 +37,25 @@ pub(crate) fn redeem_rewards<'a>(
 ) -> Result<(u64, u64, Stake), InstructionError> {
     if let StakeStateV2::Stake(_meta, stake, _stake_flags) = stake_state {
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
+            let CalculationEnvironment {
+                rewarded_epoch,
+                stake_history,
+                new_rate_activation_epoch,
+                commission_rate_in_basis_points,
+                ..
+            } = calculation_environment;
             inflation_point_calc_tracer(
                 &InflationPointCalculationEvent::EffectiveStakeAtRewardedEpoch(stake.stake(
-                    calculation_environment.rewarded_epoch,
-                    calculation_environment.stake_history,
-                    calculation_environment.new_rate_activation_epoch,
+                    rewarded_epoch,
+                    stake_history,
+                    new_rate_activation_epoch,
                 )),
             );
             inflation_point_calc_tracer(&InflationPointCalculationEvent::PriorTotalLamports(
                 stake_account_lamports_for_trace,
             ));
             // Choose which trace to emit based on the `commission_rate_in_basis_points` feature.
-            if calculation_environment.commission_rate_in_basis_points {
+            if commission_rate_in_basis_points {
                 inflation_point_calc_tracer(&InflationPointCalculationEvent::CommissionBps(
                     voter_commission_bps,
                 ));
@@ -126,6 +133,13 @@ fn calculate_stake_rewards<'a>(
     calculation_environment: CalculationEnvironment<'a>,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
 ) -> Option<CalculatedStakeRewards> {
+    let CalculationEnvironment {
+        stake_history,
+        new_rate_activation_epoch,
+        point_value,
+        rewarded_epoch,
+        ..
+    } = calculation_environment;
     // ensure to run to trigger (optional) inflation_point_calc_tracer
     let CalculatedStakePoints {
         points,
@@ -134,19 +148,19 @@ fn calculate_stake_rewards<'a>(
     } = calculate_stake_points_and_credits(
         stake,
         vote_state,
-        calculation_environment.stake_history,
+        stake_history,
         inflation_point_calc_tracer.as_ref(),
-        calculation_environment.new_rate_activation_epoch,
+        new_rate_activation_epoch,
     );
 
     // Drive credits_observed forward unconditionally when rewards are disabled
     // or when this is the stake's activation epoch
-    if calculation_environment.point_value.rewards == 0 {
+    if point_value.rewards == 0 {
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
             inflation_point_calc_tracer(&SkippedReason::DisabledInflation.into());
         }
         force_credits_update_with_skipped_reward = true;
-    } else if stake.delegation.activation_epoch == calculation_environment.rewarded_epoch {
+    } else if stake.delegation.activation_epoch == rewarded_epoch {
         // not assert!()-ed; but points should be zero
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
             inflation_point_calc_tracer(&SkippedReason::JustActivated.into());
@@ -168,7 +182,7 @@ fn calculate_stake_rewards<'a>(
         }
         return None;
     }
-    if calculation_environment.point_value.points == 0 {
+    if point_value.points == 0 {
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
             inflation_point_calc_tracer(&SkippedReason::ZeroPointValue.into());
         }
@@ -177,9 +191,9 @@ fn calculate_stake_rewards<'a>(
 
     // The final unwrap is safe, as points_value.points is guaranteed to be non zero above.
     let rewards = points
-        .checked_mul(u128::from(calculation_environment.point_value.rewards))
+        .checked_mul(u128::from(point_value.rewards))
         .expect("Rewards intermediate calculation should fit within u128")
-        .checked_div(calculation_environment.point_value.points)
+        .checked_div(point_value.points)
         .unwrap();
 
     let rewards = u64::try_from(rewards).expect("Rewards should fit within u64");
@@ -197,7 +211,7 @@ fn calculate_stake_rewards<'a>(
             rewards,
             voter_rewards,
             staker_rewards,
-            calculation_environment.point_value.clone(),
+            point_value.clone(),
         ));
     }
 

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -29,6 +29,15 @@ pub(crate) struct CalculatedStakePoints {
     pub(crate) force_credits_update_with_skipped_reward: bool,
 }
 
+/// Combination of info needed to calculate rewards
+pub(crate) struct CalculationEnvironment<'a> {
+    pub(crate) rewarded_epoch: Epoch,
+    pub(crate) point_value: &'a PointValue,
+    pub(crate) stake_history: &'a StakeHistory,
+    pub(crate) new_rate_activation_epoch: Option<Epoch>,
+    pub(crate) commission_rate_in_basis_points: bool,
+}
+
 #[derive(Debug)]
 pub enum InflationPointCalculationEvent {
     CalculatedPoints(u64, u128, u128, u128),


### PR DESCRIPTION
#### Problem

During #11332, it was brought up that some of the functions have too many parameters.

#### Summary of changes

All of the parameters are needed, so bundle some of them in a new type for arguably better legibility. No functionality change, purely cosmetic.