### PR TITLE
cleanup(deps): set solana-* deps to uniform workspace level version

### DIFF
--- a/gossip-cli/Cargo.toml
+++ b/gossip-cli/Cargo.toml
@@ -24,5 +24,5 @@ log = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-gossip = { workspace = true, features = ["agave-unstable-api"] }
 solana-net-utils = { workspace = true, features = ["agave-unstable-api"] }
-solana-pubkey = { version = "=4.1.0", features = ["rand"] }
+solana-pubkey = { workspace = true, features = ["rand"] }
 solana-version = { workspace = true }

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -40,16 +40,16 @@ semver = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 solana-clap-utils = { workspace = true }
-solana-config-interface = { version = "=2.0.0", features = ["bincode"] }
-solana-hash = "=4.2.0"
-solana-keypair = "=3.1.2"
-solana-message = "=4.0.0"
-solana-pubkey = { version = "=4.1.0", default-features = false }
+solana-config-interface = { workspace = true, features = ["bincode"] }
+solana-hash = { workspace = true }
+solana-keypair = { workspace = true }
+solana-message = { workspace = true }
+solana-pubkey = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-solana-signature = { version = "=3.3.0", default-features = false }
-solana-signer = "=3.0.0"
-solana-transaction = { version = "=4.0.0", features = ["wincode"] }
+solana-signature = { workspace = true }
+solana-signer = { workspace = true }
+solana-transaction = { workspace = true, features = ["wincode"] }
 solana-version = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -33,13 +33,13 @@ solana-bls-signatures = { workspace = true }
 solana-clap-v3-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-derivation-path = { workspace = true }
-solana-instruction = { version = "=3.3.0", features = ["bincode"] }
-solana-keypair = "=3.1.2"
-solana-message = { version = "=4.0.0", features = ["wincode"] }
-solana-pubkey = { version = "=4.1.0", default-features = false }
+solana-instruction = { workspace = true, features = ["bincode"] }
+solana-keypair = { workspace = true }
+solana-message = { workspace = true, features = ["wincode"] }
+solana-pubkey = { workspace = true }
 solana-remote-wallet = { workspace = true }
 solana-seed-derivable = { workspace = true }
-solana-signer = "=3.0.0"
+solana-signer = { workspace = true }
 solana-version = { workspace = true }
 tiny-bip39 = { workspace = true }
 

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -23,11 +23,11 @@ log = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-cli-output = { workspace = true }
-solana-hash = "=4.2.0"
+solana-hash = { workspace = true }
 solana-metrics = { workspace = true }
-solana-native-token = "=3.0.0"
+solana-native-token = { workspace = true }
 solana-notifier = { workspace = true }
-solana-pubkey = { version = "=4.1.0", default-features = false }
+solana-pubkey = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-version = { workspace = true }


### PR DESCRIPTION
#### Problem
Several crates use pinned versions of `solana-*` dependencies, but those versions are already exactly the same as workspace level versoins.

#### Summary of Changes
* set all to use `{ workspace = true }`
* `default-features = ` is removed if workspace also disables default features
* right now this is a `Cargo.toml` only change without impact on `Cargo.lock` due to all versions being the same, but crate level deps used `=`, which is not the case for workspace level versions, I guess it's fine