### PR TITLE
net: reject unsupported IPv6 socket addresses

### DIFF
--- a/net-utils/src/socket_addr_space.rs
+++ b/net-utils/src/socket_addr_space.rs
@@ -19,23 +19,44 @@ impl SocketAddrSpace {
     #[inline]
     #[must_use]
     pub fn check(&self, addr: &SocketAddr) -> bool {
+        // IPv4-only policy gate.
+        let IpAddr::V4(addr) = addr.ip() else {
+            return false;
+        };
+
         if matches!(self, SocketAddrSpace::Unspecified) {
             return true;
         }
 
         // TODO: remove these once IpAddr::is_global is stable.
-        match addr.ip() {
-            IpAddr::V4(addr) => {
-                // TODO: Consider excluding:
-                // addr.is_link_local() || addr.is_broadcast()
-                // || addr.is_documentation() || addr.is_unspecified()
-                !(addr.is_private() || addr.is_loopback())
-            }
-            IpAddr::V6(addr) => {
-                // TODO: Consider excluding:
-                // addr.is_unspecified(),
-                !addr.is_loopback()
-            }
-        }
+        // TODO: Consider excluding:
+        // addr.is_link_local() || addr.is_broadcast()
+        // || addr.is_documentation() || addr.is_unspecified()
+        !(addr.is_private() || addr.is_loopback())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_global_rejects_ipv6_sockets() {
+        let socket_addr_space = SocketAddrSpace::Global;
+        let ipv6_addr: SocketAddr = "[2001:db8::1]:1234".parse().unwrap();
+        let ipv4_mapped_ipv6_addr: SocketAddr = "[::ffff:8.8.8.8]:1234".parse().unwrap();
+
+        assert!(!socket_addr_space.check(&ipv6_addr));
+        assert!(!socket_addr_space.check(&ipv4_mapped_ipv6_addr));
+    }
+
+    #[test]
+    fn test_unspecified_rejects_ipv6_sockets() {
+        let socket_addr_space = SocketAddrSpace::Unspecified;
+        let ipv6_addr: SocketAddr = "[2001:db8::1]:1234".parse().unwrap();
+        let ipv4_mapped_ipv6_addr: SocketAddr = "[::ffff:8.8.8.8]:1234".parse().unwrap();
+
+        assert!(!socket_addr_space.check(&ipv6_addr));
+        assert!(!socket_addr_space.check(&ipv4_mapped_ipv6_addr));
     }
 }


### PR DESCRIPTION
Problem

ContactInfo allows IPv6 sockets, which are currently unsupported.
Discussed with @gregcusack - decision was to restrict to IPv4 for now.

Summary of Changes

Ensure `SocketAddrSpace::check()` is explicitly IPv4-only so ContactInfo address validation rejects IPv6 socket addresses consistently.

