### PR TITLE
Implements dynamic skip timeouts

### DIFF
--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -85,6 +85,10 @@ struct LocalContext {
     pub(crate) finalized_blocks: BTreeSet<Block>,
     pub(crate) received_shred: BTreeSet<Slot>,
     pub(crate) stats: EventHandlerStats,
+    /// When in standstill, tracks the highest parent ready slot at the time standstill was detected.
+    /// Used to calculate dynamic timeout extensions (5% per leader window since standstill).
+    /// Reset to None when a finalization event is received.
+    pub(crate) standstill_slot: Option<Slot>,
 }
 
 impl EventHandler {
@@ -119,6 +123,7 @@ impl EventHandler {
             finalized_blocks: BTreeSet::default(),
             received_shred: BTreeSet::default(),
             stats: EventHandlerStats::new(),
+            standstill_slot: None,
         };
 
         // Wait until migration has completed
@@ -210,7 +215,9 @@ impl EventHandler {
         let should_set_timeouts = vctx.vote_history.add_parent_ready(slot, parent_block);
         Self::check_pending_blocks(my_pubkey, &mut local_context.pending_blocks, vctx, votes)?;
         if should_set_timeouts {
-            timer_manager.write().set_timeouts(slot);
+            timer_manager
+                .write()
+                .set_timeouts(slot, local_context.standstill_slot);
             local_context.stats.timeout_set = local_context.stats.timeout_set.saturating_add(1);
         }
 
@@ -238,6 +245,7 @@ impl EventHandler {
             ref mut finalized_blocks,
             ref mut received_shred,
             ref mut stats,
+            ref mut standstill_slot,
         } = local_context;
         match event {
             // Block has completed replay
@@ -412,6 +420,15 @@ impl EventHandler {
                     received_shred,
                     stats,
                 );
+
+                if let Some(slot) = standstill_slot.take() {
+                    info!(
+                        "{my_pubkey}: Standstill initially detected at slot={slot} has ended at \
+                         slot={}. Ending timeout extension",
+                        block.0
+                    );
+                }
+
                 if let Some(parent_block) =
                     Self::add_missing_parent_ready(block, ctx, vctx, local_context)
                 {
@@ -436,6 +453,14 @@ impl EventHandler {
             // We have not observed a finalization certificate in a while, refresh our votes
             VotorEvent::Standstill(highest_finalized_slot) => {
                 info!("{my_pubkey}: Standstill {highest_finalized_slot}");
+                // Record the highest parent ready slot for dynamic timeout extension.
+                if standstill_slot.is_none() {
+                    let (highest_parent_ready, _) = *ctx.highest_parent_ready.read().unwrap();
+                    *standstill_slot = Some(highest_parent_ready);
+                    info!(
+                        "{my_pubkey}: Extending timeouts starting at slot {highest_parent_ready}"
+                    );
+                }
                 // certs refresh happens in CertificatePoolService
                 Self::refresh_votes(my_pubkey, highest_finalized_slot, vctx, &mut votes)?;
             }
@@ -947,6 +972,7 @@ mod tests {
             finalized_blocks: BTreeSet::new(),
             received_shred: BTreeSet::new(),
             stats: EventHandlerStats::default(),
+            standstill_slot: None,
         };
 
         EventHandlerTestContext {
@@ -1646,5 +1672,42 @@ mod tests {
         for file in files_to_remove {
             let _ = remove_file(file);
         }
+    }
+
+    #[test]
+    fn test_standstill_slot_tracking() {
+        let mut test_context = setup();
+
+        // Initially standstill_slot should be None
+        assert!(test_context.local_context.standstill_slot.is_none());
+
+        // Set up some state
+        let root_bank = test_context
+            .bank_forks
+            .read()
+            .unwrap()
+            .sharable_banks()
+            .root();
+        let bank1 = test_context.create_block_and_send_block_event(1, root_bank);
+        let block_id_1 = bank1.block_id().unwrap();
+        test_context.send_parent_ready_event(1, (0, Hash::default()));
+        test_context.check_for_vote(&Vote::new_notarization_vote(1, block_id_1));
+
+        // Send standstill event - should record the standstill slot
+        test_context.send_standstill_event(0);
+
+        // The standstill_slot should now be set to the highest parent ready
+        assert!(test_context.local_context.standstill_slot.is_some());
+        let standstill_slot = test_context.local_context.standstill_slot.unwrap();
+        // The highest parent ready should be 1 since we sent parent_ready for slot 1
+        assert_eq!(standstill_slot, 1);
+
+        // Send another standstill event - should not overwrite the existing standstill_slot
+        test_context.send_standstill_event(0);
+        assert_eq!(test_context.local_context.standstill_slot, Some(1));
+
+        // Send a finalized event - should reset standstill_slot
+        test_context.send_finalized_event((1, block_id_1), false);
+        assert!(test_context.local_context.standstill_slot.is_none());
     }
 }

--- a/votor/src/timer_manager.rs
+++ b/votor/src/timer_manager.rs
@@ -64,8 +64,10 @@ impl TimerManager {
         Self { timers, handle }
     }
 
-    pub(crate) fn set_timeouts(&self, slot: Slot) {
-        self.timers.write().set_timeouts(slot, Instant::now());
+    pub(crate) fn set_timeouts(&self, slot: Slot, standstill_slot: Option<Slot>) {
+        self.timers
+            .write()
+            .set_timeouts(slot, Instant::now(), standstill_slot);
     }
 
     pub(crate) fn join(self) {
@@ -93,7 +95,7 @@ mod tests {
         );
         let slot = 52;
         let start = Instant::now();
-        timer_manager.set_timeouts(slot);
+        timer_manager.set_timeouts(slot, None);
         // Should see two timeouts at DELTA_BLOCK and DELTA_TIMEOUT
         let mut timeouts_received = 0;
         while timeouts_received < 2 && Instant::now().duration_since(start) < Duration::from_secs(2)

--- a/votor/src/timer_manager/timers.rs
+++ b/votor/src/timer_manager/timers.rs
@@ -1,7 +1,7 @@
 use {
     crate::{event::VotorEvent, timer_manager::stats::TimerManagerStats},
     crossbeam_channel::Sender,
-    solana_clock::Slot,
+    solana_clock::{NUM_CONSECUTIVE_LEADER_SLOTS, Slot},
     solana_runtime::leader_schedule_utils::last_of_consecutive_leader_slots,
     std::{
         cmp::Reverse,
@@ -9,6 +9,25 @@ use {
         time::{Duration, Instant},
     },
 };
+
+/// Dynamic skip timeouts can be increased to a maximum of 1hour.
+const MAX_TIMEOUT_SECS: f64 = 3600.0;
+
+/// Calculate the timeout multiplier based on standstill state.
+/// Returns 1.0 if not in standstill, or 1.05^n where n is the number of
+/// leader windows since standstill started.
+fn calculate_timeout_multiplier(slot: Slot, standstill_slot: Option<Slot>) -> f64 {
+    match standstill_slot {
+        None => 1.0,
+        Some(standstill_slot) => {
+            // Calculate number of leader windows since standstill
+            let slots_since_standstill = slot.saturating_sub(standstill_slot);
+            let leader_windows = slots_since_standstill / NUM_CONSECUTIVE_LEADER_SLOTS;
+            // Extend timeout by 5% for each leader window
+            1.05_f64.powi(leader_windows as i32)
+        }
+    }
+}
 
 /// Encodes a basic state machine of the different stages involved in handling
 /// timeouts for a window of slots.
@@ -19,6 +38,8 @@ enum TimerState {
         window: VecDeque<Slot>,
         /// Time when this stage will end.
         timeout: Instant,
+        /// The scaled delta_block duration for this timer.
+        scaled_delta_block: Duration,
     },
     /// Waiting for the DELTA_BLOCK stage.
     WaitDeltaBlock {
@@ -26,6 +47,8 @@ enum TimerState {
         window: VecDeque<Slot>,
         /// Time when this stage will end.
         timeout: Instant,
+        /// The scaled delta_block duration for this timer.
+        scaled_delta_block: Duration,
     },
     /// The state machine is done.
     Done,
@@ -34,33 +57,63 @@ enum TimerState {
 impl TimerState {
     /// Creates a new instance of the state machine.
     ///
+    /// The `timeout_multiplier` is used to extend the timeout durations (e.g., 1.05 = 5% longer).
     /// Also returns the next time the timer should fire.
-    fn new(slot: Slot, delta_timeout: Duration, now: Instant) -> (Self, Instant) {
+    fn new(
+        slot: Slot,
+        delta_timeout: Duration,
+        delta_block: Duration,
+        now: Instant,
+        timeout_multiplier: f64,
+    ) -> (Self, Instant) {
         let window = (slot..=last_of_consecutive_leader_slots(slot)).collect::<VecDeque<_>>();
         assert!(!window.is_empty());
-        let timeout = now.checked_add(delta_timeout).unwrap();
-        (Self::WaitDeltaTimeout { window, timeout }, timeout)
+        // Scale the timeouts by the multiplier, capping at 1 hour.
+        let scaled_delta_timeout = Duration::from_secs_f64(
+            (delta_timeout.as_secs_f64() * timeout_multiplier).min(MAX_TIMEOUT_SECS),
+        );
+        let scaled_delta_block = Duration::from_secs_f64(
+            (delta_block.as_secs_f64() * timeout_multiplier).min(MAX_TIMEOUT_SECS),
+        );
+        let timeout = now.checked_add(scaled_delta_timeout).unwrap();
+        (
+            Self::WaitDeltaTimeout {
+                window,
+                timeout,
+                scaled_delta_block,
+            },
+            timeout,
+        )
     }
 
     /// Call to make progress on the state machine.
     ///
     /// Returns a potentially empty list of events that should be sent.
-    fn progress(&mut self, delta_block: Duration, now: Instant) -> Option<VotorEvent> {
+    fn progress(&mut self, now: Instant) -> Option<VotorEvent> {
         match self {
-            Self::WaitDeltaTimeout { window, timeout } => {
+            Self::WaitDeltaTimeout {
+                window,
+                timeout,
+                scaled_delta_block,
+            } => {
                 assert!(!window.is_empty());
                 if &now < timeout {
                     return None;
                 }
                 let slot = *window.front().unwrap();
-                let timeout = now.checked_add(delta_block).unwrap();
+                let new_timeout = now.checked_add(*scaled_delta_block).unwrap();
                 *self = Self::WaitDeltaBlock {
                     window: window.to_owned(),
-                    timeout,
+                    timeout: new_timeout,
+                    scaled_delta_block: *scaled_delta_block,
                 };
                 Some(VotorEvent::TimeoutCrashedLeader(slot))
             }
-            Self::WaitDeltaBlock { window, timeout } => {
+            Self::WaitDeltaBlock {
+                window,
+                timeout,
+                scaled_delta_block,
+            } => {
                 assert!(!window.is_empty());
                 if &now < timeout {
                     return None;
@@ -70,7 +123,7 @@ impl TimerState {
                 match window.front() {
                     None => *self = Self::Done,
                     Some(_next_slot) => {
-                        *timeout = now.checked_add(delta_block).unwrap();
+                        *timeout = now.checked_add(*scaled_delta_block).unwrap();
                     }
                 }
                 ret
@@ -82,8 +135,9 @@ impl TimerState {
     /// When would this state machine next be able to make progress.
     fn next_fire(&self) -> Option<Instant> {
         match self {
-            Self::WaitDeltaTimeout { window: _, timeout }
-            | Self::WaitDeltaBlock { window: _, timeout } => Some(*timeout),
+            Self::WaitDeltaTimeout { timeout, .. } | Self::WaitDeltaBlock { timeout, .. } => {
+                Some(*timeout)
+            }
             Self::Done => None,
         }
     }
@@ -120,9 +174,18 @@ impl Timers {
     }
 
     /// Call to set timeouts for a new window of slots.
-    pub(super) fn set_timeouts(&mut self, slot: Slot, now: Instant) {
+    /// If `standstill_slot` is provided, timeouts are extended by 5% for each leader window
+    /// since standstill started.
+    pub(super) fn set_timeouts(&mut self, slot: Slot, now: Instant, standstill_slot: Option<Slot>) {
         assert_eq!(self.heap.len(), self.timers.len());
-        let (timer, next_fire) = TimerState::new(slot, self.delta_timeout, now);
+        let timeout_multiplier = calculate_timeout_multiplier(slot, standstill_slot);
+        let (timer, next_fire) = TimerState::new(
+            slot,
+            self.delta_timeout,
+            self.delta_block,
+            now,
+            timeout_multiplier,
+        );
         // It is possible that this slot already has a timer set e.g. if there
         // are multiple ParentReady for the same slot.  Do not insert new timer then.
         let mut new_timer_inserted = false;
@@ -153,7 +216,7 @@ impl Timers {
                     }
 
                     let mut timer = self.timers.remove(&slot).unwrap();
-                    if let Some(event) = timer.progress(self.delta_block, now) {
+                    if let Some(event) = timer.progress(now) {
                         self.event_sender.send(event).unwrap();
                     }
                     if let Some(next_fire) = timer.next_fire() {
@@ -181,44 +244,48 @@ impl Timers {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crossbeam_channel::unbounded};
+    use {
+        super::*,
+        crate::common::{DELTA_BLOCK, DELTA_TIMEOUT},
+        crossbeam_channel::unbounded,
+    };
 
     #[test]
     fn timer_state_machine() {
         let one_micro = Duration::from_micros(1);
         let now = Instant::now();
         let slot = 0;
-        let (mut timer_state, next_fire) = TimerState::new(slot, one_micro, now);
+        let (mut timer_state, next_fire) = TimerState::new(slot, one_micro, one_micro, now, 1.0);
 
         assert!(matches!(
-            timer_state.progress(one_micro, next_fire,).unwrap(),
+            timer_state.progress(next_fire).unwrap(),
             VotorEvent::TimeoutCrashedLeader(0)
         ));
 
         assert!(matches!(
             timer_state
-                .progress(one_micro, timer_state.next_fire().unwrap())
+                .progress(timer_state.next_fire().unwrap())
                 .unwrap(),
             VotorEvent::Timeout(0)
         ));
 
         assert!(matches!(
             timer_state
-                .progress(one_micro, timer_state.next_fire().unwrap())
+                .progress(timer_state.next_fire().unwrap())
                 .unwrap(),
             VotorEvent::Timeout(1)
         ));
 
         assert!(matches!(
             timer_state
-                .progress(one_micro, timer_state.next_fire().unwrap())
+                .progress(timer_state.next_fire().unwrap())
                 .unwrap(),
             VotorEvent::Timeout(2)
         ));
 
         assert!(matches!(
             timer_state
-                .progress(one_micro, timer_state.next_fire().unwrap())
+                .progress(timer_state.next_fire().unwrap())
                 .unwrap(),
             VotorEvent::Timeout(3)
         ));
@@ -234,7 +301,7 @@ mod tests {
         assert!(timers.progress(now).is_none());
         assert!(receiver.try_recv().unwrap_err().is_empty());
 
-        timers.set_timeouts(0, now);
+        timers.set_timeouts(0, now, None);
         while timers.progress(now).is_some() {
             now = now.checked_add(one_micro).unwrap();
         }
@@ -253,5 +320,94 @@ mod tests {
         assert_eq!(stats.set_timeout_count(), 1);
         assert_eq!(stats.set_timeout_succeed_count(), 1);
         assert_eq!(stats.max_heap_size(), 1);
+    }
+
+    #[test]
+    fn timer_state_with_multiplier() {
+        // Test that timeout multiplier correctly extends the timeout duration
+        let delta_timeout = Duration::from_millis(100);
+        let delta_block = Duration::from_millis(50);
+        let now = Instant::now();
+        let slot = 0;
+        let multiplier = 1.5; // 50% longer timeouts
+
+        let (mut timer_state, next_fire) =
+            TimerState::new(slot, delta_timeout, delta_block, now, multiplier);
+
+        // The first timeout should fire at now + (delta_timeout * 1.5) = now + 150ms
+        let expected_first_fire = now + Duration::from_millis(150);
+        assert!(
+            next_fire >= expected_first_fire - Duration::from_micros(100)
+                && next_fire <= expected_first_fire + Duration::from_micros(100),
+            "Expected first fire around {expected_first_fire:?}, got {next_fire:?}",
+        );
+
+        // Progress the timer to get TimeoutCrashedLeader
+        assert!(matches!(
+            timer_state.progress(next_fire).unwrap(),
+            VotorEvent::TimeoutCrashedLeader(0)
+        ));
+
+        // The next fire should be at next_fire + (delta_block * 1.5) = next_fire + 75ms
+        let next = timer_state.next_fire().unwrap();
+        let expected_delta = Duration::from_millis(75);
+        let actual_delta = next - next_fire;
+        assert!(
+            actual_delta >= expected_delta - Duration::from_micros(100)
+                && actual_delta <= expected_delta + Duration::from_micros(100),
+            "Expected delta around {expected_delta:?}, got {actual_delta:?}",
+        );
+    }
+
+    #[test]
+    fn test_calculate_timeout_multiplier() {
+        // No standstill - multiplier should be 1.0
+        assert_eq!(calculate_timeout_multiplier(100, None), 1.0);
+
+        // Standstill at slot 0
+        // At slot 0 (same slot) - 0 leader windows passed
+        assert_eq!(calculate_timeout_multiplier(0, Some(0)), 1.0);
+
+        // At slot 4 (1 leader window = 4 slots) - 1.05^1
+        let multiplier = calculate_timeout_multiplier(4, Some(0));
+        assert!((multiplier - 1.05).abs() < 0.001);
+
+        // At slot 8 (2 leader windows) - 1.05^2
+        let multiplier = calculate_timeout_multiplier(8, Some(0));
+        assert!((multiplier - 1.1025).abs() < 0.001);
+
+        // At slot 40 (10 leader windows) - 1.05^10
+        let multiplier = calculate_timeout_multiplier(40, Some(0));
+        let expected = 1.05_f64.powi(10);
+        assert!((multiplier - expected).abs() < 0.001);
+
+        // Standstill at slot 20, current slot 28 (2 leader windows)
+        let multiplier = calculate_timeout_multiplier(28, Some(20));
+        assert!((multiplier - 1.1025).abs() < 0.001);
+    }
+
+    #[test]
+    fn timer_state_caps_at_max_timeout() {
+        let now = Instant::now();
+        // Use a large multiplier that would exceed MAX_TIMEOUT
+        let multiplier = 1000000.0;
+
+        let (mut timer_state, next_fire) =
+            TimerState::new(100, DELTA_TIMEOUT, DELTA_BLOCK, now, multiplier);
+
+        // The first timeout should be capped at MAX_TIMEOUT
+        let expected_first_fire = now + Duration::from_secs(MAX_TIMEOUT_SECS as u64);
+        assert_eq!(next_fire, expected_first_fire);
+
+        // Progress the timer to get TimeoutCrashedLeader
+        assert!(matches!(
+            timer_state.progress(next_fire).unwrap(),
+            VotorEvent::TimeoutCrashedLeader(100)
+        ));
+
+        // The delta_block timeout should also be capped at MAX_TIMEOUT
+        let next = timer_state.next_fire().unwrap();
+        let actual_delta = next - next_fire;
+        assert_eq!(actual_delta, Duration::from_secs(MAX_TIMEOUT_SECS as u64));
     }
 }


### PR DESCRIPTION
#### Problem

If we are in standstill (i.e. we have not finalized blocks in some time), it might be possible that due to network conditions, our timeouts are too aggressive and need to be extended.


#### Summary of Changes

Upstreams the implementation of dynamic skip timeouts.  Which increases the timeouts based on how many leader windows have passed since we last finalized a block.  The max limit is capped at 1hr.


Original PR https://github.com/anza-xyz/alpenglow/pull/729