### PR TITLE
replay: avoid allocating AsyncVerificationProgress for each slot

### DIFF
--- a/core/src/consensus/progress_map.rs
+++ b/core/src/consensus/progress_map.rs
@@ -7,7 +7,9 @@ use {
     },
     solana_clock::Slot,
     solana_hash::Hash,
-    solana_ledger::blockstore_processor::{ConfirmationProgress, ReplaySlotStats},
+    solana_ledger::blockstore_processor::{
+        AsyncVerificationProgress, ConfirmationProgress, ReplaySlotStats,
+    },
     solana_pubkey::Pubkey,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_vote::vote_account::VoteAccountsHashMap,
@@ -101,6 +103,7 @@ impl ForkProgress {
         validator_stake_info: Option<ValidatorStakeInfo>,
         num_blocks_on_fork: u64,
         num_dropped_blocks_on_fork: u64,
+        async_verification: Option<AsyncVerificationProgress>,
     ) -> Self {
         let (
             is_leader_slot,
@@ -131,7 +134,9 @@ impl ForkProgress {
             is_dead: false,
             fork_stats: ForkStats::default(),
             replay_stats: Arc::new(RwLock::new(ReplaySlotStats::default())),
-            replay_progress: Arc::new(RwLock::new(ConfirmationProgress::new(last_entry))),
+            replay_progress: Arc::new(RwLock::new(
+                ConfirmationProgress::new_with_async_verification(last_entry, async_verification),
+            )),
             num_blocks_on_fork,
             num_dropped_blocks_on_fork,
             propagated_stats: PropagatedStats {
@@ -157,6 +162,7 @@ impl ForkProgress {
         prev_leader_slot: Option<Slot>,
         num_blocks_on_fork: u64,
         num_dropped_blocks_on_fork: u64,
+        async_verification: Option<AsyncVerificationProgress>,
     ) -> Self {
         let validator_stake_info = {
             if bank.leader_id() == validator_identity {
@@ -176,6 +182,7 @@ impl ForkProgress {
             validator_stake_info,
             num_blocks_on_fork,
             num_dropped_blocks_on_fork,
+            async_verification,
         );
 
         if bank.is_frozen() {
@@ -515,7 +522,7 @@ mod test {
     fn test_is_propagated_status_on_construction() {
         // If the given ValidatorStakeInfo == None, then this is not
         // a leader slot and is_propagated == false
-        let progress = ForkProgress::new(Hash::default(), Some(9), None, 0, 0);
+        let progress = ForkProgress::new(Hash::default(), Some(9), None, 0, 0, None);
         assert!(!progress.propagated_stats.is_propagated);
 
         // If the stake is zero, then threshold is always achieved
@@ -528,6 +535,7 @@ mod test {
             }),
             0,
             0,
+            None,
         );
         assert!(progress.propagated_stats.is_propagated);
 
@@ -542,6 +550,7 @@ mod test {
             }),
             0,
             0,
+            None,
         );
         assert!(!progress.propagated_stats.is_propagated);
 
@@ -556,6 +565,7 @@ mod test {
             }),
             0,
             0,
+            None,
         );
         assert!(progress.propagated_stats.is_propagated);
 
@@ -568,6 +578,7 @@ mod test {
             Some(ValidatorStakeInfo::default()),
             0,
             0,
+            None,
         );
         assert!(!progress.propagated_stats.is_propagated);
     }
@@ -578,7 +589,10 @@ mod test {
 
         // Insert new ForkProgress for slot 10 (not a leader slot) and its
         // previous leader slot 9 (leader slot)
-        progress_map.insert(10, ForkProgress::new(Hash::default(), Some(9), None, 0, 0));
+        progress_map.insert(
+            10,
+            ForkProgress::new(Hash::default(), Some(9), None, 0, 0, None),
+        );
         progress_map.insert(
             9,
             ForkProgress::new(
@@ -587,6 +601,7 @@ mod test {
                 Some(ValidatorStakeInfo::default()),
                 0,
                 0,
+                None,
             ),
         );
 
@@ -598,7 +613,10 @@ mod test {
         // The previous leader before 8, slot 7, does not exist in
         // progress map, so is_propagated(8) should return true as
         // this implies the parent is rooted
-        progress_map.insert(8, ForkProgress::new(Hash::default(), Some(7), None, 0, 0));
+        progress_map.insert(
+            8,
+            ForkProgress::new(Hash::default(), Some(7), None, 0, 0, None),
+        );
         assert!(progress_map.get_leader_propagation_slot_must_exist(8).0);
 
         // If we set the is_propagated = true, is_propagated should return true

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -58,9 +58,9 @@ use {
         block_error::BlockError,
         blockstore::Blockstore,
         blockstore_processor::{
-            self, BlockstoreProcessorError, ChainedBlockIdCheck, ConfirmationProgress,
-            ExecuteBatchesInternalMetrics, ReplaySlotStats, TransactionStatusSender,
-            check_chained_block_id,
+            self, AsyncVerificationProgress, BlockstoreProcessorError, ChainedBlockIdCheck,
+            ConfirmationProgress, ExecuteBatchesInternalMetrics, ReplaySlotStats,
+            TransactionStatusSender, check_chained_block_id,
         },
         entry_notifier_service::EntryNotifierSender,
         leader_schedule_cache::LeaderScheduleCache,
@@ -113,6 +113,7 @@ pub const SUPERMINORITY_THRESHOLD: f64 = 1f64 / 3f64;
 pub const MAX_UNCONFIRMED_SLOTS: usize = 5;
 pub const DUPLICATE_LIVENESS_THRESHOLD: f64 = 0.1;
 pub const DUPLICATE_THRESHOLD: f64 = 1.0 - SWITCH_FORK_THRESHOLD - DUPLICATE_LIVENESS_THRESHOLD;
+const ASYNC_VERIFICATION_FREELIST_CAPACITY: usize = 5;
 
 pub(crate) const MAX_VOTE_SIGNATURES: usize = 200;
 const MAX_VOTE_REFRESH_INTERVAL_MILLIS: usize = 5000;
@@ -798,6 +799,9 @@ impl ReplayStage {
                 unfrozen_gossip_verified_vote_hashes,
                 epoch_slots_frozen_slots,
             };
+            // AsyncVerificationProgress does a large allocation for its internal channel, so we
+            // keep a free list to avoid doing one of those for each slot
+            let mut async_verification_freelist = Vec::new();
             let working_bank = {
                 let r_bank_forks = bank_forks.read().unwrap();
                 r_bank_forks.working_bank()
@@ -889,6 +893,7 @@ impl ReplayStage {
                 let new_frozen_slots = Self::process_active_banks(
                     &process_active_banks_context,
                     &mut progress,
+                    &mut async_verification_freelist,
                     &mut latest_validator_votes_for_frozen_banks,
                     &mut duplicate_slots_to_repair,
                     &mut purge_repair_slot_counter,
@@ -1775,7 +1780,15 @@ impl ReplayStage {
             let prev_leader_slot = progress.get_bank_prev_leader_slot(bank);
             progress.insert(
                 bank.slot(),
-                ForkProgress::new_from_bank(bank, my_pubkey, vote_account, prev_leader_slot, 0, 0),
+                ForkProgress::new_from_bank(
+                    bank,
+                    my_pubkey,
+                    vote_account,
+                    prev_leader_slot,
+                    0,
+                    0,
+                    None,
+                ),
             );
         }
         let root = root_bank.slot();
@@ -3185,6 +3198,7 @@ impl ReplayStage {
     fn prepare_active_bank_for_replay(
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
         my_pubkey: &Pubkey,
         vote_account: &Pubkey,
         replay_result: &mut ReplaySlotFromBlockstore,
@@ -3225,6 +3239,7 @@ impl ReplayStage {
                 prev_leader_slot,
                 num_blocks_on_fork,
                 num_dropped_blocks_on_fork,
+                async_verification_freelist.pop(),
             )
         });
 
@@ -3238,6 +3253,7 @@ impl ReplayStage {
     fn prepare_active_banks_for_replay(
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
         my_pubkey: &Pubkey,
         vote_account: &Pubkey,
     ) -> Vec<BankReplayResultTracker> {
@@ -3261,6 +3277,7 @@ impl ReplayStage {
                 let bank_replay_tracker = Self::prepare_active_bank_for_replay(
                     process_active_banks_context,
                     progress,
+                    async_verification_freelist,
                     my_pubkey,
                     vote_account,
                     &mut replay_result,
@@ -3397,6 +3414,7 @@ impl ReplayStage {
     fn process_replay_results(
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
         latest_validator_votes_for_frozen_banks: &mut LatestValidatorVotesForFrozenBanks,
         duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
         purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
@@ -3477,19 +3495,27 @@ impl ReplayStage {
                 let verify_res = {
                     let mut poh_verify_elapsed = 0;
                     let mut tx_verify_elapsed = 0;
-                    let res = bank_progress
-                        .replay_progress
-                        .write()
-                        .unwrap()
-                        .wait_for_all_verification_results(
-                            &mut poh_verify_elapsed,
-                            &mut tx_verify_elapsed,
-                        );
+                    let (res, async_verification) = {
+                        let mut replay_progress = bank_progress.replay_progress.write().unwrap();
+                        (
+                            replay_progress.wait_for_all_verification_results(
+                                &mut poh_verify_elapsed,
+                                &mut tx_verify_elapsed,
+                            ),
+                            replay_progress.take_async_verification(),
+                        )
+                    };
                     {
                         let mut stats = replay_stats.write().unwrap();
                         stats.poh_verify_elapsed += poh_verify_elapsed;
                         stats.transaction_verify_elapsed += tx_verify_elapsed;
                     }
+                    if let Some(async_verification) = async_verification {
+                        if async_verification_freelist.len() < ASYNC_VERIFICATION_FREELIST_CAPACITY
+                        {
+                            async_verification_freelist.push(async_verification);
+                        }
+                    };
                     res
                 };
                 // we send this whether the block was valid or not. It's only
@@ -3771,9 +3797,11 @@ impl ReplayStage {
         new_frozen_slots
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn process_active_banks(
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
         latest_validator_votes_for_frozen_banks: &mut LatestValidatorVotesForFrozenBanks,
         duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
         purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
@@ -3785,6 +3813,7 @@ impl ReplayStage {
         let bank_replay_result_trackers = Self::prepare_active_banks_for_replay(
             process_active_banks_context,
             progress,
+            async_verification_freelist,
             my_pubkey,
             vote_account,
         );
@@ -3804,6 +3833,7 @@ impl ReplayStage {
         Self::process_replay_results(
             process_active_banks_context,
             progress,
+            async_verification_freelist,
             latest_validator_votes_for_frozen_banks,
             duplicate_slots_to_repair,
             purge_repair_slot_counter,
@@ -4726,7 +4756,8 @@ pub(crate) mod tests {
             vote_simulator::{self, VoteSimulator},
         },
         blockstore_processor::{
-            ProcessOptions, confirm_full_slot, fill_blockstore_slot_with_ticks, process_bank_0,
+            ConfirmationProgress, ProcessOptions, confirm_full_slot,
+            fill_blockstore_slot_with_ticks, process_bank_0,
         },
         crossbeam_channel::unbounded,
         itertools::Itertools,
@@ -4928,6 +4959,7 @@ pub(crate) mod tests {
                 Some(0),
                 0,
                 0,
+                None,
             ),
         );
         assert!(progress.get_propagated_stats(1).unwrap().is_leader_slot);
@@ -5047,7 +5079,10 @@ pub(crate) mod tests {
 
         let mut progress = ProgressMap::default();
         for i in 0..=root {
-            progress.insert(i, ForkProgress::new(Hash::default(), None, None, 0, 0));
+            progress.insert(
+                i,
+                ForkProgress::new(Hash::default(), None, None, 0, 0, None),
+            );
         }
 
         let duplicate_slots_tracker: DuplicateSlotsTracker =
@@ -5153,7 +5188,10 @@ pub(crate) mod tests {
         bank_forks.write().unwrap().insert(root_bank);
         let mut progress = ProgressMap::default();
         for i in 0..=root {
-            progress.insert(i, ForkProgress::new(Hash::default(), None, None, 0, 0));
+            progress.insert(
+                i,
+                ForkProgress::new(Hash::default(), None, None, 0, 0, None),
+            );
         }
         let (drop_bank_sender, _drop_bank_receiver) = unbounded();
         let mut tbft_structs = TowerBFTStructures {
@@ -5508,9 +5546,9 @@ pub(crate) mod tests {
             }
         };
         let replay_result = {
-            let bank_progress = progress
-                .entry(slot)
-                .or_insert_with(|| ForkProgress::new(bank.last_blockhash(), None, None, 0, 0));
+            let bank_progress = progress.entry(slot).or_insert_with(|| {
+                ForkProgress::new(bank.last_blockhash(), None, None, 0, 0, None)
+            });
             let tx = match failure {
                 CompleteBankFailure::ReplayError => {
                     // trigger a replay error since from_keypair is not funded
@@ -5567,6 +5605,7 @@ pub(crate) mod tests {
         ReplayStage::process_replay_results(
             &process_active_banks_context,
             &mut progress,
+            &mut Vec::new(),
             &mut latest_validator_votes_for_frozen_banks,
             &mut duplicate_slots_to_repair,
             &mut purge_repair_slot_counter,
@@ -5616,9 +5655,9 @@ pub(crate) mod tests {
             let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
             bank_forks.write().unwrap().insert(bank1);
             let bank1 = bank_forks.read().unwrap().get_with_scheduler(1).unwrap();
-            let bank1_progress = progress
-                .entry(bank1.slot())
-                .or_insert_with(|| ForkProgress::new(bank1.last_blockhash(), None, None, 0, 0));
+            let bank1_progress = progress.entry(bank1.slot()).or_insert_with(|| {
+                ForkProgress::new(bank1.last_blockhash(), None, None, 0, 0, None)
+            });
             let shreds = shred_to_insert(
                 &validator_keypairs.values().next().unwrap().node_keypair,
                 bank1.clone(),
@@ -5641,19 +5680,20 @@ pub(crate) mod tests {
             .and_then(|replay_tx_count| {
                 let mut poh_verify_elapsed = 0;
                 let mut tx_verify_elapsed = 0;
-                bank1_progress
+                let verify_result = bank1_progress
                     .replay_progress
                     .write()
                     .unwrap()
                     .wait_for_all_verification_results(
                         &mut poh_verify_elapsed,
                         &mut tx_verify_elapsed,
-                    )?;
+                    );
                 {
                     let mut stats = bank1_progress.replay_stats.write().unwrap();
                     stats.poh_verify_elapsed += poh_verify_elapsed;
                     stats.transaction_verify_elapsed += tx_verify_elapsed;
                 }
+                verify_result?;
                 Ok(replay_tx_count)
             });
             let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -6000,7 +6040,7 @@ pub(crate) mod tests {
         // Insert the bank that contains a vote for slot 0, which confirms slot 0
         progress.insert(
             1,
-            ForkProgress::new(bank0.last_blockhash(), None, None, 0, 0),
+            ForkProgress::new(bank0.last_blockhash(), None, None, 0, 0, None),
         );
         let ancestors = bank_forks.read().unwrap().ancestors();
         let mut frozen_banks: Vec<_> = bank_forks
@@ -6436,6 +6476,7 @@ pub(crate) mod tests {
                 }),
                 0,
                 0,
+                None,
             ),
         );
         progress_map.insert(
@@ -6449,6 +6490,7 @@ pub(crate) mod tests {
                 }),
                 0,
                 0,
+                None,
             ),
         );
 
@@ -6546,6 +6588,7 @@ pub(crate) mod tests {
                     },
                     0,
                     0,
+                    None,
                 ),
             );
         }
@@ -6620,6 +6663,7 @@ pub(crate) mod tests {
                 }),
                 0,
                 0,
+                None,
             );
 
             let end_range = {
@@ -6673,7 +6717,7 @@ pub(crate) mod tests {
         // should succeed
         progress_map.insert(
             parent_slot,
-            ForkProgress::new(Hash::default(), None, None, 0, 0),
+            ForkProgress::new(Hash::default(), None, None, 0, 0, None),
         );
         assert!(ReplayStage::check_propagation_for_start_leader(
             poh_slot,
@@ -6692,6 +6736,7 @@ pub(crate) mod tests {
                 Some(ValidatorStakeInfo::default()),
                 0,
                 0,
+                None,
             ),
         );
         assert!(!ReplayStage::check_propagation_for_start_leader(
@@ -6715,7 +6760,14 @@ pub(crate) mod tests {
         let previous_leader_slot = parent_slot - 1;
         progress_map.insert(
             parent_slot,
-            ForkProgress::new(Hash::default(), Some(previous_leader_slot), None, 0, 0),
+            ForkProgress::new(
+                Hash::default(),
+                Some(previous_leader_slot),
+                None,
+                0,
+                0,
+                None,
+            ),
         );
         progress_map.insert(
             previous_leader_slot,
@@ -6725,6 +6777,7 @@ pub(crate) mod tests {
                 Some(ValidatorStakeInfo::default()),
                 0,
                 0,
+                None,
             ),
         );
 
@@ -6786,6 +6839,7 @@ pub(crate) mod tests {
                 Some(ValidatorStakeInfo::default()),
                 0,
                 0,
+                None,
             ),
         );
 
@@ -6821,6 +6875,7 @@ pub(crate) mod tests {
                 Some(ValidatorStakeInfo::default()),
                 0,
                 0,
+                None,
             ),
         );
 
@@ -6844,6 +6899,7 @@ pub(crate) mod tests {
                 Some(ValidatorStakeInfo::default()),
                 0,
                 0,
+                None,
             ),
         );
         assert!(!ReplayStage::check_propagation_for_start_leader(
@@ -7113,6 +7169,7 @@ pub(crate) mod tests {
                     Some(1),
                     0,
                     0,
+                    None,
                 ),
             );
             bank3.freeze();
@@ -7142,6 +7199,7 @@ pub(crate) mod tests {
                     Some(3),
                     0,
                     0,
+                    None,
                 ),
             );
             bank5.freeze();
@@ -7172,6 +7230,7 @@ pub(crate) mod tests {
                     Some(5),
                     0,
                     0,
+                    None,
                 ),
             );
             bank6.freeze();
@@ -8232,7 +8291,15 @@ pub(crate) mod tests {
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         progress.insert(
             bank0.slot(),
-            ForkProgress::new_from_bank(&bank0, bank0.leader_id(), &Pubkey::default(), None, 0, 0),
+            ForkProgress::new_from_bank(
+                &bank0,
+                bank0.leader_id(),
+                &Pubkey::default(),
+                None,
+                0,
+                0,
+                None,
+            ),
         );
 
         let (voting_sender, voting_receiver) = unbounded();
@@ -8247,7 +8314,15 @@ pub(crate) mod tests {
         bank1.fill_bank_with_ticks_for_tests();
         progress.insert(
             bank1.slot(),
-            ForkProgress::new_from_bank(&bank1, bank1.leader_id(), &Pubkey::default(), None, 0, 0),
+            ForkProgress::new_from_bank(
+                &bank1,
+                bank1.leader_id(),
+                &Pubkey::default(),
+                None,
+                0,
+                0,
+                None,
+            ),
         );
         tower.record_bank_vote(&bank0);
         ReplayStage::push_vote(
@@ -8312,7 +8387,15 @@ pub(crate) mod tests {
         bank2.freeze();
         progress.insert(
             bank2.slot(),
-            ForkProgress::new_from_bank(&bank2, bank2.leader_id(), &Pubkey::default(), None, 0, 0),
+            ForkProgress::new_from_bank(
+                &bank2,
+                bank2.leader_id(),
+                &Pubkey::default(),
+                None,
+                0,
+                0,
+                None,
+            ),
         );
         for refresh_bank in &[bank1.clone(), bank2.clone()] {
             progress
@@ -8457,6 +8540,7 @@ pub(crate) mod tests {
                 None,
                 0,
                 0,
+                None,
             ),
         );
 
@@ -8686,6 +8770,7 @@ pub(crate) mod tests {
                 None,
                 0,
                 0,
+                None,
             )
         });
         bank_forks.read().unwrap().get(my_slot).unwrap()
@@ -8743,6 +8828,7 @@ pub(crate) mod tests {
                 None,
                 0,
                 0,
+                None,
             )
         });
 
@@ -8806,6 +8892,7 @@ pub(crate) mod tests {
                     None,
                     0,
                     0,
+                    None,
                 )
             });
             new_bank = bank_forks.read().unwrap().get(new_slot).unwrap();
@@ -8929,6 +9016,7 @@ pub(crate) mod tests {
                 Some(0),
                 0,
                 0,
+                None,
             ),
         );
         assert!(progress.get_propagated_stats(1).unwrap().is_leader_slot);
@@ -9108,6 +9196,7 @@ pub(crate) mod tests {
                     Some(0),
                     0,
                     0,
+                    None,
                 ),
             );
             assert!(progress.get_propagated_stats(i).unwrap().is_leader_slot);
@@ -9202,6 +9291,7 @@ pub(crate) mod tests {
                 Some(0),
                 0,
                 0,
+                None,
             ),
         );
         assert!(progress.get_propagated_stats(slot_to_dump).is_some());

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -109,7 +109,7 @@ impl VoteSimulator {
                 .clone_without_scheduler();
             self.progress
                 .entry(slot)
-                .or_insert_with(|| ForkProgress::new(Hash::default(), None, None, 0, 0));
+                .or_insert_with(|| ForkProgress::new(Hash::default(), None, None, 0, 0, None));
             for (pubkey, vote) in cluster_votes.iter() {
                 if vote.contains(&parent) {
                     let keypairs = self.validator_keypairs.get(pubkey).unwrap();
@@ -292,7 +292,7 @@ impl VoteSimulator {
     ) {
         self.progress
             .entry(slot)
-            .or_insert_with(|| ForkProgress::new(Hash::default(), None, None, 0, 0))
+            .or_insert_with(|| ForkProgress::new(Hash::default(), None, None, 0, 0, None))
             .fork_stats
             .lockout_intervals
             .push(LockoutInterval {
@@ -305,7 +305,7 @@ impl VoteSimulator {
     pub fn clear_lockout_intervals(&mut self, slot: Slot) {
         self.progress
             .entry(slot)
-            .or_insert_with(|| ForkProgress::new(Hash::default(), None, None, 0, 0))
+            .or_insert_with(|| ForkProgress::new(Hash::default(), None, None, 0, 0, None))
             .fork_stats
             .lockout_intervals
             .clear()
@@ -433,7 +433,15 @@ pub fn initialize_state_with(
     let mut progress = ProgressMap::default();
     progress.insert(
         0,
-        ForkProgress::new_from_bank(&bank0, bank0.leader_id(), &Pubkey::default(), None, 0, 0),
+        ForkProgress::new_from_bank(
+            &bank0,
+            bank0.leader_id(),
+            &Pubkey::default(),
+            None,
+            0,
+            0,
+            None,
+        ),
     );
     let heaviest_subtree_fork_choice =
         HeaviestSubtreeForkChoice::new_from_bank_forks(bank_forks.clone());

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -133,7 +133,10 @@ fn test_scheduler_waited_by_drop_bank_service() {
 
         let mut progress = ProgressMap::default();
         for i in genesis..=root {
-            progress.insert(i, ForkProgress::new(Hash::default(), None, None, 0, 0));
+            progress.insert(
+                i,
+                ForkProgress::new(Hash::default(), None, None, 0, 0, None),
+            );
         }
 
         let duplicate_slots_tracker: DuplicateSlotsTracker =

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1464,7 +1464,7 @@ pub struct ConfirmationProgress {
     pub num_shreds: u64,
     pub num_entries: usize,
     pub num_txs: usize,
-    async_verification: AsyncVerificationProgress,
+    async_verification: Option<AsyncVerificationProgress>,
 }
 
 impl ConfirmationProgress {
@@ -1475,13 +1475,39 @@ impl ConfirmationProgress {
         }
     }
 
+    pub fn new_with_async_verification(
+        last_entry: Hash,
+        async_verification: Option<AsyncVerificationProgress>,
+    ) -> Self {
+        debug_assert!(
+            async_verification
+                .as_ref()
+                .map(|av| av.pending_jobs == 0 && av.first_error.is_none())
+                .unwrap_or(true)
+        );
+        Self {
+            last_entry,
+            async_verification,
+            ..Self::default()
+        }
+    }
+
+    fn async_verification(&mut self) -> &mut AsyncVerificationProgress {
+        self.async_verification
+            .get_or_insert_with(AsyncVerificationProgress::new)
+    }
+
     fn collect_available_verification_results(
         &mut self,
         poh_verify_elapsed: &mut u64,
         transaction_verify_elapsed: &mut u64,
     ) -> result::Result<(), BlockstoreProcessorError> {
         self.async_verification
-            .collect_available_results(poh_verify_elapsed, transaction_verify_elapsed)
+            .as_mut()
+            .map_or(Ok(()), |async_verification| {
+                async_verification
+                    .collect_available_results(poh_verify_elapsed, transaction_verify_elapsed)
+            })
     }
 
     pub fn wait_for_all_verification_results(
@@ -1490,7 +1516,21 @@ impl ConfirmationProgress {
         transaction_verify_elapsed: &mut u64,
     ) -> result::Result<(), BlockstoreProcessorError> {
         self.async_verification
-            .wait_for_all_results(poh_verify_elapsed, transaction_verify_elapsed)
+            .as_mut()
+            .map_or(Ok(()), |async_verification| {
+                async_verification
+                    .wait_for_all_results(poh_verify_elapsed, transaction_verify_elapsed)
+            })
+    }
+
+    pub fn take_async_verification(&mut self) -> Option<AsyncVerificationProgress> {
+        debug_assert!(
+            self.async_verification
+                .as_ref()
+                .map(|av| av.pending_jobs == 0 && av.first_error.is_none())
+                .unwrap_or(true)
+        );
+        self.async_verification.take()
     }
 }
 
@@ -1500,7 +1540,7 @@ struct AsyncVerificationResult {
     error: Option<BlockstoreProcessorError>,
 }
 
-struct AsyncVerificationProgress {
+pub struct AsyncVerificationProgress {
     sender: Sender<AsyncVerificationResult>,
     receiver: Receiver<AsyncVerificationResult>,
     pending_jobs: usize,
@@ -1519,7 +1559,7 @@ impl AsyncVerificationProgress {
     // it does, that condition is handled gracefully in spawn().
     const RESULT_CHANNEL_CAPACITY: usize = 100000;
 
-    fn new() -> Self {
+    pub fn new() -> Self {
         let (sender, receiver) = crossbeam_channel::bounded(Self::RESULT_CHANNEL_CAPACITY);
         Self {
             sender,
@@ -1890,7 +1930,7 @@ fn confirm_slot_entries(
     if !skip_verification {
         let start_hash = progress.last_entry;
         let verify_entries = entry::entries_to_verification_data(&entries);
-        progress.async_verification.spawn(
+        progress.async_verification().spawn(
             replay_tx_thread_pool,
             poh_verify_elapsed,
             transaction_verify_elapsed,
@@ -1960,7 +2000,7 @@ fn confirm_slot_entries(
         }
     } else {
         let replay_vote_sender = replay_vote_sender.cloned();
-        progress.async_verification.spawn(
+        progress.async_verification().spawn(
             replay_tx_thread_pool,
             poh_verify_elapsed,
             transaction_verify_elapsed,
@@ -2237,6 +2277,7 @@ fn load_frozen_forks(
         let mut process_single_slot_us = 0;
         let mut voting_us = 0;
 
+        let mut async_verification = None;
         while !pending_slots.is_empty() {
             timing.details.per_program_timings.clear();
             let (meta, bank, last_entry_hash) = pending_slots.pop().unwrap();
@@ -2264,7 +2305,10 @@ fn load_frozen_forks(
                 voting_us = 0;
             }
 
-            let mut progress = ConfirmationProgress::new(last_entry_hash);
+            let mut progress = ConfirmationProgress::new_with_async_verification(
+                last_entry_hash,
+                async_verification.take(),
+            );
             let mut m = Measure::start("process_single_slot");
             let bank = bank_forks.write().unwrap().insert_from_ledger(bank);
             if let Err(error) = process_single_slot(
@@ -2285,6 +2329,7 @@ fn load_frozen_forks(
                 }
                 continue;
             }
+            async_verification = progress.take_async_verification();
             txs += progress.num_txs;
 
             // Block must be frozen by this point; otherwise,


### PR DESCRIPTION
AsyncVerificationProgress allocates a large channel internally. Keep a free list so we avoid doing one of those for each slot.

The diff is large because I added an argument to ForkProgress::new_from_bank which is called a lot from tests. If you want to see a smaller diff I can add new_from_bank_with_async_progress or something, but then new_from_bank becomes a test only method...