### PR TITLE
cli: fix off-by-one in dynamic-port-range validation

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -304,11 +304,11 @@ pub fn port_validator(port: String) -> Result<(), String> {
 
 pub fn port_range_validator(port_range: String) -> Result<(), String> {
     if let Some((start, end)) = solana_net_utils::parse_port_range(&port_range) {
-        if end - start < MINIMUM_VALIDATOR_PORT_RANGE_WIDTH {
+        if end - start + 1 < MINIMUM_VALIDATOR_PORT_RANGE_WIDTH {
             Err(format!(
                 "Port range is too small.  Try --dynamic-port-range {}-{}",
                 start,
-                start + MINIMUM_VALIDATOR_PORT_RANGE_WIDTH
+                start + MINIMUM_VALIDATOR_PORT_RANGE_WIDTH - 1
             ))
         } else {
             Ok(())


### PR DESCRIPTION
#### Problem

`--dynamic-port-range 8000-8024` (25 ports) is incorrectly rejected even though the documented minimum is 25 ports. The validation computes `end - start` (8024 - 8000 = 24) instead of counting inclusively, resulting in an off-by-one error. The suggested range in the error message is also off by one.

#### Summary of Changes

- Use `end - start + 1` to correctly compute the inclusive port count
- Fix the suggested range in the error message to recommend exactly `MINIMUM_VALIDATOR_PORT_RANGE_WIDTH` ports instead of one extra

Fixes #7759