### PR TITLE
ci: use write GITHUB_TOKEN for dependabot

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   dependabot:
     timeout-minutes: 10
@@ -15,7 +18,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.PAT }}
 
       - name: update code
         env:


### PR DESCRIPTION
#### Problem

the token can no longer be loaded successfully.

after revisiting the docs, it seems we can rely on `GITHUB_TOKEN` with the write permissions 🤔 
https://docs.github.com/en/code-security/reference/supply-chain-security/troubleshoot-dependabot/troubleshooting-dependabot-on-github-actions#changing-github_token-permissions

#### Summary of Changes

it's already broken, couldn't be worse. let's try using pure `GITHUB_TOKEN` to handle it