### PR TITLE
Randomizes accounts index binning

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -8,8 +8,11 @@ mod secondary;
 mod stats;
 use {
     crate::{
-        accounts_scan::ScanConfig, ancestors::Ancestors, contains::Contains,
-        is_zero_lamport::IsZeroLamport, pubkey_bins::PubkeyBinCalculator24,
+        accounts_scan::ScanConfig,
+        ancestors::Ancestors,
+        contains::Contains,
+        is_zero_lamport::IsZeroLamport,
+        pubkey_bins::{PubkeyBinCalculator, PubkeyBinCalculatorBuilder},
         rolling_bit_field::RollingBitField,
     },
     account_map_entry::{AccountMapEntry, PreAllocatedAccountMapEntry, SlotListWriteGuard},
@@ -226,7 +229,7 @@ pub enum AccountsIndexScanResult {
 /// U: account info type to be persisted to disk
 pub struct AccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
     pub account_maps: Box<[Arc<InMemAccountsIndex<T, U>>]>,
-    pub bin_calculator: PubkeyBinCalculator24,
+    pub bin_calculator: PubkeyBinCalculator,
     program_id_index: SecondaryIndex<RwLockSecondaryIndexEntry>,
     spl_token_mint_index: SecondaryIndex<RwLockSecondaryIndexEntry>,
     spl_token_owner_index: SecondaryIndex<RwLockSecondaryIndexEntry>,
@@ -249,6 +252,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
 
     pub fn new(config: &AccountsIndexConfig, exit: Arc<AtomicBool>) -> Self {
         let (account_maps, bin_calculator, storage) = Self::allocate_accounts_index(config, exit);
+        info!("AccountsIndex bin calculator: {bin_calculator:?}");
         Self {
             purge_older_root_entries_one_slot_list: AtomicUsize::default(),
             account_maps,
@@ -275,12 +279,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         exit: Arc<AtomicBool>,
     ) -> (
         Box<[Arc<InMemAccountsIndex<T, U>>]>,
-        PubkeyBinCalculator24,
+        PubkeyBinCalculator,
         AccountsIndexStorage<T, U>,
     ) {
         let bins = config.bins.unwrap_or(BINS_DEFAULT);
         // create bin_calculator early to verify # bins is reasonable
-        let bin_calculator = PubkeyBinCalculator24::new(bins);
+        let bin_calculator = PubkeyBinCalculatorBuilder::with_bins(
+            NonZeroUsize::new(bins).expect("bins is non-zero"),
+        );
         let storage = AccountsIndexStorage::new(bins, config, exit);
 
         let account_maps: Box<_> = (0..bins)
@@ -858,7 +864,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         // lock contention.
         let bins = self.bins();
         let random_bin_offset = rng().random_range(0..bins);
-        let bin_calc = self.bin_calculator;
+        let bin_calc = &self.bin_calculator;
         items.sort_unstable_by(|(pubkey_a, _), (pubkey_b, _)| {
             ((bin_calc.bin_from_pubkey(pubkey_a) + random_bin_offset) % bins)
                 .cmp(&((bin_calc.bin_from_pubkey(pubkey_b) + random_bin_offset) % bins))
@@ -3590,14 +3596,5 @@ mod tests {
             index.handle_dead_keys(&[key], &AccountSecondaryIndexes::default()),
             vec![key].into_iter().collect::<HashSet<_>>()
         );
-    }
-
-    #[test]
-    #[should_panic(expected = "bins.is_power_of_two()")]
-    #[allow(clippy::field_reassign_with_default)]
-    fn test_illegal_bins() {
-        let mut config = AccountsIndexConfig::default();
-        config.bins = Some(3);
-        AccountsIndex::<bool, bool>::new(&config, Arc::default());
     }
 }

--- a/accounts-db/src/pubkey_bins.rs
+++ b/accounts-db/src/pubkey_bins.rs
@@ -1,48 +1,176 @@
 use {
-    solana_pubkey::Pubkey,
-    std::num::{NonZeroU32, NonZeroUsize},
+    rand::{Rng, rng},
+    solana_pubkey::{PUBKEY_BYTES, Pubkey},
+    std::{fmt, num::NonZeroUsize},
 };
 
-#[derive(Clone, Copy, Debug)]
-pub struct PubkeyBinCalculator24 {
-    // how many bits from the first 3 bytes to shift away to ignore when calculating bin
-    shift_bits: u32,
+type ReadBytesType = u32;
+
+// The bin calculator assumes a pubkey is 32 bytes, so enforce that here.
+const _: () = assert!(PUBKEY_BYTES == 32);
+
+const BITS_PER_BYTE: usize = u8::BITS as usize;
+const _: () = assert!(BITS_PER_BYTE == 8);
+
+/// The maximum number of bins we can support.
+///
+/// This is based on the number of bytes we read in `read_bytes()`.
+///
+/// Basically, if we read four bytes (32 bits) from the pubkey as it's "hash",
+/// and can have a maximum bit-offset of seven,
+/// then the maximum number of bins, as pow2, is 32 - 7 == 25.
+///
+/// 2^25 bins is over 33 million bins, and that should be more than enough.
+/// If we do ever need more, then changing ReadBytesType to u64 gets us 2^57 bins.
+///
+/// To get the real number, do `pow2(MAX_BINS_POW2)`.
+const MAX_BINS_POW2: usize = (size_of::<ReadBytesType>() - 1) * BITS_PER_BYTE + 1;
+const _: () = assert!(MAX_BINS_POW2 == 25);
+
+/// The maximum offset we can support.
+///
+/// This is based on the maximum number of bins.
+/// Take the number of bits in a pubkey (256) and subtract the number of bits for max bins (25).
+const MAX_OFFSET: usize = PUBKEY_BYTES * BITS_PER_BYTE - MAX_BINS_POW2;
+const _: () = assert!(MAX_OFFSET == 231);
+
+/// The bin calculator's byte_offset must be <= this value.
+///
+/// This ensures we can read enough bytes from the pubkey to calculate the bin.
+const MAX_BYTE_OFFSET: usize = PUBKEY_BYTES - size_of::<ReadBytesType>();
+const _: () = assert!(MAX_BYTE_OFFSET == 28);
+
+/// Used to calculate which bin a pubkey maps to.
+///
+/// This struct may be cloned, and will retain the same pubkey -> bin results.
+///
+/// To instantiate, use `PubkeyBinCalculatorBuilder::with_bins(num_bins)`.
+#[derive(Clone)]
+pub struct PubkeyBinCalculator {
+    /// Offset, in bytes, where to begin reading from the pubkey.
+    byte_offset: usize,
+    /// Offset, in bits, into the read_bytes() for the start of the bin.
+    bit_offset: usize,
+    /// Mask to calculate the bin, based on the number of bins.
+    mask: ReadBytesType,
 }
 
-impl PubkeyBinCalculator24 {
-    const MAX_BITS: u32 = 24;
-    const MAX_BINS: usize = 1_usize << Self::MAX_BITS;
+impl PubkeyBinCalculator {
+    /// Calculates the bin that `pubkey` maps to.
+    #[inline]
+    pub fn bin_from_pubkey(&self, pubkey: &Pubkey) -> usize {
+        // This debug assert checks that enough was read from the pubkey to calculate the bin.
+        // The number of bits for num_bins + number of bits for bit_offset
+        // *must* be <= number of bits read from the pubkey.
+        debug_assert!((self.mask + 1).ilog2() + self.bit_offset as u32 <= ReadBytesType::BITS);
+        let bytes = self.read_bytes(pubkey);
+        let bin = (bytes >> self.bit_offset) & self.mask;
+        // SAFETY: bin is a u32, which can fit in a usize
+        // (Unfortunately the trait `std::convert::From<u32>` is not implemented for `usize`)
+        bin as usize
+    }
 
-    /// Creates a new PubkeyBinCalculator24
+    /// Read the bytes from `pubkey` needed to calculate the bin.
+    #[inline]
+    fn read_bytes(&self, pubkey: &Pubkey) -> ReadBytesType {
+        debug_assert!(self.byte_offset <= MAX_BYTE_OFFSET);
+        let ptr = pubkey.as_array().as_ptr();
+        // Because we know we're reading valid bytes within the pubkey, unsafe is used
+        // to avoid bounds checks that would occur if reading via slice indexing.
+        //
+        // SAFETY:
+        //
+        // - `byte_offset` was checked at construction to be in range to read a ReadBytesType.
+        //
+        // add() is safe:
+        // - `byte_offset` can fit in an isize.
+        // - `byte_offset` is in-range of `pubkey`.
+        //
+        // read_unaligned() is safe:
+        // - the ptr being read is valid
+        //   - the ptr came from `pubkey`.
+        //   - the memory range being read is entirely contained within the
+        //     bounds of the allocation (this was checked above by `add()`).
+        // - the value of the type being read (ReadBytesType) is valid
+        //   - the memory of `pubkey` has been initialized
+        unsafe {
+            ptr.add(self.byte_offset)
+                .cast::<ReadBytesType>()
+                .read_unaligned()
+        }
+    }
+}
+
+impl fmt::Debug for PubkeyBinCalculator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PubkeyBinCalculator")
+            .field("num_bins", &(self.mask + 1))
+            .field(
+                "offset",
+                &(self.byte_offset * BITS_PER_BYTE + self.bit_offset),
+            )
+            .finish()
+    }
+}
+
+/// Used to build unique instances of `PubkeyBinCalculator'.
+#[derive(Debug)]
+pub struct PubkeyBinCalculatorBuilder;
+
+impl PubkeyBinCalculatorBuilder {
+    /// Builds a `PubkeyBinCalculator` with `num_bins`.
+    ///
+    /// The returned bin calculator will produce *unique* mappings
+    /// compared to other bin calculators!
     ///
     /// # Panics
     ///
     /// This function will panic if the following conditions are not met:
-    /// * `bins` must be greater than zero
-    /// * `bins` must be a power of two
-    /// * `bins` must be less than or equal to 2^24
-    pub fn new(bins: usize) -> Self {
-        // SAFETY: Caller must guarantee `bins` is non-zero.
-        let bins = NonZeroUsize::new(bins).expect("bins is non-zero");
-        assert!(bins.is_power_of_two());
-        assert!(bins.get() <= Self::MAX_BINS);
-        // SAFETY: `bins` was already non-zero, and we just asserted it fits in 24 bits.
-        let bins = unsafe { NonZeroU32::new_unchecked(bins.get() as u32) };
-        let bits = bins.ilog2();
-        Self {
-            shift_bits: Self::MAX_BITS - bits,
+    /// * `num_bins` must be a power of two
+    /// * `num_bins` must be <= 2^25
+    pub fn with_bins(num_bins: NonZeroUsize) -> PubkeyBinCalculator {
+        // Skip the beginning and end of the pubkey range, which is the most common to grind.
+        const SKIP: usize = 16;
+        let offset = rng().random_range(SKIP..=(MAX_OFFSET - SKIP));
+        Self::with_bins_and_offset(num_bins, offset)
+    }
+
+    /// Builds a `PubkeyBinCalculator` with `num_bins` and `offset`.
+    ///
+    /// The `offset` is used to instantiate a specific PubkeyHasher for the bin calculator.
+    /// Prefer `with_bins()` whenever possible.
+    ///
+    /// The returned bin calculator will produce *identical* mappings
+    /// compared to other bin calculators with the same num_bins and offset.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the following conditions are not met:
+    /// * `num_bins` must be a power of two
+    /// * `num_bins` must be <= 2^25
+    /// * `offset` must be <= 231
+    pub fn with_bins_and_offset(num_bins: NonZeroUsize, offset: usize) -> PubkeyBinCalculator {
+        assert!(
+            offset <= MAX_OFFSET,
+            "offset must be <= {MAX_OFFSET} (actual: {offset})",
+        );
+        assert!(
+            num_bins.is_power_of_two(),
+            "num_bins must be a power of two (actual: {num_bins})",
+        );
+        assert!(
+            num_bins.get() <= (1 << MAX_BINS_POW2),
+            "num_bins must be <= 2^{MAX_BINS_POW2} (actual: {num_bins})",
+        );
+        let byte_offset = offset / BITS_PER_BYTE;
+        let bit_offset = offset - (byte_offset * BITS_PER_BYTE);
+        // SAFETY: We just checked that num_bins is <= MAX_BINS, which is less than u32::MAX.
+        let num_bins_mask = u32::try_from(num_bins.get() - 1).unwrap();
+        PubkeyBinCalculator {
+            byte_offset,
+            bit_offset,
+            mask: num_bins_mask,
         }
-    }
-
-    pub fn bins(&self) -> usize {
-        1 << (Self::MAX_BITS - self.shift_bits)
-    }
-
-    #[inline]
-    pub fn bin_from_pubkey(&self, pubkey: &Pubkey) -> usize {
-        let as_ref = pubkey.as_ref();
-        (((as_ref[0] as usize) << 16) | ((as_ref[1] as usize) << 8) | (as_ref[2] as usize))
-            >> self.shift_bits
     }
 }
 
@@ -50,174 +178,131 @@ impl PubkeyBinCalculator24 {
 mod tests {
     use super::*;
 
-    impl PubkeyBinCalculator24 {
-        fn lowest_pubkey_from_bin(&self, mut bin: usize) -> Pubkey {
-            assert!(bin < self.bins());
-            bin <<= self.shift_bits;
-            let mut pubkey = Pubkey::from([0; 32]);
-            pubkey.as_mut()[0] = ((bin / 256 / 256) & 0xff) as u8;
-            pubkey.as_mut()[1] = ((bin / 256) & 0xff) as u8;
-            pubkey.as_mut()[2] = (bin & 0xff) as u8;
-            pubkey
-        }
-
-        fn highest_pubkey_from_bin(&self, mut bin: usize) -> Pubkey {
-            assert!(bin < self.bins());
-            let mask = (1 << self.shift_bits) - 1;
-            bin <<= self.shift_bits;
-            bin |= mask;
-            let mut pubkey = Pubkey::from([0xff; 32]);
-            pubkey.as_mut()[0] = ((bin / 256 / 256) & 0xff) as u8;
-            pubkey.as_mut()[1] = ((bin / 256) & 0xff) as u8;
-            pubkey.as_mut()[2] = (bin & 0xff) as u8;
-            pubkey
-        }
-    }
-
+    /// Ensure that bin calculation is deterministic.
     #[test]
-    fn test_pubkey_bins() {
-        for i in 0..=24 {
-            let bins = 2u32.pow(i);
-            let calc = PubkeyBinCalculator24::new(bins as usize);
-            assert_eq!(calc.shift_bits, 24 - i, "i: {i}");
-            for bin in 0..bins {
-                assert_eq!(
-                    bin as usize,
-                    calc.bin_from_pubkey(&calc.lowest_pubkey_from_bin(bin as usize))
-                );
-
-                assert_eq!(
-                    bin as usize,
-                    calc.bin_from_pubkey(&calc.highest_pubkey_from_bin(bin as usize))
-                );
-
-                assert_eq!(calc.bins(), bins as usize);
-            }
-        }
-    }
-
-    #[test]
-    fn test_pubkey_bins_pubkeys() {
-        let mut pk = Pubkey::from([0; 32]);
-        for i in 0..=8 {
-            let bins = 2usize.pow(i);
-            let calc = PubkeyBinCalculator24::new(bins);
-
-            let shift_bits = calc.shift_bits - 16; // we are only dealing with first byte
-
-            pk.as_mut()[0] = 0;
-            assert_eq!(0, calc.bin_from_pubkey(&pk));
-            pk.as_mut()[0] = 0xff;
-            assert_eq!(bins - 1, calc.bin_from_pubkey(&pk));
-
-            for bin in 0..bins {
-                pk.as_mut()[0] = (bin << shift_bits) as u8;
-                assert_eq!(
-                    bin,
-                    calc.bin_from_pubkey(&pk),
-                    "bin: {}/{}, shift_bits: {}, val: {}",
-                    bin,
-                    bins,
-                    shift_bits,
-                    pk.as_ref()[0]
-                );
-                if bin > 0 {
-                    pk.as_mut()[0] = ((bin << shift_bits) - 1) as u8;
-                    assert_eq!(bin - 1, calc.bin_from_pubkey(&pk));
+    fn test_bin_from_pubkey_is_deterministic() {
+        for num_bins in [1 << 10, 1 << 14, 1 << 19, 1 << MAX_BINS_POW2] {
+            let bin_calculator1 =
+                PubkeyBinCalculatorBuilder::with_bins(NonZeroUsize::new(num_bins).unwrap());
+            // second bin calculator that exercies cloning
+            let bin_calculator2 = bin_calculator1.clone();
+            for i_pubkey in 0..1_000 {
+                let pubkey = solana_pubkey::new_rand();
+                let expected_bin = bin_calculator1.bin_from_pubkey(&pubkey);
+                for i_calculation in 0..10 {
+                    let actual_bin = bin_calculator1.bin_from_pubkey(&pubkey);
+                    assert_eq!(
+                        actual_bin, expected_bin,
+                        "num_bins: {num_bins}, i_pubkey: {i_pubkey}, i_calculation: \
+                         {i_calculation}, pubkey: {pubkey}",
+                    );
                 }
-            }
-        }
-
-        for i in 9..=16 {
-            let mut pk = Pubkey::from([0; 32]);
-            let bins = 2usize.pow(i);
-            let calc = PubkeyBinCalculator24::new(bins);
-
-            let shift_bits = calc.shift_bits - 8;
-
-            pk.as_mut()[1] = 0;
-            assert_eq!(0, calc.bin_from_pubkey(&pk));
-            pk.as_mut()[0] = 0xff;
-            pk.as_mut()[1] = 0xff;
-            assert_eq!(bins - 1, calc.bin_from_pubkey(&pk));
-
-            let mut pk = Pubkey::from([0; 32]);
-            for bin in 0..bins {
-                let mut target = (bin << shift_bits) as u16;
-                pk.as_mut()[0] = (target / 256) as u8;
-                pk.as_mut()[1] = (target % 256) as u8;
-                assert_eq!(
-                    bin,
-                    calc.bin_from_pubkey(&pk),
-                    "bin: {}/{}, shift_bits: {}, val: {}",
-                    bin,
-                    bins,
-                    shift_bits,
-                    pk.as_ref()[0]
-                );
-                if bin > 0 {
-                    target -= 1;
-                    pk.as_mut()[0] = (target / 256) as u8;
-                    pk.as_mut()[1] = (target % 256) as u8;
-                    assert_eq!(bin - 1, calc.bin_from_pubkey(&pk));
-                }
-            }
-        }
-
-        for i in 17..=24 {
-            let mut pk = Pubkey::from([0; 32]);
-            let bins = 2usize.pow(i);
-            let calc = PubkeyBinCalculator24::new(bins);
-
-            let shift_bits = calc.shift_bits;
-
-            pk.as_mut()[1] = 0;
-            assert_eq!(0, calc.bin_from_pubkey(&pk));
-            pk.as_mut()[0] = 0xff;
-            pk.as_mut()[1] = 0xff;
-            pk.as_mut()[2] = 0xff;
-            assert_eq!(bins - 1, calc.bin_from_pubkey(&pk));
-
-            let mut pk = Pubkey::from([0; 32]);
-            for bin in 0..bins {
-                let mut target = (bin << shift_bits) as u32;
-                pk.as_mut()[0] = (target / 256 / 256) as u8;
-                pk.as_mut()[1] = ((target / 256) % 256) as u8;
-                pk.as_mut()[2] = (target % 256) as u8;
-                assert_eq!(
-                    bin,
-                    calc.bin_from_pubkey(&pk),
-                    "bin: {}/{}, shift_bits: {}, val: {:?}",
-                    bin,
-                    bins,
-                    shift_bits,
-                    &pk.as_ref()[0..3],
-                );
-                if bin > 0 {
-                    target -= 1;
-                    pk.as_mut()[0] = (target / 256 / 256) as u8;
-                    pk.as_mut()[1] = ((target / 256) % 256) as u8;
-                    pk.as_mut()[2] = (target % 256) as u8;
-                    assert_eq!(bin - 1, calc.bin_from_pubkey(&pk));
-                }
+                assert_eq!(expected_bin, bin_calculator2.bin_from_pubkey(&pubkey));
             }
         }
     }
 
+    /// Ensure that bin calculators from *different* builders produce different hashes.
     #[test]
-    #[should_panic(expected = "bins.is_power_of_two()")]
-    fn test_pubkey_bins_bad_non_pow2() {
-        PubkeyBinCalculator24::new(3);
+    fn test_builders_produces_unique_instances() {
+        let num_bins = NonZeroUsize::new(1).unwrap();
+        let bin_calculator1 = PubkeyBinCalculatorBuilder::with_bins(num_bins);
+        let bin_calculator2 = loop {
+            let bc2 = PubkeyBinCalculatorBuilder::with_bins(num_bins);
+            if bc2.byte_offset != bin_calculator1.byte_offset {
+                break bc2;
+            }
+        };
+        let pubkey = solana_pubkey::new_rand();
+        assert_ne!(
+            bin_calculator1.read_bytes(&pubkey),
+            bin_calculator2.read_bytes(&pubkey),
+        );
     }
 
+    /// Ensure that bin calculators from different builders, but with the
+    /// same num_bins and offset, produce *identical* hashes.
     #[test]
-    #[should_panic(expected = "bins.get() <= Self::MAX_BINS")]
-    fn test_pubkey_bins_bad_too_large() {
-        PubkeyBinCalculator24::new(1 << (PubkeyBinCalculator24::MAX_BITS + 1));
+    fn test_builders_with_same_offset_produce_identical_instances() {
+        let num_bins = NonZeroUsize::new(1 << 20).unwrap();
+        let offset = 123;
+        let bin_calculator1 = PubkeyBinCalculatorBuilder::with_bins_and_offset(num_bins, offset);
+        let bin_calculator2 = PubkeyBinCalculatorBuilder::with_bins_and_offset(num_bins, offset);
+        let pubkey = solana_pubkey::new_rand();
+        assert_eq!(
+            bin_calculator1.read_bytes(&pubkey),
+            bin_calculator2.read_bytes(&pubkey),
+        );
+        assert_eq!(
+            bin_calculator1.bin_from_pubkey(&pubkey),
+            bin_calculator2.bin_from_pubkey(&pubkey),
+        );
     }
+
+    /// Ensure all valid number of bins can be used.
     #[test]
-    #[should_panic(expected = "bins is non-zero")]
-    fn test_pubkey_bins_bad_is_zero() {
-        PubkeyBinCalculator24::new(0);
+    fn test_all_valid_bins() {
+        let pubkey = Pubkey::new_unique();
+        for num_bins_pow2 in 0..=MAX_BINS_POW2 {
+            let num_bins = NonZeroUsize::new(1 << num_bins_pow2).unwrap();
+            let bin_calculator = PubkeyBinCalculatorBuilder::with_bins(num_bins);
+            let bin = bin_calculator.bin_from_pubkey(&pubkey);
+            // wrap in a block box to ensure the compiler doesn't elide the bin calculation
+            std::hint::black_box(bin);
+        }
+    }
+
+    /// Ensure all valid offsets can be used.
+    #[test]
+    fn test_all_valid_offsets() {
+        let pubkey = Pubkey::new_unique();
+        let num_bins = NonZeroUsize::new(1).unwrap();
+        for offset in 0..=MAX_OFFSET {
+            let bin_calculator = PubkeyBinCalculatorBuilder::with_bins_and_offset(num_bins, offset);
+            let bin = bin_calculator.bin_from_pubkey(&pubkey);
+            // wrap in a block box to ensure the compiler doesn't elide the bin calculation
+            std::hint::black_box(bin);
+        }
+    }
+
+    /// Ensure non-power-of-two number of bins is not allowed.
+    #[test]
+    #[should_panic(expected = "num_bins must be a power of two")]
+    fn test_num_bins_not_power_of_two_should_panic() {
+        let num_bins = NonZeroUsize::new(3).unwrap();
+        PubkeyBinCalculatorBuilder::with_bins(num_bins);
+    }
+
+    /// Ensure number of bins is in range.
+    #[test]
+    #[should_panic(expected = "num_bins must be <= 2^25")]
+    fn test_num_bins_too_large_should_panic() {
+        let num_bins = NonZeroUsize::new(1 << (MAX_BINS_POW2 + 1)).unwrap();
+        PubkeyBinCalculatorBuilder::with_bins(num_bins);
+    }
+
+    /// Ensure offset is in range.
+    #[test]
+    #[should_panic(expected = "offset must be <= 231")]
+    fn test_bad_offset_should_panic() {
+        let num_bins = NonZeroUsize::new(1).unwrap();
+        PubkeyBinCalculatorBuilder::with_bins_and_offset(num_bins, MAX_OFFSET + 1);
+    }
+
+    /// Ensure enough is read from the pubkey to calculate the bin.
+    #[test]
+    #[should_panic(
+        expected = "(self.mask + 1).ilog2() + self.bit_offset as u32 <= ReadBytesType::BITS"
+    )]
+    fn test_not_enough_read_from_pubkey_should_panic() {
+        let num_bits_read_from_pubkey = ReadBytesType::BITS;
+        let num_bins_bits = 13;
+        let bad_bit_offset = num_bits_read_from_pubkey - num_bins_bits + 1;
+        let bin_calculator = PubkeyBinCalculator {
+            byte_offset: 0,
+            bit_offset: bad_bit_offset.try_into().unwrap(),
+            mask: (1 << num_bins_bits) - 1,
+        };
+        bin_calculator.bin_from_pubkey(&Pubkey::default());
     }
 }


### PR DESCRIPTION
### Problem

From the Problem section in https://github.com/anza-xyz/agave/pull/11528:

Binning in the accounts index is a fixed mapping. This is non-ideal as it doesn't facilitate node diversity.

Here's the number of entries per bin, with the entries sorted in descending order, for all the bins:

<img width="594" height="370" alt="Screenshot 2026-03-26 at 10 40 37 AM" src="https://github.com/user-attachments/assets/92fed707-3095-4e8b-8525-028cf4784508" />

And here's just the top 10 bins:

<img width="597" height="370" alt="Screenshot 2026-03-26 at 10 40 43 AM" src="https://github.com/user-attachments/assets/fd995d6f-67be-4113-98ba-26efd0cc4353" />

We can see the first bin is significantly larger than the rest.

This is also bad for performance when needing to lookup or insert a pubkey in that bin, as it'll take longer than the smaller bins.

### Summary of Changes

Randomize account index binning.

This is an alternative (or follow-up) implementation to #11528. The index binning is a the bit-level over the pubkey range.


### Results

#### Entries per Bin

(Same as #115128)

The current binning strategy in master ends up with a very large single bin, more than twice as large as the next largest. This PR flattens the curve.

| branch | min | max | diff |
|--------|--------|--------|--------|
| master | 133,444 | 311,782 | 178,338 |
| pr | 133,575 | 136,298 | 2,723 |


Here's the number of entries per bin, for all the bins:

<img width="632" height="390" alt="Screenshot 2026-03-26 at 10 42 44 AM" src="https://github.com/user-attachments/assets/648af2aa-8bf7-4447-b1ed-4c3ff4d8f750" />

And here's the top 10:

<img width="632" height="389" alt="Screenshot 2026-03-26 at 10 42 43 AM" src="https://github.com/user-attachments/assets/7377ed31-9a3e-4436-b146-fd366489f785" />


And here's a comparison of the top 10 between master and this PR:

<img width="630" height="390" alt="Screenshot 2026-03-26 at 10 48 16 AM" src="https://github.com/user-attachments/assets/7307f0c5-ad77-48fc-b9c3-a4db4157904e" />


#### A/B Testing

I ran two nodes on mnb, one with master and one with this pr, and then switched their builds and restarted. 

`BtJ` started with this pr (left side is pr, right side is master)
`3XU` started with master (left side is master, right side is pr)

Here's replay time for loading accounts (mean and p99). I don't see a difference. (I wasn't expecting one, as most loads are hitting in the account caches.)

<img width="923" height="883" alt="replay load" src="https://github.com/user-attachments/assets/08afe4ba-1484-410c-9d70-5e359deec900" />


Next is updating the index during store unfrozen (mean and max). I think I see a small slow down in mean but not max.

<img width="923" height="880" alt="store unfrozen" src="https://github.com/user-attachments/assets/4051ce7f-8dc2-421a-8c6e-a87347aba9af" />


Here's store frozen (mean and max). The big spikes are when squash runs. I don't see a difference here.

<img width="921" height="881" alt="store frozen" src="https://github.com/user-attachments/assets/d17647de-dad1-4f8c-9318-4e2c3e947f58" />


Lastly, here's the time (mean and max) spent loading from the index. Note this is over 10 seconds, whereas the store unfrozen/frozen were only over 1 second. Looks like a small slowdown in the mean here. Also note this metric is the load time from inside the index bin, so it doesn't include any time spent calculating the bin from pubkey. This hopefully helps show that the bins themselves are not made any worse. IOW, where's seeing some additional time within the HashMap itself, e.g. longer probe chains.

We may be able to tweak the per-bin hasher as well to get better performance.

<img width="921" height="879" alt="in mem load time" src="https://github.com/user-attachments/assets/1f2517ac-4ada-4352-bbb1-3e28f7d55a4c" />


#### Index Generation time

Generating the index has to map all the accounts into index bins. Here's the runtime of generating the index on mnb running on the same two nodes, which was restarting every 15 minutes to get this data.

Similar to above, `BtJ` started with this pr (left side is pr, right side is master), and `3XU` started with master (left side is master, right side is pr). What I see is that index generation takes a bit over 3 seconds longer.

Looking at the slowlana profiles, the runtime difference is not in the fn that actually does pubkey-to-bin calculation. Instead it is in the underlying hashmap itself. Some time is spent rehashing (as part of growing and reallocating), but that is about the same for both. Instead, similar to the other A/B tests above, there is more time spent probing/comparing in the hashbrown RawTable to find a bucket. This signals to me we can tweak/optimize the per-bin hasher if needed to get better performance.

<img width="923" height="447" alt="Screenshot 2026-04-07 at 9 02 15 AM" src="https://github.com/user-attachments/assets/105453d1-354f-4960-aeff-b059292e9679" />


### Alternatives Considered

In addition to this PR with randomized binning, we could use a real hash function to calculate the bin instead.

I evaluated ahash and siphash1-3 and found their performance was worse than this PR during index generation.

I had four nodes restarting on intervals and cycled through the four pubkey calculators. You'll see four sections below and the correspond to:
1. randomized binning (aka this pr)
2. fixed binning (aka master)
3. hashing with ahash
4. hashing with siphash1-3

Both hashing functions are slower than this PR.

<img width="925" height="443" alt="Screenshot 2026-03-31 at 2 51 08 PM" src="https://github.com/user-attachments/assets/382ba4ec-d10b-47aa-bb38-74ba31e53230" />

We also want the ability to deterministically reuse/reproduce specific binning. This PR allows that. Master currently allows that implicitly.

`ahash` *sort of* allows that. We can have `ahash` return its hash state bytes, but there's also no guarantees the internal algorithm won't change between versions. For agave worst case that likely means we could see a change between stable and beta, as they have pinned dependency versions.

`siphash1-3` allows it too. It's just the slowest, so I'm not sure why we'd want to chose it over the other options.