### PR TITLE
Bump sbpf version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10073,9 +10073,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2166d3e05d355777bee28406a544430904d5c8ad09635b0879b62a9a08584f"
+checksum = "5cc6fee0979c35ae053780a071927b068f5d9a5cb12e12b043a5ea60d67a53ca"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -478,7 +478,7 @@ solana-rpc-client-types = { path = "rpc-client-types", version = "=4.1.0-alpha.0
 solana-runtime = { path = "runtime", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-sanitize = "3.0.1"
-solana-sbpf = { version = "=0.16.0", default-features = false }
+solana-sbpf = { version = "=0.17.0", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-secp256k1-program = "3.0.1"
 solana-secp256k1-recover = "3.1.1"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8630,9 +8630,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2166d3e05d355777bee28406a544430904d5c8ad09635b0879b62a9a08584f"
+checksum = "5cc6fee0979c35ae053780a071927b068f5d9a5cb12e12b043a5ea60d67a53ca"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -137,7 +137,7 @@ solana-rpc-client = { path = "../rpc-client", version = "=4.1.0-alpha.0", defaul
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=4.1.0-alpha.0" }
 solana-runtime = { path = "../runtime", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-runtime-transaction = { path = "../runtime-transaction", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-sbpf = { version = "=0.16.0", default-features = false }
+solana-sbpf = { version = "=0.17.0", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-shred-version = "3.0.1"
 solana-signature = { version = "3.3.0", default-features = false }

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -543,7 +543,9 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     let (instruction_count, result) = vm.execute_program(&verified_executable, &mut execution_mode);
     let duration = Instant::now() - start_time;
     if let Some(trace_option) = matches.value_of("trace") {
-        vm.context_object_pointer.iterate_vm_traces(
+        // SAFETY: VM is the only holder of the InvokeContext reference, as it carries its lifetime.
+        let invoke_context_ref = unsafe { vm.context_object_pointer.as_mut() };
+        invoke_context_ref.iterate_vm_traces(
             &|instruction_context: InstructionContext, executable, register_trace| {
                 let mut analysis = LazyAnalysis::new(executable);
                 if trace_option == "stdout" {

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1399,7 +1399,10 @@ mod tests {
         solana_account::{Account, AccountSharedData, ReadableAccount},
         solana_account_info::AccountInfo,
         solana_sbpf::{
-            ebpf::MM_INPUT_START, memory_region::MemoryRegion, program::SBPFVersion, vm::Config,
+            ebpf::MM_INPUT_START,
+            memory_region::MemoryRegion,
+            program::SBPFVersion,
+            vm::{Config, ContextObject},
         },
         solana_sdk_ids::{bpf_loader, system_program},
         solana_svm_feature_set::SVMFeatureSet,
@@ -1957,10 +1960,11 @@ mod tests {
         );
 
         invoke_context
-            .set_memory_context(MemoryContext {
-                allocator: BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
-                accounts_metadata: vec![account_metadata],
-            })
+            .set_memory_context(MemoryContext::new(
+                BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
+                vec![account_metadata],
+                memory_mapping,
+            ))
             .unwrap();
 
         invoke_context
@@ -1974,10 +1978,12 @@ mod tests {
                 vec![],
             )
             .unwrap();
+
+        let mapping_ptr = invoke_context.active_mapping_ptr();
         let accounts = translate_accounts_rust(
             vm_addr,
             1,
-            &memory_mapping,
+            unsafe { mapping_ptr.as_ref() },
             &mut invoke_context,
             true, // check_aligned
         )

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -49,6 +49,7 @@ use {
         borrow::Cow,
         cell::RefCell,
         fmt::{self, Debug},
+        ptr,
         rc::Rc,
         time::Duration,
     },
@@ -107,6 +108,13 @@ impl ContextObject for InvokeContext<'_, '_> {
 
     fn get_remaining(&self) -> u64 {
         *self.compute_meter.borrow()
+    }
+
+    fn active_mapping_ptr(&mut self) -> ptr::NonNull<MemoryMapping> {
+        let last_context = self
+            .get_memory_context_mut()
+            .expect("The memory context must have been set for the current instruction");
+        ptr::NonNull::from_mut(&mut last_context.memory_mapping)
     }
 }
 
@@ -178,10 +186,37 @@ impl<'a> EnvironmentConfig<'a> {
 }
 
 /// This structure contains metadata about the memory for each instruction under execution.
-/// The BpfAllocator, accounts addresses in the guest and the memory mapping (future).
+/// The BpfAllocator, accounts addresses in the guest and the memory mapping.
 pub struct MemoryContext {
     pub allocator: BpfAllocator,
     pub accounts_metadata: Vec<SerializedAccountMetadata>,
+    memory_mapping: Box<MemoryMapping>,
+}
+
+impl MemoryContext {
+    /// Creates a new memory context
+    pub fn new(
+        allocator: BpfAllocator,
+        accounts_metadata: Vec<SerializedAccountMetadata>,
+        memory_mapping: MemoryMapping,
+    ) -> Self {
+        Self {
+            allocator,
+            accounts_metadata,
+            memory_mapping: Box::new(memory_mapping),
+        }
+    }
+
+    /// Returns an empty dummy context used for builtin functions
+    pub(crate) fn empty() -> Self {
+        Self {
+            allocator: BpfAllocator::new(0),
+            accounts_metadata: Vec::new(),
+            memory_mapping: Box::new(
+                MemoryMapping::new(Vec::new(), &Config::default(), SBPFVersion::Reserved).unwrap(),
+            ),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -212,7 +247,7 @@ pub struct InvokeContext<'a, 'ix_data> {
     /// Time spent so far executing nested program calls.
     pub total_nested_exec_time: Duration,
     pub timings: ExecuteDetailsTimings,
-    pub memory_context: Vec<Option<MemoryContext>>,
+    pub memory_context: Vec<MemoryContext>,
     /// Pairs of index in TX instruction trace and VM register trace
     register_traces: Vec<(usize, Vec<[u64; 12]>)>,
     /// Debug port to use for this executing transaction.
@@ -273,7 +308,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             }
         }
 
-        self.memory_context.push(None);
+        self.memory_context.push(MemoryContext::empty());
         self.transaction_context.push()
     }
 
@@ -584,9 +619,6 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         stable_log::program_invoke(&logger, &program_id, self.get_stack_height());
         let pre_remaining_units = self.get_remaining();
         // For now, only built-ins are invoked from here, so the VM and its Config are irrelevant.
-        let mock_config = Config::default();
-        let empty_memory_mapping =
-            MemoryMapping::new(Vec::new(), &mock_config, SBPFVersion::V0).unwrap();
         let mut vm = EbpfVm::new(
             Arc::clone(
                 &**self
@@ -597,7 +629,6 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             SBPFVersion::V0,
             // Removes lifetime tracking
             unsafe { std::mem::transmute::<&mut InvokeContext, &mut InvokeContext>(self) },
-            empty_memory_mapping,
             0,
         );
         vm.invoke_function(function);
@@ -741,7 +772,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         *self
             .memory_context
             .last_mut()
-            .ok_or(InstructionError::CallDepth)? = Some(memory_context);
+            .ok_or(InstructionError::CallDepth)? = memory_context;
         Ok(())
     }
 
@@ -749,7 +780,6 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
     pub fn get_memory_context(&self) -> Result<&MemoryContext, InstructionError> {
         self.memory_context
             .last()
-            .and_then(std::option::Option::as_ref)
             .ok_or(InstructionError::CallDepth)
     }
 
@@ -757,7 +787,6 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
     pub fn get_memory_context_mut(&mut self) -> Result<&mut MemoryContext, InstructionError> {
         self.memory_context
             .last_mut()
-            .and_then(|memory_context| memory_context.as_mut())
             .ok_or(InstructionError::CallDepth)
     }
 

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -67,15 +67,15 @@ pub fn create_vm<'a, 'b>(
             .virtual_address_space_adjustments,
         invoke_context.get_feature_set().account_data_direct_mapping,
     )?;
-    invoke_context.set_memory_context(MemoryContext {
-        allocator: BpfAllocator::new(heap_size as u64),
+    invoke_context.set_memory_context(MemoryContext::new(
+        BpfAllocator::new(heap_size as u64),
         accounts_metadata,
-    })?;
+        memory_mapping,
+    ))?;
     Ok(EbpfVm::new(
         program.get_loader().clone(),
         program.get_sbpf_version(),
         invoke_context,
-        memory_mapping,
         stack_size,
     ))
 }
@@ -255,7 +255,10 @@ pub fn execute<'a, 'b: 'a>(
         }
 
         let execute_time = Measure::start("execute");
-        let prev_nested_exec_time = vm.context_object_pointer.total_nested_exec_time;
+
+        // SAFETY: VM is the only holder of the InvokeContext reference, as it carries its lifetime.
+        let prev_nested_exec_time =
+            unsafe { vm.context_object_pointer.as_ref().total_nested_exec_time };
 
         vm.registers[1] = ebpf::MM_INPUT_START;
         // SIMD-0321: Provide offset to instruction data in VM register 2.

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -82,7 +82,7 @@ pub use {
         error::EbpfError,
         memory_region::MemoryMapping,
         program::BuiltinFunctionDefinition,
-        vm::{EbpfVm, get_runtime_environment_key},
+        vm::{EbpfVm, EncryptedHostAddressToEbpfVm, get_runtime_environment_key},
     },
     solana_transaction_context::IndexOfAccount,
 };
@@ -227,22 +227,23 @@ macro_rules! processor {
                 unreachable!()
             }
             fn vm(
-                vm: *mut $crate::EbpfVm<$crate::InvokeContext>,
+                mut vm: $crate::EncryptedHostAddressToEbpfVm<$crate::InvokeContext>,
                 _: u64,
                 _: u64,
                 _: u64,
                 _: u64,
                 _: u64,
             ) {
-                let vm = unsafe {
-                    &mut *((vm as *mut u64)
-                        .offset(-($crate::get_runtime_environment_key() as isize))
-                        as *mut $crate::EbpfVm<$crate::InvokeContext>)
-                };
-                vm.program_result =
-                    $crate::invoke_builtin_function($builtin_function, vm.context_object_pointer)
+                unsafe {
+                    vm.with_vm(|vm| {
+                        vm.program_result = $crate::invoke_builtin_function(
+                            $builtin_function,
+                            vm.context_object_pointer.as_mut(),
+                        )
                         .map_err(|err| $crate::EbpfError::SyscallError(err))
                         .into();
+                    });
+                }
             }
         };
         Some(<Converter as $crate::BuiltinFunctionDefinition<_>>::register)

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8999,9 +8999,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sbpf"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2166d3e05d355777bee28406a544430904d5c8ad09635b0879b62a9a08584f"
+checksum = "5cc6fee0979c35ae053780a071927b068f5d9a5cb12e12b043a5ea60d67a53ca"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -566,7 +566,15 @@ pub(crate) mod tests {
             Ok(0)
         }
 
-        fn vm(_: *mut solana_sbpf::vm::EbpfVm<C>, _: u64, _: u64, _: u64, _: u64, _: u64) {}
+        fn vm(
+            _: solana_sbpf::vm::EncryptedHostAddressToEbpfVm<C>,
+            _: u64,
+            _: u64,
+            _: u64,
+            _: u64,
+            _: u64,
+        ) {
+        }
         fn codegen(_: &mut solana_sbpf::program::JitCompiler<C>) {}
     }
 

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -3152,12 +3152,7 @@ mod tests {
     macro_rules! setup_alloc_test {
         ($invoke_context:ident, $memory_mapping:ident, $heap:ident) => {
             prepare_mockup!($invoke_context, program_id, bpf_loader::id());
-            $invoke_context
-                .set_memory_context(MemoryContext {
-                    allocator: BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
-                    accounts_metadata: Vec::new(),
-                })
-                .unwrap();
+            use solana_sbpf::vm::ContextObject;
             let config = Config {
                 aligned_memory_mapping: false,
                 ..Config::default()
@@ -3168,8 +3163,15 @@ mod tests {
                 $heap.as_slice_mut(),
                 ebpf::MM_HEAP_START,
             )];
-            let mut $memory_mapping =
-                MemoryMapping::new(regions, &config, SBPFVersion::V3).unwrap();
+            let mapping = MemoryMapping::new(regions, &config, SBPFVersion::V3).unwrap();
+            $invoke_context
+                .set_memory_context(MemoryContext::new(
+                    BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
+                    Vec::new(),
+                    mapping,
+                ))
+                .unwrap();
+            let $memory_mapping = unsafe { $invoke_context.active_mapping_ptr().as_mut() };
         };
     }
 
@@ -3185,7 +3187,7 @@ mod tests {
                 0,
                 0,
                 0,
-                &mut memory_mapping,
+                memory_mapping,
             );
             assert_ne!(result.unwrap(), 0);
             let result = SyscallAllocFree::rust(
@@ -3195,18 +3197,11 @@ mod tests {
                 0,
                 0,
                 0,
-                &mut memory_mapping,
+                memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
-            let result = SyscallAllocFree::rust(
-                &mut invoke_context,
-                u64::MAX,
-                0,
-                0,
-                0,
-                0,
-                &mut memory_mapping,
-            );
+            let result =
+                SyscallAllocFree::rust(&mut invoke_context, u64::MAX, 0, 0, 0, 0, memory_mapping);
             assert_eq!(result.unwrap(), 0);
         }
 
@@ -3215,7 +3210,7 @@ mod tests {
             setup_alloc_test!(invoke_context, memory_mapping, heap);
             for _ in 0..100 {
                 let result =
-                    SyscallAllocFree::rust(&mut invoke_context, 1, 0, 0, 0, 0, &mut memory_mapping);
+                    SyscallAllocFree::rust(&mut invoke_context, 1, 0, 0, 0, 0, memory_mapping);
                 assert_ne!(result.unwrap(), 0);
             }
             let result = SyscallAllocFree::rust(
@@ -3225,7 +3220,7 @@ mod tests {
                 0,
                 0,
                 0,
-                &mut memory_mapping,
+                memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
         }
@@ -3235,7 +3230,7 @@ mod tests {
             setup_alloc_test!(invoke_context, memory_mapping, heap);
             for _ in 0..12 {
                 let result =
-                    SyscallAllocFree::rust(&mut invoke_context, 1, 0, 0, 0, 0, &mut memory_mapping);
+                    SyscallAllocFree::rust(&mut invoke_context, 1, 0, 0, 0, 0, memory_mapping);
                 assert_ne!(result.unwrap(), 0);
             }
             let result = SyscallAllocFree::rust(
@@ -3245,7 +3240,7 @@ mod tests {
                 0,
                 0,
                 0,
-                &mut memory_mapping,
+                memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
         }
@@ -3261,7 +3256,7 @@ mod tests {
                 0,
                 0,
                 0,
-                &mut memory_mapping,
+                memory_mapping,
             );
             let address = result.unwrap();
             assert_ne!(address, 0);


### PR DESCRIPTION
#### Problem

solana-sbpf was released with changes in the MemoryMapping management. `InvokeContext` now should own the mapping and borrow it to the virtual machine.

#### Summary of Changes

1. `MemoryContext` now owns a `Box<MemoryMapping>` for every instruction.
2. Since the VM requires a valid MemoryMapping pointer for every instruction, builtin functions have now `MemoryContext::empty()` with dummy entries, instead of `None`.
3. Fix tests.
4. Update usages of `EncryptedHostAddressToEbpfVm`.
