### PR TITLE
Collapse secondary index scan into accounts_Db

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3438,20 +3438,26 @@ impl AccountsDb {
             &empty_ancestors
         };
 
-        self.accounts_index.index_scan_accounts(
-            ancestors,
-            scan_guard.max_root(),
-            index_key,
-            |pubkey, (account_info, slot)| {
-                let account_slot = self
-                    .get_account_accessor(slot, pubkey, &account_info.storage_location())
-                    .get_loaded_account(|loaded_account| {
-                        (pubkey, loaded_account.take_account(), slot)
-                    });
-                scan_func(account_slot)
-            },
-            config,
-        );
+        let max_root = scan_guard.max_root();
+        for pubkey in self.accounts_index.get_index_key_pubkeys(&index_key) {
+            if config.is_aborted() {
+                break;
+            }
+            self.accounts_index.get_with_and_then(
+                &pubkey,
+                Some(ancestors),
+                Some(max_root),
+                true,
+                |(slot, account_info)| {
+                    let account_slot = self
+                        .get_account_accessor(slot, &pubkey, &account_info.storage_location())
+                        .get_loaded_account(|loaded_account| {
+                            (&pubkey, loaded_account.take_account(), slot)
+                        });
+                    scan_func(account_slot)
+                },
+            );
+        }
 
         // Check whether the bank was removed while the scan was in progress.
         if scan_guard.was_scan_corrupted() {

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -147,7 +147,6 @@ pub trait DiskIndexValue:
 
 enum ScanTypes {
     Unindexed,
-    Indexed(IndexKey),
 }
 
 /// specification of how much memory the in-mem portion of account index can hold
@@ -319,36 +318,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                 // Pass "" not to log metrics, so RPC doesn't get spammy
                 self.do_scan_accounts(metric_name, ancestors, func, Some(max_root), config);
             }
-            ScanTypes::Indexed(IndexKey::ProgramId(program_id)) => {
-                self.do_scan_secondary_index(
-                    ancestors,
-                    func,
-                    &self.program_id_index,
-                    &program_id,
-                    Some(max_root),
-                    config,
-                );
-            }
-            ScanTypes::Indexed(IndexKey::SplTokenMint(mint_key)) => {
-                self.do_scan_secondary_index(
-                    ancestors,
-                    func,
-                    &self.spl_token_mint_index,
-                    &mint_key,
-                    Some(max_root),
-                    config,
-                );
-            }
-            ScanTypes::Indexed(IndexKey::SplTokenOwner(owner_key)) => {
-                self.do_scan_secondary_index(
-                    ancestors,
-                    func,
-                    &self.spl_token_owner_index,
-                    &owner_key,
-                    Some(max_root),
-                    config,
-                );
-            }
         }
     }
 
@@ -417,34 +386,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                 ("iterator_elapsed", iterator_elapsed, i64),
                 ("num_keys_iterated", num_keys_iterated, i64),
             )
-        }
-    }
-
-    fn do_scan_secondary_index<
-        F,
-        SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send,
-    >(
-        &self,
-        ancestors: &Ancestors,
-        mut func: F,
-        index: &SecondaryIndex<SecondaryIndexEntryType>,
-        index_key: &Pubkey,
-        max_root: Option<Slot>,
-        config: &ScanConfig,
-    ) where
-        F: FnMut(&Pubkey, (&T, Slot)),
-    {
-        for pubkey in index.get(index_key) {
-            if config.is_aborted() {
-                break;
-            }
-            self.get_with_and_then(
-                &pubkey,
-                Some(ancestors),
-                max_root,
-                true,
-                |(slot, account_info)| func(&pubkey, (&account_info, slot)),
-            );
         }
     }
 
@@ -556,26 +497,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         self.do_checked_scan_accounts("", ancestors, max_root, func, ScanTypes::Unindexed, config)
     }
 
-    /// call func with every pubkey and index visible from a given set of ancestors
-    pub(crate) fn index_scan_accounts<F>(
-        &self,
-        ancestors: &Ancestors,
-        max_root: Slot,
-        index_key: IndexKey,
-        func: F,
-        config: &ScanConfig,
-    ) where
-        F: FnMut(&Pubkey, (&T, Slot)),
-    {
-        // Pass "" not to log metrics, so RPC doesn't get spammy
-        self.do_checked_scan_accounts(
-            "",
-            ancestors,
-            max_root,
-            func,
-            ScanTypes::Indexed(index_key),
-            config,
-        )
+    /// Returns the list of pubkeys from the secondary index for the given key.
+    pub(crate) fn get_index_key_pubkeys(&self, index_key: &IndexKey) -> Vec<Pubkey> {
+        match index_key {
+            IndexKey::ProgramId(key) => self.program_id_index.get(key),
+            IndexKey::SplTokenMint(key) => self.spl_token_mint_index.get(key),
+            IndexKey::SplTokenOwner(key) => self.spl_token_owner_index.get(key),
+        }
     }
 
     pub fn get_rooted_entries(


### PR DESCRIPTION
#### Problem
When the accounts index no longer stores cached accounts, scan will need to scan both the accounts cache and the accounts index. This refactor makes that possible

#### Summary of Changes
- Add function to get pubkeys for secondary index pubkeys
- Collapse do_scan_secondary_index into index_scan_account in accounts_db 
- Next PR will add accounts cache index check

Fixes #
