### PR TITLE
Revert "ci: use write GITHUB_TOKEN for dependabot (#11701)"

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - master
 
-permissions:
-  contents: write
-
 jobs:
   dependabot:
     timeout-minutes: 10
@@ -18,6 +15,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.PAT }}
 
       - name: update code
         env:


### PR DESCRIPTION
This reverts commit a99444e6777e8607edc14e55f9146a578d5305ca.

#### Problem

I thought I could switch to a write permission GITHUB_TOKEN. however, I forgot the branch protection... this means it needs either a PAT or a github app generated token to bypass it

#### Summary of Changes

revert it