### PR TITLE
alpenglow: upstream double merkle as the block id for alpenglow blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11253,6 +11253,7 @@ dependencies = [
  "solana-rpc",
  "solana-rpc-client-api",
  "solana-runtime",
+ "solana-sha256-hasher",
  "solana-signature",
  "solana-signer",
  "solana-streamer",

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3553,7 +3553,7 @@ impl ReplayStage {
                 // finishes.
                 let block_id = process_active_banks_context
                     .blockstore
-                    .get_last_shred_merkle_root(bank.slot())
+                    .get_block_id(bank.slot(), &process_active_banks_context.migration_status)
                     .ok();
                 debug_assert!(block_id.is_some() || is_leader_block);
                 if block_id.is_some() {

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9665,6 +9665,7 @@ dependencies = [
  "solana-rpc",
  "solana-rpc-client-api",
  "solana-runtime",
+ "solana-sha256-hasher",
  "solana-signature",
  "solana-signer",
  "solana-streamer",

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -24,6 +24,7 @@ use {
         transaction_address_lookup_table_scanner::scan_transaction,
     },
     agave_snapshots::unpack_genesis_archive,
+    agave_votor_messages::migration::MigrationStatus,
     assert_matches::{assert_matches, debug_assert_matches},
     crossbeam_channel::{Receiver, Sender, TrySendError, bounded},
     dashmap::DashSet,
@@ -2811,6 +2812,20 @@ impl Blockstore {
             .ok_or(BlockstoreError::MissingShred(slot, last_index))?;
         shred::layout::get_merkle_root(&shred_bytes)
             .ok_or(BlockstoreError::MissingMerkleRoot(slot, last_index))
+    }
+
+    /// Retrieves the block id of this slot depending on the `migration_status`:
+    /// - For TowerBFT blocks this is the merkle root of the last shred
+    /// - For Alpenglow blocks this is the double merkle root
+    ///
+    /// Returns None if the block is not complete
+    pub fn get_block_id(&self, slot: Slot, migration_status: &MigrationStatus) -> Result<Hash> {
+        if migration_status.should_use_double_merkle_block_id(slot) {
+            let dmr = self.get_double_merkle_root(slot, BlockLocation::Original)?;
+            dmr.ok_or(BlockstoreError::SlotNotFull)
+        } else {
+            self.get_last_shred_merkle_root(slot)
+        }
     }
 
     pub fn get_data_shreds_for_slot(&self, slot: Slot, start_index: u64) -> Result<Vec<Shred>> {

--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -15,6 +15,8 @@ pub enum BlockstoreError {
     RocksDb(#[from] rocksdb::Error),
     #[error("slot is not rooted")]
     SlotNotRooted,
+    #[error("slot is not full")]
+    SlotNotFull,
     #[error("dead slot")]
     DeadSlot,
     #[error("io error: {0}")]

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2613,7 +2613,7 @@ pub fn process_single_slot(
     })?;
 
     let block_id = blockstore
-        .get_last_shred_merkle_root(slot)
+        .get_block_id(slot, migration_status)
         .expect("Full block must have block id");
     bank.set_block_id(Some(block_id));
     bank.freeze(); // all banks handled by this routine are created from complete slots

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -86,7 +86,7 @@ use {solana_keypair::Keypair, solana_perf::packet::Packet, solana_signer::Signer
 
 mod common;
 pub mod merkle;
-pub(crate) mod merkle_tree;
+pub mod merkle_tree;
 mod payload;
 mod shred_code;
 pub(crate) mod shred_data;

--- a/ledger/src/shred/merkle_tree.rs
+++ b/ledger/src/shred/merkle_tree.rs
@@ -20,7 +20,7 @@ pub(crate) const MERKLE_HASH_PREFIX_NODE: &[u8] = b"\x01SOLANA_MERKLE_SHREDS_NOD
 pub(crate) type MerkleProofEntry = [u8; 20];
 
 /// A struct to track a given Merkle tree.
-pub(crate) struct MerkleTree {
+pub struct MerkleTree {
     /// List of all the nodes in the tree.
     /// The constructor ensures that this is not empty.
     /// The last node in the list is the root of the tree.
@@ -44,7 +44,7 @@ impl MerkleTree {
         Self::try_new_with_len(shreds, num_shreds)
     }
 
-    pub(crate) fn try_new_with_len(
+    pub fn try_new_with_len(
         shreds: impl Iterator<Item = Result<Hash, Error>>,
         len: usize,
     ) -> Result<MerkleTree, Error> {
@@ -68,7 +68,7 @@ impl MerkleTree {
     }
 
     /// Returns a reference to the root of the tree.
-    pub(crate) fn root(&self) -> &Hash {
+    pub fn root(&self) -> &Hash {
         // constructor ensures that the tree contains at least one node so this unwrap() should be safe.
         self.nodes.last().unwrap()
     }

--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -36,6 +36,8 @@ pub struct ProcessShredsStats {
     pub num_extant_slots: u64,
     // When looking up chained merkle root from parent slot fails.
     pub err_unknown_chained_merkle_root: u64,
+    // When looking up the block id from the parent slot fails.
+    pub err_unknown_parent_block_id: u64,
     pub(crate) padding_bytes: usize,
     pub(crate) data_bytes: usize,
     pub(crate) num_entries: usize,
@@ -105,6 +107,11 @@ impl ProcessShredsStats {
             (
                 "err_unknown_chained_merkle_root",
                 self.err_unknown_chained_merkle_root,
+                i64
+            ),
+            (
+                "err_unknown_parent_block_id",
+                self.err_unknown_parent_block_id,
                 i64
             ),
             ("padding_bytes", self.padding_bytes, i64),
@@ -241,6 +248,7 @@ impl AddAssign<ProcessShredsStats> for ProcessShredsStats {
             num_data_shreds_hist,
             num_extant_slots,
             err_unknown_chained_merkle_root,
+            err_unknown_parent_block_id,
             padding_bytes,
             data_bytes,
             num_entries,
@@ -261,6 +269,7 @@ impl AddAssign<ProcessShredsStats> for ProcessShredsStats {
         self.coalesce_exited_rcv_timeout += coalesce_exited_rcv_timeout;
         self.num_extant_slots += num_extant_slots;
         self.err_unknown_chained_merkle_root += err_unknown_chained_merkle_root;
+        self.err_unknown_parent_block_id += err_unknown_parent_block_id;
         self.padding_bytes += padding_bytes;
         self.data_bytes += data_bytes;
         self.num_entries += num_entries;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9985,6 +9985,7 @@ dependencies = [
  "solana-rpc",
  "solana-rpc-client-api",
  "solana-runtime",
+ "solana-sha256-hasher",
  "solana-signature",
  "solana-signer",
  "solana-streamer",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6001,11 +6001,8 @@ impl Bank {
 
     pub fn set_block_id(&self, block_id: Option<Hash>) {
         let mut block_id_w = self.block_id.write().unwrap();
-        if block_id_w.is_some() {
-            debug_assert_eq!(*block_id_w, block_id);
-        } else {
-            *block_id_w = block_id;
-        }
+        debug_assert!(block_id_w.is_none() || *block_id_w == block_id);
+        *block_id_w = block_id
     }
 
     pub fn compute_budget(&self) -> Option<ComputeBudget> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6000,7 +6000,12 @@ impl Bank {
     }
 
     pub fn set_block_id(&self, block_id: Option<Hash>) {
-        *self.block_id.write().unwrap() = block_id;
+        let mut block_id_w = self.block_id.write().unwrap();
+        if block_id_w.is_some() {
+            debug_assert_eq!(*block_id_w, block_id);
+        } else {
+            *block_id_w = block_id;
+        }
     }
 
     pub fn compute_budget(&self) -> Option<ComputeBudget> {

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -43,6 +43,7 @@ solana-pubkey = { workspace = true }
 solana-rpc = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
+solana-sha256-hasher = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-streamer = { workspace = true }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -13,8 +13,10 @@ use {
     solana_keypair::Keypair,
     solana_ledger::shred::{
         MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT, ProcessShredsStats, ReedSolomonCache,
-        Shred, ShredType, Shredder,
+        Shred, ShredType, Shredder, merkle_tree::MerkleTree,
     },
+    solana_runtime::bank::Bank,
+    solana_sha256_hasher::hashv,
     solana_time_utils::AtomicInterval,
     std::{borrow::Cow, sync::RwLock},
 };
@@ -23,8 +25,10 @@ use {
 pub struct StandardBroadcastRun {
     slot: Slot,
     parent: Slot,
+    parent_block_id: Hash,
     chained_merkle_root: Hash,
     carryover_entry: Option<WorkingBankEntry>,
+    double_merkle_leaves: Vec<Hash>,
     next_shred_index: u32,
     next_code_index: u32,
     // If last_tick_height has reached bank.max_tick_height() for this slot
@@ -61,7 +65,9 @@ impl StandardBroadcastRun {
         Self {
             slot: Slot::MAX,
             parent: Slot::MAX,
+            parent_block_id: Hash::default(),
             chained_merkle_root: Hash::default(),
+            double_merkle_leaves: vec![],
             carryover_entry: None,
             next_shred_index: 0,
             next_code_index: 0,
@@ -78,6 +84,57 @@ impl StandardBroadcastRun {
             migration_status,
             votor_event_sender,
         }
+    }
+
+    /// Upon receipt of shreds from a new bank (bank.slot() != self.slot)
+    /// reinitialize any necessary state and stats.
+    fn reinitialize_state(
+        &mut self,
+        blockstore: &Blockstore,
+        bank: &Bank,
+        process_stats: &mut ProcessShredsStats,
+    ) {
+        debug_assert_ne!(bank.slot(), self.slot);
+
+        let chained_merkle_root = if self.slot == bank.parent_slot() {
+            self.chained_merkle_root
+        } else {
+            broadcast_utils::get_chained_merkle_root_from_parent(
+                bank.slot(),
+                bank.parent_slot(),
+                blockstore,
+            )
+            .unwrap_or_else(|err: Error| {
+                error!("Unknown chained Merkle root: {err:?}");
+                process_stats.err_unknown_chained_merkle_root += 1;
+                Hash::default()
+            })
+        };
+
+        let parent_block_id = bank.parent_block_id().unwrap_or_else(|| {
+            // Once SIMD-0333 is active, we can just hard unwrap here.
+            error!(
+                "Parent block id missing for slot {} parent {}",
+                bank.slot(),
+                bank.parent_slot()
+            );
+            process_stats.err_unknown_parent_block_id += 1;
+            Hash::default()
+        });
+
+        self.slot = bank.slot();
+        self.parent = bank.parent_slot();
+        self.parent_block_id = parent_block_id;
+        self.chained_merkle_root = chained_merkle_root;
+        self.double_merkle_leaves.clear();
+        self.next_shred_index = 0u32;
+        self.next_code_index = 0u32;
+        self.completed = false;
+        self.slot_broadcast_start = Instant::now();
+        self.num_batches = 0;
+
+        process_stats.receive_elapsed = 0;
+        process_stats.coalesce_elapsed = 0;
     }
 
     // If the current slot has changed, generates an empty shred indicating
@@ -147,8 +204,17 @@ impl StandardBroadcastRun {
                     *next_index = (*next_index).max(shred.index() + 1);
                 })
                 .collect();
-        if let Some(shred) = shreds.iter().max_by_key(|shred| shred.fec_set_index()) {
-            self.chained_merkle_root = shred.merkle_root().unwrap();
+
+        let fec_set_roots = shreds
+            .iter()
+            .unique_by(|shred| shred.fec_set_index())
+            .sorted_unstable_by_key(|shred| shred.fec_set_index())
+            .map(|shred| shred.merkle_root().expect("no more legacy shreds"));
+        // If necessary for perf, these leaves could start being joined in the background
+        self.double_merkle_leaves.extend(fec_set_roots);
+
+        if let Some(fec_set_root) = self.double_merkle_leaves.last() {
+            self.chained_merkle_root = *fec_set_root;
         }
         if self.next_shred_index > max_data_shreds_per_slot {
             return Err(BroadcastError::TooManyShreds);
@@ -232,31 +298,9 @@ impl StandardBroadcastRun {
                 // Refrain from generating shreds for the slot.
                 return Err(Error::DuplicateSlotBroadcast(bank.slot()));
             }
+
             // Reinitialize state for this slot.
-            let chained_merkle_root = if self.slot == bank.parent_slot() {
-                self.chained_merkle_root
-            } else {
-                broadcast_utils::get_chained_merkle_root_from_parent(
-                    bank.slot(),
-                    bank.parent_slot(),
-                    blockstore,
-                )
-                .unwrap_or_else(|err: Error| {
-                    error!("Unknown chained Merkle root: {err:?}");
-                    process_stats.err_unknown_chained_merkle_root += 1;
-                    Hash::default()
-                })
-            };
-            self.slot = bank.slot();
-            self.parent = bank.parent_slot();
-            self.chained_merkle_root = chained_merkle_root;
-            self.next_shred_index = 0u32;
-            self.next_code_index = 0u32;
-            self.completed = false;
-            self.slot_broadcast_start = Instant::now();
-            self.num_batches = 0;
-            process_stats.receive_elapsed = 0;
-            process_stats.coalesce_elapsed = 0;
+            self.reinitialize_state(blockstore, &bank, process_stats);
         }
 
         // 2) Convert entries to shreds and coding shreds
@@ -331,12 +375,35 @@ impl StandardBroadcastRun {
             self.completed = true;
 
             // Populate the block id and send for voting
-            // The block id is the merkle root of the last FEC set which is now the chained merkle root
+            let block_id = if self
+                .migration_status
+                .should_use_double_merkle_block_id(bank.slot())
+            {
+                // Block id is the double merkle root
+                let fec_set_count = self.double_merkle_leaves.len();
+                // Add the final leaf (parent info)
+                let parent_info_leaf =
+                    hashv(&[&self.parent.to_le_bytes(), Hash::default().as_bytes()]);
+                self.double_merkle_leaves.push(parent_info_leaf);
+
+                // Compute the double merkle root
+                // Blockstore population of the DoubleMerkleMeta happens asynchronously when shreds are inserted
+                let merkle_tree = MerkleTree::try_new_with_len(
+                    self.double_merkle_leaves.drain(..).map(Ok),
+                    fec_set_count + 1,
+                )
+                .expect("Double merkle tree construction cannot fail");
+                *merkle_tree.root()
+            } else {
+                // The block id is the merkle root of the last FEC set which is now the chained merkle root
+                self.chained_merkle_root
+            };
+
             broadcast_utils::set_block_id_and_send(
                 &self.migration_status,
                 &self.votor_event_sender,
                 bank,
-                self.chained_merkle_root,
+                block_id,
             )?;
         }
 

--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -277,6 +277,11 @@ impl MigrationPhase {
         self.is_alpenglow_block(slot)
     }
 
+    /// Should this block use the double merkle root as the block id (instead of chained merkle root)?
+    fn should_use_double_merkle_block_id(&self, slot: Slot) -> bool {
+        self.is_alpenglow_block(slot)
+    }
+
     /// Should this block allow the UpdateParent marker, i.e., support fast leader handover?
     fn should_allow_fast_leader_handover(&self, slot: Slot) -> bool {
         self.is_alpenglow_block(slot)
@@ -419,6 +424,7 @@ impl MigrationStatus {
     dispatch!(pub fn should_have_alpenglow_ticks(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_allow_block_markers(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_allow_fast_leader_handover(&self, slot: Slot) -> bool);
+    dispatch!(pub fn should_use_double_merkle_block_id(&self, slot: Slot) -> bool);
 
     /// The alpenglow feature flag has been activated in slot `slot`.
     /// This should only be called using the feature account of a *rooted* slot,


### PR DESCRIPTION
Upstream of https://github.com/anza-xyz/alpenglow/pull/621

#### Problem
For alpenglow blocks we use the double merkle root instead of the chained merkle root as the block id

#### Summary of Changes
In replay before freezing a bank, set the double merkle root as the block id
In broadcast, keep a running list of leaves so that we can set the double merkle root for leader banks
