### PR TITLE
repair: upstream request / response types for alpenglow repair

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
+    "solana-ledger/dev-context-only-utils",
     "solana-perf/dev-context-only-utils",
     "solana-runtime/dev-context-only-utils",
     "solana-streamer/dev-context-only-utils",

--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -1,21 +1,23 @@
 use {
     super::{
         malicious_repair_handler::{MaliciousRepairConfig, MaliciousRepairHandler},
+        repair_response::repair_response_packet_from_bytes,
         serve_repair::ServeRepair,
         standard_repair_handler::StandardRepairHandler,
     },
     crate::repair::{
         repair_response,
-        serve_repair::{AncestorHashesResponse, MAX_ANCESTOR_RESPONSES},
+        serve_repair::{AncestorHashesResponse, BlockIdRepairResponse, MAX_ANCESTOR_RESPONSES},
     },
     agave_votor_messages::migration::MigrationStatus,
     bincode::serialize,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
+    solana_hash::Hash,
     solana_ledger::{
         ancestor_iterator::{AncestorIterator, AncestorIteratorWithHash},
         blockstore::Blockstore,
-        shred::Nonce,
+        shred::{DATA_SHREDS_PER_FEC_BLOCK, ErasureSetId, Nonce},
     },
     solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, RecycledPacketBatch},
     solana_poh::poh_recorder::SharedLeaderState,
@@ -27,6 +29,20 @@ use {
         sync::{Arc, RwLock},
     },
 };
+
+/// Helper function to create a PacketBatch from a serializable response
+fn create_response_packet_batch<T: serde::Serialize>(
+    recycler: &PacketBatchRecycler,
+    response: &T,
+    from_addr: &SocketAddr,
+    nonce: Nonce,
+    debug_label: &'static str,
+) -> Option<PacketBatch> {
+    let serialized_response = serialize(response).ok()?;
+    let packet =
+        repair_response::repair_response_packet_from_bytes(serialized_response, from_addr, nonce)?;
+    Some(RecycledPacketBatch::new_with_recycler_data(recycler, debug_label, vec![packet]).into())
+}
 
 pub trait RepairHandler {
     fn blockstore(&self) -> &Blockstore;
@@ -53,6 +69,34 @@ pub trait RepairHandler {
             RecycledPacketBatch::new_with_recycler_data(
                 recycler,
                 "run_window_request",
+                vec![packet],
+            )
+            .into(),
+        )
+    }
+
+    fn run_window_request_for_block_id(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        shred_index: u64,
+        block_id: Hash,
+        nonce: Nonce,
+    ) -> Option<PacketBatch> {
+        let location = self
+            .blockstore()
+            .get_block_location(slot, block_id)
+            .ok()??;
+        let shred = self
+            .blockstore()
+            .get_data_shred_from_location(slot, shred_index, location)
+            .ok()??;
+        let packet = repair_response_packet_from_bytes(shred, from_addr, nonce)?;
+        Some(
+            RecycledPacketBatch::new_with_recycler_data(
+                recycler,
+                "run_window_request_for_block_id",
                 vec![packet],
             )
             .into(),
@@ -110,24 +154,71 @@ pub trait RepairHandler {
             vec![]
         };
         let response = AncestorHashesResponse::Hashes(ancestor_slot_hashes);
-        let serialized_response = serialize(&response).ok()?;
+        create_response_packet_batch(recycler, &response, from_addr, nonce, "run_ancestor_hashes")
+    }
 
-        // Could probably directly write response into packet via `serialize_into()`
-        // instead of incurring extra copy in `repair_response_packet_from_bytes`, but
-        // serialize_into doesn't return the written size...
-        let packet = repair_response::repair_response_packet_from_bytes(
-            serialized_response,
+    fn run_parent_fec_set_count(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        block_id: Hash,
+        nonce: Nonce,
+    ) -> Option<PacketBatch> {
+        let (double_merkle_meta, location) = self
+            .blockstore()
+            .get_double_merkle_meta_maybe_populate_proofs_for_block_id(slot, block_id)
+            .ok()??;
+
+        let slot_meta = self
+            .blockstore()
+            .meta_from_location(slot, location)
+            .ok()??;
+
+        let parent_slot = slot_meta.parent_slot?;
+        let parent_proof = double_merkle_meta.get_parent_info_proof()?.to_vec();
+
+        let response = BlockIdRepairResponse::ParentFecSetCount {
+            fec_set_count: double_merkle_meta.fec_set_count(),
+            parent_info: (parent_slot, Hash::default()),
+            parent_proof,
+        };
+        create_response_packet_batch(
+            recycler,
+            &response,
             from_addr,
             nonce,
-        )?;
-        Some(
-            RecycledPacketBatch::new_with_recycler_data(
-                recycler,
-                "run_ancestor_hashes",
-                vec![packet],
-            )
-            .into(),
+            "run_parent_fec_set_count",
         )
+    }
+
+    fn run_fec_set_root(
+        &self,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        block_id: Hash,
+        fec_set_index: u32,
+        nonce: Nonce,
+    ) -> Option<PacketBatch> {
+        let (double_merkle_meta, location) = self
+            .blockstore()
+            .get_double_merkle_meta_maybe_populate_proofs_for_block_id(slot, block_id)
+            .ok()??;
+
+        let fec_set_root = self
+            .blockstore()
+            .merkle_root_meta_from_location(ErasureSetId::new(slot, fec_set_index), location)
+            .ok()??
+            .merkle_root()?;
+        let proof_index = fec_set_index.checked_div(DATA_SHREDS_PER_FEC_BLOCK as u32)?;
+        let fec_set_proof = double_merkle_meta.get_fec_set_proof(proof_index)?.to_vec();
+
+        let response = BlockIdRepairResponse::FecSetRoot {
+            fec_set_root,
+            fec_set_proof,
+        };
+        create_response_packet_batch(recycler, &response, from_addr, nonce, "run_fec_set_root")
     }
 }
 
@@ -165,5 +256,261 @@ impl RepairHandlerType {
             leader_state,
             migration_status,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        rand::Rng,
+        solana_entry::entry::create_ticks,
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_ledger::{
+            blockstore_meta::BlockLocation,
+            get_tmp_ledger_path_auto_delete,
+            shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
+        },
+        solana_perf::packet::PacketBatchRecycler,
+        std::net::{IpAddr, Ipv4Addr, SocketAddr},
+    };
+
+    /// Creates shreds for a slot with both data and coding shreds
+    fn setup_erasure_shreds(
+        slot: Slot,
+        parent_slot: Slot,
+        num_entries: u64,
+    ) -> (Vec<Shred>, Vec<Shred>) {
+        let entries = create_ticks(num_entries, 0, Hash::default());
+        let leader_keypair = Arc::new(Keypair::new());
+        let shredder = Shredder::new(slot, parent_slot, 0, 0).unwrap();
+        let mut rng = rand::rng();
+        let chained_merkle_root = Hash::new_from_array(rng.random());
+        let (data_shreds, coding_shreds) = shredder.entries_to_merkle_shreds_for_tests(
+            &leader_keypair,
+            &entries,
+            true, // is_last_in_slot
+            chained_merkle_root,
+            0, // next_shred_index
+            0, // next_code_index
+            &ReedSolomonCache::default(),
+            &mut ProcessShredsStats::default(),
+        );
+
+        (data_shreds, coding_shreds)
+    }
+
+    /// Sets up a blockstore with a complete slot and all necessary metadata
+    fn setup_blockstore_with_complete_slot(
+        slot: Slot,
+        parent_slot: Slot,
+        num_entries: u64,
+    ) -> (Arc<Blockstore>, Hash, Vec<Hash>) {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+
+        // First, insert the parent slot so the child slot can be marked full
+        let grandparent_slot = parent_slot.saturating_sub(1);
+        let (parent_data_shreds, parent_coding_shreds) =
+            setup_erasure_shreds(parent_slot, grandparent_slot, 10);
+        blockstore
+            .insert_shreds(
+                parent_data_shreds
+                    .into_iter()
+                    .chain(parent_coding_shreds)
+                    .collect::<Vec<_>>(),
+                None,
+                true,
+            )
+            .unwrap();
+
+        // Now create the target slot
+        let (data_shreds, coding_shreds) = setup_erasure_shreds(slot, parent_slot, num_entries);
+
+        // Collect merkle roots for each FEC set
+        let mut fec_set_roots = Vec::new();
+        for shred in data_shreds.iter() {
+            if shred.index() % (DATA_SHREDS_PER_FEC_BLOCK as u32) == 0 {
+                fec_set_roots.push(shred.merkle_root().unwrap());
+            }
+        }
+
+        // Insert shreds - DoubleMerkleMeta will be computed atomically when slot becomes full
+        blockstore
+            .insert_shreds(
+                data_shreds
+                    .into_iter()
+                    .chain(coding_shreds)
+                    .collect::<Vec<_>>(),
+                None,
+                true, // is_trusted
+            )
+            .unwrap();
+
+        // Verify the slot is full
+        let slot_meta = blockstore.meta(slot).unwrap().unwrap();
+        assert!(
+            slot_meta.is_full(),
+            "Slot should be full after inserting all shreds"
+        );
+
+        // Get the double merkle root (computed during shred insertion when slot became full)
+        let block_id = blockstore
+            .get_double_merkle_root(slot, BlockLocation::Original)
+            .expect("DoubleMerkleMeta fetch should succeed")
+            .expect("DoubleMerkleMeta should exist for full slot");
+
+        (blockstore, block_id, fec_set_roots)
+    }
+
+    #[test]
+    fn test_run_fec_set_root() {
+        let slot = 1000;
+        let parent_slot = 999;
+        // Use many entries to ensure multiple FEC sets (each FEC set has 32 data shreds)
+        let num_entries = 2000;
+
+        let (blockstore, block_id, fec_set_roots) =
+            setup_blockstore_with_complete_slot(slot, parent_slot, num_entries);
+
+        let handler = StandardRepairHandler::new(blockstore.clone());
+        let recycler = PacketBatchRecycler::default();
+        let from_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+        let nonce = 12345;
+
+        // Verify we have multiple FEC sets
+        assert!(
+            fec_set_roots.len() >= 2,
+            "Should have at least 2 FEC sets for this test, got {}",
+            fec_set_roots.len()
+        );
+
+        // Test each FEC set using the actual fec_set_index (0, 32, 64, ...)
+        for (i, expected_root) in fec_set_roots.iter().enumerate() {
+            let fec_set_index = (i * DATA_SHREDS_PER_FEC_BLOCK) as u32;
+
+            let result = handler.run_fec_set_root(
+                &recycler,
+                &from_addr,
+                slot,
+                block_id,
+                fec_set_index,
+                nonce,
+            );
+
+            assert!(
+                result.is_some(),
+                "run_fec_set_root should succeed for fec_set_index {fec_set_index}"
+            );
+
+            // Deserialize the response and verify
+            let packet_batch = result.unwrap();
+            assert_eq!(packet_batch.len(), 1);
+
+            let packet = packet_batch.iter().next().unwrap();
+            let (response, response_nonce): (BlockIdRepairResponse, Nonce) =
+                bincode::deserialize(packet.data(..packet.meta().size).unwrap()).unwrap();
+
+            assert_eq!(response_nonce, nonce);
+            match response {
+                BlockIdRepairResponse::FecSetRoot {
+                    fec_set_root,
+                    fec_set_proof,
+                } => {
+                    assert_eq!(
+                        fec_set_root, *expected_root,
+                        "FEC set root should match for index {fec_set_index}"
+                    );
+                    assert!(
+                        !fec_set_proof.is_empty(),
+                        "FEC set proof should not be empty"
+                    );
+                }
+                _ => panic!("Expected FecSetRoot response"),
+            }
+        }
+
+        // Test with invalid block_id returns None
+        let invalid_block_id = Hash::new_unique();
+        let result =
+            handler.run_fec_set_root(&recycler, &from_addr, slot, invalid_block_id, 0, nonce);
+        assert!(result.is_none(), "Should return None for invalid block_id");
+
+        // Test with out-of-bounds fec_set_index returns None
+        let invalid_fec_set_index = (fec_set_roots.len() * DATA_SHREDS_PER_FEC_BLOCK) as u32;
+        let result = handler.run_fec_set_root(
+            &recycler,
+            &from_addr,
+            slot,
+            block_id,
+            invalid_fec_set_index,
+            nonce,
+        );
+        assert!(
+            result.is_none(),
+            "Should return None for out-of-bounds fec_set_index"
+        );
+    }
+
+    #[test]
+    fn test_run_parent_fec_set_count() {
+        let slot = 1000;
+        let parent_slot = 999;
+        let num_entries = 2000;
+
+        let (blockstore, block_id, fec_set_roots) =
+            setup_blockstore_with_complete_slot(slot, parent_slot, num_entries);
+
+        let handler = StandardRepairHandler::new(blockstore.clone());
+        let recycler = PacketBatchRecycler::default();
+        let from_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+        let nonce = 12345;
+
+        let result = handler.run_parent_fec_set_count(&recycler, &from_addr, slot, block_id, nonce);
+
+        assert!(result.is_some(), "run_parent_fec_set_count should succeed");
+
+        // Deserialize and verify the response
+        let packet_batch = result.unwrap();
+        assert_eq!(packet_batch.len(), 1);
+
+        let packet = packet_batch.iter().next().unwrap();
+        let (response, response_nonce): (BlockIdRepairResponse, Nonce) =
+            bincode::deserialize(packet.data(..packet.meta().size).unwrap()).unwrap();
+
+        assert_eq!(response_nonce, nonce);
+        match response {
+            BlockIdRepairResponse::ParentFecSetCount {
+                fec_set_count,
+                parent_info: (p_slot, p_block_id),
+                parent_proof,
+            } => {
+                assert_eq!(
+                    fec_set_count as usize,
+                    fec_set_roots.len(),
+                    "FEC set count should match"
+                );
+                assert_eq!(p_slot, parent_slot, "Parent slot should match");
+                assert_eq!(
+                    p_block_id,
+                    Hash::default(),
+                    "Parent block ID should be default"
+                );
+
+                assert!(!parent_proof.is_empty(), "Parent proof should not be empty");
+            }
+            _ => panic!("Expected ParentFecSetCount response"),
+        }
+
+        // Test with invalid block_id returns None
+        let invalid_block_id = Hash::new_unique();
+        let result =
+            handler.run_parent_fec_set_count(&recycler, &from_addr, slot, invalid_block_id, nonce);
+        assert!(result.is_none(), "Should return None for invalid block_id");
+
+        // Test with non-existent slot returns None
+        let result = handler.run_parent_fec_set_count(&recycler, &from_addr, 9999, block_id, nonce);
+        assert!(result.is_none(), "Should return None for non-existent slot");
     }
 }

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -9,13 +9,14 @@ use {
         cluster_slots_service::cluster_slots::ClusterSlots,
         repair::{
             duplicate_repair_status::get_ancestor_hash_repair_sample_size,
+            outstanding_requests::OutstandingRequests,
             repair_handler::RepairHandler,
             repair_service::{OutstandingShredRepairs, REPAIR_MS, RepairStats},
             request_response::RequestResponse,
             result::{Error, RepairVerifyError, Result},
         },
     },
-    agave_votor_messages::migration::MigrationStatus,
+    agave_votor_messages::{consensus_message::Block, migration::MigrationStatus},
     bincode::{Options, serialize},
     crossbeam_channel::{Receiver, RecvTimeoutError},
     lazy_lru::LruCache,
@@ -36,7 +37,10 @@ use {
     },
     solana_hash::{HASH_BYTES, Hash},
     solana_keypair::{Keypair, signable::Signable},
-    solana_ledger::shred::{self, Nonce, SIZE_OF_NONCE, ShredFetchStats},
+    solana_ledger::shred::{
+        self, DATA_SHREDS_PER_FEC_BLOCK, MAX_FEC_SETS_PER_SLOT, Nonce, SIZE_OF_NONCE,
+        ShredFetchStats, ShredType, layout::get_merkle_root, merkle_tree,
+    },
     solana_net_utils::{SocketAddrSpace, token_bucket::TokenBucket},
     solana_packet::PACKET_DATA_SIZE,
     solana_perf::packet::{
@@ -45,6 +49,7 @@ use {
     solana_poh::poh_recorder::SharedLeaderState,
     solana_pubkey::{PUBKEY_BYTES, Pubkey},
     solana_runtime::bank_forks::SharableBanks,
+    solana_sha256_hasher::hashv,
     solana_signature::{SIGNATURE_BYTES, Signature},
     solana_signer::Signer,
     solana_streamer::{
@@ -102,6 +107,14 @@ pub enum ShredRepairType {
     HighestShred(Slot, u64),
     /// Requesting the missing shred at a particular index
     Shred(Slot, u64),
+    /// Requesting the missing shred at a particular index for a specific block ID
+    ShredForBlockId {
+        slot: Slot,
+        index: u32,
+        fec_set_merkle_root: Hash,
+        // Double merkle block id
+        block_id: Hash,
+    },
 }
 
 impl ShredRepairType {
@@ -110,6 +123,7 @@ impl ShredRepairType {
             ShredRepairType::Orphan(slot)
             | ShredRepairType::HighestShred(slot, _)
             | ShredRepairType::Shred(slot, _) => *slot,
+            ShredRepairType::ShredForBlockId { slot, .. } => *slot,
         }
     }
 }
@@ -119,7 +133,9 @@ impl RequestResponse for ShredRepairType {
     fn num_expected_responses(&self) -> u32 {
         match self {
             ShredRepairType::Orphan(_) => MAX_ORPHAN_REPAIR_RESPONSES as u32,
-            ShredRepairType::Shred(_, _) | ShredRepairType::HighestShred(_, _) => 1,
+            ShredRepairType::Shred(_, _)
+            | ShredRepairType::HighestShred(_, _)
+            | ShredRepairType::ShredForBlockId { .. } => 1,
         }
     }
     fn verify_response(&self, shred: &Self::Response) -> bool {
@@ -137,6 +153,17 @@ impl RequestResponse for ShredRepairType {
             }
             ShredRepairType::Shred(slot, index) => {
                 shred_slot == *slot && get_shred_index(shred) == Some(*index)
+            }
+            ShredRepairType::ShredForBlockId {
+                slot,
+                index,
+                fec_set_merkle_root,
+                ..
+            } => {
+                shred_slot == *slot
+                    && matches!(shred::layout::get_shred_type(shred), Ok(ShredType::Data))
+                    && shred::layout::get_index(shred) == Some(*index)
+                    && get_merkle_root(shred) == Some(*fec_set_merkle_root)
             }
         }
     }
@@ -169,6 +196,127 @@ impl RequestResponse for AncestorHashesRepairType {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum BlockIdRepairType {
+    ParentAndFecSetCount {
+        slot: Slot,
+        block_id: Hash,
+    },
+
+    FecSetRoot {
+        slot: Slot,
+        block_id: Hash,
+        fec_set_index: u32,
+    },
+}
+
+#[allow(dead_code)]
+impl BlockIdRepairType {
+    pub(crate) fn block(&self) -> Block {
+        match self {
+            BlockIdRepairType::ParentAndFecSetCount { slot, block_id } => (*slot, *block_id),
+            BlockIdRepairType::FecSetRoot { slot, block_id, .. } => (*slot, *block_id),
+        }
+    }
+
+    pub(crate) fn slot(&self) -> Slot {
+        self.block().0
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum BlockIdRepairResponse {
+    ParentFecSetCount {
+        fec_set_count: u32,
+        parent_info: (Slot, Hash),
+        parent_proof: Vec<u8>,
+    },
+
+    FecSetRoot {
+        fec_set_root: Hash,
+        fec_set_proof: Vec<u8>,
+    },
+
+    Ping {
+        ping: Ping,
+    },
+}
+
+impl RequestResponse for BlockIdRepairType {
+    type Response = BlockIdRepairResponse;
+
+    fn num_expected_responses(&self) -> u32 {
+        // The only variable in the response are the merkle proofs.
+        // Even assuming an extreme of u64::MAX fec sets, that corresponds to
+        // 63 * 20 = 1260 bytes for a proof which fits in one packet.
+        1
+    }
+
+    fn verify_response(&self, response: &Self::Response) -> bool {
+        match (self, response) {
+            (_, Self::Response::Ping { ping }) => ping.verify(),
+            (
+                Self::ParentAndFecSetCount {
+                    slot: _slot,
+                    block_id,
+                },
+                Self::Response::ParentFecSetCount {
+                    fec_set_count,
+                    parent_info: (parent_slot, parent_block_id),
+                    parent_proof,
+                },
+            ) => {
+                if *fec_set_count > MAX_FEC_SETS_PER_SLOT {
+                    return false;
+                }
+
+                // + 1 here to account for the parent info which is the final leaf of the tree
+                let proof_size = merkle_tree::get_proof_size(*fec_set_count as usize + 1);
+                if parent_proof.len()
+                    != proof_size as usize * merkle_tree::SIZE_OF_MERKLE_PROOF_ENTRY
+                {
+                    return false;
+                }
+
+                let parent_info_leaf =
+                    hashv(&[&parent_slot.to_le_bytes(), parent_block_id.as_ref()]);
+                merkle_tree::verify_merkle_proof(
+                    parent_info_leaf,
+                    *fec_set_count as usize,
+                    parent_proof,
+                    *block_id,
+                )
+                .is_ok()
+            }
+
+            (
+                Self::FecSetRoot {
+                    slot: _slot,
+                    block_id,
+                    fec_set_index,
+                },
+                Self::Response::FecSetRoot {
+                    fec_set_root,
+                    fec_set_proof,
+                },
+            ) => {
+                debug_assert_eq!(*fec_set_index as usize % DATA_SHREDS_PER_FEC_BLOCK, 0);
+                // Convert from shred-space to leaf-index
+                let leaf_index = *fec_set_index as usize / DATA_SHREDS_PER_FEC_BLOCK;
+                merkle_tree::verify_merkle_proof(
+                    *fec_set_root,
+                    leaf_index,
+                    fec_set_proof,
+                    *block_id,
+                )
+                .is_ok()
+            }
+
+            (Self::ParentAndFecSetCount { .. }, _) | (Self::FecSetRoot { .. }, _) => false,
+        }
+    }
+}
+
 #[derive(Default)]
 struct ServeRepairStats {
     total_requests: usize,
@@ -187,7 +335,13 @@ struct ServeRepairStats {
     orphan: usize,
     pong: usize,
     ancestor_hashes: usize,
+    parent: usize,
+    fec_set_root: usize,
+    window_index_for_block_id: usize,
     window_index_misses: usize,
+    parent_misses: usize,
+    fec_set_root_misses: usize,
+    window_index_for_block_id_misses: usize,
     ping_cache_check_failed: usize,
     pings_sent: usize,
     decode_time_us: u64,
@@ -237,17 +391,26 @@ impl RepairRequestHeader {
             nonce,
         }
     }
+
+    /// Returns the nonce for this repair request.
+    pub fn nonce(&self) -> Nonce {
+        self.nonce
+    }
 }
 
 type Ping = ping_pong::Ping<REPAIR_PING_TOKEN_SIZE>;
 type PingCache = ping_pong::PingCache<REPAIR_PING_TOKEN_SIZE>;
 
 /// Window protocol messages
+/// Appending new messages here is safe as long as it is feature gated.
+/// Changing the format of an existing message is possible but not advised.
+/// Removing a message is possible by first removing the sender and feature gating the response.
+/// The message can then be removed once the feature gate is active and there are no responders.
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiEnumVisitor, AbiExample, StableAbi),
     frozen_abi(
-        api_digest = "HbUQDATKfpN8pjyyarSGa8uN4SuLNTvMf7T5b66ajnNZ",
+        api_digest = "2wGmauKxLKD81QzmBo7CtW1tKVr9P5WgMs7RzJA9kvpd",
         abi_digest = "7DpV7t5vZAWSZEshJ4hAVTHnR37jzLwUMYhs1fGrX3G5"
     )
 )]
@@ -278,6 +441,24 @@ pub enum RepairProtocol {
     AncestorHashes {
         header: RepairRequestHeader,
         slot: Slot,
+    },
+    ParentAndFecSetCount {
+        header: RepairRequestHeader,
+        slot: Slot,
+        block_id: Hash,
+    },
+    FecSetRoot {
+        header: RepairRequestHeader,
+        slot: Slot,
+        block_id: Hash,
+        fec_set_index: u32,
+    },
+    WindowIndexForBlockId {
+        header: RepairRequestHeader,
+        slot: Slot,
+        shred_index: u32,
+        fec_set_merkle_root: Hash,
+        block_id: Hash,
     },
 }
 
@@ -350,10 +531,13 @@ impl RepairProtocol {
             | Self::LegacyOrphanWithNonce
             | Self::LegacyAncestorHashes => None,
             Self::Pong(pong) => Some(pong.from()),
-            Self::WindowIndex { header, .. } => Some(&header.sender),
-            Self::HighestWindowIndex { header, .. } => Some(&header.sender),
-            Self::Orphan { header, .. } => Some(&header.sender),
-            Self::AncestorHashes { header, .. } => Some(&header.sender),
+            Self::WindowIndex { header, .. }
+            | Self::HighestWindowIndex { header, .. }
+            | Self::Orphan { header, .. }
+            | Self::AncestorHashes { header, .. }
+            | Self::ParentAndFecSetCount { header, .. }
+            | Self::FecSetRoot { header, .. }
+            | Self::WindowIndexForBlockId { header, .. } => Some(&header.sender),
         }
     }
 
@@ -370,7 +554,10 @@ impl RepairProtocol {
             | Self::WindowIndex { .. }
             | Self::HighestWindowIndex { .. }
             | Self::Orphan { .. }
-            | Self::AncestorHashes { .. } => true,
+            | Self::AncestorHashes { .. }
+            | Self::ParentAndFecSetCount { .. }
+            | Self::FecSetRoot { .. }
+            | Self::WindowIndexForBlockId { .. } => true,
         }
     }
 
@@ -378,7 +565,10 @@ impl RepairProtocol {
         match self {
             RepairProtocol::WindowIndex { .. }
             | RepairProtocol::HighestWindowIndex { .. }
-            | RepairProtocol::AncestorHashes { .. } => 1,
+            | RepairProtocol::AncestorHashes { .. }
+            | RepairProtocol::ParentAndFecSetCount { .. }
+            | RepairProtocol::FecSetRoot { .. }
+            | RepairProtocol::WindowIndexForBlockId { .. } => 1,
             RepairProtocol::Orphan { .. } => MAX_ORPHAN_REPAIR_RESPONSES,
             RepairProtocol::Pong(_) => 0, // no response
             RepairProtocol::LegacyWindowIndex
@@ -601,6 +791,76 @@ impl ServeRepair {
                     stats.pong += 1;
                     ping_cache.add(pong, *from_addr, Instant::now());
                     (None, "Pong")
+                }
+                RepairProtocol::ParentAndFecSetCount {
+                    header: RepairRequestHeader { nonce, .. },
+                    slot,
+                    block_id,
+                } => {
+                    stats.parent += 1;
+                    let response = if self.migration_status.should_allow_block_markers(*slot) {
+                        let response = self.repair_handler.run_parent_fec_set_count(
+                            recycler, from_addr, *slot, *block_id, *nonce,
+                        );
+                        if response.is_none() {
+                            stats.parent_misses += 1;
+                        }
+                        response
+                    } else {
+                        None
+                    };
+                    (response, "Parent")
+                }
+                RepairProtocol::FecSetRoot {
+                    header: RepairRequestHeader { nonce, .. },
+                    slot,
+                    block_id,
+                    fec_set_index,
+                } => {
+                    stats.fec_set_root += 1;
+                    let response = if self.migration_status.should_allow_block_markers(*slot) {
+                        let response = self.repair_handler.run_fec_set_root(
+                            recycler,
+                            from_addr,
+                            *slot,
+                            *block_id,
+                            *fec_set_index,
+                            *nonce,
+                        );
+                        if response.is_none() {
+                            stats.fec_set_root_misses += 1;
+                        }
+                        response
+                    } else {
+                        None
+                    };
+                    (response, "FecSetRoot")
+                }
+                RepairProtocol::WindowIndexForBlockId {
+                    header: RepairRequestHeader { nonce, .. },
+                    slot,
+                    shred_index,
+                    fec_set_merkle_root: _,
+                    block_id,
+                } => {
+                    stats.window_index_for_block_id += 1;
+                    let response = if self.migration_status.should_allow_block_markers(*slot) {
+                        let batch = self.repair_handler.run_window_request_for_block_id(
+                            recycler,
+                            from_addr,
+                            *slot,
+                            u64::from(*shred_index),
+                            *block_id,
+                            *nonce,
+                        );
+                        if batch.is_none() {
+                            stats.window_index_for_block_id_misses += 1;
+                        }
+                        batch
+                    } else {
+                        None
+                    };
+                    (response, "WindowIndexForBlockIdWithNonce")
                 }
                 RepairProtocol::LegacyWindowIndex
                 | RepairProtocol::LegacyWindowIndexWithNonce
@@ -908,6 +1168,13 @@ impl ServeRepair {
             ),
             ("self_repair", stats.err_self_repair, i64),
             ("window_index", stats.window_index, i64),
+            ("parent", stats.parent, i64),
+            ("fec_set_root", stats.fec_set_root, i64),
+            (
+                "window_index_for_block_id",
+                stats.window_index_for_block_id,
+                i64
+            ),
             (
                 "request-highest-window-index",
                 stats.highest_window_index,
@@ -921,6 +1188,13 @@ impl ServeRepair {
             ),
             ("pong", stats.pong, i64),
             ("window_index_misses", stats.window_index_misses, i64),
+            ("parent_misses", stats.parent_misses, i64),
+            ("fec_set_root_misses", stats.fec_set_root_misses, i64),
+            (
+                "window_index_for_block_id_misses",
+                stats.window_index_for_block_id_misses,
+                i64
+            ),
             (
                 "ping_cache_check_failed",
                 stats.ping_cache_check_failed,
@@ -1017,7 +1291,10 @@ impl ServeRepair {
             RepairProtocol::WindowIndex { header, .. }
             | RepairProtocol::HighestWindowIndex { header, .. }
             | RepairProtocol::Orphan { header, .. }
-            | RepairProtocol::AncestorHashes { header, .. } => {
+            | RepairProtocol::AncestorHashes { header, .. }
+            | RepairProtocol::ParentAndFecSetCount { header, .. }
+            | RepairProtocol::FecSetRoot { header, .. }
+            | RepairProtocol::WindowIndexForBlockId { header, .. } => {
                 if &header.recipient != my_id {
                     return Err(Error::from(RepairVerifyError::IdMismatch));
                 }
@@ -1073,8 +1350,13 @@ impl ServeRepair {
             match request {
                 RepairProtocol::WindowIndex { .. }
                 | RepairProtocol::HighestWindowIndex { .. }
-                | RepairProtocol::Orphan { .. } => {
+                | RepairProtocol::Orphan { .. }
+                | RepairProtocol::WindowIndexForBlockId { .. } => {
                     let ping = RepairResponse::Ping(ping);
+                    Packet::from_data(Some(from_addr), ping).ok()
+                }
+                RepairProtocol::ParentAndFecSetCount { .. } | RepairProtocol::FecSetRoot { .. } => {
+                    let ping = BlockIdRepairResponse::Ping { ping };
                     Packet::from_data(Some(from_addr), ping).ok()
                 }
                 RepairProtocol::AncestorHashes { .. } => {
@@ -1245,6 +1527,52 @@ impl ServeRepair {
         Ok(Some((peer.serve_repair, out)))
     }
 
+    /// Similar to [`Self::repair_request`] but for [`BlockIdRepairType`] requests.
+    /// Uses stake-weighted peer selection rather than cluster_slots weights.
+    #[allow(dead_code)]
+    pub(crate) fn block_id_repair_request(
+        &self,
+        repair_validators: &Option<HashSet<Pubkey>>,
+        repair_request: BlockIdRepairType,
+        peers_cache: &mut LruCache<Slot, RepairPeers>,
+        outstanding_requests: &mut OutstandingRequests<BlockIdRepairType>,
+        identity_keypair: &Keypair,
+        staked_nodes: &HashMap<Pubkey, u64>,
+    ) -> Result<(Vec<u8>, SocketAddr)> {
+        let slot = repair_request.slot();
+        let repair_peers = match peers_cache.get(&slot) {
+            Some(entry) if entry.asof.elapsed() < REPAIR_PEERS_CACHE_TTL => entry,
+            _ => {
+                peers_cache.pop(&slot);
+                let repair_peers =
+                    self.repair_peers(repair_validators, slot, &identity_keypair.pubkey());
+                let weights: Vec<u64> = repair_peers
+                    .iter()
+                    .map(|peer| staked_nodes.get(peer.pubkey()).copied().unwrap_or(0))
+                    .collect();
+                let repair_peers = RepairPeers::new(Instant::now(), &repair_peers, &weights)?;
+                peers_cache.put(slot, repair_peers);
+                peers_cache.get(&slot).unwrap()
+            }
+        };
+        let peer = repair_peers.sample(&mut rand::rng());
+        let nonce = outstanding_requests.add_request(repair_request, timestamp());
+
+        let out = self.map_block_id_repair_request(
+            &repair_request,
+            &peer.pubkey,
+            nonce,
+            identity_keypair,
+        )?;
+        debug!(
+            "Sending block_id repair request from {} to {} for {:#?}",
+            identity_keypair.pubkey(),
+            peer.pubkey,
+            repair_request
+        );
+        Ok((out, peer.serve_repair))
+    }
+
     pub(crate) fn repair_request_ancestor_hashes_sample_peers(
         &self,
         slot: Slot,
@@ -1334,6 +1662,56 @@ impl ServeRepair {
                     slot: *slot,
                 }
             }
+            ShredRepairType::ShredForBlockId {
+                slot,
+                index,
+                fec_set_merkle_root,
+                block_id,
+            } => RepairProtocol::WindowIndexForBlockId {
+                header,
+                slot: *slot,
+                shred_index: *index,
+                fec_set_merkle_root: *fec_set_merkle_root,
+                block_id: *block_id,
+            },
+        };
+        Self::repair_proto_to_bytes(&request_proto, identity_keypair)
+    }
+
+    /// Transforms a [`BlockIdRepairType`] into a signed repair protocol message.
+    #[allow(dead_code)]
+    pub(crate) fn map_block_id_repair_request(
+        &self,
+        repair_request: &BlockIdRepairType,
+        repair_peer_id: &Pubkey,
+        nonce: Nonce,
+        identity_keypair: &Keypair,
+    ) -> Result<Vec<u8>> {
+        let header = RepairRequestHeader {
+            signature: Signature::default(),
+            sender: identity_keypair.pubkey(),
+            recipient: *repair_peer_id,
+            timestamp: timestamp(),
+            nonce,
+        };
+        let request_proto = match repair_request {
+            BlockIdRepairType::ParentAndFecSetCount { slot, block_id } => {
+                RepairProtocol::ParentAndFecSetCount {
+                    header,
+                    slot: *slot,
+                    block_id: *block_id,
+                }
+            }
+            BlockIdRepairType::FecSetRoot {
+                slot,
+                block_id,
+                fec_set_index,
+            } => RepairProtocol::FecSetRoot {
+                header,
+                slot: *slot,
+                block_id: *block_id,
+                fec_set_index: *fec_set_index,
+            },
         };
         Self::repair_proto_to_bytes(&request_proto, identity_keypair)
     }
@@ -2362,12 +2740,30 @@ mod tests {
             );
             shreds.remove(index as usize)
         }
+        fn new_test_coding_shred(slot: Slot, index: u32) -> Shred {
+            let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 0).unwrap();
+            let keypair = Keypair::new();
+            let reed_solomon_cache = ReedSolomonCache::default();
+            let (_, mut shreds) = shredder.entries_to_merkle_shreds_for_tests(
+                &keypair,
+                &[],
+                true,
+                Hash::default(),
+                0,
+                0,
+                &reed_solomon_cache,
+                &mut ProcessShredsStats::default(),
+            );
+            shreds.remove(index as usize)
+        }
+
         let repair = ShredRepairType::Orphan(9);
-        // Ensure new options are added to this test
         match repair {
             ShredRepairType::Orphan(_)
             | ShredRepairType::HighestShred(_, _)
-            | ShredRepairType::Shred(_, _) => (),
+            | ShredRepairType::Shred(_, _)
+            | ShredRepairType::ShredForBlockId { .. } => (),
+            // Ensure new options are added below to this test
         };
 
         let slot = 9;
@@ -2401,6 +2797,34 @@ mod tests {
         assert!(request.verify_response(shred.payload()));
         let shred = new_test_data_shred(slot, index + 1);
         assert!(!request.verify_response(shred.payload()));
+        let shred = new_test_data_shred(slot + 1, index);
+        assert!(!request.verify_response(shred.payload()));
+
+        // ShredForBlockId
+        let shred = new_test_data_shred(slot, index);
+        let merkle_root = shred.merkle_root().expect("No more legacy shreds");
+        let request = ShredRepairType::ShredForBlockId {
+            slot,
+            index,
+            fec_set_merkle_root: merkle_root,
+            block_id: Hash::new_unique(),
+        };
+        assert!(request.verify_response(shred.payload()));
+        // bad fec set root
+        let request = ShredRepairType::ShredForBlockId {
+            slot,
+            index,
+            fec_set_merkle_root: Hash::new_unique(),
+            block_id: Hash::new_unique(),
+        };
+        assert!(!request.verify_response(shred.payload()));
+        // coding shred
+        let shred = new_test_coding_shred(slot, index);
+        assert!(!request.verify_response(shred.payload()));
+        // bad index
+        let shred = new_test_data_shred(slot, index + 1);
+        assert!(!request.verify_response(shred.payload()));
+        // bad slot
         let shred = new_test_data_shred(slot + 1, index);
         assert!(!request.verify_response(shred.payload()));
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -570,7 +570,6 @@ impl Blockstore {
 
     /// Checks all available block versions, if we have a *complete* block for
     /// `block_id`, returns the location where it is stored
-    #[allow(dead_code)]
     pub fn get_block_location(&self, slot: Slot, block_id: Hash) -> Result<Option<BlockLocation>> {
         for location in [
             BlockLocation::Original,
@@ -633,6 +632,25 @@ impl Blockstore {
             .unwrap_or_else(|| Index::new(slot));
         index.data_mut().insert(shred_index as u64);
         self.alt_index_cf.put((slot, block_id), &index)
+    }
+
+    /// Test helper: directly set the double merkle root for a slot/location.
+    /// This simulates Turbine completing for a slot with a specific block_id.
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn set_double_merkle_root(
+        &self,
+        slot: Slot,
+        block_location: BlockLocation,
+        double_merkle_root: Hash,
+    ) -> Result<()> {
+        use crate::blockstore_meta::DoubleMerkleMeta;
+        let meta = DoubleMerkleMeta {
+            double_merkle_root,
+            fec_set_count: 1,       // Minimal valid value
+            proofs: ByteBuf::new(), // Empty proofs for testing
+        };
+        self.double_merkle_meta_cf
+            .put((slot, block_location), &meta)
     }
 
     /// Returns true if the specified slot is full.
@@ -730,7 +748,7 @@ impl Blockstore {
         self.merkle_root_meta_cf.get(erasure_set.store_key())
     }
 
-    fn merkle_root_meta_from_location(
+    pub fn merkle_root_meta_from_location(
         &self,
         erasure_set: ErasureSetId,
         location: BlockLocation,
@@ -766,6 +784,26 @@ impl Blockstore {
                 merkle_root_meta,
             ),
         }
+    }
+
+    /// Gets the double merkle meta for the given block denoted by block id
+    /// If the meta is present but the proofs have not yet been populated - generate and store them
+    /// returning the updated double merkle meta along with the location
+    pub fn get_double_merkle_meta_maybe_populate_proofs_for_block_id(
+        &self,
+        slot: Slot,
+        block_id: Hash,
+    ) -> Result<Option<(DoubleMerkleMeta, BlockLocation)>> {
+        // Find which column this block resides in (if any)
+        let Some(location) = self.get_block_location(slot, block_id)? else {
+            return Ok(None);
+        };
+
+        // Get the doulbe merkle meta - the block must be full, so we can unwrap here
+        let dmm = self
+            .get_double_merkle_meta_maybe_populate_proofs(slot, location)?
+            .expect("block is full, double merkle meta must exist");
+        Ok(Some((dmm, location)))
     }
 
     /// Gets the double merkle meta for the given block.
@@ -1410,7 +1448,7 @@ impl Blockstore {
         merkle_root_metas: &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
         write_batch: &mut WriteBatch,
     ) -> Result<()> {
-        let fec_set_count = (last_index / (DATA_SHREDS_PER_FEC_BLOCK as u64) + 1) as usize;
+        let fec_set_count = last_index as u32 / (DATA_SHREDS_PER_FEC_BLOCK as u32) + 1;
         let merkle_tree = self.build_double_merkle_tree(
             slot,
             location,
@@ -1440,7 +1478,7 @@ impl Blockstore {
         &self,
         slot: Slot,
         location: BlockLocation,
-        fec_set_count: usize,
+        fec_set_count: u32,
         slot_metas: Option<&HashMap<(BlockLocation, Slot), SlotMetaWorkingSetEntry>>,
         merkle_root_metas: Option<
             &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
@@ -1461,7 +1499,7 @@ impl Blockstore {
         // Collect merkle roots for each FEC set
         let merkle_tree_leaves = (0..fec_set_count)
             .map(|i| {
-                let fec_set_index = (i * DATA_SHREDS_PER_FEC_BLOCK) as u32;
+                let fec_set_index = i * DATA_SHREDS_PER_FEC_BLOCK as u32;
                 let erasure_set = ErasureSetId::new(slot, fec_set_index);
                 self.get_merkle_root_from_tracker_or_db(location, erasure_set, merkle_root_metas)
                     .map_err(|_| shred::Error::InvalidMerkleRoot)
@@ -1473,7 +1511,7 @@ impl Blockstore {
                 parent_block_id.as_ref(),
             ]))));
 
-        MerkleTree::try_new_with_len(merkle_tree_leaves, fec_set_count + 1)
+        MerkleTree::try_new_with_len(merkle_tree_leaves, fec_set_count as usize + 1)
             .map_err(|_| BlockstoreError::MerkleTreeConstructionFailure(slot, location))
     }
 
@@ -1491,7 +1529,7 @@ impl Blockstore {
             None,
             None,
         )?;
-        let tree_size = double_merkle_meta.fec_set_count + 1;
+        let tree_size = double_merkle_meta.fec_set_count as usize + 1;
         let proof_len_bytes = get_proof_size(tree_size) as usize * SIZE_OF_MERKLE_PROOF_ENTRY;
         let mut proofs = ByteBuf::with_capacity(tree_size * proof_len_bytes);
 
@@ -5809,9 +5847,7 @@ pub mod tests {
             genesis_utils::{GenesisConfigInfo, create_genesis_config},
             shred::{
                 max_ticks_per_n_shreds,
-                merkle_tree::{
-                    MerkleProofEntry, SIZE_OF_MERKLE_PROOF_ENTRY, get_merkle_root, get_proof_size,
-                },
+                merkle_tree::{SIZE_OF_MERKLE_PROOF_ENTRY, get_proof_size, verify_merkle_proof},
             },
         },
         assert_matches::assert_matches,
@@ -12197,7 +12233,7 @@ pub mod tests {
             .get_double_merkle_meta_maybe_populate_proofs(slot, block_location)
             .unwrap()
             .unwrap();
-        let proof_size = get_proof_size(double_merkle_meta.fec_set_count + 1) as usize;
+        let proof_size = get_proof_size(double_merkle_meta.fec_set_count as usize + 1) as usize;
         assert_eq!(
             double_merkle_meta.proofs.len(),
             4 * proof_size * SIZE_OF_MERKLE_PROOF_ENTRY
@@ -12206,36 +12242,25 @@ pub mod tests {
         // Verify the proofs
         // FEC sets
         for (fec_set, root) in fec_set_roots.iter().enumerate() {
-            let proof: Vec<_> = double_merkle_meta
-                .get_fec_set_proof(fec_set)
-                .unwrap()
-                .chunks(SIZE_OF_MERKLE_PROOF_ENTRY)
-                .map(<&MerkleProofEntry>::try_from)
-                .map(std::result::Result::unwrap)
-                .collect();
-            assert_eq!(proof_size, proof.len());
-
-            let verified_root = get_merkle_root(fec_set, *root, proof).unwrap();
-            assert_eq!(double_merkle_meta.double_merkle_root, verified_root);
+            verify_merkle_proof(
+                *root,
+                fec_set,
+                double_merkle_meta
+                    .get_fec_set_proof(fec_set as u32)
+                    .unwrap(),
+                double_merkle_meta.double_merkle_root,
+            )
+            .unwrap();
         }
 
         // Parent info - final proof
-        let parent_info_proof: Vec<_> = double_merkle_meta
-            .get_parent_info_proof()
-            .unwrap()
-            .chunks(SIZE_OF_MERKLE_PROOF_ENTRY)
-            .map(<&MerkleProofEntry>::try_from)
-            .map(std::result::Result::unwrap)
-            .collect();
-        assert_eq!(proof_size, parent_info_proof.len());
-
-        let verified_root = get_merkle_root(
-            double_merkle_meta.fec_set_count,
+        verify_merkle_proof(
             parent_info_hash,
-            parent_info_proof,
+            double_merkle_meta.fec_set_count as usize,
+            double_merkle_meta.get_parent_info_proof().unwrap(),
+            double_merkle_meta.double_merkle_root,
         )
         .unwrap();
-        assert_eq!(double_merkle_meta.double_merkle_root, verified_root);
 
         // Slot not full should return None
         let incomplete_slot = 1001;

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -654,7 +654,7 @@ impl MerkleRootMeta {
         }
     }
 
-    pub(crate) fn merkle_root(&self) -> Option<Hash> {
+    pub fn merkle_root(&self) -> Option<Hash> {
         self.merkle_root
     }
 
@@ -734,7 +734,7 @@ pub struct DoubleMerkleMeta {
     pub(crate) double_merkle_root: Hash,
 
     /// The number of fec sets in this block
-    pub(crate) fec_set_count: usize,
+    pub(crate) fec_set_count: u32,
 
     /// The merkle proofs.
     /// Each proof is of size `get_proof_size(fec_set_count + 1)`
@@ -748,18 +748,26 @@ pub struct DoubleMerkleMeta {
 }
 
 impl DoubleMerkleMeta {
+    /// Returns the number of fec sets in the block.
+    pub fn fec_set_count(&self) -> u32 {
+        self.fec_set_count
+    }
+
     /// Return the proof associated with the leaf of fec set `fec_set_index`
     /// Returns `None` if the proofs are yet to be populated or `fec_set_index` is out of bounds
-    pub fn get_fec_set_proof(&self, fec_set_index: usize) -> Option<&[u8]> {
+    pub fn get_fec_set_proof(&self, fec_set_index: u32) -> Option<&[u8]> {
         if fec_set_index >= self.fec_set_count {
             return None;
         }
         if self.proofs.is_empty() {
             return None;
         }
+        let fec_set_count =
+            usize::try_from(self.fec_set_count).expect("fec_set_count should fit in usize");
+        let fec_set_index = usize::try_from(fec_set_index).ok()?;
 
         let proof_size =
-            usize::from(get_proof_size(self.fec_set_count + 1)) * SIZE_OF_MERKLE_PROOF_ENTRY;
+            usize::from(get_proof_size(fec_set_count + 1)) * SIZE_OF_MERKLE_PROOF_ENTRY;
         Some(&self.proofs[fec_set_index * proof_size..(fec_set_index + 1) * proof_size])
     }
 
@@ -770,9 +778,11 @@ impl DoubleMerkleMeta {
             return None;
         }
 
+        let fec_set_count =
+            usize::try_from(self.fec_set_count).expect("fec_set_count should fit in usize");
         let proof_size =
-            usize::from(get_proof_size(self.fec_set_count + 1)) * SIZE_OF_MERKLE_PROOF_ENTRY;
-        Some(&self.proofs[self.fec_set_count * proof_size..])
+            usize::from(get_proof_size(fec_set_count + 1)) * SIZE_OF_MERKLE_PROOF_ENTRY;
+        Some(&self.proofs[fec_set_count * proof_size..])
     }
 }
 

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -125,6 +125,9 @@ pub const SHREDS_PER_FEC_BLOCK: usize = DATA_SHREDS_PER_FEC_BLOCK + CODING_SHRED
 pub const MAX_DATA_SHREDS_PER_SLOT: usize = 32_768;
 pub const MAX_CODE_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT;
 
+pub const MAX_FEC_SETS_PER_SLOT: u32 =
+    MAX_DATA_SHREDS_PER_SLOT as u32 / DATA_SHREDS_PER_FEC_BLOCK as u32;
+
 // Statically compute the typical data batch size assuming:
 // 1. 32:32 erasure coding batch
 // 2. Merkles are chained
@@ -333,10 +336,10 @@ impl ShredId {
 
 /// Tuple which identifies erasure coding set that the shred belongs to.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub(crate) struct ErasureSetId(Slot, /*fec_set_index:*/ u32);
+pub struct ErasureSetId(Slot, /*fec_set_index:*/ u32);
 
 impl ErasureSetId {
-    pub(crate) fn new(slot: Slot, fec_set_index: u32) -> Self {
+    pub fn new(slot: Slot, fec_set_index: u32) -> Self {
         Self(slot, fec_set_index)
     }
 

--- a/ledger/src/shred/merkle_tree.rs
+++ b/ledger/src/shred/merkle_tree.rs
@@ -6,9 +6,9 @@ use {
 pub(crate) const SIZE_OF_MERKLE_ROOT: usize = std::mem::size_of::<Hash>();
 const_assert_eq!(SIZE_OF_MERKLE_ROOT, 32);
 const_assert_eq!(SIZE_OF_MERKLE_PROOF_ENTRY, 20);
-pub(crate) const SIZE_OF_MERKLE_PROOF_ENTRY: usize = std::mem::size_of::<MerkleProofEntry>();
+pub const SIZE_OF_MERKLE_PROOF_ENTRY: usize = std::mem::size_of::<MerkleProofEntry>();
 // Number of proof entries for the standard 64 shred batch.
-pub(crate) const PROOF_ENTRIES_FOR_32_32_BATCH: u8 = 6;
+pub const PROOF_ENTRIES_FOR_32_32_BATCH: u8 = 6;
 
 // Defense against second preimage attack:
 // https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack
@@ -17,7 +17,7 @@ pub(crate) const PROOF_ENTRIES_FOR_32_32_BATCH: u8 = 6;
 pub(crate) const MERKLE_HASH_PREFIX_LEAF: &[u8] = b"\x00SOLANA_MERKLE_SHREDS_LEAF";
 pub(crate) const MERKLE_HASH_PREFIX_NODE: &[u8] = b"\x01SOLANA_MERKLE_SHREDS_NODE";
 
-pub(crate) type MerkleProofEntry = [u8; 20];
+pub type MerkleProofEntry = [u8; 20];
 
 /// A struct to track a given Merkle tree.
 pub struct MerkleTree {
@@ -73,7 +73,7 @@ impl MerkleTree {
         self.nodes.last().unwrap()
     }
 
-    pub(crate) fn make_merkle_proof(
+    pub fn make_merkle_proof(
         &self,
         mut index: usize, // leaf index ~ shred's erasure shard index.
         mut size: usize,  // number of leaves ~ erasure batch size.
@@ -131,13 +131,33 @@ where
         .ok_or(Error::InvalidMerkleProof)
 }
 
+/// Given a flattened merkle `proof` for `node` at `index`,
+/// verify the proof against merkle root `root`
+pub fn verify_merkle_proof(
+    node: Hash,
+    index: usize,
+    proof: &[u8],
+    expected_root: Hash,
+) -> Result<(), Error> {
+    let proof = proof
+        .chunks(SIZE_OF_MERKLE_PROOF_ENTRY)
+        .map(<&MerkleProofEntry>::try_from)
+        .map(|entry| entry.map_err(|_| Error::InvalidMerkleProof))
+        .collect::<Result<Vec<_>, Error>>()?;
+    let merkle_root = get_merkle_root(index, node, proof)?;
+
+    (merkle_root == expected_root)
+        .then_some(())
+        .ok_or(Error::InvalidMerkleProof)
+}
+
 // Given number of shreds, returns the number of nodes in the Merkle tree.
 pub fn get_merkle_tree_size(num_shreds: usize) -> usize {
     successors(Some(num_shreds), |&k| (k > 1).then_some((k + 1) >> 1)).sum()
 }
 
 // Maps number of (code + data) shreds to merkle_proof.len().
-pub(crate) const fn get_proof_size(num_shreds: usize) -> u8 {
+pub const fn get_proof_size(num_shreds: usize) -> u8 {
     let bits = usize::BITS - num_shreds.leading_zeros();
     let proof_size = if num_shreds.is_power_of_two() {
         bits.saturating_sub(1)

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -84,7 +84,7 @@ pub(super) fn get_shred_variant(shred: &[u8]) -> Result<ShredVariant, Error> {
 }
 
 #[inline]
-pub(super) fn get_shred_type(shred: &[u8]) -> Result<ShredType, Error> {
+pub fn get_shred_type(shred: &[u8]) -> Result<ShredType, Error> {
     get_shred_variant(shred).map(ShredType::from)
 }
 


### PR DESCRIPTION
Upstreams:
- https://github.com/anza-xyz/alpenglow/pull/646
- https://github.com/anza-xyz/alpenglow/pull/669
- https://github.com/anza-xyz/alpenglow/pull/672
- https://github.com/anza-xyz/alpenglow/pull/776
- (partial) https://github.com/anza-xyz/alpenglow/pull/707

#### Problem
Alpenglow has a separate repair mechanism for requesting a specific version of a block denominated by the double merkle root block id.

This requires 3 new request types:
- Parent and fec set count
- Fec set root
- Shred for specific fec set root

#### Summary of Changes
Upstream the relevant changes to add these request & response types.
Next upstream PR will add the service that sends & receives these messages
