### PR TITLE
sbpf-debugger: skip JIT execution only when debug_port is set

### DIFF
--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -215,11 +215,11 @@ pub fn execute<'a, 'b: 'a>(
         #[cfg_attr(feature = "sbpf-debugger", expect(unused_assignments))]
         let mut execution_mode = ExecutionMode::PreferJit;
         #[cfg(feature = "sbpf-debugger")]
-        let (debug_port, debug_metadata) = {
+        let (debug_port, debug_metadata) = if invoke_context.debug_port.is_some() {
             execution_mode = ExecutionMode::Interpreted;
             (
                 invoke_context.debug_port,
-                format!(
+                Some(format!(
                     "program_id={};cpi_level={};caller={}",
                     program_id,
                     instruction_context.get_stack_height().saturating_sub(1),
@@ -234,8 +234,10 @@ pub fn execute<'a, 'b: 'a>(
                         .and_then(|ctx| ctx.get_program_key().ok())
                         .map(|key| key.to_string())
                         .unwrap_or_else(|| "none".into())
-                ),
+                )),
             )
+        } else {
+            (None, None)
         };
 
         let compute_meter_prev = invoke_context.get_remaining();
@@ -251,7 +253,7 @@ pub fn execute<'a, 'b: 'a>(
         #[cfg(feature = "sbpf-debugger")]
         {
             vm.debug_port = debug_port;
-            vm.debug_metadata = Some(debug_metadata);
+            vm.debug_metadata = debug_metadata;
         }
 
         let execute_time = Measure::start("execute");

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -212,7 +212,7 @@ pub fn execute<'a, 'b: 'a>(
 
     let mut create_vm_time = Measure::start("create_vm");
     let execution_result = {
-        #[cfg_attr(feature = "sbpf-debugger", expect(unused_assignments))]
+        #[cfg_attr(feature = "sbpf-debugger", allow(unused_assignments))]
         let mut execution_mode = ExecutionMode::PreferJit;
         #[cfg(feature = "sbpf-debugger")]
         let (debug_port, debug_metadata) = if invoke_context.debug_port.is_some() {

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -212,7 +212,6 @@ pub fn execute<'a, 'b: 'a>(
 
     let mut create_vm_time = Measure::start("create_vm");
     let execution_result = {
-        #[cfg_attr(feature = "sbpf-debugger", allow(unused_assignments))]
         let mut execution_mode = ExecutionMode::PreferJit;
         #[cfg(feature = "sbpf-debugger")]
         let (debug_port, debug_metadata) = if invoke_context.debug_port.is_some() {


### PR DESCRIPTION
#### Problem

The `program-runtime`'s `sbpf-debugger` feature flag *unconditionally* forces `interpreted` mode and builds debug metadata. 

#### Summary of Changes

Previously the `sbpf-debugger` feature flag unconditionally forced `interpreted` mode and built debug metadata. Now these only happen when a debug port is actually set, allowing more fine-grained control at runtime. Test harnesses can safely enable the sbpf-debugger feature in `program-runtime` without affecting execution - `jit` mode is used as usual unless a debug port is explicitly configured, in which case execution falls back to interpreted mode as required by the debugger. 

@Lichtso @LucasSte @nagisa