### PR TITLE
Decouple syscalls list from platform tools

### DIFF
--- a/syscalls/gen-syscall-list/.gitignore
+++ b/syscalls/gen-syscall-list/.gitignore
@@ -1,0 +1,1 @@
+*/syscalls.txt

--- a/syscalls/gen-syscall-list/.gitignore
+++ b/syscalls/gen-syscall-list/.gitignore
@@ -1,1 +1,1 @@
-*/syscalls.txt
+syscalls.txt

--- a/syscalls/gen-syscall-list/build.rs
+++ b/syscalls/gen-syscall-list/build.rs
@@ -15,7 +15,7 @@ use {
  */
 fn main() {
     let syscalls_rs_name = "../src/lib.rs";
-    let syscalls_txt_name = "src/syscalls.txt";
+    let syscalls_txt_name = "syscalls.txt";
     println!("cargo::rerun-if-changed={syscalls_rs_name}");
     println!("cargo::rerun-if-changed=build.rs");
 

--- a/syscalls/gen-syscall-list/build.rs
+++ b/syscalls/gen-syscall-list/build.rs
@@ -15,9 +15,8 @@ use {
  */
 fn main() {
     let syscalls_rs_name = "../src/lib.rs";
-    let syscalls_txt_name = "../../platform-tools-sdk/sbf/syscalls.txt";
+    let syscalls_txt_name = "src/syscalls.txt";
     println!("cargo::rerun-if-changed={syscalls_rs_name}");
-    println!("cargo::rerun-if-changed={syscalls_txt_name}");
     println!("cargo::rerun-if-changed=build.rs");
 
     let syscalls_rs_path = PathBuf::from(syscalls_rs_name);


### PR DESCRIPTION
#### Problem

The generation of the syscalls list still depends on the `platform-tools-sdk` folder, hindering the creation of the new repository and deleting the files from Agave.

#### Summary of Changes

Generate the syscall list inside `gen-syscall-list`, which we can easily build in the new repository.
