### PR TITLE
feat: add MVP `agave-orchestrator` & CLI args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,7 @@ name = "agave-validator"
 version = "4.1.0-alpha.0"
 dependencies = [
  "agave-logger",
+ "agave-orchestrator",
  "agave-snapshots",
  "agave-votor",
  "agave-xdp",
@@ -359,6 +360,7 @@ dependencies = [
  "jsonrpc-ipc-server",
  "libc",
  "log",
+ "nix",
  "num_cpus",
  "predicates",
  "pretty_assertions",
@@ -7718,6 +7720,7 @@ dependencies = [
  "agave-feature-set",
  "agave-logger",
  "agave-math-utils",
+ "agave-orchestrator",
  "agave-reserved-account-keys",
  "agave-scheduler-bindings",
  "agave-scheduling-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,9 @@ dependencies = [
 [[package]]
 name = "agave-orchestrator"
 version = "4.1.0-alpha.0"
+dependencies = [
+ "nix",
+]
 
 [[package]]
 name = "agave-precompiles"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-orchestrator"
+version = "4.1.0-alpha.0"
+
+[[package]]
 name = "agave-precompiles"
 version = "4.1.0-alpha.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ used_underscore_binding = "deny"
 [workspace.dependencies]
 Inflector = "0.11.4"
 agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
+agave-orchestrator = { path = "orchestrator", version = "=4.1.0-alpha.0" }
 agave-bls-cert-verify = { path = "bls-cert-verify", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-feature-set = { path = "feature-set", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 agave-fs = { path = "fs", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
     "metrics",
     "net-utils",
     "notifier",
+    "orchestrator",
     "perf",
     "platform-tools-sdk/gen-headers",
     "poh",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,6 +40,7 @@ frozen-abi = [
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
 agave-bls-cert-verify = { workspace = true }
+agave-orchestrator = { workspace = true }
 agave-feature-set = { workspace = true }
 agave-logger = { workspace = true }
 agave-math-utils = { workspace = true }

--- a/core/src/scheduler_bindings_server.rs
+++ b/core/src/scheduler_bindings_server.rs
@@ -1,9 +1,13 @@
 use {
-    crate::banking_stage::BankingControlMsg, agave_scheduling_utils::handshake, std::path::Path,
-    tokio::sync::mpsc,
+    crate::banking_stage::BankingControlMsg, agave_orchestrator::OrchestratorStream,
+    agave_scheduling_utils::handshake, std::path::Path, tokio::sync::mpsc,
 };
 
-pub(crate) fn spawn(path: &Path, session_sender: mpsc::Sender<BankingControlMsg>) {
+pub(crate) fn spawn(
+    path: &Path,
+    session_sender: mpsc::Sender<BankingControlMsg>,
+    mut orchestrator_stream: Option<OrchestratorStream>,
+) {
     // NB: Panic on start if we can't bind.
     let _ = std::fs::remove_file(path);
     let mut listener = handshake::server::Server::new(path).unwrap();
@@ -11,6 +15,15 @@ pub(crate) fn spawn(path: &Path, session_sender: mpsc::Sender<BankingControlMsg>
     std::thread::Builder::new()
         .name("solBindingSrv".to_string())
         .spawn(move || {
+            // Signal readiness to orchestrator if present.
+            if let Some(stream) = orchestrator_stream.as_mut() {
+                use std::io::Write;
+                match stream.write_all(&[0x01]) {
+                    Ok(()) => info!("Sent readiness signal to orchestrator"),
+                    Err(err) => error!("Failed to send orchestrator readiness signal: {err}"),
+                }
+            }
+
             loop {
                 match listener.accept() {
                     Ok(session) => {

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -24,6 +24,7 @@ use {
         tpu_entry_notifier::TpuEntryNotifier,
         validator::{BlockProductionMethod, GeneratorConfig},
     },
+    agave_orchestrator::OrchestratorStream,
     agave_votor::event::VotorEventSender,
     crossbeam_channel::{Receiver, bounded, unbounded},
     solana_clock::Slot,
@@ -149,6 +150,7 @@ impl Tpu {
         key_notifiers: Arc<RwLock<KeyUpdaters>>,
         banking_control_receiver: mpsc::Receiver<BankingControlMsg>,
         scheduler_bindings: Option<(PathBuf, mpsc::Sender<BankingControlMsg>)>,
+        orchestrator_stream: Option<OrchestratorStream>,
         cancel: CancellationToken,
         votor_event_sender: VotorEventSender,
     ) -> Self {
@@ -326,10 +328,17 @@ impl Tpu {
 
         #[cfg(unix)]
         if let Some((path, banking_control_sender)) = scheduler_bindings {
-            super::scheduler_bindings_server::spawn(&path, banking_control_sender);
+            super::scheduler_bindings_server::spawn(
+                &path,
+                banking_control_sender,
+                orchestrator_stream,
+            );
         }
         #[cfg(not(unix))]
-        assert!(scheduler_bindings.is_none());
+        {
+            assert!(scheduler_bindings.is_none());
+            assert!(orchestrator_stream.is_none());
+        }
 
         let SpawnForwardingStageResult {
             join_handle: forwarding_stage,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -169,6 +169,7 @@ use {
     tokio::{runtime::Runtime as TokioRuntime, sync::mpsc},
     tokio_util::sync::CancellationToken,
 };
+use agave_orchestrator::OrchestratorStream;
 
 const MAX_COMPLETED_DATA_SETS_IN_CHANNEL: usize = 100_000;
 const WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT: u64 = 80;
@@ -676,6 +677,7 @@ impl Validator {
         tpu_config: ValidatorTpuConfig,
         admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
         xdp_builder_with_src_addr: Option<(TransmitterBuilder, SocketAddrV4)>,
+        orchestrator_stream: Option<OrchestratorStream>,
     ) -> Result<Self> {
         let exit = Arc::new(AtomicBool::new(false));
         Self::new_with_exit(
@@ -693,6 +695,7 @@ impl Validator {
             tpu_config,
             admin_rpc_service_post_init,
             xdp_builder_with_src_addr,
+            orchestrator_stream,
             exit,
         )
     }
@@ -713,6 +716,7 @@ impl Validator {
         tpu_config: ValidatorTpuConfig,
         admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
         xdp_builder_with_src_addr: Option<(TransmitterBuilder, SocketAddrV4)>,
+        orchestrator_stream: Option<OrchestratorStream>,
         exit: Arc<AtomicBool>,
     ) -> Result<Self> {
         #[cfg(debug_assertions)]
@@ -1747,6 +1751,7 @@ impl Validator {
                     banking_control_sender.clone(),
                 )
             }),
+            orchestrator_stream,
             cancel,
             votor_event_sender,
         );
@@ -2999,6 +3004,7 @@ mod tests {
             ValidatorTpuConfig::new_for_tests(),
             Arc::new(RwLock::new(None)),
             None,
+            None, // orchestrator_stream
         )
         .expect("assume successful validator start");
         assert_eq!(
@@ -3218,6 +3224,7 @@ mod tests {
                     ValidatorTpuConfig::new_for_tests(),
                     Arc::new(RwLock::new(None)),
                     None,
+                    None, // orchestrator_stream
                 )
                 .expect("assume successful validator start")
             })

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -465,6 +465,7 @@ impl LocalCluster {
                 ValidatorTpuConfig::new_for_tests(),
                 Arc::new(RwLock::new(None)),
                 None,
+                None, // orchestrator_stream
             )
             .expect("assume successful validator start");
 
@@ -675,6 +676,7 @@ impl LocalCluster {
             ValidatorTpuConfig::new_for_tests(),
             Arc::new(RwLock::new(None)),
             None,
+            None, // orchestrator_stream
         )
         .expect("assume successful validator start");
 
@@ -741,6 +743,7 @@ impl LocalCluster {
                 ValidatorTpuConfig::new_for_tests(),
                 Arc::new(RwLock::new(None)),
                 None,
+                None, // orchestrator_stream
             )
             .unwrap_or_else(|e| panic!("Cluster leader failed to start: {e:?}"));
 
@@ -805,6 +808,7 @@ impl LocalCluster {
                     ValidatorTpuConfig::new_for_tests(),
                     Arc::new(RwLock::new(None)),
                     None,
+                    None, // orchestrator_stream
                 )
                 .unwrap_or_else(|e| panic!("Validator {i} failed to start: {e:?}"));
 
@@ -1437,6 +1441,7 @@ impl Cluster for LocalCluster {
             ValidatorTpuConfig::new_for_tests(),
             Arc::new(RwLock::new(None)),
             None,
+            None, // orchestrator_stream
         )
         .expect("assume successful validator start");
         cluster_validator_info.validator = Some(restarted_node);

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "agave-orchestrator"
+readme = "../README.md"
+documentation = "https://docs.rs/agave-orchestrator"
+version = { workspace = true }
+authors = { workspace = true }
+description = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -11,3 +11,6 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+
+[target."cfg(unix)".dependencies]
+nix = { workspace = true, features = ["process", "signal"] }

--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -1,0 +1,4 @@
+#[cfg(unix)]
+pub type OrchestratorStream = std::os::unix::net::UnixStream;
+#[cfg(not(unix))]
+pub type OrchestratorStream = ();

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    todo!("agave-orchestrator");
+}

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -1,17 +1,29 @@
+#![cfg(unix)]
+
 use std::{
     io::Read,
     os::{fd::FromRawFd, unix::net::UnixStream},
 };
 
-fn main() {
-    // TODO: Can we use clap-v4, its so much nicer => probably not cause of workspace :(.
-    let args: Vec<String> = std::env::args().collect();
-    let fd_idx = args
-        .iter()
-        .position(|a| a == "--orch-fd")
-        .expect("missing --orch-fd");
-    let fd: i32 = args[fd_idx + 1].parse().expect("bad fd");
+// TODO: Replace manual parsing with CLAP, just ideally not more clap v2.
 
+fn parse_arg<'a>(args: &'a [String], name: &str) -> Option<&'a str> {
+    args.iter()
+        .position(|a| a == name)
+        .map(|i| args[i + 1].as_str())
+}
+
+fn require_arg<'a>(args: &'a [String], name: &str) -> &'a str {
+    parse_arg(args, name).unwrap_or_else(|| panic!("missing {name}"))
+}
+
+fn main() {
+    // Parse args.
+    let args: Vec<String> = std::env::args().collect();
+    let fd: i32 = require_arg(&args, "--orch-fd").parse().expect("bad fd");
+    let ipc_path = require_arg(&args, "--ipc-path");
+    let scheduler_bin = require_arg(&args, "--external-scheduler-bin");
+    let scheduler_config = parse_arg(&args, "--external-scheduler-config");
     eprintln!("[orchestrator] started; orch-fd={fd}");
 
     // SAFETY: fd was passed to us by the parent process via fork+exec.
@@ -23,19 +35,59 @@ fn main() {
     assert_eq!(buf[0], 0x01, "unexpected readiness byte");
     eprintln!("[orchestrator] validator is ready");
 
-    // Wait for validator exit.
-    loop {
-        match stream.read(&mut buf) {
-            Ok(len) => {
-                assert_eq!(len, 0);
+    // Spawn the external scheduler.
+    //
+    // SAFETY: Orchestrator is single threaded.
+    let scheduler_pid = unsafe { spawn_scheduler(scheduler_bin, ipc_path, scheduler_config) };
+    eprintln!("[orchestrator] spawned scheduler; pid={scheduler_pid}");
 
-                break;
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
-            Err(err) => panic!("Unexpected IO err; err={err}"),
+    // Monitor the scheduler.
+    match nix::sys::wait::waitpid(scheduler_pid, None) {
+        Ok(status) => {
+            eprintln!("[orchestrator] scheduler exited; status={status:?}");
+        }
+        Err(err) => {
+            eprintln!("[orchestrator] waitpid failed; err={err}");
         }
     }
 
-    // Log & exit.
+    // Wait for validator exit (EOF on UDS).
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(_) => continue,
+            Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(err) => {
+                eprintln!("[orchestrator] UDS read error; err={err}");
+                break;
+            }
+        }
+    }
     eprintln!("[orchestrator] validator exited");
+
+    eprintln!("[orchestrator] exiting");
+}
+
+unsafe fn spawn_scheduler(bin: &str, ipc_path: &str, config: Option<&str>) -> nix::unistd::Pid {
+    use nix::unistd::{ForkResult, execv, fork};
+
+    let c_bin = std::ffi::CString::new(bin).unwrap();
+    let mut argv = vec![
+        c_bin.clone(),
+        std::ffi::CString::new("--bindings-ipc").unwrap(),
+        std::ffi::CString::new(ipc_path).unwrap(),
+    ];
+    if let Some(cfg) = config {
+        argv.push(std::ffi::CString::new("--config").unwrap());
+        argv.push(std::ffi::CString::new(cfg).unwrap());
+    }
+
+    // SAFETY: The orchestrator is single-threaded at this point.
+    match unsafe { fork() }.expect("fork failed") {
+        ForkResult::Child => {
+            let err = execv(&c_bin, &argv).err().unwrap();
+            panic!("execv failed; bin={bin}; err={err:?}");
+        }
+        ForkResult::Parent { child } => child,
+    }
 }

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -1,3 +1,41 @@
+use std::{
+    io::Read,
+    os::{fd::FromRawFd, unix::net::UnixStream},
+};
+
 fn main() {
-    todo!("agave-orchestrator");
+    // TODO: Can we use clap-v4, its so much nicer => probably not cause of workspace :(.
+    let args: Vec<String> = std::env::args().collect();
+    let fd_idx = args
+        .iter()
+        .position(|a| a == "--orch-fd")
+        .expect("missing --orch-fd");
+    let fd: i32 = args[fd_idx + 1].parse().expect("bad fd");
+
+    eprintln!("[orchestrator] started; orch-fd={fd}");
+
+    // SAFETY: fd was passed to us by the parent process via fork+exec.
+    let mut stream = unsafe { UnixStream::from_raw_fd(fd) };
+
+    // Wait for validator readiness.
+    let mut buf = [0u8; 1];
+    stream.read_exact(&mut buf).expect("read readiness byte");
+    assert_eq!(buf[0], 0x01, "unexpected readiness byte");
+    eprintln!("[orchestrator] validator is ready");
+
+    // Wait for validator exit.
+    loop {
+        match stream.read(&mut buf) {
+            Ok(len) => {
+                assert_eq!(len, 0);
+
+                break;
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(err) => panic!("Unexpected IO err; err={err}"),
+        }
+    }
+
+    // Log & exit.
+    eprintln!("[orchestrator] validator exited");
 }

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1167,6 +1167,7 @@ impl TestValidator {
             ValidatorTpuConfig::new_for_tests(),
             config.admin_rpc_service_post_init.clone(),
             None,
+            None, // orchestrator_stream
         )?);
 
         let test_validator = TestValidator {

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -19,6 +19,7 @@ agave-unstable-api = []
 
 [dependencies]
 agave-logger = { workspace = true }
+agave-orchestrator = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-votor = { workspace = true }
 agave-xdp = { workspace = true }
@@ -98,6 +99,7 @@ jemallocator = { workspace = true }
 caps = { workspace = true }
 
 [target."cfg(unix)".dependencies]
+nix = { workspace = true, features = ["socket", "process", "signal", "fs"] }
 libc = { workspace = true }
 
 [dev-dependencies]

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1250,6 +1250,7 @@ mod tests {
                 ValidatorTpuConfig::new_for_tests(),
                 post_init.clone(),
                 None,
+                None, // orchestrator_stream
             )
             .expect("assume successful validator start");
             assert_eq!(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1192,7 +1192,24 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("orchestrator")
             .takes_value(true)
             .value_name("PATH")
+            .requires("external_scheduler_bin")
             .help("Path to orchestrator binary. Spawns an orchestrator child process to manage external scheduler lifecycle."),
+    )
+    .arg(
+        Arg::with_name("external_scheduler_bin")
+            .long("external-scheduler-bin")
+            .takes_value(true)
+            .value_name("PATH")
+            .requires("orchestrator")
+            .help("Path to external scheduler binary, spawned by the orchestrator"),
+    )
+    .arg(
+        Arg::with_name("external_scheduler_config")
+            .long("external-scheduler-config")
+            .takes_value(true)
+            .value_name("PATH")
+            .requires("external_scheduler_bin")
+            .help("Path to config file passed to the external scheduler"),
     )
     .arg(
         Arg::with_name("unified_scheduler_handler_threads")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1188,6 +1188,13 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Enables external processes to connect and manage block production"),
     )
     .arg(
+        Arg::with_name("orchestrator")
+            .long("orchestrator")
+            .takes_value(true)
+            .value_name("PATH")
+            .help("Path to orchestrator binary. Spawns an orchestrator child process to manage external scheduler lifecycle."),
+    )
+    .arg(
         Arg::with_name("unified_scheduler_handler_threads")
             .long("unified-scheduler-handler-threads")
             .value_name("COUNT")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -105,10 +105,25 @@ pub fn execute(
 
     // Spawn orchestrator child process as early as possible (fork safety).
     #[cfg(unix)]
-    let orchestrator_stream = matches
-        .value_of("orchestrator")
+    let orchestrator_stream = matches.value_of("orchestrator").map(|bin| {
+        let ipc_path = run_args.ledger_path.join("scheduler_bindings.ipc");
+        let ipc_str = ipc_path.to_str().expect("ipc path not valid UTF-8");
+
+        let mut extra_args: Vec<&str> = vec![
+            "--ipc-path",
+            ipc_str,
+            "--external-scheduler-bin",
+            matches
+                .value_of("external_scheduler_bin")
+                .expect("orchestrator needs scheduler bin"),
+        ];
+        if let Some(path) = matches.value_of("external_scheduler_config") {
+            extra_args.extend(["--external-scheduler-config", path]);
+        }
+
         // SAFETY: No threads have been spawned yet.
-        .map(|bin| unsafe { super::orchestrator::spawn_orchestrator(std::path::Path::new(bin)) });
+        unsafe { super::orchestrator::spawn_orchestrator(std::path::Path::new(bin), &extra_args) }
+    });
     #[cfg(not(unix))]
     let orchestrator_stream = None;
 
@@ -881,7 +896,8 @@ pub fn execute(
             ),
         },
         enable_block_production_forwarding: staked_nodes_overrides_path.is_some(),
-        enable_scheduler_bindings: matches.is_present("enable_scheduler_bindings"),
+        enable_scheduler_bindings: matches.is_present("enable_scheduler_bindings")
+            || matches.is_present("orchestrator"),
         banking_trace_dir_byte_limit: parse_banking_trace_dir_byte_limit(matches),
         validator_exit: Arc::new(RwLock::new(Exit::default())),
         validator_exit_backpressure: [(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -103,6 +103,15 @@ pub fn execute(
 
     let run_args = RunArgs::from_clap_arg_match(matches)?;
 
+    // Spawn orchestrator child process as early as possible (fork safety).
+    #[cfg(unix)]
+    let orchestrator_stream = matches
+        .value_of("orchestrator")
+        // SAFETY: No threads have been spawned yet.
+        .map(|bin| unsafe { super::orchestrator::spawn_orchestrator(std::path::Path::new(bin)) });
+    #[cfg(not(unix))]
+    let orchestrator_stream = None;
+
     let cli::thread_args::NumThreadConfig {
         accounts_db_background_threads,
         accounts_db_foreground_threads,
@@ -1126,6 +1135,7 @@ pub fn execute(
         },
         admin_service_post_init,
         xdp_builder_with_src_addr,
+        orchestrator_stream,
         exit,
     )
     .map_err(|err| format!("{err:?}"))?;

--- a/validator/src/commands/run/mod.rs
+++ b/validator/src/commands/run/mod.rs
@@ -1,4 +1,6 @@
 pub mod args;
 pub mod execute;
+#[cfg(unix)]
+pub mod orchestrator;
 
 pub use {args::add_args, execute::execute};

--- a/validator/src/commands/run/orchestrator.rs
+++ b/validator/src/commands/run/orchestrator.rs
@@ -16,7 +16,7 @@ use {
 /// # Safety
 /// - Must be called before any threads are spawned (allocating CString between fork &
 ///   execv is not multithread safe).
-pub unsafe fn spawn_orchestrator(bin: &Path) -> UnixStream {
+pub unsafe fn spawn_orchestrator(bin: &Path, extra_args: &[&str]) -> UnixStream {
     let (validator_fd, orch_fd) = socket::socketpair(
         AddressFamily::Unix,
         SockType::Stream,
@@ -38,11 +38,14 @@ pub unsafe fn spawn_orchestrator(bin: &Path) -> UnixStream {
                 .to_str()
                 .expect("orchestrator bin path is not valid UTF-8");
             let c_bin = std::ffi::CString::new(bin_str).unwrap();
-            let args = [
+            let mut args = vec![
                 c_bin.clone(),
                 std::ffi::CString::new("--orch-fd").unwrap(),
                 std::ffi::CString::new(orch_fd.as_raw_fd().to_string()).unwrap(),
             ];
+            for arg in extra_args {
+                args.push(std::ffi::CString::new(*arg).unwrap());
+            }
             let err = unistd::execv(&c_bin, &args).err().unwrap();
 
             // Only reachable if execv fails.

--- a/validator/src/commands/run/orchestrator.rs
+++ b/validator/src/commands/run/orchestrator.rs
@@ -1,0 +1,60 @@
+use {
+    log::info,
+    nix::{
+        fcntl::{FcntlArg, FdFlag, fcntl},
+        sys::socket::{self, AddressFamily, SockFlag, SockType},
+        unistd::{self, ForkResult},
+    },
+    std::{
+        os::{fd::AsRawFd, unix::net::UnixStream},
+        path::Path,
+    },
+};
+
+/// Spawns the orchestrator and returns agave's side of the UDS pair.
+///
+/// # Safety
+/// - Must be called before any threads are spawned (allocating CString between fork &
+///   execv is not multithread safe).
+pub unsafe fn spawn_orchestrator(bin: &Path) -> UnixStream {
+    let (validator_fd, orch_fd) = socket::socketpair(
+        AddressFamily::Unix,
+        SockType::Stream,
+        None,
+        SockFlag::SOCK_CLOEXEC,
+    )
+    .expect("socketpair failed");
+
+    // let orch_raw = orch_fd.into_raw_fd();
+
+    // SAFETY: Caller ensures no other threads exist.
+    match unsafe { unistd::fork() }.expect("fork failed") {
+        ForkResult::Child => {
+            // Clear CLOEXEC on orch_raw so it survives execv.
+            fcntl(&orch_fd, FcntlArg::F_SETFD(FdFlag::empty())).expect("clear CLOEXEC");
+
+            // Execv into the new binary.
+            let bin_str = bin
+                .to_str()
+                .expect("orchestrator bin path is not valid UTF-8");
+            let c_bin = std::ffi::CString::new(bin_str).unwrap();
+            let args = [
+                c_bin.clone(),
+                std::ffi::CString::new("--orch-fd").unwrap(),
+                std::ffi::CString::new(orch_fd.as_raw_fd().to_string()).unwrap(),
+            ];
+            let err = unistd::execv(&c_bin, &args).err().unwrap();
+
+            // Only reachable if execv fails.
+            panic!("execv failed; bin={bin_str}; err={err:?}");
+        }
+        ForkResult::Parent { child } => {
+            info!(
+                "Spawned orchestrator child process; pid={child}; bin={}",
+                bin.display()
+            );
+
+            UnixStream::from(validator_fd)
+        }
+    }
+}


### PR DESCRIPTION
#### Problem

- We want to move to a model where external schedulers can be managed by agave-orchestrator.

#### Summary of Changes

- We expose various orchestrator related CLI args.
- Orchestrator forks off early from core validator.
- Orchestrator spawns the external scheduler once it receives the readiness signal.