### PR TITLE
runtime_transaction: TransactionConfiguration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10046,7 +10046,6 @@ dependencies = [
  "bincode",
  "criterion",
  "rand 0.9.2",
- "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-compute-budget-interface",
  "solana-hash 4.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10046,6 +10046,7 @@ dependencies = [
  "bincode",
  "criterion",
  "rand 0.9.2",
+ "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-compute-budget-interface",
  "solana-hash 4.2.0",

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -490,7 +490,7 @@ impl Consumer {
         let fee = solana_fee::calculate_fee(
             transaction,
             bank.fee_structure().lamports_per_signature,
-            transaction_configuration.prioritization_fee,
+            transaction_configuration.priority_fee_lamports,
             FeeFeatures::from(bank.feature_set.as_ref()),
         );
         let (mut fee_payer_account, _slot) = bank

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -487,11 +487,8 @@ impl Consumer {
         error_counters: &mut TransactionErrorMetrics,
     ) -> Result<(), TransactionError> {
         let fee_payer = transaction.fee_payer();
-        let fee_budget_limits = FeeBudgetLimits::from(
-            transaction
-                .compute_budget_instruction_details()
-                .sanitize_and_convert_to_compute_budget_limits(&bank.feature_set)?,
-        );
+        let fee_budget_limits =
+            FeeBudgetLimits::from(transaction.compute_budget_limits(&bank.feature_set)?);
         let fee = solana_fee::calculate_fee(
             transaction,
             bank.fee_structure().lamports_per_signature,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -7,7 +7,6 @@ use {
     },
     itertools::Itertools,
     solana_fee::FeeFeatures,
-    solana_fee_structure::FeeBudgetLimits,
     solana_measure::measure_us,
     solana_poh::{
         poh_recorder::PohRecorderError,
@@ -487,12 +486,11 @@ impl Consumer {
         error_counters: &mut TransactionErrorMetrics,
     ) -> Result<(), TransactionError> {
         let fee_payer = transaction.fee_payer();
-        let fee_budget_limits =
-            FeeBudgetLimits::from(transaction.compute_budget_limits(&bank.feature_set)?);
+        let transaction_configuration = transaction.transaction_configuration(&bank.feature_set)?;
         let fee = solana_fee::calculate_fee(
             transaction,
             bank.fee_structure().lamports_per_signature,
-            fee_budget_limits.prioritization_fee,
+            transaction_configuration.prioritization_fee,
             FeeFeatures::from(bank.feature_set.as_ref()),
         );
         let (mut fee_payer_account, _slot) = bank

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -24,14 +24,14 @@ use {
     solana_address_lookup_table_interface::state::estimate_last_valid_slot,
     solana_clock::{Epoch, Slot},
     solana_cost_model::cost_model::CostModel,
-    solana_fee_structure::FeeBudgetLimits,
     solana_message::v0::LoadedAddresses,
     solana_runtime::{
         bank::Bank,
         bank_forks::{BankPair, SharableBanks},
     },
     solana_runtime_transaction::{
-        runtime_transaction::RuntimeTransaction, transaction_meta::StaticMeta,
+        runtime_transaction::RuntimeTransaction,
+        transaction_meta::{StaticMeta, TransactionConfiguration},
         transaction_with_meta::TransactionWithMeta,
     },
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
@@ -415,14 +415,15 @@ impl TransactionViewReceiveAndBuffer {
             enable_instruction_accounts_limit,
         )?;
 
-        let Ok(compute_budget_limits) = view.compute_budget_limits(&working_bank.feature_set)
+        let Ok(transaction_configuration) =
+            view.transaction_configuration(&working_bank.feature_set)
         else {
             return Err(PacketHandlingError::ComputeBudget);
         };
 
         let max_age = calculate_max_age(root_bank.epoch(), deactivation_slot, root_bank.slot());
-        let fee_budget_limits = FeeBudgetLimits::from(compute_budget_limits);
-        let (priority, cost) = calculate_priority_and_cost(&view, &fee_budget_limits, working_bank);
+        let (priority, cost) =
+            calculate_priority_and_cost(&view, &transaction_configuration, working_bank);
 
         Ok(TransactionState::new(view, max_age, priority, cost))
     }
@@ -516,11 +517,11 @@ pub(crate) fn load_addresses_for_view<D: TransactionData>(
 /// the current transaction costs.
 pub(crate) fn calculate_priority_and_cost(
     transaction: &impl TransactionWithMeta,
-    fee_budget_limits: &FeeBudgetLimits,
+    transaction_configuration: &TransactionConfiguration,
     bank: &Bank,
 ) -> (u64, u64) {
     let cost = CostModel::calculate_cost(transaction, &bank.feature_set).sum();
-    let reward = bank.calculate_reward_for_transaction(transaction, fee_budget_limits);
+    let reward = bank.calculate_reward_for_transaction(transaction, transaction_configuration);
 
     // We need a multiplier here to avoid rounding down too aggressively.
     // For many transactions, the cost will be greater than the fees in terms of raw lamports.

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -415,9 +415,7 @@ impl TransactionViewReceiveAndBuffer {
             enable_instruction_accounts_limit,
         )?;
 
-        let Ok(compute_budget_limits) = view
-            .compute_budget_instruction_details()
-            .sanitize_and_convert_to_compute_budget_limits(&working_bank.feature_set)
+        let Ok(compute_budget_limits) = view.compute_budget_limits(&working_bank.feature_set)
         else {
             return Err(PacketHandlingError::ComputeBudget);
         };

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -31,7 +31,7 @@ use {
     },
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction,
-        transaction_meta::{StaticMeta, TransactionConfiguration},
+        transaction_meta::{TransactionConfiguration, TransactionMeta},
         transaction_with_meta::TransactionWithMeta,
     },
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -489,7 +489,7 @@ mod tests {
         solana_poh::poh_recorder::{LeaderState, SharedLeaderState},
         solana_pubkey::Pubkey,
         solana_runtime::{bank::Bank, bank_forks::BankForks},
-        solana_runtime_transaction::transaction_meta::StaticMeta,
+        solana_runtime_transaction::transaction_meta::TransactionMeta,
         solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
         solana_transaction::Transaction,

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -130,10 +130,7 @@ pub(crate) fn ensure_banking_stage_setup(
                     .ok()?;
 
                     // Determine priority.
-                    let compute_budget_limits = tx
-                        .compute_budget_instruction_details()
-                        .sanitize_and_convert_to_compute_budget_limits(&bank.feature_set)
-                        .ok()?;
+                    let compute_budget_limits = tx.compute_budget_limits(&bank.feature_set).ok()?;
                     let (priority, _cost) =
                         calculate_priority_and_cost(&tx, &compute_budget_limits.into(), &bank);
                     let task_id = BankingStageHelper::new_task_id(task_id_base + i, priority);

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -42,7 +42,7 @@ use {
     solana_poh::{poh_recorder::PohRecorder, transaction_recorder::TransactionRecorder},
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_runtime_transaction::{
-        runtime_transaction::RuntimeTransaction, transaction_meta::StaticMeta,
+        runtime_transaction::RuntimeTransaction, transaction_meta::TransactionMeta,
     },
     solana_svm_transaction::{
         message_address_table_lookup::SVMMessageAddressTableLookup, svm_message::SVMMessage,

--- a/core/src/banking_stage/unified_scheduler.rs
+++ b/core/src/banking_stage/unified_scheduler.rs
@@ -130,9 +130,10 @@ pub(crate) fn ensure_banking_stage_setup(
                     .ok()?;
 
                     // Determine priority.
-                    let compute_budget_limits = tx.compute_budget_limits(&bank.feature_set).ok()?;
+                    let transaction_configuration =
+                        tx.transaction_configuration(&bank.feature_set).ok()?;
                     let (priority, _cost) =
-                        calculate_priority_and_cost(&tx, &compute_budget_limits.into(), &bank);
+                        calculate_priority_and_cost(&tx, &transaction_configuration, &bank);
                     let task_id = BankingStageHelper::new_task_id(task_id_base + i, priority);
 
                     Some(helper.create_new_task(

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -26,7 +26,7 @@ use {
     solana_poh::poh_recorder::PohRecorderError,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_runtime_transaction::{
-        runtime_transaction::RuntimeTransaction, transaction_meta::StaticMeta,
+        runtime_transaction::RuntimeTransaction, transaction_meta::TransactionMeta,
         transaction_with_meta::TransactionWithMeta,
     },
     solana_svm::{
@@ -583,7 +583,7 @@ mod tests {
         solana_perf::packet::BytesPacket,
         solana_poh::record_channels::record_channels,
         solana_runtime::genesis_utils::ValidatorVoteKeypairs,
-        solana_runtime_transaction::transaction_meta::StaticMeta,
+        solana_runtime_transaction::transaction_meta::TransactionMeta,
         solana_svm::account_loader::CheckedTransactionDetails,
         solana_system_transaction as system_transaction,
         std::collections::HashSet,

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -599,7 +599,7 @@ fn calculate_priority(
 
     // Manually estimate fee here since currently interface doesn't allow a on SVM type.
     // Doesn't need to be 100% accurate so long as close and consistent.
-    let prioritization_fee = transaction_configuration.prioritization_fee;
+    let prioritization_fee = transaction_configuration.priority_fee_lamports;
     let signature_details = transaction.signature_details();
     let signature_fee = signature_details
         .total_signatures()

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -593,10 +593,7 @@ fn calculate_priority(
     transaction: &RuntimeTransaction<SanitizedTransactionView<&[u8]>>,
     bank: &Bank,
 ) -> Option<u64> {
-    let compute_budget_limits = transaction
-        .compute_budget_instruction_details()
-        .sanitize_and_convert_to_compute_budget_limits(&bank.feature_set)
-        .ok()?;
+    let compute_budget_limits = transaction.compute_budget_limits(&bank.feature_set).ok()?;
     let fee_budget_limits = FeeBudgetLimits::from(compute_budget_limits);
 
     // Manually estimate fee here since currently interface doesn't allow a on SVM type.

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -9,7 +9,7 @@ use {
     crossbeam_channel::{Receiver, RecvTimeoutError},
     packet_container::PacketContainer,
     solana_cost_model::cost_model::CostModel,
-    solana_fee_structure::{FeeBudgetLimits, FeeDetails},
+    solana_fee_structure::FeeDetails,
     solana_gossip::{cluster_info::ClusterInfo, contact_info::Protocol, node::NodeMultihoming},
     solana_keypair::Keypair,
     solana_net_utils::{multihomed_sockets::BindIpAddrs, token_bucket::TokenBucket},
@@ -593,12 +593,13 @@ fn calculate_priority(
     transaction: &RuntimeTransaction<SanitizedTransactionView<&[u8]>>,
     bank: &Bank,
 ) -> Option<u64> {
-    let compute_budget_limits = transaction.compute_budget_limits(&bank.feature_set).ok()?;
-    let fee_budget_limits = FeeBudgetLimits::from(compute_budget_limits);
+    let transaction_configuration = transaction
+        .transaction_configuration(&bank.feature_set)
+        .ok()?;
 
     // Manually estimate fee here since currently interface doesn't allow a on SVM type.
     // Doesn't need to be 100% accurate so long as close and consistent.
-    let prioritization_fee = fee_budget_limits.prioritization_fee;
+    let prioritization_fee = transaction_configuration.prioritization_fee;
     let signature_details = transaction.signature_details();
     let signature_fee = signature_details
         .total_signatures()

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -20,7 +20,7 @@ use {
         bank_forks::SharableBanks,
     },
     solana_runtime_transaction::{
-        runtime_transaction::RuntimeTransaction, transaction_meta::StaticMeta,
+        runtime_transaction::RuntimeTransaction, transaction_meta::TransactionMeta,
     },
     solana_streamer::sendmmsg::{SendPktsError, batch_send},
     solana_tls_utils::NotifyKeyUpdate,

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -12,7 +12,7 @@ use {
     solana_compute_budget::compute_budget_limits::DEFAULT_HEAP_COST,
     solana_fee_structure::FeeStructure,
     solana_pubkey::Pubkey,
-    solana_runtime_transaction::transaction_meta::StaticMeta,
+    solana_runtime_transaction::transaction_meta::TransactionMeta,
     solana_sdk_ids::system_program,
     solana_svm_transaction::{instruction::SVMInstruction, svm_message::SVMStaticMessage},
     solana_system_interface::{
@@ -32,7 +32,7 @@ enum SystemProgramAccountAllocation {
 }
 
 impl CostModel {
-    pub fn calculate_cost<'a, Tx: StaticMeta + SVMStaticMessage>(
+    pub fn calculate_cost<'a, Tx: TransactionMeta + SVMStaticMessage>(
         transaction: &'a Tx,
         feature_set: &FeatureSet,
     ) -> TransactionCost<'a, Tx> {
@@ -58,7 +58,7 @@ impl CostModel {
 
     // Calculate executed transaction CU cost, with actual execution and loaded accounts size
     // costs.
-    pub fn calculate_cost_for_executed_transaction<'a, Tx: StaticMeta + SVMStaticMessage>(
+    pub fn calculate_cost_for_executed_transaction<'a, Tx: TransactionMeta + SVMStaticMessage>(
         transaction: &'a Tx,
         actual_programs_execution_cost: u64,
         actual_loaded_accounts_data_size_bytes: u32,
@@ -91,7 +91,7 @@ impl CostModel {
     /// - `meta` - transaction meta
     /// - `instructions` - transaction instructions
     /// - `num_write_locks` - number of requested write locks
-    pub fn estimate_cost<'a, Tx: StaticMeta>(
+    pub fn estimate_cost<'a, Tx: TransactionMeta>(
         transaction: &'a Tx,
         instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
         num_write_locks: u64,
@@ -116,7 +116,7 @@ impl CostModel {
         )
     }
 
-    fn calculate_non_vote_transaction_cost<'a, Tx: StaticMeta>(
+    fn calculate_non_vote_transaction_cost<'a, Tx: TransactionMeta>(
         transaction: &'a Tx,
         instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
         num_write_locks: u64,
@@ -145,7 +145,7 @@ impl CostModel {
     }
 
     /// Returns signature details and the total signature cost
-    fn get_signature_cost(transaction: &impl StaticMeta) -> u64 {
+    fn get_signature_cost(transaction: &impl TransactionMeta) -> u64 {
         let signatures_count_detail = transaction.signature_details();
 
         signatures_count_detail
@@ -175,7 +175,7 @@ impl CostModel {
 
     /// Return (programs_execution_cost, loaded_accounts_data_size_cost)
     fn get_estimated_execution_cost(
-        transaction: &impl StaticMeta,
+        transaction: &impl TransactionMeta,
         feature_set: &FeatureSet,
     ) -> (u64, u64) {
         // if failed to process compute_budget instructions, the transaction will not be executed
@@ -196,7 +196,7 @@ impl CostModel {
     }
 
     /// Return the instruction data bytes cost.
-    fn get_instructions_data_cost(transaction: &impl StaticMeta) -> u16 {
+    fn get_instructions_data_cost(transaction: &impl TransactionMeta) -> u16 {
         transaction.instruction_data_len() / (INSTRUCTION_DATA_BYTES_COST as u16)
     }
 

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -181,11 +181,11 @@ impl CostModel {
         // if failed to process compute_budget instructions, the transaction will not be executed
         // by `bank`, therefore it should be considered as no execution cost by cost model.
         let (programs_execution_costs, loaded_accounts_data_size_cost) =
-            match transaction.compute_budget_limits(feature_set) {
+            match transaction.transaction_configuration(feature_set) {
                 Ok(compute_budget_limits) => (
                     u64::from(compute_budget_limits.compute_unit_limit),
                     Self::calculate_loaded_accounts_data_size_cost(
-                        compute_budget_limits.loaded_accounts_bytes.get(),
+                        compute_budget_limits.loaded_accounts_data_size_limit.get(),
                         feature_set,
                     ),
                 ),

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -180,19 +180,17 @@ impl CostModel {
     ) -> (u64, u64) {
         // if failed to process compute_budget instructions, the transaction will not be executed
         // by `bank`, therefore it should be considered as no execution cost by cost model.
-        let (programs_execution_costs, loaded_accounts_data_size_cost) = match transaction
-            .compute_budget_instruction_details()
-            .sanitize_and_convert_to_compute_budget_limits(feature_set)
-        {
-            Ok(compute_budget_limits) => (
-                u64::from(compute_budget_limits.compute_unit_limit),
-                Self::calculate_loaded_accounts_data_size_cost(
-                    compute_budget_limits.loaded_accounts_bytes.get(),
-                    feature_set,
+        let (programs_execution_costs, loaded_accounts_data_size_cost) =
+            match transaction.compute_budget_limits(feature_set) {
+                Ok(compute_budget_limits) => (
+                    u64::from(compute_budget_limits.compute_unit_limit),
+                    Self::calculate_loaded_accounts_data_size_cost(
+                        compute_budget_limits.loaded_accounts_bytes.get(),
+                        feature_set,
+                    ),
                 ),
-            ),
-            Err(_) => (0, 0),
-        };
+                Err(_) => (0, 0),
+            };
 
         (programs_execution_costs, loaded_accounts_data_size_cost)
     }

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -182,10 +182,10 @@ impl CostModel {
         // by `bank`, therefore it should be considered as no execution cost by cost model.
         let (programs_execution_costs, loaded_accounts_data_size_cost) =
             match transaction.transaction_configuration(feature_set) {
-                Ok(compute_budget_limits) => (
-                    u64::from(compute_budget_limits.compute_unit_limit),
+                Ok(config) => (
+                    u64::from(config.compute_unit_limit),
                     Self::calculate_loaded_accounts_data_size_cost(
-                        compute_budget_limits.loaded_accounts_data_size_limit.get(),
+                        config.loaded_accounts_data_size_limit.get(),
                         feature_set,
                     ),
                 ),

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -1,6 +1,6 @@
 use {
     crate::block_cost_limits, solana_pubkey::Pubkey,
-    solana_runtime_transaction::transaction_meta::StaticMeta,
+    solana_runtime_transaction::transaction_meta::TransactionMeta,
     solana_svm_transaction::svm_message::SVMMessage,
 };
 
@@ -24,7 +24,7 @@ pub enum TransactionCost<'a, Tx> {
     Transaction(UsageCostDetails<'a, Tx>),
 }
 
-impl<Tx: StaticMeta> TransactionCost<'_, Tx> {
+impl<Tx: TransactionMeta> TransactionCost<'_, Tx> {
     pub fn sum(&self) -> u64 {
         #![allow(clippy::assertions_on_constants)]
         match self {
@@ -108,7 +108,7 @@ impl<Tx: SVMMessage> TransactionCost<'_, Tx> {
     }
 }
 
-impl<Tx: StaticMeta> TransactionCost<'_, Tx> {
+impl<Tx: TransactionMeta> TransactionCost<'_, Tx> {
     pub fn num_transaction_signatures(&self) -> u64 {
         match self {
             Self::SimpleVote { .. } => 1,
@@ -278,7 +278,7 @@ impl solana_svm_transaction::svm_transaction::SVMTransaction for WritableKeysTra
 }
 
 #[cfg(feature = "dev-context-only-utils")]
-impl solana_runtime_transaction::transaction_meta::StaticMeta for WritableKeysTransaction {
+impl solana_runtime_transaction::transaction_meta::TransactionMeta for WritableKeysTransaction {
     fn message_hash(&self) -> &solana_hash::Hash {
         unimplemented!("WritableKeysTransaction::message_hash")
     }

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -293,14 +293,14 @@ impl solana_runtime_transaction::transaction_meta::StaticMeta for WritableKeysTr
         &DUMMY
     }
 
-    fn compute_budget_limits(
+    fn transaction_configuration(
         &self,
         _feature_set: &agave_feature_set::FeatureSet,
     ) -> Result<
-        solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
+        solana_runtime_transaction::transaction_meta::TransactionConfiguration,
         solana_transaction::TransactionError,
     > {
-        unimplemented!("WritableKeysTransaction::compute_budget_limits")
+        unimplemented!("WritableKeysTransaction::transaction_configuration")
     }
 
     fn instruction_data_len(&self) -> u16 {

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "dev-context-only-utils")]
-use solana_compute_budget_instruction::compute_budget_instruction_details::ComputeBudgetInstructionDetails;
 use {
     crate::block_cost_limits, solana_pubkey::Pubkey,
     solana_runtime_transaction::transaction_meta::StaticMeta,
@@ -295,8 +293,14 @@ impl solana_runtime_transaction::transaction_meta::StaticMeta for WritableKeysTr
         &DUMMY
     }
 
-    fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails {
-        unimplemented!("WritableKeysTransaction::compute_budget_instruction_details")
+    fn compute_budget_limits(
+        &self,
+        _feature_set: &agave_feature_set::FeatureSet,
+    ) -> Result<
+        solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
+        solana_transaction::TransactionError,
+    > {
+        unimplemented!("WritableKeysTransaction::compute_budget_limits")
     }
 
     fn instruction_data_len(&self) -> u16 {

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8610,7 +8610,9 @@ dependencies = [
 name = "solana-runtime-transaction"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-feature-set",
  "agave-transaction-view",
+ "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-hash 4.2.0",
  "solana-message",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8612,7 +8612,6 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-transaction-view",
- "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-hash 4.2.0",
  "solana-message",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8251,7 +8251,9 @@ dependencies = [
 name = "solana-runtime-transaction"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "agave-feature-set",
  "agave-transaction-view",
+ "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-hash 4.2.0",
  "solana-message",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8253,7 +8253,6 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-transaction-view",
- "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-hash 4.2.0",
  "solana-message",

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -9351,6 +9351,15 @@ pub mod tests {
             assert_eq!(expected, actual);
         }
 
+        fn get_effective_price(price: u64, transaction_cu_limit: u64) -> u64 {
+            price
+                .saturating_mul(transaction_cu_limit) // fee in micro lamports
+                .div_ceil(1_000_000) // fee in lamports rounded up
+                .saturating_mul(1_000_000) // fee in micro-lamports rounded up
+                .checked_div(transaction_cu_limit) // effective price in micro-lamports per CU
+                .unwrap_or(0)
+        }
+
         let rpc = RpcHandler::start();
         assert_eq!(
             rpc.get_prioritization_fee_cache().available_block_count(),
@@ -9361,7 +9370,9 @@ pub mod tests {
         let account0 = Pubkey::new_unique();
         let account1 = Pubkey::new_unique();
         let account2 = Pubkey::new_unique();
-        let price0 = 42;
+        let price0 = 42u64;
+        let transaction_cu_limit = 6_000;
+        let effective_price0 = get_effective_price(price0, transaction_cu_limit);
         let transactions = vec![
             Transaction::new_unsigned(Message::new(
                 &[
@@ -9401,7 +9412,7 @@ pub mod tests {
             &mut response,
             &mut vec![RpcPrioritizationFee {
                 slot: slot0,
-                prioritization_fee: price0,
+                prioritization_fee: effective_price0,
             }],
         );
 
@@ -9423,6 +9434,7 @@ pub mod tests {
         let slot1 = rpc.working_bank().slot();
         let bank1_id = rpc.working_bank().bank_id();
         let price1 = 11;
+        let effective_price1 = get_effective_price(price1, transaction_cu_limit);
         let transactions = vec![
             Transaction::new_unsigned(Message::new(
                 &[
@@ -9469,7 +9481,7 @@ pub mod tests {
             &mut vec![
                 RpcPrioritizationFee {
                     slot: slot0,
-                    prioritization_fee: price0,
+                    prioritization_fee: effective_price0,
                 },
                 RpcPrioritizationFee {
                     slot: slot1,
@@ -9493,7 +9505,7 @@ pub mod tests {
                 },
                 RpcPrioritizationFee {
                     slot: slot1,
-                    prioritization_fee: price1,
+                    prioritization_fee: effective_price1,
                 },
             ],
         );

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -23,7 +23,6 @@ dev-context-only-utils = ["solana-compute-budget-instruction/dev-context-only-ut
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-transaction-view = { workspace = true }
-solana-compute-budget = { workspace = true }
 solana-compute-budget-instruction = { workspace = true }
 solana-hash = { workspace = true }
 solana-message = { workspace = true, features = ["blake3", "wincode"] }

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -21,7 +21,9 @@ agave-unstable-api = []
 dev-context-only-utils = ["solana-compute-budget-instruction/dev-context-only-utils"]
 
 [dependencies]
+agave-feature-set = { workspace = true }
 agave-transaction-view = { workspace = true }
+solana-compute-budget = { workspace = true }
 solana-compute-budget-instruction = { workspace = true }
 solana-hash = { workspace = true }
 solana-message = { workspace = true, features = ["blake3", "wincode"] }

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -66,7 +66,7 @@ impl<T> TransactionMeta for RuntimeTransaction<T> {
         Ok(TransactionConfiguration {
             updated_heap_bytes: compute_budget_limits.updated_heap_bytes,
             compute_unit_limit: compute_budget_limits.compute_unit_limit,
-            prioritization_fee: compute_budget_limits.get_prioritization_fee(),
+            priority_fee_lamports: compute_budget_limits.get_prioritization_fee(),
             loaded_accounts_data_size_limit: compute_budget_limits.loaded_accounts_bytes,
         })
     }

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -10,7 +10,9 @@
 //!    ALT, RuntimeTransaction<SanitizedMessage> transits into Dynamically Loaded state,
 //!    with its dynamic metadata loaded.
 use {
-    crate::transaction_meta::{DynamicMeta, StaticMeta, TransactionConfiguration, TransactionMeta},
+    crate::transaction_meta::{
+        CachedTransactionMeta, DynamicMeta, StaticMeta, TransactionConfiguration,
+    },
     agave_feature_set::FeatureSet,
     core::ops::Deref,
     solana_compute_budget_instruction::compute_budget_instruction_details::*,
@@ -36,7 +38,7 @@ pub struct RuntimeTransaction<T> {
     transaction: T,
     // transaction meta is a collection of fields, it is updated
     // during message state transition
-    meta: TransactionMeta,
+    meta: CachedTransactionMeta,
 }
 
 impl<T> RuntimeTransaction<T> {

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -11,7 +11,9 @@
 //!    with its dynamic metadata loaded.
 use {
     crate::transaction_meta::{DynamicMeta, StaticMeta, TransactionMeta},
+    agave_feature_set::FeatureSet,
     core::ops::Deref,
+    solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_compute_budget_instruction::compute_budget_instruction_details::*,
     solana_hash::Hash,
     solana_message::{AccountKeys, TransactionSignatureDetails},
@@ -23,6 +25,7 @@ use {
         svm_message::{SVMMessage, SVMStaticMessage},
         svm_transaction::SVMTransaction,
     },
+    solana_transaction::TransactionError,
 };
 
 mod sdk_transactions;
@@ -53,8 +56,13 @@ impl<T> StaticMeta for RuntimeTransaction<T> {
     fn signature_details(&self) -> &TransactionSignatureDetails {
         &self.meta.signature_details
     }
-    fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails {
-        &self.meta.compute_budget_instruction_details
+    fn compute_budget_limits(
+        &self,
+        feature_set: &FeatureSet,
+    ) -> Result<ComputeBudgetLimits, TransactionError> {
+        self.meta
+            .compute_budget_instruction_details
+            .sanitize_and_convert_to_compute_budget_limits(feature_set)
     }
     fn instruction_data_len(&self) -> u16 {
         self.meta.instruction_data_len

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -10,9 +10,7 @@
 //!    ALT, RuntimeTransaction<SanitizedMessage> transits into Dynamically Loaded state,
 //!    with its dynamic metadata loaded.
 use {
-    crate::transaction_meta::{
-        CachedTransactionMeta, DynamicMeta, StaticMeta, TransactionConfiguration,
-    },
+    crate::transaction_meta::{CachedTransactionMeta, TransactionConfiguration, TransactionMeta},
     agave_feature_set::FeatureSet,
     core::ops::Deref,
     solana_compute_budget_instruction::compute_budget_instruction_details::*,
@@ -47,7 +45,7 @@ impl<T> RuntimeTransaction<T> {
     }
 }
 
-impl<T> StaticMeta for RuntimeTransaction<T> {
+impl<T> TransactionMeta for RuntimeTransaction<T> {
     fn message_hash(&self) -> &Hash {
         &self.meta.message_hash
     }
@@ -70,8 +68,6 @@ impl<T> StaticMeta for RuntimeTransaction<T> {
         self.meta.instruction_data_len
     }
 }
-
-impl<T: SVMMessage> DynamicMeta for RuntimeTransaction<T> {}
 
 impl<T> Deref for RuntimeTransaction<T> {
     type Target = T;

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -10,10 +10,9 @@
 //!    ALT, RuntimeTransaction<SanitizedMessage> transits into Dynamically Loaded state,
 //!    with its dynamic metadata loaded.
 use {
-    crate::transaction_meta::{DynamicMeta, StaticMeta, TransactionMeta},
+    crate::transaction_meta::{DynamicMeta, StaticMeta, TransactionConfiguration, TransactionMeta},
     agave_feature_set::FeatureSet,
     core::ops::Deref,
-    solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_compute_budget_instruction::compute_budget_instruction_details::*,
     solana_hash::Hash,
     solana_message::{AccountKeys, TransactionSignatureDetails},
@@ -56,13 +55,14 @@ impl<T> StaticMeta for RuntimeTransaction<T> {
     fn signature_details(&self) -> &TransactionSignatureDetails {
         &self.meta.signature_details
     }
-    fn compute_budget_limits(
+    fn transaction_configuration(
         &self,
         feature_set: &FeatureSet,
-    ) -> Result<ComputeBudgetLimits, TransactionError> {
+    ) -> Result<TransactionConfiguration, TransactionError> {
         self.meta
             .compute_budget_instruction_details
             .sanitize_and_convert_to_compute_budget_limits(feature_set)
+            .map(TransactionConfiguration::from)
     }
     fn instruction_data_len(&self) -> u16 {
         self.meta.instruction_data_len

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -59,10 +59,16 @@ impl<T> TransactionMeta for RuntimeTransaction<T> {
         &self,
         feature_set: &FeatureSet,
     ) -> Result<TransactionConfiguration, TransactionError> {
-        self.meta
+        let compute_budget_limits = self
+            .meta
             .compute_budget_instruction_details
-            .sanitize_and_convert_to_compute_budget_limits(feature_set)
-            .map(TransactionConfiguration::from)
+            .sanitize_and_convert_to_compute_budget_limits(feature_set)?;
+        Ok(TransactionConfiguration {
+            updated_heap_bytes: compute_budget_limits.updated_heap_bytes,
+            compute_unit_limit: compute_budget_limits.compute_unit_limit,
+            prioritization_fee: compute_budget_limits.get_prioritization_fee(),
+            loaded_accounts_data_size_limit: compute_budget_limits.loaded_accounts_bytes,
+        })
     }
     fn instruction_data_len(&self) -> u16 {
         self.meta.instruction_data_len

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -353,8 +353,7 @@ mod tests {
 
         for feature_set in [FeatureSet::default(), FeatureSet::all_enabled()] {
             let compute_budget_limits = runtime_transaction_static
-                .compute_budget_instruction_details()
-                .sanitize_and_convert_to_compute_budget_limits(&feature_set)
+                .compute_budget_limits(&feature_set)
                 .unwrap();
             assert_eq!(compute_unit_limit, compute_budget_limits.compute_unit_limit);
             assert_eq!(compute_unit_price, compute_budget_limits.compute_unit_price);

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -353,13 +353,16 @@ mod tests {
 
         for feature_set in [FeatureSet::default(), FeatureSet::all_enabled()] {
             let compute_budget_limits = runtime_transaction_static
-                .compute_budget_limits(&feature_set)
+                .transaction_configuration(&feature_set)
                 .unwrap();
             assert_eq!(compute_unit_limit, compute_budget_limits.compute_unit_limit);
-            assert_eq!(compute_unit_price, compute_budget_limits.compute_unit_price);
+            assert_eq!(
+                compute_unit_price * u64::from(compute_unit_limit) / 1_000_000,
+                compute_budget_limits.prioritization_fee
+            );
             assert_eq!(
                 loaded_accounts_bytes,
-                compute_budget_limits.loaded_accounts_bytes.get()
+                compute_budget_limits.loaded_accounts_data_size_limit.get()
             );
         }
     }

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -2,7 +2,7 @@ use {
     super::{ComputeBudgetInstructionDetails, RuntimeTransaction},
     crate::{
         instruction_meta::InstructionMeta,
-        transaction_meta::{StaticMeta, TransactionMeta},
+        transaction_meta::{CachedTransactionMeta, StaticMeta},
         transaction_with_meta::TransactionWithMeta,
     },
     solana_message::{AddressLoader, TransactionSignatureDetails},
@@ -60,7 +60,7 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
 
         Ok(Self {
             transaction: sanitized_versioned_tx,
-            meta: TransactionMeta {
+            meta: CachedTransactionMeta {
                 message_hash,
                 is_simple_vote_transaction: is_simple_vote_tx,
                 signature_details,

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -352,17 +352,22 @@ mod tests {
         assert_eq!(0, signature_details.num_ed25519_instruction_signatures());
 
         for feature_set in [FeatureSet::default(), FeatureSet::all_enabled()] {
-            let compute_budget_limits = runtime_transaction_static
+            let transaction_configuration = runtime_transaction_static
                 .transaction_configuration(&feature_set)
                 .unwrap();
-            assert_eq!(compute_unit_limit, compute_budget_limits.compute_unit_limit);
             assert_eq!(
-                compute_unit_price * u64::from(compute_unit_limit) / 1_000_000,
-                compute_budget_limits.prioritization_fee
+                compute_unit_limit,
+                transaction_configuration.compute_unit_limit
+            );
+            assert_eq!(
+                compute_unit_price,
+                transaction_configuration.compute_unit_price_in_microlamports()
             );
             assert_eq!(
                 loaded_accounts_bytes,
-                compute_budget_limits.loaded_accounts_data_size_limit.get()
+                transaction_configuration
+                    .loaded_accounts_data_size_limit
+                    .get()
             );
         }
     }

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -2,7 +2,7 @@ use {
     super::{ComputeBudgetInstructionDetails, RuntimeTransaction},
     crate::{
         instruction_meta::InstructionMeta,
-        transaction_meta::{CachedTransactionMeta, StaticMeta},
+        transaction_meta::{CachedTransactionMeta, TransactionMeta},
         transaction_with_meta::TransactionWithMeta,
     },
     solana_message::{AddressLoader, TransactionSignatureDetails},

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -2,7 +2,7 @@ use {
     super::{ComputeBudgetInstructionDetails, RuntimeTransaction},
     crate::{
         instruction_meta::InstructionMeta,
-        transaction_meta::{StaticMeta, TransactionMeta},
+        transaction_meta::{CachedTransactionMeta, StaticMeta},
         transaction_with_meta::TransactionWithMeta,
     },
     agave_transaction_view::{
@@ -65,7 +65,7 @@ fn from_sanitized_transaction_view<D>(
     transaction: &SanitizedTransactionView<D>,
     message_hash: MessageHash,
     is_simple_vote_tx: Option<bool>,
-) -> Result<TransactionMeta>
+) -> Result<CachedTransactionMeta>
 where
     D: TransactionData,
 {
@@ -90,7 +90,7 @@ where
     let compute_budget_instruction_details =
         ComputeBudgetInstructionDetails::try_from(transaction.program_instructions_iter())?;
 
-    Ok(TransactionMeta {
+    Ok(CachedTransactionMeta {
         message_hash,
         is_simple_vote_transaction: is_simple_vote_tx,
         signature_details,

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -2,7 +2,7 @@ use {
     super::{ComputeBudgetInstructionDetails, RuntimeTransaction},
     crate::{
         instruction_meta::InstructionMeta,
-        transaction_meta::{CachedTransactionMeta, StaticMeta},
+        transaction_meta::{CachedTransactionMeta, TransactionMeta},
         transaction_with_meta::TransactionWithMeta,
     },
     agave_transaction_view::{

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -12,8 +12,11 @@
 //! RuntimeTransaction types, not the TransactionMeta itself.
 //!
 use {
+    agave_feature_set::FeatureSet,
+    solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_compute_budget_instruction::compute_budget_instruction_details::ComputeBudgetInstructionDetails,
     solana_hash::Hash, solana_message::TransactionSignatureDetails,
+    solana_transaction::TransactionError,
 };
 
 /// metadata can be extracted statically from sanitized transaction,
@@ -22,7 +25,10 @@ pub trait StaticMeta {
     fn message_hash(&self) -> &Hash;
     fn is_simple_vote_transaction(&self) -> bool;
     fn signature_details(&self) -> &TransactionSignatureDetails;
-    fn compute_budget_instruction_details(&self) -> &ComputeBudgetInstructionDetails;
+    fn compute_budget_limits(
+        &self,
+        feature_set: &FeatureSet,
+    ) -> Result<ComputeBudgetLimits, TransactionError>;
     fn instruction_data_len(&self) -> u16;
 }
 

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -13,7 +13,6 @@
 //!
 use {
     agave_feature_set::FeatureSet,
-    solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_compute_budget_instruction::compute_budget_instruction_details::ComputeBudgetInstructionDetails,
     solana_hash::Hash, solana_message::TransactionSignatureDetails,
     solana_transaction::TransactionError, std::num::NonZeroU32,
@@ -45,18 +44,6 @@ pub struct TransactionConfiguration {
     pub compute_unit_limit: u32,
     pub prioritization_fee: u64,
     pub loaded_accounts_data_size_limit: NonZeroU32,
-}
-
-impl From<ComputeBudgetLimits> for TransactionConfiguration {
-    fn from(compute_budget_limits: ComputeBudgetLimits) -> Self {
-        let prioritization_fee = compute_budget_limits.get_prioritization_fee();
-        TransactionConfiguration {
-            updated_heap_bytes: compute_budget_limits.updated_heap_bytes,
-            compute_unit_limit: compute_budget_limits.compute_unit_limit,
-            prioritization_fee,
-            loaded_accounts_data_size_limit: compute_budget_limits.loaded_accounts_bytes,
-        }
-    }
 }
 
 impl TransactionConfiguration {

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -16,7 +16,7 @@ use {
     solana_compute_budget::compute_budget_limits::ComputeBudgetLimits,
     solana_compute_budget_instruction::compute_budget_instruction_details::ComputeBudgetInstructionDetails,
     solana_hash::Hash, solana_message::TransactionSignatureDetails,
-    solana_transaction::TransactionError,
+    solana_transaction::TransactionError, std::num::NonZeroU32,
 };
 
 /// metadata can be extracted statically from sanitized transaction,
@@ -47,4 +47,23 @@ pub struct TransactionMeta {
     pub(crate) signature_details: TransactionSignatureDetails,
     pub(crate) compute_budget_instruction_details: ComputeBudgetInstructionDetails,
     pub(crate) instruction_data_len: u16,
+}
+
+pub struct TransactionConfiguration {
+    pub updated_heap_bytes: u32,
+    pub compute_unit_limit: u32,
+    pub prioritization_fee: u64,
+    pub loaded_accounts_bytes: NonZeroU32,
+}
+
+impl From<ComputeBudgetLimits> for TransactionConfiguration {
+    fn from(compute_budget_limits: ComputeBudgetLimits) -> Self {
+        let prioritization_fee = compute_budget_limits.get_prioritization_fee();
+        TransactionConfiguration {
+            updated_heap_bytes: compute_budget_limits.updated_heap_bytes,
+            compute_unit_limit: compute_budget_limits.compute_unit_limit,
+            prioritization_fee,
+            loaded_accounts_bytes: compute_budget_limits.loaded_accounts_bytes,
+        }
+    }
 }

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -19,9 +19,7 @@ use {
     solana_transaction::TransactionError, std::num::NonZeroU32,
 };
 
-/// metadata can be extracted statically from sanitized transaction,
-/// for example: message hash, simple-vote-tx flag, limits set by instructions
-pub trait StaticMeta {
+pub trait TransactionMeta {
     fn message_hash(&self) -> &Hash;
     fn is_simple_vote_transaction(&self) -> bool;
     fn signature_details(&self) -> &TransactionSignatureDetails;
@@ -31,13 +29,6 @@ pub trait StaticMeta {
     ) -> Result<TransactionConfiguration, TransactionError>;
     fn instruction_data_len(&self) -> u16;
 }
-
-/// Statically loaded meta is a supertrait of Dynamically loaded meta, when
-/// transaction transited successfully into dynamically loaded, it should
-/// have both meta data populated and available.
-/// Dynamic metadata available after accounts addresses are loaded from
-/// on-chain ALT, examples are: transaction usage costs, nonce account.
-pub trait DynamicMeta: StaticMeta {}
 
 #[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
 #[derive(Debug)]

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -42,7 +42,7 @@ pub struct CachedTransactionMeta {
 pub struct TransactionConfiguration {
     pub updated_heap_bytes: u32,
     pub compute_unit_limit: u32,
-    pub prioritization_fee: u64,
+    pub priority_fee_lamports: u64,
     pub loaded_accounts_data_size_limit: NonZeroU32,
 }
 
@@ -54,7 +54,7 @@ impl TransactionConfiguration {
     /// return a higher value here than their specified cu_price in the
     /// compute budget instruction.
     pub fn compute_unit_price_in_microlamports(&self) -> u64 {
-        self.prioritization_fee
+        self.priority_fee_lamports
             .saturating_mul(1_000_000)
             .checked_div(self.compute_unit_limit as u64)
             .unwrap_or(0)

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -58,3 +58,14 @@ impl From<ComputeBudgetLimits> for TransactionConfiguration {
         }
     }
 }
+
+impl TransactionConfiguration {
+    /// Compute the compute unit price in micro-lamports per compute unit.
+    /// Only used for legacy operations.
+    pub fn compute_unit_price_in_microlamports(&self) -> u64 {
+        self.prioritization_fee
+            .saturating_mul(1_000_000)
+            .checked_div(self.compute_unit_limit as u64)
+            .unwrap_or(0)
+    }
+}

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -61,7 +61,11 @@ impl From<ComputeBudgetLimits> for TransactionConfiguration {
 
 impl TransactionConfiguration {
     /// Compute the compute unit price in micro-lamports per compute unit.
-    /// Only used for legacy operations.
+    ///
+    /// Note: that this will return an effective price according to the actual
+    /// fee paid - i.e. legacy/v0 transactions that have fees rounded up will
+    /// return a higher value here than their specified cu_price in the
+    /// compute budget instruction.
     pub fn compute_unit_price_in_microlamports(&self) -> u64 {
         self.prioritization_fee
             .saturating_mul(1_000_000)

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -41,7 +41,7 @@ pub trait DynamicMeta: StaticMeta {}
 
 #[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
 #[derive(Debug)]
-pub struct TransactionMeta {
+pub struct CachedTransactionMeta {
     pub(crate) message_hash: Hash,
     pub(crate) is_simple_vote_transaction: bool,
     pub(crate) signature_details: TransactionSignatureDetails,

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -25,10 +25,10 @@ pub trait StaticMeta {
     fn message_hash(&self) -> &Hash;
     fn is_simple_vote_transaction(&self) -> bool;
     fn signature_details(&self) -> &TransactionSignatureDetails;
-    fn compute_budget_limits(
+    fn transaction_configuration(
         &self,
         feature_set: &FeatureSet,
-    ) -> Result<ComputeBudgetLimits, TransactionError>;
+    ) -> Result<TransactionConfiguration, TransactionError>;
     fn instruction_data_len(&self) -> u16;
 }
 
@@ -53,7 +53,7 @@ pub struct TransactionConfiguration {
     pub updated_heap_bytes: u32,
     pub compute_unit_limit: u32,
     pub prioritization_fee: u64,
-    pub loaded_accounts_bytes: NonZeroU32,
+    pub loaded_accounts_data_size_limit: NonZeroU32,
 }
 
 impl From<ComputeBudgetLimits> for TransactionConfiguration {
@@ -63,7 +63,7 @@ impl From<ComputeBudgetLimits> for TransactionConfiguration {
             updated_heap_bytes: compute_budget_limits.updated_heap_bytes,
             compute_unit_limit: compute_budget_limits.compute_unit_limit,
             prioritization_fee,
-            loaded_accounts_bytes: compute_budget_limits.loaded_accounts_bytes,
+            loaded_accounts_data_size_limit: compute_budget_limits.loaded_accounts_bytes,
         }
     }
 }

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -54,9 +54,10 @@ impl TransactionConfiguration {
     /// return a higher value here than their specified cu_price in the
     /// compute budget instruction.
     pub fn compute_unit_price_in_microlamports(&self) -> u64 {
-        self.priority_fee_lamports
-            .saturating_mul(1_000_000)
-            .checked_div(self.compute_unit_limit as u64)
+        (self.priority_fee_lamports as u128)
+            .saturating_mul(1_000_000u128)
+            .checked_div(self.compute_unit_limit as u128)
+            .and_then(|x| u64::try_from(x).ok())
             .unwrap_or(0)
     }
 }

--- a/runtime-transaction/src/transaction_with_meta.rs
+++ b/runtime-transaction/src/transaction_with_meta.rs
@@ -1,11 +1,11 @@
 use {
-    crate::transaction_meta::StaticMeta,
+    crate::transaction_meta::TransactionMeta,
     solana_svm_transaction::svm_transaction::SVMTransaction,
     solana_transaction::{sanitized::SanitizedTransaction, versioned::VersionedTransaction},
     std::borrow::Cow,
 };
 
-pub trait TransactionWithMeta: StaticMeta + SVMTransaction {
+pub trait TransactionWithMeta: TransactionMeta + SVMTransaction {
     /// Required to interact with geyser plugins.
     /// This function should not be used except for interacting with geyser.
     /// It may do numerous allocations that negatively impact performance.

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -107,8 +107,7 @@ impl Bank {
                 Ok(()) => {
                     let compute_budget_and_limits = tx
                         .borrow()
-                        .compute_budget_instruction_details()
-                        .sanitize_and_convert_to_compute_budget_limits(feature_set)
+                        .compute_budget_limits(feature_set)
                         .map(|limit| {
                             let fee_budget = FeeBudgetLimits::from(limit);
                             let fee_details = calculate_fee_details(

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -3,8 +3,8 @@ use {
     agave_feature_set::FeatureSet,
     solana_accounts_db::blockhash_queue::BlockhashQueue,
     solana_clock::{MAX_TRANSACTION_FORWARDING_DELAY, Slot},
+    solana_compute_budget::compute_budget::SVMTransactionExecutionBudget,
     solana_fee::{FeeFeatures, calculate_fee_details},
-    solana_fee_structure::FeeBudgetLimits,
     solana_nonce::state::{Data as NonceData, DurableNonce},
     solana_nonce_account as nonce_account,
     solana_program_runtime::execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
@@ -107,13 +107,12 @@ impl Bank {
                 Ok(()) => {
                     let compute_budget_and_limits = tx
                         .borrow()
-                        .compute_budget_limits(feature_set)
-                        .map(|limit| {
-                            let fee_budget = FeeBudgetLimits::from(limit);
+                        .transaction_configuration(feature_set)
+                        .map(|config| {
                             let fee_details = calculate_fee_details(
                                 tx.borrow(),
                                 self.fee_structure.lamports_per_signature,
-                                fee_budget.prioritization_fee,
+                                config.prioritization_fee,
                                 fee_features,
                             );
                             if let Some(compute_budget) = self.compute_budget {
@@ -121,15 +120,22 @@ impl Bank {
                                 // It should be removed along with the change to favor transaction's compute budget limits
                                 // over configured compute budget in Bank.
                                 compute_budget.get_compute_budget_and_limits(
-                                    fee_budget.loaded_accounts_data_size_limit,
+                                    config.loaded_accounts_data_size_limit,
                                     fee_details,
                                 )
                             } else {
-                                limit.get_compute_budget_and_limits(
-                                    fee_budget.loaded_accounts_data_size_limit,
+                                SVMTransactionExecutionAndFeeBudgetLimits {
+                                    budget: SVMTransactionExecutionBudget {
+                                        compute_unit_limit: u64::from(config.compute_unit_limit),
+                                        heap_size: config.updated_heap_bytes,
+                                        ..SVMTransactionExecutionBudget::new_with_defaults(
+                                            raise_cpi_limit,
+                                        )
+                                    },
+                                    loaded_accounts_data_size_limit: config
+                                        .loaded_accounts_data_size_limit,
                                     fee_details,
-                                    raise_cpi_limit,
-                                )
+                                }
                             }
                         })
                         .inspect_err(|_err| {

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -112,7 +112,7 @@ impl Bank {
                             let fee_details = calculate_fee_details(
                                 tx.borrow(),
                                 self.fee_structure.lamports_per_signature,
-                                config.prioritization_fee,
+                                config.priority_fee_lamports,
                                 fee_features,
                             );
                             if let Some(compute_budget) = self.compute_budget {

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -4,10 +4,11 @@ use {
     log::debug,
     solana_account::{ReadableAccount, WritableAccount},
     solana_fee::FeeFeatures,
-    solana_fee_structure::FeeBudgetLimits,
     solana_pubkey::Pubkey,
     solana_reward_info::RewardType,
-    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
+    solana_runtime_transaction::{
+        transaction_meta::TransactionConfiguration, transaction_with_meta::TransactionWithMeta,
+    },
     solana_svm::rent_calculator::{get_account_rent_state, transition_allowed},
     solana_system_interface::program as system_program,
     std::{result::Result, sync::atomic::Ordering::Relaxed},
@@ -64,12 +65,12 @@ impl Bank {
     pub fn calculate_reward_for_transaction(
         &self,
         transaction: &impl TransactionWithMeta,
-        fee_budget_limits: &FeeBudgetLimits,
+        transaction_configuration: &TransactionConfiguration,
     ) -> u64 {
         let fee_details = solana_fee::calculate_fee_details(
             transaction,
             self.fee_structure().lamports_per_signature,
-            fee_budget_limits.prioritization_fee,
+            transaction_configuration.prioritization_fee,
             FeeFeatures::from(self.feature_set.as_ref()),
         );
         let FeeDistribution {

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -70,7 +70,7 @@ impl Bank {
         let fee_details = solana_fee::calculate_fee_details(
             transaction,
             self.fee_structure().lamports_per_signature,
-            transaction_configuration.prioritization_fee,
+            transaction_configuration.priority_fee_lamports,
             FeeFeatures::from(self.feature_set.as_ref()),
         );
         let FeeDistribution {

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -220,21 +220,21 @@ impl PrioritizationFeeCache {
                     continue;
                 }
 
-                let compute_budget_limits =
-                    sanitized_transaction.compute_budget_limits(&bank.feature_set);
+                let transaction_configuration =
+                    sanitized_transaction.transaction_configuration(&bank.feature_set);
                 let lock_result = validate_account_locks(
                     sanitized_transaction.account_keys(),
                     bank.get_transaction_account_lock_limit(),
                 );
 
-                if compute_budget_limits.is_err() || lock_result.is_err() {
+                if transaction_configuration.is_err() || lock_result.is_err() {
                     continue;
                 }
-                let compute_budget_limits = compute_budget_limits.unwrap();
+                let transaction_configuration = transaction_configuration.unwrap();
 
                 // filter out any transaction that requests zero compute_unit_limit
                 // since its priority fee amount is not instructive
-                if compute_budget_limits.compute_unit_limit == 0 {
+                if transaction_configuration.compute_unit_limit == 0 {
                     continue;
                 }
 
@@ -247,17 +247,23 @@ impl PrioritizationFeeCache {
                     .collect();
 
                 let (prioritization_fee, calculate_prioritization_fee_us) =
-                    measure_us!(compute_budget_limits.get_prioritization_fee());
+                    measure_us!(transaction_configuration.prioritization_fee);
                 self.metrics
                     .accumulate_total_calculate_prioritization_fee_elapsed_us(
                         calculate_prioritization_fee_us,
                     );
 
+                let compute_unit_price = transaction_configuration
+                    .prioritization_fee
+                    .checked_div(u64::from(transaction_configuration.compute_unit_limit))
+                    .unwrap_or(0)
+                    .saturating_mul(1_000_000);
+
                 self.sender
                     .send(CacheServiceUpdate::TransactionUpdate {
                         slot: bank.slot(),
                         bank_id: bank.bank_id(),
-                        compute_unit_price: compute_budget_limits.compute_unit_price,
+                        compute_unit_price,
                         prioritization_fee,
                         writable_accounts,
                     })

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -253,12 +253,8 @@ impl PrioritizationFeeCache {
                         calculate_prioritization_fee_us,
                     );
 
-                let compute_unit_price = transaction_configuration
-                    .prioritization_fee
-                    .checked_div(u64::from(transaction_configuration.compute_unit_limit))
-                    .unwrap_or(0)
-                    .saturating_mul(1_000_000);
-
+                let compute_unit_price =
+                    transaction_configuration.compute_unit_price_in_microlamports();
                 self.sender
                     .send(CacheServiceUpdate::TransactionUpdate {
                         slot: bank.slot(),

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -247,7 +247,7 @@ impl PrioritizationFeeCache {
                     .collect();
 
                 let (prioritization_fee, calculate_prioritization_fee_us) =
-                    measure_us!(transaction_configuration.prioritization_fee);
+                    measure_us!(transaction_configuration.priority_fee_lamports);
                 self.metrics
                     .accumulate_total_calculate_prioritization_fee_elapsed_us(
                         calculate_prioritization_fee_us,

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -253,6 +253,7 @@ impl PrioritizationFeeCache {
                         calculate_prioritization_fee_us,
                     );
 
+                // See rounding note on `compute_unit_price_in_microlamports`.
                 let compute_unit_price =
                     transaction_configuration.compute_unit_price_in_microlamports();
                 self.sender
@@ -549,9 +550,9 @@ mod tests {
         // [2,   a,    c          ]  -->  [2,     2,         5,         2        ]
         //
         let txs = [
-            build_sanitized_transaction_for_test(5, &write_account_a, &write_account_b),
-            build_sanitized_transaction_for_test(9, &write_account_b, &write_account_c),
-            build_sanitized_transaction_for_test(2, &write_account_a, &write_account_c),
+            build_sanitized_transaction_for_test(5_000_000, &write_account_a, &write_account_b),
+            build_sanitized_transaction_for_test(9_000_000, &write_account_b, &write_account_c),
+            build_sanitized_transaction_for_test(2_000_000, &write_account_a, &write_account_c),
         ];
 
         let bank = Arc::new(Bank::default_for_tests());
@@ -571,9 +572,12 @@ mod tests {
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, slot, bank.bank_id());
             let lock = prioritization_fee_cache.cache.read().unwrap();
             let fee = lock.get(&slot).unwrap();
-            assert_eq!(2, fee.get_min_compute_unit_price().unwrap());
+            assert_eq!(2_000_000, fee.get_min_compute_unit_price().unwrap());
             assert!(fee.get_writable_account_fee(&write_account_a).is_none());
-            assert_eq!(5, fee.get_writable_account_fee(&write_account_b).unwrap());
+            assert_eq!(
+                5_000_000,
+                fee.get_writable_account_fee(&write_account_b).unwrap()
+            );
             assert!(fee.get_writable_account_fee(&write_account_c).is_none());
         }
     }
@@ -680,9 +684,9 @@ mod tests {
         // Assert after add one transaction for slot 1
         {
             let txs = [
-                build_sanitized_transaction_for_test(2, &write_account_a, &write_account_b),
+                build_sanitized_transaction_for_test(2_000_000, &write_account_a, &write_account_b),
                 build_sanitized_transaction_for_test(
-                    1,
+                    1_000_000,
                     &Pubkey::new_unique(),
                     &Pubkey::new_unique(),
                 ),
@@ -722,28 +726,28 @@ mod tests {
             // after block is completed
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 1, bank1.bank_id());
             assert_eq!(
-                vec![(1, 1)],
+                vec![(1, 1_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[])
             );
             assert_eq!(
-                vec![(1, 2)],
+                vec![(1, 2_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a])
             );
             assert_eq!(
-                vec![(1, 2)],
+                vec![(1, 2_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b])
             );
             assert_eq!(
-                vec![(1, 1)],
+                vec![(1, 1_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c])
             );
             assert_eq!(
-                vec![(1, 2)],
+                vec![(1, 2_000_000)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b])
             );
             assert_eq!(
-                vec![(1, 2)],
+                vec![(1, 2_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -755,9 +759,9 @@ mod tests {
         // Assert after add one transaction for slot 2
         {
             let txs = [
-                build_sanitized_transaction_for_test(4, &write_account_b, &write_account_c),
+                build_sanitized_transaction_for_test(4_000_000, &write_account_b, &write_account_c),
                 build_sanitized_transaction_for_test(
-                    3,
+                    3_000_000,
                     &Pubkey::new_unique(),
                     &Pubkey::new_unique(),
                 ),
@@ -765,28 +769,28 @@ mod tests {
             sync_update(&prioritization_fee_cache, bank2.clone(), txs.iter());
             // before block is marked as completed
             assert_eq!(
-                vec![(1, 1)],
+                vec![(1, 1_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[])
             );
             assert_eq!(
-                vec![(1, 2)],
+                vec![(1, 2_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a])
             );
             assert_eq!(
-                vec![(1, 2)],
+                vec![(1, 2_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b])
             );
             assert_eq!(
-                vec![(1, 1)],
+                vec![(1, 1_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c])
             );
             assert_eq!(
-                vec![(1, 2)],
+                vec![(1, 2_000_000)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b])
             );
             assert_eq!(
-                vec![(1, 2)],
+                vec![(1, 2_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -796,28 +800,28 @@ mod tests {
             // after block is completed
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 2, bank2.bank_id());
             assert_eq!(
-                vec![(1, 1), (2, 3)],
+                vec![(1, 1_000_000), (2, 3_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[]),
             );
             assert_eq!(
-                vec![(1, 2), (2, 3)],
+                vec![(1, 2_000_000), (2, 3_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a]),
             );
             assert_eq!(
-                vec![(1, 2), (2, 4)],
+                vec![(1, 2_000_000), (2, 4_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b]),
             );
             assert_eq!(
-                vec![(1, 1), (2, 4)],
+                vec![(1, 1_000_000), (2, 4_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c]),
             );
             assert_eq!(
-                vec![(1, 2), (2, 4)],
+                vec![(1, 2_000_000), (2, 4_000_000)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b]),
             );
             assert_eq!(
-                vec![(1, 2), (2, 4)],
+                vec![(1, 2_000_000), (2, 4_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -829,9 +833,9 @@ mod tests {
         // Assert after add one transaction for slot 3
         {
             let txs = [
-                build_sanitized_transaction_for_test(6, &write_account_a, &write_account_c),
+                build_sanitized_transaction_for_test(6_000_000, &write_account_a, &write_account_c),
                 build_sanitized_transaction_for_test(
-                    5,
+                    5_000_000,
                     &Pubkey::new_unique(),
                     &Pubkey::new_unique(),
                 ),
@@ -839,28 +843,28 @@ mod tests {
             sync_update(&prioritization_fee_cache, bank3.clone(), txs.iter());
             // before block is marked as completed
             assert_eq!(
-                vec![(1, 1), (2, 3)],
+                vec![(1, 1_000_000), (2, 3_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[]),
             );
             assert_eq!(
-                vec![(1, 2), (2, 3)],
+                vec![(1, 2_000_000), (2, 3_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a]),
             );
             assert_eq!(
-                vec![(1, 2), (2, 4)],
+                vec![(1, 2_000_000), (2, 4_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b]),
             );
             assert_eq!(
-                vec![(1, 1), (2, 4)],
+                vec![(1, 1_000_000), (2, 4_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c]),
             );
             assert_eq!(
-                vec![(1, 2), (2, 4)],
+                vec![(1, 2_000_000), (2, 4_000_000)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b]),
             );
             assert_eq!(
-                vec![(1, 2), (2, 4)],
+                vec![(1, 2_000_000), (2, 4_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -870,28 +874,28 @@ mod tests {
             // after block is completed
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 3, bank3.bank_id());
             assert_eq!(
-                vec![(1, 1), (2, 3), (3, 5)],
+                vec![(1, 1_000_000), (2, 3_000_000), (3, 5_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[]),
             );
             assert_eq!(
-                vec![(1, 2), (2, 3), (3, 6)],
+                vec![(1, 2_000_000), (2, 3_000_000), (3, 6_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a]),
             );
             assert_eq!(
-                vec![(1, 2), (2, 4), (3, 5)],
+                vec![(1, 2_000_000), (2, 4_000_000), (3, 5_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b]),
             );
             assert_eq!(
-                vec![(1, 1), (2, 4), (3, 6)],
+                vec![(1, 1_000_000), (2, 4_000_000), (3, 6_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c]),
             );
             assert_eq!(
-                vec![(1, 2), (2, 4), (3, 6)],
+                vec![(1, 2_000_000), (2, 4_000_000), (3, 6_000_000)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b]),
             );
             assert_eq!(
-                vec![(1, 2), (2, 4), (3, 6)],
+                vec![(1, 2_000_000), (2, 4_000_000), (3, 6_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -924,9 +928,9 @@ mod tests {
         // Assert after add transactions for bank1 of slot 1
         {
             let txs = [
-                build_sanitized_transaction_for_test(2, &write_account_a, &write_account_b),
+                build_sanitized_transaction_for_test(2_000_000, &write_account_a, &write_account_b),
                 build_sanitized_transaction_for_test(
-                    1,
+                    1_000_000,
                     &Pubkey::new_unique(),
                     &Pubkey::new_unique(),
                 ),
@@ -953,28 +957,28 @@ mod tests {
 
             // and data available for query are from bank1
             assert_eq!(
-                vec![(slot, 1)],
+                vec![(slot, 1_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[])
             );
             assert_eq!(
-                vec![(slot, 2)],
+                vec![(slot, 2_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a])
             );
             assert_eq!(
-                vec![(slot, 2)],
+                vec![(slot, 2_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b])
             );
             assert_eq!(
-                vec![(slot, 1)],
+                vec![(slot, 1_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c])
             );
             assert_eq!(
-                vec![(slot, 2)],
+                vec![(slot, 2_000_000)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b])
             );
             assert_eq!(
-                vec![(slot, 2)],
+                vec![(slot, 2_000_000)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -220,10 +220,8 @@ impl PrioritizationFeeCache {
                     continue;
                 }
 
-                let compute_budget_limits = sanitized_transaction
-                    .compute_budget_instruction_details()
-                    .sanitize_and_convert_to_compute_budget_limits(&bank.feature_set);
-
+                let compute_budget_limits =
+                    sanitized_transaction.compute_budget_limits(&bank.feature_set);
                 let lock_result = validate_account_locks(
                     sanitized_transaction.account_keys(),
                     bank.get_transaction_account_lock_limit(),


### PR DESCRIPTION
#### Problem
- Exposing ComputeBudgetInstructionDetails does not make sense in a world with txv1

#### Summary of Changes
- `TransactionMeta::transaction_configuration  -> TransationConfiguration`
-  Remove `TransactionMeta::compute_budget_instruction_details`
- Rename `StaticMeta` to `TransactionMeta`
- Delete `DynamicMeta`

Fixes #
