### PR TITLE
alpenglow: fix race condition in setting genesis info for migration

### DIFF
--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -475,22 +475,29 @@ impl MigrationStatus {
     /// received a genesis certificate and it matches.
     pub fn set_genesis_block(&self, discovered_genesis_block @ (slot, _): Block) {
         let mut phase = self.phase.write().unwrap();
+        if phase.is_pre_feature_activation() {
+            unreachable!(
+                "{}: Programmer error, attempting to set genesis cert while pre migration",
+                self.my_pubkey()
+            );
+        }
+
         let MigrationPhase::Migration {
             migration_slot,
             genesis_block,
             genesis_cert,
         } = &mut *phase
         else {
-            unreachable!(
-                "{}: Programmer error, attempting to set genesis block while not in migration",
-                self.my_pubkey()
-            );
+            // We've already transitioned to `ReadyToEnable` or further, no action needed
+            return;
         };
-        assert!(
-            genesis_block.is_none(),
-            "Attempting to overwrite genesis block to {discovered_genesis_block:?}. Programmer \
-             error"
-        );
+
+        if let Some(prev_genesis_block) = genesis_block {
+            assert_eq!(
+                *prev_genesis_block, discovered_genesis_block,
+                "We have discovered two different alpenglow genesis blocks. Something is wrong",
+            );
+        }
 
         assert!(
             slot < *migration_slot,
@@ -534,17 +541,23 @@ impl MigrationStatus {
     /// Transitions to `ReadyToEnable` if we have already received a genesis block and it matches.
     pub fn set_genesis_certificate(&self, cert: Arc<Certificate>) {
         let mut phase = self.phase.write().unwrap();
+        if phase.is_pre_feature_activation() {
+            unreachable!(
+                "{}: Programmer error, attempting to set genesis cert while pre migration",
+                self.my_pubkey()
+            );
+        }
+
         let MigrationPhase::Migration {
             migration_slot,
             genesis_block,
             genesis_cert,
         } = &mut *phase
         else {
-            unreachable!(
-                "{}: Programmer error, attempting to set genesis cert while not in migration",
-                self.my_pubkey()
-            );
+            // We've already transitioned to `ReadyToEnable` or further, no action needed
+            return;
         };
+
         let CertificateType::Genesis(slot, block_id) = cert.cert_type else {
             unreachable!("Programmer error adding invalid genesis certificate");
         };


### PR DESCRIPTION
#### Problem
There is a race condition with setting the genesis info:
1. Replay thread can set the genesis info:
  a. Via participating in the migration (discovery)  https://github.com/anza-xyz/agave/blob/25a8250dec904c158a0a09adcd92c7313db3354a/core/src/replay_stage.rs#L3915
  b. Via receiving the first alpenglow block https://github.com/anza-xyz/agave/blob/25a8250dec904c158a0a09adcd92c7313db3354a/runtime/src/block_component_processor.rs#L195-L201
  
2. Consensus pool thread can set the genesis certificate via receiving it via the BLS Sigverifier https://github.com/anza-xyz/agave/blob/25a8250dec904c158a0a09adcd92c7313db3354a/votor/src/consensus_pool.rs#L365

Technically any of these calls could transition us from `Migration` -> `ReadyToEnable`.
As an example, suppose we received the first alpenglow block, and the certificate from the BLS sigverifier at the same time:
- replay calls `set_genesis_block`
- consensus pool calls `set_genesis_certificate` (transitions us to `ReadyToEnable`)
- replay calls `set_genesis_certificate`

Currently this will panic, as we don't expect these `set_genesis_*` fns to be called outside of `Migration`

#### Summary of Changes
Allow leniency, only panic if these `fns` are called `PreFeatureActivation`


s/o Nikita for finding the bug 🎉 