### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Release channels have their own copy of this changelog:
 * Using `minimal` for `--accounts-index-limit` is now deprecated.
 * `--account-shrink-path` is now deprecated.
 * `sbf-sdk.tar.bz2` is not included anymore in the Agave release tarball. The file will be made available in the new
-  `cargo-build-sbf` repository.
+  [`cargo-build-sbf`](https://github.com/anza-xyz/cargo-build-sbf) repository.
 #### Changes
 
 ## 4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Release channels have their own copy of this changelog:
 #### Deprecations
 * Using `minimal` for `--accounts-index-limit` is now deprecated.
 * `--account-shrink-path` is now deprecated.
+* `sbf-sdk.tar.bz2` is not included anymore in the Agave release tarball. The file will be made available in the new
+  `cargo-build-sbf` repository.
 #### Changes
 
 ## 4.0.0


### PR DESCRIPTION
#### Problem

We removed `sbf-sdk.tar.bz2` from the Agave release, but we left that unannounced. Although the usage of the C SDK may be low, we should still inform that the object is no longer available.

#### Summary of Changes

Update the changelog.