### PR TITLE
blockstore: revert alpenglow related blockstore columns & logic

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -17,7 +17,6 @@ use {
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
         blockstore::{Blockstore, BlockstoreInsertionMetrics, PossibleDuplicateShred},
-        blockstore_meta::BlockLocation,
         leader_schedule_cache::LeaderScheduleCache,
         shred::{self, ReedSolomonCache, Shred},
     },
@@ -196,7 +195,7 @@ where
             ws_metrics.num_repairs.fetch_add(1, Ordering::Relaxed);
         }
         let shred = Shred::new_from_serialized_shred(shred).ok()?;
-        Some((Cow::Owned(shred), repair, BlockLocation::Original))
+        Some((Cow::Owned(shred), repair))
     };
     let now = Instant::now();
     let shreds: Vec<_> = thread_pool.install(|| {
@@ -208,7 +207,7 @@ where
     });
     ws_metrics.handle_packets_elapsed_us += now.elapsed().as_micros() as u64;
     ws_metrics.num_shreds_received += shreds.len();
-    let completed_data_sets = blockstore.insert_shreds_at_location_handle_duplicate(
+    let completed_data_sets = blockstore.insert_shreds_handle_duplicate(
         shreds,
         Some(leader_schedule_cache),
         false, // is_trusted

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -260,12 +260,6 @@ pub struct Blockstore {
     orphans_cf: LedgerColumn<cf::Orphans>,
     duplicate_slots_cf: LedgerColumn<cf::DuplicateSlots>,
 
-    // Shred insertion column families for handling Alpenglow alternate blocks
-    alt_data_shred_cf: LedgerColumn<cf::AlternateShredData>,
-    alt_meta_cf: LedgerColumn<cf::AlternateSlotMeta>,
-    alt_index_cf: LedgerColumn<cf::AlternateIndex>,
-    alt_merkle_root_meta_cf: LedgerColumn<cf::AlternateMerkleRootMeta>,
-
     // Block status column families
     bank_hash_cf: LedgerColumn<cf::BankHash>,
     optimistic_slots_cf: LedgerColumn<cf::OptimisticSlots>,
@@ -412,11 +406,6 @@ impl Blockstore {
         let orphans_cf = db.column();
         let duplicate_slots_cf = db.column();
 
-        let alt_data_shred_cf = db.column();
-        let alt_meta_cf = db.column();
-        let alt_index_cf = db.column();
-        let alt_merkle_root_meta_cf = db.column();
-
         let bank_hash_cf = db.column();
         let optimistic_slots_cf = db.column();
         let roots_cf = db.column();
@@ -462,11 +451,6 @@ impl Blockstore {
             roots_cf,
             transaction_memos_cf,
             transaction_status_cf,
-            alt_meta_cf,
-            alt_index_cf,
-            alt_data_shred_cf,
-            alt_merkle_root_meta_cf,
-
             new_shreds_signals: Mutex::default(),
             completed_slots_senders: Mutex::default(),
             insert_shreds_lock: Mutex::<()>::default(),
@@ -577,54 +561,6 @@ impl Blockstore {
         self.meta_cf.get(slot)
     }
 
-    /// Returns the SlotMeta of the specified slot from the specified location
-    pub fn meta_from_location(
-        &self,
-        slot: Slot,
-        location: BlockLocation,
-    ) -> Result<Option<SlotMeta>> {
-        match location {
-            BlockLocation::Original => self.meta_cf.get(slot),
-            BlockLocation::Alternate { block_id } => self.alt_meta_cf.get((slot, block_id)),
-        }
-    }
-
-    /// Puts the SlotMeta of the specified slot in the column for the specified location
-    #[allow(dead_code)]
-    fn put_meta_in_batch(
-        &self,
-        write_batch: &mut WriteBatch,
-        slot: Slot,
-        location: BlockLocation,
-        meta: &SlotMeta,
-    ) -> Result<()> {
-        match location {
-            BlockLocation::Original => self.meta_cf.put_in_batch(write_batch, slot, meta),
-            BlockLocation::Alternate { block_id } => {
-                self.alt_meta_cf
-                    .put_in_batch(write_batch, (slot, block_id), meta)
-            }
-        }
-    }
-
-    /// Inserts a shred index into the alternate index for testing purposes.
-    /// This simulates receiving a data shred for an alternate block.
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn insert_shred_index_for_alternate_block(
-        &self,
-        slot: Slot,
-        block_id: Hash,
-        shred_index: u32,
-    ) -> Result<()> {
-        use crate::blockstore_meta::Index;
-        let mut index = self
-            .alt_index_cf
-            .get((slot, block_id))?
-            .unwrap_or_else(|| Index::new(slot));
-        index.data_mut().insert(shred_index as u64);
-        self.alt_index_cf.put((slot, block_id), &index)
-    }
-
     /// Returns true if the specified slot is full.
     pub fn is_full(&self, slot: Slot) -> bool {
         if let Ok(Some(meta)) = self.meta_cf.get(slot) {
@@ -718,46 +654,6 @@ impl Blockstore {
 
     fn merkle_root_meta(&self, erasure_set: ErasureSetId) -> Result<Option<MerkleRootMeta>> {
         self.merkle_root_meta_cf.get(erasure_set.store_key())
-    }
-
-    #[allow(dead_code)]
-    fn merkle_root_meta_from_location(
-        &self,
-        erasure_set: ErasureSetId,
-        location: BlockLocation,
-    ) -> Result<Option<MerkleRootMeta>> {
-        match location {
-            BlockLocation::Original => self.merkle_root_meta_cf.get(erasure_set.store_key()),
-            BlockLocation::Alternate { block_id } => {
-                let (slot, fec_set_index) = erasure_set.store_key();
-                self.alt_merkle_root_meta_cf
-                    .get((slot, fec_set_index, block_id))
-            }
-        }
-    }
-
-    /// Puts the MerkleRootMeta of the specified erasure set in the column for the specified location
-    #[allow(dead_code)]
-    fn put_merkle_root_meta_in_batch(
-        &self,
-        write_batch: &mut WriteBatch,
-        erasure_set: ErasureSetId,
-        location: BlockLocation,
-        merkle_root_meta: &MerkleRootMeta,
-    ) -> Result<()> {
-        let (slot, fec_set_index) = erasure_set.store_key();
-        match location {
-            BlockLocation::Original => self.merkle_root_meta_cf.put_in_batch(
-                write_batch,
-                (slot, fec_set_index),
-                merkle_root_meta,
-            ),
-            BlockLocation::Alternate { block_id } => self.alt_merkle_root_meta_cf.put_in_batch(
-                write_batch,
-                (slot, fec_set_index, block_id),
-                merkle_root_meta,
-            ),
-        }
     }
 
     /// Check whether the specified slot is an orphan slot which does not
@@ -975,11 +871,6 @@ impl Blockstore {
         self.merkle_root_meta_cf.submit_rocksdb_cf_metrics();
         self.orphans_cf.submit_rocksdb_cf_metrics();
         self.duplicate_slots_cf.submit_rocksdb_cf_metrics();
-
-        self.alt_data_shred_cf.submit_rocksdb_cf_metrics();
-        self.alt_meta_cf.submit_rocksdb_cf_metrics();
-        self.alt_index_cf.submit_rocksdb_cf_metrics();
-        self.alt_merkle_root_meta_cf.submit_rocksdb_cf_metrics();
 
         self.bank_hash_cf.submit_rocksdb_cf_metrics();
         self.optimistic_slots_cf.submit_rocksdb_cf_metrics();
@@ -1232,34 +1123,6 @@ impl Blockstore {
                 &mut shred_insertion_tracker.duplicate_shreds,
             );
         }
-    }
-
-    /// Gets the merkle root from the tracker if available, otherwise from the db.
-    #[allow(dead_code)]
-    fn get_merkle_root_from_tracker_or_db(
-        &self,
-        location: BlockLocation,
-        erasure_set: ErasureSetId,
-        merkle_root_metas: &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
-    ) -> Result<Option<Hash>> {
-        let err = || {
-            BlockstoreError::MissingMerkleRoot(
-                erasure_set.slot(),
-                erasure_set.fec_set_index() as u64,
-            )
-        };
-        // First check the tracker
-        if let Some(working_entry) = merkle_root_metas.get(&(location, erasure_set)) {
-            return Ok(Some(working_entry.as_ref().merkle_root().ok_or_else(err)?));
-        }
-
-        // Fall back to the db
-        self.merkle_root_meta_from_location(erasure_set, location)
-            .and_then(|maybe_meta| {
-                maybe_meta
-                    .map(|meta| meta.merkle_root().ok_or_else(err))
-                    .transpose()
-            })
     }
 
     fn commit_updates_to_write_batch(
@@ -2497,7 +2360,16 @@ impl Blockstore {
     }
 
     pub fn get_data_shreds_for_slot(&self, slot: Slot, start_index: u64) -> Result<Vec<Shred>> {
-        self.get_data_shreds_for_slot_from_location(slot, start_index, BlockLocation::Original)
+        self.slot_data_iterator(slot, start_index)
+            .expect("blockstore couldn't fetch iterator")
+            .map(|(_, bytes)| {
+                Shred::new_from_serialized_shred(Vec::from(bytes)).map_err(|err| {
+                    BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(
+                        format!("Could not reconstruct shred from shred payload: {err:?}"),
+                    )))
+                })
+            })
+            .collect()
     }
 
     #[cfg(test)]
@@ -2553,99 +2425,6 @@ impl Blockstore {
             .expect("blockstore couldn't fetch iterator")
             .map(|(_, bytes)| Shred::new_from_serialized_shred(Vec::from(bytes)))
             .collect()
-    }
-
-    pub fn get_data_shred_from_location(
-        &self,
-        slot: Slot,
-        index: u64,
-        location: BlockLocation,
-    ) -> Result<Option<Vec<u8>>> {
-        match location {
-            BlockLocation::Original => self.get_data_shred(slot, index),
-            BlockLocation::Alternate { block_id } => {
-                self.alt_data_shred_cf.get_bytes((slot, index, block_id))
-            }
-        }
-    }
-
-    /// Gets all data shreds for a slot from the specified location.
-    /// Returns shreds in index order starting from `start_index`.
-    pub fn get_data_shreds_for_slot_from_location(
-        &self,
-        slot: Slot,
-        start_index: u64,
-        location: BlockLocation,
-    ) -> Result<Vec<Shred>> {
-        // Get the index to determine capacity for pre-allocation
-        let Some(index) = self.get_index_from_location(slot, location)? else {
-            return Ok(Vec::new());
-        };
-        let num_shreds = index.data().count_range(start_index..);
-        let mut shreds = Vec::with_capacity(num_shreds);
-
-        let shred_bytes_iter: Box<dyn Iterator<Item = Box<[u8]>>> = match location {
-            BlockLocation::Original => {
-                let iter = self
-                    .data_shred_cf
-                    .iter(IteratorMode::From(
-                        (slot, start_index),
-                        IteratorDirection::Forward,
-                    ))?
-                    .take_while(move |((shred_slot, _), _)| *shred_slot == slot)
-                    .map(|(_, bytes)| bytes);
-                Box::new(iter)
-            }
-            BlockLocation::Alternate { block_id } => {
-                let iter = self
-                    .alt_data_shred_cf
-                    .iter(IteratorMode::From(
-                        (slot, start_index, block_id),
-                        IteratorDirection::Forward,
-                    ))?
-                    .take_while(move |((shred_slot, _, shred_block_id), _)| {
-                        *shred_slot == slot && *shred_block_id == block_id
-                    })
-                    .map(|(_, bytes)| bytes);
-                Box::new(iter)
-            }
-        };
-
-        for bytes in shred_bytes_iter {
-            let shred = Shred::new_from_serialized_shred(Vec::from(bytes)).map_err(|err| {
-                BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(format!(
-                    "Could not reconstruct shred from shred payload: {err:?}"
-                ))))
-            })?;
-            shreds.push(shred);
-        }
-
-        Ok(shreds)
-    }
-
-    /// Puts the shred of the specified slot-index in the column for the specified location
-    #[allow(dead_code)]
-    fn put_data_shred_in_batch(
-        &self,
-        write_batch: &mut WriteBatch,
-        slot: Slot,
-        index: u64,
-        location: BlockLocation,
-        shred: &[u8],
-    ) {
-        match location {
-            BlockLocation::Original => {
-                self.data_shred_cf
-                    .put_bytes_in_batch(write_batch, (slot, index), shred);
-            }
-            BlockLocation::Alternate { block_id } => {
-                self.alt_data_shred_cf.put_bytes_in_batch(
-                    write_batch,
-                    (slot, index, block_id),
-                    shred,
-                );
-            }
-        }
     }
 
     // Only used by tests
@@ -2737,35 +2516,6 @@ impl Blockstore {
 
     pub fn get_index(&self, slot: Slot) -> Result<Option<Index>> {
         self.index_cf.get(slot)
-    }
-
-    pub fn get_index_from_location(
-        &self,
-        slot: Slot,
-        location: BlockLocation,
-    ) -> Result<Option<Index>> {
-        match location {
-            BlockLocation::Original => self.get_index(slot),
-            BlockLocation::Alternate { block_id } => self.alt_index_cf.get((slot, block_id)),
-        }
-    }
-
-    /// Puts the Index of the specified erasure set in the column for the specified location
-    #[allow(dead_code)]
-    fn put_index_in_batch(
-        &self,
-        write_batch: &mut WriteBatch,
-        slot: Slot,
-        location: BlockLocation,
-        index: &Index,
-    ) -> Result<()> {
-        match location {
-            BlockLocation::Original => self.index_cf.put_in_batch(write_batch, slot, index),
-            BlockLocation::Alternate { block_id } => {
-                self.alt_index_cf
-                    .put_in_batch(write_batch, (slot, block_id), index)
-            }
-        }
     }
 
     /// Manually update the meta for a slot.

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -25,7 +25,7 @@ use {
     },
     agave_feature_set::FeatureSet,
     agave_snapshots::unpack_genesis_archive,
-    assert_matches::{assert_matches, debug_assert_matches},
+    assert_matches::debug_assert_matches,
     crossbeam_channel::{Receiver, Sender, TrySendError, bounded},
     dashmap::DashSet,
     itertools::Itertools,
@@ -312,21 +312,20 @@ pub struct SlotMetaWorkingSetEntry {
 }
 
 struct ShredInsertionTracker<'a> {
-    // Map which contains data shreds that have just been inserted. They will
-    // later be written to `cf::ShredData` or `cf::AlternateShredData`
-    just_inserted_shreds: HashMap<(BlockLocation, ShredId), Cow<'a, Shred>>,
+    // Map which contains data shreds that have just been inserted.
+    just_inserted_shreds: HashMap<ShredId, Cow<'a, Shred>>,
     // In-memory map that maintains the dirty copy of the erasure meta.  It will
     // later be written to `cf::ErasureMeta`
     erasure_metas: BTreeMap<ErasureSetId, WorkingEntry<ErasureMeta>>,
     // In-memory map that maintains the dirty copy of the merkle root meta. It
-    // will later be written to `cf::MerkleRootMeta` or `cf::AlternateMerkleRootMeta`
-    merkle_root_metas: HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
+    // will later be written to `cf::MerkleRootMeta`
+    merkle_root_metas: HashMap<ErasureSetId, WorkingEntry<MerkleRootMeta>>,
     // In-memory map that maintains the dirty copy of the index meta.  It will
-    // later be written to `cf::SlotMeta` or `cf::AlternateSlotMeta`
-    slot_meta_working_set: HashMap<(BlockLocation, Slot), SlotMetaWorkingSetEntry>,
+    // later be written to `cf::SlotMeta`
+    slot_meta_working_set: HashMap<u64, SlotMetaWorkingSetEntry>,
     // In-memory map that maintains the dirty copy of the index meta.  It will
-    // later be written to `cf::Index` or `cf::AlternateIndex`
-    index_working_set: HashMap<(BlockLocation, Slot), IndexMetaWorkingSetEntry>,
+    // later be written to `cf::Index`
+    index_working_set: HashMap<u64, IndexMetaWorkingSetEntry>,
     duplicate_shreds: Vec<PossibleDuplicateShred>,
     // Collection of the current blockstore writes which will be committed
     // atomically.
@@ -591,6 +590,7 @@ impl Blockstore {
     }
 
     /// Puts the SlotMeta of the specified slot in the column for the specified location
+    #[allow(dead_code)]
     fn put_meta_in_batch(
         &self,
         write_batch: &mut WriteBatch,
@@ -720,6 +720,7 @@ impl Blockstore {
         self.merkle_root_meta_cf.get(erasure_set.store_key())
     }
 
+    #[allow(dead_code)]
     fn merkle_root_meta_from_location(
         &self,
         erasure_set: ErasureSetId,
@@ -736,6 +737,7 @@ impl Blockstore {
     }
 
     /// Puts the MerkleRootMeta of the specified erasure set in the column for the specified location
+    #[allow(dead_code)]
     fn put_merkle_root_meta_in_batch(
         &self,
         write_batch: &mut WriteBatch,
@@ -888,18 +890,16 @@ impl Blockstore {
         false
     }
 
-    /// Return the available data shreds for recovery.
-    /// Note: that we do not do recovery on the Alternate shred columns
     fn get_recovery_data_shreds<'a>(
         &'a self,
         index: &'a Index,
         erasure_meta: &'a ErasureMeta,
-        prev_inserted_shreds: &'a HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+        prev_inserted_shreds: &'a HashMap<ShredId, Cow<'_, Shred>>,
     ) -> impl Iterator<Item = Shred> + 'a {
         let slot = index.slot;
         erasure_meta.data_shreds_indices().filter_map(move |i| {
             let key = ShredId::new(slot, u32::try_from(i).unwrap(), ShredType::Data);
-            if let Some(shred) = prev_inserted_shreds.get(&(BlockLocation::Original, key)) {
+            if let Some(shred) = prev_inserted_shreds.get(&key) {
                 return Some(shred.as_ref().clone());
             }
             if !index.data().contains(i) {
@@ -919,18 +919,16 @@ impl Blockstore {
         })
     }
 
-    /// Return the available coding shreds for recovery.
-    /// Note: that we do not do recovery on the Alternate shred columns
     fn get_recovery_coding_shreds<'a>(
         &'a self,
         index: &'a Index,
         erasure_meta: &'a ErasureMeta,
-        prev_inserted_shreds: &'a HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+        prev_inserted_shreds: &'a HashMap<ShredId, Cow<'_, Shred>>,
     ) -> impl Iterator<Item = Shred> + 'a {
         let slot = index.slot;
         erasure_meta.coding_shreds_indices().filter_map(move |i| {
             let key = ShredId::new(slot, u32::try_from(i).unwrap(), ShredType::Code);
-            if let Some(shred) = prev_inserted_shreds.get(&(BlockLocation::Original, key)) {
+            if let Some(shred) = prev_inserted_shreds.get(&key) {
                 return Some(shred.as_ref().clone());
             }
             if !index.coding().contains(i) {
@@ -950,13 +948,11 @@ impl Blockstore {
         })
     }
 
-    /// Performs shred recovery for `erasure_meta`
-    /// Note: that we do not do recovery on the Alternate shred columns
     fn recover_shreds<'a>(
         &'a self,
         index: &'a Index,
         erasure_meta: &'a ErasureMeta,
-        prev_inserted_shreds: &'a HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+        prev_inserted_shreds: &'a HashMap<ShredId, Cow<'_, Shred>>,
         reed_solomon_cache: &'a ReedSolomonCache,
     ) -> std::result::Result<impl Iterator<Item = Shred> + 'a, shred::Error> {
         // Find shreds for this erasure set and try recovery
@@ -1004,7 +1000,7 @@ impl Blockstore {
     fn attempt_shred_insertion<'a>(
         &self,
         shreds: impl IntoIterator<
-            Item = (Cow<'a, Shred>, /*is_repaired:*/ bool, BlockLocation),
+            Item = (Cow<'a, Shred>, /*is_repaired:*/ bool),
             IntoIter: ExactSizeIterator,
         >,
         is_trusted: bool,
@@ -1015,7 +1011,7 @@ impl Blockstore {
         let shreds = shreds.into_iter();
         metrics.num_shreds += shreds.len();
         let mut start = Measure::start("Shred insertion");
-        for (shred, is_repaired, location) in shreds {
+        for (shred, is_repaired) in shreds {
             let shred_source = if is_repaired {
                 ShredSource::Repaired
             } else {
@@ -1025,7 +1021,6 @@ impl Blockstore {
                 ShredType::Data => {
                     match self.check_insert_data_shred(
                         shred,
-                        location,
                         shred_insertion_tracker,
                         is_trusted,
                         leader_schedule,
@@ -1054,9 +1049,6 @@ impl Blockstore {
                     };
                 }
                 ShredType::Code => {
-                    // Block id based repair (the source for populating the Alternate column) cannot receive
-                    // coding shreds. Thus if we receive a coding shred, it must be for `BlockLocation::Original`
-                    debug_assert_matches!(location, BlockLocation::Original);
                     self.check_insert_coding_shred(
                         shred,
                         shred_insertion_tracker,
@@ -1075,8 +1067,8 @@ impl Blockstore {
     fn try_shred_recovery<'a>(
         &'a self,
         erasure_metas: &'a BTreeMap<ErasureSetId, WorkingEntry<ErasureMeta>>,
-        index_working_set: &'a HashMap<(BlockLocation, u64), IndexMetaWorkingSetEntry>,
-        prev_inserted_shreds: &'a HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+        index_working_set: &'a HashMap<u64, IndexMetaWorkingSetEntry>,
+        prev_inserted_shreds: &'a HashMap<ShredId, Cow<'_, Shred>>,
         reed_solomon_cache: &'a ReedSolomonCache,
     ) -> impl Iterator<Item = Shred> + 'a {
         // Recovery rules:
@@ -1084,15 +1076,12 @@ impl Blockstore {
         // 2. For new data shreds, check if an erasure set exists. If not, don't try recovery
         // 3. Before trying recovery, check if enough number of shreds have been received
         // 3a. Enough number of shreds = (#data + #coding shreds) > erasure.num_data
-        // 4. Only perform rceovery in the Original column
         erasure_metas
             .iter()
             .filter_map(|(erasure_set, working_erasure_meta)| {
                 let erasure_meta = working_erasure_meta.as_ref();
                 let slot = erasure_set.slot();
-                let index_meta_entry = index_working_set
-                    .get(&(BlockLocation::Original, slot))
-                    .expect("Index");
+                let index_meta_entry = index_working_set.get(&slot).expect("Index");
                 let index = &index_meta_entry.index;
                 erasure_meta
                     .should_recover_shreds(index)
@@ -1114,8 +1103,6 @@ impl Blockstore {
     /// 1. Verify signatures
     /// 2. Insert into blockstore
     /// 3. Send for retransmit.
-    ///
-    /// Note: We only perform recovery for the Original shred column
     fn handle_shred_recovery(
         &self,
         leader_schedule: Option<&LeaderScheduleCache>,
@@ -1159,7 +1146,6 @@ impl Blockstore {
         for shred in recovered_data_shreds {
             *match self.check_insert_data_shred(
                 Cow::Owned(shred),
-                BlockLocation::Original,
                 shred_insertion_tracker,
                 is_trusted,
                 leader_schedule,
@@ -1180,8 +1166,6 @@ impl Blockstore {
         metrics.shred_recovery_elapsed_us += start.as_us();
     }
 
-    /// Check the chained merkle root consistency between newly inserted FEC sets.
-    /// Note: This check is not performed on Alternate columns as the shreds are already pre verified.
     fn check_chained_merkle_root_consistency(
         &self,
         shred_insertion_tracker: &mut ShredInsertionTracker,
@@ -1195,10 +1179,7 @@ impl Blockstore {
             if self.has_duplicate_shreds_in_slot(slot) {
                 continue;
             }
-
             // First coding shred from this erasure batch, check the forward merkle root chaining
-            // Note: This check is not performed on Alternate columns, as we cannot repair coding shreds
-            // and all shreds are trusted as they are verified via a separate merkle proof on repair ingest
             let erasure_meta = working_erasure_meta.as_ref();
             let shred_id = ShredId::new(
                 slot,
@@ -1209,7 +1190,7 @@ impl Blockstore {
             );
             let shred = shred_insertion_tracker
                 .just_inserted_shreds
-                .get(&(BlockLocation::Original, shred_id))
+                .get(&shred_id)
                 .expect("Erasure meta was just created, initial shred must exist");
 
             self.check_forward_chained_merkle_root_consistency(
@@ -1221,7 +1202,7 @@ impl Blockstore {
             );
         }
 
-        for ((location, erasure_set), working_merkle_root_meta) in
+        for (erasure_set, working_merkle_root_meta) in
             shred_insertion_tracker.merkle_root_metas.iter()
         {
             if !working_merkle_root_meta.should_write() {
@@ -1232,14 +1213,7 @@ impl Blockstore {
             if self.has_duplicate_shreds_in_slot(slot) {
                 continue;
             }
-
             // First shred from this erasure batch, check the backwards merkle root chaining
-            // Note: this check is not performed on Alternate columns as they are already validated
-            // via a separate merkle proof on repair ingest
-            if !matches!(location, BlockLocation::Original) {
-                continue;
-            }
-
             let merkle_root_meta = working_merkle_root_meta.as_ref();
             let shred_id = ShredId::new(
                 slot,
@@ -1248,7 +1222,7 @@ impl Blockstore {
             );
             let shred = shred_insertion_tracker
                 .just_inserted_shreds
-                .get(&(*location, shred_id))
+                .get(&shred_id)
                 .expect("Merkle root meta was just created, initial shred must exist");
 
             self.check_backwards_chained_merkle_root_consistency(
@@ -1315,29 +1289,23 @@ impl Blockstore {
             )?;
         }
 
-        for (&(location, erasure_set), working_merkle_root_meta) in
-            &shred_insertion_tracker.merkle_root_metas
-        {
+        for (erasure_set, working_merkle_root_meta) in &shred_insertion_tracker.merkle_root_metas {
             if !working_merkle_root_meta.should_write() {
                 // No need to rewrite the column
                 continue;
             }
-            self.put_merkle_root_meta_in_batch(
+            self.merkle_root_meta_cf.put_in_batch(
                 &mut shred_insertion_tracker.write_batch,
-                erasure_set,
-                location,
+                erasure_set.store_key(),
                 working_merkle_root_meta.as_ref(),
             )?;
         }
 
-        for (&(location, slot), index_working_set_entry) in
-            shred_insertion_tracker.index_working_set.iter()
-        {
+        for (&slot, index_working_set_entry) in shred_insertion_tracker.index_working_set.iter() {
             if index_working_set_entry.did_insert_occur {
-                self.put_index_in_batch(
+                self.index_cf.put_in_batch(
                     &mut shred_insertion_tracker.write_batch,
                     slot,
-                    location,
                     &index_working_set_entry.index,
                 )?;
             }
@@ -1385,7 +1353,7 @@ impl Blockstore {
     ///     pair to the `cf::Index` column family for each index_working_set_entry which insert did occur in this function call.
     ///
     /// Arguments:
-    ///  - `shreds`: the shreds to be inserted, alongside the location to insert.
+    ///  - `shreds`: the shreds to be inserted.
     ///  - `is_repaired`: a boolean vector aligned with `shreds` where each
     ///    boolean indicates whether the corresponding shred is repaired or not.
     ///  - `leader_schedule`: the leader schedule
@@ -1404,7 +1372,7 @@ impl Blockstore {
     fn do_insert_shreds<'a>(
         &self,
         shreds: impl IntoIterator<
-            Item = (Cow<'a, Shred>, /*is_repaired:*/ bool, BlockLocation),
+            Item = (Cow<'a, Shred>, /*is_repaired:*/ bool),
             IntoIter: ExactSizeIterator,
         >,
         leader_schedule: Option<&LeaderScheduleCache>,
@@ -1486,46 +1454,13 @@ impl Blockstore {
         })
     }
 
-    /// Simlar to `insert_shreds_at_location_handle_duplicate`  but always inserts
-    /// shreds in the original column specified by `BlockLocation::Original`
+    // Attempts to recover and retransmit recovered shreds (also identifying
+    // and handling duplicate shreds). Broadcast stage should instead call
+    // Blockstore::insert_shreds when inserting own shreds during leader slots.
     pub fn insert_shreds_handle_duplicate<'a, F>(
         &self,
         shreds: impl IntoIterator<
             Item = (Cow<'a, Shred>, /*is_repaired:*/ bool),
-            IntoIter: ExactSizeIterator,
-        >,
-        leader_schedule: Option<&LeaderScheduleCache>,
-        is_trusted: bool,
-        retransmit_sender: &EvictingSender<Vec<shred::Payload>>,
-        handle_duplicate: &F,
-        reed_solomon_cache: &ReedSolomonCache,
-        metrics: &mut BlockstoreInsertionMetrics,
-    ) -> Result<Vec<CompletedDataSetInfo>>
-    where
-        F: Fn(PossibleDuplicateShred),
-    {
-        self.insert_shreds_at_location_handle_duplicate(
-            shreds
-                .into_iter()
-                .map(|(shred, is_repaired)| (shred, is_repaired, BlockLocation::Original)),
-            leader_schedule,
-            is_trusted,
-            retransmit_sender,
-            handle_duplicate,
-            reed_solomon_cache,
-            metrics,
-        )
-    }
-
-    /// Inserts `shreds` into the column specified by  the `BlockLocation`.
-    ///
-    /// Additionally attempts to recover and retransmit recovered shreds (also identifying
-    /// and handling duplicate shreds). Broadcast stage should instead call
-    /// Blockstore::insert_shreds when inserting own shreds during leader slots.
-    pub fn insert_shreds_at_location_handle_duplicate<'a, F>(
-        &self,
-        shreds: impl IntoIterator<
-            Item = (Cow<'a, Shred>, /*is_repaired:*/ bool, BlockLocation),
             IntoIter: ExactSizeIterator,
         >,
         leader_schedule: Option<&LeaderScheduleCache>,
@@ -1618,7 +1553,7 @@ impl Blockstore {
     ) -> Result<Vec<CompletedDataSetInfo>> {
         let shreds = shreds
             .into_iter()
-            .map(|shred| (shred, /*is_repaired:*/ false, BlockLocation::Original));
+            .map(|shred| (shred, /*is_repaired:*/ false));
         let insert_results = self.do_insert_shreds(
             shreds,
             leader_schedule,
@@ -1648,11 +1583,7 @@ impl Blockstore {
     ) -> Vec<PossibleDuplicateShred> {
         let insert_results = self
             .do_insert_shreds(
-                [(
-                    Cow::Owned(shred),
-                    /*is_repaired:*/ false,
-                    BlockLocation::Original,
-                )],
+                [(Cow::Owned(shred), /*is_repaired:*/ false)],
                 Some(leader_schedule),
                 false,
                 None, // (reed_solomon_cache, retransmit_sender)
@@ -1663,7 +1594,6 @@ impl Blockstore {
     }
 
     #[allow(clippy::too_many_arguments)]
-    /// Note: Coding shreds can only be inserted into the Original columns
     fn check_insert_coding_shred<'a>(
         &self,
         shred: Cow<'a, Shred>,
@@ -1686,25 +1616,19 @@ impl Blockstore {
             ..
         } = shred_insertion_tracker;
 
-        let index_meta_working_set_entry = match self.get_index_meta_entry(
-            slot,
-            BlockLocation::Original,
-            index_working_set,
-            index_meta_time_us,
-        ) {
-            Ok(entry) => entry,
-            Err(err) => {
-                error!("blockstore error during coding shred insertion: {err}");
-                return false;
-            }
-        };
+        let index_meta_working_set_entry =
+            match self.get_index_meta_entry(slot, index_working_set, index_meta_time_us) {
+                Ok(entry) => entry,
+                Err(err) => {
+                    error!("blockstore error during coding shred insertion: {err}");
+                    return false;
+                }
+            };
 
         let index_meta = &mut index_meta_working_set_entry.index;
         let erasure_set = shred.erasure_set();
 
-        if let HashMapEntry::Vacant(entry) =
-            merkle_root_metas.entry((BlockLocation::Original, erasure_set))
-        {
+        if let HashMapEntry::Vacant(entry) = merkle_root_metas.entry(erasure_set) {
             if let Some(meta) = self.merkle_root_meta(erasure_set).unwrap() {
                 entry.insert(WorkingEntry::Clean(meta));
             }
@@ -1724,16 +1648,13 @@ impl Blockstore {
                 return false;
             }
 
-            if let Some(merkle_root_meta) =
-                merkle_root_metas.get(&(BlockLocation::Original, erasure_set))
-            {
+            if let Some(merkle_root_meta) = merkle_root_metas.get(&erasure_set) {
                 // A previous shred has been inserted in this batch or in blockstore
                 // Compare our current shred against the previous shred for potential
                 // conflicts
                 if !self.check_merkle_root_consistency(
                     just_inserted_shreds,
                     slot,
-                    BlockLocation::Original,
                     merkle_root_meta.as_ref(),
                     &shred,
                     duplicate_shreds,
@@ -1799,13 +1720,8 @@ impl Blockstore {
             return false;
         }
 
-        self.slots_stats.record_shred(
-            shred.slot(),
-            BlockLocation::Original,
-            shred.fec_set_index(),
-            shred_source,
-            None,
-        );
+        self.slots_stats
+            .record_shred(shred.slot(), shred.fec_set_index(), shred_source, None);
 
         // insert coding shred into rocks
         let result = self
@@ -1817,13 +1733,11 @@ impl Blockstore {
             metrics.num_inserted += 1;
 
             merkle_root_metas
-                .entry((BlockLocation::Original, erasure_set))
+                .entry(erasure_set)
                 .or_insert(WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
         }
 
-        if let HashMapEntry::Vacant(entry) =
-            just_inserted_shreds.entry((BlockLocation::Original, shred.id()))
-        {
+        if let HashMapEntry::Vacant(entry) = just_inserted_shreds.entry(shred.id()) {
             metrics.num_coding_shreds_inserted += 1;
             entry.insert(shred);
         }
@@ -1836,17 +1750,13 @@ impl Blockstore {
         shred: &Shred,
         slot: Slot,
         erasure_meta: &ErasureMeta,
-        just_received_shreds: &'a HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+        just_received_shreds: &'a HashMap<ShredId, Cow<'_, Shred>>,
     ) -> Option<Cow<'a, shred::Payload>> {
         // Search for the shred which set the initial erasure config, either inserted,
         // or in the current batch in just_received_shreds.
         let index = erasure_meta.first_received_coding_shred_index()?;
         let shred_id = ShredId::new(slot, index, ShredType::Code);
-        let maybe_shred = self.get_shred_from_just_inserted_or_db(
-            just_received_shreds,
-            shred_id,
-            BlockLocation::Original,
-        );
+        let maybe_shred = self.get_shred_from_just_inserted_or_db(just_received_shreds, shred_id);
 
         if index != 0 || maybe_shred.is_some() {
             return maybe_shred;
@@ -1864,7 +1774,7 @@ impl Blockstore {
                 }
             } else if let Some(potential_shred) = {
                 let key = ShredId::new(slot, u32::try_from(coding_index).unwrap(), ShredType::Code);
-                just_received_shreds.get(&(BlockLocation::Original, key))
+                just_received_shreds.get(&key)
             } {
                 if shred.erasure_mismatch(potential_shred).unwrap() {
                     return Some(Cow::Borrowed(potential_shred.payload()));
@@ -1890,7 +1800,6 @@ impl Blockstore {
     ///
     /// Arguments:
     /// - `shred`: the shred to be inserted
-    /// - `location`: the location to insert into
     /// - `shred_insertion_tracker`: collection of shred insertion tracking
     ///   data.
     /// - `is_trusted`: if false, this function will check whether the
@@ -1903,7 +1812,6 @@ impl Blockstore {
     fn check_insert_data_shred<'a>(
         &self,
         shred: Cow<'a, Shred>,
-        location: BlockLocation,
         shred_insertion_tracker: &mut ShredInsertionTracker<'a>,
         is_trusted: bool,
         leader_schedule: Option<&LeaderScheduleCache>,
@@ -1925,12 +1833,11 @@ impl Blockstore {
         } = shred_insertion_tracker;
 
         let index_meta_working_set_entry =
-            self.get_index_meta_entry(slot, location, index_working_set, index_meta_time_us)?;
+            self.get_index_meta_entry(slot, index_working_set, index_meta_time_us)?;
         let index_meta = &mut index_meta_working_set_entry.index;
         let slot_meta_entry = self.get_slot_meta_entry(
             slot_meta_working_set,
             slot,
-            location,
             shred
                 .parent()
                 .map_err(|_| InsertDataShredError::InvalidShred)?,
@@ -1938,11 +1845,8 @@ impl Blockstore {
 
         let slot_meta = &mut slot_meta_entry.new_slot_meta.borrow_mut();
         let erasure_set = shred.erasure_set();
-        if let HashMapEntry::Vacant(entry) = merkle_root_metas.entry((location, erasure_set)) {
-            if let Some(meta) = self
-                .merkle_root_meta_from_location(erasure_set, location)
-                .unwrap()
-            {
+        if let HashMapEntry::Vacant(entry) = merkle_root_metas.entry(erasure_set) {
+            if let Some(meta) = self.merkle_root_meta(erasure_set).unwrap() {
                 entry.insert(WorkingEntry::Clean(meta));
             }
         }
@@ -1975,7 +1879,6 @@ impl Blockstore {
 
             if !self.should_insert_data_shred(
                 &shred,
-                location,
                 slot_meta,
                 just_inserted_shreds,
                 self.max_root(),
@@ -1986,14 +1889,13 @@ impl Blockstore {
                 return Err(InsertDataShredError::InvalidShred);
             }
 
-            if let Some(merkle_root_meta) = merkle_root_metas.get(&(location, erasure_set)) {
+            if let Some(merkle_root_meta) = merkle_root_metas.get(&erasure_set) {
                 // A previous shred has been inserted in this batch or in blockstore
                 // Compare our current shred against the previous shred for potential
                 // conflicts
                 if !self.check_merkle_root_consistency(
                     just_inserted_shreds,
                     slot,
-                    location,
                     merkle_root_meta.as_ref(),
                     &shred,
                     duplicate_shreds,
@@ -2016,15 +1918,15 @@ impl Blockstore {
             slot_meta,
             index_meta.data_mut(),
             &shred,
-            location,
             write_batch,
             shred_source,
         );
         newly_completed_data_sets.extend(completed_data_sets);
+
         merkle_root_metas
-            .entry((location, erasure_set))
+            .entry(erasure_set)
             .or_insert(WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
-        just_inserted_shreds.insert((location, shred.id()), shred);
+        just_inserted_shreds.insert(shred.id(), shred);
         index_meta_working_set_entry.did_insert_occur = true;
         slot_meta_entry.did_insert_occur = true;
         if let BTreeMapEntry::Vacant(entry) = erasure_metas.entry(erasure_set) {
@@ -2073,28 +1975,24 @@ impl Blockstore {
     /// shreds or the backing store. Returns None if there is no shred.
     fn get_shred_from_just_inserted_or_db<'a>(
         &'a self,
-        just_inserted_shreds: &'a HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+        just_inserted_shreds: &'a HashMap<ShredId, Cow<'_, Shred>>,
         shred_id: ShredId,
-        location: BlockLocation,
     ) -> Option<Cow<'a, shred::Payload>> {
         let (slot, index, shred_type) = shred_id.unpack();
-        match (just_inserted_shreds.get(&(location, shred_id)), shred_type) {
+        match (just_inserted_shreds.get(&shred_id), shred_type) {
             (Some(shred), _) => Some(Cow::Borrowed(shred.payload())),
             // If it doesn't exist in the just inserted set, it must exist in
             // the backing store
             (_, ShredType::Data) => self
-                .get_data_shred_from_location(slot, u64::from(index), location)
+                .get_data_shred(slot, u64::from(index))
                 .unwrap()
                 .map(shred::Payload::from)
                 .map(Cow::Owned),
-            (_, ShredType::Code) => {
-                // Coding shreds can only be present in the Original column
-                assert_matches!(location, BlockLocation::Original);
-                self.get_coding_shred(slot, u64::from(index))
-                    .unwrap()
-                    .map(shred::Payload::from)
-                    .map(Cow::Owned)
-            }
+            (_, ShredType::Code) => self
+                .get_coding_shred(slot, u64::from(index))
+                .unwrap()
+                .map(shred::Payload::from)
+                .map(Cow::Owned),
         }
     }
 
@@ -2105,9 +2003,8 @@ impl Blockstore {
     /// `duplicate_shreds`.
     fn check_merkle_root_consistency(
         &self,
-        just_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+        just_inserted_shreds: &HashMap<ShredId, Cow<'_, Shred>>,
         slot: Slot,
-        location: BlockLocation,
         merkle_root_meta: &MerkleRootMeta,
         shred: &Shred,
         duplicate_shreds: &mut Vec<PossibleDuplicateShred>,
@@ -2138,7 +2035,7 @@ impl Blockstore {
                 merkle_root_meta.first_received_shred_type(),
             );
             let Some(conflicting_shred) = self
-                .get_shred_from_just_inserted_or_db(just_inserted_shreds, shred_id, location)
+                .get_shred_from_just_inserted_or_db(just_inserted_shreds, shred_id)
                 .map(Cow::into_owned)
             else {
                 error!(
@@ -2176,15 +2073,12 @@ impl Blockstore {
     ///
     /// This is intended to be used right after `shred`'s `erasure_meta`
     /// has been created for the first time.
-    ///
-    /// This check is only to be performed on the Original column, as Alternate
-    /// column shreds are already pre verified
     fn check_forward_chained_merkle_root_consistency(
         &self,
         shred: &Shred,
         erasure_meta: &ErasureMeta,
-        just_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
-        merkle_root_metas: &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
+        just_inserted_shreds: &HashMap<ShredId, Cow<'_, Shred>>,
+        merkle_root_metas: &HashMap<ErasureSetId, WorkingEntry<MerkleRootMeta>>,
         duplicate_shreds: &mut Vec<PossibleDuplicateShred>,
     ) -> bool {
         debug_assert!(erasure_meta.check_coding_shred(shred));
@@ -2198,7 +2092,7 @@ impl Blockstore {
         };
         let next_erasure_set = ErasureSetId::new(slot, next_fec_set_index);
         let Some(next_merkle_root_meta) = merkle_root_metas
-            .get(&(BlockLocation::Original, next_erasure_set))
+            .get(&next_erasure_set)
             .map(WorkingEntry::as_ref)
             .map(Cow::Borrowed)
             .or_else(|| {
@@ -2215,13 +2109,10 @@ impl Blockstore {
             next_merkle_root_meta.first_received_shred_index(),
             next_merkle_root_meta.first_received_shred_type(),
         );
-        let Some(next_shred) = Self::get_shred_from_just_inserted_or_db(
-            self,
-            just_inserted_shreds,
-            next_shred_id,
-            BlockLocation::Original,
-        )
-        .map(Cow::into_owned) else {
+        let Some(next_shred) =
+            Self::get_shred_from_just_inserted_or_db(self, just_inserted_shreds, next_shred_id)
+                .map(Cow::into_owned)
+        else {
             error!(
                 "Shred {next_shred_id:?} indicated by merkle root meta {next_merkle_root_meta:?} \
                  is missing from blockstore. This should only happen in extreme cases where \
@@ -2264,13 +2155,10 @@ impl Blockstore {
     ///
     /// This is intended to be used right after `shred`'s `merkle_root_meta`
     /// has been created for the first time.
-    ///
-    /// This check is only to be performed on the Original column, as Alternate
-    /// column shreds are already pre verified
     fn check_backwards_chained_merkle_root_consistency(
         &self,
         shred: &Shred,
-        just_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+        just_inserted_shreds: &HashMap<ShredId, Cow<'_, Shred>>,
         erasure_metas: &BTreeMap<ErasureSetId, WorkingEntry<ErasureMeta>>,
         duplicate_shreds: &mut Vec<PossibleDuplicateShred>,
     ) -> bool {
@@ -2306,13 +2194,10 @@ impl Blockstore {
                 .expect("First received coding index must fit in u32"),
             ShredType::Code,
         );
-        let Some(prev_shred) = Self::get_shred_from_just_inserted_or_db(
-            self,
-            just_inserted_shreds,
-            prev_shred_id,
-            BlockLocation::Original,
-        )
-        .map(Cow::into_owned) else {
+        let Some(prev_shred) =
+            Self::get_shred_from_just_inserted_or_db(self, just_inserted_shreds, prev_shred_id)
+                .map(Cow::into_owned)
+        else {
             warn!(
                 "Shred {prev_shred_id:?} indicated by the erasure meta {prev_erasure_meta:?} is \
                  missing from blockstore. This can happen if you have recently upgraded from a \
@@ -2357,9 +2242,8 @@ impl Blockstore {
     fn should_insert_data_shred(
         &self,
         shred: &Shred,
-        location: BlockLocation,
         slot_meta: &SlotMeta,
-        just_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+        just_inserted_shreds: &HashMap<ShredId, Cow<'_, Shred>>,
         max_root: Slot,
         leader_schedule: Option<&LeaderScheduleCache>,
         shred_source: ShredSource,
@@ -2388,7 +2272,7 @@ impl Blockstore {
                     ShredType::Data,
                 );
                 let Some(ending_shred) = self
-                    .get_shred_from_just_inserted_or_db(just_inserted_shreds, shred_id, location)
+                    .get_shred_from_just_inserted_or_db(just_inserted_shreds, shred_id)
                     .map(Cow::into_owned)
                 else {
                     error!(
@@ -2438,7 +2322,7 @@ impl Blockstore {
                     ShredType::Data,
                 );
                 let Some(ending_shred) = self
-                    .get_shred_from_just_inserted_or_db(just_inserted_shreds, shred_id, location)
+                    .get_shred_from_just_inserted_or_db(just_inserted_shreds, shred_id)
                     .map(Cow::into_owned)
                 else {
                     error!(
@@ -2520,7 +2404,6 @@ impl Blockstore {
         slot_meta: &mut SlotMeta,
         data_index: &'a mut ShredIndex,
         shred: &Shred,
-        location: BlockLocation,
         write_batch: &mut WriteBatch,
         shred_source: ShredSource,
     ) -> impl Iterator<Item = CompletedDataSetInfo> + 'a + use<'a> {
@@ -2557,7 +2440,8 @@ impl Blockstore {
 
         // Commit step: commit all changes to the mutable structures at once, or none at all.
         // We don't want only a subset of these changes going through.
-        self.put_data_shred_in_batch(write_batch, slot, index, location, shred.payload());
+        self.data_shred_cf
+            .put_bytes_in_batch(write_batch, (slot, index), shred.payload());
         data_index.insert(index);
         let newly_completed_data_sets = update_slot_meta(
             last_in_slot,
@@ -2572,7 +2456,6 @@ impl Blockstore {
 
         self.slots_stats.record_shred(
             shred.slot(),
-            location,
             shred.fec_set_index(),
             shred_source,
             Some(slot_meta),
@@ -2740,7 +2623,8 @@ impl Blockstore {
         Ok(shreds)
     }
 
-    /// Puts the shred of the specified slot-index in the column for the specified location.
+    /// Puts the shred of the specified slot-index in the column for the specified location
+    #[allow(dead_code)]
     fn put_data_shred_in_batch(
         &self,
         write_batch: &mut WriteBatch,
@@ -2867,6 +2751,7 @@ impl Blockstore {
     }
 
     /// Puts the Index of the specified erasure set in the column for the specified location
+    #[allow(dead_code)]
     fn put_index_in_batch(
         &self,
         write_batch: &mut WriteBatch,
@@ -4651,9 +4536,6 @@ impl Blockstore {
     /// checks whether any of its direct and indirect children slots are connected
     /// or not.
     ///
-    /// Note: This chaining only occurs for `SlotMeta`s in the column associated with
-    /// `BlockLocation::Original`
-    ///
     /// This function may update column families [`cf::SlotMeta`] and
     /// [`cf::Orphans`].
     ///
@@ -4664,12 +4546,12 @@ impl Blockstore {
     /// - `db`: the blockstore db that stores both shreds and their metadata.
     /// - `write_batch`: the write batch which includes all the updates of the
     ///   the current write and ensures their atomicity.
-    /// - `working_set`: a (location, slot-id) to SlotMetaWorkingSetEntry map.  This function
+    /// - `working_set`: a slot-id to SlotMetaWorkingSetEntry map.  This function
     ///   will remove all entries which insertion did not actually occur.
     fn handle_chaining(
         &self,
         write_batch: &mut WriteBatch,
-        working_set: &mut HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
+        working_set: &mut HashMap<u64, SlotMetaWorkingSetEntry>,
         metrics: &mut BlockstoreInsertionMetrics,
     ) -> Result<()> {
         let mut start = Measure::start("Shred chaining");
@@ -4677,15 +4559,7 @@ impl Blockstore {
         working_set.retain(|_, entry| entry.did_insert_occur);
         let mut new_chained_slots = HashMap::new();
         let working_set_slots: Vec<_> = working_set.keys().collect();
-        for (location, slot) in working_set_slots {
-            if !matches!(location, BlockLocation::Original) {
-                // We do not perform SlotMeta chaining for alternate versions of slots.
-                // We only chain SlotMeta across the original column.
-                //
-                // Alternate versions of blocks are stored in blockstore, but switching them into replay is
-                // handled separately.
-                continue;
-            }
+        for slot in working_set_slots {
             self.handle_chaining_for_slot(write_batch, working_set, &mut new_chained_slots, *slot)?;
         }
 
@@ -4719,10 +4593,6 @@ impl Blockstore {
     /// This function may update column family [`cf::Orphans`] and indirectly
     /// update SlotMeta from its output parameter `new_chained_slots`.
     ///
-    /// Note: This function works under the assumption that `slot` refers to the
-    /// column associated with `BlockLocation::Original`. `SlotMeta` chaining for
-    /// alternate versions is not supported.
-    ///
     /// Arguments:
     /// `db`: the underlying db for blockstore
     /// `write_batch`: the write batch which includes all the updates of the
@@ -4734,12 +4604,12 @@ impl Blockstore {
     fn handle_chaining_for_slot(
         &self,
         write_batch: &mut WriteBatch,
-        working_set: &HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
+        working_set: &HashMap<u64, SlotMetaWorkingSetEntry>,
         new_chained_slots: &mut HashMap<u64, Rc<RefCell<SlotMeta>>>,
         slot: Slot,
     ) -> Result<()> {
         let slot_meta_entry = working_set
-            .get(&(BlockLocation::Original, slot))
+            .get(&slot)
             .expect("Slot must exist in the working_set hashmap");
 
         let meta = &slot_meta_entry.new_slot_meta;
@@ -4807,13 +4677,12 @@ impl Blockstore {
     }
 
     /// Traverse all the children (direct and indirect) of `slot_meta`, and apply
-    /// `slot_function` to each of the children in `BlockLocation::Original`
-    /// (but not `slot_meta`).
+    /// `slot_function` to each of the children (but not `slot_meta`).
     ///
     /// Arguments:
     /// `db`: the blockstore db that stores shreds and their metadata.
     /// `slot_meta`: the SlotMeta of the above `slot`.
-    /// `working_set`: a (location, slot-id) to SlotMetaWorkingSetEntry map which is used
+    /// `working_set`: a slot-id to SlotMetaWorkingSetEntry map which is used
     ///   to traverse the graph.
     /// `passed_visited_slots`: all the traversed slots which have passed the
     ///   slot_function.  This may also include the input `slot`.
@@ -4823,8 +4692,8 @@ impl Blockstore {
     fn traverse_children_mut<F>(
         &self,
         slot_meta: &Rc<RefCell<SlotMeta>>,
-        working_set: &HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
-        passed_visited_slots: &mut HashMap<u64, Rc<RefCell<SlotMeta>>>,
+        working_set: &HashMap<u64, SlotMetaWorkingSetEntry>,
+        passed_visisted_slots: &mut HashMap<u64, Rc<RefCell<SlotMeta>>>,
         slot_function: F,
     ) -> Result<()>
     where
@@ -4835,7 +4704,7 @@ impl Blockstore {
         while !next_slots.is_empty() {
             let slot = next_slots.pop_front().unwrap();
             let meta_ref =
-                self.find_slot_meta_else_create(working_set, passed_visited_slots, slot)?;
+                self.find_slot_meta_else_create(working_set, passed_visisted_slots, slot)?;
             let mut meta = meta_ref.borrow_mut();
             if slot_function(&mut meta) {
                 meta.next_slots
@@ -4863,7 +4732,7 @@ impl Blockstore {
     ///    newly completed.
     fn commit_slot_meta_working_set(
         &self,
-        slot_meta_working_set: &HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
+        slot_meta_working_set: &HashMap<u64, SlotMetaWorkingSetEntry>,
         write_batch: &mut WriteBatch,
     ) -> Result<(bool, Vec<u64>)> {
         let mut should_signal = false;
@@ -4872,18 +4741,18 @@ impl Blockstore {
 
         // Check if any metadata was changed, if so, insert the new version of the
         // metadata into the write batch
-        for (&(location, slot), slot_meta_entry) in slot_meta_working_set.iter() {
+        for (slot, slot_meta_entry) in slot_meta_working_set.iter() {
             // Any slot that wasn't written to should have been filtered out by now.
             assert!(slot_meta_entry.did_insert_occur);
             let meta: &SlotMeta = &RefCell::borrow(&*slot_meta_entry.new_slot_meta);
             let meta_backup = &slot_meta_entry.old_slot_meta;
             if !completed_slots_senders.is_empty() && is_newly_completed_slot(meta, meta_backup) {
-                newly_completed_slots.push(slot);
+                newly_completed_slots.push(*slot);
             }
             // Check if the working copy of the metadata has changed
             if Some(meta) != meta_backup.as_ref() {
                 should_signal = should_signal || slot_has_updates(meta, meta_backup);
-                self.put_meta_in_batch(write_batch, slot, location, meta)?;
+                self.meta_cf.put_in_batch(write_batch, *slot, meta)?;
             }
         }
 
@@ -4904,23 +4773,21 @@ impl Blockstore {
     /// - `slot_meta_working_set`: a in-memory structure for storing the cached
     ///   SlotMeta.
     /// - `slot`: the slot for loading its meta.
-    /// - `location`: the column to query
     /// - `parent_slot`: the parent slot to be assigned to the specified slot meta
     ///
     /// This function returns the matched `SlotMetaWorkingSetEntry`.  If such entry
     /// does not exist in the database, a new entry will be created.
     fn get_slot_meta_entry<'a>(
         &self,
-        slot_meta_working_set: &'a mut HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
+        slot_meta_working_set: &'a mut HashMap<u64, SlotMetaWorkingSetEntry>,
         slot: Slot,
-        location: BlockLocation,
         parent_slot: Slot,
     ) -> Result<&'a mut SlotMetaWorkingSetEntry> {
         // Check if we've already inserted the slot metadata for this shred's slot
-        let entry = match slot_meta_working_set.entry((location, slot)) {
+        let entry = match slot_meta_working_set.entry(slot) {
             HashMapEntry::Occupied(occupied_entry) => occupied_entry.into_mut(),
             HashMapEntry::Vacant(vacant_entry) => {
-                let meta = self.meta_from_location(slot, location)?;
+                let meta = self.meta_cf.get(slot)?;
                 // Insert a new 2-tuple of the metadata (working copy, backup copy)
                 let slot_meta_entry = if let Some(mut meta) = meta {
                     let backup = Some(meta.clone());
@@ -4940,9 +4807,9 @@ impl Blockstore {
         Ok(entry)
     }
 
-    /// Returns the `SlotMeta` with the specified `slot_index` from the column associated
-    /// with `BlockLocation::Original`. The resulting `SlotMeta` could be either from the cache
-    /// or from the DB. Specifically, the function:
+    /// Returns the `SlotMeta` with the specified `slot_index`.  The resulting
+    /// `SlotMeta` could be either from the cache or from the DB.  Specifically,
+    /// the function:
     ///
     /// 1) Finds the slot metadata in the cache of dirty slot metadata we've
     ///    previously touched, otherwise:
@@ -4952,7 +4819,7 @@ impl Blockstore {
     /// Also see [`find_slot_meta_in_cached_state`] and [`find_slot_meta_in_db_else_create`].
     fn find_slot_meta_else_create<'a>(
         &self,
-        working_set: &'a HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
+        working_set: &'a HashMap<u64, SlotMetaWorkingSetEntry>,
         chained_slots: &'a mut HashMap<u64, Rc<RefCell<SlotMeta>>>,
         slot_index: u64,
     ) -> Result<Rc<RefCell<SlotMeta>>> {
@@ -4965,8 +4832,7 @@ impl Blockstore {
     }
 
     /// A helper function to [`find_slot_meta_else_create`] that searches the
-    /// `SlotMeta` based on the specified `slot` in the `BlockLocation::Original` column
-    /// of `db` and updates `insert_map`.
+    /// `SlotMeta` based on the specified `slot` in `db` and updates `insert_map`.
     ///
     /// If the specified `db` does not contain a matched entry, then it will create
     /// a dummy orphan slot in the database.
@@ -4989,17 +4855,15 @@ impl Blockstore {
     fn get_index_meta_entry<'a>(
         &self,
         slot: Slot,
-        location: BlockLocation,
-        index_working_set: &'a mut HashMap<(BlockLocation, u64), IndexMetaWorkingSetEntry>,
+        index_working_set: &'a mut HashMap<u64, IndexMetaWorkingSetEntry>,
         index_meta_time_us: &mut u64,
     ) -> Result<&'a mut IndexMetaWorkingSetEntry> {
         let mut total_start = Measure::start("Total elapsed");
-        let index_meta_entry = match index_working_set.entry((location, slot)) {
+
+        let index_meta_entry = match index_working_set.entry(slot) {
             HashMapEntry::Occupied(occupied_entry) => occupied_entry.into_mut(),
             HashMapEntry::Vacant(vacant_entry) => {
-                let index = self
-                    .get_index_from_location(slot, location)?
-                    .unwrap_or_else(|| Index::new(slot));
+                let index = self.index_cf.get(slot)?.unwrap_or_else(|| Index::new(slot));
                 let index_entry = IndexMetaWorkingSetEntry {
                     index,
                     did_insert_occur: false,
@@ -5007,6 +4871,7 @@ impl Blockstore {
                 vacant_entry.insert(index_entry)
             }
         };
+
         total_start.stop();
         *index_meta_time_us += total_start.as_us();
 
@@ -5148,15 +5013,15 @@ fn send_signals(
     }
 }
 
-/// Returns the `SlotMeta` of the specified `slot` associated with `BlockLocation::Original`
-/// from the two cached states: `working_set` and `chained_slots`.  If both contain the `SlotMeta`,
-/// then the latest one from the `working_set` will be returned.
+/// Returns the `SlotMeta` of the specified `slot` from the two cached states:
+/// `working_set` and `chained_slots`.  If both contain the `SlotMeta`, then
+/// the latest one from the `working_set` will be returned.
 fn find_slot_meta_in_cached_state<'a>(
-    working_set: &'a HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
+    working_set: &'a HashMap<u64, SlotMetaWorkingSetEntry>,
     chained_slots: &'a HashMap<u64, Rc<RefCell<SlotMeta>>>,
     slot: Slot,
 ) -> Option<Rc<RefCell<SlotMeta>>> {
-    if let Some(entry) = working_set.get(&(BlockLocation::Original, slot)) {
+    if let Some(entry) = working_set.get(&slot) {
         Some(entry.new_slot_meta.clone())
     } else {
         chained_slots.get(&slot).cloned()
@@ -5627,6 +5492,7 @@ pub mod tests {
             shred::max_ticks_per_n_shreds,
         },
         assert_matches::assert_matches,
+        bincode::serialize,
         crossbeam_channel::unbounded,
         rand::{rng, seq::SliceRandom},
         solana_account_decoder::parse_token::UiTokenAmount,
@@ -5664,7 +5530,7 @@ pub mod tests {
                 vec![CompiledInstruction::new(1, &(), vec![0])],
             );
             entries.push(next_entry_mut(&mut Hash::default(), 0, vec![transaction]));
-            let mut tick = create_ticks(1, 0, hash(&bincode::serialize(&x).unwrap()));
+            let mut tick = create_ticks(1, 0, hash(&serialize(&x).unwrap()));
             entries.append(&mut tick);
         }
         entries
@@ -7390,7 +7256,6 @@ pub mod tests {
         assert!(terminator_shred.last_in_slot());
         assert!(blockstore.should_insert_data_shred(
             &terminator_shred,
-            BlockLocation::Original,
             &slot_meta,
             &HashMap::new(),
             max_root,
@@ -7415,7 +7280,6 @@ pub mod tests {
         assert!(
             !blockstore.should_insert_data_shred(
                 &terminator_shred,
-                BlockLocation::Original,
                 &slot_meta,
                 &HashMap::new(),
                 max_root,
@@ -7458,7 +7322,6 @@ pub mod tests {
         assert!(
             !blockstore.should_insert_data_shred(
                 &past_tail_shreds[5], // 5 is not magic, could be any shred from this set
-                BlockLocation::Original,
                 &slot_meta,
                 &HashMap::new(),
                 max_root,
@@ -7541,7 +7404,7 @@ pub mod tests {
         assert_eq!(merkle_root_metas.len(), 1);
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, coding_shred.erasure_set()))
+                .get(&coding_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .merkle_root(),
@@ -7549,7 +7412,7 @@ pub mod tests {
         );
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, coding_shred.erasure_set()))
+                .get(&coding_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .first_received_shred_index(),
@@ -7557,15 +7420,14 @@ pub mod tests {
         );
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, coding_shred.erasure_set()))
+                .get(&coding_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .first_received_shred_type(),
             ShredType::Code,
         );
 
-        for ((location, erasure_set), working_merkle_root_meta) in merkle_root_metas {
-            assert_eq!(location, BlockLocation::Original);
+        for (erasure_set, working_merkle_root_meta) in merkle_root_metas {
             blockstore
                 .merkle_root_meta_cf
                 .put(erasure_set.store_key(), working_merkle_root_meta.as_ref())
@@ -7604,7 +7466,7 @@ pub mod tests {
         assert_eq!(merkle_root_metas.len(), 1);
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, coding_shred.erasure_set()))
+                .get(&coding_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .merkle_root(),
@@ -7612,7 +7474,7 @@ pub mod tests {
         );
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, coding_shred.erasure_set()))
+                .get(&coding_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .first_received_shred_index(),
@@ -7660,7 +7522,7 @@ pub mod tests {
         assert_eq!(merkle_root_metas.len(), 2);
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, coding_shred.erasure_set()))
+                .get(&coding_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .merkle_root(),
@@ -7668,7 +7530,7 @@ pub mod tests {
         );
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, coding_shred.erasure_set()))
+                .get(&coding_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .first_received_shred_index(),
@@ -7676,7 +7538,7 @@ pub mod tests {
         );
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, new_coding_shred.erasure_set()))
+                .get(&new_coding_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .merkle_root(),
@@ -7684,7 +7546,7 @@ pub mod tests {
         );
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, new_coding_shred.erasure_set()))
+                .get(&new_coding_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .first_received_shred_index(),
@@ -7710,7 +7572,6 @@ pub mod tests {
         blockstore
             .check_insert_data_shred(
                 Cow::Borrowed(&data_shred),
-                BlockLocation::Original,
                 &mut shred_insertion_tracker,
                 false,
                 None,
@@ -7725,7 +7586,7 @@ pub mod tests {
         assert_eq!(merkle_root_metas.len(), 1);
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, data_shred.erasure_set()))
+                .get(&data_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .merkle_root(),
@@ -7733,7 +7594,7 @@ pub mod tests {
         );
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, data_shred.erasure_set()))
+                .get(&data_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .first_received_shred_index(),
@@ -7741,15 +7602,14 @@ pub mod tests {
         );
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, data_shred.erasure_set()))
+                .get(&data_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .first_received_shred_type(),
             ShredType::Data,
         );
 
-        for ((location, erasure_set), working_merkle_root_meta) in merkle_root_metas {
-            assert_eq!(location, BlockLocation::Original);
+        for (erasure_set, working_merkle_root_meta) in merkle_root_metas {
             blockstore
                 .merkle_root_meta_cf
                 .put(erasure_set.store_key(), working_merkle_root_meta.as_ref())
@@ -7769,7 +7629,6 @@ pub mod tests {
             blockstore
                 .check_insert_data_shred(
                     Cow::Owned(new_data_shred),
-                    BlockLocation::Original,
                     &mut shred_insertion_tracker,
                     false,
                     None,
@@ -7795,7 +7654,7 @@ pub mod tests {
         assert_eq!(merkle_root_metas.len(), 1);
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, data_shred.erasure_set()))
+                .get(&data_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .merkle_root(),
@@ -7803,7 +7662,7 @@ pub mod tests {
         );
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, data_shred.erasure_set()))
+                .get(&data_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .first_received_shred_index(),
@@ -7858,7 +7717,6 @@ pub mod tests {
         blockstore
             .check_insert_data_shred(
                 Cow::Borrowed(&new_data_shred),
-                BlockLocation::Original,
                 &mut shred_insertion_tracker,
                 false,
                 None,
@@ -7894,7 +7752,7 @@ pub mod tests {
         );
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, new_data_shred.erasure_set()))
+                .get(&new_data_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .merkle_root(),
@@ -7902,7 +7760,7 @@ pub mod tests {
         );
         assert_eq!(
             merkle_root_metas
-                .get(&(BlockLocation::Original, new_data_shred.erasure_set()))
+                .get(&new_data_shred.erasure_set())
                 .unwrap()
                 .as_ref()
                 .first_received_shred_index(),
@@ -9481,7 +9339,7 @@ pub mod tests {
                     vec![CompiledInstruction::new(1, &(), vec![0])],
                 );
                 entries.push(next_entry_mut(&mut Hash::default(), 0, vec![transaction]));
-                let mut tick = create_ticks(1, 0, hash(&bincode::serialize(address).unwrap()));
+                let mut tick = create_ticks(1, 0, hash(&serialize(address).unwrap()));
                 entries.append(&mut tick);
             }
             entries
@@ -10081,13 +9939,9 @@ pub mod tests {
             setup_erasure_shreds(slot, 0, 100);
 
         let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
-        let coding_shreds = coding_shreds.into_iter().map(|shred| {
-            (
-                Cow::Owned(shred),
-                /*is_repaired:*/ false,
-                BlockLocation::Original,
-            )
-        });
+        let coding_shreds = coding_shreds
+            .into_iter()
+            .map(|shred| (Cow::Owned(shred), /*is_repaired:*/ false));
         blockstore
             .do_insert_shreds(
                 coding_shreds,
@@ -10598,7 +10452,7 @@ pub mod tests {
 
         let deprecated_rewards: StoredExtendedRewards = protobuf_rewards.clone().into();
         for slot in 0..2 {
-            let data = bincode::serialize(&deprecated_rewards).unwrap();
+            let data = serialize(&deprecated_rewards).unwrap();
             blockstore.rewards_cf.put_bytes(slot, &data).unwrap();
         }
         for slot in 2..4 {
@@ -10679,7 +10533,7 @@ pub mod tests {
         let protobuf_status: generated::TransactionStatusMeta = status.into();
 
         for slot in 0..2 {
-            let data = bincode::serialize(&deprecated_status).unwrap();
+            let data = serialize(&deprecated_status).unwrap();
             blockstore
                 .transaction_status_cf
                 .put_bytes((Signature::default(), slot), &data)

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -19,7 +19,6 @@ use {
         shred::{
             self, DATA_SHREDS_PER_FEC_BLOCK, ErasureSetId, ProcessShredsStats, ReedSolomonCache,
             Shred, ShredId, ShredType, Shredder,
-            merkle_tree::{MerkleTree, SIZE_OF_MERKLE_PROOF_ENTRY, get_proof_size},
         },
         slot_stats::{ShredSource, SlotsStats},
         transaction_address_lookup_table_scanner::scan_transaction,
@@ -34,7 +33,6 @@ use {
     rand::Rng,
     rayon::iter::{IntoParallelIterator, ParallelIterator},
     rocksdb::{DBRawIterator, LiveFile},
-    serde_bytes::ByteBuf,
     solana_account::ReadableAccount,
     solana_address_lookup_table_interface::state::AddressLookupTable,
     solana_clock::{DEFAULT_TICKS_PER_SECOND, Slot, UnixTimestamp},
@@ -43,13 +41,12 @@ use {
         entry::{Entry, MaxDataShredsLen, create_ticks},
     },
     solana_genesis_config::{DEFAULT_GENESIS_ARCHIVE, DEFAULT_GENESIS_FILE, GenesisConfig},
-    solana_hash::{HASH_BYTES, Hash},
+    solana_hash::Hash,
     solana_keypair::Keypair,
     solana_measure::measure::Measure,
     solana_metrics::datapoint_error,
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
-    solana_sha256_hasher::hashv,
     solana_signature::Signature,
     solana_signer::Signer,
     solana_storage_proto::{StoredExtendedRewards, StoredTransactionStatusMeta},
@@ -260,7 +257,6 @@ pub struct Blockstore {
     index_cf: LedgerColumn<cf::Index>,
     erasure_meta_cf: LedgerColumn<cf::ErasureMeta>,
     merkle_root_meta_cf: LedgerColumn<cf::MerkleRootMeta>,
-    double_merkle_meta_cf: LedgerColumn<cf::DoubleMerkleMeta>,
     orphans_cf: LedgerColumn<cf::Orphans>,
     duplicate_slots_cf: LedgerColumn<cf::DuplicateSlots>,
 
@@ -414,7 +410,6 @@ impl Blockstore {
         let index_cf = db.column();
         let erasure_meta_cf = db.column();
         let merkle_root_meta_cf = db.column();
-        let double_merkle_meta_cf = db.column();
         let orphans_cf = db.column();
         let duplicate_slots_cf = db.column();
 
@@ -461,7 +456,6 @@ impl Blockstore {
             erasure_meta_cf,
             index_cf,
             merkle_root_meta_cf,
-            double_merkle_meta_cf,
             meta_cf,
             optimistic_slots_cf,
             perf_samples_cf,
@@ -577,21 +571,6 @@ impl Blockstore {
         // Database::destroy() fails if the root directory doesn't exist
         fs::create_dir_all(ledger_path)?;
         Rocks::destroy(&Path::new(ledger_path).join(BLOCKSTORE_DIRECTORY_ROCKS_LEVEL))
-    }
-
-    /// Checks all available block versions, if we have a *complete* block for
-    /// `block_id`, returns the location where it is stored
-    #[allow(dead_code)]
-    pub fn get_block_location(&self, slot: Slot, block_id: Hash) -> Result<Option<BlockLocation>> {
-        for location in [
-            BlockLocation::Original,
-            BlockLocation::Alternate { block_id },
-        ] {
-            if self.get_double_merkle_root(slot, location)? == Some(block_id) {
-                return Ok(Some(location));
-            }
-        }
-        Ok(None)
     }
 
     /// Returns the SlotMeta of the specified slot.
@@ -777,50 +756,6 @@ impl Blockstore {
                 merkle_root_meta,
             ),
         }
-    }
-
-    /// Gets the double merkle meta for the given block.
-    /// If the meta is present but the proofs have not yet been populated - generate and store them
-    /// and return the updated double merkle meta
-    pub fn get_double_merkle_meta_maybe_populate_proofs(
-        &self,
-        slot: Slot,
-        location: BlockLocation,
-    ) -> Result<Option<DoubleMerkleMeta>> {
-        let Some(mut double_merkle_meta) = self.double_merkle_meta_cf.get((slot, location))? else {
-            return Ok(None);
-        };
-
-        if double_merkle_meta.proofs.is_empty() {
-            self.populate_double_merkle_meta_proofs(slot, location, &mut double_merkle_meta)?;
-            self.double_merkle_meta_cf
-                .put((slot, location), &double_merkle_meta)?;
-        }
-
-        Ok(Some(double_merkle_meta))
-    }
-
-    /// Gets the double merkle root for the block in the given location.
-    /// Returns `None` if the block is not full.
-    /// DoubleMerkleMeta is computed atomically during shred insertion when a slot becomes full.
-    pub fn get_double_merkle_root(
-        &self,
-        slot: Slot,
-        location: BlockLocation,
-    ) -> Result<Option<Hash>> {
-        let Some(double_merkle_meta_bytes) =
-            self.double_merkle_meta_cf.get_slice((slot, location))?
-        else {
-            debug_assert!(
-                self.meta_from_location(slot, location)
-                    .unwrap()
-                    .is_none_or(|meta| !meta.is_full())
-            );
-            return Ok(None);
-        };
-
-        let dmr: Hash = wincode::deserialize(&double_merkle_meta_bytes[0..HASH_BYTES])?;
-        Ok(Some(dmr))
     }
 
     /// Check whether the specified slot is an orphan slot which does not
@@ -1325,148 +1260,13 @@ impl Blockstore {
         }
     }
 
-    /// Computes and adds DoubleMerkleMeta to the write_batch for any newly completed slots.
-    fn compute_double_merkle_meta_for_newly_completed_slots(
-        &self,
-        shred_insertion_tracker: &mut ShredInsertionTracker,
-    ) -> Result<()> {
-        for (&(location, slot), slot_meta_entry) in
-            shred_insertion_tracker.slot_meta_working_set.iter()
-        {
-            let meta = RefCell::borrow(&*slot_meta_entry.new_slot_meta);
-            if !is_newly_completed_slot(&meta, &slot_meta_entry.old_slot_meta) {
-                continue;
-            }
-
-            self.build_double_merkle_meta_in_batch(
-                slot,
-                location,
-                meta.last_index.expect("Slot is full"),
-                &shred_insertion_tracker.slot_meta_working_set,
-                &shred_insertion_tracker.merkle_root_metas,
-                &mut shred_insertion_tracker.write_batch,
-            )?;
-        }
-        Ok(())
-    }
-
-    /// Builds DoubleMerkleMeta for a completed slot and adds it to the write batch.
-    /// Expects the block to be full
-    fn build_double_merkle_meta_in_batch(
-        &self,
-        slot: Slot,
-        location: BlockLocation,
-        last_index: u64,
-        slot_metas: &HashMap<(BlockLocation, Slot), SlotMetaWorkingSetEntry>,
-        merkle_root_metas: &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
-        write_batch: &mut WriteBatch,
-    ) -> Result<()> {
-        let fec_set_count = (last_index / (DATA_SHREDS_PER_FEC_BLOCK as u64) + 1) as usize;
-        let merkle_tree = self.build_double_merkle_tree(
-            slot,
-            location,
-            fec_set_count,
-            Some(slot_metas),
-            Some(merkle_root_metas),
-        )?;
-
-        let double_merkle_root = *merkle_tree.root();
-        // We don't build the proofs here as they are only needed to serve repair requests.
-        // These will be built later when calling `get_double_merkle_meta_maybe_populate_proofs`
-        let proofs = ByteBuf::new();
-
-        // Create and add DoubleMerkleMeta to write batch
-        let double_merkle_meta = DoubleMerkleMeta {
-            double_merkle_root,
-            fec_set_count,
-            proofs,
-        };
-
-        self.double_merkle_meta_cf
-            .put_in_batch(write_batch, (slot, location), &double_merkle_meta)
-    }
-
-    /// Builds the double merkle tree for a completed block (expects the block to be full)
-    fn build_double_merkle_tree(
-        &self,
-        slot: Slot,
-        location: BlockLocation,
-        fec_set_count: usize,
-        slot_metas: Option<&HashMap<(BlockLocation, Slot), SlotMetaWorkingSetEntry>>,
-        merkle_root_metas: Option<
-            &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
-        >,
-    ) -> Result<MerkleTree> {
-        // Get the parent info from tracker if specified first, then fall back to db
-        let Some((Some(parent_slot), parent_block_id)) =
-            self.get_parent_info_from_tracker_or_db(slot, location, slot_metas)?
-        else {
-            // Something has gone wrong here - the block is full yet the slot meta/parent slot info was missing!
-            error!(
-                "slot {slot} location {location} was full, yet the slot meta is missing / \
-                 incomplete"
-            );
-            return Err(BlockstoreError::ParentInfoUnavailable(slot, location));
-        };
-
-        // Collect merkle roots for each FEC set
-        let merkle_tree_leaves = (0..fec_set_count)
-            .map(|i| {
-                let fec_set_index = (i * DATA_SHREDS_PER_FEC_BLOCK) as u32;
-                let erasure_set = ErasureSetId::new(slot, fec_set_index);
-                self.get_merkle_root_from_tracker_or_db(location, erasure_set, merkle_root_metas)
-                    .map_err(|_| shred::Error::InvalidMerkleRoot)
-                    .and_then(|mr| mr.ok_or(shred::Error::InvalidMerkleRoot))
-            })
-            // Add parent info as the last leaf
-            .chain(std::iter::once(Ok(hashv(&[
-                &parent_slot.to_le_bytes(),
-                parent_block_id.as_ref(),
-            ]))));
-
-        MerkleTree::try_new_with_len(merkle_tree_leaves, fec_set_count + 1)
-            .map_err(|_| BlockstoreError::MerkleTreeConstructionFailure(slot, location))
-    }
-
-    /// Populates the proofs for the block at `slot` `location` into the `double_merkle_meta`
-    fn populate_double_merkle_meta_proofs(
-        &self,
-        slot: Slot,
-        location: BlockLocation,
-        double_merkle_meta: &mut DoubleMerkleMeta,
-    ) -> Result<()> {
-        let merkle_tree = self.build_double_merkle_tree(
-            slot,
-            location,
-            double_merkle_meta.fec_set_count,
-            None,
-            None,
-        )?;
-        let tree_size = double_merkle_meta.fec_set_count + 1;
-        let proof_len_bytes = get_proof_size(tree_size) as usize * SIZE_OF_MERKLE_PROOF_ENTRY;
-        let mut proofs = ByteBuf::with_capacity(tree_size * proof_len_bytes);
-
-        for leaf_index in 0..tree_size {
-            for proof_entry in merkle_tree.make_merkle_proof(leaf_index, tree_size) {
-                let proof_entry = proof_entry
-                    .map_err(|_| BlockstoreError::MerkleProofConstructionFailure(slot, location))?;
-                proofs.extend_from_slice(proof_entry);
-            }
-        }
-
-        double_merkle_meta.proofs = proofs;
-
-        Ok(())
-    }
-
     /// Gets the merkle root from the tracker if available, otherwise from the db.
+    #[allow(dead_code)]
     fn get_merkle_root_from_tracker_or_db(
         &self,
         location: BlockLocation,
         erasure_set: ErasureSetId,
-        merkle_root_metas: Option<
-            &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
-        >,
+        merkle_root_metas: &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
     ) -> Result<Option<Hash>> {
         let err = || {
             BlockstoreError::MissingMerkleRoot(
@@ -1474,10 +1274,8 @@ impl Blockstore {
                 erasure_set.fec_set_index() as u64,
             )
         };
-        // First check the tracker if available
-        if let Some(working_entry) =
-            merkle_root_metas.and_then(|mm| mm.get(&(location, erasure_set)))
-        {
+        // First check the tracker
+        if let Some(working_entry) = merkle_root_metas.get(&(location, erasure_set)) {
             return Ok(Some(working_entry.as_ref().merkle_root().ok_or_else(err)?));
         }
 
@@ -1488,25 +1286,6 @@ impl Blockstore {
                     .map(|meta| meta.merkle_root().ok_or_else(err))
                     .transpose()
             })
-    }
-
-    /// Gets the parent info for this block using the slot meta from the tracker if available, otherwise from the db
-    fn get_parent_info_from_tracker_or_db(
-        &self,
-        slot: Slot,
-        location: BlockLocation,
-        slot_metas: Option<&HashMap<(BlockLocation, Slot), SlotMetaWorkingSetEntry>>,
-    ) -> Result<Option<(Option<Slot>, Hash)>> {
-        if let Some(working_entry) = slot_metas.and_then(|sm| sm.get(&(location, slot))) {
-            // First check the tracker if available
-            let parent_slot = RefCell::borrow(&*working_entry.new_slot_meta).parent_slot;
-            Ok(Some((parent_slot, Hash::default())))
-        } else if let Some(meta) = self.meta_from_location(slot, location)? {
-            // Fall back to DB
-            Ok(Some((meta.parent_slot, Hash::default())))
-        } else {
-            Ok(None)
-        }
     }
 
     fn commit_updates_to_write_batch(
@@ -1679,9 +1458,6 @@ impl Blockstore {
         )?;
 
         self.check_chained_merkle_root_consistency(&mut shred_insertion_tracker);
-
-        // Compute DoubleMerkleMeta for any newly completed slots so it's committed atomically
-        self.compute_double_merkle_meta_for_newly_completed_slots(&mut shred_insertion_tracker)?;
 
         let (should_signal, newly_completed_slots) =
             self.commit_updates_to_write_batch(&mut shred_insertion_tracker, metrics)?;
@@ -5848,12 +5624,7 @@ pub mod tests {
         super::*,
         crate::{
             genesis_utils::{GenesisConfigInfo, create_genesis_config},
-            shred::{
-                max_ticks_per_n_shreds,
-                merkle_tree::{
-                    MerkleProofEntry, SIZE_OF_MERKLE_PROOF_ENTRY, get_merkle_root, get_proof_size,
-                },
-            },
+            shred::max_ticks_per_n_shreds,
         },
         assert_matches::assert_matches,
         crossbeam_channel::unbounded,
@@ -5879,7 +5650,6 @@ pub mod tests {
             InnerInstruction, InnerInstructions, Reward, Rewards, TransactionTokenBalance,
         },
         std::{cmp::Ordering, num::NonZeroUsize, time::Duration},
-        test_case::test_case,
     };
 
     // used for tests only
@@ -12335,168 +12105,6 @@ pub mod tests {
         assert_eq!(
             tx_status2.status,
             Err(TransactionError::InsufficientFundsForFee)
-        );
-    }
-
-    #[test_case(false ; "original_location")]
-    #[test_case(true ; "alternate_location")]
-    fn test_get_double_merkle_root(use_alternate_location: bool) {
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-
-        let parent_slot = 990;
-        let parent_block_id = Hash::default();
-        let slot = 1000;
-        let num_entries = 200;
-
-        // Create a set of shreds for a complete block
-        let (data_shreds, _, leader_schedule) =
-            setup_erasure_shreds(slot, parent_slot, num_entries);
-
-        // Collect FEC set merkle roots for verification
-        let mut fec_set_roots = [Hash::default(); 3];
-        for shred in data_shreds.iter() {
-            if shred.index() % (DATA_SHREDS_PER_FEC_BLOCK as u32) == 0 {
-                fec_set_roots[(shred.index() as usize) / DATA_SHREDS_PER_FEC_BLOCK] =
-                    shred.merkle_root().unwrap();
-            }
-        }
-
-        let parent_info_hash = hashv(&[&parent_slot.to_le_bytes(), parent_block_id.as_ref()]);
-        let merkle_tree_leaves: Vec<_> = fec_set_roots
-            .iter()
-            .copied()
-            .chain(std::iter::once(parent_info_hash))
-            .map(Ok)
-            .collect();
-        let merkle_tree = MerkleTree::try_new(merkle_tree_leaves.into_iter()).unwrap();
-        let expected_double_merkle_root = *merkle_tree.root();
-
-        let block_location = if use_alternate_location {
-            BlockLocation::Alternate {
-                block_id: expected_double_merkle_root,
-            }
-        } else {
-            BlockLocation::Original
-        };
-
-        // Insert shreds into blockstore at the specified location
-        let shreds = data_shreds
-            .iter()
-            .map(|shred| (Cow::Borrowed(shred), use_alternate_location, block_location));
-        let insert_results = blockstore
-            .do_insert_shreds(
-                shreds,
-                Some(&leader_schedule),
-                false,
-                None,
-                &mut BlockstoreInsertionMetrics::default(),
-            )
-            .unwrap();
-        assert!(insert_results.duplicate_shreds.is_empty());
-
-        let slot_meta = blockstore
-            .meta_from_location(slot, block_location)
-            .unwrap()
-            .unwrap();
-        assert!(slot_meta.is_full());
-
-        // Test getting the double merkle root
-        let double_merkle_root = blockstore
-            .get_double_merkle_root(slot, block_location)
-            .unwrap()
-            .unwrap();
-
-        let double_merkle_meta = blockstore
-            .double_merkle_meta_cf
-            .get((slot, block_location))
-            .unwrap()
-            .unwrap();
-
-        // Verify the double merkle root matches our pre-computed value
-        assert_eq!(double_merkle_root, expected_double_merkle_root);
-        assert_eq!(double_merkle_meta.double_merkle_root, double_merkle_root);
-        assert_eq!(double_merkle_meta.fec_set_count, 3); // With 200 entries, we should have 3 FEC sets
-        // Proofs are empty
-        assert_eq!(double_merkle_meta.proofs.len(), 0);
-
-        // Generate the proofs
-        let double_merkle_meta = blockstore
-            .get_double_merkle_meta_maybe_populate_proofs(slot, block_location)
-            .unwrap()
-            .unwrap();
-        let proof_size = get_proof_size(double_merkle_meta.fec_set_count + 1) as usize;
-        assert_eq!(
-            double_merkle_meta.proofs.len(),
-            4 * proof_size * SIZE_OF_MERKLE_PROOF_ENTRY
-        ); // 3 FEC sets + 1 parent info
-
-        // Verify the proofs
-        // FEC sets
-        for (fec_set, root) in fec_set_roots.iter().enumerate() {
-            let proof: Vec<_> = double_merkle_meta
-                .get_fec_set_proof(fec_set)
-                .unwrap()
-                .chunks(SIZE_OF_MERKLE_PROOF_ENTRY)
-                .map(<&MerkleProofEntry>::try_from)
-                .map(std::result::Result::unwrap)
-                .collect();
-            assert_eq!(proof_size, proof.len());
-
-            let verified_root = get_merkle_root(fec_set, *root, proof).unwrap();
-            assert_eq!(double_merkle_meta.double_merkle_root, verified_root);
-        }
-
-        // Parent info - final proof
-        let parent_info_proof: Vec<_> = double_merkle_meta
-            .get_parent_info_proof()
-            .unwrap()
-            .chunks(SIZE_OF_MERKLE_PROOF_ENTRY)
-            .map(<&MerkleProofEntry>::try_from)
-            .map(std::result::Result::unwrap)
-            .collect();
-        assert_eq!(proof_size, parent_info_proof.len());
-
-        let verified_root = get_merkle_root(
-            double_merkle_meta.fec_set_count,
-            parent_info_hash,
-            parent_info_proof,
-        )
-        .unwrap();
-        assert_eq!(double_merkle_meta.double_merkle_root, verified_root);
-
-        // Slot not full should return None
-        let incomplete_slot = 1001;
-        let (partial_shreds, _, leader_schedule) =
-            setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot(
-                incomplete_slot,
-                slot, // parent is 1000
-                5,
-                0,
-                Hash::new_from_array(rand::random()),
-                false, // not last in slot
-            );
-
-        let shreds = partial_shreds
-            .iter()
-            .take(3)
-            .map(|shred| (Cow::Borrowed(shred), use_alternate_location, block_location));
-        let insert_results = blockstore
-            .do_insert_shreds(
-                shreds,
-                Some(&leader_schedule),
-                false,
-                None,
-                &mut BlockstoreInsertionMetrics::default(),
-            )
-            .unwrap();
-        assert!(insert_results.duplicate_shreds.is_empty());
-
-        assert!(
-            blockstore
-                .get_double_merkle_root(incomplete_slot, block_location)
-                .unwrap()
-                .is_none()
         );
     }
 }

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -135,29 +135,12 @@ impl Blockstore {
     /// that preserves `slot`'s `next_slots`. This ensures that `slot`'s fork is
     /// replayable upon repair of `slot`.
     pub(crate) fn purge_slot_cleanup_chaining(&self, slot: Slot) -> Result<()> {
-        self.do_purge_slot_cleanup_chaining(slot, /* purge_alt_columns */ true)
-    }
-
-    /// Like `purge_slot_cleanup_chaining` but preserves alternate block columns.
-    /// Used when switching from an alternate block to allow repair data to be retained.
-    #[allow(dead_code)]
-    pub(crate) fn purge_slot_cleanup_chaining_keep_alt(&self, slot: Slot) -> Result<()> {
-        self.do_purge_slot_cleanup_chaining(slot, /* purge_alt_columns */ false)
-    }
-
-    fn do_purge_slot_cleanup_chaining(&self, slot: Slot, purge_alt_columns: bool) -> Result<()> {
         let Some(mut slot_meta) = self.meta(slot)? else {
             return Err(BlockstoreError::SlotUnavailable);
         };
         let mut write_batch = self.get_write_batch()?;
 
-        self.purge_range(
-            &mut write_batch,
-            slot,
-            slot,
-            PurgeType::Exact,
-            purge_alt_columns,
-        )?;
+        self.purge_range(&mut write_batch, slot, slot, PurgeType::Exact)?;
 
         if let Some(parent_slot) = slot_meta.parent_slot {
             let parent_slot_meta = self.meta(parent_slot)?;
@@ -208,13 +191,7 @@ impl Blockstore {
         let mut write_batch = self.get_write_batch()?;
 
         let mut delete_range_timer = Measure::start("delete_range");
-        self.purge_range(
-            &mut write_batch,
-            from_slot,
-            to_slot,
-            purge_type,
-            /* purge_alt_columns */ true,
-        )?;
+        self.purge_range(&mut write_batch, from_slot, to_slot, purge_type)?;
         delete_range_timer.stop();
 
         let mut write_timer = Measure::start("write_batch");
@@ -256,7 +233,6 @@ impl Blockstore {
         from_slot: Slot,
         to_slot: Slot,
         purge_type: PurgeType,
-        purge_alt_columns: bool,
     ) -> Result<()> {
         self.meta_cf
             .delete_range_in_batch(write_batch, from_slot, to_slot);
@@ -290,18 +266,6 @@ impl Blockstore {
             .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.merkle_root_meta_cf
             .delete_range_in_batch(write_batch, from_slot, to_slot);
-
-        if purge_alt_columns {
-            // Purge all alternate columns
-            self.alt_meta_cf
-                .delete_range_in_batch(write_batch, from_slot, to_slot);
-            self.alt_index_cf
-                .delete_range_in_batch(write_batch, from_slot, to_slot);
-            self.alt_data_shred_cf
-                .delete_range_in_batch(write_batch, from_slot, to_slot);
-            self.alt_merkle_root_meta_cf
-                .delete_range_in_batch(write_batch, from_slot, to_slot);
-        }
 
         match purge_type {
             PurgeType::Exact => self.purge_special_columns_exact(write_batch, from_slot, to_slot),
@@ -340,12 +304,6 @@ impl Blockstore {
         self.optimistic_slots_cf
             .delete_file_in_range(from_slot, to_slot)?;
         self.merkle_root_meta_cf
-            .delete_file_in_range(from_slot, to_slot)?;
-        self.alt_meta_cf.delete_file_in_range(from_slot, to_slot)?;
-        self.alt_index_cf.delete_file_in_range(from_slot, to_slot)?;
-        self.alt_data_shred_cf
-            .delete_file_in_range(from_slot, to_slot)?;
-        self.alt_merkle_root_meta_cf
             .delete_file_in_range(from_slot, to_slot)
     }
 

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -301,19 +301,6 @@ impl Blockstore {
                 .delete_range_in_batch(write_batch, from_slot, to_slot);
             self.alt_merkle_root_meta_cf
                 .delete_range_in_batch(write_batch, from_slot, to_slot);
-            // This column stores information for both the original and alternate
-            // columns. When `purge_alt_columns` is specified we delete the
-            // entire column.
-            self.double_merkle_meta_cf
-                .delete_range_in_batch(write_batch, from_slot, to_slot);
-        } else {
-            // This column stores information for both the original and alternate
-            // locations. When `purge_alt_columns` is not specified we only delete the
-            // data associated with the original column.
-            for slot in from_slot..=to_slot {
-                self.double_merkle_meta_cf
-                    .delete_in_batch(write_batch, (slot, BlockLocation::Original));
-            }
         }
 
         match purge_type {
@@ -359,8 +346,6 @@ impl Blockstore {
         self.alt_data_shred_cf
             .delete_file_in_range(from_slot, to_slot)?;
         self.alt_merkle_root_meta_cf
-            .delete_file_in_range(from_slot, to_slot)?;
-        self.double_merkle_meta_cf
             .delete_file_in_range(from_slot, to_slot)
     }
 

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -2,7 +2,7 @@
 use {
     crate::{
         blockstore::error::Result,
-        blockstore_meta::{self, BlockLocation, PerfSample},
+        blockstore_meta::{self, PerfSample},
     },
     bincode::Options as BincodeOptions,
     serde::{Serialize, de::DeserializeOwned},
@@ -243,16 +243,6 @@ pub mod columns {
     /// * index type: `(slot: u64, fec_set_index: u32, block_id: Hash)`
     /// * value type: [`blockstore_meta::MerkleRootMeta`]
     pub struct AlternateMerkleRootMeta;
-
-    #[derive(Debug)]
-    /// The double merkle root metadata column
-    ///
-    /// This column stores details about the double merkle root of a block.
-    /// We update this column when we finish ingesting all the shreds of the block.
-    ///
-    /// * index type: `(Slot, BlockLocation)`
-    /// * value type: [`blockstore_meta::DoubleMerkleMeta`]
-    pub struct DoubleMerkleMeta;
 }
 
 macro_rules! convert_column_index_to_key_bytes {
@@ -830,45 +820,6 @@ impl ColumnName for columns::AlternateMerkleRootMeta {
 }
 impl TypedColumn for columns::AlternateMerkleRootMeta {
     type Type = blockstore_meta::MerkleRootMeta;
-}
-
-impl Column for columns::DoubleMerkleMeta {
-    type Index = (Slot, BlockLocation);
-    // Key size: Slot (8 bytes) + Hash (32 bytes)
-    // When BlockLocation::Original, the hash is Hash::default().
-    type Key = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
-
-    #[inline]
-    fn key((slot, location): &Self::Index) -> Self::Key {
-        debug_assert_eq!(std::mem::size_of::<Slot>(), 8);
-        convert_column_index_to_key_bytes!(Key,
-            ..8 => &slot.to_be_bytes(),
-            8.. => &location.as_bytes()
-        )
-    }
-
-    fn index(key: &[u8]) -> Self::Index {
-        convert_column_key_bytes_to_index!(key,
-            0..8 => Slot::from_be_bytes,
-            8..40 => BlockLocation::from_bytes,
-        )
-    }
-
-    fn as_index(slot: Slot) -> Self::Index {
-        (slot, BlockLocation::Original)
-    }
-
-    fn slot((slot, _location): Self::Index) -> Slot {
-        slot
-    }
-}
-
-impl ColumnName for columns::DoubleMerkleMeta {
-    const NAME: &'static str = "double_merkle_meta";
-}
-
-impl TypedColumn for columns::DoubleMerkleMeta {
-    type Type = blockstore_meta::DoubleMerkleMeta;
 }
 
 #[cfg(test)]

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -7,7 +7,6 @@ use {
     bincode::Options as BincodeOptions,
     serde::{Serialize, de::DeserializeOwned},
     solana_clock::{Slot, UnixTimestamp},
-    solana_hash::{HASH_BYTES, Hash},
     solana_pubkey::{PUBKEY_BYTES, Pubkey},
     solana_signature::{SIGNATURE_BYTES, Signature},
     solana_storage_proto::convert::generated,
@@ -39,16 +38,6 @@ pub mod columns {
     /// * index type: `u64` (see [`SlotColumn`])
     /// * value type: [`blockstore_meta::SlotMeta`]
     pub struct SlotMeta;
-
-    #[derive(Debug)]
-    /// The alternate slot metadata column.
-    ///
-    /// Similar to [`SlotMeta`], however this column is only populated for alternate
-    /// versions fetched via block_id based repair.
-    ///
-    /// * index type: `(slot: u64, block_id: Hash)`
-    /// * value type: [`blockstore_meta::SlotMeta`]
-    pub struct AlternateSlotMeta;
 
     #[derive(Debug)]
     /// The orphans column.
@@ -132,16 +121,6 @@ pub mod columns {
     pub struct Index;
 
     #[derive(Debug)]
-    /// The alternate index column.
-    ///
-    /// Similar to [`Index`], however this column is only populated for alternate
-    /// versions fetched via block_id based repair.
-    ///
-    /// * index type: `(slot: u64, block_id: Hash)`
-    /// * value type: [`blockstore_meta::Index`]
-    pub struct AlternateIndex;
-
-    #[derive(Debug)]
     /// The shred data column
     ///
     /// * index type: `(u64, u64)`
@@ -154,16 +133,6 @@ pub mod columns {
     /// * index type: `(u64, u64)`
     /// * value type: [`Vec<u8>`]
     pub struct ShredCode;
-
-    #[derive(Debug)]
-    /// The alternate shred data column
-    ///
-    /// Similar to [`ShredData`], however this column is only populated for alternate
-    /// versions fetched via block_id based repair.
-    ///
-    /// * index type: `(slot: u64, shred_index: u64, block_id: Hash)`
-    /// * value type: [`Vec<u8>`]
-    pub struct AlternateShredData;
 
     #[derive(Debug)]
     /// The transaction status column
@@ -231,18 +200,8 @@ pub mod columns {
     /// Its index type is (Slot, fec_set_index).
     ///
     /// * index type: `crate::shred::ErasureSetId` `(Slot, fec_set_index: u32)`
-    /// * value type: [`blockstore_meta::MerkleRootMeta`]
+    /// * value type: [`blockstore_meta::MerkleRootMeta`]`
     pub struct MerkleRootMeta;
-
-    #[derive(Debug)]
-    /// The alternate merkle root meta column
-    ///
-    /// Similar to [`MerkleRootMeta`], however this column is only populated for alternate
-    /// versions fetched via block_id based repair.
-    ///
-    /// * index type: `(slot: u64, fec_set_index: u32, block_id: Hash)`
-    /// * value type: [`blockstore_meta::MerkleRootMeta`]
-    pub struct AlternateMerkleRootMeta;
 }
 
 macro_rules! convert_column_index_to_key_bytes {
@@ -258,14 +217,6 @@ macro_rules! convert_column_key_bytes_to_index {
     ($k:ident, $($a:literal..$b:literal => $f:expr),* $(,)?) => {{
         ($($f(<[u8; $b-$a]>::try_from(&$k[$a..$b]).unwrap())),*)
     }};
-}
-
-fn deserialize_fixint_reject_trailing<T: DeserializeOwned>(data: &[u8]) -> Result<T> {
-    let config = bincode::DefaultOptions::new()
-        // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
-        .with_fixint_encoding()
-        .reject_trailing_bytes();
-    Ok(config.deserialize(data)?)
 }
 
 pub trait Column {
@@ -548,39 +499,6 @@ impl ColumnName for columns::ShredData {
     const NAME: &'static str = "data_shred";
 }
 
-impl Column for columns::AlternateShredData {
-    type Index = (Slot, /*shred index:*/ u64, /* block id*/ Hash);
-    type Key = [u8; std::mem::size_of::<Slot>() + std::mem::size_of::<u64>() + HASH_BYTES];
-
-    #[inline]
-    fn key((slot, index, hash): &Self::Index) -> Self::Key {
-        convert_column_index_to_key_bytes!(Key,
-            ..8 => &slot.to_be_bytes(),
-            8..16 => &index.to_be_bytes(),
-            16.. => &hash.to_bytes(),
-        )
-    }
-
-    fn index(key: &[u8]) -> Self::Index {
-        convert_column_key_bytes_to_index!(key,
-            0..8  => Slot::from_be_bytes,
-            8..16 => u64::from_be_bytes,  // shred index
-            16..48 => Hash::new_from_array,
-        )
-    }
-
-    fn slot(index: Self::Index) -> Slot {
-        index.0
-    }
-
-    fn as_index(slot: Slot) -> Self::Index {
-        (slot, 0, Hash::default())
-    }
-}
-impl ColumnName for columns::AlternateShredData {
-    const NAME: &'static str = "alt_data_shred";
-}
-
 impl SlotColumn for columns::Index {}
 impl ColumnName for columns::Index {
     const NAME: &'static str = "index";
@@ -589,40 +507,12 @@ impl TypedColumn for columns::Index {
     type Type = blockstore_meta::Index;
 
     fn deserialize(data: &[u8]) -> Result<Self::Type> {
-        deserialize_fixint_reject_trailing(data)
-    }
-}
+        let config = bincode::DefaultOptions::new()
+            // `bincode::serialize` uses fixint encoding by default, so we need to use the same here
+            .with_fixint_encoding()
+            .reject_trailing_bytes();
 
-impl Column for columns::AlternateIndex {
-    // AlternateIndex and AlternateSlotMeta share the same key type so reuse code here
-    type Index = <columns::AlternateSlotMeta as Column>::Index;
-    type Key = <columns::AlternateSlotMeta as Column>::Key;
-
-    #[inline]
-    fn key(index: &Self::Index) -> Self::Key {
-        <columns::AlternateSlotMeta as Column>::key(index)
-    }
-
-    fn index(key: &[u8]) -> Self::Index {
-        <columns::AlternateSlotMeta as Column>::index(key)
-    }
-
-    fn slot(index: Self::Index) -> Slot {
-        <columns::AlternateSlotMeta as Column>::slot(index)
-    }
-
-    fn as_index(slot: Slot) -> Self::Index {
-        <columns::AlternateSlotMeta as Column>::as_index(slot)
-    }
-}
-impl ColumnName for columns::AlternateIndex {
-    const NAME: &'static str = "alt_index";
-}
-impl TypedColumn for columns::AlternateIndex {
-    type Type = <columns::Index as TypedColumn>::Type;
-
-    fn deserialize(data: &[u8]) -> Result<Self::Type> {
-        <columns::Index as TypedColumn>::deserialize(data)
+        Ok(config.deserialize(data)?)
     }
 }
 
@@ -672,40 +562,6 @@ impl ColumnName for columns::SlotMeta {
 }
 impl TypedColumn for columns::SlotMeta {
     type Type = blockstore_meta::SlotMeta;
-}
-
-impl Column for columns::AlternateSlotMeta {
-    type Index = (Slot, /* block_id */ Hash);
-    type Key = [u8; std::mem::size_of::<Slot>() + HASH_BYTES];
-
-    #[inline]
-    fn key((slot, block_id): &Self::Index) -> Self::Key {
-        convert_column_index_to_key_bytes!(Key,
-            ..8 => &slot.to_be_bytes(),
-            8.. => &block_id.to_bytes(),
-        )
-    }
-
-    fn index(key: &[u8]) -> Self::Index {
-        convert_column_key_bytes_to_index!(key,
-            0..8  => Slot::from_be_bytes,
-            8..40 => Hash::new_from_array,
-        )
-    }
-
-    fn slot(index: Self::Index) -> Slot {
-        index.0
-    }
-
-    fn as_index(slot: Slot) -> Self::Index {
-        (slot, Hash::default())
-    }
-}
-impl ColumnName for columns::AlternateSlotMeta {
-    const NAME: &'static str = "alt_meta";
-}
-impl TypedColumn for columns::AlternateSlotMeta {
-    type Type = <columns::SlotMeta as TypedColumn>::Type;
 }
 
 impl Column for columns::ErasureMeta {
@@ -782,43 +638,6 @@ impl ColumnName for columns::MerkleRootMeta {
     const NAME: &'static str = "merkle_root_meta";
 }
 impl TypedColumn for columns::MerkleRootMeta {
-    type Type = blockstore_meta::MerkleRootMeta;
-}
-
-impl Column for columns::AlternateMerkleRootMeta {
-    type Index = (Slot, /*fec_set_index:*/ u32, /* block_id */ Hash);
-    type Key = [u8; std::mem::size_of::<Slot>() + std::mem::size_of::<u32>() + HASH_BYTES];
-
-    #[inline]
-    fn key((slot, fec_set_index, block_id): &Self::Index) -> Self::Key {
-        convert_column_index_to_key_bytes!(Key,
-            ..8 => &slot.to_be_bytes(),
-            8..12 => &fec_set_index.to_be_bytes(),
-            12.. => &block_id.to_bytes(),
-        )
-    }
-
-    fn index(key: &[u8]) -> Self::Index {
-        convert_column_key_bytes_to_index!(key,
-            0..8  => Slot::from_be_bytes,
-            8..12 => u32::from_be_bytes,  // fec_set_index
-            12..44 => Hash::new_from_array, // block_id
-        )
-    }
-
-    fn slot((slot, _fec_set_index, _block_id): Self::Index) -> Slot {
-        slot
-    }
-
-    fn as_index(slot: Slot) -> Self::Index {
-        (slot, 0, Hash::default())
-    }
-}
-
-impl ColumnName for columns::AlternateMerkleRootMeta {
-    const NAME: &'static str = "alt_merkle_root_meta";
-}
-impl TypedColumn for columns::AlternateMerkleRootMeta {
     type Type = blockstore_meta::MerkleRootMeta;
 }
 

--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -1,8 +1,8 @@
 //! The error that can be produced from Blockstore operations.
 
 use {
-    super::PurgeType, crate::blockstore_meta::BlockLocation,
-    agave_snapshots::hardened_unpack::UnpackError, solana_clock::Slot, thiserror::Error,
+    super::PurgeType, agave_snapshots::hardened_unpack::UnpackError, solana_clock::Slot,
+    thiserror::Error,
 };
 
 #[derive(Error, Debug)]
@@ -19,8 +19,6 @@ pub enum BlockstoreError {
     DeadSlot,
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("deserialization error: {0}")]
-    Deserialize(#[from] wincode::ReadError),
     #[error("serialization error: {0}")]
     Serialize(#[from] bincode::Error),
     #[error("fs extra error: {0}")]
@@ -41,12 +39,6 @@ pub enum BlockstoreError {
     ProtobufDecodeError(#[from] prost::DecodeError),
     #[error("parent entries unavailable")]
     ParentEntriesUnavailable,
-    #[error("parent info unavailable: slot {0} location {1}")]
-    ParentInfoUnavailable(Slot, BlockLocation),
-    #[error("merkle tree construction failure: slot {0} location {1}")]
-    MerkleTreeConstructionFailure(Slot, BlockLocation),
-    #[error("merkle proof construction failure: slot {0} location {1}")]
-    MerkleProofConstructionFailure(Slot, BlockLocation),
     #[error("slot unavailable")]
     SlotUnavailable,
     #[error("unsupported transaction version")]

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -194,7 +194,6 @@ impl Rocks {
             new_cf_descriptor::<columns::AlternateIndex>(options, oldest_slot),
             new_cf_descriptor::<columns::AlternateShredData>(options, oldest_slot),
             new_cf_descriptor::<columns::AlternateMerkleRootMeta>(options, oldest_slot),
-            new_cf_descriptor::<columns::DoubleMerkleMeta>(options, oldest_slot),
         ];
 
         // When remaining columns are optional we can just return immediately here.
@@ -239,7 +238,7 @@ impl Rocks {
         cf_descriptors
     }
 
-    const fn columns() -> [&'static str; 24] {
+    const fn columns() -> [&'static str; 23] {
         [
             columns::ErasureMeta::NAME,
             columns::DeadSlots::NAME,
@@ -264,7 +263,6 @@ impl Rocks {
             columns::AlternateIndex::NAME,
             columns::AlternateShredData::NAME,
             columns::AlternateMerkleRootMeta::NAME,
-            columns::DoubleMerkleMeta::NAME,
         ]
     }
 
@@ -585,26 +583,6 @@ where
 
         let key = <C as Column>::key(&index);
         let result = self.backend.get_cf(self.handle(), key);
-
-        if let Some(op_start_instant) = is_perf_enabled {
-            report_rocksdb_read_perf(
-                C::NAME,
-                PERF_METRIC_OP_NAME_GET,
-                &op_start_instant.elapsed(),
-                &self.column_options,
-            );
-        }
-        result
-    }
-
-    pub fn get_slice(&self, index: C::Index) -> Result<Option<DBPinnableSlice<'_>>> {
-        let is_perf_enabled = maybe_enable_rocksdb_perf(
-            self.column_options.rocks_perf_sample_interval,
-            &self.read_perf_status,
-        );
-
-        let key = <C as Column>::key(&index);
-        let result = self.backend.get_pinned_cf(self.handle(), key);
 
         if let Some(op_start_instant) = is_perf_enabled {
             report_rocksdb_read_perf(

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -190,10 +190,6 @@ impl Rocks {
             new_cf_descriptor::<columns::BlockHeight>(options, oldest_slot),
             new_cf_descriptor::<columns::OptimisticSlots>(options, oldest_slot),
             new_cf_descriptor::<columns::MerkleRootMeta>(options, oldest_slot),
-            new_cf_descriptor::<columns::AlternateSlotMeta>(options, oldest_slot),
-            new_cf_descriptor::<columns::AlternateIndex>(options, oldest_slot),
-            new_cf_descriptor::<columns::AlternateShredData>(options, oldest_slot),
-            new_cf_descriptor::<columns::AlternateMerkleRootMeta>(options, oldest_slot),
         ];
 
         // When remaining columns are optional we can just return immediately here.
@@ -238,7 +234,7 @@ impl Rocks {
         cf_descriptors
     }
 
-    const fn columns() -> [&'static str; 23] {
+    const fn columns() -> [&'static str; 19] {
         [
             columns::ErasureMeta::NAME,
             columns::DeadSlots::NAME,
@@ -259,10 +255,6 @@ impl Rocks {
             columns::BlockHeight::NAME,
             columns::OptimisticSlots::NAME,
             columns::MerkleRootMeta::NAME,
-            columns::AlternateSlotMeta::NAME,
-            columns::AlternateIndex::NAME,
-            columns::AlternateShredData::NAME,
-            columns::AlternateMerkleRootMeta::NAME,
         ]
     }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -1,16 +1,12 @@
 use {
     crate::{
         bit_vec::BitVec,
-        shred::{
-            self, DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, Shred, ShredType,
-            merkle_tree::{SIZE_OF_MERKLE_PROOF_ENTRY, get_proof_size},
-        },
+        shred::{self, DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, Shred, ShredType},
     },
     bitflags::bitflags,
     serde::{Deserialize, Deserializer, Serialize, Serializer},
-    serde_bytes::ByteBuf,
     solana_clock::{Slot, UnixTimestamp},
-    solana_hash::{HASH_BYTES, Hash},
+    solana_hash::Hash,
     std::{
         fmt::Display,
         ops::{Range, RangeBounds},
@@ -293,24 +289,6 @@ pub struct DuplicateSlotProof {
 pub enum BlockLocation {
     Original,
     Alternate { block_id: Hash },
-}
-
-impl BlockLocation {
-    pub(crate) fn from_bytes(bytes: [u8; HASH_BYTES]) -> Self {
-        let block_id = Hash::new_from_array(bytes);
-        if block_id == Hash::default() {
-            Self::Original
-        } else {
-            Self::Alternate { block_id }
-        }
-    }
-
-    pub(crate) fn as_bytes(&self) -> [u8; HASH_BYTES] {
-        match self {
-            BlockLocation::Original => Hash::default().to_bytes(),
-            BlockLocation::Alternate { block_id } => block_id.to_bytes(),
-        }
-    }
 }
 
 impl Display for BlockLocation {
@@ -717,55 +695,6 @@ impl OptimisticSlotMetaVersioned {
         match self {
             OptimisticSlotMetaVersioned::V0(meta) => meta.timestamp,
         }
-    }
-}
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
-pub struct DoubleMerkleMeta {
-    /// The double merkle root computed as the root of the merkle tree
-    /// containing the merkle roots of each fec set + the parent info (parent_slot, parent_double_merkle_root)
-    pub(crate) double_merkle_root: Hash,
-
-    /// The number of fec sets in this block
-    pub(crate) fec_set_count: usize,
-
-    /// The merkle proofs.
-    /// Each proof is of size `get_proof_size(fec_set_count + 1)`
-    /// This `ByteBuf` contains the concatenated proofs for all the fec set leaves and the parent info leaf
-    ///
-    /// The size of this vec is `(fec_set_count + 1) * get_proof_size(fec_set_count + 1) * SIZE_OF_MERKLE_PROOF_ENTRY`
-    /// To access the proof for the i-th leaf:
-    ///   `proofs[i * get_proof_size(fec_set_count + 1) * SIZE_OF_MERKLE_PROOF_ENTRY
-    ///      ..(i + 1) * get_proof_size(fec_set_count + 1) * SIZE_OF_MERKLE_PROOF_ENTRY]`
-    pub(crate) proofs: ByteBuf,
-}
-
-impl DoubleMerkleMeta {
-    /// Return the proof associated with the leaf of fec set `fec_set_index`
-    /// Returns `None` if the proofs are yet to be populated or `fec_set_index` is out of bounds
-    pub fn get_fec_set_proof(&self, fec_set_index: usize) -> Option<&[u8]> {
-        if fec_set_index >= self.fec_set_count {
-            return None;
-        }
-        if self.proofs.is_empty() {
-            return None;
-        }
-
-        let proof_size =
-            usize::from(get_proof_size(self.fec_set_count + 1)) * SIZE_OF_MERKLE_PROOF_ENTRY;
-        Some(&self.proofs[fec_set_index * proof_size..(fec_set_index + 1) * proof_size])
-    }
-
-    /// Return the proof associated with the parent info leaf
-    /// Returns `None` if the proofs are yet to be populated
-    pub fn get_parent_info_proof(&self) -> Option<&[u8]> {
-        if self.proofs.is_empty() {
-            return None;
-        }
-
-        let proof_size =
-            usize::from(get_proof_size(self.fec_set_count + 1)) * SIZE_OF_MERKLE_PROOF_ENTRY;
-        Some(&self.proofs[self.fec_set_count * proof_size..])
     }
 }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -7,10 +7,7 @@ use {
     serde::{Deserialize, Deserializer, Serialize, Serializer},
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
-    std::{
-        fmt::Display,
-        ops::{Range, RangeBounds},
-    },
+    std::ops::{Range, RangeBounds},
     wincode::{SchemaRead, SchemaWrite},
 };
 
@@ -284,22 +281,6 @@ pub struct DuplicateSlotProof {
     pub shred2: shred::Payload,
 }
 
-/// Which column an associated block currently resides
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum BlockLocation {
-    Original,
-    Alternate { block_id: Hash },
-}
-
-impl Display for BlockLocation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BlockLocation::Original => write!(f, "Original"),
-            BlockLocation::Alternate { block_id } => write!(f, "Alternate({block_id})"),
-        }
-    }
-}
-
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub enum FrozenHashVersioned {
     Current(FrozenHashStatus),
@@ -378,6 +359,7 @@ impl ShredIndex {
         }
     }
 
+    #[allow(unused)]
     pub(crate) fn contains(&self, idx: u64) -> bool {
         self.index.contains(idx as usize)
     }
@@ -386,15 +368,6 @@ impl ShredIndex {
         if let Ok(true) = self.index.insert(idx as usize) {
             self.num_shreds += 1;
         }
-    }
-
-    pub(crate) fn count_range<R>(&self, bounds: R) -> usize
-    where
-        R: RangeBounds<u64>,
-    {
-        let start = bounds.start_bound().map(|&b| b as usize);
-        let end = bounds.end_bound().map(|&b| b as usize);
-        self.index.range((start, end)).count_ones()
     }
 
     pub(crate) fn range<R>(&self, bounds: R) -> impl Iterator<Item = u64> + '_

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -86,7 +86,7 @@ use {solana_keypair::Keypair, solana_perf::packet::Packet, solana_signer::Signer
 
 mod common;
 pub mod merkle;
-pub(crate) mod merkle_tree;
+mod merkle_tree;
 mod payload;
 mod shred_code;
 pub(crate) mod shred_data;

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -344,10 +344,6 @@ impl ErasureSetId {
         self.0
     }
 
-    pub(crate) fn fec_set_index(&self) -> u32 {
-        self.1
-    }
-
     // Storage key for ErasureMeta and MerkleRootMeta in blockstore db.
     // Note: ErasureMeta column uses u64 so this will need to be typecast
     pub(crate) fn store_key(&self) -> (Slot, /*fec_set_index:*/ u32) {

--- a/ledger/src/shred/merkle_tree.rs
+++ b/ledger/src/shred/merkle_tree.rs
@@ -41,19 +41,12 @@ impl MerkleTree {
             return Err(Error::EmptyIterator);
         }
         let num_shreds = shreds.len();
-        Self::try_new_with_len(shreds, num_shreds)
-    }
-
-    pub(crate) fn try_new_with_len(
-        shreds: impl Iterator<Item = Result<Hash, Error>>,
-        len: usize,
-    ) -> Result<MerkleTree, Error> {
-        let capacity = get_merkle_tree_size(len);
+        let capacity = get_merkle_tree_size(num_shreds);
         let mut nodes = Vec::with_capacity(capacity);
         for shred in shreds {
             nodes.push(shred?);
         }
-        let init = (len > 1).then_some(len);
+        let init = (num_shreds > 1).then_some(num_shreds);
         for size in successors(init, |&k| (k > 2).then_some((k + 1) >> 1)) {
             let offset = nodes.len() - size;
             for index in (offset..offset + size).step_by(2) {
@@ -137,6 +130,7 @@ pub fn get_merkle_tree_size(num_shreds: usize) -> usize {
 }
 
 // Maps number of (code + data) shreds to merkle_proof.len().
+#[cfg(test)]
 pub(crate) const fn get_proof_size(num_shreds: usize) -> u8 {
     let bits = usize::BITS - num_shreds.leading_zeros();
     let proof_size = if num_shreds.is_power_of_two() {

--- a/ledger/src/slot_stats.rs
+++ b/ledger/src/slot_stats.rs
@@ -1,5 +1,5 @@
 use {
-    crate::blockstore_meta::{BlockLocation, SlotMeta},
+    crate::blockstore_meta::SlotMeta,
     bitflags::bitflags,
     lru::LruCache,
     solana_clock::Slot,
@@ -19,85 +19,42 @@ bitflags! {
     #[derive(Copy, Clone, Default)]
     struct SlotFlags: u8 {
         const DEAD   = 0b00000001;
-        const ROOTED = 0b00000010;
+        const FULL   = 0b00000010;
+        const ROOTED = 0b00000100;
     }
 }
 
 #[derive(Clone, Default)]
-struct LocationShredStats {
+pub struct SlotStats {
     turbine_fec_set_index_counts: HashMap</*fec_set_index*/ u32, /*count*/ usize>,
     num_repaired: usize,
     num_recovered: usize,
     last_index: u64,
-    is_full: bool,
-}
-
-#[derive(Clone, Default)]
-pub struct SlotStats {
-    original: LocationShredStats,
-    alternate: LocationShredStats,
     flags: SlotFlags,
 }
 
 impl SlotStats {
-    fn min_index_count(stats: &LocationShredStats) -> usize {
-        stats
-            .turbine_fec_set_index_counts
+    pub fn get_min_index_count(&self) -> usize {
+        self.turbine_fec_set_index_counts
             .values()
             .min()
             .copied()
             .unwrap_or_default()
     }
 
-    fn location_stats(&self, location: BlockLocation) -> &LocationShredStats {
-        match location {
-            BlockLocation::Original => &self.original,
-            BlockLocation::Alternate { .. } => &self.alternate,
-        }
-    }
-
-    fn location_stats_mut(&mut self, location: BlockLocation) -> &mut LocationShredStats {
-        match location {
-            BlockLocation::Original => &mut self.original,
-            BlockLocation::Alternate { .. } => &mut self.alternate,
-        }
-    }
-
-    pub fn get_min_index_count(&self, location: BlockLocation) -> usize {
-        Self::min_index_count(self.location_stats(location))
-    }
-
-    fn report_location(&self, slot: Slot, name: &'static str, location_stats: &LocationShredStats) {
-        let min_fec_set_count = Self::min_index_count(location_stats);
+    fn report(&self, slot: Slot) {
+        let min_fec_set_count = self.get_min_index_count();
         datapoint_info!(
-            name,
+            "slot_stats_tracking_complete",
             ("slot", slot, i64),
-            ("last_index", location_stats.last_index, i64),
-            ("num_repaired", location_stats.num_repaired, i64),
-            ("num_recovered", location_stats.num_recovered, i64),
+            ("last_index", self.last_index, i64),
+            ("num_repaired", self.num_repaired, i64),
+            ("num_recovered", self.num_recovered, i64),
             ("min_turbine_fec_set_count", min_fec_set_count, i64),
-            ("is_full", location_stats.is_full, bool),
+            ("is_full", self.flags.contains(SlotFlags::FULL), bool),
             ("is_rooted", self.flags.contains(SlotFlags::ROOTED), bool),
             ("is_dead", self.flags.contains(SlotFlags::DEAD), bool),
         );
-    }
-
-    fn should_report(location_stats: &LocationShredStats) -> bool {
-        location_stats.is_full
-            || location_stats.num_recovered > 0
-            || location_stats.num_repaired > 0
-            || !location_stats.turbine_fec_set_index_counts.is_empty()
-    }
-
-    fn report(&self, slot: Slot) {
-        self.report_location(slot, "slot_stats_tracking_complete", &self.original);
-        if Self::should_report(&self.alternate) {
-            self.report_location(
-                slot,
-                "slot_stats_tracking_complete_alternate",
-                &self.alternate,
-            );
-        }
     }
 }
 
@@ -139,7 +96,6 @@ impl SlotsStats {
     pub(crate) fn record_shred(
         &self,
         slot: Slot,
-        location: BlockLocation,
         fec_set_index: u32,
         source: ShredSource,
         slot_meta: Option<&SlotMeta>,
@@ -147,12 +103,11 @@ impl SlotsStats {
         let (slot_full_reporting_info, evicted) = {
             let mut stats = self.stats.lock().unwrap();
             let (slot_stats, evicted) = Self::get_or_default_with_eviction_check(&mut stats, slot);
-            let location_stats = slot_stats.location_stats_mut(location);
             match source {
-                ShredSource::Recovered => location_stats.num_recovered += 1,
-                ShredSource::Repaired => location_stats.num_repaired += 1,
+                ShredSource::Recovered => slot_stats.num_recovered += 1,
+                ShredSource::Repaired => slot_stats.num_repaired += 1,
                 ShredSource::Turbine => {
-                    *location_stats
+                    *slot_stats
                         .turbine_fec_set_index_counts
                         .entry(fec_set_index)
                         .or_default() += 1
@@ -161,20 +116,17 @@ impl SlotsStats {
             let mut slot_full_reporting_info = None;
             if let Some(meta) = slot_meta {
                 if meta.is_full() {
-                    location_stats.last_index = meta.last_index.unwrap();
-                    if !location_stats.is_full {
-                        location_stats.is_full = true;
-                        slot_full_reporting_info = Some((
-                            location,
-                            location_stats.num_repaired,
-                            location_stats.num_recovered,
-                        ));
+                    slot_stats.last_index = meta.last_index.unwrap();
+                    if !slot_stats.flags.contains(SlotFlags::FULL) {
+                        slot_stats.flags |= SlotFlags::FULL;
+                        slot_full_reporting_info =
+                            Some((slot_stats.num_repaired, slot_stats.num_recovered));
                     }
                 }
             }
             (slot_full_reporting_info, evicted)
         };
-        if let Some((location, num_repaired, num_recovered)) = slot_full_reporting_info {
+        if let Some((num_repaired, num_recovered)) = slot_full_reporting_info {
             let slot_meta = slot_meta.unwrap();
             let total_time_ms =
                 solana_time_utils::timestamp().saturating_sub(slot_meta.first_shred_timestamp);
@@ -182,24 +134,14 @@ impl SlotsStats {
                 .last_index
                 .and_then(|ix| i64::try_from(ix).ok())
                 .unwrap_or(-1);
-            match location {
-                BlockLocation::Original => datapoint_info!(
-                    "shred_insert_is_full",
-                    ("slot", slot, i64),
-                    ("total_time_ms", total_time_ms, i64),
-                    ("last_index", last_index, i64),
-                    ("num_repaired", num_repaired, i64),
-                    ("num_recovered", num_recovered, i64),
-                ),
-                BlockLocation::Alternate { .. } => datapoint_info!(
-                    "shred_insert_is_full_alternate",
-                    ("slot", slot, i64),
-                    ("total_time_ms", total_time_ms, i64),
-                    ("last_index", last_index, i64),
-                    ("num_repaired", num_repaired, i64),
-                    ("num_recovered", num_recovered, i64),
-                ),
-            }
+            datapoint_info!(
+                "shred_insert_is_full",
+                ("slot", slot, i64),
+                ("total_time_ms", total_time_ms, i64),
+                ("last_index", last_index, i64),
+                ("num_repaired", num_repaired, i64),
+                ("num_recovered", num_recovered, i64),
+            );
         }
         if let Some((evicted_slot, evicted_stats)) = evicted {
             evicted_stats.report(evicted_slot);
@@ -218,16 +160,10 @@ impl SlotsStats {
         }
     }
 
-    /// Marks the slot as dead.
-    /// Note this refers to the original column: the alternate column can never be dead
-    /// - shreds are pre-verified and we never replay out of the alternate column
     pub fn mark_dead(&self, slot: Slot) {
         self.add_flag(slot, SlotFlags::DEAD);
     }
 
-    /// Marks the original column as rooted.
-    /// Note this refers to the original column: the alternate column can never be rooted
-    /// - we never replay out of the alternate column and rooting requires replay.
     pub fn mark_rooted(&self, slot: Slot) {
         self.add_flag(slot, SlotFlags::ROOTED);
     }


### PR DESCRIPTION
#### Problem
We added new blockstore columns for alpenglow and logic in:
- #10944 
- #11388 
- #11611 

This results in being unable to load a v3.1/v4.0 ledger with master

#### Summary of Changes
Revert the addition and logic associated with the new columns:
- AlternateSlotMeta
- AlternateIndex
- AlternateShredData
- AlternateMerkleRootMeta
- DoubleMerkleMeta

We'll look to reintroduce these as 2 commits:
1. Introduce the new columns but no logic touching them
2. Add the logic that reads and writes to the columns

And backport (1)

Note: the 3rd commit [Revert "alpenglow: upstream alternate shred blockstore columns ](https://github.com/anza-xyz/agave/pull/11733/changes/d0e65bc5d07788afd4c4fbe9f40e471800f37b7b) did not apply cleanly due to the reordering in #11453 , would be good to take a look that i haven't messed anything up when fixing conflicts