### PR TITLE
svm: delete loader v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10587,8 +10587,6 @@ dependencies = [
  "solana-instructions-sysvar",
  "solana-keypair",
  "solana-loader-v3-interface",
- "solana-loader-v4-interface",
- "solana-loader-v4-program",
  "solana-message",
  "solana-native-token",
  "solana-nonce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -355,7 +355,7 @@ smallvec = { version = "1.15.1", default-features = false, features = ["union"] 
 smpl_jwt = "0.9.0"
 socket2 = "0.6.3"
 soketto = "0.8"
-solana-account = "4.1.0"
+solana-account = "4.2.0"
 solana-account-decoder = { path = "account-decoder", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-account-info = "3.1.1"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9093,8 +9093,6 @@ dependencies = [
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-loader-v3-interface",
- "solana-loader-v4-interface",
- "solana-loader-v4-program",
  "solana-message",
  "solana-nonce",
  "solana-nonce-account",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9450,8 +9450,6 @@ dependencies = [
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-loader-v3-interface",
- "solana-loader-v4-interface",
- "solana-loader-v4-program",
  "solana-message",
  "solana-nonce",
  "solana-nonce-account",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -28,12 +28,10 @@ frozen-abi = [
 ]
 metrics = [
     "solana-bpf-loader-program/metrics",
-    "solana-loader-v4-program/metrics",
     "solana-program-runtime/metrics",
 ]
 shuttle-test = [
     "solana-bpf-loader-program/shuttle-test",
-    "solana-loader-v4-program/shuttle-test",
     "solana-program-runtime/shuttle-test",
     "solana-svm-type-overrides/shuttle-test",
 ]
@@ -58,8 +56,6 @@ solana-hash = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-instructions-sysvar = { workspace = true }
 solana-loader-v3-interface = { workspace = true, features = ["bincode"] }
-solana-loader-v4-interface = { workspace = true }
-solana-loader-v4-program = { workspace = true }
 solana-message = { workspace = true }
 solana-nonce = { workspace = true }
 solana-nonce-account = { workspace = true, features = ["wincode"] }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -27,7 +27,7 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_sdk_ids::{
-        bpf_loader_upgradeable, native_loader,
+        bpf_loader_upgradeable, loader_v4, native_loader,
         sysvar::{self, slot_history},
     },
     solana_svm_callback::{AccountState, TransactionProcessingCallback},
@@ -516,9 +516,6 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
             // handle cases that LoaderV3 presumably makes impossible, such as self-referential
             // program accounts or multiply-referenced programdata accounts, for added safety.
             //
-            // If in the future LoaderV3 programs are migrated to LoaderV4, this entire code block
-            // can be deleted.
-            //
             // If this is a valid LoaderV3 program...
             if bpf_loader_upgradeable::check_id(account.owner())
                 && let Ok(UpgradeableLoaderState::Program {
@@ -571,7 +568,21 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
         };
 
         let owner_id = program_account.owner();
-        if !native_loader::check_id(owner_id) && !PROGRAM_OWNERS.contains(owner_id) {
+
+        // A feature gate is required to remove Loader V4 from this load-time
+        // ownership check. If it was removed, transactions which attempt to
+        // invoke Loader V4-owned accounts would result in fees-only transaction
+        // errors, which do not meter CUs.
+        //
+        // An attacker could easily trigger this by assigning an all-zero
+        // System account to Loader V4 and invoking it in a transaction
+        // message. Some nodes would return an execution error while others
+        // would return a fees-only transaction. The former will affect the
+        // cost tracker, while the latter will not.
+        if !native_loader::check_id(owner_id)
+            && !PROGRAM_OWNERS.contains(owner_id)
+            && !loader_v4::check_id(owner_id)
+        {
             error_metrics.invalid_program_for_execution += 1;
             return Err(TransactionError::InvalidProgramForExecution);
         }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -4,7 +4,6 @@ use {
     solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMut},
     solana_clock::Slot,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
-    solana_loader_v4_interface::state::{LoaderV4State, LoaderV4Status},
     solana_program_runtime::{
         loaded_programs::ProgramRuntimeEnvironment,
         program_cache_entry::{
@@ -26,7 +25,6 @@ pub(crate) enum ProgramAccountLoadResult {
     ProgramOfLoaderV1(AccountSharedData),
     ProgramOfLoaderV2(AccountSharedData),
     ProgramOfLoaderV3(AccountSharedData, AccountSharedData, Slot),
-    ProgramOfLoaderV4(AccountSharedData, Slot),
 }
 
 pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
@@ -36,15 +34,11 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
     let (program_account, last_modification_slot) = callbacks.get_account_shared_data(pubkey)?;
 
     let load_result = if loader_v4::check_id(program_account.owner()) {
-        solana_loader_v4_program::get_state(program_account.data())
-            .ok()
-            .and_then(|state| {
-                (!matches!(state.status, LoaderV4Status::Retracted)).then_some(state.slot)
-            })
-            .map(|slot| ProgramAccountLoadResult::ProgramOfLoaderV4(program_account, slot))
-            .unwrap_or(ProgramAccountLoadResult::InvalidAccountData(
-                ProgramCacheEntryOwner::LoaderV4,
-            ))
+        // Loader V4 was removed, but this branch can't be removed without a
+        // feature gate. However, since no valid Loader V4 state exists on any
+        // network, we can just always error here, since this was always the
+        // result anyway.
+        ProgramAccountLoadResult::InvalidAccountData(ProgramCacheEntryOwner::LoaderV4)
     } else if bpf_loader_upgradeable::check_id(program_account.owner()) {
         if let Ok(UpgradeableLoaderState::Program {
             programdata_address,
@@ -158,27 +152,6 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
                 .map_err(|_| ())
             })
             .map_err(|_| (deployment_slot, ProgramCacheEntryOwner::LoaderV3)),
-
-        ProgramAccountLoadResult::ProgramOfLoaderV4(program_account, deployment_slot) => {
-            program_account
-                .data()
-                .get(LoaderV4State::program_data_offset()..)
-                .ok_or(())
-                .and_then(|elf_bytes| {
-                    ProgramCacheEntry::new(
-                        &loader_v4::id(),
-                        ProgramRuntimeEnvironment::clone(program_runtime_environment),
-                        deployment_slot,
-                        deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
-                        elf_bytes,
-                        program_account.data().len(),
-                        #[cfg(feature = "metrics")]
-                        &mut load_program_metrics,
-                    )
-                    .map_err(|_| ())
-                })
-                .map_err(|_| (deployment_slot, ProgramCacheEntryOwner::LoaderV4))
-        }
     }
     .unwrap_or_else(|(deployment_slot, owner)| {
         let env = ProgramRuntimeEnvironment::clone(program_runtime_environment);
@@ -224,9 +197,11 @@ pub(crate) fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
         }
         Err(TransactionError::ProgramAccountNotFound)
     } else if loader_v4::check_id(program.owner()) {
-        let state = solana_loader_v4_program::get_state(program.data())
-            .map_err(|_| TransactionError::ProgramAccountNotFound)?;
-        Ok(state.slot)
+        // Loader V4 was removed, but this branch can't be removed without a
+        // feature gate. However, since no valid Loader V4 state exists on any
+        // network, we can just always error here, since this was always the
+        // result anyway.
+        Err(TransactionError::ProgramAccountNotFound)
     } else {
         Ok(0)
     }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -51,6 +51,7 @@ use {
     },
     solana_pubkey::Pubkey,
     solana_rent::Rent,
+    solana_sdk_ids::loader_v4,
     solana_svm_callback::TransactionProcessingCallback,
     solana_svm_feature_set::SVMFeatureSet,
     solana_svm_log_collector::LogCollector,
@@ -822,7 +823,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 cache_entry.stats.uses.fetch_add(1, Ordering::Relaxed);
             } else if let Some((account, last_modification_slot)) =
                 account_loader.get_account_shared_data(account_key)
-                && PROGRAM_OWNERS.contains(account.owner())
+                // A feature gate is required to remove Loader V4 from this
+                // ownership check. For more information, see similar comments
+                // in the account_loader and program_loader modules.
+                && (PROGRAM_OWNERS.contains(account.owner()) || loader_v4::check_id(account.owner()))
             {
                 program_accounts_set.insert(*account_key, last_modification_slot);
             }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -13,7 +13,7 @@ use {
     solana_compute_budget_interface::ComputeBudgetInstruction,
     solana_fee_structure::FeeDetails,
     solana_hash::Hash,
-    solana_instruction::{AccountMeta, Instruction},
+    solana_instruction::{AccountMeta, Instruction, error::InstructionError},
     solana_keypair::Keypair,
     solana_loader_v3_interface::{
         get_program_data_address, instruction as loaderv3_instruction,
@@ -30,7 +30,8 @@ use {
     },
     solana_pubkey::Pubkey,
     solana_sdk_ids::{
-        bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, compute_budget, native_loader,
+        bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, compute_budget, loader_v4,
+        native_loader,
     },
     solana_signer::Signer,
     solana_svm::{
@@ -2635,6 +2636,110 @@ fn program_cache_create_account() {
         env.test_entry = test_entry;
         env.execute();
     }
+}
+
+// Invoking an account whose owner is `loader_v4::id()` must result in an
+// **executed-failed** transaction (NOT fees-only) with an
+// `InstructionError::UnsupportedProgramId` at the failing instruction index.
+//
+// This is the consensus invariant maintained by the manual carve-out at
+// `svm/src/account_loader.rs:590-593`.
+//
+// If the carve-out was removed without a feature gate, the transaction would
+// instead be `ProcessedTransaction::FeesOnly { load_error: TransactionError::InvalidProgramForExecution, .. }`
+// and the cost tracker would see zero CUs for the transaction. This would
+// break consensus, since a multi-instruction tx currently consumes the CUs of
+// the entire transaction, including any preceding successful instruction.
+#[test]
+fn loader_v4_owned_account_invocation() {
+    let mut test_entry = SvmTestEntry::default();
+
+    let fee_payer_keypair = Keypair::new();
+    let fee_payer = fee_payer_keypair.pubkey();
+
+    let mut fee_payer_data =
+        AccountSharedData::new(LAMPORTS_PER_SOL * 10, 0, &system_program::id());
+    fee_payer_data.set_rent_epoch(u64::MAX);
+    test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+    // Mock an account owned by Loader V4.
+    //
+    // Currently there is no way to create a valid Loader V4-owned program on
+    // any network, since the feature has never been enabled. However, accounts
+    // can still be assigned to Loader V4, but their data must be all-zeroes.
+    let loader_v4_account_id = Pubkey::new_unique();
+    let mut loader_v4_account_data =
+        AccountSharedData::new(LAMPORTS_PER_SOL, 10_240, &loader_v4::id());
+    loader_v4_account_data.set_rent_epoch(u64::MAX);
+    test_entry.add_initial_account(loader_v4_account_id, &loader_v4_account_data);
+
+    let recipient = Pubkey::new_unique();
+
+    // tx 0: single-instruction invocation of the Loader V4-owned account.
+    let single_ix_tx = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            loader_v4_account_id,
+            &[],
+            vec![],
+        )],
+        Some(&fee_payer),
+        &[&fee_payer_keypair],
+        Hash::default(),
+    );
+    test_entry.push_transaction_with_status(single_ix_tx, ExecutionStatus::ExecutedFailed);
+
+    // tx 1: system transfer + Loader V4 invocation.
+    let multi_ix_tx = Transaction::new_signed_with_payer(
+        &[
+            system_instruction::transfer(&fee_payer, &recipient, 1),
+            Instruction::new_with_bytes(loader_v4_account_id, &[], vec![]),
+        ],
+        Some(&fee_payer),
+        &[&fee_payer_keypair],
+        Hash::default(),
+    );
+    test_entry.push_transaction_with_status(multi_ix_tx, ExecutionStatus::ExecutedFailed);
+
+    // Each failed tx still pays the signature fee.
+    test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE * 2);
+
+    let env = SvmTestEnvironment::create(test_entry);
+    let output = env.execute();
+
+    // tx 0: failing instruction is at index 0, no CUs consumed because the
+    // Loader V4 instruction short-circuits in `process_executable_chain`
+    // before reaching `consume_checked`.
+    let executed = output.processing_results[0]
+        .processed_transaction()
+        .unwrap()
+        .execution_details()
+        .unwrap();
+    assert_eq!(
+        executed.status,
+        Err(TransactionError::InstructionError(
+            0,
+            InstructionError::UnsupportedProgramId,
+        )),
+    );
+    assert_eq!(executed.executed_units, 0);
+
+    // tx 1: failing instruction is at index 1; ix 0 (system transfer) ran
+    // to completion and consumed builtin CUs. Those CUs are visible to the
+    // cost tracker precisely *because* the transaction stayed on the
+    // executed-failed path instead of degrading to fees-only.
+    let executed = output.processing_results[1]
+        .processed_transaction()
+        .unwrap()
+        .execution_details()
+        .unwrap();
+    assert_eq!(
+        executed.status,
+        Err(TransactionError::InstructionError(
+            1,
+            InstructionError::UnsupportedProgramId,
+        )),
+    );
+    assert!(executed.executed_units > 0);
 }
 
 #[test_case(false, false; "close::scan_only")]


### PR DESCRIPTION
#### Problem
As per [RFC-0423](https://github.com/solana-foundation/solana-improvement-documents/discussions/423), Loader V4 will be redesigned and reintroduced as an on-chain program. The builtin implementation should be removed.

#### Summary of Changes
This is the final precursor to removing Loader V4 from the validator.

The most consensus-sensitive piece is within `svm`, so I intentionally left all ownership checks in account/program loading in-tact. This change really just removes state parsing attempts (using `solana-loader-v4-interface`) from the transaction processing pipeline, operating under the assumption that they were always failing anyway.

This PR also safely bumps `solana-account` to 4.2.0, which contains [this change](https://github.com/anza-xyz/solana-sdk/pull/654), removing Loader V4 from `PROGRAM_OWNERS`. In both places where `PROGRAM_OWNERS` is used, I've also manually included Loader V4's ID with a comment.

Broken off https://github.com/anza-xyz/agave/pull/10396