### PR TITLE
retain CAP_DAC_OVERRIDE to avoid breaking running validator as root

### DIFF
--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -94,6 +94,7 @@ pub fn execute(
     matches: &ArgMatches,
     solana_version: &str,
     operation: Operation,
+    config: super::Config,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Debugging panics is easier with a backtrace
     if env::var_os("RUST_BACKTRACE").is_none() {
@@ -262,6 +263,9 @@ pub fn execute(
 
     let exit = Arc::new(AtomicBool::new(false));
 
+    #[cfg(not(target_os = "linux"))]
+    let _ = config;
+
     #[cfg(target_os = "linux")]
     let xdp_builder_with_src_addr = {
         use {
@@ -272,15 +276,22 @@ pub fn execute(
             },
         };
 
+        let super::Config { primordial_caps } = config;
+
         let mut required_caps = HashSet::new();
         let mut retained_caps = HashSet::new();
-        let supported_caps = HashSet::from_iter([
+        let mut supported_caps = HashSet::from_iter([
             CAP_BPF,
             CAP_NET_ADMIN,
             CAP_NET_RAW,
             CAP_PERFMON,
             CAP_SYS_NICE,
         ]);
+
+        // make sure we keep any primordial caps
+        supported_caps.extend(primordial_caps.clone());
+        required_caps.extend(primordial_caps.clone());
+        retained_caps.extend(primordial_caps.clone());
 
         if let Some(xdp_config) = retransmit_xdp.as_ref() {
             required_caps.insert(CAP_NET_ADMIN);

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -328,9 +328,12 @@ pub fn execute(
                  consider removing them from your operational configuration.",
             );
         }
+
         // drop all caps that the current configuration does not require
+        caps::set(None, CapSet::Effective, &required_caps)
+            .expect("linux allows effective capset to be set");
         caps::set(None, CapSet::Permitted, &required_caps)
-            .expect("permitted capset to be writable");
+            .expect("linux allows permitted capset to be set");
 
         // XDP _MUST_ be setup _BEFORE_ the app spawns any threads to ensure linux
         // capabilities do not leak, leaving the process in a state where it could
@@ -368,6 +371,8 @@ pub fn execute(
         });
 
         // we're done with caps needed to init xdp now. remove them from our process
+        caps::set(None, CapSet::Effective, &retained_caps)
+            .expect("linux allows effective capset to be set");
         caps::set(None, CapSet::Permitted, &retained_caps)
             .expect("linux allows permitted capset to be set");
 

--- a/validator/src/commands/run/mod.rs
+++ b/validator/src/commands/run/mod.rs
@@ -2,3 +2,8 @@ pub mod args;
 pub mod execute;
 
 pub use {args::add_args, execute::execute};
+
+pub struct Config {
+    #[cfg(target_os = "linux")]
+    pub primordial_caps: caps::CapsHashSet,
+}

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -25,8 +25,9 @@ pub fn main() {
     let (subcommand, maybe_subcommand_matches) = matches.subcommand();
 
     #[cfg(target_os = "linux")]
-    {
-        use caps::CapSet;
+    let run_config = {
+        use caps::{CapSet, Capability::CAP_DAC_OVERRIDE, CapsHashSet};
+
         // we don't aim to execve from the validator, so we can clear most of the
         // capability sets. clear the ambient set explicitly even though it is
         // implicitly cleared by clearing the inheritable set
@@ -35,23 +36,48 @@ pub fn main() {
             .expect("linux allows inheritable capset to be cleared");
 
         // we'll raise caps when and where we need them
-        caps::clear(None, CapSet::Effective).expect("linux allows effective capset to be cleared");
+        let primordial_caps = if subcommand.is_empty() || subcommand == "run" {
+            // the CAP_DAC_OVERRIDE (file permissions bypass) cap isn't typically needed.
+            // however if it is already in our effective set, likely due to the operator
+            // foolishly running the node as root, either via sudo or suid, we need to
+            // retain it to ensure expected filesystem accessibility
+            let retain_if_set = CapsHashSet::from([CAP_DAC_OVERRIDE]);
+            let permitted = caps::read(None, CapSet::Permitted)
+                .expect("linux allows permitted capset to be read");
+            let effective = caps::read(None, CapSet::Effective)
+                .expect("linux allows effective capset to be read");
+            let primordial_caps =
+                CapsHashSet::from_iter(retain_if_set.intersection(&permitted).copied());
+            let primordial_caps =
+                CapsHashSet::from_iter(primordial_caps.intersection(&effective).copied());
 
-        if !(subcommand.is_empty() || subcommand == "run") {
+            caps::set(None, CapSet::Effective, &primordial_caps)
+                .expect("linux allows effective capset to be set");
+
+            primordial_caps
+        } else {
             caps::clear(None, CapSet::Effective)
                 .expect("linux allows effective capset to be cleared");
             // we only need caps to run the actual valididator. clear them here
             // for all other subcommands
             caps::clear(None, CapSet::Permitted)
-                .expect("linux allows permitted capset to be cleared")
-        }
-    }
+                .expect("linux allows permitted capset to be cleared");
+
+            CapsHashSet::new()
+        };
+
+        commands::run::Config { primordial_caps }
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    let run_config = commands::run::Config {};
 
     match (subcommand, maybe_subcommand_matches) {
         ("init", _) => commands::run::execute(
             &matches,
             solana_version,
             commands::run::execute::Operation::Initialize,
+            run_config,
         )
         .inspect_err(|err| error!("Failed to initialize validator: {err}"))
         .map_err(commands::Error::Dynamic),
@@ -59,6 +85,7 @@ pub fn main() {
             &matches,
             solana_version,
             commands::run::execute::Operation::Run,
+            run_config,
         )
         .inspect_err(|err| error!("Failed to start validator: {err}"))
         .map_err(commands::Error::Dynamic),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -38,6 +38,8 @@ pub fn main() {
         caps::clear(None, CapSet::Effective).expect("linux allows effective capset to be cleared");
 
         if !(subcommand.is_empty() || subcommand == "run") {
+            caps::clear(None, CapSet::Effective)
+                .expect("linux allows effective capset to be cleared");
             // we only need caps to run the actual valididator. clear them here
             // for all other subcommands
             caps::clear(None, CapSet::Permitted)

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -287,6 +287,8 @@ impl TransmitterBuilder {
             || {
                 // we need to retain CAP_NET_ADMIN in case the netlink socket needs reinitialized
                 let retained_caps = caps::CapsHashSet::from_iter([caps::Capability::CAP_NET_ADMIN]);
+                caps::set(None, caps::CapSet::Effective, &retained_caps)
+                    .expect("linux allows effective capset to be set");
                 caps::set(None, caps::CapSet::Permitted, &retained_caps)
                     .expect("linux allows permitted capset to be set");
                 info!("route monitor thread started");


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/9133 was a little aggressive with dropping "unneeded" capabilities. this broke running the validator as root. which i mean... good you fucking deserve it, but we'll kill the ability to do so more smoothly

#### Summary of Changes
be sure to retain CAP_DAC_OVERRIDE if it's already in the process' effective cap set so we don't lose file permissions bypass