### PR TITLE
Decouple bind address from public ip, add `--advertised-ip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Release channels have their own copy of this changelog:
 #### Changes
 ### Validator
 #### Breaking
-* `--bind-address` no longer determines the validator's advertised gossip IP. Use `--advertised-ip` to explicitly set the advertised public IP; otherwise the validator resolves it via the entrypoint IP echo server, or falls back to `127.0.0.1` when no entrypoint is configured.
+* `--bind-address` no longer determines the validator's advertised gossip IP. Use `--advertised-ip` to explicitly set the advertised public IP; otherwise the validator resolves it via the entrypoint IP echo server, or falls back to `127.0.0.1` when no entrypoint is configured. Bootstrap validators that do not pass `--entrypoint` must now also pass `--advertised-ip`.
 #### Deprecations
 * Using `minimal` for `--accounts-index-limit` is now deprecated.
 * `--account-shrink-path` is now deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ Release channels have their own copy of this changelog:
 #### Changes
 ### Validator
 #### Breaking
+* `--bind-address` no longer determines the validator's advertised gossip IP. Use `--advertised-ip` to explicitly set the advertised public IP; otherwise the validator resolves it via the entrypoint IP echo server, or falls back to `127.0.0.1` when no entrypoint is configured.
 #### Deprecations
 * Using `minimal` for `--accounts-index-limit` is now deprecated.
 * `--account-shrink-path` is now deprecated.
 #### Changes
+* Added `--advertised-ip` to configure the validator's advertised gossip IP independently of `--bind-address`. In multihomed configurations, the active `--bind-address` continues to be advertised.
 
 ## 4.0.0
 ### RPC

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -634,7 +634,6 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("HOST")
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
-                .hidden(hidden_unless_forced())
                 .help(
                     "Use when running a validator behind a NAT. DNS name or IP address for this \
                      validator to advertise in gossip. This address will be used as the target \

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -635,13 +635,10 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
                 .help(
-                    "Use when running a validator behind a NAT. DNS name or IP address for this \
-                     validator to advertise in gossip. This address will be used as the target \
-                     destination address for peers trying to contact this node. [default: the \
-                     first --bind-address, or ask --entrypoint when --bind-address is not \
-                     provided, or 127.0.0.1 when --entrypoint is not provided]. Note: this \
-                     argument cannot be used in a multihoming context (when multiple \
-                     --bind-address values are provided).",
+                    "Public IP address for this validator to advertise in gossip. [default: ask \
+                     --entrypoint via its IP echo server, or 127.0.0.1 when --entrypoint is not \
+                     provided]. In a multihoming context (> 1 --bind-address), this flag is \
+                     ignored and the active --bind-address is advertised instead.",
                 ),
         )
         .arg(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -802,12 +802,10 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .validator(solana_net_utils::is_host)
             .help(
-                "Use when running a validator behind a NAT. DNS name or IP address for this \
-                 validator to advertise in gossip. This address will be used as the target \
-                 destination address for peers trying to contact this node. [default: ask \
-                 --entrypoint, or 127.0.0.1 when --entrypoint is not provided]. Note: this \
-                 argument cannot be used in a multihoming context (when multiple --bind-address \
-                 values are provided).",
+                "Public IP address for this validator to advertise in gossip. [default: ask \
+                 --entrypoint via its IP echo server, or 127.0.0.1 when --entrypoint is not \
+                 provided]. In a multihoming context (> 1 --bind-address), this flag is ignored \
+                 and the active --bind-address is advertised instead.",
             ),
     )
     .arg(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -796,6 +796,21 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
+        Arg::with_name("advertised_ip")
+            .long("advertised-ip")
+            .value_name("HOST")
+            .takes_value(true)
+            .validator(solana_net_utils::is_host)
+            .help(
+                "Use when running a validator behind a NAT. DNS name or IP address for this \
+                 validator to advertise in gossip. This address will be used as the target \
+                 destination address for peers trying to contact this node. [default: ask \
+                 --entrypoint, or 127.0.0.1 when --entrypoint is not provided]. Note: this \
+                 argument cannot be used in a multihoming context (when multiple --bind-address \
+                 values are provided).",
+            ),
+    )
+    .arg(
         Arg::with_name("rpc_bind_address")
             .long("rpc-bind-address")
             .value_name("HOST")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -177,36 +177,7 @@ pub fn execute(
         })
         .transpose()?;
 
-    let advertised_ip = if let Some(cli_ip) = advertised_ip {
-        cli_ip
-    } else if !entrypoint_addrs.is_empty() {
-        let mut order: Vec<_> = (0..entrypoint_addrs.len()).collect();
-        order.shuffle(&mut rng());
-
-        order
-            .into_iter()
-            .find_map(|i| {
-                let entrypoint_addr = &entrypoint_addrs[i];
-                info!(
-                    "Contacting {entrypoint_addr} to determine the validator's public IP \
-                     address"
-                );
-                solana_net_utils::get_public_ip_addr_with_binding(
-                    entrypoint_addr,
-                    bind_addresses.active(),
-                )
-                .map_or_else(
-                    |err| {
-                        warn!("Failed to contact cluster entrypoint {entrypoint_addr}: {err}");
-                        None
-                    },
-                    Some,
-                )
-            })
-            .ok_or_else(|| "unable to determine the validator's public IP address".to_string())?
-    } else {
-        IpAddr::V4(Ipv4Addr::LOCALHOST)
-    };
+    let advertised_ip = resolve_advertised_ip(&bind_addresses, advertised_ip, &entrypoint_addrs)?;
     let gossip_port = value_t!(matches, "gossip_port", u16).or_else(|_| {
         solana_net_utils::find_available_port_in_range(bind_addresses.active(), (0, 1))
             .map_err(|err| format!("unable to find an available gossip port: {err}"))
@@ -236,10 +207,15 @@ pub fn execute(
         })
         .transpose()?;
 
-    if bind_addresses.len() > 1 && public_tvu_addr.is_some() {
-        Err(String::from(
-            "--public-tvu-address can not be used in a multihoming context",
-        ))?;
+    if bind_addresses.multihoming_enabled() {
+        for (addr, flag) in [
+            (public_tvu_addr.is_some(), "--public-tvu-address"),
+            (public_tpu_addr.is_some(), "--public-tpu-address"),
+        ] {
+            if addr {
+                Err(format!("{flag} can not be used in a multihoming context"))?;
+            }
+        }
     }
 
     let num_quic_endpoints = value_t_or_exit!(matches, "num_quic_endpoints", NonZeroUsize);
@@ -469,23 +445,6 @@ pub fn execute(
         "gossip_validators",
         "--gossip-validator",
     )?;
-
-    if bind_addresses.len() > 1 {
-        for (flag, msg) in [
-            (
-                "advertised_ip",
-                "--advertised-ip cannot be used in a multihoming context",
-            ),
-            (
-                "public_tpu_addr",
-                "--public-tpu-address can not be used in a multihoming context",
-            ),
-        ] {
-            if matches.is_present(flag) {
-                Err(String::from(msg))?;
-            }
-        }
-    }
 
     let rpc_bind_address = if matches.is_present("rpc_bind_address") {
         solana_net_utils::parse_host(matches.value_of("rpc_bind_address").unwrap())
@@ -1187,6 +1146,44 @@ fn get_cluster_shred_version(entrypoints: &[SocketAddr], bind_address: IpAddr) -
     None
 }
 
+fn resolve_advertised_ip(
+    bind_addresses: &BindIpAddrs,
+    cli_advertised_ip: Option<IpAddr>,
+    entrypoint_addrs: &[SocketAddr],
+) -> Result<IpAddr, String> {
+    if bind_addresses.multihoming_enabled() {
+        Ok(bind_addresses.active())
+    } else if let Some(cli_ip) = cli_advertised_ip {
+        Ok(cli_ip)
+    } else if !entrypoint_addrs.is_empty() {
+        let mut order: Vec<_> = (0..entrypoint_addrs.len()).collect();
+        order.shuffle(&mut rng());
+
+        order
+            .into_iter()
+            .find_map(|i| {
+                let entrypoint_addr = &entrypoint_addrs[i];
+                info!(
+                    "Contacting {entrypoint_addr} to determine the validator's public IP address"
+                );
+                solana_net_utils::get_public_ip_addr_with_binding(
+                    entrypoint_addr,
+                    bind_addresses.active(),
+                )
+                .map_or_else(
+                    |err| {
+                        warn!("Failed to contact cluster entrypoint {entrypoint_addr}: {err}");
+                        None
+                    },
+                    Some,
+                )
+            })
+            .ok_or_else(|| "unable to determine the validator's public IP address".to_string())
+    } else {
+        Ok(IpAddr::V4(Ipv4Addr::LOCALHOST))
+    }
+}
+
 fn parse_banking_trace_dir_byte_limit(matches: &ArgMatches) -> u64 {
     if matches.is_present("disable_banking_trace") {
         // disable with an explicit flag; This effectively becomes `opt-out` by resetting to
@@ -1375,4 +1372,123 @@ fn new_snapshot_config(
     }
 
     Ok(snapshot_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            cli::{DefaultArgs, thread_args::thread_args},
+            commands::run::args::add_args,
+        },
+        clap::App,
+        std::net::Ipv4Addr,
+    };
+
+    fn bind_addresses_from_args(args: &[&str]) -> BindIpAddrs {
+        let default_args = DefaultArgs::new();
+        let matches = add_args(App::new("run_command"), &default_args)
+            .args(&thread_args(&default_args.thread_args))
+            .get_matches_from(args);
+
+        let parsed = matches
+            .values_of("bind_address")
+            .expect("bind_address should always be present due to default")
+            .map(solana_net_utils::parse_host)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        BindIpAddrs::new(parsed).unwrap()
+    }
+
+    fn cli_advertised_ip_from_args(args: &[&str]) -> Option<IpAddr> {
+        let default_args = DefaultArgs::new();
+        let matches = add_args(App::new("run_command"), &default_args)
+            .args(&thread_args(&default_args.thread_args))
+            .get_matches_from(args);
+
+        matches
+            .value_of("advertised_ip")
+            .map(|advertised_ip| solana_net_utils::parse_host(advertised_ip).unwrap())
+    }
+
+    #[test]
+    fn resolve_advertised_ip_is_decoupled_unless_multihoming() {
+        let cli_ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10));
+
+        let single_bind = BindIpAddrs::new(vec![IpAddr::V4(Ipv4Addr::LOCALHOST)]).unwrap();
+        assert_eq!(
+            resolve_advertised_ip(&single_bind, Some(cli_ip), &[]).unwrap(),
+            cli_ip,
+        );
+
+        let multihomed = BindIpAddrs::new(vec![
+            IpAddr::V4(Ipv4Addr::new(198, 51, 100, 10)),
+            IpAddr::V4(Ipv4Addr::new(198, 51, 100, 11)),
+        ])
+        .unwrap();
+        assert_eq!(
+            resolve_advertised_ip(&multihomed, Some(cli_ip), &[]).unwrap(),
+            multihomed.active(),
+        );
+    }
+
+    #[test]
+    fn single_homed_advertised_ip_without_entrypoint_uses_default_bind_address() {
+        let args = ["run_command", "--advertised-ip", "192.0.2.10"];
+        let bind_addresses = bind_addresses_from_args(&args);
+        let cli_advertised_ip = cli_advertised_ip_from_args(&args);
+
+        assert_eq!(bind_addresses.active(), IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        assert_eq!(
+            resolve_advertised_ip(&bind_addresses, cli_advertised_ip, &[]).unwrap(),
+            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+        );
+    }
+
+    #[test]
+    fn single_homed_advertised_ip_with_entrypoint_uses_default_bind_address() {
+        let args = [
+            "run_command",
+            "--advertised-ip",
+            "192.0.2.10",
+            "--entrypoint",
+            "203.0.113.20:8001",
+        ];
+        let bind_addresses = bind_addresses_from_args(&args);
+        let cli_advertised_ip = cli_advertised_ip_from_args(&args);
+
+        assert_eq!(bind_addresses.active(), IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        assert_eq!(
+            resolve_advertised_ip(
+                &bind_addresses,
+                cli_advertised_ip,
+                &[SocketAddr::from((Ipv4Addr::new(203, 0, 113, 20), 8001))],
+            )
+            .unwrap(),
+            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+        );
+    }
+
+    #[test]
+    fn single_homed_explicit_bind_address_and_advertised_ip_stay_distinct() {
+        let args = [
+            "run_command",
+            "--bind-address",
+            "198.51.100.10",
+            "--advertised-ip",
+            "192.0.2.10",
+        ];
+        let bind_addresses = bind_addresses_from_args(&args);
+        let cli_advertised_ip = cli_advertised_ip_from_args(&args);
+
+        assert_eq!(
+            bind_addresses.active(),
+            IpAddr::V4(Ipv4Addr::new(198, 51, 100, 10)),
+        );
+        assert_eq!(
+            resolve_advertised_ip(&bind_addresses, cli_advertised_ip, &[]).unwrap(),
+            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+        );
+    }
 }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -179,8 +179,6 @@ pub fn execute(
 
     let advertised_ip = if let Some(cli_ip) = advertised_ip {
         cli_ip
-    } else if !bind_addresses.active().is_unspecified() && !bind_addresses.active().is_loopback() {
-        bind_addresses.active()
     } else if !entrypoint_addrs.is_empty() {
         let mut order: Vec<_> = (0..entrypoint_addrs.len()).collect();
         order.shuffle(&mut rng());
@@ -190,7 +188,8 @@ pub fn execute(
             .find_map(|i| {
                 let entrypoint_addr = &entrypoint_addrs[i];
                 info!(
-                    "Contacting {entrypoint_addr} to determine the validator's public IP address"
+                    "Contacting {entrypoint_addr} to determine the validator's public IP \
+                     address"
                 );
                 solana_net_utils::get_public_ip_addr_with_binding(
                     entrypoint_addr,
@@ -475,9 +474,7 @@ pub fn execute(
         for (flag, msg) in [
             (
                 "advertised_ip",
-                "--advertised-ip cannot be used in a multihoming context. In multihoming, the \
-                 validator will advertise the first --bind-address as this node's public IP \
-                 address.",
+                "--advertised-ip cannot be used in a multihoming context",
             ),
             (
                 "public_tpu_addr",


### PR DESCRIPTION
First PR in the quest to remove ip echo ip discovery. see: https://github.com/anza-xyz/agave/pull/11586

#### Problem
If we remove public IP discovery, we also need to decouple the meaning of `--bind-address`:
1) if user does not pass in `--bind-address`, they rely on the ip echo server to get their public IP
2) if a user does pass in --bind-address, they will bind to the `--bind-address` locally and then set that same address as their public IP. This is very confusing and doesn't work if running behind a NAT

#### Summary of Changes
1) user can specify a public ip address they want to advertise via `--advertised-ip`
2) bind address never sets public ip unless in multihoming context