### PR TITLE
fix: metric double counting

### DIFF
--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -597,10 +597,6 @@ impl LeaderSlotMetricsTracker {
                 .cost_model_throttled_transactions_count += cost_model_throttled_transactions_count;
 
             leader_slot_metrics
-                .packet_count_metrics
-                .cost_model_throttled_transactions_count += cost_model_throttled_transactions_count;
-
-            leader_slot_metrics
                 .timing_metrics
                 .process_packets_timings
                 .cost_model_us += cost_model_us;


### PR DESCRIPTION
#### Problem

Hi team, this PR fixes a metric-related issue: `cost_model_throttled_transactions_count` is submitted twice (overestimated).

#### Summary of Changes

Removed one of the recordings.

Fixes #

As above.