### PR TITLE
refactor syscalls: get the MemoryMapping from InvokeContext instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10140,8 +10140,6 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 [[package]]
 name = "solana-sbpf"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc6fee0979c35ae053780a071927b068f5d9a5cb12e12b043a5ea60d67a53ca"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10139,7 +10139,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.17.0"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd96c15a4cb8884e9b660cb71796d1bca8d3eb6d38e68067508ce37dc66874bc"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -624,3 +624,4 @@ codegen-units = 1
 [patch.crates-io]
 # for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
+solana-sbpf = { path = "../sbpf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -478,7 +478,7 @@ solana-rpc-client-types = { path = "rpc-client-types", version = "=4.1.0-alpha.0
 solana-runtime = { path = "runtime", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-sanitize = "3.0.1"
-solana-sbpf = { version = "=0.17.0", default-features = false }
+solana-sbpf = { version = "=0.18.0", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-secp256k1-program = "3.0.1"
 solana-secp256k1-recover = "3.1.1"
@@ -624,4 +624,3 @@ codegen-units = 1
 [patch.crates-io]
 # for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
-solana-sbpf = { path = "../sbpf" }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8696,9 +8696,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc6fee0979c35ae053780a071927b068f5d9a5cb12e12b043a5ea60d67a53ca"
+checksum = "fd96c15a4cb8884e9b660cb71796d1bca8d3eb6d38e68067508ce37dc66874bc"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -137,7 +137,7 @@ solana-rpc-client = { path = "../rpc-client", version = "=4.1.0-alpha.0", defaul
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=4.1.0-alpha.0" }
 solana-runtime = { path = "../runtime", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-runtime-transaction = { path = "../runtime-transaction", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-sbpf = { version = "=0.17.0", default-features = false }
+solana-sbpf = { version = "=0.18.0", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-shred-version = "3.0.1"
 solana-signature = { version = "3.3.0", default-features = false }

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -536,10 +536,10 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     let (instruction_count, result) = vm.execute_program(&verified_executable, &mut execution_mode);
     let duration = Instant::now() - start_time;
     if let Some(trace_option) = matches.value_of("trace") {
-        // SAFETY: VM is the only holder of the InvokeContext reference, as it carries its lifetime.
-        let invoke_context_ref = unsafe { vm.context_object_pointer.as_mut() };
-        invoke_context_ref.iterate_vm_traces(
-            &|instruction_context: InstructionContext, executable, register_trace| {
+        vm.context()
+            .iterate_vm_traces(&|instruction_context: InstructionContext,
+                                 executable,
+                                 register_trace| {
                 let mut analysis = LazyAnalysis::new(executable);
                 if trace_option == "stdout" {
                     writeln!(
@@ -572,8 +572,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
                         .disassemble_register_trace(&mut fd, register_trace)
                         .unwrap();
                 }
-            },
-        );
+            });
     }
     drop(vm);
 

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -282,6 +282,8 @@ impl<'a> CallerAccount<'a> {
     // Create a CallerAccount given an AccountInfo.
     pub fn from_account_info(
         invoke_context: &InvokeContext,
+        memory_mapping: &MemoryMapping,
+        check_aligned: bool,
         _vm_addr: u64,
         account_info: &solana_account_info::AccountInfo,
         account_metadata: &crate::invoke_context::SerializedAccountMetadata,
@@ -314,8 +316,6 @@ impl<'a> CallerAccount<'a> {
 
         // account_info points to host memory. The addresses used internally are
         // in vm space so they need to be translated.
-        let check_aligned = invoke_context.get_check_aligned();
-        let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
         let lamports = {
             // Double translate lamports out of RefCell
             let ptr = translate_type::<u64>(
@@ -416,6 +416,8 @@ impl<'a> CallerAccount<'a> {
     // Create a CallerAccount given a SolAccountInfo.
     fn from_sol_account_info(
         invoke_context: &InvokeContext,
+        memory_mapping: &MemoryMapping,
+        check_aligned: bool,
         vm_addr: u64,
         account_info: &SolAccountInfo,
         account_metadata: &crate::invoke_context::SerializedAccountMetadata,
@@ -461,8 +463,6 @@ impl<'a> CallerAccount<'a> {
             )?;
         }
 
-        let check_aligned = invoke_context.get_check_aligned();
-        let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
         // account_info points to host memory. The addresses used internally are
         // in vm space so they need to be translated.
         let lamports = translate_type_mut_for_cpi::<u64>(
@@ -618,17 +618,23 @@ pub fn translate_accounts_rust<'a>(
     account_infos_len: u64,
     invoke_context: &InvokeContext,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
+    let check_aligned = invoke_context.get_check_aligned();
+    let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
     translate_account_infos(
         account_infos_addr,
         account_infos_len,
         |account_info: &AccountInfo| account_info.key as *const _ as u64,
         invoke_context,
+        memory_mapping,
+        check_aligned,
         |account_infos, account_info_keys| {
             translate_accounts_common(
                 &account_info_keys,
                 account_infos,
                 account_infos_addr,
                 invoke_context,
+                memory_mapping,
+                check_aligned,
                 CallerAccount::from_account_info,
             )
         },
@@ -753,17 +759,23 @@ pub fn translate_accounts_c<'a>(
     account_infos_len: u64,
     invoke_context: &InvokeContext,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
+    let check_aligned = invoke_context.get_check_aligned();
+    let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
     translate_account_infos(
         account_infos_addr,
         account_infos_len,
         |account_info: &SolAccountInfo| account_info.key_addr,
         invoke_context,
+        memory_mapping,
+        check_aligned,
         |account_infos, account_info_keys| {
             translate_accounts_common(
                 &account_info_keys,
                 account_infos,
                 account_infos_addr,
                 invoke_context,
+                memory_mapping,
+                check_aligned,
                 CallerAccount::from_sol_account_info,
             )
         },
@@ -943,13 +955,13 @@ fn translate_account_infos<T, R>(
     account_infos_len: u64,
     key_addr: impl Fn(&T) -> u64,
     invoke_context: &InvokeContext,
+    memory_mapping: &MemoryMapping,
+    check_aligned: bool,
     cb: impl FnOnce(&[T], Vec<&Pubkey>) -> R,
 ) -> Result<R, Error> {
     let syscall_parameter_address_restrictions = invoke_context
         .get_feature_set()
         .syscall_parameter_address_restrictions;
-    let check_aligned = invoke_context.get_check_aligned();
-    let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
 
     // In the same vein as the other check_account_info_pointer() checks, we don't lock
     // this pointer to a specific address but we don't want it to be inside accounts, or
@@ -997,10 +1009,19 @@ fn translate_accounts_common<'a, T, F>(
     account_infos: &[T],
     account_infos_addr: u64,
     invoke_context: &InvokeContext,
+    memory_mapping: &MemoryMapping,
+    check_aligned: bool,
     do_translate: F,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error>
 where
-    F: Fn(&InvokeContext, u64, &T, &SerializedAccountMetadata) -> Result<CallerAccount<'a>, Error>,
+    F: Fn(
+        &InvokeContext,
+        &MemoryMapping,
+        bool,
+        u64,
+        &T,
+        &SerializedAccountMetadata,
+    ) -> Result<CallerAccount<'a>, Error>,
 {
     let transaction_context = &invoke_context.transaction_context;
     let next_instruction_context = transaction_context.get_next_instruction_context()?;
@@ -1071,6 +1092,8 @@ where
             let caller_account =
                 do_translate(
                     invoke_context,
+                    memory_mapping,
+                    check_aligned,
                     account_infos_addr.saturating_add(
                         caller_account_index.saturating_mul(mem::size_of::<T>()) as u64,
                     ),
@@ -1093,8 +1116,6 @@ where
                 // account (caller_account). We need to update the corresponding
                 // BorrowedAccount (callee_account) so the callee can see the
                 // changes.
-                let check_aligned = invoke_context.get_check_aligned();
-                let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
                 update_callee_account(
                     memory_mapping,
                     check_aligned,
@@ -1998,8 +2019,12 @@ mod tests {
         invoke_context
             .memory_contexts
             .mock_set_mapping(memory_mapping);
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping().unwrap();
         let caller_account = CallerAccount::from_account_info(
             &invoke_context,
+            memory_mapping,
+            check_aligned,
             vm_addr,
             account_info,
             &account_metadata,

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1967,7 +1967,9 @@ mod tests {
 
         let account_info = translate_type::<AccountInfo>(&memory_mapping, vm_addr, false).unwrap();
 
-        invoke_context.memory_contexts.mock_set_mapping(memory_mapping);
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         let caller_account = CallerAccount::from_account_info(
             &invoke_context,
             vm_addr,

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -282,8 +282,6 @@ impl<'a> CallerAccount<'a> {
     // Create a CallerAccount given an AccountInfo.
     pub fn from_account_info(
         invoke_context: &InvokeContext,
-        memory_mapping: &solana_sbpf::memory_region::MemoryMapping,
-        check_aligned: bool,
         _vm_addr: u64,
         account_info: &solana_account_info::AccountInfo,
         account_metadata: &crate::invoke_context::SerializedAccountMetadata,
@@ -316,6 +314,8 @@ impl<'a> CallerAccount<'a> {
 
         // account_info points to host memory. The addresses used internally are
         // in vm space so they need to be translated.
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
         let lamports = {
             // Double translate lamports out of RefCell
             let ptr = translate_type::<u64>(
@@ -366,7 +366,7 @@ impl<'a> CallerAccount<'a> {
                 )?;
             } else {
                 // Moved to translate_accounts_common() via feature gate.
-                invoke_context.consume_checked(
+                invoke_context.compute_meter.consume_checked(
                     (data.len() as u64)
                         .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
                         .unwrap_or(u64::MAX),
@@ -416,8 +416,6 @@ impl<'a> CallerAccount<'a> {
     // Create a CallerAccount given a SolAccountInfo.
     fn from_sol_account_info(
         invoke_context: &InvokeContext,
-        memory_mapping: &solana_sbpf::memory_region::MemoryMapping,
-        check_aligned: bool,
         vm_addr: u64,
         account_info: &SolAccountInfo,
         account_metadata: &crate::invoke_context::SerializedAccountMetadata,
@@ -463,6 +461,8 @@ impl<'a> CallerAccount<'a> {
             )?;
         }
 
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
         // account_info points to host memory. The addresses used internally are
         // in vm space so they need to be translated.
         let lamports = translate_type_mut_for_cpi::<u64>(
@@ -478,7 +478,7 @@ impl<'a> CallerAccount<'a> {
 
         if !syscall_parameter_address_restrictions {
             // Moved to translate_accounts_common() via feature gate.
-            invoke_context.consume_checked(
+            invoke_context.compute_meter.consume_checked(
                 account_info
                     .data_len
                     .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
@@ -533,32 +533,27 @@ impl<'a> CallerAccount<'a> {
 pub trait SyscallInvokeSigned {
     fn translate_instruction(
         addr: u64,
-        memory_mapping: &MemoryMapping,
         invoke_context: &mut InvokeContext,
-        check_aligned: bool,
     ) -> Result<Instruction, Error>;
     fn translate_accounts<'a>(
         account_infos_addr: u64,
         account_infos_len: u64,
-        memory_mapping: &MemoryMapping,
         invoke_context: &mut InvokeContext,
-        check_aligned: bool,
     ) -> Result<Vec<TranslatedAccount<'a>>, Error>;
     fn translate_signers(
         program_id: &Pubkey,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
-        memory_mapping: &MemoryMapping,
-        check_aligned: bool,
+        invoke_context: &mut InvokeContext,
     ) -> Result<Vec<Pubkey>, Error>;
 }
 
 pub fn translate_instruction_rust(
     addr: u64,
-    memory_mapping: &MemoryMapping,
     invoke_context: &mut InvokeContext,
-    check_aligned: bool,
 ) -> Result<Instruction, Error> {
+    let check_aligned = invoke_context.get_check_aligned();
+    let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
     let ix = translate_type::<StableInstruction>(memory_mapping, addr, check_aligned)?;
     let account_metas = translate_slice::<mem::MaybeUninit<AccountMeta>>(
         memory_mapping,
@@ -588,7 +583,9 @@ pub fn translate_instruction_rust(
     total_cu_translation_cost =
         total_cu_translation_cost.saturating_add(account_meta_translation_cost);
 
-    consume_compute_meter(invoke_context, total_cu_translation_cost)?;
+    invoke_context
+        .compute_meter
+        .consume_checked(total_cu_translation_cost)?;
 
     let mut accounts = Vec::with_capacity(account_metas.len());
     for account_meta in account_metas {
@@ -619,27 +616,14 @@ pub fn translate_instruction_rust(
 pub fn translate_accounts_rust<'a>(
     account_infos_addr: u64,
     account_infos_len: u64,
-    memory_mapping: &MemoryMapping,
     invoke_context: &mut InvokeContext,
-    check_aligned: bool,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
-    let (account_infos, account_info_keys) = translate_account_infos(
+    translate_accounts_common(
         account_infos_addr,
         account_infos_len,
-        |account_info: &AccountInfo| account_info.key as *const _ as u64,
-        memory_mapping,
         invoke_context,
-        check_aligned,
-    )?;
-
-    translate_accounts_common(
-        &account_info_keys,
-        account_infos,
-        account_infos_addr,
-        invoke_context,
-        memory_mapping,
-        check_aligned,
         CallerAccount::from_account_info,
+        |account_info: &AccountInfo| account_info.key as *const _ as u64,
     )
 }
 
@@ -647,9 +631,10 @@ pub fn translate_signers_rust(
     program_id: &Pubkey,
     signers_seeds_addr: u64,
     signers_seeds_len: u64,
-    memory_mapping: &MemoryMapping,
-    check_aligned: bool,
+    invoke_context: &InvokeContext,
 ) -> Result<Vec<Pubkey>, Error> {
+    let check_aligned = invoke_context.get_check_aligned();
+    let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
     let mut signers = Vec::new();
     if signers_seeds_len > 0 {
         let signers_seeds = translate_slice::<VmSlice<VmSlice<u8>>>(
@@ -689,10 +674,10 @@ pub fn translate_signers_rust(
 
 pub fn translate_instruction_c(
     addr: u64,
-    memory_mapping: &MemoryMapping,
     invoke_context: &mut InvokeContext,
-    check_aligned: bool,
 ) -> Result<Instruction, Error> {
+    let check_aligned = invoke_context.get_check_aligned();
+    let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
     let ix_c = translate_type::<SolInstruction>(memory_mapping, addr, check_aligned)?;
 
     let program_id = translate_type::<Pubkey>(memory_mapping, ix_c.program_id_addr, check_aligned)?;
@@ -720,7 +705,9 @@ pub fn translate_instruction_c(
     total_cu_translation_cost =
         total_cu_translation_cost.saturating_add(account_meta_translation_cost);
 
-    consume_compute_meter(invoke_context, total_cu_translation_cost)?;
+    invoke_context
+        .compute_meter
+        .consume_checked(total_cu_translation_cost)?;
 
     let mut accounts = Vec::with_capacity(ix_c.accounts_len as usize);
     for account_meta in account_metas {
@@ -756,27 +743,14 @@ pub fn translate_instruction_c(
 pub fn translate_accounts_c<'a>(
     account_infos_addr: u64,
     account_infos_len: u64,
-    memory_mapping: &MemoryMapping,
     invoke_context: &mut InvokeContext,
-    check_aligned: bool,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
-    let (account_infos, account_info_keys) = translate_account_infos(
+    translate_accounts_common(
         account_infos_addr,
         account_infos_len,
-        |account_info: &SolAccountInfo| account_info.key_addr,
-        memory_mapping,
         invoke_context,
-        check_aligned,
-    )?;
-
-    translate_accounts_common(
-        &account_info_keys,
-        account_infos,
-        account_infos_addr,
-        invoke_context,
-        memory_mapping,
-        check_aligned,
         CallerAccount::from_sol_account_info,
+        |account_info: &SolAccountInfo| account_info.key_addr,
     )
 }
 
@@ -784,9 +758,10 @@ pub fn translate_signers_c(
     program_id: &Pubkey,
     signers_seeds_addr: u64,
     signers_seeds_len: u64,
-    memory_mapping: &MemoryMapping,
-    check_aligned: bool,
+    invoke_context: &InvokeContext,
 ) -> Result<Vec<Pubkey>, Error> {
+    let check_aligned = invoke_context.get_check_aligned();
+    let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
     if signers_seeds_len > 0 {
         let signers_seeds = translate_slice::<SolSignerSeedsC>(
             memory_mapping,
@@ -832,16 +807,13 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
     account_infos_len: u64,
     signers_seeds_addr: u64,
     signers_seeds_len: u64,
-    memory_mapping: &mut MemoryMapping,
 ) -> Result<u64, Error> {
     // CPI entry.
     //
     // Translate the inputs to the syscall and synchronize the caller's account
     // changes so the callee can see them.
-    consume_compute_meter(
-        invoke_context,
-        invoke_context.get_execution_cost().invoke_units,
-    )?;
+    let amount = invoke_context.get_execution_cost().invoke_units;
+    invoke_context.compute_meter.consume_checked(amount)?;
     let syscall_parameter_address_restrictions = invoke_context
         .get_feature_set()
         .syscall_parameter_address_restrictions;
@@ -851,32 +823,22 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
     let account_data_direct_mapping = invoke_context.get_feature_set().account_data_direct_mapping;
     let check_aligned = invoke_context.get_check_aligned();
 
-    let instruction = S::translate_instruction(
-        instruction_addr,
-        memory_mapping,
-        invoke_context,
-        check_aligned,
-    )?;
-    let transaction_context = &invoke_context.transaction_context;
-    let instruction_context = transaction_context.get_current_instruction_context()?;
-    let caller_program_id = instruction_context.get_program_key()?;
+    let instruction = S::translate_instruction(instruction_addr, invoke_context)?;
+    let instruction_context = invoke_context
+        .transaction_context
+        .get_current_instruction_context()?;
+    let caller_program_id = instruction_context.get_program_key()?.clone();
     let signers = S::translate_signers(
-        caller_program_id,
+        &caller_program_id,
         signers_seeds_addr,
         signers_seeds_len,
-        memory_mapping,
-        check_aligned,
+        invoke_context,
     )?;
     check_authorized_program(&instruction.program_id, &instruction.data, invoke_context)?;
     invoke_context.prepare_next_cpi_instruction(instruction, &signers)?;
 
-    let mut accounts = S::translate_accounts(
-        account_infos_addr,
-        account_infos_len,
-        memory_mapping,
-        invoke_context,
-        check_aligned,
-    )?;
+    let mut accounts =
+        S::translate_accounts(account_infos_addr, account_infos_len, invoke_context)?;
 
     if syscall_parameter_address_restrictions {
         // before initiating CPI, the caller may have modified the
@@ -885,6 +847,7 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
         // changes.
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
         for translated_account in accounts.iter_mut() {
             let callee_account = instruction_context
                 .try_borrow_instruction_account(translated_account.index_in_caller)?;
@@ -921,7 +884,6 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
         if translated_account.update_caller_account_info {
             update_caller_account(
                 invoke_context,
-                memory_mapping,
                 check_aligned,
                 &mut translated_account.caller_account,
                 &mut callee_account,
@@ -933,6 +895,7 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
     }
 
     if virtual_address_space_adjustments {
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         for translated_account in accounts.iter() {
             let mut callee_account = instruction_context
                 .try_borrow_instruction_account(translated_account.index_in_caller)?;
@@ -959,82 +922,17 @@ pub struct TranslatedAccount<'a> {
     pub update_caller_account_info: bool,
 }
 
-fn translate_account_infos<'a, T, F>(
+// Finish translating accounts and build TranslatedAccount from CallerAccount.
+fn translate_accounts_common<'a, T, F, KF>(
     account_infos_addr: u64,
     account_infos_len: u64,
-    key_addr: F,
-    memory_mapping: &'a MemoryMapping,
     invoke_context: &mut InvokeContext,
-    check_aligned: bool,
-) -> Result<(&'a [T], Vec<&'a Pubkey>), Error>
-where
-    F: Fn(&T) -> u64,
-{
-    let syscall_parameter_address_restrictions = invoke_context
-        .get_feature_set()
-        .syscall_parameter_address_restrictions;
-
-    // In the same vein as the other check_account_info_pointer() checks, we don't lock
-    // this pointer to a specific address but we don't want it to be inside accounts, or
-    // callees might be able to write to the pointed memory.
-    if syscall_parameter_address_restrictions
-        && account_infos_addr
-            .saturating_add(account_infos_len.saturating_mul(std::mem::size_of::<T>() as u64))
-            >= ebpf::MM_INPUT_START
-    {
-        return Err(CpiError::InvalidPointer.into());
-    }
-
-    let account_infos = translate_slice::<T>(
-        memory_mapping,
-        account_infos_addr,
-        account_infos_len,
-        check_aligned,
-    )?;
-    check_account_infos(account_infos.len())?;
-
-    let account_infos_bytes = account_infos.len().saturating_mul(ACCOUNT_INFO_BYTE_SIZE);
-
-    consume_compute_meter(
-        invoke_context,
-        (account_infos_bytes as u64)
-            .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
-            .unwrap_or(u64::MAX),
-    )?;
-
-    let mut account_info_keys = Vec::with_capacity(account_infos_len as usize);
-    #[expect(clippy::needless_range_loop)]
-    for account_index in 0..account_infos_len as usize {
-        #[expect(clippy::indexing_slicing)]
-        let account_info = &account_infos[account_index];
-        account_info_keys.push(translate_type::<Pubkey>(
-            memory_mapping,
-            key_addr(account_info),
-            check_aligned,
-        )?);
-    }
-    Ok((account_infos, account_info_keys))
-}
-
-// Finish translating accounts and build TranslatedAccount from CallerAccount.
-fn translate_accounts_common<'a, T, F>(
-    account_info_keys: &[&Pubkey],
-    account_infos: &[T],
-    account_infos_addr: u64,
-    invoke_context: &mut InvokeContext,
-    memory_mapping: &MemoryMapping,
-    check_aligned: bool,
     do_translate: F,
+    key_addr: KF,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error>
 where
-    F: Fn(
-        &InvokeContext,
-        &MemoryMapping,
-        bool,
-        u64,
-        &T,
-        &SerializedAccountMetadata,
-    ) -> Result<CallerAccount<'a>, Error>,
+    F: Fn(&InvokeContext, u64, &T, &SerializedAccountMetadata) -> Result<CallerAccount<'a>, Error>,
+    KF: Fn(&T) -> u64,
 {
     let transaction_context = &invoke_context.transaction_context;
     let next_instruction_context = transaction_context.get_next_instruction_context()?;
@@ -1045,7 +943,8 @@ where
     // unwrapping here is fine: we're in a syscall and the method below fails
     // only outside syscalls
     let accounts_metadata = &invoke_context
-        .get_memory_context()
+        .memory_contexts
+        .memory_context()
         .unwrap()
         .accounts_metadata;
 
@@ -1074,15 +973,53 @@ where
             .transaction_context
             .get_key_of_account_at_index(instruction_account.index_in_transaction)?;
 
+        // In the same vein as the other check_account_info_pointer() checks, we don't lock
+        // this pointer to a specific address but we don't want it to be inside accounts, or
+        // callees might be able to write to the pointed memory.
+        if syscall_parameter_address_restrictions
+            && account_infos_addr
+                .saturating_add(account_infos_len.saturating_mul(std::mem::size_of::<T>() as u64))
+                >= ebpf::MM_INPUT_START
+        {
+            return Err(CpiError::InvalidPointer.into());
+        }
+
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
+        let account_infos = translate_slice::<T>(
+            memory_mapping,
+            account_infos_addr,
+            account_infos_len,
+            check_aligned,
+        )?;
+        check_account_infos(account_infos.len())?;
+
+        let account_infos_bytes = account_infos.len().saturating_mul(ACCOUNT_INFO_BYTE_SIZE);
+
+        let amount = (account_infos_bytes as u64)
+            .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
+            .unwrap_or(u64::MAX);
+        invoke_context.compute_meter.consume_checked(amount)?;
+
+        let mut account_info_keys = Vec::with_capacity(account_infos_len as usize);
+        #[expect(clippy::needless_range_loop)]
+        for account_index in 0..account_infos_len as usize {
+            #[expect(clippy::indexing_slicing)]
+            let account_info = &account_infos[account_index];
+            account_info_keys.push(translate_type::<Pubkey>(
+                memory_mapping,
+                key_addr(account_info),
+                check_aligned,
+            )?);
+        }
+
         #[expect(deprecated)]
         if callee_account.is_executable() {
             // Use the known account
-            consume_compute_meter(
-                invoke_context,
-                (callee_account.get_data().len() as u64)
-                    .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
-                    .unwrap_or(u64::MAX),
-            )?;
+            let amount = (callee_account.get_data().len() as u64)
+                .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
+                .unwrap_or(u64::MAX);
+            invoke_context.compute_meter.consume_checked(amount)?;
         } else if let Some(caller_account_index) =
             account_info_keys.iter().position(|key| *key == account_key)
         {
@@ -1106,8 +1043,6 @@ where
             let caller_account =
                 do_translate(
                     invoke_context,
-                    memory_mapping,
-                    check_aligned,
                     account_infos_addr.saturating_add(
                         caller_account_index.saturating_mul(mem::size_of::<T>()) as u64,
                     ),
@@ -1117,12 +1052,10 @@ where
 
             if syscall_parameter_address_restrictions {
                 // Moved from do_translate() via feature gate.
-                consume_compute_meter(
-                    invoke_context,
-                    (*caller_account.ref_to_len_in_vm)
-                        .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
-                        .unwrap_or(u64::MAX),
-                )?;
+                let amount = (*caller_account.ref_to_len_in_vm)
+                    .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
+                    .unwrap_or(u64::MAX);
+                invoke_context.compute_meter.consume_checked(amount)?;
             }
             let update_caller = if syscall_parameter_address_restrictions {
                 // update_callee_account() is moved to cpi_common()
@@ -1132,6 +1065,8 @@ where
                 // account (caller_account). We need to update the corresponding
                 // BorrowedAccount (callee_account) so the callee can see the
                 // changes.
+                let check_aligned = invoke_context.get_check_aligned();
+                let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
                 update_callee_account(
                     memory_mapping,
                     check_aligned,
@@ -1160,11 +1095,6 @@ where
     }
 
     Ok(accounts)
-}
-
-fn consume_compute_meter(invoke_context: &InvokeContext, amount: u64) -> Result<(), Error> {
-    invoke_context.consume_checked(amount)?;
-    Ok(())
 }
 
 // Update the given account before executing CPI.
@@ -1294,7 +1224,6 @@ fn update_caller_account_region(
 // accounts (regardless of the current size of an account).
 fn update_caller_account(
     invoke_context: &InvokeContext,
-    memory_mapping: &MemoryMapping,
     check_aligned: bool,
     caller_account: &mut CallerAccount<'_>,
     callee_account: &mut BorrowedInstructionAccount<'_, '_>,
@@ -1329,6 +1258,7 @@ fn update_caller_account(
         return Err(Box::new(InstructionError::InvalidRealloc));
     }
 
+    let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
     if prev_len != post_len {
         // when virtual_address_space_adjustments is enabled we don't cache the serialized data in
         // caller_account.serialized_data. See CallerAccount::from_account_info.
@@ -1884,13 +1814,7 @@ mod tests {
         };
         let memory_mapping = MemoryMapping::new(vec![region], &config, SBPFVersion::V3).unwrap();
 
-        let ins = translate_instruction_rust(
-            vm_addr,
-            &memory_mapping,
-            &mut invoke_context,
-            true, // check_aligned
-        )
-        .unwrap();
+        let ins = translate_instruction_rust(vm_addr, &mut invoke_context).unwrap();
         assert_eq!(ins.program_id, program_id);
         assert_eq!(ins.accounts, accounts);
         assert_eq!(ins.data, data);
@@ -1960,6 +1884,7 @@ mod tests {
         );
 
         invoke_context
+            .memory_contexts
             .set_memory_context(MemoryContext::new(
                 BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
                 vec![account_metadata],
@@ -1980,14 +1905,7 @@ mod tests {
             .unwrap();
 
         let mapping_ptr = invoke_context.active_mapping_ptr();
-        let accounts = translate_accounts_rust(
-            vm_addr,
-            1,
-            unsafe { mapping_ptr.as_ref() },
-            &mut invoke_context,
-            true, // check_aligned
-        )
-        .unwrap();
+        let accounts = translate_accounts_rust(vm_addr, 1, &mut invoke_context).unwrap();
         assert_eq!(accounts.len(), 1);
         let caller_account = &accounts[0].caller_account;
         assert_eq!(caller_account.serialized_data, account.data());
@@ -2058,8 +1976,6 @@ mod tests {
 
         let caller_account = CallerAccount::from_account_info(
             &invoke_context,
-            &memory_mapping,
-            true, // check_aligned
             vm_addr,
             account_info,
             &account_metadata,
@@ -2124,7 +2040,6 @@ mod tests {
 
         update_caller_account(
             &invoke_context,
-            &memory_mapping,
             true, // check_aligned
             &mut caller_account,
             &mut callee_account,
@@ -2194,7 +2109,6 @@ mod tests {
 
             update_caller_account(
                 &invoke_context,
-                &memory_mapping,
                 true, // check_aligned
                 &mut caller_account,
                 &mut callee_account,
@@ -2221,7 +2135,6 @@ mod tests {
             .unwrap();
         update_caller_account(
             &invoke_context,
-            &memory_mapping,
             true, // check_aligned
             &mut caller_account,
             &mut callee_account,
@@ -2240,7 +2153,6 @@ mod tests {
         assert_matches!(
             update_caller_account(
                 &invoke_context,
-                &memory_mapping,
                 true, // check_aligned
                 &mut caller_account,
                 &mut callee_account,
@@ -2258,7 +2170,6 @@ mod tests {
             .unwrap();
         update_caller_account(
             &invoke_context,
-            &memory_mapping,
             true, // check_aligned
             &mut caller_account,
             &mut callee_account,

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -618,13 +618,21 @@ pub fn translate_accounts_rust<'a>(
     account_infos_len: u64,
     invoke_context: &InvokeContext,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
-    translate_accounts_common(
+    translate_account_infos(
         account_infos_addr,
         account_infos_len,
-        invoke_context,
-        CallerAccount::from_account_info,
         |account_info: &AccountInfo| account_info.key as *const _ as u64,
-    )
+        invoke_context,
+        |account_infos, account_info_keys| {
+            translate_accounts_common(
+                &account_info_keys,
+                account_infos,
+                account_infos_addr,
+                invoke_context,
+                CallerAccount::from_account_info,
+            )
+        },
+    )?
 }
 
 pub fn translate_signers_rust(
@@ -745,13 +753,21 @@ pub fn translate_accounts_c<'a>(
     account_infos_len: u64,
     invoke_context: &InvokeContext,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
-    translate_accounts_common(
+    translate_account_infos(
         account_infos_addr,
         account_infos_len,
-        invoke_context,
-        CallerAccount::from_sol_account_info,
         |account_info: &SolAccountInfo| account_info.key_addr,
-    )
+        invoke_context,
+        |account_infos, account_info_keys| {
+            translate_accounts_common(
+                &account_info_keys,
+                account_infos,
+                account_infos_addr,
+                invoke_context,
+                CallerAccount::from_sol_account_info,
+            )
+        },
+    )?
 }
 
 pub fn translate_signers_c(
@@ -922,17 +938,69 @@ pub struct TranslatedAccount<'a> {
     pub update_caller_account_info: bool,
 }
 
-// Finish translating accounts and build TranslatedAccount from CallerAccount.
-fn translate_accounts_common<'a, T, F, KF>(
+fn translate_account_infos<T, R>(
     account_infos_addr: u64,
     account_infos_len: u64,
+    key_addr: impl Fn(&T) -> u64,
+    invoke_context: &InvokeContext,
+    cb: impl FnOnce(&[T], Vec<&Pubkey>) -> R,
+) -> Result<R, Error> {
+    let syscall_parameter_address_restrictions = invoke_context
+        .get_feature_set()
+        .syscall_parameter_address_restrictions;
+    let check_aligned = invoke_context.get_check_aligned();
+    let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
+
+    // In the same vein as the other check_account_info_pointer() checks, we don't lock
+    // this pointer to a specific address but we don't want it to be inside accounts, or
+    // callees might be able to write to the pointed memory.
+    if syscall_parameter_address_restrictions
+        && account_infos_addr
+            .saturating_add(account_infos_len.saturating_mul(std::mem::size_of::<T>() as u64))
+            >= ebpf::MM_INPUT_START
+    {
+        return Err(CpiError::InvalidPointer.into());
+    }
+
+    let account_infos = translate_slice::<T>(
+        memory_mapping,
+        account_infos_addr,
+        account_infos_len,
+        check_aligned,
+    )?;
+    check_account_infos(account_infos.len())?;
+
+    let account_infos_bytes = account_infos.len().saturating_mul(ACCOUNT_INFO_BYTE_SIZE);
+
+    let amount = (account_infos_bytes as u64)
+        .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
+        .unwrap_or(u64::MAX);
+    invoke_context.compute_meter.consume_checked(amount)?;
+
+    let mut account_info_keys = Vec::with_capacity(account_infos_len as usize);
+    #[expect(clippy::needless_range_loop)]
+    for account_index in 0..account_infos_len as usize {
+        #[expect(clippy::indexing_slicing)]
+        let account_info = &account_infos[account_index];
+        account_info_keys.push(translate_type::<Pubkey>(
+            memory_mapping,
+            key_addr(account_info),
+            check_aligned,
+        )?);
+    }
+    Ok(cb(account_infos, account_info_keys))
+}
+
+// Finish translating accounts and build TranslatedAccount from CallerAccount.
+fn translate_accounts_common<'a, T, F>(
+    account_info_keys: &[&Pubkey],
+    account_infos: &[T],
+    account_infos_addr: u64,
     invoke_context: &InvokeContext,
     do_translate: F,
-    key_addr: KF,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error>
 where
     F: Fn(&InvokeContext, u64, &T, &SerializedAccountMetadata) -> Result<CallerAccount<'a>, Error>,
-    KF: Fn(&T) -> u64,
 {
     let transaction_context = &invoke_context.transaction_context;
     let next_instruction_context = transaction_context.get_next_instruction_context()?;
@@ -972,46 +1040,6 @@ where
         let account_key = invoke_context
             .transaction_context
             .get_key_of_account_at_index(instruction_account.index_in_transaction)?;
-
-        // In the same vein as the other check_account_info_pointer() checks, we don't lock
-        // this pointer to a specific address but we don't want it to be inside accounts, or
-        // callees might be able to write to the pointed memory.
-        if syscall_parameter_address_restrictions
-            && account_infos_addr
-                .saturating_add(account_infos_len.saturating_mul(std::mem::size_of::<T>() as u64))
-                >= ebpf::MM_INPUT_START
-        {
-            return Err(CpiError::InvalidPointer.into());
-        }
-
-        let check_aligned = invoke_context.get_check_aligned();
-        let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
-        let account_infos = translate_slice::<T>(
-            memory_mapping,
-            account_infos_addr,
-            account_infos_len,
-            check_aligned,
-        )?;
-        check_account_infos(account_infos.len())?;
-
-        let account_infos_bytes = account_infos.len().saturating_mul(ACCOUNT_INFO_BYTE_SIZE);
-
-        let amount = (account_infos_bytes as u64)
-            .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
-            .unwrap_or(u64::MAX);
-        invoke_context.compute_meter.consume_checked(amount)?;
-
-        let mut account_info_keys = Vec::with_capacity(account_infos_len as usize);
-        #[expect(clippy::needless_range_loop)]
-        for account_index in 0..account_infos_len as usize {
-            #[expect(clippy::indexing_slicing)]
-            let account_info = &account_infos[account_index];
-            account_info_keys.push(translate_type::<Pubkey>(
-                memory_mapping,
-                key_addr(account_info),
-                check_aligned,
-            )?);
-        }
 
         #[expect(deprecated)]
         if callee_account.is_executable() {

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -827,7 +827,7 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
     let instruction_context = invoke_context
         .transaction_context
         .get_current_instruction_context()?;
-    let caller_program_id = instruction_context.get_program_key()?.clone();
+    let caller_program_id = instruction_context.get_program_key()?;
     let signers = S::translate_signers(
         &caller_program_id,
         signers_seeds_addr,
@@ -1810,8 +1810,11 @@ mod tests {
             ..Config::default()
         };
         let memory_mapping = MemoryMapping::new(vec![region], &config, SBPFVersion::V3).unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
-        let ins = translate_instruction_rust(vm_addr, &mut invoke_context).unwrap();
+        let ins = translate_instruction_rust(vm_addr, &invoke_context).unwrap();
         assert_eq!(ins.program_id, program_id);
         assert_eq!(ins.accounts, accounts);
         assert_eq!(ins.data, data);
@@ -1840,16 +1843,10 @@ mod tests {
             aligned_memory_mapping: false,
             ..Config::default()
         };
-        let memory_mapping = MemoryMapping::new(vec![region], &config, SBPFVersion::V3).unwrap();
+        *invoke_context.memory_contexts.memory_mapping_mut().unwrap() =
+            MemoryMapping::new(vec![region], &config, SBPFVersion::V3).unwrap();
 
-        let signers = translate_signers_rust(
-            &program_id,
-            vm_addr,
-            1,
-            &memory_mapping,
-            true, // check_aligned
-        )
-        .unwrap();
+        let signers = translate_signers_rust(&program_id, vm_addr, 1, &invoke_context).unwrap();
         assert_eq!(signers[0], derived_key);
     }
 
@@ -1901,8 +1898,7 @@ mod tests {
             )
             .unwrap();
 
-        let mapping_ptr = invoke_context.active_mapping_ptr();
-        let accounts = translate_accounts_rust(vm_addr, 1, &mut invoke_context).unwrap();
+        let accounts = translate_accounts_rust(vm_addr, 1, &invoke_context).unwrap();
         assert_eq!(accounts.len(), 1);
         let caller_account = &accounts[0].caller_account;
         assert_eq!(caller_account.serialized_data, account.data());
@@ -2021,6 +2017,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let mut caller_account = mock_caller_account.caller_account();
         let instruction_context = invoke_context
@@ -2079,6 +2078,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let data_slice = mock_caller_account.data_slice();
         let len_ptr = unsafe {

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -533,24 +533,24 @@ impl<'a> CallerAccount<'a> {
 pub trait SyscallInvokeSigned {
     fn translate_instruction(
         addr: u64,
-        invoke_context: &mut InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<Instruction, Error>;
     fn translate_accounts<'a>(
         account_infos_addr: u64,
         account_infos_len: u64,
-        invoke_context: &mut InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<Vec<TranslatedAccount<'a>>, Error>;
     fn translate_signers(
         program_id: &Pubkey,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
-        invoke_context: &mut InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<Vec<Pubkey>, Error>;
 }
 
 pub fn translate_instruction_rust(
     addr: u64,
-    invoke_context: &mut InvokeContext,
+    invoke_context: &InvokeContext,
 ) -> Result<Instruction, Error> {
     let check_aligned = invoke_context.get_check_aligned();
     let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
@@ -616,7 +616,7 @@ pub fn translate_instruction_rust(
 pub fn translate_accounts_rust<'a>(
     account_infos_addr: u64,
     account_infos_len: u64,
-    invoke_context: &mut InvokeContext,
+    invoke_context: &InvokeContext,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
     translate_accounts_common(
         account_infos_addr,
@@ -674,7 +674,7 @@ pub fn translate_signers_rust(
 
 pub fn translate_instruction_c(
     addr: u64,
-    invoke_context: &mut InvokeContext,
+    invoke_context: &InvokeContext,
 ) -> Result<Instruction, Error> {
     let check_aligned = invoke_context.get_check_aligned();
     let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
@@ -743,7 +743,7 @@ pub fn translate_instruction_c(
 pub fn translate_accounts_c<'a>(
     account_infos_addr: u64,
     account_infos_len: u64,
-    invoke_context: &mut InvokeContext,
+    invoke_context: &InvokeContext,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
     translate_accounts_common(
         account_infos_addr,
@@ -926,7 +926,7 @@ pub struct TranslatedAccount<'a> {
 fn translate_accounts_common<'a, T, F, KF>(
     account_infos_addr: u64,
     account_infos_len: u64,
-    invoke_context: &mut InvokeContext,
+    invoke_context: &InvokeContext,
     do_translate: F,
     key_addr: KF,
 ) -> Result<Vec<TranslatedAccount<'a>>, Error>
@@ -1329,10 +1329,7 @@ mod tests {
         solana_account::{Account, AccountSharedData, ReadableAccount},
         solana_account_info::AccountInfo,
         solana_sbpf::{
-            ebpf::MM_INPUT_START,
-            memory_region::MemoryRegion,
-            program::SBPFVersion,
-            vm::{Config, ContextObject},
+            ebpf::MM_INPUT_START, memory_region::MemoryRegion, program::SBPFVersion, vm::Config,
         },
         solana_sdk_ids::{bpf_loader, system_program},
         solana_svm_feature_set::SVMFeatureSet,

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -829,7 +829,7 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
         .get_current_instruction_context()?;
     let caller_program_id = instruction_context.get_program_key()?;
     let signers = S::translate_signers(
-        &caller_program_id,
+        caller_program_id,
         signers_seeds_addr,
         signers_seeds_len,
         invoke_context,

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1967,6 +1967,7 @@ mod tests {
 
         let account_info = translate_type::<AccountInfo>(&memory_mapping, vm_addr, false).unwrap();
 
+        invoke_context.memory_contexts.mock_set_mapping(memory_mapping);
         let caller_account = CallerAccount::from_account_info(
             &invoke_context,
             vm_addr,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -102,7 +102,9 @@ impl ContextObject for InvokeContext<'_, '_> {
         // 1 to 1 instruction to compute unit mapping
         // ignore overflow, Ebpf will bail if exceeded
         let compute_meter = self.compute_meter.0.get();
-        self.compute_meter.0.set(compute_meter.saturating_sub(amount));
+        self.compute_meter
+            .0
+            .set(compute_meter.saturating_sub(amount));
     }
 
     fn get_remaining(&self) -> u64 {
@@ -242,6 +244,15 @@ impl MemoryContexts {
     pub fn memory_mapping_mut(&mut self) -> Result<&mut MemoryMapping, InstructionError> {
         let last_context = self.memory_context_mut()?;
         Ok(&mut last_context.memory_mapping)
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn mock_set_mapping(&mut self, memory_mapping: MemoryMapping) {
+        self.0 = vec![MemoryContext {
+            allocator: BpfAllocator::new(0),
+            accounts_metadata: vec![],
+            memory_mapping: Box::new(memory_mapping),
+        }];
     }
 }
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -209,6 +209,7 @@ impl ComputeMeter {
     /// Set compute units
     ///
     /// Only use for tests and benchmarks
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn mock_set_remaining(&self, remaining: u64) {
         self.0.set(remaining);
     }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -73,7 +73,6 @@ macro_rules! declare_process_instruction {
                 _arg2: u64,
                 _arg3: u64,
                 _arg4: u64,
-                _memory_mapping: &mut $crate::solana_sbpf::memory_region::MemoryMapping,
             ) -> Result<u64, Box<dyn std::error::Error>> {
                 fn process_instruction_inner(
                     $invoke_context: &mut $crate::invoke_context::InvokeContext,
@@ -82,7 +81,7 @@ macro_rules! declare_process_instruction {
 
                 let consumption_result = if $cu_to_consume > 0
                 {
-                    invoke_context.consume_checked($cu_to_consume)
+                    invoke_context.compute_meter.consume_checked($cu_to_consume)
                 } else {
                     Ok(())
                 };
@@ -102,19 +101,20 @@ impl ContextObject for InvokeContext<'_, '_> {
     fn consume(&mut self, amount: u64) {
         // 1 to 1 instruction to compute unit mapping
         // ignore overflow, Ebpf will bail if exceeded
-        let mut compute_meter = self.compute_meter.borrow_mut();
+        let mut compute_meter = self.compute_meter.0.borrow_mut();
         *compute_meter = compute_meter.saturating_sub(amount);
     }
 
     fn get_remaining(&self) -> u64 {
-        *self.compute_meter.borrow()
+        *self.compute_meter.0.borrow()
     }
 
     fn active_mapping_ptr(&mut self) -> ptr::NonNull<MemoryMapping> {
-        let last_context = self
-            .get_memory_context_mut()
+        let memory = self
+            .memory_contexts
+            .memory_mapping_mut()
             .expect("The memory context must have been set for the current instruction");
-        ptr::NonNull::from_mut(&mut last_context.memory_mapping)
+        ptr::NonNull::from_mut(memory)
     }
 }
 
@@ -183,6 +183,66 @@ impl<'a> EnvironmentConfig<'a> {
             sysvar_cache,
         }
     }
+
+    /// Get cached sysvars
+    pub fn sysvar_cache(&self) -> &SysvarCache {
+        self.sysvar_cache
+    }
+}
+
+pub struct ComputeMeter(RefCell<u64>);
+
+impl ComputeMeter {
+    /// Consume compute units
+    pub fn consume_checked(&self, amount: u64) -> Result<(), Box<dyn std::error::Error>> {
+        let mut compute_meter = self.0.borrow_mut();
+        let exceeded = *compute_meter < amount;
+        *compute_meter = compute_meter.saturating_sub(amount);
+        if exceeded {
+            return Err(Box::new(InstructionError::ComputationalBudgetExceeded));
+        }
+        Ok(())
+    }
+
+    /// Set compute units
+    ///
+    /// Only use for tests and benchmarks
+    pub fn mock_set_remaining(&self, remaining: u64) {
+        *self.0.borrow_mut() = remaining;
+    }
+}
+
+pub struct MemoryContexts(Vec<MemoryContext>);
+
+impl MemoryContexts {
+    /// Set this instruction's [`MemoryContext`].
+    pub fn set_memory_context(
+        &mut self,
+        memory_context: MemoryContext,
+    ) -> Result<(), InstructionError> {
+        *self.0.last_mut().ok_or(InstructionError::CallDepth)? = memory_context;
+        Ok(())
+    }
+
+    /// Get current instruction's [`MemoryContext`]
+    pub fn memory_context(&self) -> Result<&MemoryContext, InstructionError> {
+        self.0.last().ok_or(InstructionError::CallDepth)
+    }
+
+    /// Get current instruction's [`MemoryContext`] for mutable use.
+    pub fn memory_context_mut(&mut self) -> Result<&mut MemoryContext, InstructionError> {
+        self.0.last_mut().ok_or(InstructionError::CallDepth)
+    }
+
+    pub fn memory_mapping(&self) -> Result<&MemoryMapping, InstructionError> {
+        let last_context = self.memory_context()?;
+        Ok(&last_context.memory_mapping)
+    }
+
+    pub fn memory_mapping_mut(&mut self) -> Result<&mut MemoryMapping, InstructionError> {
+        let last_context = self.memory_context_mut()?;
+        Ok(&mut last_context.memory_mapping)
+    }
 }
 
 /// This structure contains metadata about the memory for each instruction under execution.
@@ -242,12 +302,12 @@ pub struct InvokeContext<'a, 'ix_data> {
     execution_cost: SVMTransactionExecutionCost,
     /// Instruction compute meter, for tracking compute units consumed against
     /// the designated compute budget during program execution.
-    compute_meter: RefCell<u64>,
+    pub compute_meter: ComputeMeter,
     log_collector: Option<Rc<RefCell<LogCollector>>>,
     /// Time spent so far executing nested program calls.
     pub total_nested_exec_time: Duration,
     pub timings: ExecuteDetailsTimings,
-    pub memory_context: Vec<MemoryContext>,
+    pub memory_contexts: MemoryContexts,
     /// Pairs of index in TX instruction trace and VM register trace
     register_traces: Vec<(usize, Vec<[u64; 12]>)>,
     /// Debug port to use for this executing transaction.
@@ -271,10 +331,10 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             log_collector,
             compute_budget,
             execution_cost,
-            compute_meter: RefCell::new(compute_budget.compute_unit_limit),
+            compute_meter: ComputeMeter(RefCell::new(compute_budget.compute_unit_limit)),
             total_nested_exec_time: Duration::ZERO,
             timings: ExecuteDetailsTimings::default(),
-            memory_context: Vec::new(),
+            memory_contexts: MemoryContexts(Vec::new()),
             register_traces: Vec::new(),
             #[cfg(feature = "sbpf-debugger")]
             debug_port: None,
@@ -308,13 +368,13 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             }
         }
 
-        self.memory_context.push(MemoryContext::empty());
+        self.memory_contexts.0.push(MemoryContext::empty());
         self.transaction_context.push()
     }
 
     /// Pop a stack frame from the invocation stack
     pub(crate) fn pop(&mut self) -> Result<(), InstructionError> {
-        self.memory_context.pop();
+        self.memory_contexts.0.pop();
         self.transaction_context.pop()
     }
 
@@ -672,24 +732,6 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         self.log_collector.clone()
     }
 
-    /// Consume compute units
-    pub fn consume_checked(&self, amount: u64) -> Result<(), Box<dyn std::error::Error>> {
-        let mut compute_meter = self.compute_meter.borrow_mut();
-        let exceeded = *compute_meter < amount;
-        *compute_meter = compute_meter.saturating_sub(amount);
-        if exceeded {
-            return Err(Box::new(InstructionError::ComputationalBudgetExceeded));
-        }
-        Ok(())
-    }
-
-    /// Set compute units
-    ///
-    /// Only use for tests and benchmarks
-    pub fn mock_set_remaining(&self, remaining: u64) {
-        *self.compute_meter.borrow_mut() = remaining;
-    }
-
     #[cfg(feature = "dev-context-only-utils")]
     pub fn set_alpenglow_migration_succeeded_for_tests(&mut self, succeeded: bool) {
         self.environment_config.alpenglow_migration_succeeded = succeeded;
@@ -726,11 +768,6 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         self.environment_config.alpenglow_migration_succeeded
     }
 
-    /// Get cached sysvars
-    pub fn get_sysvar_cache(&self) -> &SysvarCache {
-        self.environment_config.sysvar_cache
-    }
-
     /// Get cached epoch total stake.
     pub fn get_epoch_stake(&self) -> u64 {
         self.environment_config
@@ -762,32 +799,6 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             })
             .map(|owner_key| owner_key != bpf_loader_deprecated::id())
             .unwrap_or(true)
-    }
-
-    // Set this instruction memory context
-    pub fn set_memory_context(
-        &mut self,
-        memory_context: MemoryContext,
-    ) -> Result<(), InstructionError> {
-        *self
-            .memory_context
-            .last_mut()
-            .ok_or(InstructionError::CallDepth)? = memory_context;
-        Ok(())
-    }
-
-    // Get this instruction's MemoryContext
-    pub fn get_memory_context(&self) -> Result<&MemoryContext, InstructionError> {
-        self.memory_context
-            .last()
-            .ok_or(InstructionError::CallDepth)
-    }
-
-    // Get this instruction's MemoryContext
-    pub fn get_memory_context_mut(&mut self) -> Result<&mut MemoryContext, InstructionError> {
-        self.memory_context
-            .last_mut()
-            .ok_or(InstructionError::CallDepth)
     }
 
     /// Insert a VM register trace
@@ -1055,7 +1066,8 @@ pub fn mock_process_instruction_with_feature_set<
     );
     program_cache_for_tx_batch.set_slot_for_tests(
         invoke_context
-            .get_sysvar_cache()
+            .environment_config
+            .sysvar_cache()
             .get_clock()
             .map(|clock| clock.slot)
             .unwrap_or(1),

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -47,7 +47,7 @@ use {
     std::{
         alloc::Layout,
         borrow::Cow,
-        cell::RefCell,
+        cell::{Cell, RefCell},
         fmt::{self, Debug},
         ptr,
         rc::Rc,
@@ -101,12 +101,12 @@ impl ContextObject for InvokeContext<'_, '_> {
     fn consume(&mut self, amount: u64) {
         // 1 to 1 instruction to compute unit mapping
         // ignore overflow, Ebpf will bail if exceeded
-        let mut compute_meter = self.compute_meter.0.borrow_mut();
-        *compute_meter = compute_meter.saturating_sub(amount);
+        let compute_meter = self.compute_meter.0.get();
+        self.compute_meter.0.set(compute_meter.saturating_sub(amount));
     }
 
     fn get_remaining(&self) -> u64 {
-        *self.compute_meter.0.borrow()
+        self.compute_meter.0.get()
     }
 
     fn active_mapping_ptr(&mut self) -> ptr::NonNull<MemoryMapping> {
@@ -190,14 +190,14 @@ impl<'a> EnvironmentConfig<'a> {
     }
 }
 
-pub struct ComputeMeter(RefCell<u64>);
+pub struct ComputeMeter(Cell<u64>);
 
 impl ComputeMeter {
     /// Consume compute units
     pub fn consume_checked(&self, amount: u64) -> Result<(), Box<dyn std::error::Error>> {
-        let mut compute_meter = self.0.borrow_mut();
-        let exceeded = *compute_meter < amount;
-        *compute_meter = compute_meter.saturating_sub(amount);
+        let compute_meter = self.0.get();
+        let exceeded = compute_meter < amount;
+        self.0.set(compute_meter.saturating_sub(amount));
         if exceeded {
             return Err(Box::new(InstructionError::ComputationalBudgetExceeded));
         }
@@ -208,7 +208,7 @@ impl ComputeMeter {
     ///
     /// Only use for tests and benchmarks
     pub fn mock_set_remaining(&self, remaining: u64) {
-        *self.0.borrow_mut() = remaining;
+        self.0.set(remaining);
     }
 }
 
@@ -331,7 +331,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             log_collector,
             compute_budget,
             execution_cost,
-            compute_meter: ComputeMeter(RefCell::new(compute_budget.compute_unit_limit)),
+            compute_meter: ComputeMeter(Cell::new(compute_budget.compute_unit_limit)),
             total_nested_exec_time: Duration::ZERO,
             timings: ExecuteDetailsTimings::default(),
             memory_contexts: MemoryContexts(Vec::new()),
@@ -1247,6 +1247,7 @@ mod tests {
                         desired_result,
                     } => {
                         invoke_context
+                            .compute_meter
                             .consume_checked(compute_units_to_consume)
                             .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
                         return desired_result;

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -320,7 +320,10 @@ pub mod get_sysvar_with_account_check {
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<SlotHashes>, InstructionError> {
         check_sysvar_account::<SlotHashes>(instruction_context, instruction_account_index)?;
-        invoke_context.environment_config.sysvar_cache().get_slot_hashes()
+        invoke_context
+            .environment_config
+            .sysvar_cache()
+            .get_slot_hashes()
     }
 
     #[expect(deprecated)]
@@ -330,7 +333,10 @@ pub mod get_sysvar_with_account_check {
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<RecentBlockhashes>, InstructionError> {
         check_sysvar_account::<RecentBlockhashes>(instruction_context, instruction_account_index)?;
-        invoke_context.environment_config.sysvar_cache().get_recent_blockhashes()
+        invoke_context
+            .environment_config
+            .sysvar_cache()
+            .get_recent_blockhashes()
     }
 
     pub fn stake_history(
@@ -339,7 +345,10 @@ pub mod get_sysvar_with_account_check {
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<StakeHistory>, InstructionError> {
         check_sysvar_account::<StakeHistory>(instruction_context, instruction_account_index)?;
-        invoke_context.environment_config.sysvar_cache().get_stake_history()
+        invoke_context
+            .environment_config
+            .sysvar_cache()
+            .get_stake_history()
     }
 
     pub fn last_restart_slot(
@@ -348,7 +357,10 @@ pub mod get_sysvar_with_account_check {
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<LastRestartSlot>, InstructionError> {
         check_sysvar_account::<LastRestartSlot>(instruction_context, instruction_account_index)?;
-        invoke_context.environment_config.sysvar_cache().get_last_restart_slot()
+        invoke_context
+            .environment_config
+            .sysvar_cache()
+            .get_last_restart_slot()
     }
 }
 

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -302,7 +302,7 @@ pub mod get_sysvar_with_account_check {
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<Clock>, InstructionError> {
         check_sysvar_account::<Clock>(instruction_context, instruction_account_index)?;
-        invoke_context.get_sysvar_cache().get_clock()
+        invoke_context.environment_config.sysvar_cache().get_clock()
     }
 
     pub fn rent(
@@ -311,7 +311,7 @@ pub mod get_sysvar_with_account_check {
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<Rent>, InstructionError> {
         check_sysvar_account::<Rent>(instruction_context, instruction_account_index)?;
-        invoke_context.get_sysvar_cache().get_rent()
+        invoke_context.environment_config.sysvar_cache().get_rent()
     }
 
     pub fn slot_hashes(
@@ -320,7 +320,7 @@ pub mod get_sysvar_with_account_check {
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<SlotHashes>, InstructionError> {
         check_sysvar_account::<SlotHashes>(instruction_context, instruction_account_index)?;
-        invoke_context.get_sysvar_cache().get_slot_hashes()
+        invoke_context.environment_config.sysvar_cache().get_slot_hashes()
     }
 
     #[expect(deprecated)]
@@ -330,7 +330,7 @@ pub mod get_sysvar_with_account_check {
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<RecentBlockhashes>, InstructionError> {
         check_sysvar_account::<RecentBlockhashes>(instruction_context, instruction_account_index)?;
-        invoke_context.get_sysvar_cache().get_recent_blockhashes()
+        invoke_context.environment_config.sysvar_cache().get_recent_blockhashes()
     }
 
     pub fn stake_history(
@@ -339,7 +339,7 @@ pub mod get_sysvar_with_account_check {
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<StakeHistory>, InstructionError> {
         check_sysvar_account::<StakeHistory>(instruction_context, instruction_account_index)?;
-        invoke_context.get_sysvar_cache().get_stake_history()
+        invoke_context.environment_config.sysvar_cache().get_stake_history()
     }
 
     pub fn last_restart_slot(
@@ -348,7 +348,7 @@ pub mod get_sysvar_with_account_check {
         instruction_account_index: IndexOfAccount,
     ) -> Result<Arc<LastRestartSlot>, InstructionError> {
         check_sysvar_account::<LastRestartSlot>(instruction_context, instruction_account_index)?;
-        invoke_context.get_sysvar_cache().get_last_restart_slot()
+        invoke_context.environment_config.sysvar_cache().get_last_restart_slot()
     }
 }
 

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -67,11 +67,13 @@ pub fn create_vm<'a, 'b>(
             .virtual_address_space_adjustments,
         invoke_context.get_feature_set().account_data_direct_mapping,
     )?;
-    invoke_context.set_memory_context(MemoryContext::new(
-        BpfAllocator::new(heap_size as u64),
-        accounts_metadata,
-        memory_mapping,
-    ))?;
+    invoke_context
+        .memory_contexts
+        .set_memory_context(MemoryContext::new(
+            BpfAllocator::new(heap_size as u64),
+            accounts_metadata,
+            memory_mapping,
+        ))?;
     Ok(EbpfVm::new(
         program.get_loader().clone(),
         program.get_sbpf_version(),
@@ -127,10 +129,12 @@ macro_rules! create_vm {
         let stack_size = $program.get_config().stack_size();
         let heap_size = invoke_context.get_compute_budget().heap_size;
         let heap_cost_result =
-            invoke_context.consume_checked($crate::__private::calculate_heap_cost(
-                heap_size,
-                invoke_context.get_execution_cost().heap_cost,
-            ));
+            invoke_context
+                .compute_meter
+                .consume_checked($crate::__private::calculate_heap_cost(
+                    heap_size,
+                    invoke_context.get_execution_cost().heap_cost,
+                ));
         let $vm = heap_cost_result.and_then(|_| {
             let (mut stack, mut heap) = $crate::__private::MEMORY_POOL
                 .with_borrow_mut(|pool| (pool.get_stack(stack_size), pool.get_heap(heap_size)));
@@ -253,10 +257,7 @@ pub fn execute<'a, 'b: 'a>(
         }
 
         let execute_time = Measure::start("execute");
-
-        // SAFETY: VM is the only holder of the InvokeContext reference, as it carries its lifetime.
-        let prev_nested_exec_time =
-            unsafe { vm.context_object_pointer.as_ref().total_nested_exec_time };
+        let prev_nested_exec_time = vm.context().total_nested_exec_time;
 
         vm.registers[1] = ebpf::MM_INPUT_START;
         vm.registers[2] = instruction_data_offset as u64;
@@ -412,7 +413,10 @@ pub fn execute<'a, 'b: 'a>(
             virtual_address_space_adjustments,
             account_data_direct_mapping,
             parameter_bytes,
-            &invoke_context.get_memory_context()?.accounts_metadata,
+            &invoke_context
+                .memory_contexts
+                .memory_context()?
+                .accounts_metadata,
         )
     }
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -123,7 +123,7 @@ pub fn invoke_builtin_function(
     let instruction_account_indices = 0..instruction_context.get_number_of_instruction_accounts();
 
     // mock builtin program must consume units
-    invoke_context.consume_checked(1)?;
+    invoke_context.compute_meter.consume_checked(1)?;
 
     let log_collector = invoke_context.get_log_collector();
     let program_id = instruction_context.get_program_key()?;
@@ -223,7 +223,6 @@ macro_rules! processor {
                 _: u64,
                 _: u64,
                 _: u64,
-                _: &mut $crate::MemoryMapping,
             ) -> Result<u64, Box<dyn std::error::Error>> {
                 unreachable!()
             }
@@ -237,12 +236,10 @@ macro_rules! processor {
             ) {
                 unsafe {
                     vm.with_vm(|vm| {
-                        vm.program_result = $crate::invoke_builtin_function(
-                            $builtin_function,
-                            vm.context_object_pointer.as_mut(),
-                        )
-                        .map_err(|err| $crate::EbpfError::SyscallError(err))
-                        .into();
+                        vm.program_result =
+                            $crate::invoke_builtin_function($builtin_function, vm.context())
+                                .map_err(|err| $crate::EbpfError::SyscallError(err))
+                                .into();
                     });
                 }
             }
@@ -257,6 +254,7 @@ fn get_sysvar<T: Default + SysvarSerialize + Sized + serde::de::DeserializeOwned
 ) -> u64 {
     let invoke_context = get_invoke_context();
     if invoke_context
+        .compute_meter
         .consume_checked(invoke_context.get_execution_cost().sysvar_base_cost + T::size_of() as u64)
         .is_err()
     {
@@ -295,6 +293,7 @@ impl SyscallStubs {
         let sysvar_buf_cost = length.checked_div(cpi_bytes_per_unit).unwrap_or(0);
 
         if invoke_context
+            .compute_meter
             .consume_checked(
                 sysvar_base_cost
                     .saturating_add(sysvar_id_cost)
@@ -306,7 +305,7 @@ impl SyscallStubs {
         }
 
         // Fetch the sysvar from the cache.
-        let Ok(sysvar) = fetch(get_invoke_context().get_sysvar_cache()) else {
+        let Ok(sysvar) = fetch(get_invoke_context().environment_config.sysvar_cache()) else {
             return UNSUPPORTED_SYSVAR;
         };
 
@@ -469,38 +468,60 @@ impl solana_sysvar::program_stubs::SyscallStubs for SyscallStubs {
 
     fn sol_get_clock_sysvar(&self, var_addr: *mut u8) -> u64 {
         get_sysvar(
-            get_invoke_context().get_sysvar_cache().get_clock(),
+            get_invoke_context()
+                .environment_config
+                .sysvar_cache()
+                .get_clock(),
             var_addr,
         )
     }
 
     fn sol_get_epoch_schedule_sysvar(&self, var_addr: *mut u8) -> u64 {
         get_sysvar(
-            get_invoke_context().get_sysvar_cache().get_epoch_schedule(),
+            get_invoke_context()
+                .environment_config
+                .sysvar_cache()
+                .get_epoch_schedule(),
             var_addr,
         )
     }
 
     fn sol_get_epoch_rewards_sysvar(&self, var_addr: *mut u8) -> u64 {
         get_sysvar(
-            get_invoke_context().get_sysvar_cache().get_epoch_rewards(),
+            get_invoke_context()
+                .environment_config
+                .sysvar_cache()
+                .get_epoch_rewards(),
             var_addr,
         )
     }
 
     #[allow(deprecated)]
     fn sol_get_fees_sysvar(&self, var_addr: *mut u8) -> u64 {
-        get_sysvar(get_invoke_context().get_sysvar_cache().get_fees(), var_addr)
+        get_sysvar(
+            get_invoke_context()
+                .environment_config
+                .sysvar_cache()
+                .get_fees(),
+            var_addr,
+        )
     }
 
     fn sol_get_rent_sysvar(&self, var_addr: *mut u8) -> u64 {
-        get_sysvar(get_invoke_context().get_sysvar_cache().get_rent(), var_addr)
+        get_sysvar(
+            get_invoke_context()
+                .environment_config
+                .sysvar_cache()
+                .get_rent(),
+            var_addr,
+        )
     }
 
     fn sol_get_last_restart_slot(&self, var_addr: *mut u8) -> u64 {
         get_sysvar(
             get_invoke_context()
-                .get_sysvar_cache()
+                .environment_config
+                .sysvar_cache()
                 .get_last_restart_slot(),
             var_addr,
         )

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1195,7 +1195,7 @@ mod tests {
             Err(InstructionError::ProgramFailedToComplete),
             Entrypoint::register,
             |invoke_context| {
-                invoke_context.mock_set_remaining(0);
+                invoke_context.compute_meter.mock_set_remaining(0);
                 test_utils::load_all_invoked_programs(invoke_context);
             },
             |_invoke_context| {},

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -18,7 +18,7 @@ use {
         vm::execute,
     },
     solana_pubkey::Pubkey,
-    solana_sbpf::{declare_builtin_function, memory_region::MemoryMapping},
+    solana_sbpf::declare_builtin_function,
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, native_loader},
     solana_svm_log_collector::{LogCollector, ic_logger_msg, ic_msg},
     solana_svm_measure::measure::Measure,
@@ -69,7 +69,6 @@ declare_builtin_function!(
         _arg2: u64,
         _arg3: u64,
         _arg4: u64,
-        _memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Box<dyn std::error::Error>> {
         process_instruction_inner(invoke_context)
     }
@@ -93,17 +92,23 @@ pub(crate) fn process_instruction_inner<'a>(
     if native_loader::check_id(&owner_id) {
         let program_id = instruction_context.get_program_key()?;
         return if bpf_loader_upgradeable::check_id(program_id) {
-            invoke_context.consume_checked(UPGRADEABLE_LOADER_COMPUTE_UNITS)?;
+            invoke_context
+                .compute_meter
+                .consume_checked(UPGRADEABLE_LOADER_COMPUTE_UNITS)?;
             process_loader_upgradeable_instruction(invoke_context)
         } else if bpf_loader::check_id(program_id) {
-            invoke_context.consume_checked(DEFAULT_LOADER_COMPUTE_UNITS)?;
+            invoke_context
+                .compute_meter
+                .consume_checked(DEFAULT_LOADER_COMPUTE_UNITS)?;
             ic_logger_msg!(
                 log_collector,
                 "BPF loader management instructions are no longer supported",
             );
             Err(InstructionError::UnsupportedProgramId)
         } else if bpf_loader_deprecated::check_id(program_id) {
-            invoke_context.consume_checked(DEPRECATED_LOADER_COMPUTE_UNITS)?;
+            invoke_context
+                .compute_meter
+                .consume_checked(DEPRECATED_LOADER_COMPUTE_UNITS)?;
             ic_logger_msg!(log_collector, "Deprecated loader is no longer supported");
             Err(InstructionError::UnsupportedProgramId)
         } else {
@@ -694,7 +699,10 @@ fn process_loader_upgradeable_instruction(
                         ic_logger_msg!(log_collector, "Program account not owned by loader");
                         return Err(InstructionError::IncorrectProgramId);
                     }
-                    let clock = invoke_context.get_sysvar_cache().get_clock()?;
+                    let clock = invoke_context
+                        .environment_config
+                        .sysvar_cache()
+                        .get_clock()?;
                     if clock.slot == slot {
                         ic_logger_msg!(log_collector, "Program was deployed in this block already");
                         return Err(InstructionError::InvalidArgument);
@@ -718,7 +726,10 @@ fn process_loader_upgradeable_instruction(
                                 &instruction_context,
                                 &log_collector,
                             )?;
-                            let clock = invoke_context.get_sysvar_cache().get_clock()?;
+                            let clock = invoke_context
+                                .environment_config
+                                .sysvar_cache()
+                                .get_clock()?;
                             invoke_context
                                 .program_cache_for_tx_batch
                                 .store_modified_entry(
@@ -853,7 +864,8 @@ fn common_extend_program(
     }
 
     let clock_slot = invoke_context
-        .get_sysvar_cache()
+        .environment_config
+        .sysvar_cache()
         .get_clock()
         .map(|clock| clock.slot)?;
 
@@ -896,7 +908,10 @@ fn common_extend_program(
 
     let required_payment = {
         let balance = programdata_account.get_lamports();
-        let rent = invoke_context.get_sysvar_cache().get_rent()?;
+        let rent = invoke_context
+            .environment_config
+            .sysvar_cache()
+            .get_rent()?;
         let min_balance = rent.minimum_balance(new_len).max(1);
         min_balance.saturating_sub(balance)
     };

--- a/programs/loader-v4/src/lib.rs
+++ b/programs/loader-v4/src/lib.rs
@@ -15,7 +15,7 @@ use {
         vm::execute,
     },
     solana_pubkey::Pubkey,
-    solana_sbpf::{declare_builtin_function, memory_region::MemoryMapping},
+    solana_sbpf::declare_builtin_function,
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4},
     solana_svm_log_collector::{LogCollector, ic_logger_msg},
     solana_svm_measure::measure::Measure,
@@ -212,7 +212,10 @@ fn process_instruction_set_program_length(
     let required_lamports = if new_size == 0 {
         0
     } else {
-        let rent = invoke_context.get_sysvar_cache().get_rent()?;
+        let rent = invoke_context
+            .environment_config
+            .sysvar_cache()
+            .get_rent()?;
         rent.minimum_balance(LoaderV4State::program_data_offset().saturating_add(new_size as usize))
             .max(1)
     };
@@ -274,7 +277,11 @@ fn process_instruction_deploy(invoke_context: &mut InvokeContext) -> Result<(), 
         &program,
         authority_address,
     )?;
-    let current_slot = invoke_context.get_sysvar_cache().get_clock()?.slot;
+    let current_slot = invoke_context
+        .environment_config
+        .sysvar_cache()
+        .get_clock()?
+        .slot;
 
     // Slot = 0 indicates that the program hasn't been deployed yet. So no need to check for the cooldown slots.
     // (Without this check, the program deployment is failing in freshly started test validators. That's
@@ -323,7 +330,11 @@ fn process_instruction_retract(invoke_context: &mut InvokeContext) -> Result<(),
         &program,
         authority_address,
     )?;
-    let current_slot = invoke_context.get_sysvar_cache().get_clock()?.slot;
+    let current_slot = invoke_context
+        .environment_config
+        .sysvar_cache()
+        .get_clock()?
+        .slot;
     if state.slot.saturating_add(DEPLOYMENT_COOLDOWN_IN_SLOTS) > current_slot {
         ic_logger_msg!(
             log_collector,
@@ -429,7 +440,6 @@ declare_builtin_function!(
         _arg2: u64,
         _arg3: u64,
         _arg4: u64,
-        _memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Box<dyn std::error::Error>> {
         process_instruction_inner(invoke_context)
     }
@@ -444,7 +454,9 @@ fn process_instruction_inner<'a>(
     let instruction_data = instruction_context.get_instruction_data();
     let program_id = instruction_context.get_program_key()?;
     if loader_v4::check_id(program_id) {
-        invoke_context.consume_checked(DEFAULT_COMPUTE_UNITS)?;
+        invoke_context
+            .compute_meter
+            .consume_checked(DEFAULT_COMPUTE_UNITS)?;
         match limited_deserialize(instruction_data, solana_packet::PACKET_DATA_SIZE as u64)? {
             LoaderV4Instruction::Write { offset, bytes } => {
                 process_instruction_write(invoke_context, offset, bytes)

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9064,9 +9064,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sbpf"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc6fee0979c35ae053780a071927b068f5d9a5cb12e12b043a5ea60d67a53ca"
+checksum = "fd96c15a4cb8884e9b660cb71796d1bca8d3eb6d38e68067508ce37dc66874bc"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -275,8 +275,14 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
         }
         VoteInstruction::Withdraw(lamports) => {
             instruction_context.check_number_of_instruction_accounts(2)?;
-            let rent_sysvar = invoke_context.environment_config.sysvar_cache().get_rent()?;
-            let clock_sysvar = invoke_context.environment_config.sysvar_cache().get_clock()?;
+            let rent_sysvar = invoke_context
+                .environment_config
+                .sysvar_cache()
+                .get_rent()?;
+            let clock_sysvar = invoke_context
+                .environment_config
+                .sysvar_cache()
+                .get_clock()?;
 
             drop(me);
             vote_state::withdraw(
@@ -313,11 +319,17 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             if !is_init_account_v2_enabled {
                 return Err(InstructionError::InvalidInstructionData);
             }
-            let rent = invoke_context.environment_config.sysvar_cache().get_rent()?;
+            let rent = invoke_context
+                .environment_config
+                .sysvar_cache()
+                .get_rent()?;
             if !rent.is_exempt(me.get_lamports(), me.get_data().len()) {
                 return Err(InstructionError::InsufficientFunds);
             }
-            let clock = invoke_context.environment_config.sysvar_cache().get_clock()?;
+            let clock = invoke_context
+                .environment_config
+                .sysvar_cache()
+                .get_clock()?;
             vote_state::initialize_account_v2(
                 &mut me,
                 target_version,
@@ -366,7 +378,10 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 NewCommissionCollector::NewAccount(collector_account)
             };
 
-            let rent = invoke_context.environment_config.sysvar_cache().get_rent()?;
+            let rent = invoke_context
+                .environment_config
+                .sysvar_cache()
+                .get_rent()?;
 
             vote_state::update_commission_collector(
                 &mut me,

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -107,6 +107,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
     let is_vote_authorize_with_bls_enabled = is_vote_authorize_with_bls_enabled(invoke_context);
     let consume_pop_compute_units = || {
         invoke_context
+            .compute_meter
             .consume_checked(BLS_PROOF_OF_POSSESSION_VERIFICATION_COMPUTE_UNITS)
             .map_err(|_| InstructionError::ComputationalBudgetExceeded)
     };
@@ -183,7 +184,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             )
         }
         VoteInstruction::UpdateCommission(commission) => {
-            let sysvar_cache = invoke_context.get_sysvar_cache();
+            let sysvar_cache = invoke_context.environment_config.sysvar_cache();
 
             // Disable the commission update rule after the "delay commission
             // update" feature is activated because it imposes a minimum delay
@@ -226,7 +227,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             if should_reject_legacy_vote_instructions(invoke_context) {
                 return Err(InstructionError::InvalidInstructionData);
             }
-            let sysvar_cache = invoke_context.get_sysvar_cache();
+            let sysvar_cache = invoke_context.environment_config.sysvar_cache();
             let slot_hashes = sysvar_cache.get_slot_hashes()?;
             let clock = sysvar_cache.get_clock()?;
             vote_state::process_vote_state_update(
@@ -243,7 +244,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             if should_reject_legacy_vote_instructions(invoke_context) {
                 return Err(InstructionError::InvalidInstructionData);
             }
-            let sysvar_cache = invoke_context.get_sysvar_cache();
+            let sysvar_cache = invoke_context.environment_config.sysvar_cache();
             let slot_hashes = sysvar_cache.get_slot_hashes()?;
             let clock = sysvar_cache.get_clock()?;
             vote_state::process_vote_state_update(
@@ -260,7 +261,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             if invoke_context.is_alpenglow_migration_succeeded() {
                 return Err(InstructionError::InvalidInstructionData);
             }
-            let sysvar_cache = invoke_context.get_sysvar_cache();
+            let sysvar_cache = invoke_context.environment_config.sysvar_cache();
             let slot_hashes = sysvar_cache.get_slot_hashes()?;
             let clock = sysvar_cache.get_clock()?;
             vote_state::process_tower_sync(
@@ -274,8 +275,8 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
         }
         VoteInstruction::Withdraw(lamports) => {
             instruction_context.check_number_of_instruction_accounts(2)?;
-            let rent_sysvar = invoke_context.get_sysvar_cache().get_rent()?;
-            let clock_sysvar = invoke_context.get_sysvar_cache().get_clock()?;
+            let rent_sysvar = invoke_context.environment_config.sysvar_cache().get_rent()?;
+            let clock_sysvar = invoke_context.environment_config.sysvar_cache().get_clock()?;
 
             drop(me);
             vote_state::withdraw(
@@ -312,11 +313,11 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             if !is_init_account_v2_enabled {
                 return Err(InstructionError::InvalidInstructionData);
             }
-            let rent = invoke_context.get_sysvar_cache().get_rent()?;
+            let rent = invoke_context.environment_config.sysvar_cache().get_rent()?;
             if !rent.is_exempt(me.get_lamports(), me.get_data().len()) {
                 return Err(InstructionError::InsufficientFunds);
             }
-            let clock = invoke_context.get_sysvar_cache().get_clock()?;
+            let clock = invoke_context.environment_config.sysvar_cache().get_clock()?;
             vote_state::initialize_account_v2(
                 &mut me,
                 target_version,
@@ -365,7 +366,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 NewCommissionCollector::NewAccount(collector_account)
             };
 
-            let rent = invoke_context.get_sysvar_cache().get_rent()?;
+            let rent = invoke_context.environment_config.sysvar_cache().get_rent()?;
 
             vote_state::update_commission_collector(
                 &mut me,

--- a/programs/zk-elgamal-proof/src/lib.rs
+++ b/programs/zk-elgamal-proof/src/lib.rs
@@ -195,6 +195,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
     match instruction {
         ProofInstruction::CloseContextState => {
             invoke_context
+                .compute_meter
                 .consume_checked(CLOSE_CONTEXT_STATE_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             ic_msg!(invoke_context, "CloseContextState");
@@ -202,6 +203,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
         }
         ProofInstruction::VerifyZeroCiphertext => {
             invoke_context
+                .compute_meter
                 .consume_checked(VERIFY_ZERO_CIPHERTEXT_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             ic_msg!(invoke_context, "VerifyZeroCiphertext");
@@ -211,6 +213,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
         }
         ProofInstruction::VerifyCiphertextCiphertextEquality => {
             invoke_context
+                .compute_meter
                 .consume_checked(VERIFY_CIPHERTEXT_CIPHERTEXT_EQUALITY_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             ic_msg!(invoke_context, "VerifyCiphertextCiphertextEquality");
@@ -221,6 +224,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
         }
         ProofInstruction::VerifyCiphertextCommitmentEquality => {
             invoke_context
+                .compute_meter
                 .consume_checked(VERIFY_CIPHERTEXT_COMMITMENT_EQUALITY_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             ic_msg!(invoke_context, "VerifyCiphertextCommitmentEquality");
@@ -231,6 +235,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
         }
         ProofInstruction::VerifyPubkeyValidity => {
             invoke_context
+                .compute_meter
                 .consume_checked(VERIFY_PUBKEY_VALIDITY_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             ic_msg!(invoke_context, "VerifyPubkeyValidity");
@@ -240,6 +245,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
         }
         ProofInstruction::VerifyPercentageWithCap => {
             invoke_context
+                .compute_meter
                 .consume_checked(VERIFY_PERCENTAGE_WITH_CAP_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             ic_msg!(invoke_context, "VerifyPercentageWithCap");
@@ -249,6 +255,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
         }
         ProofInstruction::VerifyBatchedRangeProofU64 => {
             invoke_context
+                .compute_meter
                 .consume_checked(VERIFY_BATCHED_RANGE_PROOF_U64_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             ic_msg!(invoke_context, "VerifyBatchedRangeProofU64");
@@ -258,6 +265,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
         }
         ProofInstruction::VerifyBatchedRangeProofU128 => {
             invoke_context
+                .compute_meter
                 .consume_checked(VERIFY_BATCHED_RANGE_PROOF_U128_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             ic_msg!(invoke_context, "VerifyBatchedRangeProofU128");
@@ -267,6 +275,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
         }
         ProofInstruction::VerifyBatchedRangeProofU256 => {
             invoke_context
+                .compute_meter
                 .consume_checked(VERIFY_BATCHED_RANGE_PROOF_U256_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             ic_msg!(invoke_context, "VerifyBatchedRangeProofU256");
@@ -276,6 +285,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
         }
         ProofInstruction::VerifyGroupedCiphertext2HandlesValidity => {
             invoke_context
+                .compute_meter
                 .consume_checked(VERIFY_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             ic_msg!(invoke_context, "VerifyGroupedCiphertext2HandlesValidity");
@@ -286,6 +296,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
         }
         ProofInstruction::VerifyBatchedGroupedCiphertext2HandlesValidity => {
             invoke_context
+                .compute_meter
                 .consume_checked(VERIFY_BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             ic_msg!(
@@ -299,6 +310,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
         }
         ProofInstruction::VerifyGroupedCiphertext3HandlesValidity => {
             invoke_context
+                .compute_meter
                 .consume_checked(VERIFY_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             ic_msg!(invoke_context, "VerifyGroupedCiphertext3HandlesValidity");
@@ -309,6 +321,7 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
         }
         ProofInstruction::VerifyBatchedGroupedCiphertext3HandlesValidity => {
             invoke_context
+                .compute_meter
                 .consume_checked(VERIFY_BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;
             ic_msg!(

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4577,9 +4577,8 @@ pub mod tests {
         solana_nonce::{self as nonce, state::DurableNonce},
         solana_program_option::COption,
         solana_program_runtime::{
-            invoke_context::InvokeContext,
-            program_cache_entry::ProgramCacheEntry,
-            solana_sbpf::{declare_builtin_function, memory_region::MemoryMapping},
+            invoke_context::InvokeContext, program_cache_entry::ProgramCacheEntry,
+            solana_sbpf::declare_builtin_function,
         },
         solana_rpc_client_api::{
             custom_error::{
@@ -4697,7 +4696,9 @@ pub mod tests {
         invoke_context: &mut InvokeContext,
     ) -> std::result::Result<u64, Box<dyn std::error::Error>> {
         let log_collector = invoke_context.get_log_collector();
-        invoke_context.consume_checked(TestBuiltinEntrypoint::COMPUTE_UNITS)?;
+        invoke_context
+            .compute_meter
+            .consume_checked(TestBuiltinEntrypoint::COMPUTE_UNITS)?;
 
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
@@ -4741,7 +4742,6 @@ pub mod tests {
             _arg2: u64,
             _arg3: u64,
             _arg4: u64,
-            _memory_mapping: &mut MemoryMapping,
         ) -> Result<u64, Box<dyn std::error::Error>> {
             test_builtin_processor(invoke_context)
         }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -538,10 +538,7 @@ pub(crate) mod tests {
         solana_native_token::LAMPORTS_PER_SOL,
         solana_program_runtime::{
             program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryType},
-            solana_sbpf::{
-                self, memory_region::MemoryMapping, program::BuiltinFunctionDefinition,
-                vm::ContextObject,
-            },
+            solana_sbpf::{self, program::BuiltinFunctionDefinition, vm::ContextObject},
         },
         solana_pubkey::Pubkey,
         solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, native_loader, system_program},
@@ -561,7 +558,6 @@ pub(crate) mod tests {
             _: u64,
             _: u64,
             _: u64,
-            _: &mut MemoryMapping,
         ) -> Result<u64, Box<dyn std::error::Error>> {
             Ok(0)
         }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11342,7 +11342,10 @@ fn test_failed_simulation_compute_units() {
         (bank.get_account(&program_id).unwrap().data().len() + TRANSACTION_ACCOUNT_BASE_SIZE * 2)
             as u32;
     declare_process_instruction!(MockBuiltin, MOCK_BUILTIN_UNITS, |invoke_context| {
-        invoke_context.compute_meter.consume_checked(TEST_UNITS).unwrap();
+        invoke_context
+            .compute_meter
+            .consume_checked(TEST_UNITS)
+            .unwrap();
         Err(InstructionError::InvalidInstructionData)
     });
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11342,7 +11342,7 @@ fn test_failed_simulation_compute_units() {
         (bank.get_account(&program_id).unwrap().data().len() + TRANSACTION_ACCOUNT_BASE_SIZE * 2)
             as u32;
     declare_process_instruction!(MockBuiltin, MOCK_BUILTIN_UNITS, |invoke_context| {
-        invoke_context.consume_checked(TEST_UNITS).unwrap();
+        invoke_context.compute_meter.consume_checked(TEST_UNITS).unwrap();
         Err(InstructionError::InvalidInstructionData)
     });
 

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -18,7 +18,6 @@ declare_builtin_function!(
         account_infos_len: u64,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         cpi_common::<Self>(
             invoke_context,
@@ -27,7 +26,6 @@ declare_builtin_function!(
             account_infos_len,
             signers_seeds_addr,
             signers_seeds_len,
-            memory_mapping,
         )
     }
 );
@@ -35,42 +33,30 @@ declare_builtin_function!(
 impl SyscallInvokeSigned for SyscallInvokeSignedRust {
     fn translate_instruction(
         addr: u64,
-        memory_mapping: &MemoryMapping,
         invoke_context: &mut InvokeContext,
-        check_aligned: bool,
     ) -> Result<Instruction, Error> {
-        translate_instruction_rust(addr, memory_mapping, invoke_context, check_aligned)
+        translate_instruction_rust(addr, invoke_context)
     }
 
     fn translate_accounts<'a>(
         account_infos_addr: u64,
         account_infos_len: u64,
-        memory_mapping: &MemoryMapping,
         invoke_context: &mut InvokeContext,
-        check_aligned: bool,
     ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
-        translate_accounts_rust(
-            account_infos_addr,
-            account_infos_len,
-            memory_mapping,
-            invoke_context,
-            check_aligned,
-        )
+        translate_accounts_rust(account_infos_addr, account_infos_len, invoke_context)
     }
 
     fn translate_signers(
         program_id: &Pubkey,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
-        memory_mapping: &MemoryMapping,
-        check_aligned: bool,
+        invoke_context: &mut InvokeContext,
     ) -> Result<Vec<Pubkey>, Error> {
         translate_signers_rust(
             program_id,
             signers_seeds_addr,
             signers_seeds_len,
-            memory_mapping,
-            check_aligned,
+            invoke_context,
         )
     }
 }
@@ -85,7 +71,6 @@ declare_builtin_function!(
         account_infos_len: u64,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         cpi_common::<Self>(
             invoke_context,
@@ -94,7 +79,6 @@ declare_builtin_function!(
             account_infos_len,
             signers_seeds_addr,
             signers_seeds_len,
-            memory_mapping,
         )
     }
 );
@@ -102,42 +86,30 @@ declare_builtin_function!(
 impl SyscallInvokeSigned for SyscallInvokeSignedC {
     fn translate_instruction(
         addr: u64,
-        memory_mapping: &MemoryMapping,
         invoke_context: &mut InvokeContext,
-        check_aligned: bool,
     ) -> Result<Instruction, Error> {
-        translate_instruction_c(addr, memory_mapping, invoke_context, check_aligned)
+        translate_instruction_c(addr, invoke_context)
     }
 
     fn translate_accounts<'a>(
         account_infos_addr: u64,
         account_infos_len: u64,
-        memory_mapping: &MemoryMapping,
         invoke_context: &mut InvokeContext,
-        check_aligned: bool,
     ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
-        translate_accounts_c(
-            account_infos_addr,
-            account_infos_len,
-            memory_mapping,
-            invoke_context,
-            check_aligned,
-        )
+        translate_accounts_c(account_infos_addr, account_infos_len, invoke_context)
     }
 
     fn translate_signers(
         program_id: &Pubkey,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
-        memory_mapping: &MemoryMapping,
-        check_aligned: bool,
+        invoke_context: &mut InvokeContext,
     ) -> Result<Vec<Pubkey>, Error> {
         translate_signers_c(
             program_id,
             signers_seeds_addr,
             signers_seeds_len,
-            memory_mapping,
-            check_aligned,
+            invoke_context,
         )
     }
 }

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -33,7 +33,7 @@ declare_builtin_function!(
 impl SyscallInvokeSigned for SyscallInvokeSignedRust {
     fn translate_instruction(
         addr: u64,
-        invoke_context: &mut InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<Instruction, Error> {
         translate_instruction_rust(addr, invoke_context)
     }
@@ -41,7 +41,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
     fn translate_accounts<'a>(
         account_infos_addr: u64,
         account_infos_len: u64,
-        invoke_context: &mut InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
         translate_accounts_rust(account_infos_addr, account_infos_len, invoke_context)
     }
@@ -50,7 +50,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
         program_id: &Pubkey,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
-        invoke_context: &mut InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<Vec<Pubkey>, Error> {
         translate_signers_rust(
             program_id,
@@ -86,7 +86,7 @@ declare_builtin_function!(
 impl SyscallInvokeSigned for SyscallInvokeSignedC {
     fn translate_instruction(
         addr: u64,
-        invoke_context: &mut InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<Instruction, Error> {
         translate_instruction_c(addr, invoke_context)
     }
@@ -94,7 +94,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
     fn translate_accounts<'a>(
         account_infos_addr: u64,
         account_infos_len: u64,
-        invoke_context: &mut InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
         translate_accounts_c(account_infos_addr, account_infos_len, invoke_context)
     }
@@ -103,7 +103,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
         program_id: &Pubkey,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
-        invoke_context: &mut InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<Vec<Pubkey>, Error> {
         translate_signers_c(
             program_id,

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -271,11 +271,6 @@ mod bls12_381_curve_id {
     pub(crate) const BLS12_381_G2_BE: u64 = 6 | 0x80;
 }
 
-fn consume_compute_meter(invoke_context: &InvokeContext, amount: u64) -> Result<(), Error> {
-    invoke_context.consume_checked(amount)?;
-    Ok(())
-}
-
 // NOTE: This macro name is checked by gen-syscall-list to create the list of
 // syscalls. If this macro name is changed, or if a new one is added, then
 // gen-syscall-list/build.rs must also be updated.
@@ -693,7 +688,6 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         Err(SyscallError::Abort.into())
     }
@@ -710,15 +704,15 @@ declare_builtin_function!(
         line: u64,
         column: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
-        consume_compute_meter(invoke_context, len)?;
+        invoke_context.compute_meter.consume_checked(len)?;
 
+        let check_aligned = invoke_context.get_check_aligned();
         translate_string_and_do(
-            memory_mapping,
+            invoke_context.memory_contexts.memory_mapping()?,
             file,
             len,
-            invoke_context.get_check_aligned(),
+            check_aligned,
             &mut |string: &str| Err(SyscallError::Panic(string.to_string(), line, column).into()),
         )
     }
@@ -739,7 +733,6 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let align = if invoke_context.get_check_aligned() {
             BPF_ALIGN_OF_U128
@@ -749,7 +742,7 @@ declare_builtin_function!(
         let Ok(layout) = Layout::from_size_align(size as usize, align) else {
             return Ok(0);
         };
-        let allocator = &mut invoke_context.get_memory_context_mut()?.allocator;
+        let allocator = &mut invoke_context.memory_contexts.memory_context_mut()?.allocator;
         if free_addr == 0 {
             match allocator.alloc(layout) {
                 Ok(addr) => Ok(addr),
@@ -797,19 +790,20 @@ declare_builtin_function!(
         program_id_addr: u64,
         address_addr: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let cost = invoke_context
             .get_execution_cost()
             .create_program_address_units;
-        consume_compute_meter(invoke_context, cost)?;
+        invoke_context.compute_meter.consume_checked(cost)?;
 
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         let (seeds, program_id) = translate_and_check_program_address_inputs(
             seeds_addr,
             seeds_len,
             program_id_addr,
             memory_mapping,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?;
 
         let Ok(new_address) = Pubkey::create_program_address(&seeds, program_id) else {
@@ -817,7 +811,7 @@ declare_builtin_function!(
         };
         translate_mut!(
             memory_mapping,
-            invoke_context.get_check_aligned(),
+            check_aligned,
             let address: &mut [u8] = map(address_addr, std::mem::size_of::<Pubkey>() as u64)?;
         );
         address.copy_from_slice(new_address.as_ref());
@@ -835,19 +829,20 @@ declare_builtin_function!(
         program_id_addr: u64,
         address_addr: u64,
         bump_seed_addr: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let cost = invoke_context
             .get_execution_cost()
             .create_program_address_units;
-        consume_compute_meter(invoke_context, cost)?;
+        invoke_context.compute_meter.consume_checked(cost)?;
 
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         let (seeds, program_id) = translate_and_check_program_address_inputs(
             seeds_addr,
             seeds_len,
             program_id_addr,
             memory_mapping,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?;
 
         let mut bump_seed = [u8::MAX];
@@ -861,7 +856,7 @@ declare_builtin_function!(
                 {
                     translate_mut!(
                         memory_mapping,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                         let bump_seed_ref: &mut u8 = map(bump_seed_addr)?;
                         let address: &mut [u8] = map(address_addr, std::mem::size_of::<Pubkey>() as u64)?;
                     );
@@ -871,7 +866,7 @@ declare_builtin_function!(
                 }
             }
             bump_seed[0] = bump_seed[0].saturating_sub(1);
-            consume_compute_meter(invoke_context, cost)?;
+            invoke_context.compute_meter.consume_checked(cost)?;
         }
         Ok(1)
     }
@@ -887,27 +882,28 @@ declare_builtin_function!(
         signature_addr: u64,
         result_addr: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let cost = invoke_context.get_execution_cost().secp256k1_recover_cost;
-        consume_compute_meter(invoke_context, cost)?;
+        invoke_context.compute_meter.consume_checked(cost)?;
 
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         translate_mut!(
             memory_mapping,
-            invoke_context.get_check_aligned(),
+            check_aligned,
             let secp256k1_recover_result: &mut [u8] = map(result_addr, SECP256K1_PUBLIC_KEY_LENGTH as u64)?;
         );
         let hash = translate_slice::<u8>(
             memory_mapping,
             hash_addr,
             keccak::HASH_BYTES as u64,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?;
         let signature = translate_slice::<u8>(
             memory_mapping,
             signature_addr,
             SECP256K1_SIGNATURE_LENGTH as u64,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?;
 
         let Ok(message) = libsecp256k1::Message::parse_slice(hash) else {
@@ -949,7 +945,6 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         use {
             crate::bls12_381_curve_id::*,
@@ -966,17 +961,19 @@ declare_builtin_function!(
             return Err(SyscallError::InvalidAttribute.into());
         }
 
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
         match curve_id {
             CURVE25519_EDWARDS => {
                 let cost = invoke_context
                     .get_execution_cost()
                     .curve25519_edwards_validate_point_cost;
-                consume_compute_meter(invoke_context, cost)?;
+                invoke_context.compute_meter.consume_checked(cost)?;
 
                 let point = translate_type::<edwards::PodEdwardsPoint>(
                     memory_mapping,
                     point_addr,
-                    invoke_context.get_check_aligned(),
+                    check_aligned,
                 )?;
 
                 if edwards::validate_edwards(point) {
@@ -989,12 +986,12 @@ declare_builtin_function!(
                 let cost = invoke_context
                     .get_execution_cost()
                     .curve25519_ristretto_validate_point_cost;
-                consume_compute_meter(invoke_context, cost)?;
+                invoke_context.compute_meter.consume_checked(cost)?;
 
                 let point = translate_type::<ristretto::PodRistrettoPoint>(
                     memory_mapping,
                     point_addr,
-                    invoke_context.get_check_aligned(),
+                    check_aligned,
                 )?;
 
                 if ristretto::validate_ristretto(point) {
@@ -1007,12 +1004,12 @@ declare_builtin_function!(
                 let cost = invoke_context
                     .get_execution_cost()
                     .bls12_381_g1_validate_cost;
-                consume_compute_meter(invoke_context, cost)?;
+                invoke_context.compute_meter.consume_checked(cost)?;
 
                 let point = translate_type::<solana_bls12_381_syscall::PodG1Point>(
                     memory_mapping,
                     point_addr,
-                    invoke_context.get_check_aligned(),
+                    check_aligned,
                 )?;
 
                 let endianness = if curve_id == BLS12_381_G1_LE {
@@ -1035,12 +1032,12 @@ declare_builtin_function!(
                 let cost = invoke_context
                     .get_execution_cost()
                     .bls12_381_g2_validate_cost;
-                consume_compute_meter(invoke_context, cost)?;
+                invoke_context.compute_meter.consume_checked(cost)?;
 
                 let point = translate_type::<solana_bls12_381_syscall::PodG2Point>(
                     memory_mapping,
                     point_addr,
-                    invoke_context.get_check_aligned(),
+                    check_aligned,
                 )?;
 
                 let endianness = if curve_id == BLS12_381_G2_LE {
@@ -1083,7 +1080,6 @@ declare_builtin_function!(
         result_addr: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         use {
             crate::bls12_381_curve_id::*,
@@ -1093,17 +1089,19 @@ declare_builtin_function!(
             },
         };
 
+        let check_aligned = invoke_context.get_check_aligned();
         match curve_id {
             BLS12_381_G1_LE | BLS12_381_G1_BE => {
                 let cost = invoke_context
                     .get_execution_cost()
                     .bls12_381_g1_decompress_cost;
-                consume_compute_meter(invoke_context, cost)?;
+                invoke_context.compute_meter.consume_checked(cost)?;
 
+                let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                 let compressed_point = translate_type::<PodBLSG1Compressed>(
                     memory_mapping,
                     point_addr,
-                    invoke_context.get_check_aligned(),
+                    check_aligned,
                 )?;
 
                 let endianness = if curve_id == BLS12_381_G1_LE {
@@ -1119,7 +1117,7 @@ declare_builtin_function!(
                 ) {
                     translate_mut!(
                         memory_mapping,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                         let result_ref_mut: &mut PodBLSG1Point = map(result_addr)?;
                     );
                     *result_ref_mut = affine_point;
@@ -1132,12 +1130,13 @@ declare_builtin_function!(
                 let cost = invoke_context
                     .get_execution_cost()
                     .bls12_381_g2_decompress_cost;
-                consume_compute_meter(invoke_context, cost)?;
+                invoke_context.compute_meter.consume_checked(cost)?;
 
+                let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                 let compressed_point = translate_type::<PodBLSG2Compressed>(
                     memory_mapping,
                     point_addr,
-                    invoke_context.get_check_aligned(),
+                    check_aligned,
                 )?;
 
                 let endianness = if curve_id == BLS12_381_G2_LE {
@@ -1153,7 +1152,7 @@ declare_builtin_function!(
                 ) {
                     translate_mut!(
                         memory_mapping,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                         let result_ref_mut: &mut PodBLSG2Point = map(result_addr)?;
                     );
                     *result_ref_mut = affine_point;
@@ -1181,7 +1180,6 @@ declare_builtin_function!(
         left_input_addr: u64,
         right_input_addr: u64,
         result_point_addr: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         use {
             crate::bls12_381_curve_id::*,
@@ -1205,29 +1203,31 @@ declare_builtin_function!(
             return Err(SyscallError::InvalidAttribute.into());
         }
 
+        let check_aligned = invoke_context.get_check_aligned();
         match curve_id {
             CURVE25519_EDWARDS => match group_op {
                 ADD => {
                     let cost = invoke_context
                         .get_execution_cost()
                         .curve25519_edwards_add_cost;
-                    consume_compute_meter(invoke_context, cost)?;
+                    invoke_context.compute_meter.consume_checked(cost)?;
 
+                    let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                     let left_point = translate_type::<PodEdwardsPoint>(
                         memory_mapping,
                         left_input_addr,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                     )?;
                     let right_point = translate_type::<PodEdwardsPoint>(
                         memory_mapping,
                         right_input_addr,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                     )?;
 
                     if let Some(result_point) = edwards::add_edwards(left_point, right_point) {
                         translate_mut!(
                             memory_mapping,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                             let result_point_ref_mut: &mut PodEdwardsPoint = map(result_point_addr)?;
                         );
                         *result_point_ref_mut = result_point;
@@ -1240,23 +1240,24 @@ declare_builtin_function!(
                     let cost = invoke_context
                         .get_execution_cost()
                         .curve25519_edwards_subtract_cost;
-                    consume_compute_meter(invoke_context, cost)?;
+                    invoke_context.compute_meter.consume_checked(cost)?;
 
+                    let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                     let left_point = translate_type::<PodEdwardsPoint>(
                         memory_mapping,
                         left_input_addr,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                     )?;
                     let right_point = translate_type::<PodEdwardsPoint>(
                         memory_mapping,
                         right_input_addr,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                     )?;
 
                     if let Some(result_point) = edwards::subtract_edwards(left_point, right_point) {
                         translate_mut!(
                             memory_mapping,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                             let result_point_ref_mut: &mut PodEdwardsPoint = map(result_point_addr)?;
                         );
                         *result_point_ref_mut = result_point;
@@ -1269,23 +1270,24 @@ declare_builtin_function!(
                     let cost = invoke_context
                         .get_execution_cost()
                         .curve25519_edwards_multiply_cost;
-                    consume_compute_meter(invoke_context, cost)?;
+                    invoke_context.compute_meter.consume_checked(cost)?;
 
+                    let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                     let scalar = translate_type::<scalar::PodScalar>(
                         memory_mapping,
                         left_input_addr,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                     )?;
                     let input_point = translate_type::<PodEdwardsPoint>(
                         memory_mapping,
                         right_input_addr,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                     )?;
 
                     if let Some(result_point) = edwards::multiply_edwards(scalar, input_point) {
                         translate_mut!(
                             memory_mapping,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                             let result_point_ref_mut: &mut PodEdwardsPoint = map(result_point_addr)?;
                         );
                         *result_point_ref_mut = result_point;
@@ -1308,23 +1310,24 @@ declare_builtin_function!(
                     let cost = invoke_context
                         .get_execution_cost()
                         .curve25519_ristretto_add_cost;
-                    consume_compute_meter(invoke_context, cost)?;
+                    invoke_context.compute_meter.consume_checked(cost)?;
 
+                    let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                     let left_point = translate_type::<PodRistrettoPoint>(
                         memory_mapping,
                         left_input_addr,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                     )?;
                     let right_point = translate_type::<PodRistrettoPoint>(
                         memory_mapping,
                         right_input_addr,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                     )?;
 
                     if let Some(result_point) = ristretto::add_ristretto(left_point, right_point) {
                         translate_mut!(
                             memory_mapping,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                             let result_point_ref_mut: &mut PodRistrettoPoint = map(result_point_addr)?;
                         );
                         *result_point_ref_mut = result_point;
@@ -1337,17 +1340,18 @@ declare_builtin_function!(
                     let cost = invoke_context
                         .get_execution_cost()
                         .curve25519_ristretto_subtract_cost;
-                    consume_compute_meter(invoke_context, cost)?;
+                    invoke_context.compute_meter.consume_checked(cost)?;
 
+                    let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                     let left_point = translate_type::<PodRistrettoPoint>(
                         memory_mapping,
                         left_input_addr,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                     )?;
                     let right_point = translate_type::<PodRistrettoPoint>(
                         memory_mapping,
                         right_input_addr,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                     )?;
 
                     if let Some(result_point) =
@@ -1355,7 +1359,7 @@ declare_builtin_function!(
                     {
                         translate_mut!(
                             memory_mapping,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                             let result_point_ref_mut: &mut PodRistrettoPoint = map(result_point_addr)?;
                         );
                         *result_point_ref_mut = result_point;
@@ -1368,23 +1372,24 @@ declare_builtin_function!(
                     let cost = invoke_context
                         .get_execution_cost()
                         .curve25519_ristretto_multiply_cost;
-                    consume_compute_meter(invoke_context, cost)?;
+                    invoke_context.compute_meter.consume_checked(cost)?;
 
+                    let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                     let scalar = translate_type::<scalar::PodScalar>(
                         memory_mapping,
                         left_input_addr,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                     )?;
                     let input_point = translate_type::<PodRistrettoPoint>(
                         memory_mapping,
                         right_input_addr,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                     )?;
 
                     if let Some(result_point) = ristretto::multiply_ristretto(scalar, input_point) {
                         translate_mut!(
                             memory_mapping,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                             let result_point_ref_mut: &mut PodRistrettoPoint = map(result_point_addr)?;
                         );
                         *result_point_ref_mut = result_point;
@@ -1412,17 +1417,18 @@ declare_builtin_function!(
                 match group_op {
                     ADD => {
                         let cost = invoke_context.get_execution_cost().bls12_381_g1_add_cost;
-                        consume_compute_meter(invoke_context, cost)?;
+                        invoke_context.compute_meter.consume_checked(cost)?;
 
+                        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                         let left_point = translate_type::<PodBLSG1Point>(
                             memory_mapping,
                             left_input_addr,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                         )?;
                         let right_point = translate_type::<PodBLSG1Point>(
                             memory_mapping,
                             right_input_addr,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                         )?;
 
                         if let Some(result_point) = solana_bls12_381_syscall::bls12_381_g1_addition(
@@ -1433,7 +1439,7 @@ declare_builtin_function!(
                         ) {
                             translate_mut!(
                                 memory_mapping,
-                                invoke_context.get_check_aligned(),
+                                check_aligned,
                                 let result_point_ref_mut: &mut PodBLSG1Point = map(result_point_addr)?;
                             );
                             *result_point_ref_mut = result_point;
@@ -1446,17 +1452,18 @@ declare_builtin_function!(
                         let cost = invoke_context
                             .get_execution_cost()
                             .bls12_381_g1_subtract_cost;
-                        consume_compute_meter(invoke_context, cost)?;
+                        invoke_context.compute_meter.consume_checked(cost)?;
 
+                        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                         let left_point = translate_type::<PodBLSG1Point>(
                             memory_mapping,
                             left_input_addr,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                         )?;
                         let right_point = translate_type::<PodBLSG1Point>(
                             memory_mapping,
                             right_input_addr,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                         )?;
 
                         if let Some(result_point) =
@@ -1469,7 +1476,7 @@ declare_builtin_function!(
                         {
                             translate_mut!(
                                 memory_mapping,
-                                invoke_context.get_check_aligned(),
+                                check_aligned,
                                 let result_point_ref_mut: &mut PodBLSG1Point = map(result_point_addr)?;
                             );
                             *result_point_ref_mut = result_point;
@@ -1482,17 +1489,18 @@ declare_builtin_function!(
                         let cost = invoke_context
                             .get_execution_cost()
                             .bls12_381_g1_multiply_cost;
-                        consume_compute_meter(invoke_context, cost)?;
+                        invoke_context.compute_meter.consume_checked(cost)?;
 
+                        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                         let scalar = translate_type::<PodBLSScalar>(
                             memory_mapping,
                             left_input_addr,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                         )?;
                         let point = translate_type::<PodBLSG1Point>(
                             memory_mapping,
                             right_input_addr,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                         )?;
 
                         if let Some(result_point) =
@@ -1505,7 +1513,7 @@ declare_builtin_function!(
                         {
                             translate_mut!(
                                 memory_mapping,
-                                invoke_context.get_check_aligned(),
+                                check_aligned,
                                 let result_point_ref_mut: &mut PodBLSG1Point = map(result_point_addr)?;
                             );
                             *result_point_ref_mut = result_point;
@@ -1529,17 +1537,18 @@ declare_builtin_function!(
                 match group_op {
                     ADD => {
                         let cost = invoke_context.get_execution_cost().bls12_381_g2_add_cost;
-                        consume_compute_meter(invoke_context, cost)?;
+                        invoke_context.compute_meter.consume_checked(cost)?;
 
+                        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                         let left_point = translate_type::<PodBLSG2Point>(
                             memory_mapping,
                             left_input_addr,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                         )?;
                         let right_point = translate_type::<PodBLSG2Point>(
                             memory_mapping,
                             right_input_addr,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                         )?;
 
                         if let Some(result_point) = solana_bls12_381_syscall::bls12_381_g2_addition(
@@ -1550,7 +1559,7 @@ declare_builtin_function!(
                         ) {
                             translate_mut!(
                                 memory_mapping,
-                                invoke_context.get_check_aligned(),
+                                check_aligned,
                                 let result_point_ref_mut: &mut PodBLSG2Point = map(result_point_addr)?;
                             );
                             *result_point_ref_mut = result_point;
@@ -1563,17 +1572,18 @@ declare_builtin_function!(
                         let cost = invoke_context
                             .get_execution_cost()
                             .bls12_381_g2_subtract_cost;
-                        consume_compute_meter(invoke_context, cost)?;
+                        invoke_context.compute_meter.consume_checked(cost)?;
 
+                        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                         let left_point = translate_type::<PodBLSG2Point>(
                             memory_mapping,
                             left_input_addr,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                         )?;
                         let right_point = translate_type::<PodBLSG2Point>(
                             memory_mapping,
                             right_input_addr,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                         )?;
 
                         if let Some(result_point) =
@@ -1586,7 +1596,7 @@ declare_builtin_function!(
                         {
                             translate_mut!(
                                 memory_mapping,
-                                invoke_context.get_check_aligned(),
+                                check_aligned,
                                 let result_point_ref_mut: &mut PodBLSG2Point = map(result_point_addr)?;
                             );
                             *result_point_ref_mut = result_point;
@@ -1599,17 +1609,18 @@ declare_builtin_function!(
                         let cost = invoke_context
                             .get_execution_cost()
                             .bls12_381_g2_multiply_cost;
-                        consume_compute_meter(invoke_context, cost)?;
+                        invoke_context.compute_meter.consume_checked(cost)?;
 
+                        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                         let scalar = translate_type::<PodBLSScalar>(
                             memory_mapping,
                             left_input_addr,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                         )?;
                         let point = translate_type::<PodBLSG2Point>(
                             memory_mapping,
                             right_input_addr,
-                            invoke_context.get_check_aligned(),
+                            check_aligned,
                         )?;
 
                         if let Some(result_point) =
@@ -1622,7 +1633,7 @@ declare_builtin_function!(
                         {
                             translate_mut!(
                                 memory_mapping,
-                                invoke_context.get_check_aligned(),
+                                check_aligned,
                                 let result_point_ref_mut: &mut PodBLSG2Point = map(result_point_addr)?;
                             );
                             *result_point_ref_mut = result_point;
@@ -1659,7 +1670,6 @@ declare_builtin_function!(
         points_addr: u64,
         points_len: u64,
         result_point_addr: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         use solana_curve25519::{
             curve_syscall_traits::*,
@@ -1672,6 +1682,7 @@ declare_builtin_function!(
             return Err(Box::new(SyscallError::InvalidLength));
         }
 
+        let check_aligned = invoke_context.get_check_aligned();
         match curve_id {
             CURVE25519_EDWARDS => {
                 let cost = invoke_context
@@ -1683,26 +1694,27 @@ declare_builtin_function!(
                             .curve25519_edwards_msm_incremental_cost
                             .saturating_mul(points_len.saturating_sub(1)),
                     );
-                consume_compute_meter(invoke_context, cost)?;
+                invoke_context.compute_meter.consume_checked(cost)?;
 
+                let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                 let scalars = translate_slice::<scalar::PodScalar>(
                     memory_mapping,
                     scalars_addr,
                     points_len,
-                    invoke_context.get_check_aligned(),
+                    check_aligned,
                 )?;
 
                 let points = translate_slice::<PodEdwardsPoint>(
                     memory_mapping,
                     points_addr,
                     points_len,
-                    invoke_context.get_check_aligned(),
+                    check_aligned,
                 )?;
 
                 if let Some(result_point) = edwards::multiscalar_multiply_edwards(scalars, points) {
                     translate_mut!(
                         memory_mapping,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                         let result_point_ref_mut: &mut PodEdwardsPoint = map(result_point_addr)?;
                     );
                     *result_point_ref_mut = result_point;
@@ -1722,20 +1734,21 @@ declare_builtin_function!(
                             .curve25519_ristretto_msm_incremental_cost
                             .saturating_mul(points_len.saturating_sub(1)),
                     );
-                consume_compute_meter(invoke_context, cost)?;
+                invoke_context.compute_meter.consume_checked(cost)?;
 
+                let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                 let scalars = translate_slice::<scalar::PodScalar>(
                     memory_mapping,
                     scalars_addr,
                     points_len,
-                    invoke_context.get_check_aligned(),
+                    check_aligned,
                 )?;
 
                 let points = translate_slice::<PodRistrettoPoint>(
                     memory_mapping,
                     points_addr,
                     points_len,
-                    invoke_context.get_check_aligned(),
+                    check_aligned,
                 )?;
 
                 if let Some(result_point) =
@@ -1743,7 +1756,7 @@ declare_builtin_function!(
                 {
                     translate_mut!(
                         memory_mapping,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                         let result_point_ref_mut: &mut PodRistrettoPoint = map(result_point_addr)?;
                     );
                     *result_point_ref_mut = result_point;
@@ -1777,7 +1790,6 @@ declare_builtin_function!(
         g1_points_addr: u64,
         g2_points_addr: u64,
         result_addr: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         use {
             crate::bls12_381_curve_id::*,
@@ -1787,6 +1799,7 @@ declare_builtin_function!(
             },
         };
 
+        let check_aligned = invoke_context.get_check_aligned();
         match curve_id {
             BLS12_381_LE | BLS12_381_BE => {
                 let execution_cost = invoke_context.get_execution_cost();
@@ -1797,20 +1810,21 @@ declare_builtin_function!(
                             .bls12_381_additional_pair_cost
                             .saturating_mul(num_pairs.saturating_sub(1)),
                     );
-                consume_compute_meter(invoke_context, cost)?;
+                invoke_context.compute_meter.consume_checked(cost)?;
 
+                let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
                 let g1_points = translate_slice::<PodBLSG1Point>(
                     memory_mapping,
                     g1_points_addr,
                     num_pairs,
-                    invoke_context.get_check_aligned(),
+                    check_aligned,
                 )?;
 
                 let g2_points = translate_slice::<PodBLSG2Point>(
                     memory_mapping,
                     g2_points_addr,
                     num_pairs,
-                    invoke_context.get_check_aligned(),
+                    check_aligned,
                 )?;
 
                 let endianness = if curve_id == BLS12_381_LE {
@@ -1827,7 +1841,7 @@ declare_builtin_function!(
                 ) {
                     translate_mut!(
                         memory_mapping,
-                        invoke_context.get_check_aligned(),
+                        check_aligned,
                         let result_ref_mut: &mut PodBLSGtElement = map(result_addr)?;
                     );
                     *result_ref_mut = gt_element;
@@ -1853,7 +1867,6 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let execution_cost = invoke_context.get_execution_cost();
 
@@ -1861,7 +1874,7 @@ declare_builtin_function!(
             .checked_div(execution_cost.cpi_bytes_per_unit)
             .unwrap_or(u64::MAX)
             .saturating_add(execution_cost.syscall_base_cost);
-        consume_compute_meter(invoke_context, cost)?;
+        invoke_context.compute_meter.consume_checked(cost)?;
 
         if len > MAX_RETURN_DATA as u64 {
             return Err(SyscallError::ReturnDataTooLarge(len, MAX_RETURN_DATA as u64).into());
@@ -1870,11 +1883,13 @@ declare_builtin_function!(
         let return_data = if len == 0 {
             Vec::new()
         } else {
+            let check_aligned = invoke_context.get_check_aligned();
+            let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
             translate_slice::<u8>(
                 memory_mapping,
                 addr,
                 len,
-                invoke_context.get_check_aligned(),
+                check_aligned,
             )?
             .to_vec()
         };
@@ -1901,11 +1916,10 @@ declare_builtin_function!(
         program_id_addr: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let execution_cost = invoke_context.get_execution_cost();
 
-        consume_compute_meter(invoke_context, execution_cost.syscall_base_cost)?;
+        invoke_context.compute_meter.consume_checked(execution_cost.syscall_base_cost)?;
 
         let (program_id, return_data) = invoke_context.transaction_context.get_return_data();
         let length = length.min(return_data.len() as u64);
@@ -1914,11 +1928,12 @@ declare_builtin_function!(
                 .saturating_add(size_of::<Pubkey>() as u64)
                 .checked_div(execution_cost.cpi_bytes_per_unit)
                 .unwrap_or(u64::MAX);
-            consume_compute_meter(invoke_context, cost)?;
-
+            invoke_context.compute_meter.consume_checked(cost)?;
+            let check_aligned = invoke_context.get_check_aligned();
+            let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
             translate_mut!(
                 memory_mapping,
-                invoke_context.get_check_aligned(),
+                check_aligned,
                 let return_data_result: &mut [u8] = map(return_data_addr, length)?;
                 let program_id_result: &mut Pubkey = map(program_id_addr)?;
             );
@@ -1949,11 +1964,10 @@ declare_builtin_function!(
         program_id_addr: u64,
         data_addr: u64,
         accounts_addr: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let execution_cost = invoke_context.get_execution_cost();
 
-        consume_compute_meter(invoke_context, execution_cost.syscall_base_cost)?;
+        invoke_context.compute_meter.consume_checked(execution_cost.syscall_base_cost)?;
 
         let stack_height = invoke_context.get_stack_height();
         let mut reverse_index_at_stack_height = 0;
@@ -1991,10 +2005,12 @@ declare_builtin_function!(
             }
         }
 
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         if let Some(instruction_context) = found_instruction_context {
             translate_mut!(
                 memory_mapping,
-                invoke_context.get_check_aligned(),
+                check_aligned,
                 let result_header: &mut ProcessedSiblingInstruction = map(meta_addr)?;
             );
 
@@ -2004,7 +2020,7 @@ declare_builtin_function!(
             {
                 translate_mut!(
                     memory_mapping,
-                    invoke_context.get_check_aligned(),
+                    check_aligned,
                     let program_id: &mut Pubkey = map(program_id_addr)?;
                     let data: &mut [u8] = map(data_addr, result_header.data_len)?;
                     let accounts: &mut [AccountMeta] = map(accounts_addr, result_header.accounts_len)?;
@@ -2049,11 +2065,10 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let execution_cost = invoke_context.get_execution_cost();
 
-        consume_compute_meter(invoke_context, execution_cost.syscall_base_cost)?;
+        invoke_context.compute_meter.consume_checked(execution_cost.syscall_base_cost)?;
 
         Ok(invoke_context.get_stack_height() as u64)
     }
@@ -2069,7 +2084,6 @@ declare_builtin_function!(
         input_size: u64,
         result_addr: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         use solana_bn254::versioned::{
             alt_bn128_versioned_g1_addition, alt_bn128_versioned_g1_multiplication,
@@ -2147,18 +2161,20 @@ declare_builtin_function!(
             }
         };
 
-        consume_compute_meter(invoke_context, cost)?;
+        invoke_context.compute_meter.consume_checked(cost)?;
 
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         translate_mut!(
             memory_mapping,
-            invoke_context.get_check_aligned(),
+            check_aligned,
             let call_result: &mut [u8] = map(result_addr, output as u64)?;
         );
         let input = translate_slice::<u8>(
             memory_mapping,
             input_addr,
             input_size,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?;
 
         let result_point = match group_op {
@@ -2235,13 +2251,14 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
         let params = &translate_slice::<BigModExpParams>(
             memory_mapping,
             params,
             1,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?
         .first()
         .ok_or(SyscallError::InvalidLength)?;
@@ -2255,44 +2272,44 @@ declare_builtin_function!(
 
         let execution_cost = invoke_context.get_execution_cost();
         // the compute units are calculated by the quadratic equation `0.5 input_len^2 + 190`
-        consume_compute_meter(
-            invoke_context,
-            execution_cost.syscall_base_cost.saturating_add(
-                input_len
-                    .saturating_mul(input_len)
-                    .checked_div(execution_cost.big_modular_exponentiation_cost_divisor)
-                    .unwrap_or(u64::MAX)
-                    .saturating_add(execution_cost.big_modular_exponentiation_base_cost),
-            ),
-        )?;
+        let cost = execution_cost.syscall_base_cost.saturating_add(
+            input_len
+                .saturating_mul(input_len)
+                .checked_div(execution_cost.big_modular_exponentiation_cost_divisor)
+                .unwrap_or(u64::MAX)
+                .saturating_add(execution_cost.big_modular_exponentiation_base_cost),
+        );
+        invoke_context.compute_meter.consume_checked(cost)?;
 
         let base = translate_slice::<u8>(
             memory_mapping,
             params.base as *const _ as u64,
             params.base_len,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?;
 
         let exponent = translate_slice::<u8>(
             memory_mapping,
             params.exponent as *const _ as u64,
             params.exponent_len,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?;
 
         let modulus = translate_slice::<u8>(
             memory_mapping,
             params.modulus as *const _ as u64,
             params.modulus_len,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?;
 
         let value = big_mod_exp(base, exponent, modulus);
 
+        let modulus_len = params.modulus_len;
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         translate_mut!(
             memory_mapping,
-            invoke_context.get_check_aligned(),
-            let return_value_ref_mut: &mut [u8] = map(return_value, params.modulus_len)?;
+            check_aligned,
+            let return_value_ref_mut: &mut [u8] = map(return_value, modulus_len)?;
         );
         return_value_ref_mut.copy_from_slice(value.as_slice());
 
@@ -2310,7 +2327,6 @@ declare_builtin_function!(
         vals_addr: u64,
         vals_len: u64,
         result_addr: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let parameters: poseidon::Parameters = parameters.try_into()?;
         let endianness: poseidon::Endianness = endianness.try_into()?;
@@ -2332,27 +2348,24 @@ declare_builtin_function!(
             );
             return Err(SyscallError::ArithmeticOverflow.into());
         };
-        consume_compute_meter(invoke_context, cost.to_owned())?;
+        invoke_context.compute_meter.consume_checked(cost.to_owned())?;
 
+        let check_aligned = invoke_context.get_check_aligned();
+        let poseidon_enforce_padding = invoke_context.get_feature_set().poseidon_enforce_padding;
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         translate_mut!(
             memory_mapping,
-            invoke_context.get_check_aligned(),
+            check_aligned,
             let hash_result: &mut [u8] = map(result_addr, poseidon::HASH_BYTES as u64)?;
         );
-        let inputs = translate_slice::<VmSlice<u8>>(
-            memory_mapping,
-            vals_addr,
-            vals_len,
-            invoke_context.get_check_aligned(),
-        )?;
+        let inputs =
+            translate_slice::<VmSlice<u8>>(memory_mapping, vals_addr, vals_len, check_aligned)?;
         let inputs = inputs
             .iter()
-            .map(|input| {
-                translate_vm_slice(input, memory_mapping, invoke_context.get_check_aligned())
-            })
+            .map(|input| translate_vm_slice(input, memory_mapping, check_aligned))
             .collect::<Result<Vec<_>, Error>>()?;
 
-        let result = if invoke_context.get_feature_set().poseidon_enforce_padding {
+        let result = if poseidon_enforce_padding {
             poseidon::hashv(parameters, endianness, inputs.as_slice())
         } else {
             poseidon::legacy::hashv(parameters, endianness, inputs.as_slice())
@@ -2376,10 +2389,9 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let execution_cost = invoke_context.get_execution_cost();
-        consume_compute_meter(invoke_context, execution_cost.syscall_base_cost)?;
+        invoke_context.compute_meter.consume_checked(execution_cost.syscall_base_cost)?;
 
         use solana_sbpf::vm::ContextObject;
         Ok(invoke_context.get_remaining())
@@ -2396,7 +2408,6 @@ declare_builtin_function!(
         input_size: u64,
         result_addr: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         use solana_bn254::{
             prelude::{ALT_BN128_G1_POINT_SIZE, ALT_BN128_G2_POINT_SIZE},
@@ -2448,18 +2459,20 @@ declare_builtin_function!(
             }
         };
 
-        consume_compute_meter(invoke_context, cost)?;
+        invoke_context.compute_meter.consume_checked(cost)?;
 
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         translate_mut!(
             memory_mapping,
-            invoke_context.get_check_aligned(),
+            check_aligned,
             let call_result: &mut [u8] = map(result_addr, output as u64)?;
         );
         let input = translate_slice::<u8>(
             memory_mapping,
             input_addr,
             input_size,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?;
 
         match op {
@@ -2528,7 +2541,6 @@ declare_builtin_function!(
         result_addr: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let compute_budget = invoke_context.get_compute_budget();
         let compute_cost = invoke_context.get_execution_cost();
@@ -2546,11 +2558,13 @@ declare_builtin_function!(
             return Err(SyscallError::TooManySlices.into());
         }
 
-        consume_compute_meter(invoke_context, hash_base_cost)?;
-
+        invoke_context.compute_meter.consume_checked(hash_base_cost)?;
+        let check_aligned = invoke_context.get_check_aligned();
+        let mem_op_base_cost = compute_cost.mem_op_base_cost;
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         translate_mut!(
             memory_mapping,
-            invoke_context.get_check_aligned(),
+            check_aligned,
             let hash_result: &mut [u8] = map(result_addr, std::mem::size_of::<H::Output>() as u64)?;
         );
         let mut hasher = H::create_hasher();
@@ -2559,19 +2573,19 @@ declare_builtin_function!(
                 memory_mapping,
                 vals_addr,
                 vals_len,
-                invoke_context.get_check_aligned(),
+                check_aligned,
             )?;
 
             for val in vals.iter() {
-                let bytes = translate_vm_slice(val, memory_mapping, invoke_context.get_check_aligned())?;
-                let cost = compute_cost.mem_op_base_cost.max(
+                let bytes = translate_vm_slice(val, memory_mapping, check_aligned)?;
+                let cost = mem_op_base_cost.max(
                     hash_byte_cost.saturating_mul(
                         val.len()
                             .checked_div(2)
                             .expect("div by non-zero literal"),
                     ),
                 );
-                consume_compute_meter(invoke_context, cost)?;
+                invoke_context.compute_meter.consume_checked(cost)?;
                 hasher.hash(bytes);
             }
         }
@@ -2590,7 +2604,6 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let compute_cost = invoke_context.get_execution_cost();
 
@@ -2603,7 +2616,7 @@ declare_builtin_function!(
             // syscall_base
             // ```
             let compute_units = compute_cost.syscall_base_cost;
-            consume_compute_meter(invoke_context, compute_units)?;
+            invoke_context.compute_meter.consume_checked(compute_units)?;
             //
             // Control flow:
             //
@@ -2628,7 +2641,7 @@ declare_builtin_function!(
                         .unwrap_or(u64::MAX),
                 )
                 .saturating_add(compute_cost.mem_op_base_cost);
-            consume_compute_meter(invoke_context, compute_units)?;
+            invoke_context.compute_meter.consume_checked(compute_units)?;
             //
             // Control flow:
             //
@@ -2641,6 +2654,7 @@ declare_builtin_function!(
             //   If the provided vote address corresponds to an account that is not a vote
             //   account or does not exist, the syscall will return `0` for active stake.
             let check_aligned = invoke_context.get_check_aligned();
+            let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
             let vote_address = translate_type::<Pubkey>(memory_mapping, var_addr, check_aligned)?;
 
             Ok(invoke_context.get_epoch_stake_for_vote_account(vote_address))
@@ -2958,7 +2972,7 @@ mod tests {
         prepare_mockup!(invoke_context, program_id, bpf_loader::id());
         let config = Config::default();
         let mut memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
-        let result = SyscallAbort::rust(&mut invoke_context, 0, 0, 0, 0, 0, &mut memory_mapping);
+        let result = SyscallAbort::rust(&mut invoke_context, 0, 0, 0, 0, 0);
         result.unwrap();
     }
 
@@ -2976,7 +2990,9 @@ mod tests {
         )
         .unwrap();
 
-        invoke_context.mock_set_remaining(string.len() as u64 - 1);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(string.len() as u64 - 1);
         let result = SyscallPanic::rust(
             &mut invoke_context,
             0x100000000,
@@ -2984,14 +3000,15 @@ mod tests {
             42,
             84,
             0,
-            &mut memory_mapping,
         );
         assert_matches!(
             result,
             Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
         );
 
-        invoke_context.mock_set_remaining(string.len() as u64);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(string.len() as u64);
         let result = SyscallPanic::rust(
             &mut invoke_context,
             0x100000000,
@@ -2999,7 +3016,6 @@ mod tests {
             42,
             84,
             0,
-            &mut memory_mapping,
         );
         result.unwrap();
     }
@@ -3017,7 +3033,7 @@ mod tests {
         )
         .unwrap();
 
-        invoke_context.mock_set_remaining(400 - 1);
+        invoke_context.compute_meter.mock_set_remaining(400 - 1);
         let result = SyscallLog::rust(
             &mut invoke_context,
             0x100000001, // AccessViolation
@@ -3025,7 +3041,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_access_violation!(result, 0x100000001, string.len() as u64);
         let result = SyscallLog::rust(
@@ -3035,7 +3050,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_access_violation!(result, 0x100000000, string.len() as u64 * 2);
 
@@ -3046,7 +3060,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
         result.unwrap();
         let result = SyscallLog::rust(
@@ -3056,7 +3069,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_matches!(
             result,
@@ -3078,10 +3090,10 @@ mod tests {
         prepare_mockup!(invoke_context, program_id, bpf_loader::id());
         let cost = invoke_context.get_execution_cost().log_64_units;
 
-        invoke_context.mock_set_remaining(cost);
+        invoke_context.compute_meter.mock_set_remaining(cost);
         let config = Config::default();
         let mut memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
-        let result = SyscallLogU64::rust(&mut invoke_context, 1, 2, 3, 4, 5, &mut memory_mapping);
+        let result = SyscallLogU64::rust(&mut invoke_context, 1, 2, 3, 4, 5);
         result.unwrap();
 
         assert_eq!(
@@ -3115,28 +3127,18 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_access_violation!(result, 0x100000001, 32);
 
-        invoke_context.mock_set_remaining(1);
-        let result =
-            SyscallLogPubkey::rust(&mut invoke_context, 100, 32, 0, 0, 0, &mut memory_mapping);
+        invoke_context.compute_meter.mock_set_remaining(1);
+        let result = SyscallLogPubkey::rust(&mut invoke_context, 100, 32, 0, 0, 0);
         assert_matches!(
             result,
             Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
         );
 
-        invoke_context.mock_set_remaining(cost);
-        let result = SyscallLogPubkey::rust(
-            &mut invoke_context,
-            0x100000000,
-            0,
-            0,
-            0,
-            0,
-            &mut memory_mapping,
-        );
+        invoke_context.compute_meter.mock_set_remaining(cost);
+        let result = SyscallLogPubkey::rust(&mut invoke_context, 0x100000000, 0, 0, 0, 0);
         result.unwrap();
 
         assert_eq!(
@@ -3165,6 +3167,7 @@ mod tests {
             )];
             let mapping = MemoryMapping::new(regions, &config, SBPFVersion::V3).unwrap();
             $invoke_context
+                .memory_contexts
                 .set_memory_context(MemoryContext::new(
                     BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
                     Vec::new(),
@@ -3187,7 +3190,6 @@ mod tests {
                 0,
                 0,
                 0,
-                memory_mapping,
             );
             assert_ne!(result.unwrap(), 0);
             let result = SyscallAllocFree::rust(
@@ -3197,11 +3199,9 @@ mod tests {
                 0,
                 0,
                 0,
-                memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
-            let result =
-                SyscallAllocFree::rust(&mut invoke_context, u64::MAX, 0, 0, 0, 0, memory_mapping);
+            let result = SyscallAllocFree::rust(&mut invoke_context, u64::MAX, 0, 0, 0, 0);
             assert_eq!(result.unwrap(), 0);
         }
 
@@ -3209,8 +3209,7 @@ mod tests {
         {
             setup_alloc_test!(invoke_context, memory_mapping, heap);
             for _ in 0..100 {
-                let result =
-                    SyscallAllocFree::rust(&mut invoke_context, 1, 0, 0, 0, 0, memory_mapping);
+                let result = SyscallAllocFree::rust(&mut invoke_context, 1, 0, 0, 0, 0);
                 assert_ne!(result.unwrap(), 0);
             }
             let result = SyscallAllocFree::rust(
@@ -3220,7 +3219,6 @@ mod tests {
                 0,
                 0,
                 0,
-                memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
         }
@@ -3229,8 +3227,7 @@ mod tests {
         {
             setup_alloc_test!(invoke_context, memory_mapping, heap);
             for _ in 0..12 {
-                let result =
-                    SyscallAllocFree::rust(&mut invoke_context, 1, 0, 0, 0, 0, memory_mapping);
+                let result = SyscallAllocFree::rust(&mut invoke_context, 1, 0, 0, 0, 0);
                 assert_ne!(result.unwrap(), 0);
             }
             let result = SyscallAllocFree::rust(
@@ -3240,7 +3237,6 @@ mod tests {
                 0,
                 0,
                 0,
-                memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
         }
@@ -3249,15 +3245,8 @@ mod tests {
 
         fn aligned<T>() {
             setup_alloc_test!(invoke_context, memory_mapping, heap);
-            let result = SyscallAllocFree::rust(
-                &mut invoke_context,
-                size_of::<T>() as u64,
-                0,
-                0,
-                0,
-                0,
-                memory_mapping,
-            );
+            let result =
+                SyscallAllocFree::rust(&mut invoke_context, size_of::<T>() as u64, 0, 0, 0, 0);
             let address = result.unwrap();
             assert_ne!(address, 0);
             assert!(address_is_aligned::<T>(address));
@@ -3302,7 +3291,7 @@ mod tests {
         )
         .unwrap();
 
-        invoke_context.mock_set_remaining(
+        invoke_context.compute_meter.mock_set_remaining(
             (invoke_context.get_execution_cost().sha256_base_cost
                 + invoke_context.get_execution_cost().mem_op_base_cost.max(
                     invoke_context
@@ -3313,15 +3302,8 @@ mod tests {
                 * 4,
         );
 
-        let result = SyscallHash::<Sha256Hasher>::rust(
-            &mut invoke_context,
-            ro_va,
-            ro_len,
-            rw_va,
-            0,
-            0,
-            &mut memory_mapping,
-        );
+        let result =
+            SyscallHash::<Sha256Hasher>::rust(&mut invoke_context, ro_va, ro_len, rw_va, 0, 0);
         result.unwrap();
 
         let hash_local = hashv(&[bytes1.as_ref(), bytes2.as_ref()]).to_bytes();
@@ -3333,7 +3315,6 @@ mod tests {
             rw_va,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_access_violation!(result, ro_va - 1, 32);
         let result = SyscallHash::<Sha256Hasher>::rust(
@@ -3343,7 +3324,6 @@ mod tests {
             rw_va,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_access_violation!(result, ro_va, 48);
         let result = SyscallHash::<Sha256Hasher>::rust(
@@ -3353,18 +3333,10 @@ mod tests {
             rw_va - 1, // AccessViolation
             0,
             0,
-            &mut memory_mapping,
         );
         assert_access_violation!(result, rw_va - 1, HASH_BYTES as u64);
-        let result = SyscallHash::<Sha256Hasher>::rust(
-            &mut invoke_context,
-            ro_va,
-            ro_len,
-            rw_va,
-            0,
-            0,
-            &mut memory_mapping,
-        );
+        let result =
+            SyscallHash::<Sha256Hasher>::rust(&mut invoke_context, ro_va, ro_len, rw_va, 0, 0);
         assert_matches!(
             result,
             Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
@@ -3400,7 +3372,7 @@ mod tests {
         )
         .unwrap();
 
-        invoke_context.mock_set_remaining(
+        invoke_context.compute_meter.mock_set_remaining(
             (invoke_context
                 .get_execution_cost()
                 .curve25519_edwards_validate_point_cost)
@@ -3414,7 +3386,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_eq!(0, result.unwrap());
 
@@ -3425,7 +3396,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_eq!(1, result.unwrap());
 
@@ -3436,7 +3406,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_matches!(
             result,
@@ -3473,7 +3442,7 @@ mod tests {
         )
         .unwrap();
 
-        invoke_context.mock_set_remaining(
+        invoke_context.compute_meter.mock_set_remaining(
             (invoke_context
                 .get_execution_cost()
                 .curve25519_ristretto_validate_point_cost)
@@ -3487,7 +3456,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_eq!(0, result.unwrap());
 
@@ -3498,7 +3466,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_eq!(1, result.unwrap());
 
@@ -3509,7 +3476,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_matches!(
             result,
@@ -3560,7 +3526,7 @@ mod tests {
         )
         .unwrap();
 
-        invoke_context.mock_set_remaining(
+        invoke_context.compute_meter.mock_set_remaining(
             (invoke_context
                 .get_execution_cost()
                 .curve25519_edwards_add_cost
@@ -3580,7 +3546,6 @@ mod tests {
             left_point_va,
             right_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -3597,7 +3562,6 @@ mod tests {
             invalid_point_va,
             right_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
         assert_eq!(1, result.unwrap());
 
@@ -3608,7 +3572,6 @@ mod tests {
             left_point_va,
             right_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -3625,7 +3588,6 @@ mod tests {
             invalid_point_va,
             right_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
         assert_eq!(1, result.unwrap());
 
@@ -3636,7 +3598,6 @@ mod tests {
             scalar_va,
             right_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
 
         result.unwrap();
@@ -3653,7 +3614,6 @@ mod tests {
             scalar_va,
             invalid_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
         assert_eq!(1, result.unwrap());
 
@@ -3664,7 +3624,6 @@ mod tests {
             scalar_va,
             invalid_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
         assert_matches!(
             result,
@@ -3715,7 +3674,7 @@ mod tests {
         )
         .unwrap();
 
-        invoke_context.mock_set_remaining(
+        invoke_context.compute_meter.mock_set_remaining(
             (invoke_context
                 .get_execution_cost()
                 .curve25519_ristretto_add_cost
@@ -3735,7 +3694,6 @@ mod tests {
             left_point_va,
             right_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -3752,7 +3710,6 @@ mod tests {
             invalid_point_va,
             right_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
         assert_eq!(1, result.unwrap());
 
@@ -3763,7 +3720,6 @@ mod tests {
             left_point_va,
             right_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -3780,7 +3736,6 @@ mod tests {
             invalid_point_va,
             right_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(1, result.unwrap());
@@ -3792,7 +3747,6 @@ mod tests {
             scalar_va,
             right_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
 
         result.unwrap();
@@ -3809,7 +3763,6 @@ mod tests {
             scalar_va,
             invalid_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(1, result.unwrap());
@@ -3821,7 +3774,6 @@ mod tests {
             scalar_va,
             invalid_point_va,
             result_point_va,
-            &mut memory_mapping,
         );
         assert_matches!(
             result,
@@ -3885,7 +3837,7 @@ mod tests {
         )
         .unwrap();
 
-        invoke_context.mock_set_remaining(
+        invoke_context.compute_meter.mock_set_remaining(
             invoke_context
                 .get_execution_cost()
                 .curve25519_edwards_msm_base_cost
@@ -3907,7 +3859,6 @@ mod tests {
             edwards_points_va,
             2,
             result_point_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -3924,7 +3875,6 @@ mod tests {
             ristretto_points_va,
             2,
             result_point_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -3979,7 +3929,7 @@ mod tests {
         .unwrap();
 
         // test Edwards
-        invoke_context.mock_set_remaining(500_000);
+        invoke_context.compute_meter.mock_set_remaining(500_000);
         let result = SyscallCurveMultiscalarMultiplication::rust(
             &mut invoke_context,
             CURVE25519_EDWARDS,
@@ -3987,7 +3937,6 @@ mod tests {
             edwards_points_va,
             512, // below maximum vector length
             result_point_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -3997,7 +3946,7 @@ mod tests {
         ];
         assert_eq!(expected_product, result_point);
 
-        invoke_context.mock_set_remaining(500_000);
+        invoke_context.compute_meter.mock_set_remaining(500_000);
         let result = SyscallCurveMultiscalarMultiplication::rust(
             &mut invoke_context,
             CURVE25519_EDWARDS,
@@ -4005,7 +3954,6 @@ mod tests {
             edwards_points_va,
             513, // above maximum vector length
             result_point_va,
-            &mut memory_mapping,
         )
         .unwrap_err()
         .downcast::<SyscallError>()
@@ -4014,7 +3962,7 @@ mod tests {
         assert_eq!(*result, SyscallError::InvalidLength);
 
         // test Ristretto
-        invoke_context.mock_set_remaining(500_000);
+        invoke_context.compute_meter.mock_set_remaining(500_000);
         let result = SyscallCurveMultiscalarMultiplication::rust(
             &mut invoke_context,
             CURVE25519_RISTRETTO,
@@ -4022,7 +3970,6 @@ mod tests {
             ristretto_points_va,
             512, // below maximum vector length
             result_point_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -4032,7 +3979,7 @@ mod tests {
         ];
         assert_eq!(expected_product, result_point);
 
-        invoke_context.mock_set_remaining(500_000);
+        invoke_context.compute_meter.mock_set_remaining(500_000);
         let result = SyscallCurveMultiscalarMultiplication::rust(
             &mut invoke_context,
             CURVE25519_RISTRETTO,
@@ -4040,7 +3987,6 @@ mod tests {
             ristretto_points_va,
             513, // above maximum vector length
             result_point_va,
-            &mut memory_mapping,
         )
         .unwrap_err()
         .downcast::<SyscallError>()
@@ -4165,15 +4111,8 @@ mod tests {
             )
             .unwrap();
 
-            let result = SyscallGetClockSysvar::rust(
-                &mut invoke_context,
-                got_clock_obj_va,
-                0,
-                0,
-                0,
-                0,
-                &mut memory_mapping,
-            );
+            let result =
+                SyscallGetClockSysvar::rust(&mut invoke_context, got_clock_obj_va, 0, 0, 0, 0);
             assert_eq!(result.unwrap(), 0);
             assert_eq!(got_clock_obj, src_clock);
 
@@ -4192,7 +4131,6 @@ mod tests {
                 0,
                 Clock::size_of() as u64,
                 0,
-                &mut memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
 
@@ -4236,7 +4174,6 @@ mod tests {
                 0,
                 0,
                 0,
-                &mut memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
             assert_eq!(got_epochschedule_obj, src_epochschedule);
@@ -4260,7 +4197,6 @@ mod tests {
                 0,
                 EpochSchedule::size_of() as u64,
                 0,
-                &mut memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
 
@@ -4291,15 +4227,7 @@ mod tests {
             )
             .unwrap();
 
-            let result = SyscallGetFeesSysvar::rust(
-                &mut invoke_context,
-                got_fees_va,
-                0,
-                0,
-                0,
-                0,
-                &mut memory_mapping,
-            );
+            let result = SyscallGetFeesSysvar::rust(&mut invoke_context, got_fees_va, 0, 0, 0, 0);
             assert_eq!(result.unwrap(), 0);
             assert_eq!(got_fees, src_fees);
 
@@ -4331,15 +4259,8 @@ mod tests {
             )
             .unwrap();
 
-            let result = SyscallGetRentSysvar::rust(
-                &mut invoke_context,
-                got_rent_obj_va,
-                0,
-                0,
-                0,
-                0,
-                &mut memory_mapping,
-            );
+            let result =
+                SyscallGetRentSysvar::rust(&mut invoke_context, got_rent_obj_va, 0, 0, 0, 0);
             assert_eq!(result.unwrap(), 0);
             assert_eq!(got_rent_obj, src_rent);
 
@@ -4356,7 +4277,6 @@ mod tests {
                 0,
                 Rent::size_of() as u64,
                 0,
-                &mut memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
 
@@ -4399,7 +4319,6 @@ mod tests {
                 0,
                 0,
                 0,
-                &mut memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
             assert_eq!(got_rewards_obj, src_rewards);
@@ -4422,7 +4341,6 @@ mod tests {
                 0,
                 EpochRewards::size_of() as u64,
                 0,
-                &mut memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
 
@@ -4465,7 +4383,6 @@ mod tests {
                 0,
                 0,
                 0,
-                &mut memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
             assert_eq!(got_restart_obj, src_restart);
@@ -4481,7 +4398,6 @@ mod tests {
                 0,
                 LastRestartSlot::size_of() as u64,
                 0,
-                &mut memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
 
@@ -4551,7 +4467,6 @@ mod tests {
                 0,
                 StakeHistory::size_of() as u64,
                 0,
-                &mut memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
 
@@ -4611,7 +4526,6 @@ mod tests {
                 0,
                 SlotHashes::size_of() as u64,
                 0,
-                &mut memory_mapping,
             );
             assert_eq!(result.unwrap(), 0);
 
@@ -4668,7 +4582,6 @@ mod tests {
                 0,
                 Clock::size_of() as u64,
                 0,
-                &mut memory_mapping,
             )
             .unwrap_err();
 
@@ -4686,7 +4599,6 @@ mod tests {
                 0,
                 Clock::size_of() as u64,
                 0,
-                &mut memory_mapping,
             )
             .unwrap_err();
 
@@ -4703,7 +4615,6 @@ mod tests {
                 0,
                 Clock::size_of() as u64,
                 0,
-                &mut memory_mapping,
             )
             .unwrap_err();
 
@@ -4721,7 +4632,6 @@ mod tests {
                 u64::MAX - Clock::size_of() as u64 / 2,
                 Clock::size_of() as u64,
                 0,
-                &mut memory_mapping,
             )
             .unwrap_err();
 
@@ -4742,7 +4652,6 @@ mod tests {
                 0,
                 Clock::size_of() as u64,
                 0,
-                &mut memory_mapping,
             )
             .unwrap();
 
@@ -4765,7 +4674,6 @@ mod tests {
                 1,
                 Clock::size_of() as u64,
                 0,
-                &mut memory_mapping,
             )
             .unwrap();
 
@@ -4780,7 +4688,6 @@ mod tests {
                 0,
                 Clock::size_of() as u64,
                 0,
-                &mut memory_mapping,
             )
             .unwrap();
 
@@ -4797,7 +4704,6 @@ mod tests {
         u64,
         u64,
         u64,
-        &mut MemoryMapping,
     ) -> Result<u64, Box<dyn std::error::Error>>;
 
     fn call_program_address_common<'a, 'b: 'a>(
@@ -4849,7 +4755,6 @@ mod tests {
             } else {
                 BUMP_SEED_VA
             },
-            &mut memory_mapping,
         );
         result.map(|_| (address, bump_seed))
     }
@@ -4906,15 +4811,8 @@ mod tests {
 
         prepare_mockup!(invoke_context, program_id, bpf_loader::id());
 
-        let result = SyscallSetReturnData::rust(
-            &mut invoke_context,
-            SRC_VA,
-            data.len() as u64,
-            0,
-            0,
-            0,
-            &mut memory_mapping,
-        );
+        let result =
+            SyscallSetReturnData::rust(&mut invoke_context, SRC_VA, data.len() as u64, 0, 0, 0);
         assert_eq!(result.unwrap(), 0);
 
         let result = SyscallGetReturnData::rust(
@@ -4924,7 +4822,6 @@ mod tests {
             PROGRAM_ID_VA,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_eq!(result.unwrap() as usize, data.len());
         assert_eq!(data.get(0..data_buffer.len()).unwrap(), data_buffer);
@@ -4937,7 +4834,6 @@ mod tests {
             PROGRAM_ID_VA,
             0,
             0,
-            &mut memory_mapping,
         );
         assert_matches!(
             result,
@@ -5030,7 +4926,9 @@ mod tests {
         processed_sibling_instruction.accounts_len = 1;
 
         let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
             0,
@@ -5038,7 +4936,6 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            &mut memory_mapping,
         );
         assert_eq!(result.unwrap(), 1);
         {
@@ -5081,7 +4978,9 @@ mod tests {
         }
 
         let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
             1,
@@ -5089,7 +4988,6 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            &mut memory_mapping,
         );
 
         assert_eq!(result.unwrap(), 1);
@@ -5133,7 +5031,9 @@ mod tests {
         }
 
         let syscall_base_cost = invoke_context.get_execution_cost().syscall_base_cost;
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
             2,
@@ -5141,12 +5041,13 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            &mut memory_mapping,
         );
 
         assert_eq!(result.unwrap(), 0);
 
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
             0,
@@ -5154,7 +5055,6 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(META_OFFSET as u64),
-            &mut memory_mapping,
         );
         assert_matches!(
             result,
@@ -5297,7 +5197,9 @@ mod tests {
         invoke_context.transaction_context.push().unwrap();
 
         // Invoking the syscall from B5 should return false
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
             0,
@@ -5305,7 +5207,6 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            &mut memory_mapping,
         );
         assert_eq!(result.unwrap(), 0);
 
@@ -5335,7 +5236,9 @@ mod tests {
         invoke_context.transaction_context.pop().unwrap();
 
         // Invoking the syscall from B6 with index zero should return ix B5
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
             0,
@@ -5343,7 +5246,6 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            &mut memory_mapping,
         );
 
         assert_eq!(result.unwrap(), 1);
@@ -5387,7 +5289,9 @@ mod tests {
         }
 
         // Invoking the syscall from B6 with index one should return false
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
             1,
@@ -5395,7 +5299,6 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            &mut memory_mapping,
         );
         assert_eq!(result.unwrap(), 0);
 
@@ -5414,7 +5317,9 @@ mod tests {
         invoke_context.transaction_context.push().unwrap();
 
         // Invoking the syscall from B8 with index zero should return ix B6
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
             0,
@@ -5422,7 +5327,6 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            &mut memory_mapping,
         );
 
         assert_eq!(result.unwrap(), 1);
@@ -5466,7 +5370,9 @@ mod tests {
         }
 
         // Invoking the syscall from B6 with index one should return ix B5
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
             1,
@@ -5474,7 +5380,6 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            &mut memory_mapping,
         );
 
         assert_eq!(result.unwrap(), 1);
@@ -5518,7 +5423,9 @@ mod tests {
         }
 
         // Invoking the syscall from B8 with index two should return false
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
             2,
@@ -5526,7 +5433,6 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            &mut memory_mapping,
         );
         assert_eq!(result.unwrap(), 0);
 
@@ -5541,7 +5447,9 @@ mod tests {
         invoke_context.transaction_context.push().unwrap();
 
         // Invoking the syscall from B with index zero should return ix C
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         processed_sibling_instruction.data_len = 1;
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
@@ -5550,7 +5458,6 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            &mut memory_mapping,
         );
 
         assert_eq!(result.unwrap(), 1);
@@ -5605,7 +5512,9 @@ mod tests {
         invoke_context.transaction_context.push().unwrap();
 
         // Invoking the CPI from C1 with index zero should return false.
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
             0,
@@ -5613,7 +5522,6 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            &mut memory_mapping,
         );
         assert_eq!(result.unwrap(), 0);
 
@@ -5631,7 +5539,9 @@ mod tests {
         invoke_context.transaction_context.push().unwrap();
 
         // Invoking the syscall from C2 with index zero should return ix C1
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         processed_sibling_instruction.data_len = 2;
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
@@ -5640,7 +5550,6 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            &mut memory_mapping,
         );
 
         assert_eq!(result.unwrap(), 1);
@@ -5684,7 +5593,9 @@ mod tests {
         }
 
         // Invoking the CPI from C2 with index one should return false.
-        invoke_context.mock_set_remaining(syscall_base_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(syscall_base_cost);
         let result = SyscallGetProcessedSiblingInstruction::rust(
             &mut invoke_context,
             1,
@@ -5692,7 +5603,6 @@ mod tests {
             VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
             VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
-            &mut memory_mapping,
         );
         assert_eq!(result.unwrap(), 0);
     }
@@ -5793,7 +5703,7 @@ mod tests {
                 .unwrap(),
             create_program_address(&mut invoke_context, &[b"Talking"], &address).unwrap(),
         );
-        invoke_context.mock_set_remaining(0);
+        invoke_context.compute_meter.mock_set_remaining(0);
         assert_matches!(
             create_program_address(&mut invoke_context, &[b"", &[1]], &address),
             Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
@@ -5811,7 +5721,9 @@ mod tests {
 
         for _ in 0..1_000 {
             let address = Pubkey::new_unique();
-            invoke_context.mock_set_remaining(cost * max_tries);
+            invoke_context
+                .compute_meter
+                .mock_set_remaining(cost * max_tries);
             let (found_address, bump_seed) =
                 try_find_program_address(&mut invoke_context, &[b"Lil'", b"Bits"], &address)
                     .unwrap();
@@ -5827,19 +5739,27 @@ mod tests {
         }
 
         let seeds: &[&[u8]] = &[b""];
-        invoke_context.mock_set_remaining(cost * max_tries);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(cost * max_tries);
         let (_, bump_seed) =
             try_find_program_address(&mut invoke_context, seeds, &address).unwrap();
-        invoke_context.mock_set_remaining(cost * (max_tries - bump_seed as u64));
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(cost * (max_tries - bump_seed as u64));
         try_find_program_address(&mut invoke_context, seeds, &address).unwrap();
-        invoke_context.mock_set_remaining(cost * (max_tries - bump_seed as u64 - 1));
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(cost * (max_tries - bump_seed as u64 - 1));
         assert_matches!(
             try_find_program_address(&mut invoke_context, seeds, &address),
             Result::Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ComputationalBudgetExceeded
         );
 
         let exceeded_seed = &[127; MAX_SEED_LEN + 1];
-        invoke_context.mock_set_remaining(cost * (max_tries - 1));
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(cost * (max_tries - 1));
         assert_matches!(
             try_find_program_address(&mut invoke_context, &[exceeded_seed], &address),
             Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::BadSeeds(PubkeyError::MaxSeedLengthExceeded)
@@ -5863,7 +5783,9 @@ mod tests {
             &[16],
             &[17],
         ];
-        invoke_context.mock_set_remaining(cost * (max_tries - 1));
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(cost * (max_tries - 1));
         assert_matches!(
             try_find_program_address(&mut invoke_context, exceeded_seeds, &address),
             Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::BadSeeds(PubkeyError::MaxSeedLengthExceeded)
@@ -5918,21 +5840,14 @@ mod tests {
             .unwrap();
 
             let budget = invoke_context.get_execution_cost();
-            invoke_context.mock_set_remaining(
+            invoke_context.compute_meter.mock_set_remaining(
                 budget.syscall_base_cost
                     + (MAX_LEN * MAX_LEN) / budget.big_modular_exponentiation_cost_divisor
                     + budget.big_modular_exponentiation_base_cost,
             );
 
-            let result = SyscallBigModExp::rust(
-                &mut invoke_context,
-                VADDR_PARAMS,
-                VADDR_OUT,
-                0,
-                0,
-                0,
-                &mut memory_mapping,
-            );
+            let result =
+                SyscallBigModExp::rust(&mut invoke_context, VADDR_PARAMS, VADDR_OUT, 0, 0, 0);
 
             assert_eq!(result.unwrap(), 0);
         }
@@ -5960,21 +5875,14 @@ mod tests {
             .unwrap();
 
             let budget = invoke_context.get_execution_cost();
-            invoke_context.mock_set_remaining(
+            invoke_context.compute_meter.mock_set_remaining(
                 budget.syscall_base_cost
                     + (INV_LEN * INV_LEN) / budget.big_modular_exponentiation_cost_divisor
                     + budget.big_modular_exponentiation_base_cost,
             );
 
-            let result = SyscallBigModExp::rust(
-                &mut invoke_context,
-                VADDR_PARAMS,
-                VADDR_OUT,
-                0,
-                0,
-                0,
-                &mut memory_mapping,
-            );
+            let result =
+                SyscallBigModExp::rust(&mut invoke_context, VADDR_PARAMS, VADDR_OUT, 0, 0, 0);
 
             assert_matches!(
                 result,
@@ -6020,22 +5928,16 @@ mod tests {
             &program_runtime_environments,
             &sysvar_cache,
         );
-        invoke_context.mock_set_remaining(compute_budget.compute_unit_limit);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(compute_budget.compute_unit_limit);
 
         let null_pointer_var = std::ptr::null::<Pubkey>() as u64;
 
         let mut memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
 
-        let result = SyscallGetEpochStake::rust(
-            &mut invoke_context,
-            null_pointer_var,
-            0,
-            0,
-            0,
-            0,
-            &mut memory_mapping,
-        )
-        .unwrap();
+        let result =
+            SyscallGetEpochStake::rust(&mut invoke_context, null_pointer_var, 0, 0, 0, 0).unwrap();
 
         assert_eq!(result, EXPECTED_TOTAL_STAKE);
     }
@@ -6102,20 +6004,15 @@ mod tests {
             )
             .unwrap();
 
-            let result = SyscallGetEpochStake::rust(
-                &mut invoke_context,
-                vote_address_var,
-                0,
-                0,
-                0,
-                0,
-                &mut memory_mapping,
-            );
+            let result =
+                SyscallGetEpochStake::rust(&mut invoke_context, vote_address_var, 0, 0, 0, 0);
 
             assert_access_violation!(result, vote_address_var, 32);
         }
 
-        invoke_context.mock_set_remaining(compute_budget.compute_unit_limit);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(compute_budget.compute_unit_limit);
         {
             // Otherwise, the syscall returns a `u64` integer representing the
             // total active stake delegated to the vote account at the provided
@@ -6132,21 +6029,16 @@ mod tests {
             )
             .unwrap();
 
-            let result = SyscallGetEpochStake::rust(
-                &mut invoke_context,
-                vote_address_var,
-                0,
-                0,
-                0,
-                0,
-                &mut memory_mapping,
-            )
-            .unwrap();
+            let result =
+                SyscallGetEpochStake::rust(&mut invoke_context, vote_address_var, 0, 0, 0, 0)
+                    .unwrap();
 
             assert_eq!(result, EXPECTED_EPOCH_STAKE);
         }
 
-        invoke_context.mock_set_remaining(compute_budget.compute_unit_limit);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(compute_budget.compute_unit_limit);
         {
             // If the provided vote address corresponds to an account that is
             // not a vote account or does not exist, the syscall will write
@@ -6164,16 +6056,9 @@ mod tests {
             )
             .unwrap();
 
-            let result = SyscallGetEpochStake::rust(
-                &mut invoke_context,
-                vote_address_var,
-                0,
-                0,
-                0,
-                0,
-                &mut memory_mapping,
-            )
-            .unwrap();
+            let result =
+                SyscallGetEpochStake::rust(&mut invoke_context, vote_address_var, 0, 0, 0, 0)
+                    .unwrap();
 
             assert_eq!(result, 0); // `0` for active stake.
         }
@@ -6233,15 +6118,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = SyscallMemcmp::rust(
-            &mut invoke_context,
-            src_a,
-            src_b,
-            4,
-            0x300000000,
-            0,
-            &mut memory_mapping,
-        );
+        let result = SyscallMemcmp::rust(&mut invoke_context, src_a, src_b, 4, 0x300000000, 0);
         result.unwrap();
         assert_eq!(result_mem, expected_result);
     }
@@ -6268,8 +6145,7 @@ mod tests {
         )
         .unwrap();
 
-        let result =
-            SyscallMemmove::rust(&mut invoke_context, dst, src, 4, 0, 0, &mut memory_mapping);
+        let result = SyscallMemmove::rust(&mut invoke_context, dst, src, 4, 0, 0);
         result.unwrap();
         let mut hasher = DefaultHasher::new();
         mem.hash(&mut hasher);
@@ -6289,15 +6165,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = SyscallMemset::rust(
-            &mut invoke_context,
-            dst,
-            value,
-            4,
-            0,
-            0,
-            &mut memory_mapping,
-        );
+        let result = SyscallMemset::rust(&mut invoke_context, dst, value, 4, 0, 0);
         result.unwrap();
         let mut hasher = DefaultHasher::new();
         mem.hash(&mut hasher);
@@ -6317,8 +6185,7 @@ mod tests {
         )
         .unwrap();
 
-        let result =
-            SyscallMemcpy::rust(&mut invoke_context, dst, src, 4, 0, 0, &mut memory_mapping);
+        let result = SyscallMemcpy::rust(&mut invoke_context, dst, src, 4, 0, 0);
         assert_matches!(
             result,
             Result::Err(error) if error.downcast_ref::<SyscallError>().unwrap() == &SyscallError::CopyOverlapping
@@ -6340,14 +6207,11 @@ mod tests {
         )
         .unwrap();
 
-        let result =
-            SyscallMemcpy::rust(&mut invoke_context, dst, src, 4, 0, 0, &mut memory_mapping);
+        let result = SyscallMemcpy::rust(&mut invoke_context, dst, src, 4, 0, 0);
         assert_access_violation!(result, fault_address, 4);
-        let result =
-            SyscallMemmove::rust(&mut invoke_context, dst, src, 4, 0, 0, &mut memory_mapping);
+        let result = SyscallMemmove::rust(&mut invoke_context, dst, src, 4, 0, 0);
         assert_access_violation!(result, fault_address, 4);
-        let result =
-            SyscallMemcmp::rust(&mut invoke_context, dst, src, 4, 0, 0, &mut memory_mapping);
+        let result = SyscallMemcmp::rust(&mut invoke_context, dst, src, 4, 0, 0);
         assert_access_violation!(result, fault_address, 4);
     }
 
@@ -6364,7 +6228,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = SyscallMemset::rust(&mut invoke_context, dst, 0, 4, 0, 0, &mut memory_mapping);
+        let result = SyscallMemset::rust(&mut invoke_context, dst, 0, 4, 0, 0);
         assert_access_violation!(result, dst, 4);
     }
 
@@ -6387,7 +6251,6 @@ mod tests {
             4,
             0x100000000,
             0,
-            &mut memory_mapping,
         );
         assert_access_violation!(result, 0x100000000, 4);
     }
@@ -6478,7 +6341,9 @@ mod tests {
         .unwrap();
 
         let bls12_381_g1_add_cost = invoke_context.get_execution_cost().bls12_381_g1_add_cost;
-        invoke_context.mock_set_remaining(2 * bls12_381_g1_add_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(2 * bls12_381_g1_add_cost);
 
         let result = SyscallCurveGroupOps::rust(
             &mut invoke_context,
@@ -6487,7 +6352,6 @@ mod tests {
             p1_be_va,
             p2_be_va,
             result_be_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -6500,7 +6364,6 @@ mod tests {
             p1_le_va,
             p2_le_va,
             result_le_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -6596,7 +6459,9 @@ mod tests {
         let bls12_381_g1_subtract_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g1_subtract_cost;
-        invoke_context.mock_set_remaining(2 * bls12_381_g1_subtract_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(2 * bls12_381_g1_subtract_cost);
 
         let result = SyscallCurveGroupOps::rust(
             &mut invoke_context,
@@ -6605,7 +6470,6 @@ mod tests {
             p1_be_va,
             p2_be_va,
             result_be_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -6618,7 +6482,6 @@ mod tests {
             p1_le_va,
             p2_le_va,
             result_le_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -6707,7 +6570,9 @@ mod tests {
         let bls12_381_g1_multiply_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g1_multiply_cost;
-        invoke_context.mock_set_remaining(2 * bls12_381_g1_multiply_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(2 * bls12_381_g1_multiply_cost);
 
         let result = SyscallCurveGroupOps::rust(
             &mut invoke_context,
@@ -6716,7 +6581,6 @@ mod tests {
             scalar_be_va,
             point_be_va,
             result_be_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -6729,7 +6593,6 @@ mod tests {
             scalar_le_va,
             point_le_va,
             result_le_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -6854,7 +6717,9 @@ mod tests {
         .unwrap();
 
         let bls12_381_g2_add_cost = invoke_context.get_execution_cost().bls12_381_g2_add_cost;
-        invoke_context.mock_set_remaining(2 * bls12_381_g2_add_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(2 * bls12_381_g2_add_cost);
 
         let result = SyscallCurveGroupOps::rust(
             &mut invoke_context,
@@ -6863,7 +6728,6 @@ mod tests {
             p1_be_va,
             p2_be_va,
             result_be_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -6876,7 +6740,6 @@ mod tests {
             p1_le_va,
             p2_le_va,
             result_le_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7004,7 +6867,9 @@ mod tests {
         let bls12_381_g2_subtract_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g2_subtract_cost;
-        invoke_context.mock_set_remaining(2 * bls12_381_g2_subtract_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(2 * bls12_381_g2_subtract_cost);
 
         let result = SyscallCurveGroupOps::rust(
             &mut invoke_context,
@@ -7013,7 +6878,6 @@ mod tests {
             p1_be_va,
             p2_be_va,
             result_be_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7026,7 +6890,6 @@ mod tests {
             p1_le_va,
             p2_le_va,
             result_le_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7136,7 +6999,9 @@ mod tests {
         let bls12_381_g2_multiply_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g2_multiply_cost;
-        invoke_context.mock_set_remaining(2 * bls12_381_g2_multiply_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(2 * bls12_381_g2_multiply_cost);
 
         let result = SyscallCurveGroupOps::rust(
             &mut invoke_context,
@@ -7145,7 +7010,6 @@ mod tests {
             scalar_be_va,
             point_be_va,
             result_be_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7158,7 +7022,6 @@ mod tests {
             scalar_le_va,
             point_le_va,
             result_le_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7250,7 +7113,9 @@ mod tests {
         .unwrap();
 
         let bls12_381_one_pair_cost = invoke_context.get_execution_cost().bls12_381_one_pair_cost;
-        invoke_context.mock_set_remaining(bls12_381_one_pair_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(bls12_381_one_pair_cost);
 
         let result = SyscallCurvePairingMap::rust(
             &mut invoke_context,
@@ -7259,7 +7124,6 @@ mod tests {
             g1_va,
             g2_va,
             result_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7351,7 +7215,9 @@ mod tests {
         .unwrap();
 
         let bls12_381_one_pair_cost = invoke_context.get_execution_cost().bls12_381_one_pair_cost;
-        invoke_context.mock_set_remaining(bls12_381_one_pair_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(bls12_381_one_pair_cost);
 
         let result = SyscallCurvePairingMap::rust(
             &mut invoke_context,
@@ -7360,7 +7226,6 @@ mod tests {
             g1_va,
             g2_va,
             result_va,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7429,7 +7294,9 @@ mod tests {
         let bls12_381_g2_decompress_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g2_decompress_cost;
-        invoke_context.mock_set_remaining(2 * bls12_381_g2_decompress_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(2 * bls12_381_g2_decompress_cost);
 
         let result = SyscallCurveDecompress::rust(
             &mut invoke_context,
@@ -7438,7 +7305,6 @@ mod tests {
             result_be_va,
             0,
             0,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7451,7 +7317,6 @@ mod tests {
             result_le_va,
             0,
             0,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7536,7 +7401,9 @@ mod tests {
         let bls12_381_g2_decompress_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g2_decompress_cost;
-        invoke_context.mock_set_remaining(2 * bls12_381_g2_decompress_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(2 * bls12_381_g2_decompress_cost);
 
         let result = SyscallCurveDecompress::rust(
             &mut invoke_context,
@@ -7545,7 +7412,6 @@ mod tests {
             result_be_va,
             0,
             0,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7558,7 +7424,6 @@ mod tests {
             result_le_va,
             0,
             0,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7610,7 +7475,9 @@ mod tests {
         let bls12_381_g1_validate_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g1_validate_cost;
-        invoke_context.mock_set_remaining(2 * bls12_381_g1_validate_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(2 * bls12_381_g1_validate_cost);
 
         let result = SyscallCurvePointValidation::rust(
             &mut invoke_context,
@@ -7619,7 +7486,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7631,7 +7497,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7694,7 +7559,9 @@ mod tests {
         let bls12_381_g2_validate_cost = invoke_context
             .get_execution_cost()
             .bls12_381_g2_validate_cost;
-        invoke_context.mock_set_remaining(2 * bls12_381_g2_validate_cost);
+        invoke_context
+            .compute_meter
+            .mock_set_remaining(2 * bls12_381_g2_validate_cost);
 
         let result = SyscallCurvePointValidation::rust(
             &mut invoke_context,
@@ -7703,7 +7570,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());
@@ -7715,7 +7581,6 @@ mod tests {
             0,
             0,
             0,
-            &mut memory_mapping,
         );
 
         assert_eq!(0, result.unwrap());

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2348,7 +2348,9 @@ declare_builtin_function!(
             );
             return Err(SyscallError::ArithmeticOverflow.into());
         };
-        invoke_context.compute_meter.consume_checked(cost.to_owned())?;
+        invoke_context
+            .compute_meter
+            .consume_checked(cost.to_owned())?;
 
         let check_aligned = invoke_context.get_check_aligned();
         let poseidon_enforce_padding = invoke_context.get_feature_set().poseidon_enforce_padding;
@@ -2616,7 +2618,9 @@ declare_builtin_function!(
             // syscall_base
             // ```
             let compute_units = compute_cost.syscall_base_cost;
-            invoke_context.compute_meter.consume_checked(compute_units)?;
+            invoke_context
+                .compute_meter
+                .consume_checked(compute_units)?;
             //
             // Control flow:
             //
@@ -2641,7 +2645,9 @@ declare_builtin_function!(
                         .unwrap_or(u64::MAX),
                 )
                 .saturating_add(compute_cost.mem_op_base_cost);
-            invoke_context.compute_meter.consume_checked(compute_units)?;
+            invoke_context
+                .compute_meter
+                .consume_checked(compute_units)?;
             //
             // Control flow:
             //
@@ -2971,7 +2977,10 @@ mod tests {
     fn test_syscall_abort() {
         prepare_mockup!(invoke_context, program_id, bpf_loader::id());
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
+        let memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         let result = SyscallAbort::rust(&mut invoke_context, 0, 0, 0, 0, 0);
         result.unwrap();
     }
@@ -2983,13 +2992,15 @@ mod tests {
 
         let string = "Gaggablaghblagh!";
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![MemoryRegion::new_readonly(string.as_bytes(), 0x100000000)],
             &config,
             SBPFVersion::V3,
         )
         .unwrap();
-
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         invoke_context
             .compute_meter
             .mock_set_remaining(string.len() as u64 - 1);
@@ -3026,13 +3037,15 @@ mod tests {
 
         let string = "Gaggablaghblagh!";
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![MemoryRegion::new_readonly(string.as_bytes(), 0x100000000)],
             &config,
             SBPFVersion::V3,
         )
         .unwrap();
-
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(400 - 1);
         let result = SyscallLog::rust(
             &mut invoke_context,
@@ -3092,7 +3105,10 @@ mod tests {
 
         invoke_context.compute_meter.mock_set_remaining(cost);
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
+        let memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         let result = SyscallLogU64::rust(&mut invoke_context, 1, 2, 3, 4, 5);
         result.unwrap();
 
@@ -3113,12 +3129,15 @@ mod tests {
 
         let pubkey = Pubkey::from_str("MoqiU1vryuCGQSxFKA1SZ316JdLEFFhoAu6cKUNk7dN").unwrap();
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![MemoryRegion::new_readonly(bytes_of(&pubkey), 0x100000000)],
             &config,
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let result = SyscallLogPubkey::rust(
             &mut invoke_context,
@@ -3152,9 +3171,8 @@ mod tests {
     }
 
     macro_rules! setup_alloc_test {
-        ($invoke_context:ident, $memory_mapping:ident, $heap:ident) => {
+        ($invoke_context:ident, $heap:ident) => {
             prepare_mockup!($invoke_context, program_id, bpf_loader::id());
-            use solana_sbpf::vm::ContextObject;
             let config = Config {
                 aligned_memory_mapping: false,
                 ..Config::default()
@@ -3174,7 +3192,6 @@ mod tests {
                     mapping,
                 ))
                 .unwrap();
-            let $memory_mapping = unsafe { $invoke_context.active_mapping_ptr().as_mut() };
         };
     }
 
@@ -3182,7 +3199,7 @@ mod tests {
     fn test_syscall_sol_alloc_free() {
         // large alloc
         {
-            setup_alloc_test!(invoke_context, memory_mapping, heap);
+            setup_alloc_test!(invoke_context, heap);
             let result = SyscallAllocFree::rust(
                 &mut invoke_context,
                 solana_program_entrypoint::HEAP_LENGTH as u64,
@@ -3207,7 +3224,7 @@ mod tests {
 
         // many small unaligned allocs
         {
-            setup_alloc_test!(invoke_context, memory_mapping, heap);
+            setup_alloc_test!(invoke_context, heap);
             for _ in 0..100 {
                 let result = SyscallAllocFree::rust(&mut invoke_context, 1, 0, 0, 0, 0);
                 assert_ne!(result.unwrap(), 0);
@@ -3225,7 +3242,7 @@ mod tests {
 
         // many small aligned allocs
         {
-            setup_alloc_test!(invoke_context, memory_mapping, heap);
+            setup_alloc_test!(invoke_context, heap);
             for _ in 0..12 {
                 let result = SyscallAllocFree::rust(&mut invoke_context, 1, 0, 0, 0, 0);
                 assert_ne!(result.unwrap(), 0);
@@ -3244,7 +3261,7 @@ mod tests {
         // aligned allocs
 
         fn aligned<T>() {
-            setup_alloc_test!(invoke_context, memory_mapping, heap);
+            setup_alloc_test!(invoke_context, heap);
             let result =
                 SyscallAllocFree::rust(&mut invoke_context, size_of::<T>() as u64, 0, 0, 0, 0);
             let address = result.unwrap();
@@ -3279,7 +3296,7 @@ mod tests {
         let ro_len = bytes_to_hash.len() as u64;
         let ro_va = 0x100000000;
         let rw_va = 0x200000000;
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(bytes_of_slice(&bytes_to_hash), ro_va),
                 MemoryRegion::new_writable(bytes_of_slice_mut(&mut hash_result), rw_va),
@@ -3290,7 +3307,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
-
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(
             (invoke_context.get_execution_cost().sha256_base_cost
                 + invoke_context.get_execution_cost().mem_op_base_cost.max(
@@ -3362,7 +3381,7 @@ mod tests {
         ];
         let invalid_bytes_va = 0x200000000;
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&valid_bytes, valid_bytes_va),
                 MemoryRegion::new_readonly(&invalid_bytes, invalid_bytes_va),
@@ -3372,6 +3391,9 @@ mod tests {
         )
         .unwrap();
 
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(
             (invoke_context
                 .get_execution_cost()
@@ -3432,7 +3454,7 @@ mod tests {
         ];
         let invalid_bytes_va = 0x200000000;
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&valid_bytes, valid_bytes_va),
                 MemoryRegion::new_readonly(&invalid_bytes, invalid_bytes_va),
@@ -3442,6 +3464,9 @@ mod tests {
         )
         .unwrap();
 
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(
             (invoke_context
                 .get_execution_cost()
@@ -3513,7 +3538,7 @@ mod tests {
         let mut result_point: [u8; 32] = [0; 32];
         let result_point_va = 0x500000000;
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(bytes_of_slice(&left_point), left_point_va),
                 MemoryRegion::new_readonly(bytes_of_slice(&right_point), right_point_va),
@@ -3526,6 +3551,9 @@ mod tests {
         )
         .unwrap();
 
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(
             (invoke_context
                 .get_execution_cost()
@@ -3661,7 +3689,7 @@ mod tests {
         let mut result_point: [u8; 32] = [0; 32];
         let result_point_va = 0x500000000;
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(bytes_of_slice(&left_point), left_point_va),
                 MemoryRegion::new_readonly(bytes_of_slice(&right_point), right_point_va),
@@ -3674,6 +3702,9 @@ mod tests {
         )
         .unwrap();
 
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(
             (invoke_context
                 .get_execution_cost()
@@ -3825,7 +3856,7 @@ mod tests {
         let mut result_point: [u8; 32] = [0; 32];
         let result_point_va = 0x400000000;
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(bytes_of_slice(&scalars), scalars_va),
                 MemoryRegion::new_readonly(bytes_of_slice(&edwards_points), edwards_points_va),
@@ -3837,6 +3868,9 @@ mod tests {
         )
         .unwrap();
 
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(
             invoke_context
                 .get_execution_cost()
@@ -3916,7 +3950,7 @@ mod tests {
         let mut result_point: [u8; 32] = [0; 32];
         let result_point_va = 0x400000000;
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(bytes_of_slice(&scalars), scalars_va),
                 MemoryRegion::new_readonly(bytes_of_slice(&edwards_points), edwards_points_va),
@@ -3929,6 +3963,9 @@ mod tests {
         .unwrap();
 
         // test Edwards
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(500_000);
         let result = SyscallCurveMultiscalarMultiplication::rust(
             &mut invoke_context,
@@ -4100,7 +4137,7 @@ mod tests {
             let clock_id_va = 0x300000000;
             let clock_id = Clock::id().to_bytes();
 
-            let mut memory_mapping = MemoryMapping::new(
+            let memory_mapping = MemoryMapping::new(
                 vec![
                     MemoryRegion::new_writable(bytes_of_mut(&mut got_clock_obj), got_clock_obj_va),
                     MemoryRegion::new_writable(&mut got_clock_buf, got_clock_buf_va),
@@ -4110,6 +4147,9 @@ mod tests {
                 SBPFVersion::V3,
             )
             .unwrap();
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
 
             let result =
                 SyscallGetClockSysvar::rust(&mut invoke_context, got_clock_obj_va, 0, 0, 0, 0);
@@ -4150,7 +4190,7 @@ mod tests {
             let epochschedule_id_va = 0x300000000;
             let epochschedule_id = EpochSchedule::id().to_bytes();
 
-            let mut memory_mapping = MemoryMapping::new(
+            let memory_mapping = MemoryMapping::new(
                 vec![
                     MemoryRegion::new_writable(
                         bytes_of_mut(&mut got_epochschedule_obj),
@@ -4166,6 +4206,9 @@ mod tests {
                 SBPFVersion::V3,
             )
             .unwrap();
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
 
             let result = SyscallGetEpochScheduleSysvar::rust(
                 &mut invoke_context,
@@ -4217,7 +4260,7 @@ mod tests {
             let mut got_fees = Fees::default();
             let got_fees_va = 0x100000000;
 
-            let mut memory_mapping = MemoryMapping::new(
+            let memory_mapping = MemoryMapping::new(
                 vec![MemoryRegion::new_writable(
                     bytes_of_mut(&mut got_fees),
                     got_fees_va,
@@ -4226,6 +4269,9 @@ mod tests {
                 SBPFVersion::V3,
             )
             .unwrap();
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
 
             let result = SyscallGetFeesSysvar::rust(&mut invoke_context, got_fees_va, 0, 0, 0, 0);
             assert_eq!(result.unwrap(), 0);
@@ -4248,7 +4294,7 @@ mod tests {
             let rent_id_va = 0x300000000;
             let rent_id = Rent::id().to_bytes();
 
-            let mut memory_mapping = MemoryMapping::new(
+            let memory_mapping = MemoryMapping::new(
                 vec![
                     MemoryRegion::new_writable(bytes_of_mut(&mut got_rent_obj), got_rent_obj_va),
                     MemoryRegion::new_writable(&mut got_rent_buf, got_rent_buf_va),
@@ -4258,6 +4304,9 @@ mod tests {
                 SBPFVersion::V3,
             )
             .unwrap();
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
 
             let result =
                 SyscallGetRentSysvar::rust(&mut invoke_context, got_rent_obj_va, 0, 0, 0, 0);
@@ -4298,7 +4347,7 @@ mod tests {
             let rewards_id_va = 0x300000000;
             let rewards_id = EpochRewards::id().to_bytes();
 
-            let mut memory_mapping = MemoryMapping::new(
+            let memory_mapping = MemoryMapping::new(
                 vec![
                     MemoryRegion::new_writable(
                         bytes_of_mut(&mut got_rewards_obj),
@@ -4311,6 +4360,9 @@ mod tests {
                 SBPFVersion::V3,
             )
             .unwrap();
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
 
             let result = SyscallGetEpochRewardsSysvar::rust(
                 &mut invoke_context,
@@ -4362,7 +4414,7 @@ mod tests {
             let restart_id_va = 0x300000000;
             let restart_id = LastRestartSlot::id().to_bytes();
 
-            let mut memory_mapping = MemoryMapping::new(
+            let memory_mapping = MemoryMapping::new(
                 vec![
                     MemoryRegion::new_writable(
                         bytes_of_mut(&mut got_restart_obj),
@@ -4375,6 +4427,9 @@ mod tests {
                 SBPFVersion::V3,
             )
             .unwrap();
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
 
             let result = SyscallGetLastRestartSlotSysvar::rust(
                 &mut invoke_context,
@@ -4450,7 +4505,7 @@ mod tests {
             let history_id_va = 0x200000000;
             let history_id = StakeHistory::id().to_bytes();
 
-            let mut memory_mapping = MemoryMapping::new(
+            let memory_mapping = MemoryMapping::new(
                 vec![
                     MemoryRegion::new_writable(&mut got_history_buf, got_history_buf_va),
                     MemoryRegion::new_readonly(&history_id, history_id_va),
@@ -4459,6 +4514,9 @@ mod tests {
                 SBPFVersion::V3,
             )
             .unwrap();
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
 
             let result = SyscallGetSysvar::rust(
                 &mut invoke_context,
@@ -4509,7 +4567,7 @@ mod tests {
             let hashes_id_va = 0x200000000;
             let hashes_id = SlotHashes::id().to_bytes();
 
-            let mut memory_mapping = MemoryMapping::new(
+            let memory_mapping = MemoryMapping::new(
                 vec![
                     MemoryRegion::new_writable(&mut got_hashes_buf, got_hashes_buf_va),
                     MemoryRegion::new_readonly(&hashes_id, hashes_id_va),
@@ -4518,6 +4576,9 @@ mod tests {
                 SBPFVersion::V3,
             )
             .unwrap();
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
 
             let result = SyscallGetSysvar::rust(
                 &mut invoke_context,
@@ -4554,17 +4615,6 @@ mod tests {
         let got_clock_buf_ro = vec![0; Clock::size_of()];
         let got_clock_buf_ro_va = 0x500000000;
 
-        let mut memory_mapping = MemoryMapping::new(
-            vec![
-                MemoryRegion::new_readonly(&clock_id, clock_id_va),
-                MemoryRegion::new_writable(&mut got_clock_buf_rw, got_clock_buf_rw_va),
-                MemoryRegion::new_readonly(&got_clock_buf_ro, got_clock_buf_ro_va),
-            ],
-            &config,
-            SBPFVersion::V3,
-        )
-        .unwrap();
-
         let access_violation_err =
             std::mem::discriminant(&EbpfError::AccessViolation(AccessType::Load, 0, 0, ""));
 
@@ -4573,6 +4623,19 @@ mod tests {
         {
             // start without the clock sysvar because we expect to hit specific errors before loading it
             with_mock_invoke_context!(invoke_context, transaction_context, vec![]);
+            let memory_mapping = MemoryMapping::new(
+                vec![
+                    MemoryRegion::new_readonly(&clock_id, clock_id_va),
+                    MemoryRegion::new_writable(&mut got_clock_buf_rw, got_clock_buf_rw_va),
+                    MemoryRegion::new_readonly(&got_clock_buf_ro, got_clock_buf_ro_va),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
 
             // Abort: "Not all bytes in VM memory range `[sysvar_id, sysvar_id + 32)` are readable."
             let e = SyscallGetSysvar::rust(
@@ -4664,7 +4727,20 @@ mod tests {
                 sysvar::clock::id(),
                 create_account_shared_data_for_test(&src_clock),
             )];
+            let memory_mapping = MemoryMapping::new(
+                vec![
+                    MemoryRegion::new_readonly(&clock_id, clock_id_va),
+                    MemoryRegion::new_writable(&mut got_clock_buf_rw, got_clock_buf_rw_va),
+                    MemoryRegion::new_readonly(&got_clock_buf_ro, got_clock_buf_ro_va),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap();
             with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
 
             // "`1` if `offset + length` is greater than the length of the sysvar data."
             let result = SyscallGetSysvar::rust(
@@ -4742,7 +4818,10 @@ mod tests {
             bytes_of_slice(&mock_slices),
             SEEDS_VA,
         ));
-        let mut memory_mapping = MemoryMapping::new(regions, &config, SBPFVersion::V3).unwrap();
+        let memory_mapping = MemoryMapping::new(regions, &config, SBPFVersion::V3).unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let result = syscall(
             invoke_context,
@@ -4798,7 +4877,7 @@ mod tests {
         let mut id_buffer = vec![0; 32];
 
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&data, SRC_VA),
                 MemoryRegion::new_writable(&mut data_buffer, DST_VA),
@@ -4810,6 +4889,9 @@ mod tests {
         .unwrap();
 
         prepare_mockup!(invoke_context, program_id, bpf_loader::id());
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let result =
             SyscallSetReturnData::rust(&mut invoke_context, SRC_VA, data.len() as u64, 0, 0, 0);
@@ -4914,12 +4996,15 @@ mod tests {
         const END_OFFSET: usize = ACCOUNTS_OFFSET + std::mem::size_of::<AccountInfo>() * 4;
         let mut memory = [0u8; END_OFFSET];
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![MemoryRegion::new_writable(&mut memory, VM_BASE_ADDRESS)],
             &config,
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         let processed_sibling_instruction =
             unsafe { &mut *memory.as_mut_ptr().cast::<ProcessedSiblingInstruction>() };
         processed_sibling_instruction.data_len = 1;
@@ -4939,21 +5024,22 @@ mod tests {
         );
         assert_eq!(result.unwrap(), 1);
         {
+            let memory_mapping = invoke_context.memory_contexts.memory_mapping().unwrap();
             let program_id = translate_type::<Pubkey>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
                 true,
             )
             .unwrap();
             let data = translate_slice::<u8>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
                 processed_sibling_instruction.data_len,
                 true,
             )
             .unwrap();
             let accounts = translate_slice::<AccountMeta>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
                 processed_sibling_instruction.accounts_len,
                 true,
@@ -4992,21 +5078,22 @@ mod tests {
 
         assert_eq!(result.unwrap(), 1);
         {
+            let memory_mapping = invoke_context.memory_contexts.memory_mapping().unwrap();
             let program_id = translate_type::<Pubkey>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
                 true,
             )
             .unwrap();
             let data = translate_slice::<u8>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
                 processed_sibling_instruction.data_len,
                 true,
             )
             .unwrap();
             let accounts = translate_slice::<AccountMeta>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
                 processed_sibling_instruction.accounts_len,
                 true,
@@ -5083,12 +5170,15 @@ mod tests {
         const END_OFFSET: usize = ACCOUNTS_OFFSET + std::mem::size_of::<AccountInfo>() * 4;
         let mut memory = [0u8; END_OFFSET];
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![MemoryRegion::new_writable(&mut memory, VM_BASE_ADDRESS)],
             &config,
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
         let processed_sibling_instruction =
             unsafe { &mut *memory.as_mut_ptr().cast::<ProcessedSiblingInstruction>() };
         processed_sibling_instruction.data_len = 2;
@@ -5250,21 +5340,22 @@ mod tests {
 
         assert_eq!(result.unwrap(), 1);
         {
+            let memory_mapping = invoke_context.memory_contexts.memory_mapping().unwrap();
             let program_id = translate_type::<Pubkey>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
                 true,
             )
             .unwrap();
             let data = translate_slice::<u8>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
                 processed_sibling_instruction.data_len,
                 true,
             )
             .unwrap();
             let accounts = translate_slice::<AccountMeta>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
                 processed_sibling_instruction.accounts_len,
                 true,
@@ -5331,21 +5422,22 @@ mod tests {
 
         assert_eq!(result.unwrap(), 1);
         {
+            let memory_mapping = invoke_context.memory_contexts.memory_mapping().unwrap();
             let program_id = translate_type::<Pubkey>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
                 true,
             )
             .unwrap();
             let data = translate_slice::<u8>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
                 processed_sibling_instruction.data_len,
                 true,
             )
             .unwrap();
             let accounts = translate_slice::<AccountMeta>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
                 processed_sibling_instruction.accounts_len,
                 true,
@@ -5384,21 +5476,22 @@ mod tests {
 
         assert_eq!(result.unwrap(), 1);
         {
+            let memory_mapping = invoke_context.memory_contexts.memory_mapping().unwrap();
             let program_id = translate_type::<Pubkey>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
                 true,
             )
             .unwrap();
             let data = translate_slice::<u8>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
                 processed_sibling_instruction.data_len,
                 true,
             )
             .unwrap();
             let accounts = translate_slice::<AccountMeta>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
                 processed_sibling_instruction.accounts_len,
                 true,
@@ -5462,21 +5555,22 @@ mod tests {
 
         assert_eq!(result.unwrap(), 1);
         {
+            let memory_mapping = invoke_context.memory_contexts.memory_mapping().unwrap();
             let program_id = translate_type::<Pubkey>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
                 true,
             )
             .unwrap();
             let data = translate_slice::<u8>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
                 processed_sibling_instruction.data_len,
                 true,
             )
             .unwrap();
             let accounts = translate_slice::<AccountMeta>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
                 processed_sibling_instruction.accounts_len,
                 true,
@@ -5554,21 +5648,22 @@ mod tests {
 
         assert_eq!(result.unwrap(), 1);
         {
+            let memory_mapping = invoke_context.memory_contexts.memory_mapping().unwrap();
             let program_id = translate_type::<Pubkey>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(PROGRAM_ID_OFFSET as u64),
                 true,
             )
             .unwrap();
             let data = translate_slice::<u8>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(DATA_OFFSET as u64),
                 processed_sibling_instruction.data_len,
                 true,
             )
             .unwrap();
             let accounts = translate_slice::<AccountMeta>(
-                &memory_mapping,
+                memory_mapping,
                 VM_BASE_ADDRESS.saturating_add(ACCOUNTS_OFFSET as u64),
                 processed_sibling_instruction.accounts_len,
                 true,
@@ -5828,7 +5923,7 @@ mod tests {
                 modulus_len: MAX_LEN,
             };
 
-            let mut memory_mapping = MemoryMapping::new(
+            let memory_mapping = MemoryMapping::new(
                 vec![
                     MemoryRegion::new_readonly(bytes_of(&params_max_len), VADDR_PARAMS),
                     MemoryRegion::new_readonly(&data, VADDR_DATA),
@@ -5839,6 +5934,9 @@ mod tests {
             )
             .unwrap();
 
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
             let budget = invoke_context.get_execution_cost();
             invoke_context.compute_meter.mock_set_remaining(
                 budget.syscall_base_cost
@@ -5863,7 +5961,7 @@ mod tests {
                 modulus_len: INV_LEN,
             };
 
-            let mut memory_mapping = MemoryMapping::new(
+            let memory_mapping = MemoryMapping::new(
                 vec![
                     MemoryRegion::new_readonly(bytes_of(&params_inv_len), VADDR_PARAMS),
                     MemoryRegion::new_readonly(&data, VADDR_DATA),
@@ -5873,7 +5971,9 @@ mod tests {
                 SBPFVersion::V3,
             )
             .unwrap();
-
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
             let budget = invoke_context.get_execution_cost();
             invoke_context.compute_meter.mock_set_remaining(
                 budget.syscall_base_cost
@@ -5934,7 +6034,10 @@ mod tests {
 
         let null_pointer_var = std::ptr::null::<Pubkey>() as u64;
 
-        let mut memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
+        let memory_mapping = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let result =
             SyscallGetEpochStake::rust(&mut invoke_context, null_pointer_var, 0, 0, 0, 0).unwrap();
@@ -5994,7 +6097,7 @@ mod tests {
             // memory range `[vote_addr, vote_addr + 32)` are readable.
             let vote_address_var = 0x100000000;
 
-            let mut memory_mapping = MemoryMapping::new(
+            let memory_mapping = MemoryMapping::new(
                 vec![
                     // Invalid read-only memory region.
                     MemoryRegion::new_readonly(&[2; 31], vote_address_var),
@@ -6003,6 +6106,9 @@ mod tests {
                 SBPFVersion::V3,
             )
             .unwrap();
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
 
             let result =
                 SyscallGetEpochStake::rust(&mut invoke_context, vote_address_var, 0, 0, 0, 0);
@@ -6019,7 +6125,7 @@ mod tests {
             // address.
             let vote_address_var = 0x100000000;
 
-            let mut memory_mapping = MemoryMapping::new(
+            let memory_mapping = MemoryMapping::new(
                 vec![MemoryRegion::new_readonly(
                     bytes_of(&TARGET_VOTE_ADDRESS),
                     vote_address_var,
@@ -6028,6 +6134,9 @@ mod tests {
                 SBPFVersion::V3,
             )
             .unwrap();
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
 
             let result =
                 SyscallGetEpochStake::rust(&mut invoke_context, vote_address_var, 0, 0, 0, 0)
@@ -6046,7 +6155,7 @@ mod tests {
             let vote_address_var = 0x100000000;
             let not_a_vote_address = Pubkey::new_unique(); // Not a vote account.
 
-            let mut memory_mapping = MemoryMapping::new(
+            let memory_mapping = MemoryMapping::new(
                 vec![MemoryRegion::new_readonly(
                     bytes_of(&not_a_vote_address),
                     vote_address_var,
@@ -6055,6 +6164,9 @@ mod tests {
                 SBPFVersion::V3,
             )
             .unwrap();
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping(memory_mapping);
 
             let result =
                 SyscallGetEpochStake::rust(&mut invoke_context, vote_address_var, 0, 0, 0, 0)
@@ -6107,7 +6219,7 @@ mod tests {
         let mem = (0..12).collect::<Vec<u8>>();
         let mut result_mem = vec![0; 4];
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&mem, 0x100000000),
                 MemoryRegion::new_readonly(&mem, 0x200000000),
@@ -6117,6 +6229,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let result = SyscallMemcmp::rust(&mut invoke_context, src_a, src_b, 4, 0x300000000, 0);
         result.unwrap();
@@ -6135,7 +6250,7 @@ mod tests {
         prepare_mockup!(invoke_context, program_id, bpf_loader::id());
         let mut mem = (0..24).collect::<Vec<u8>>();
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_writable(&mut mem[..12], 0x100000000),
                 MemoryRegion::new_writable(&mut mem[12..], 0x200000000),
@@ -6144,6 +6259,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let result = SyscallMemmove::rust(&mut invoke_context, dst, src, 4, 0, 0);
         result.unwrap();
@@ -6158,12 +6276,15 @@ mod tests {
         prepare_mockup!(invoke_context, program_id, bpf_loader::id());
         let mut mem = (0..12).collect::<Vec<u8>>();
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![MemoryRegion::new_writable(&mut mem, 0x100000000)],
             &config,
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let result = SyscallMemset::rust(&mut invoke_context, dst, value, 4, 0, 0);
         result.unwrap();
@@ -6178,12 +6299,15 @@ mod tests {
         prepare_mockup!(invoke_context, program_id, bpf_loader::id());
         let mut mem = (0..12).collect::<Vec<u8>>();
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![MemoryRegion::new_writable(&mut mem, 0x100000000)],
             &config,
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let result = SyscallMemcpy::rust(&mut invoke_context, dst, src, 4, 0, 0);
         assert_matches!(
@@ -6200,12 +6324,15 @@ mod tests {
         prepare_mockup!(invoke_context, program_id, bpf_loader::id());
         let mut mem = (0..12).collect::<Vec<u8>>();
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![MemoryRegion::new_writable(&mut mem, 0x100000000)],
             &config,
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let result = SyscallMemcpy::rust(&mut invoke_context, dst, src, 4, 0, 0);
         assert_access_violation!(result, fault_address, 4);
@@ -6221,12 +6348,15 @@ mod tests {
         prepare_mockup!(invoke_context, program_id, bpf_loader::id());
         let mut mem = (0..12).collect::<Vec<u8>>();
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![MemoryRegion::new_writable(&mut mem, 0x100000000)],
             &config,
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let result = SyscallMemset::rust(&mut invoke_context, dst, 0, 4, 0, 0);
         assert_access_violation!(result, dst, 4);
@@ -6237,12 +6367,15 @@ mod tests {
         prepare_mockup!(invoke_context, program_id, bpf_loader::id());
         let mem = (0..12).collect::<Vec<u8>>();
         let config = Config::default();
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![MemoryRegion::new_readonly(&mem, 0x100000000)],
             &config,
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let result = SyscallMemcmp::rust(
             &mut invoke_context,
@@ -6326,7 +6459,7 @@ mod tests {
         let mut result_be_buf = [0u8; 96];
         let mut result_le_buf = [0u8; 96];
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&p1_bytes_be, p1_be_va),
                 MemoryRegion::new_readonly(&p2_bytes_be, p2_be_va),
@@ -6339,6 +6472,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let bls12_381_g1_add_cost = invoke_context.get_execution_cost().bls12_381_g1_add_cost;
         invoke_context
@@ -6442,7 +6578,7 @@ mod tests {
         let mut result_be_buf = [0u8; 96];
         let mut result_le_buf = [0u8; 96];
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&sub_p1_be, p1_be_va),
                 MemoryRegion::new_readonly(&sub_p2_be, p2_be_va),
@@ -6455,6 +6591,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let bls12_381_g1_subtract_cost = invoke_context
             .get_execution_cost()
@@ -6553,7 +6692,7 @@ mod tests {
         let mut result_be_buf = [0u8; 96];
         let mut result_le_buf = [0u8; 96];
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&mul_scalar_be, scalar_be_va),
                 MemoryRegion::new_readonly(&mul_point_be, point_be_va),
@@ -6566,6 +6705,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let bls12_381_g1_multiply_cost = invoke_context
             .get_execution_cost()
@@ -6702,7 +6844,7 @@ mod tests {
         let mut result_be_buf = [0u8; 192];
         let mut result_le_buf = [0u8; 192];
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&p1_bytes_be, p1_be_va),
                 MemoryRegion::new_readonly(&p2_bytes_be, p2_be_va),
@@ -6715,6 +6857,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let bls12_381_g2_add_cost = invoke_context.get_execution_cost().bls12_381_g2_add_cost;
         invoke_context
@@ -6850,7 +6995,7 @@ mod tests {
         let mut result_be_buf = [0u8; 192];
         let mut result_le_buf = [0u8; 192];
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&sub_p1_be, p1_be_va),
                 MemoryRegion::new_readonly(&sub_p2_be, p2_be_va),
@@ -6863,6 +7008,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let bls12_381_g2_subtract_cost = invoke_context
             .get_execution_cost()
@@ -6982,7 +7130,7 @@ mod tests {
         let mut result_be_buf = [0u8; 192];
         let mut result_le_buf = [0u8; 192];
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&mul_scalar_be, scalar_be_va),
                 MemoryRegion::new_readonly(&mul_point_be, point_be_va),
@@ -6995,6 +7143,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let bls12_381_g2_multiply_cost = invoke_context
             .get_execution_cost()
@@ -7101,7 +7252,7 @@ mod tests {
 
         let mut result_buf = [0u8; 576]; // GT size
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&g1_bytes, g1_va),
                 MemoryRegion::new_readonly(&g2_bytes, g2_va),
@@ -7111,6 +7262,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let bls12_381_one_pair_cost = invoke_context.get_execution_cost().bls12_381_one_pair_cost;
         invoke_context
@@ -7203,7 +7357,7 @@ mod tests {
 
         let mut result_buf = [0u8; 576]; // GT size
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&g1_bytes, g1_va),
                 MemoryRegion::new_readonly(&g2_bytes, g2_va),
@@ -7213,6 +7367,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let bls12_381_one_pair_cost = invoke_context.get_execution_cost().bls12_381_one_pair_cost;
         invoke_context
@@ -7279,7 +7436,7 @@ mod tests {
         let mut result_be_buf = [0u8; 96];
         let mut result_le_buf = [0u8; 96];
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&compressed_be, input_be_va),
                 MemoryRegion::new_writable(&mut result_be_buf, result_be_va),
@@ -7290,6 +7447,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let bls12_381_g2_decompress_cost = invoke_context
             .get_execution_cost()
@@ -7386,7 +7546,7 @@ mod tests {
         let mut result_be_buf = [0u8; 192];
         let mut result_le_buf = [0u8; 192];
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&compressed_be, input_be_va),
                 MemoryRegion::new_writable(&mut result_be_buf, result_be_va),
@@ -7397,6 +7557,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let bls12_381_g2_decompress_cost = invoke_context
             .get_execution_cost()
@@ -7462,7 +7625,7 @@ mod tests {
         let point_be_va = 0x100000000;
         let point_le_va = 0x200000000;
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&point_bytes_be, point_be_va),
                 MemoryRegion::new_readonly(&point_bytes_le, point_le_va),
@@ -7471,6 +7634,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let bls12_381_g1_validate_cost = invoke_context
             .get_execution_cost()
@@ -7546,7 +7712,7 @@ mod tests {
         let point_be_va = 0x100000000;
         let point_le_va = 0x200000000;
 
-        let mut memory_mapping = MemoryMapping::new(
+        let memory_mapping = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&point_bytes_be, point_be_va),
                 MemoryRegion::new_readonly(&point_bytes_le, point_le_va),
@@ -7555,6 +7721,9 @@ mod tests {
             SBPFVersion::V3,
         )
         .unwrap();
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping(memory_mapping);
 
         let bls12_381_g2_validate_cost = invoke_context
             .get_execution_cost()

--- a/syscalls/src/logging.rs
+++ b/syscalls/src/logging.rs
@@ -12,19 +12,20 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let cost = invoke_context
             .get_execution_cost()
             .syscall_base_cost
             .max(len);
-        consume_compute_meter(invoke_context, cost)?;
+        invoke_context.compute_meter.consume_checked(cost)?;
 
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
         translate_string_and_do(
             memory_mapping,
             addr,
             len,
-            invoke_context.get_check_aligned(),
+            check_aligned,
             &mut |string: &str| {
                 stable_log::program_log(&invoke_context.get_log_collector(), string);
                 Ok(0)
@@ -44,10 +45,9 @@ declare_builtin_function!(
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        _memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let cost = invoke_context.get_execution_cost().log_64_units;
-        consume_compute_meter(invoke_context, cost)?;
+        invoke_context.compute_meter.consume_checked(cost)?;
 
         stable_log::program_log(
             &invoke_context.get_log_collector(),
@@ -67,10 +67,9 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let cost = invoke_context.get_execution_cost().syscall_base_cost;
-        consume_compute_meter(invoke_context, cost)?;
+        invoke_context.compute_meter.consume_checked(cost)?;
 
         ic_logger_msg!(
             invoke_context.get_log_collector(),
@@ -91,15 +90,16 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let cost = invoke_context.get_execution_cost().log_pubkey_units;
-        consume_compute_meter(invoke_context, cost)?;
+        invoke_context.compute_meter.consume_checked(cost)?;
 
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
         let pubkey = translate_type::<Pubkey>(
             memory_mapping,
             pubkey_addr,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?;
         stable_log::program_log(&invoke_context.get_log_collector(), &pubkey.to_string());
         Ok(0)
@@ -116,36 +116,33 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         let execution_cost = invoke_context.get_execution_cost();
 
-        consume_compute_meter(invoke_context, execution_cost.syscall_base_cost)?;
+        invoke_context.compute_meter.consume_checked(execution_cost.syscall_base_cost)?;
 
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
         let untranslated_fields = translate_slice::<VmSlice<u8>>(
             memory_mapping,
             addr,
             len,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?;
 
-        consume_compute_meter(
-            invoke_context,
-            execution_cost
-                .syscall_base_cost
-                .saturating_mul(untranslated_fields.len() as u64),
-        )?;
-        consume_compute_meter(
-            invoke_context,
-            untranslated_fields
-                .iter()
-                .fold(0, |total, e| total.saturating_add(e.len())),
-        )?;
+        let cost = execution_cost
+            .syscall_base_cost
+            .saturating_mul(untranslated_fields.len() as u64);
+        invoke_context.compute_meter.consume_checked(cost)?;
+        let cost = untranslated_fields
+            .iter()
+            .fold(0u64, |total, e| total.saturating_add(e.len()));
+        invoke_context.compute_meter.consume_checked(cost)?;
 
         let mut fields = Vec::with_capacity(untranslated_fields.len());
 
         for untranslated_field in untranslated_fields {
-            fields.push(translate_vm_slice(untranslated_field, memory_mapping, invoke_context.get_check_aligned())?);
+            fields.push(translate_vm_slice(untranslated_field, memory_mapping, check_aligned)?);
         }
 
         let log_collector = invoke_context.get_log_collector();

--- a/syscalls/src/mem_ops.rs
+++ b/syscalls/src/mem_ops.rs
@@ -6,7 +6,7 @@ fn mem_op_consume(invoke_context: &mut InvokeContext, n: u64) -> Result<(), Erro
         n.checked_div(compute_cost.cpi_bytes_per_unit)
             .unwrap_or(u64::MAX),
     );
-    consume_compute_meter(invoke_context, cost)
+    invoke_context.compute_meter.consume_checked(cost)
 }
 
 /// Check that two regions do not overlap.
@@ -33,7 +33,6 @@ declare_builtin_function!(
         n: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         mem_op_consume(invoke_context, n)?;
 
@@ -42,7 +41,7 @@ declare_builtin_function!(
         }
 
         // host addresses can overlap so we always invoke memmove
-        memmove(invoke_context, dst_addr, src_addr, n, memory_mapping)
+        memmove(invoke_context, dst_addr, src_addr, n)
     }
 );
 
@@ -56,11 +55,9 @@ declare_builtin_function!(
         n: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         mem_op_consume(invoke_context, n)?;
-
-        memmove(invoke_context, dst_addr, src_addr, n, memory_mapping)
+        memmove(invoke_context, dst_addr, src_addr, n)
     }
 );
 
@@ -74,21 +71,22 @@ declare_builtin_function!(
         n: u64,
         cmp_result_addr: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         mem_op_consume(invoke_context, n)?;
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
 
         let s1 = translate_slice::<u8>(
             memory_mapping,
             s1_addr,
             n,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?;
         let s2 = translate_slice::<u8>(
             memory_mapping,
             s2_addr,
             n,
-            invoke_context.get_check_aligned(),
+            check_aligned,
         )?;
 
         debug_assert_eq!(s1.len(), n as usize);
@@ -101,7 +99,7 @@ declare_builtin_function!(
 
         translate_mut!(
             memory_mapping,
-            invoke_context.get_check_aligned(),
+            check_aligned,
             let cmp_result_ref_mut: &mut i32 = map(cmp_result_addr)?;
         );
         *cmp_result_ref_mut = result;
@@ -120,13 +118,14 @@ declare_builtin_function!(
         n: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         mem_op_consume(invoke_context, n)?;
 
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         translate_mut!(
             memory_mapping,
-            invoke_context.get_check_aligned(),
+            check_aligned,
             let s: &mut [u8] = map(dst_addr, n)?;
         );
         s.fill(c as u8);
@@ -139,21 +138,16 @@ fn memmove(
     dst_addr: u64,
     src_addr: u64,
     n: u64,
-    memory_mapping: &mut MemoryMapping,
 ) -> Result<u64, Error> {
+    let check_aligned = invoke_context.get_check_aligned();
+    let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
     translate_mut!(
         memory_mapping,
-        invoke_context.get_check_aligned(),
+        check_aligned,
         let dst_ref_mut: &mut [u8] = map(dst_addr, n)?;
     );
     let dst_ptr = dst_ref_mut.as_mut_ptr();
-    let src_ptr = translate_slice::<u8>(
-        memory_mapping,
-        src_addr,
-        n,
-        invoke_context.get_check_aligned(),
-    )?
-    .as_ptr();
+    let src_ptr = translate_slice::<u8>(memory_mapping, src_addr, n, check_aligned)?.as_ptr();
 
     unsafe { std::ptr::copy(src_ptr, dst_ptr, n as usize) };
     Ok(0)

--- a/syscalls/src/sysvar.rs
+++ b/syscalls/src/sysvar.rs
@@ -6,17 +6,13 @@ use {
 fn get_sysvar<T: std::fmt::Debug + SysvarSerialize + Clone>(
     sysvar: Result<Arc<T>, InstructionError>,
     var_addr: u64,
-    check_aligned: bool,
-    memory_mapping: &mut MemoryMapping,
     invoke_context: &mut InvokeContext,
 ) -> Result<u64, Error> {
-    consume_compute_meter(
-        invoke_context,
-        invoke_context
-            .get_execution_cost()
-            .sysvar_base_cost
-            .saturating_add(size_of::<T>() as u64),
-    )?;
+    let amount = invoke_context
+        .get_execution_cost()
+        .sysvar_base_cost
+        .saturating_add(size_of::<T>() as u64);
+    invoke_context.compute_meter.consume_checked(amount)?;
 
     if var_addr >= ebpf::MM_INPUT_START
         && invoke_context
@@ -25,6 +21,9 @@ fn get_sysvar<T: std::fmt::Debug + SysvarSerialize + Clone>(
     {
         return Err(SyscallError::InvalidPointer.into());
     }
+
+    let check_aligned = invoke_context.get_check_aligned();
+    let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
     translate_mut!(
         memory_mapping,
         check_aligned,
@@ -51,13 +50,10 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         get_sysvar(
-            invoke_context.get_sysvar_cache().get_clock(),
+            invoke_context.environment_config.sysvar_cache().get_clock(),
             var_addr,
-            invoke_context.get_check_aligned(),
-            memory_mapping,
             invoke_context,
         )
     }
@@ -73,13 +69,10 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         get_sysvar(
-            invoke_context.get_sysvar_cache().get_epoch_schedule(),
+            invoke_context.environment_config.sysvar_cache().get_epoch_schedule(),
             var_addr,
-            invoke_context.get_check_aligned(),
-            memory_mapping,
             invoke_context,
         )
     }
@@ -95,13 +88,10 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         get_sysvar(
-            invoke_context.get_sysvar_cache().get_epoch_rewards(),
+            invoke_context.environment_config.sysvar_cache().get_epoch_rewards(),
             var_addr,
-            invoke_context.get_check_aligned(),
-            memory_mapping,
             invoke_context,
         )
     }
@@ -117,15 +107,12 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         #[expect(deprecated)]
         {
             get_sysvar(
-                invoke_context.get_sysvar_cache().get_fees(),
+                invoke_context.environment_config.sysvar_cache().get_fees(),
                 var_addr,
-                invoke_context.get_check_aligned(),
-                memory_mapping,
                 invoke_context,
             )
         }
@@ -142,13 +129,10 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         get_sysvar(
-            invoke_context.get_sysvar_cache().get_rent(),
+            invoke_context.environment_config.sysvar_cache().get_rent(),
             var_addr,
-            invoke_context.get_check_aligned(),
-            memory_mapping,
             invoke_context,
         )
     }
@@ -164,13 +148,10 @@ declare_builtin_function!(
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
         get_sysvar(
-            invoke_context.get_sysvar_cache().get_last_restart_slot(),
+            invoke_context.environment_config.sysvar_cache().get_last_restart_slot(),
             var_addr,
-            invoke_context.get_check_aligned(),
-            memory_mapping,
             invoke_context,
         )
     }
@@ -191,9 +172,7 @@ declare_builtin_function!(
         offset: u64,
         length: u64,
         _arg5: u64,
-        memory_mapping: &mut MemoryMapping,
     ) -> Result<u64, Error> {
-        let check_aligned = invoke_context.get_check_aligned();
         let SVMTransactionExecutionCost {
             sysvar_base_cost,
             cpi_bytes_per_unit,
@@ -204,12 +183,10 @@ declare_builtin_function!(
         // Abort: "Compute budget is exceeded."
         let sysvar_id_cost = 32_u64.checked_div(cpi_bytes_per_unit).unwrap_or(0);
         let sysvar_buf_cost = length.checked_div(cpi_bytes_per_unit).unwrap_or(0);
-        consume_compute_meter(
-            invoke_context,
-            sysvar_base_cost
-                .saturating_add(sysvar_id_cost)
-                .saturating_add(std::cmp::max(sysvar_buf_cost, mem_op_base_cost)),
-        )?;
+        let cost = sysvar_base_cost
+            .saturating_add(sysvar_id_cost)
+            .saturating_add(std::cmp::max(sysvar_buf_cost, mem_op_base_cost));
+        invoke_context.compute_meter.consume_checked(cost)?;
 
         if var_addr >= ebpf::MM_INPUT_START
             && invoke_context
@@ -218,6 +195,9 @@ declare_builtin_function!(
         {
             return Err(SyscallError::InvalidPointer.into());
         }
+
+        let check_aligned = invoke_context.get_check_aligned();
+        let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         // Abort: "Not all bytes in VM memory range `[var_addr, var_addr + length)` are writable."
         translate_mut!(
             memory_mapping,
@@ -238,10 +218,12 @@ declare_builtin_function!(
             .checked_add(length)
             .ok_or(InstructionError::ArithmeticOverflow)?;
 
-        let cache = invoke_context.get_sysvar_cache();
 
         // "`2` if the sysvar data is not present in the Sysvar Cache."
-        let Some(sysvar_buf) = cache.sysvar_id_to_buffer(sysvar_id) else { return Ok(SYSVAR_NOT_FOUND) };
+        let cache = invoke_context.environment_config.sysvar_cache();
+        let Some(sysvar_buf) = cache.sysvar_id_to_buffer(sysvar_id) else {
+            return Ok(SYSVAR_NOT_FOUND)
+        };
 
         // "`1` if `offset + length` is greater than the length of the sysvar data."
         if let Some(sysvar_slice) = sysvar_buf.get(offset as usize..offset_length as usize) {


### PR DESCRIPTION
This is a pretty large change which is mostly mechanical rewrites from one way to another.

The important part really here is that in order to make lifetimes work out and borrowck happy in the implementation of syscalls, the InvokeContext has had its methods borrowing from inside of it moved to the field types (with those types being added for e.g. `ComputeMeter` or `MemoryContexts`.)

This is meant to not introduce any functional changes at all.