### PR TITLE
Split creation from initialization of memory mapping

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -537,6 +537,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     );
 
     invoke_context
+        .memory_contexts
         .set_memory_context(MemoryContext::new(
             BpfAllocator::new(heap_size as u64),
             account_lengths,

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -13,7 +13,7 @@ use {
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_program_runtime::{
         create_vm,
-        invoke_context::InvokeContext,
+        invoke_context::{BpfAllocator, InvokeContext, MemoryContext},
         loaded_programs::ProgramRuntimeEnvironment,
         program_cache_entry::{
             DELAY_VISIBILITY_SLOT_OFFSET, ProgramCacheEntry, ProgramCacheEntryType,
@@ -28,6 +28,7 @@ use {
         assembler::assemble,
         ebpf::MM_INPUT_START,
         elf::Executable,
+        memory_region::{MemoryMapping, MemoryRegion},
         static_analysis::Analysis,
         verifier::RequisiteVerifier,
         vm::{CallFrame, ExecutionMode},
@@ -513,15 +514,37 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
         )
         .unwrap();
 
+    let regions = vec![MemoryRegion::default(); 3]
+        .into_iter()
+        .chain(regions)
+        .collect();
     let program = matches.value_of("PROGRAM").unwrap();
     let verified_executable = load_program(Path::new(program), program_id, &invoke_context);
-    create_vm!(
-        vm,
-        &verified_executable,
+
+    let heap_size = invoke_context.get_compute_budget().heap_size;
+    let virtual_address_space_adjustments = invoke_context
+        .get_feature_set()
+        .virtual_address_space_adjustments;
+    let account_data_direct_mapping = invoke_context.get_feature_set().account_data_direct_mapping;
+    let memory_mapping = MemoryMapping::new_uninitialized(
         regions,
-        account_lengths,
-        &mut invoke_context,
+        verified_executable.get_config(),
+        verified_executable.get_sbpf_version(),
+        invoke_context.transaction_context.access_violation_handler(
+            virtual_address_space_adjustments,
+            account_data_direct_mapping,
+        ),
     );
+
+    invoke_context
+        .set_memory_context(MemoryContext::new(
+            BpfAllocator::new(heap_size as u64),
+            account_lengths,
+            memory_mapping,
+        ))
+        .unwrap();
+
+    create_vm!(vm, &verified_executable, &mut invoke_context,);
     let (mut vm, _, _) = vm.unwrap();
     let start_time = Instant::now();
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -26,7 +26,7 @@ use {
         ebpf::MM_HEAP_START,
         elf::{ElfError, Executable as GenericExecutable},
         error::{EbpfError, ProgramResult},
-        memory_region::MemoryMapping,
+        memory_region::{MemoryMapping, MemoryRegion},
         program::{BuiltinProgram, SBPFVersion},
         vm::{Config, ContextObject, EbpfVm},
     },
@@ -288,6 +288,16 @@ impl MemoryContext {
                 MemoryMapping::new(Vec::new(), &Config::default(), SBPFVersion::Reserved).unwrap(),
             ),
         }
+    }
+
+    pub fn get_memory_regions_mut(&mut self) -> &mut [MemoryRegion] {
+        self.memory_mapping.get_regions_mut()
+    }
+
+    pub fn initialize(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        self.memory_mapping
+            .initialize()
+            .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
     }
 }
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -26,7 +26,7 @@ use {
         ebpf::MM_HEAP_START,
         elf::{ElfError, Executable as GenericExecutable},
         error::{EbpfError, ProgramResult},
-        memory_region::{MemoryMapping, MemoryRegion},
+        memory_region::MemoryMapping,
         program::{BuiltinProgram, SBPFVersion},
         vm::{Config, ContextObject, EbpfVm},
     },
@@ -288,16 +288,6 @@ impl MemoryContext {
                 MemoryMapping::new(Vec::new(), &Config::default(), SBPFVersion::Reserved).unwrap(),
             ),
         }
-    }
-
-    pub fn get_memory_regions_mut(&mut self) -> &mut [MemoryRegion] {
-        self.memory_mapping.get_regions_mut()
-    }
-
-    pub fn initialize(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        self.memory_mapping
-            .initialize()
-            .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
     }
 }
 

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -68,8 +68,10 @@ fn configure_program_regions<'a, C: ContextObject>(
     stack: &'a mut [u8],
     heap: &'a mut [u8],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let memory_context = invoke_context.get_memory_context_mut()?;
-    let regions = memory_context.get_memory_regions_mut();
+    let mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
+    let regions = mapping
+        .get_regions_mut()
+        .expect("The memory mapping should not have been initialized");
 
     let ro_area = regions
         .get_mut(0)
@@ -96,7 +98,9 @@ fn configure_program_regions<'a, C: ContextObject>(
         .expect("The regions vector must have at least three entries");
     *heap_area = MemoryRegion::new_writable(heap, MM_HEAP_START);
 
-    memory_context.initialize()
+    mapping
+        .initialize()
+        .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
 }
 
 /// Create the SBF virtual machine
@@ -156,6 +160,7 @@ fn set_memory_context<'b>(
     );
 
     invoke_context
+        .memory_contexts
         .set_memory_context(MemoryContext::new(
             BpfAllocator::new(heap_size as u64),
             accounts_metadata,

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -13,7 +13,7 @@ use {
     solana_instruction::error::InstructionError,
     solana_program_entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
     solana_sbpf::{
-        ebpf::{self, MM_HEAP_START},
+        ebpf::{self, MM_HEAP_START, MM_STACK_START},
         elf::Executable,
         error::{EbpfError, ProgramResult},
         memory_region::{AccessType, MemoryMapping, MemoryRegion},
@@ -22,7 +22,7 @@ use {
     solana_sdk_ids::bpf_loader_deprecated,
     solana_svm_log_collector::ic_logger_msg,
     solana_svm_measure::measure::Measure,
-    solana_transaction_context::{IndexOfAccount, transaction::TransactionContext},
+    solana_transaction_context::IndexOfAccount,
     std::{cell::RefCell, mem, time::Duration},
 };
 
@@ -48,32 +48,12 @@ pub fn calculate_heap_cost(heap_size: u32, heap_cost: u64) -> u64 {
 #[cfg_attr(feature = "svm-internal", qualifiers(pub))]
 pub fn create_vm<'a, 'b>(
     program: &'a Executable<InvokeContext<'b, 'b>>,
-    regions: Vec<MemoryRegion>,
-    accounts_metadata: Vec<SerializedAccountMetadata>,
     invoke_context: &'a mut InvokeContext<'b, 'b>,
     stack: &mut [u8],
     heap: &mut [u8],
 ) -> Result<EbpfVm<'a, InvokeContext<'b, 'b>>, Box<dyn std::error::Error>> {
     let stack_size = stack.len();
-    let heap_size = heap.len();
-    let memory_mapping = create_memory_mapping(
-        program,
-        stack,
-        heap,
-        regions,
-        invoke_context.transaction_context,
-        invoke_context
-            .get_feature_set()
-            .virtual_address_space_adjustments,
-        invoke_context.get_feature_set().account_data_direct_mapping,
-    )?;
-    invoke_context
-        .memory_contexts
-        .set_memory_context(MemoryContext::new(
-            BpfAllocator::new(heap_size as u64),
-            accounts_metadata,
-            memory_mapping,
-        ))?;
+    configure_program_regions(invoke_context, program, stack, heap)?;
     Ok(EbpfVm::new(
         program.get_loader().clone(),
         program.get_sbpf_version(),
@@ -82,49 +62,41 @@ pub fn create_vm<'a, 'b>(
     ))
 }
 
-fn create_memory_mapping<'a, C: ContextObject>(
+fn configure_program_regions<'a, C: ContextObject>(
+    invoke_context: &mut InvokeContext,
     executable: &Executable<C>,
     stack: &'a mut [u8],
     heap: &'a mut [u8],
-    additional_regions: Vec<MemoryRegion>,
-    transaction_context: &TransactionContext,
-    virtual_address_space_adjustments: bool,
-    account_data_direct_mapping: bool,
-) -> Result<MemoryMapping, Box<dyn std::error::Error>> {
-    let config = executable.get_config();
-    let sbpf_version = executable.get_sbpf_version();
-    let regions: Vec<MemoryRegion> = vec![
-        executable.get_ro_region(),
-        MemoryRegion::new_writable_gapped(
-            stack,
-            ebpf::MM_STACK_START,
-            if sbpf_version.stack_frame_gaps() && config.enable_stack_frame_gaps {
-                config.stack_frame_size as u64
-            } else {
-                0
-            },
-        ),
-        MemoryRegion::new_writable(heap, MM_HEAP_START),
-    ]
-    .into_iter()
-    .chain(additional_regions)
-    .collect();
+) -> Result<(), Box<dyn std::error::Error>> {
+    let memory_context = invoke_context.get_memory_context_mut()?;
+    let regions = memory_context.get_memory_regions_mut();
 
-    Ok(MemoryMapping::new_with_access_violation_handler(
-        regions,
-        config,
-        sbpf_version,
-        transaction_context.access_violation_handler(
-            virtual_address_space_adjustments,
-            account_data_direct_mapping,
-        ),
-    )?)
+    let ro_area = regions.get_mut(0).unwrap();
+    *ro_area = executable.get_ro_region();
+
+    let sbpf_version = executable.get_sbpf_version();
+    let stack_area = regions.get_mut(1).unwrap();
+    let config = executable.get_config();
+    *stack_area = MemoryRegion::new_writable_gapped(
+        stack,
+        MM_STACK_START,
+        if sbpf_version.stack_frame_gaps() && config.enable_stack_frame_gaps {
+            config.stack_frame_size as u64
+        } else {
+            0
+        },
+    );
+
+    let heap_area = regions.get_mut(2).unwrap();
+    *heap_area = MemoryRegion::new_writable(heap, MM_HEAP_START);
+
+    memory_context.initialize()
 }
 
 /// Create the SBF virtual machine
 #[macro_export]
 macro_rules! create_vm {
-    ($vm:ident, $program:expr, $regions:expr, $accounts_metadata:expr, $invoke_context:expr $(,)?) => {
+    ($vm:ident, $program:expr, $invoke_context:expr $(,)?) => {
         let invoke_context = &*$invoke_context;
         let stack_size = $program.get_config().stack_size();
         let heap_size = invoke_context.get_compute_budget().heap_size;
@@ -140,8 +112,6 @@ macro_rules! create_vm {
                 .with_borrow_mut(|pool| (pool.get_stack(stack_size), pool.get_heap(heap_size)));
             let vm = $crate::__private::create_vm(
                 $program,
-                $regions,
-                $accounts_metadata,
                 $invoke_context,
                 stack
                     .as_slice_mut()
@@ -154,6 +124,38 @@ macro_rules! create_vm {
             vm.map(|vm| (vm, stack, heap))
         });
     };
+}
+
+fn set_memory_context<'b>(
+    regions: Vec<MemoryRegion>,
+    accounts_metadata: Vec<SerializedAccountMetadata>,
+    invoke_context: &mut InvokeContext<'b, 'b>,
+    executable: &Executable<InvokeContext<'b, 'b>>,
+    virtual_address_space_adjustments: bool,
+    account_data_direct_mapping: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let heap_size = invoke_context.get_compute_budget().heap_size;
+    let regions = vec![MemoryRegion::default(); 3]
+        .into_iter()
+        .chain(regions)
+        .collect();
+    let memory_mapping = MemoryMapping::new_uninitialized(
+        regions,
+        executable.get_config(),
+        executable.get_sbpf_version(),
+        invoke_context.transaction_context.access_violation_handler(
+            virtual_address_space_adjustments,
+            account_data_direct_mapping,
+        ),
+    );
+
+    invoke_context
+        .set_memory_context(MemoryContext::new(
+            BpfAllocator::new(heap_size as u64),
+            accounts_metadata,
+            memory_mapping,
+        ))
+        .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)
 }
 
 #[cfg_attr(feature = "svm-internal", qualifiers(pub))]
@@ -211,37 +213,51 @@ pub fn execute<'a, 'b: 'a>(
         })
         .collect::<Vec<_>>();
 
+    #[cfg(feature = "sbpf-debugger")]
+    let (debug_port, debug_metadata) = if invoke_context.debug_port.is_some() {
+        (
+            invoke_context.debug_port,
+            Some(format!(
+                "program_id={};cpi_level={};caller={}",
+                program_id,
+                instruction_context.get_stack_height().saturating_sub(1),
+                invoke_context
+                    .get_stack_height()
+                    .checked_sub(2)
+                    .and_then(|nesting_level| {
+                        transaction_context
+                            .get_instruction_context_at_nesting_level(nesting_level)
+                            .ok()
+                    })
+                    .and_then(|ctx| ctx.get_program_key().ok())
+                    .map(|key| key.to_string())
+                    .unwrap_or_else(|| "none".into())
+            )),
+        )
+    } else {
+        (None, None)
+    };
+
+    set_memory_context(
+        regions,
+        accounts_metadata,
+        invoke_context,
+        executable,
+        virtual_address_space_adjustments,
+        account_data_direct_mapping,
+    )?;
+
     let mut create_vm_time = Measure::start("create_vm");
     let execution_result = {
         let mut execution_mode = ExecutionMode::PreferJit;
+
         #[cfg(feature = "sbpf-debugger")]
-        let (debug_port, debug_metadata) = if invoke_context.debug_port.is_some() {
+        if invoke_context.debug_port.is_some() {
             execution_mode = ExecutionMode::Interpreted;
-            (
-                invoke_context.debug_port,
-                Some(format!(
-                    "program_id={};cpi_level={};caller={}",
-                    program_id,
-                    instruction_context.get_stack_height().saturating_sub(1),
-                    invoke_context
-                        .get_stack_height()
-                        .checked_sub(2)
-                        .and_then(|nesting_level| {
-                            transaction_context
-                                .get_instruction_context_at_nesting_level(nesting_level)
-                                .ok()
-                        })
-                        .and_then(|ctx| ctx.get_program_key().ok())
-                        .map(|key| key.to_string())
-                        .unwrap_or_else(|| "none".into())
-                )),
-            )
-        } else {
-            (None, None)
-        };
+        }
 
         let compute_meter_prev = invoke_context.get_remaining();
-        create_vm!(vm, executable, regions, accounts_metadata, invoke_context);
+        create_vm!(vm, executable, invoke_context);
         let (mut vm, stack, heap) = match vm {
             Ok(info) => info,
             Err(e) => {

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -127,7 +127,7 @@ macro_rules! create_vm {
 }
 
 fn set_memory_context<'b>(
-    regions: Vec<MemoryRegion>,
+    additional_initialized_regions: Vec<MemoryRegion>,
     accounts_metadata: Vec<SerializedAccountMetadata>,
     invoke_context: &mut InvokeContext<'b, 'b>,
     executable: &Executable<InvokeContext<'b, 'b>>,
@@ -137,7 +137,7 @@ fn set_memory_context<'b>(
     let heap_size = invoke_context.get_compute_budget().heap_size;
     let regions = vec![MemoryRegion::default(); 3]
         .into_iter()
-        .chain(regions)
+        .chain(additional_initialized_regions)
         .collect();
     let memory_mapping = MemoryMapping::new_uninitialized(
         regions,

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -72,16 +72,11 @@ fn configure_program_regions<'a, C: ContextObject>(
     let regions = mapping
         .get_regions_mut()
         .expect("The memory mapping should not have been initialized");
-
-    let ro_area = regions
-        .get_mut(0)
-        .expect("The regions vector must have at least three entries");
+    let [ro_area, stack_area, heap_area, ..] = regions else {
+        panic!("the regions vector must have at least three entries")
+    };
     *ro_area = executable.get_ro_region();
-
     let sbpf_version = executable.get_sbpf_version();
-    let stack_area = regions
-        .get_mut(1)
-        .expect("The regions vector must have at least three entries");
     let config = executable.get_config();
     *stack_area = MemoryRegion::new_writable_gapped(
         stack,
@@ -92,12 +87,7 @@ fn configure_program_regions<'a, C: ContextObject>(
             0
         },
     );
-
-    let heap_area = regions
-        .get_mut(2)
-        .expect("The regions vector must have at least three entries");
     *heap_area = MemoryRegion::new_writable(heap, MM_HEAP_START);
-
     mapping
         .initialize()
         .map_err(|err| Box::new(err) as Box<dyn std::error::Error>)

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -71,11 +71,15 @@ fn configure_program_regions<'a, C: ContextObject>(
     let memory_context = invoke_context.get_memory_context_mut()?;
     let regions = memory_context.get_memory_regions_mut();
 
-    let ro_area = regions.get_mut(0).unwrap();
+    let ro_area = regions
+        .get_mut(0)
+        .expect("The regions vector must have at least three entries");
     *ro_area = executable.get_ro_region();
 
     let sbpf_version = executable.get_sbpf_version();
-    let stack_area = regions.get_mut(1).unwrap();
+    let stack_area = regions
+        .get_mut(1)
+        .expect("The regions vector must have at least three entries");
     let config = executable.get_config();
     *stack_area = MemoryRegion::new_writable_gapped(
         stack,
@@ -87,7 +91,9 @@ fn configure_program_regions<'a, C: ContextObject>(
         },
     );
 
-    let heap_area = regions.get_mut(2).unwrap();
+    let heap_area = regions
+        .get_mut(2)
+        .expect("The regions vector must have at least three entries");
     *heap_area = MemoryRegion::new_writable(heap, MM_HEAP_START);
 
     memory_context.initialize()
@@ -238,6 +244,7 @@ pub fn execute<'a, 'b: 'a>(
         (None, None)
     };
 
+    let mut create_vm_time = Measure::start("create_vm");
     set_memory_context(
         regions,
         accounts_metadata,
@@ -247,7 +254,6 @@ pub fn execute<'a, 'b: 'a>(
         account_data_direct_mapping,
     )?;
 
-    let mut create_vm_time = Measure::start("create_vm");
     let execution_result = {
         let mut execution_mode = ExecutionMode::PreferJit;
 


### PR DESCRIPTION
#### Problem

For ABIv2, the memory mapping is only created once per transaction, and we don't need to initialize it (i.e. sort it). Instead, we just need to configure progam-specific areas for each instruction (heap, stack, and rodata).

This setting requires us to split creation and initialization of the memory mapping, so that we can use ABIv1 and v2 simultaneously with a shared interface.

#### Summary of Changes

1. Create `fn set_memory_context` to create an unitialized memory mapping.
2. Create `fn configure_program_regions` to configure program specific regions and initialize the mapping.
