### PR TITLE
replay: upstream switching duplicate banks on ParentReady

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -33,7 +33,10 @@ use {
         window_service::DuplicateSlotReceiver,
     },
     agave_votor::{
-        event::{CompletedBlock, LeaderWindowInfo, VotorEvent, VotorEventSender},
+        event::{
+            CompletedBlock, LeaderWindowInfo, SwitchBankEvent, SwitchBankEventReceiver, VotorEvent,
+            VotorEventSender,
+        },
         root_utils,
         vote_history_storage::SavedVoteHistory,
         voting_service::BLSOp,
@@ -55,7 +58,8 @@ use {
     solana_keypair::Keypair,
     solana_leader_schedule::SlotLeader,
     solana_ledger::{
-        blockstore::{Blockstore, UpdateParentReceiver},
+        blockstore::{Blockstore, BlockstoreError, UpdateParentReceiver},
+        blockstore_meta::BlockLocation,
         blockstore_processor::{
             self, AsyncVerificationProgress, BlockstoreProcessorError, ChainedBlockIdCheck,
             ConfirmationProgress, ExecuteBatchesInternalMetrics, ReplaySlotStats,
@@ -457,6 +461,7 @@ pub struct ReplayReceivers {
     pub gossip_verified_vote_hash_receiver: Receiver<(Pubkey, u64, Hash)>,
     pub popular_pruned_forks_receiver: Receiver<Vec<u64>>,
     pub bank_forks_controller_receiver: BankForksCommandReceiver,
+    pub switch_bank_receiver: SwitchBankEventReceiver,
 }
 
 /// Timing information for the ReplayStage main processing loop
@@ -771,6 +776,7 @@ impl ReplayStage {
             gossip_verified_vote_hash_receiver,
             popular_pruned_forks_receiver,
             bank_forks_controller_receiver,
+            switch_bank_receiver,
         } = receivers;
 
         trace!("replay stage");
@@ -855,6 +861,7 @@ impl ReplayStage {
             // AsyncVerificationProgress does a large allocation for its internal channel, so we
             // keep a free list to avoid doing one of those for each slot
             let mut async_verification_freelist = Vec::new();
+            let mut pending_switch = None;
             let working_bank = {
                 let r_bank_forks = bank_forks.read().unwrap();
                 r_bank_forks.working_bank()
@@ -996,7 +1003,6 @@ impl ReplayStage {
 
                 // Check if we've completed the migration conditions
                 if migration_status.is_ready_to_enable() {
-                    let shared_leader_state = poh_recorder.read().unwrap().shared_leader_state();
                     Self::enable_alpenglow(
                         &exit,
                         &my_pubkey,
@@ -1004,7 +1010,7 @@ impl ReplayStage {
                         bank_forks.as_ref(),
                         blockstore.as_ref(),
                         &mut poh_controller,
-                        &shared_leader_state,
+                        &poh_shared_leader_state,
                         leader_schedule_cache.as_ref(),
                         &mut ancestors,
                         &mut descendants,
@@ -1037,6 +1043,19 @@ impl ReplayStage {
                         &mut progress,
                         did_complete_bank,
                     );
+                    Self::process_switch_bank_events(
+                        &my_pubkey,
+                        &switch_bank_receiver,
+                        &mut pending_switch,
+                        &blockstore,
+                        &bank_forks,
+                        &mut progress,
+                        &mut async_verification_freelist,
+                    )
+                    .expect("Blockstore operations must succeed");
+                    // Banks might have been switched above, these maps are no longer accurate
+                    drop(ancestors);
+                    drop(descendants);
                 } else {
                     let forks_root = bank_forks.read().unwrap().root();
                     // Process cluster-agreed versions of duplicate slots for which we potentially
@@ -2318,6 +2337,146 @@ impl ReplayStage {
         descendants
             .remove(&slot)
             .expect("must exist based on earlier check");
+    }
+
+    /// Process switch block events from votor
+    ///
+    /// When receiving a switch request for block b we attempt to switch out the bank in slot(b)
+    /// for b if the bank in slot(b) does not match the block id for b.
+    ///
+    /// When we need to switch a bank b, we first defer until we've repaired the ancestory of b:
+    /// - We must have block b and all of its ancestors up to any ancestor we've already replayed
+    /// - If no ancestor is replayed and it links back <= root, we can ignore this request
+    ///
+    /// Then to perform the switch for b and all of its ancestors identified above we:
+    /// - Clear the existing bank (if one exists) in the slot from bank forks and progress
+    /// - Use `blockstore::switch_block_from_alternate` to atomically switch the shreds fetched
+    ///   by informed repair into the original column
+    ///
+    /// At this point generate_new_bank_forks can replay the fork up to b
+    ///
+    /// We only care about the latest switch event. When deferring while waiting for repair we store
+    /// this in `pending_switch`
+    fn process_switch_bank_events(
+        my_pubkey: &Pubkey,
+        switch_bank_receiver: &SwitchBankEventReceiver,
+        pending_switch: &mut Option<(Slot, Hash)>,
+        blockstore: &Blockstore,
+        bank_forks: &RwLock<BankForks>,
+        progress: &mut ProgressMap,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+    ) -> Result<(), BlockstoreError> {
+        let root = bank_forks.read().unwrap().root();
+
+        if let Some(switch_bank_event) = switch_bank_receiver
+            .try_iter()
+            .max()
+            .filter(|SwitchBankEvent::Switch { slot, .. }| *slot > root)
+        {
+            let (slot, block_id) = switch_bank_event.block();
+
+            // Overwrite the pending switch, later switches take precedence
+            if Some(slot) >= pending_switch.map(|(slot, _)| slot) {
+                if let Some(prev_switch_request) = pending_switch.replace((slot, block_id)) {
+                    trace!(
+                        "{my_pubkey}: Overwriting previous switch request {prev_switch_request:?} \
+                         with ({slot}, {block_id})"
+                    );
+                } else {
+                    trace!("{my_pubkey}: Received switch request in {slot} to {block_id}");
+                }
+            }
+        };
+
+        let Some((slot, block_id)) = *pending_switch else {
+            return Ok(());
+        };
+
+        if bank_forks.read().unwrap().block_id(slot) == Some(block_id) {
+            // Nothing to switch
+            *pending_switch = None;
+            return Ok(());
+        }
+
+        // Check if we have received the block and all of its ancestors and collect the ones we
+        // need to switch out
+        let mut ancestor_slot = slot;
+        let mut ancestor_block_id = block_id;
+        let mut blocks_to_switch = vec![];
+        loop {
+            if ancestor_slot <= root {
+                // This is either (1) an outdated attempt to switch out the
+                // root or (2) attempt to switch to a fork that would end up
+                // switching out the root, so we should ignore
+                *pending_switch = None;
+                return Ok(());
+            }
+
+            let Some(location) = blockstore.get_block_location(ancestor_slot, ancestor_block_id)?
+            else {
+                trace!(
+                    "{my_pubkey}: Waiting for repair, deferring switch to block {ancestor_slot} \
+                     {ancestor_block_id}"
+                );
+                // Still waiting on repair to finish - keep pending request
+                return Ok(());
+            };
+
+            if location != BlockLocation::Original {
+                // Need to switch this block
+                blocks_to_switch.push((ancestor_slot, location));
+            }
+
+            let slot_meta = blockstore
+                .meta_from_location(ancestor_slot, location)?
+                .expect("Full slots must contain SlotMeta");
+            let parent_slot = slot_meta
+                .parent_slot
+                .expect("Full slots must have a parent");
+            let parent_block_id = slot_meta.parent_block_id;
+
+            if bank_forks.read().unwrap().block_id(parent_slot) == Some(parent_block_id)
+                // Genesis cannot be duplicate
+                || parent_slot == 0
+            {
+                info!(
+                    "{my_pubkey}: Ancestor in slot {parent_slot} found in bank forks, time to \
+                     switch"
+                );
+                // We have this ancestor replayed, time to switch
+                break;
+            }
+
+            // Check the next ancestor
+            ancestor_block_id = parent_block_id;
+            ancestor_slot = parent_slot;
+        }
+
+        let slots_to_clear = bank_forks
+            .read()
+            .unwrap()
+            .slots_to_clear(blocks_to_switch.iter().map(|(slot, _)| *slot));
+
+        info!("{my_pubkey}: Clearing banks for switching and descendants: {slots_to_clear:?}");
+        Self::clear_banks(
+            &slots_to_clear,
+            bank_forks,
+            progress,
+            async_verification_freelist,
+        );
+
+        // Banks are clear, move shreds in blockstore
+        for (slot, location) in blocks_to_switch {
+            info!("{my_pubkey}: Switching {slot} from {location:?}");
+
+            // Switch the blockstore data atomically, handles slot meta chaining so generate new bank forks can proceed
+            blockstore.switch_block_from_alternate(slot, location)?;
+            info!("{my_pubkey}: Switched {slot} from {location:?}");
+        }
+
+        *pending_switch = None;
+
+        Ok(())
     }
 
     /// For slots to clear, clear the bank from progress, bank forks, and recycle the async verification

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -428,6 +428,13 @@ impl Tvu {
             completed_slots_receiver,
         };
 
+        // Create switch block event channel for ReplayStage
+        // We emit a switch bank event when we observe a ParentReady.
+        // The event is immediately consumed and the latest is stored in ReplayStage.
+        // We overprovision at 100 leader windows - we would require almost 3 minutes of stuck
+        // replay to hit the limit.
+        let (switch_bank_sender, switch_bank_receiver) = bounded(100);
+
         let window_service = {
             let epoch_schedule = bank_forks
                 .read()
@@ -515,6 +522,7 @@ impl Tvu {
             leader_window_info_sender,
             highest_parent_ready,
             event_sender: votor_event_sender.clone(),
+            switch_bank_sender,
             own_vote_sender: consensus_message_sender.clone(),
             reward_certs_sender,
             repair_event_sender,
@@ -558,6 +566,7 @@ impl Tvu {
             gossip_verified_vote_hash_receiver,
             popular_pruned_forks_receiver,
             bank_forks_controller_receiver,
+            switch_bank_receiver,
         };
 
         let replay_stage_config = ReplayStageConfig {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -83,7 +83,7 @@ use {
         path::{Path, PathBuf},
         rc::Rc,
         sync::{
-            Arc, Mutex, RwLock,
+            Arc, Mutex, MutexGuard, RwLock,
             atomic::{AtomicBool, AtomicU64, Ordering},
         },
     },
@@ -2101,10 +2101,39 @@ impl Blockstore {
 
         // Acquire the insertion lock
         let mut start = Measure::start("Blockstore lock");
-        let _lock = self.insert_shreds_lock.lock().unwrap();
+        let lock = self.insert_shreds_lock.lock().unwrap();
         start.stop();
         metrics.insert_lock_elapsed_us += start.as_us();
 
+        let result = self.do_insert_shreds_locked(
+            &lock,
+            shreds,
+            leader_schedule,
+            is_trusted,
+            shred_recovery_context,
+            metrics,
+        );
+
+        // Roll up metrics
+        total_start.stop();
+        metrics.total_elapsed_us += total_start.as_us();
+
+        result
+    }
+
+    /// Core shred insertion logic.
+    fn do_insert_shreds_locked<'a>(
+        &self,
+        _insert_shreds_lock: &MutexGuard<'_, ()>,
+        shreds: impl IntoIterator<
+            Item = (Cow<'a, Shred>, /*is_repaired:*/ bool, BlockLocation),
+            IntoIter: ExactSizeIterator,
+        >,
+        leader_schedule: Option<&LeaderScheduleCache>,
+        is_trusted: bool,
+        shred_recovery_context: Option<&mut ShredRecoveryContext>,
+        metrics: &mut BlockstoreInsertionMetrics,
+    ) -> Result<InsertResults> {
         let shreds = shreds.into_iter();
         let mut shred_insertion_tracker =
             ShredInsertionTracker::new(shreds.len(), self.get_write_batch()?);
@@ -2156,9 +2185,6 @@ impl Blockstore {
             update_parent_signals,
         );
 
-        // Roll up metrics
-        total_start.stop();
-        metrics.total_elapsed_us += total_start.as_us();
         metrics.index_meta_time_us += shred_insertion_tracker.index_meta_time_us;
 
         Ok(InsertResults {
@@ -2290,6 +2316,99 @@ impl Blockstore {
                 Err(e) => panic!("Purge database operations failed {e}"),
             }
         }
+    }
+
+    /// Helper to copy shreds from one location to another.
+    /// Reads all data shreds from `from_location` and inserts them at `to_location`.
+    fn copy_shreds_locked(
+        &self,
+        lock: &std::sync::MutexGuard<'_, ()>,
+        slot: Slot,
+        from_location: BlockLocation,
+        to_location: BlockLocation,
+    ) -> Result<()> {
+        let shreds = self.get_data_shreds_for_slot_from_location(
+            slot,
+            /* start_index */ 0,
+            from_location,
+        )?;
+
+        let shreds = shreds.into_iter().map(|shred| {
+            (Cow::Owned(shred), /*is_repaired:*/ false, to_location)
+        });
+        self.do_insert_shreds_locked(
+            lock,
+            shreds,
+            None, // leader_schedule
+            true, // is_trusted
+            None, // should_recover_shreds
+            &mut BlockstoreInsertionMetrics::default(),
+        )?;
+
+        Ok(())
+    }
+
+    /// Switch the block in `slot` from an alternate location to the original location.
+    /// This atomically:
+    /// 1. Back up the original column data if it's a valid block that we don't have
+    /// 2. Purges the original column data while preserving alternate columns
+    /// 3. Copies shreds from the alternate location to the original location
+    /// 4. Verify that the switch was successful
+    ///
+    /// Holds `insert_shreds_lock` for the entire operation.
+    ///
+    /// Assumes that the block at `location` is full.
+    pub fn switch_block_from_alternate(
+        &self,
+        slot: Slot,
+        from_location: BlockLocation,
+    ) -> Result<()> {
+        assert!(
+            !matches!(from_location, BlockLocation::Original),
+            "Cannot switch from Original location"
+        );
+
+        let lock = self.insert_shreds_lock.lock().unwrap();
+
+        // 1. Backup the original block if needed
+        if let Some(dmr) = self.get_double_merkle_root(slot, BlockLocation::Original)? {
+            let backup_location = BlockLocation::Alternate { block_id: dmr };
+            if self
+                .get_double_merkle_root(slot, backup_location)?
+                .is_none()
+            {
+                self.copy_shreds_locked(&lock, slot, BlockLocation::Original, backup_location)?;
+            }
+        }
+
+        // 2. Purge the original column data, keeping alternate columns intact
+        self.purge_slot_cleanup_chaining_keep_alt(slot)
+            .or_else(|err| {
+                if matches!(err, BlockstoreError::SlotUnavailable) {
+                    // There was no block in the original column, continue to copying
+                    Ok(())
+                } else {
+                    Err(err)
+                }
+            })?;
+
+        // 3. Copy shreds from alternate location to original
+        let alt_meta = self
+            .meta_from_location(slot, from_location)?
+            .expect("Alternate slot must have SlotMeta");
+        debug_assert!(alt_meta.is_full(), "Alternate slot must be full");
+
+        self.copy_shreds_locked(&lock, slot, from_location, BlockLocation::Original)?;
+
+        // 4. Verify the switch was successful
+        debug_assert!(
+            self.meta(slot)?
+                .expect("Slot must have SlotMeta after switch")
+                .is_full(),
+            "Slot must be full after switch"
+        );
+
+        Ok(())
     }
 
     // Bypasses erasure recovery becuase it is called from broadcast stage

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -143,7 +143,6 @@ impl Blockstore {
 
     /// Like `purge_slot_cleanup_chaining` but preserves alternate block columns.
     /// Used when switching from an alternate block to allow repair data to be retained.
-    #[allow(dead_code)]
     pub(crate) fn purge_slot_cleanup_chaining_keep_alt(&self, slot: Slot) -> Result<()> {
         self.do_purge_slot_cleanup_chaining(slot, /* purge_alt_columns */ false)
     }

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -18,7 +18,7 @@ use {
     solana_program_runtime::loaded_programs::{BlockRelation, ForkGraph},
     solana_unified_scheduler_logic::SchedulingMode,
     std::{
-        collections::{HashMap, HashSet, hash_map::Entry},
+        collections::{BTreeSet, HashMap, HashSet, hash_map::Entry},
         ops::Index,
         sync::{Arc, RwLock},
         time::Instant,
@@ -190,6 +190,34 @@ impl BankForks {
     /// Create a map of bank slot id to the set of all of its descendants
     pub fn descendants(&self) -> HashMap<Slot, HashSet<Slot>> {
         self.descendants.clone()
+    }
+
+    /// For use when we want to remove `slots` from `BankForks`. It's not safe to remove
+    /// a bank if it's descendant(s) are still in BankForks.
+    ///
+    /// Returns the supplied slots and any descendants that are still present in bank forks
+    pub fn slots_to_clear(&self, slots: impl IntoIterator<Item = Slot>) -> BTreeSet<Slot> {
+        let root = self.root();
+        let mut slots_to_clear = BTreeSet::new();
+
+        for slot in slots.into_iter() {
+            if slot <= root {
+                continue;
+            }
+            if self.banks.contains_key(&slot) {
+                slots_to_clear.insert(slot);
+            }
+            if let Some(slot_descendants) = self.descendants.get(&slot) {
+                slots_to_clear.extend(
+                    slot_descendants
+                        .iter()
+                        .copied()
+                        .filter(|descendant| self.banks.contains_key(descendant)),
+                );
+            }
+        }
+
+        slots_to_clear
     }
 
     pub fn frozen_banks(&self) -> impl Iterator<Item = (Slot, Arc<Bank>)> + '_ {
@@ -1108,6 +1136,31 @@ mod tests {
         assert_eq!(children, *descendants.get(&0).unwrap());
         assert!(descendants[&1].is_empty());
         assert!(descendants[&2].is_empty());
+    }
+
+    #[test]
+    fn test_bank_forks_slots_to_clear() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let bank_forks = BankForks::new_rw_arc(bank);
+
+        extend_bank_forks(
+            bank_forks.clone(),
+            &[(0, 1), (1, 2), (1, 3), (2, 4), (0, 5)],
+        );
+
+        assert_eq!(
+            bank_forks.read().unwrap().slots_to_clear([2]),
+            [2, 4].into_iter().collect()
+        );
+        assert_eq!(
+            bank_forks.read().unwrap().slots_to_clear([1]),
+            [1, 2, 3, 4].into_iter().collect(),
+        );
+        assert_eq!(
+            bank_forks.read().unwrap().slots_to_clear([0]),
+            BTreeSet::<Slot>::new()
+        );
     }
 
     #[test]

--- a/votor/src/event.rs
+++ b/votor/src/event.rs
@@ -106,7 +106,7 @@ pub type RepairEventReceiver = Receiver<RepairEvent>;
 pub enum RepairEvent {
     /// We require that this block be fetched. This can happen for the following reasons:
     /// - The block has received a NotarizeFallback certificate or stronger
-    /// - TODO(ashwin): An intrawindow block has reached the SafeToNotar threshold, however we need
+    /// - An intrawindow block has reached the SafeToNotar threshold, however we need
     ///   to check that the parent has reached notarize-fallback requiring us to fetch this block
     FetchBlock { slot: Slot, block_id: Hash },
 }
@@ -115,6 +115,24 @@ impl RepairEvent {
     pub fn slot(&self) -> Slot {
         match self {
             RepairEvent::FetchBlock { slot, .. } => *slot,
+        }
+    }
+}
+
+pub type SwitchBankEventSender = Sender<SwitchBankEvent>;
+pub type SwitchBankEventReceiver = Receiver<SwitchBankEvent>;
+
+/// Event sent to replay_stage when a bank needs to be switched as a result of a ParentReady
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SwitchBankEvent {
+    /// We need to switch any existing banks to this bank including ancestors
+    Switch { slot: Slot, block_id: Hash },
+}
+
+impl SwitchBankEvent {
+    pub fn block(&self) -> Block {
+        match self {
+            SwitchBankEvent::Switch { slot, block_id } => (*slot, *block_id),
         }
     }
 }

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -6,7 +6,10 @@ use {
         commitment::{CommitmentType, update_commitment_cache},
         common::DELTA_FIRST_SLICE,
         consensus_metrics::ConsensusMetricsEvent,
-        event::{CompletedBlock, RepairEvent, RepairEventSender, VotorEvent, VotorEventReceiver},
+        event::{
+            CompletedBlock, RepairEvent, RepairEventSender, SwitchBankEvent, SwitchBankEventSender,
+            VotorEvent, VotorEventReceiver,
+        },
         event_handler::stats::EventHandlerStats,
         root_utils::{self, RootContext},
         timer_manager::TimerManager,
@@ -208,7 +211,7 @@ impl EventHandler {
 
     fn handle_parent_ready_event(
         slot: Slot,
-        parent_block: Block,
+        parent_block @ (parent_slot, _): Block,
         vctx: &mut VotingContext,
         ctx: &SharedContext,
         local_context: &mut LocalContext,
@@ -217,6 +220,12 @@ impl EventHandler {
     ) -> Result<(), EventLoopError> {
         let my_pubkey = &local_context.my_pubkey;
         info!("{my_pubkey}: Parent ready {slot} {parent_block:?}");
+
+        // We need to ensure that we've replayed the parent bank.
+        if parent_slot > vctx.sharable_banks.root().slot() {
+            request_switch(&ctx.switch_bank_sender, *my_pubkey, parent_block)?;
+        }
+
         let should_set_timeouts = vctx.vote_history.add_parent_ready(slot, parent_block);
         Self::check_pending_blocks(my_pubkey, &mut local_context.pending_blocks, vctx, votes)?;
         if should_set_timeouts {
@@ -850,8 +859,6 @@ impl EventHandler {
 }
 
 /// Sends a repair event to the block ID repair service.
-/// Tries non-blocking send first; if the channel is full, logs an error and blocks.
-/// Returns an error if the channel is disconnected.
 fn request_repair(
     sender: &RepairEventSender,
     my_pubkey: Pubkey,
@@ -876,6 +883,31 @@ fn request_repair(
     }
 }
 
+/// Sends a switch bank event to replay.
+fn request_switch(
+    sender: &SwitchBankEventSender,
+    my_pubkey: Pubkey,
+    block: Block,
+) -> Result<(), EventLoopError> {
+    let (slot, block_id) = block;
+    let event = SwitchBankEvent::Switch { slot, block_id };
+    match sender.try_send(event) {
+        Ok(()) => Ok(()),
+        Err(TrySendError::Full(event)) => {
+            error!(
+                "{my_pubkey}: Switch bank event channel is full, this should not happen. Blocking \
+                 to send event for slot {slot}"
+            );
+            sender
+                .send(event)
+                .map_err(|_| EventLoopError::SenderDisconnected(SendError(())))
+        }
+        Err(TrySendError::Disconnected(_)) => {
+            Err(EventLoopError::SenderDisconnected(SendError(())))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
@@ -883,7 +915,7 @@ mod tests {
         crate::{
             commitment::CommitmentAggregationData,
             consensus_metrics::ConsensusMetricsEventReceiver,
-            event::{LeaderWindowInfo, RepairEventReceiver},
+            event::{LeaderWindowInfo, RepairEventReceiver, SwitchBankEventReceiver},
             vote_history_storage::{
                 FileVoteHistoryStorage, SavedVoteHistory, SavedVoteHistoryVersions,
                 VoteHistoryStorage,
@@ -938,6 +970,8 @@ mod tests {
         consensus_metrics_receiver: ConsensusMetricsEventReceiver,
         #[allow(dead_code)] // Keep receiver alive to prevent SenderDisconnected errors
         repair_event_receiver: RepairEventReceiver,
+        #[allow(dead_code)]
+        switch_bank_receiver: SwitchBankEventReceiver,
         shared_context: SharedContext,
         voting_context: VotingContext,
         root_context: RootContext,
@@ -1002,6 +1036,7 @@ mod tests {
         let (consensus_metrics_sender, consensus_metrics_receiver) = unbounded();
         let (leader_window_info_sender, leader_window_info_receiver) = unbounded();
         let (repair_event_sender, repair_event_receiver) = unbounded();
+        let (switch_bank_sender, switch_bank_receiver) = unbounded();
         let timer_manager = Arc::new(PlRwLock::new(TimerManager::new(
             event_sender,
             exit,
@@ -1060,6 +1095,7 @@ mod tests {
             blockstore: blockstore.clone(),
             highest_parent_ready: highest_parent_ready.clone(),
             repair_event_sender,
+            switch_bank_sender,
         };
 
         let vote_history = VoteHistory::new(my_node_keypair.pubkey(), 0);
@@ -1103,6 +1139,7 @@ mod tests {
             cluster_info,
             consensus_metrics_receiver,
             repair_event_receiver,
+            switch_bank_receiver,
             highest_parent_ready,
             shared_context,
             voting_context,

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -18,7 +18,7 @@
 //!   │        │         │                              │ │                        │ │Voting Service│
 //!   │        │         │                              │ │                        │ └──────────────┘
 //!   │        │         │                              │ │                        │
-//!   │   ┌────┼─────────┼───────────────┐              │ │                        │
+//!   │   ┌────┼─────────┼───────────────┐              │ │    Switch Bank         │
 //!   │   │                              │              │ │      Block             │ ┌────────────────────┐
 //!   │   │   Consensus Pool Service     │              │ │  ┌─────────────────────│─┼ Replay / Broadcast │
 //!   │   │                              │              │ │  │                     │ └────────────────────┘
@@ -51,7 +51,10 @@ use {
         },
         consensus_pool_service::{ConsensusPoolContext, ConsensusPoolService},
         consensus_rewards::ConsensusRewardsService,
-        event::{LeaderWindowInfo, RepairEventSender, VotorEventReceiver, VotorEventSender},
+        event::{
+            LeaderWindowInfo, RepairEventSender, SwitchBankEventSender, VotorEventReceiver,
+            VotorEventSender,
+        },
         event_handler::{EventHandler, EventHandlerContext},
         generated_cert_types::GeneratedCertTypes,
         root_utils::RootContext,
@@ -116,6 +119,7 @@ pub struct VotorConfig {
     pub own_vote_sender: Sender<Vec<ConsensusMessage>>,
     pub reward_certs_sender: Sender<BuildRewardCertsResponse>,
     pub repair_event_sender: RepairEventSender,
+    pub switch_bank_sender: SwitchBankEventSender,
 
     // Receivers
     pub event_receiver: VotorEventReceiver,
@@ -134,6 +138,7 @@ pub(crate) struct SharedContext {
     pub(crate) highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
     pub(crate) vote_history_storage: Arc<dyn VoteHistoryStorage>,
     pub(crate) repair_event_sender: RepairEventSender,
+    pub(crate) switch_bank_sender: SwitchBankEventSender,
 }
 
 pub struct Votor {
@@ -165,6 +170,7 @@ impl Votor {
             event_sender,
             own_vote_sender,
             repair_event_sender,
+            switch_bank_sender,
             event_receiver,
             consensus_message_receiver,
             consensus_metrics_sender,
@@ -191,6 +197,7 @@ impl Votor {
             leader_window_info_sender,
             vote_history_storage,
             repair_event_sender: repair_event_sender.clone(),
+            switch_bank_sender,
         };
 
         let voting_context = VotingContext {


### PR DESCRIPTION
Upstream of https://github.com/anza-xyz/alpenglow/pull/710

#### Problem
When a duplicate block of interest is noted, we fetch it via the block id repair service.
This loads the block into the alternate shred column in blockstore.

If the duplicate block actually ends up becoming necessary for replay, we need to switch the current bank in that slot to this alternate block

#### Summary of Changes
Add a `SwitchBank` event that is emitted by Votor. In replay, if:
- Event to Switch to `b` is received
- Current bank in bank forks does not match `b` / is missing
- `b` and all relevant ancestors have been fetched by repair

For each of `b` and its ancestors that live in the alternate shred column:
- Remove the bank from bank forks
- Remove from progress map
- Atomically switch from alternate -> original
  - (optional) copy the current block in the original column -> alternate if it's a full block
  - purge the columns in `slot(b)` while preserving the alternate column
  - fetch the shreds from `BlockLocation::Alternate(b)`
  - Insert them into `BlockLocation::Orignal` for `slot(b)` which also performs SlotMeta chaining

Then replay should automagically start replaying `b` via `generate_new_bank_forks`
