### PR TITLE
ledger/blockstore: fix duplicate _nanos suffix in merge operator metric name

### DIFF
--- a/ledger/src/blockstore_metrics.rs
+++ b/ledger/src/blockstore_metrics.rs
@@ -570,7 +570,7 @@ pub(crate) fn report_rocksdb_write_perf(
             ),
             // Time spent on merge operator.
             (
-                "merge_operator_nanos_nanos",
+                "merge_operator_nanos",
                 perf_context.metric(PerfMetric::MergeOperatorTimeNanos) as i64,
                 i64
             ),


### PR DESCRIPTION
#### Problem

The RocksDB write performance report used an inconsistent metric field name (`merge_operator_nanos_nanos`) with a duplicated `_nanos` suffix.

#### Summary of Changes

- Rename the datapoint field to `merge_operator_nanos` in `report_rocksdb_write_perf` so it matches the intended naming and other perf metrics.
