### PR TITLE
fix toctou in program statistics merge_from

### DIFF
--- a/program-runtime/src/program_metrics.rs
+++ b/program-runtime/src/program_metrics.rs
@@ -112,7 +112,7 @@ impl ProgramStatistics {
         let other_interpretations = other.interpreted_invocations.load(ord);
         let this_interpretations = self
             .interpreted_invocations
-            .fetch_add(other.interpreted_invocations.load(ord), ord);
+            .fetch_add(other_interpretations, ord);
         self.total_interpretation_time_us
             .fetch_add(other.total_interpretation_time_us.load(ord), ord);
         if let Some(comp_ema) = ProgramCacheStats::combined_ema::<


### PR DESCRIPTION
## summary
- fix toctou race in ProgramStatistics::merge_from
- interpreted_invocations was being re-loaded atomically instead of using the already loaded local variable

## test plan
- verified other fields already use the loaded value pattern correctly

fixes #11730