### PR TITLE
cli: program: remove ExtendProgramChecked

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -169,9 +169,8 @@ pub enum ProgramCliCommand {
         use_lamports_unit: bool,
         bypass_warning: bool,
     },
-    ExtendProgramChecked {
+    ExtendProgram {
         program_pubkey: Pubkey,
-        authority_signer_index: SignerIndex,
         payer_signer_index: SignerIndex,
         additional_bytes: u32,
     },
@@ -646,16 +645,6 @@ impl ProgramSubCommands for App<'_, '_> {
                                 ),
                         )
                         .arg(
-                            Arg::with_name("authority")
-                                .long("authority")
-                                .value_name("AUTHORITY_SIGNER")
-                                .takes_value(true)
-                                .validator(is_valid_signer)
-                                .help(
-                                    "Upgrade authority [default: the default configured keypair]",
-                                ),
-                        )
-                        .arg(
                             Arg::with_name("payer")
                                 .long("payer")
                                 .value_name("PAYER_SIGNER")
@@ -1008,15 +997,11 @@ pub fn parse_program_subcommand(
         ("extend", Some(matches)) => {
             let program_pubkey = pubkey_of(matches, "program_id").unwrap();
             let additional_bytes = value_of(matches, "additional_bytes").unwrap();
-
-            let (authority_signer, authority_pubkey) =
-                signer_of(matches, "authority", wallet_manager)?;
             let (payer_signer, payer_pubkey) = signer_of(matches, "payer", wallet_manager)?;
 
             let signer_info = default_signer.generate_unique_signers(
                 vec![
                     Some(default_signer.signer_from_path(matches, wallet_manager)?),
-                    authority_signer,
                     payer_signer,
                 ],
                 matches,
@@ -1024,9 +1009,8 @@ pub fn parse_program_subcommand(
             )?;
 
             CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::ExtendProgramChecked {
+                command: CliCommand::Program(ProgramCliCommand::ExtendProgram {
                     program_pubkey,
-                    authority_signer_index: signer_info.index_of(authority_pubkey).unwrap(),
                     payer_signer_index: signer_info.index_of(payer_pubkey).unwrap(),
                     additional_bytes,
                 }),
@@ -1237,9 +1221,8 @@ pub async fn process_program_subcommand(
             )
             .await
         }
-        ProgramCliCommand::ExtendProgramChecked {
+        ProgramCliCommand::ExtendProgram {
             program_pubkey,
-            authority_signer_index,
             payer_signer_index,
             additional_bytes,
         } => {
@@ -1247,7 +1230,6 @@ pub async fn process_program_subcommand(
                 &rpc_client,
                 config,
                 *program_pubkey,
-                *authority_signer_index,
                 *payer_signer_index,
                 *additional_bytes,
             )
@@ -2416,12 +2398,10 @@ async fn process_extend_program(
     rpc_client: &RpcClient,
     config: &CliConfig<'_>,
     program_pubkey: Pubkey,
-    authority_signer_index: SignerIndex,
     payer_signer_index: SignerIndex,
     additional_bytes: u32,
 ) -> ProcessResult {
     let fee_payer_pubkey = config.signers[0].pubkey();
-    let authority_signer = config.signers[authority_signer_index];
     let payer_signer = config.signers[payer_signer_index];
     let payer_pubkey = payer_signer.pubkey();
 
@@ -2468,41 +2448,19 @@ async fn process_extend_program(
         _ => Err(format!("Program {program_pubkey} is closed")),
     }?;
 
-    let upgrade_authority_address = upgrade_authority_address
+    upgrade_authority_address
         .ok_or_else(|| format!("Program {program_pubkey} is not upgradeable"))?;
 
-    if authority_signer.pubkey() != upgrade_authority_address {
-        return Err(format!(
-            "Upgrade authority {} does not match {}",
-            upgrade_authority_address,
-            authority_signer.pubkey(),
-        )
-        .into());
-    }
-
     let blockhash = rpc_client.get_latest_blockhash().await?;
-    let feature_set = fetch_feature_set(rpc_client).await?;
 
-    let instruction = if feature_set.snapshot().enable_extend_program_checked {
-        loader_v3_instruction::extend_program_checked(
-            &program_pubkey,
-            &upgrade_authority_address,
-            Some(&payer_pubkey),
-            additional_bytes,
-        )
-    } else {
-        loader_v3_instruction::extend_program(
-            &program_pubkey,
-            Some(&payer_pubkey),
-            additional_bytes,
-        )
-    };
+    let instruction = loader_v3_instruction::extend_program(
+        &program_pubkey,
+        Some(&payer_pubkey),
+        additional_bytes,
+    );
     let mut tx = Transaction::new_unsigned(Message::new(&[instruction], Some(&fee_payer_pubkey)));
 
-    tx.try_sign(
-        &[config.signers[0], authority_signer, payer_signer],
-        blockhash,
-    )?;
+    tx.try_sign(&[config.signers[0], payer_signer], blockhash)?;
     let result = rpc_client
         .send_and_confirm_transaction_with_spinner_and_config(
             &tx,
@@ -2972,8 +2930,7 @@ async fn extend_program_data_if_needed(
         _ => Err(format!("Program {program_id} is closed")),
     }?;
 
-    let upgrade_authority_address = upgrade_authority_address
-        .ok_or_else(|| format!("Program {program_id} is not upgradeable"))?;
+    upgrade_authority_address.ok_or_else(|| format!("Program {program_id} is not upgradeable"))?;
 
     let required_len = UpgradeableLoaderState::size_of_programdata(program_len);
     let max_permitted_data_length = usize::try_from(MAX_PERMITTED_DATA_LENGTH).unwrap();
@@ -2997,17 +2954,8 @@ async fn extend_program_data_if_needed(
     let additional_bytes =
         u32::try_from(additional_bytes).expect("`u32` is big enough to hold an account size");
 
-    let feature_set = fetch_feature_set(rpc_client).await?;
-    let instruction = if feature_set.snapshot().enable_extend_program_checked {
-        loader_v3_instruction::extend_program_checked(
-            program_id,
-            &upgrade_authority_address,
-            Some(fee_payer),
-            additional_bytes,
-        )
-    } else {
-        loader_v3_instruction::extend_program(program_id, Some(fee_payer), additional_bytes)
-    };
+    let instruction =
+        loader_v3_instruction::extend_program(program_id, Some(fee_payer), additional_bytes);
     initial_instructions.push(instruction);
 
     Ok(())
@@ -4449,42 +4397,12 @@ mod tests {
         assert_eq!(
             parse_command(&test_command, &default_signer, &mut None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::ExtendProgramChecked {
+                command: CliCommand::Program(ProgramCliCommand::ExtendProgram {
                     program_pubkey,
-                    authority_signer_index: 0,
                     payer_signer_index: 0,
                     additional_bytes
                 }),
                 signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
-            }
-        );
-
-        // with authority
-        let authority_keypair = Keypair::new();
-        let authority_keypair_file = make_tmp_path("authority_keypair_file");
-        write_keypair_file(&authority_keypair, &authority_keypair_file).unwrap();
-        let test_command = test_commands.clone().get_matches_from(vec![
-            "test",
-            "program",
-            "extend",
-            &program_pubkey.to_string(),
-            &additional_bytes.to_string(),
-            "--authority",
-            &authority_keypair_file,
-        ]);
-        assert_eq!(
-            parse_command(&test_command, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::ExtendProgramChecked {
-                    program_pubkey,
-                    authority_signer_index: 1,
-                    payer_signer_index: 0,
-                    additional_bytes
-                }),
-                signers: vec![
-                    Box::new(read_keypair_file(&keypair_file).unwrap()),
-                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
-                ],
             }
         );
 
@@ -4504,43 +4422,13 @@ mod tests {
         assert_eq!(
             parse_command(&test_command, &default_signer, &mut None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::ExtendProgramChecked {
+                command: CliCommand::Program(ProgramCliCommand::ExtendProgram {
                     program_pubkey,
-                    authority_signer_index: 0,
                     payer_signer_index: 1,
                     additional_bytes
                 }),
                 signers: vec![
                     Box::new(read_keypair_file(&keypair_file).unwrap()),
-                    Box::new(read_keypair_file(&payer_keypair_file).unwrap()),
-                ],
-            }
-        );
-
-        // with both authority and payer
-        let test_command = test_commands.clone().get_matches_from(vec![
-            "test",
-            "program",
-            "extend",
-            &program_pubkey.to_string(),
-            &additional_bytes.to_string(),
-            "--authority",
-            &authority_keypair_file,
-            "--payer",
-            &payer_keypair_file,
-        ]);
-        assert_eq!(
-            parse_command(&test_command, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::ExtendProgramChecked {
-                    program_pubkey,
-                    authority_signer_index: 1,
-                    payer_signer_index: 2,
-                    additional_bytes
-                }),
-                signers: vec![
-                    Box::new(read_keypair_file(&keypair_file).unwrap()),
-                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                     Box::new(read_keypair_file(&payer_keypair_file).unwrap()),
                 ],
             }

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
-    agave_feature_set::enable_alt_bn128_syscall,
+    agave_feature_set::{enable_alt_bn128_syscall, enable_extend_program_checked},
     assert_matches::assert_matches,
     serde_json::Value,
     solana_account::{ReadableAccount, state_traits::StateMut},
@@ -59,7 +59,8 @@ fn test_validator_genesis(mint_keypair: &Keypair) -> TestValidatorGenesis {
         })
         .faucet_addr(Some(run_local_faucet_with_unique_port_for_tests(
             mint_keypair.insecure_clone(),
-        )));
+        )))
+        .deactivate_features(&[enable_extend_program_checked::id()]);
     genesis
 }
 
@@ -1516,10 +1517,9 @@ async fn test_cli_program_extend_program() {
     file.read_to_end(&mut new_program_data).unwrap();
     let new_max_len = new_program_data.len();
     let additional_bytes = (new_max_len - max_len) as u32;
-    config.signers = vec![&keypair, &upgrade_authority];
-    config.command = CliCommand::Program(ProgramCliCommand::ExtendProgramChecked {
+    config.signers = vec![&keypair];
+    config.command = CliCommand::Program(ProgramCliCommand::ExtendProgram {
         program_pubkey: program_keypair.pubkey(),
-        authority_signer_index: 1,
         payer_signer_index: 0,
         additional_bytes: additional_bytes - 1,
     });
@@ -1571,10 +1571,9 @@ async fn test_cli_program_extend_program() {
     wait_n_slots(&rpc_client, 1).await;
 
     // Extend 1 last byte
-    config.signers = vec![&keypair, &upgrade_authority];
-    config.command = CliCommand::Program(ProgramCliCommand::ExtendProgramChecked {
+    config.signers = vec![&keypair];
+    config.command = CliCommand::Program(ProgramCliCommand::ExtendProgram {
         program_pubkey: program_keypair.pubkey(),
-        authority_signer_index: 1,
         payer_signer_index: 0,
         additional_bytes: 1,
     });
@@ -1619,11 +1618,10 @@ async fn test_cli_program_extend_program() {
     let programdata_account = rpc_client.get_account(&programdata_pubkey).await.unwrap();
     let prev_len = programdata_account.data.len();
 
-    config.signers = vec![&keypair, &upgrade_authority, &rent_payer];
-    config.command = CliCommand::Program(ProgramCliCommand::ExtendProgramChecked {
+    config.signers = vec![&keypair, &rent_payer];
+    config.command = CliCommand::Program(ProgramCliCommand::ExtendProgram {
         program_pubkey: program_keypair.pubkey(),
-        authority_signer_index: 1,
-        payer_signer_index: 2,
+        payer_signer_index: 1,
         additional_bytes: 1024,
     });
     process_command(&config).await.unwrap();


### PR DESCRIPTION
#### Problem
[SIMD-0164](https://github.com/solana-foundation/solana-improvement-documents/pull/164) was closed and never landed. Therefore the `ExtendProgramChecked` instruction should not exist.

#### Summary of Changes
Remove it from the CLI.

