### PR TITLE
core: fix inverted reporting interval check in bls sigverifier

### DIFF
--- a/core/src/bls_sigverify/stats.rs
+++ b/core/src/bls_sigverify/stats.rs
@@ -30,7 +30,7 @@ impl Reporting {
 
     /// Returns `true` if reporting should be done else `false`.
     fn should_report(&self, root_slot: Slot) -> bool {
-        self.slot + SLOTS_INTERVAL >= root_slot || self.time.elapsed() > DURATION_INTERVAL
+        root_slot >= self.slot + SLOTS_INTERVAL || self.time.elapsed() > DURATION_INTERVAL
     }
 }
 


### PR DESCRIPTION
## Problem

`Reporting::should_report()` in `core/src/bls_sigverify/stats.rs` has the slot threshold comparison inverted:

```rust
self.slot + SLOTS_INTERVAL >= root_slot
```

This returns `true` when fewer than `SLOTS_INTERVAL` (10) slots have passed and `false` when more have passed, which is the opposite of intended behavior. Stats are reported too frequently instead of waiting for the configured interval.

Resolves #11732

## Proposed Changes

Invert the comparison to:

```rust
root_slot >= self.slot + SLOTS_INTERVAL
```

Now reporting triggers only after 10+ slots have passed since the last report, as intended.

## Test Plan

- [x] Verified the logic: with `slot=100` and `SLOTS_INTERVAL=10`, `should_report(105)` correctly returns `false` (only 5 slots passed) and `should_report(115)` correctly returns `true` (15 slots passed)