### PR TITLE
Uses `ClusterInfo` in `ConsensusPool` to look up `my_pubkey`

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -25,6 +25,7 @@ use {
     log::trace,
     solana_clock::{Epoch, Slot},
     solana_epoch_schedule::EpochSchedule,
+    solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_runtime::{bank::Bank, epoch_stakes::VersionedEpochStakes},
@@ -100,11 +101,12 @@ fn get_key_and_stakes(
     }
     Ok((*vote_key, stake, epoch_stakes.total_stake()))
 }
+
 /// Container to store received votes and certificates.
 ///
 /// Based on received votes and certificates, generates new `VotorEvent`s and generates new certificates.
 pub(crate) struct ConsensusPool {
-    my_pubkey: Pubkey,
+    cluster_info: Arc<ClusterInfo>,
     // Vote pools to do bean counting for votes.
     vote_pools: BTreeMap<PoolId, VotePool>,
     /// Completed certificates
@@ -133,28 +135,28 @@ pub(crate) struct ConsensusPool {
 
 impl ConsensusPool {
     pub(crate) fn new_from_root_bank_pre_migration(
-        my_pubkey: Pubkey,
+        cluster_info: Arc<ClusterInfo>,
         bank: &Bank,
         generated_cert_types: Arc<GeneratedCertTypes>,
         migration_status: Arc<MigrationStatus>,
     ) -> Self {
-        let mut pool = Self::new_from_root_bank(my_pubkey, bank, generated_cert_types);
+        let mut pool = Self::new_from_root_bank(cluster_info, bank, generated_cert_types);
         pool.migration_status = Some(migration_status);
         pool
     }
 
     pub fn new_from_root_bank(
-        my_pubkey: Pubkey,
+        cluster_info: Arc<ClusterInfo>,
         bank: &Bank,
         generated_cert_types: Arc<GeneratedCertTypes>,
     ) -> Self {
         // To account for genesis and snapshots we allow default block id until
         // block id can be serialized  as part of the snapshot
         let root_block = (bank.slot(), bank.block_id().unwrap_or_default());
-        let parent_ready_tracker = ParentReadyTracker::new(my_pubkey, root_block);
+        let parent_ready_tracker = ParentReadyTracker::new(cluster_info.clone(), root_block);
 
         Self {
-            my_pubkey,
+            cluster_info,
             vote_pools: BTreeMap::new(),
             completed_certificates: BTreeMap::new(),
             highest_finalized_slot: None,
@@ -308,7 +310,11 @@ impl ConsensusPool {
         cert: Arc<Certificate>,
         events: &mut Vec<VotorEvent>,
     ) {
-        trace!("{}: Inserting certificate {:?}", self.my_pubkey, cert_type);
+        trace!(
+            "{}: Inserting certificate {:?}",
+            self.cluster_info.id(),
+            cert_type
+        );
         self.completed_certificates.insert(cert_type, cert.clone());
         match cert_type {
             CertificateType::NotarizeFallback(slot, block_id) => {
@@ -579,11 +585,6 @@ impl ConsensusPool {
     }
 
     #[cfg(test)]
-    pub(crate) fn my_pubkey(&self) -> Pubkey {
-        self.my_pubkey
-    }
-
-    #[cfg(test)]
     fn make_start_leader_decision(
         &self,
         my_leader_slot: Slot,
@@ -637,14 +638,6 @@ impl ConsensusPool {
         self.last_pruned_slot = root_slot;
     }
 
-    /// Updates the pubkey used for logging purposes only.
-    /// This avoids the need to recreate the entire certificate pool since it's
-    /// not distinguished by the pubkey.
-    pub fn update_pubkey(&mut self, new_pubkey: Pubkey) {
-        self.my_pubkey = new_pubkey;
-        self.parent_ready_tracker.update_pubkey(new_pubkey);
-    }
-
     pub(crate) fn maybe_report(&mut self) {
         self.stats.maybe_report();
     }
@@ -675,7 +668,11 @@ impl ConsensusPool {
                     _ => None,
                 };
                 if cert_to_send.is_some() {
-                    trace!("{}: Refreshing certificate {:?}", self.my_pubkey, cert_type);
+                    trace!(
+                        "{}: Refreshing certificate {:?}",
+                        self.cluster_info.id(),
+                        cert_type
+                    );
                 }
                 cert_to_send
             })
@@ -687,6 +684,7 @@ impl ConsensusPool {
 mod tests {
     use {
         super::*,
+        crate::tests::get_cluster_info,
         agave_votor_messages::consensus_message::{BLS_KEYPAIR_DERIVE_SEED, VoteMessage},
         solana_bls_signatures::{
             Pubkey as BLSPubkey, Signature as BLSSignature, VerifiableSignature,
@@ -694,6 +692,7 @@ mod tests {
         },
         solana_clock::Slot,
         solana_hash::Hash,
+        solana_keypair::Keypair,
         solana_runtime::{
             bank::{Bank, NewBankOptions, SlotLeader},
             bank_forks::BankForks,
@@ -721,10 +720,11 @@ mod tests {
             let bank_forks = create_bank_forks(&validator_keypairs);
             let root_bank = bank_forks.read().unwrap().root_bank();
             let generated_cert_types = Arc::new(GeneratedCertTypes::default());
+            let cluster_info = get_cluster_info(Keypair::new());
             Self {
                 validators: validator_keypairs,
                 pool: ConsensusPool::new_from_root_bank(
-                    Pubkey::new_unique(),
+                    cluster_info,
                     &root_bank,
                     generated_cert_types.clone(),
                 ),
@@ -2060,18 +2060,6 @@ mod tests {
             .signature
             .verify(&bls_pubkey, &signed_message)
             .expect("vote message signature should verify");
-    }
-
-    #[test]
-    fn test_update_pubkey() {
-        let new_pubkey = Pubkey::new_unique();
-        let mut ctx = TestContext::new();
-        let old_pubkey = ctx.pool.my_pubkey();
-        assert_eq!(ctx.pool.parent_ready_tracker.my_pubkey(), old_pubkey);
-        assert_ne!(old_pubkey, new_pubkey);
-        ctx.pool.update_pubkey(new_pubkey);
-        assert_eq!(ctx.pool.my_pubkey(), new_pubkey);
-        assert_eq!(ctx.pool.parent_ready_tracker.my_pubkey(), new_pubkey);
     }
 
     #[test]

--- a/votor/src/consensus_pool/parent_ready_tracker.rs
+++ b/votor/src/consensus_pool/parent_ready_tracker.rs
@@ -15,9 +15,10 @@
 use {
     crate::{common::MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE, event::VotorEvent},
     agave_votor_messages::consensus_message::Block,
+    core::fmt,
     solana_clock::{NUM_CONSECUTIVE_LEADER_SLOTS, Slot},
-    solana_pubkey::Pubkey,
-    std::collections::HashMap,
+    solana_gossip::cluster_info::ClusterInfo,
+    std::{collections::HashMap, sync::Arc},
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -27,17 +28,21 @@ pub(crate) enum BlockProductionParent {
     Parent(Block),
 }
 
-#[derive(Clone, Debug, Default)]
-pub(crate) struct ParentReadyTracker {
-    /// Our pubkey for logging
-    my_pubkey: Pubkey,
+struct DebugIgnore<T>(T);
 
+impl<T> fmt::Debug for DebugIgnore<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "<ignored>")
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ParentReadyTracker {
+    cluster_info: DebugIgnore<Arc<ClusterInfo>>,
     /// Parent ready status for each slot
     slot_statuses: HashMap<Slot, ParentReadyStatus>,
-
     /// Root
     root: Slot,
-
     /// Highest slot with parent ready status
     // TODO: While the voting loop is sequential we track every slot (not just the first in window)
     // However once we handle all slots concurrently we will update this to only count first leader
@@ -58,7 +63,7 @@ struct ParentReadyStatus {
 
 impl ParentReadyTracker {
     /// Creates a new tracker with the root bank as implicitely notarized fallback
-    pub(super) fn new(my_pubkey: Pubkey, root_block @ (root_slot, _): Block) -> Self {
+    pub(super) fn new(cluster_info: Arc<ClusterInfo>, root_block @ (root_slot, _): Block) -> Self {
         let mut slot_statuses = HashMap::new();
         slot_statuses.insert(
             root_slot,
@@ -77,7 +82,7 @@ impl ParentReadyTracker {
             },
         );
         Self {
-            my_pubkey,
+            cluster_info: DebugIgnore(cluster_info),
             slot_statuses,
             root: root_slot,
             highest_with_parent_ready: root_slot.saturating_add(1),
@@ -100,7 +105,7 @@ impl ParentReadyTracker {
         }
         trace!(
             "{}: Adding new notar fallback for {block:?}",
-            self.my_pubkey
+            self.cluster_info.0.id()
         );
         status.notar_fallbacks.push(block);
         assert!(status.notar_fallbacks.len() <= MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE);
@@ -109,7 +114,7 @@ impl ParentReadyTracker {
         for s in slot.saturating_add(1).. {
             trace!(
                 "{}: Adding new parent ready for {s} parent {block:?}",
-                self.my_pubkey
+                self.cluster_info.0.id()
             );
             let status = self.slot_statuses.entry(s).or_default();
             if !status.parents_ready.contains(&block) {
@@ -138,7 +143,7 @@ impl ParentReadyTracker {
             return;
         }
 
-        trace!("{}: Adding new skip for {slot:?}", self.my_pubkey);
+        trace!("{}: Adding new skip for {slot:?}", self.cluster_info.0.id());
         let status = self.slot_statuses.entry(slot).or_default();
         status.skip = true;
 
@@ -177,7 +182,7 @@ impl ParentReadyTracker {
         for s in future_slots {
             trace!(
                 "{}: Adding new parent ready for {s} parents {potential_parents:?}",
-                self.my_pubkey,
+                self.cluster_info.0.id(),
             );
             let status = self.slot_statuses.entry(s).or_default();
             for &block in &potential_parents {
@@ -233,29 +238,20 @@ impl ParentReadyTracker {
         self.root = root;
         self.slot_statuses.retain(|&s, _| s >= root);
     }
-
-    /// Updates the pubkey. Note that the pubkey is used for logging purposes only.
-    pub fn update_pubkey(&mut self, new_pubkey: Pubkey) {
-        self.my_pubkey = new_pubkey;
-    }
-
-    #[cfg(test)]
-    pub fn my_pubkey(&self) -> Pubkey {
-        self.my_pubkey
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use {
-        super::*, itertools::Itertools, solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
-        solana_hash::Hash, solana_pubkey::Pubkey,
+        super::*, crate::tests::get_cluster_info, itertools::Itertools,
+        solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS, solana_hash::Hash, solana_keypair::Keypair,
     };
 
     #[test]
     fn basic() {
+        let cluster_info = get_cluster_info(Keypair::new());
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(cluster_info, genesis);
         let mut events = vec![];
 
         for i in 1..2 * NUM_CONSECUTIVE_LEADER_SLOTS {
@@ -268,8 +264,9 @@ mod tests {
 
     #[test]
     fn skips() {
+        let cluster_info = get_cluster_info(Keypair::new());
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(cluster_info, genesis);
         let mut events = vec![];
         let block = (1, Hash::new_unique());
 
@@ -285,8 +282,9 @@ mod tests {
 
     #[test]
     fn out_of_order() {
+        let cluster_info = get_cluster_info(Keypair::new());
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(cluster_info, genesis);
         let mut events = vec![];
         let block = (1, Hash::new_unique());
 
@@ -304,9 +302,10 @@ mod tests {
 
     #[test]
     fn snapshot_wfsm() {
+        let cluster_info = get_cluster_info(Keypair::new());
         let root_slot = 2147;
         let root_block = (root_slot, Hash::new_unique());
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), root_block);
+        let mut tracker = ParentReadyTracker::new(cluster_info, root_block);
         let mut events = vec![];
 
         assert!(tracker.parent_ready(root_slot + 1, root_block));
@@ -332,8 +331,9 @@ mod tests {
 
     #[test]
     fn highest_parent_ready_out_of_order() {
+        let cluster_info = get_cluster_info(Keypair::new());
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(cluster_info, genesis);
         let mut events = vec![];
         assert_eq!(tracker.highest_parent_ready(), 1);
 
@@ -354,8 +354,9 @@ mod tests {
 
     #[test]
     fn missed_window() {
+        let cluster_info = get_cluster_info(Keypair::new());
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(cluster_info, genesis);
         let mut events = vec![];
         assert_eq!(tracker.highest_parent_ready(), 1);
         assert_eq!(
@@ -384,8 +385,9 @@ mod tests {
 
     #[test]
     fn pick_more_skips() {
+        let cluster_info = get_cluster_info(Keypair::new());
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(Pubkey::default(), genesis);
+        let mut tracker = ParentReadyTracker::new(cluster_info, genesis);
         let mut events = vec![];
 
         for i in 1..=10 {

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -131,7 +131,6 @@ impl ConsensusPoolService {
 
     fn process_consensus_message(
         ctx: &mut ConsensusPoolContext,
-        my_pubkey: &Pubkey,
         message: ConsensusMessage,
         consensus_pool: &mut ConsensusPool,
         events: &mut Vec<VotorEvent>,
@@ -150,7 +149,7 @@ impl ConsensusPoolService {
         let (new_finalized_slot, new_certificates_to_send) =
             Self::add_message_and_maybe_update_commitment(
                 &root_bank,
-                my_pubkey,
+                &ctx.cluster_info.id(),
                 &ctx.my_vote_pubkey,
                 message,
                 consensus_pool,
@@ -184,27 +183,26 @@ impl ConsensusPoolService {
     // Main loop for the certificate pool service, it only exits when any channel is disconnected
     fn consensus_pool_ingest_loop(mut ctx: ConsensusPoolContext) -> Result<(), ()> {
         let mut events = vec![];
-        let mut my_pubkey = ctx.cluster_info.id();
         let root_bank = ctx.sharable_banks.root();
 
         // Unlike the other votor threads, consensus pool starts even before alpenglow is enabled
         // As it is required to track the Genesis Vote.
         let mut consensus_pool = if ctx.migration_status.is_alpenglow_enabled() {
             ConsensusPool::new_from_root_bank(
-                my_pubkey,
+                ctx.cluster_info.clone(),
                 &root_bank,
                 ctx.generated_cert_types.clone(),
             )
         } else {
             ConsensusPool::new_from_root_bank_pre_migration(
-                my_pubkey,
+                ctx.cluster_info.clone(),
                 &root_bank,
                 ctx.generated_cert_types.clone(),
                 ctx.migration_status.clone(),
             )
         };
 
-        info!("{}: Certificate pool loop starting", &my_pubkey);
+        info!("{}: Certificate pool loop starting", ctx.cluster_info.id());
         let mut stats = ConsensusPoolServiceStats::new();
         let mut highest_parent_ready = root_bank.slot();
 
@@ -216,14 +214,6 @@ impl ConsensusPoolService {
 
         // Ingest votes into certificate pool and notify voting loop of new events
         while !ctx.exit.load(Ordering::Relaxed) {
-            // Update the current pubkey if it has changed
-            let new_pubkey = ctx.cluster_info.id();
-            if my_pubkey != new_pubkey {
-                my_pubkey = new_pubkey;
-                consensus_pool.update_pubkey(my_pubkey);
-                warn!("Certificate pool pubkey updated to {my_pubkey}");
-            }
-
             // Kick off parent ready event, this either happens:
             // - When we first migrate to alpenglow from TowerBFT - kick off with genesis block
             // - If we startup post alpenglow migration - kick off with root block
@@ -249,7 +239,6 @@ impl ConsensusPoolService {
             Self::add_produce_block_event(
                 &mut highest_parent_ready,
                 &consensus_pool,
-                &my_pubkey,
                 &mut ctx,
                 &mut events,
                 &mut stats,
@@ -276,7 +265,10 @@ impl ConsensusPoolService {
                         return Self::handle_channel_disconnected(&mut ctx, channel_name.as_str());
                     }
                     Err(e) => {
-                        trace!("{my_pubkey}: unable to push standstill certificates into pool {e}");
+                        trace!(
+                            "{}: unable to push standstill certificates into pool {e}",
+                            ctx.cluster_info.id()
+                        );
                     }
                 }
             }
@@ -302,7 +294,6 @@ impl ConsensusPoolService {
             for message in messages {
                 match Self::process_consensus_message(
                     &mut ctx,
-                    &my_pubkey,
                     message,
                     &mut consensus_pool,
                     &mut events,
@@ -315,7 +306,11 @@ impl ConsensusPoolService {
                     }
                     Err(e) => {
                         // This is a non critical error, a duplicate vote for example
-                        trace!("{}: unable to push vote into pool {}", &my_pubkey, e);
+                        trace!(
+                            "{}: unable to push vote into pool {}",
+                            ctx.cluster_info.id(),
+                            e
+                        );
                         stats.add_message_failed += 1;
                     }
                 }
@@ -361,7 +356,6 @@ impl ConsensusPoolService {
     fn add_produce_block_event(
         highest_parent_ready: &mut Slot,
         consensus_pool: &ConsensusPool,
-        my_pubkey: &Pubkey,
         ctx: &mut ConsensusPoolContext,
         events: &mut Vec<VotorEvent>,
         stats: &mut ConsensusPoolServiceStats,
@@ -396,7 +390,7 @@ impl ConsensusPoolService {
             return;
         };
 
-        if &slot_leader.id != my_pubkey {
+        if slot_leader.id != ctx.cluster_info.id() {
             return;
         }
 
@@ -405,8 +399,9 @@ impl ConsensusPoolService {
 
         if (start_slot..=end_slot).any(|s| ctx.blockstore.has_existing_shreds_for_slot(s)) {
             warn!(
-                "{my_pubkey}: We have already produced shreds in the window \
-                 {start_slot}-{end_slot}, skipping production of our leader window"
+                "{}: We have already produced shreds in the window {start_slot}-{end_slot}, \
+                 skipping production of our leader window",
+                ctx.cluster_info.id()
             );
             return;
         }
@@ -417,18 +412,17 @@ impl ConsensusPoolService {
         {
             BlockProductionParent::MissedWindow => {
                 warn!(
-                    "{my_pubkey}: Leader slot {start_slot} has already been certified, skipping \
-                     production of {start_slot}-{end_slot}"
+                    "{}: Leader slot {start_slot} has already been certified, skipping production \
+                     of {start_slot}-{end_slot}",
+                    ctx.cluster_info.id()
                 );
                 stats.parent_ready_missed_window += 1;
             }
             BlockProductionParent::ParentNotReady => {
-                // This can't happen, place holder depending on how we hook up optimistic
-                ctx.exit.store(true, Ordering::Relaxed);
-                panic!(
-                    "Must have a block production parent: {:#?}",
+                unreachable!(
+                    "Must have block production parent: {:#?}",
                     consensus_pool.parent_ready_tracker
-                );
+                )
             }
             BlockProductionParent::Parent(parent_block) => {
                 events.push(VotorEvent::ProduceWindow(LeaderWindowInfo {
@@ -452,6 +446,7 @@ impl ConsensusPoolService {
 mod tests {
     use {
         super::*,
+        crate::tests::get_cluster_info,
         agave_votor_messages::{
             consensus_message::{BLS_KEYPAIR_DERIVE_SEED, CertificateType, VoteMessage},
             vote::Vote,
@@ -459,10 +454,9 @@ mod tests {
         solana_bls_signatures::{
             keypair::Keypair as BLSKeypair, signature::Signature as BLSSignature,
         },
-        solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
+        solana_gossip::cluster_info::ClusterInfo,
         solana_hash::Hash,
         solana_ledger::get_tmp_ledger_path_auto_delete,
-        solana_net_utils::SocketAddrSpace,
         solana_runtime::{
             bank_forks::{BankForks, SharableBanks},
             genesis_utils::{
@@ -486,6 +480,7 @@ mod tests {
         my_vote_pubkey: Pubkey,
         blockstore: Arc<Blockstore>,
         exit: Arc<AtomicBool>,
+        cluster_info: Arc<ClusterInfo>,
     }
 
     impl Default for TestContext {
@@ -519,8 +514,9 @@ mod tests {
                 Arc::new(LeaderScheduleCache::new_from_bank(&sharable_banks.root()));
 
             let root_bank = sharable_banks.root();
+            let cluster_info = get_cluster_info(my_keypair.insecure_clone());
             let consensus_pool = ConsensusPool::new_from_root_bank(
-                my_pubkey,
+                cluster_info.clone(),
                 &root_bank,
                 Arc::new(GeneratedCertTypes::default()),
             );
@@ -539,6 +535,7 @@ mod tests {
                 my_vote_pubkey,
                 blockstore,
                 exit: Arc::new(AtomicBool::new(false)),
+                cluster_info,
             }
         }
     }
@@ -734,11 +731,7 @@ mod tests {
             exit: ctx.exit.clone(),
             migration_status: Arc::new(MigrationStatus::post_migration_status()),
             generated_cert_types: Arc::new(GeneratedCertTypes::default()),
-            cluster_info: Arc::new(ClusterInfo::new(
-                ContactInfo::new_localhost(&ctx.my_pubkey, 0),
-                Arc::new(ctx.validator_keypairs[0].node_keypair.insecure_clone()),
-                SocketAddrSpace::Unspecified,
-            )),
+            cluster_info: ctx.cluster_info.clone(),
             my_vote_pubkey: ctx.my_vote_pubkey,
             blockstore: ctx.blockstore.clone(),
             sharable_banks: ctx.sharable_banks.clone(),
@@ -759,7 +752,6 @@ mod tests {
         ConsensusPoolService::add_produce_block_event(
             &mut highest_parent_ready,
             &ctx.consensus_pool,
-            &ctx.my_pubkey,
             &mut pool_ctx,
             &mut events,
             &mut stats,

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -32,3 +32,22 @@ pub mod votor;
 #[cfg_attr(feature = "frozen-abi", macro_use)]
 #[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;
+
+#[cfg(test)]
+mod tests {
+    use {
+        solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
+        solana_keypair::Keypair,
+        solana_net_utils::SocketAddrSpace,
+        solana_signer::Signer,
+        std::sync::Arc,
+    };
+
+    pub(crate) fn get_cluster_info(keypair: Keypair) -> Arc<ClusterInfo> {
+        Arc::new(ClusterInfo::new(
+            ContactInfo::new_localhost(&keypair.pubkey(), 0),
+            Arc::new(keypair),
+            SocketAddrSpace::Unspecified,
+        ))
+    }
+}


### PR DESCRIPTION
#### Problem

Some old code in various consensus pool related modules is contains logic to check for when the node's pubkey is updated.  We already have all the logic efficiently handled in `ClusterInfo` so we do not need to reimplement it.

#### Summary of Changes

- Uses `ClusterInfo` in `ConsensusPool` and `ParentReadyTracker`
- Instead of passing `my_pubkey` around and checking when it has updated, the users simply use `ClusterInfo`.
