### PR TITLE
accounts-db: fix small-batch refcount verification

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1649,9 +1649,12 @@ impl AccountsDb {
             },
         );
         let total = pubkey_refcount.len();
+        if total == 0 {
+            return;
+        }
         let failed = AtomicBool::default();
         let threads = quarter_thread_count();
-        let per_batch = total / threads;
+        let per_batch = total.div_ceil(threads);
         (0..=threads).into_par_iter().for_each(|attempt| {
             pubkey_refcount
                 .iter()

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -2039,6 +2039,26 @@ define_accounts_db_test!(test_full_clean_refcount_first, |accounts| {
     do_full_clean_refcount(accounts, true);
 });
 
+define_accounts_db_test!(
+    test_exhaustively_verify_refcounts_small_dataset_detects_mismatch,
+    panic = "exhaustively_verify_refcounts failed",
+    |accounts| {
+        let slot = 0;
+        let pubkey = Pubkey::new_unique();
+        let account = AccountSharedData::new(1, 0, &Pubkey::default());
+
+        accounts.store_for_tests((slot, [(&pubkey, &account)].as_slice()));
+        accounts.add_root_and_flush_write_cache(slot);
+
+        accounts.accounts_index.get_and_then(&pubkey, |entry| {
+            entry.unwrap().addref();
+            (false, ())
+        });
+
+        accounts.exhaustively_verify_refcounts(Some(slot));
+    }
+);
+
 #[test]
 fn test_clean_stored_dead_slots_empty() {
     let accounts = AccountsDb::new_single_for_tests();


### PR DESCRIPTION
  #### Problem                                                                                                                                                                                         
                                                                                                                                                                                                       
  `exhaustively_verify_refcounts()` silently skips verification when the number of pubkeys is smaller than `quarter_thread_count()`. In that case `per_batch` becomes `0`, every parallel iteration takes an empty batch, and refcount mismatches go undetected.                                                                                                                                         
                                                                                                                                                                                                       
  #### Summary of Changes                                                                                                                                                                              

  Return early when there are no pubkeys to verify, clamp `per_batch` to at least `1`, and add a regression test that covers a single-pubkey refcount mismatch.                                        
 