### PR TITLE
TransactionView add txv1 supports to TransactionFrame

### DIFF
--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -2,8 +2,8 @@ use {
     crate::{
         address_table_lookup_frame::{AddressTableLookupFrame, AddressTableLookupIterator},
         bytes::{
-            advance_offset_for_array, advance_offset_for_type, check_remaining, read_byte,
-            unchecked_copy_value,
+            advance_offset_for_array, advance_offset_for_type, check_remaining,
+            unchecked_copy_value, unchecked_read_byte,
         },
         instructions_frame::{InstructionsFrame, InstructionsIterator},
         message_header_frame::MessageHeaderFrame,
@@ -40,14 +40,14 @@ impl TransactionFrame {
     /// Parse a serialized transaction and verify basic structure.
     /// The `bytes` parameter must have no trailing data.
     pub(crate) fn try_new(bytes: &[u8]) -> Result<Self> {
-        if Self::is_wire_transaction_legacy_and_v0(bytes)? {
-            Self::try_new_from_legacy_and_v0(bytes)
+        if Self::is_legacy_or_v0(bytes)? {
+            Self::try_new_as_legacy_or_v0(bytes)
         } else {
-            Self::try_new_from_v1(bytes)
+            Self::try_new_as_v1(bytes)
         }
     }
 
-    fn try_new_from_legacy_and_v0(bytes: &[u8]) -> Result<Self> {
+    fn try_new_as_legacy_or_v0(bytes: &[u8]) -> Result<Self> {
         let mut offset = 0;
         let signature = SignatureFrame::try_new(bytes, &mut offset)?;
         let message_header = MessageHeaderFrame::try_new(bytes, &mut offset)?;
@@ -68,9 +68,7 @@ impl TransactionFrame {
                 total_readonly_lookup_accounts: 0,
             },
             TransactionVersion::V0 => AddressTableLookupFrame::try_new(bytes, &mut offset)?,
-            TransactionVersion::V1 => {
-                return Err(TransactionViewError::ParseError);
-            }
+            TransactionVersion::V1 => unreachable!("unexpected variant"),
         };
 
         // Verify that the entire transaction was parsed.
@@ -89,33 +87,46 @@ impl TransactionFrame {
         })
     }
 
-    fn try_new_from_v1(bytes: &[u8]) -> Result<Self> {
+    fn try_new_as_v1(bytes: &[u8]) -> Result<Self> {
         let mut offset: usize = 0;
+
+        // Fixed-size txv1 prefix up through NumAddresses:
+        // VersionByte (u8)
+        // LegacyHeader (u8, u8, u8)
+        // TransactionConfigMask (u32)
+        // LifetimeSpecifier ([u8; 32])
+        // NumInstructions (u8)
+        // NumAddresses (u8)
+        const FIXED_V1_PREFIX_LEN: usize = 1 + 3 + 4 + core::mem::size_of::<Hash>() + 1 + 1;
+
+        check_remaining(bytes, offset, FIXED_V1_PREFIX_LEN)?;
+
+        // SAFETY: have checked bytes have enough space for preifx all the way up to
+        //         NumAddresses.
 
         // message offset would be the first byte of txv1 packet, which is version byte
         let message_offset = offset as u16;
         // Version Byte
-        let version = read_byte(bytes, &mut offset)?;
+        let version = unsafe { unchecked_read_byte(bytes, &mut offset) };
         let version = match version & !solana_message::MESSAGE_VERSION_PREFIX {
             1 => TransactionVersion::V1,
             _ => return Err(TransactionViewError::ParseError),
         };
         // Legacy Header
-        let num_required_signatures = read_byte(bytes, &mut offset)?;
-        let num_readonly_signed_accounts = read_byte(bytes, &mut offset)?;
-        let num_readonly_unsigned_accounts = read_byte(bytes, &mut offset)?;
+        let num_required_signatures = unsafe { unchecked_read_byte(bytes, &mut offset) };
+        let num_readonly_signed_accounts = unsafe { unchecked_read_byte(bytes, &mut offset) };
+        let num_readonly_unsigned_accounts = unsafe { unchecked_read_byte(bytes, &mut offset) };
         // Transaction Config Bit Mask
         let transaction_config_mask_offset = offset;
-        check_remaining(bytes, transaction_config_mask_offset, 4)?;
-        let transaction_config_mask =
-            unsafe { unchecked_copy_value(bytes, transaction_config_mask_offset) };
-        advance_offset_for_type::<u32>(bytes, &mut offset)?;
+        let transaction_config_mask: u32 = unsafe { unchecked_copy_value(bytes, offset) };
+        offset = offset.wrapping_add(core::mem::size_of::<u32>());
         // Lifetime specifier
         let recent_blockhash_offset = offset as u16;
-        advance_offset_for_type::<Hash>(bytes, &mut offset)?;
+        offset = offset.wrapping_add(core::mem::size_of::<Hash>());
         // Num instructions and addresses
-        let num_instructions = read_byte(bytes, &mut offset)?;
-        let num_addresses = read_byte(bytes, &mut offset)?;
+        let num_instructions = unsafe { unchecked_read_byte(bytes, &mut offset) };
+        let num_addresses = unsafe { unchecked_read_byte(bytes, &mut offset) };
+
         // addresses
         let addresses_offset = offset as u16;
         advance_offset_for_array::<Pubkey>(bytes, &mut offset, u16::from(num_addresses))?;
@@ -171,7 +182,7 @@ impl TransactionFrame {
         Ok(frame)
     }
 
-    fn is_wire_transaction_legacy_and_v0(bytes: &[u8]) -> Result<bool> {
+    fn is_legacy_or_v0(bytes: &[u8]) -> Result<bool> {
         let first_byte = *bytes.first().ok_or(TransactionViewError::ParseError)?;
 
         // In wire format:
@@ -858,7 +869,7 @@ mod tests {
         let tx = simple_v1_transaction();
         let bytes = wincode::serialize(&tx).unwrap();
 
-        assert!(!TransactionFrame::is_wire_transaction_legacy_and_v0(&bytes).unwrap());
+        assert!(!TransactionFrame::is_legacy_or_v0(&bytes).unwrap());
     }
 
     #[test]
@@ -870,13 +881,13 @@ mod tests {
         };
         let bytes = wincode::serialize(&tx).unwrap();
 
-        assert!(TransactionFrame::is_wire_transaction_legacy_and_v0(&bytes).unwrap());
+        assert!(TransactionFrame::is_legacy_or_v0(&bytes).unwrap());
     }
 
     #[test]
-    fn test_is_wire_transaction_legacy_and_v0_empty_bytes() {
+    fn test_is_legacy_or_v0_empty_bytes() {
         assert!(matches!(
-            TransactionFrame::is_wire_transaction_legacy_and_v0(&[]),
+            TransactionFrame::is_legacy_or_v0(&[]),
             Err(TransactionViewError::ParseError),
         ));
     }

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -1,7 +1,10 @@
 use {
     crate::{
         address_table_lookup_frame::{AddressTableLookupFrame, AddressTableLookupIterator},
-        bytes::advance_offset_for_type,
+        bytes::{
+            advance_offset_for_array, advance_offset_for_type, check_remaining, read_byte,
+            unchecked_copy_value,
+        },
         instructions_frame::{InstructionsFrame, InstructionsIterator},
         message_header_frame::MessageHeaderFrame,
         result::{Result, TransactionViewError},
@@ -37,6 +40,14 @@ impl TransactionFrame {
     /// Parse a serialized transaction and verify basic structure.
     /// The `bytes` parameter must have no trailing data.
     pub(crate) fn try_new(bytes: &[u8]) -> Result<Self> {
+        if Self::is_wire_transaction_legacy_and_v0(bytes)? {
+            Self::try_new_from_legacy_and_v0(bytes)
+        } else {
+            Self::try_new_from_v1(bytes)
+        }
+    }
+
+    fn try_new_from_legacy_and_v0(bytes: &[u8]) -> Result<Self> {
         let mut offset = 0;
         let signature = SignatureFrame::try_new(bytes, &mut offset)?;
         let message_header = MessageHeaderFrame::try_new(bytes, &mut offset)?;
@@ -76,6 +87,99 @@ impl TransactionFrame {
             address_table_lookup,
             transaction_config_frame: TransactionConfigFrame::not_applicable(),
         })
+    }
+
+    fn try_new_from_v1(bytes: &[u8]) -> Result<Self> {
+        let mut offset: usize = 0;
+
+        // message offset would be the first byte of txv1 packet, which is version byte
+        let message_offset = offset as u16;
+        // Version Byte
+        let version = read_byte(bytes, &mut offset)?;
+        let version = match version & !solana_message::MESSAGE_VERSION_PREFIX {
+            1 => TransactionVersion::V1,
+            _ => return Err(TransactionViewError::ParseError),
+        };
+        // Legacy Header
+        let num_required_signatures = read_byte(bytes, &mut offset)?;
+        let num_readonly_signed_accounts = read_byte(bytes, &mut offset)?;
+        let num_readonly_unsigned_accounts = read_byte(bytes, &mut offset)?;
+        // Transaction COnfig Bit Mask
+        let transaction_config_mask_offset = offset;
+        check_remaining(bytes, transaction_config_mask_offset, 4)?;
+        let transaction_config_mask =
+            unsafe { unchecked_copy_value(bytes, transaction_config_mask_offset) };
+        advance_offset_for_type::<u32>(bytes, &mut offset)?;
+        // Lifetime specifier
+        let recent_blockhash_offset = offset as u16;
+        advance_offset_for_type::<Hash>(bytes, &mut offset)?;
+        // Num instructions and addresses
+        let num_instructions = read_byte(bytes, &mut offset)?;
+        let num_addresses = read_byte(bytes, &mut offset)?;
+        // addresses
+        let addresses_offset = offset as u16;
+        advance_offset_for_array::<Pubkey>(bytes, &mut offset, u16::from(num_addresses))?;
+        // config value slots: one 4-byte slot per set bit in mask
+        let transaction_config_frame = TransactionConfigFrame::try_new(
+            bytes,
+            transaction_config_mask_offset,
+            transaction_config_mask,
+            &mut offset,
+        )?;
+        // instruction headers and payloads
+        let instructions = InstructionsFrame::try_new_for_v1(bytes, &mut offset, num_instructions)?;
+        // signatures
+        let signatures_offset = offset as u16;
+        advance_offset_for_array::<Signature>(
+            bytes,
+            &mut offset,
+            u16::from(num_required_signatures),
+        )?;
+        // Verify that the entire transaction was parsed.
+        if offset != bytes.len() {
+            return Err(TransactionViewError::ParseError);
+        }
+
+        let frame = Self {
+            signature: SignatureFrame {
+                num_signatures: num_required_signatures,
+                offset: signatures_offset,
+            },
+            message_header: MessageHeaderFrame {
+                offset: message_offset,
+                version,
+                num_required_signatures,
+                num_readonly_signed_accounts,
+                num_readonly_unsigned_accounts,
+            },
+            static_account_keys: StaticAccountKeysFrame {
+                num_static_accounts: num_addresses, // always static accounts in txv1
+                offset: addresses_offset,
+            },
+            recent_blockhash_offset,
+            instructions,
+            // Don't have ATL in txv1
+            address_table_lookup: AddressTableLookupFrame {
+                num_address_table_lookups: 0,
+                offset: 0,
+                total_writable_lookup_accounts: 0,
+                total_readonly_lookup_accounts: 0,
+            },
+            transaction_config_frame,
+        };
+
+        Ok(frame)
+    }
+
+    fn is_wire_transaction_legacy_and_v0(bytes: &[u8]) -> Result<bool> {
+        let first_byte = *bytes.first().ok_or(TransactionViewError::ParseError)?;
+
+        // In wire format:
+        // - Legacy/v0 transactions start with signatures (compact-u16 count).
+        //   Packet size limits keep the signature count well below 128, so the
+        //   first byte never has MSB set.
+        // - v1 transactions start with a version byte with MSB = 1.
+        Ok((first_byte & solana_message::MESSAGE_VERSION_PREFIX) == 0)
     }
 
     /// Return the number of signatures in the transaction.
@@ -148,6 +252,12 @@ impl TransactionFrame {
     #[inline]
     pub(crate) fn transaction_config_frame(&self) -> &TransactionConfigFrame {
         &self.transaction_config_frame
+    }
+
+    /// Return the offset to signature
+    #[inline]
+    pub(crate) fn signatures_offset(&self) -> u16 {
+        self.signature.offset
     }
 }
 

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -104,7 +104,7 @@ impl TransactionFrame {
         let num_required_signatures = read_byte(bytes, &mut offset)?;
         let num_readonly_signed_accounts = read_byte(bytes, &mut offset)?;
         let num_readonly_unsigned_accounts = read_byte(bytes, &mut offset)?;
-        // Transaction COnfig Bit Mask
+        // Transaction Config Bit Mask
         let transaction_config_mask_offset = offset;
         check_remaining(bytes, transaction_config_mask_offset, 4)?;
         let transaction_config_mask =

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -34,6 +34,8 @@ pub(crate) struct TransactionFrame {
     address_table_lookup: AddressTableLookupFrame,
     /// Transaction config framing data
     transaction_config_frame: TransactionConfigFrame,
+    /// The end of data
+    end_offset: u16,
 }
 
 impl TransactionFrame {
@@ -84,6 +86,7 @@ impl TransactionFrame {
             instructions,
             address_table_lookup,
             transaction_config_frame: TransactionConfigFrame::not_applicable(),
+            end_offset: offset as u16,
         })
     }
 
@@ -177,6 +180,7 @@ impl TransactionFrame {
                 total_readonly_lookup_accounts: 0,
             },
             transaction_config_frame,
+            end_offset: offset as u16,
         };
 
         Ok(frame)
@@ -253,22 +257,20 @@ impl TransactionFrame {
         self.address_table_lookup.total_readonly_lookup_accounts
     }
 
-    /// Return the offset to the message.
+    /// Return the range to the message as [begin, end]
     #[inline]
-    pub(crate) fn message_offset(&self) -> u16 {
-        self.message_header.offset
+    pub(crate) fn message_range(&self) -> (u16, u16) {
+        let end = match self.version() {
+            TransactionVersion::V1 => self.signature.offset,
+            _ => self.end_offset,
+        };
+        (self.message_header.offset, end)
     }
 
     /// Return transaction_config_frame
     #[inline]
     pub(crate) fn transaction_config_frame(&self) -> &TransactionConfigFrame {
         &self.transaction_config_frame
-    }
-
-    /// Return the offset to signature
-    #[inline]
-    pub(crate) fn signatures_offset(&self) -> u16 {
-        self.signature.offset
     }
 }
 
@@ -392,6 +394,17 @@ impl TransactionFrame {
             num_address_table_lookups: self.address_table_lookup.num_address_table_lookups,
             index: 0,
         }
+    }
+}
+
+#[cfg(test)]
+impl TransactionFrame {
+    pub(crate) fn message_offset(&self) -> u16 {
+        self.message_header.offset
+    }
+
+    pub(crate) fn signatures_offset(&self) -> u16 {
+        self.signature.offset
     }
 }
 

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -388,7 +388,10 @@ impl TransactionFrame {
 mod tests {
     use {
         super::*,
-        solana_message::{AddressLookupTableAccount, Message, MessageHeader, VersionedMessage, v0},
+        solana_message::{
+            AddressLookupTableAccount, Message, MessageHeader, VersionedMessage,
+            compiled_instruction::CompiledInstruction, v0, v1,
+        },
         solana_pubkey::Pubkey,
         solana_signature::Signature,
         solana_system_interface::instruction::{self as system_instruction, SystemInstruction},
@@ -544,6 +547,43 @@ mod tests {
                 )
                 .unwrap(),
             ),
+        }
+    }
+
+    fn simple_v1_transaction() -> VersionedTransaction {
+        let payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let other = Pubkey::new_unique();
+
+        VersionedTransaction {
+            signatures: vec![Signature::default()],
+            message: VersionedMessage::V1(v1::Message {
+                header: MessageHeader {
+                    num_required_signatures: 1,
+                    num_readonly_signed_accounts: 0,
+                    num_readonly_unsigned_accounts: 1,
+                },
+                config: v1::TransactionConfig {
+                    priority_fee: Some(123),
+                    compute_unit_limit: Some(456),
+                    loaded_accounts_data_size_limit: Some(789),
+                    heap_size: Some(1024),
+                },
+                lifetime_specifier: Hash::default(),
+                account_keys: vec![payer, other, program],
+                instructions: vec![
+                    CompiledInstruction {
+                        program_id_index: 2,
+                        accounts: vec![0, 1],
+                        data: vec![10, 11, 12],
+                    },
+                    CompiledInstruction {
+                        program_id_index: 2,
+                        accounts: vec![],
+                        data: vec![99],
+                    },
+                ],
+            }),
         }
     }
 
@@ -787,5 +827,116 @@ mod tests {
 
             assert!(iter.next().is_none());
         }
+    }
+
+    #[test]
+    fn test_v1_transaction_frame_parses() {
+        let tx = simple_v1_transaction();
+        let bytes = wincode::serialize(&tx).unwrap();
+
+        let frame = TransactionFrame::try_new(&bytes).unwrap();
+
+        assert!(matches!(frame.version(), TransactionVersion::V1));
+        assert_eq!(frame.num_signatures(), 1);
+        assert_eq!(frame.num_required_signatures(), 1);
+        assert_eq!(frame.num_readonly_signed_static_accounts(), 0);
+        assert_eq!(frame.num_readonly_unsigned_static_accounts(), 1);
+        assert_eq!(frame.num_static_account_keys(), 3);
+        assert_eq!(frame.num_instructions(), 2);
+
+        // txv1 should not have ALTs
+        assert_eq!(frame.num_address_table_lookups(), 0);
+        assert_eq!(frame.total_writable_lookup_accounts(), 0);
+        assert_eq!(frame.total_readonly_lookup_accounts(), 0);
+
+        // new v1-only frame metadata
+        assert!(frame.signatures_offset() > frame.message_offset());
+    }
+
+    #[test]
+    fn test_v1_is_not_legacy_or_v0() {
+        let tx = simple_v1_transaction();
+        let bytes = wincode::serialize(&tx).unwrap();
+
+        assert!(!TransactionFrame::is_wire_transaction_legacy_and_v0(&bytes).unwrap());
+    }
+
+    #[test]
+    fn test_legacy_is_legacy_or_v0() {
+        let payer = Pubkey::new_unique();
+        let tx = VersionedTransaction {
+            signatures: vec![Signature::default()],
+            message: VersionedMessage::Legacy(solana_message::Message::new(&[], Some(&payer))),
+        };
+        let bytes = wincode::serialize(&tx).unwrap();
+
+        assert!(TransactionFrame::is_wire_transaction_legacy_and_v0(&bytes).unwrap());
+    }
+
+    #[test]
+    fn test_is_wire_transaction_legacy_and_v0_empty_bytes() {
+        assert!(matches!(
+            TransactionFrame::is_wire_transaction_legacy_and_v0(&[]),
+            Err(TransactionViewError::ParseError),
+        ));
+    }
+
+    #[test]
+    fn test_v1_rejects_unknown_version() {
+        let tx = simple_v1_transaction();
+        let mut bytes = wincode::serialize(&tx).unwrap();
+
+        // First byte is version-tagged for versioned messages.
+        // Flip underlying version to an unsupported value.
+        bytes[0] = solana_message::MESSAGE_VERSION_PREFIX | 2;
+
+        assert!(matches!(
+            TransactionFrame::try_new(&bytes),
+            Err(TransactionViewError::ParseError),
+        ));
+    }
+
+    #[test]
+    fn test_v1_rejects_trailing_byte() {
+        let tx = simple_v1_transaction();
+        let mut bytes = wincode::serialize(&tx).unwrap();
+        bytes.push(0);
+
+        assert!(matches!(
+            TransactionFrame::try_new(&bytes),
+            Err(TransactionViewError::ParseError),
+        ));
+    }
+
+    #[test]
+    fn test_v1_rejects_truncated_bytes() {
+        let tx = simple_v1_transaction();
+        let bytes = wincode::serialize(&tx).unwrap();
+
+        assert!(matches!(
+            TransactionFrame::try_new(&bytes[..bytes.len() - 1]),
+            Err(TransactionViewError::ParseError),
+        ));
+    }
+
+    #[test]
+    fn test_v1_instruction_iteration() {
+        let tx = simple_v1_transaction();
+        let bytes = wincode::serialize(&tx).unwrap();
+        let frame = TransactionFrame::try_new(&bytes).unwrap();
+
+        let mut iter = unsafe { frame.instructions_iter(&bytes) };
+
+        let ix0 = iter.next().unwrap();
+        assert_eq!(ix0.program_id_index, 2);
+        assert_eq!(ix0.accounts, &[0, 1]);
+        assert_eq!(ix0.data, &[10, 11, 12]);
+
+        let ix1 = iter.next().unwrap();
+        assert_eq!(ix1.program_id_index, 2);
+        assert_eq!(ix1.accounts, &[] as &[u8]);
+        assert_eq!(ix1.data, &[99]);
+
+        assert!(iter.next().is_none());
     }
 }

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -34,8 +34,8 @@ pub(crate) struct TransactionFrame {
     address_table_lookup: AddressTableLookupFrame,
     /// Transaction config framing data
     transaction_config_frame: TransactionConfigFrame,
-    /// The end of data
-    end_offset: u16,
+    /// The data length in bytes
+    data_len: u16,
 }
 
 impl TransactionFrame {
@@ -86,7 +86,7 @@ impl TransactionFrame {
             instructions,
             address_table_lookup,
             transaction_config_frame: TransactionConfigFrame::not_applicable(),
-            end_offset: offset as u16,
+            data_len: offset as u16,
         })
     }
 
@@ -180,7 +180,7 @@ impl TransactionFrame {
                 total_readonly_lookup_accounts: 0,
             },
             transaction_config_frame,
-            end_offset: offset as u16,
+            data_len: offset as u16,
         };
 
         Ok(frame)
@@ -262,7 +262,7 @@ impl TransactionFrame {
     pub(crate) fn message_range(&self) -> (u16, u16) {
         let end = match self.version() {
             TransactionVersion::V1 => self.signature.offset,
-            _ => self.end_offset,
+            _ => self.data_len,
         };
         (self.message_header.offset, end)
     }

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -182,13 +182,8 @@ impl<const SANITIZED: bool, D: TransactionData> TransactionView<SANITIZED, D> {
     /// This does not include the signatures.
     #[inline]
     pub fn message_data(&self) -> &[u8] {
-        let data = self.data();
-        let start = usize::from(self.frame.message_offset());
-        let end = match self.version() {
-            TransactionVersion::V1 => usize::from(self.frame.signatures_offset()),
-            _ => data.len(),
-        };
-        &data[start..end]
+        let (start, end) = self.frame.message_range();
+        &self.data()[usize::from(start)..usize::from(end)]
     }
 
     #[inline]

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -491,7 +491,7 @@ mod tests {
     }
 
     #[test]
-    fn test_v1_signatures_still_accessible() {
+    fn test_v1_signatures_accessible() {
         let tx = simple_v1_transaction();
         let bytes = wincode::serialize(&tx).unwrap();
         let view = TransactionView::try_new_unsanitized(bytes.as_ref()).unwrap();

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -182,7 +182,13 @@ impl<const SANITIZED: bool, D: TransactionData> TransactionView<SANITIZED, D> {
     /// This does not include the signatures.
     #[inline]
     pub fn message_data(&self) -> &[u8] {
-        &self.data()[usize::from(self.frame.message_offset())..]
+        let data = self.data();
+        let start = usize::from(self.frame.message_offset());
+        let end = match self.version() {
+            TransactionVersion::V1 => usize::from(self.frame.signatures_offset()),
+            _ => data.len(),
+        };
+        &data[start..end]
     }
 
     #[inline]

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -369,7 +369,9 @@ impl<D: TransactionData> SVMStaticMessage for &TransactionView<true, D> {
 mod tests {
     use {
         super::*,
-        solana_message::{Message, VersionedMessage},
+        solana_message::{
+            Message, MessageHeader, VersionedMessage, compiled_instruction::CompiledInstruction, v1,
+        },
         solana_pubkey::Pubkey,
         solana_signature::Signature,
         solana_system_interface::instruction as system_instruction,
@@ -431,5 +433,81 @@ mod tests {
     #[test]
     fn test_multiple_transfers() {
         verify_transaction_view_frame(&multiple_transfers());
+    }
+
+    fn simple_v1_transaction() -> VersionedTransaction {
+        let payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+
+        VersionedTransaction {
+            signatures: vec![Signature::default()],
+            message: VersionedMessage::V1(v1::Message {
+                header: MessageHeader {
+                    num_required_signatures: 1,
+                    num_readonly_signed_accounts: 0,
+                    num_readonly_unsigned_accounts: 0,
+                },
+                config: v1::TransactionConfig {
+                    priority_fee: Some(111),
+                    compute_unit_limit: Some(222),
+                    loaded_accounts_data_size_limit: Some(333),
+                    heap_size: Some(1024),
+                },
+                lifetime_specifier: Hash::default(),
+                account_keys: vec![payer, program],
+                instructions: vec![CompiledInstruction {
+                    program_id_index: 1,
+                    accounts: vec![0],
+                    data: vec![1, 2, 3, 4],
+                }],
+            }),
+        }
+    }
+
+    #[test]
+    fn test_v1_transaction_config_present() {
+        let tx = simple_v1_transaction();
+        let bytes = wincode::serialize(&tx).unwrap();
+        let view = TransactionView::try_new_unsanitized(bytes.as_ref()).unwrap();
+
+        assert!(matches!(view.version(), TransactionVersion::V1));
+
+        let config = view.transaction_config().expect("v1 should have config");
+        assert_eq!(config.priority_fee_lamports().unwrap(), 111);
+        assert_eq!(config.compute_unit_limit().unwrap(), 222);
+        assert_eq!(config.loaded_accounts_data_size_limit().unwrap(), 333);
+        assert_eq!(config.requested_heap_size().unwrap(), 1024);
+    }
+
+    #[test]
+    fn test_v1_message_data_excludes_signatures() {
+        let tx = simple_v1_transaction();
+        let bytes = wincode::serialize(&tx).unwrap();
+        let view = TransactionView::try_new_unsanitized(bytes.as_ref()).unwrap();
+
+        let message_data = view.message_data();
+
+        // For v1, message_data should stop before the signatures region.
+        assert!(message_data.len() < bytes.len());
+
+        let full_message = &bytes
+            [usize::from(view.frame.message_offset())..usize::from(view.frame.signatures_offset())];
+        assert_eq!(message_data, full_message);
+    }
+
+    #[test]
+    fn test_v1_signatures_still_accessible() {
+        let tx = simple_v1_transaction();
+        let bytes = wincode::serialize(&tx).unwrap();
+        let view = TransactionView::try_new_unsanitized(bytes.as_ref()).unwrap();
+
+        assert_eq!(view.signatures().len(), 1);
+        assert_eq!(view.static_account_keys().len(), 2);
+
+        let instructions: Vec<_> = view.instructions_iter().collect();
+        assert_eq!(instructions.len(), 1);
+        assert_eq!(instructions[0].program_id_index, 1);
+        assert_eq!(instructions[0].accounts, &[0]);
+        assert_eq!(instructions[0].data, &[1, 2, 3, 4]);
     }
 }


### PR DESCRIPTION
#### Problem

After added txv1 support to `InstructionsFrame` and `TransactionConfigFrame`, `TransactionFrame`, and `TransactionView` in general, can support txv1 too.

#### Summary of Changes
- Add `V1` to `TransactionVersion`,
  - updated `receive_and_buffer` to treat v1 as legacy when fetching ALT
  - added V1 support in `to_versioned_transaction()` in `RuntimeTransaction` 
- Add txv1 support to `TransactionFrame`,
- Update `TransactionView::message_data()` to return message portion (for sigverify)

Fixes #
