### PR TITLE
Decouple BPF-loader tests from platform-tools-sdk

### DIFF
--- a/programs/bpf_loader/test_elfs/makefile
+++ b/programs/bpf_loader/test_elfs/makefile
@@ -1,2 +1,2 @@
-SBF_SDK := ../../../platform-tools-sdk/sbf/c
+SBF_SDK := ../../programs/sbf/c
 include $(SBF_SDK)/sbf.mk


### PR DESCRIPTION
#### Problem

There are two old C tests in the bpf-loader folder, that are still using the platform-tools-sdk path.

We could potentially re-write those in Rust at some point.

#### Summary of Changes

Point to the SDK in the programs folder.