### PR TITLE
transaction-view: use wincode where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
  "solana-system-interface 3.1.0",
  "solana-transaction",
  "solana-transaction-context",
+ "wincode",
 ]
 
 [[package]]

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -34,8 +34,9 @@ solana-keypair = { workspace = true }
 solana-message = { workspace = true, features = ["serde"] }
 solana-signature = { workspace = true, features = ["serde"] }
 solana-signer = { workspace = true }
-solana-system-interface = { workspace = true, features = ["bincode"] }
+solana-system-interface = { workspace = true, features = ["wincode"] }
 solana-transaction = { workspace = true, features = ["serde", "wincode"] }
+wincode = { workspace = true }
 
 [[bench]]
 name = "bytes"

--- a/transaction-view/benches/transaction_view.rs
+++ b/transaction-view/benches/transaction_view.rs
@@ -25,7 +25,7 @@ const NUM_TRANSACTIONS: usize = 1024;
 fn serialize_transactions(transactions: Vec<VersionedTransaction>) -> Vec<Vec<u8>> {
     transactions
         .into_iter()
-        .map(|transaction| bincode::serialize(&transaction).unwrap())
+        .map(|transaction| wincode::serialize(&transaction).unwrap())
         .collect()
 }
 
@@ -37,7 +37,7 @@ fn bench_transactions_parsing(
     group.bench_function("VersionedTransaction", |c| {
         c.iter(|| {
             for bytes in serialized_transactions.iter() {
-                let _ = bincode::deserialize::<VersionedTransaction>(black_box(bytes)).unwrap();
+                let _ = wincode::deserialize::<VersionedTransaction>(black_box(bytes)).unwrap();
             }
         });
     });
@@ -46,7 +46,7 @@ fn bench_transactions_parsing(
     group.bench_function("SanitizedVersionedTransaction", |c| {
         c.iter(|| {
             for bytes in serialized_transactions.iter() {
-                let tx = bincode::deserialize::<VersionedTransaction>(black_box(bytes)).unwrap();
+                let tx = wincode::deserialize::<VersionedTransaction>(black_box(bytes)).unwrap();
                 let _ = SanitizedVersionedTransaction::try_new(tx).unwrap();
             }
         });

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -289,7 +289,7 @@ mod tests {
                 recent_blockhash: Hash::default(),
             }),
         };
-        let bytes = bincode::serialize(&transaction).unwrap();
+        let bytes = wincode::serialize(&transaction).unwrap();
         let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
         let result = ResolvedTransactionView::try_new(view, None, &HashSet::default());
         assert!(matches!(
@@ -320,7 +320,7 @@ mod tests {
                 recent_blockhash: Hash::default(),
             }),
         };
-        let bytes = bincode::serialize(&transaction).unwrap();
+        let bytes = wincode::serialize(&transaction).unwrap();
         let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
         let result =
             ResolvedTransactionView::try_new(view, Some(loaded_addresses), &HashSet::default());
@@ -357,7 +357,7 @@ mod tests {
                 recent_blockhash: Hash::default(),
             }),
         };
-        let bytes = bincode::serialize(&transaction).unwrap();
+        let bytes = wincode::serialize(&transaction).unwrap();
         let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
         let result =
             ResolvedTransactionView::try_new(view, Some(loaded_addresses), &HashSet::default());
@@ -407,7 +407,7 @@ mod tests {
                 readonly: vec![key2],
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
-            let bytes = bincode::serialize(&transaction).unwrap();
+            let bytes = wincode::serialize(&transaction).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
@@ -430,7 +430,7 @@ mod tests {
                 readonly: vec![key2],
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
-            let bytes = bincode::serialize(&transaction).unwrap();
+            let bytes = wincode::serialize(&transaction).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
@@ -453,7 +453,7 @@ mod tests {
                 readonly: vec![key2],
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
-            let bytes = bincode::serialize(&transaction).unwrap();
+            let bytes = wincode::serialize(&transaction).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
@@ -514,7 +514,7 @@ mod tests {
         {
             let static_keys = vec![key0, key1, key2];
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
-            let bytes = bincode::serialize(&transaction).unwrap();
+            let bytes = wincode::serialize(&transaction).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
@@ -533,7 +533,7 @@ mod tests {
         {
             let static_keys = vec![key0, key1, bpf_loader_upgradeable::ID];
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
-            let bytes = bincode::serialize(&transaction).unwrap();
+            let bytes = wincode::serialize(&transaction).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
@@ -556,7 +556,7 @@ mod tests {
                 readonly: vec![bpf_loader_upgradeable::ID],
             };
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
-            let bytes = bincode::serialize(&transaction).unwrap();
+            let bytes = wincode::serialize(&transaction).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
 
             let resolved_view = ResolvedTransactionView::try_new(

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -189,7 +189,7 @@ mod tests {
     #[test]
     fn test_sanitize_multiple_transfers() {
         let transaction = multiple_transfers();
-        let data = bincode::serialize(&transaction).unwrap();
+        let data = wincode::serialize(&transaction).unwrap();
         let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
         assert!(view.sanitize(true).is_ok());
     }
@@ -208,7 +208,7 @@ mod tests {
                 (0..3).map(|_| Pubkey::new_unique()).collect(),
                 vec![],
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
                 sanitize_signatures(&view),
@@ -228,7 +228,7 @@ mod tests {
                 (0..3).map(|_| Pubkey::new_unique()).collect(),
                 vec![],
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
                 sanitize_signatures(&view),
@@ -248,7 +248,7 @@ mod tests {
                 (0..1).map(|_| Pubkey::new_unique()).collect(),
                 vec![],
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
                 sanitize_signatures(&view),
@@ -273,7 +273,7 @@ mod tests {
                     readonly_indexes: vec![6, 7, 8],
                 }],
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
                 sanitize_signatures(&view),
@@ -296,7 +296,7 @@ mod tests {
                 (0..2).map(|_| Pubkey::new_unique()).collect(),
                 vec![],
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
                 sanitize_account_access(&view),
@@ -316,7 +316,7 @@ mod tests {
                 (0..2).map(|_| Pubkey::new_unique()).collect(),
                 vec![],
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
                 sanitize_account_access(&view),
@@ -348,7 +348,7 @@ mod tests {
                     },
                 ],
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
                 sanitize_account_access(&view),
@@ -396,7 +396,7 @@ mod tests {
                 account_keys.clone(),
                 valid_instructions.clone(),
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert!(sanitize_instructions(&view, true).is_ok());
 
@@ -407,7 +407,7 @@ mod tests {
                 valid_instructions.clone(),
                 atls.clone(),
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert!(sanitize_instructions(&view, true).is_ok());
         }
@@ -423,7 +423,7 @@ mod tests {
                     account_keys.clone(),
                     instructions,
                 );
-                let data = bincode::serialize(&transaction).unwrap();
+                let data = wincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
                     sanitize_instructions(&view, true),
@@ -442,7 +442,7 @@ mod tests {
                     instructions,
                     atls.clone(),
                 );
-                let data = bincode::serialize(&transaction).unwrap();
+                let data = wincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
                     sanitize_instructions(&view, true),
@@ -460,7 +460,7 @@ mod tests {
                     account_keys.clone(),
                     instructions,
                 );
-                let data = bincode::serialize(&transaction).unwrap();
+                let data = wincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
                     sanitize_instructions(&view, true),
@@ -480,7 +480,7 @@ mod tests {
                     account_keys.clone(),
                     instructions,
                 );
-                let data = bincode::serialize(&transaction).unwrap();
+                let data = wincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
                     sanitize_instructions(&view, true),
@@ -504,7 +504,7 @@ mod tests {
                     instructions,
                     atls.clone(),
                 );
-                let data = bincode::serialize(&transaction).unwrap();
+                let data = wincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
                     sanitize_instructions(&view, true),
@@ -527,7 +527,7 @@ mod tests {
                 account_keys.clone(),
                 too_many_instructions.clone(),
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
                 sanitize_instructions(&view, true),
@@ -541,7 +541,7 @@ mod tests {
                 too_many_instructions.clone(),
                 atls.clone(),
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
                 sanitize_instructions(&view, true),
@@ -561,7 +561,7 @@ mod tests {
                 account_keys.clone(),
                 vec![instr],
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
                 sanitize_instructions(&view, true),
@@ -580,7 +580,7 @@ mod tests {
                 account_keys.clone(),
                 vec![instr],
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             // Exactly 255 accounts must pass sanitization.
             assert!(sanitize_instructions(&view, true).is_ok());
@@ -623,7 +623,7 @@ mod tests {
                 transaction.message.address_table_lookups().unwrap().len(),
                 2
             );
-            let data = bincode::serialize(&transaction).unwrap();
+            let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
                 sanitize_address_table_lookups(&view),

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -283,7 +283,7 @@ mod tests {
     };
 
     fn verify_transaction_view_frame(tx: &VersionedTransaction) {
-        let bytes = bincode::serialize(tx).unwrap();
+        let bytes = wincode::serialize(tx).unwrap();
         let frame = TransactionFrame::try_new(&bytes).unwrap();
 
         assert_eq!(frame.signature.num_signatures, tx.signatures.len() as u8);
@@ -457,7 +457,7 @@ mod tests {
     #[test]
     fn test_trailing_byte() {
         let tx = simple_transfer();
-        let mut bytes = bincode::serialize(&tx).unwrap();
+        let mut bytes = wincode::serialize(&tx).unwrap();
         bytes.push(0);
         assert!(TransactionFrame::try_new(&bytes).is_err());
     }
@@ -465,14 +465,14 @@ mod tests {
     #[test]
     fn test_insufficient_bytes() {
         let tx = simple_transfer();
-        let bytes = bincode::serialize(&tx).unwrap();
+        let bytes = wincode::serialize(&tx).unwrap();
         assert!(TransactionFrame::try_new(&bytes[..bytes.len().wrapping_sub(1)]).is_err());
     }
 
     #[test]
     fn test_signature_overflow() {
         let tx = simple_transfer();
-        let mut bytes = bincode::serialize(&tx).unwrap();
+        let mut bytes = wincode::serialize(&tx).unwrap();
         // Set the number of signatures to u16::MAX
         bytes[0] = 0xff;
         bytes[1] = 0xff;
@@ -483,7 +483,7 @@ mod tests {
     #[test]
     fn test_account_key_overflow() {
         let tx = simple_transfer();
-        let mut bytes = bincode::serialize(&tx).unwrap();
+        let mut bytes = wincode::serialize(&tx).unwrap();
         // Set the number of accounts to u16::MAX
         let offset = 1 + core::mem::size_of::<Signature>() + 3;
         bytes[offset] = 0xff;
@@ -495,7 +495,7 @@ mod tests {
     #[test]
     fn test_instructions_overflow() {
         let tx = simple_transfer();
-        let mut bytes = bincode::serialize(&tx).unwrap();
+        let mut bytes = wincode::serialize(&tx).unwrap();
         // Set the number of instructions to u16::MAX
         let offset = 1
             + core::mem::size_of::<Signature>()
@@ -513,7 +513,7 @@ mod tests {
     fn test_alt_overflow() {
         let tx = simple_transfer_v0();
         let ix_bytes = tx.message.instructions()[0].data.len();
-        let mut bytes = bincode::serialize(&tx).unwrap();
+        let mut bytes = wincode::serialize(&tx).unwrap();
         // Set the number of instructions to u16::MAX
         let offset = 1 // byte for num signatures
             + core::mem::size_of::<Signature>() // signature
@@ -535,7 +535,7 @@ mod tests {
     #[test]
     fn test_basic_accessors() {
         let tx = simple_transfer();
-        let bytes = bincode::serialize(&tx).unwrap();
+        let bytes = wincode::serialize(&tx).unwrap();
         let frame = TransactionFrame::try_new(&bytes).unwrap();
 
         assert_eq!(frame.num_signatures(), 1);
@@ -563,7 +563,7 @@ mod tests {
     #[test]
     fn test_instructions_iter_empty() {
         let tx = minimally_sized_transaction();
-        let bytes = bincode::serialize(&tx).unwrap();
+        let bytes = wincode::serialize(&tx).unwrap();
         let frame = TransactionFrame::try_new(&bytes).unwrap();
 
         // SAFETY: `bytes` is the same slice used to create `frame`.
@@ -576,7 +576,7 @@ mod tests {
     #[test]
     fn test_instructions_iter_single() {
         let tx = simple_transfer();
-        let bytes = bincode::serialize(&tx).unwrap();
+        let bytes = wincode::serialize(&tx).unwrap();
         let frame = TransactionFrame::try_new(&bytes).unwrap();
 
         // SAFETY: `bytes` is the same slice used to create `frame`.
@@ -587,7 +587,7 @@ mod tests {
             assert_eq!(ix.accounts, &[0, 1]);
             assert_eq!(
                 ix.data,
-                &bincode::serialize(&SystemInstruction::Transfer { lamports: 1 }).unwrap()
+                &wincode::serialize(&SystemInstruction::Transfer { lamports: 1 }).unwrap()
             );
             assert!(iter.next().is_none());
         }
@@ -596,7 +596,7 @@ mod tests {
     #[test]
     fn test_instructions_iter_multiple() {
         let tx = multiple_transfers();
-        let bytes = bincode::serialize(&tx).unwrap();
+        let bytes = wincode::serialize(&tx).unwrap();
         let frame = TransactionFrame::try_new(&bytes).unwrap();
 
         // SAFETY: `bytes` is the same slice used to create `frame`.
@@ -607,14 +607,14 @@ mod tests {
             assert_eq!(ix.accounts, &[0, 1]);
             assert_eq!(
                 ix.data,
-                &bincode::serialize(&SystemInstruction::Transfer { lamports: 1 }).unwrap()
+                &wincode::serialize(&SystemInstruction::Transfer { lamports: 1 }).unwrap()
             );
             let ix = iter.next().unwrap();
             assert_eq!(ix.program_id_index, 3);
             assert_eq!(ix.accounts, &[0, 2]);
             assert_eq!(
                 ix.data,
-                &bincode::serialize(&SystemInstruction::Transfer { lamports: 1 }).unwrap()
+                &wincode::serialize(&SystemInstruction::Transfer { lamports: 1 }).unwrap()
             );
             assert!(iter.next().is_none());
         }
@@ -623,7 +623,7 @@ mod tests {
     #[test]
     fn test_address_table_lookup_iter_empty() {
         let tx = simple_transfer();
-        let bytes = bincode::serialize(&tx).unwrap();
+        let bytes = wincode::serialize(&tx).unwrap();
         let frame = TransactionFrame::try_new(&bytes).unwrap();
 
         // SAFETY: `bytes` is the same slice used to create `frame`.
@@ -636,7 +636,7 @@ mod tests {
     #[test]
     fn test_address_table_lookup_iter_single() {
         let tx = v0_with_single_lookup();
-        let bytes = bincode::serialize(&tx).unwrap();
+        let bytes = wincode::serialize(&tx).unwrap();
         let frame = TransactionFrame::try_new(&bytes).unwrap();
 
         let atls_actual = tx.message.address_table_lookups().unwrap();
@@ -654,7 +654,7 @@ mod tests {
     #[test]
     fn test_address_table_lookup_iter_multiple() {
         let tx = v0_with_multiple_lookups();
-        let bytes = bincode::serialize(&tx).unwrap();
+        let bytes = wincode::serialize(&tx).unwrap();
         let frame = TransactionFrame::try_new(&bytes).unwrap();
 
         let atls_actual = tx.message.address_table_lookups().unwrap();

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -371,7 +371,7 @@ mod tests {
     };
 
     fn verify_transaction_view_frame(tx: &VersionedTransaction) {
-        let bytes = bincode::serialize(tx).unwrap();
+        let bytes = wincode::serialize(tx).unwrap();
         let view = TransactionView::try_new_unsanitized(bytes.as_ref()).unwrap();
 
         assert_eq!(view.num_signatures(), tx.signatures.len() as u8);


### PR DESCRIPTION
#### Problem
- replacing bincode (de)ser for transactions with wincode


#### Summary of Changes
- move transaction/instruction serialization from bincode -> wincode

Fixes #
