### PR TITLE
sending wincode encoded txv1 tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11050,6 +11050,7 @@ dependencies = [
  "solana-transaction-error",
  "thiserror 2.0.18",
  "tokio",
+ "wincode",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9492,6 +9492,7 @@ dependencies = [
  "solana-transaction-error",
  "thiserror 2.0.18",
  "tokio",
+ "wincode",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9812,6 +9812,7 @@ dependencies = [
  "solana-transaction-error",
  "thiserror 2.0.18",
  "tokio",
+ "wincode",
 ]
 
 [[package]]

--- a/tpu-client/Cargo.toml
+++ b/tpu-client/Cargo.toml
@@ -41,3 +41,4 @@ solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+wincode = { workspace = true }

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -145,7 +145,16 @@ where
     ) -> TransportResult<()> {
         let wire_transactions = transactions
             .into_par_iter()
-            .map(|tx| bincode::serialize(&tx).expect("serialize Transaction in send_batch"))
+            .map(|tx| {
+                match tx.version() {
+                    solana_transaction::versioned::TransactionVersion::Number(1) => {
+                        wincode::serialize(&tx).expect("serialize v1 Transaction in send_batch")
+                    },
+                    _ => {
+                        bincode::serialize(&tx).expect("serialize legacy and V0 Transaction in send_batch")
+                    }
+                }
+            })
             .collect::<Vec<_>>();
         self.invoke(
             self.tpu_client


### PR DESCRIPTION
#### Problem

txv1 transaction can only use `wincode`

#### Summary of Changes
- use `wincode` for v1 tx

Fixes #
