### PR TITLE
Remove Automated CI Check Language from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,12 +122,13 @@ component author and other potentially interested parties.
 
 ### Draft Pull Requests
 
-Consider opening all PRs as Draft Pull Requests first. Using a draft PR allows
-you to start the CI automation, review the changes, write a detailed problem
-description and explain your solution.
+Consider opening all PRs as Draft Pull Requests first. Using a draft PR
+allows you to review the changes, write a detailed problem description
+and explain your solution.
 
-Once the description is written and CI succeeds, click the "Ready to Review" button
-and add reviewers. Adding reviewers before CI succeeds is a fast path to losing
+Once the description is written and you have passed the local CI checks
+described above, click the "Ready to Review" button and add reviewers. Adding
+reviewers before CI succeeds is a fast path to losing
 reviewer engagement. Not only will they be notified and see the PR is not yet
 ready for them, they will also be bombarded with additional notifications
 each time you push a commit to get past CI or until they "mute" the PR. Once
@@ -137,7 +138,7 @@ sent when you push commits and edit the PR description. Use draft PRs
 liberally.  Don't bug the humans until you have gotten past the bots.
 
 If your PR has received a lot of feedback and needs a lot of rework, feel free
-to convert it into a draft until issues are resolved and CI is green.
+to convert it into a draft until issues are resolved.
 
 Do not add reviewers to draft PRs.  GitHub doesn't automatically clear
 approvals when you click "Ready for Review", so a review that meant "I approve

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,10 +135,10 @@ the direction is appropriate. Making pull requests "Ready To Review" before
 CI succeeds locally is a fast path to losing reviewer engagement. The reviewer
 will need to add the CI label each time a commit is pushed to re-run the CI
 checks leading to back and forth iterations until they "mute" the PR. Once
-muted, you'll need to reach out over some other medium, such as Discord, to
-request they have another look. When you use draft PRs, no notifications are
-sent when you push commits and edit the PR description. Use draft PRs
-liberally.  Don't bug the humans until you have gotten past the bots.
+mute, you'll need to reach out over some other medium, such as Discord, to
+request they have another look. When you use draft PRs, reviewers are aware
+that they can ignore any updates to the review. Use draft PRs liberally.
+Don't bug the humans until you can pass the automated tests.
 
 If your PR has received a lot of feedback and needs a lot of rework, feel free
 to convert it into a draft until issues are resolved.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,14 +124,17 @@ component author and other potentially interested parties.
 
 Consider opening all PRs as Draft Pull Requests first. Using a draft PR
 allows you to review the changes, write a detailed problem description
-and explain your solution.
+and explain your solution. For community pull requests, reviewers are 
+automatically be added. You should see the community-pr-subscribers added
+as a reviewer.  
 
 Once the description is written and you have passed the local CI checks
-described above, click the "Ready to Review" button and add reviewers. Adding
-reviewers before CI succeeds is a fast path to losing
-reviewer engagement. Not only will they be notified and see the PR is not yet
-ready for them, they will also be bombarded with additional notifications
-each time you push a commit to get past CI or until they "mute" the PR. Once
+described above, click the "Ready to Review" button. Someone from the Anza
+team will review the pull request and add the CI label to trigger CI if
+the direction is appropriate. Making pull requests "Ready To Review" before 
+CI succeeds locally is a fast path to losing reviewer engagement. The reviewer
+will need to add the CI label each time a commit is pushed to re-run the CI
+checks leading to back and forth iterations until they "mute" the PR. Once
 muted, you'll need to reach out over some other medium, such as Discord, to
 request they have another look. When you use draft PRs, no notifications are
 sent when you push commits and edit the PR description. Use draft PRs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ the direction is appropriate. Making pull requests "Ready To Review" before
 CI succeeds locally is a fast path to losing reviewer engagement. The reviewer
 will need to add the CI label each time a commit is pushed to re-run the CI
 checks leading to back and forth iterations until they "mute" the PR. Once
-mute, you'll need to reach out over some other medium, such as Discord, to
+muted, you'll need to reach out over some other medium, such as Discord, to
 request they have another look. When you use draft PRs, reviewers are aware
 that they can ignore any updates to the review. Use draft PRs liberally.
 Don't bug the humans until you can pass the automated tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,14 +124,14 @@ component author and other potentially interested parties.
 
 Consider opening all PRs as Draft Pull Requests first. Using a draft PR
 allows you to review the changes, write a detailed problem description
-and explain your solution. For community pull requests, reviewers are 
+and explain your solution. For community pull requests, reviewers are
 automatically be added. You should see the community-pr-subscribers added
-as a reviewer.  
+as a reviewer.
 
 Once the description is written and you have passed the local CI checks
 described above, click the "Ready to Review" button. Someone from the Anza
 team will review the pull request and add the CI label to trigger CI if
-the direction is appropriate. Making pull requests "Ready To Review" before 
+the direction is appropriate. Making pull requests "Ready To Review" before
 CI succeeds locally is a fast path to losing reviewer engagement. The reviewer
 will need to add the CI label each time a commit is pushed to re-run the CI
 checks leading to back and forth iterations until they "mute" the PR. Once

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ component author and other potentially interested parties.
 Consider opening all PRs as Draft Pull Requests first. Using a draft PR
 allows you to review the changes, write a detailed problem description
 and explain your solution. For community pull requests, reviewers are
-automatically be added. You should see the community-pr-subscribers added
+added automatically. You should see the community-pr-subscribers added
 as a reviewer.
 
 Once the description is written and you have passed the local CI checks


### PR DESCRIPTION
#### Problem
Current writing of Contributing.MD is that contributors should pass automated CI checks before moving a pull request from draft to Ready to Review. However, contributors are unable to run automated CI checks, so this is not possible. This occurred with someone recently trying to contribute. 

#### Summary of Changes
- Modified language to state that they should pass the local CI checks before moving PR to Ready to Review 

Fixes #
