### PR TITLE
vote-program: remove target version 3

### DIFF
--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -680,7 +680,6 @@ impl VoteStateHandle for VoteStateV4 {
 /// The target version to convert all deserialized vote state into.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum VoteStateTargetVersion {
-    V3,
     V4,
     // New vote state versions will be added here...
 }
@@ -688,7 +687,6 @@ pub enum VoteStateTargetVersion {
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq)]
 enum TargetVoteState {
-    V3(VoteStateV3),
     V4(VoteStateV4),
     // New vote state versions will be added here...
 }
@@ -706,21 +704,18 @@ pub struct VoteStateHandler {
 impl VoteStateHandle for VoteStateHandler {
     fn authorized_withdrawer(&self) -> &Pubkey {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.authorized_withdrawer(),
             TargetVoteState::V4(v4) => v4.authorized_withdrawer(),
         }
     }
 
     fn set_authorized_withdrawer(&mut self, authorized_withdrawer: Pubkey) {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.set_authorized_withdrawer(authorized_withdrawer),
             TargetVoteState::V4(v4) => v4.set_authorized_withdrawer(authorized_withdrawer),
         }
     }
 
     fn authorized_voters(&self) -> &AuthorizedVoters {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.authorized_voters(),
             TargetVoteState::V4(v4) => v4.authorized_voters(),
         }
     }
@@ -737,13 +732,6 @@ impl VoteStateHandle for VoteStateHandler {
         F: Fn(Pubkey) -> Result<(), InstructionError>,
     {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.set_new_authorized_voter(
-                authorized_pubkey,
-                current_epoch,
-                target_epoch,
-                bls_pubkey,
-                verify,
-            ),
             TargetVoteState::V4(v4) => v4.set_new_authorized_voter(
                 authorized_pubkey,
                 current_epoch,
@@ -759,168 +747,144 @@ impl VoteStateHandle for VoteStateHandler {
         current_epoch: Epoch,
     ) -> Result<Pubkey, InstructionError> {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.get_and_update_authorized_voter(current_epoch),
             TargetVoteState::V4(v4) => v4.get_and_update_authorized_voter(current_epoch),
         }
     }
 
     fn commission(&self) -> u8 {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.commission(),
             TargetVoteState::V4(v4) => v4.commission(),
         }
     }
 
     fn set_commission(&mut self, commission: u8) {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.set_commission(commission),
             TargetVoteState::V4(v4) => v4.set_commission(commission),
         }
     }
 
     fn set_inflation_rewards_commission_bps(&mut self, commission_bps: u16) {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.set_inflation_rewards_commission_bps(commission_bps),
             TargetVoteState::V4(v4) => v4.set_inflation_rewards_commission_bps(commission_bps),
         }
     }
 
     fn set_block_revenue_commission_bps(&mut self, commission_bps: u16) {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.set_block_revenue_commission_bps(commission_bps),
             TargetVoteState::V4(v4) => v4.set_block_revenue_commission_bps(commission_bps),
         }
     }
 
     fn node_pubkey(&self) -> &Pubkey {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.node_pubkey(),
             TargetVoteState::V4(v4) => v4.node_pubkey(),
         }
     }
 
     fn set_node_pubkey(&mut self, node_pubkey: Pubkey) {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.set_node_pubkey(node_pubkey),
             TargetVoteState::V4(v4) => v4.set_node_pubkey(node_pubkey),
         }
     }
 
     fn set_inflation_rewards_collector(&mut self, collector: Pubkey) {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.set_inflation_rewards_collector(collector),
             TargetVoteState::V4(v4) => v4.set_inflation_rewards_collector(collector),
         }
     }
 
     fn set_block_revenue_collector(&mut self, collector: Pubkey) {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.set_block_revenue_collector(collector),
             TargetVoteState::V4(v4) => v4.set_block_revenue_collector(collector),
         }
     }
 
     fn pending_delegator_rewards(&self) -> u64 {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.pending_delegator_rewards(),
             TargetVoteState::V4(v4) => v4.pending_delegator_rewards(),
         }
     }
 
     fn add_pending_delegator_rewards(&mut self, amount: u64) -> Result<(), InstructionError> {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.add_pending_delegator_rewards(amount),
             TargetVoteState::V4(v4) => v4.add_pending_delegator_rewards(amount),
         }
     }
 
     fn votes(&self) -> &VecDeque<LandedVote> {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.votes(),
             TargetVoteState::V4(v4) => v4.votes(),
         }
     }
 
     fn votes_mut(&mut self) -> &mut VecDeque<LandedVote> {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.votes_mut(),
             TargetVoteState::V4(v4) => v4.votes_mut(),
         }
     }
 
     fn set_votes(&mut self, votes: VecDeque<LandedVote>) {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.set_votes(votes),
             TargetVoteState::V4(v4) => v4.set_votes(votes),
         }
     }
 
     fn contains_slot(&self, candidate_slot: Slot) -> bool {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.contains_slot(candidate_slot),
             TargetVoteState::V4(v4) => v4.contains_slot(candidate_slot),
         }
     }
 
     fn last_lockout(&self) -> Option<&Lockout> {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.last_lockout(),
             TargetVoteState::V4(v4) => v4.last_lockout(),
         }
     }
 
     fn last_voted_slot(&self) -> Option<Slot> {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.last_voted_slot(),
             TargetVoteState::V4(v4) => v4.last_voted_slot(),
         }
     }
 
     fn root_slot(&self) -> Option<Slot> {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.root_slot(),
             TargetVoteState::V4(v4) => v4.root_slot(),
         }
     }
 
     fn set_root_slot(&mut self, root_slot: Option<Slot>) {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.set_root_slot(root_slot),
             TargetVoteState::V4(v4) => v4.set_root_slot(root_slot),
         }
     }
 
     fn current_epoch(&self) -> Epoch {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.current_epoch(),
             TargetVoteState::V4(v4) => v4.current_epoch(),
         }
     }
 
     fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)> {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.epoch_credits(),
             TargetVoteState::V4(v4) => v4.epoch_credits(),
         }
     }
 
     fn epoch_credits_mut(&mut self) -> &mut Vec<(Epoch, u64, u64)> {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.epoch_credits_mut(),
             TargetVoteState::V4(v4) => v4.epoch_credits_mut(),
         }
     }
 
     fn last_timestamp(&self) -> &BlockTimestamp {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.last_timestamp(),
             TargetVoteState::V4(v4) => v4.last_timestamp(),
         }
     }
 
     fn set_last_timestamp(&mut self, timestamp: BlockTimestamp) {
         match &mut self.target_state {
-            TargetVoteState::V3(v3) => v3.set_last_timestamp(timestamp),
             TargetVoteState::V4(v4) => v4.set_last_timestamp(timestamp),
         }
     }
@@ -930,14 +894,12 @@ impl VoteStateHandle for VoteStateHandler {
         vote_account: &mut BorrowedInstructionAccount,
     ) -> Result<(), InstructionError> {
         match self.target_state {
-            TargetVoteState::V3(v3) => v3.set_vote_account_state(vote_account),
             TargetVoteState::V4(v4) => v4.set_vote_account_state(vote_account),
         }
     }
 
     fn has_bls_pubkey(&self) -> bool {
         match &self.target_state {
-            TargetVoteState::V3(v3) => v3.has_bls_pubkey(),
             TargetVoteState::V4(v4) => v4.has_bls_pubkey(),
         }
     }
@@ -951,9 +913,6 @@ impl VoteStateHandler {
         target_version: VoteStateTargetVersion,
     ) -> Result<(), InstructionError> {
         match target_version {
-            VoteStateTargetVersion::V3 => {
-                VoteStateV3::new(vote_init, clock).set_vote_account_state(vote_account)
-            }
             VoteStateTargetVersion::V4 => {
                 let vote_state =
                     VoteStateV4::new_with_defaults(vote_account.get_key(), vote_init, clock);
@@ -969,12 +928,6 @@ impl VoteStateHandler {
         target_version: VoteStateTargetVersion,
     ) -> Result<(), InstructionError> {
         match target_version {
-            VoteStateTargetVersion::V3 => {
-                // We should not be able to reach here because we only call this function
-                // when both Vote State V4 and BLS features are enabled.
-                // See `is_vote_authorize_with_bls_enabled` in vote_processor.rs.
-                Err(InstructionError::InvalidInstructionData)
-            }
             VoteStateTargetVersion::V4 => {
                 let vote_state = VoteStateV4::new(vote_init, clock);
                 vote_state.set_vote_account_state(vote_account)
@@ -987,9 +940,6 @@ impl VoteStateHandler {
         target_version: VoteStateTargetVersion,
     ) -> Result<(), InstructionError> {
         match target_version {
-            VoteStateTargetVersion::V3 => {
-                VoteStateV3::default().set_vote_account_state(vote_account)
-            }
             VoteStateTargetVersion::V4 => {
                 // As per SIMD-0185, clear the entire account.
                 vote_account.get_data_mut()?.fill(0);
@@ -1004,19 +954,12 @@ impl VoteStateHandler {
     ) -> Result<(), InstructionError> {
         let length = vote_account.get_data().len();
         let expected = match target_version {
-            VoteStateTargetVersion::V3 => VoteStateV3::size_of(),
             VoteStateTargetVersion::V4 => VoteStateV4::size_of(),
         };
         if length != expected {
             Err(InstructionError::InvalidAccountData)
         } else {
             Ok(())
-        }
-    }
-
-    pub(crate) fn new_v3(vote_state: VoteStateV3) -> Self {
-        Self {
-            target_state: TargetVoteState::V3(vote_state),
         }
     }
 
@@ -1027,40 +970,20 @@ impl VoteStateHandler {
     }
 
     #[cfg(test)]
-    pub fn default_v3() -> Self {
-        Self::new_v3(VoteStateV3::default())
-    }
-
-    #[cfg(test)]
     pub fn default_v4() -> Self {
         Self::new_v4(VoteStateV4::default())
-    }
-
-    #[cfg(test)]
-    pub fn as_ref_v3(&self) -> &VoteStateV3 {
-        match &self.target_state {
-            TargetVoteState::V3(v3) => v3,
-            _ => panic!("not a v3"),
-        }
     }
 
     #[cfg(test)]
     pub fn as_ref_v4(&self) -> &VoteStateV4 {
         match &self.target_state {
             TargetVoteState::V4(v4) => v4,
-            _ => panic!("not a v4"),
         }
     }
 
     #[cfg(test)]
     pub fn serialize(self) -> Vec<u8> {
         match self.target_state {
-            TargetVoteState::V3(v3) => {
-                let mut data = vec![0; VoteStateV3::size_of()];
-                let versioned = VoteStateVersions::V3(Box::new(v3));
-                bincode::serialize_into(&mut data[..], &versioned).unwrap();
-                data
-            }
             TargetVoteState::V4(v4) => {
                 let mut data = vec![0; VoteStateV4::size_of()];
                 let versioned = VoteStateVersions::V4(Box::new(v4));
@@ -1750,80 +1673,6 @@ mod tests {
         assert_eq!(vote_state.process_timestamp(0, timestamp), Ok(()));
     }
 
-    enum ExpectedVoteStateVersion {
-        V1_14_11,
-        V3,
-    }
-
-    fn init_vote_account_state_v3_and_assert(
-        vote_pubkey: Pubkey,
-        vote_account: AccountSharedData,
-        vote_init: &VoteInit,
-        clock: &Clock,
-        rent: Rent,
-        expected_version: ExpectedVoteStateVersion,
-    ) {
-        let transaction_context = mock_transaction_context(vote_pubkey, vote_account, rent);
-        let instruction_context = transaction_context.get_next_instruction_context().unwrap();
-        let mut vote_account = instruction_context
-            .try_borrow_instruction_account(0)
-            .unwrap();
-
-        // Initialize.
-        VoteStateHandler::init_vote_account_state(
-            &mut vote_account,
-            vote_init,
-            clock,
-            VoteStateTargetVersion::V3,
-        )
-        .unwrap();
-
-        let vote_state_versions = vote_account.get_state::<VoteStateVersions>().unwrap();
-
-        match expected_version {
-            ExpectedVoteStateVersion::V1_14_11 => {
-                assert!(matches!(
-                    vote_state_versions,
-                    VoteStateVersions::V1_14_11(_)
-                ));
-                assert!(!vote_state_versions.is_uninitialized());
-
-                // Verify fields.
-                if let VoteStateVersions::V1_14_11(v1_14_11) = vote_state_versions {
-                    assert_eq!(v1_14_11.node_pubkey, vote_init.node_pubkey);
-                    assert_eq!(
-                        v1_14_11.authorized_voters.get_authorized_voter(0),
-                        Some(vote_init.authorized_voter)
-                    );
-                    assert_eq!(
-                        v1_14_11.authorized_withdrawer,
-                        vote_init.authorized_withdrawer
-                    );
-                    assert_eq!(v1_14_11.commission, vote_init.commission);
-                } else {
-                    panic!("should be v1_14_11");
-                }
-            }
-            ExpectedVoteStateVersion::V3 => {
-                assert!(matches!(vote_state_versions, VoteStateVersions::V3(_)));
-                assert!(!vote_state_versions.is_uninitialized());
-
-                // Verify fields.
-                if let VoteStateVersions::V3(v3) = vote_state_versions {
-                    assert_eq!(v3.node_pubkey, vote_init.node_pubkey);
-                    assert_eq!(
-                        v3.authorized_voters.get_authorized_voter(0),
-                        Some(vote_init.authorized_voter)
-                    );
-                    assert_eq!(v3.authorized_withdrawer, vote_init.authorized_withdrawer);
-                    assert_eq!(v3.commission, vote_init.commission);
-                } else {
-                    panic!("should be v3");
-                }
-            }
-        }
-    }
-
     fn init_vote_account_state_v4_and_assert(
         vote_pubkey: Pubkey,
         vote_account: AccountSharedData,
@@ -1886,42 +1735,6 @@ mod tests {
         }
     }
 
-    fn deinit_vote_account_state_v3_and_assert(
-        vote_pubkey: Pubkey,
-        vote_account: AccountSharedData,
-        rent: Rent,
-        expected_version: ExpectedVoteStateVersion,
-    ) {
-        let transaction_context = mock_transaction_context(vote_pubkey, vote_account, rent);
-        let instruction_context = transaction_context.get_next_instruction_context().unwrap();
-        let mut vote_account = instruction_context
-            .try_borrow_instruction_account(0)
-            .unwrap();
-
-        // Deinitialize.
-        VoteStateHandler::deinitialize_vote_account_state(
-            &mut vote_account,
-            VoteStateTargetVersion::V3,
-        )
-        .unwrap();
-
-        let vote_state_versions = vote_account.get_state::<VoteStateVersions>().unwrap();
-
-        match expected_version {
-            ExpectedVoteStateVersion::V1_14_11 => {
-                assert!(matches!(
-                    vote_state_versions,
-                    VoteStateVersions::V1_14_11(_)
-                ));
-                assert!(vote_state_versions.is_uninitialized());
-            }
-            ExpectedVoteStateVersion::V3 => {
-                assert!(matches!(vote_state_versions, VoteStateVersions::V3(_)));
-                assert!(vote_state_versions.is_uninitialized());
-            }
-        }
-    }
-
     fn deinit_vote_account_state_v4_and_assert(
         vote_pubkey: Pubkey,
         vote_account: AccountSharedData,
@@ -1952,64 +1765,6 @@ mod tests {
             VoteStateVersions::Uninitialized
         ));
         assert!(vote_state_versions.is_uninitialized());
-    }
-
-    #[test]
-    fn test_init_vote_account_state_v3() {
-        let vote_pubkey = Pubkey::new_unique();
-        let vote_init = VoteInit {
-            node_pubkey: Pubkey::new_unique(),
-            authorized_voter: Pubkey::new_unique(),
-            authorized_withdrawer: Pubkey::new_unique(),
-            commission: 5,
-        };
-        let clock = Clock::default();
-        let rent = Rent::default();
-
-        // First create a vote account that's too small for v3.
-        let v1_14_11_size = VoteState1_14_11::size_of();
-        let lamports = rent.minimum_balance(v1_14_11_size);
-        let vote_account = AccountSharedData::new(lamports, v1_14_11_size, &id());
-
-        // Initialize - should default to v1_14_11.
-        init_vote_account_state_v3_and_assert(
-            vote_pubkey,
-            vote_account,
-            &vote_init,
-            &clock,
-            rent.clone(),
-            ExpectedVoteStateVersion::V1_14_11,
-        );
-
-        // Create a vote account that's too small for v3, but has enough
-        // lamports for resize.
-        let v3_size = VoteStateV3::size_of();
-        let lamports = rent.minimum_balance(v3_size);
-        let vote_account = AccountSharedData::new(lamports, v1_14_11_size, &id());
-
-        // Initialize - should resize and create v3.
-        init_vote_account_state_v3_and_assert(
-            vote_pubkey,
-            vote_account,
-            &vote_init,
-            &clock,
-            rent.clone(),
-            ExpectedVoteStateVersion::V3,
-        );
-
-        // Now create a vote account that's large enough for v3.
-        let lamports = rent.minimum_balance(v3_size);
-        let vote_account = AccountSharedData::new(lamports, v3_size, &id());
-
-        // Initialize - should create v3.
-        init_vote_account_state_v3_and_assert(
-            vote_pubkey,
-            vote_account,
-            &vote_init,
-            &clock,
-            rent,
-            ExpectedVoteStateVersion::V3,
-        );
     }
 
     #[test]
@@ -2067,51 +1822,6 @@ mod tests {
             &clock,
             rent,
             Ok(()),
-        );
-    }
-
-    #[test]
-    fn test_deinitialize_vote_account_state_v3() {
-        let vote_pubkey = Pubkey::new_unique();
-        let rent = Rent::default();
-
-        // First create a vote account that's too small for v3.
-        let v1_14_11_size = VoteState1_14_11::size_of();
-        let lamports = rent.minimum_balance(v1_14_11_size);
-        let vote_account = AccountSharedData::new(lamports, v1_14_11_size, &id());
-
-        // Deinitialize - should default to v1_14_11.
-        deinit_vote_account_state_v3_and_assert(
-            vote_pubkey,
-            vote_account,
-            rent.clone(),
-            ExpectedVoteStateVersion::V1_14_11,
-        );
-
-        // Create a vote account that's too small for v3, but has enough
-        // lamports for resize.
-        let v3_size = VoteStateV3::size_of();
-        let lamports = rent.minimum_balance(v3_size);
-        let vote_account = AccountSharedData::new(lamports, v1_14_11_size, &id());
-
-        // Deinitialize - should resize and create v3.
-        deinit_vote_account_state_v3_and_assert(
-            vote_pubkey,
-            vote_account,
-            rent.clone(),
-            ExpectedVoteStateVersion::V3,
-        );
-
-        // Now create a vote account that's large enough for v3.
-        let lamports = rent.minimum_balance(v3_size);
-        let vote_account = AccountSharedData::new(lamports, v3_size, &id());
-
-        // Deinitialize - should create v3.
-        deinit_vote_account_state_v3_and_assert(
-            vote_pubkey,
-            vote_account,
-            rent,
-            ExpectedVoteStateVersion::V3,
         );
     }
 
@@ -2194,24 +1904,15 @@ mod tests {
     }
 
     #[test]
-    fn test_commission_v3_v4_parity() {
-        // Verify commission() returns the same value for equivalent V3
-        // and V4 states, both directly and through migration.
+    fn test_commission_v3_v4_preserved() {
+        // Verify commission() returns the same value through V3→V4 migration.
         let vote_pubkey = Pubkey::new_unique();
         for n in [0u8, 1, 50, 100, 101, 255] {
-            // Direct construction.
             let v3 = VoteStateV3 {
                 commission: n,
                 ..Default::default()
             };
-            let v3_handler = VoteStateHandler::new_v3(v3.clone());
 
-            let mut v4_handler = VoteStateHandler::new_v4(VoteStateV4::default());
-            v4_handler.set_commission(n);
-
-            assert_eq!(v3_handler.commission(), v4_handler.commission());
-
-            // Through V3→V4 migration.
             let versioned = VoteStateVersions::V3(Box::new(v3));
             let migrated = try_convert_to_vote_state_v4(versioned, &vote_pubkey).unwrap();
             let migrated_handler = VoteStateHandler::new_v4(migrated);
@@ -2541,20 +2242,6 @@ mod tests {
 
     #[test]
     fn test_set_inflation_rewards_commission_bps() {
-        // V3: try to set various values - should all be no-ops.
-        let mut handler = VoteStateHandler::new_v3(VoteStateV3::default());
-        let original_commission = handler.commission();
-
-        handler.set_inflation_rewards_commission_bps(500);
-        assert_eq!(handler.commission(), original_commission);
-
-        handler.set_inflation_rewards_commission_bps(10_000);
-        assert_eq!(handler.commission(), original_commission);
-
-        handler.set_inflation_rewards_commission_bps(15_000);
-        assert_eq!(handler.commission(), original_commission);
-
-        // V4: actual live updates.
         let mut handler = VoteStateHandler::new_v4(VoteStateV4::default());
 
         // First test some "normal" values.

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -33,41 +33,12 @@ use {
     },
 };
 
-// Switch that preserves old behavior before vote state v4 feature gate.
-// This should be cleaned up when vote state v4 is activated.
-enum PreserveBehaviorInHandlerHelper {
-    V3 { check_initialized: bool },
-    V4,
-}
-
-impl PreserveBehaviorInHandlerHelper {
-    fn new(target_version: VoteStateTargetVersion, check_initialized: bool) -> Self {
-        match target_version {
-            VoteStateTargetVersion::V3 => Self::V3 { check_initialized },
-            VoteStateTargetVersion::V4 => Self::V4,
-        }
-    }
-}
-
 fn get_vote_state_handler_checked(
     vote_account: &BorrowedInstructionAccount,
-    preserve_behavior: PreserveBehaviorInHandlerHelper,
+    target_version: VoteStateTargetVersion,
 ) -> Result<VoteStateHandler, InstructionError> {
-    match preserve_behavior {
-        PreserveBehaviorInHandlerHelper::V3 { check_initialized } => {
-            // Existing flow before v4 feature gate activation:
-            // 1. Deserialize as `VoteState3`, converting during deserialization
-            // 2. Check for uninitialized
-            //
-            // Some callsites would deserialize without checking initialization
-            // status, hence the nested `check_initialized` switch.
-            let vote_state = VoteStateV3::deserialize(vote_account.get_data())?;
-            if check_initialized && vote_state.is_uninitialized() {
-                return Err(InstructionError::UninitializedAccount);
-            }
-            Ok(VoteStateHandler::new_v3(vote_state))
-        }
-        PreserveBehaviorInHandlerHelper::V4 => {
+    match target_version {
+        VoteStateTargetVersion::V4 => {
             // New flow after v4 feature gate activation:
             // 1. Deserialize as `VoteStateVersions`
             // 2. Check for uninitialized
@@ -729,10 +700,7 @@ pub fn authorize<S: std::hash::BuildHasher, F>(
 where
     F: FnOnce() -> Result<(), InstructionError>,
 {
-    let mut vote_state = get_vote_state_handler_checked(
-        vote_account,
-        PreserveBehaviorInHandlerHelper::new(target_version, false),
-    )?;
+    let mut vote_state = get_vote_state_handler_checked(vote_account, target_version)?;
 
     match vote_authorize {
         VoteAuthorize::Voter => {
@@ -810,10 +778,7 @@ pub fn update_validator_identity<S: std::hash::BuildHasher>(
     signers: &HashSet<Pubkey, S>,
     custom_commission_collector_enabled: bool,
 ) -> Result<(), InstructionError> {
-    let mut vote_state = get_vote_state_handler_checked(
-        vote_account,
-        PreserveBehaviorInHandlerHelper::new(target_version, false),
-    )?;
+    let mut vote_state = get_vote_state_handler_checked(vote_account, target_version)?;
 
     // current authorized withdrawer must say "yay"
     verify_authorized_signer(vote_state.authorized_withdrawer(), signers)?;
@@ -842,10 +807,7 @@ pub fn update_commission<S: std::hash::BuildHasher>(
     clock: &Clock,
     disable_commission_update_rule: bool,
 ) -> Result<(), InstructionError> {
-    let vote_state_result = get_vote_state_handler_checked(
-        vote_account,
-        PreserveBehaviorInHandlerHelper::new(target_version, false),
-    );
+    let vote_state_result = get_vote_state_handler_checked(vote_account, target_version);
     let enforce_commission_update_rule = !disable_commission_update_rule
         && match vote_state_result.as_ref() {
             Ok(decoded_vote_state) => commission > decoded_vote_state.commission(),
@@ -881,10 +843,7 @@ pub fn update_commission_bps<S: std::hash::BuildHasher>(
         return Err(InstructionError::InvalidInstructionData);
     }
 
-    let mut vote_state = get_vote_state_handler_checked(
-        vote_account,
-        PreserveBehaviorInHandlerHelper::new(target_version, false),
-    )?;
+    let mut vote_state = get_vote_state_handler_checked(vote_account, target_version)?;
 
     // No commission update rule, per SIMD-0249 and SIMD-0291.
 
@@ -917,10 +876,7 @@ pub fn update_commission_collector<S: std::hash::BuildHasher>(
     signers: &HashSet<Pubkey, S>,
     rent: &Rent,
 ) -> Result<(), InstructionError> {
-    let mut vote_state = get_vote_state_handler_checked(
-        vote_account,
-        PreserveBehaviorInHandlerHelper::new(target_version, true),
-    )?;
+    let mut vote_state = get_vote_state_handler_checked(vote_account, target_version)?;
 
     // Require authorized withdrawer to sign.
     verify_authorized_signer(vote_state.authorized_withdrawer(), signers)?;
@@ -1118,10 +1074,7 @@ pub fn withdraw<S: std::hash::BuildHasher>(
 ) -> Result<(), InstructionError> {
     let mut vote_account =
         instruction_context.try_borrow_instruction_account(vote_account_index)?;
-    let vote_state = get_vote_state_handler_checked(
-        &vote_account,
-        PreserveBehaviorInHandlerHelper::new(target_version, false),
-    )?;
+    let vote_state = get_vote_state_handler_checked(&vote_account, target_version)?;
 
     verify_authorized_signer(vote_state.authorized_withdrawer(), signers)?;
 
@@ -1244,10 +1197,7 @@ pub fn process_vote_with_account<S: std::hash::BuildHasher>(
     vote: &Vote,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_state = get_vote_state_handler_checked(
-        vote_account,
-        PreserveBehaviorInHandlerHelper::new(target_version, true),
-    )?;
+    let mut vote_state = get_vote_state_handler_checked(vote_account, target_version)?;
 
     let authorized_voter = vote_state.get_and_update_authorized_voter(clock.epoch)?;
     verify_authorized_signer(&authorized_voter, signers)?;
@@ -1271,10 +1221,7 @@ pub fn process_vote_state_update<S: std::hash::BuildHasher>(
     vote_state_update: VoteStateUpdate,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_state = get_vote_state_handler_checked(
-        vote_account,
-        PreserveBehaviorInHandlerHelper::new(target_version, true),
-    )?;
+    let mut vote_state = get_vote_state_handler_checked(vote_account, target_version)?;
 
     let authorized_voter = vote_state.get_and_update_authorized_voter(clock.epoch)?;
     verify_authorized_signer(&authorized_voter, signers)?;
@@ -1325,10 +1272,7 @@ pub fn process_tower_sync<S: std::hash::BuildHasher>(
     tower_sync: TowerSync,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_state = get_vote_state_handler_checked(
-        vote_account,
-        PreserveBehaviorInHandlerHelper::new(target_version, true),
-    )?;
+    let mut vote_state = get_vote_state_handler_checked(vote_account, target_version)?;
 
     let authorized_voter = vote_state.get_and_update_authorized_voter(clock.epoch)?;
     verify_authorized_signer(&authorized_voter, signers)?;
@@ -1470,9 +1414,6 @@ mod tests {
         let clock = Clock::default();
 
         match target_version {
-            VoteStateTargetVersion::V3 => {
-                VoteStateHandler::new_v3(VoteStateV3::new(&vote_init, &clock))
-            }
             VoteStateTargetVersion::V4 => VoteStateHandler::new_v4(VoteStateV4::new_with_defaults(
                 vote_pubkey,
                 &vote_init,
@@ -1481,7 +1422,6 @@ mod tests {
         }
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_vote_state_upgrade_from_1_14_11(target_version: VoteStateTargetVersion) {
         let vote_pubkey = solana_pubkey::new_rand();
@@ -1534,10 +1474,6 @@ mod tests {
         // Create an initial vote account that is sized for the 1_14_11 version of vote state, and has only the
         // required lamports for rent exempt minimum at that size
         let vote_state_v1_14_11 = match target_version {
-            VoteStateTargetVersion::V3 => {
-                // v3 can be converted directly to V1_14_11.
-                VoteState1_14_11::from(vote_state.as_ref_v3().clone())
-            }
             VoteStateTargetVersion::V4 => {
                 // v4 cannot be converted directly to V1_14_11.
                 VoteState1_14_11 {
@@ -1597,11 +1533,8 @@ mod tests {
         assert_matches!(vote_state_version, VoteStateVersions::V1_14_11(_));
 
         // Convert the vote state to current as would occur during vote instructions
-        let converted_vote_state = get_vote_state_handler_checked(
-            &borrowed_account,
-            PreserveBehaviorInHandlerHelper::new(target_version, true),
-        )
-        .unwrap();
+        let converted_vote_state =
+            get_vote_state_handler_checked(&borrowed_account, target_version).unwrap();
 
         // Check to make sure that the vote_state is unchanged
         assert!(vote_state == converted_vote_state);
@@ -1611,17 +1544,6 @@ mod tests {
         // Now re-set the vote account state, knowing the account only has
         // enough lamports for V1_14_11.
         match target_version {
-            VoteStateTargetVersion::V3 => {
-                // V3 will write out as V1_14_11.
-                assert_eq!(
-                    vote_state
-                        .clone()
-                        .set_vote_account_state(&mut borrowed_account),
-                    Ok(())
-                );
-                let vote_state_version = borrowed_account.get_state::<VoteStateVersions>().unwrap();
-                assert_matches!(vote_state_version, VoteStateVersions::V1_14_11(_));
-            }
             VoteStateTargetVersion::V4 => {
                 // V4 will throw an error.
                 assert_eq!(
@@ -1634,11 +1556,8 @@ mod tests {
         }
 
         // Convert the vote state to current as would occur during vote instructions
-        let converted_vote_state = get_vote_state_handler_checked(
-            &borrowed_account,
-            PreserveBehaviorInHandlerHelper::new(target_version, true),
-        )
-        .unwrap();
+        let converted_vote_state =
+            get_vote_state_handler_checked(&borrowed_account, target_version).unwrap();
 
         // Check to make sure that the vote_state is unchanged
         assert!(vote_state == converted_vote_state);
@@ -1647,8 +1566,7 @@ mod tests {
 
         // Now top-up the vote account's lamports to be rent exempt for the target version.
         let space = match target_version {
-            VoteStateTargetVersion::V3 => VoteStateV3::size_of(),
-            VoteStateTargetVersion::V4 => VoteStateV4::size_of(), // They're the same, but for posterity
+            VoteStateTargetVersion::V4 => VoteStateV4::size_of(),
         };
         assert_eq!(
             borrowed_account.set_lamports(rent.minimum_balance(space)),
@@ -1664,26 +1582,19 @@ mod tests {
         // The vote state version should match the target version.
         let vote_state_version = borrowed_account.get_state::<VoteStateVersions>().unwrap();
         match target_version {
-            VoteStateTargetVersion::V3 => {
-                assert_matches!(vote_state_version, VoteStateVersions::V3(_));
-            }
             VoteStateTargetVersion::V4 => {
                 assert_matches!(vote_state_version, VoteStateVersions::V4(_));
             }
         }
 
         // Convert the vote state to current as would occur during vote instructions
-        let converted_vote_state = get_vote_state_handler_checked(
-            &borrowed_account,
-            PreserveBehaviorInHandlerHelper::new(target_version, true),
-        )
-        .unwrap();
+        let converted_vote_state =
+            get_vote_state_handler_checked(&borrowed_account, target_version).unwrap();
 
         // Check to make sure that the vote_state is unchanged
         assert_eq!(vote_state, converted_vote_state);
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_vote_lockout(target_version: VoteStateTargetVersion) {
         let mut vote_state = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
@@ -1718,7 +1629,7 @@ mod tests {
     }
 
     #[test_matrix(
-        [VoteStateTargetVersion::V3, VoteStateTargetVersion::V4],
+        [VoteStateTargetVersion::V4],
         [true, false]
     )]
     fn test_update_commission(
@@ -1780,12 +1691,9 @@ mod tests {
 
         // Increase commission in first half of epoch -- allowed
         assert_eq!(
-            get_vote_state_handler_checked(
-                &borrowed_account,
-                PreserveBehaviorInHandlerHelper::new(target_version, true),
-            )
-            .unwrap()
-            .commission(),
+            get_vote_state_handler_checked(&borrowed_account, target_version,)
+                .unwrap()
+                .commission(),
             10
         );
         assert_matches!(
@@ -1801,12 +1709,9 @@ mod tests {
             Ok(())
         );
         assert_eq!(
-            get_vote_state_handler_checked(
-                &borrowed_account,
-                PreserveBehaviorInHandlerHelper::new(target_version, true),
-            )
-            .unwrap()
-            .commission(),
+            get_vote_state_handler_checked(&borrowed_account, target_version,)
+                .unwrap()
+                .commission(),
             11
         );
 
@@ -1820,12 +1725,9 @@ mod tests {
             &second_half_clock,
             disable_commission_update_rule,
         );
-        let state_commission = get_vote_state_handler_checked(
-            &borrowed_account,
-            PreserveBehaviorInHandlerHelper::new(target_version, true),
-        )
-        .unwrap()
-        .commission();
+        let state_commission = get_vote_state_handler_checked(&borrowed_account, target_version)
+            .unwrap()
+            .commission();
         if disable_commission_update_rule {
             assert_matches!(result, Ok(()));
             assert_eq!(state_commission, 12);
@@ -1848,22 +1750,16 @@ mod tests {
             Ok(())
         );
         assert_eq!(
-            get_vote_state_handler_checked(
-                &borrowed_account,
-                PreserveBehaviorInHandlerHelper::new(target_version, true),
-            )
-            .unwrap()
-            .commission(),
+            get_vote_state_handler_checked(&borrowed_account, target_version,)
+                .unwrap()
+                .commission(),
             10
         );
 
         assert_eq!(
-            get_vote_state_handler_checked(
-                &borrowed_account,
-                PreserveBehaviorInHandlerHelper::new(target_version, true),
-            )
-            .unwrap()
-            .commission(),
+            get_vote_state_handler_checked(&borrowed_account, target_version,)
+                .unwrap()
+                .commission(),
             10
         );
 
@@ -1881,12 +1777,9 @@ mod tests {
             Ok(())
         );
         assert_eq!(
-            get_vote_state_handler_checked(
-                &borrowed_account,
-                PreserveBehaviorInHandlerHelper::new(target_version, true),
-            )
-            .unwrap()
-            .commission(),
+            get_vote_state_handler_checked(&borrowed_account, target_version,)
+                .unwrap()
+                .commission(),
             9
         );
     }
@@ -1997,11 +1890,8 @@ mod tests {
                 true,
             )
             .unwrap();
-            let handler = get_vote_state_handler_checked(
-                &borrowed_account,
-                PreserveBehaviorInHandlerHelper::new(target_version, true),
-            )
-            .unwrap();
+            let handler =
+                get_vote_state_handler_checked(&borrowed_account, target_version).unwrap();
             assert_eq!(
                 handler.as_ref_v4().inflation_rewards_commission_bps,
                 new_commission_bps
@@ -2025,7 +1915,6 @@ mod tests {
         commission_bps_roundtrip(50_000); // 500%
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_vote_double_lockout_after_expiration(target_version: VoteStateTargetVersion) {
         let mut vote_state = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
@@ -2053,7 +1942,6 @@ mod tests {
         check_lockouts(&vote_state);
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_expire_multiple_votes(target_version: VoteStateTargetVersion) {
         let mut vote_state = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
@@ -2085,7 +1973,6 @@ mod tests {
         assert_eq!(vote_state.votes()[2].confirmation_count(), 1);
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_vote_credits(target_version: VoteStateTargetVersion) {
         let mut vote_state = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
@@ -2104,7 +1991,6 @@ mod tests {
         assert_eq!(vote_state.credits(), 3);
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_duplicate_vote(target_version: VoteStateTargetVersion) {
         let mut vote_state = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
@@ -2116,7 +2002,6 @@ mod tests {
         assert!(vote_state.nth_recent_lockout(2).is_none());
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_nth_recent_lockout(target_version: VoteStateTargetVersion) {
         let mut vote_state = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
@@ -2155,7 +2040,6 @@ mod tests {
     }
 
     /// check that two accounts with different data can be brought to the same state with one vote submission
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_process_missed_votes(target_version: VoteStateTargetVersion) {
         let mut vote_state_a = vote_state_new_for_test(&solana_pubkey::new_rand(), target_version);
@@ -2181,7 +2065,6 @@ mod tests {
         assert_eq!(recent_votes(&vote_state_a), recent_votes(&vote_state_b));
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_vote_skips_old_vote(mut vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
@@ -2198,7 +2081,6 @@ mod tests {
         assert_eq!(recent, recent_votes(&vote_state));
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_check_slots_are_valid_vote_empty_slot_hashes(vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
@@ -2208,7 +2090,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_check_slots_are_valid_new_vote(vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
@@ -2219,7 +2100,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_check_slots_are_valid_bad_hash(vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
@@ -2230,7 +2110,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_check_slots_are_valid_bad_slot(vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![1], Hash::default());
@@ -2241,7 +2120,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_check_slots_are_valid_duplicate_vote(mut vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
@@ -2256,7 +2134,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_check_slots_are_valid_next_vote(mut vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
@@ -2274,7 +2151,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_check_slots_are_valid_next_vote_only(mut vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![0], Hash::default());
@@ -2292,7 +2168,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_vote_empty_slots(mut vote_state: VoteStateHandler) {
         let vote = Vote::new(vec![], Hash::default());
@@ -2320,7 +2195,6 @@ mod tests {
     }
 
     // Test vote credit updates after "one credit per slot" feature is enabled
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_vote_state_update_increment_credits(mut vote_state: VoteStateHandler) {
         // Test data: a sequence of groups of votes to simulate having been cast, after each group a vote
@@ -2397,7 +2271,6 @@ mod tests {
     }
 
     // Test vote credit updates after "timely vote credits" feature is enabled
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_timely_credits(target_version: VoteStateTargetVersion) {
         // Each of the following (Vec<Slot>, Slot, u32) tuples gives a set of slots to cast votes on, a slot in which
@@ -2565,7 +2438,6 @@ mod tests {
         ];
 
         let new_vote_state = || match target_version {
-            VoteStateTargetVersion::V3 => VoteStateHandler::default_v3(),
             VoteStateTargetVersion::V4 => VoteStateHandler::default_v4(),
         };
 
@@ -2615,7 +2487,6 @@ mod tests {
         }
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_retroactive_voting_timely_credits(mut vote_state: VoteStateHandler) {
         // Each of the following (Vec<(Slot, int)>, Slot, Option<Slot>, u32) tuples gives the following data:
@@ -2728,7 +2599,6 @@ mod tests {
             });
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_too_many_votes(mut vote_state1: VoteStateHandler) {
         let bad_votes: VecDeque<Lockout> = (0..=MAX_LOCKOUT_HISTORY)
@@ -2753,7 +2623,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_state_root_rollback(mut vote_state1: VoteStateHandler) {
         for i in 0..MAX_LOCKOUT_HISTORY + 2 {
@@ -2797,7 +2666,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_state_zero_confirmations(mut vote_state1: VoteStateHandler) {
         let current_epoch = vote_state1.current_epoch();
@@ -2837,7 +2705,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_state_confirmations_too_large(initial_vote_state: VoteStateHandler) {
         let mut vote_state1 = initial_vote_state.clone();
@@ -2878,7 +2745,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_state_slot_smaller_than_root(mut vote_state1: VoteStateHandler) {
         let current_epoch = vote_state1.current_epoch();
@@ -2919,7 +2785,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_state_slots_not_ordered(mut vote_state1: VoteStateHandler) {
         let current_epoch = vote_state1.current_epoch();
@@ -2959,7 +2824,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_state_confirmations_not_ordered(mut vote_state1: VoteStateHandler) {
         let current_epoch = vote_state1.current_epoch();
@@ -2999,7 +2863,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_state_new_vote_state_lockout_mismatch(
         mut vote_state1: VoteStateHandler,
@@ -3026,7 +2889,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_state_confirmation_rollback(mut vote_state1: VoteStateHandler) {
         let current_epoch = vote_state1.current_epoch();
@@ -3061,7 +2923,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_state_root_progress(mut vote_state1: VoteStateHandler) {
         for i in 0..MAX_LOCKOUT_HISTORY {
@@ -3095,7 +2956,6 @@ mod tests {
         }
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_state_same_slot_but_not_common_ancestor(
         initial_vote_state: VoteStateHandler,
@@ -3155,7 +3015,6 @@ mod tests {
         assert_eq!(vote_state1, vote_state2);
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_state_lockout_violation(initial_vote_state: VoteStateHandler) {
         // Construct on-chain vote state
@@ -3197,7 +3056,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_state_lockout_violation2(initial_vote_state: VoteStateHandler) {
         // Construct on-chain vote state
@@ -3240,7 +3098,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_state_expired_ancestor_not_removed(mut vote_state1: VoteStateHandler) {
         // Construct on-chain vote state
@@ -3285,7 +3142,6 @@ mod tests {
         assert_eq!(vote_state1, vote_state2,);
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_process_new_vote_current_state_contains_bigger_slots(
         mut vote_state1: VoteStateHandler,
@@ -3342,7 +3198,6 @@ mod tests {
         assert_eq!(*vote_state1.votes(), good_votes);
     }
 
-    #[test_case(VoteStateHandler::default_v3() ; "VoteStateV3")]
     #[test_case(VoteStateHandler::default_v4() ; "VoteStateV4")]
     fn test_filter_old_votes(mut vote_state: VoteStateHandler) {
         let old_vote_slot = 1;
@@ -3391,7 +3246,6 @@ mod tests {
         slot_hashes: &[(Slot, Hash)],
     ) -> VoteStateHandler {
         let mut vote_state = match target_version {
-            VoteStateTargetVersion::V3 => VoteStateHandler::default_v3(),
             VoteStateTargetVersion::V4 => VoteStateHandler::default_v4(),
         };
 
@@ -3409,7 +3263,6 @@ mod tests {
         vote_state
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_empty(target_version: VoteStateTargetVersion) {
         let empty_slot_hashes = build_slot_hashes(vec![]);
@@ -3442,7 +3295,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_too_old(target_version: VoteStateTargetVersion) {
         let slot_hashes = build_slot_hashes(vec![1, 2, 3, 4]);
@@ -3554,7 +3406,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_older_than_history_root(
         target_version: VoteStateTargetVersion,
@@ -3688,7 +3539,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_slots_not_ordered(
         target_version: VoteStateTargetVersion,
@@ -3731,7 +3581,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_older_than_history_slots_filtered(
         target_version: VoteStateTargetVersion,
@@ -3782,7 +3631,6 @@ mod tests {
         assert!(do_process_tower_sync(&mut vote_state, &slot_hashes, 0, 0, tower_sync,).is_ok());
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_older_than_history_slots_not_filtered(
         target_version: VoteStateTargetVersion,
@@ -3830,7 +3678,6 @@ mod tests {
         assert!(do_process_tower_sync(&mut vote_state, &slot_hashes, 0, 0, tower_sync,).is_ok());
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_older_than_history_slots_filtered_and_not_filtered(
         target_version: VoteStateTargetVersion,
@@ -3891,7 +3738,6 @@ mod tests {
         assert!(do_process_tower_sync(&mut vote_state, &slot_hashes, 0, 0, tower_sync,).is_ok());
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_slot_not_on_fork(
         target_version: VoteStateTargetVersion,
@@ -3949,7 +3795,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_root_on_different_fork(
         target_version: VoteStateTargetVersion,
@@ -3988,7 +3833,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_slot_newer_than_slot_history(
         target_version: VoteStateTargetVersion,
@@ -4017,7 +3861,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_slot_all_slot_hashes_in_update_ok(
         target_version: VoteStateTargetVersion,
@@ -4065,7 +3908,6 @@ mod tests {
         assert!(do_process_tower_sync(&mut vote_state, &slot_hashes, 0, 0, tower_sync,).is_ok());
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_slot_some_slot_hashes_in_update_ok(
         target_version: VoteStateTargetVersion,
@@ -4117,7 +3959,6 @@ mod tests {
         );
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_check_and_filter_proposed_vote_state_slot_hash_mismatch(
         target_version: VoteStateTargetVersion,
@@ -4475,11 +4316,7 @@ mod tests {
 
         let get_commission_collector =
             |vote_account: &BorrowedInstructionAccount, kind: CommissionKind| {
-                let handler = get_vote_state_handler_checked(
-                    vote_account,
-                    PreserveBehaviorInHandlerHelper::new(target_version, true),
-                )
-                .unwrap();
+                let handler = get_vote_state_handler_checked(vote_account, target_version).unwrap();
                 let vote_state = handler.as_ref_v4();
                 match kind {
                     CommissionKind::InflationRewards => vote_state.inflation_rewards_collector,
@@ -4885,7 +4722,6 @@ mod tests {
         transaction_context
     }
 
-    #[test_case(VoteStateTargetVersion::V3 ; "VoteStateV3")]
     #[test_case(VoteStateTargetVersion::V4 ; "VoteStateV4")]
     fn test_withdraw(target_version: VoteStateTargetVersion) {
         // Verify withdraw boundary conditions around the rent-exempt
@@ -5181,7 +5017,7 @@ mod tests {
         // `get_vote_state_handler_checked` with V4 target triggers the full
         // deser -> conversion path; `set_vote_account_state` writes it back.
         let vote_state =
-            get_vote_state_handler_checked(&borrowed, PreserveBehaviorInHandlerHelper::V4).unwrap();
+            get_vote_state_handler_checked(&borrowed, VoteStateTargetVersion::V4).unwrap();
         vote_state.set_vote_account_state(&mut borrowed).unwrap();
 
         // Inspect raw account data written by the handler.
@@ -5215,7 +5051,7 @@ mod tests {
         borrowed.get_data_mut().unwrap()[v4_serialized_len..].fill(0xDE);
 
         let vote_state =
-            get_vote_state_handler_checked(&borrowed, PreserveBehaviorInHandlerHelper::V4).unwrap();
+            get_vote_state_handler_checked(&borrowed, VoteStateTargetVersion::V4).unwrap();
         vote_state.set_vote_account_state(&mut borrowed).unwrap();
 
         let deserialized = VoteStateV4::deserialize(borrowed.get_data(), &vote_pubkey).unwrap();
@@ -5280,7 +5116,7 @@ mod tests {
 
         // Step 2: V3 -> V4 conversion via the handler.
         let vote_state =
-            get_vote_state_handler_checked(&borrowed, PreserveBehaviorInHandlerHelper::V4).unwrap();
+            get_vote_state_handler_checked(&borrowed, VoteStateTargetVersion::V4).unwrap();
         vote_state.set_vote_account_state(&mut borrowed).unwrap();
 
         let v4_after_convert = VoteStateV4::deserialize(borrowed.get_data(), &vote_pubkey).unwrap();
@@ -5340,7 +5176,7 @@ mod tests {
 
         // Round-trip through the handler with the stale bytes.
         let vote_state =
-            get_vote_state_handler_checked(&borrowed, PreserveBehaviorInHandlerHelper::V4).unwrap();
+            get_vote_state_handler_checked(&borrowed, VoteStateTargetVersion::V4).unwrap();
         vote_state.set_vote_account_state(&mut borrowed).unwrap();
 
         let deserialized = VoteStateV4::deserialize(borrowed.get_data(), &vote_pubkey).unwrap();
@@ -5356,7 +5192,7 @@ mod tests {
         borrowed.get_data_mut().unwrap()[v4_empty_serialized_len..].fill(0xCD);
 
         let vote_state =
-            get_vote_state_handler_checked(&borrowed, PreserveBehaviorInHandlerHelper::V4).unwrap();
+            get_vote_state_handler_checked(&borrowed, VoteStateTargetVersion::V4).unwrap();
         vote_state.set_vote_account_state(&mut borrowed).unwrap();
 
         let deserialized = VoteStateV4::deserialize(borrowed.get_data(), &vote_pubkey).unwrap();
@@ -5398,8 +5234,7 @@ mod tests {
 
             // Round-trip through the handler to verify.
             let vote_state =
-                get_vote_state_handler_checked(&borrowed, PreserveBehaviorInHandlerHelper::V4)
-                    .unwrap();
+                get_vote_state_handler_checked(&borrowed, VoteStateTargetVersion::V4).unwrap();
             vote_state.set_vote_account_state(&mut borrowed).unwrap();
 
             let deserialized = VoteStateV4::deserialize(borrowed.get_data(), &vote_pubkey).unwrap();
@@ -5458,7 +5293,7 @@ mod tests {
 
         // Drive conversion through the handler.
         let vote_state =
-            get_vote_state_handler_checked(&borrowed, PreserveBehaviorInHandlerHelper::V4).unwrap();
+            get_vote_state_handler_checked(&borrowed, VoteStateTargetVersion::V4).unwrap();
         vote_state.set_vote_account_state(&mut borrowed).unwrap();
 
         let v4 = VoteStateV4::deserialize(borrowed.get_data(), &vote_pubkey).unwrap();


### PR DESCRIPTION
#### Problem
SIMD-0185 (Vote State V4) is active on all networks and the feature was cleaned up in #11759. We can further clean up the vote program a bit.

#### Summary of Changes
Remove the target version for V3 vote state, since it will never be a _target_ version again. Also drops the `PreserveBehaviorInHandlerHelper` API, which was for backwards compatibility leading up to the activation of SIMD-0185.

Part of https://github.com/anza-xyz/agave/issues/10899