### PR TITLE
bump solana-vote-interface to 5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
  "solana-program-pack",
  "solana-pubkey 4.2.0",
  "solana-rayon-threadlimit",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-rpc",
  "solana-rpc-client",
  "solana-rpc-client-api",
@@ -6792,7 +6792,7 @@ dependencies = [
  "solana-program-option",
  "solana-program-pack",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-slot-hashes",
  "solana-slot-history",
@@ -6926,7 +6926,7 @@ dependencies = [
  "solana-nohash-hasher",
  "solana-pubkey 4.2.0",
  "solana-rayon-threadlimit",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-reward-info",
  "solana-sdk-ids",
  "solana-sha256-hasher",
@@ -7032,7 +7032,7 @@ dependencies = [
  "solana-message",
  "solana-program-pack",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-runtime",
  "solana-signature",
  "solana-signer",
@@ -7247,7 +7247,7 @@ dependencies = [
  "solana-program",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-slot-hashes",
@@ -7456,7 +7456,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-pubsub-client",
  "solana-remote-wallet",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-rpc",
  "solana-rpc-client",
  "solana-rpc-client-api",
@@ -7871,7 +7871,7 @@ dependencies = [
  "solana-program-binaries",
  "solana-pubkey 4.2.0",
  "solana-rayon-threadlimit",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-rpc",
  "solana-rpc-client-api",
  "solana-runtime",
@@ -8250,7 +8250,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-system-interface 3.1.0",
 ]
@@ -8373,7 +8373,7 @@ dependencies = [
  "solana-native-token",
  "solana-poh-config",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-runtime",
@@ -8409,7 +8409,7 @@ dependencies = [
  "solana-keypair",
  "solana-poh-config",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-sha256-hasher",
  "solana-shred-version",
@@ -8971,7 +8971,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-pubsub-client",
  "solana-quic-client",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-runtime",
@@ -9361,7 +9361,7 @@ dependencies = [
  "solana-program-option",
  "solana-program-pack",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-secp256k1-recover",
  "solana-serde-varint",
@@ -9383,7 +9383,7 @@ dependencies = [
  "solana-account 4.1.0",
  "solana-loader-v3-interface",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "spl-generic-token",
 ]
@@ -9467,7 +9467,7 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-signer",
@@ -9534,7 +9534,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-program-test",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-runtime",
  "solana-sbpf",
  "solana-sdk-ids",
@@ -9663,15 +9663,6 @@ dependencies = [
 
 [[package]]
 name = "solana-rent"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b702d8c43711e3c8a9284a4f1bbc6a3de2553deb25b0c8142f9a44ef0ce5ddc1"
-dependencies = [
- "solana-sdk-macro",
-]
-
-[[package]]
-name = "solana-rent"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1771d726d4854f1818c750e14aff40b19d84720d0b1b6d53e50e8f16cb6bd62"
@@ -9758,7 +9749,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
  "solana-rayon-threadlimit",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-rpc",
  "solana-rpc-client-api",
  "solana-runtime",
@@ -9943,7 +9934,7 @@ dependencies = [
  "solana-net-utils",
  "solana-pubkey 4.2.0",
  "solana-pubsub-client",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-signature",
@@ -10055,7 +10046,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
  "solana-rayon-threadlimit",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-reward-info",
  "solana-runtime",
  "solana-runtime-transaction",
@@ -10614,7 +10605,7 @@ dependencies = [
  "solana-program-pack",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-secp256k1-program",
@@ -10800,7 +10791,7 @@ dependencies = [
  "solana-packet 4.1.0",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-sha256-hasher",
  "solana-svm-callback",
@@ -10855,7 +10846,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-memory",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-slot-hashes",
@@ -10911,7 +10902,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-program-test",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-rpc",
  "solana-rpc-client",
  "solana-rpc-client-api",
@@ -11124,7 +11115,7 @@ dependencies = [
  "solana-instructions-sysvar",
  "solana-program-entrypoint",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-signature",
@@ -11394,9 +11385,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "5.0.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b4fb47dbad5a777e08ac4b1259e1fc5839c2e250512902a6d3b814f5c6040f"
+checksum = "d444ce30b6b4f9c281ba06061ea96638d063b53c2171b1e41ba02ebff79ed28f"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -11413,7 +11404,7 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
- "solana-rent 3.0.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-serde-varint",
  "solana-serialize-utils",
@@ -11444,7 +11435,7 @@ dependencies = [
  "solana-packet 4.1.0",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-sha256-hasher",
  "solana-slot-hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -533,7 +533,7 @@ solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=4
 solana-validator-exit = "3.0.0"
 solana-version = { path = "version", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-vote = { path = "vote", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-vote-interface = "5.0.0"
+solana-vote-interface = "5.1.0"
 solana-vote-program = { path = "programs/vote", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-zk-sdk = "5.0.1"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
  "solana-poh",
  "solana-pubkey 4.2.0",
  "solana-rayon-threadlimit",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-rpc",
  "solana-rpc-client",
  "solana-rpc-client-api",
@@ -5844,7 +5844,7 @@ dependencies = [
  "solana-program-option",
  "solana-program-pack",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-slot-hashes",
  "solana-slot-history",
@@ -5931,7 +5931,7 @@ dependencies = [
  "solana-nohash-hasher",
  "solana-pubkey 4.2.0",
  "solana-rayon-threadlimit",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-reward-info",
  "solana-signer",
  "solana-slot-hashes",
@@ -6024,7 +6024,7 @@ dependencies = [
  "solana-message",
  "solana-program-pack",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-signature",
  "solana-sysvar",
  "solana-transaction",
@@ -6908,7 +6908,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-system-interface 3.1.0",
 ]
@@ -6977,7 +6977,7 @@ dependencies = [
  "solana-keypair",
  "solana-poh-config",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-sha256-hasher",
  "solana-shred-version",
@@ -7701,7 +7701,7 @@ dependencies = [
  "solana-program-option",
  "solana-program-pack",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-secp256k1-recover",
  "solana-serde-varint",
@@ -7723,7 +7723,7 @@ dependencies = [
  "solana-account 4.1.0",
  "solana-loader-v3-interface",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "spl-generic-token",
 ]
@@ -7800,7 +7800,7 @@ dependencies = [
  "solana-message",
  "solana-program-entrypoint",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-slot-hashes",
@@ -7861,7 +7861,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-runtime",
  "solana-sbpf",
  "solana-sdk-ids",
@@ -7973,15 +7973,6 @@ dependencies = [
  "thiserror 2.0.18",
  "trezor-client",
  "uriparse",
-]
-
-[[package]]
-name = "solana-rent"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b702d8c43711e3c8a9284a4f1bbc6a3de2553deb25b0c8142f9a44ef0ce5ddc1"
-dependencies = [
- "solana-sdk-macro",
 ]
 
 [[package]]
@@ -8268,7 +8259,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
  "solana-rayon-threadlimit",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-reward-info",
  "solana-runtime-transaction",
  "solana-sdk-ids",
@@ -8363,7 +8354,7 @@ dependencies = [
  "solana-message",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-sbf-rust-invoke-dep",
@@ -9453,7 +9444,7 @@ dependencies = [
  "solana-program-pack",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-svm-callback",
  "solana-svm-feature-set",
@@ -9523,7 +9514,7 @@ dependencies = [
  "solana-precompile-error",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-svm",
  "solana-svm-callback",
@@ -9698,7 +9689,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-memory",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-slot-hashes",
@@ -9754,7 +9745,7 @@ dependencies = [
  "solana-program-runtime",
  "solana-program-test",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-rpc",
  "solana-rpc-client",
  "solana-rpc-client-api",
@@ -9873,7 +9864,7 @@ dependencies = [
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
 ]
@@ -10100,9 +10091,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "5.0.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b4fb47dbad5a777e08ac4b1259e1fc5839c2e250512902a6d3b814f5c6040f"
+checksum = "d444ce30b6b4f9c281ba06061ea96638d063b53c2171b1e41ba02ebff79ed28f"
 dependencies = [
  "bincode",
  "cfg_eval",
@@ -10116,7 +10107,7 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
- "solana-rent 3.0.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-serde-varint",
  "solana-serialize-utils",
@@ -10141,7 +10132,7 @@ dependencies = [
  "solana-packet 4.1.0",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rent 4.1.0",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-slot-hashes",
  "solana-system-interface 3.1.0",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -168,7 +168,7 @@ solana-svm-type-overrides = { path = "../../svm-type-overrides", version = "=4.1
 solana-system-interface = { version = "=3.1", features = ["bincode"] }
 solana-sysvar = "=4.0.0"
 solana-vote = { path = "../../vote", version = "=4.1.0-alpha.0" }
-solana-vote-interface = "5.0.0"
+solana-vote-interface = "5.1.0"
 solana-vote-program = { path = "../../programs/vote", version = "=4.1.0-alpha.0" }
 test-case = "3.3.1"
 thiserror = "2.0"

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -2028,7 +2028,7 @@ mod tests {
                 &instruction_data,
                 transaction_accounts.clone(),
                 instruction_accounts.clone(),
-                error(InstructionError::UninitializedAccount),
+                error(InstructionError::InvalidAccountData),
             );
         }
     }
@@ -2861,7 +2861,7 @@ mod tests {
                     is_writable: false,
                 },
             ],
-            Err(InstructionError::UninitializedAccount),
+            Err(InstructionError::InvalidAccountData),
         );
 
         // Re-initialize with new fields.
@@ -4094,7 +4094,7 @@ mod tests {
         let vote_pubkey = solana_pubkey::new_rand();
         let vote_account = AccountSharedData::new(100, vote_state_size_of(), &id());
 
-        let expected_error = InstructionError::UninitializedAccount;
+        let expected_error = InstructionError::InvalidAccountData;
 
         let features = VoteProgramFeatures {
             ..Default::default()
@@ -4552,7 +4552,7 @@ mod tests {
                 (source_pubkey, source_account.clone()),
             ],
             instruction_accounts.clone(),
-            Err(InstructionError::UninitializedAccount),
+            Err(InstructionError::InvalidAccountData),
         );
 
         // Fail - Vote account is initialized but V3 (not V4).


### PR DESCRIPTION
#### Problem
Bumps `solana-vote-interface` to 5.1, which includes this error code change: https://github.com/anza-xyz/solana-sdk/pull/447

I initially worried this might be a consensus-breaking change, and detailed those thoughts in [this now-closed SDK PR](https://github.com/anza-xyz/solana-sdk/pull/600), however @joncinque and I affirmed the change is safe.

Here's some more context on [transaction error codes and consensus](https://gist.github.com/buffalojoec/6b463e94637deeb2e82af434214ecc64), for those interested.

#### Summary of Changes
Bumps `solana-vote-interface` to 5.1, which includes this error code change: https://github.com/anza-xyz/solana-sdk/pull/447