### PR TITLE
chore(deps): bump wincode to 0.5.1 and SDK crates to compatible versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
  "qualifier_attr",
  "rayon",
  "solana-bls-signatures",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-signer-store",
  "thiserror 2.0.18",
  "wincode",
@@ -88,7 +88,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-pubkey 4.2.0",
  "solana-sha256-hasher",
@@ -117,7 +117,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "log",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-signature",
  "solana-transaction",
@@ -147,7 +147,7 @@ dependencies = [
  "serde_yaml",
  "solana-clap-utils",
  "solana-config-interface",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-pubkey 4.2.0",
@@ -227,7 +227,7 @@ dependencies = [
  "assert_matches",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sha256-hasher",
  "test-case",
 ]
@@ -289,7 +289,7 @@ dependencies = [
  "solana-accounts-db",
  "solana-clock",
  "solana-genesis-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-lattice-hash",
  "solana-measure",
  "solana-metrics",
@@ -316,7 +316,7 @@ dependencies = [
  "agave-transaction-view",
  "bincode",
  "criterion",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -327,7 +327,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-context",
  "wincode",
@@ -367,7 +367,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-clap-utils",
@@ -383,7 +383,7 @@ dependencies = [
  "solana-genesis-utils",
  "solana-geyser-plugin-manager",
  "solana-gossip",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-inflation",
  "solana-keypair",
  "solana-ledger",
@@ -406,7 +406,7 @@ dependencies = [
  "solana-signer",
  "solana-storage-bigtable",
  "solana-streamer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-test-validator",
  "solana-time-utils",
  "solana-tpu-client",
@@ -452,7 +452,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-gossip",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-ledger",
  "solana-measure",
@@ -487,13 +487,13 @@ dependencies = [
  "agave-votor-messages",
  "log",
  "serde",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-bls-signatures",
  "solana-clock",
  "solana-epoch-schedule",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-pubkey 4.2.0",
  "solana-signer-store",
  "tempfile",
@@ -512,7 +512,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-cli-config",
  "solana-cli-output",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-metrics",
  "solana-native-token",
  "solana-notifier",
@@ -6747,9 +6747,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862b95723ec6f2a27451d2fc7f4f8cf1f80a79627dcfed63879aac4ea5fe3bc2"
+checksum = "2bbea62563f5143b29fff5aa6af57426bc1beb77c6416b5c1c8e7d1266272c21"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -6778,14 +6778,14 @@ dependencies = [
  "bv",
  "serde",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface",
  "solana-clock",
  "solana-config-interface",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-loader-v3-interface",
  "solana-nonce",
@@ -6817,7 +6817,7 @@ dependencies = [
  "bs58",
  "serde",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-pubkey 4.2.0",
  "zstd",
 ]
@@ -6830,7 +6830,7 @@ checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
  "bincode",
  "serde_core",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-program-error",
  "solana-program-memory",
 ]
@@ -6853,7 +6853,7 @@ dependencies = [
  "solana-core",
  "solana-faucet",
  "solana-gossip",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-local-cluster",
@@ -6869,7 +6869,7 @@ dependencies = [
  "solana-runtime",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-test-validator",
  "solana-transaction",
  "solana-transaction-status",
@@ -6907,7 +6907,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "smallvec",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-bucket-map",
@@ -6916,7 +6916,7 @@ dependencies = [
  "solana-fee-calculator",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-lattice-hash",
@@ -6936,7 +6936,7 @@ dependencies = [
  "solana-slot-history",
  "solana-stake-interface",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-time-utils",
  "solana-transaction",
@@ -6959,14 +6959,14 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
 dependencies = [
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
 ]
 
 [[package]]
 name = "solana-address"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f08236dacd0e6dc8234becef58e27c8567856644ef509d7e97957d55a91dc72"
+checksum = "f1384b52c435a750cc9c538760fc7bb472fd78e65a9900a2d07312c5bb335b72"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -6992,9 +6992,9 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-interface"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8df0b083c10ce32490410f3795016b1b5d9b4d094658c0a5e496753645b7cd"
+checksum = "115b4f773acc4f3f3cb986b0d335e9845c0368c82b0940410935bc11ae065578"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -7023,12 +7023,12 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "borsh",
  "futures 0.3.32",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-banks-interface",
  "solana-banks-server",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-program-pack",
  "solana-pubkey 4.2.0",
@@ -7036,7 +7036,7 @@ dependencies = [
  "solana-runtime",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-transaction",
  "solana-transaction-context",
@@ -7052,10 +7052,10 @@ name = "solana-banks-interface"
 version = "4.1.0-alpha.0"
 dependencies = [
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-pubkey 4.2.0",
  "solana-signature",
@@ -7073,11 +7073,11 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "futures 0.3.32",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-banks-interface",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-net-utils",
  "solana-pubkey 4.2.0",
@@ -7135,7 +7135,7 @@ checksum = "7116e1d942a2432ca3f514625104757ab8a56233787e95144c93950029e31176"
 dependencies = [
  "blake3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -7151,7 +7151,7 @@ dependencies = [
  "solana-bloom",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sanitize",
  "solana-sha256-hasher",
  "solana-signature",
@@ -7232,7 +7232,7 @@ dependencies = [
  "criterion",
  "qualifier_attr",
  "rand 0.9.2",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-bpf-loader-program",
  "solana-clock",
@@ -7257,7 +7257,7 @@ dependencies = [
  "solana-svm-measure",
  "solana-svm-type-overrides",
  "solana-syscalls",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction-context",
  "static_assertions",
  "test-case",
@@ -7269,7 +7269,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "assert_matches",
  "bincode",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bpf-loader-program",
  "solana-instruction",
  "solana-keypair",
@@ -7278,7 +7278,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-error",
 ]
@@ -7312,7 +7312,7 @@ dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-loader-v4-program",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
@@ -7348,7 +7348,7 @@ dependencies = [
  "solana-cluster-type",
  "solana-commitment-config",
  "solana-derivation-path",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-native-token",
@@ -7358,7 +7358,7 @@ dependencies = [
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "tempfile",
  "thiserror 2.0.18",
  "tiny-bip39",
@@ -7380,7 +7380,7 @@ dependencies = [
  "solana-cluster-type",
  "solana-commitment-config",
  "solana-derivation-path",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-native-token",
@@ -7391,7 +7391,7 @@ dependencies = [
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-zk-sdk 5.0.1",
  "tempfile",
  "thiserror 2.0.18",
@@ -7421,7 +7421,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-address-lookup-table-interface",
  "solana-bls-signatures",
@@ -7440,7 +7440,7 @@ dependencies = [
  "solana-feature-gate-interface",
  "solana-fee-calculator",
  "solana-fee-structure",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-loader-v3-interface",
@@ -7469,7 +7469,7 @@ dependencies = [
  "solana-slot-history",
  "solana-stake-interface",
  "solana-syscalls",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-test-validator",
  "solana-tpu-client",
  "solana-transaction",
@@ -7514,14 +7514,14 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-bincode",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-clock",
  "solana-epoch-info",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-packet 4.1.0",
@@ -7532,7 +7532,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-stake-interface",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-status",
@@ -7554,7 +7554,7 @@ dependencies = [
  "log",
  "solana-commitment-config",
  "solana-connection-cache",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-measure",
  "solana-message",
@@ -7599,7 +7599,7 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-runtime",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-test-validator",
  "solana-transaction-status",
@@ -7615,17 +7615,17 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19635cc703678bcb26eb6faee4a363c71f4a0d622c445d9b70c048c42f4cbcd3"
 dependencies = [
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-commitment-config",
  "solana-epoch-info",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
  "solana-pubkey 4.2.0",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-error",
 ]
@@ -7651,7 +7651,7 @@ checksum = "3a494cf8eda7d98d9f0144b288bb409c88308d2e86f15cc1045aa77b83304718"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -7685,7 +7685,7 @@ dependencies = [
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-compute-budget-interface",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -7695,7 +7695,7 @@ dependencies = [
  "solana-signer",
  "solana-stake-interface",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-error",
 ]
@@ -7824,7 +7824,7 @@ dependencies = [
  "shaq",
  "signal-hook",
  "slab",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-bincode",
@@ -7851,7 +7851,7 @@ dependencies = [
  "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-hard-forks",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-leader-schedule",
@@ -7889,7 +7889,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-program",
  "solana-system-transaction",
  "solana-sysvar",
@@ -7944,7 +7944,7 @@ dependencies = [
  "solana-fee-structure",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -7956,7 +7956,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-program",
  "solana-system-transaction",
  "solana-transaction",
@@ -8094,11 +8094,11 @@ dependencies = [
  "rand 0.9.2",
  "rayon",
  "smallvec",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-bls-signatures",
  "solana-clock",
  "solana-entry",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-measure",
  "solana-merkle-tree",
@@ -8135,7 +8135,7 @@ checksum = "f5e7b0ba210593ba8ddd39d6d234d81795d1671cebf3026baa10d5dc23ac42f0"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -8148,8 +8148,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee8beac9bff4db9225e57d532d169b0be5e447f1e6601a2f50f27a01bf5518f"
 dependencies = [
  "siphasher 0.3.11",
- "solana-address 2.5.0",
- "solana-hash 4.2.0",
+ "solana-address 2.6.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -8185,12 +8185,12 @@ checksum = "0eb265ff95e28eceda117e2e3d2d2a611ecbbfe911dfeeeecd1521814540ffab"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-nonce",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -8202,7 +8202,7 @@ dependencies = [
  "log",
  "solana-cli-output",
  "solana-faucet",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -8211,7 +8211,7 @@ dependencies = [
  "solana-packet 4.1.0",
  "solana-pubkey 4.2.0",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-transaction",
  "spl-memo-interface",
@@ -8245,14 +8245,14 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 4.2.0",
  "solana-rent 4.1.0",
  "solana-sdk-ids",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
@@ -8266,9 +8266,9 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-calculator"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2a5675b2cf8d407c672dc1776492b1f382337720ddf566645ae43237a3d8c3"
+checksum = "57e8add96b5741573e9f7529c4bb7719cfcfa999c3847a68cdfaef0cb6adf567"
 dependencies = [
  "log",
  "serde",
@@ -8351,7 +8351,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bls-signatures",
  "solana-borsh",
  "solana-clap-utils",
@@ -8399,12 +8399,12 @@ dependencies = [
  "memmap2 0.5.10",
  "serde",
  "serde_derive",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-clock",
  "solana-cluster-type",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-inflation",
  "solana-keypair",
  "solana-poh-config",
@@ -8425,7 +8425,7 @@ dependencies = [
  "log",
  "solana-download-utils",
  "solana-genesis-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-rpc-client",
  "thiserror 2.0.18",
 ]
@@ -8443,11 +8443,11 @@ dependencies = [
  "libloading",
  "log",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-clock",
  "solana-entry",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-ledger",
  "solana-measure",
  "solana-message",
@@ -8500,7 +8500,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-gossip",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-ledger",
  "solana-measure",
@@ -8564,14 +8564,14 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "337c246447142f660f778cf6cb582beba8e28deb05b3b24bfb9ffd7c562e5f41"
 dependencies = [
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
 name = "solana-hash"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8064ea1d591ec791be95245058ca40f4f5345d390c200069d0f79bbf55bfae55"
+checksum = "f1b113239362cee7093bfb250467138f079a2a03673181dc15bff6ccd677912d"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -8600,17 +8600,15 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97881335fc698deb46c6571945969aae6d93a14e2fff792a368b4fac872f116"
+checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
 dependencies = [
  "bincode",
  "borsh",
  "serde",
  "serde_derive",
  "solana-define-syscall 5.0.0",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
  "wincode",
@@ -8656,7 +8654,7 @@ checksum = "ed1c0d16d6fdeba12291a1f068cdf0d479d9bff1141bf44afd7aa9d485f65ef8"
 dependencies = [
  "sha3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -8696,7 +8694,7 @@ dependencies = [
  "five8",
  "five8_core",
  "rand 0.9.2",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-derivation-path",
  "solana-seed-derivable",
  "solana-seed-phrase",
@@ -8788,7 +8786,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_bytes",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
@@ -8801,7 +8799,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-genesis-config",
  "solana-genesis-utils",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-leader-schedule",
@@ -8832,7 +8830,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
@@ -8904,7 +8902,7 @@ name = "solana-loader-v4-program"
 version = "4.1.0-alpha.0"
 dependencies = [
  "bincode",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-bpf-loader-program",
  "solana-clock",
@@ -8941,7 +8939,7 @@ dependencies = [
  "rand 0.9.2",
  "rayon",
  "serial_test",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-client",
  "solana-client-traits",
@@ -8958,7 +8956,7 @@ dependencies = [
  "solana-genesis-utils",
  "solana-gossip",
  "solana-hard-forks",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-leader-schedule",
  "solana-ledger",
@@ -8981,7 +8979,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-stake-interface",
  "solana-streamer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-tpu-client",
@@ -9008,22 +9006,22 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "fast-math",
  "hex",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sha256-hasher",
 ]
 
 [[package]]
 name = "solana-message"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6435a6070b6c5898201aae845db328cf3bd3cebc17b55af9b43138da5ced4a85"
+checksum = "cf3349552a323d44d8936b81f003ea7a2fea8566684ebf0dc25d34ad4df2b103"
 dependencies = [
  "blake3",
  "lazy_static",
  "serde",
  "serde_derive",
- "solana-address 2.5.0",
- "solana-hash 4.2.0",
+ "solana-address 2.6.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-sanitize",
  "solana-sdk-ids",
@@ -9101,14 +9099,14 @@ checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 
 [[package]]
 name = "solana-nonce"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc469152a63284ef959b80c59cda015262a021da55d3b8fe42171d89c4b64f8"
+checksum = "d95dbc9f2e33b6c10e231df15cb2a3bff9ea7eab6347f9e316fe75c97fd67bbb"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-pubkey 4.2.0",
  "solana-sha256-hasher",
  "wincode",
@@ -9116,12 +9114,12 @@ dependencies = [
 
 [[package]]
 name = "solana-nonce-account"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964f9fa300e4c4d8c02f747736fdffc7612ebd583a46e07cacb0dad118ba91eb"
+checksum = "cda945f4ccb317791c26379ca8ec410c5938aa7a5eff211fe5fe0bb428c3a75f"
 dependencies = [
- "solana-account 4.1.0",
- "solana-hash 4.2.0",
+ "solana-account 4.2.0",
+ "solana-hash 4.3.0",
  "solana-nonce",
  "solana-sdk-ids",
  "wincode",
@@ -9134,7 +9132,7 @@ dependencies = [
  "log",
  "reqwest 0.12.28",
  "serde_json",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -9212,7 +9210,7 @@ dependencies = [
  "solana-clock",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-metrics",
@@ -9223,7 +9221,7 @@ dependencies = [
  "solana-short-vec",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
@@ -9252,7 +9250,7 @@ dependencies = [
  "shuttle",
  "solana-clock",
  "solana-entry",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-leader-schedule",
  "solana-ledger",
@@ -9347,7 +9345,7 @@ dependencies = [
  "solana-epoch-stake",
  "solana-example-mocks",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-instructions-sysvar",
@@ -9380,7 +9378,7 @@ name = "solana-program-binaries"
 version = "4.1.0-alpha.0"
 dependencies = [
  "bincode",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-loader-v3-interface",
  "solana-pubkey 4.2.0",
  "solana-rent 4.1.0",
@@ -9449,7 +9447,7 @@ dependencies = [
  "qualifier_attr",
  "rand 0.9.2",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-clock",
  "solana-epoch-rewards",
@@ -9457,7 +9455,7 @@ dependencies = [
  "solana-fee-structure",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-keypair",
@@ -9481,7 +9479,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction",
@@ -9503,10 +9501,10 @@ dependencies = [
  "chrono-humanize",
  "log",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-accounts-db",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-banks-client",
  "solana-banks-interface",
  "solana-banks-server",
@@ -9519,7 +9517,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-fee-calculator",
  "solana-genesis-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-loader-v3-interface",
@@ -9542,7 +9540,7 @@ dependencies = [
  "solana-stake-interface",
  "solana-svm-log-collector",
  "solana-svm-timings",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction",
@@ -9571,7 +9569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
 dependencies = [
  "rand 0.9.2",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
 ]
 
 [[package]]
@@ -9721,7 +9719,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "soketto",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
@@ -9740,7 +9738,7 @@ dependencies = [
  "solana-fee-structure",
  "solana-genesis-config",
  "solana-gossip",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-ledger",
@@ -9773,7 +9771,7 @@ dependencies = [
  "solana-storage-bigtable",
  "solana-svm",
  "solana-svm-log-collector",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-time-utils",
@@ -9819,7 +9817,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-account-decoder-client-types",
  "solana-clock",
@@ -9827,7 +9825,7 @@ dependencies = [
  "solana-epoch-info",
  "solana-epoch-schedule",
  "solana-feature-gate-interface",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -9873,12 +9871,12 @@ dependencies = [
  "clap 2.33.3",
  "futures 0.3.32",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-clap-utils",
  "solana-commitment-config",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-nonce",
@@ -9888,7 +9886,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sha256-hasher",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "thiserror 2.0.18",
  "tokio",
@@ -9905,7 +9903,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-clock",
  "solana-commitment-config",
  "solana-fee-calculator",
@@ -9938,7 +9936,7 @@ dependencies = [
  "solana-clock",
  "solana-commitment-config",
  "solana-connection-cache",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-net-utils",
  "solana-pubkey 4.2.0",
@@ -10004,7 +10002,7 @@ dependencies = [
  "serde_with",
  "shuttle",
  "smallvec",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
@@ -10033,7 +10031,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-genesis-config",
  "solana-hard-forks",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-inflation",
  "solana-instruction",
  "solana-instruction-error",
@@ -10075,7 +10073,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-syscalls",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-sysvar-id",
@@ -10113,7 +10111,7 @@ dependencies = [
  "rand 0.9.2",
  "solana-compute-budget-instruction",
  "solana-compute-budget-interface",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -10123,7 +10121,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-transaction",
  "solana-transaction-context",
@@ -10162,7 +10160,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
 dependencies = [
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
 ]
 
 [[package]]
@@ -10246,10 +10244,10 @@ dependencies = [
  "crossbeam-channel",
  "itertools 0.14.0",
  "log",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-fee-calculator",
  "solana-genesis-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
@@ -10260,7 +10258,7 @@ dependencies = [
  "solana-runtime",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-tls-utils",
@@ -10306,7 +10304,7 @@ checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
 dependencies = [
  "sha2 0.10.9",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -10327,15 +10325,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6c79722e299d957958bf33695f7cd1ef6724ff55563c60fd9e3e24487cccde2"
 dependencies = [
  "solana-hard-forks",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sha256-hasher",
 ]
 
 [[package]]
 name = "solana-signature"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132a93134f1262aa832f1849b83bec6c9945669b866da18661a427943b9e801e"
+checksum = "e7a73c6e97cc2108be0adf6a6ea326434f8398df9d7eed81da2a4548b69e971c"
 dependencies = [
  "ed25519-dalek 2.2.0",
  "five8",
@@ -10379,7 +10377,7 @@ checksum = "2585f70191623887329dfb5078da3a00e15e3980ea67f42c2e10b07028419f43"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sdk-ids",
  "solana-sysvar-id",
 ]
@@ -10412,7 +10410,7 @@ name = "solana-stake-accounts"
 version = "4.1.0-alpha.0"
 dependencies = [
  "clap 2.33.3",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-cli-output",
@@ -10456,7 +10454,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 4.2.0",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-sysvar-id",
 ]
@@ -10481,7 +10479,7 @@ dependencies = [
  "serde",
  "smpl_jwt",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-metrics",
@@ -10513,7 +10511,7 @@ dependencies = [
  "protobuf-src",
  "serde",
  "solana-account-decoder",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-message",
  "solana-pubkey 4.2.0",
@@ -10585,7 +10583,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "shuttle",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bpf-loader-program",
  "solana-clock",
  "solana-compute-budget",
@@ -10597,7 +10595,7 @@ dependencies = [
  "solana-fee-structure",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-keypair",
@@ -10630,7 +10628,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-svm-type-overrides",
  "solana-syscalls",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-program",
  "solana-system-transaction",
  "solana-sysvar",
@@ -10648,7 +10646,7 @@ dependencies = [
 name = "solana-svm-callback"
 version = "4.1.0-alpha.0"
 dependencies = [
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-clock",
  "solana-precompile-error",
  "solana-pubkey 4.2.0",
@@ -10682,13 +10680,13 @@ dependencies = [
 name = "solana-svm-transaction"
 version = "4.1.0-alpha.0"
 dependencies = [
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-nonce",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-signature",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "static_assertions",
  "test-case",
@@ -10711,7 +10709,7 @@ dependencies = [
  "bincode",
  "libsecp256k1",
  "num-traits",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-big-mod-exp",
  "solana-blake3-hasher",
@@ -10723,7 +10721,7 @@ dependencies = [
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keccak-hasher",
  "solana-last-restart-slot",
@@ -10767,14 +10765,14 @@ dependencies = [
 
 [[package]]
 name = "solana-system-interface"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95a6f2e23ed861d6444ad4a6d6896c418d7d101b960787e65a8e33157cee81b"
+checksum = "55b54965bf0b76fa8e2b35376583efddd4d916618cfe595bf48c7d7b55a9e628"
 dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-instruction",
  "solana-msg",
  "solana-program-error",
@@ -10789,11 +10787,11 @@ dependencies = [
  "bincode",
  "criterion",
  "log",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-compute-budget",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-nonce",
  "solana-nonce-account",
@@ -10806,7 +10804,7 @@ dependencies = [
  "solana-svm-callback",
  "solana-svm-feature-set",
  "solana-svm-log-collector",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-program",
  "solana-sysvar",
  "solana-transaction-context",
@@ -10818,12 +10816,12 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a39522012be4127884bc611d65f58f1cf33a3afb7baee7e6774be90b48edc3c"
 dependencies = [
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-pubkey 4.2.0",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
 ]
 
@@ -10848,7 +10846,7 @@ dependencies = [
  "solana-fee-calculator",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
@@ -10869,7 +10867,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
 dependencies = [
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-sdk-ids",
 ]
 
@@ -10885,7 +10883,7 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-cli-output",
  "solana-clock",
@@ -10967,7 +10965,7 @@ dependencies = [
  "solana-cli-output",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -10982,7 +10980,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-stake-interface",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-test-validator",
  "solana-transaction",
  "solana-transaction-error",
@@ -10999,14 +10997,14 @@ name = "solana-tps-client"
 version = "4.1.0-alpha.0"
 dependencies = [
  "log",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-client",
  "solana-client-traits",
  "solana-clock",
  "solana-commitment-config",
  "solana-connection-cache",
  "solana-epoch-info",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-net-utils",
@@ -11091,14 +11089,14 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc0d18f4f109cc1777459271800755705ca6d1aba319934611e1d4f6bb162b5"
+checksum = "a6aefe6edf26c6daa57f6caa1af119083abeaaf177a4ba38b4b492ca2ff2f7fd"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-address 2.5.0",
- "solana-hash 4.2.0",
+ "solana-address 2.6.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-message",
@@ -11118,7 +11116,7 @@ dependencies = [
  "bincode",
  "qualifier_attr",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-instruction",
  "solana-instructions-sysvar",
@@ -11128,7 +11126,7 @@ dependencies = [
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-signature",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction-context",
  "static_assertions",
  "wincode",
@@ -11136,9 +11134,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8396904805b0b385b9de115a652fe80fd01e5b98ce0513f4fcd8184ada9bb792"
+checksum = "4a2165ad25b694c654d5395fc7a049452a192376e4c96a7fad05580f6ba5ba1c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -11165,7 +11163,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-address-lookup-table-interface",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-loader-v2-interface",
  "solana-loader-v3-interface",
@@ -11176,7 +11174,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signature",
  "solana-stake-interface",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status",
@@ -11240,7 +11238,7 @@ dependencies = [
  "solana-entry",
  "solana-genesis-config",
  "solana-gossip",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-ledger",
  "solana-measure",
@@ -11286,7 +11284,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "assert_matches",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-message",
  "solana-pubkey 4.2.0",
@@ -11315,7 +11313,7 @@ dependencies = [
  "solana-clock",
  "solana-cost-model",
  "solana-entry",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-ledger",
  "solana-metrics",
@@ -11368,12 +11366,12 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-clock",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-packet 4.1.0",
@@ -11409,7 +11407,7 @@ dependencies = [
  "solana-clock",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
@@ -11418,7 +11416,7 @@ dependencies = [
  "solana-serde-varint",
  "solana-serialize-utils",
  "solana-short-vec",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
@@ -11431,7 +11429,7 @@ dependencies = [
  "bincode",
  "criterion",
  "log",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-bls-signatures",
  "solana-clock",
@@ -11439,7 +11437,7 @@ dependencies = [
  "solana-fee-calculator",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-packet 4.1.0",
  "solana-program-runtime",
@@ -11449,7 +11447,7 @@ dependencies = [
  "solana-sha256-hasher",
  "solana-slot-hashes",
  "solana-svm-feature-set",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-program",
  "solana-transaction-context",
  "solana-vote-interface",
@@ -11487,7 +11485,7 @@ name = "solana-zk-elgamal-proof-program-tests"
 version = "4.1.0-alpha.0"
 dependencies = [
  "bytemuck",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-compute-budget",
  "solana-compute-budget-interface",
  "solana-instruction",
@@ -11495,7 +11493,7 @@ dependencies = [
  "solana-program-test",
  "solana-pubkey 4.2.0",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-error",
  "solana-zk-sdk 5.0.1",
@@ -11559,7 +11557,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha3",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-derivation-path",
  "solana-instruction",
  "solana-sdk-ids",
@@ -11751,7 +11749,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-instruction",
  "solana-nullable",
  "solana-program-error",
@@ -13028,9 +13026,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.4.9"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657690780ce23e6f66576a782ffd88eb353512381817029cc1d7a99154bb6d1f"
+checksum = "a61f8f0a55eb6cae5d7b7ad2eca536a944deb9722a948525181069064ecd1abc"
 dependencies = [
  "bytes",
  "pastey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -362,8 +362,8 @@ solana-account-decoder = { path = "account-decoder", version = "=4.1.0-alpha.0",
 solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-account-info = "3.1.1"
 solana-accounts-db = { path = "accounts-db", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-address = "2.5.0"
-solana-address-lookup-table-interface = "3.0.1"
+solana-address = "2.6.0"
+solana-address-lookup-table-interface = "3.1.0"
 solana-banks-client = { path = "banks-client", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-banks-interface = { path = "banks-interface", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-banks-server = { path = "banks-server", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -409,7 +409,7 @@ solana-epoch-schedule = "3.0.0"
 solana-faucet = { path = "faucet", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-feature-gate-interface = "4.0.0"
 solana-fee = { path = "fee", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-fee-calculator = "3.1.0"
+solana-fee-calculator = "3.2.0"
 solana-fee-structure = "3.0.0"
 solana-file-download = "3.1.4"
 solana-frozen-abi = "3.2.2"
@@ -420,9 +420,9 @@ solana-genesis-utils = { path = "genesis-utils", version = "=4.1.0-alpha.0", fea
 solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-gossip = { path = "gossip", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-hard-forks = "3.0.1"
-solana-hash = "4.2.0"
+solana-hash = "4.3.0"
 solana-inflation = "3.0.0"
-solana-instruction = "3.3.0"
+solana-instruction = "3.4.0"
 solana-instruction-error = "2.3.0"
 solana-instructions-sysvar = "3.0.0"
 solana-keccak-hasher = "3.1.0"
@@ -438,14 +438,14 @@ solana-loader-v4-program = { path = "programs/loader-v4", version = "=4.1.0-alph
 solana-local-cluster = { path = "local-cluster", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-measure = { path = "measure", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-merkle-tree = { path = "merkle-tree", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-message = "4.0.0"
+solana-message = "4.1.0"
 solana-metrics = { path = "metrics", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-msg = "3.1.0"
 solana-native-token = "3.0.0"
 solana-net-utils = { path = "net-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-nohash-hasher = "0.2.1"
-solana-nonce = "3.1.0"
-solana-nonce-account = "4.0.0"
+solana-nonce = "3.2.0"
+solana-nonce-account = "4.1.0"
 solana-notifier = { path = "notifier", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-offchain-message = "3.0.0"
 solana-packet = "4.1.0"
@@ -492,7 +492,7 @@ solana-serialize-utils = "3.1.1"
 solana-sha256-hasher = "3.1.0"
 solana-short-vec = "3.2.0"
 solana-shred-version = "3.0.1"
-solana-signature = { version = "3.3.0", default-features = false }
+solana-signature = { version = "3.4.0", default-features = false }
 solana-signer = "3.0.0"
 solana-signer-store = "0.1.0"
 solana-slot-hashes = "3.0.1"
@@ -511,7 +511,7 @@ solana-svm-timings = { path = "svm-timings", version = "=4.1.0-alpha.0", feature
 solana-svm-transaction = { path = "svm-transaction", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm-type-overrides = { path = "svm-type-overrides", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-syscalls = { path = "syscalls", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
-solana-system-interface = { version = "3.1", features = ["alloc", "bincode", "serde", "wincode"] }
+solana-system-interface = { version = "3.2", features = ["alloc", "bincode", "serde", "wincode"] }
 solana-system-program = { path = "programs/system", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-system-transaction = "4.0.0"
 solana-sysvar = "4.0.0"
@@ -521,9 +521,9 @@ solana-time-utils = "3.0.0"
 solana-tls-utils = { path = "tls-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-tpu-client = { path = "tpu-client", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-tpu-client-next = { path = "tpu-client-next", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-transaction = "4.0.0"
+solana-transaction = "4.1.0"
 solana-transaction-context = { path = "transaction-context", version = "=4.1.0-alpha.0", features = ["agave-unstable-api", "bincode"] }
-solana-transaction-error = "3.1.0"
+solana-transaction-error = "3.2.0"
 solana-transaction-status = { path = "transaction-status", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-turbine = { path = "turbine", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -578,7 +578,7 @@ unwrap_none = "0.1.2"
 uriparse = "0.6.4"
 url = "2.5.8"
 winapi = "0.3.8"
-wincode = { version = "0.4.9", features = ["derive", "solana-short-vec"] }
+wincode = { version = "0.5.1", features = ["derive", "solana-short-vec"] }
 winreg = "0.55"
 x509-parser = "0.18.1"
 zstd = "0.13.3"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -82,7 +82,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-pubkey 4.2.0",
  "solana-sha256-hasher",
@@ -108,7 +108,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "log",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-signature",
  "solana-transaction",
@@ -153,7 +153,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "signal-hook",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-clap-utils",
@@ -167,7 +167,7 @@ dependencies = [
  "solana-genesis-config",
  "solana-genesis-utils",
  "solana-geyser-plugin-manager",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-inflation",
  "solana-instruction",
  "solana-keypair",
@@ -192,7 +192,7 @@ dependencies = [
  "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-syscalls",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-status",
@@ -296,7 +296,7 @@ dependencies = [
  "solana-accounts-db",
  "solana-clock",
  "solana-genesis-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-lattice-hash",
  "solana-measure",
  "solana-metrics",
@@ -315,10 +315,10 @@ dependencies = [
  "ahash 0.8.12",
  "clap 2.34.0",
  "rayon",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-pubkey 4.2.0",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-version",
 ]
 
@@ -326,7 +326,7 @@ dependencies = [
 name = "agave-transaction-view"
 version = "4.1.0-alpha.0"
 dependencies = [
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-packet 4.1.0",
  "solana-pubkey 4.2.0",
@@ -362,7 +362,7 @@ dependencies = [
  "solana-connection-cache",
  "solana-epoch-schedule",
  "solana-gossip",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-ledger",
  "solana-measure",
@@ -390,11 +390,11 @@ dependencies = [
  "agave-feature-set",
  "log",
  "serde",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-bls-signatures",
  "solana-clock",
  "solana-epoch-schedule",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-pubkey 4.2.0",
  "solana-signer-store",
  "thiserror 2.0.18",
@@ -6079,9 +6079,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862b95723ec6f2a27451d2fc7f4f8cf1f80a79627dcfed63879aac4ea5fe3bc2"
+checksum = "2bbea62563f5143b29fff5aa6af57426bc1beb77c6416b5c1c8e7d1266272c21"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -6107,7 +6107,7 @@ dependencies = [
  "bv",
  "serde",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface",
  "solana-clock",
@@ -6144,7 +6144,7 @@ dependencies = [
  "bs58",
  "serde",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-pubkey 4.2.0",
  "zstd",
 ]
@@ -6155,7 +6155,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-program-error",
  "solana-program-memory",
 ]
@@ -6180,13 +6180,13 @@ dependencies = [
  "seqlock",
  "serde",
  "smallvec",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-address-lookup-table-interface",
  "solana-bucket-map",
  "solana-clock",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-lattice-hash",
  "solana-measure",
@@ -6201,7 +6201,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-stake-interface",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-time-utils",
  "solana-transaction",
@@ -6219,14 +6219,14 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
 dependencies = [
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
 ]
 
 [[package]]
 name = "solana-address"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f08236dacd0e6dc8234becef58e27c8567856644ef509d7e97957d55a91dc72"
+checksum = "f1384b52c435a750cc9c538760fc7bb472fd78e65a9900a2d07312c5bb335b72"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -6249,9 +6249,9 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-interface"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8df0b083c10ce32490410f3795016b1b5d9b4d094658c0a5e496753645b7cd"
+checksum = "115b4f773acc4f3f3cb986b0d335e9845c0368c82b0940410935bc11ae065578"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6280,11 +6280,11 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "borsh",
  "futures 0.3.32",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-banks-interface",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-program-pack",
  "solana-pubkey 4.2.0",
@@ -6305,10 +6305,10 @@ name = "solana-banks-interface"
 version = "4.1.0-alpha.0"
 dependencies = [
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-pubkey 4.2.0",
  "solana-signature",
@@ -6326,11 +6326,11 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "futures 0.3.32",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-banks-interface",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-net-utils",
  "solana-pubkey 4.2.0",
@@ -6363,7 +6363,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
@@ -6376,7 +6376,7 @@ dependencies = [
  "solana-fee-calculator",
  "solana-genesis",
  "solana-genesis-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-local-cluster",
@@ -6397,7 +6397,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-streamer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-test-validator",
  "solana-time-utils",
  "solana-tps-client",
@@ -6440,7 +6440,7 @@ checksum = "7116e1d942a2432ca3f514625104757ab8a56233787e95144c93950029e31176"
 dependencies = [
  "blake3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -6522,7 +6522,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "bincode",
  "qualifier_attr",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-clock",
  "solana-instruction",
@@ -6538,7 +6538,7 @@ dependencies = [
  "solana-svm-measure",
  "solana-svm-type-overrides",
  "solana-syscalls",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction-context",
 ]
 
@@ -6567,7 +6567,7 @@ dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-loader-v4-program",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
@@ -6600,7 +6600,7 @@ dependencies = [
  "solana-cluster-type",
  "solana-commitment-config",
  "solana-derivation-path",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-native-token",
@@ -6644,14 +6644,14 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-bincode",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-clock",
  "solana-epoch-info",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-packet 4.1.0",
  "solana-pubkey 4.2.0",
@@ -6659,7 +6659,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signature",
  "solana-stake-interface",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-status",
  "solana-transaction-status-client-types",
@@ -6679,7 +6679,7 @@ dependencies = [
  "log",
  "solana-commitment-config",
  "solana-connection-cache",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-measure",
  "solana-message",
@@ -6708,17 +6708,17 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19635cc703678bcb26eb6faee4a363c71f4a0d622c445d9b70c048c42f4cbcd3"
 dependencies = [
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-commitment-config",
  "solana-epoch-info",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
  "solana-pubkey 4.2.0",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-error",
 ]
@@ -6744,7 +6744,7 @@ checksum = "3a494cf8eda7d98d9f0144b288bb409c88308d2e86f15cc1045aa77b83304718"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -6884,7 +6884,7 @@ dependencies = [
  "shaq",
  "signal-hook",
  "slab",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-bincode",
@@ -6905,7 +6905,7 @@ dependencies = [
  "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-hard-forks",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-leader-schedule",
@@ -6938,7 +6938,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-time-utils",
@@ -6987,7 +6987,7 @@ dependencies = [
  "solana-runtime-transaction",
  "solana-sdk-ids",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction-error",
  "solana-vote-program",
 ]
@@ -7098,10 +7098,10 @@ dependencies = [
  "num_cpus",
  "rayon",
  "smallvec",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-bls-signatures",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-measure",
  "solana-merkle-tree",
  "solana-message",
@@ -7134,7 +7134,7 @@ checksum = "f5e7b0ba210593ba8ddd39d6d234d81795d1671cebf3026baa10d5dc23ac42f0"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -7147,8 +7147,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee8beac9bff4db9225e57d532d169b0be5e447f1e6601a2f50f27a01bf5518f"
 dependencies = [
  "siphasher 0.3.11",
- "solana-address 2.5.0",
- "solana-hash 4.2.0",
+ "solana-address 2.6.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -7171,7 +7171,7 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "solana-cli-output",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -7180,7 +7180,7 @@ dependencies = [
  "solana-packet 4.1.0",
  "solana-pubkey 4.2.0",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-transaction",
  "spl-memo-interface",
@@ -7198,14 +7198,14 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 4.2.0",
  "solana-rent",
  "solana-sdk-ids",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
@@ -7219,9 +7219,9 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-calculator"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2a5675b2cf8d407c672dc1776492b1f382337720ddf566645ae43237a3d8c3"
+checksum = "57e8add96b5741573e9f7529c4bb7719cfcfa999c3847a68cdfaef0cb6adf567"
 dependencies = [
  "log",
  "serde",
@@ -7265,7 +7265,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bls-signatures",
  "solana-clap-utils",
  "solana-cli-config",
@@ -7309,12 +7309,12 @@ dependencies = [
  "memmap2 0.5.10",
  "serde",
  "serde_derive",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-clock",
  "solana-cluster-type",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-inflation",
  "solana-keypair",
  "solana-poh-config",
@@ -7335,7 +7335,7 @@ dependencies = [
  "log",
  "solana-download-utils",
  "solana-genesis-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-rpc-client",
  "thiserror 2.0.18",
 ]
@@ -7353,11 +7353,11 @@ dependencies = [
  "libloading",
  "log",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-clock",
  "solana-entry",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-ledger",
  "solana-measure",
  "solana-message",
@@ -7402,7 +7402,7 @@ dependencies = [
  "solana-clock",
  "solana-entry",
  "solana-epoch-schedule",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-ledger",
  "solana-measure",
@@ -7447,14 +7447,14 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "337c246447142f660f778cf6cb582beba8e28deb05b3b24bfb9ffd7c562e5f41"
 dependencies = [
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
 name = "solana-hash"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8064ea1d591ec791be95245058ca40f4f5345d390c200069d0f79bbf55bfae55"
+checksum = "f1b113239362cee7093bfb250467138f079a2a03673181dc15bff6ccd677912d"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -7478,9 +7478,9 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97881335fc698deb46c6571945969aae6d93a14e2fff792a368b4fac872f116"
+checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
 dependencies = [
  "bincode",
  "borsh",
@@ -7530,7 +7530,7 @@ checksum = "ed1c0d16d6fdeba12291a1f068cdf0d479d9bff1141bf44afd7aa9d485f65ef8"
 dependencies = [
  "sha3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -7544,7 +7544,7 @@ dependencies = [
  "five8",
  "five8_core",
  "rand 0.9.2",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-derivation-path",
  "solana-seed-derivable",
  "solana-seed-phrase",
@@ -7625,7 +7625,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_bytes",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
@@ -7635,7 +7635,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-genesis-config",
  "solana-genesis-utils",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-leader-schedule",
@@ -7663,7 +7663,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
@@ -7731,7 +7731,7 @@ dependencies = [
 name = "solana-loader-v4-program"
 version = "4.1.0-alpha.0"
 dependencies = [
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-bpf-loader-program",
  "solana-instruction",
@@ -7762,7 +7762,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "rayon",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-client",
  "solana-client-traits",
@@ -7777,7 +7777,7 @@ dependencies = [
  "solana-genesis-config",
  "solana-gossip",
  "solana-hard-forks",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-leader-schedule",
  "solana-ledger",
@@ -7799,7 +7799,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-stake-interface",
  "solana-streamer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-tpu-client",
@@ -7825,22 +7825,22 @@ name = "solana-merkle-tree"
 version = "4.1.0-alpha.0"
 dependencies = [
  "fast-math",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sha256-hasher",
 ]
 
 [[package]]
 name = "solana-message"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6435a6070b6c5898201aae845db328cf3bd3cebc17b55af9b43138da5ced4a85"
+checksum = "cf3349552a323d44d8936b81f003ea7a2fea8566684ebf0dc25d34ad4df2b103"
 dependencies = [
  "blake3",
  "lazy_static",
  "serde",
  "serde_derive",
- "solana-address 2.5.0",
- "solana-hash 4.2.0",
+ "solana-address 2.6.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-sanitize",
  "solana-sdk-ids",
@@ -7907,14 +7907,14 @@ checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 
 [[package]]
 name = "solana-nonce"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc469152a63284ef959b80c59cda015262a021da55d3b8fe42171d89c4b64f8"
+checksum = "d95dbc9f2e33b6c10e231df15cb2a3bff9ea7eab6347f9e316fe75c97fd67bbb"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-pubkey 4.2.0",
  "solana-sha256-hasher",
  "wincode",
@@ -7922,12 +7922,12 @@ dependencies = [
 
 [[package]]
 name = "solana-nonce-account"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964f9fa300e4c4d8c02f747736fdffc7612ebd583a46e07cacb0dad118ba91eb"
+checksum = "cda945f4ccb317791c26379ca8ec410c5938aa7a5eff211fe5fe0bb428c3a75f"
 dependencies = [
- "solana-account 4.1.0",
- "solana-hash 4.2.0",
+ "solana-account 4.2.0",
+ "solana-hash 4.3.0",
  "solana-nonce",
  "solana-sdk-ids",
  "wincode",
@@ -7998,7 +7998,7 @@ dependencies = [
  "rayon",
  "serde",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-metrics",
@@ -8008,7 +8008,7 @@ dependencies = [
  "solana-short-vec",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
@@ -8029,7 +8029,7 @@ dependencies = [
  "qualifier_attr",
  "solana-clock",
  "solana-entry",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-leader-schedule",
  "solana-ledger",
  "solana-measure",
@@ -8090,7 +8090,7 @@ name = "solana-program-binaries"
 version = "4.1.0-alpha.0"
 dependencies = [
  "bincode",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-loader-v3-interface",
  "solana-pubkey 4.2.0",
  "solana-rent",
@@ -8155,13 +8155,13 @@ dependencies = [
  "percentage",
  "rand 0.9.2",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-clock",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-structure",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-loader-v3-interface",
@@ -8181,7 +8181,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction-context",
@@ -8201,10 +8201,10 @@ dependencies = [
  "chrono-humanize",
  "log",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-accounts-db",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-banks-client",
  "solana-banks-interface",
  "solana-banks-server",
@@ -8216,7 +8216,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-fee-calculator",
  "solana-genesis-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-loader-v3-interface",
@@ -8237,7 +8237,7 @@ dependencies = [
  "solana-stake-interface",
  "solana-svm-log-collector",
  "solana-svm-timings",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction",
@@ -8265,7 +8265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
 dependencies = [
  "rand 0.9.2",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
 ]
 
 [[package]]
@@ -8390,7 +8390,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-cli-output",
@@ -8404,7 +8404,7 @@ dependencies = [
  "solana-faucet",
  "solana-genesis-config",
  "solana-gossip",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-ledger",
  "solana-measure",
@@ -8425,7 +8425,7 @@ dependencies = [
  "solana-slot-history",
  "solana-storage-bigtable",
  "solana-svm",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-time-utils",
@@ -8463,7 +8463,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-account-decoder-client-types",
  "solana-clock",
@@ -8471,7 +8471,7 @@ dependencies = [
  "solana-epoch-info",
  "solana-epoch-schedule",
  "solana-feature-gate-interface",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-message",
  "solana-pubkey 4.2.0",
@@ -8507,9 +8507,9 @@ dependencies = [
 name = "solana-rpc-client-nonce-utils"
 version = "4.1.0-alpha.0"
 dependencies = [
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-commitment-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-nonce",
  "solana-pubkey 4.2.0",
@@ -8528,7 +8528,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-clock",
  "solana-commitment-config",
  "solana-fee-calculator",
@@ -8580,7 +8580,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smallvec",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
@@ -8607,7 +8607,7 @@ dependencies = [
  "solana-fee-structure",
  "solana-genesis-config",
  "solana-hard-forks",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-inflation",
  "solana-instruction",
  "solana-keypair",
@@ -8646,7 +8646,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-syscalls",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-sysvar-id",
@@ -8677,7 +8677,7 @@ dependencies = [
  "agave-feature-set",
  "agave-transaction-view",
  "solana-compute-budget-instruction",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
@@ -8718,7 +8718,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
 dependencies = [
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
 ]
 
 [[package]]
@@ -8798,7 +8798,7 @@ dependencies = [
  "crossbeam-channel",
  "itertools 0.14.0",
  "log",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
@@ -8850,7 +8850,7 @@ checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
 dependencies = [
  "sha2 0.10.9",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -8869,15 +8869,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6c79722e299d957958bf33695f7cd1ef6724ff55563c60fd9e3e24487cccde2"
 dependencies = [
  "solana-hard-forks",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sha256-hasher",
 ]
 
 [[package]]
 name = "solana-signature"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132a93134f1262aa832f1849b83bec6c9945669b866da18661a427943b9e801e"
+checksum = "e7a73c6e97cc2108be0adf6a6ea326434f8398df9d7eed81da2a4548b69e971c"
 dependencies = [
  "ed25519-dalek 2.2.0",
  "five8",
@@ -8918,7 +8918,7 @@ checksum = "2585f70191623887329dfb5078da3a00e15e3980ea67f42c2e10b07028419f43"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sdk-ids",
  "solana-sysvar-id",
 ]
@@ -8961,7 +8961,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 4.2.0",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-sysvar-id",
 ]
@@ -9013,7 +9013,7 @@ dependencies = [
  "protobuf-src",
  "serde",
  "solana-account-decoder",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-message",
  "solana-pubkey 4.2.0",
@@ -9071,10 +9071,10 @@ dependencies = [
  "percentage",
  "qualifier_attr",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-clock",
  "solana-fee-structure",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-loader-v3-interface",
@@ -9096,7 +9096,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar-id",
  "solana-transaction-context",
  "solana-transaction-error",
@@ -9108,7 +9108,7 @@ dependencies = [
 name = "solana-svm-callback"
 version = "4.1.0-alpha.0"
 dependencies = [
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-clock",
  "solana-precompile-error",
  "solana-pubkey 4.2.0",
@@ -9148,7 +9148,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-build 0.14.3",
  "protosol",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
@@ -9165,7 +9165,7 @@ dependencies = [
  "bincode",
  "env_logger",
  "prost 0.14.3",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bpf-loader-program",
  "solana-clock",
  "solana-compute-budget",
@@ -9203,7 +9203,7 @@ dependencies = [
 name = "solana-svm-transaction"
 version = "4.1.0-alpha.0"
 dependencies = [
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
@@ -9225,7 +9225,7 @@ dependencies = [
  "bincode",
  "libsecp256k1",
  "num-traits",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-big-mod-exp",
  "solana-blake3-hasher",
@@ -9234,7 +9234,7 @@ dependencies = [
  "solana-clock",
  "solana-cpi",
  "solana-curve25519 4.0.0",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keccak-hasher",
  "solana-poseidon",
@@ -9273,14 +9273,14 @@ dependencies = [
 
 [[package]]
 name = "solana-system-interface"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95a6f2e23ed861d6444ad4a6d6896c418d7d101b960787e65a8e33157cee81b"
+checksum = "55b54965bf0b76fa8e2b35376583efddd4d916618cfe595bf48c7d7b55a9e628"
 dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-instruction",
  "solana-msg",
  "solana-program-error",
@@ -9293,7 +9293,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "bincode",
  "log",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-fee-calculator",
  "solana-instruction",
@@ -9304,7 +9304,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-svm-log-collector",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-transaction-context",
 ]
@@ -9315,12 +9315,12 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a39522012be4127884bc611d65f58f1cf33a3afb7baee7e6774be90b48edc3c"
 dependencies = [
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-pubkey 4.2.0",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
 ]
 
@@ -9341,7 +9341,7 @@ dependencies = [
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
@@ -9362,7 +9362,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
 dependencies = [
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-sdk-ids",
 ]
 
@@ -9378,7 +9378,7 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-cli-output",
  "solana-clock",
@@ -9441,14 +9441,14 @@ name = "solana-tps-client"
 version = "4.1.0-alpha.0"
 dependencies = [
  "log",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-client",
  "solana-client-traits",
  "solana-clock",
  "solana-commitment-config",
  "solana-connection-cache",
  "solana-epoch-info",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-net-utils",
@@ -9523,14 +9523,14 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc0d18f4f109cc1777459271800755705ca6d1aba319934611e1d4f6bb162b5"
+checksum = "a6aefe6edf26c6daa57f6caa1af119083abeaaf177a4ba38b4b492ca2ff2f7fd"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-address 2.5.0",
- "solana-hash 4.2.0",
+ "solana-address 2.6.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-message",
@@ -9549,7 +9549,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "bincode",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-pubkey 4.2.0",
@@ -9560,9 +9560,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8396904805b0b385b9de115a652fe80fd01e5b98ce0513f4fcd8184ada9bb792"
+checksum = "4a2165ad25b694c654d5395fc7a049452a192376e4c96a7fad05580f6ba5ba1c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -9585,7 +9585,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-address-lookup-table-interface",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-loader-v2-interface",
  "solana-loader-v3-interface",
@@ -9596,7 +9596,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signature",
  "solana-stake-interface",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
@@ -9652,7 +9652,7 @@ dependencies = [
  "solana-cluster-type",
  "solana-entry",
  "solana-gossip",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-ledger",
  "solana-measure",
@@ -9694,7 +9694,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "assert_matches",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-pubkey 4.2.0",
  "solana-runtime-transaction",
  "solana-transaction",
@@ -9760,10 +9760,10 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-packet 4.1.0",
@@ -9792,7 +9792,7 @@ dependencies = [
  "serde_derive",
  "serde_with",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
@@ -9801,7 +9801,7 @@ dependencies = [
  "solana-serde-varint",
  "solana-serialize-utils",
  "solana-short-vec",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
@@ -9811,12 +9811,12 @@ dependencies = [
  "agave-feature-set",
  "bincode",
  "log",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-bls-signatures",
  "solana-clock",
  "solana-epoch-schedule",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-packet 4.1.0",
  "solana-program-runtime",
@@ -9824,7 +9824,7 @@ dependencies = [
  "solana-rent",
  "solana-sdk-ids",
  "solana-slot-hashes",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction-context",
  "solana-vote-interface",
 ]
@@ -9910,7 +9910,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha3",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-derivation-path",
  "solana-instruction",
  "solana-sdk-ids",
@@ -10114,7 +10114,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-instruction",
  "solana-nullable",
  "solana-program-error",
@@ -11366,9 +11366,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.4.9"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657690780ce23e6f66576a782ffd88eb353512381817029cc1d7a99154bb6d1f"
+checksum = "a61f8f0a55eb6cae5d7b7ad2eca536a944deb9722a948525181069064ecd1abc"
 dependencies = [
  "bytes",
  "pastey",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -85,7 +85,7 @@ serde_json = "1.0.149"
 serde_yaml = "0.9.34"
 serial_test = "3.2.0"
 signal-hook = "0.4.4"
-solana-account = "4.0.0"
+solana-account = "4.1.0"
 solana-account-decoder = { path = "../account-decoder", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-accounts-db = { path = "../accounts-db", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -106,27 +106,27 @@ solana-cost-model = { path = "../cost-model", version = "=4.1.0-alpha.0", featur
 solana-entry = { path = "../entry", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-faucet = { path = "../faucet", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-feature-gate-interface = "4.0.0"
-solana-fee-calculator = "3.1.0"
+solana-fee-calculator = "3.2.0"
 solana-genesis = { path = "../genesis", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-genesis-config = "4.0.0"
 solana-genesis-utils = { path = "../genesis-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-hash = "4.2.0"
+solana-hash = "4.3.0"
 solana-inflation = "3.0.0"
-solana-instruction = "3.3.0"
-solana-instruction-error = "2.1.0"
-solana-keypair = "3.0.1"
+solana-instruction = "3.4.0"
+solana-instruction-error = "2.3.0"
+solana-keypair = "3.1.2"
 solana-ledger = { path = "../ledger", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-loader-v3-interface = "6.1.0"
 solana-loader-v4-interface = "3.1.0"
 solana-loader-v4-program = { path = "../programs/loader-v4", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-local-cluster = { path = "../local-cluster", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-measure = { path = "../measure", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-message = "4.0.0"
+solana-message = "4.1.0"
 solana-metrics = { path = "../metrics", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-native-token = "3.0.0"
 solana-net-utils = { path = "../net-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-nonce = "3.1.0"
+solana-nonce = "3.2.0"
 solana-precompile-error = "3.0.0"
 solana-program-runtime = { path = "../program-runtime", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-pubkey = { version = "4.2.0", default-features = false }
@@ -140,7 +140,7 @@ solana-runtime-transaction = { path = "../runtime-transaction", version = "=4.1.
 solana-sbpf = { version = "=0.17.0", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-shred-version = "3.0.1"
-solana-signature = { version = "3.3.0", default-features = false }
+solana-signature = { version = "3.4.0", default-features = false }
 solana-signer = "3.0.0"
 solana-stake-interface = "3.0.0"
 solana-storage-bigtable = { path = "../storage-bigtable", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -154,14 +154,14 @@ solana-svm-test-harness-instr = { path = "../svm-test-harness/instr", version = 
 solana-svm-timings = { path = "../svm-timings", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm-transaction = { path = "../svm-transaction", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-syscalls = { path = "../syscalls", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-system-interface = "3.1"
+solana-system-interface = "3.2"
 solana-system-program = { path = "../programs/system", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-sysvar-id = "3.1.0"
 solana-test-validator = { path = "../test-validator", version = "=4.1.0-alpha.0" }
 solana-time-utils = "3.0.0"
 solana-tps-client = { path = "../tps-client", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-tpu-client = { path = "../tpu-client", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
-solana-transaction = "4.0.0"
+solana-transaction = "4.1.0"
 solana-transaction-context = { path = "../transaction-context", version = "=4.1.0-alpha.0", features = ["agave-unstable-api", "bincode"] }
 solana-transaction-status = { path = "../transaction-status", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -41,15 +41,15 @@ serde = { workspace = true }
 serde_yaml = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-config-interface = { version = "=2.0.0", features = ["bincode"] }
-solana-hash = "=4.2.0"
+solana-hash = "=4.3.0"
 solana-keypair = "=3.1.2"
-solana-message = "=4.0.0"
+solana-message = "=4.1.0"
 solana-pubkey = { version = "=4.2.0", default-features = false }
 solana-rpc-client = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-solana-signature = { version = "=3.3.0", default-features = false }
+solana-signature = { version = "=3.4.0", default-features = false }
 solana-signer = "=3.0.0"
-solana-transaction = { version = "=4.0.0", features = ["wincode"] }
+solana-transaction = { version = "=4.1.0", features = ["wincode"] }
 solana-version = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -33,9 +33,9 @@ solana-bls-signatures = { workspace = true }
 solana-clap-v3-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-derivation-path = { workspace = true }
-solana-instruction = { version = "=3.3.0", features = ["bincode"] }
+solana-instruction = { version = "=3.4.0", features = ["bincode"] }
 solana-keypair = "=3.1.2"
-solana-message = { version = "=4.0.0", features = ["wincode"] }
+solana-message = { version = "=4.1.0", features = ["wincode"] }
 solana-pubkey = { version = "=4.2.0", default-features = false }
 solana-remote-wallet = { workspace = true }
 solana-seed-derivable = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -82,7 +82,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-pubkey 4.2.0",
  "solana-sha256-hasher",
@@ -108,7 +108,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "log",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-signature",
  "solana-transaction",
@@ -218,7 +218,7 @@ dependencies = [
  "solana-accounts-db",
  "solana-clock",
  "solana-genesis-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-lattice-hash",
  "solana-measure",
  "solana-metrics",
@@ -234,7 +234,7 @@ dependencies = [
 name = "agave-transaction-view"
 version = "4.1.0-alpha.0"
 dependencies = [
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-packet 4.1.0",
  "solana-pubkey 4.2.0",
@@ -275,7 +275,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-clap-utils",
  "solana-cli-config",
@@ -290,7 +290,7 @@ dependencies = [
  "solana-genesis-utils",
  "solana-geyser-plugin-manager",
  "solana-gossip",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-inflation",
  "solana-keypair",
  "solana-ledger",
@@ -311,7 +311,7 @@ dependencies = [
  "solana-signer",
  "solana-storage-bigtable",
  "solana-streamer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-test-validator",
  "solana-tpu-client",
  "solana-turbine",
@@ -350,7 +350,7 @@ dependencies = [
  "solana-connection-cache",
  "solana-epoch-schedule",
  "solana-gossip",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-ledger",
  "solana-measure",
@@ -378,11 +378,11 @@ dependencies = [
  "agave-feature-set",
  "log",
  "serde",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-bls-signatures",
  "solana-clock",
  "solana-epoch-schedule",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-pubkey 4.2.0",
  "solana-signer-store",
  "thiserror 2.0.18",
@@ -5803,9 +5803,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862b95723ec6f2a27451d2fc7f4f8cf1f80a79627dcfed63879aac4ea5fe3bc2"
+checksum = "2bbea62563f5143b29fff5aa6af57426bc1beb77c6416b5c1c8e7d1266272c21"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -5831,7 +5831,7 @@ dependencies = [
  "bv",
  "serde",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface",
  "solana-clock",
@@ -5868,7 +5868,7 @@ dependencies = [
  "bs58",
  "serde",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-pubkey 4.2.0",
  "zstd",
 ]
@@ -5881,7 +5881,7 @@ checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
  "bincode",
  "serde_core",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-program-error",
  "solana-program-memory",
 ]
@@ -5892,7 +5892,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc141b940560430425ebaadb7645496c45f6a10fad9911d719bd03eab7f4d422"
 dependencies = [
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-program-error",
 ]
 
@@ -5916,13 +5916,13 @@ dependencies = [
  "seqlock",
  "serde",
  "smallvec",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-address-lookup-table-interface",
  "solana-bucket-map",
  "solana-clock",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-lattice-hash",
  "solana-measure",
@@ -5937,7 +5937,7 @@ dependencies = [
  "solana-slot-hashes",
  "solana-stake-interface",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-time-utils",
  "solana-transaction",
@@ -5955,14 +5955,14 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
 dependencies = [
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
 ]
 
 [[package]]
 name = "solana-address"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f08236dacd0e6dc8234becef58e27c8567856644ef509d7e97957d55a91dc72"
+checksum = "f1384b52c435a750cc9c538760fc7bb472fd78e65a9900a2d07312c5bb335b72"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -5985,9 +5985,9 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-interface"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8df0b083c10ce32490410f3795016b1b5d9b4d094658c0a5e496753645b7cd"
+checksum = "115b4f773acc4f3f3cb986b0d335e9845c0368c82b0940410935bc11ae065578"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6016,11 +6016,11 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "borsh",
  "futures 0.3.32",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-banks-interface",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-program-pack",
  "solana-pubkey 4.2.0",
@@ -6041,10 +6041,10 @@ name = "solana-banks-interface"
 version = "4.1.0-alpha.0"
 dependencies = [
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-pubkey 4.2.0",
  "solana-signature",
@@ -6062,11 +6062,11 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "futures 0.3.32",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-banks-interface",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-net-utils",
  "solana-pubkey 4.2.0",
@@ -6112,7 +6112,7 @@ checksum = "7116e1d942a2432ca3f514625104757ab8a56233787e95144c93950029e31176"
 dependencies = [
  "blake3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -6194,7 +6194,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "bincode",
  "qualifier_attr",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-clock",
  "solana-instruction",
@@ -6210,7 +6210,7 @@ dependencies = [
  "solana-svm-measure",
  "solana-svm-type-overrides",
  "solana-syscalls",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction-context",
 ]
 
@@ -6239,7 +6239,7 @@ dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-loader-v4-program",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
@@ -6272,7 +6272,7 @@ dependencies = [
  "solana-cluster-type",
  "solana-commitment-config",
  "solana-derivation-path",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-native-token",
@@ -6316,14 +6316,14 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-bincode",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-clock",
  "solana-epoch-info",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-packet 4.1.0",
  "solana-pubkey 4.2.0",
@@ -6331,7 +6331,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signature",
  "solana-stake-interface",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-status",
  "solana-transaction-status-client-types",
@@ -6351,7 +6351,7 @@ dependencies = [
  "log",
  "solana-commitment-config",
  "solana-connection-cache",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-measure",
  "solana-message",
@@ -6380,17 +6380,17 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19635cc703678bcb26eb6faee4a363c71f4a0d622c445d9b70c048c42f4cbcd3"
 dependencies = [
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-commitment-config",
  "solana-epoch-info",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
  "solana-pubkey 4.2.0",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-error",
 ]
@@ -6416,7 +6416,7 @@ checksum = "3a494cf8eda7d98d9f0144b288bb409c88308d2e86f15cc1045aa77b83304718"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -6556,7 +6556,7 @@ dependencies = [
  "shaq",
  "signal-hook",
  "slab",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-bincode",
@@ -6577,7 +6577,7 @@ dependencies = [
  "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-hard-forks",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-leader-schedule",
@@ -6610,7 +6610,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-time-utils",
@@ -6659,7 +6659,7 @@ dependencies = [
  "solana-runtime-transaction",
  "solana-sdk-ids",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction-error",
  "solana-vote-program",
 ]
@@ -6776,10 +6776,10 @@ dependencies = [
  "num_cpus",
  "rayon",
  "smallvec",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-bls-signatures",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-measure",
  "solana-merkle-tree",
  "solana-message",
@@ -6812,7 +6812,7 @@ checksum = "f5e7b0ba210593ba8ddd39d6d234d81795d1671cebf3026baa10d5dc23ac42f0"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -6825,8 +6825,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee8beac9bff4db9225e57d532d169b0be5e447f1e6601a2f50f27a01bf5518f"
 dependencies = [
  "siphasher 0.3.11",
- "solana-address 2.5.0",
- "solana-hash 4.2.0",
+ "solana-address 2.6.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -6860,12 +6860,12 @@ checksum = "0eb265ff95e28eceda117e2e3d2d2a611ecbbfe911dfeeeecd1521814540ffab"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-nonce",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -6876,7 +6876,7 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "solana-cli-output",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -6885,7 +6885,7 @@ dependencies = [
  "solana-packet 4.1.0",
  "solana-pubkey 4.2.0",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-transaction",
  "spl-memo-interface",
@@ -6903,14 +6903,14 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 4.2.0",
  "solana-rent 4.1.0",
  "solana-sdk-ids",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
@@ -6924,9 +6924,9 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-calculator"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2a5675b2cf8d407c672dc1776492b1f382337720ddf566645ae43237a3d8c3"
+checksum = "57e8add96b5741573e9f7529c4bb7719cfcfa999c3847a68cdfaef0cb6adf567"
 dependencies = [
  "log",
  "serde",
@@ -6967,12 +6967,12 @@ dependencies = [
  "memmap2 0.5.10",
  "serde",
  "serde_derive",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-clock",
  "solana-cluster-type",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-inflation",
  "solana-keypair",
  "solana-poh-config",
@@ -6993,7 +6993,7 @@ dependencies = [
  "log",
  "solana-download-utils",
  "solana-genesis-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-rpc-client",
  "thiserror 2.0.18",
 ]
@@ -7011,11 +7011,11 @@ dependencies = [
  "libloading",
  "log",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-clock",
  "solana-entry",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-ledger",
  "solana-measure",
  "solana-message",
@@ -7060,7 +7060,7 @@ dependencies = [
  "solana-clock",
  "solana-entry",
  "solana-epoch-schedule",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-ledger",
  "solana-measure",
@@ -7105,14 +7105,14 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "337c246447142f660f778cf6cb582beba8e28deb05b3b24bfb9ffd7c562e5f41"
 dependencies = [
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
 name = "solana-hash"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8064ea1d591ec791be95245058ca40f4f5345d390c200069d0f79bbf55bfae55"
+checksum = "f1b113239362cee7093bfb250467138f079a2a03673181dc15bff6ccd677912d"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -7137,9 +7137,9 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97881335fc698deb46c6571945969aae6d93a14e2fff792a368b4fac872f116"
+checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
 dependencies = [
  "bincode",
  "borsh",
@@ -7189,7 +7189,7 @@ checksum = "ed1c0d16d6fdeba12291a1f068cdf0d479d9bff1141bf44afd7aa9d485f65ef8"
 dependencies = [
  "sha3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -7203,7 +7203,7 @@ dependencies = [
  "five8",
  "five8_core",
  "rand 0.9.2",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-derivation-path",
  "solana-seed-derivable",
  "solana-seed-phrase",
@@ -7284,7 +7284,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_bytes",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
@@ -7294,7 +7294,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-genesis-config",
  "solana-genesis-utils",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-leader-schedule",
@@ -7322,7 +7322,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-timings",
  "solana-svm-transaction",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
@@ -7390,7 +7390,7 @@ dependencies = [
 name = "solana-loader-v4-program"
 version = "4.1.0-alpha.0"
 dependencies = [
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-bpf-loader-program",
  "solana-instruction",
@@ -7416,22 +7416,22 @@ name = "solana-merkle-tree"
 version = "4.1.0-alpha.0"
 dependencies = [
  "fast-math",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sha256-hasher",
 ]
 
 [[package]]
 name = "solana-message"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6435a6070b6c5898201aae845db328cf3bd3cebc17b55af9b43138da5ced4a85"
+checksum = "cf3349552a323d44d8936b81f003ea7a2fea8566684ebf0dc25d34ad4df2b103"
 dependencies = [
  "blake3",
  "lazy_static",
  "serde",
  "serde_derive",
- "solana-address 2.5.0",
- "solana-hash 4.2.0",
+ "solana-address 2.6.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-sanitize",
  "solana-sdk-ids",
@@ -7498,14 +7498,14 @@ checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 
 [[package]]
 name = "solana-nonce"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc469152a63284ef959b80c59cda015262a021da55d3b8fe42171d89c4b64f8"
+checksum = "d95dbc9f2e33b6c10e231df15cb2a3bff9ea7eab6347f9e316fe75c97fd67bbb"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-pubkey 4.2.0",
  "solana-sha256-hasher",
  "wincode",
@@ -7513,12 +7513,12 @@ dependencies = [
 
 [[package]]
 name = "solana-nonce-account"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964f9fa300e4c4d8c02f747736fdffc7612ebd583a46e07cacb0dad118ba91eb"
+checksum = "cda945f4ccb317791c26379ca8ec410c5938aa7a5eff211fe5fe0bb428c3a75f"
 dependencies = [
- "solana-account 4.1.0",
- "solana-hash 4.2.0",
+ "solana-account 4.2.0",
+ "solana-hash 4.3.0",
  "solana-nonce",
  "solana-sdk-ids",
  "wincode",
@@ -7588,7 +7588,7 @@ dependencies = [
  "rand 0.9.2",
  "rayon",
  "serde",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-metrics",
  "solana-packet 4.1.0",
@@ -7612,7 +7612,7 @@ dependencies = [
  "qualifier_attr",
  "solana-clock",
  "solana-entry",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-leader-schedule",
  "solana-ledger",
  "solana-measure",
@@ -7687,7 +7687,7 @@ dependencies = [
  "solana-epoch-stake",
  "solana-example-mocks",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-instructions-sysvar",
@@ -7720,7 +7720,7 @@ name = "solana-program-binaries"
 version = "4.1.0-alpha.0"
 dependencies = [
  "bincode",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-loader-v3-interface",
  "solana-pubkey 4.2.0",
  "solana-rent 4.1.0",
@@ -7787,13 +7787,13 @@ dependencies = [
  "percentage",
  "rand 0.9.2",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-clock",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-structure",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-loader-v3-interface",
@@ -7813,7 +7813,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction-context",
@@ -7833,10 +7833,10 @@ dependencies = [
  "chrono-humanize",
  "log",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-accounts-db",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-banks-client",
  "solana-banks-interface",
  "solana-banks-server",
@@ -7848,7 +7848,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-fee-calculator",
  "solana-genesis-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-loader-v3-interface",
@@ -7869,7 +7869,7 @@ dependencies = [
  "solana-stake-interface",
  "solana-svm-log-collector",
  "solana-svm-timings",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction",
@@ -7897,7 +7897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
 dependencies = [
  "rand 0.9.2",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
 ]
 
 [[package]]
@@ -8031,7 +8031,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-cli-output",
@@ -8045,7 +8045,7 @@ dependencies = [
  "solana-faucet",
  "solana-genesis-config",
  "solana-gossip",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-ledger",
  "solana-measure",
@@ -8066,7 +8066,7 @@ dependencies = [
  "solana-slot-history",
  "solana-storage-bigtable",
  "solana-svm",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-time-utils",
@@ -8104,7 +8104,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-decoder",
  "solana-account-decoder-client-types",
  "solana-clock",
@@ -8112,7 +8112,7 @@ dependencies = [
  "solana-epoch-info",
  "solana-epoch-schedule",
  "solana-feature-gate-interface",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-message",
  "solana-pubkey 4.2.0",
@@ -8148,9 +8148,9 @@ dependencies = [
 name = "solana-rpc-client-nonce-utils"
 version = "4.1.0-alpha.0"
 dependencies = [
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-commitment-config",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-nonce",
  "solana-pubkey 4.2.0",
@@ -8169,7 +8169,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-clock",
  "solana-commitment-config",
  "solana-fee-calculator",
@@ -8221,7 +8221,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smallvec",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
@@ -8248,7 +8248,7 @@ dependencies = [
  "solana-fee-structure",
  "solana-genesis-config",
  "solana-hard-forks",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-inflation",
  "solana-instruction",
  "solana-keypair",
@@ -8287,7 +8287,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-syscalls",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-sysvar",
  "solana-sysvar-id",
@@ -8318,7 +8318,7 @@ dependencies = [
  "agave-feature-set",
  "agave-transaction-view",
  "solana-compute-budget-instruction",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
@@ -8345,7 +8345,7 @@ dependencies = [
  "agave-validator",
  "bincode",
  "borsh",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-client-traits",
  "solana-clock",
@@ -8356,7 +8356,7 @@ dependencies = [
  "solana-fee",
  "solana-fee-calculator",
  "solana-fee-structure",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-loader-v3-interface",
@@ -8378,7 +8378,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-transaction",
  "solana-transaction-error",
@@ -8543,7 +8543,7 @@ name = "solana-sbf-rust-direct-account-pointers"
 version = "4.1.0-alpha.0"
 dependencies = [
  "solana-account-view",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-cpi",
  "solana-program-entrypoint",
  "solana-program-error",
@@ -8639,7 +8639,7 @@ dependencies = [
  "solana-sbf-rust-invoked-dep",
  "solana-sbf-rust-realloc-dep",
  "solana-sdk-ids",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
@@ -8694,7 +8694,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sbf-rust-invoked-dep",
  "solana-sdk-ids",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
@@ -8839,7 +8839,7 @@ dependencies = [
  "solana-program-error",
  "solana-pubkey 4.2.0",
  "solana-sbf-rust-realloc-dep",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
@@ -8863,7 +8863,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sbf-rust-realloc-dep",
  "solana-sbf-rust-realloc-invoke-dep",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
@@ -8905,7 +8905,7 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-pubkey 4.2.0",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
@@ -8926,7 +8926,7 @@ name = "solana-sbf-rust-secp256k1-recover"
 version = "4.1.0-alpha.0"
 dependencies = [
  "libsecp256k1",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keccak-hasher",
  "solana-msg",
  "solana-program-entrypoint",
@@ -8939,7 +8939,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "blake3",
  "solana-blake3-hasher",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keccak-hasher",
  "solana-msg",
  "solana-program-entrypoint",
@@ -8995,7 +8995,7 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-pubkey 4.2.0",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
@@ -9085,7 +9085,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
 dependencies = [
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
 ]
 
 [[package]]
@@ -9165,7 +9165,7 @@ dependencies = [
  "crossbeam-channel",
  "itertools 0.14.0",
  "log",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
@@ -9217,7 +9217,7 @@ checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
 dependencies = [
  "sha2 0.10.9",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
 ]
 
 [[package]]
@@ -9236,15 +9236,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6c79722e299d957958bf33695f7cd1ef6724ff55563c60fd9e3e24487cccde2"
 dependencies = [
  "solana-hard-forks",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sha256-hasher",
 ]
 
 [[package]]
 name = "solana-signature"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132a93134f1262aa832f1849b83bec6c9945669b866da18661a427943b9e801e"
+checksum = "e7a73c6e97cc2108be0adf6a6ea326434f8398df9d7eed81da2a4548b69e971c"
 dependencies = [
  "ed25519-dalek 2.2.0",
  "five8",
@@ -9285,7 +9285,7 @@ checksum = "2585f70191623887329dfb5078da3a00e15e3980ea67f42c2e10b07028419f43"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-sdk-ids",
  "solana-sysvar-id",
 ]
@@ -9327,7 +9327,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 4.2.0",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-sysvar-id",
 ]
@@ -9379,7 +9379,7 @@ dependencies = [
  "protobuf-src",
  "serde",
  "solana-account-decoder",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-message",
  "solana-pubkey 4.2.0",
@@ -9437,10 +9437,10 @@ dependencies = [
  "percentage",
  "qualifier_attr",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-clock",
  "solana-fee-structure",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-loader-v3-interface",
@@ -9462,7 +9462,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar-id",
  "solana-transaction-context",
  "solana-transaction-error",
@@ -9474,7 +9474,7 @@ dependencies = [
 name = "solana-svm-callback"
 version = "4.1.0-alpha.0"
 dependencies = [
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-clock",
  "solana-precompile-error",
  "solana-pubkey 4.2.0",
@@ -9499,7 +9499,7 @@ version = "4.1.0-alpha.0"
 name = "solana-svm-test-harness-fixture"
 version = "4.1.0-alpha.0"
 dependencies = [
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
@@ -9513,7 +9513,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "bincode",
  "env_logger",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bpf-loader-program",
  "solana-clock",
  "solana-compute-budget",
@@ -9551,7 +9551,7 @@ dependencies = [
 name = "solana-svm-transaction"
 version = "4.1.0-alpha.0"
 dependencies = [
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-message",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
@@ -9573,7 +9573,7 @@ dependencies = [
  "bincode",
  "libsecp256k1",
  "num-traits",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-account-info",
  "solana-big-mod-exp",
  "solana-blake3-hasher",
@@ -9582,7 +9582,7 @@ dependencies = [
  "solana-clock",
  "solana-cpi",
  "solana-curve25519 4.0.0",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keccak-hasher",
  "solana-poseidon",
@@ -9621,14 +9621,14 @@ dependencies = [
 
 [[package]]
 name = "solana-system-interface"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95a6f2e23ed861d6444ad4a6d6896c418d7d101b960787e65a8e33157cee81b"
+checksum = "55b54965bf0b76fa8e2b35376583efddd4d916618cfe595bf48c7d7b55a9e628"
 dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-instruction",
  "solana-msg",
  "solana-program-error",
@@ -9641,7 +9641,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "bincode",
  "log",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-fee-calculator",
  "solana-instruction",
@@ -9652,7 +9652,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-svm-log-collector",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-transaction-context",
 ]
@@ -9663,12 +9663,12 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a39522012be4127884bc611d65f58f1cf33a3afb7baee7e6774be90b48edc3c"
 dependencies = [
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-message",
  "solana-pubkey 4.2.0",
  "solana-signer",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
 ]
 
@@ -9691,7 +9691,7 @@ dependencies = [
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
@@ -9712,7 +9712,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
 dependencies = [
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-sdk-ids",
 ]
 
@@ -9728,7 +9728,7 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "serde_json",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-accounts-db",
  "solana-cli-output",
  "solana-clock",
@@ -9843,14 +9843,14 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc0d18f4f109cc1777459271800755705ca6d1aba319934611e1d4f6bb162b5"
+checksum = "a6aefe6edf26c6daa57f6caa1af119083abeaaf177a4ba38b4b492ca2ff2f7fd"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-address 2.5.0",
- "solana-hash 4.2.0",
+ "solana-address 2.6.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-message",
@@ -9869,7 +9869,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "bincode",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-pubkey 4.2.0",
@@ -9880,9 +9880,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8396904805b0b385b9de115a652fe80fd01e5b98ce0513f4fcd8184ada9bb792"
+checksum = "4a2165ad25b694c654d5395fc7a049452a192376e4c96a7fad05580f6ba5ba1c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -9905,7 +9905,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-address-lookup-table-interface",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-loader-v2-interface",
  "solana-loader-v3-interface",
@@ -9916,7 +9916,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signature",
  "solana-stake-interface",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
@@ -9972,7 +9972,7 @@ dependencies = [
  "solana-cluster-type",
  "solana-entry",
  "solana-gossip",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-keypair",
  "solana-ledger",
  "solana-measure",
@@ -10014,7 +10014,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "assert_matches",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-pubkey 4.2.0",
  "solana-runtime-transaction",
  "solana-transaction",
@@ -10080,10 +10080,10 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "serde",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-keypair",
  "solana-packet 4.1.0",
@@ -10112,7 +10112,7 @@ dependencies = [
  "serde_derive",
  "serde_with",
  "solana-clock",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
@@ -10121,7 +10121,7 @@ dependencies = [
  "solana-serde-varint",
  "solana-serialize-utils",
  "solana-short-vec",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
 ]
 
 [[package]]
@@ -10131,12 +10131,12 @@ dependencies = [
  "agave-feature-set",
  "bincode",
  "log",
- "solana-account 4.1.0",
+ "solana-account 4.2.0",
  "solana-bincode",
  "solana-bls-signatures",
  "solana-clock",
  "solana-epoch-schedule",
- "solana-hash 4.2.0",
+ "solana-hash 4.3.0",
  "solana-instruction",
  "solana-packet 4.1.0",
  "solana-program-runtime",
@@ -10144,7 +10144,7 @@ dependencies = [
  "solana-rent 4.1.0",
  "solana-sdk-ids",
  "solana-slot-hashes",
- "solana-system-interface 3.1.0",
+ "solana-system-interface 3.2.0",
  "solana-transaction-context",
  "solana-vote-interface",
 ]
@@ -10230,7 +10230,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha3",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-derivation-path",
  "solana-instruction",
  "solana-sdk-ids",
@@ -10422,7 +10422,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-address 2.5.0",
+ "solana-address 2.6.0",
  "solana-instruction",
  "solana-nullable",
  "solana-program-error",
@@ -11654,9 +11654,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.4.9"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657690780ce23e6f66576a782ffd88eb353512381817029cc1d7a99154bb6d1f"
+checksum = "a61f8f0a55eb6cae5d7b7ad2eca536a944deb9722a948525181069064ecd1abc"
 dependencies = [
  "bytes",
  "pastey",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -122,7 +122,7 @@ serde = { version = "1.0.112", features = ["derive"] }
 serde_json = "1.0.149"
 solana-account-info = "=3.1.1"
 solana-account-view = "=2.0.0"
-solana-address = "=2.5.0"
+solana-address = "=2.6.0"
 solana-big-mod-exp = "=3.0.0"
 solana-blake3-hasher = { version = "=3.1.0", features = ["blake3"] }
 solana-bn254 = "=3.2.1"
@@ -133,8 +133,8 @@ solana-cpi = "=3.1.0"
 solana-curve25519 = "=4.0.0"
 solana-define-syscall = "=3.0.0"
 solana-fee = { path = "../../fee", version = "=4.1.0-alpha.0" }
-solana-hash = { version = "=4.2.0", features = ["bytemuck", "serde", "std"] }
-solana-instruction = "=3.3.0"
+solana-hash = { version = "=4.3.0", features = ["bytemuck", "serde", "std"] }
+solana-instruction = "=3.4.0"
 solana-instructions-sysvar = "=3.0.0"
 solana-keccak-hasher = { version = "=3.1.0", features = ["sha3"] }
 solana-msg = "=3.1.0"
@@ -165,7 +165,7 @@ solana-svm-test-harness-instr = { path = "../../svm-test-harness/instr", version
 solana-svm-timings = { path = "../../svm-timings", version = "=4.1.0-alpha.0" }
 solana-svm-transaction = { path = "../../svm-transaction", version = "=4.1.0-alpha.0" }
 solana-svm-type-overrides = { path = "../../svm-type-overrides", version = "=4.1.0-alpha.0" }
-solana-system-interface = { version = "=3.1", features = ["bincode"] }
+solana-system-interface = { version = "=3.2", features = ["bincode"] }
 solana-sysvar = "=4.0.0"
 solana-vote = { path = "../../vote", version = "=4.1.0-alpha.0" }
 solana-vote-interface = "5.0.0"
@@ -200,15 +200,15 @@ solana-compute-budget-instruction = { workspace = true, features = [
 ] }
 solana-compute-budget-interface = "3.0.0"
 solana-fee = { workspace = true }
-solana-fee-calculator = "3.0.0"
+solana-fee-calculator = "3.2.0"
 solana-fee-structure = "3.0.0"
-solana-hash = "4.2.0"
+solana-hash = "4.3.0"
 solana-instruction = { workspace = true }
-solana-keypair = "3.0.0"
+solana-keypair = "3.1.2"
 solana-loader-v3-interface = "6.1.0"
-solana-message = "4.0.0"
+solana-message = "4.1.0"
 solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-solana-pubkey = "4.1.0"
+solana-pubkey = "4.2.0"
 solana-rent = "4.1.0"
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime-transaction = { workspace = true, features = [
@@ -228,8 +228,8 @@ solana-svm-transaction = { workspace = true }
 solana-svm-type-overrides = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-sysvar = "4.0.0"
-solana-transaction = "4.0.0"
-solana-transaction-error = "3.0.0"
+solana-transaction = "4.1.0"
+solana-transaction-error = "3.2.0"
 solana-vote = { workspace = true }
 solana-vote-interface = { workspace = true }
 solana-vote-program = { workspace = true }

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -23,7 +23,7 @@ log = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-cli-output = { workspace = true }
-solana-hash = "=4.2.0"
+solana-hash = "=4.3.0"
 solana-metrics = { workspace = true }
 solana-native-token = "=3.0.0"
 solana-notifier = { workspace = true }


### PR DESCRIPTION
#### Problem
Wincode version bump 0.4.9 -> 0.5.1 causes incompatibility in all SDK crates that expose wincode trait APIs, so they need to be updated together. 

#### Summary of Changes
+wincode = "0.5.1"
+solana-address = "2.6.0"
+solana-address-lookup-table-interface = "3.1.0"
+solana-fee-calculator = "3.2.0"
+solana-hash = "4.3.0"
+solana-instruction = "3.4.0"
+solana-instruction-error = "2.3.0"
+solana-message = "4.1.0"
+solana-nonce = "3.2.0"
+solana-nonce-account = "4.1.0"
+solana-signature = "3.4.0"
+solana-system-interface = "3.2"
+solana-transaction = "4.1.0"
+solana-transaction-error = "3.2.0"
