### PR TITLE
gossip: Remove bincode dependency switching to wincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7174,6 +7174,7 @@ name = "solana-bloom"
 version = "4.2.0-alpha.0"
 dependencies = [
  "bencher",
+ "bincode",
  "bv",
  "fnv",
  "rand 0.9.4",
@@ -7187,6 +7188,7 @@ dependencies = [
  "solana-sha256-hasher",
  "solana-signature",
  "solana-time-utils",
+ "wincode",
 ]
 
 [[package]]
@@ -8509,7 +8511,6 @@ dependencies = [
  "agave-random",
  "anyhow",
  "arc-swap",
- "arrayvec",
  "assert_matches",
  "bincode",
  "bs58",
@@ -8567,7 +8568,9 @@ dependencies = [
  "solana-vote",
  "solana-vote-interface",
  "solana-vote-program",
+ "solana-wincode-varint",
  "static_assertions",
+ "tempfile",
  "test-case",
  "thiserror 2.0.18",
  "wincode",
@@ -11381,6 +11384,8 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-sanitize",
  "solana-serde-varint",
+ "solana-wincode-varint",
+ "wincode",
 ]
 
 [[package]]
@@ -11484,6 +11489,15 @@ dependencies = [
  "solana-vote-interface",
  "solana-vote-program",
  "test-case",
+]
+
+[[package]]
+name = "solana-wincode-varint"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6679e72a01dcfe7ff180f0e9d3a0d165e4e9664426930014f2702e7571c259c7"
+dependencies = [
+ "wincode",
 ]
 
 [[package]]
@@ -13061,6 +13075,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37095eb18dd6254c66217edc61a29d83d51f8818de8a2ffe88e4584ad73fb5f9"
 dependencies = [
+ "bv",
  "bytes",
  "pastey",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8570,6 +8570,8 @@ dependencies = [
  "solana-vote-program",
  "solana-wincode-varint",
  "static_assertions",
+ "strum",
+ "strum_macros",
  "tempfile",
  "test-case",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -518,6 +518,7 @@ solana-version = { path = "version", version = "=4.2.0-alpha.0", features = ["ag
 solana-vote = { path = "vote", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-vote-interface = "6.0.0"
 solana-vote-program = { path = "programs/vote", version = "=4.2.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+solana-wincode-varint = "1.0.0"
 solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-zk-sdk = "5.0.1"
 solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -38,12 +38,14 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-sanitize = { workspace = true }
 solana-time-utils = { workspace = true }
+wincode = { workspace = true, features = ["bv"] }
 
 [dev-dependencies]
 bencher = { workspace = true }
+bincode = { workspace = true }
 rayon = { workspace = true }
 solana-bloom = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-hash = { workspace = true, features = ["atomic"] }
+solana-hash = { workspace = true, features = ["atomic", "wincode"] }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-signature = { workspace = true, features = ["std"] }
 

--- a/bloom/src/bloom.rs
+++ b/bloom/src/bloom.rs
@@ -14,6 +14,7 @@ use {
         ops::Deref,
         sync::atomic::{AtomicU64, Ordering},
     },
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 /// Generate a stable hash of `self` for each `hash_index`
@@ -23,7 +24,7 @@ pub trait BloomHashIndex {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq, SchemaWrite, SchemaRead)]
 pub struct Bloom<T: BloomHashIndex> {
     pub keys: Vec<u64>,
     pub bits: BitVec<u64>,
@@ -478,5 +479,28 @@ mod test {
             bloom.add(hash_value);
         }
         assert_eq!(bits, bloom.bits);
+    }
+
+    #[test]
+    fn test_wincode_compatibility_bloom() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let num_keys = rng.random_range(1..8usize);
+            let keys: Vec<u64> = (0..num_keys).map(|_| rng.random()).collect();
+            let num_bits = rng.random_range(1..1024usize);
+            let mut bloom = Bloom::<Hash>::new(num_bits, keys);
+            let num_inserts = rng.random_range(0..32usize);
+            for _ in 0..num_inserts {
+                bloom.add(&generate_random_hash());
+            }
+
+            let bincode_bytes = bincode::serialize(&bloom).unwrap();
+            let wincode_bytes = wincode::serialize(&bloom).unwrap();
+            assert_eq!(bincode_bytes, wincode_bytes);
+            let wincode_decoded: Bloom<Hash> = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(bloom, wincode_decoded);
+            let bincode_decoded: Bloom<Hash> = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(bloom, bincode_decoded);
+        }
     }
 }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6464,6 +6464,7 @@ dependencies = [
  "serde",
  "solana-sanitize",
  "solana-time-utils",
+ "wincode",
 ]
 
 [[package]]
@@ -7394,9 +7395,7 @@ dependencies = [
  "agave-logger",
  "agave-random",
  "arc-swap",
- "arrayvec",
  "assert_matches",
- "bincode",
  "bv",
  "crossbeam-channel",
  "flate2",
@@ -7440,6 +7439,7 @@ dependencies = [
  "solana-version",
  "solana-vote",
  "solana-vote-program",
+ "solana-wincode-varint",
  "static_assertions",
  "thiserror 2.0.18",
  "wincode",
@@ -9764,6 +9764,8 @@ dependencies = [
  "serde",
  "solana-sanitize",
  "solana-serde-varint",
+ "solana-wincode-varint",
+ "wincode",
 ]
 
 [[package]]
@@ -9843,6 +9845,15 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "solana-transaction-context",
  "solana-vote-interface",
+]
+
+[[package]]
+name = "solana-wincode-varint"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6679e72a01dcfe7ff180f0e9d3a0d165e4e9664426930014f2702e7571c259c7"
+dependencies = [
+ "wincode",
 ]
 
 [[package]]
@@ -11396,6 +11407,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37095eb18dd6254c66217edc61a29d83d51f8818de8a2ffe88e4584ad73fb5f9"
 dependencies = [
+ "bv",
  "bytes",
  "pastey",
  "proc-macro2",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -34,9 +34,7 @@ dev-context-only-utils = ["dep:prost", "dep:protosol", "solana-bloom/dev-context
 agave-logger = { workspace = true }
 agave-random = { workspace = true }
 arc-swap = { workspace = true }
-arrayvec = { workspace = true }
 assert_matches = { workspace = true }
-bincode = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 crossbeam-channel = { workspace = true }
 flate2 = { workspace = true }
@@ -84,16 +82,18 @@ solana-signature = { workspace = true, default-features = false }
 solana-signer = { workspace = true }
 solana-streamer = { workspace = true }
 solana-time-utils = { workspace = true }
-solana-transaction = { workspace = true }
+solana-transaction = { workspace = true, features = ["wincode"] }
 solana-version = { workspace = true }
 solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
+solana-wincode-varint = { workspace = true }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
 wincode = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 bs58 = { workspace = true }
 criterion = { workspace = true }
 num_cpus = { workspace = true }
@@ -106,6 +106,7 @@ solana-signature = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
 solana-vote-interface = { workspace = true }
 static_assertions = { workspace = true }
+tempfile = { workspace = true }
 test-case = { workspace = true }
 
 [[bench]]

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -106,6 +106,8 @@ solana-signature = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
 solana-vote-interface = { workspace = true }
 static_assertions = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -36,7 +36,7 @@ use {
             DUPLICATE_SHRED_MAX_PAYLOAD_SIZE, MAX_INCREMENTAL_SNAPSHOT_HASHES,
             MAX_PRUNE_DATA_NODES, PULL_RESPONSE_MAX_PAYLOAD_SIZE,
             PULL_RESPONSE_MIN_SERIALIZED_SIZE, PUSH_MESSAGE_MAX_PAYLOAD_SIZE, Ping, PingCache,
-            Protocol, PruneData, split_gossip_messages,
+            Protocol, PruneData, deserialize_protocol, split_gossip_messages,
         },
         weighted_shuffle::WeightedShuffle,
     },
@@ -131,6 +131,11 @@ pub const MINIMUM_NUM_TVU_RECEIVE_SOCKETS: NonZeroUsize = NonZeroUsize::new(1).u
 pub const DEFAULT_NUM_TVU_RECEIVE_SOCKETS: NonZeroUsize = MINIMUM_NUM_TVU_RECEIVE_SOCKETS;
 pub const MINIMUM_NUM_TVU_RETRANSMIT_SOCKETS: NonZeroUsize = NonZeroUsize::new(1).unwrap();
 pub const DEFAULT_NUM_TVU_RETRANSMIT_SOCKETS: NonZeroUsize = NonZeroUsize::new(12).unwrap();
+
+// Contact-info save/restore handles trusted local data, so disable wincode's
+// default 4 MiB preallocation limit (which defends untrusted wire input).
+type ContactInfoFileConfig =
+    wincode::config::Configuration<true, { wincode::config::PREALLOCATION_SIZE_LIMIT_DISABLED }>;
 
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum ClusterInfoError {
@@ -328,7 +333,11 @@ impl ClusterInfo {
         match File::create(tmp_filename) {
             Ok(file) => {
                 let mut writer = BufWriter::new(file);
-                if let Err(err) = wincode::serialize_into(&mut writer, &nodes) {
+                if let Err(err) = wincode::config::serialize_into(
+                    &mut writer,
+                    &nodes,
+                    ContactInfoFileConfig::new(),
+                ) {
                     warn!(
                         "Failed to serialize contact info info {}: {}",
                         tmp_filename.display(),
@@ -375,12 +384,14 @@ impl ClusterInfo {
         }
 
         let nodes: Vec<CrdsValue> = match File::open(&filename) {
-            Ok(file) => {
-                wincode::deserialize_from(&mut BufReader::new(file)).unwrap_or_else(|err| {
-                    warn!("Failed to deserialize {}: {}", filename.display(), err);
-                    vec![]
-                })
-            }
+            Ok(file) => wincode::config::deserialize_from(
+                &mut BufReader::new(file),
+                ContactInfoFileConfig::new(),
+            )
+            .unwrap_or_else(|err| {
+                warn!("Failed to deserialize {}: {}", filename.display(), err);
+                vec![]
+            }),
             Err(err) => {
                 warn!("Failed to open {}: {}", filename.display(), err);
                 vec![]
@@ -2090,8 +2101,11 @@ impl ClusterInfo {
             stakes: &HashMap<Pubkey, u64>,
             stats: &GossipStats,
         ) -> Option<(SocketAddr, Protocol)> {
-            let mut protocol: Protocol =
-                stats.record_received_packet(packet.deserialize_slice::<Protocol, _>(..))?;
+            let result: wincode::ReadResult<Protocol> = packet
+                .data(..)
+                .ok_or(wincode::ReadError::Custom("packet discarded"))
+                .and_then(deserialize_protocol);
+            let mut protocol: Protocol = stats.record_received_packet(result)?;
             protocol.sanitize().ok()?;
             if let Protocol::PullResponse(_, values) | Protocol::PushMessage(_, values) =
                 &mut protocol
@@ -2495,9 +2509,20 @@ fn make_gossip_packet_batch<S: Borrow<SocketAddr>>(
     recycler: &PacketBatchRecycler,
     stats: &GossipStats,
 ) -> RecycledPacketBatch {
-    let record_gossip_packet = |(_, pkt): &(_, Protocol)| stats.record_gossip_packet(pkt);
-    let pkts = pkts.into_iter().inspect(record_gossip_packet);
-    RecycledPacketBatch::new_with_recycler_data_and_dests(recycler, "gossip_packet_batch", pkts)
+    let pkts = pkts.into_iter();
+    let mut batch =
+        RecycledPacketBatch::new_with_recycler(recycler, pkts.len(), "gossip_packet_batch");
+    for (addr, pkt) in pkts {
+        let addr = addr.borrow();
+        if !addr.ip().is_unspecified() && addr.port() != 0 {
+            if let Some(packet) = make_gossip_packet(addr, &pkt, stats) {
+                batch.push(packet);
+            }
+        } else {
+            trace!("Dropping packet, as destination is unknown");
+        }
+    }
+    batch
 }
 
 #[inline]
@@ -2506,16 +2531,22 @@ fn make_gossip_packet(
     pkt: &Protocol,
     stats: &GossipStats,
 ) -> Option<Packet> {
-    match Packet::from_data(Some(addr.borrow()), pkt) {
-        Err(err) => {
+    let mut packet = Packet::default();
+    let size = {
+        let buffer = packet.buffer_mut();
+        let initial_len = buffer.len();
+        let mut writer: &mut [u8] = buffer;
+        if let Err(err) = wincode::serialize_into(&mut writer, pkt) {
             error!("failed to write gossip packet: {err:?}");
-            None
+            return None;
         }
-        Ok(out) => {
-            stats.record_gossip_packet(pkt);
-            Some(out)
-        }
-    }
+        initial_len - writer.len()
+    };
+    let meta = packet.meta_mut();
+    meta.size = size;
+    meta.set_socket_addr(addr.borrow());
+    stats.record_gossip_packet(pkt);
+    Some(packet)
 }
 
 #[cfg(test)]

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -328,7 +328,7 @@ impl ClusterInfo {
         match File::create(tmp_filename) {
             Ok(file) => {
                 let mut writer = BufWriter::new(file);
-                if let Err(err) = bincode::serialize_into(&mut writer, &nodes) {
+                if let Err(err) = wincode::serialize_into(&mut writer, &nodes) {
                     warn!(
                         "Failed to serialize contact info info {}: {}",
                         tmp_filename.display(),
@@ -376,7 +376,7 @@ impl ClusterInfo {
 
         let nodes: Vec<CrdsValue> = match File::open(&filename) {
             Ok(file) => {
-                bincode::deserialize_from(&mut BufReader::new(file)).unwrap_or_else(|err| {
+                wincode::deserialize_from(&mut BufReader::new(file)).unwrap_or_else(|err| {
                     warn!("Failed to deserialize {}: {}", filename.display(), err);
                     vec![]
                 })
@@ -2530,7 +2530,6 @@ mod tests {
             protocol::tests::new_rand_remote_node,
             socketaddr,
         },
-        bincode::serialize,
         itertools::izip,
         solana_keypair::Keypair,
         solana_ledger::shred::Shredder,
@@ -2727,9 +2726,14 @@ mod tests {
             pongs.into_iter()
         ) {
             assert_eq!(packet.meta().socket_addr(), socket);
-            let bytes = serialize(&pong).unwrap();
+            let bytes = wincode::serialize(&pong).unwrap();
+            assert_eq!(bytes, bincode::serialize(&pong).unwrap());
             match packet.deserialize_slice(..).unwrap() {
-                Protocol::PongMessage(pong) => assert_eq!(serialize(&pong).unwrap(), bytes),
+                Protocol::PongMessage(pong) => {
+                    let pong_bytes = wincode::serialize(&pong).unwrap();
+                    assert_eq!(pong_bytes, bincode::serialize(&pong).unwrap());
+                    assert_eq!(pong_bytes, bytes);
+                }
                 _ => panic!("invalid packet!"),
             }
         }
@@ -2791,6 +2795,46 @@ mod tests {
         cluster_info.insert_info(d);
         let gossip_crds = cluster_info.gossip.crds.read().unwrap();
         assert!(gossip_crds.get::<&CrdsValue>(&label).is_some());
+    }
+
+    #[test]
+    fn test_save_restore_contact_info_round_trip() {
+        let tmpdir = tempfile::tempdir().unwrap();
+
+        let self_keypair = Arc::new(Keypair::new());
+        let self_ci = ContactInfo::new_localhost(&self_keypair.pubkey(), timestamp());
+        let mut cluster_info_a =
+            ClusterInfo::new(self_ci, self_keypair, SocketAddrSpace::Unspecified);
+        // Sets contact_info_path; no file to load yet.
+        cluster_info_a.restore_contact_info(tmpdir.path(), 0);
+
+        let peer1 = ContactInfo::new_localhost(&solana_pubkey::new_rand(), timestamp());
+        let peer2 = ContactInfo::new_localhost(&solana_pubkey::new_rand(), timestamp());
+        let peer1_pubkey = *peer1.pubkey();
+        let peer2_pubkey = *peer2.pubkey();
+        cluster_info_a.insert_info(peer1);
+        cluster_info_a.insert_info(peer2);
+        cluster_info_a.save_contact_info();
+
+        let other_keypair = Arc::new(Keypair::new());
+        let other_ci = ContactInfo::new_localhost(&other_keypair.pubkey(), timestamp());
+        let mut cluster_info_b =
+            ClusterInfo::new(other_ci, other_keypair, SocketAddrSpace::Unspecified);
+        cluster_info_b.restore_contact_info(tmpdir.path(), 0);
+
+        let gossip_crds = cluster_info_b.gossip.crds.read().unwrap();
+        assert!(
+            gossip_crds
+                .get::<&CrdsValue>(&CrdsValueLabel::ContactInfo(peer1_pubkey))
+                .is_some(),
+            "peer1 missing after restore"
+        );
+        assert!(
+            gossip_crds
+                .get::<&CrdsValue>(&CrdsValueLabel::ContactInfo(peer2_pubkey))
+                .is_some(),
+            "peer2 missing after restore"
+        );
     }
 
     fn assert_in_range(x: u16, range: (u16, u16)) {

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -15,10 +15,12 @@ use {
     std::{
         cmp::Ordering,
         collections::HashSet,
+        mem::MaybeUninit,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         time::{SystemTime, UNIX_EPOCH},
     },
     thiserror::Error,
+    wincode::{ReadError, ReadResult, SchemaRead, SchemaWrite, config::Config, io::Reader},
 };
 
 const DEFAULT_RPC_PORT: u16 = 8899;
@@ -77,10 +79,11 @@ pub enum Error {
     UnusedIpAddr(IpAddr),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, SchemaWrite)]
 pub struct ContactInfo {
     pubkey: Pubkey,
     #[serde(with = "serde_varint")]
+    #[wincode(with = "solana_wincode_varint::Leb128Int<u64>")]
     wallclock: u64,
     // When the node instance was first created.
     // Identifies duplicate running instances.
@@ -89,23 +92,28 @@ pub struct ContactInfo {
     version: solana_version::Version,
     // All IP addresses are unique and referenced at least once in sockets.
     #[serde(with = "short_vec")]
+    #[wincode(with = "wincode::containers::Vec<IpAddr, short_vec::ShortU16>")]
     addrs: Vec<IpAddr>,
     // All sockets have a unique key and a valid IP address index.
     #[serde(with = "short_vec")]
+    #[wincode(with = "wincode::containers::Vec<SocketEntry, short_vec::ShortU16>")]
     sockets: Vec<SocketEntry>,
     #[serde(with = "short_vec")]
+    #[wincode(with = "wincode::containers::Vec<Extension, short_vec::ShortU16>")]
     extensions: Vec<Extension>,
     // Only sanitized socket-addrs can be cached!
     #[serde(skip_serializing)]
+    #[wincode(skip(default_val = EMPTY_SOCKET_ADDR_CACHE))]
     cache: [SocketAddr; SOCKET_CACHE_SIZE],
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize, SchemaWrite, SchemaRead)]
 pub(crate) struct SocketEntry {
     pub(crate) key: u8,   // Protocol identifier, e.g. tvu, tpu, etc
     pub(crate) index: u8, // IpAddr index in the accompanying addrs vector.
     #[serde(with = "serde_varint")]
+    #[wincode(with = "solana_wincode_varint::Leb128Int<u16>")]
     pub(crate) offset: u16, // Port offset with respect to the previous entry.
 }
 
@@ -127,20 +135,24 @@ define_tlv_enum!(
 // verified and self.cache needs to be populated. This type serves as a
 // workaround since serde does not have an initializer.
 // https://github.com/serde-rs/serde/issues/642
-#[derive(Deserialize)]
+#[derive(Deserialize, SchemaRead)]
 struct ContactInfoLite {
     pubkey: Pubkey,
     #[serde(with = "serde_varint")]
+    #[wincode(with = "solana_wincode_varint::Leb128Int<u64>")]
     wallclock: u64,
     outset: u64,
     shred_version: u16,
     version: solana_version::Version,
     #[serde(with = "short_vec")]
+    #[wincode(with = "wincode::containers::Vec<IpAddr, short_vec::ShortU16>")]
     addrs: Vec<IpAddr>,
     #[serde(with = "short_vec")]
+    #[wincode(with = "wincode::containers::Vec<SocketEntry, short_vec::ShortU16>")]
     sockets: Vec<SocketEntry>,
     #[allow(dead_code)]
     #[serde(with = "short_vec")]
+    #[wincode(with = "wincode::containers::Vec<TlvRecord, short_vec::ShortU16>")]
     extensions: Vec<TlvRecord>,
 }
 
@@ -598,6 +610,18 @@ impl TryFrom<ContactInfoLite> for ContactInfo {
     }
 }
 
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for ContactInfo {
+    type Dst = ContactInfo;
+
+    fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let lite = <ContactInfoLite as SchemaRead<'de, C>>::get(reader)?;
+        let node = ContactInfo::try_from(lite)
+            .map_err(|_| ReadError::Custom("ContactInfo: invalid entries"))?;
+        dst.write(node);
+        Ok(())
+    }
+}
+
 impl Sanitize for ContactInfo {
     fn sanitize(&self) -> Result<(), SanitizeError> {
         if self.wallclock >= MAX_WALLCLOCK {
@@ -976,8 +1000,10 @@ mod tests {
                 .is_ok()
             );
             // Assert that serde round trips.
-            let bytes = bincode::serialize(&node).unwrap();
-            let other: ContactInfo = bincode::deserialize(&bytes).unwrap();
+            let bytes = wincode::serialize(&node).unwrap();
+            assert_eq!(bytes, bincode::serialize(&node).unwrap());
+            let other: ContactInfo = wincode::deserialize(&bytes).unwrap();
+            assert_eq!(other, bincode::deserialize::<ContactInfo>(&bytes).unwrap());
             assert_eq!(node, other);
         }
     }
@@ -1090,6 +1116,43 @@ mod tests {
             assert!(!other.check_duplicate(&node));
             assert_eq!(node.overrides(&other), Some(false));
             assert_eq!(other.overrides(&node), Some(true));
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_contact_info() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let node = ContactInfo::new_rand(&mut rng, None);
+
+            let bincode_bytes = bincode::serialize(&node).unwrap();
+            let wincode_decoded: ContactInfo = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(node, wincode_decoded);
+
+            let wincode_bytes = wincode::serialize(&node).unwrap();
+            assert_eq!(wincode_bytes, bincode_bytes);
+            let bincode_decoded: ContactInfo = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(node, bincode_decoded);
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_socket_entry() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let entry = SocketEntry {
+                key: rng.random(),
+                index: rng.random(),
+                offset: rng.random(),
+            };
+
+            let bincode_bytes = bincode::serialize(&entry).unwrap();
+            let wincode_decoded: SocketEntry = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(entry, wincode_decoded);
+
+            let wincode_bytes = wincode::serialize(&entry).unwrap();
+            let bincode_decoded: SocketEntry = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(entry, bincode_decoded);
         }
     }
 }

--- a/gossip/src/crds_data.rs
+++ b/gossip/src/crds_data.rs
@@ -72,6 +72,7 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for RejectNonzeroU8 {
 /// * LowestSlot index is deprecated
 #[allow(clippy::large_enum_variant)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[cfg_attr(test, derive(strum_macros::EnumCount))]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, SchemaWrite, SchemaRead)]
 pub enum CrdsData {
     #[allow(private_interfaces)]

--- a/gossip/src/crds_data.rs
+++ b/gossip/src/crds_data.rs
@@ -14,7 +14,12 @@ use {
     solana_time_utils::timestamp,
     solana_transaction::Transaction,
     solana_vote::vote_parser,
-    std::collections::BTreeSet,
+    std::{collections::BTreeSet, mem::MaybeUninit},
+    wincode::{
+        ReadError, ReadResult, SchemaRead, SchemaWrite, TypeMeta, WriteResult,
+        config::Config,
+        io::{Reader, Writer},
+    },
 };
 
 pub(crate) const MAX_WALLCLOCK: u64 = 1_000_000_000_000_000;
@@ -30,22 +35,52 @@ pub(crate) type EpochSlotsIndex = u8;
 pub(crate) const MAX_EPOCH_SLOTS: EpochSlotsIndex = 255;
 
 // Helper for deprecated types
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Clone, Debug, PartialEq, Eq, SchemaWrite)]
 pub(crate) struct Deprecated {}
 reject_deserialize!(Deprecated, "Trying to deserialize deprecated type");
+
+// Wincode schema that reads a u8 and rejects non-zero values, mirroring the
+// serde `reject_nonzero_u8` deserializer used on the LowestSlot index field.
+struct RejectNonzeroU8;
+unsafe impl<C: Config> SchemaWrite<C> for RejectNonzeroU8 {
+    type Src = u8;
+    const TYPE_META: TypeMeta = <u8 as SchemaWrite<C>>::TYPE_META;
+
+    fn size_of(src: &u8) -> WriteResult<usize> {
+        <u8 as SchemaWrite<C>>::size_of(src)
+    }
+    fn write(writer: impl Writer, src: &u8) -> WriteResult<()> {
+        <u8 as SchemaWrite<C>>::write(writer, src)
+    }
+}
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for RejectNonzeroU8 {
+    type Dst = u8;
+    const TYPE_META: TypeMeta = <u8 as SchemaRead<'de, C>>::TYPE_META.keep_zero_copy(false);
+
+    fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<u8>) -> ReadResult<()> {
+        let index = <u8 as SchemaRead<'de, C>>::get(reader)?;
+        if index != 0 {
+            return Err(ReadError::Custom("LowestSlot index must be 0"));
+        }
+        dst.write(index);
+        Ok(())
+    }
+}
 
 /// CrdsData that defines the different types of items CrdsValues can hold
 /// * Merge Strategy - Latest wallclock is picked
 /// * LowestSlot index is deprecated
 #[allow(clippy::large_enum_variant)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, SchemaWrite, SchemaRead)]
 pub enum CrdsData {
     #[allow(private_interfaces)]
     LegacyContactInfo(Deprecated), // Deprecated
     Vote(VoteIndex, Vote),
     LowestSlot(
-        #[serde(deserialize_with = "reject_nonzero_u8")] u8, // u8 is deprecated
+        #[serde(deserialize_with = "reject_nonzero_u8")]
+        #[wincode(with = "RejectNonzeroU8")]
+        u8, // u8 is deprecated
         LowestSlot,
     ),
     #[allow(private_interfaces)]
@@ -216,7 +251,7 @@ impl From<&ContactInfo> for CrdsData {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct SnapshotHashes {
     pub from: Pubkey,
     pub full: (Slot, Hash),
@@ -243,7 +278,7 @@ impl Sanitize for SnapshotHashes {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct LowestSlot {
     pub(crate) from: Pubkey,
     root: Slot, //deprecated
@@ -323,12 +358,13 @@ where
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, SchemaWrite)]
 pub struct Vote {
     pub(crate) from: Pubkey,
     transaction: Transaction,
     pub(crate) wallclock: u64,
     #[serde(skip_serializing)]
+    #[wincode(skip)]
     slot: Option<Slot>,
 }
 
@@ -400,6 +436,27 @@ impl<'de> Deserialize<'de> for Vote {
     }
 }
 
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for Vote {
+    type Dst = Self;
+
+    fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self>) -> ReadResult<()> {
+        #[derive(SchemaRead)]
+        struct VoteLite {
+            from: Pubkey,
+            transaction: Transaction,
+            wallclock: u64,
+        }
+        let lite = <VoteLite as SchemaRead<'de, C>>::get(reader)?;
+        lite.transaction
+            .sanitize()
+            .map_err(|_| ReadError::Custom("Vote: invalid transaction"))?;
+        let vote = Vote::new(lite.from, lite.transaction, lite.wallclock)
+            .ok_or(ReadError::Custom("Vote: invalid vote tx"))?;
+        dst.write(vote);
+        Ok(())
+    }
+}
+
 pub(crate) fn sanitize_wallclock(wallclock: u64) -> Result<(), SanitizeError> {
     if wallclock >= MAX_WALLCLOCK {
         Err(SanitizeError::ValueOutOfBounds)
@@ -417,6 +474,18 @@ macro_rules! reject_deserialize {
                 D::Error: serde::de::Error,
             {
                 Err(serde::de::Error::custom($msg))
+            }
+        }
+
+        // Mirror the serde rejection for wincode so deprecated types fail to deserialize
+        // by either path, whether read directly or as a CrdsData variant.
+        unsafe impl<'de, C: wincode::config::Config> wincode::SchemaRead<'de, C> for $ty {
+            type Dst = Self;
+            fn read(
+                _reader: impl wincode::io::Reader<'de>,
+                _dst: &mut std::mem::MaybeUninit<Self>,
+            ) -> wincode::ReadResult<()> {
+                Err(wincode::ReadError::Custom($msg))
             }
         }
     };
@@ -494,14 +563,76 @@ mod test {
         )
         .unwrap();
         assert_eq!(vote.slot, Some(7));
-        let bytes = bincode::serialize(&vote).unwrap();
-        let other = bincode::deserialize(&bytes[..]).unwrap();
+        let bytes = wincode::serialize(&vote).unwrap();
+        assert_eq!(bytes, bincode::serialize(&vote).unwrap());
+        let other = wincode::deserialize(&bytes[..]).unwrap();
+        assert_eq!(other, bincode::deserialize::<Vote>(&bytes[..]).unwrap());
         assert_eq!(vote, other);
         assert_eq!(other.slot, Some(7));
         let bytes = bincode::options().serialize(&vote).unwrap();
         let other = bincode::options().deserialize(&bytes[..]).unwrap();
         assert_eq!(vote, other);
         assert_eq!(other.slot, Some(7));
+    }
+
+    #[test]
+    fn test_wincode_compatibility_lowest_slot() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let lowest_slot = LowestSlot::new_rand(&mut rng, None);
+
+            let bincode_bytes = bincode::serialize(&lowest_slot).unwrap();
+            let wincode_decoded: LowestSlot = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(lowest_slot, wincode_decoded);
+
+            let wincode_bytes = wincode::serialize(&lowest_slot).unwrap();
+            let bincode_decoded: LowestSlot = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(lowest_slot, bincode_decoded);
+
+            assert_eq!(bincode_bytes, wincode_bytes);
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_snapshot_hashes() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let num_incremental = rng.random_range(0usize..5);
+            let snapshot_hashes = SnapshotHashes {
+                from: solana_pubkey::new_rand(),
+                full: (rng.random(), Hash::new_unique()),
+                incremental: (0..num_incremental)
+                    .map(|_| (rng.random(), Hash::new_unique()))
+                    .collect(),
+                wallclock: new_rand_timestamp(&mut rng),
+            };
+
+            let bincode_bytes = bincode::serialize(&snapshot_hashes).unwrap();
+            let wincode_decoded: SnapshotHashes = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(snapshot_hashes, wincode_decoded);
+
+            let wincode_bytes = wincode::serialize(&snapshot_hashes).unwrap();
+            let bincode_decoded: SnapshotHashes = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(snapshot_hashes, bincode_decoded);
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_vote() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let keypair = Keypair::new();
+            let vote =
+                Vote::new(keypair.pubkey(), new_test_vote_tx(&mut rng), timestamp()).unwrap();
+
+            let bincode_bytes = bincode::serialize(&vote).unwrap();
+            let wincode_decoded: Vote = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(vote, wincode_decoded);
+
+            let wincode_bytes = wincode::serialize(&vote).unwrap();
+            let bincode_decoded: Vote = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(vote, bincode_decoded);
+        }
     }
 
     #[test]
@@ -528,8 +659,10 @@ mod test {
             CrdsData::LegacySnapshotHashes(Deprecated {}),
         ];
 
-        for value in deprecated_values {
-            let bytes = bincode::serialize(&value).unwrap();
+        for value in &deprecated_values {
+            let bytes = wincode::serialize(value).unwrap();
+            assert_eq!(bytes, bincode::serialize(value).unwrap());
+            assert!(wincode::deserialize::<CrdsData>(&bytes[..]).is_err());
             assert!(bincode::deserialize::<CrdsData>(&bytes[..]).is_err());
         }
 
@@ -544,7 +677,9 @@ mod test {
         // LowestSlot(0, ...) -> should be deserialized successfully
         let lowest_slot =
             CrdsData::LowestSlot(0, LowestSlot::new(keypair.pubkey(), 0, timestamp()));
-        let bytes = bincode::serialize(&lowest_slot).unwrap();
+        let bytes = wincode::serialize(&lowest_slot).unwrap();
+        assert_eq!(bytes, bincode::serialize(&lowest_slot).unwrap());
+        assert!(wincode::deserialize::<CrdsData>(&bytes[..]).is_ok());
         assert!(bincode::deserialize::<CrdsData>(&bytes[..]).is_ok());
     }
 }

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -48,6 +48,7 @@ use {
         },
         time::Duration,
     },
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 pub const CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS: u64 = 15000;
@@ -57,7 +58,7 @@ pub const FALSE_RATE: f64 = 0.1f64;
 pub const KEYS: f64 = 8f64;
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, SchemaWrite, SchemaRead)]
 pub struct CrdsFilter {
     pub filter: Bloom<Hash>,
     mask: u64,
@@ -606,7 +607,7 @@ impl Index<&Pubkey> for CrdsTimeouts<'_> {
     }
 }
 
-// Returns max_bytes for the bloom filter such that bincode serialized
+// Returns max_bytes for the bloom filter such that the serialized
 // Protocol::PullRequest(CrdsFilter, CrdsValue) fits in a packet.
 pub(crate) fn get_max_bloom_filter_bytes(caller: &CrdsValue) -> usize {
     // Maps serialized size of CrdsFilter to max_bytes of bloom filter.
@@ -618,7 +619,7 @@ pub(crate) fn get_max_bloom_filter_bytes(caller: &CrdsValue) -> usize {
             let mut iter = Vec::<CrdsFilter>::from(filters)
                 .into_iter()
                 .map(|filter| {
-                    bincode::serialized_size(&filter)
+                    wincode::serialized_size(&filter)
                         .map(usize::try_from)
                         .unwrap()
                         .unwrap()
@@ -638,12 +639,12 @@ pub(crate) fn get_max_bloom_filter_bytes(caller: &CrdsValue) -> usize {
         });
         out
     });
-    // Maximum bincode serialized size of CrdsFilter in
+    // Maximum serialized size of CrdsFilter in
     // Protocol::PullRequest(CrdsFilter, CrdsValue)
     let size_of_filter = PACKET_DATA_SIZE
         .checked_sub(
             // 4 bytes for u32 enum variant identifier of Protocol.
-            4 + caller.bincode_serialized_size(),
+            4 + caller.serialized_size(),
         )
         .unwrap();
     MAX_BYTES_CACHE
@@ -1327,11 +1328,15 @@ pub(crate) mod tests {
         let packet_data_size_range = (PACKET_DATA_SIZE - 7)..=PACKET_DATA_SIZE;
         let max_bytes = get_max_bloom_filter_bytes(caller);
         let filters = CrdsFilterSet::new(rng, num_items, max_bytes);
-        let request_bytes = caller.bincode_serialized_size() as u64;
+        let request_bytes = caller.serialized_size() as u64;
         for filter in Vec::<CrdsFilter>::from(filters) {
-            let request_bytes = 4 + request_bytes + bincode::serialized_size(&filter).unwrap();
+            let filter_size = wincode::serialized_size(&filter).unwrap();
+            assert_eq!(filter_size, bincode::serialized_size(&filter).unwrap());
+            let request_bytes = 4 + request_bytes + filter_size;
             let request = Protocol::PullRequest(filter, caller.clone());
-            let request = bincode::serialize(&request).unwrap();
+            let request_wincode = wincode::serialize(&request).unwrap();
+            assert_eq!(request_wincode, bincode::serialize(&request).unwrap());
+            let request = request_wincode;
             assert!(packet_data_size_range.contains(&request.len()));
             assert_eq!(request.len() as u64, request_bytes);
         }
@@ -1480,5 +1485,23 @@ pub(crate) mod tests {
         filter.mask = canonical_mask & !lsb;
         assert!(filter.test_mask(&hash));
         assert!(!filter.test_mask(&bad_hash));
+    }
+
+    #[test]
+    fn test_wincode_compatibility_crds_filter() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let num_items = rng.random_range(0..1000);
+            let max_bytes = rng.random_range(32..512);
+            let filter = CrdsFilter::new_rand(num_items, max_bytes);
+
+            let bincode_bytes = bincode::serialize(&filter).unwrap();
+            let wincode_decoded: CrdsFilter = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(filter, wincode_decoded);
+
+            let wincode_bytes = wincode::serialize(&filter).unwrap();
+            let bincode_decoded: CrdsFilter = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(filter, bincode_decoded);
+        }
     }
 }

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -5,8 +5,6 @@ use {
         duplicate_shred::DuplicateShredIndex,
         epoch_slots::EpochSlots,
     },
-    arrayvec::ArrayVec,
-    bincode::serialize,
     rand::Rng,
     serde::{Deserialize, Serialize, de::Deserializer},
     solana_hash::Hash,
@@ -16,16 +14,21 @@ use {
     solana_sanitize::{Sanitize, SanitizeError},
     solana_signature::Signature,
     solana_signer::Signer,
-    std::borrow::{Borrow, Cow},
+    std::{
+        borrow::{Borrow, Cow},
+        mem::MaybeUninit,
+    },
+    wincode::{ReadError, ReadResult, SchemaRead, SchemaWrite, config::Config, io::Reader},
 };
 
 /// CrdsValue that is replicated across the cluster
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Clone, Debug, PartialEq, Eq, SchemaWrite)]
 pub struct CrdsValue {
     signature: Signature,
     data: CrdsData,
     #[serde(skip_serializing)]
+    #[wincode(skip)]
     hash: Hash, // Sha256 hash of [signature, data].
 }
 
@@ -42,7 +45,7 @@ impl Signable for CrdsValue {
     }
 
     fn signable_data(&self) -> Cow<'static, [u8]> {
-        Cow::Owned(serialize(&self.data).expect("failed to serialize CrdsData"))
+        Cow::Owned(wincode::serialize(&self.data).expect("failed to serialize CrdsData"))
     }
 
     fn get_signature(&self) -> Signature {
@@ -90,9 +93,9 @@ impl CrdsValueLabel {
 
 impl CrdsValue {
     pub fn new(data: CrdsData, keypair: &Keypair) -> Self {
-        let bincode_serialized_data = bincode::serialize(&data).unwrap();
-        let signature = keypair.sign_message(&bincode_serialized_data);
-        let hash = solana_sha256_hasher::hashv(&[signature.as_ref(), &bincode_serialized_data]);
+        let serialized_data = wincode::serialize(&data).unwrap();
+        let signature = keypair.sign_message(&serialized_data);
+        let hash = solana_sha256_hasher::hashv(&[signature.as_ref(), &serialized_data]);
         Self {
             signature,
             data,
@@ -102,9 +105,9 @@ impl CrdsValue {
 
     #[cfg(test)]
     pub(crate) fn new_unsigned(data: CrdsData) -> Self {
-        let bincode_serialized_data = bincode::serialize(&data).unwrap();
+        let serialized_data = wincode::serialize(&data).unwrap();
         let signature = Signature::default();
-        let hash = solana_sha256_hasher::hashv(&[signature.as_ref(), &bincode_serialized_data]);
+        let hash = solana_sha256_hasher::hashv(&[signature.as_ref(), &serialized_data]);
         Self {
             signature,
             data,
@@ -190,12 +193,47 @@ impl CrdsValue {
         Some(epoch_slots)
     }
 
-    /// Returns the bincode serialized size (in bytes) of the CrdsValue.
-    pub fn bincode_serialized_size(&self) -> usize {
-        bincode::serialized_size(&self)
+    /// Returns the serialized size (in bytes) of the CrdsValue.
+    pub fn serialized_size(&self) -> usize {
+        wincode::serialized_size(&self)
             .map(usize::try_from)
             .unwrap()
             .unwrap()
+    }
+}
+
+// Computes sha256(signature || serialize(data)) using a stack buffer.
+// PACKET_DATA_SIZE is always enough since the value originated in a packet.
+fn compute_crds_value_hash(signature: &Signature, data: &CrdsData) -> wincode::WriteResult<Hash> {
+    let mut buffer = [MaybeUninit::<u8>::uninit(); PACKET_DATA_SIZE];
+    let mut writer: &mut [MaybeUninit<u8>] = &mut buffer;
+    wincode::serialize_into(&mut writer, data)?;
+    let written = PACKET_DATA_SIZE - writer.len();
+    // SAFETY: wincode's "Writer for &mut [MaybeUninit<u8>]" initializes every
+    // consumed slot before advancing the cursor, so the first "written" bytes are init.
+    let bytes = unsafe { std::slice::from_raw_parts(buffer.as_ptr().cast::<u8>(), written) };
+    Ok(solana_sha256_hasher::hashv(&[signature.as_ref(), bytes]))
+}
+
+// Manual implementation of SchemaRead for CrdsValue in order to populate
+// CrdsValue.hash which is skipped in serialization.
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for CrdsValue {
+    type Dst = Self;
+    fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self>) -> ReadResult<()> {
+        #[derive(SchemaRead)]
+        struct CrdsValueLite {
+            signature: Signature,
+            data: CrdsData,
+        }
+        let CrdsValueLite { signature, data } = <CrdsValueLite as SchemaRead<'de, C>>::get(reader)?;
+        let hash = compute_crds_value_hash(&signature, &data)
+            .map_err(|_| ReadError::Custom("failed to serialize CrdsData"))?;
+        dst.write(Self {
+            signature,
+            data,
+            hash,
+        });
+        Ok(())
     }
 }
 
@@ -212,12 +250,7 @@ impl<'de> Deserialize<'de> for CrdsValue {
             data: CrdsData,
         }
         let CrdsValue { signature, data } = CrdsValue::deserialize(deserializer)?;
-        // To compute the hash of the received CrdsData we need to re-serialize it
-        // PACKET_DATA_SIZE is always enough since we have just received the value in a packet
-        // ArrayVec allows us to write serialized data into stack memory without initializing it
-        let mut buffer = ArrayVec::<u8, PACKET_DATA_SIZE>::new();
-        bincode::serialize_into(&mut buffer, &data).map_err(serde::de::Error::custom)?;
-        let hash = solana_sha256_hasher::hashv(&[signature.as_ref(), &buffer]);
+        let hash = compute_crds_value_hash(&signature, &data).map_err(serde::de::Error::custom)?;
         Ok(Self {
             signature,
             data,
@@ -231,7 +264,6 @@ mod test {
     use {
         super::*,
         crate::crds_data::{LowestSlot, Vote},
-        bincode::deserialize,
         rand::SeedableRng as _,
         rand_chacha::ChaChaRng,
         solana_keypair::Keypair,
@@ -298,8 +330,13 @@ mod test {
         value.sign(keypair);
         let original_signature = value.get_signature();
         for _ in 0..num_tries {
-            let serialized_value = serialize(value).unwrap();
-            let deserialized_value: CrdsValue = deserialize(&serialized_value).unwrap();
+            let serialized_value = wincode::serialize(value).unwrap();
+            assert_eq!(serialized_value, bincode::serialize(value).unwrap());
+            let deserialized_value: CrdsValue = wincode::deserialize(&serialized_value).unwrap();
+            assert_eq!(
+                deserialized_value,
+                bincode::deserialize::<CrdsValue>(&serialized_value).unwrap()
+            );
 
             // Signatures shouldn't change
             let deserialized_signature = deserialized_value.get_signature();
@@ -395,16 +432,49 @@ mod test {
                 CrdsValue::new(CrdsData::Vote(5, vote), &keypair)
             },
         ];
-        let bytes = bincode::serialize(&values).unwrap();
+        let bytes = wincode::serialize(&values).unwrap();
+        assert_eq!(bytes, bincode::serialize(&values).unwrap());
         // Serialized bytes are fixed and should never change.
         assert_eq!(
             solana_sha256_hasher::hash(&bytes),
             Hash::from_str("BTg284TRo5S5PpbA9YZaab5rKeoLNAj7arwadvG6XVLT").unwrap()
         );
         // serialize -> deserialize should round trip.
+        let wincode_values = wincode::deserialize::<Vec<CrdsValue>>(&bytes).unwrap();
         assert_eq!(
-            bincode::deserialize::<Vec<CrdsValue>>(&bytes).unwrap(),
-            values
+            wincode_values,
+            bincode::deserialize::<Vec<CrdsValue>>(&bytes).unwrap()
         );
+        assert_eq!(wincode_values, values);
+    }
+
+    #[test]
+    fn test_wincode_compatibility_crds_value() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let value = CrdsValue::new_rand(&mut rng, None);
+            let bincode_bytes = bincode::serialize(&value).unwrap();
+            let wincode_bytes = wincode::serialize(&value).unwrap();
+            assert_eq!(
+                bincode_bytes,
+                wincode_bytes,
+                "bytes differ for {:?}",
+                value.label()
+            );
+            // Deprecated types and Vote with test-only invalid transactions intentionally
+            // fail serde deserialization; skip those.
+            let Ok(bincode_decoded) = bincode::deserialize::<CrdsValue>(&bincode_bytes) else {
+                continue;
+            };
+            let wincode_decoded: CrdsValue = wincode::deserialize(&bincode_bytes)
+                .unwrap_or_else(|e| panic!("wincode deser failed for {:?}: {e}", value.label()));
+            assert_eq!(
+                bincode_decoded,
+                wincode_decoded,
+                "deser mismatch for {:?}",
+                value.label()
+            );
+            assert_eq!(value, bincode_decoded);
+        }
     }
 }

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -16,6 +16,7 @@ use {
         num::TryFromIntError,
     },
     thiserror::Error,
+    wincode::{ReadError, SchemaRead, SchemaWrite, WriteError},
 };
 
 const DUPLICATE_SHRED_HEADER_SIZE: usize = 63;
@@ -24,7 +25,7 @@ pub(crate) type DuplicateShredIndex = u16;
 pub(crate) const MAX_DUPLICATE_SHREDS: DuplicateShredIndex = 512;
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, SchemaWrite, SchemaRead)]
 pub struct DuplicateShred {
     pub(crate) from: Pubkey,
     pub(crate) wallclock: u64,
@@ -108,9 +109,9 @@ pub enum Error {
     #[error("missing data chunk")]
     MissingDataChunk,
     #[error("wincode deserialization error")]
-    WincodeReadError(#[from] wincode::ReadError),
+    WincodeReadError(#[from] ReadError),
     #[error("wincode serialization error")]
-    WincodeWriteError(#[from] wincode::WriteError),
+    WincodeWriteError(#[from] WriteError),
     #[error("shred type mismatch")]
     ShredTypeMismatch,
     #[error("slot mismatch")]
@@ -379,6 +380,33 @@ pub(crate) mod tests {
     };
 
     #[test]
+    fn test_wincode_compatibility_duplicate_shred() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let chunk_len = rng.random_range(0..64usize);
+            let dup = DuplicateShred {
+                from: Pubkey::new_unique(),
+                wallclock: rng.random(),
+                slot: rng.random(),
+                _unused: rng.random(),
+                _unused_shred_type: rng.random(),
+                num_chunks: rng.random(),
+                chunk_index: rng.random(),
+                chunk: (0..chunk_len).map(|_| rng.random()).collect(),
+            };
+
+            let bincode_bytes = bincode::serialize(&dup).unwrap();
+            let wincode_decoded: DuplicateShred = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(dup, wincode_decoded);
+
+            let wincode_bytes = wincode::serialize(&dup).unwrap();
+            assert_eq!(wincode_bytes, bincode_bytes);
+            let bincode_decoded: DuplicateShred = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(dup, bincode_decoded);
+        }
+    }
+
+    #[test]
     fn test_duplicate_shred_header_size() {
         let dup = DuplicateShred {
             from: Pubkey::new_unique(),
@@ -390,14 +418,12 @@ pub(crate) mod tests {
             chunk: Vec::default(),
             _unused: 0,
         };
-        assert_eq!(
-            bincode::serialize(&dup).unwrap().len(),
-            DUPLICATE_SHRED_HEADER_SIZE
-        );
-        assert_eq!(
-            bincode::serialized_size(&dup).unwrap(),
-            DUPLICATE_SHRED_HEADER_SIZE as u64
-        );
+        let dup_bytes = wincode::serialize(&dup).unwrap();
+        assert_eq!(dup_bytes, bincode::serialize(&dup).unwrap());
+        assert_eq!(dup_bytes.len(), DUPLICATE_SHRED_HEADER_SIZE);
+        let dup_size = wincode::serialized_size(&dup).unwrap();
+        assert_eq!(dup_size, bincode::serialized_size(&dup).unwrap());
+        assert_eq!(dup_size, DUPLICATE_SHRED_HEADER_SIZE as u64);
     }
 
     pub(crate) fn new_rand_shred<R: Rng>(

--- a/gossip/src/epoch_slots.rs
+++ b/gossip/src/epoch_slots.rs
@@ -3,7 +3,6 @@ use {
         crds_data::{self, MAX_SLOT, MAX_WALLCLOCK},
         protocol::MAX_CRDS_OBJECT_SIZE,
     },
-    bincode::serialized_size,
     bv::BitVec,
     flate2::{Compress, Compression, Decompress, FlushCompress, FlushDecompress},
     serde::{Deserialize, Serialize},
@@ -11,11 +10,13 @@ use {
     solana_pubkey::Pubkey,
     solana_sanitize::{Sanitize, SanitizeError},
     std::{borrow::Cow, cell::RefCell, sync::Arc},
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 pub const MAX_SLOTS_PER_ENTRY: usize = 2048 * 8;
+
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct Uncompressed {
     pub first_slot: Slot,
     pub num: usize,
@@ -44,7 +45,7 @@ impl Sanitize for Uncompressed {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct Flate2 {
     pub first_slot: Slot,
     pub num: usize,
@@ -198,7 +199,7 @@ impl Uncompressed {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub enum CompressedSlots {
     Flate2(Flate2),
     Uncompressed(Uncompressed),
@@ -265,7 +266,7 @@ impl CompressedSlots {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct EpochSlots {
     pub from: Pubkey,
     pub slots: Vec<CompressedSlots>,
@@ -340,8 +341,8 @@ impl EpochSlots {
         Ok(())
     }
     pub fn max_compressed_slot_size(&self) -> isize {
-        let len_header = serialized_size(self).unwrap();
-        let len_slot = serialized_size(&CompressedSlots::default()).unwrap();
+        let len_header = wincode::serialized_size(self).unwrap();
+        let len_slot = wincode::serialized_size(&CompressedSlots::default()).unwrap();
         MAX_CRDS_OBJECT_SIZE as isize - (len_header + len_slot) as isize
     }
 
@@ -527,6 +528,98 @@ mod tests {
         let mut slots = EpochSlots::default();
         assert_eq!(slots.fill(&range, 2), 5000);
         assert!(slots.to_slots(0).eq(range));
+    }
+
+    #[test]
+    fn test_wincode_compatibility_uncompressed() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let mut unc = Uncompressed::new(rng.random_range(1..=16usize));
+            let first: Slot = rng.random_range(0..10_000);
+            let num: u64 = rng.random_range(0..64);
+            let slots: Vec<_> = (0..num).map(|i| first + i).collect();
+            unc.add(&slots);
+
+            let bincode_bytes = bincode::serialize(&unc).unwrap();
+            let wincode_decoded: Uncompressed = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(unc, wincode_decoded);
+
+            let wincode_bytes = wincode::serialize(&unc).unwrap();
+            let bincode_decoded: Uncompressed = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(unc, bincode_decoded);
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_flate2() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            // Arbitrary bytes — wire-format equivalence does not require a valid compressed stream.
+            let len = rng.random_range(0..64usize);
+            let flate2 = Flate2 {
+                first_slot: rng.random(),
+                num: rng.random_range(0..1000),
+                compressed: Arc::new((0..len).map(|_| rng.random::<u8>()).collect()),
+            };
+
+            let bincode_bytes = bincode::serialize(&flate2).unwrap();
+            let wincode_decoded: Flate2 = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(flate2, wincode_decoded);
+
+            let wincode_bytes = wincode::serialize(&flate2).unwrap();
+            let bincode_decoded: Flate2 = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(flate2, bincode_decoded);
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_compressed_slots() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let mut unc = Uncompressed::new(rng.random_range(1..=16usize));
+            let first: Slot = rng.random_range(0..10_000);
+            let num: u64 = rng.random_range(0..64);
+            let slots: Vec<_> = (0..num).map(|i| first + i).collect();
+            unc.add(&slots);
+            let cs = CompressedSlots::Uncompressed(unc);
+
+            let bincode_bytes = bincode::serialize(&cs).unwrap();
+            let wincode_decoded: CompressedSlots = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(cs, wincode_decoded);
+            let wincode_bytes = wincode::serialize(&cs).unwrap();
+            let bincode_decoded: CompressedSlots = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(cs, bincode_decoded);
+
+            let len = rng.random_range(0..64usize);
+            let cs = CompressedSlots::Flate2(Flate2 {
+                first_slot: rng.random(),
+                num: rng.random_range(0..1000),
+                compressed: Arc::new((0..len).map(|_| rng.random::<u8>()).collect()),
+            });
+
+            let bincode_bytes = bincode::serialize(&cs).unwrap();
+            let wincode_decoded: CompressedSlots = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(cs, wincode_decoded);
+            let wincode_bytes = wincode::serialize(&cs).unwrap();
+            let bincode_decoded: CompressedSlots = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(cs, bincode_decoded);
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_epoch_slots() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let epoch_slots = EpochSlots::new_rand(&mut rng, None);
+
+            let bincode_bytes = bincode::serialize(&epoch_slots).unwrap();
+            let wincode_decoded: EpochSlots = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(epoch_slots, wincode_decoded);
+
+            let wincode_bytes = wincode::serialize(&epoch_slots).unwrap();
+            let bincode_decoded: EpochSlots = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(epoch_slots, bincode_decoded);
+        }
     }
 
     fn make_rand_slots<R: Rng>(rng: &mut R) -> impl Iterator<Item = Slot> + '_ {

--- a/gossip/src/gossip_error.rs
+++ b/gossip/src/gossip_error.rs
@@ -20,7 +20,7 @@ pub enum GossipError {
     #[error("send error")]
     SendError,
     #[error("serialization error")]
-    Serialize(#[from] Box<bincode::ErrorKind>),
+    Serialize(#[from] wincode::Error),
 }
 
 impl<T> std::convert::From<SendError<T>> for GossipError {

--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -17,6 +17,7 @@ use {
         net::{IpAddr, SocketAddr},
         time::{Duration, Instant},
     },
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 const KEY_REFRESH_CADENCE: Duration = Duration::from_secs(60);
@@ -27,7 +28,7 @@ const PONG_SIGNATURE_SAMPLE_LEADING_ZEROS: u32 = 5;
 // N should always be >= 8 and only the first 8 bytes are used. So the new code
 // should only use N == 8.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize, SchemaRead, SchemaWrite)]
 pub struct Ping<const N: usize> {
     from: Pubkey,
     #[serde(with = "BigArray")]
@@ -36,7 +37,9 @@ pub struct Ping<const N: usize> {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize, SchemaRead, SchemaWrite)]
+// repr(C) makes this struct zero-copy eligible in wincode.
+#[repr(C)]
 pub struct Pong {
     from: Pubkey,
     hash: Hash, // Hash of received ping token.
@@ -443,6 +446,45 @@ mod tests {
             let (check, ping) = cache.check(&mut rng, &this_node, now, node);
             assert!(!check);
             assert_eq!(seen_nodes.insert(node), ping.is_some());
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_ping() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let keypair = Keypair::new();
+            let ping = Ping::<32>::new(rng.random(), &keypair);
+
+            let bincode_bytes = bincode::serialize(&ping).unwrap();
+            let wincode_decoded: Ping<32> = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(ping, wincode_decoded);
+
+            let wincode_bytes = wincode::serialize(&ping).unwrap();
+            let bincode_decoded: Ping<32> = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(ping, bincode_decoded);
+
+            assert_eq!(bincode_bytes, wincode_bytes);
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_pong() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let keypair = Keypair::new();
+            let ping = Ping::<32>::new(rng.random(), &keypair);
+            let pong = Pong::new(&ping, &keypair);
+
+            let bincode_bytes = bincode::serialize(&pong).unwrap();
+            let wincode_decoded: Pong = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(pong, wincode_decoded);
+
+            let wincode_bytes = wincode::serialize(&pong).unwrap();
+            let bincode_decoded: Pong = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(pong, bincode_decoded);
+
+            assert_eq!(bincode_bytes, wincode_bytes);
         }
     }
 

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -43,6 +43,16 @@ const PRUNE_DATA_PREFIX: &[u8] = b"\xffSOLANA_PRUNE_DATA";
 const GOSSIP_PING_TOKEN_SIZE: usize = 32;
 /// Minimum serialized size of a Protocol::PullResponse packet.
 pub(crate) const PULL_RESPONSE_MIN_SERIALIZED_SIZE: usize = 161;
+const MIN_CRDS_VALUE_SERIALIZED_SIZE: usize =
+    PULL_RESPONSE_MIN_SERIALIZED_SIZE - (PACKET_DATA_SIZE - PULL_RESPONSE_MAX_PAYLOAD_SIZE);
+const MAX_CRDS_VALUES_PER_PACKET: usize =
+    (PULL_RESPONSE_MAX_PAYLOAD_SIZE / MIN_CRDS_VALUE_SERIALIZED_SIZE) + 1;
+// Wincode's preallocation limit is decoded collection memory, not input bytes.
+// Bound it to the largest CRDS value vector that can fit in one gossip packet.
+const GOSSIP_PROTOCOL_PREALLOC_LIMIT: usize =
+    MAX_CRDS_VALUES_PER_PACKET * std::mem::size_of::<CrdsValue>();
+type GossipProtocolWincodeConfig =
+    wincode::config::Configuration<true, GOSSIP_PROTOCOL_PREALLOC_LIMIT>;
 
 /// Gossip protocol messages base enum
 #[derive(Serialize, Deserialize, Debug, SchemaRead, SchemaWrite)]
@@ -61,6 +71,13 @@ pub(crate) enum Protocol {
 
 pub(crate) type Ping = ping_pong::Ping<GOSSIP_PING_TOKEN_SIZE>;
 pub(crate) type PingCache = ping_pong::PingCache<GOSSIP_PING_TOKEN_SIZE>;
+
+pub(crate) fn deserialize_protocol(input: &[u8]) -> wincode::ReadResult<Protocol> {
+    wincode::config::deserialize_exact::<Protocol, GossipProtocolWincodeConfig>(
+        input,
+        GossipProtocolWincodeConfig::new(),
+    )
+}
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, SchemaRead, SchemaWrite)]
@@ -509,7 +526,7 @@ pub fn gossip_decode_to_effects(input: &[u8]) -> protosol::protos::GossipEffects
             msg: None,
         };
     }
-    let result = wincode::deserialize_exact::<Protocol>(input);
+    let result = deserialize_protocol(input);
 
     match result {
         Ok(proto) if proto.sanitize().is_ok() => {
@@ -532,15 +549,17 @@ pub(crate) mod tests {
         super::*,
         crate::{
             contact_info::ContactInfo,
-            crds_data::{self, CrdsData, LowestSlot, SnapshotHashes, Vote as CrdsVote},
+            crds_data::{self, CrdsData, Deprecated, LowestSlot, SnapshotHashes, Vote as CrdsVote},
             duplicate_shred::{self, MAX_DUPLICATE_SHREDS, tests::new_rand_shred},
+            epoch_slots::EpochSlots,
+            restart_crds_values::{RestartHeaviestFork, RestartLastVotedForkSlots},
         },
         rand::Rng,
         solana_clock::Slot,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::shred::Shredder,
-        solana_perf::packet::Packet,
+        solana_perf::{packet::Packet, test_tx::new_test_vote_tx},
         solana_signer::Signer,
         solana_time_utils::timestamp,
         solana_transaction::Transaction,
@@ -603,6 +622,20 @@ pub(crate) mod tests {
         };
         prune_data.sign(self_keypair);
         prune_data
+    }
+
+    #[test]
+    fn test_deserialize_protocol_rejects_large_vec_preallocation() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&2u32.to_le_bytes()); // Protocol::PushMessage.
+        bytes.extend_from_slice(&Pubkey::new_unique().to_bytes());
+        bytes.extend_from_slice(&u64::MAX.to_le_bytes()); // Vec<CrdsValue> length.
+
+        let err = deserialize_protocol(&bytes).unwrap_err();
+        assert!(matches!(
+            err,
+            wincode::ReadError::PreallocationSizeLimit { .. }
+        ));
     }
 
     #[test]
@@ -726,6 +759,85 @@ pub(crate) mod tests {
                 PULL_RESPONSE_MIN_SERIALIZED_SIZE <= size,
                 "pull-response serialized size: {size}"
             );
+        }
+    }
+
+    #[test]
+    fn test_min_crds_value_serialized_size_holds() {
+        let mut rng = rand::rng();
+        let keypair = Keypair::new();
+
+        // Build a DuplicateShred for the corresponding variant.
+        let leader = Arc::new(Keypair::new());
+        let (slot, parent_slot, reference_tick, version) = (53084024, 53084023, 0, 0);
+        let shredder = Shredder::new(slot, parent_slot, reference_tick, version).unwrap();
+        let next_shred_index = rng.random_range(0..32_000);
+        let shred = new_rand_shred(&mut rng, next_shred_index, &shredder, &leader);
+        let other_payload = {
+            let other = new_rand_shred(&mut rng, next_shred_index, &shredder, &leader);
+            other.into_payload()
+        };
+        let leader_schedule = |s| (s == slot).then_some(leader.pubkey());
+        let dup_shred = duplicate_shred::from_shred(
+            shred,
+            keypair.pubkey(),
+            other_payload,
+            Some(leader_schedule),
+            timestamp(),
+            DUPLICATE_SHRED_MAX_PAYLOAD_SIZE,
+            version,
+        )
+        .unwrap()
+        .next()
+        .unwrap();
+
+        let vote =
+            CrdsVote::new(keypair.pubkey(), new_test_vote_tx(&mut rng), timestamp()).unwrap();
+
+        // One representative per CrdsData variant. The array length is keyed to
+        // strum::EnumCount, so adding a new CrdsData variant without listing it
+        // here is a compile error (wrong array length).
+        use strum::EnumCount;
+        let variants: [CrdsData; CrdsData::COUNT] = [
+            CrdsData::LegacyContactInfo(Deprecated {}),
+            CrdsData::Vote(0, vote),
+            CrdsData::LowestSlot(0, LowestSlot::new(Pubkey::new_unique(), 0, timestamp())),
+            CrdsData::LegacySnapshotHashes(Deprecated {}),
+            CrdsData::AccountsHashes(Deprecated {}),
+            CrdsData::EpochSlots(0, EpochSlots::new_rand(&mut rng, None)),
+            CrdsData::LegacyVersion(Deprecated {}),
+            CrdsData::Version(Deprecated {}),
+            CrdsData::NodeInstance(Deprecated {}),
+            CrdsData::DuplicateShred(0, dup_shred),
+            CrdsData::SnapshotHashes(SnapshotHashes {
+                from: Pubkey::new_unique(),
+                full: (0, Hash::default()),
+                incremental: vec![],
+                wallclock: timestamp(),
+            }),
+            CrdsData::ContactInfo(ContactInfo::new_localhost(
+                &Pubkey::new_unique(),
+                timestamp(),
+            )),
+            CrdsData::RestartLastVotedForkSlots(RestartLastVotedForkSlots::new_rand(
+                &mut rng, None,
+            )),
+            CrdsData::RestartHeaviestFork(RestartHeaviestFork::new_rand(&mut rng, None)),
+        ];
+
+        for data in variants {
+            let value = CrdsValue::new_unsigned(data);
+            let bytes = wincode::serialize(&value).unwrap();
+            // Deprecated variants fail to deserialize; only assert the bound
+            // for variants that can appear in a successfully-parsed Protocol.
+            if wincode::deserialize::<CrdsValue>(&bytes).is_ok() {
+                assert!(
+                    bytes.len() >= MIN_CRDS_VALUE_SERIALIZED_SIZE,
+                    "MIN_CRDS_VALUE_SERIALIZED_SIZE ({MIN_CRDS_VALUE_SERIALIZED_SIZE}) \
+                     underestimates serialized size {}",
+                    bytes.len(),
+                );
+            }
         }
     }
 

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -6,7 +6,6 @@ use {
         crds_value::CrdsValue,
         ping_pong::{self, Pong},
     },
-    bincode::serialize,
     serde::{Deserialize, Serialize},
     solana_keypair::signable::Signable,
     solana_perf::packet::PACKET_DATA_SIZE,
@@ -18,6 +17,7 @@ use {
         fmt::Debug,
         result::Result,
     },
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 pub(crate) const MAX_CRDS_OBJECT_SIZE: usize = 928;
@@ -45,7 +45,7 @@ const GOSSIP_PING_TOKEN_SIZE: usize = 32;
 pub(crate) const PULL_RESPONSE_MIN_SERIALIZED_SIZE: usize = 161;
 
 /// Gossip protocol messages base enum
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, SchemaRead, SchemaWrite)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Protocol {
     PullRequest(CrdsFilter, CrdsValue),
@@ -63,7 +63,7 @@ pub(crate) type Ping = ping_pong::Ping<GOSSIP_PING_TOKEN_SIZE>;
 pub(crate) type PingCache = ping_pong::PingCache<GOSSIP_PING_TOKEN_SIZE>;
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, SchemaRead, SchemaWrite)]
 pub(crate) struct PruneData {
     /// Pubkey of the node that sent this prune data
     pub(crate) pubkey: Pubkey,
@@ -78,10 +78,10 @@ pub(crate) struct PruneData {
 }
 
 impl Protocol {
-    /// Returns the bincode serialized size (in bytes) of the Protocol.
+    /// Returns the serialized size (in bytes) of the Protocol.
     #[cfg(test)]
-    fn bincode_serialized_size(&self) -> usize {
-        bincode::serialized_size(self)
+    fn serialized_size(&self) -> usize {
+        wincode::serialized_size(self)
             .map(usize::try_from)
             .unwrap()
             .unwrap()
@@ -103,7 +103,7 @@ impl Protocol {
 
 impl PruneData {
     fn signable_data_without_prefix(&self) -> Cow<'static, [u8]> {
-        #[derive(Serialize)]
+        #[derive(Serialize, SchemaWrite)]
         struct SignData<'a> {
             pubkey: &'a Pubkey,
             prunes: &'a [Pubkey],
@@ -116,11 +116,11 @@ impl PruneData {
             destination: &self.destination,
             wallclock: self.wallclock,
         };
-        Cow::Owned(serialize(&data).expect("should serialize PruneData"))
+        Cow::Owned(wincode::serialize(&data).expect("should serialize PruneData"))
     }
 
     fn signable_data_with_prefix(&self) -> Cow<'static, [u8]> {
-        #[derive(Serialize)]
+        #[derive(Serialize, SchemaWrite)]
         struct SignDataWithPrefix<'a> {
             prefix: &'a [u8],
             pubkey: &'a Pubkey,
@@ -135,7 +135,7 @@ impl PruneData {
             destination: &self.destination,
             wallclock: self.wallclock,
         };
-        Cow::Owned(serialize(&data).expect("should serialize PruneDataWithPrefix"))
+        Cow::Owned(wincode::serialize(&data).expect("should serialize PruneDataWithPrefix"))
     }
 
     fn verify_data(&self, use_prefix: bool) -> bool {
@@ -223,7 +223,9 @@ impl Signable for PruneData {
 /// max_chunk_size.
 /// Note: some messages cannot be contained within that size so in the worst case this returns
 /// N nested Vecs with 1 item each.
-pub(crate) fn split_gossip_messages<T: Serialize + Debug>(
+pub(crate) fn split_gossip_messages<
+    T: Serialize + Debug + SchemaWrite<wincode::config::DefaultConfig, Src = T>,
+>(
     max_chunk_size: usize,
     data_feed: impl IntoIterator<Item = T>,
 ) -> impl Iterator<Item = Vec<T>> {
@@ -235,7 +237,7 @@ pub(crate) fn split_gossip_messages<T: Serialize + Debug>(
             let Some(data) = data_feed.next() else {
                 return (!buffer.is_empty()).then(|| std::mem::take(&mut buffer));
             };
-            let data_size = match bincode::serialized_size(&data) {
+            let data_size = match wincode::serialized_size(&data) {
                 Ok(size) => size as usize,
                 Err(err) => {
                     error!("serialized_size failed: {err:?}");
@@ -262,7 +264,6 @@ pub fn gossip_decode_to_effects(input: &[u8]) -> protosol::protos::GossipEffects
             crds_data::CrdsData, crds_gossip_pull::CrdsFilter as NativeCrdsFilter,
             crds_value::CrdsValue as NativeCrdsValue, ping_pong::Pong,
         },
-        bincode::Options as _,
         bv::Bits,
         protosol::protos::{
             GossipBloom, GossipCompressedSlots, GossipContactInfo, GossipCrdsData,
@@ -361,7 +362,7 @@ pub fn gossip_decode_to_effects(input: &[u8]) -> protosol::protos::GossipEffects
             }
             CrdsData::Vote(idx, vote) => {
                 let tx_bytes =
-                    bincode::serialize(vote.transaction()).expect("vote transaction serialization");
+                    wincode::serialize(vote.transaction()).expect("vote transaction serialization");
                 Some(gossip_crds_data::Data::Vote(GossipVote {
                     index: *idx as u32,
                     from: vote.from().to_bytes().to_vec(),
@@ -499,11 +500,16 @@ pub fn gossip_decode_to_effects(input: &[u8]) -> protosol::protos::GossipEffects
         }
     }
 
-    let result = bincode::options()
-        .with_limit(PACKET_DATA_SIZE as u64)
-        .with_fixint_encoding()
-        .reject_trailing_bytes()
-        .deserialize::<Protocol>(input);
+    // Reject over-long inputs upfront so an over-long input whose prefix
+    // encodes a valid Protocol can't slip through; deserialize_exact rejects
+    // any trailing bytes that remain within the packet window.
+    if input.len() > PACKET_DATA_SIZE {
+        return GossipEffects {
+            valid: false,
+            msg: None,
+        };
+    }
+    let result = wincode::deserialize_exact::<Protocol>(input);
 
     match result {
         Ok(proto) if proto.sanitize().is_ok() => {
@@ -654,7 +660,7 @@ pub(crate) mod tests {
         let header = Protocol::PushMessage(Pubkey::default(), Vec::default());
         assert_eq!(
             PUSH_MESSAGE_MAX_PAYLOAD_SIZE,
-            PACKET_DATA_SIZE - header.bincode_serialized_size()
+            PACKET_DATA_SIZE - header.serialized_size()
         );
     }
 
@@ -663,7 +669,7 @@ pub(crate) mod tests {
         let header = Protocol::PullResponse(Pubkey::default(), Vec::default());
         assert_eq!(
             PULL_RESPONSE_MAX_PAYLOAD_SIZE,
-            PACKET_DATA_SIZE - header.bincode_serialized_size()
+            PACKET_DATA_SIZE - header.serialized_size()
         );
     }
 
@@ -703,9 +709,9 @@ pub(crate) mod tests {
             let data = CrdsData::DuplicateShred(MAX_DUPLICATE_SHREDS - 1, chunk);
             let value = CrdsValue::new(data, &keypair);
             let pull_response = Protocol::PullResponse(keypair.pubkey(), vec![value.clone()]);
-            assert!(pull_response.bincode_serialized_size() < PACKET_DATA_SIZE);
+            assert!(pull_response.serialized_size() < PACKET_DATA_SIZE);
             let push_message = Protocol::PushMessage(keypair.pubkey(), vec![value.clone()]);
-            assert!(push_message.bincode_serialized_size() < PACKET_DATA_SIZE);
+            assert!(push_message.serialized_size() < PACKET_DATA_SIZE);
         }
     }
 
@@ -715,7 +721,7 @@ pub(crate) mod tests {
         for _ in 0..100 {
             let crds_values = vec![CrdsValue::new_rand(&mut rng, None)];
             let pull_response = Protocol::PullResponse(Pubkey::new_unique(), crds_values);
-            let size = pull_response.bincode_serialized_size();
+            let size = pull_response.serialized_size();
             assert!(
                 PULL_RESPONSE_MIN_SERIALIZED_SIZE <= size,
                 "pull-response serialized size: {size}"
@@ -763,13 +769,9 @@ pub(crate) mod tests {
         let header_size = PACKET_DATA_SIZE - PUSH_MESSAGE_MAX_PAYLOAD_SIZE;
         for values in splits {
             // Assert that sum of parts equals the whole.
-            let size = header_size
-                + values
-                    .iter()
-                    .map(CrdsValue::bincode_serialized_size)
-                    .sum::<usize>();
+            let size = header_size + values.iter().map(CrdsValue::serialized_size).sum::<usize>();
             let message = Protocol::PushMessage(self_pubkey, values);
-            assert_eq!(message.bincode_serialized_size(), size);
+            assert_eq!(message.serialized_size(), size);
             // Assert that the message fits into a packet.
             assert!(Packet::from_data(Some(&socket), message).is_ok());
         }
@@ -801,13 +803,9 @@ pub(crate) mod tests {
         let header_size = PACKET_DATA_SIZE - PULL_RESPONSE_MAX_PAYLOAD_SIZE;
         for values in splits {
             // Assert that sum of parts equals the whole.
-            let size = header_size
-                + values
-                    .iter()
-                    .map(CrdsValue::bincode_serialized_size)
-                    .sum::<usize>();
+            let size = header_size + values.iter().map(CrdsValue::serialized_size).sum::<usize>();
             let message = Protocol::PullResponse(self_pubkey, values);
-            assert_eq!(message.bincode_serialized_size(), size);
+            assert_eq!(message.serialized_size(), size);
             // Assert that the message fits into a packet.
             assert!(Packet::from_data(Some(&socket), message).is_ok());
         }
@@ -824,7 +822,7 @@ pub(crate) mod tests {
             incremental: incremental.clone(),
             wallclock: 0,
         }));
-        while value.bincode_serialized_size() < PUSH_MESSAGE_MAX_PAYLOAD_SIZE {
+        while value.serialized_size() < PUSH_MESSAGE_MAX_PAYLOAD_SIZE {
             incremental.push((0, Hash::default()));
             value = CrdsValue::new_unsigned(CrdsData::SnapshotHashes(SnapshotHashes {
                 from: Pubkey::default(),
@@ -840,7 +838,7 @@ pub(crate) mod tests {
 
     fn test_split_messages(value: CrdsValue) {
         const NUM_VALUES: usize = 30;
-        let value_size = value.bincode_serialized_size();
+        let value_size = value.serialized_size();
         let num_values_per_payload = (PUSH_MESSAGE_MAX_PAYLOAD_SIZE / value_size).max(1);
 
         // Expected len is the ceiling of the division
@@ -902,7 +900,7 @@ pub(crate) mod tests {
         )
         .unwrap();
         let vote = CrdsValue::new(CrdsData::Vote(1, vote), &Keypair::new());
-        assert!(vote.bincode_serialized_size() <= PUSH_MESSAGE_MAX_PAYLOAD_SIZE);
+        assert!(vote.serialized_size() <= PUSH_MESSAGE_MAX_PAYLOAD_SIZE);
     }
 
     #[test]
@@ -930,6 +928,172 @@ pub(crate) mod tests {
 
         let is_valid = prune_data.verify();
         assert!(is_valid, "Signature should be valid with prefix");
+    }
+
+    #[test]
+    fn test_wincode_compatibility_prune_data() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let keypair = Keypair::new();
+            let prune_data = new_rand_prune_data(&mut rng, &keypair, None);
+
+            let bincode_bytes = bincode::serialize(&prune_data).unwrap();
+            let wincode_decoded: PruneData = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(prune_data, wincode_decoded);
+
+            let wincode_bytes = wincode::serialize(&prune_data).unwrap();
+            let bincode_decoded: PruneData = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(prune_data, bincode_decoded);
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_vote_transaction() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let keypair = Keypair::new();
+            let slots = (0..rng.random_range(1..32)).map(|_| rng.random()).collect();
+            let vote = Vote::new(slots, Hash::new_unique());
+            let vote_ix = vote_instruction::vote_switch(
+                &keypair.pubkey(),
+                &keypair.pubkey(),
+                vote,
+                Hash::new_unique(),
+            );
+            let mut vote_tx = Transaction::new_with_payer(&[vote_ix], Some(&keypair.pubkey()));
+            vote_tx.partial_sign(&[&keypair], Hash::new_unique());
+
+            let bincode_bytes = bincode::serialize(&vote_tx).unwrap();
+            let wincode_bytes = wincode::serialize(&vote_tx).unwrap();
+            assert_eq!(bincode_bytes, wincode_bytes);
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_prune_signable_data() {
+        // Signed/verified bytes — any divergence would silently break signatures.
+        #[derive(Serialize)]
+        struct SignDataMirror<'a> {
+            pubkey: &'a Pubkey,
+            prunes: &'a [Pubkey],
+            destination: &'a Pubkey,
+            wallclock: u64,
+        }
+        #[derive(Serialize)]
+        struct SignDataWithPrefixMirror<'a> {
+            prefix: &'a [u8],
+            pubkey: &'a Pubkey,
+            prunes: &'a [Pubkey],
+            destination: &'a Pubkey,
+            wallclock: u64,
+        }
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let keypair = Keypair::new();
+            let prune_data = new_rand_prune_data(&mut rng, &keypair, None);
+
+            let wincode_no_prefix = prune_data.signable_data_without_prefix();
+            let bincode_no_prefix = bincode::serialize(&SignDataMirror {
+                pubkey: &prune_data.pubkey,
+                prunes: &prune_data.prunes,
+                destination: &prune_data.destination,
+                wallclock: prune_data.wallclock,
+            })
+            .unwrap();
+            assert_eq!(wincode_no_prefix.as_ref(), bincode_no_prefix.as_slice());
+
+            let wincode_with_prefix = prune_data.signable_data_with_prefix();
+            let bincode_with_prefix = bincode::serialize(&SignDataWithPrefixMirror {
+                prefix: PRUNE_DATA_PREFIX,
+                pubkey: &prune_data.pubkey,
+                prunes: &prune_data.prunes,
+                destination: &prune_data.destination,
+                wallclock: prune_data.wallclock,
+            })
+            .unwrap();
+            assert_eq!(wincode_with_prefix.as_ref(), bincode_with_prefix.as_slice());
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_protocol_prune_message() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let keypair = Keypair::new();
+            let prune_data = new_rand_prune_data(&mut rng, &keypair, None);
+            let protocol = Protocol::PruneMessage(keypair.pubkey(), prune_data);
+
+            let bincode_bytes = bincode::serialize(&protocol).unwrap();
+            let wincode_bytes = wincode::serialize(&protocol).unwrap();
+            assert_eq!(bincode_bytes, wincode_bytes);
+
+            let wincode_decoded: Protocol = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(wincode::serialize(&wincode_decoded).unwrap(), bincode_bytes);
+
+            let bincode_decoded: Protocol = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(bincode::serialize(&bincode_decoded).unwrap(), wincode_bytes);
+        }
+    }
+
+    fn new_rand_contact_info_crds_value<R: Rng>(rng: &mut R) -> CrdsValue {
+        let keypair = Keypair::new();
+        let ci = ContactInfo::new_rand(rng, Some(keypair.pubkey()));
+        CrdsValue::new(CrdsData::ContactInfo(ci), &keypair)
+    }
+
+    fn assert_protocol_wincode_compat(protocol: &Protocol) {
+        let bincode_bytes = bincode::serialize(protocol).unwrap();
+        let wincode_bytes = wincode::serialize(protocol).unwrap();
+        assert_eq!(bincode_bytes, wincode_bytes);
+        let wincode_decoded: Protocol = wincode::deserialize(&bincode_bytes).unwrap();
+        assert_eq!(wincode::serialize(&wincode_decoded).unwrap(), bincode_bytes);
+        let bincode_decoded: Protocol = bincode::deserialize(&wincode_bytes).unwrap();
+        assert_eq!(bincode::serialize(&bincode_decoded).unwrap(), wincode_bytes);
+    }
+
+    #[test]
+    fn test_wincode_compatibility_protocol_pull_request() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let filter = CrdsFilter::new_rand(rng.random_range(0..1000), rng.random_range(32..512));
+            let crds_value = new_rand_contact_info_crds_value(&mut rng);
+            assert_protocol_wincode_compat(&Protocol::PullRequest(filter, crds_value));
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_protocol_pull_response() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let values: Vec<_> = (0..rng.random_range(1usize..8))
+                .map(|_| new_rand_contact_info_crds_value(&mut rng))
+                .collect();
+            assert_protocol_wincode_compat(&Protocol::PullResponse(Pubkey::new_unique(), values));
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_protocol_push_message() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let values: Vec<_> = (0..rng.random_range(1usize..8))
+                .map(|_| new_rand_contact_info_crds_value(&mut rng))
+                .collect();
+            assert_protocol_wincode_compat(&Protocol::PushMessage(Pubkey::new_unique(), values));
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_protocol_ping_pong() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let keypair = Keypair::new();
+            let token: [u8; GOSSIP_PING_TOKEN_SIZE] = rng.random();
+            let ping = Ping::new(token, &keypair);
+            let pong = Pong::new(&ping, &keypair);
+            assert_protocol_wincode_compat(&Protocol::PingMessage(ping));
+            assert_protocol_wincode_compat(&Protocol::PongMessage(pong));
+        }
     }
 
     #[test]

--- a/gossip/src/restart_crds_values.rs
+++ b/gossip/src/restart_crds_values.rs
@@ -9,11 +9,13 @@ use {
     solana_pubkey::Pubkey,
     solana_sanitize::{Sanitize, SanitizeError},
     solana_serde_varint as serde_varint,
+    solana_wincode_varint::Leb128Int,
     thiserror::Error,
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
 pub struct RestartLastVotedForkSlots {
     pub from: Pubkey,
     pub wallclock: u64,
@@ -30,7 +32,9 @@ pub enum RestartLastVotedForkSlotsError {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
+// repr(C) makes this struct zero-copy eligible in wincode.
+#[repr(C)]
 pub struct RestartHeaviestFork {
     pub from: Pubkey,
     pub wallclock: u64,
@@ -41,24 +45,28 @@ pub struct RestartHeaviestFork {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, SchemaWrite, SchemaRead)]
 enum SlotsOffsets {
     RunLengthEncoding(RunLengthEncoding),
     RawOffsets(RawOffsets),
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
-struct U16(#[serde(with = "serde_varint")] u16);
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, SchemaWrite, SchemaRead)]
+struct U16(
+    #[serde(with = "serde_varint")]
+    #[wincode(with = "Leb128Int<u16>")]
+    u16,
+);
 
 // The vector always starts with 1. Encode number of 1's and 0's consecutively.
 // For example, 110000111 is [2, 4, 3].
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, SchemaWrite, SchemaRead)]
 struct RunLengthEncoding(Vec<U16>);
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, SchemaWrite, SchemaRead)]
 struct RawOffsets(BitVec<u8>);
 
 impl Sanitize for RestartLastVotedForkSlots {
@@ -225,7 +233,7 @@ mod test {
             crds_value::{CrdsValue, CrdsValueLabel},
             protocol::MAX_CRDS_OBJECT_SIZE,
         },
-        bincode::serialized_size,
+        bv::BitsPush,
         solana_keypair::Keypair,
         solana_signer::Signer,
         solana_time_utils::timestamp,
@@ -251,9 +259,11 @@ mod test {
         )
         .unwrap();
         // If the following assert fails, please update RestartLastVotedForkSlots::MAX_BYTES
+        let header_size = wincode::serialized_size(&header).unwrap();
+        assert_eq!(header_size, bincode::serialized_size(&header).unwrap());
         assert_eq!(
             RestartLastVotedForkSlots::MAX_BYTES,
-            MAX_CRDS_OBJECT_SIZE - serialized_size(&header).unwrap() as usize
+            MAX_CRDS_OBJECT_SIZE - header_size as usize
         );
 
         // Create large enough slots to make sure we are discarding some to make slots fit.
@@ -268,7 +278,12 @@ mod test {
             0,
         )
         .unwrap();
-        assert!(serialized_size(&large_slots).unwrap() <= MAX_CRDS_OBJECT_SIZE as u64);
+        let large_slots_size = wincode::serialized_size(&large_slots).unwrap();
+        assert_eq!(
+            large_slots_size,
+            bincode::serialized_size(&large_slots).unwrap()
+        );
+        assert!(large_slots_size <= MAX_CRDS_OBJECT_SIZE as u64);
         let retrieved_slots = large_slots.to_slots(0);
         assert!(retrieved_slots.len() <= range.len());
         assert!(retrieved_slots.last().unwrap() - retrieved_slots.first().unwrap() > 5000);
@@ -322,7 +337,12 @@ mod test {
             shred_version,
         )
         .unwrap();
-        assert!(serialized_size(&large_slots).unwrap() < MAX_CRDS_OBJECT_SIZE as u64);
+        let large_slots_size = wincode::serialized_size(&large_slots).unwrap();
+        assert_eq!(
+            large_slots_size,
+            bincode::serialized_size(&large_slots).unwrap()
+        );
+        assert!(large_slots_size < MAX_CRDS_OBJECT_SIZE as u64);
         let retrieved_slots = large_slots.to_slots(0);
         assert_eq!(retrieved_slots, large_slots_vec);
     }
@@ -355,6 +375,168 @@ mod test {
         let large_length = 500;
         let range: Vec<Slot> = make_rand_slots(&mut rng).take(large_length).collect();
         check_run_length_encoding(range);
+    }
+
+    #[test]
+    fn test_wincode_compatibility_run_length_encoding() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let len = rng.random_range(0..32usize);
+            let rle = RunLengthEncoding((0..len).map(|_| U16(rng.random())).collect());
+            let bincode_bytes = bincode::serialize(&rle).unwrap();
+            let wincode_bytes = wincode::serialize(&rle).unwrap();
+            assert_eq!(bincode_bytes, wincode_bytes);
+            assert_eq!(
+                rle,
+                wincode::deserialize::<RunLengthEncoding>(&bincode_bytes).unwrap()
+            );
+            assert_eq!(
+                rle,
+                bincode::deserialize::<RunLengthEncoding>(&wincode_bytes).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_raw_offsets() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let nblocks = rng.random_range(0usize..64);
+            let mut bitvec = BitVec::<u8>::new();
+            for _ in 0..nblocks {
+                bitvec.push_block(rng.random::<u8>());
+            }
+            let nbits = if nblocks == 0 {
+                0
+            } else {
+                rng.random_range(0u64..nblocks as u64 * 8 + 1)
+            };
+            bitvec.truncate(nbits);
+            // shrink_to_fit matches RawOffsets::new behavior: serde serializes
+            // the backing block count, so it must equal block_len() for the
+            // two wire formats to be identical.
+            bitvec.shrink_to_fit();
+            let raw = RawOffsets(bitvec);
+            let bincode_bytes = bincode::serialize(&raw).unwrap();
+            let wincode_bytes = wincode::serialize(&raw).unwrap();
+            assert_eq!(bincode_bytes, wincode_bytes);
+            assert_eq!(
+                raw,
+                wincode::deserialize::<RawOffsets>(&bincode_bytes).unwrap()
+            );
+            assert_eq!(
+                raw,
+                bincode::deserialize::<RawOffsets>(&wincode_bytes).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_slots_offsets() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let len = rng.random_range(0..32usize);
+            let offsets = SlotsOffsets::RunLengthEncoding(RunLengthEncoding(
+                (0..len).map(|_| U16(rng.random())).collect(),
+            ));
+            let bincode_bytes = bincode::serialize(&offsets).unwrap();
+            let wincode_bytes = wincode::serialize(&offsets).unwrap();
+            assert_eq!(bincode_bytes, wincode_bytes);
+            assert_eq!(
+                offsets,
+                wincode::deserialize::<SlotsOffsets>(&bincode_bytes).unwrap()
+            );
+            assert_eq!(
+                offsets,
+                bincode::deserialize::<SlotsOffsets>(&wincode_bytes).unwrap()
+            );
+        }
+        for _ in 0..1000 {
+            let nblocks = rng.random_range(0usize..64);
+            let mut bitvec = BitVec::<u8>::new();
+            for _ in 0..nblocks {
+                bitvec.push_block(rng.random::<u8>());
+            }
+            let nbits = if nblocks == 0 {
+                0
+            } else {
+                rng.random_range(0u64..nblocks as u64 * 8 + 1)
+            };
+            bitvec.truncate(nbits);
+            // shrink_to_fit matches RawOffsets::new behavior: serde serializes
+            // the backing block count, so it must equal block_len() for the
+            // two wire formats to be identical.
+            bitvec.shrink_to_fit();
+            let offsets = SlotsOffsets::RawOffsets(RawOffsets(bitvec));
+            let bincode_bytes = bincode::serialize(&offsets).unwrap();
+            let wincode_bytes = wincode::serialize(&offsets).unwrap();
+            assert_eq!(bincode_bytes, wincode_bytes);
+            assert_eq!(
+                offsets,
+                wincode::deserialize::<SlotsOffsets>(&bincode_bytes).unwrap()
+            );
+            assert_eq!(
+                offsets,
+                bincode::deserialize::<SlotsOffsets>(&wincode_bytes).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_restart_last_voted_fork_slots() {
+        let mut rng = rand::rng();
+        // Test RawOffsets variant (small slot ranges from new_rand).
+        for _ in 0..1000 {
+            let slots = RestartLastVotedForkSlots::new_rand(&mut rng, None);
+            let bincode_bytes = bincode::serialize(&slots).unwrap();
+            let wincode_decoded: RestartLastVotedForkSlots =
+                wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(slots, wincode_decoded);
+            let wincode_bytes = wincode::serialize(&slots).unwrap();
+            let bincode_decoded: RestartLastVotedForkSlots =
+                bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(slots, bincode_decoded);
+        }
+        // Test RunLengthEncoding variant: consecutive slots produce a single large run
+        // (num_encoded_slots > MAX_BYTES * 8), forcing RunLengthEncoding to be chosen.
+        for _ in 0..100 {
+            let base: Slot = rng.random_range(0..100_000);
+            let range: Vec<Slot> = (base..base + 8001).collect();
+            let keypair = solana_keypair::Keypair::new();
+            let slots = RestartLastVotedForkSlots::new(
+                keypair.pubkey(),
+                new_rand_timestamp(&mut rng),
+                &range,
+                Hash::new_unique(),
+                1,
+            )
+            .unwrap();
+            assert!(matches!(slots.offsets, SlotsOffsets::RunLengthEncoding(_)));
+            let bincode_bytes = bincode::serialize(&slots).unwrap();
+            let wincode_decoded: RestartLastVotedForkSlots =
+                wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(slots, wincode_decoded);
+            let wincode_bytes = wincode::serialize(&slots).unwrap();
+            let bincode_decoded: RestartLastVotedForkSlots =
+                bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(slots, bincode_decoded);
+        }
+    }
+
+    #[test]
+    fn test_wincode_compatibility_restart_heaviest_fork() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let fork = RestartHeaviestFork::new_rand(&mut rng, None);
+            let bincode_bytes = bincode::serialize(&fork).unwrap();
+            let wincode_decoded: RestartHeaviestFork =
+                wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(fork, wincode_decoded);
+            let wincode_bytes = wincode::serialize(&fork).unwrap();
+            let bincode_decoded: RestartHeaviestFork =
+                bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(fork, bincode_decoded);
+        }
     }
 
     #[test]

--- a/gossip/src/tlv.rs
+++ b/gossip/src/tlv.rs
@@ -1,15 +1,17 @@
 use {
     serde::{Deserialize, Serialize},
     solana_short_vec as short_vec,
+    wincode::{ReadError, SchemaRead, SchemaWrite, WriteError},
 };
 
-/// Type-Length-Value encoding wrapper for bincode
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+/// Type-Length-Value encoding wrapper
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, SchemaWrite, SchemaRead)]
 pub(crate) struct TlvRecord {
     // type
     pub(crate) typ: u8,
     // length and serialized bytes of the value
     #[serde(with = "short_vec")]
+    #[wincode(with = "wincode::containers::Vec<u8, short_vec::ShortU16>")]
     pub(crate) bytes: Vec<u8>,
 }
 
@@ -32,6 +34,20 @@ macro_rules! define_tlv_enum {
             )*
         }
 
+        unsafe impl<C: wincode::config::Config> wincode::SchemaWrite<C> for $enum_name {
+            type Src = Self;
+
+            fn size_of(value: &Self::Src) -> wincode::WriteResult<usize> {
+                let tlv_rec = TlvRecord::try_from(value).map_err(|_| wincode::WriteError::Custom("invalid as tlv_rec"))?;
+                <TlvRecord as wincode::SchemaWrite<C>>::size_of(&tlv_rec)
+            }
+
+            fn write(writer: impl wincode::io::Writer, value: &Self::Src) -> wincode::WriteResult<()> {
+                let tlv_rec = TlvRecord::try_from(value).map_err(|_| wincode::WriteError::Custom("invalid as tlv_rec"))?;
+                <TlvRecord as wincode::SchemaWrite<C>>::write(writer, &tlv_rec)
+            }
+        }
+
         // Serialize enum by first converting into TlvRecord, and then serializing that
         impl serde::Serialize for $enum_name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -49,7 +65,7 @@ macro_rules! define_tlv_enum {
             fn try_from(value: &TlvRecord) -> Result<Self, Self::Error> {
                 match value.typ {
                     $(
-                        $typ => Ok(Self::$variant(bincode::deserialize::<$inner>(&value.bytes)?)),
+                        $typ => Ok(Self::$variant(wincode::deserialize::<$inner>(&value.bytes)?)),
                     )*
                     _ => Err(TlvDecodeError::UnknownType(value.typ)),
                 }
@@ -57,19 +73,33 @@ macro_rules! define_tlv_enum {
         }
         // define conversion into TLV wire format
         impl TryFrom<&$enum_name> for TlvRecord {
-            type Error = bincode::Error;
+            type Error = $crate::tlv::TlvEncodeError;
             fn try_from(value: &$enum_name) -> Result<Self, Self::Error> {
-                use serde::ser::Error;
                 match value {
                     $(
                         $enum_name::$variant(inner) => Ok(TlvRecord {
                             typ: $typ,
-                            bytes: bincode::serialize(inner)?,
+                            bytes: wincode::serialize(inner)?,
                         }),
                     )*
                     #[allow(unreachable_patterns)]
-                    _ => Err(bincode::Error::custom("Unsupported enum variant")),
+                    _ => Err($crate::tlv::TlvEncodeError::UnsupportedVariant),
                 }
+            }
+        }
+
+        unsafe impl<'de, C: wincode::config::Config> wincode::SchemaRead<'de, C> for $enum_name {
+            type Dst = Self;
+
+            fn read(
+                reader: impl wincode::io::Reader<'de>,
+                dst: &mut std::mem::MaybeUninit<Self::Dst>,
+            ) -> wincode::ReadResult<()> {
+                let rec = <$crate::tlv::TlvRecord as wincode::SchemaRead<'de, C>>::get(reader)?;
+                let value = Self::try_from(&rec)
+                    .map_err(|_| wincode::ReadError::Custom("TlvRecord conversion failed"))?;
+                dst.write(value);
+                Ok(())
             }
         }
     };
@@ -80,7 +110,15 @@ pub enum TlvDecodeError {
     #[error("Unknown type: {0}")]
     UnknownType(u8),
     #[error("Malformed payload: {0}")]
-    MalformedPayload(#[from] bincode::Error),
+    MalformedPayload(#[from] ReadError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TlvEncodeError {
+    #[error("Serialization failed: {0}")]
+    Wincode(#[from] WriteError),
+    #[error("Unsupported enum variant")]
+    UnsupportedVariant,
 }
 
 /// Parses a slice of serialized TLV records into a provided type. Unsupported
@@ -91,7 +129,10 @@ pub(crate) fn parse<'a, T: TryFrom<&'a TlvRecord>>(entries: &'a [TlvRecord]) -> 
 
 #[cfg(test)]
 mod tests {
-    use crate::tlv::{TlvDecodeError, TlvRecord};
+    use {
+        crate::tlv::{TlvDecodeError, TlvRecord},
+        rand::Rng,
+    };
 
     define_tlv_enum! (pub(crate) enum ExtensionNew {
         1=>Test(u64),
@@ -114,8 +155,13 @@ mod tests {
             ExtensionNew::NewString(String::from("bla")),
         ];
 
-        let new_bytes = bincode::serialize(&new_tlv_data).unwrap();
-        let tlv_vec: Vec<TlvRecord> = bincode::deserialize(&new_bytes).unwrap();
+        let new_bytes = wincode::serialize(&new_tlv_data).unwrap();
+        assert_eq!(new_bytes, bincode::serialize(&new_tlv_data).unwrap());
+        let tlv_vec: Vec<TlvRecord> = wincode::deserialize(&new_bytes).unwrap();
+        assert_eq!(
+            tlv_vec,
+            bincode::deserialize::<Vec<TlvRecord>>(&new_bytes).unwrap()
+        );
         // check that both TLV are encoded correctly
         let new: Vec<ExtensionNew> = crate::tlv::parse(&tlv_vec);
         assert!(matches!(new[0], ExtensionNew::Test(42)));
@@ -143,9 +189,14 @@ mod tests {
             ExtensionLegacy::Test(42),
             ExtensionLegacy::LegacyString(String::from("foo")),
         ];
-        let legacy_bytes = bincode::serialize(&legacy_tlv_data).unwrap();
+        let legacy_bytes = wincode::serialize(&legacy_tlv_data).unwrap();
+        assert_eq!(legacy_bytes, bincode::serialize(&legacy_tlv_data).unwrap());
 
-        let tlv_vec: Vec<TlvRecord> = bincode::deserialize(&legacy_bytes).unwrap();
+        let tlv_vec: Vec<TlvRecord> = wincode::deserialize(&legacy_bytes).unwrap();
+        assert_eq!(
+            tlv_vec,
+            bincode::deserialize::<Vec<TlvRecord>>(&legacy_bytes).unwrap()
+        );
         // Just in case make sure that legacy data is serialized correctly
         let legacy: Vec<ExtensionLegacy> = crate::tlv::parse(&tlv_vec);
         assert!(matches!(legacy[0], ExtensionLegacy::Test(42)));
@@ -162,5 +213,43 @@ mod tests {
         } else {
             panic!("Wrong deserialization")
         };
+    }
+
+    #[test]
+    fn test_wincode_compatibility_tlv_record() {
+        let mut rng = rand::rng();
+        // Test various byte lengths to exercise all ShortU16 varint widths:
+        //   0-127:   1-byte varint
+        //   128-16383: 2-byte varint
+        let lengths: &[usize] = &[0, 1, 64, 127, 128, 255, 1000, 16383];
+        for &len in lengths {
+            let record = TlvRecord {
+                typ: rng.random::<u8>(),
+                bytes: (0..len).map(|_| rng.random::<u8>()).collect(),
+            };
+            let bincode_bytes = bincode::serialize(&record).unwrap();
+            let wincode_bytes = wincode::serialize(&record).unwrap();
+            assert_eq!(
+                bincode_bytes, wincode_bytes,
+                "bytes differ for TlvRecord with len={len}"
+            );
+            let wincode_decoded: TlvRecord = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(record, wincode_decoded);
+            let bincode_decoded: TlvRecord = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(record, bincode_decoded);
+        }
+        // Also fuzz with random lengths and types
+        for _ in 0..1000 {
+            let len = rng.random_range(0usize..256);
+            let record = TlvRecord {
+                typ: rng.random::<u8>(),
+                bytes: (0..len).map(|_| rng.random::<u8>()).collect(),
+            };
+            let bincode_bytes = bincode::serialize(&record).unwrap();
+            let wincode_bytes = wincode::serialize(&record).unwrap();
+            assert_eq!(bincode_bytes, wincode_bytes);
+            let wincode_decoded: TlvRecord = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(record, wincode_decoded);
+        }
     }
 }

--- a/gossip/src/wire_format_tests.rs
+++ b/gossip/src/wire_format_tests.rs
@@ -17,8 +17,12 @@ mod tests {
         Ok(pkt)
     }
 
-    fn serialize<T: Serialize>(pkt: T) -> Vec<u8> {
-        bincode::serialize(&pkt).unwrap()
+    fn serialize<T: Serialize + wincode::SchemaWrite<wincode::config::DefaultConfig, Src = T>>(
+        pkt: T,
+    ) -> Vec<u8> {
+        let wincode_bytes = wincode::serialize(&pkt).unwrap();
+        assert_eq!(wincode_bytes, bincode::serialize(&pkt).unwrap());
+        wincode_bytes
     }
 
     fn find_differences(a: &[u8], b: &[u8]) -> Option<usize> {

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
-    bincode::serialized_size,
     itertools::Itertools,
     log::*,
     rayon::{ThreadPool, ThreadPoolBuilder, prelude::*},
@@ -393,10 +392,7 @@ fn network_run_push(
                 let mut pruned: HashSet<(Pubkey, Pubkey)> = HashSet::new();
                 for (to, msgs) in push_messages {
                     // 8 bytes for encoding the length of the vector.
-                    bytes += 8 + msgs
-                        .iter()
-                        .map(CrdsValue::bincode_serialized_size)
-                        .sum::<usize>();
+                    bytes += 8 + msgs.iter().map(CrdsValue::serialized_size).sum::<usize>();
                     num_msgs += 1;
                     let origins: HashSet<_> = network
                         .get(&to)
@@ -420,7 +416,12 @@ fn network_run_push(
                             pruned.insert((from, *prune_key));
                         }
 
-                        bytes += serialized_size(&prune_keys).unwrap() as usize;
+                        let prune_keys_size = wincode::serialized_size(&prune_keys).unwrap();
+                        assert_eq!(
+                            prune_keys_size,
+                            bincode::serialized_size(&prune_keys).unwrap()
+                        );
+                        bytes += prune_keys_size as usize;
                         delivered += 1;
 
                         network
@@ -575,7 +576,7 @@ fn network_run_pull(
                     .iter()
                     .map(|f| f.filter.bits.len() as usize / 8)
                     .sum::<usize>();
-                bytes += caller_info.bincode_serialized_size();
+                bytes += caller_info.serialized_size();
                 let requests: Vec<_> = filters
                     .into_iter()
                     .map(|filter| PullRequest {
@@ -603,10 +604,7 @@ fn network_run_pull(
                     })
                     .unwrap();
                 // 8 bytes for encoding the length of the vector.
-                bytes += 8 + rsp
-                    .iter()
-                    .map(CrdsValue::bincode_serialized_size)
-                    .sum::<usize>();
+                bytes += 8 + rsp.iter().map(CrdsValue::serialized_size).sum::<usize>();
                 msgs += rsp.len();
                 if let Some(node) = network.get(&from) {
                     let mut stats = ProcessPullStats::default();

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6141,6 +6141,7 @@ dependencies = [
  "serde",
  "solana-sanitize",
  "solana-time-utils",
+ "wincode",
 ]
 
 [[package]]
@@ -7057,9 +7058,7 @@ dependencies = [
  "agave-logger",
  "agave-random",
  "arc-swap",
- "arrayvec",
  "assert_matches",
- "bincode",
  "bv",
  "crossbeam-channel",
  "flate2",
@@ -7103,6 +7102,7 @@ dependencies = [
  "solana-version",
  "solana-vote",
  "solana-vote-program",
+ "solana-wincode-varint",
  "static_assertions",
  "thiserror 2.0.18",
  "wincode",
@@ -10069,6 +10069,8 @@ dependencies = [
  "serde",
  "solana-sanitize",
  "solana-serde-varint",
+ "solana-wincode-varint",
+ "wincode",
 ]
 
 [[package]]
@@ -10148,6 +10150,15 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "solana-transaction-context",
  "solana-vote-interface",
+]
+
+[[package]]
+name = "solana-wincode-varint"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6679e72a01dcfe7ff180f0e9d3a0d165e4e9664426930014f2702e7571c259c7"
+dependencies = [
+ "wincode",
 ]
 
 [[package]]
@@ -11669,6 +11680,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37095eb18dd6254c66217edc61a29d83d51f8818de8a2ffe88e4584ad73fb5f9"
 dependencies = [
+ "bv",
  "bytes",
  "pastey",
  "proc-macro2",

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -33,6 +33,8 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-sanitize = { workspace = true }
 solana-serde-varint = { workspace = true }
+solana-wincode-varint = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 bincode = { workspace = true }

--- a/version/src/v4.rs
+++ b/version/src/v4.rs
@@ -4,7 +4,13 @@ use {
     serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _, ser::Error as _},
     solana_sanitize::Sanitize,
     solana_serde_varint as serde_varint,
-    std::{convert::TryInto, fmt, str::FromStr},
+    solana_wincode_varint::Leb128Int,
+    std::{convert::TryInto, fmt, mem::MaybeUninit, str::FromStr},
+    wincode::{
+        ReadError, ReadResult, SchemaRead, SchemaWrite, WriteError, WriteResult,
+        config::Config,
+        io::{Reader, Writer},
+    },
 };
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
@@ -80,9 +86,13 @@ impl FromStr for Prerelease {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, SchemaRead, SchemaWrite)]
 #[serde(transparent)]
-struct PackedMinor(#[serde(with = "serde_varint")] u16);
+struct PackedMinor(
+    #[serde(with = "serde_varint")]
+    #[wincode(with = "Leb128Int<u16>")]
+    u16,
+);
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum PackedMinorPackError {
@@ -271,18 +281,81 @@ impl fmt::Display for Version {
 }
 
 impl Sanitize for Version {}
+
+unsafe impl<C: Config> SchemaWrite<C> for Version {
+    type Src = Version;
+
+    fn size_of(src: &Version) -> WriteResult<usize> {
+        let serialized = Self::to_serialized(src)?;
+        <SerializedVersion as SchemaWrite<C>>::size_of(&serialized)
+    }
+
+    fn write(writer: impl Writer, src: &Version) -> WriteResult<()> {
+        let serialized = Self::to_serialized(src)?;
+        <SerializedVersion as SchemaWrite<C>>::write(writer, &serialized)
+    }
+}
+
+impl Version {
+    fn to_serialized(src: &Version) -> WriteResult<SerializedVersion> {
+        let (packed_minor, patch) = PackedMinor::try_pack(src.minor, src.patch, &src.prerelease)
+            .map_err(|_| WriteError::Custom("Version: invalid minor/patch/prerelease"))?;
+        let client = u16::try_from(src.client.clone())
+            .map_err(|_| WriteError::Custom("Version: invalid client ID"))?;
+        Ok(SerializedVersion {
+            major: src.major,
+            packed_minor,
+            patch,
+            commit: src.commit,
+            feature_set: src.feature_set,
+            client,
+        })
+    }
+}
+
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for Version {
+    type Dst = Version;
+
+    fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let SerializedVersion {
+            major,
+            packed_minor,
+            patch,
+            commit,
+            feature_set,
+            client,
+        } = <SerializedVersion as SchemaRead<'de, C>>::get(reader)?;
+        let (minor, patch, prerelease) = packed_minor
+            .try_unpack(patch)
+            .map_err(|_| ReadError::Custom("Version: invalid packed minor"))?;
+        dst.write(Version {
+            major,
+            minor,
+            patch,
+            commit,
+            feature_set,
+            client: ClientId::from(client),
+            prerelease,
+        });
+        Ok(())
+    }
+}
+
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, SchemaRead, SchemaWrite)]
 struct SerializedVersion {
     #[serde(with = "serde_varint")]
+    #[wincode(with = "Leb128Int<u16>")]
     major: u16,
     #[serde(rename = "minor")]
     packed_minor: PackedMinor,
     #[serde(with = "serde_varint")]
+    #[wincode(with = "Leb128Int<u16>")]
     patch: u16,
     commit: u32,
     feature_set: u32,
     #[serde(with = "serde_varint")]
+    #[wincode(with = "Leb128Int<u16>")]
     client: u16,
 }
 
@@ -351,7 +424,46 @@ impl<'de> Deserialize<'de> for Version {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::v3};
+    use {super::*, crate::v3, rand::Rng};
+
+    fn random_version(rng: &mut impl Rng) -> Version {
+        let minor = rng.random::<u16>() & PackedMinor::PRERELEASE_MINOR_MAX;
+        let (prerelease, patch) = match rng.random::<u8>() % 4 {
+            0 => (Prerelease::Stable, rng.random::<u16>()),
+            1 => (Prerelease::ReleaseCandidate(rng.random()), 0),
+            2 => (Prerelease::Beta(rng.random()), 0),
+            _ => (Prerelease::Alpha(rng.random()), 0),
+        };
+        Version::new_from_parts(
+            rng.random(),
+            minor,
+            patch,
+            rng.random(),
+            rng.random(),
+            ClientId::from(rng.random::<u16>()),
+            prerelease,
+        )
+    }
+
+    #[test]
+    fn test_wincode_compatibility() {
+        let mut rng = rand::rng();
+        for _ in 0..1000 {
+            let version = random_version(&mut rng);
+
+            // Serialize with bincode, deserialize with wincode, check results agree.
+            let bincode_bytes = bincode::serialize(&version).unwrap();
+            let wincode_decoded: Version = wincode::deserialize(&bincode_bytes).unwrap();
+            assert_eq!(version, wincode_decoded);
+
+            // Serialize with wincode, deserialize with bincode, check results agree.
+            let wincode_bytes = wincode::serialize(&version).unwrap();
+            let bincode_decoded: Version = bincode::deserialize(&wincode_bytes).unwrap();
+            assert_eq!(version, bincode_decoded);
+
+            assert_eq!(bincode_bytes, wincode_bytes);
+        }
+    }
 
     #[test]
     fn test_prerelease_patch_is_valid() {


### PR DESCRIPTION
#### Problem

Removes all use of bincode from gossip module replacing with wincode.

#### Summary of Changes

* All serialization/deserialization now happens through wincode.
* For each type add tests that check that wincode output matches that of bincode.
* bincode now a dev dependency for the gossip crate