### PR TITLE
scheduler: improve held retries

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -112,6 +112,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
         let bank = leader_state
             .working_bank()
             .expect("active_leader_state should only return an active bank");
+        let attempted_slot = bank.slot();
         self.metrics
             .count_metrics
             .num_messages_processed
@@ -131,6 +132,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
 
         self.consumed_sender.send(FinishedConsumeWork {
             work,
+            attempted_slot: Some(attempted_slot),
             retryable_indexes: output
                 .execute_and_commit_transactions_output
                 .retryable_transaction_indexes,
@@ -169,6 +171,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
         self.metrics.has_data.store(true, Ordering::Relaxed);
         self.consumed_sender.send(FinishedConsumeWork {
             work,
+            attempted_slot: None,
             retryable_indexes,
         })?;
         Ok(())
@@ -2918,6 +2921,7 @@ mod tests {
         assert_eq!(consumed.work.batch_id, bid);
         assert_eq!(consumed.work.ids, vec![id]);
         assert_eq!(consumed.work.max_ages, vec![max_age]);
+        assert_eq!(consumed.attempted_slot, None);
         assert_eq!(
             consumed.retryable_indexes,
             vec![RetryableIndex::new(0, true)]
@@ -2968,6 +2972,7 @@ mod tests {
         for i in 0..num_batches {
             let consumed = consumed_receiver.recv().unwrap();
             assert_eq!(consumed.work.batch_id, TransactionBatchId::new(i as u64));
+            assert_eq!(consumed.attempted_slot, None);
             assert_eq!(
                 consumed.retryable_indexes,
                 vec![RetryableIndex::new(0, true)]
@@ -3026,6 +3031,7 @@ mod tests {
         assert_eq!(consumed.work.batch_id, bid);
         assert_eq!(consumed.work.ids, vec![id]);
         assert_eq!(consumed.work.max_ages, vec![max_age]);
+        assert_eq!(consumed.attempted_slot, Some(bank.slot()));
         assert_eq!(consumed.retryable_indexes, Vec::new());
 
         drop(test_frame);
@@ -3082,6 +3088,7 @@ mod tests {
         assert_eq!(consumed.work.batch_id, bid);
         assert_eq!(consumed.work.ids, vec![id1, id2]);
         assert_eq!(consumed.work.max_ages, vec![max_age, max_age]);
+        assert_eq!(consumed.attempted_slot, Some(bank.slot()));
 
         assert_eq!(consumed.retryable_indexes, vec![]);
 
@@ -3156,12 +3163,14 @@ mod tests {
         assert_eq!(consumed.work.batch_id, bid1);
         assert_eq!(consumed.work.ids, vec![id1]);
         assert_eq!(consumed.work.max_ages, vec![max_age]);
+        assert_eq!(consumed.attempted_slot, Some(bank.slot()));
         assert_eq!(consumed.retryable_indexes, Vec::new());
 
         let consumed = consumed_receiver.recv().unwrap();
         assert_eq!(consumed.work.batch_id, bid2);
         assert_eq!(consumed.work.ids, vec![id2]);
         assert_eq!(consumed.work.max_ages, vec![max_age]);
+        assert_eq!(consumed.attempted_slot, Some(bank.slot()));
         assert_eq!(consumed.retryable_indexes, Vec::new());
 
         drop(test_frame);

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -399,7 +399,7 @@ impl Consumer {
                 |(index, processing_result)| {
                     processing_result.was_processed().then_some(RetryableIndex {
                         index,
-                        immediately_retryable: true, // recording errors are always immediately retryable
+                        immediately_retryable: false,
                     })
                 },
             ));
@@ -724,7 +724,7 @@ mod tests {
             retryable_transaction_indexes,
             vec![RetryableIndex {
                 index: 0,
-                immediately_retryable: true
+                immediately_retryable: false
             }]
         );
         assert_matches!(
@@ -1245,7 +1245,7 @@ mod tests {
             .retryable_transaction_indexes
             .sort_unstable();
         let expected: Vec<_> = (0..transactions.len())
-            .map(|index| RetryableIndex::new(index, true))
+            .map(|index| RetryableIndex::new(index, false))
             .collect();
         assert_eq!(
             execute_and_commit_transactions_output.retryable_transaction_indexes,

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -49,5 +49,6 @@ pub struct ConsumeWork<Tx> {
 /// Processed transactions.
 pub struct FinishedConsumeWork<Tx> {
     pub work: ConsumeWork<Tx>,
+    pub attempted_slot: Option<Slot>,
     pub retryable_indexes: Vec<RetryableIndex>,
 }

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -761,6 +761,7 @@ mod tests {
         finished_work_sender
             .send(FinishedConsumeWork {
                 work: thread_0_work.into_iter().next().unwrap(),
+                attempted_slot: None,
                 retryable_indexes: vec![],
             })
             .unwrap();

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -765,7 +765,7 @@ mod tests {
                 retryable_indexes: vec![],
             })
             .unwrap();
-        scheduler.receive_completed(&mut container).unwrap();
+        scheduler.receive_completed(&mut container, None).unwrap();
         let scheduling_summary = scheduler
             .schedule(
                 &mut container,

--- a/core/src/banking_stage/transaction_scheduler/scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler.rs
@@ -3,6 +3,7 @@ use {
         scheduler_common::SchedulingCommon, scheduler_error::SchedulerError,
         transaction_state::TransactionState, transaction_state_container::StateContainer,
     },
+    solana_clock::Slot,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     std::num::Saturating,
 };
@@ -24,13 +25,14 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
     fn receive_completed(
         &mut self,
         container: &mut impl StateContainer<Tx>,
+        most_recent_leader_slot: Option<Slot>,
     ) -> Result<(usize, usize), SchedulerError> {
         let mut total_num_transactions = Saturating::<usize>(0);
         let mut total_num_retryable = Saturating::<usize>(0);
         loop {
             let (num_transactions, num_retryable) = self
                 .scheduling_common_mut()
-                .try_receive_completed(container)?;
+                .try_receive_completed(container, most_recent_leader_slot)?;
             if num_transactions == 0 {
                 break;
             }

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -11,6 +11,7 @@ use {
     },
     crossbeam_channel::{Receiver, Sender, TryRecvError},
     itertools::izip,
+    solana_clock::Slot,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
 };
 
@@ -216,6 +217,7 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
     pub fn try_receive_completed(
         &mut self,
         container: &mut impl StateContainer<Tx>,
+        most_recent_leader_slot: Option<Slot>,
     ) -> Result<(usize, usize), SchedulerError> {
         match self.finished_consume_work_receiver.try_recv() {
             Ok(FinishedConsumeWork {
@@ -245,6 +247,7 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
                                 transaction,
                                 retryable_index.immediately_retryable,
                                 attempted_slot,
+                                most_recent_leader_slot,
                             );
                             retryable_iter.next();
                             continue;
@@ -521,7 +524,7 @@ mod tests {
 
         finished_work_sender.send(finished_work).unwrap();
         let (num_transactions, num_retryable) =
-            common.try_receive_completed(&mut container).unwrap();
+            common.try_receive_completed(&mut container, None).unwrap();
         assert_eq!(num_transactions, num_scheduled);
         assert_eq!(num_retryable, 0);
         assert_eq!(container.buffer_size(), 0);
@@ -545,12 +548,33 @@ mod tests {
             retryable_indexes,
         };
         finished_work_sender.send(finished_work).unwrap();
-        let (num_transactions, num_retryable) =
-            common.try_receive_completed(&mut container).unwrap();
+        let (num_transactions, num_retryable) = common
+            .try_receive_completed(&mut container, Some(42))
+            .unwrap();
         assert_eq!(num_transactions, num_scheduled);
         assert_eq!(num_retryable, expected_num_retryable);
         assert_eq!(container.buffer_size(), expected_num_retryable);
         assert_eq!(container.queue_size(), expected_num_retryable - 1); // held transaction not in queue.
+
+        // Stale attempted slot should bypass held_transactions.
+        add_transactions_to_container(&mut container, 1);
+        pop_and_add_transaction(&mut container, &mut common, 0);
+        let num_scheduled = common.send_batch(0).unwrap();
+        let work = work_receivers[0].try_recv().unwrap();
+        assert_eq!(work.ids.len(), num_scheduled);
+        let retryable_indexes = vec![RetryableIndex::new(0, false)];
+        let finished_work = FinishedConsumeWork {
+            work,
+            attempted_slot: Some(41),
+            retryable_indexes,
+        };
+        finished_work_sender.send(finished_work).unwrap();
+        let (num_transactions, num_retryable) = common
+            .try_receive_completed(&mut container, Some(42))
+            .unwrap();
+        assert_eq!(num_transactions, num_scheduled);
+        assert_eq!(num_retryable, 1);
+        assert_eq!(container.queue_size(), expected_num_retryable);
     }
 
     #[test]
@@ -578,6 +602,6 @@ mod tests {
         finished_work_sender.send(finished_work).unwrap();
 
         // This should panic because the retryable indexes are not in order.
-        let _ = common.try_receive_completed(&mut container);
+        let _ = common.try_receive_completed(&mut container, None);
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -556,6 +556,26 @@ mod tests {
         assert_eq!(container.buffer_size(), expected_num_retryable);
         assert_eq!(container.queue_size(), expected_num_retryable - 1); // held transaction not in queue.
 
+        // Immediately retryable transactions should bypass held_transactions even if slot matches.
+        add_transactions_to_container(&mut container, 1);
+        pop_and_add_transaction(&mut container, &mut common, 0);
+        let num_scheduled = common.send_batch(0).unwrap();
+        let work = work_receivers[0].try_recv().unwrap();
+        assert_eq!(work.ids.len(), num_scheduled);
+        let retryable_indexes = vec![RetryableIndex::new(0, true)];
+        let finished_work = FinishedConsumeWork {
+            work,
+            attempted_slot: Some(42),
+            retryable_indexes,
+        };
+        finished_work_sender.send(finished_work).unwrap();
+        let (num_transactions, num_retryable) = common
+            .try_receive_completed(&mut container, Some(42))
+            .unwrap();
+        assert_eq!(num_transactions, num_scheduled);
+        assert_eq!(num_retryable, 1);
+        assert_eq!(container.queue_size(), expected_num_retryable);
+
         // Stale attempted slot should bypass held_transactions.
         add_transactions_to_container(&mut container, 1);
         pop_and_add_transaction(&mut container, &mut common, 0);
@@ -574,7 +594,7 @@ mod tests {
             .unwrap();
         assert_eq!(num_transactions, num_scheduled);
         assert_eq!(num_retryable, 1);
-        assert_eq!(container.queue_size(), expected_num_retryable);
+        assert_eq!(container.queue_size(), expected_num_retryable + 1);
     }
 
     #[test]

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -226,6 +226,7 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
                         transactions,
                         max_ages: _,
                     },
+                attempted_slot: _,
                 retryable_indexes,
             }) => {
                 let num_transactions = ids.len();
@@ -513,6 +514,7 @@ mod tests {
         let retryable_indexes = vec![];
         let finished_work = FinishedConsumeWork {
             work,
+            attempted_slot: None,
             retryable_indexes,
         };
 
@@ -538,6 +540,7 @@ mod tests {
         let expected_num_retryable = retryable_indexes.len();
         let finished_work = FinishedConsumeWork {
             work,
+            attempted_slot: None,
             retryable_indexes,
         };
         finished_work_sender.send(finished_work).unwrap();
@@ -568,6 +571,7 @@ mod tests {
         let retryable_indexes = vec![RetryableIndex::new(1, true), RetryableIndex::new(0, true)];
         let finished_work = FinishedConsumeWork {
             work,
+            attempted_slot: None,
             retryable_indexes,
         };
         finished_work_sender.send(finished_work).unwrap();

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -226,7 +226,7 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
                         transactions,
                         max_ages: _,
                     },
-                attempted_slot: _,
+                attempted_slot,
                 retryable_indexes,
             }) => {
                 let num_transactions = ids.len();
@@ -244,6 +244,7 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
                                 id,
                                 transaction,
                                 retryable_index.immediately_retryable,
+                                attempted_slot,
                             );
                             retryable_iter.next();
                             continue;
@@ -540,7 +541,7 @@ mod tests {
         let expected_num_retryable = retryable_indexes.len();
         let finished_work = FinishedConsumeWork {
             work,
-            attempted_slot: None,
+            attempted_slot: Some(42),
             retryable_indexes,
         };
         finished_work_sender.send(finished_work).unwrap();

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -150,7 +150,9 @@ where
                 .maybe_report_and_reset_slot(new_leader_slot);
 
             if most_recent_leader_slot != new_leader_slot {
-                self.container.flush_held_transactions();
+                if let Some(new_leader_slot) = new_leader_slot {
+                    self.container.flush_held_transactions(new_leader_slot);
+                }
                 most_recent_leader_slot = new_leader_slot;
                 cost_pacer = decision.bank().map(|b| {
                     let cost_tracker = b.read_cost_tracker().unwrap();
@@ -188,7 +190,7 @@ where
                 });
             }
 
-            self.receive_completed()?;
+            self.receive_completed(most_recent_leader_slot)?;
             let scheduled = self.process_transactions(&decision, cost_pacer.as_ref(), &now)?;
             if scheduled == 0 {
                 let (_, clean_time_us) = measure_us!(self.incremental_recheck());
@@ -378,9 +380,14 @@ where
     }
 
     /// Receives completed transactions from the workers and updates metrics.
-    fn receive_completed(&mut self) -> Result<(), SchedulerError> {
-        let ((num_transactions, num_retryable), receive_completed_time_us) =
-            measure_us!(self.scheduler.receive_completed(&mut self.container)?);
+    fn receive_completed(
+        &mut self,
+        most_recent_leader_slot: Option<u64>,
+    ) -> Result<(), SchedulerError> {
+        let ((num_transactions, num_retryable), receive_completed_time_us) = measure_us!(
+            self.scheduler
+                .receive_completed(&mut self.container, most_recent_leader_slot)?
+        );
 
         self.count_metrics.update(|count_metrics| {
             count_metrics.num_finished += num_transactions;
@@ -628,7 +635,7 @@ mod tests {
             .decision_maker
             .make_consume_or_forward_decision();
         assert!(matches!(decision, BufferedPacketsDecision::Consume(_)));
-        assert!(scheduler_controller.receive_completed().is_ok());
+        assert!(scheduler_controller.receive_completed(None).is_ok());
 
         // Time is not a reliable way for deterministic testing.
         // Loop here until no more packets are received, this avoids parallel

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -680,6 +680,7 @@ mod tests {
                     transactions: vec![],
                     max_ages: vec![],
                 },
+                attempted_slot: None,
                 retryable_indexes: vec![],
             })
             .unwrap();
@@ -1008,6 +1009,7 @@ mod tests {
         finished_consume_work_sender
             .send(FinishedConsumeWork {
                 work: consume_work,
+                attempted_slot: None,
                 retryable_indexes: vec![RetryableIndex::new(1, true)],
             })
             .unwrap();

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -150,9 +150,7 @@ where
                 .maybe_report_and_reset_slot(new_leader_slot);
 
             if most_recent_leader_slot != new_leader_slot {
-                if let Some(new_leader_slot) = new_leader_slot {
-                    self.container.flush_held_transactions(new_leader_slot);
-                }
+                self.container.flush_held_transactions(new_leader_slot);
                 most_recent_leader_slot = new_leader_slot;
                 cost_pacer = decision.bank().map(|b| {
                     let cost_tracker = b.read_cost_tracker().unwrap();

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -114,7 +114,10 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
     /// Remove transaction by id.
     fn remove_by_id(&mut self, id: TransactionId);
 
-    fn flush_held_transactions(&mut self, slot: Slot);
+    /// Release held transactions whose attempted slot no longer matches the
+    /// current leader slot. If there is no leader slot, release all held
+    /// transactions.
+    fn flush_held_transactions(&mut self, slot: Option<Slot>);
 
     fn get_min_max_priority(&self) -> Option<(u64, u64)>;
 
@@ -209,11 +212,11 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
             .remove(&TransactionPriorityId::new(state.priority(), id));
     }
 
-    fn flush_held_transactions(&mut self, slot: Slot) {
+    fn flush_held_transactions(&mut self, slot: Option<Slot>) {
         let mut held_transactions = core::mem::take(&mut self.held_transactions);
         let mut held_ids = Vec::with_capacity(held_transactions.len());
         held_transactions.retain(|held| {
-            if held.attempted_slot != slot {
+            if Some(held.attempted_slot) != slot {
                 held_ids.push(held.priority_id);
                 false
             } else {
@@ -391,7 +394,7 @@ impl StateContainer<RuntimeTransactionView> for TransactionViewStateContainer {
     }
 
     #[inline]
-    fn flush_held_transactions(&mut self, slot: Slot) {
+    fn flush_held_transactions(&mut self, slot: Option<Slot>) {
         self.inner.flush_held_transactions(slot);
     }
 
@@ -590,7 +593,7 @@ mod tests {
             .0;
         container.retry_transaction(held_b.id, transaction_b, false, Some(41), Some(41));
 
-        container.flush_held_transactions(42);
+        container.flush_held_transactions(Some(42));
 
         assert_eq!(
             container.held_transactions,
@@ -617,11 +620,32 @@ mod tests {
             .0;
         container.retry_transaction(priority_id.id, transaction, false, Some(42), Some(42));
 
-        container.flush_held_transactions(42);
+        container.flush_held_transactions(Some(42));
         assert_eq!(container.queue_size(), 0);
         assert_eq!(container.held_transactions.len(), 1);
 
-        container.flush_held_transactions(43);
+        container.flush_held_transactions(Some(43));
+        assert!(container.held_transactions.is_empty());
+        assert_eq!(container.queue_size(), 1);
+        assert_eq!(container.pop(), Some(priority_id));
+    }
+
+    #[test]
+    fn test_flush_held_transactions_releases_all_without_leader_slot() {
+        let mut container = TransactionStateContainer::with_capacity(5);
+        let (transaction, max_age, priority, cost) = test_transaction(10);
+        container.insert_new_transaction(transaction, max_age, priority, cost);
+
+        let priority_id = container.pop().unwrap();
+        let transaction = container
+            .get_mut_transaction_state(priority_id.id)
+            .unwrap()
+            .take_transaction_for_scheduling()
+            .0;
+        container.retry_transaction(priority_id.id, transaction, false, Some(42), Some(42));
+
+        container.flush_held_transactions(None);
+
         assert!(container.held_transactions.is_empty());
         assert_eq!(container.queue_size(), 1);
         assert_eq!(container.pop(), Some(priority_id));

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -213,17 +213,17 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
     }
 
     fn flush_held_transactions(&mut self, slot: Option<Slot>) {
+        // Take temporary ownership of the held transactions to avoid borrowing issues when
+        // reinserting into the queue.
         let mut held_transactions = core::mem::take(&mut self.held_transactions);
-        let mut held_ids = Vec::with_capacity(held_transactions.len());
-        held_transactions.retain(|held| {
-            if Some(held.attempted_slot) != slot {
-                held_ids.push(held.priority_id);
-                false
-            } else {
-                true
-            }
-        });
-        self.push_ids_into_queue(held_ids.into_iter());
+
+        self.push_ids_into_queue(
+            held_transactions
+                .extract_if(.., |held| Some(held.attempted_slot) != slot)
+                .map(|held| held.priority_id),
+        );
+
+        // Replace the held transactions with the remaining transactions that were not flushed.
         self.held_transactions = held_transactions;
     }
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -3,12 +3,19 @@ use {
     crate::banking_stage::scheduler_messages::TransactionId,
     agave_transaction_view::resolved_transaction_view::ResolvedTransactionView,
     slab::{Slab, VacantEntry},
+    solana_clock::Slot,
     solana_packet::PACKET_DATA_SIZE,
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
     },
     std::{collections::BTreeSet, iter::Rev, ops::Bound, sync::Arc},
 };
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct HeldTransaction {
+    priority_id: TransactionPriorityId,
+    attempted_slot: Slot,
+}
 
 /// This structure will hold `TransactionState` for the entirety of a
 /// transaction's lifetime in the scheduler and BankingStage as a whole.
@@ -39,7 +46,7 @@ pub(crate) struct TransactionStateContainer<Tx: TransactionWithMeta> {
     capacity: usize,
     priority_queue: BTreeSet<TransactionPriorityId>,
     id_to_transaction_state: Slab<TransactionState<Tx>>,
-    held_transactions: Vec<TransactionPriorityId>,
+    held_transactions: Vec<HeldTransaction>,
 }
 
 pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
@@ -71,6 +78,7 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
         transaction_id: TransactionId,
         transaction: Tx,
         immediately_retryable: bool,
+        attempted_slot: Option<Slot>,
     ) {
         let transaction_state = self
             .get_mut_transaction_state(transaction_id)
@@ -81,7 +89,10 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
         if immediately_retryable {
             self.push_ids_into_queue(std::iter::once(priority_id));
         } else {
-            self.hold_transaction(priority_id);
+            self.hold_transaction(
+                priority_id,
+                attempted_slot.expect("held transaction must have attempted slot"),
+            );
         }
     }
 
@@ -97,7 +108,7 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
     ) -> usize;
 
     /// Hold the tarnsaction until the next flush (next slot).
-    fn hold_transaction(&mut self, priority_id: TransactionPriorityId);
+    fn hold_transaction(&mut self, priority_id: TransactionPriorityId, attempted_slot: Slot);
 
     /// Remove transaction by id.
     fn remove_by_id(&mut self, id: TransactionId);
@@ -182,8 +193,11 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
         num_dropped
     }
 
-    fn hold_transaction(&mut self, priority_id: TransactionPriorityId) {
-        self.held_transactions.push(priority_id);
+    fn hold_transaction(&mut self, priority_id: TransactionPriorityId, attempted_slot: Slot) {
+        self.held_transactions.push(HeldTransaction {
+            priority_id,
+            attempted_slot,
+        });
     }
 
     fn remove_by_id(&mut self, id: TransactionId) {
@@ -196,7 +210,7 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
 
     fn flush_held_transactions(&mut self) {
         let mut held_transactions = core::mem::take(&mut self.held_transactions);
-        self.push_ids_into_queue(held_transactions.drain(..));
+        self.push_ids_into_queue(held_transactions.drain(..).map(|held| held.priority_id));
         core::mem::swap(&mut self.held_transactions, &mut held_transactions);
     }
 
@@ -357,8 +371,8 @@ impl StateContainer<RuntimeTransactionView> for TransactionViewStateContainer {
     }
 
     #[inline]
-    fn hold_transaction(&mut self, priority_id: TransactionPriorityId) {
-        self.inner.hold_transaction(priority_id);
+    fn hold_transaction(&mut self, priority_id: TransactionPriorityId, attempted_slot: Slot) {
+        self.inner.hold_transaction(priority_id, attempted_slot);
     }
 
     #[inline]
@@ -475,6 +489,30 @@ mod tests {
             container
                 .get_mut_transaction_state(non_existing_id)
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn test_hold_retry_stores_attempted_slot() {
+        let mut container = TransactionStateContainer::with_capacity(5);
+        let (transaction, max_age, priority, cost) = test_transaction(10);
+        container.insert_new_transaction(transaction, max_age, priority, cost);
+
+        let priority_id = container.pop().unwrap();
+        let transaction = container
+            .get_mut_transaction_state(priority_id.id)
+            .unwrap()
+            .take_transaction_for_scheduling()
+            .0;
+
+        container.retry_transaction(priority_id.id, transaction, false, Some(42));
+
+        assert_eq!(
+            container.held_transactions,
+            vec![HeldTransaction {
+                priority_id,
+                attempted_slot: 42,
+            }]
         );
     }
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -79,6 +79,7 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
         transaction: Tx,
         immediately_retryable: bool,
         attempted_slot: Option<Slot>,
+        most_recent_leader_slot: Option<Slot>,
     ) {
         let transaction_state = self
             .get_mut_transaction_state(transaction_id)
@@ -86,7 +87,7 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
         let priority_id = TransactionPriorityId::new(transaction_state.priority(), transaction_id);
         transaction_state.retry_transaction(transaction);
 
-        if immediately_retryable {
+        if immediately_retryable || most_recent_leader_slot != attempted_slot {
             self.push_ids_into_queue(std::iter::once(priority_id));
         } else {
             self.hold_transaction(
@@ -113,7 +114,7 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
     /// Remove transaction by id.
     fn remove_by_id(&mut self, id: TransactionId);
 
-    fn flush_held_transactions(&mut self);
+    fn flush_held_transactions(&mut self, slot: Slot);
 
     fn get_min_max_priority(&self) -> Option<(u64, u64)>;
 
@@ -208,10 +209,19 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
             .remove(&TransactionPriorityId::new(state.priority(), id));
     }
 
-    fn flush_held_transactions(&mut self) {
+    fn flush_held_transactions(&mut self, slot: Slot) {
         let mut held_transactions = core::mem::take(&mut self.held_transactions);
-        self.push_ids_into_queue(held_transactions.drain(..).map(|held| held.priority_id));
-        core::mem::swap(&mut self.held_transactions, &mut held_transactions);
+        let mut held_ids = Vec::with_capacity(held_transactions.len());
+        held_transactions.retain(|held| {
+            if held.attempted_slot != slot {
+                held_ids.push(held.priority_id);
+                false
+            } else {
+                true
+            }
+        });
+        self.push_ids_into_queue(held_ids.into_iter());
+        self.held_transactions = held_transactions;
     }
 
     fn get_min_max_priority(&self) -> Option<(u64, u64)> {
@@ -381,8 +391,8 @@ impl StateContainer<RuntimeTransactionView> for TransactionViewStateContainer {
     }
 
     #[inline]
-    fn flush_held_transactions(&mut self) {
-        self.inner.flush_held_transactions();
+    fn flush_held_transactions(&mut self, slot: Slot) {
+        self.inner.flush_held_transactions(slot);
     }
 
     #[inline]
@@ -505,7 +515,7 @@ mod tests {
             .take_transaction_for_scheduling()
             .0;
 
-        container.retry_transaction(priority_id.id, transaction, false, Some(42));
+        container.retry_transaction(priority_id.id, transaction, false, Some(42), Some(42));
 
         assert_eq!(
             container.held_transactions,
@@ -514,6 +524,107 @@ mod tests {
                 attempted_slot: 42,
             }]
         );
+    }
+
+    #[test]
+    fn test_stale_attempted_slot_bypasses_held_transactions() {
+        let mut container = TransactionStateContainer::with_capacity(5);
+        let (transaction, max_age, priority, cost) = test_transaction(10);
+        container.insert_new_transaction(transaction, max_age, priority, cost);
+
+        let priority_id = container.pop().unwrap();
+        let transaction = container
+            .get_mut_transaction_state(priority_id.id)
+            .unwrap()
+            .take_transaction_for_scheduling()
+            .0;
+
+        container.retry_transaction(priority_id.id, transaction, false, Some(41), Some(42));
+
+        assert!(container.held_transactions.is_empty());
+        assert_eq!(container.queue_size(), 1);
+        assert_eq!(container.pop(), Some(priority_id));
+    }
+
+    #[test]
+    fn test_immediately_retryable_transaction_is_not_held() {
+        let mut container = TransactionStateContainer::with_capacity(5);
+        let (transaction, max_age, priority, cost) = test_transaction(10);
+        container.insert_new_transaction(transaction, max_age, priority, cost);
+
+        let priority_id = container.pop().unwrap();
+        let transaction = container
+            .get_mut_transaction_state(priority_id.id)
+            .unwrap()
+            .take_transaction_for_scheduling()
+            .0;
+
+        container.retry_transaction(priority_id.id, transaction, true, Some(42), Some(42));
+
+        assert!(container.held_transactions.is_empty());
+        assert_eq!(container.queue_size(), 1);
+        assert_eq!(container.pop(), Some(priority_id));
+    }
+
+    #[test]
+    fn test_flush_held_transactions_keeps_matching_slot() {
+        let mut container = TransactionStateContainer::with_capacity(5);
+
+        let (transaction_a, max_age_a, priority_a, cost_a) = test_transaction(10);
+        container.insert_new_transaction(transaction_a, max_age_a, priority_a, cost_a);
+        let held_a = container.pop().unwrap();
+        let transaction_a = container
+            .get_mut_transaction_state(held_a.id)
+            .unwrap()
+            .take_transaction_for_scheduling()
+            .0;
+        container.retry_transaction(held_a.id, transaction_a, false, Some(42), Some(42));
+
+        let (transaction_b, max_age_b, priority_b, cost_b) = test_transaction(20);
+        container.insert_new_transaction(transaction_b, max_age_b, priority_b, cost_b);
+        let held_b = container.pop().unwrap();
+        let transaction_b = container
+            .get_mut_transaction_state(held_b.id)
+            .unwrap()
+            .take_transaction_for_scheduling()
+            .0;
+        container.retry_transaction(held_b.id, transaction_b, false, Some(41), Some(41));
+
+        container.flush_held_transactions(42);
+
+        assert_eq!(
+            container.held_transactions,
+            vec![HeldTransaction {
+                priority_id: held_a,
+                attempted_slot: 42,
+            }]
+        );
+        assert_eq!(container.queue_size(), 1);
+        assert_eq!(container.pop(), Some(held_b));
+    }
+
+    #[test]
+    fn test_flush_held_transactions_releases_after_slot_change() {
+        let mut container = TransactionStateContainer::with_capacity(5);
+        let (transaction, max_age, priority, cost) = test_transaction(10);
+        container.insert_new_transaction(transaction, max_age, priority, cost);
+
+        let priority_id = container.pop().unwrap();
+        let transaction = container
+            .get_mut_transaction_state(priority_id.id)
+            .unwrap()
+            .take_transaction_for_scheduling()
+            .0;
+        container.retry_transaction(priority_id.id, transaction, false, Some(42), Some(42));
+
+        container.flush_held_transactions(42);
+        assert_eq!(container.queue_size(), 0);
+        assert_eq!(container.held_transactions.len(), 1);
+
+        container.flush_held_transactions(43);
+        assert!(container.held_transactions.is_empty());
+        assert_eq!(container.queue_size(), 1);
+        assert_eq!(container.pop(), Some(priority_id));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
- We don't actually check if we're on a new slot, so we might be holding transactions for longer than we expect.
- IF a transaction fails near the end of a block with a non-retryable error, but the scheduler only picks it up AFTER detecting the new slot, it would be held for an entire extra slot

#### Summary of Changes
- Track attempted slot for consume work done
- Retry on differnet slot detected

Fixes #
