### PR TITLE
gossip: swap vec by slice in entrypoints param of discover_peers()

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -1355,7 +1355,7 @@ fn main() {
             info!("Finding cluster entry: {entrypoint_addr:?}");
             let (gossip_nodes, _validators) = discover_peers(
                 None,
-                &vec![entrypoint_addr],
+                &[entrypoint_addr],
                 None,
                 Duration::from_secs(60),
                 None,

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -148,7 +148,7 @@ pub fn discover_validators(
     const DISCOVER_CLUSTER_TIMEOUT: Duration = Duration::from_secs(120);
     let (_all_peers, validators) = discover_peers(
         None,
-        &vec![*entrypoint],
+        &[*entrypoint],
         Some(num_nodes),
         DISCOVER_CLUSTER_TIMEOUT,
         None,
@@ -162,7 +162,7 @@ pub fn discover_validators(
 
 pub fn discover_peers(
     keypair: Option<Keypair>,
-    entrypoints: &Vec<SocketAddr>,
+    entrypoints: &[SocketAddr],
     num_nodes: Option<usize>, // num_nodes only counts validators, excludes spy nodes
     timeout: Duration,
     find_nodes_by_pubkey: Option<&[Pubkey]>,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -527,7 +527,7 @@ impl LocalCluster {
 
         discover_peers(
             None,
-            &vec![cluster.entry_point_info.gossip().unwrap()],
+            &[cluster.entry_point_info.gossip().unwrap()],
             Some(config.node_stakes.len() + config.num_listeners as usize),
             Duration::from_secs(120),
             None,


### PR DESCRIPTION
### Description

The `discover_peers()` takes `&Vec<SocketAddr>` as its `entrypoints` parameter.

### Summary of changes

- Update `discover_peers()` to take `&[SocketAddr]` instead
- Fix in callers