### PR TITLE
gossip: PruneMessage ditch extra pubkey

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1933,8 +1933,7 @@ impl ClusterInfo {
                         wallclock,
                     };
                     prune_data.sign(&self_keypair);
-                    let prune_message = Protocol::PruneMessage(self_pubkey, prune_data);
-                    (addr, prune_message)
+                    (addr, Protocol::PruneMessage(prune_data))
                 })
                 .collect()
         })
@@ -2050,7 +2049,7 @@ impl ClusterInfo {
                         push_messages.push((from, data));
                     }
                 }
-                Protocol::PruneMessage(_from, data) => prune_messages.push(data),
+                Protocol::PruneMessage(data) => prune_messages.push(data),
                 Protocol::PingMessage(ping) => ping_messages.push((from_addr, ping)),
                 Protocol::PongMessage(pong) => pong_messages.push((from_addr, pong)),
             }
@@ -2439,7 +2438,7 @@ fn discard_different_shred_version(
         // check_pull_request_shred_version).
         Protocol::PullRequest(..) => return,
         // No CRDS values in Prune, Ping and Pong messages.
-        Protocol::PruneMessage(_, _) | Protocol::PingMessage(_) | Protocol::PongMessage(_) => {
+        Protocol::PruneMessage(_) | Protocol::PingMessage(_) | Protocol::PongMessage(_) => {
             return;
         }
     };

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -51,9 +51,7 @@ pub(crate) enum Protocol {
     PullRequest(CrdsFilter, CrdsValue),
     PullResponse(Pubkey, Vec<CrdsValue>),
     PushMessage(Pubkey, Vec<CrdsValue>),
-    // TODO: Remove the redundant outer pubkey here,
-    // and use the inner PruneData.pubkey instead.
-    PruneMessage(Pubkey, PruneData),
+    PruneMessage(PruneData),
     PingMessage(Ping),
     PongMessage(Pong),
     // Update count_packets_received if new variants are added here.
@@ -94,7 +92,7 @@ impl Protocol {
             Self::PullRequest(_, caller) => caller.verify(),
             Self::PullResponse(_, data) => data.iter().all(CrdsValue::verify),
             Self::PushMessage(_, data) => data.iter().all(CrdsValue::verify),
-            Self::PruneMessage(_, data) => data.verify(),
+            Self::PruneMessage(data) => data.verify(),
             Self::PingMessage(ping) => ping.verify(),
             Self::PongMessage(pong) => pong.verify(),
         }
@@ -171,13 +169,7 @@ impl Sanitize for Protocol {
                 // other nodes that have inserted it into their Crds table
                 val.sanitize()
             }
-            Protocol::PruneMessage(from, val) => {
-                if *from != val.pubkey {
-                    Err(SanitizeError::InvalidValue)
-                } else {
-                    val.sanitize()
-                }
-            }
+            Protocol::PruneMessage(val) => val.sanitize(),
             Protocol::PingMessage(ping) => ping.sanitize(),
             Protocol::PongMessage(pong) => pong.sanitize(),
         }
@@ -399,7 +391,7 @@ pub(crate) mod tests {
             let self_keypair = Keypair::new();
             let prune_data =
                 new_rand_prune_data(&mut rng, &self_keypair, Some(MAX_PRUNE_DATA_NODES));
-            let prune_message = Protocol::PruneMessage(self_keypair.pubkey(), prune_data);
+            let prune_message = Protocol::PruneMessage(prune_data);
             let socket = new_rand_socket_addr(&mut rng);
             assert!(Packet::from_data(Some(&socket), prune_message).is_ok());
         }
@@ -407,7 +399,7 @@ pub(crate) mod tests {
         let self_keypair = Keypair::new();
         let prune_data =
             new_rand_prune_data(&mut rng, &self_keypair, Some(MAX_PRUNE_DATA_NODES + 1));
-        let prune_message = Protocol::PruneMessage(self_keypair.pubkey(), prune_data);
+        let prune_message = Protocol::PruneMessage(prune_data);
         let socket = new_rand_socket_addr(&mut rng);
         assert!(Packet::from_data(Some(&socket), prune_message).is_err());
     }
@@ -618,7 +610,7 @@ pub(crate) mod tests {
             wallclock: MAX_WALLCLOCK,
             ..PruneData::default()
         };
-        let msg = Protocol::PruneMessage(Pubkey::default(), pd);
+        let msg = Protocol::PruneMessage(pd);
         assert_eq!(msg.sanitize(), Err(SanitizeError::ValueOutOfBounds));
     }
 
@@ -633,10 +625,8 @@ pub(crate) mod tests {
             wallclock: timestamp(),
         };
         prune_data.sign(&keypair);
-        let prune_message = Protocol::PruneMessage(keypair.pubkey(), prune_data.clone());
+        let prune_message = Protocol::PruneMessage(prune_data.clone());
         assert_eq!(prune_message.sanitize(), Ok(()));
-        let prune_message = Protocol::PruneMessage(Pubkey::new_unique(), prune_data);
-        assert_eq!(prune_message.sanitize(), Err(SanitizeError::InvalidValue));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

`Protocol::PruneMessage` carries sender pubkey twice, once as the outer enum field and again inside PruneData.pubkey.

#### Summary of Changes
- Removed extra pubkey from `Protocol::PruneMessage` and made `PruneData.pubkey` the single source of truth.