### PR TITLE
gossip: put insert_info() behind DCOU

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -191,6 +191,7 @@ solana-compute-budget-program = { path = "../programs/compute-budget", features 
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-core = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-cost-model = { path = "../cost-model", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-gossip = { path = "../gossip", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-keypair = { workspace = true }
 solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-loader-v3-interface = { workspace = true }

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -29,6 +29,7 @@ frozen-abi = [
     "solana-vote-program/frozen-abi",
 ]
 agave-unstable-api = []
+dev-context-only-utils = []
 
 [dependencies]
 agave-logger = { workspace = true }
@@ -97,7 +98,7 @@ bs58 = { workspace = true }
 criterion = { workspace = true }
 num_cpus = { workspace = true }
 serial_test = { workspace = true }
-solana-gossip = { path = ".", features = ["agave-unstable-api"] }
+solana-gossip = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-perf = { path = "../perf", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -241,7 +241,7 @@ impl ClusterInfo {
         send_gossip_packets(pings, recycler, sender, &self.stats);
     }
 
-    // TODO kill insert_info, only used by tests
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
     pub fn insert_info(&self, node: ContactInfo) {
         let entry = CrdsValue::new(CrdsData::ContactInfo(node), &self.keypair());
         if let Err(err) = {

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -105,6 +105,7 @@ solana-cluster-type = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-fee-structure = { workspace = true }
+solana-gossip = { path = "../gossip", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-instruction = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-nonce = { workspace = true }

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -59,6 +59,7 @@ assert_matches = { workspace = true }
 bencher = { workspace = true }
 bs58 = { workspace = true }
 solana-genesis-config = { workspace = true }
+solana-gossip = { path = "../gossip", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-signature = { workspace = true, features = ["rand"] }


### PR DESCRIPTION
#### Problem

As described in the TODO [here](https://github.com/anza-xyz/agave/blob/master/gossip/src/cluster_info.rs#L244) its used in tests only, but isn't gated.

#### Summary of Changes
- Gated `insert_info()` helper behind DCOU