### PR TITLE
Adds `SkipFallback` as conflicting with `Finalize`

### DIFF
--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -11,7 +11,11 @@ pub type Stake = u64;
 
 pub const fn conflicting_types(vote_type: VoteType) -> &'static [VoteType] {
     match vote_type {
-        VoteType::Finalize => &[VoteType::NotarizeFallback, VoteType::Skip],
+        VoteType::Finalize => &[
+            VoteType::NotarizeFallback,
+            VoteType::Skip,
+            VoteType::SkipFallback,
+        ],
         VoteType::Notarize => &[VoteType::Skip, VoteType::NotarizeFallback],
         VoteType::NotarizeFallback => &[VoteType::Finalize, VoteType::Notarize],
         VoteType::Skip => &[
@@ -19,7 +23,7 @@ pub const fn conflicting_types(vote_type: VoteType) -> &'static [VoteType] {
             VoteType::Notarize,
             VoteType::SkipFallback,
         ],
-        VoteType::SkipFallback => &[VoteType::Skip],
+        VoteType::SkipFallback => &[VoteType::Skip, VoteType::Finalize],
         VoteType::Genesis => &[
             VoteType::Finalize,
             VoteType::Notarize,


### PR DESCRIPTION
#### Problem
This combination is also slashable
https://github.com/qkniep/alpenglow/blob/446ed761bdc24c9e9990396336bf431be950085b/src/consensus/pool/slot_state.rs#L439

#### Summary of Changes
Add it to the conflicting types list

This is an upstream of https://github.com/anza-xyz/alpenglow/pull/773.