### PR TITLE
Uses `Fraction` instead of `float` for various ratios

### DIFF
--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -1,6 +1,7 @@
 use {
     agave_votor_messages::{
         consensus_message::CertificateType,
+        fraction::Fraction,
         vote::{Vote, VoteType},
     },
     std::time::Duration,
@@ -57,11 +58,11 @@ pub fn vote_to_cert_types(vote: &Vote) -> Vec<CertificateType> {
 pub const MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES: usize = 1;
 pub const MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE: usize = 3;
 
-pub const SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY: f64 = 0.4;
-pub const SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP: f64 = 0.2;
-pub const SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP: f64 = 0.6;
+pub const SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY: Fraction = Fraction::from_percentage(40);
+pub const SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP: Fraction = Fraction::from_percentage(20);
+pub const SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP: Fraction = Fraction::from_percentage(60);
 
-pub const SAFE_TO_SKIP_THRESHOLD: f64 = 0.4;
+pub const SAFE_TO_SKIP_THRESHOLD: Fraction = Fraction::from_percentage(40);
 
 /// Time bound assumed on network transmission delays during periods of synchrony.
 pub(crate) const DELTA: Duration = Duration::from_millis(250);

--- a/votor/src/consensus_pool/slot_stake_counters.rs
+++ b/votor/src/consensus_pool/slot_stake_counters.rs
@@ -7,9 +7,9 @@ use {
         consensus_pool::stats::ConsensusPoolStats,
         event::VotorEvent,
     },
-    agave_votor_messages::vote::Vote,
+    agave_votor_messages::{fraction::Fraction, vote::Vote},
     solana_hash::Hash,
-    std::collections::BTreeMap,
+    std::{collections::BTreeMap, num::NonZeroU64},
 };
 
 #[derive(Debug, Default)]
@@ -89,14 +89,20 @@ impl SlotStakeCounters {
                 return false; // I voted for the same block, no need to send NotarizeFallback
             }
         }
-        let skip_ratio = self.skip_total as f64 / self.total_stake as f64;
-        let notarized_ratio = *stake as f64 / self.total_stake as f64;
-        trace!("safe_to_notar {block_id:?} {skip_ratio} {notarized_ratio}");
+        trace!(
+            "safe_to_notar {block_id:?} skip_ratio={} notarized_ratio={}",
+            self.skip_total as f64 / self.total_stake as f64,
+            *stake as f64 / self.total_stake as f64
+        );
         // Check if the block fits condition (i) 40% of stake holders voted notarize
+        let total_stake = NonZeroU64::new(self.total_stake).unwrap();
+        let notarized_ratio = Fraction::new(*stake, total_stake);
+        let notarized_plus_skip_ratio =
+            Fraction::new(self.skip_total.checked_add(*stake).unwrap(), total_stake);
         notarized_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY
             // Check if the block fits condition (ii) 20% notarized, and 60% notarized or skip
             || (notarized_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP
-                && notarized_ratio + skip_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP)
+                && notarized_plus_skip_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_AND_SKIP)
     }
 
     fn is_safe_to_skip(&self) -> bool {
@@ -112,11 +118,13 @@ impl SlotStakeCounters {
                 self.notarize_total,
                 self.top_notarized_stake
             );
-            self.skip_total
-                .saturating_add(self.notarize_total.saturating_sub(self.top_notarized_stake))
-                as f64
-                / self.total_stake as f64
-                >= SAFE_TO_SKIP_THRESHOLD
+
+            let num_stake = self
+                .skip_total
+                .saturating_add(self.notarize_total.saturating_sub(self.top_notarized_stake));
+            let total_stake = NonZeroU64::new(self.total_stake).unwrap();
+
+            Fraction::new(num_stake, total_stake) >= SAFE_TO_SKIP_THRESHOLD
         } else {
             false
         }


### PR DESCRIPTION
#### Problem
`float`s are less precise and we have a `Fraction` abstraction now that allows us to avoid `float` maths.

#### Summary of Changes

Uses `Fraction` instead of `float` for various consensus ratios and maths.
