### PR TITLE
add TransactionVersion::V1

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -487,7 +487,7 @@ pub(crate) fn load_addresses_for_view<D: TransactionData>(
     bank: &Bank,
 ) -> Result<(Option<LoadedAddresses>, Slot), PacketHandlingError> {
     match view.version() {
-        TransactionVersion::Legacy => Ok((None, u64::MAX)),
+        TransactionVersion::Legacy | TransactionVersion::V1 => Ok((None, u64::MAX)),
         TransactionVersion::V0 => bank
             .load_addresses_from_ref(view.address_table_lookup_iter())
             .map(|(loaded_addresses, deactivation_slot)| {

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -208,6 +208,22 @@ impl<D: TransactionData> TransactionWithMeta for RuntimeTransaction<ResolvedTran
                     })
                     .collect(),
             }),
+            TransactionVersion::V1 => {
+                let config_view = self.transaction_config().expect("V1 must have config_view");
+                let config = solana_message::v1::TransactionConfig {
+                    priority_fee: config_view.priority_fee_lamports(),
+                    compute_unit_limit: config_view.compute_unit_limit(),
+                    loaded_accounts_data_size_limit: config_view.loaded_accounts_data_size_limit(),
+                    heap_size: config_view.requested_heap_size(),
+                };
+                VersionedMessage::V1(solana_message::v1::Message {
+                    header,
+                    config,
+                    lifetime_specifier: recent_blockhash,
+                    account_keys: static_account_keys,
+                    instructions,
+                })
+            }
         };
 
         VersionedTransaction {

--- a/transaction-view/src/transaction_frame.rs
+++ b/transaction-view/src/transaction_frame.rs
@@ -57,6 +57,9 @@ impl TransactionFrame {
                 total_readonly_lookup_accounts: 0,
             },
             TransactionVersion::V0 => AddressTableLookupFrame::try_new(bytes, &mut offset)?,
+            TransactionVersion::V1 => {
+                return Err(TransactionViewError::ParseError);
+            }
         };
 
         // Verify that the entire transaction was parsed.

--- a/transaction-view/src/transaction_version.rs
+++ b/transaction-view/src/transaction_version.rs
@@ -5,4 +5,5 @@ pub enum TransactionVersion {
     #[default]
     Legacy = u8::MAX,
     V0 = 0,
+    V1 = 1,
 }


### PR DESCRIPTION
#### Problem

few ongoing PRs (11789, 11805) need `V1` definition. Easier to manage and review PRs if this bit of change is reviewed/merged first.

#### Summary of Changes
- Add `V1` to TransactionVersion
- Impl `V1` to_versioned_transaction()
- cover `V1` arms in other places

Fixes #
