### PR TITLE
accounts-index: add per-bin in-memory entry count stats

### DIFF
--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -487,7 +487,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
                     let index = self.next_bucket_to_flush();
                     in_mem[index].flush(can_advance_age);
                 }
-                self.stats.report_stats(self);
+                self.stats.report_stats(self, &in_mem);
                 if self.all_buckets_flushed_at_current_age() {
                     break;
                 }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1334,6 +1334,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let map = self.map_internal.read().unwrap();
         (map.len(), map.capacity())
     }
+
+    /// Returns the number of entries currently held in memory for this bin.
+    pub(crate) fn len(&self) -> usize {
+        self.map_internal.read().unwrap().len()
+    }
 }
 
 /// State of reservoir sampling algorithm for flush/eviction candidates.

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -7,7 +7,10 @@ use {
     solana_time_utils::AtomicInterval,
     std::{
         fmt::Debug,
-        sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+        },
     },
 };
 
@@ -182,6 +185,7 @@ impl Stats {
     pub fn report_stats<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>(
         &self,
         storage: &BucketMapHolder<T, U>,
+        in_mem: &[Arc<InMemAccountsIndex<T, U>>],
     ) {
         let elapsed_ms = self.last_time.elapsed_ms();
         if elapsed_ms < STATS_INTERVAL_MS {
@@ -203,6 +207,8 @@ impl Stats {
             })
             .unwrap_or_default();
         let disk_stats = Self::get_stats(disk_per_bucket_counts);
+        let mem_per_bucket_counts = in_mem.iter().map(|bin| bin.len()).collect();
+        let mem_stats = Self::get_stats(mem_per_bucket_counts);
 
         const US_PER_MS: u64 = 1_000;
 
@@ -317,6 +323,10 @@ impl Stats {
                 ("max_in_bin_disk", disk_stats.1, i64),
                 ("count_from_bins_disk", disk_stats.2, i64),
                 ("median_from_bins_disk", disk_stats.3, i64),
+                ("min_in_bin_mem", mem_stats.0, i64),
+                ("max_in_bin_mem", mem_stats.1, i64),
+                ("count_from_bins_mem", mem_stats.2, i64),
+                ("median_from_bins_mem", mem_stats.3, i64),
                 (
                     "gets_from_mem",
                     self.gets_from_mem.swap(0, Ordering::Relaxed),
@@ -620,6 +630,10 @@ impl Stats {
                 ("inserts", self.inserts.swap(0, Ordering::Relaxed), i64),
                 ("deletes", self.deletes.swap(0, Ordering::Relaxed), i64),
                 ("keys", self.keys.swap(0, Ordering::Relaxed), i64),
+                ("min_in_bin_mem", mem_stats.0, i64),
+                ("max_in_bin_mem", mem_stats.1, i64),
+                ("count_from_bins_mem", mem_stats.2, i64),
+                ("median_from_bins_mem", mem_stats.3, i64),
             );
         }
     }


### PR DESCRIPTION
#### Problem
Accounts index does not currently track the min/max per bin in the in memory index. This information is useful to determine effectiveness of binning and flushing strategies


#### Summary of Changes
Add in memory stats (identical to disk stats) to the accounts index stat reporting 


#### Notes
This requires read locking each of the bins. Total duration of the entire stats call was measured and averaged around 250us. This means the average read lock duration is on the order of 30ns. The stats are only logged once every 10s, so the cost of the locks is negligible. 
```
[2026-04-08T22:52:13.433292845Z INFO  solana_accounts_db::accounts_index::stats] report_stats took 250us
```
Fixes #
