### PR TITLE
chore: slotSubscribe reduce ambiguity about its job

### DIFF
--- a/pubsub-client/src/nonblocking/pubsub_client.rs
+++ b/pubsub-client/src/nonblocking/pubsub_client.rs
@@ -491,7 +491,7 @@ impl PubsubClient {
 
     /// Subscribe to slot events.
     ///
-    /// Receives messages of type [`SlotInfo`] when a slot is processed.
+    /// Receives messages of type [`SlotInfo`] when processing of a slot begins.
     ///
     /// # RPC Reference
     ///

--- a/pubsub-client/src/pubsub_client.rs
+++ b/pubsub-client/src/pubsub_client.rs
@@ -696,7 +696,7 @@ impl PubsubClient {
 
     /// Subscribe to slot events.
     ///
-    /// Receives messages of type [`SlotInfo`] when a slot is processed.
+    /// Receives messages of type [`SlotInfo`] when processing of a slot begins.
     ///
     /// # RPC Reference
     ///

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -154,7 +154,7 @@ pub trait RpcSolPubSub {
         id: PubSubSubscriptionId,
     ) -> Result<bool>;
 
-    // Get notification when slot is encountered
+    // Get notification when processing of a slot begins
     #[pubsub(subscription = "slotNotification", subscribe, name = "slotSubscribe")]
     fn slot_subscribe(&self, meta: Self::Metadata, subscriber: Subscriber<SlotInfo>);
 
@@ -308,7 +308,7 @@ mod internal {
         #[rpc(name = "signatureUnsubscribe")]
         fn signature_unsubscribe(&self, id: SubscriptionId) -> Result<bool>;
 
-        // Get notification when slot is encountered
+        // Get notification when processing of a slot begins
         #[rpc(name = "slotSubscribe")]
         fn slot_subscribe(&self) -> Result<SubscriptionId>;
 


### PR DESCRIPTION
#### Problem
"processed" is massively ambiguous as it is a commitment which means the entire slot has been replayed. 

use "when a slot processing begins"
- Does not leak any of the implementation details: bank...
- "processing" as in will eventually lead to processed, reuse the concept but use it correctly

Where it is emitted for reference
https://github.com/anza-xyz/agave/blob/10faa052a97232f68c6c4a2ee8a90d50edf0575e/core/src/replay_stage.rs#L4684-L4695

Follow up is to do the same to https://solana.com/docs/rpc/websocket/slotsubscribe which is even worse

#### Summary of Changes


Fixes #
