### PR TITLE
Introduces `VotorEvent::BlockNotarFallback`

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -318,6 +318,7 @@ impl ConsensusPool {
         self.completed_certificates.insert(cert_type, cert.clone());
         match cert_type {
             CertificateType::NotarizeFallback(slot, block_id) => {
+                events.push(VotorEvent::BlockNotarFallback((slot, block_id)));
                 self.parent_ready_tracker
                     .add_new_notar_fallback_or_stronger((slot, block_id), events);
             }

--- a/votor/src/event.rs
+++ b/votor/src/event.rs
@@ -35,6 +35,9 @@ pub enum VotorEvent {
     /// The block has received a notarization certificate
     BlockNotarized(Block),
 
+    /// The block has received a notar-fallback certificate
+    BlockNotarFallback(Block),
+
     /// Received the first shred for the slot.
     FirstShred(Slot),
 
@@ -82,6 +85,7 @@ impl VotorEvent {
             | VotorEvent::SafeToNotar((s, _))
             | VotorEvent::Finalized((s, _), _)
             | VotorEvent::BlockNotarized((s, _))
+            | VotorEvent::BlockNotarFallback((s, _))
             | VotorEvent::ParentReady {
                 slot: s,
                 parent_block: _,

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -314,6 +314,10 @@ impl EventHandler {
                 Self::try_final(my_pubkey, block, vctx, &mut votes)?;
             }
 
+            VotorEvent::BlockNotarFallback(block) => {
+                info!("{my_pubkey}: Block notar-fallback {block:?}");
+            }
+
             VotorEvent::FirstShred(slot) => {
                 info!("{my_pubkey}: First shred {slot}");
                 received_shred.insert(slot);

--- a/votor/src/event_handler/stats.rs
+++ b/votor/src/event_handler/stats.rs
@@ -94,6 +94,7 @@ impl Default for EventHandlerStats {
 pub enum StatsEvent {
     Block,
     BlockNotarized,
+    BlockNotarFallback,
     FirstShred,
     ParentReady,
     TimeoutCrashedLeader,
@@ -111,6 +112,7 @@ impl StatsEvent {
         match event {
             VotorEvent::Block(_) => StatsEvent::Block,
             VotorEvent::BlockNotarized(_) => StatsEvent::BlockNotarized,
+            VotorEvent::BlockNotarFallback(_) => StatsEvent::BlockNotarFallback,
             VotorEvent::FirstShred(_) => StatsEvent::FirstShred,
             VotorEvent::ParentReady { .. } => StatsEvent::ParentReady,
             VotorEvent::TimeoutCrashedLeader(_) => StatsEvent::TimeoutCrashedLeader,


### PR DESCRIPTION
#### Problem

We want to upstream repair from the AG repo.  In order to be able to request repair, the consensus pool has to tell the votor event handler when a block has received notar fallback.

#### Summary of Changes

Introduces the `VotorEvent::BlockNoarFallback` which will be used in the votor event handler to request repair in future PRs.  Currently, it is effectively a NOP.

This is a subset of https://github.com/anza-xyz/alpenglow/pull/707.