### PR TITLE
`ConsensusPool` produces `ValidatedBlockFinalizationCert`

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -26,6 +26,7 @@ use {
         bank::{Bank, NewBankOptions},
         bank_forks::BankForks,
         leader_schedule_utils::{last_of_consecutive_leader_slots, leader_slot_index},
+        validated_block_finalization::ValidatedBlockFinalizationCert,
     },
     stats::{LoopMetrics, SlotMetrics},
     std::{
@@ -83,6 +84,7 @@ pub struct BlockCreationLoopConfig {
     pub leader_window_info_receiver: Receiver<LeaderWindowInfo>,
     pub highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
     pub replay_highest_frozen: Arc<ReplayHighestFrozen>,
+    pub highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
 
     // Channel to receive RecordReceiver from PohService
     pub record_receiver_receiver: Receiver<RecordReceiver>,
@@ -93,6 +95,7 @@ struct LeaderContext {
     my_pubkey: Pubkey,
     leader_window_info_receiver: Receiver<LeaderWindowInfo>,
     highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
+    highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
 
     blockstore: Arc<Blockstore>,
     record_receiver: RecordReceiver,
@@ -153,6 +156,7 @@ fn start_loop(config: BlockCreationLoopConfig) {
         highest_parent_ready,
         replay_highest_frozen,
         record_receiver_receiver,
+        highest_finalized,
     } = config;
 
     // Similar to Votor, if this loop dies kill the validator
@@ -189,6 +193,7 @@ fn start_loop(config: BlockCreationLoopConfig) {
         replay_highest_frozen,
         metrics: LoopMetrics::default(),
         slot_metrics: SlotMetrics::default(),
+        highest_finalized,
     };
 
     // Setup poh

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -59,6 +59,7 @@ use {
     solana_runtime::{
         bank::MAX_ALPENGLOW_VOTE_ACCOUNTS, bank_forks::BankForks, commitment::BlockCommitmentCache,
         prioritization_fee_cache::PrioritizationFeeCache, snapshot_controller::SnapshotController,
+        validated_block_finalization::ValidatedBlockFinalizationCert,
         vote_sender_types::ReplayVoteSender,
     },
     solana_streamer::{
@@ -164,6 +165,7 @@ pub struct AlpenglowInitializationState {
     pub leader_window_info_sender: Sender<LeaderWindowInfo>,
     pub replay_highest_frozen: Arc<ReplayHighestFrozen>,
     pub highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
+    pub highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
 
     // Main communication channel
     pub votor_event_sender: VotorEventSender,
@@ -252,6 +254,7 @@ impl Tvu {
             key_notifiers,
             bls_connection_cache,
             voting_service_test_override,
+            highest_finalized,
         } = votor_init;
 
         // streamer and sigverify for A2A BLS messages
@@ -478,6 +481,7 @@ impl Tvu {
             reward_certs_sender,
             build_reward_certs_receiver,
             generated_cert_types,
+            highest_finalized,
         };
         let votor = Votor::new(votor_config);
 
@@ -848,6 +852,7 @@ pub mod tests {
                 key_notifiers,
                 bls_connection_cache: Arc::new(bls_connection_cache),
                 voting_service_test_override: None,
+                highest_finalized: Arc::new(RwLock::new(None)),
             },
         )
         .expect("assume success");

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1466,6 +1466,7 @@ impl Validator {
 
         let replay_highest_frozen = Arc::new(ReplayHighestFrozen::default());
         let highest_parent_ready = Arc::new(RwLock::default());
+        let highest_finalized = Arc::new(RwLock::new(None));
 
         let block_creation_loop_config = BlockCreationLoopConfig {
             exit: exit.clone(),
@@ -1481,6 +1482,7 @@ impl Validator {
             highest_parent_ready: highest_parent_ready.clone(),
             replay_highest_frozen: replay_highest_frozen.clone(),
             record_receiver_receiver,
+            highest_finalized: highest_finalized.clone(),
         };
         let block_creation_loop = BlockCreationLoop::new(block_creation_loop_config);
 
@@ -1624,6 +1626,7 @@ impl Validator {
                 key_notifiers: key_notifiers.clone(),
                 bls_connection_cache,
                 voting_service_test_override: config.voting_service_test_override.clone(),
+                highest_finalized,
             },
         )
         .map_err(ValidatorError::Other)?;

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -16,7 +16,7 @@ use {
         generated_cert_types::GeneratedCertTypes,
     },
     agave_votor_messages::{
-        consensus_message::{Block, Certificate, CertificateType, ConsensusMessage, VoteMessage},
+        consensus_message::{Certificate, CertificateType, ConsensusMessage, VoteMessage},
         fraction::Fraction,
         migration::MigrationStatus,
         vote::{Vote, VoteType},
@@ -27,7 +27,7 @@ use {
     solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
-    solana_runtime::bank::Bank,
+    solana_runtime::{bank::Bank, validated_block_finalization::ValidatedBlockFinalizationCert},
     std::{cmp::Ordering, collections::BTreeMap, num::NonZeroU64, sync::Arc},
     thiserror::Error,
 };
@@ -115,11 +115,9 @@ pub(crate) struct ConsensusPool {
     /// - They have a potential parent block with a NotarizeFallback certificate
     /// - All slots from the parent have a Skip certificate
     pub(crate) parent_ready_tracker: ParentReadyTracker,
-    /// Highest slot that has a Finalized variant certificate
-    highest_finalized_slot: Option<Slot>,
-    /// Highest slot that has Finalize+Notarize or FinalizeFast, for use in standstill
-    /// Also add a bool to indicate whether this slot has FinalizeFast certificate
-    highest_finalized_with_notarize: Option<(Slot, bool)>,
+    /// Highest finalization certificate (Finalize+Notarize or FinalizeFast)
+    /// Used for block footer inclusion and standstill certificate filtering
+    highest_finalized_slot_cert: Option<ValidatedBlockFinalizationCert>,
     /// Stats for the certificate pool
     stats: ConsensusPoolStats,
     /// Slot stake counters, used to calculate safe_to_notar and safe_to_skip
@@ -156,8 +154,7 @@ impl ConsensusPool {
             cluster_info,
             vote_pools: BTreeMap::new(),
             completed_certificates: BTreeMap::new(),
-            highest_finalized_slot: None,
-            highest_finalized_with_notarize: None,
+            highest_finalized_slot_cert: None,
             parent_ready_tracker,
             stats: ConsensusPoolStats::default(),
             slot_stake_counters_map: BTreeMap::new(),
@@ -204,11 +201,12 @@ impl ConsensusPool {
     /// of the related certificates are newly complete.
     /// For each newly constructed certificate
     /// - Insert it into `self.certificates`
-    /// - Potentially update `self.highest_finalized_slot`,
+    /// - Potentially update `self.highest_finalized_slot_cert`,
     /// - If we have a new highest finalized slot, return it
     /// - update any newly created events
     fn update_certificates(
         &mut self,
+        root_bank: &Bank,
         vote: &Vote,
         block_id: Option<Hash>,
         events: &mut Vec<VotorEvent>,
@@ -257,7 +255,7 @@ impl ConsensusPool {
                 }
             });
             let new_cert = Arc::new(cert_builder.build()?);
-            self.insert_certificate(cert_type, new_cert.clone(), events);
+            self.insert_certificate(root_bank, cert_type, new_cert.clone(), events);
             self.generated_cert_types.insert_cert(cert_type);
             self.stats.incr_generated_cert(&new_cert.cert_type);
             new_certificates_to_send.push(new_cert);
@@ -303,6 +301,7 @@ impl ConsensusPool {
 
     fn insert_certificate(
         &mut self,
+        root_bank: &Bank,
         cert_type: CertificateType,
         cert: Arc<Certificate>,
         events: &mut Vec<VotorEvent>,
@@ -324,44 +323,46 @@ impl ConsensusPool {
                 events.push(VotorEvent::BlockNotarized((slot, block_id)));
                 self.parent_ready_tracker
                     .add_new_notar_fallback_or_stronger((slot, block_id), events);
-                if self.is_finalized(slot) {
+
+                if let Some(finalize_cert) = self.get_finalize_cert(slot) {
                     // It's fine to set FastFinalization to false here, because
                     // we will report correctly as long as we have FastFinalization cert.
                     events.push(VotorEvent::Finalized((slot, block_id), false));
-                    if self
-                        .highest_finalized_with_notarize
-                        .is_none_or(|(s, _)| s < slot)
-                    {
-                        self.highest_finalized_with_notarize = Some((slot, false));
+                    if self.highest_finalized_slot().is_none_or(|s| s < slot) {
+                        self.highest_finalized_slot_cert =
+                            Some(ValidatedBlockFinalizationCert::from_validated_slow(
+                                Arc::unwrap_or_clone(finalize_cert.clone()),
+                                Arc::unwrap_or_clone(cert),
+                                root_bank,
+                            ));
                     }
                 }
             }
             CertificateType::Finalize(slot) => {
-                if let Some(block) = self.get_notarized_block(slot) {
-                    events.push(VotorEvent::Finalized(block, false));
-                    if self
-                        .highest_finalized_with_notarize
-                        .is_none_or(|(s, _)| s < slot)
-                    {
-                        self.highest_finalized_with_notarize = Some((slot, false));
+                if let Some(notarize_cert) = self.get_notarize_cert(slot) {
+                    let (_s, block_id) = notarize_cert.cert_type.to_block().unwrap();
+                    events.push(VotorEvent::Finalized((slot, block_id), false));
+                    if self.highest_finalized_slot().is_none_or(|s| s < slot) {
+                        self.highest_finalized_slot_cert =
+                            Some(ValidatedBlockFinalizationCert::from_validated_slow(
+                                Arc::unwrap_or_clone(cert),
+                                Arc::unwrap_or_clone(notarize_cert),
+                                root_bank,
+                            ));
                     }
-                }
-                if self.highest_finalized_slot.is_none_or(|s| s < slot) {
-                    self.highest_finalized_slot = Some(slot);
                 }
             }
             CertificateType::FinalizeFast(slot, block_id) => {
                 events.push(VotorEvent::Finalized((slot, block_id), true));
                 self.parent_ready_tracker
                     .add_new_notar_fallback_or_stronger((slot, block_id), events);
-                if self.highest_finalized_slot.is_none_or(|s| s < slot) {
-                    self.highest_finalized_slot = Some(slot);
-                }
-                if self
-                    .highest_finalized_with_notarize
-                    .is_none_or(|(s, _)| s <= slot)
-                {
-                    self.highest_finalized_with_notarize = Some((slot, true));
+                // Use <= for FastFinalize since it supersedes standard finalization at the same slot
+                if self.highest_finalized_slot().is_none_or(|s| s <= slot) {
+                    self.highest_finalized_slot_cert =
+                        Some(ValidatedBlockFinalizationCert::from_validated_fast(
+                            Arc::unwrap_or_clone(cert),
+                            root_bank,
+                        ));
                 }
             }
             CertificateType::Genesis(slot, block_id) => {
@@ -390,18 +391,16 @@ impl ConsensusPool {
         message: ConsensusMessage,
         events: &mut Vec<VotorEvent>,
     ) -> Result<(Option<Slot>, Vec<Arc<Certificate>>), AddVoteError> {
-        let current_highest_finalized_slot = self.highest_finalized_slot;
+        let current_highest_finalized_slot = self.highest_finalized_slot();
         let new_certficates_to_send = match message {
             ConsensusMessage::Vote(vote_message) => {
                 self.add_vote(root_bank, my_vote_pubkey, vote_message, events)?
             }
-            ConsensusMessage::Certificate(cert) => {
-                self.add_certificate(root_bank.slot(), cert, events)?
-            }
+            ConsensusMessage::Certificate(cert) => self.add_certificate(root_bank, cert, events)?,
         };
         // If we have a new highest finalized slot, return it
-        let new_finalized_slot = if self.highest_finalized_slot > current_highest_finalized_slot {
-            self.highest_finalized_slot
+        let new_finalized_slot = if self.highest_finalized_slot() > current_highest_finalized_slot {
+            self.highest_finalized_slot()
         } else {
             None
         };
@@ -475,18 +474,18 @@ impl ConsensusPool {
         }
         self.stats.incr_ingested_vote_type(vote_type);
 
-        self.update_certificates(vote, block_id, events, total_stake)
+        self.update_certificates(root_bank, vote, block_id, events, total_stake)
     }
 
     fn add_certificate(
         &mut self,
-        root_slot: Slot,
+        root_bank: &Bank,
         cert: Certificate,
         events: &mut Vec<VotorEvent>,
     ) -> Result<Vec<Arc<Certificate>>, AddVoteError> {
         let cert_type = cert.cert_type;
         self.stats.incoming_certs = self.stats.incoming_certs.saturating_add(1);
-        if cert_type.slot() < root_slot {
+        if cert_type.slot() < root_bank.slot() {
             self.stats.out_of_range_certs = self.stats.out_of_range_certs.saturating_add(1);
             return Err(AddVoteError::UnrootedSlot);
         }
@@ -495,20 +494,31 @@ impl ConsensusPool {
             return Ok(vec![]);
         }
         let cert = Arc::new(cert);
-        self.insert_certificate(cert_type, cert.clone(), events);
+        self.insert_certificate(root_bank, cert_type, cert.clone(), events);
         self.stats.incr_ingested_cert(&cert_type);
 
         Ok(vec![cert])
     }
 
-    /// Get the notarized block in `slot`
-    fn get_notarized_block(&self, slot: Slot) -> Option<Block> {
+    /// Get the Notarize certificate for a slot
+    fn get_notarize_cert(&self, slot: Slot) -> Option<Arc<Certificate>> {
         self.completed_certificates
             .iter()
-            .find_map(|(cert_type, _)| match cert_type {
-                CertificateType::Notarize(s, block_id) if slot == *s => Some((*s, *block_id)),
+            .find_map(|(cert_type, cert)| match cert_type {
+                CertificateType::Notarize(s, _) if slot == *s => Some(cert.clone()),
                 _ => None,
             })
+    }
+
+    /// Get the Finalize certificate for a slot
+    fn get_finalize_cert(&self, slot: Slot) -> Option<&Arc<Certificate>> {
+        self.completed_certificates
+            .get(&CertificateType::Finalize(slot))
+    }
+
+    /// Get the highest finalized slot (slow or fast)
+    pub(crate) fn highest_finalized_slot(&self) -> Option<Slot> {
+        self.highest_finalized_slot_cert.as_ref().map(|c| c.slot())
     }
 
     #[cfg(test)]
@@ -539,20 +549,8 @@ impl ConsensusPool {
             .unwrap_or(0)
     }
 
-    pub(crate) fn highest_finalized_slot(&self) -> Slot {
-        self.completed_certificates
-            .keys()
-            .filter_map(|cert_type| match cert_type {
-                CertificateType::Finalize(s) => Some(s),
-                CertificateType::FinalizeFast(s, _) => Some(s),
-                _ => None,
-            })
-            .max()
-            .copied()
-            .unwrap_or(0)
-    }
-
     /// Checks if any block in the slot `s` is finalized
+    #[cfg(test)]
     fn is_finalized(&self, slot: Slot) -> bool {
         self.completed_certificates.keys().any(|cert_type| {
             matches!(cert_type, CertificateType::Finalize(s) | CertificateType::FinalizeFast(s, _) if *s == slot)
@@ -634,13 +632,16 @@ impl ConsensusPool {
     }
 
     pub(crate) fn get_certs_for_standstill(&self) -> Vec<Arc<Certificate>> {
-        let (highest_finalized_with_notarize_slot, has_fast_finalize) =
-            self.highest_finalized_with_notarize.unwrap_or((0, false));
+        let (highest_slot, has_fast_finalize) = self
+            .highest_finalized_slot_cert
+            .as_ref()
+            .map(|certs| (certs.slot(), certs.is_fast()))
+            .unwrap_or((0, false));
         self.completed_certificates
             .iter()
             .filter_map(|(cert_type, cert)| {
                 let cert_to_send = match (
-                    cert_type.slot().cmp(&highest_finalized_with_notarize_slot),
+                    cert_type.slot().cmp(&highest_slot),
                     cert_type,
                     has_fast_finalize,
                 ) {
@@ -669,6 +670,12 @@ impl ConsensusPool {
             })
             .collect()
     }
+
+    /// Returns the highest finalization certificates (slow w/ notarize or fast)
+    /// This is used to populate the `final_cert` field in block footers.
+    pub(crate) fn get_highest_finalization_certs(&self) -> Option<ValidatedBlockFinalizationCert> {
+        self.highest_finalized_slot_cert.clone()
+    }
 }
 
 #[cfg(test)]
@@ -677,6 +684,7 @@ mod tests {
         super::*,
         crate::tests::get_cluster_info,
         agave_votor_messages::consensus_message::{BLS_KEYPAIR_DERIVE_SEED, VoteMessage},
+        bitvec::vec::BitVec,
         solana_bls_signatures::{
             Pubkey as BLSPubkey, Signature as BLSSignature, VerifiableSignature,
             keypair::Keypair as BLSKeypair,
@@ -691,9 +699,16 @@ mod tests {
                 ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
             },
         },
+        solana_signer_store::encode_base2,
         std::sync::{Arc, RwLock},
         test_case::test_case,
     };
+
+    fn dummy_bitmap() -> Vec<u8> {
+        let mut bitvec = BitVec::repeat(false, 1);
+        bitvec.set(0, true);
+        encode_base2(&bitvec).unwrap()
+    }
 
     struct TestContext {
         validators: Vec<ValidatorVoteKeypairs>,
@@ -745,7 +760,10 @@ mod tests {
                 }
                 Vote::Skip(vote) => assert_eq!(self.pool.highest_skip_slot(), vote.slot),
                 Vote::SkipFallback(vote) => assert_eq!(self.pool.highest_skip_slot(), vote.slot),
-                Vote::Finalize(vote) => assert_eq!(self.pool.highest_finalized_slot(), vote.slot),
+                Vote::Finalize(vote) => assert_eq!(
+                    self.pool.highest_finalized_slot().unwrap_or_default(),
+                    vote.slot
+                ),
                 Vote::Genesis(_genesis_vote) => (),
             }
         }
@@ -1044,8 +1062,22 @@ mod tests {
     ) {
         let mut ctx = TestContext::new();
         let my_validator_ix = 5;
+
+        // For Finalize votes, we need a corresponding Notarize certificate first
+        // because finalization requires both Finalize and Notarize certificates
+        if vote.is_finalize() {
+            let notarize_cert = Certificate {
+                cert_type: CertificateType::Notarize(vote.slot(), Hash::default()),
+                signature: BLSSignature::default(),
+                bitmap: dummy_bitmap(),
+            };
+            ctx.add_message(ConsensusMessage::Certificate(notarize_cert));
+        }
+
         let highest_slot_fn = match &vote {
-            Vote::Finalize(_) => |pool: &ConsensusPool| pool.highest_finalized_slot(),
+            Vote::Finalize(_) => {
+                |pool: &ConsensusPool| pool.highest_finalized_slot().unwrap_or_default()
+            }
             Vote::Notarize(_) => |pool: &ConsensusPool| pool.highest_notarized_slot(),
             Vote::NotarizeFallback(_) => |pool: &ConsensusPool| pool.highest_notarized_slot(),
             Vote::Skip(_) => |pool: &ConsensusPool| pool.highest_skip_slot(),
@@ -1106,11 +1138,33 @@ mod tests {
         let cert = Certificate {
             cert_type,
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
+
+        // For Finalize certificates, we need a corresponding Notarize certificate first
+        // because finalization requires both certificates to be present
+        if matches!(cert_type, CertificateType::Finalize(slot) if slot == 5) {
+            let notarize_cert = Certificate {
+                cert_type: CertificateType::Notarize(5, Hash::default()),
+                signature: BLSSignature::default(),
+                bitmap: dummy_bitmap(),
+            };
+            ctx.add_message(ConsensusMessage::Certificate(notarize_cert));
+        }
+
         let message = ConsensusMessage::Certificate(cert.clone());
         // Add the certificate to the pool
-        let (new_finalized_slot, certs_to_send) = ctx.add_message(message.clone()); // Because this is the first certificate of this type, it should be sent out.
+        let root_bank = ctx.bank_forks.read().unwrap().root_bank();
+        let (new_finalized_slot, certs_to_send) = ctx
+            .pool
+            .add_message(
+                &root_bank,
+                &Pubkey::new_unique(),
+                message.clone(),
+                &mut vec![],
+            )
+            .unwrap();
+        // Because this is the first certificate of this type, it should be sent out.
         if matches!(cert_type, CertificateType::Finalize(_))
             || matches!(cert_type, CertificateType::FinalizeFast(_, _))
         {
@@ -1119,17 +1173,27 @@ mod tests {
             assert!(new_finalized_slot.is_none());
         }
         assert_eq!(certs_to_send.len(), 1);
-        assert_eq!(*certs_to_send[0], cert);
+        assert!(certs_to_send.iter().any(|c| **c == cert));
 
         // Adding the cert again will not trigger another send
-        let (new_finalized_slot, certs_to_send) = ctx.add_message(message);
+        let (new_finalized_slot, certs_to_send) = ctx
+            .pool
+            .add_message(&root_bank, &Pubkey::new_unique(), message, &mut vec![])
+            .unwrap();
         assert!(new_finalized_slot.is_none());
         assert_eq!(certs_to_send, []);
 
         // Now add the vote from everyone else, this will not trigger a certificate send
         for rank in 0..ctx.validators.len() {
-            let (_, certs_to_send) =
-                ctx.add_message(dummy_vote_message(&ctx.validators, &vote, rank));
+            let (_, certs_to_send) = ctx
+                .pool
+                .add_message(
+                    &root_bank,
+                    &Pubkey::new_unique(),
+                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    &mut vec![],
+                )
+                .unwrap();
             assert!(
                 !certs_to_send
                     .iter()
@@ -1677,7 +1741,7 @@ mod tests {
         let cert_1 = Certificate {
             cert_type: CertificateType::Skip(1),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.pool
             .add_message(
@@ -1690,7 +1754,7 @@ mod tests {
         let cert_2 = Certificate {
             cert_type: CertificateType::FinalizeFast(2, Hash::new_unique()),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.pool
             .add_message(
@@ -1731,7 +1795,7 @@ mod tests {
         let cert = ConsensusMessage::Certificate(Certificate {
             cert_type,
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         });
         assert!(
             ctx.pool
@@ -1751,13 +1815,13 @@ mod tests {
         let cert_3 = Certificate {
             cert_type: CertificateType::NotarizeFallback(3, Hash::new_unique()),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_3));
         let cert_4 = Certificate {
             cert_type: CertificateType::Finalize(4),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_4));
         // Should return both certificates
@@ -1772,7 +1836,7 @@ mod tests {
         let cert_5 = Certificate {
             cert_type: CertificateType::Notarize(5, Hash::new_unique()),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_5));
 
@@ -1780,7 +1844,7 @@ mod tests {
         let cert_5_finalize = Certificate {
             cert_type: CertificateType::Finalize(5),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_5_finalize));
 
@@ -1788,7 +1852,7 @@ mod tests {
         let cert_5 = Certificate {
             cert_type: CertificateType::FinalizeFast(5, Hash::new_unique()),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_5));
         // Should return only FinalizeFast cert on 5
@@ -1803,7 +1867,7 @@ mod tests {
         let cert_6 = Certificate {
             cert_type: CertificateType::Notarize(6, Hash::new_unique()),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_6));
         // Should return certs on 5 and 6
@@ -1818,14 +1882,14 @@ mod tests {
         let cert_6_finalize = Certificate {
             cert_type: CertificateType::Finalize(6),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_6_finalize));
         // Add a NotarizeFallback cert on 6
         let cert_6_notarize_fallback = Certificate {
             cert_type: CertificateType::NotarizeFallback(6, Hash::new_unique()),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_6_notarize_fallback));
         // This should not be returned because 6 is the current highest finalized slot
@@ -1841,7 +1905,7 @@ mod tests {
         let cert_7 = Certificate {
             cert_type: CertificateType::Skip(7),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_7));
         // Should return certs on 6 and 7
@@ -1860,13 +1924,13 @@ mod tests {
         let cert_8_finalize = Certificate {
             cert_type: CertificateType::Finalize(8),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_8_finalize));
         let cert_8_notarize = Certificate {
             cert_type: CertificateType::Notarize(8, Hash::new_unique()),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_8_notarize));
 
@@ -1891,7 +1955,7 @@ mod tests {
             let cert = Certificate {
                 cert_type: CertificateType::Notarize(slot, hash),
                 signature: BLSSignature::default(),
-                bitmap: Vec::new(),
+                bitmap: dummy_bitmap(),
             };
             ctx.pool
                 .add_message(
@@ -1919,7 +1983,7 @@ mod tests {
             let cert = Certificate {
                 cert_type: CertificateType::FinalizeFast(slot, hash),
                 signature: BLSSignature::default(),
-                bitmap: Vec::new(),
+                bitmap: dummy_bitmap(),
             };
             ctx.pool
                 .add_message(
@@ -1947,14 +2011,14 @@ mod tests {
             let cert = Certificate {
                 cert_type: CertificateType::NotarizeFallback(slot, hash),
                 signature: BLSSignature::default(),
-                bitmap: Vec::new(),
+                bitmap: dummy_bitmap(),
             };
             ctx.add_message(ConsensusMessage::Certificate(cert));
         }
         let cert = Certificate {
             cert_type: CertificateType::FinalizeFast(11, hash),
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.pool
             .add_message(
@@ -2010,7 +2074,7 @@ mod tests {
         let cert = Certificate {
             cert_type,
             signature: BLSSignature::default(),
-            bitmap: Vec::new(),
+            bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert));
         assert!(!ctx.generated_cert_types.has_cert(&cert_type));

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -26,11 +26,12 @@ use {
     solana_runtime::{
         bank::Bank, bank_forks::SharableBanks,
         leader_schedule_utils::last_of_consecutive_leader_slots,
+        validated_block_finalization::ValidatedBlockFinalizationCert,
     },
     stats::ConsensusPoolServiceStats,
     std::{
         sync::{
-            Arc,
+            Arc, RwLock,
             atomic::{AtomicBool, Ordering},
         },
         thread::{self, Builder, JoinHandle},
@@ -59,6 +60,8 @@ pub(crate) struct ConsensusPoolContext {
     pub(crate) bls_sender: Sender<BLSOp>,
     pub(crate) event_sender: VotorEventSender,
     pub(crate) commitment_sender: Sender<CommitmentAggregationData>,
+
+    pub(crate) highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
 }
 
 pub(crate) struct ConsensusPoolService {
@@ -87,12 +90,15 @@ impl ConsensusPoolService {
         new_certificates_to_send: Vec<Arc<Certificate>>,
         standstill_timer: &mut Instant,
         stats: &mut ConsensusPoolServiceStats,
+        highest_finalized: &RwLock<Option<ValidatedBlockFinalizationCert>>,
     ) -> Result<(), AddVoteError> {
         // If we have a new finalized slot, update the root and send new certificates
         if new_finalized_slot.is_some() {
             // Reset standstill timer
             *standstill_timer = Instant::now();
             stats.new_finalized_slot += 1;
+
+            *highest_finalized.write().unwrap() = consensus_pool.get_highest_finalization_certs();
         }
         let bank = sharable_banks.root();
         consensus_pool.maybe_prune(bank.slot());
@@ -164,6 +170,7 @@ impl ConsensusPoolService {
             new_certificates_to_send,
             standstill_timer,
             stats,
+            &ctx.highest_finalized,
         )
     }
 
@@ -250,7 +257,7 @@ impl ConsensusPoolService {
                 // Genesis cert though.
                 if kick_off_parent_ready {
                     events.push(VotorEvent::Standstill(
-                        consensus_pool.highest_finalized_slot(),
+                        consensus_pool.highest_finalized_slot().unwrap_or(0),
                     ));
                 }
                 stats.standstill = true;
@@ -475,6 +482,7 @@ mod tests {
         blockstore: Arc<Blockstore>,
         exit: Arc<AtomicBool>,
         cluster_info: Arc<ClusterInfo>,
+        highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
     }
 
     impl Default for TestContext {
@@ -530,6 +538,7 @@ mod tests {
                 blockstore,
                 exit: Arc::new(AtomicBool::new(false)),
                 cluster_info,
+                highest_finalized: Arc::new(RwLock::new(None)),
             }
         }
     }
@@ -591,6 +600,7 @@ mod tests {
                     new_certificates_to_send,
                     &mut standstill_timer,
                     &mut stats,
+                    &ctx.highest_finalized,
                 )
                 .unwrap();
             }
@@ -670,6 +680,7 @@ mod tests {
             new_certificates_to_send,
             &mut standstill_timer,
             &mut stats,
+            &ctx.highest_finalized,
         )
         .unwrap();
 
@@ -734,6 +745,7 @@ mod tests {
             bls_sender: ctx.bls_sender.clone(),
             event_sender: crossbeam_channel::unbounded().0,
             commitment_sender: ctx.commitment_sender.clone(),
+            highest_finalized: ctx.highest_finalized.clone(),
         };
         let mut stats = ConsensusPoolServiceStats::new();
 
@@ -845,6 +857,7 @@ mod tests {
             certificates,
             &mut standstill_timer,
             &mut stats,
+            &ctx.highest_finalized,
         );
 
         assert!(result.is_ok());

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -78,6 +78,7 @@ use {
     solana_runtime::{
         bank_forks::BankForks, installed_scheduler_pool::BankWithScheduler,
         snapshot_controller::SnapshotController,
+        validated_block_finalization::ValidatedBlockFinalizationCert,
     },
     std::{
         collections::HashMap,
@@ -105,6 +106,7 @@ pub struct VotorConfig {
     pub leader_schedule_cache: Arc<LeaderScheduleCache>,
     pub rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
     pub consensus_metrics_sender: ConsensusMetricsEventSender,
+    pub highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
 
     // Senders / Notifiers
     pub snapshot_controller: Option<Arc<SnapshotController>>,
@@ -176,6 +178,7 @@ impl Votor {
             build_reward_certs_receiver,
             reward_certs_sender,
             generated_cert_types,
+            highest_finalized,
         } = config;
 
         let migration_status = bank_forks.read().unwrap().migration_status();
@@ -246,6 +249,7 @@ impl Votor {
             bls_sender,
             event_sender,
             commitment_sender,
+            highest_finalized,
         };
 
         let metrics = ConsensusMetrics::start_metrics_loop(


### PR DESCRIPTION
#### Problem

A validator needs to include a `ValidatedBlockFinalizationCert` in the block footer for the highest block that it has finalized.


#### Summary of Changes

This is part of the change to implement the entire feature.  In this PR, the consensus pool creates and populates a `ValidatedBlockFinalizationCert` for the highest block that it has finalized.  This will be used in the block creation loop in subsequent PRs.
