### PR TITLE
feat(runtime): serialize obsolete accounts file with wincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "wincode",
  "zstd",
 ]
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "wincode",
  "zstd",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -227,6 +227,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "wincode",
  "zstd",
 ]
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -57,6 +57,7 @@ use {
     },
     storage::SerializableStorage,
     types::{SerdeAccountsLtHash, UnusedRentCollector},
+    wincode::{SchemaReadOwned, SchemaWrite, io::std_write::WriteAdapter},
 };
 
 mod obsolete_accounts;
@@ -67,12 +68,13 @@ mod types;
 mod utils;
 
 pub(crate) use {
-    obsolete_accounts::SerdeObsoleteAccountsMap,
+    obsolete_accounts::{SerdeObsoleteAccounts, SerdeObsoleteAccountsMap},
     status_cache::{deserialize_status_cache, serialize_status_cache},
     storage::{SerializableAccountStorageEntry, SerializedAccountsFileId},
 };
 
-const MAX_STREAM_SIZE: u64 = 32 * 1024 * 1024 * 1024;
+const MAX_STREAM_SIZE: usize = 32 * 1024 * 1024 * 1024;
+type MaxStreamSizeConfig = wincode::config::Configuration<true, MAX_STREAM_SIZE>;
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Deserialize)]
@@ -373,15 +375,20 @@ impl<T> SnapshotAccountsDbFields<T> {
     }
 }
 
-pub(crate) fn serialize_into<W, T>(writer: W, value: &T) -> bincode::Result<()>
+pub(crate) fn serialize_into<W, T>(writer: W, value: &T) -> wincode::WriteResult<()>
 where
     W: Write,
-    T: Serialize,
+    T: SchemaWrite<MaxStreamSizeConfig, Src = T>,
 {
-    bincode::options()
-        .with_fixint_encoding()
-        .with_limit(MAX_STREAM_SIZE)
-        .serialize_into(writer, value)
+    wincode::config::serialize_into(WriteAdapter::new(writer), value, MaxStreamSizeConfig::new())
+}
+
+pub(crate) fn deserialize_wincode_from<R, T>(reader: R) -> wincode::ReadResult<T>
+where
+    R: Read,
+    T: SchemaReadOwned<MaxStreamSizeConfig, Dst = T>,
+{
+    wincode::config::deserialize_from(io::BufReader::new(reader), MaxStreamSizeConfig::new())
 }
 
 pub(crate) fn deserialize_from<R, T>(reader: R) -> bincode::Result<T>
@@ -390,7 +397,7 @@ where
     T: DeserializeOwned,
 {
     bincode::options()
-        .with_limit(MAX_STREAM_SIZE)
+        .with_limit(MAX_STREAM_SIZE as u64)
         .with_fixint_encoding()
         .allow_trailing_bytes()
         .deserialize_from::<R, T>(reader)

--- a/runtime/src/serde_snapshot/obsolete_accounts.rs
+++ b/runtime/src/serde_snapshot/obsolete_accounts.rs
@@ -43,7 +43,7 @@ impl SerdeObsoleteAccounts {
         }
     }
 
-    pub(crate) fn into_tuple(self) -> (ObsoleteAccounts, u32, usize) {
+    pub(crate) fn into_tuple(self) -> (ObsoleteAccounts, AccountsFileId, usize) {
         let accounts = self
             .accounts
             .into_iter()

--- a/runtime/src/serde_snapshot/obsolete_accounts.rs
+++ b/runtime/src/serde_snapshot/obsolete_accounts.rs
@@ -1,19 +1,20 @@
 use {
     crate::serde_snapshot::SerializedAccountsFileId,
     dashmap::DashMap,
-    rayon::iter::{IntoParallelRefIterator, ParallelIterator},
-    serde::{Deserialize, Serialize},
+    rayon::iter::{IntoParallelIterator, ParallelIterator},
+    serde::Serialize,
     solana_accounts_db::{
         ObsoleteAccountItem, ObsoleteAccounts, account_info::Offset,
         account_storage_entry::AccountStorageEntry, accounts_db::AccountsFileId,
     },
     solana_clock::Slot,
     std::sync::Arc,
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Debug, Default, Serialize, Deserialize)]
-struct SerdeObsoleteAccounts {
+#[derive(Debug, Default, Serialize, SchemaRead, SchemaWrite)]
+pub(crate) struct SerdeObsoleteAccounts {
     /// The ID of the associated account file. Used for verification to ensure the restored
     /// obsolete accounts correspond to the correct account file
     pub id: SerializedAccountsFileId,
@@ -41,6 +42,24 @@ impl SerdeObsoleteAccounts {
             accounts,
         }
     }
+
+    pub(crate) fn into_tuple(self) -> (ObsoleteAccounts, u32, usize) {
+        let accounts = self
+            .accounts
+            .into_iter()
+            .map(|(offset, data_len, slot)| ObsoleteAccountItem {
+                offset,
+                data_len,
+                slot,
+            })
+            .collect();
+
+        (
+            ObsoleteAccounts { accounts },
+            self.id as AccountsFileId,
+            self.bytes as usize,
+        )
+    }
 }
 
 /// Represents a map of obsolete accounts data for multiple slots.
@@ -51,9 +70,9 @@ impl SerdeObsoleteAccounts {
     derive(AbiExample),
     frozen_abi(digest = "12qimMBghYs9dL4nhws7Xe1B5MXWBV75VTMTGLHxevYE")
 )]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Debug, SchemaRead, SchemaWrite)]
 pub(crate) struct SerdeObsoleteAccountsMap {
-    map: DashMap<Slot, SerdeObsoleteAccounts>,
+    map: Vec<(Slot, SerdeObsoleteAccounts)>,
 }
 
 impl SerdeObsoleteAccountsMap {
@@ -62,35 +81,20 @@ impl SerdeObsoleteAccountsMap {
         snapshot_storages: &[Arc<AccountStorageEntry>],
         snapshot_slot: Slot,
     ) -> Self {
-        let map = DashMap::with_capacity(snapshot_storages.len());
-        snapshot_storages.par_iter().for_each(|storage| {
-            map.insert(
-                storage.slot(),
-                SerdeObsoleteAccounts::new_from_storage_entry_at_slot(storage, snapshot_slot),
-            );
-        });
+        let map = snapshot_storages
+            .into_par_iter()
+            .map(|storage| {
+                (
+                    storage.slot(),
+                    SerdeObsoleteAccounts::new_from_storage_entry_at_slot(storage, snapshot_slot),
+                )
+            })
+            .collect();
         SerdeObsoleteAccountsMap { map }
     }
 
-    /// Removes and returns the obsolete accounts data for a given slot.
-    pub(crate) fn remove(&self, slot: &Slot) -> Option<(ObsoleteAccounts, AccountsFileId, usize)> {
-        self.map.remove(slot).map(|(_, entry)| {
-            let accounts = entry
-                .accounts
-                .into_iter()
-                .map(|(offset, data_len, slot)| ObsoleteAccountItem {
-                    offset,
-                    data_len,
-                    slot,
-                })
-                .collect();
-
-            (
-                ObsoleteAccounts { accounts },
-                entry.id as AccountsFileId,
-                entry.bytes as usize,
-            )
-        })
+    pub(crate) fn into_dashmap(self) -> DashMap<Slot, SerdeObsoleteAccounts> {
+        self.map.into_iter().collect()
     }
 }
 
@@ -98,8 +102,8 @@ impl SerdeObsoleteAccountsMap {
 mod test {
     use {
         super::*,
-        crate::serde_snapshot::{deserialize_from, serialize_into},
-        std::io::{BufReader, BufWriter, Cursor},
+        crate::serde_snapshot::{deserialize_wincode_from, serialize_into},
+        std::io::Cursor,
         test_case::test_case,
     };
 
@@ -149,26 +153,22 @@ mod test {
 
         // Serialize the obsolete accounts map
         let mut buf = Vec::new();
-        let cursor = Cursor::new(&mut buf);
-        let mut writer = BufWriter::new(cursor);
-        serialize_into(&mut writer, &obsolete_accounts_map).unwrap();
-        drop(writer);
+        serialize_into(Cursor::new(&mut buf), &obsolete_accounts_map).unwrap();
 
         // Deserialize the obsolete accounts map
         let cursor = Cursor::new(buf.as_slice());
-        let mut reader = BufReader::new(cursor);
         let deserialized_obsolete_accounts: SerdeObsoleteAccountsMap =
-            deserialize_from(&mut reader).unwrap();
+            deserialize_wincode_from(cursor).unwrap();
+        let map = deserialized_obsolete_accounts.into_dashmap();
 
         // Verify the deserialized data matches the original obsolete accounts
-        assert_eq!(
-            deserialized_obsolete_accounts.map.len(),
-            obsolete_accounts.len()
-        );
+        assert_eq!(map.len(), obsolete_accounts.len());
         for (slot, obsolete_accounts) in obsolete_accounts {
-            let deserialized_obsolete_accounts =
-                deserialized_obsolete_accounts.remove(&slot).unwrap();
-            assert_eq!(obsolete_accounts, deserialized_obsolete_accounts.0);
+            let deserialized_obsolete_accounts = map.remove(&slot).unwrap();
+            assert_eq!(
+                obsolete_accounts,
+                deserialized_obsolete_accounts.1.into_tuple().0
+            );
         }
     }
 }

--- a/runtime/src/serde_snapshot/obsolete_accounts.rs
+++ b/runtime/src/serde_snapshot/obsolete_accounts.rs
@@ -68,7 +68,7 @@ impl SerdeObsoleteAccounts {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "12qimMBghYs9dL4nhws7Xe1B5MXWBV75VTMTGLHxevYE")
+    frozen_abi(digest = "7Hb4XtqaUBY27yyz7V1kVXZ9aTnary8GDroB12JRvGjz")
 )]
 #[derive(Serialize, Debug, SchemaRead, SchemaWrite)]
 pub(crate) struct SerdeObsoleteAccountsMap {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -715,7 +715,6 @@ fn serialize_obsolete_accounts(
         ))
     })?;
 
-    file_stream.flush()?;
     Ok(file_stream.bytes_written())
 }
 
@@ -739,11 +738,9 @@ fn deserialize_obsolete_accounts(
         return Err(IoError::other(error_message).into());
     }
 
-    let mut data_file_stream = BufReader::new(obsolete_accounts_file);
-
-    let obsolete_accounts = serde_snapshot::deserialize_from(&mut data_file_stream)?;
-
-    Ok(obsolete_accounts)
+    Ok(serde_snapshot::deserialize_wincode_from(
+        obsolete_accounts_file,
+    )?)
 }
 
 pub fn serialize_snapshot_data_file<F>(data_file_path: &Path, serializer: F) -> Result<u64>
@@ -2648,11 +2645,13 @@ mod tests {
         // Deserialize
         let deserialized_accounts =
             deserialize_obsolete_accounts(bank_snapshot_dir, MAX_OBSOLETE_ACCOUNTS_FILE_SIZE)
-                .unwrap();
+                .unwrap()
+                .into_dashmap();
 
         // Verify
         for storage in &snapshot_storages {
-            assert!(deserialized_accounts.remove(&storage.slot()).unwrap().2 == 0);
+            let obsolete_accounts = deserialized_accounts.remove(&storage.slot()).unwrap().1;
+            assert!(obsolete_accounts.into_tuple().2 == 0);
         }
     }
 

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -3,10 +3,12 @@
 use {
     super::{SnapshotError, SnapshotFrom},
     crate::serde_snapshot::{
-        SerdeObsoleteAccountsMap, reconstruct_single_storage, remap_and_reconstruct_single_storage,
+        SerdeObsoleteAccounts, SerdeObsoleteAccountsMap, reconstruct_single_storage,
+        remap_and_reconstruct_single_storage,
     },
     agave_fs::FileInfo,
     crossbeam_channel::{Receiver, Sender, select, unbounded},
+    dashmap::DashMap,
     log::*,
     rayon::{
         ThreadPool, ThreadPoolBuilder,
@@ -52,7 +54,7 @@ pub(crate) struct SnapshotStorageRebuilder {
     /// specify how storages are accessed
     storage_access: StorageAccess,
     /// obsolete accounts for all storages
-    obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
+    obsolete_accounts: DashMap<Slot, SerdeObsoleteAccounts>,
 }
 
 impl SnapshotStorageRebuilder {
@@ -78,7 +80,9 @@ impl SnapshotStorageRebuilder {
             num_collisions: AtomicUsize::new(0),
             snapshot_from,
             storage_access,
-            obsolete_accounts,
+            obsolete_accounts: obsolete_accounts
+                .map(|map| map.into_dashmap())
+                .unwrap_or_default(),
         }
     }
 
@@ -202,8 +206,8 @@ impl SnapshotStorageRebuilder {
                 old_append_vec_id as AccountsFileId,
                 self.storage_access,
                 self.obsolete_accounts
-                    .as_ref()
-                    .and_then(|accounts| accounts.remove(&slot)),
+                    .remove(&slot)
+                    .map(|(_, accounts)| accounts.into_tuple()),
             )?,
         };
 

--- a/snapshots/Cargo.toml
+++ b/snapshots/Cargo.toml
@@ -41,6 +41,7 @@ symlink = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]

--- a/snapshots/src/error.rs
+++ b/snapshots/src/error.rs
@@ -21,6 +21,9 @@ pub enum SnapshotError {
     #[error("serialization error: {0}")]
     Serialize(#[from] bincode::Error),
 
+    #[error("deserialization error: {0}")]
+    DeserializeWincode(#[from] wincode::ReadError),
+
     #[error("crossbeam send error: {0}")]
     CrossbeamSend(#[from] crossbeam_channel::SendError<PathBuf>),
 


### PR DESCRIPTION
#### Problem
Obsolete accounts map is serialized and deserialized into its own file using `bincode`. This is an isolated use-case that can already be converted to use `wincode`.

#### Summary of Changes
* deserialize into Vec, which is in very efficient in terms of allocation since static data size of items + length read from prefix allows doing only one alloc
* convert to dashmap on creation of `SnapshotStorageRebuilder`
* conversion of `SerdeObsoleteAccounts` to tuple with `ObsoleteAccounts` is moved into `SerdeObsoleteAccounts` that is invoked by the user directly (instead of through remove in `SerdeObsoleteAccountsMap`)
* for serialization skip creating dashmap embedded in `SerdeObsoleteAccountsMap` entirely, just collect to vec, which uses the same bincode wire format as maps - collect still uses rayon, perf will be better since it just skips all the hasmap building logic

##### Performance impact
Reduce time for deserialize obsolete accounts map from 150ms (deserialize) to 57ms (deserialize into vec) + 32ms (into_dashmap)