### PR TITLE
Adds `node_pubkey` in `BLSPubkeyStakeEntry` and upstreams assorted cleanups

### DIFF
--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -282,7 +282,7 @@ impl SigVerifier {
                 self.stats.discard_vote_invalid_rank += 1;
                 None
             })?;
-        let ret = Some((entry.pubkey, entry.bls_pubkey));
+        let ret = Some((entry.vote_account_pubkey, entry.bls_pubkey));
         if vote.vote.slot() > root_slot {
             return ret;
         }

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -552,9 +552,9 @@ mod tests {
                 .bls_pubkey_to_rank_map();
             (0..rank_map.len())
                 .find_map(|rank| {
-                    rank_map
-                        .get_pubkey_stake_entry(rank)
-                        .and_then(|entry| (entry.pubkey == target_vote_pubkey).then_some(rank))
+                    rank_map.get_pubkey_stake_entry(rank).and_then(|entry| {
+                        (entry.vote_account_pubkey == target_vote_pubkey).then_some(rank)
+                    })
                 })
                 .unwrap()
         };
@@ -616,9 +616,9 @@ mod tests {
                 .bls_pubkey_to_rank_map();
             (0..rank_map.len())
                 .find_map(|rank| {
-                    rank_map
-                        .get_pubkey_stake_entry(rank)
-                        .and_then(|entry| (entry.pubkey == non_target_vote_pubkey).then_some(rank))
+                    rank_map.get_pubkey_stake_entry(rank).and_then(|entry| {
+                        (entry.vote_account_pubkey == non_target_vote_pubkey).then_some(rank)
+                    })
                 })
                 .unwrap()
         };

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -4,14 +4,14 @@ use {
         Deserialize, Deserializer, Serialize, Serializer,
         de::{SeqAccess, Visitor},
     },
-    solana_bls_signatures::{
-        BLS_PUBLIC_KEY_COMPRESSED_SIZE,
-        pubkey::{PubkeyAffine as BLSPubkeyAffine, PubkeyCompressed as BLSPubkeyCompressed},
+    solana_bls_signatures::pubkey::{
+        PubkeyAffine as BLSPubkeyAffine, PubkeyCompressed as BLSPubkeyCompressed,
     },
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
     solana_stake_interface::state::Stake,
     solana_vote::vote_account::{VoteAccounts, VoteAccountsHashMap},
+    solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
     std::{
         collections::HashMap,
         fmt,
@@ -27,8 +27,13 @@ pub type EpochAuthorizedVoters = HashMap<Pubkey, Pubkey>;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct BLSPubkeyStakeEntry {
-    pub pubkey: Pubkey,
+    /// The address containing the vote account
+    pub vote_account_pubkey: Pubkey,
+    /// The identity of the validator specified in the vote account
+    pub node_pubkey: Pubkey,
+    /// The bls pubkey of the validator specified in the vote account
     pub bls_pubkey: BLSPubkeyAffine,
+    /// The stake of the validator
     pub stake: u64,
 }
 
@@ -40,16 +45,18 @@ pub struct BLSPubkeyStakeEntry {
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct BLSPubkeyToRankMap {
     rank_map: HashMap<BLSPubkeyCompressed, u16>,
+    vote_pubkey_to_rank: HashMap<Pubkey, u16>,
     sorted_pubkeys: Vec<BLSPubkeyStakeEntry>,
 }
 
-// Even though BLSPubkeyToRankMap is not serialized in `VersionedEpochStakes`, still need to
-// derive `frozen-abi` for it because `VersionedEpochStakes` cannot derive `Default`.
+// We cannot auto derive `AbiExample` for `BLSPubkeyToRankMap` because
+// the `BLSPubkeyAffine` type does not implement `AbiExample` or `Default`.
 #[cfg(feature = "frozen-abi")]
 impl solana_frozen_abi::abi_example::AbiExample for BLSPubkeyToRankMap {
     fn example() -> Self {
         Self {
             rank_map: HashMap::new(),
+            vote_pubkey_to_rank: HashMap::new(),
             sorted_pubkeys: Vec::new(),
         }
     }
@@ -66,45 +73,55 @@ pub(crate) fn bls_pubkey_compressed_bytes_to_bls_pubkey(
 
 impl BLSPubkeyToRankMap {
     pub fn new(epoch_vote_accounts_hash_map: &VoteAccountsHashMap) -> Self {
-        let mut pubkey_stake_pair_vec: Vec<(Pubkey, BLSPubkeyCompressed, BLSPubkeyAffine, u64)> =
+        let mut keys_stake_entry_with_compressed: Vec<(BLSPubkeyStakeEntry, BLSPubkeyCompressed)> =
             epoch_vote_accounts_hash_map
                 .iter()
-                .filter_map(|(pubkey, (stake, account))| {
+                .filter_map(|(&vote_account_pubkey, (stake, account))| {
                     if *stake > 0 {
+                        let node_pubkey = *account.vote_state_view().node_pubkey();
                         account
                             .vote_state_view()
                             .bls_pubkey_compressed()
                             .and_then(bls_pubkey_compressed_bytes_to_bls_pubkey)
                             .map(|(bls_pubkey_compressed, bls_pubkey)| {
-                                (*pubkey, bls_pubkey_compressed, bls_pubkey, *stake)
+                                (
+                                    BLSPubkeyStakeEntry {
+                                        vote_account_pubkey,
+                                        node_pubkey,
+                                        bls_pubkey,
+                                        stake: *stake,
+                                    },
+                                    bls_pubkey_compressed,
+                                )
                             })
                     } else {
                         None
                     }
                 })
                 .collect();
-        pubkey_stake_pair_vec.sort_by(
-            |(_, a_pubkey_compressed, _, a_stake), (_, b_pubkey_compressed, _, b_stake)| {
-                b_stake
-                    .cmp(a_stake)
+        keys_stake_entry_with_compressed.sort_by(
+            |(a_entry, a_pubkey_compressed), (b_entry, b_pubkey_compressed)| {
+                b_entry
+                    .stake
+                    .cmp(&a_entry.stake)
                     .then(a_pubkey_compressed.cmp(b_pubkey_compressed))
             },
         );
-        let mut sorted_pubkeys = Vec::new();
-        let mut bls_pubkey_to_rank_map = HashMap::new();
-        for (rank, (pubkey, bls_pubkey_compressed, bls_pubkey, stake)) in
-            pubkey_stake_pair_vec.into_iter().enumerate()
+        let mut sorted_pubkeys = Vec::with_capacity(keys_stake_entry_with_compressed.len());
+        let mut bls_pubkey_to_rank_map =
+            HashMap::with_capacity(keys_stake_entry_with_compressed.len());
+        let mut vote_pubkey_to_rank_map =
+            HashMap::with_capacity(keys_stake_entry_with_compressed.len());
+        for (rank, (entry, bls_pubkey_compressed)) in
+            keys_stake_entry_with_compressed.into_iter().enumerate()
         {
-            let entry = BLSPubkeyStakeEntry {
-                pubkey,
-                bls_pubkey,
-                stake,
-            };
-            sorted_pubkeys.push(entry);
+            vote_pubkey_to_rank_map.insert(entry.vote_account_pubkey, rank as u16);
             bls_pubkey_to_rank_map.insert(bls_pubkey_compressed, rank as u16);
+            sorted_pubkeys.push(entry);
         }
         Self {
             rank_map: bls_pubkey_to_rank_map,
+            vote_pubkey_to_rank: vote_pubkey_to_rank_map,
             sorted_pubkeys,
         }
     }
@@ -120,6 +137,10 @@ impl BLSPubkeyToRankMap {
     pub fn get_rank(&self, bls_pubkey: &BLSPubkeyAffine) -> Option<&u16> {
         let bls_pubkey_compressed = BLSPubkeyCompressed(bls_pubkey.to_bytes_compressed());
         self.rank_map.get(&bls_pubkey_compressed)
+    }
+
+    pub fn get_rank_for_vote_pubkey(&self, vote_pubkey: &Pubkey) -> Option<&u16> {
+        self.vote_pubkey_to_rank.get(vote_pubkey)
     }
 
     pub fn get_pubkey_stake_entry(&self, index: usize) -> Option<&BLSPubkeyStakeEntry> {
@@ -446,8 +467,7 @@ pub(crate) mod tests {
         solana_account::AccountSharedData,
         solana_bls_signatures::keypair::Keypair as BLSKeypair,
         solana_rent::Rent,
-        solana_vote::vote_account::{VoteAccount, VoteAccounts},
-        solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
+        solana_vote::vote_account::VoteAccount,
         solana_vote_program::vote_state::create_v4_account_with_authorized,
         std::iter,
         test_case::test_case,
@@ -536,8 +556,8 @@ pub(crate) mod tests {
             new_vote_accounts(num_nodes, num_vote_accounts_per_node, is_alpenglow);
 
         let expected_authorized_voters: HashMap<_, _> = vote_accounts_map
-            .values()
-            .flat_map(|vote_accounts| {
+            .iter()
+            .flat_map(|(_, vote_accounts)| {
                 vote_accounts
                     .iter()
                     .map(|v| (v.vote_account, v.authorized_voter))
@@ -635,18 +655,20 @@ pub(crate) mod tests {
         let epoch_stakes = VersionedEpochStakes::new_for_tests(epoch_vote_accounts.clone(), 0);
         let bls_pubkey_to_rank_map = epoch_stakes.bls_pubkey_to_rank_map();
         assert_eq!(bls_pubkey_to_rank_map.len(), num_vote_accounts);
-        for (pubkey, (stake, vote_account)) in epoch_vote_accounts {
+        for (vote_account_pubkey, (stake, vote_account)) in epoch_vote_accounts {
             let vote_state_view = vote_account.vote_state_view();
             let (_comp, bls_pubkey) = bls_pubkey_compressed_bytes_to_bls_pubkey(
                 vote_state_view.bls_pubkey_compressed().unwrap(),
             )
             .unwrap();
+            let node_pubkey = *vote_state_view.node_pubkey();
             let index = bls_pubkey_to_rank_map.get_rank(&bls_pubkey).unwrap();
             assert!(index >= &0 && index < &(num_vote_accounts as u16));
             assert_eq!(
                 bls_pubkey_to_rank_map.get_pubkey_stake_entry(*index as usize),
                 Some(&BLSPubkeyStakeEntry {
-                    pubkey,
+                    vote_account_pubkey,
+                    node_pubkey,
                     bls_pubkey,
                     stake,
                 })

--- a/runtime/src/validated_block_finalization.rs
+++ b/runtime/src/validated_block_finalization.rs
@@ -389,7 +389,7 @@ impl ValidatedBlockFinalizationCert {
             .filter_map(|rank| {
                 rank_map
                     .get_pubkey_stake_entry(rank)
-                    .map(|entry| entry.pubkey)
+                    .map(|entry| entry.vote_account_pubkey)
             })
             .collect())
     }

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -94,7 +94,7 @@ impl ValidatedRewardCert {
 
         let mut rank_map = |ind: usize| {
             rank_map.get_pubkey_stake_entry(ind).map(|entry| {
-                validators.push(entry.pubkey);
+                validators.push(entry.vote_account_pubkey);
                 entry.bls_pubkey
             })
         };

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -87,9 +87,16 @@ fn get_key_and_stakes(
     };
     if entry.stake == 0 {
         // Since we have a valid rank, this should never happen, there is no rank for zero stake.
-        panic!("Validator stake is zero for pubkey: {}", entry.pubkey);
+        panic!(
+            "Validator stake is zero for pubkey: {}",
+            entry.vote_account_pubkey
+        );
     }
-    Ok((entry.pubkey, entry.stake, epoch_stakes.total_stake()))
+    Ok((
+        entry.vote_account_pubkey,
+        entry.stake,
+        epoch_stakes.total_stake(),
+    ))
 }
 
 /// Container to store received votes and certificates.

--- a/votor/src/consensus_rewards/entry/partial_cert.rs
+++ b/votor/src/consensus_rewards/entry/partial_cert.rs
@@ -64,7 +64,10 @@ impl PartialCert {
                 if *ind {
                     return Err(AddVoteError::Duplicate);
                 }
-                let pubkey = rank_map.get_pubkey_stake_entry(rank.into()).unwrap().pubkey;
+                let pubkey = rank_map
+                    .get_pubkey_stake_entry(rank.into())
+                    .unwrap()
+                    .vote_account_pubkey;
                 self.validators.push(pubkey);
                 self.signature.aggregate_with(std::iter::once(signature))?;
                 *ind = true;


### PR DESCRIPTION
#### Problem and summary of changes

There are places where we will need access to the associated `node_pubkey` of the validator.  This PR adds support for storing `node_pubkey` in `BLSPubkeyStakeEntry`.  In future PRs, we will use it  in various places.
