### PR TITLE
core: fix forwarding config and receiver typo names

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -123,7 +123,7 @@ pub(crate) struct SpawnForwardingStageResult {
 
 pub(crate) fn spawn_forwarding_stage(
     receiver: Receiver<(BankingPacketBatch, bool)>,
-    tpu_forwaring_client_config: ForwardingClientConfig<'_>,
+    tpu_forwarding_client_config: ForwardingClientConfig<'_>,
     vote_client_udp_socket: UdpSocket,
     sharable_banks: SharableBanks,
     forward_address_getter: ForwardAddressGetter,
@@ -136,7 +136,7 @@ pub(crate) fn spawn_forwarding_stage(
         runtime_handle,
         cancel,
         node_multihoming,
-    } = tpu_forwaring_client_config;
+    } = tpu_forwarding_client_config;
 
     // Create TPU clients for each socket provided.
     // Number of clients is same as number of bind IP addresses.

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -129,7 +129,7 @@ impl Tpu {
         replay_vote_sender: ReplayVoteSender,
         bank_notification_sender: Option<BankNotificationSenderConfig>,
         duplicate_confirmed_slot_sender: DuplicateConfirmedSlotsSender,
-        tpu_forwaring_client_config: ForwardingClientConfig,
+        tpu_forwarding_client_config: ForwardingClientConfig,
         keypair: &Keypair,
         log_messages_bytes_limit: Option<usize>,
         staked_nodes: &Arc<RwLock<StakedNodes>>,
@@ -336,7 +336,7 @@ impl Tpu {
             client_updater,
         } = spawn_forwarding_stage(
             forward_stage_receiver,
-            tpu_forwaring_client_config,
+            tpu_forwarding_client_config,
             vote_forwarding_client_socket,
             bank_forks.read().unwrap().sharable_banks(),
             ForwardAddressGetter::new(cluster_info.clone(), poh_recorder.clone()),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1687,7 +1687,7 @@ impl Validator {
         )
         .map_err(ValidatorError::Other)?;
 
-        let tpu_forwaring_client_config = {
+        let tpu_forwarding_client_config = {
             let runtime_handle = tpu_client_next_runtime
                 .as_ref()
                 .map(TokioRuntime::handle)
@@ -1700,7 +1700,7 @@ impl Validator {
                 node_multihoming: node_multihoming.clone(),
             }
         };
-        let (banking_control_sender, banking_control_reciever) = mpsc::channel(1);
+        let (banking_control_sender, banking_control_receiver) = mpsc::channel(1);
         let tpu = Tpu::new_with_client(
             &cluster_info,
             &poh_recorder,
@@ -1731,7 +1731,7 @@ impl Validator {
             replay_vote_sender,
             bank_notification_sender,
             duplicate_confirmed_slot_sender,
-            tpu_forwaring_client_config,
+            tpu_forwarding_client_config,
             &identity_keypair,
             config.runtime_config.log_messages_bytes_limit,
             &staked_nodes,
@@ -1749,7 +1749,7 @@ impl Validator {
             config.enable_block_production_forwarding,
             config.generator_config.clone(),
             key_notifiers.clone(),
-            banking_control_reciever,
+            banking_control_receiver,
             config.enable_scheduler_bindings.then(|| {
                 (
                     ledger_path.join("scheduler_bindings.ipc"),


### PR DESCRIPTION
  #### Problem
  Core forwarding-path code contains misspelled internal identifiers (`tpu_forwaring_client_config`, `banking_control_reciever`), which reduces readability and makes code search/refactoring less reliable.

  #### Solution
  Rename these identifiers to `tpu_forwarding_client_config` and `banking_control_receiver` across the related call chain in `validator.rs`, `tpu.rs`, and `forwarding_stage.rs`, with no behavioral change.
                                                                                                                                                                   
                                                                                                                                                                   
  #### Summary of Changes                                                                                                                                          
                                                                                                                                                                   
  - Renamed `tpu_forwaring_client_config` to `tpu_forwarding_client_config` in the validator/TPU/forwarding-stage call path.                                       
  - Renamed `banking_control_reciever` to `banking_control_receiver` in validator setup and TPU wiring.                                                            
  - Kept the change scope to internal identifier cleanup only; no logic or behavior changes.                                                                       
                          