### PR TITLE
explicit scheduler teardown on prune

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2043,6 +2043,18 @@ impl ReplayStage {
         let slot_descendants = slot_descendants.unwrap();
         Self::purge_ancestors_descendants(slot_to_purge, &slot_descendants, ancestors, descendants);
 
+        let banks_to_remove: Vec<_> = {
+            let bank_forks = bank_forks.read().unwrap();
+            slot_descendants
+                .iter()
+                .chain(std::iter::once(&slot_to_purge))
+                .filter_map(|slot| bank_forks.get_with_scheduler(*slot))
+                .collect()
+        };
+        for bank in banks_to_remove {
+            let _ = bank.wait_for_completed_scheduler();
+        }
+
         // Grab the Slot and BankId's of the banks we need to purge, then clear the banks
         // from BankForks
         let (slots_to_purge, removed_banks): (Vec<(Slot, BankId)>, Vec<BankWithScheduler>) = {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -645,19 +645,8 @@ impl BankForks {
         // We want to collect timing separately, and the 2nd collect requires
         // a unique borrow to self which is already borrowed by self.banks
         let mut prune_slots_time = Measure::start("prune_slots");
-        let highest_super_majority_root = highest_super_majority_root.unwrap_or(root);
         let prune_slots: Vec<_> = self
-            .banks
-            .keys()
-            .copied()
-            .filter(|slot| {
-                let keep = *slot == root
-                    || self.descendants[&root].contains(slot)
-                    || (*slot < root
-                        && *slot >= highest_super_majority_root
-                        && self.descendants[slot].contains(&root));
-                !keep
-            })
+            .get_non_rooted(root, highest_super_majority_root)
             .collect();
         prune_slots_time.stop();
 
@@ -673,6 +662,22 @@ impl BankForks {
             prune_slots_time.as_ms(),
             prune_remove_time.as_ms(),
         )
+    }
+
+    pub fn get_non_rooted(
+        &self,
+        root: Slot,
+        highest_super_majority_root: Option<Slot>,
+    ) -> impl Iterator<Item = Slot> + '_ {
+        let highest_super_majority_root = highest_super_majority_root.unwrap_or(root);
+        self.banks.keys().copied().filter(move |slot| {
+            let keep = *slot == root
+                || self.descendants[&root].contains(slot)
+                || (*slot < root
+                    && *slot >= highest_super_majority_root
+                    && self.descendants[slot].contains(&root));
+            !keep
+        })
     }
 }
 

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -197,6 +197,17 @@ pub fn set_bank_forks_root<CB>(
 ) where
     CB: FnOnce(&BankForks),
 {
+    let banks_to_remove: Vec<_> = {
+        let bank_forks = bank_forks.read().unwrap();
+        bank_forks
+            .get_non_rooted(new_root, highest_super_majority_root)
+            .filter_map(|slot| bank_forks.get_with_scheduler(slot))
+            .collect()
+    };
+    for bank in banks_to_remove {
+        let _ = bank.wait_for_completed_scheduler();
+    }
+
     bank_forks.read().unwrap().prune_program_cache(new_root);
     let removed_banks = bank_forks.write().unwrap().set_root(
         new_root,


### PR DESCRIPTION
#### Problem
  - Banks selected for pruning could still have an installed scheduler.
  - Scheduler teardown was deferred until later drop-time cleanup instead of happening in the prune flow.
  - That delayed reclaiming scheduler resources even after a bank had already been chosen for removal.

#### Summary of Changes
  - Move scheduler teardown into the prune flow.
  - Wait for any installed scheduler on a bank selected for pruning to complete before removing the bank.
  - Reclaim scheduler resources earlier, instead of waiting for drop-time cleanup.
  - Share the non-rooted bank selection logic to keep pruning criteria consistent.