### PR TITLE
Pool memory for EbpfVm::execute_program callframes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10119,9 +10119,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd96c15a4cb8884e9b660cb71796d1bca8d3eb6d38e68067508ce37dc66874bc"
+checksum = "0ae39fc6751e42572cec386b5691acd516b208ae457dbf59dd2002093b22288c"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -476,7 +476,7 @@ solana-rpc-client-types = { path = "rpc-client-types", version = "=4.1.0-alpha.0
 solana-runtime = { path = "runtime", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-sanitize = "3.0.1"
-solana-sbpf = { version = "=0.18.0", default-features = false }
+solana-sbpf = { version = "=0.19.0", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-secp256k1-program = "3.0.1"
 solana-secp256k1-recover = "3.1.1"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -4840,7 +4840,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
@@ -8694,9 +8694,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd96c15a4cb8884e9b660cb71796d1bca8d3eb6d38e68067508ce37dc66874bc"
+checksum = "0ae39fc6751e42572cec386b5691acd516b208ae457dbf59dd2002093b22288c"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -137,7 +137,7 @@ solana-rpc-client = { path = "../rpc-client", version = "=4.1.0-alpha.0", defaul
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=4.1.0-alpha.0" }
 solana-runtime = { path = "../runtime", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-runtime-transaction = { path = "../runtime-transaction", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-sbpf = { version = "=0.18.0", default-features = false }
+solana-sbpf = { version = "=0.19.0", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-shred-version = "3.0.1"
 solana-signature = { version = "3.4.0", default-features = false }

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -25,8 +25,12 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
     solana_sbpf::{
-        assembler::assemble, ebpf::MM_INPUT_START, elf::Executable, static_analysis::Analysis,
-        verifier::RequisiteVerifier, vm::ExecutionMode,
+        assembler::assemble,
+        ebpf::MM_INPUT_START,
+        elf::Executable,
+        static_analysis::Analysis,
+        verifier::RequisiteVerifier,
+        vm::{CallFrame, ExecutionMode},
     },
     solana_sdk_ids::{bpf_loader_upgradeable, sysvar},
     solana_syscalls::create_program_runtime_environment,
@@ -530,10 +534,17 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
     } else {
         ExecutionMode::Interpreted
     };
+    let mut call_frames = match execution_mode {
+        ExecutionMode::Jit => vec![],
+        ExecutionMode::Interpreted | ExecutionMode::PreferJit => {
+            vec![CallFrame::default(); verified_executable.get_config().max_call_depth]
+        }
+    };
     vm.registers[1] = MM_INPUT_START;
     vm.registers[2] = instruction_data_offset as u64;
 
-    let (instruction_count, result) = vm.execute_program(&verified_executable, &mut execution_mode);
+    let (instruction_count, result) =
+        vm.execute_program(&verified_executable, &mut execution_mode, &mut call_frames);
     let duration = Instant::now() - start_time;
     if let Some(trace_option) = matches.value_of("trace") {
         vm.context()

--- a/program-runtime/src/mem_pool.rs
+++ b/program-runtime/src/mem_pool.rs
@@ -3,8 +3,11 @@ use {
         MAX_CALL_DEPTH, MAX_HEAP_FRAME_BYTES, MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268,
         MIN_HEAP_FRAME_BYTES, STACK_FRAME_SIZE,
     },
-    solana_sbpf::{aligned_memory::AlignedMemory, ebpf::HOST_ALIGN},
-    std::array,
+    solana_sbpf::{aligned_memory::AlignedMemory, ebpf::HOST_ALIGN, vm::CallFrame},
+    std::{
+        array,
+        ops::{Deref, DerefMut},
+    },
 };
 
 trait Reset {
@@ -57,9 +60,43 @@ impl Reset for AlignedMemory<{ HOST_ALIGN }> {
     }
 }
 
+pub struct CallFrameBuffer(Box<[CallFrame; MAX_CALL_DEPTH]>);
+
+impl Default for CallFrameBuffer {
+    fn default() -> Self {
+        let mut mem = Box::<[CallFrame; MAX_CALL_DEPTH]>::new_uninit();
+        let ptr = mem.as_mut_ptr().cast::<CallFrame>();
+        for i in 0..MAX_CALL_DEPTH {
+            unsafe { ptr.add(i).write(CallFrame::default()) }
+        }
+        Self(unsafe { mem.assume_init() })
+    }
+}
+
+impl Reset for CallFrameBuffer {
+    fn reset(&mut self) {
+        self.fill(CallFrame::default())
+    }
+}
+
+impl Deref for CallFrameBuffer {
+    type Target = [CallFrame];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+
+impl DerefMut for CallFrameBuffer {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut_slice()
+    }
+}
+
 pub struct VmMemoryPool {
     stack: Pool<AlignedMemory<{ HOST_ALIGN }>, MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268>,
     heap: Pool<AlignedMemory<{ HOST_ALIGN }>, MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268>,
+    call_frame: Pool<CallFrameBuffer, MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268>,
 }
 
 impl VmMemoryPool {
@@ -71,6 +108,7 @@ impl VmMemoryPool {
             heap: Pool::new(array::from_fn(|_| {
                 AlignedMemory::zero_filled(MAX_HEAP_FRAME_BYTES as usize)
             })),
+            call_frame: Pool::new(array::from_fn(|_| CallFrameBuffer::default())),
         }
     }
 
@@ -107,6 +145,14 @@ impl VmMemoryPool {
                 && heap_size <= MAX_HEAP_FRAME_BYTES as usize
         );
         self.heap.put(heap)
+    }
+
+    pub fn get_call_frames(&mut self) -> CallFrameBuffer {
+        self.call_frame.get().unwrap_or_default()
+    }
+
+    pub fn put_call_frames(&mut self, call_frame: CallFrameBuffer) -> bool {
+        self.call_frame.put(call_frame)
     }
 }
 

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -261,11 +261,15 @@ pub fn execute<'a, 'b: 'a>(
 
         vm.registers[1] = ebpf::MM_INPUT_START;
         vm.registers[2] = instruction_data_offset as u64;
-        let (compute_units_consumed, result) = vm.execute_program(executable, &mut execution_mode);
+        let mut call_frames =
+            MEMORY_POOL.with_borrow_mut(|memory_pool| memory_pool.get_call_frames());
+        let (compute_units_consumed, result) =
+            vm.execute_program(executable, &mut execution_mode, &mut call_frames);
         let register_trace = std::mem::take(&mut vm.register_trace);
         MEMORY_POOL.with_borrow_mut(|memory_pool| {
             memory_pool.put_stack(stack);
             memory_pool.put_heap(heap);
+            memory_pool.put_call_frames(call_frames);
             debug_assert!(memory_pool.stack_len() <= MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268);
             debug_assert!(memory_pool.heap_len() <= MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268);
         });

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9053,9 +9053,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sbpf"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd96c15a4cb8884e9b660cb71796d1bca8d3eb6d38e68067508ce37dc66874bc"
+checksum = "0ae39fc6751e42572cec386b5691acd516b208ae457dbf59dd2002093b22288c"
 dependencies = [
  "byteorder",
  "combine 3.8.1",


### PR DESCRIPTION
#### Problem
Before `sbpf` v0.19, every instantiation of an `EbpfVm` [would allocate a new `Vec<CallFrame>`](https://github.com/anza-xyz/sbpf/blob/388f46aa72ee8f6cbc5819617b74bf447840edce/src/vm.rs#L408). In agave, this means allocating a new `Vec<CallFrame>` for every ix in banking worker / replay.

<img width="4058" height="754" alt="image" src="https://github.com/user-attachments/assets/71d364f6-5606-4b8f-99c8-747a679ff400" />

As shown above, this represents ~6% of all allocations while replaying transactions, roughly 17k allocations per second.


#### Summary of Changes

`sbpf` v0.19 moved `call_frames` from `EbpfVm` to `Interpreter`, and accordingly made `call_frames` a parameter to `EbpvVm::execute_program`, which is responsible for instantiating an `Interpreter` if `ExecutionMode` is set to `Interpreter` or `PreferJit` if JIT is not available. See https://github.com/anza-xyz/sbpf/pull/163.

This updates agave to support `sbpf` v0.19. The implementation leverages the existing memory pooling system used for `heap` and `stack` memory to provide a pooling solution for call frames.
