### PR TITLE
Remove fn block_timeout

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -277,9 +277,10 @@ fn reset_poh_recorder(bank: &Arc<Bank>, ctx: &LeaderContext) {
 }
 
 // From the passed in bank (used for determining slot times) and leader block
-// index, return the block timeout from the start of the leader window.
+// index with the leader window, return the duration after which we should
+// publish the final shred for the block with starting point being the start of
+// the leader window.
 fn block_timeout(bank: &Bank, leader_block_index: usize) -> Duration {
-    // The block timeout is the time we expect to produce a block if we start producing immediately at the start of the slot
     Duration::from_nanos_u128(bank.ns_per_slot)
         .saturating_mul((leader_block_index as u32).saturating_add(1))
 }

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -276,10 +276,10 @@ fn reset_poh_recorder(bank: &Arc<Bank>, ctx: &LeaderContext) {
         .reset(bank.clone(), next_leader_slot);
 }
 
-// From the passed in bank (used for determining slot times) and leader block
-// index with the leader window, return the duration after which we should
-// publish the final shred for the block with starting point being the start of
-// the leader window.
+/// From the passed in bank (used for determining slot times) and leader block
+/// index within the leader window, returns the duration after which we should
+/// publish the final shred for the block with starting point being the start of
+/// the leader window.
 fn block_timeout(bank: &Bank, leader_block_index: usize) -> Duration {
     Duration::from_nanos_u128(bank.ns_per_slot)
         .saturating_mul((leader_block_index as u32).saturating_add(1))
@@ -301,16 +301,8 @@ fn produce_window(
     while !ctx.exit.load(Ordering::Relaxed) && slot <= end_slot {
         // Insert the bank. In case `replay_stage` is slow and `parent_slot` is not
         // yet frozen, we wait up until the timeout.
-        start_leader_wait_for_parent_replay(slot, parent_slot, skip_timer, ctx)?;
-
-        let timeout = block_timeout(
-            &ctx.poh_recorder
-                .read()
-                .unwrap()
-                .bank()
-                .expect("Bank must exist"),
-            leader_slot_index(slot),
-        );
+        let working_bank = start_leader_wait_for_parent_replay(slot, parent_slot, skip_timer, ctx)?;
+        let timeout = block_timeout(&working_bank, leader_slot_index(slot));
         trace!(
             "{my_pubkey}: waiting for leader bank {slot} to finish, remaining time: {}",
             timeout.saturating_sub(skip_timer.elapsed()).as_millis(),
@@ -419,7 +411,7 @@ fn start_leader_wait_for_parent_replay(
     parent_slot: Slot,
     skip_timer: Instant,
     ctx: &mut LeaderContext,
-) -> Result<(), StartLeaderError> {
+) -> Result<Arc<Bank>, StartLeaderError> {
     trace!(
         "{}: Attempting to start leader slot {slot} parent {parent_slot}",
         ctx.my_pubkey
@@ -463,7 +455,12 @@ fn start_leader_wait_for_parent_replay(
                         );
                     });
 
-                return Ok(());
+                return Ok(ctx
+                    .poh_recorder
+                    .read()
+                    .unwrap()
+                    .bank()
+                    .expect("We just started the leader, so the bank must exist"));
             }
             Err(StartLeaderError::ReplayIsBehind(_, _)) => {
                 trace!(

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -9,7 +9,7 @@ use {
         banking_trace::BankingTracer,
         replay_stage::{Finalizer, ReplayStage},
     },
-    agave_votor::{common::block_timeout, event::LeaderWindowInfo},
+    agave_votor::event::LeaderWindowInfo,
     crossbeam_channel::Receiver,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
@@ -276,6 +276,14 @@ fn reset_poh_recorder(bank: &Arc<Bank>, ctx: &LeaderContext) {
         .reset(bank.clone(), next_leader_slot);
 }
 
+// From the passed in bank (used for determining slot times) and leader block
+// index, return the block timeout from the start of the leader window.
+fn block_timeout(bank: &Bank, leader_block_index: usize) -> Duration {
+    // The block timeout is the time we expect to produce a block if we start producing immediately at the start of the slot
+    Duration::from_nanos_u128(bank.ns_per_slot)
+        .saturating_mul((leader_block_index as u32).saturating_add(1))
+}
+
 /// Produces the leader window from `start_slot` -> `end_slot` using parent
 /// `parent_slot` while abiding to the `skip_timer`
 fn produce_window(
@@ -294,8 +302,14 @@ fn produce_window(
         // yet frozen, we wait up until the timeout.
         start_leader_wait_for_parent_replay(slot, parent_slot, skip_timer, ctx)?;
 
-        let leader_index = leader_slot_index(slot);
-        let timeout = block_timeout(leader_index);
+        let timeout = block_timeout(
+            &ctx.poh_recorder
+                .read()
+                .unwrap()
+                .bank()
+                .expect("Bank must exist"),
+            leader_slot_index(slot),
+        );
         trace!(
             "{my_pubkey}: waiting for leader bank {slot} to finish, remaining time: {}",
             timeout.saturating_sub(skip_timer.elapsed()).as_millis(),
@@ -410,7 +424,10 @@ fn start_leader_wait_for_parent_replay(
         ctx.my_pubkey
     );
     let my_pubkey = ctx.my_pubkey;
-    let timeout = block_timeout(leader_slot_index(slot));
+    let timeout = block_timeout(
+        &ctx.bank_forks.read().unwrap().root_bank(),
+        leader_slot_index(slot),
+    );
     let end_slot = last_of_consecutive_leader_slots(slot);
 
     let mut slot_delay_start = Measure::start("slot_delay");

--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -75,11 +75,3 @@ pub(crate) const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
 
 /// Timeout for standstill detection mechanism.
 pub(crate) const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);
-
-/// Block timeout, when we should publish the final shred for the leader block index
-/// within the leader window
-#[inline]
-pub fn block_timeout(leader_block_index: usize) -> Duration {
-    // TODO: based on testing, perhaps adjust this
-    DELTA_BLOCK.saturating_mul((leader_block_index as u32).saturating_add(1))
-}


### PR DESCRIPTION
#### Problem
`fn block_timeout` uses a hardcoded slot time (`DELTA_BLOCK`) for timeout value. Makes it impossible to dynamically change slot time. 

#### Summary of Changes
Grab slot time value from the bank instead