### PR TITLE
refactor: to calculate prioritization_fee directly from ComputeBudgetLimits

### DIFF
--- a/compute-budget/src/compute_budget_limits.rs
+++ b/compute-budget/src/compute_budget_limits.rs
@@ -4,7 +4,7 @@ pub use solana_program_runtime::execution_budget::{
     MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES, MIN_HEAP_FRAME_BYTES,
 };
 use {
-    solana_fee_structure::{FeeBudgetLimits, FeeDetails},
+    solana_fee_structure::FeeDetails,
     solana_program_runtime::execution_budget::{
         SVMTransactionExecutionAndFeeBudgetLimits, SVMTransactionExecutionBudget,
     },
@@ -66,34 +66,6 @@ fn get_prioritization_fee(compute_unit_price: u64, compute_unit_limit: u64) -> u
         .checked_div(MICRO_LAMPORTS_PER_LAMPORT as u128)
         .and_then(|fee| u64::try_from(fee).ok())
         .unwrap_or(u64::MAX)
-}
-
-impl From<ComputeBudgetLimits> for FeeBudgetLimits {
-    fn from(val: ComputeBudgetLimits) -> Self {
-        let prioritization_fee =
-            get_prioritization_fee(val.compute_unit_price, u64::from(val.compute_unit_limit));
-
-        FeeBudgetLimits {
-            loaded_accounts_data_size_limit: val.loaded_accounts_bytes,
-            heap_cost: DEFAULT_HEAP_COST,
-            compute_unit_limit: u64::from(val.compute_unit_limit),
-            prioritization_fee,
-        }
-    }
-}
-
-impl From<&ComputeBudgetLimits> for FeeBudgetLimits {
-    fn from(val: &ComputeBudgetLimits) -> Self {
-        let prioritization_fee =
-            get_prioritization_fee(val.compute_unit_price, u64::from(val.compute_unit_limit));
-
-        FeeBudgetLimits {
-            loaded_accounts_data_size_limit: val.loaded_accounts_bytes,
-            heap_cost: DEFAULT_HEAP_COST,
-            compute_unit_limit: u64::from(val.compute_unit_limit),
-            prioritization_fee,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -21,7 +21,7 @@ use {
     solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
     solana_compute_budget_interface::ComputeBudgetInstruction,
     solana_fee_calculator::FeeRateGovernor,
-    solana_fee_structure::{FeeBin, FeeBudgetLimits, FeeStructure},
+    solana_fee_structure::{FeeBin, FeeStructure},
     solana_hash::Hash,
     solana_instruction::{AccountMeta, Instruction, error::InstructionError},
     solana_keypair::Keypair,
@@ -3948,17 +3948,16 @@ fn test_program_fees() {
         &ReservedAccountKeys::empty_key_set(),
     )
     .unwrap();
-    let fee_budget_limits = FeeBudgetLimits::from(
-        process_compute_budget_instructions(
-            SVMStaticMessage::program_instructions_iter(&sanitized_message),
-            &feature_set,
-        )
-        .unwrap_or_default(),
-    );
+    let prioritization_fee = process_compute_budget_instructions(
+        SVMStaticMessage::program_instructions_iter(&sanitized_message),
+        &feature_set,
+    )
+    .unwrap_or_default()
+    .get_prioritization_fee();
     let expected_normal_fee = solana_fee::calculate_fee(
         &sanitized_message,
         fee_structure.lamports_per_signature,
-        fee_budget_limits.prioritization_fee,
+        prioritization_fee,
         bank.feature_set.as_ref().into(),
     );
     bank_client
@@ -3980,17 +3979,16 @@ fn test_program_fees() {
         &ReservedAccountKeys::empty_key_set(),
     )
     .unwrap();
-    let fee_budget_limits = FeeBudgetLimits::from(
-        process_compute_budget_instructions(
-            SVMStaticMessage::program_instructions_iter(&sanitized_message),
-            &feature_set,
-        )
-        .unwrap_or_default(),
-    );
+    let prioritization_fee = process_compute_budget_instructions(
+        SVMStaticMessage::program_instructions_iter(&sanitized_message),
+        &feature_set,
+    )
+    .unwrap_or_default()
+    .get_prioritization_fee();
     let expected_prioritized_fee = solana_fee::calculate_fee(
         &sanitized_message,
         fee_structure.lamports_per_signature,
-        fee_budget_limits.prioritization_fee,
+        prioritization_fee,
         bank.feature_set.as_ref().into(),
     );
     assert!(expected_normal_fee < expected_prioritized_fee);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -114,7 +114,7 @@ use {
     solana_feature_gate_interface as feature,
     solana_fee::FeeFeatures,
     solana_fee_calculator::FeeRateGovernor,
-    solana_fee_structure::{FeeBudgetLimits, FeeDetails, FeeStructure},
+    solana_fee_structure::{FeeDetails, FeeStructure},
     solana_genesis_config::GenesisConfig,
     solana_hard_forks::HardForks,
     solana_hash::Hash,
@@ -2978,17 +2978,16 @@ impl Bank {
         &self,
         message: &impl SVMMessage,
     ) -> u64 {
-        let fee_budget_limits = FeeBudgetLimits::from(
-            process_compute_budget_instructions(
-                message.program_instructions_iter(),
-                &self.feature_set,
-            )
-            .unwrap_or_default(),
-        );
+        let prioritization_fee = process_compute_budget_instructions(
+            message.program_instructions_iter(),
+            &self.feature_set,
+        )
+        .unwrap_or_default()
+        .get_prioritization_fee();
         solana_fee::calculate_fee(
             message,
             self.fee_structure().lamports_per_signature,
-            fee_budget_limits.prioritization_fee,
+            prioritization_fee,
             FeeFeatures::from(self.feature_set.as_ref()),
         )
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9183,17 +9183,16 @@ fn test_call_precomiled_program() {
 }
 
 fn calculate_test_fee(message: &impl SVMMessage, fee_structure: &FeeStructure) -> u64 {
-    let fee_budget_limits = FeeBudgetLimits::from(
-        process_compute_budget_instructions(
-            message.program_instructions_iter(),
-            &FeatureSet::default(),
-        )
-        .unwrap_or_default(),
-    );
+    let prioritization_fee = process_compute_budget_instructions(
+        message.program_instructions_iter(),
+        &FeatureSet::default(),
+    )
+    .unwrap_or_default()
+    .get_prioritization_fee();
     solana_fee::calculate_fee(
         message,
         fee_structure.lamports_per_signature,
-        fee_budget_limits.prioritization_fee,
+        prioritization_fee,
         FeeFeatures {},
     )
 }
@@ -9295,15 +9294,13 @@ fn test_calculate_fee_compute_units() {
             Some(&Pubkey::new_unique()),
         ));
         let fee = calculate_test_fee(&message, &fee_structure);
-        let fee_budget_limits = FeeBudgetLimits::from(ComputeBudgetLimits {
+        let prioritization_fee = ComputeBudgetLimits {
             compute_unit_price: PRIORITIZATION_FEE_RATE,
             compute_unit_limit: requested_compute_units,
             ..ComputeBudgetLimits::default()
-        });
-        assert_eq!(
-            fee,
-            lamports_per_signature + fee_budget_limits.prioritization_fee
-        );
+        }
+        .get_prioritization_fee();
+        assert_eq!(fee, lamports_per_signature + prioritization_fee);
     }
 }
 
@@ -9316,11 +9313,12 @@ fn test_calculate_prioritization_fee() {
 
     let request_units = 1_000_000_u32;
     let request_unit_price = 2_000_000_000_u64;
-    let fee_budget_limits = FeeBudgetLimits::from(ComputeBudgetLimits {
+    let prioritization_fee = ComputeBudgetLimits {
         compute_unit_price: request_unit_price,
         compute_unit_limit: request_units,
         ..ComputeBudgetLimits::default()
-    });
+    }
+    .get_prioritization_fee();
 
     let message = new_sanitized_message(Message::new(
         &[
@@ -9333,7 +9331,7 @@ fn test_calculate_prioritization_fee() {
     let fee = calculate_test_fee(&message, &fee_structure);
     assert_eq!(
         fee,
-        fee_structure.lamports_per_signature + fee_budget_limits.prioritization_fee
+        fee_structure.lamports_per_signature + prioritization_fee
     );
 }
 


### PR DESCRIPTION
#### Problem

`ComputeBudgetLimits` is needlessly converted into `FeeBudgetLimits` only to get `prioritization_fee`, which is directly available via its public API.

#### Summary of Changes
- remove unnecessary `From` impl
- when needed, `get_prioritization_fee()` directly from `ComputeBudgetLimits`

Fixes #
