### PR TITLE
fuzz: expose private Agave methods and types for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11353,6 +11353,7 @@ dependencies = [
  "bencher",
  "bincode",
  "log",
+ "qualifier_attr",
  "rand 0.9.4",
  "serde",
  "solana-account 4.2.0",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9776,6 +9776,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "bincode",
  "log",
+ "qualifier_attr",
  "rand 0.9.4",
  "serde",
  "solana-account 4.2.0",

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -153,6 +153,7 @@ fn get_first_error<T, Tx: SVMTransaction>(
         .unwrap_or(Ok(()))
 }
 
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn create_thread_pool(num_threads: usize) -> ThreadPool {
     rayon::ThreadPoolBuilder::new()
         .num_threads(num_threads)

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10087,6 +10087,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "bincode",
  "log",
+ "qualifier_attr",
  "rand 0.9.4",
  "serde",
  "solana-account 4.2.0",

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 use {
     core::borrow::Borrow,
     solana_account::AccountSharedData,
@@ -129,6 +131,7 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
     }
 }
 
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn collect_accounts_for_failed_tx<'a>(
     collected_accounts: &mut Vec<(&'a Pubkey, &'a AccountSharedData)>,
     collected_account_transactions: &mut Option<Vec<&'a SanitizedTransaction>>,

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 use {
     crate::{stake_history::StakeHistory, stakes::SerdeStakesToStakeFormat},
     serde::{
@@ -160,6 +162,7 @@ pub struct NodeVoteAccounts {
 /// Its bincode serializaiton format is identical as `VersionedEpochStakes`, but allows faster
 /// deserialization by ignoring serialized stake delegations entirely.
 #[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) enum DeserializableVersionedEpochStakes {
     Current {
         stakes: DeserializableEpochStakes,
@@ -203,6 +206,7 @@ impl From<DeserializableVersionedEpochStakes> for VersionedEpochStakes {
 }
 
 impl VersionedEpochStakes {
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn new(stakes: SerdeStakesToStakeFormat, leader_schedule_epoch: Epoch) -> Self {
         let stakes = EpochStakes::from(stakes);
         let epoch_vote_accounts = stakes.vote_accounts();
@@ -403,6 +407,7 @@ impl From<SerdeStakesToStakeFormat> for EpochStakes {
 ///
 /// Needed because snapshots contain additional fields no longer present in EpochStakes.
 #[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) struct DeserializableEpochStakes {
     vote_accounts: VoteAccounts,
     #[serde(deserialize_with = "deserialize_and_ignore_stake_delegations")]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2,7 +2,10 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 
+#[cfg(not(feature = "dev-context-only-utils"))]
 mod account_saver;
+#[cfg(feature = "dev-context-only-utils")]
+pub mod account_saver;
 pub mod accounts_background_service;
 pub mod bank;
 pub mod bank_client;
@@ -30,7 +33,10 @@ pub mod snapshot_controller;
 pub mod snapshot_minimizer;
 pub mod snapshot_package;
 pub mod snapshot_utils;
+#[cfg(not(feature = "dev-context-only-utils"))]
 mod stake_account;
+#[cfg(feature = "dev-context-only-utils")]
+pub mod stake_account;
 pub mod stake_history;
 pub mod stake_utils;
 pub mod stake_weighted_timestamp;

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi::abi_example::AbiExample;
 use {
@@ -47,6 +49,7 @@ impl<T> StakeAccount<T> {
 
 impl StakeAccount<Delegation> {
     #[inline]
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn delegation(&self) -> &Delegation {
         // Safe to unwrap here because StakeAccount<Delegation> will always
         // only wrap a stake-state which is a delegation.

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -1,7 +1,5 @@
 //! Stakes serve as a cache of stake and vote accounts to derive
 //! node stakes
-#[cfg(feature = "dev-context-only-utils")]
-use solana_stake_interface::state::Stake;
 use {
     crate::{stake_account, stake_history::StakeHistory},
     imbl::HashMap as ImblHashMap,
@@ -27,11 +25,18 @@ use {
     },
     thiserror::Error,
 };
+#[cfg(feature = "dev-context-only-utils")]
+use {
+    qualifier_attr::{field_qualifiers, qualifiers},
+    solana_stake_interface::state::Stake,
+};
 
 mod serde_stakes;
-pub(crate) use serde_stakes::{
-    DeserializableStakes, SerdeStakesToStakeFormat, serialize_stake_accounts_to_delegation_format,
-};
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+pub(crate) use serde_stakes::DeserializableStakes;
+pub use serde_stakes::SerdeStakesToStakeFormat;
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+pub(crate) use serde_stakes::serialize_stake_accounts_to_delegation_format;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -164,6 +169,16 @@ impl StakesCache {
 /// stake-delegations.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Default, Clone, PartialEq, Debug, Serialize)]
+#[cfg_attr(
+    feature = "dev-context-only-utils",
+    field_qualifiers(
+        vote_accounts(pub),
+        stake_delegations(pub),
+        unused(pub),
+        epoch(pub),
+        stake_history(pub),
+    )
+)]
 pub struct Stakes<T: Clone> {
     /// vote accounts
     vote_accounts: VoteAccounts,
@@ -225,6 +240,7 @@ impl Stakes<StakeAccount> {
     /// full account state for respective stake pubkeys. get_account function
     /// should return the account at the respective slot where stakes where
     /// cached.
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn load_from_deserialized_delegations<F>(
         stakes: DeserializableStakes<Delegation>,
         get_account: F,

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 use {
     super::{StakeAccount, Stakes},
     crate::stake_history::StakeHistory,
@@ -70,6 +72,7 @@ impl Serialize for SerdeStakesToStakeFormat {
     }
 }
 
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) fn serialize_stake_accounts_to_delegation_format<S: Serializer>(
     stakes: &Stakes<StakeAccount>,
     serializer: S,
@@ -180,6 +183,7 @@ impl Serialize for SerdeStakeAccountMapToStakeFormat {
 /// deserialization without creating imbl::HashMap (such conversion is deferred until
 /// data is actually needed).
 #[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) struct DeserializableStakes<T> {
     pub vote_accounts: VoteAccounts,
     pub stake_delegations: Vec<(Pubkey, T)>,

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -18,7 +18,7 @@ name = "solana_vote"
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = ["dep:rand", "dep:bincode"]
+dev-context-only-utils = ["dep:qualifier_attr", "dep:rand", "dep:bincode"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
@@ -28,6 +28,7 @@ frozen-abi = [
 [dependencies]
 bincode = { workspace = true, optional = true }
 log = { workspace = true }
+qualifier_attr = { workspace = true, optional = true }
 rand = { version = "0.9.4", optional = true }
 serde = { workspace = true, features = ["rc"] }
 solana-account = { workspace = true, features = ["bincode"] }

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::field_qualifiers;
 use {
     crate::vote_state_view::VoteStateView,
     log::*,
@@ -42,6 +44,10 @@ struct VoteAccountInner {
 pub type VoteAccountsHashMap = HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>;
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "dev-context-only-utils",
+    field_qualifiers(vote_accounts(pub))
+)]
 pub struct VoteAccounts {
     #[serde(deserialize_with = "deserialize_accounts_hash_map")]
     vote_accounts: Arc<VoteAccountsHashMap>,


### PR DESCRIPTION
#### Problem

Many methods and types used for testing production Agave code against Firedancer is private.

#### Summary of Changes

Changes the visibility of several helper methods from private/protected to public.

