### PR TITLE
gossip: add conformance tests checking cross-client protocol correctness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5426,12 +5426,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -5446,13 +5456,26 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.14.3",
  "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.117",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5474,7 +5497,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -5512,6 +5535,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protosol"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acef24e715f0ce9ac6491004da1c35c919c60517f976f61e0f05f34d22e873ec"
+dependencies = [
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -8503,6 +8535,8 @@ dependencies = [
  "log",
  "num-traits",
  "num_cpus",
+ "prost 0.11.9",
+ "protosol",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rayon",
@@ -8802,7 +8836,7 @@ dependencies = [
  "num_cpus",
  "num_enum",
  "proptest",
- "prost",
+ "prost 0.14.3",
  "qualifier_attr",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -10477,7 +10511,7 @@ dependencies = [
  "http 1.4.0",
  "hyper-util",
  "log",
- "prost",
+ "prost 0.14.3",
  "prost-types",
  "serde",
  "smpl_jwt",
@@ -10510,7 +10544,7 @@ dependencies = [
  "bincode",
  "bs58",
  "enum-iterator",
- "prost",
+ "prost 0.14.3",
  "protobuf-src",
  "serde",
  "solana-account-decoder",
@@ -12451,7 +12485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.14.3",
  "tonic",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,6 +320,7 @@ proptest = "1.11"
 prost = "0.14.3"
 prost-types = "0.14.3"
 protobuf-src = "1.1.0"
+protosol = "=6.1.0"
 qualifier_attr = { version = "0.2.2", default-features = false }
 quinn = "0.11.9"
 rand = "0.9.4"

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -18,6 +18,7 @@ name = "solana_bloom"
 
 [features]
 agave-unstable-api = []
+dev-context-only-utils = []
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
@@ -41,7 +42,7 @@ solana-time-utils = { workspace = true }
 [dev-dependencies]
 bencher = { workspace = true }
 rayon = { workspace = true }
-solana-bloom = { path = ".", features = ["agave-unstable-api"] }
+solana-bloom = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-hash = { workspace = true, features = ["atomic"] }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-signature = { workspace = true, features = ["std"] }

--- a/bloom/src/bloom.rs
+++ b/bloom/src/bloom.rs
@@ -67,6 +67,11 @@ impl<T: BloomHashIndex> Sanitize for Bloom<T> {
 }
 
 impl<T: BloomHashIndex> Bloom<T> {
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn num_bits_set(&self) -> u64 {
+        self.num_bits_set
+    }
+
     pub fn new(num_bits: usize, keys: Vec<u64>) -> Self {
         let bits = BitVec::new_fill(false, num_bits as u64);
         Bloom {

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -28,7 +28,7 @@ frozen-abi = [
     "solana-vote-program/frozen-abi",
 ]
 agave-unstable-api = []
-dev-context-only-utils = []
+dev-context-only-utils = ["dep:prost", "dep:protosol", "solana-bloom/dev-context-only-utils"]
 
 [dependencies]
 agave-logger = { workspace = true }
@@ -45,6 +45,8 @@ itertools = { workspace = true }
 lazy-lru = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
+prost = { version = "0.11", optional = true }
+protosol = { workspace = true, optional = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -102,11 +102,11 @@ pub struct ContactInfo {
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-struct SocketEntry {
-    key: u8,   // Protocol identifier, e.g. tvu, tpu, etc
-    index: u8, // IpAddr index in the accompanying addrs vector.
+pub(crate) struct SocketEntry {
+    pub(crate) key: u8,   // Protocol identifier, e.g. tvu, tpu, etc
+    pub(crate) index: u8, // IpAddr index in the accompanying addrs vector.
     #[serde(with = "serde_varint")]
-    offset: u16, // Port offset with respect to the previous entry.
+    pub(crate) offset: u16, // Port offset with respect to the previous entry.
 }
 
 define_tlv_enum!(
@@ -238,9 +238,25 @@ impl ContactInfo {
         self.shred_version
     }
 
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    #[inline]
+    pub(crate) fn outset(&self) -> u64 {
+        self.outset
+    }
+
     #[inline]
     pub(crate) fn version(&self) -> &solana_version::Version {
         &self.version
+    }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    pub(crate) fn addrs(&self) -> &[IpAddr] {
+        &self.addrs
+    }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    pub(crate) fn sockets(&self) -> &[SocketEntry] {
+        &self.sockets
     }
 
     pub fn hot_swap_pubkey(&mut self, pubkey: Pubkey) {

--- a/gossip/src/crds_data.rs
+++ b/gossip/src/crds_data.rs
@@ -296,7 +296,17 @@ pub struct LowestSlot {
 }
 
 impl LowestSlot {
-    pub(crate) fn new(from: Pubkey, lowest: Slot, wallclock: u64) -> Self {
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    pub(crate) fn wallclock(&self) -> u64 {
+        self.wallclock
+    }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    pub(crate) fn from(&self) -> &Pubkey {
+        &self.from
+    }
+
+    pub fn new(from: Pubkey, lowest: Slot, wallclock: u64) -> Self {
         Self {
             from,
             root: 0,
@@ -395,6 +405,16 @@ impl Vote {
 
     pub(crate) fn transaction(&self) -> &Transaction {
         &self.transaction
+    }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    pub(crate) fn from(&self) -> &Pubkey {
+        &self.from
+    }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    pub(crate) fn wallclock(&self) -> u64 {
+        self.wallclock
     }
 
     pub(crate) fn slot(&self) -> Option<Slot> {

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -90,8 +90,18 @@ impl solana_sanitize::Sanitize for CrdsFilter {
 }
 
 impl CrdsFilter {
-    #[cfg(test)]
-    pub(crate) fn new_rand(num_items: usize, max_bytes: usize) -> Self {
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    pub(crate) fn mask(&self) -> u64 {
+        self.mask
+    }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    pub(crate) fn get_mask_bits(&self) -> u32 {
+        self.mask_bits
+    }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    pub fn new_rand(num_items: usize, max_bytes: usize) -> Self {
         let max_bits = (max_bytes * 8) as f64;
         let max_items = Self::max_items(max_bits, FALSE_RATE, KEYS);
         let mask_bits = Self::mask_bits(num_items as f64, max_items);

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -51,6 +51,30 @@ impl DuplicateShred {
     pub(crate) fn chunk_index(&self) -> u8 {
         self.chunk_index
     }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    #[inline]
+    pub(crate) fn from(&self) -> &Pubkey {
+        &self.from
+    }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    #[inline]
+    pub(crate) fn wallclock(&self) -> u64 {
+        self.wallclock
+    }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    #[inline]
+    pub(crate) fn slot(&self) -> Slot {
+        self.slot
+    }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    #[inline]
+    pub(crate) fn chunk(&self) -> &[u8] {
+        &self.chunk
+    }
 }
 
 #[derive(Debug, Error)]

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -56,4 +56,7 @@ extern crate solana_frozen_abi_macro;
 #[macro_use]
 extern crate solana_metrics;
 
+#[cfg(feature = "dev-context-only-utils")]
+pub use protocol::gossip_decode_to_effects;
+
 mod wire_format_tests;

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -255,6 +255,271 @@ pub(crate) fn split_gossip_messages<T: Serialize + Debug>(
     })
 }
 
+#[cfg(feature = "dev-context-only-utils")]
+pub fn gossip_decode_to_effects(input: &[u8]) -> protosol::protos::GossipEffects {
+    use {
+        crate::{
+            crds_data::CrdsData, crds_gossip_pull::CrdsFilter as NativeCrdsFilter,
+            crds_value::CrdsValue as NativeCrdsValue, ping_pong::Pong,
+        },
+        bincode::Options as _,
+        bv::Bits,
+        protosol::protos::{
+            GossipBloom, GossipCompressedSlots, GossipContactInfo, GossipCrdsData,
+            GossipCrdsFilter, GossipCrdsValue, GossipDuplicateShred, GossipEffects,
+            GossipEpochSlots, GossipIncrementalHash, GossipIpAddr, GossipIpv6Addr,
+            GossipLowestSlot, GossipMsg, GossipPing, GossipPong, GossipPruneData,
+            GossipPruneMessage, GossipPullRequest, GossipPullResponse, GossipPushMessage,
+            GossipSnapshotHashes, GossipSocketEntry, GossipVote, gossip_compressed_slots,
+            gossip_crds_data, gossip_ip_addr, gossip_msg,
+        },
+        solana_sanitize::Sanitize,
+    };
+
+    fn convert_ping(ping: &Ping) -> gossip_msg::Msg {
+        gossip_msg::Msg::Ping(GossipPing {
+            from: ping.pubkey().to_bytes().to_vec(),
+            token: ping.signable_data().to_vec(),
+            signature: ping.get_signature().as_ref().to_vec(),
+        })
+    }
+
+    fn convert_pong(pong: &Pong) -> gossip_msg::Msg {
+        gossip_msg::Msg::Pong(GossipPong {
+            from: pong.from().to_bytes().to_vec(),
+            hash: pong.signable_data().to_vec(),
+            signature: pong.signature().as_ref().to_vec(),
+        })
+    }
+
+    fn convert_bloom(bloom: &solana_bloom::bloom::Bloom<solana_hash::Hash>) -> GossipBloom {
+        let mut bits_bytes = Vec::new();
+        for i in 0..bloom.bits.block_len() {
+            bits_bytes.extend_from_slice(&bloom.bits.get_block(i).to_le_bytes());
+        }
+        GossipBloom {
+            keys: bloom.keys.clone(),
+            bits: bits_bytes,
+            num_bits_set: bloom.num_bits_set(),
+        }
+    }
+
+    fn convert_crds_filter(filter: &NativeCrdsFilter) -> GossipCrdsFilter {
+        let mask_bits = filter.get_mask_bits();
+        GossipCrdsFilter {
+            filter: Some(convert_bloom(&filter.filter)),
+            mask: NativeCrdsFilter::canonical_mask(filter.mask(), mask_bits),
+            mask_bits,
+        }
+    }
+
+    fn convert_crds_data(data: &CrdsData) -> GossipCrdsData {
+        let converted = match data {
+            CrdsData::ContactInfo(ci) => {
+                let v = ci.version();
+                Some(gossip_crds_data::Data::ContactInfo(GossipContactInfo {
+                    pubkey: ci.pubkey().to_bytes().to_vec(),
+                    wallclock: ci.wallclock(),
+                    outset: ci.outset(),
+                    shred_version: ci.shred_version() as u32,
+                    version_major: v.major() as u32,
+                    version_minor: v.minor() as u32,
+                    version_patch: v.patch() as u32,
+                    version_commit: v.commit(),
+                    version_feature_set: v.feature_set(),
+                    version_client: u16::try_from(v.client().clone()).expect("valid client id")
+                        as u32,
+                    addrs: ci
+                        .addrs()
+                        .iter()
+                        .map(|a| GossipIpAddr {
+                            addr: Some(match a {
+                                std::net::IpAddr::V4(v4) => {
+                                    gossip_ip_addr::Addr::Ipv4(u32::from(*v4))
+                                }
+                                std::net::IpAddr::V6(v6) => {
+                                    let octets = v6.octets();
+                                    gossip_ip_addr::Addr::Ipv6(GossipIpv6Addr {
+                                        hi: u64::from_be_bytes(octets[..8].try_into().unwrap()),
+                                        lo: u64::from_be_bytes(octets[8..].try_into().unwrap()),
+                                    })
+                                }
+                            }),
+                        })
+                        .collect(),
+                    sockets: ci
+                        .sockets()
+                        .iter()
+                        .map(|s| GossipSocketEntry {
+                            key: s.key as u32,
+                            index: s.index as u32,
+                            offset: s.offset as u32,
+                        })
+                        .collect(),
+                    extensions: vec![],
+                }))
+            }
+            CrdsData::Vote(idx, vote) => {
+                let tx_bytes =
+                    bincode::serialize(vote.transaction()).expect("vote transaction serialization");
+                Some(gossip_crds_data::Data::Vote(GossipVote {
+                    index: *idx as u32,
+                    from: vote.from().to_bytes().to_vec(),
+                    wallclock: vote.wallclock(),
+                    transaction: tx_bytes,
+                }))
+            }
+            CrdsData::LowestSlot(_, ls) => {
+                Some(gossip_crds_data::Data::LowestSlot(GossipLowestSlot {
+                    index: 0,
+                    from: ls.from().to_bytes().to_vec(),
+                    lowest: ls.lowest,
+                    wallclock: ls.wallclock(),
+                }))
+            }
+            CrdsData::EpochSlots(idx, es) => {
+                use crate::epoch_slots::CompressedSlots;
+                let slots = es
+                    .slots
+                    .iter()
+                    .map(|cs| match cs {
+                        CompressedSlots::Uncompressed(u) => {
+                            let mut bits = Vec::new();
+                            for i in 0..u.slots.block_len() {
+                                bits.extend_from_slice(&u.slots.get_block(i).to_le_bytes());
+                            }
+                            GossipCompressedSlots {
+                                first_slot: u.first_slot,
+                                num: u.num as u64,
+                                data: Some(gossip_compressed_slots::Data::Uncompressed(bits)),
+                            }
+                        }
+                        CompressedSlots::Flate2(f) => GossipCompressedSlots {
+                            first_slot: f.first_slot,
+                            num: f.num as u64,
+                            data: Some(gossip_compressed_slots::Data::Flate2(
+                                f.compressed.to_vec(),
+                            )),
+                        },
+                    })
+                    .collect();
+                Some(gossip_crds_data::Data::EpochSlots(GossipEpochSlots {
+                    index: *idx as u32,
+                    from: es.from.to_bytes().to_vec(),
+                    wallclock: es.wallclock,
+                    slots,
+                }))
+            }
+            CrdsData::SnapshotHashes(sh) => Some(gossip_crds_data::Data::SnapshotHashes(
+                GossipSnapshotHashes {
+                    from: sh.from.to_bytes().to_vec(),
+                    full_slot: sh.full.0,
+                    full_hash: sh.full.1.to_bytes().to_vec(),
+                    incremental: sh
+                        .incremental
+                        .iter()
+                        .map(|(slot, hash)| GossipIncrementalHash {
+                            slot: *slot,
+                            hash: hash.to_bytes().to_vec(),
+                        })
+                        .collect(),
+                    wallclock: sh.wallclock,
+                },
+            )),
+            CrdsData::DuplicateShred(idx, ds) => Some(gossip_crds_data::Data::DuplicateShred(
+                GossipDuplicateShred {
+                    index: *idx as u32,
+                    from: ds.from().to_bytes().to_vec(),
+                    wallclock: ds.wallclock(),
+                    slot: ds.slot(),
+                    shred_index: 0,
+                    shred_type: 0,
+                    num_chunks: ds.num_chunks() as u32,
+                    chunk_index: ds.chunk_index() as u32,
+                    chunk: ds.chunk().to_vec(),
+                },
+            )),
+            CrdsData::LegacyContactInfo(..)
+            | CrdsData::LegacySnapshotHashes(..)
+            | CrdsData::AccountsHashes(..)
+            | CrdsData::LegacyVersion(..)
+            | CrdsData::Version(..)
+            | CrdsData::NodeInstance(..)
+            | CrdsData::RestartLastVotedForkSlots(..)
+            | CrdsData::RestartHeaviestFork(..) => None,
+        };
+        GossipCrdsData { data: converted }
+    }
+
+    fn convert_crds_value(value: &NativeCrdsValue) -> GossipCrdsValue {
+        GossipCrdsValue {
+            signature: value.get_signature().as_ref().to_vec(),
+            data: Some(convert_crds_data(value.data())),
+        }
+    }
+
+    fn convert_prune_data(pd: &PruneData) -> GossipPruneData {
+        GossipPruneData {
+            pubkey: pd.pubkey.to_bytes().to_vec(),
+            prunes: pd.prunes.iter().map(|p| p.to_bytes().to_vec()).collect(),
+            signature: pd.signature.as_ref().to_vec(),
+            destination: pd.destination.to_bytes().to_vec(),
+            wallclock: pd.wallclock,
+        }
+    }
+
+    fn convert_protocol(proto: &Protocol) -> gossip_msg::Msg {
+        match proto {
+            Protocol::PingMessage(ping) => convert_ping(ping),
+            Protocol::PongMessage(pong) => convert_pong(pong),
+            Protocol::PullRequest(filter, value) => {
+                gossip_msg::Msg::PullRequest(GossipPullRequest {
+                    filter: Some(convert_crds_filter(filter)),
+                    value: Some(convert_crds_value(value)),
+                })
+            }
+            Protocol::PullResponse(pubkey, values) => {
+                gossip_msg::Msg::PullResponse(GossipPullResponse {
+                    pubkey: pubkey.to_bytes().to_vec(),
+                    values: values.iter().map(convert_crds_value).collect(),
+                })
+            }
+            Protocol::PushMessage(pubkey, values) => {
+                gossip_msg::Msg::PushMessage(GossipPushMessage {
+                    pubkey: pubkey.to_bytes().to_vec(),
+                    values: values.iter().map(convert_crds_value).collect(),
+                })
+            }
+            Protocol::PruneMessage(pubkey, data) => {
+                gossip_msg::Msg::PruneMessage(GossipPruneMessage {
+                    pubkey: pubkey.to_bytes().to_vec(),
+                    data: Some(convert_prune_data(data)),
+                })
+            }
+        }
+    }
+
+    let result = bincode::options()
+        .with_limit(PACKET_DATA_SIZE as u64)
+        .with_fixint_encoding()
+        .reject_trailing_bytes()
+        .deserialize::<Protocol>(input);
+
+    match result {
+        Ok(proto) if proto.sanitize().is_ok() => {
+            let msg = convert_protocol(&proto);
+            GossipEffects {
+                valid: true,
+                msg: Some(GossipMsg { msg: Some(msg) }),
+            }
+        }
+        _ => GossipEffects {
+            valid: false,
+            msg: None,
+        },
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use {

--- a/gossip/tests/conformance/fixtures.rs
+++ b/gossip/tests/conformance/fixtures.rs
@@ -1,0 +1,238 @@
+use {super::get_effects, crate::helpers::*};
+
+fn write_fixture(dir: &std::path::Path, name: &str, input: &[u8]) {
+    use {
+        prost::Message,
+        protosol::protos::{FixtureMetadata, GossipFixture},
+    };
+
+    let effects = get_effects(input);
+    let fixture = GossipFixture {
+        metadata: Some(FixtureMetadata {
+            fn_entrypoint: "gossip_decode_to_effects".into(),
+        }),
+        input: input.to_vec(),
+        output: Some(effects),
+    };
+    let mut buf = Vec::new();
+    fixture.encode(&mut buf).unwrap();
+    let path = dir.join(format!("{name}.fix"));
+    std::fs::write(&path, &buf)
+        .unwrap_or_else(|e| panic!("Failed to write {}: {e}", path.display()));
+}
+
+/// Generate protobuf fixture files for cross-implementation conformance
+/// testing. Ignored because it writes to disk and is meant to be run
+/// manually: `FIXTURE_DIR=<path> cargo test -p solana-gossip --test conformance -- --ignored`
+#[test]
+#[ignore]
+fn generate_gossip_fixtures() {
+    let dir = std::path::PathBuf::from(
+        std::env::var("FIXTURE_DIR").unwrap_or_else(|_| "fixtures/gossip".into()),
+    );
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let pk = [0x11; 32];
+    let sig = [0u8; 64];
+
+    // Ping
+    write_fixture(&dir, "ping_valid", &make_ping_bytes(&pk, &[0x22; 32], &sig));
+    write_fixture(
+        &dir,
+        "ping_default_fields",
+        &make_ping_bytes(&[0u8; 32], &[0u8; 32], &[0u8; 64]),
+    );
+
+    // Pong
+    write_fixture(&dir, "pong_valid", &make_pong_bytes(&pk, &[0x55; 32], &sig));
+    write_fixture(
+        &dir,
+        "pong_default_fields",
+        &make_pong_bytes(&[0u8; 32], &[0u8; 32], &[0u8; 64]),
+    );
+
+    // Prune
+    write_fixture(
+        &dir,
+        "prune_valid",
+        &make_prune_bytes(&pk, &pk, &[[0x22; 32]], &sig, &[0x33; 32], 1_000_000),
+    );
+    write_fixture(
+        &dir,
+        "prune_mismatched_pubkeys",
+        &make_prune_bytes(&[0xAA; 32], &[0xBB; 32], &[], &sig, &[0u8; 32], 1_000_000),
+    );
+    write_fixture(
+        &dir,
+        "prune_wallclock_at_max",
+        &make_prune_bytes(&pk, &pk, &[], &sig, &[0u8; 32], super::MAX_WALLCLOCK),
+    );
+    write_fixture(
+        &dir,
+        "prune_wallclock_below_max",
+        &make_prune_bytes(&pk, &pk, &[], &sig, &[0u8; 32], super::MAX_WALLCLOCK - 1),
+    );
+    {
+        let prunes: Vec<[u8; 32]> = (0..32u8).map(|i| [i; 32]).collect();
+        write_fixture(
+            &dir,
+            "prune_many_nodes",
+            &make_prune_bytes(&pk, &pk, &prunes, &sig, &[0u8; 32], 1_000_000),
+        );
+    }
+
+    // PullResponse
+    {
+        let ci = make_contact_info_crds_data(&pk, 1_000_000);
+        let val = make_crds_value_bytes(&sig, &ci);
+        write_fixture(
+            &dir,
+            "pull_response_valid",
+            &make_pull_response_bytes(&pk, &[val]),
+        );
+    }
+    write_fixture(
+        &dir,
+        "pull_response_empty",
+        &make_pull_response_bytes(&pk, &[]),
+    );
+
+    // PullRequest
+    {
+        let filter = make_crds_filter_bytes();
+        let ci = make_contact_info_crds_data(&pk, 1_000_000);
+        let val = make_crds_value_bytes(&sig, &ci);
+        write_fixture(
+            &dir,
+            "pull_request_contact_info",
+            &make_pull_request_bytes(&filter, &val),
+        );
+    }
+
+    // PushMessage
+    {
+        let ci = make_contact_info_crds_data(&pk, 1_000_000);
+        let val = make_crds_value_bytes(&sig, &ci);
+        write_fixture(
+            &dir,
+            "push_message_valid",
+            &make_push_message_bytes(&pk, &[val]),
+        );
+    }
+    {
+        let ci = make_contact_info_crds_data(&pk, 1_000_000);
+        let sh = make_snapshot_hashes_crds_data(&pk, 100, &[0xAA; 32], &[], 1_000_000);
+        let val1 = make_crds_value_bytes(&sig, &ci);
+        let val2 = make_crds_value_bytes(&sig, &sh);
+        write_fixture(
+            &dir,
+            "push_message_multiple",
+            &make_push_message_bytes(&pk, &[val1, val2]),
+        );
+    }
+
+    // ContactInfo
+    {
+        let ci = make_contact_info_crds_data(&pk, 1_000_000);
+        let val = make_crds_value_bytes(&sig, &ci);
+        write_fixture(
+            &dir,
+            "contact_info_valid",
+            &make_push_message_bytes(&pk, &[val]),
+        );
+    }
+    {
+        let ci = make_contact_info_localhost_crds_data(&pk, 1_000_000);
+        let val = make_crds_value_bytes(&sig, &ci);
+        write_fixture(
+            &dir,
+            "contact_info_localhost",
+            &make_push_message_bytes(&pk, &[val]),
+        );
+    }
+
+    // Vote
+    {
+        let vote = make_vote_crds_data(0, &pk, 1_000_000);
+        let val = make_crds_value_bytes(&sig, &vote);
+        write_fixture(&dir, "vote_valid", &make_push_message_bytes(&pk, &[val]));
+    }
+
+    // CrdsData edge cases
+    {
+        let es = make_epoch_slots_crds_data(255, &pk, 1_000_000);
+        let val = make_crds_value_bytes(&sig, &es);
+        write_fixture(
+            &dir,
+            "epoch_slots_index_at_max",
+            &make_push_message_bytes(&pk, &[val]),
+        );
+    }
+    {
+        let ls = make_lowest_slot_crds_data(1, &pk, 42, 1_000_000);
+        let val = make_crds_value_bytes(&sig, &ls);
+        write_fixture(
+            &dir,
+            "lowest_slot_nonzero_index",
+            &make_push_message_bytes(&pk, &[val]),
+        );
+    }
+    {
+        let sh =
+            make_snapshot_hashes_crds_data(&pk, 1_000_000_000_000_000, &[0xAA; 32], &[], 1_000_000);
+        let val = make_crds_value_bytes(&sig, &sh);
+        write_fixture(
+            &dir,
+            "snapshot_hashes_slot_at_max",
+            &make_pull_response_bytes(&pk, &[val]),
+        );
+    }
+    {
+        let sh =
+            make_snapshot_hashes_crds_data(&pk, 100, &[0xAA; 32], &[(50, [0xBB; 32])], 1_000_000);
+        let val = make_crds_value_bytes(&sig, &sh);
+        write_fixture(
+            &dir,
+            "snapshot_hashes_incremental_not_above_full",
+            &make_pull_response_bytes(&pk, &[val]),
+        );
+    }
+
+    // DuplicateShred
+    {
+        let ds = make_duplicate_shred_crds_data(0, &pk, 1_000_000, 42, 0, 0, 3, 0, &[0xDE; 32]);
+        let val = make_crds_value_bytes(&sig, &ds);
+        write_fixture(
+            &dir,
+            "duplicate_shred_valid",
+            &make_push_message_bytes(&pk, &[val]),
+        );
+    }
+    {
+        let ds = make_duplicate_shred_crds_data(0, &pk, 1_000_000, 42, 99, 0xAB, 3, 0, &[0xDE; 32]);
+        let val = make_crds_value_bytes(&sig, &ds);
+        write_fixture(
+            &dir,
+            "duplicate_shred_deprecated_fields_zeroed",
+            &make_push_message_bytes(&pk, &[val]),
+        );
+    }
+
+    // Deserialization edge cases
+    write_fixture(&dir, "empty_input", &[]);
+    write_fixture(
+        &dir,
+        "truncated_input",
+        &make_ping_bytes(&pk, &[0x22; 32], &sig)[..66],
+    );
+    {
+        let mut d = make_ping_bytes(&pk, &[0x22; 32], &sig);
+        d.push(0xFF);
+        write_fixture(&dir, "trailing_bytes", &d);
+    }
+
+    eprintln!(
+        "Generated fixtures in {}",
+        dir.canonicalize().unwrap_or(dir.clone()).display()
+    );
+}

--- a/gossip/tests/conformance/helpers.rs
+++ b/gossip/tests/conformance/helpers.rs
@@ -1,0 +1,240 @@
+// Binary layout helpers.
+//
+// Protocol is bincode-serialized with fixint encoding:
+//   4-byte LE u32 variant discriminant, then variant fields.
+//
+// Variant indices (from enum declaration order):
+//   0 = PullRequest(CrdsFilter, CrdsValue)
+//   1 = PullResponse(Pubkey, Vec<CrdsValue>)
+//   2 = PushMessage(Pubkey, Vec<CrdsValue>)
+//   3 = PruneMessage(Pubkey, PruneData)
+//   4 = PingMessage(Ping)
+//   5 = PongMessage(Pong)
+//
+// Ping { from: Pubkey(32), token: [u8; 32], signature: Signature(64) }
+// Pong { from: Pubkey(32), hash: Hash(32), signature: Signature(64) }
+// PruneData { pubkey: Pubkey(32), prunes: Vec<Pubkey>(8+n*32),
+//             signature: Signature(64), destination: Pubkey(32), wallclock: u64(8) }
+// CrdsValue { signature: Signature(64), data: CrdsData(4+...) }
+//
+// CrdsData variant indices:
+//   0 = LegacyContactInfo    (deprecated)
+//   1 = Vote(u8, Vote)
+//   2 = LowestSlot(u8, LowestSlot)
+//   3 = LegacySnapshotHashes (deprecated)
+//   4 = AccountsHashes       (deprecated)
+//   5 = EpochSlots(u8, EpochSlots)
+//   6 = LegacyVersion        (deprecated)
+//   7 = Version              (deprecated)
+//   8 = NodeInstance          (deprecated)
+//   9 = DuplicateShred(u16, DuplicateShred)
+//  10 = SnapshotHashes
+//  11 = ContactInfo
+
+/// Build a PingMessage (variant 4) from raw fields.
+pub(crate) fn make_ping_bytes(from: &[u8; 32], token: &[u8; 32], signature: &[u8; 64]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(132);
+    buf.extend_from_slice(&4u32.to_le_bytes());
+    buf.extend_from_slice(from);
+    buf.extend_from_slice(token);
+    buf.extend_from_slice(signature);
+    buf
+}
+
+/// Build a PongMessage (variant 5) from raw fields.
+pub(crate) fn make_pong_bytes(from: &[u8; 32], hash: &[u8; 32], signature: &[u8; 64]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(132);
+    buf.extend_from_slice(&5u32.to_le_bytes());
+    buf.extend_from_slice(from);
+    buf.extend_from_slice(hash);
+    buf.extend_from_slice(signature);
+    buf
+}
+
+/// Build a PruneMessage (variant 3) from raw fields.
+pub(crate) fn make_prune_bytes(
+    outer_pubkey: &[u8; 32],
+    pubkey: &[u8; 32],
+    prunes: &[[u8; 32]],
+    signature: &[u8; 64],
+    destination: &[u8; 32],
+    wallclock: u64,
+) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&3u32.to_le_bytes());
+    buf.extend_from_slice(outer_pubkey);
+    // PruneData
+    buf.extend_from_slice(pubkey);
+    buf.extend_from_slice(&(prunes.len() as u64).to_le_bytes());
+    for p in prunes {
+        buf.extend_from_slice(p);
+    }
+    buf.extend_from_slice(signature);
+    buf.extend_from_slice(destination);
+    buf.extend_from_slice(&wallclock.to_le_bytes());
+    buf
+}
+
+/// Build a PullResponse (variant 1) from raw fields.
+pub(crate) fn make_pull_response_bytes(pubkey: &[u8; 32], values: &[Vec<u8>]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&1u32.to_le_bytes());
+    buf.extend_from_slice(pubkey);
+    buf.extend_from_slice(&(values.len() as u64).to_le_bytes());
+    for v in values {
+        buf.extend_from_slice(v);
+    }
+    buf
+}
+
+/// Build a PushMessage (variant 2) from raw fields.
+pub(crate) fn make_push_message_bytes(pubkey: &[u8; 32], values: &[Vec<u8>]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&2u32.to_le_bytes());
+    buf.extend_from_slice(pubkey);
+    buf.extend_from_slice(&(values.len() as u64).to_le_bytes());
+    for v in values {
+        buf.extend_from_slice(v);
+    }
+    buf
+}
+
+/// Build a CrdsValue: signature(64) + crds_data_bytes.
+pub(crate) fn make_crds_value_bytes(signature: &[u8; 64], crds_data: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(64usize.saturating_add(crds_data.len()));
+    buf.extend_from_slice(signature);
+    buf.extend_from_slice(crds_data);
+    buf
+}
+
+/// Build a ContactInfo CrdsData (variant 11).
+/// ContactInfo is a complex serialized struct; this builds a minimal valid one.
+pub(crate) fn make_contact_info_crds_data(pubkey: &[u8; 32], wallclock: u64) -> Vec<u8> {
+    use solana_gossip::{contact_info::ContactInfo, crds_data::CrdsData};
+    let ci = ContactInfo::new(
+        solana_pubkey::Pubkey::from(*pubkey),
+        wallclock,
+        0, // shred_version
+    );
+    bincode::serialize(&CrdsData::ContactInfo(ci)).unwrap()
+}
+
+/// Build a ContactInfo CrdsData with localhost sockets populated.
+pub(crate) fn make_contact_info_localhost_crds_data(pubkey: &[u8; 32], wallclock: u64) -> Vec<u8> {
+    use solana_gossip::{contact_info::ContactInfo, crds_data::CrdsData};
+    let mut ci = ContactInfo::new_localhost(&solana_pubkey::Pubkey::from(*pubkey), wallclock);
+    ci.set_wallclock(wallclock);
+    bincode::serialize(&CrdsData::ContactInfo(ci)).unwrap()
+}
+
+/// Build a SnapshotHashes CrdsData (variant 10).
+pub(crate) fn make_snapshot_hashes_crds_data(
+    from: &[u8; 32],
+    full_slot: u64,
+    full_hash: &[u8; 32],
+    incremental: &[(u64, [u8; 32])],
+    wallclock: u64,
+) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&10u32.to_le_bytes()); // CrdsData::SnapshotHashes discriminant
+    buf.extend_from_slice(from);
+    // full: (u64, Hash)
+    buf.extend_from_slice(&full_slot.to_le_bytes());
+    buf.extend_from_slice(full_hash);
+    // incremental: Vec<(u64, Hash)>
+    buf.extend_from_slice(&(incremental.len() as u64).to_le_bytes());
+    for (slot, hash) in incremental {
+        buf.extend_from_slice(&slot.to_le_bytes());
+        buf.extend_from_slice(hash);
+    }
+    buf.extend_from_slice(&wallclock.to_le_bytes());
+    buf
+}
+
+/// Build an EpochSlots CrdsData (variant 5).
+pub(crate) fn make_epoch_slots_crds_data(index: u8, from: &[u8; 32], wallclock: u64) -> Vec<u8> {
+    // EpochSlots is serialized by bincode. Build and serialize.
+    use solana_gossip::{crds_data::CrdsData, epoch_slots::EpochSlots};
+    let es = EpochSlots::new(solana_pubkey::Pubkey::from(*from), wallclock);
+    bincode::serialize(&CrdsData::EpochSlots(index, es)).unwrap()
+}
+
+/// Build a LowestSlot CrdsData (variant 2).
+pub(crate) fn make_lowest_slot_crds_data(
+    index: u8,
+    from: &[u8; 32],
+    lowest: u64,
+    wallclock: u64,
+) -> Vec<u8> {
+    use solana_gossip::crds_data::{CrdsData, LowestSlot};
+    let ls = LowestSlot::new(solana_pubkey::Pubkey::from(*from), lowest, wallclock);
+    let mut data = bincode::serialize(&CrdsData::LowestSlot(0, ls)).unwrap();
+    // Patch the index byte (offset 4 in the serialized CrdsData)
+    data[4] = index;
+    data
+}
+
+/// Build a PullRequest (variant 0) from raw CrdsFilter + CrdsValue bytes.
+pub(crate) fn make_pull_request_bytes(filter_bytes: &[u8], value_bytes: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&0u32.to_le_bytes());
+    buf.extend_from_slice(filter_bytes);
+    buf.extend_from_slice(value_bytes);
+    buf
+}
+
+/// Build a serialized CrdsFilter. The Bloom filter has a complex layout,
+/// so we construct and serialize the Rust object.
+pub(crate) fn make_crds_filter_bytes() -> Vec<u8> {
+    use solana_gossip::crds_gossip_pull::CrdsFilter;
+    bincode::serialize(&CrdsFilter::new_rand(1, 128)).unwrap()
+}
+
+/// Build a Vote CrdsData (variant 1).
+/// The inner Transaction is complex; we construct and serialize via Rust objects.
+pub(crate) fn make_vote_crds_data(index: u8, from: &[u8; 32], wallclock: u64) -> Vec<u8> {
+    use {
+        solana_gossip::crds_data::{CrdsData, Vote as CrdsVote},
+        solana_keypair::Keypair,
+        solana_signer::Signer,
+        solana_vote_program::{vote_instruction, vote_state::Vote},
+    };
+    let keypair = Keypair::new_from_array(*from);
+    let vote = Vote::new(vec![1], solana_hash::Hash::default());
+    let vote_ix = vote_instruction::vote(&keypair.pubkey(), &keypair.pubkey(), vote);
+    let mut vote_tx =
+        solana_transaction::Transaction::new_with_payer(&[vote_ix], Some(&keypair.pubkey()));
+    vote_tx.partial_sign(&[&keypair], solana_hash::Hash::default());
+    let crds_vote = CrdsVote::new(solana_pubkey::Pubkey::from(*from), vote_tx, wallclock)
+        .expect("valid vote tx");
+    bincode::serialize(&CrdsData::Vote(index, crds_vote)).unwrap()
+}
+
+/// Build a DuplicateShred CrdsData (variant 9).
+/// Allows setting the deprecated `shred_index` and `shred_type` wire fields
+/// to test that the harness zeroes them out.
+pub(crate) fn make_duplicate_shred_crds_data(
+    index: u16,
+    from: &[u8; 32],
+    wallclock: u64,
+    slot: u64,
+    shred_index: u32,
+    shred_type: u8,
+    num_chunks: u8,
+    chunk_index: u8,
+    chunk: &[u8],
+) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&9u32.to_le_bytes()); // CrdsData::DuplicateShred discriminant
+    buf.extend_from_slice(&index.to_le_bytes()); // u16 index
+    buf.extend_from_slice(from); // from: Pubkey
+    buf.extend_from_slice(&wallclock.to_le_bytes());
+    buf.extend_from_slice(&slot.to_le_bytes());
+    buf.extend_from_slice(&shred_index.to_le_bytes()); // _unused (formerly shred_index)
+    buf.push(shred_type); // _unused_shred_type
+    buf.push(num_chunks);
+    buf.push(chunk_index);
+    buf.extend_from_slice(&(chunk.len() as u64).to_le_bytes());
+    buf.extend_from_slice(chunk);
+    buf
+}

--- a/gossip/tests/conformance/main.rs
+++ b/gossip/tests/conformance/main.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "dev-context-only-utils")]
+
+//! Gossip conformance tests and fixture generation.
+
+mod fixtures;
+mod helpers;
+mod tests;
+
+use protosol::protos::{GossipEffects, gossip_msg};
+
+pub(crate) const MAX_WALLCLOCK: u64 = 1_000_000_000_000_000;
+
+pub(crate) fn get_effects(input: &[u8]) -> GossipEffects {
+    solana_gossip::gossip_decode_to_effects(input)
+}
+
+pub(crate) fn check(input: &[u8], expect_valid: bool) {
+    let effects = get_effects(input);
+    assert_eq!(
+        effects.valid,
+        expect_valid,
+        "effects.valid mismatch: input len={}, expected {expect_valid}",
+        input.len(),
+    );
+    if !expect_valid {
+        assert!(effects.msg.is_none(), "invalid input should have no msg");
+    } else {
+        assert!(effects.msg.is_some(), "valid input should have a msg");
+    }
+}
+
+/// Returns the inner gossip_msg::Msg variant from effects, panicking if invalid.
+pub(crate) fn unwrap_msg(effects: &GossipEffects) -> &gossip_msg::Msg {
+    effects
+        .msg
+        .as_ref()
+        .expect("effects.msg is None")
+        .msg
+        .as_ref()
+        .expect("msg.msg is None")
+}

--- a/gossip/tests/conformance/tests.rs
+++ b/gossip/tests/conformance/tests.rs
@@ -1,0 +1,656 @@
+use {
+    super::{MAX_WALLCLOCK, check, get_effects, unwrap_msg},
+    crate::helpers::*,
+    protosol::protos::{GossipEffects, gossip_crds_data, gossip_msg},
+};
+
+// Ping tests
+
+#[test]
+fn test_conformance_ping_valid() {
+    let from = [0x11; 32];
+    let token = [0x22; 32];
+    let sig = [0x33; 64];
+    let data = make_ping_bytes(&from, &token, &sig);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::Ping(p) => {
+            assert_eq!(p.from, from);
+            assert_eq!(p.token, token);
+            assert_eq!(p.signature, sig);
+        }
+        other => panic!("expected Ping, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_conformance_ping_default_fields() {
+    let data = make_ping_bytes(&[0u8; 32], &[0u8; 32], &[0u8; 64]);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::Ping(p) => {
+            assert_eq!(p.from, vec![0u8; 32]);
+            assert_eq!(p.token, vec![0u8; 32]);
+            assert_eq!(p.signature, vec![0u8; 64]);
+        }
+        other => panic!("expected Ping, got {other:?}"),
+    }
+}
+
+// Pong tests
+
+#[test]
+fn test_conformance_pong_valid() {
+    let from = [0x44; 32];
+    let hash = [0x55; 32];
+    let sig = [0x66; 64];
+    let data = make_pong_bytes(&from, &hash, &sig);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::Pong(p) => {
+            assert_eq!(p.from, from);
+            assert_eq!(p.hash, hash);
+            assert_eq!(p.signature, sig);
+        }
+        other => panic!("expected Pong, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_conformance_pong_default_fields() {
+    let data = make_pong_bytes(&[0u8; 32], &[0u8; 32], &[0u8; 64]);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::Pong(p) => {
+            assert_eq!(p.from, vec![0u8; 32]);
+            assert_eq!(p.hash, vec![0u8; 32]);
+            assert_eq!(p.signature, vec![0u8; 64]);
+        }
+        other => panic!("expected Pong, got {other:?}"),
+    }
+}
+
+// Prune tests
+
+#[test]
+fn test_conformance_prune_valid() {
+    let pk = [0x11; 32];
+    let prune_node = [0x22; 32];
+    let sig = [0u8; 64];
+    let dest = [0x33; 32];
+    let wc = 1_000_000u64;
+    let data = make_prune_bytes(&pk, &pk, &[prune_node], &sig, &dest, wc);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::PruneMessage(pm) => {
+            assert_eq!(pm.pubkey, pk);
+            let pd = pm.data.as_ref().unwrap();
+            assert_eq!(pd.pubkey, pk);
+            assert_eq!(pd.prunes.len(), 1);
+            assert_eq!(pd.prunes[0].as_slice(), &prune_node);
+            assert_eq!(pd.destination, dest);
+            assert_eq!(pd.wallclock, wc);
+            assert_eq!(pd.signature.len(), 64);
+        }
+        other => panic!("expected PruneMessage, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_conformance_prune_mismatched_pubkeys() {
+    let data = make_prune_bytes(
+        &[0xAA; 32], // outer pubkey
+        &[0xBB; 32], // PruneData.pubkey (mismatch)
+        &[],
+        &[0u8; 64],
+        &[0u8; 32],
+        1_000_000,
+    );
+    check(&data, false);
+}
+
+#[test]
+fn test_conformance_prune_wallclock_at_max() {
+    let pk = [0x11; 32];
+    let data = make_prune_bytes(&pk, &pk, &[], &[0u8; 64], &[0u8; 32], MAX_WALLCLOCK);
+    check(&data, false);
+}
+
+#[test]
+fn test_conformance_prune_wallclock_below_max() {
+    let pk = [0x11; 32];
+    let data = make_prune_bytes(&pk, &pk, &[], &[0u8; 64], &[0u8; 32], MAX_WALLCLOCK - 1);
+    check(&data, true);
+}
+
+#[test]
+fn test_conformance_prune_many_nodes() {
+    let pk = [0x11; 32];
+    let prunes: Vec<[u8; 32]> = (0..32u8).map(|i| [i; 32]).collect();
+    let data = make_prune_bytes(&pk, &pk, &prunes, &[0u8; 64], &[0u8; 32], 1_000_000);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::PruneMessage(pm) => {
+            let pd = pm.data.as_ref().unwrap();
+            assert_eq!(pd.prunes.len(), 32);
+            for (i, proto_prune) in pd.prunes.iter().enumerate() {
+                assert_eq!(proto_prune.as_slice(), &[i as u8; 32]);
+            }
+        }
+        other => panic!("expected PruneMessage, got {other:?}"),
+    }
+}
+
+// PullResponse tests
+
+#[test]
+fn test_conformance_pull_response_empty() {
+    let pk = [0x44; 32];
+    let data = make_pull_response_bytes(&pk, &[]);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::PullResponse(pr) => {
+            assert_eq!(pr.pubkey, pk);
+            assert!(pr.values.is_empty());
+        }
+        other => panic!("expected PullResponse, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_conformance_pull_response_valid() {
+    let pk = [0x44; 32];
+    let ci_data = make_contact_info_crds_data(&pk, 1_000_000);
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &ci_data);
+    let data = make_pull_response_bytes(&pk, &[crds_val]);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::PullResponse(pr) => {
+            assert_eq!(pr.pubkey, pk);
+            assert_eq!(pr.values.len(), 1);
+            let crds_data = pr.values[0].data.as_ref().unwrap();
+            match crds_data.data.as_ref().unwrap() {
+                gossip_crds_data::Data::ContactInfo(ci) => {
+                    assert_eq!(ci.pubkey, pk);
+                }
+                other => panic!("expected ContactInfo, got {other:?}"),
+            }
+        }
+        other => panic!("expected PullResponse, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_conformance_contact_info_extra_fields() {
+    use protosol::protos::gossip_ip_addr;
+
+    let pk = [0x44; 32];
+    let ci_data = make_contact_info_localhost_crds_data(&pk, 1_000_000);
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &ci_data);
+    let data = make_push_message_bytes(&pk, &[crds_val]);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::PushMessage(pm) => {
+            assert_eq!(pm.values.len(), 1);
+            let crds_data = pm.values[0].data.as_ref().unwrap();
+            match crds_data.data.as_ref().unwrap() {
+                gossip_crds_data::Data::ContactInfo(ci) => {
+                    assert_eq!(ci.pubkey, pk);
+
+                    // Deduped 127.0.0.1 addr.
+                    assert!(!ci.addrs.is_empty(), "expected at least one addr");
+                    match ci.addrs[0].addr.as_ref().unwrap() {
+                        gossip_ip_addr::Addr::Ipv4(v4) => {
+                            assert_eq!(
+                                *v4,
+                                u32::from(std::net::Ipv4Addr::LOCALHOST),
+                                "expected 127.0.0.1"
+                            );
+                        }
+                        other => panic!("expected IPv4 addr, got {other:?}"),
+                    }
+
+                    assert!(
+                        ci.sockets.len() >= 8,
+                        "expected >=8 sockets, got {}",
+                        ci.sockets.len()
+                    );
+                    for s in &ci.sockets {
+                        assert_eq!(s.index, 0, "all sockets should reference addr index 0");
+                    }
+
+                    assert!(ci.extensions.is_empty(), "extensions should be empty");
+                }
+                other => panic!("expected ContactInfo, got {other:?}"),
+            }
+        }
+        other => panic!("expected PushMessage, got {other:?}"),
+    }
+}
+
+// PushMessage tests
+
+#[test]
+fn test_conformance_push_message_valid() {
+    let pk = [0x55; 32];
+    let ci_data = make_contact_info_crds_data(&pk, 1_000_000);
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &ci_data);
+    let data = make_push_message_bytes(&pk, &[crds_val]);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::PushMessage(pm) => {
+            assert_eq!(pm.pubkey, pk);
+            assert_eq!(pm.values.len(), 1);
+        }
+        other => panic!("expected PushMessage, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_conformance_push_message_multiple() {
+    let pk = [0x55; 32];
+    let ci_data = make_contact_info_crds_data(&pk, 1_000_000);
+    let crds_val1 = make_crds_value_bytes(&[0u8; 64], &ci_data);
+    let sh_data = make_snapshot_hashes_crds_data(&pk, 100, &[0xAA; 32], &[], 1_000_000);
+    let crds_val2 = make_crds_value_bytes(&[0u8; 64], &sh_data);
+    let data = make_push_message_bytes(&pk, &[crds_val1, crds_val2]);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::PushMessage(pm) => {
+            assert_eq!(pm.pubkey, pk);
+            assert_eq!(pm.values.len(), 2);
+            match pm.values[0].data.as_ref().unwrap().data.as_ref().unwrap() {
+                gossip_crds_data::Data::ContactInfo(ci) => {
+                    assert_eq!(ci.pubkey, pk);
+                }
+                other => panic!("expected ContactInfo, got {other:?}"),
+            }
+            match pm.values[1].data.as_ref().unwrap().data.as_ref().unwrap() {
+                gossip_crds_data::Data::SnapshotHashes(sh) => {
+                    assert_eq!(sh.from, pk);
+                    assert_eq!(sh.full_slot, 100);
+                    assert!(sh.incremental.is_empty());
+                }
+                other => panic!("expected SnapshotHashes, got {other:?}"),
+            }
+        }
+        other => panic!("expected PushMessage, got {other:?}"),
+    }
+}
+
+// CrdsData edge case tests
+
+#[test]
+fn test_conformance_epoch_slots_index_at_max() {
+    let pk = [0x66; 32];
+    let es_data = make_epoch_slots_crds_data(255, &pk, 1_000_000);
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &es_data);
+    let data = make_push_message_bytes(&pk, &[crds_val]);
+    check(&data, false);
+}
+
+#[test]
+fn test_conformance_lowest_slot_nonzero_index() {
+    let pk = [0x77; 32];
+    let ls_data = make_lowest_slot_crds_data(1, &pk, 42, 1_000_000); // index=1 invalid
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &ls_data);
+    let data = make_push_message_bytes(&pk, &[crds_val]);
+    check(&data, false);
+}
+
+#[test]
+fn test_conformance_snapshot_hashes_slot_at_max() {
+    let pk = [0x88; 32];
+    let sh_data =
+        make_snapshot_hashes_crds_data(&pk, 1_000_000_000_000_000, &[0xAA; 32], &[], 1_000_000);
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &sh_data);
+    let data = make_pull_response_bytes(&pk, &[crds_val]);
+    check(&data, false);
+}
+
+#[test]
+fn test_conformance_snapshot_hashes_incremental_not_above_full() {
+    let pk = [0x99; 32];
+    let sh_data = make_snapshot_hashes_crds_data(
+        &pk,
+        100,
+        &[0xAA; 32],
+        &[(50, [0xBB; 32])], // incremental slot 50 < full slot 100
+        1_000_000,
+    );
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &sh_data);
+    let data = make_pull_response_bytes(&pk, &[crds_val]);
+    check(&data, false);
+}
+
+// PullRequest tests
+
+#[test]
+fn test_conformance_pull_request_contact_info() {
+    let pk = [0xAA; 32];
+    let filter = make_crds_filter_bytes();
+    let ci_data = make_contact_info_crds_data(&pk, 1_000_000);
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &ci_data);
+    let data = make_pull_request_bytes(&filter, &crds_val);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::PullRequest(pr) => {
+            assert!(pr.filter.is_some());
+            let crds_val = pr.value.as_ref().unwrap();
+            assert_eq!(crds_val.signature.len(), 64);
+            let crds_data = crds_val.data.as_ref().unwrap();
+            match crds_data.data.as_ref().unwrap() {
+                gossip_crds_data::Data::ContactInfo(ci) => {
+                    assert_eq!(ci.pubkey, pk);
+                }
+                other => panic!("expected ContactInfo, got {other:?}"),
+            }
+        }
+        other => panic!("expected PullRequest, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_conformance_pull_request_snapshot_hashes_rejected() {
+    let pk = [0xAA; 32];
+    let filter = make_crds_filter_bytes();
+    let sh_data = make_snapshot_hashes_crds_data(&pk, 100, &[0xBB; 32], &[], 1_000_000);
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &sh_data);
+    let data = make_pull_request_bytes(&filter, &crds_val);
+    check(&data, false);
+}
+
+#[test]
+fn test_conformance_pull_request_lowest_slot_rejected() {
+    let pk = [0xAA; 32];
+    let filter = make_crds_filter_bytes();
+    let ls_data = make_lowest_slot_crds_data(0, &pk, 42, 1_000_000);
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &ls_data);
+    let data = make_pull_request_bytes(&filter, &crds_val);
+    check(&data, false);
+}
+
+// Vote tests
+
+#[test]
+fn test_conformance_vote_index_valid() {
+    let pk = [0xCC; 32];
+    let vote_data = make_vote_crds_data(0, &pk, 1_000_000);
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &vote_data);
+    let data = make_push_message_bytes(&pk, &[crds_val]);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::PushMessage(pm) => {
+            match pm.values[0].data.as_ref().unwrap().data.as_ref().unwrap() {
+                gossip_crds_data::Data::Vote(v) => {
+                    assert_eq!(v.index, 0);
+                    assert!(!v.transaction.is_empty());
+                }
+                other => panic!("expected Vote, got {other:?}"),
+            }
+        }
+        other => panic!("expected PushMessage, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_conformance_vote_index_at_max() {
+    let pk = [0xCC; 32];
+    let vote_data = make_vote_crds_data(32, &pk, 1_000_000);
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &vote_data);
+    let data = make_push_message_bytes(&pk, &[crds_val]);
+    check(&data, false);
+}
+
+// DuplicateShred tests
+
+#[test]
+fn test_conformance_duplicate_shred_nonzero_deprecated_fields() {
+    let pk = [0xDD; 32];
+    let ds_data = make_duplicate_shred_crds_data(
+        0,          // index
+        &pk,        // from
+        1_000_000,  // wallclock
+        42,         // slot
+        0xDEAD,     // shred_index (non-zero, deprecated)
+        0xFF,       // shred_type (non-zero, deprecated)
+        1,          // num_chunks
+        0,          // chunk_index
+        &[1, 2, 3], // chunk
+    );
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &ds_data);
+    let data = make_push_message_bytes(&pk, &[crds_val]);
+    check(&data, true);
+
+    let effects = get_effects(&data);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::PushMessage(pm) => {
+            match pm.values[0].data.as_ref().unwrap().data.as_ref().unwrap() {
+                gossip_crds_data::Data::DuplicateShred(ds) => {
+                    assert_eq!(ds.shred_index, 0, "deprecated shred_index must be zeroed");
+                    assert_eq!(ds.shred_type, 0, "deprecated shred_type must be zeroed");
+                    assert_eq!(ds.slot, 42);
+                    assert_eq!(ds.from, pk);
+                    assert_eq!(ds.num_chunks, 1);
+                    assert_eq!(ds.chunk_index, 0);
+                    assert_eq!(ds.chunk, vec![1, 2, 3]);
+                }
+                other => panic!("expected DuplicateShred, got {other:?}"),
+            }
+        }
+        other => panic!("expected PushMessage, got {other:?}"),
+    }
+}
+
+// Deserialization edge cases
+
+#[test]
+fn test_conformance_empty_input() {
+    check(&[], false);
+}
+
+#[test]
+fn test_conformance_truncated_input() {
+    let data = make_ping_bytes(&[0x11; 32], &[0x22; 32], &[0x33; 64]);
+    let truncated = &data[..data.len() / 2];
+    check(truncated, false);
+}
+
+#[test]
+fn test_conformance_trailing_bytes() {
+    let mut data = make_ping_bytes(&[0x11; 32], &[0x22; 32], &[0x33; 64]);
+    data.push(0xFF);
+    check(&data, false);
+}
+
+// Serialization output tests
+//
+// Verify that gossip_decode_to_effects produces identical protobuf-encoded
+// output bytes for known inputs. Both Firedancer and Agave should produce
+// the same encoded GossipEffects for the same wire bytes.
+
+fn encode_effects(input: &[u8]) -> Vec<u8> {
+    use prost::Message;
+    get_effects(input).encode_to_vec()
+}
+
+#[test]
+fn test_conformance_encode_invalid() {
+    // Any invalid input should produce: GossipEffects { valid: false, msg: None }
+    // protobuf encoding: field 1 (valid) = false is default, so omitted = empty
+    let encoded = encode_effects(&[]);
+    assert!(
+        encoded.is_empty(),
+        "invalid input should encode to empty protobuf"
+    );
+
+    let encoded = encode_effects(&[0xFF; 3]);
+    assert!(
+        encoded.is_empty(),
+        "truncated input should encode to empty protobuf"
+    );
+}
+
+#[test]
+fn test_conformance_encode_ping() {
+    let from = [0x11; 32];
+    let token = [0x22; 32];
+    let sig = [0x33; 64];
+    let input = make_ping_bytes(&from, &token, &sig);
+    let encoded = encode_effects(&input);
+
+    // Decode back and verify round-trip
+    use prost::Message;
+    let effects = GossipEffects::decode(encoded.as_slice()).unwrap();
+    assert!(effects.valid);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::Ping(p) => {
+            assert_eq!(p.from, from);
+            assert_eq!(p.token, token);
+            assert_eq!(p.signature, sig);
+        }
+        other => panic!("expected Ping, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_conformance_encode_pong() {
+    let from = [0x44; 32];
+    let hash = [0x55; 32];
+    let sig = [0x66; 64];
+    let input = make_pong_bytes(&from, &hash, &sig);
+    let encoded = encode_effects(&input);
+
+    use prost::Message;
+    let effects = GossipEffects::decode(encoded.as_slice()).unwrap();
+    assert!(effects.valid);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::Pong(p) => {
+            assert_eq!(p.from, from);
+            assert_eq!(p.hash, hash);
+            assert_eq!(p.signature, sig);
+        }
+        other => panic!("expected Pong, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_conformance_encode_prune() {
+    let pk = [0x11; 32];
+    let prune_node = [0x22; 32];
+    let sig = [0u8; 64];
+    let dest = [0x33; 32];
+    let wc = 1_000_000u64;
+    let input = make_prune_bytes(&pk, &pk, &[prune_node], &sig, &dest, wc);
+    let encoded = encode_effects(&input);
+
+    use prost::Message;
+    let effects = GossipEffects::decode(encoded.as_slice()).unwrap();
+    assert!(effects.valid);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::PruneMessage(pm) => {
+            assert_eq!(pm.pubkey, pk);
+            let pd = pm.data.as_ref().unwrap();
+            assert_eq!(pd.pubkey, pk);
+            assert_eq!(pd.prunes.len(), 1);
+            assert_eq!(pd.prunes[0].as_slice(), &prune_node);
+            assert_eq!(pd.destination, dest);
+            assert_eq!(pd.wallclock, wc);
+        }
+        other => panic!("expected PruneMessage, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_conformance_encode_pull_response() {
+    let pk = [0x44; 32];
+    let ci_data = make_contact_info_crds_data(&pk, 1_000_000);
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &ci_data);
+    let input = make_pull_response_bytes(&pk, &[crds_val]);
+    let encoded = encode_effects(&input);
+
+    use prost::Message;
+    let effects = GossipEffects::decode(encoded.as_slice()).unwrap();
+    assert!(effects.valid);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::PullResponse(pr) => {
+            assert_eq!(pr.pubkey, pk);
+            assert_eq!(pr.values.len(), 1);
+        }
+        other => panic!("expected PullResponse, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_conformance_encode_push_message() {
+    let pk = [0x55; 32];
+    let ci_data = make_contact_info_crds_data(&pk, 1_000_000);
+    let crds_val = make_crds_value_bytes(&[0u8; 64], &ci_data);
+    let input = make_push_message_bytes(&pk, &[crds_val]);
+    let encoded = encode_effects(&input);
+
+    use prost::Message;
+    let effects = GossipEffects::decode(encoded.as_slice()).unwrap();
+    assert!(effects.valid);
+    let msg = unwrap_msg(&effects);
+    match msg {
+        gossip_msg::Msg::PushMessage(pm) => {
+            assert_eq!(pm.pubkey, pk);
+            assert_eq!(pm.values.len(), 1);
+        }
+        other => panic!("expected PushMessage, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_conformance_encode_deterministic() {
+    // Same input must always produce identical encoded output
+    let input = make_ping_bytes(&[0x11; 32], &[0x22; 32], &[0u8; 64]);
+    let a = encode_effects(&input);
+    let b = encode_effects(&input);
+    assert_eq!(a, b, "encoding must be deterministic");
+}


### PR DESCRIPTION
#### Problem

Cross-client gossip conformance testing currently has no way to verify that two implementations parse gossip messages into the same semantic structure from the raw bytes over-the-wire.

#### Summary of Changes

Adds gossip conformance tests and a conversion harness that deserializes raw gossip wire bytes and produces a structured protobuf representation of the parsed message (`GossipEffects`). This lets differential conformance testing tools compare not just validity, but the actual field-level interpretation of every gossip message variant between e.g. Agave vs. Firedancer/Sig/etc. Note that these same tests will run via an FFI interface against Firedancer, Sig, and Agave to help ensure that all three clients agree on the same protocol.