### PR TITLE
vote-program: move default methods from VoteStateHandler to VoteState…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11411,6 +11411,7 @@ dependencies = [
  "bincode",
  "criterion",
  "log",
+ "qualifier_attr",
  "solana-account 4.2.0",
  "solana-bincode",
  "solana-bls-signatures",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -204,6 +204,7 @@ solana-signer-store = { workspace = true }
 solana-system-program = { path = "../programs/system", features = ["agave-unstable-api"] }
 solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-vote = { path = "../vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-vote-program = { path = "../programs/vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
 spl-memo-interface = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -339,7 +339,7 @@ mod tests {
         solana_vote::vote_transaction,
         solana_vote_program::vote_state::{
             self, BLS_PUBLIC_KEY_COMPRESSED_SIZE, MAX_LOCKOUT_HISTORY, TowerSync, VoteStateV4,
-            VoteStateVersions, process_slot_vote_unchecked,
+            VoteStateVersions, handler::VoteStateHandler, process_slot_vote_unchecked,
         },
     };
 
@@ -550,19 +550,22 @@ mod tests {
         // Create bank
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
-        let mut vote_state1 = VoteStateV4::deserialize(vote_account1.data(), &pk1).unwrap();
+        let mut vote_state1 =
+            VoteStateHandler::new_v4(VoteStateV4::deserialize(vote_account1.data(), &pk1).unwrap());
         process_slot_vote_unchecked(&mut vote_state1, 3);
         process_slot_vote_unchecked(&mut vote_state1, 5);
+        let vote_state1 = vote_state1.unwrap_v4();
         if !with_node_vote_state {
             let versioned = VoteStateVersions::new_v4(vote_state1.clone());
             vote_account1.set_state(&versioned).unwrap();
             bank.store_account(&pk1, &vote_account1);
         }
 
-        let mut vote_state2 = VoteStateV4::deserialize(vote_account2.data(), &pk2).unwrap();
+        let mut vote_state2 =
+            VoteStateHandler::new_v4(VoteStateV4::deserialize(vote_account2.data(), &pk2).unwrap());
         process_slot_vote_unchecked(&mut vote_state2, 9);
         process_slot_vote_unchecked(&mut vote_state2, 10);
-        let versioned = VoteStateVersions::new_v4(vote_state2);
+        let versioned = VoteStateVersions::new_v4(vote_state2.unwrap_v4());
         vote_account2.set_state(&versioned).unwrap();
         bank.store_account(&pk2, &vote_account2);
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1829,7 +1829,8 @@ pub mod test {
         solana_slot_history::SlotHistory,
         solana_vote::vote_account::VoteAccount,
         solana_vote_program::vote_state::{
-            MAX_LOCKOUT_HISTORY, Vote, VoteStateV4, VoteStateVersions, process_slot_vote_unchecked,
+            MAX_LOCKOUT_HISTORY, Vote, VoteStateV4, VoteStateVersions, handler::VoteStateHandler,
+            process_slot_vote_unchecked,
         },
         std::{
             collections::{HashMap, VecDeque},
@@ -1852,12 +1853,12 @@ pub mod test {
                     owner: solana_vote_program::id(),
                     ..Account::default()
                 });
-                let mut vote_state = VoteStateV4::default();
+                let mut vote_state = VoteStateHandler::new_v4(VoteStateV4::default());
                 for slot in *votes {
                     process_slot_vote_unchecked(&mut vote_state, *slot);
                 }
                 VoteStateV4::serialize(
-                    &VoteStateVersions::new_v4(vote_state),
+                    &VoteStateVersions::new_v4(vote_state.unwrap_v4()),
                     account.data_as_mut_slice(),
                 )
                 .expect("serialize state");

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4839,7 +4839,9 @@ pub(crate) mod tests {
         solana_transaction_status::VersionedTransactionWithStatusMeta,
         solana_unified_scheduler_pool::DefaultSchedulerPool,
         solana_vote::vote_transaction,
-        solana_vote_program::vote_state::{self, TowerSync, VoteStateV4, VoteStateVersions},
+        solana_vote_program::vote_state::{
+            self, TowerSync, VoteStateV4, VoteStateVersions, handler::VoteStateHandler,
+        },
         std::{
             fs::remove_dir_all,
             iter,
@@ -5797,9 +5799,11 @@ pub(crate) mod tests {
     fn test_replay_commitment_cache() {
         fn leader_vote(vote_slot: Slot, bank: &Bank, pubkey: &Pubkey) -> (Pubkey, TowerVoteState) {
             let mut leader_vote_account = bank.get_account(pubkey).unwrap();
-            let mut vote_state =
-                VoteStateV4::deserialize(leader_vote_account.data(), pubkey).unwrap();
+            let mut vote_state = VoteStateHandler::new_v4(
+                VoteStateV4::deserialize(leader_vote_account.data(), pubkey).unwrap(),
+            );
             vote_state::process_slot_vote_unchecked(&mut vote_state, vote_slot);
+            let vote_state = vote_state.unwrap_v4();
             let versioned = VoteStateVersions::new_v4(vote_state.clone());
             leader_vote_account.set_state(&versioned).unwrap();
             bank.store_account(pubkey, &leader_vote_account);

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -18,7 +18,7 @@ name = "solana_vote_program"
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = []
+dev-context-only-utils = ["dep:qualifier_attr"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
@@ -30,6 +30,7 @@ frozen-abi = [
 agave-feature-set = { workspace = true }
 bincode = { workspace = true }
 log = { workspace = true }
+qualifier_attr = { workspace = true, optional = true }
 solana-account = { workspace = true }
 solana-bincode = { workspace = true }
 solana-bls-signatures = { workspace = true }

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -19,8 +19,8 @@ use {
     solana_vote_program::{
         vote_instruction::VoteInstruction,
         vote_state::{
-            MAX_LOCKOUT_HISTORY, TowerSync, Vote, VoteInit, VoteStateUpdate, VoteStateV3,
-            VoteStateVersions, handler::VoteStateHandle,
+            MAX_LOCKOUT_HISTORY, TowerSync, Vote, VoteInitV2, VoteStateUpdate, VoteStateV4,
+            VoteStateVersions, handler::VoteStateHandler,
         },
     },
     test::Bencher,
@@ -45,22 +45,22 @@ fn create_accounts() -> (
     let vote_pubkey = Pubkey::new_unique();
     let authority_pubkey = Pubkey::new_unique();
     let vote_account = {
-        let mut vote_state = VoteStateV3::new(
-            &VoteInit {
+        let mut vote_state = VoteStateHandler::new_v4(VoteStateV4::new(
+            &VoteInitV2 {
                 node_pubkey: authority_pubkey,
                 authorized_voter: authority_pubkey,
                 authorized_withdrawer: authority_pubkey,
-                commission: 0,
+                ..Default::default()
             },
             &clock,
-        );
+        ));
 
         for next_vote_slot in 0..num_initial_votes {
             vote_state.process_next_vote_slot(next_vote_slot, 0, 0);
         }
-        let mut vote_account_data: Vec<u8> = vec![0; VoteStateV3::size_of()];
-        let versioned = VoteStateVersions::new_v3(vote_state);
-        VoteStateV3::serialize(&versioned, &mut vote_account_data).unwrap();
+        let mut vote_account_data: Vec<u8> = vec![0; VoteStateV4::size_of()];
+        let versioned = VoteStateVersions::new_v4(vote_state.unwrap_v4());
+        VoteStateV4::serialize(&versioned, &mut vote_account_data).unwrap();
 
         Account {
             lamports: 1,

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -22,8 +22,9 @@ use {
         vote_processor::Entrypoint,
         vote_state::{
             MAX_LOCKOUT_HISTORY, TowerSync, Vote, VoteAuthorize, VoteAuthorizeCheckedWithSeedArgs,
-            VoteAuthorizeWithSeedArgs, VoteInit, VoteStateUpdate, VoteStateV3, VoteStateVersions,
-            create_v4_account_with_authorized, handler::VoteStateHandle,
+            VoteAuthorizeWithSeedArgs, VoteInit, VoteInitV2, VoteStateUpdate, VoteStateV3,
+            VoteStateV4, VoteStateVersions, create_v4_account_with_authorized,
+            handler::VoteStateHandler,
         },
     },
 };
@@ -55,22 +56,22 @@ fn create_accounts() -> (
     let vote_pubkey = Pubkey::new_unique();
     let authority_pubkey = Pubkey::new_unique();
     let vote_account = {
-        let mut vote_state = VoteStateV3::new(
-            &VoteInit {
+        let mut vote_state = VoteStateHandler::new_v4(VoteStateV4::new(
+            &VoteInitV2 {
                 node_pubkey: authority_pubkey,
                 authorized_voter: authority_pubkey,
                 authorized_withdrawer: authority_pubkey,
-                commission: 0,
+                ..Default::default()
             },
             &clock,
-        );
+        ));
 
         for next_vote_slot in 0..num_initial_votes {
             vote_state.process_next_vote_slot(next_vote_slot, 0, 0);
         }
-        let mut vote_account_data: Vec<u8> = vec![0; VoteStateV3::size_of()];
-        let versioned = VoteStateVersions::new_v3(vote_state);
-        VoteStateV3::serialize(&versioned, &mut vote_account_data).unwrap();
+        let mut vote_account_data: Vec<u8> = vec![0; VoteStateV4::size_of()];
+        let versioned = VoteStateVersions::new_v4(vote_state.unwrap_v4());
+        VoteStateV4::serialize(&versioned, &mut vote_account_data).unwrap();
 
         Account {
             lamports: 1,

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -12,13 +12,14 @@
 
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
+#[cfg(test)]
+use solana_vote_interface::authorized_voters::AuthorizedVoters;
 use {
     solana_clock::{Clock, Epoch, Slot, UnixTimestamp},
     solana_instruction::error::InstructionError,
     solana_pubkey::Pubkey,
     solana_transaction_context::instruction_accounts::BorrowedInstructionAccount,
     solana_vote_interface::{
-        authorized_voters::AuthorizedVoters,
         error::VoteError,
         state::{
             BLS_PUBLIC_KEY_COMPRESSED_SIZE, BlockTimestamp, LandedVote, Lockout,
@@ -36,6 +37,7 @@ pub trait VoteStateHandle {
 
     fn set_authorized_withdrawer(&mut self, authorized_withdrawer: Pubkey);
 
+    #[cfg(test)]
     fn authorized_voters(&self) -> &AuthorizedVoters;
 
     fn set_new_authorized_voter<F>(
@@ -118,6 +120,7 @@ impl VoteStateHandle for VoteStateV3 {
         self.authorized_withdrawer = authorized_withdrawer;
     }
 
+    #[cfg(test)]
     fn authorized_voters(&self) -> &AuthorizedVoters {
         &self.authorized_voters
     }
@@ -342,6 +345,7 @@ impl VoteStateHandle for VoteStateV4 {
         self.authorized_withdrawer = authorized_withdrawer;
     }
 
+    #[cfg(test)]
     fn authorized_voters(&self) -> &AuthorizedVoters {
         &self.authorized_voters
     }
@@ -563,6 +567,7 @@ impl VoteStateHandle for VoteStateHandler {
         }
     }
 
+    #[cfg(test)]
     fn authorized_voters(&self) -> &AuthorizedVoters {
         match &self.target_state {
             TargetVoteState::V4(v4) => v4.authorized_voters(),

--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -10,6 +10,8 @@
 //! getter and setter API around vote state, for all operations required by the
 //! vote program.
 
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 use {
     solana_clock::{Clock, Epoch, Slot, UnixTimestamp},
     solana_instruction::error::InstructionError,
@@ -105,159 +107,6 @@ pub trait VoteStateHandle {
     ) -> Result<(), InstructionError>;
 
     fn has_bls_pubkey(&self) -> bool;
-
-    fn credits_for_vote_at_index(&self, index: usize) -> u64 {
-        let latency = self
-            .votes()
-            .get(index)
-            .map_or(0, |landed_vote| landed_vote.latency);
-
-        // If latency is 0, this means that the Lockout was created and stored from a software version that did not
-        // store vote latencies; in this case, 1 credit is awarded
-        if latency == 0 {
-            1
-        } else {
-            match latency.checked_sub(VOTE_CREDITS_GRACE_SLOTS) {
-                None | Some(0) => {
-                    // latency was <= VOTE_CREDITS_GRACE_SLOTS, so maximum credits are awarded
-                    VOTE_CREDITS_MAXIMUM_PER_SLOT as u64
-                }
-
-                Some(diff) => {
-                    // diff = latency - VOTE_CREDITS_GRACE_SLOTS, and diff > 0
-                    // Subtract diff from VOTE_CREDITS_MAXIMUM_PER_SLOT which is the number of credits to award
-                    match VOTE_CREDITS_MAXIMUM_PER_SLOT.checked_sub(diff) {
-                        // If diff >= VOTE_CREDITS_MAXIMUM_PER_SLOT, 1 credit is awarded
-                        None | Some(0) => 1,
-
-                        Some(credits) => credits as u64,
-                    }
-                }
-            }
-        }
-    }
-
-    fn increment_credits(&mut self, epoch: Epoch, credits: u64) {
-        // increment credits, record by epoch
-
-        // never seen a credit
-        if self.epoch_credits().is_empty() {
-            self.epoch_credits_mut().push((epoch, 0, 0));
-        } else if epoch != self.epoch_credits().last().unwrap().0 {
-            let (_, credits, prev_credits) = *self.epoch_credits().last().unwrap();
-
-            if credits != prev_credits {
-                // if credits were earned previous epoch
-                // append entry at end of list for the new epoch
-                self.epoch_credits_mut().push((epoch, credits, credits));
-            } else {
-                // else just move the current epoch
-                self.epoch_credits_mut().last_mut().unwrap().0 = epoch;
-            }
-
-            // Remove too old epoch_credits
-            if self.epoch_credits().len() > MAX_EPOCH_CREDITS_HISTORY {
-                self.epoch_credits_mut().remove(0);
-            }
-        }
-
-        self.epoch_credits_mut().last_mut().unwrap().1 = self
-            .epoch_credits()
-            .last()
-            .unwrap()
-            .1
-            .saturating_add(credits);
-    }
-
-    fn process_timestamp(&mut self, slot: Slot, timestamp: UnixTimestamp) -> Result<(), VoteError> {
-        let last_timestamp = self.last_timestamp();
-        if (slot < last_timestamp.slot || timestamp < last_timestamp.timestamp)
-            || (slot == last_timestamp.slot
-                && &BlockTimestamp { slot, timestamp } != last_timestamp
-                && last_timestamp.slot != 0)
-        {
-            return Err(VoteError::TimestampTooOld);
-        }
-        self.set_last_timestamp(BlockTimestamp { slot, timestamp });
-        Ok(())
-    }
-
-    fn pop_expired_votes(&mut self, next_vote_slot: Slot) {
-        while let Some(vote) = self.last_lockout() {
-            if !vote.is_locked_out_at_slot(next_vote_slot) {
-                self.votes_mut().pop_back();
-            } else {
-                break;
-            }
-        }
-    }
-
-    fn double_lockouts(&mut self) {
-        let stack_depth = self.votes().len();
-        for (i, v) in self.votes_mut().iter_mut().enumerate() {
-            // Don't increase the lockout for this vote until we get more confirmations
-            // than the max number of confirmations this vote has seen
-            if stack_depth
-                > i.checked_add(v.confirmation_count() as usize).expect(
-                    "`confirmation_count` and tower_size should be bounded by \
-                     `MAX_LOCKOUT_HISTORY`",
-                )
-            {
-                v.lockout.increase_confirmation_count(1);
-            }
-        }
-    }
-
-    fn process_next_vote_slot(&mut self, next_vote_slot: Slot, epoch: Epoch, current_slot: Slot) {
-        // Ignore votes for slots earlier than we already have votes for
-        if self
-            .last_voted_slot()
-            .is_some_and(|last_voted_slot| next_vote_slot <= last_voted_slot)
-        {
-            return;
-        }
-
-        self.pop_expired_votes(next_vote_slot);
-
-        let landed_vote = LandedVote {
-            latency: compute_vote_latency(next_vote_slot, current_slot),
-            lockout: Lockout::new(next_vote_slot),
-        };
-
-        // Once the stack is full, pop the oldest lockout and distribute rewards
-        if self.votes().len() == MAX_LOCKOUT_HISTORY {
-            let credits = self.credits_for_vote_at_index(0);
-            let landed_vote = self.votes_mut().pop_front().unwrap();
-            self.set_root_slot(Some(landed_vote.slot()));
-
-            self.increment_credits(epoch, credits);
-        }
-        self.votes_mut().push_back(landed_vote);
-        self.double_lockouts();
-    }
-
-    #[cfg(test)]
-    fn credits(&self) -> u64 {
-        if self.epoch_credits().is_empty() {
-            0
-        } else {
-            self.epoch_credits().last().unwrap().1
-        }
-    }
-
-    #[cfg(test)]
-    fn nth_recent_lockout(&self, position: usize) -> Option<&Lockout> {
-        if position < self.votes().len() {
-            let pos = self
-                .votes()
-                .len()
-                .checked_sub(position)
-                .and_then(|pos| pos.checked_sub(1))?;
-            self.votes().get(pos).map(|vote| &vote.lockout)
-        } else {
-            None
-        }
-    }
 }
 
 impl VoteStateHandle for VoteStateV3 {
@@ -963,20 +812,192 @@ impl VoteStateHandler {
         }
     }
 
+    pub(crate) fn credits_for_vote_at_index(&self, index: usize) -> u64 {
+        let latency = self
+            .votes()
+            .get(index)
+            .map_or(0, |landed_vote| landed_vote.latency);
+
+        // If latency is 0, this means that the Lockout was created and stored from a software version that did not
+        // store vote latencies; in this case, 1 credit is awarded
+        if latency == 0 {
+            1
+        } else {
+            match latency.checked_sub(VOTE_CREDITS_GRACE_SLOTS) {
+                None | Some(0) => {
+                    // latency was <= VOTE_CREDITS_GRACE_SLOTS, so maximum credits are awarded
+                    VOTE_CREDITS_MAXIMUM_PER_SLOT as u64
+                }
+
+                Some(diff) => {
+                    // diff = latency - VOTE_CREDITS_GRACE_SLOTS, and diff > 0
+                    // Subtract diff from VOTE_CREDITS_MAXIMUM_PER_SLOT which is the number of credits to award
+                    match VOTE_CREDITS_MAXIMUM_PER_SLOT.checked_sub(diff) {
+                        // If diff >= VOTE_CREDITS_MAXIMUM_PER_SLOT, 1 credit is awarded
+                        None | Some(0) => 1,
+
+                        Some(credits) => credits as u64,
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    pub(crate) fn increment_credits(&mut self, epoch: Epoch, credits: u64) {
+        // increment credits, record by epoch
+
+        // never seen a credit
+        if self.epoch_credits().is_empty() {
+            self.epoch_credits_mut().push((epoch, 0, 0));
+        } else if epoch != self.epoch_credits().last().unwrap().0 {
+            let (_, credits, prev_credits) = *self.epoch_credits().last().unwrap();
+
+            if credits != prev_credits {
+                // if credits were earned previous epoch
+                // append entry at end of list for the new epoch
+                self.epoch_credits_mut().push((epoch, credits, credits));
+            } else {
+                // else just move the current epoch
+                self.epoch_credits_mut().last_mut().unwrap().0 = epoch;
+            }
+
+            // Remove too old epoch_credits
+            if self.epoch_credits().len() > MAX_EPOCH_CREDITS_HISTORY {
+                self.epoch_credits_mut().remove(0);
+            }
+        }
+
+        self.epoch_credits_mut().last_mut().unwrap().1 = self
+            .epoch_credits()
+            .last()
+            .unwrap()
+            .1
+            .saturating_add(credits);
+    }
+
+    pub(crate) fn process_timestamp(
+        &mut self,
+        slot: Slot,
+        timestamp: UnixTimestamp,
+    ) -> Result<(), VoteError> {
+        let last_timestamp = self.last_timestamp();
+        if (slot < last_timestamp.slot || timestamp < last_timestamp.timestamp)
+            || (slot == last_timestamp.slot
+                && &BlockTimestamp { slot, timestamp } != last_timestamp
+                && last_timestamp.slot != 0)
+        {
+            return Err(VoteError::TimestampTooOld);
+        }
+        self.set_last_timestamp(BlockTimestamp { slot, timestamp });
+        Ok(())
+    }
+
+    fn pop_expired_votes(&mut self, next_vote_slot: Slot) {
+        while let Some(vote) = self.last_lockout() {
+            if !vote.is_locked_out_at_slot(next_vote_slot) {
+                self.votes_mut().pop_back();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn double_lockouts(&mut self) {
+        let stack_depth = self.votes().len();
+        for (i, v) in self.votes_mut().iter_mut().enumerate() {
+            // Don't increase the lockout for this vote until we get more confirmations
+            // than the max number of confirmations this vote has seen
+            if stack_depth
+                > i.checked_add(v.confirmation_count() as usize).expect(
+                    "`confirmation_count` and tower_size should be bounded by \
+                     `MAX_LOCKOUT_HISTORY`",
+                )
+            {
+                v.lockout.increase_confirmation_count(1);
+            }
+        }
+    }
+
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    pub(crate) fn process_next_vote_slot(
+        &mut self,
+        next_vote_slot: Slot,
+        epoch: Epoch,
+        current_slot: Slot,
+    ) {
+        // Ignore votes for slots earlier than we already have votes for
+        if self
+            .last_voted_slot()
+            .is_some_and(|last_voted_slot| next_vote_slot <= last_voted_slot)
+        {
+            return;
+        }
+
+        self.pop_expired_votes(next_vote_slot);
+
+        let landed_vote = LandedVote {
+            latency: compute_vote_latency(next_vote_slot, current_slot),
+            lockout: Lockout::new(next_vote_slot),
+        };
+
+        // Once the stack is full, pop the oldest lockout and distribute rewards
+        if self.votes().len() == MAX_LOCKOUT_HISTORY {
+            let credits = self.credits_for_vote_at_index(0);
+            let landed_vote = self.votes_mut().pop_front().unwrap();
+            self.set_root_slot(Some(landed_vote.slot()));
+
+            self.increment_credits(epoch, credits);
+        }
+        self.votes_mut().push_back(landed_vote);
+        self.double_lockouts();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn credits(&self) -> u64 {
+        if self.epoch_credits().is_empty() {
+            0
+        } else {
+            self.epoch_credits().last().unwrap().1
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn nth_recent_lockout(&self, position: usize) -> Option<&Lockout> {
+        if position < self.votes().len() {
+            let pos = self
+                .votes()
+                .len()
+                .checked_sub(position)
+                .and_then(|pos| pos.checked_sub(1))?;
+            self.votes().get(pos).map(|vote| &vote.lockout)
+        } else {
+            None
+        }
+    }
+
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn new_v4(vote_state: VoteStateV4) -> Self {
         Self {
             target_state: TargetVoteState::V4(vote_state),
         }
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
     pub fn default_v4() -> Self {
         Self::new_v4(VoteStateV4::default())
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
     pub fn as_ref_v4(&self) -> &VoteStateV4 {
         match &self.target_state {
+            TargetVoteState::V4(v4) => v4,
+        }
+    }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    pub fn unwrap_v4(self) -> VoteStateV4 {
+        match self.target_state {
             TargetVoteState::V4(v4) => v4,
         }
     }
@@ -1574,9 +1595,8 @@ mod tests {
         }
     }
 
-    #[test_case(VoteStateV3::default() ; "VoteStateV3")]
-    #[test_case(VoteStateV4::default() ; "VoteStateV4")]
-    fn test_vote_state_epoch_credits<T: VoteStateHandle>(mut vote_state: T) {
+    #[test_case(VoteStateHandler::new_v4(VoteStateV4::default()) ; "VoteStateV4")]
+    fn test_vote_state_epoch_credits(mut vote_state: VoteStateHandler) {
         assert_eq!(vote_state.credits(), 0);
         assert_eq!(vote_state.epoch_credits().clone(), vec![]);
 
@@ -1599,9 +1619,8 @@ mod tests {
         assert_eq!(vote_state.epoch_credits().clone(), expected);
     }
 
-    #[test_case(VoteStateV3::default() ; "VoteStateV3")]
-    #[test_case(VoteStateV4::default() ; "VoteStateV4")]
-    fn test_vote_state_epoch0_no_credits<T: VoteStateHandle>(mut vote_state: T) {
+    #[test_case(VoteStateHandler::new_v4(VoteStateV4::default()) ; "VoteStateV4")]
+    fn test_vote_state_epoch0_no_credits(mut vote_state: VoteStateHandler) {
         assert_eq!(vote_state.epoch_credits().len(), 0);
         vote_state.increment_credits(1, 1);
         assert_eq!(vote_state.epoch_credits().len(), 1);
@@ -1610,9 +1629,8 @@ mod tests {
         assert_eq!(vote_state.epoch_credits().len(), 2);
     }
 
-    #[test_case(VoteStateV3::default() ; "VoteStateV3")]
-    #[test_case(VoteStateV4::default() ; "VoteStateV4")]
-    fn test_vote_state_increment_credits<T: VoteStateHandle>(mut vote_state: T) {
+    #[test_case(VoteStateHandler::new_v4(VoteStateV4::default()) ; "VoteStateV4")]
+    fn test_vote_state_increment_credits(mut vote_state: VoteStateHandler) {
         let credits = (MAX_EPOCH_CREDITS_HISTORY + 2) as u64;
         for i in 0..credits {
             vote_state.increment_credits(i, 1);
@@ -1621,9 +1639,8 @@ mod tests {
         assert!(vote_state.epoch_credits().len() <= MAX_EPOCH_CREDITS_HISTORY);
     }
 
-    #[test_case(VoteStateV3::default() ; "VoteStateV3")]
-    #[test_case(VoteStateV4::default() ; "VoteStateV4")]
-    fn test_vote_process_timestamp<T: VoteStateHandle>(mut vote_state: T) {
+    #[test_case(VoteStateHandler::new_v4(VoteStateV4::default()) ; "VoteStateV4")]
+    fn test_vote_process_timestamp(mut vote_state: VoteStateHandler) {
         let (slot, timestamp) = (15, 1_575_412_285);
         vote_state.set_last_timestamp(BlockTimestamp { slot, timestamp });
 
@@ -2276,51 +2293,5 @@ mod tests {
         ] {
             assert_eq!(compute_vote_latency(voted_for_slot, current_slot), expected);
         }
-    }
-
-    #[test]
-    fn test_process_timestamp_v3_v4_parity() {
-        let mut v3 = VoteStateV3::default();
-        let mut v4 = VoteStateV4::default();
-
-        let timestamps = [
-            (10, 1_000_000),
-            (11, 1_000_001),
-            (15, 1_000_005),
-            (20, 1_000_010),
-        ];
-        for (slot, ts) in timestamps {
-            assert_eq!(
-                v3.process_timestamp(slot, ts),
-                v4.process_timestamp(slot, ts)
-            );
-            assert_eq!(v3.last_timestamp(), v4.last_timestamp());
-        }
-    }
-
-    #[test]
-    fn test_process_next_vote_slot_v3_v4_parity() {
-        let voter = Pubkey::new_unique();
-        let mut v3 = VoteStateV3 {
-            authorized_voters: AuthorizedVoters::new(0, voter),
-            ..Default::default()
-        };
-        let mut v4 = VoteStateV4 {
-            authorized_voters: AuthorizedVoters::new(0, voter),
-            ..Default::default()
-        };
-
-        for slot in [5, 10, 15, 20] {
-            v3.process_next_vote_slot(slot, 0, 20);
-            v4.process_next_vote_slot(slot, 0, 20);
-        }
-
-        // Both should have identical vote state after processing.
-        assert_eq!(v3.votes().len(), v4.votes().len());
-        for (lv3, lv4) in v3.votes().iter().zip(v4.votes().iter()) {
-            assert_eq!(lv3.slot(), lv4.slot());
-            assert_eq!(lv3.confirmation_count(), lv4.confirmation_count());
-        }
-        assert_eq!(v3.root_slot(), v4.root_slot());
     }
 }

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -609,8 +609,8 @@ pub fn process_new_vote_state(
     Ok(())
 }
 
-pub fn process_vote_unfiltered<T: VoteStateHandle>(
-    vote_state: &mut T,
+pub fn process_vote_unfiltered(
+    vote_state: &mut VoteStateHandler,
     vote_slots: &[Slot],
     vote: &Vote,
     slot_hashes: &[SlotHash],
@@ -655,8 +655,8 @@ pub fn process_vote(
 }
 
 /// "unchecked" functions used by tests and Tower
-pub fn process_vote_unchecked<T: VoteStateHandle>(
-    vote_state: &mut T,
+pub fn process_vote_unchecked(
+    vote_state: &mut VoteStateHandler,
     vote: Vote,
 ) -> Result<(), VoteError> {
     if vote.slots.is_empty() {
@@ -674,13 +674,13 @@ pub fn process_vote_unchecked<T: VoteStateHandle>(
 }
 
 #[cfg(test)]
-pub fn process_slot_votes_unchecked<T: VoteStateHandle>(vote_state: &mut T, slots: &[Slot]) {
+pub fn process_slot_votes_unchecked(vote_state: &mut VoteStateHandler, slots: &[Slot]) {
     for slot in slots {
         process_slot_vote_unchecked(vote_state, *slot);
     }
 }
 
-pub fn process_slot_vote_unchecked<T: VoteStateHandle>(vote_state: &mut T, slot: Slot) {
+pub fn process_slot_vote_unchecked(vote_state: &mut VoteStateHandler, slot: Slot) {
     let _ = process_vote_unchecked(vote_state, Vote::new(vec![slot], Hash::default()));
 }
 

--- a/runtime/benches/epoch_turnover.rs
+++ b/runtime/benches/epoch_turnover.rs
@@ -21,7 +21,7 @@ use {
     },
     solana_sysvar::epoch_rewards::{self, EpochRewards},
     solana_vote_interface::state::{MAX_LOCKOUT_HISTORY, VoteStateV4, VoteStateVersions},
-    solana_vote_program::vote_state::process_slot_vote_unchecked,
+    solana_vote_program::vote_state::{handler::VoteStateHandler, process_slot_vote_unchecked},
     std::{
         hint::black_box,
         sync::{Arc, RwLock},
@@ -74,13 +74,15 @@ fn populate_vote_accounts(bank: &Bank, vote_pubkeys: Vec<Pubkey>) {
     for vote_pubkey in vote_pubkeys.into_iter() {
         let mut vote_account = bank.get_account(&vote_pubkey).unwrap();
 
-        let mut vote_state = VoteStateV4::deserialize(vote_account.data(), &vote_pubkey).unwrap();
+        let mut vote_state = VoteStateHandler::new_v4(
+            VoteStateV4::deserialize(vote_account.data(), &vote_pubkey).unwrap(),
+        );
 
         for i in 0..SYNTHETIC_VOTE_SLOTS {
             process_slot_vote_unchecked(&mut vote_state, i);
         }
 
-        let versioned = VoteStateVersions::V4(Box::new(vote_state));
+        let versioned = VoteStateVersions::V4(Box::new(vote_state.unwrap_v4()));
         vote_account.set_state(&versioned).unwrap();
 
         bank.store_account(&vote_pubkey, &vote_account);

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -440,7 +440,10 @@ mod tests {
         solana_system_transaction as system_transaction,
         solana_vote::vote_transaction,
         solana_vote_interface::state::{MAX_LOCKOUT_HISTORY, VoteStateV4, VoteStateVersions},
-        solana_vote_program::vote_state::{self, TowerSync, handler::VoteStateHandle},
+        solana_vote_program::vote_state::{
+            self, TowerSync,
+            handler::{VoteStateHandle, VoteStateHandler},
+        },
         std::sync::{Arc, RwLock},
     };
 
@@ -645,23 +648,14 @@ mod tests {
             let mut vote_account = bank
                 .get_account(&vote_pubkey)
                 .unwrap_or_else(|| panic!("missing vote account {vote_pubkey:?}"));
-            let mut vote_state =
-                Some(VoteStateV4::deserialize(vote_account.data(), &vote_pubkey).unwrap());
-            if let Some(state) = vote_state.as_mut() {
-                state.set_commission(commission);
-            }
+            let mut vote_state = VoteStateHandler::new_v4(
+                VoteStateV4::deserialize(vote_account.data(), &vote_pubkey).unwrap(),
+            );
+            vote_state.set_commission(commission);
             for i in 0..MAX_LOCKOUT_HISTORY + 42 {
-                if let Some(state) = vote_state.as_mut() {
-                    vote_state::process_slot_vote_unchecked(state, i as u64);
-                }
-                let versioned = VoteStateVersions::V4(Box::new(vote_state.take().unwrap()));
+                vote_state::process_slot_vote_unchecked(&mut vote_state, i as u64);
+                let versioned = VoteStateVersions::V4(Box::new(vote_state.as_ref_v4().clone()));
                 vote_account.set_state(&versioned).unwrap();
-                match versioned {
-                    VoteStateVersions::V4(v) => {
-                        vote_state = Some(*v);
-                    }
-                    _ => panic!("Has to be of type V4"),
-                };
             }
             bank.store_account_and_update_capitalization(&vote_pubkey, &vote_account);
         }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -122,7 +122,7 @@ use {
         vote_state::{
             self, BlockTimestamp, MAX_LOCKOUT_HISTORY, VoteAuthorize, VoteInit, VoteStateV4,
             VoteStateVersions, VoterWithBLSArgs, create_bls_pubkey_and_proof_of_possession,
-            create_v4_account_with_authorized,
+            create_v4_account_with_authorized, handler::VoteStateHandler,
         },
     },
     spl_generic_token::token,
@@ -777,20 +777,13 @@ where
     bank0.store_account_and_update_capitalization(&stake_id, &stake_account);
 
     // generate some rewards
-    let mut vote_state = Some(VoteStateV4::deserialize(vote_account.data(), &vote_id).unwrap());
+    let mut vote_state =
+        VoteStateHandler::new_v4(VoteStateV4::deserialize(vote_account.data(), &vote_id).unwrap());
     for i in 0..MAX_LOCKOUT_HISTORY + 42 {
-        if let Some(v) = vote_state.as_mut() {
-            vote_state::process_slot_vote_unchecked(v, i as u64)
-        }
-        let versioned = VoteStateVersions::V4(Box::new(vote_state.take().unwrap()));
+        vote_state::process_slot_vote_unchecked(&mut vote_state, i as u64);
+        let versioned = VoteStateVersions::V4(Box::new(vote_state.as_ref_v4().clone()));
         vote_account.set_state(&versioned).unwrap();
         bank0.store_account_and_update_capitalization(&vote_id, &vote_account);
-        match versioned {
-            VoteStateVersions::V4(v) => {
-                vote_state = Some(*v);
-            }
-            _ => panic!("Has to be of type V4"),
-        };
     }
     bank0.store_account_and_update_capitalization(&vote_id, &vote_account);
     bank0.freeze();
@@ -948,20 +941,13 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
     bank.store_account_and_update_capitalization(&stake_id2, &stake_account2);
 
     // generate some rewards
-    let mut vote_state = Some(VoteStateV4::deserialize(vote_account.data(), &vote_id).unwrap());
+    let mut vote_state =
+        VoteStateHandler::new_v4(VoteStateV4::deserialize(vote_account.data(), &vote_id).unwrap());
     for i in 0..MAX_LOCKOUT_HISTORY + 42 {
-        if let Some(v) = vote_state.as_mut() {
-            vote_state::process_slot_vote_unchecked(v, i as u64)
-        }
-        let versioned = VoteStateVersions::V4(Box::new(vote_state.take().unwrap()));
+        vote_state::process_slot_vote_unchecked(&mut vote_state, i as u64);
+        let versioned = VoteStateVersions::V4(Box::new(vote_state.as_ref_v4().clone()));
         vote_account.set_state(&versioned).unwrap();
         bank.store_account_and_update_capitalization(&vote_id, &vote_account);
-        match versioned {
-            VoteStateVersions::V4(v) => {
-                vote_state = Some(*v);
-            }
-            _ => panic!("Has to be of type V4"),
-        };
     }
     bank.store_account_and_update_capitalization(&vote_id, &vote_account);
 

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -279,7 +279,10 @@ mod tests {
         solana_native_token::LAMPORTS_PER_SOL,
         solana_pubkey::Pubkey,
         solana_stake_interface::{stake_history::StakeHistory, state::Delegation},
-        solana_vote_program::vote_state::{VoteStateV4, handler::VoteStateHandle},
+        solana_vote_program::vote_state::{
+            VoteStateV4,
+            handler::{VoteStateHandle, VoteStateHandler},
+        },
         test_case::test_case,
     };
 
@@ -297,11 +300,16 @@ mod tests {
 
     #[test]
     fn test_stake_state_redeem_rewards() {
-        let mut vote_state = VoteStateV4::default();
+        let mut vote_state = VoteStateHandler::new_v4(VoteStateV4::default());
         // assume stake.stake() is right
         // bootstrap means fully-vested stake at epoch 0
         let stake_lamports = 1;
-        let mut stake = new_stake(stake_lamports, &Pubkey::default(), &vote_state, u64::MAX);
+        let mut stake = new_stake(
+            stake_lamports,
+            &Pubkey::default(),
+            vote_state.as_ref_v4(),
+            u64::MAX,
+        );
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
@@ -311,8 +319,8 @@ mod tests {
             None,
             redeem_stake_rewards(
                 &mut stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 0,
                     point_value: &PointValue {
@@ -336,8 +344,8 @@ mod tests {
             Some((stake_lamports * 2, 0)),
             redeem_stake_rewards(
                 &mut stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 0,
                     point_value: &PointValue {
@@ -361,10 +369,10 @@ mod tests {
 
     #[test]
     fn test_stake_state_calculate_rewards() {
-        let mut vote_state = VoteStateV4::default();
+        let mut vote_state = VoteStateHandler::new_v4(VoteStateV4::default());
         // assume stake.stake() is right
         // bootstrap means fully-vested stake at epoch 0
-        let mut stake = new_stake(1, &Pubkey::default(), &vote_state, u64::MAX);
+        let mut stake = new_stake(1, &Pubkey::default(), vote_state.as_ref_v4(), u64::MAX);
 
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
@@ -375,8 +383,8 @@ mod tests {
             None,
             calculate_stake_rewards(
                 &stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 0,
                     point_value: &PointValue {
@@ -404,8 +412,8 @@ mod tests {
             }),
             calculate_stake_rewards(
                 &stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 0,
                     point_value: &PointValue {
@@ -430,8 +438,8 @@ mod tests {
             }),
             calculate_stake_rewards(
                 &stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 0,
                     point_value: &PointValue {
@@ -459,8 +467,8 @@ mod tests {
             }),
             calculate_stake_rewards(
                 &stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 1,
                     point_value: &PointValue {
@@ -486,8 +494,8 @@ mod tests {
             }),
             calculate_stake_rewards(
                 &stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 2,
                     point_value: &PointValue {
@@ -515,8 +523,8 @@ mod tests {
             }),
             calculate_stake_rewards(
                 &stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 2,
                     point_value: &PointValue {
@@ -533,13 +541,13 @@ mod tests {
 
         // same as above, but is a really small commission out of 32 bits,
         //  verify that None comes back on small redemptions where no one gets paid
-        vote_state.inflation_rewards_commission_bps = 100;
+        vote_state.set_inflation_rewards_commission_bps(100);
         assert_eq!(
             None, // would be Some((0, 2 * 1 + 1 * 2, 4)),
             calculate_stake_rewards(
                 &stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 2,
                     point_value: &PointValue {
@@ -553,13 +561,13 @@ mod tests {
                 null_tracer(),
             )
         );
-        vote_state.inflation_rewards_commission_bps = 9900;
+        vote_state.set_inflation_rewards_commission_bps(9900);
         assert_eq!(
             None, // would be Some((0, 2 * 1 + 1 * 2, 4)),
             calculate_stake_rewards(
                 &stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 2,
                     point_value: &PointValue {
@@ -585,8 +593,8 @@ mod tests {
             }),
             calculate_stake_rewards(
                 &stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 2,
                     point_value: &PointValue {
@@ -612,8 +620,8 @@ mod tests {
             }),
             calculate_stake_rewards(
                 &stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 2,
                     point_value: &PointValue {
@@ -636,7 +644,7 @@ mod tests {
             },
             calculate_stake_points_and_credits(
                 &stake,
-                DelegatedVoteState::from(&vote_state),
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None
@@ -655,7 +663,7 @@ mod tests {
             },
             calculate_stake_points_and_credits(
                 &stake,
-                DelegatedVoteState::from(&vote_state),
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None
@@ -671,7 +679,7 @@ mod tests {
             },
             calculate_stake_points_and_credits(
                 &stake,
-                DelegatedVoteState::from(&vote_state),
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None
@@ -679,7 +687,7 @@ mod tests {
         );
 
         // get rewards and credits observed when not the activation epoch
-        vote_state.inflation_rewards_commission_bps = 0;
+        vote_state.set_inflation_rewards_commission_bps(0);
         stake.credits_observed = 3;
         stake.delegation.activation_epoch = 1;
         assert_eq!(
@@ -690,8 +698,8 @@ mod tests {
             }),
             calculate_stake_rewards(
                 &stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 2,
                     point_value: &PointValue {
@@ -718,8 +726,8 @@ mod tests {
             }),
             calculate_stake_rewards(
                 &stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 2,
                     point_value: &PointValue {
@@ -738,9 +746,9 @@ mod tests {
     #[test_case(u64::MAX, 1_000, u64::MAX => panics "Rewards intermediate calculation should fit within u128")]
     #[test_case(1, u64::MAX, u64::MAX => panics "Rewards should fit within u64")]
     fn calculate_rewards_tests(stake: u64, rewards: u64, credits: u64) {
-        let mut vote_state = VoteStateV4::default();
+        let mut vote_state = VoteStateHandler::new_v4(VoteStateV4::default());
 
-        let stake = new_stake(stake, &Pubkey::default(), &vote_state, u64::MAX);
+        let stake = new_stake(stake, &Pubkey::default(), vote_state.as_ref_v4(), u64::MAX);
 
         vote_state.increment_credits(0, credits);
 
@@ -750,8 +758,8 @@ mod tests {
 
         calculate_stake_rewards(
             &stake,
-            vote_state.inflation_rewards_commission_bps,
-            DelegatedVoteState::from(&vote_state),
+            vote_state.as_ref_v4().inflation_rewards_commission_bps,
+            DelegatedVoteState::from(vote_state.as_ref_v4()),
             CalculationEnvironment {
                 rewarded_epoch: 0,
                 point_value: &PointValue { rewards, points: 1 },
@@ -765,14 +773,14 @@ mod tests {
 
     #[test]
     fn test_stake_state_calculate_points_with_typical_values() {
-        let vote_state = VoteStateV4::default();
+        let vote_state = VoteStateHandler::new_v4(VoteStateV4::default());
 
         // bootstrap means fully-vested stake at epoch 0 with
         //  10_000_000 SOL is a big but not unreasaonable stake
         let stake = new_stake(
             10_000_000 * LAMPORTS_PER_SOL,
             &Pubkey::default(),
-            &vote_state,
+            vote_state.as_ref_v4(),
             u64::MAX,
         );
         let stake_history = &StakeHistory::default();
@@ -784,8 +792,8 @@ mod tests {
             None,
             calculate_stake_rewards(
                 &stake,
-                vote_state.inflation_rewards_commission_bps,
-                DelegatedVoteState::from(&vote_state),
+                vote_state.as_ref_v4().inflation_rewards_commission_bps,
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 CalculationEnvironment {
                     rewarded_epoch: 0,
                     point_value: &PointValue {

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -240,7 +240,7 @@ mod tests {
     use {
         super::*,
         solana_native_token::LAMPORTS_PER_SOL,
-        solana_vote_program::vote_state::{VoteStateV4, handler::VoteStateHandle},
+        solana_vote_program::vote_state::{VoteStateV4, handler::VoteStateHandler},
     };
 
     impl<'a> From<&'a VoteStateV4> for DelegatedVoteState<'a> {
@@ -266,14 +266,14 @@ mod tests {
 
     #[test]
     fn test_stake_state_calculate_points_with_typical_values() {
-        let mut vote_state = VoteStateV4::default();
+        let mut vote_state = VoteStateHandler::new_v4(VoteStateV4::default());
 
         // bootstrap means fully-vested stake at epoch 0 with
         //  10_000_000 SOL is a big but not unreasonable stake
         let stake = new_stake(
             10_000_000 * LAMPORTS_PER_SOL,
             &Pubkey::default(),
-            &vote_state,
+            vote_state.as_ref_v4(),
             u64::MAX,
         );
 
@@ -289,7 +289,7 @@ mod tests {
             u128::from(stake.delegation.stake) * epoch_slots,
             calculate_stake_points(
                 &stake,
-                DelegatedVoteState::from(&vote_state),
+                DelegatedVoteState::from(vote_state.as_ref_v4()),
                 &StakeHistory::default(),
                 null_tracer(),
                 None


### PR DESCRIPTION
#### Problem
SIMD-0185 (Vote State V4) is active on all networks and the feature was cleaned up in #11759. We can further clean up the vote program a bit.

#### Summary of Changes
Move the default implementations from the `VoteStateHandle` trait to the `VoteStateHandler` API. This change sets up the next PR, which will remove the `VoteStateHandle` trait completely, and everything will just flow through `VoteStateHandler`.

Part of https://github.com/anza-xyz/agave/issues/10899