### PR TITLE
Add optional context to RPC responses

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1981,6 +1981,7 @@ pub async fn process_transaction_history(
                             encoding: Some(UiTransactionEncoding::Base64),
                             commitment: Some(CommitmentConfig::confirmed()),
                             max_supported_transaction_version: Some(0),
+                            with_context: None,
                         },
                     )
                     .await

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -832,6 +832,7 @@ pub async fn process_confirm(
                                 encoding: Some(UiTransactionEncoding::Base64),
                                 commitment: Some(CommitmentConfig::confirmed()),
                                 max_supported_transaction_version: Some(0),
+                                with_context: None,
                             },
                         )
                         .await

--- a/rpc-client-types/src/config.rs
+++ b/rpc-client-types/src/config.rs
@@ -223,6 +223,9 @@ pub struct RpcSignaturesForAddressConfig {
     pub before: Option<String>, // Signature as base-58 string
     pub until: Option<String>,  // Signature as base-58 string
     pub limit: Option<usize>,
+    /// If true, wrap the response in `{ context: { slot, ... }, value: ... }`.
+    /// If false or omitted, return the legacy response shape for backwards compatibility.
+    pub with_context: Option<bool>,
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
     pub min_context_slot: Option<Slot>,
@@ -309,6 +312,9 @@ pub struct RpcTransactionConfig {
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
     pub max_supported_transaction_version: Option<u8>,
+    /// If true, wrap the response in `{ context: { slot, ... }, value: ... }`.
+    /// If false or omitted, return the legacy response shape for backwards compatibility.
+    pub with_context: Option<bool>,
 }
 
 impl EncodingConfig for RpcTransactionConfig {

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -2735,6 +2735,7 @@ impl RpcClient {
             before: config.before.map(|signature| signature.to_string()),
             until: config.until.map(|signature| signature.to_string()),
             limit: config.limit,
+            with_context: None,
             commitment: config.commitment,
             min_context_slot: None,
         };

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -2469,6 +2469,7 @@ impl RpcClient {
     ///     encoding: Some(UiTransactionEncoding::Json),
     ///     commitment: Some(CommitmentConfig::confirmed()),
     ///     max_supported_transaction_version: Some(0),
+    ///     with_context: None,
     /// };
     /// let transaction = rpc_client.get_transaction_with_config(
     ///     &signature,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1747,18 +1747,27 @@ impl JsonRpcRequestProcessor {
         &self,
         signature: Signature,
         config: Option<RpcEncodingConfigWrapper<RpcTransactionConfig>>,
-    ) -> Result<Option<EncodedConfirmedTransactionWithStatusMeta>> {
+    ) -> Result<OptionalContext<Option<EncodedConfirmedTransactionWithStatusMeta>>> {
         self.check_if_transaction_history_enabled()?;
 
         let config = config
             .map(|config| config.convert_to_current())
             .unwrap_or_default();
+        let with_context = config.with_context.unwrap_or_default();
         let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Json);
         let max_supported_transaction_version = config.max_supported_transaction_version;
         let commitment = config.commitment.unwrap_or_default();
         check_is_at_least_confirmed(commitment)?;
 
         let confirmed_bank = self.bank(Some(CommitmentConfig::confirmed()));
+        let context_slot = if commitment.is_confirmed() {
+            confirmed_bank.slot()
+        } else {
+            self.block_commitment_cache
+                .read()
+                .unwrap()
+                .highest_super_majority_root()
+        };
         let confirmed_transaction = self
             .runtime
             .spawn_blocking({
@@ -1781,7 +1790,7 @@ impl JsonRpcRequestProcessor {
                     Ok(confirmed_tx_with_meta.encode(encoding, max_supported_transaction_version).map_err(RpcCustomError::from)?)
                 };
 
-        match confirmed_transaction.unwrap_or(None) {
+        let value = match confirmed_transaction.unwrap_or(None) {
             Some(mut confirmed_transaction) => {
                 if commitment.is_confirmed()
                     && confirmed_bank // should be redundant
@@ -1794,32 +1803,41 @@ impl JsonRpcRequestProcessor {
                             .get(confirmed_transaction.slot)
                             .map(|bank| bank.clock().unix_timestamp);
                     }
-                    return Ok(Some(encode_transaction(confirmed_transaction)?));
-                }
-
-                if confirmed_transaction.slot
+                    Some(encode_transaction(confirmed_transaction)?)
+                } else if confirmed_transaction.slot
                     <= self
                         .block_commitment_cache
                         .read()
                         .unwrap()
                         .highest_super_majority_root()
                 {
-                    return Ok(Some(encode_transaction(confirmed_transaction)?));
+                    Some(encode_transaction(confirmed_transaction)?)
+                } else {
+                    None
                 }
             }
             None => {
                 if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
-                    return bigtable_ledger_storage
+                    bigtable_ledger_storage
                         .get_confirmed_transaction(&signature)
                         .await
                         .unwrap_or(None)
                         .map(encode_transaction)
-                        .transpose();
+                        .transpose()?
+                } else {
+                    None
                 }
             }
-        }
+        };
 
-        Ok(None)
+        Ok(if with_context {
+            OptionalContext::Context(RpcResponse {
+                context: RpcResponseContext::new(context_slot),
+                value,
+            })
+        } else {
+            OptionalContext::NoContext(value)
+        })
     }
 
     pub async fn get_signatures_for_address(
@@ -1828,11 +1846,12 @@ impl JsonRpcRequestProcessor {
         before: Option<Signature>,
         until: Option<Signature>,
         mut limit: usize,
-        config: RpcContextConfig,
-    ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
+        config: RpcSignaturesForAddressConfig,
+    ) -> Result<OptionalContext<Vec<RpcConfirmedTransactionStatusWithSignature>>> {
         self.check_if_transaction_history_enabled()?;
 
         let commitment = config.commitment.unwrap_or_default();
+        let with_context = config.with_context.unwrap_or_default();
         check_is_at_least_confirmed(commitment)?;
 
         let highest_super_majority_root = self
@@ -1840,8 +1859,11 @@ impl JsonRpcRequestProcessor {
             .read()
             .unwrap()
             .highest_super_majority_root();
-        let highest_slot = if commitment.is_confirmed() {
-            let confirmed_bank = self.get_bank_with_config(config)?;
+        let context_slot = if commitment.is_confirmed() {
+            let confirmed_bank = self.get_bank_with_config(RpcContextConfig {
+                commitment: Some(commitment),
+                min_context_slot: config.min_context_slot,
+            })?;
             confirmed_bank.slot()
         } else {
             let min_context_slot = config.min_context_slot.unwrap_or_default();
@@ -1860,7 +1882,7 @@ impl JsonRpcRequestProcessor {
             found_until,
         } = self
             .blockstore
-            .get_confirmed_signatures_for_address2(address, highest_slot, before, until, limit)
+            .get_confirmed_signatures_for_address2(address, context_slot, before, until, limit)
             .map_err(|err| Error::invalid_params(format!("{err}")))?;
 
         let map_results = |results: Vec<ConfirmedTransactionStatusWithSignature>| {
@@ -1969,7 +1991,16 @@ impl JsonRpcRequestProcessor {
             }
         }
 
-        Ok(map_results(results))
+        let value = map_results(results);
+
+        Ok(if with_context {
+            OptionalContext::Context(RpcResponse {
+                context: RpcResponseContext::new(context_slot),
+                value,
+            })
+        } else {
+            OptionalContext::NoContext(value)
+        })
     }
 
     pub async fn get_first_available_block(&self) -> Slot {
@@ -3592,7 +3623,7 @@ pub mod rpc_full {
             meta: Self::Metadata,
             signature_str: String,
             config: Option<RpcEncodingConfigWrapper<RpcTransactionConfig>>,
-        ) -> BoxFuture<Result<Option<EncodedConfirmedTransactionWithStatusMeta>>>;
+        ) -> BoxFuture<Result<OptionalContext<Option<EncodedConfirmedTransactionWithStatusMeta>>>>;
 
         #[rpc(meta, name = "getSignaturesForAddress")]
         fn get_signatures_for_address(
@@ -3600,7 +3631,7 @@ pub mod rpc_full {
             meta: Self::Metadata,
             address: String,
             config: Option<RpcSignaturesForAddressConfig>,
-        ) -> BoxFuture<Result<Vec<RpcConfirmedTransactionStatusWithSignature>>>;
+        ) -> BoxFuture<Result<OptionalContext<Vec<RpcConfirmedTransactionStatusWithSignature>>>>;
 
         #[rpc(meta, name = "getFirstAvailableBlock")]
         fn get_first_available_block(&self, meta: Self::Metadata) -> BoxFuture<Result<Slot>>;
@@ -4202,7 +4233,8 @@ pub mod rpc_full {
             meta: Self::Metadata,
             signature_str: String,
             config: Option<RpcEncodingConfigWrapper<RpcTransactionConfig>>,
-        ) -> BoxFuture<Result<Option<EncodedConfirmedTransactionWithStatusMeta>>> {
+        ) -> BoxFuture<Result<OptionalContext<Option<EncodedConfirmedTransactionWithStatusMeta>>>>
+        {
             debug!("get_transaction rpc request received: {signature_str:?}");
             let signature = verify_signature(&signature_str);
             if let Err(err) = signature {
@@ -4216,11 +4248,13 @@ pub mod rpc_full {
             meta: Self::Metadata,
             address: String,
             config: Option<RpcSignaturesForAddressConfig>,
-        ) -> BoxFuture<Result<Vec<RpcConfirmedTransactionStatusWithSignature>>> {
+        ) -> BoxFuture<Result<OptionalContext<Vec<RpcConfirmedTransactionStatusWithSignature>>>>
+        {
             let RpcSignaturesForAddressConfig {
                 before,
                 until,
                 limit,
+                with_context,
                 commitment,
                 min_context_slot,
             } = config.unwrap_or_default();
@@ -4235,7 +4269,11 @@ pub mod rpc_full {
                         before,
                         until,
                         limit,
-                        RpcContextConfig {
+                        RpcSignaturesForAddressConfig {
+                            before: None,
+                            until: None,
+                            limit: None,
+                            with_context,
                             commitment,
                             min_context_slot,
                         },
@@ -6011,6 +6049,58 @@ pub mod tests {
         );
         let result: Vec<RpcKeyedAccount> = parse_success_result(rpc.handle_request_sync(request));
         assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_rpc_get_transaction_with_context() {
+        let rpc = RpcHandler::start();
+        let confirmed_block_signatures = rpc.create_test_transactions_and_populate_blockstore();
+        let signature = confirmed_block_signatures
+            .first()
+            .expect("expected at least one confirmed signature")
+            .to_string();
+
+        let request = create_test_request(
+            "getTransaction",
+            Some(json!([
+                signature,
+                {
+                    "encoding": "json",
+                    "commitment": "confirmed",
+                    "withContext": true,
+                }
+            ])),
+        );
+
+        let result: RpcResponse<Option<EncodedConfirmedTransactionWithStatusMeta>> =
+            parse_success_result(rpc.handle_request_sync(request));
+
+        assert_eq!(result.context, RpcResponseContext::new(0));
+        assert!(result.value.is_some());
+    }
+
+    #[test]
+    fn test_rpc_get_signatures_for_address_with_context() {
+        let rpc = RpcHandler::start();
+        rpc.create_test_transactions_and_populate_blockstore();
+
+        let request = create_test_request(
+            "getSignaturesForAddress",
+            Some(json!([
+                rpc.mint_keypair.pubkey().to_string(),
+                {
+                    "limit": 10,
+                    "commitment": "confirmed",
+                    "withContext": true,
+                }
+            ])),
+        );
+
+        let result: RpcResponse<Vec<RpcConfirmedTransactionStatusWithSignature>> =
+            parse_success_result(rpc.handle_request_sync(request));
+
+        assert_eq!(result.context, RpcResponseContext::new(0));
+        // Response shape should include context when requested, even if no signatures are found.
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Several RPC methods return plain values without a `context` object, which prevents clients (indexers, wallets, bots, and load-balanced deployments) from determining data freshness and making reliable atomic decisions across multiple calls. In particular, `getTransaction` can return `null` without any `context.slot`, and `getSignaturesForAddress` does not return context even though it supports `minContextSlot`, making it difficult to detect lag and reason about pagination consistency.

This PR addresses the inconsistency highlighted in [anza-xyz/agave#9028](https://github.com/anza-xyz/agave/issues/9028) by adding an opt-in, backwards-compatible context envelope to these methods.

#### Summary of Changes
* Add an optional `withContext` flag to:
    * `RpcTransactionConfig` (used by `getTransaction`)
    * `RpcSignaturesForAddressConfig` (used by `getSignaturesForAddress`)
* Update server-side RPC handlers so that:
    * When `withContext: true`, responses are returned as `{ context, value }`
    * When `withContext` is omitted or false, the legacy response shape is preserved
* Implement the above using the existing OptionalContext<T> pattern to avoid breaking existing clients
* Add RPC unit tests that send JSON-RPC requests with `withContext: true` and assert the response includes context
* Update in-repo Rust call sites constructing the config structs to include the new fields (e.g., `with_context: None`) where required

## Testing
* Added unit tests in rpc verifying the `withContext: true` response shape for:
    * `getTransaction`
     * `getSignaturesForAddress`
* Example command:
```bash
cargo test -p solana-rpc --features agave-unstable-api test_rpc_get_transaction_with_context
cargo test -p solana-rpc --features agave-unstable-api test_rpc_get_signatures_for_address_with_context
```

## Backwards compatibility
* The default response format is unchanged (legacy shape).
* The context-wrapped response is only returned when explicitly requested via withContext: true.
* The response is encoded via OptionalContext<T> (untagged) so both response shapes remain supported.

## Note
I've just changed the `getTransaction` and `getSignaturesForAddress` since it was the most recurring issue in [anza-xyz/agave#9028](https://github.com/anza-xyz/agave/issues/9028) (And to keep the PR short). I'd be happy to make further changes suggested in the issue based on feedbacks

Closes #9028 