### PR TITLE
fix(scheduling-utils): gate handshake on cfg(unix)

### DIFF
--- a/scheduling-utils/src/handshake/mod.rs
+++ b/scheduling-utils/src/handshake/mod.rs
@@ -1,6 +1,4 @@
-#[cfg(unix)]
 pub mod client;
-#[cfg(unix)]
 pub mod server;
 mod shared;
 #[cfg(test)]

--- a/scheduling-utils/src/lib.rs
+++ b/scheduling-utils/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod thread_aware_account_locks;
 
 pub mod bridge;
+#[cfg(unix)]
 pub mod handshake;
 pub mod pubkeys_ptr;
 pub mod responses_region;


### PR DESCRIPTION
#### Problem

- Various content is not used on non unix targets.

#### Summary of Changes

- Hoist the unix gate to the handhsake module instead of just subcomponents.
