### PR TITLE
EntryBytesBudget

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -10,12 +10,12 @@ use {
     solana_measure::measure_us,
     solana_poh::{
         poh_recorder::PohRecorderError,
-        transaction_recorder::{
-            RecordTransactionsSummary, RecordTransactionsTimings, TransactionRecorder,
-        },
+        transaction_recorder::{RecordTransactionsTimings, TransactionRecorder},
     },
     solana_runtime::{
-        bank::{Bank, LoadAndExecuteTransactionsOutput},
+        bank::{
+            Bank, LoadAndExecuteTransactionsOutput, entry_bytes_budget::EntryBytesReserveError,
+        },
         transaction_batch::TransactionBatch,
     },
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
@@ -32,6 +32,11 @@ use {
 
 /// Consumer will create chunks of transactions from buffer with up to this size.
 pub const TARGET_NUM_TRANSACTIONS_PER_BATCH: usize = 64;
+
+const SERIALIZED_ENTRIES_OVERHEAD: u64 = {
+    48  // Entry Header
+    + 8 // Vec<Entry> length
+};
 
 #[derive(Debug)]
 pub struct ExecutionFlags {
@@ -368,12 +373,14 @@ impl Consumer {
             attempted_processing_count: processing_results.len() as u64,
         };
 
+        let mut entry_bytes = SERIALIZED_ENTRIES_OVERHEAD;
         let (processed_transactions, processing_results_to_transactions_us) = measure_us!(
             processing_results
                 .iter()
                 .zip(batch.sanitized_transactions())
                 .filter_map(|(processing_result, tx)| {
                     if processing_result.was_processed() {
+                        entry_bytes += tx.serialized_size() as u64;
                         Some(tx.to_versioned_transaction())
                     } else {
                         None
@@ -385,25 +392,33 @@ impl Consumer {
         let (freeze_lock, freeze_lock_us) = measure_us!(bank.freeze_lock());
         execute_and_commit_timings.freeze_lock_us = freeze_lock_us;
 
-        let (record_transactions_summary, record_us) = measure_us!(
+        let reserved_bytes =
+            bank.entry_bytes_budget()
+                .reserve(entry_bytes)
+                .map_err(|err| match err {
+                    EntryBytesReserveError::ExceedsSlotLimit => PohRecorderError::MaxHeightReached,
+                });
+        let (record_transactions_summary, record_us) = measure_us!(reserved_bytes.map(|_| {
             self.transaction_recorder
                 .record_transactions(bank.bank_id(), processed_transactions)
-        );
+        }));
         execute_and_commit_timings.record_us = record_us;
 
-        let RecordTransactionsSummary {
-            result: record_transactions_result,
-            record_transactions_timings,
-            starting_transaction_index,
-        } = record_transactions_summary;
-        execute_and_commit_timings.record_transactions_timings = RecordTransactionsTimings {
-            processing_results_to_transactions_us: Saturating(
-                processing_results_to_transactions_us,
-            ),
-            ..record_transactions_timings
+        let (recording_result, starting_transaction_index) = match record_transactions_summary {
+            Ok(summary) => {
+                execute_and_commit_timings.record_transactions_timings =
+                    RecordTransactionsTimings {
+                        processing_results_to_transactions_us: Saturating(
+                            processing_results_to_transactions_us,
+                        ),
+                        ..summary.record_transactions_timings
+                    };
+                (summary.result, summary.starting_transaction_index)
+            }
+            Err(err) => (Err(err), None),
         };
 
-        if let Err(recorder_err) = record_transactions_result {
+        if let Err(recorder_err) = recording_result {
             retryable_transaction_indexes.extend(processing_results.iter().enumerate().filter_map(
                 |(index, processing_result)| {
                     processing_result.was_processed().then_some(RetryableIndex {

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -322,6 +322,10 @@ impl solana_runtime_transaction::transaction_with_meta::TransactionWithMeta
     fn to_versioned_transaction(&self) -> solana_transaction::versioned::VersionedTransaction {
         unimplemented!("WritableKeysTransaction::to_versioned_transaction")
     }
+
+    fn serialized_size(&self) -> usize {
+        unimplemented!("WritableKeysTransaction::serialized_size")
+    }
 }
 
 #[cfg(test)]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8687,6 +8687,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-transaction-view",
+ "bincode",
  "solana-compute-budget-instruction",
  "solana-hash 4.3.0",
  "solana-message",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8319,6 +8319,7 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-transaction-view",
+ "bincode",
  "solana-compute-budget-instruction",
  "solana-hash 4.3.0",
  "solana-message",

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -23,6 +23,7 @@ dev-context-only-utils = ["solana-compute-budget-instruction/dev-context-only-ut
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-transaction-view = { workspace = true }
+bincode = { workspace = true }
 solana-compute-budget-instruction = { workspace = true }
 solana-hash = { workspace = true }
 solana-message = { workspace = true, features = ["blake3", "wincode"] }
@@ -30,14 +31,13 @@ solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true }
 solana-svm-transaction = { workspace = true }
-solana-transaction = { workspace = true }
+solana-transaction = { workspace = true, features = ["serde"] }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
 
 [dev-dependencies]
 agave-feature-set = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
-bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
 solana-compute-budget-instruction = { path = "../compute-budget-instruction", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -151,6 +151,11 @@ impl TransactionWithMeta for RuntimeTransaction<SanitizedTransaction> {
     fn to_versioned_transaction(&self) -> VersionedTransaction {
         self.transaction.to_versioned_transaction()
     }
+
+    fn serialized_size(&self) -> usize {
+        bincode::serialized_size(&self.to_versioned_transaction())
+            .expect("versioned transaction serialization should succeed") as usize
+    }
 }
 
 #[cfg(feature = "dev-context-only-utils")]
@@ -370,6 +375,24 @@ mod tests {
                     .get()
             );
         }
+    }
+
+    #[test]
+    fn test_serialized_size() {
+        let transaction = RuntimeTransaction::<SanitizedTransaction>::try_from(
+            RuntimeTransaction::<SanitizedVersionedTransaction>::try_from(
+                non_vote_sanitized_versioned_transaction(),
+                MessageHash::Compute,
+                None,
+            )
+            .unwrap(),
+            SimpleAddressLoader::Disabled,
+            &ReservedAccountKeys::empty_key_set(),
+        )
+        .unwrap();
+
+        let expected = bincode::serialized_size(&transaction.to_versioned_transaction()).unwrap();
+        assert_eq!(transaction.serialized_size(), expected as usize);
     }
 
     #[test]

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -231,6 +231,10 @@ impl<D: TransactionData> TransactionWithMeta for RuntimeTransaction<ResolvedTran
             message,
         }
     }
+
+    fn serialized_size(&self) -> usize {
+        self.transaction.data().len()
+    }
 }
 
 #[cfg(test)]
@@ -435,6 +439,37 @@ mod tests {
             sanitized_transaction,
             Some(loaded_addresses),
             &reserved_key_set,
+        );
+    }
+
+    #[test]
+    fn test_serialized_size() {
+        let serialized_transaction =
+            bincode::serialize(&VersionedTransaction::from(system_transaction::transfer(
+                &Keypair::new(),
+                &Pubkey::new_unique(),
+                1,
+                Hash::new_unique(),
+            )))
+            .unwrap();
+        let transaction_view =
+            SanitizedTransactionView::try_new_sanitized(&serialized_transaction[..], true).unwrap();
+        let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
+            transaction_view,
+            MessageHash::Compute,
+            None,
+        )
+        .unwrap();
+        let runtime_transaction = RuntimeTransaction::<ResolvedTransactionView<_>>::try_new(
+            runtime_transaction,
+            None,
+            &ReservedAccountKeys::empty_key_set(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            runtime_transaction.serialized_size(),
+            serialized_transaction.len()
         );
     }
 }

--- a/runtime-transaction/src/transaction_with_meta.rs
+++ b/runtime-transaction/src/transaction_with_meta.rs
@@ -14,4 +14,8 @@ pub trait TransactionWithMeta: TransactionMeta + SVMTransaction {
     /// `VersionedTransaction`. This should not be used unless necessary, as it
     /// performs numerous allocations that negatively impact performance.
     fn to_versioned_transaction(&self) -> VersionedTransaction;
+
+    /// Returns the serialized transaction size in bytes.
+    /// Runtime metadata is not included.
+    fn serialized_size(&self) -> usize;
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -37,6 +37,7 @@ use {
     crate::{
         account_saver::collect_accounts_to_store,
         bank::{
+            entry_bytes_budget::EntryBytesBudget,
             metrics::*,
             partitioned_epoch_rewards::{
                 CachedVoteAccounts, EpochRewardStatus, RewardCommissionAccounts,
@@ -228,6 +229,7 @@ mod address_lookup_table;
 pub mod bank_hash_details;
 pub mod builtins;
 mod check_transactions;
+pub mod entry_bytes_budget;
 mod fee_distribution;
 mod metrics;
 pub(crate) mod partitioned_epoch_rewards;
@@ -556,6 +558,7 @@ impl PartialEq for Bank {
             transaction_error_count: _,
             transaction_entries_count: _,
             transactions_per_entry_max: _,
+            entry_bytes_consumed: _,
             tick_height,
             signature_count,
             capitalization,
@@ -690,6 +693,7 @@ impl BankFieldsToSerialize {
 pub enum RewardCalculationEvent<'a, 'b> {
     Staking(&'a Pubkey, &'b InflationPointCalculationEvent),
 }
+const MAX_ENTRY_BYTES_PER_SLOT: u64 = 20 * 1024 * 1024; // 20 MiB
 
 /// type alias is not supported for trait in rust yet. As a workaround, we define the
 /// `RewardCalcTracer` trait explicitly and implement it on any type that implement
@@ -800,6 +804,9 @@ pub struct Bank {
 
     /// The max number of transaction in an entry in this slot
     transactions_per_entry_max: AtomicU64,
+
+    /// The number of entry bytes reserved for recording in this slot.
+    entry_bytes_consumed: EntryBytesBudget,
 
     /// Bank tick height
     tick_height: AtomicU64,
@@ -1106,6 +1113,7 @@ impl Bank {
             transaction_error_count: AtomicU64::default(),
             transaction_entries_count: AtomicU64::default(),
             transactions_per_entry_max: AtomicU64::default(),
+            entry_bytes_consumed: EntryBytesBudget::new(MAX_ENTRY_BYTES_PER_SLOT),
             tick_height: AtomicU64::default(),
             signature_count: AtomicU64::default(),
             capitalization: AtomicU64::default(),
@@ -1362,6 +1370,7 @@ impl Bank {
             transaction_error_count: AtomicU64::new(0),
             transaction_entries_count: AtomicU64::new(0),
             transactions_per_entry_max: AtomicU64::new(0),
+            entry_bytes_consumed: EntryBytesBudget::new(parent.entry_bytes_budget().slot_limit()),
             // we will .clone_with_epoch() this soon after stake data update; so just .clone() for now
             stakes_cache,
             epoch_stakes,
@@ -1948,6 +1957,7 @@ impl Bank {
             transaction_error_count: AtomicU64::default(),
             transaction_entries_count: AtomicU64::default(),
             transactions_per_entry_max: AtomicU64::default(),
+            entry_bytes_consumed: EntryBytesBudget::new(MAX_ENTRY_BYTES_PER_SLOT),
             tick_height: AtomicU64::new(fields.tick_height),
             signature_count: AtomicU64::new(fields.signature_count),
             capitalization: AtomicU64::new(fields.capitalization),
@@ -4751,6 +4761,10 @@ impl Bank {
 
     pub fn transactions_per_entry_max(&self) -> u64 {
         self.transactions_per_entry_max.load(Relaxed)
+    }
+
+    pub fn entry_bytes_budget(&self) -> &EntryBytesBudget {
+        &self.entry_bytes_consumed
     }
 
     fn increment_transaction_count(&self, tx_count: u64) {

--- a/runtime/src/bank/entry_bytes_budget.rs
+++ b/runtime/src/bank/entry_bytes_budget.rs
@@ -1,0 +1,76 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryBytesReserveError {
+    ExceedsSlotLimit,
+}
+
+#[derive(Debug)]
+pub struct EntryBytesBudget {
+    consumed: AtomicU64,
+    slot_limit: u64,
+}
+
+impl EntryBytesBudget {
+    pub const fn new(slot_limit: u64) -> Self {
+        Self {
+            consumed: AtomicU64::new(0),
+            slot_limit,
+        }
+    }
+
+    pub const fn slot_limit(&self) -> u64 {
+        self.slot_limit
+    }
+
+    pub fn reserve(&self, bytes: u64) -> std::result::Result<(), EntryBytesReserveError> {
+        loop {
+            let current = self.consumed.load(Ordering::Acquire);
+            let next = current.saturating_add(bytes);
+            if next > self.slot_limit {
+                return Err(EntryBytesReserveError::ExceedsSlotLimit);
+            }
+
+            if self
+                .consumed
+                .compare_exchange(current, next, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const TEST_SLOT_LIMIT: u64 = 1_000;
+
+    #[test]
+    fn test_load_new() {
+        let budget = EntryBytesBudget::new(TEST_SLOT_LIMIT);
+        assert_eq!(budget.consumed.load(Ordering::Acquire), 0);
+        assert_eq!(budget.slot_limit(), TEST_SLOT_LIMIT);
+    }
+
+    #[test]
+    fn test_reserve() {
+        let budget = EntryBytesBudget::new(TEST_SLOT_LIMIT);
+
+        assert!(budget.reserve(100).is_ok());
+        assert_eq!(budget.consumed.load(Ordering::Acquire), 100);
+    }
+
+    #[test]
+    fn test_reserve_rejects_over_limit() {
+        let budget = EntryBytesBudget::new(TEST_SLOT_LIMIT);
+
+        assert!(budget.reserve(TEST_SLOT_LIMIT - 1).is_ok());
+        assert_eq!(
+            budget.reserve(2),
+            Err(EntryBytesReserveError::ExceedsSlotLimit)
+        );
+        assert_eq!(budget.consumed.load(Ordering::Acquire), TEST_SLOT_LIMIT - 1);
+    }
+}


### PR DESCRIPTION
#### Problem
  - Large blocks take longer to propagate through Turbine.
  - We want to bound block size by bytes, not just transaction volume, to reduce propagation delay.

#### Summary of Changes
  - Added EntryBytesBudget to Bank with a 20 MiB per-slot limit and atomic byte reservation.
  - Updated banking stage recording to estimate serialized entry bytes for processed transactions and reserve that budget before recording.
  - Stop recording when the entry byte budget is exhausted, using the existing recorder flow for slot-ending behavior.
  - Extended TransactionWithMeta with serialized_size() and implemented it for the runtime transaction types used here.
  - Added tests for byte-budget reservation and serialized-size calculation.