### PR TITLE
cpi: fix error message + add clone attribute for MemoryTranslationError

### DIFF
--- a/program-runtime/src/memory.rs
+++ b/program-runtime/src/memory.rs
@@ -7,11 +7,11 @@ use {
 };
 
 /// Error types for memory translation operations.
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq, Clone)]
 pub enum MemoryTranslationError {
     #[error("Unaligned pointer")]
     UnalignedPointer,
-    #[error("Invalid length")]
+    #[error("InvalidLength")]
     InvalidLength,
 }
 


### PR DESCRIPTION
#### Problem
The string message for `MemoryTranslationError::InvalidLength` is inconsistent with `SyscallError::InvalidLength` and `CpiError::InvalidLength`. Additionally, the clone attribute is needed downstream inside solfuzz-agave to handle errors when capturing test effects.

#### Summary of Changes
* Derive `Clone` for `MemoryTranslationError`
* Change string error message from `Invalid length` to `InvalidLength` for `MemoryTranslationError::InvalidLength`.
