### PR TITLE
Make ancestors mandatory for get_with_and_then

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3458,7 +3458,7 @@ impl AccountsDb {
             }
             self.accounts_index.get_with_and_then(
                 &pubkey,
-                Some(ancestors),
+                ancestors,
                 Some(max_root),
                 true,
                 |(slot, account_info)| {
@@ -3605,7 +3605,7 @@ impl AccountsDb {
         let max_root_slot = ancestors.min_slot();
         self.accounts_index.get_with_and_then(
             pubkey,
-            Some(ancestors),
+            ancestors,
             max_root_slot,
             true,
             |(slot, account_info)| {
@@ -4823,7 +4823,7 @@ impl AccountsDb {
                             .accounts_index
                             .get_with_and_then(
                                 &pubkey,
-                                Some(ancestors),
+                                ancestors,
                                 Some(startup_slot),
                                 false,
                                 |(slot, account_info)| {
@@ -4882,7 +4882,7 @@ impl AccountsDb {
                         self.accounts_index
                             .get_with_and_then(
                                 &pubkey,
-                                Some(ancestors),
+                                ancestors,
                                 Some(startup_slot),
                                 false,
                                 |(slot, account_info)| {
@@ -5625,7 +5625,7 @@ impl AccountsDb {
                     return;
                 }
                 if account.is_zero_lamport() {
-                    if ancestors.is_some() {
+                    if let Some(ancestors) = ancestors {
                         if let Some(is_zero_lamport) = self.accounts_index.get_with_and_then(
                             pubkey,
                             ancestors,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -881,23 +881,15 @@ fn test_clean_zero_lamport_and_dead_slot() {
     let ancestors = Ancestors::from(vec![0]);
     let (slot1, account_info1) = accounts
         .accounts_index
-        .get_with_and_then(
-            &pubkey1,
-            Some(&ancestors),
-            None,
-            false,
-            |(slot, account_info)| (slot, account_info),
-        )
+        .get_with_and_then(&pubkey1, &ancestors, None, false, |(slot, account_info)| {
+            (slot, account_info)
+        })
         .unwrap();
     let (slot2, account_info2) = accounts
         .accounts_index
-        .get_with_and_then(
-            &pubkey2,
-            Some(&ancestors),
-            None,
-            false,
-            |(slot, account_info)| (slot, account_info),
-        )
+        .get_with_and_then(&pubkey2, &ancestors, None, false, |(slot, account_info)| {
+            (slot, account_info)
+        })
         .unwrap();
     assert_eq!(slot1, 0);
     assert_eq!(slot1, slot2);
@@ -1514,15 +1506,16 @@ fn test_accounts_db_purge_keep_live() {
     // since the store count will not be zero
     accounts.store_for_tests((current_slot, [(&pubkey2, &account2)].as_slice()));
     accounts.add_root_and_flush_write_cache(current_slot);
+    let ancestors = Ancestors::from(vec![accounts.accounts_index.max_root_inclusive()]);
     let (slot1, account_info1) = accounts
         .accounts_index
-        .get_with_and_then(&pubkey, None, None, false, |(slot, account_info)| {
+        .get_with_and_then(&pubkey, &ancestors, None, false, |(slot, account_info)| {
             (slot, account_info)
         })
         .unwrap();
     let (slot2, account_info2) = accounts
         .accounts_index
-        .get_with_and_then(&pubkey2, None, None, false, |(slot, account_info)| {
+        .get_with_and_then(&pubkey2, &ancestors, None, false, |(slot, account_info)| {
             (slot, account_info)
         })
         .unwrap();
@@ -3283,7 +3276,7 @@ impl AccountsDb {
 
         self.accounts_index.get_with_and_then(
             pubkey,
-            Some(&ancestors),
+            &ancestors,
             max_root,
             false,
             |(slot_found, account_info)| {
@@ -3494,11 +3487,12 @@ fn test_accounts_db_cache_clean_dead_slots() {
 
     // Before the flush, we can find entries in the database for slots < alive_slot if we specify
     // a smaller max root
+    let ancestors = Ancestors::from(vec![last_dead_slot]);
     for key in &keys {
         assert!(
             accounts_db
                 .accounts_index
-                .get_with_and_then(key, None, Some(last_dead_slot), false, |_| {})
+                .get_with_and_then(key, &ancestors, Some(last_dead_slot), false, |_| {})
                 .is_some()
         );
     }
@@ -3520,7 +3514,7 @@ fn test_accounts_db_cache_clean_dead_slots() {
         assert!(
             accounts_db
                 .accounts_index
-                .get_with_and_then(key, None, Some(last_dead_slot), false, |_| {})
+                .get_with_and_then(key, &ancestors, Some(last_dead_slot), false, |_| {})
                 .is_none()
         );
     }
@@ -5483,13 +5477,14 @@ fn test_shrink_collect_with_obsolete_accounts() {
     db.add_root_and_flush_write_cache(slot);
 
     let storage = db.get_and_assert_single_storage(slot);
+    let ancestors = Ancestors::from(vec![db.accounts_index.max_root_inclusive()]);
 
     for (i, pubkey) in pubkeys.iter().enumerate() {
         // Mark Some accounts obsolete. These will include zero lamport and non zero lamport accounts
         if i % 5 == 0 {
             // Lookup the pubkey in the database and find the AccountInfo
             db.accounts_index
-                .get_with_and_then(pubkey, None, None, false, |account_info| {
+                .get_with_and_then(pubkey, &ancestors, None, false, |account_info| {
                     db.remove_dead_accounts(
                         [account_info].iter(),
                         None,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3486,13 +3486,13 @@ fn test_accounts_db_cache_clean_dead_slots() {
     }
 
     // Before the flush, we can find entries in the database for slots < alive_slot if we specify
-    // a smaller max root
+    // an older ancestor set
     let ancestors = Ancestors::from(vec![last_dead_slot]);
     for key in &keys {
         assert!(
             accounts_db
                 .accounts_index
-                .get_with_and_then(key, &ancestors, Some(last_dead_slot), false, |_| {})
+                .get_with_and_then(key, &ancestors, None, false, |_| {})
                 .is_some()
         );
     }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -314,14 +314,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     pub(crate) fn get_with_and_then<R>(
         &self,
         pubkey: &Pubkey,
-        ancestors: Option<&Ancestors>,
+        ancestors: &Ancestors,
         max_root: Option<Slot>,
         should_add_to_in_mem_cache: bool,
         callback: impl FnOnce(SlotListItem<T>) -> R,
     ) -> Option<R> {
         self.get_and_then(pubkey, |entry| {
             let callback_result = entry.and_then(|entry| {
-                self.get_account_info_with_and_then(entry, ancestors, max_root, callback)
+                self.get_account_info_with_and_then(entry, Some(ancestors), max_root, callback)
             });
             (should_add_to_in_mem_cache, callback_result)
         })
@@ -352,7 +352,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     fn contains_with(
         &self,
         pubkey: &Pubkey,
-        ancestors: Option<&Ancestors>,
+        ancestors: &Ancestors,
         max_root: Option<Slot>,
     ) -> bool {
         self.get_with_and_then(pubkey, ancestors, max_root, false, |_| ())
@@ -1373,8 +1373,7 @@ mod tests {
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let ancestors = Ancestors::default();
         let key = &key;
-        assert!(!index.contains_with(key, Some(&ancestors), None));
-        assert!(!index.contains_with(key, None, None));
+        assert!(!index.contains_with(key, &ancestors, None));
 
         let mut num = 0;
         index.scan_accounts(
@@ -1451,8 +1450,7 @@ mod tests {
         assert!(gc.is_empty());
 
         let ancestors = Ancestors::default();
-        assert!(!index.contains_with(&key, Some(&ancestors), None));
-        assert!(!index.contains_with(&key, None, None));
+        assert!(!index.contains_with(&key, &ancestors, None));
 
         let mut num = 0;
         index.scan_accounts(
@@ -1513,8 +1511,7 @@ mod tests {
         index.set_startup(Startup::Normal);
 
         let mut ancestors = Ancestors::default();
-        assert!(!index.contains_with(pubkey, Some(&ancestors), None));
-        assert!(!index.contains_with(pubkey, None, None));
+        assert!(!index.contains_with(pubkey, &ancestors, None));
 
         let mut num = 0;
         index.scan_accounts(
@@ -1525,7 +1522,7 @@ mod tests {
         );
         assert_eq!(num, 0);
         ancestors.insert(slot);
-        assert!(index.contains_with(pubkey, Some(&ancestors), None));
+        assert!(index.contains_with(pubkey, &ancestors, None));
         assert_eq!(index.ref_count_from_storage(pubkey), 1);
         index.scan_accounts(
             &ancestors,
@@ -1546,8 +1543,7 @@ mod tests {
         index.set_startup(Startup::Normal);
 
         let mut ancestors = Ancestors::default();
-        assert!(!index.contains_with(pubkey, Some(&ancestors), None));
-        assert!(!index.contains_with(pubkey, None, None));
+        assert!(!index.contains_with(pubkey, &ancestors, None));
 
         let mut num = 0;
         index.scan_accounts(
@@ -1558,7 +1554,7 @@ mod tests {
         );
         assert_eq!(num, 0);
         ancestors.insert(slot);
-        assert!(index.contains_with(pubkey, Some(&ancestors), None));
+        assert!(index.contains_with(pubkey, &ancestors, None));
         assert_eq!(index.ref_count_from_storage(pubkey), 1);
         index.scan_accounts(
             &ancestors,
@@ -1955,8 +1951,7 @@ mod tests {
         assert_eq!(1, account_maps_stats_len(&index));
 
         let mut ancestors = Ancestors::default();
-        assert!(!index.contains_with(&key, Some(&ancestors), None));
-        assert!(!index.contains_with(&key, None, None));
+        assert!(!index.contains_with(&key, &ancestors, None));
         index.get_and_then(&key, |entry| {
             let (stored_slot, value) = entry.unwrap().slot_list_read_lock()[0];
             assert_eq!(stored_slot, slot);
@@ -1973,7 +1968,7 @@ mod tests {
         );
         assert_eq!(num, 0);
         ancestors.insert(slot);
-        assert!(index.contains_with(&key, Some(&ancestors), None));
+        assert!(index.contains_with(&key, &ancestors, None));
         index.scan_accounts(
             &ancestors,
             index.max_root_inclusive(),
@@ -2001,7 +1996,7 @@ mod tests {
         assert!(gc.is_empty());
 
         let ancestors = Ancestors::from(vec![1]);
-        assert!(!index.contains_with(&key, Some(&ancestors), None));
+        assert!(!index.contains_with(&key, &ancestors, None));
 
         let mut num = 0;
         index.scan_accounts(
@@ -2126,16 +2121,10 @@ mod tests {
 
         let ancestors = Ancestors::from(vec![0]);
         index
-            .get_with_and_then(
-                &key,
-                Some(&ancestors),
-                None,
-                false,
-                |(slot, account_info)| {
-                    assert_eq!(slot, 0);
-                    assert!(account_info);
-                },
-            )
+            .get_with_and_then(&key, &ancestors, None, false, |(slot, account_info)| {
+                assert_eq!(slot, 0);
+                assert!(account_info);
+            })
             .unwrap();
 
         let mut num = 0;
@@ -2246,8 +2235,9 @@ mod tests {
         assert!(gc.is_empty());
 
         index.add_root(0);
+        let ancestors = Ancestors::from(vec![index.max_root_inclusive()]);
         index
-            .get_with_and_then(&key, None, None, false, |(slot, account_info)| {
+            .get_with_and_then(&key, &ancestors, None, false, |(slot, account_info)| {
                 assert_eq!(slot, 0);
                 assert!(account_info);
             })
@@ -2293,16 +2283,10 @@ mod tests {
         );
         assert!(gc.is_empty());
         index
-            .get_with_and_then(
-                &key,
-                Some(&ancestors),
-                None,
-                false,
-                |(slot, account_info)| {
-                    assert_eq!(slot, 0);
-                    assert_eq!(account_info, 1);
-                },
-            )
+            .get_with_and_then(&key, &ancestors, None, false, |(slot, account_info)| {
+                assert_eq!(slot, 0);
+                assert_eq!(account_info, 1);
+            })
             .unwrap();
 
         let mut gc = ReclaimsSlotList::new();
@@ -2318,16 +2302,10 @@ mod tests {
         );
         assert_eq!(gc, ReclaimsSlotList::from([(0, 1)]));
         index
-            .get_with_and_then(
-                &key,
-                Some(&ancestors),
-                None,
-                false,
-                |(slot, account_info)| {
-                    assert_eq!(slot, 0);
-                    assert_eq!(account_info, 0);
-                },
-            )
+            .get_with_and_then(&key, &ancestors, None, false, |(slot, account_info)| {
+                assert_eq!(slot, 0);
+                assert_eq!(account_info, 0);
+            })
             .unwrap();
     }
 
@@ -2361,29 +2339,17 @@ mod tests {
         );
         assert!(gc.is_empty());
         index
-            .get_with_and_then(
-                &key,
-                Some(&ancestors),
-                None,
-                false,
-                |(slot, account_info)| {
-                    assert_eq!(slot, 0);
-                    assert!(account_info);
-                },
-            )
+            .get_with_and_then(&key, &ancestors, None, false, |(slot, account_info)| {
+                assert_eq!(slot, 0);
+                assert!(account_info);
+            })
             .unwrap();
         let ancestors = Ancestors::from(vec![1]);
         index
-            .get_with_and_then(
-                &key,
-                Some(&ancestors),
-                None,
-                false,
-                |(slot, account_info)| {
-                    assert_eq!(slot, 1);
-                    assert!(!account_info);
-                },
-            )
+            .get_with_and_then(&key, &ancestors, None, false, |(slot, account_info)| {
+                assert_eq!(slot, 1);
+                assert!(!account_info);
+            })
             .unwrap();
     }
 
@@ -2450,8 +2416,9 @@ mod tests {
         // Updating index should not purge older roots, only purges
         // previous updates within the same slot
         assert_eq!(gc, ReclaimsSlotList::new());
+        let ancestors = Ancestors::from(vec![index.max_root_inclusive()]);
         index
-            .get_with_and_then(&key, None, None, false, |(slot, account_info)| {
+            .get_with_and_then(&key, &ancestors, None, false, |(slot, account_info)| {
                 assert_eq!(slot, 3);
                 assert!(account_info);
             })
@@ -2779,31 +2746,19 @@ mod tests {
         // Verify that the item added is in in the slot list
         let ancestors = Ancestors::from(vec![reclaim_slot]);
         index
-            .get_with_and_then(
-                &key,
-                Some(&ancestors),
-                None,
-                false,
-                |(slot, account_info)| {
-                    assert_eq!(slot, reclaim_slot);
-                    assert_eq!(account_info, account_value);
-                },
-            )
+            .get_with_and_then(&key, &ancestors, None, false, |(slot, account_info)| {
+                assert_eq!(slot, reclaim_slot);
+                assert_eq!(account_info, account_value);
+            })
             .unwrap();
 
         // Verify that the newer item remains in the slot list
         let ancestors = Ancestors::from(vec![reclaim_slot + 1]);
         index
-            .get_with_and_then(
-                &key,
-                Some(&ancestors),
-                None,
-                false,
-                |(slot, account_info)| {
-                    assert_eq!(slot, reclaim_slot + 1);
-                    assert_eq!(account_info, account_value + 1);
-                },
-            )
+            .get_with_and_then(&key, &ancestors, None, false, |(slot, account_info)| {
+                assert_eq!(slot, reclaim_slot + 1);
+                assert_eq!(account_info, account_value + 1);
+            })
             .unwrap();
     }
 


### PR DESCRIPTION
#### Problem
Get_with_and_then always uses ancestors during runtime, but optionally can have None for testing purposes. This creates a potential vector for bugs if it's used improperly runtime.

#### Summary of Changes
- Make ancestors non-optional 
- Calls to get_with_and_then with None for max_root and ancestors end up using the index max_root. Replace those callsites with the equivalent ancestors structure which is ancestors with index.max_root added

Fixes #
