### PR TITLE
xdp: enforce SocketAddrV4 in xdp api

### DIFF
--- a/net-utils/src/socket_addr_space.rs
+++ b/net-utils/src/socket_addr_space.rs
@@ -1,4 +1,4 @@
-use std::net::{IpAddr, SocketAddr};
+use std::net::{SocketAddr, SocketAddrV4};
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum SocketAddrSpace {
@@ -18,23 +18,33 @@ impl SocketAddrSpace {
     /// Returns true if the IP address is valid.
     #[inline]
     #[must_use]
+    pub fn check_v4(&self, addr: &SocketAddrV4) -> bool {
+        if matches!(self, SocketAddrSpace::Unspecified) {
+            return true;
+        }
+
+        let addr = addr.ip();
+        // TODO: Consider excluding:
+        // addr.is_link_local() || addr.is_broadcast()
+        // || addr.is_documentation() || addr.is_unspecified()
+        !(addr.is_private() || addr.is_loopback())
+    }
+
+    /// Returns true if the IP address is valid.
+    #[inline]
+    #[must_use]
     pub fn check(&self, addr: &SocketAddr) -> bool {
         if matches!(self, SocketAddrSpace::Unspecified) {
             return true;
         }
 
         // TODO: remove these once IpAddr::is_global is stable.
-        match addr.ip() {
-            IpAddr::V4(addr) => {
-                // TODO: Consider excluding:
-                // addr.is_link_local() || addr.is_broadcast()
-                // || addr.is_documentation() || addr.is_unspecified()
-                !(addr.is_private() || addr.is_loopback())
-            }
-            IpAddr::V6(addr) => {
+        match addr {
+            SocketAddr::V4(addr) => self.check_v4(addr),
+            SocketAddr::V6(addr) => {
                 // TODO: Consider excluding:
                 // addr.is_unspecified(),
-                !addr.is_loopback()
+                !addr.ip().is_loopback()
             }
         }
     }

--- a/turbine/src/addr_cache.rs
+++ b/turbine/src/addr_cache.rs
@@ -8,7 +8,7 @@ use {
     std::{
         cmp::Reverse,
         collections::{HashMap, VecDeque, hash_map::Entry},
-        net::SocketAddr,
+        net::SocketAddrV4,
     },
 };
 
@@ -51,8 +51,8 @@ pub(crate) struct AddrCache {
 struct CacheEntry {
     // Root distance and socket addresses cached either speculatively or when
     // retransmitting incoming shreds.
-    code: Vec<Option<(/*root_distance:*/ u8, Box<[SocketAddr]>)>>,
-    data: Vec<Option<(/*root_distance:*/ u8, Box<[SocketAddr]>)>>,
+    code: Vec<Option<(/*root_distance:*/ u8, Box<[SocketAddrV4]>)>>,
+    data: Vec<Option<(/*root_distance:*/ u8, Box<[SocketAddrV4]>)>>,
     // Code and data indices where [..index] are fully populated.
     index_code: usize,
     index_data: usize,
@@ -81,7 +81,7 @@ impl AddrCache {
 
     // Returns (root-distance, socket-addresses) cached for the given shred-id.
     #[inline]
-    pub(crate) fn get(&self, shred: &ShredId) -> Option<(/*root_distance:*/ u8, &[SocketAddr])> {
+    pub(crate) fn get(&self, shred: &ShredId) -> Option<(/*root_distance:*/ u8, &[SocketAddrV4])> {
         self.cache
             .get(&shred.slot())?
             .get(shred.shred_type(), shred.index())
@@ -92,7 +92,7 @@ impl AddrCache {
     pub(crate) fn put(
         &mut self,
         shred: &ShredId,
-        entry: (/*root_distance:*/ u8, Box<[SocketAddr]>),
+        entry: (/*root_distance:*/ u8, Box<[SocketAddrV4]>),
     ) {
         self.get_cache_entry_mut(shred.slot())
             .put(shred.shred_type(), shred.index(), entry);
@@ -266,7 +266,7 @@ impl CacheEntry {
         &self,
         shred_type: ShredType,
         shred_index: u32,
-    ) -> Option<(/*root_distance:*/ u8, &[SocketAddr])> {
+    ) -> Option<(/*root_distance:*/ u8, &[SocketAddrV4])> {
         match shred_type {
             ShredType::Code => &self.code,
             ShredType::Data => &self.data,
@@ -283,7 +283,7 @@ impl CacheEntry {
         &mut self,
         shred_type: ShredType,
         shred_index: u32,
-        entry: (/*root_distance:*/ u8, Box<[SocketAddr]>),
+        entry: (/*root_distance:*/ u8, Box<[SocketAddrV4]>),
     ) {
         let cache = match shred_type {
             ShredType::Code => &mut self.code,

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -32,7 +32,7 @@ use {
     solana_time_utils::{AtomicInterval, timestamp},
     std::{
         collections::{HashMap, HashSet},
-        net::UdpSocket,
+        net::{SocketAddr, UdpSocket},
         sync::{
             Arc, Mutex, RwLock,
             atomic::{AtomicBool, Ordering},
@@ -518,7 +518,7 @@ pub fn broadcast_shreds(
                 let addr = cluster_nodes
                     .get_broadcast_peer(&key)?
                     .tvu(Protocol::UDP)
-                    .filter(|addr| !addr.is_ipv6() && socket_addr_space.check(addr))?;
+                    .filter(|addr| socket_addr_space.check_v4(addr))?;
 
                 Some((shred.payload(), addr))
             })
@@ -531,6 +531,9 @@ pub fn broadcast_shreds(
     match socket {
         BroadcastSocket::Udp(s) => {
             let mut send_mmsg_time = Measure::start("send_mmsg");
+            let packets = packets
+                .iter()
+                .map(|(payload, addr)| (payload, SocketAddr::V4(*addr)));
             match batch_send(s, packets) {
                 Ok(()) => (),
                 Err(SendPktsError::IoError(ioerr, num_failed)) => {

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -379,7 +379,8 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             .iter()
             .filter_map(|shred| {
                 let node = cluster_nodes.get_broadcast_peer(&shred.id())?;
-                if !socket_addr_space.check(&node.tvu(Protocol::UDP)?) {
+                let addr = node.tvu(Protocol::UDP)?;
+                if !socket_addr_space.check_v4(&addr) {
                     return None;
                 }
                 if self
@@ -428,7 +429,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     );
                 }
 
-                Some(vec![(shred.payload(), node.tvu(Protocol::UDP)?)])
+                Some(vec![(shred.payload(), SocketAddr::V4(addr))])
             })
             .flatten()
             .collect();

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -31,7 +31,7 @@ use {
         collections::{HashMap, HashSet},
         iter::repeat_with,
         marker::PhantomData,
-        net::SocketAddr,
+        net::{SocketAddr, SocketAddrV4},
         sync::{Arc, OnceLock, RwLock},
         time::{Duration, Instant},
     },
@@ -68,7 +68,7 @@ enum NodeId {
 pub(crate) struct ContactInfo {
     pubkey: Pubkey,
     wallclock: u64,
-    tvu_udp: Option<SocketAddr>,
+    tvu_udp: Option<SocketAddrV4>,
 }
 
 pub struct Node {
@@ -137,7 +137,7 @@ impl ContactInfo {
     }
 
     #[inline]
-    pub(crate) fn tvu(&self, protocol: Protocol) -> Option<SocketAddr> {
+    pub(crate) fn tvu(&self, protocol: Protocol) -> Option<SocketAddrV4> {
         match protocol {
             Protocol::QUIC => None,
             Protocol::UDP => self.tvu_udp,
@@ -265,7 +265,7 @@ impl ClusterNodes<RetransmitStage> {
         shred: &ShredId,
         fanout: usize,
         socket_addr_space: &SocketAddrSpace,
-    ) -> Result<(/*root_distance:*/ u8, Vec<SocketAddr>), Error> {
+    ) -> Result<(/*root_distance:*/ u8, Vec<SocketAddrV4>), Error> {
         // Exclude slot leader from list of nodes.
         if slot_leader == &self.pubkey {
             return Err(Error::Loopback {
@@ -287,7 +287,7 @@ impl ClusterNodes<RetransmitStage> {
             let protocol = get_broadcast_protocol(shred);
             let peers = peers
                 .filter_map(|k| self.nodes[k].contact_info()?.tvu(protocol))
-                .filter(|addr| !addr.is_ipv6() && socket_addr_space.check(addr))
+                .filter(|addr| socket_addr_space.check_v4(addr))
                 .collect();
             let root_distance = get_root_distance(index, fanout);
             Ok((root_distance, peers))
@@ -450,7 +450,7 @@ const MAX_NUM_NODES_PER_IP_ADDRESS: usize = 1;
 fn dedup_tvu_addrs(nodes: &mut Vec<Node>) {
     const TVU_PROTOCOLS: [Protocol; 1] = [Protocol::UDP];
     let capacity = nodes.len().saturating_mul(2);
-    // Tracks (Protocol, SocketAddr) tuples already observed.
+    // Tracks (Protocol, SocketAddrV4) tuples already observed.
     let mut addrs = HashSet::with_capacity(capacity);
     // Maps IP addresses to number of nodes at that IP address.
     let mut counts = HashMap::with_capacity(capacity);
@@ -467,7 +467,7 @@ fn dedup_tvu_addrs(nodes: &mut Vec<Node>) {
                 continue;
             };
             let count: usize = *counts
-                .entry((protocol, addr.ip()))
+                .entry((protocol, *addr.ip()))
                 .and_modify(|count| *count += 1)
                 .or_insert(1);
             if !addrs.insert((protocol, addr)) || count > MAX_NUM_NODES_PER_IP_ADDRESS {
@@ -644,7 +644,10 @@ impl From<&GossipContactInfo> for ContactInfo {
         Self {
             pubkey: *node.pubkey(),
             wallclock: node.wallclock(),
-            tvu_udp: node.tvu(Protocol::UDP),
+            tvu_udp: match node.tvu(Protocol::UDP) {
+                Some(SocketAddr::V4(addr)) => Some(addr),
+                Some(SocketAddr::V6(_)) | None => None,
+            },
         }
     }
 }

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -33,12 +33,12 @@ use {
         bank::{Bank, MAX_LEADER_SCHEDULE_STAKES},
         bank_forks::BankForks,
     },
-    solana_streamer::sendmmsg::{SendPktsError, multi_target_send},
+    solana_streamer::sendmmsg::{SendPktsError, batch_send},
     solana_time_utils::timestamp,
     std::{
         borrow::Cow,
         collections::{HashMap, HashSet},
-        net::{SocketAddr, UdpSocket},
+        net::{SocketAddr, SocketAddrV4, UdpSocket},
         ops::AddAssign,
         sync::{
             Arc, RwLock,
@@ -77,7 +77,7 @@ struct RetransmitShredOutput {
     // Number of nodes the shred was retransmitted to.
     num_nodes: usize,
     // Addresses the shred was sent to if there was a cache miss.
-    addrs: Option<Box<[SocketAddr]>>,
+    addrs: Option<Box<[SocketAddrV4]>>,
 }
 
 #[derive(Default)]
@@ -95,7 +95,7 @@ pub(crate) struct RetransmitSlotStats {
     num_shreds_sent: [usize; MAX_NUM_TURBINE_HOPS],
     // Root distance and socket-addresses the shreds were sent to if there was
     // a cache miss.
-    pub(crate) addrs: Vec<(ShredId, /*root_distance:*/ u8, Box<[SocketAddr]>)>,
+    pub(crate) addrs: Vec<(ShredId, /*root_distance:*/ u8, Box<[SocketAddrV4]>)>,
 }
 
 struct RetransmitStats {
@@ -485,7 +485,8 @@ fn retransmit_shred(
         RetransmitSocket::Xdp(sender) => {
             let mut sent = num_addrs;
             if num_addrs > 0
-                && let Err(e) = sender.try_send(key.index() as usize, addrs.to_vec(), shred.bytes)
+                && let Err(e) =
+                    sender.try_send(key.index() as usize, addrs.as_ref().to_vec(), shred.bytes)
             {
                 log::warn!("xdp channel full: {e:?}");
                 stats
@@ -497,7 +498,8 @@ fn retransmit_shred(
         }
         RetransmitSocket::Socket(_) | RetransmitSocket::Multihomed { .. } => {
             let socket = socket.get_socket();
-            match multi_target_send(socket, shred, &addrs) {
+            let packets = addrs.iter().map(|addr| (&shred, SocketAddr::V4(*addr)));
+            match batch_send(socket, packets) {
                 Ok(()) => num_addrs,
                 Err(SendPktsError::IoError(ioerr, num_failed)) => {
                     error!(
@@ -535,7 +537,7 @@ fn get_retransmit_addrs<'a>(
     addr_cache: &'a AddrCache,
     socket_addr_space: &SocketAddrSpace,
     stats: &RetransmitStats,
-) -> Option<(/*root_distance:*/ u8, Cow<'a, [SocketAddr]>)> {
+) -> Option<(/*root_distance:*/ u8, Cow<'a, [SocketAddrV4]>)> {
     if let Some((root_distance, addrs)) = addr_cache.get(shred) {
         stats.addr_cache_hit.fetch_add(1, Ordering::Relaxed);
         return Some((root_distance, Cow::Borrowed(addrs)));

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -14,18 +14,14 @@ use {
     aya::Ebpf,
     crossbeam_channel::TryRecvError,
     log::info,
-    std::{
-        net::{IpAddr, Ipv4Addr},
-        thread::Builder,
-        time::Duration,
-    },
+    std::{net::Ipv4Addr, thread::Builder, time::Duration},
 };
 use {
     bytes::Bytes,
     crossbeam_channel::{Sender, TrySendError},
     std::{
         error::Error,
-        net::{SocketAddr, SocketAddrV4},
+        net::SocketAddrV4,
         sync::{Arc, atomic::AtomicBool},
         thread,
     },
@@ -125,27 +121,27 @@ pub struct XdpSender {
 }
 
 pub enum XdpAddrs {
-    Single(SocketAddr),
-    Multi(Vec<SocketAddr>),
+    Single(SocketAddrV4),
+    Multi(Vec<SocketAddrV4>),
 }
 
-impl From<SocketAddr> for XdpAddrs {
+impl From<SocketAddrV4> for XdpAddrs {
     #[inline]
-    fn from(addr: SocketAddr) -> Self {
+    fn from(addr: SocketAddrV4) -> Self {
         XdpAddrs::Single(addr)
     }
 }
 
-impl From<Vec<SocketAddr>> for XdpAddrs {
+impl From<Vec<SocketAddrV4>> for XdpAddrs {
     #[inline]
-    fn from(addrs: Vec<SocketAddr>) -> Self {
+    fn from(addrs: Vec<SocketAddrV4>) -> Self {
         XdpAddrs::Multi(addrs)
     }
 }
 
-impl AsRef<[SocketAddr]> for XdpAddrs {
+impl AsRef<[SocketAddrV4]> for XdpAddrs {
     #[inline]
-    fn as_ref(&self) -> &[SocketAddr] {
+    fn as_ref(&self) -> &[SocketAddrV4] {
         match self {
             XdpAddrs::Single(addr) => std::slice::from_ref(addr),
             XdpAddrs::Multi(addrs) => addrs,
@@ -363,10 +359,7 @@ impl TransmitterBuilder {
                     .spawn(move || {
                         tx_loop.run(receiver, drop_sender, move |ip| {
                             let r = atomic_router.load();
-                            match ip {
-                                IpAddr::V4(ip) => r.route_v4(*ip).ok(),
-                                IpAddr::V6(_) => None,
-                            }
+                            r.route_v4(*ip).ok()
                         })
                     })
                     .unwrap(),

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -17,7 +17,7 @@ use {
     crossbeam_channel::{Receiver, Sender, TryRecvError},
     libc::{_SC_PAGESIZE, sysconf},
     std::{
-        net::{IpAddr, SocketAddr, SocketAddrV4},
+        net::{Ipv4Addr, SocketAddrV4},
         thread,
         time::Duration,
     },
@@ -184,7 +184,7 @@ pub struct TxLoop<U: Umem> {
 /// [`TxPacket`] represents a packet to transmit via XDP to a list of addresses with the provided
 /// `payload` and source address.
 pub trait TxPacket {
-    type Addrs: AsRef<[SocketAddr]>;
+    type Addrs: AsRef<[SocketAddrV4]>;
     type Payload: AsRef<[u8]>;
 
     /// List of destination addresses to which the packet should be sent.
@@ -198,7 +198,7 @@ pub trait TxPacket {
 }
 
 impl<U: Umem> TxLoop<U> {
-    pub fn run<T: TxPacket, R: Fn(&IpAddr) -> Option<NextHop>>(
+    pub fn run<T: TxPacket, R: Fn(&Ipv4Addr) -> Option<NextHop>>(
         self,
         receiver: Receiver<T>,
         drop_sender: Sender<T>,
@@ -301,15 +301,12 @@ impl<U: Umem> TxLoop<U> {
                     // at this point we're guaranteed to have a frame to write the next packet into and
                     // a slot in the ring to submit it
                     let mut frame = umem.reserve().unwrap();
-                    let IpAddr::V4(dst_ip) = addr.ip() else {
-                        panic!("IPv6 not supported");
-                    };
+                    let dst_ip = addr.ip();
 
                     let payload = item.payload().as_ref();
                     let len = payload.len();
 
-                    let dst = addr.ip();
-                    let Some(next_hop) = route_fn(&dst) else {
+                    let Some(next_hop) = route_fn(dst_ip) else {
                         log::warn!("dropping packet: no route for peer {addr}");
                         batched_packets -= 1;
                         umem.release(frame.offset());
@@ -325,7 +322,7 @@ impl<U: Umem> TxLoop<U> {
                             &src_mac,
                             &gre.mac_addr,
                             inner_src_ip,
-                            &dst_ip,
+                            dst_ip,
                             src_port,
                             addr.port(),
                             payload,
@@ -362,7 +359,7 @@ impl<U: Umem> TxLoop<U> {
                         write_ip_header_for_udp(
                             &mut packet[ETH_HEADER_SIZE..],
                             src_ip,
-                            &dst_ip,
+                            dst_ip,
                             (UDP_HEADER_SIZE + len) as u16,
                         );
 
@@ -370,7 +367,7 @@ impl<U: Umem> TxLoop<U> {
                             &mut packet[ETH_HEADER_SIZE + IP_HEADER_SIZE..],
                             src_ip,
                             src_port,
-                            &dst_ip,
+                            dst_ip,
                             addr.port(),
                             len as u16,
                             // don't do checksums


### PR DESCRIPTION
#### Problem
agave-xdp doesn't support ipv6. But the API takes in a `SocketAddr` which can be v4 or v6. 

#### Summary of Changes
Update agave-xdp API to only accept `SocketAddrV4`