### PR TITLE
SIMD-0232: Support custom collector for block rewards

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -44,7 +44,7 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_runtime::{
-        bank::{Bank, SlotLeader},
+        bank::Bank,
         bank_forks::BankForks,
         commitment::BlockCommitmentCache,
         genesis_utils::{GenesisConfigInfo, create_genesis_config_with_leader_ex},
@@ -1335,6 +1335,7 @@ impl ProgramTestContext {
     /// Force the working bank ahead to a new slot
     pub fn warp_to_slot(&mut self, warp_slot: Slot) -> Result<(), ProgramTestError> {
         let bank = self.bank_forks.read().unwrap().working_bank();
+        let leader = *bank.leader();
 
         // Fill ticks until a new blockhash is recorded, otherwise retried transactions will have
         // the same signature
@@ -1354,7 +1355,7 @@ impl ProgramTestContext {
             bank.freeze();
             bank
         } else {
-            let warped = Bank::warp_from_parent(bank, SlotLeader::default(), pre_warp_slot);
+            let warped = Bank::warp_from_parent(bank, leader, pre_warp_slot);
             self.bank_forks
                 .write()
                 .unwrap()
@@ -1369,7 +1370,7 @@ impl ProgramTestContext {
         );
 
         // warp_bank is frozen so go forward to get unfrozen bank at warp_slot
-        let bank_at_warp_slot = Bank::new_from_parent(warp_bank, SlotLeader::default(), warp_slot);
+        let bank_at_warp_slot = Bank::new_from_parent(warp_bank, leader, warp_slot);
         self.bank_forks.write().unwrap().insert(bank_at_warp_slot);
 
         // Update block commitment cache, otherwise banks server will poll at
@@ -1397,6 +1398,7 @@ impl ProgramTestContext {
     /// warp forward one more slot and force reward interval end
     pub fn warp_forward_force_reward_interval_end(&mut self) -> Result<(), ProgramTestError> {
         let bank = self.bank_forks.read().unwrap().working_bank();
+        let leader = *bank.leader();
 
         // Fill ticks until a new blockhash is recorded, otherwise retried transactions will have
         // the same signature
@@ -1411,7 +1413,7 @@ impl ProgramTestContext {
 
         // warp_bank is frozen so go forward to get unfrozen bank at warp_slot
         let warp_slot = pre_warp_slot + 1;
-        let mut warp_bank = Bank::new_from_parent(bank, SlotLeader::default(), warp_slot);
+        let mut warp_bank = Bank::new_from_parent(bank, leader, warp_slot);
 
         warp_bank.force_reward_interval_end_for_tests();
         self.bank_forks.write().unwrap().insert(warp_bank);

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -37,7 +37,7 @@ use {
         bank_forks::BankForks,
         genesis_utils::{
             GenesisConfigInfo, bootstrap_validator_stake_lamports, create_genesis_config,
-            create_genesis_config_with_leader_ex,
+            create_genesis_config_with_leader, create_genesis_config_with_leader_ex,
         },
         loader_utils::{
             create_program, load_upgradeable_buffer, load_upgradeable_program_and_advance_slot,
@@ -3900,12 +3900,13 @@ fn test_program_fees() {
     agave_logger::setup();
 
     let congestion_multiplier = 1;
+    let initial_balance = 1000;
 
     let GenesisConfigInfo {
         mut genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config(500_000_000);
+    } = create_genesis_config_with_leader(500_000_000, &Pubkey::new_unique(), initial_balance);
 
     genesis_config.fee_rate_governor = FeeRateGovernor::new(congestion_multiplier, 0);
     let mut bank = Bank::new_for_tests(&genesis_config);

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5047,7 +5047,8 @@ pub mod tests {
 
         fn advance_bank_to_confirmed_slot(&self, slot: Slot) -> Arc<Bank> {
             let parent_bank = self.working_bank();
-            let child_bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), slot);
+            let leader = *parent_bank.leader();
+            let child_bank = Bank::new_from_parent(parent_bank, leader, slot);
             let bank = self
                 .bank_forks
                 .write()

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -40,13 +40,14 @@ impl FeeDistribution {
 }
 
 impl Bank {
-    // Distribute collected transaction fees for this slot to leader.id (= current leader).
+    // Distribute collected transaction fees for this slot to the block revenue collector
+    // id for the current leader.
     //
     // Each validator is incentivized to process more transactions to earn more transaction fees.
     // Transaction fees are rewarded for the computing resource utilization cost, directly
     // proportional to their actual processing power.
     //
-    // leader.id is rotated according to stake-weighted leader schedule. So the opportunity of
+    // The leader is rotated according to stake-weighted leader schedule. So the opportunity of
     // earning transaction fees are fairly distributed by stake. And missing the opportunity
     // (not producing a block as a leader) earns nothing. So, being online is incentivized as a
     // form of transaction fees as well.
@@ -121,7 +122,8 @@ impl Bank {
         // `Bank::current_epoch_stakes()`.
         let feature_snapshot = self.feature_set.snapshot();
         let collector_id = if feature_snapshot.custom_commission_collector {
-            self.epoch_stakes
+            let vote_account = self
+                .epoch_stakes
                 .get(&self.epoch)
                 .and_then(|stakes| {
                     stakes
@@ -129,8 +131,14 @@ impl Bank {
                         .vote_accounts()
                         .get(&self.leader.vote_address)
                 })
-                .and_then(|vote_account| vote_account.vote_state_view().block_revenue_collector())
-                .expect("The vote state for the leader must exist with a block collector id")
+                .expect("The vote account for the leader must exist");
+            // Protection in case the leader is on a vote state without a
+            // collector id, which can happen if a dormant pre-v4 vote state
+            // accrues stake.
+            vote_account
+                .vote_state_view()
+                .block_revenue_collector()
+                .unwrap_or(&self.leader.id)
         } else {
             &self.leader.id
         };
@@ -151,7 +159,7 @@ impl Bank {
             Err(err) => {
                 debug!(
                     "Burned {} lamport tx fee instead of sending to {} due to {}",
-                    deposit, self.leader.id, err
+                    deposit, collector_id, err
                 );
                 datapoint_warn!(
                     "bank-burned_fee",

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -158,8 +158,8 @@ impl Bank {
             }
             Err(err) => {
                 debug!(
-                    "Burned {} lamport tx fee instead of sending to {} due to {}",
-                    deposit, collector_id, err
+                    "Burned {deposit} lamport tx fee instead of sending to {collector_id} due to \
+                     {err}"
                 );
                 datapoint_warn!(
                     "bank-burned_fee",

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -2,7 +2,7 @@ use {
     super::Bank,
     crate::{bank::CollectorFeeDetails, reward_info::RewardInfo},
     log::debug,
-    solana_account::{ReadableAccount, WritableAccount},
+    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_fee::FeeFeatures,
     solana_pubkey::Pubkey,
     solana_reward_info::RewardType,
@@ -23,6 +23,8 @@ enum DepositFeeError {
     LamportOverflow,
     #[error("invalid fee account owner")]
     InvalidAccountOwner,
+    #[error("collector is a reserved account")]
+    ReservedCollector,
 }
 
 #[derive(Default)]
@@ -112,10 +114,33 @@ impl Bank {
             return 0;
         }
 
-        match self.deposit_fees(&self.leader.id, deposit) {
+        // Per SIMD-0232: the commission collector address should be fetched
+        // from the state of the vote account at the beginning of the previous
+        // epoch. This is the vote account state used to build the leader
+        // schedule for the current epoch, which *DOES NOT* correspond to
+        // `Bank::current_epoch_stakes()`.
+        let feature_snapshot = self.feature_set.snapshot();
+        let collector_id = if feature_snapshot.custom_commission_collector
+            && feature_snapshot.vote_state_v4
+        {
+            self.epoch_stakes
+                .get(&self.epoch)
+                .and_then(|stakes| {
+                    stakes
+                        .stakes()
+                        .vote_accounts()
+                        .get(&self.leader.vote_address)
+                })
+                .and_then(|vote_account| vote_account.vote_state_view().block_revenue_collector())
+                .expect("The vote state for the leader must exist with a block collector id")
+        } else {
+            &self.leader.id
+        };
+
+        match self.deposit_fees(collector_id, deposit) {
             Ok(post_balance) => {
                 self.rewards.write().unwrap().push((
-                    self.leader.id,
+                    *collector_id,
                     RewardInfo {
                         reward_type: RewardType::Fee,
                         lamports: deposit as i64,
@@ -142,38 +167,79 @@ impl Bank {
     }
 
     // Deposits fees into a specified account and if successful, returns the new balance of that account
-    fn deposit_fees(&self, pubkey: &Pubkey, fees: u64) -> Result<u64, DepositFeeError> {
+    fn deposit_fees(&self, collector_id: &Pubkey, fees: u64) -> Result<u64, DepositFeeError> {
         let mut account = self
-            .get_account_with_fixed_root_no_cache(pubkey)
+            .get_account_with_fixed_root_no_cache(collector_id)
             .unwrap_or_default();
+
+        let feature_snapshot = self.feature_set.snapshot();
+        if feature_snapshot.custom_commission_collector {
+            let pre_lamports = account.lamports();
+            account
+                .checked_add_lamports(fees)
+                .map_err(|_| DepositFeeError::LamportOverflow)?;
+            self.check_block_revenue_collector_account(collector_id, pre_lamports, &account)?;
+        } else {
+            if !system_program::check_id(account.owner()) {
+                return Err(DepositFeeError::InvalidAccountOwner);
+            }
+
+            let recipient_pre_rent_state = get_account_rent_state(
+                &self.rent_collector().rent,
+                account.lamports(),
+                account.data().len(),
+            );
+            let distribution = account.checked_add_lamports(fees);
+            if distribution.is_err() {
+                return Err(DepositFeeError::LamportOverflow);
+            }
+
+            let recipient_post_rent_state = get_account_rent_state(
+                &self.rent_collector().rent,
+                account.lamports(),
+                account.data().len(),
+            );
+            let rent_state_transition_allowed =
+                transition_allowed(&recipient_pre_rent_state, &recipient_post_rent_state);
+            if !rent_state_transition_allowed {
+                return Err(DepositFeeError::InvalidRentPayingAccount);
+            }
+        }
+
+        self.store_account(collector_id, &account);
+        Ok(account.lamports())
+    }
+
+    fn check_block_revenue_collector_account(
+        &self,
+        collector_id: &Pubkey,
+        pre_lamports: u64,
+        account: &AccountSharedData,
+    ) -> Result<(), DepositFeeError> {
+        if collector_id == &self.leader.vote_address {
+            return Ok(());
+        }
 
         if !system_program::check_id(account.owner()) {
             return Err(DepositFeeError::InvalidAccountOwner);
         }
 
-        let recipient_pre_rent_state = get_account_rent_state(
-            &self.rent_collector().rent,
-            account.lamports(),
-            account.data().len(),
-        );
-        let distribution = account.checked_add_lamports(fees);
-        if distribution.is_err() {
-            return Err(DepositFeeError::LamportOverflow);
+        if self.reserved_account_keys.is_reserved(collector_id) {
+            return Err(DepositFeeError::ReservedCollector);
         }
 
-        let recipient_post_rent_state = get_account_rent_state(
-            &self.rent_collector().rent,
-            account.lamports(),
-            account.data().len(),
-        );
-        let rent_state_transition_allowed =
-            transition_allowed(&recipient_pre_rent_state, &recipient_post_rent_state);
-        if !rent_state_transition_allowed {
+        // TODO use SIMD-0392 feature
+        let relax_post_execution_balance_checks = false;
+        if !self
+            .rent_collector()
+            .rent
+            .is_exempt(account.lamports(), account.data().len())
+            && (!relax_post_execution_balance_checks || pre_lamports == 0)
+        {
             return Err(DepositFeeError::InvalidRentPayingAccount);
         }
 
-        self.store_account(pubkey, &account);
-        Ok(account.lamports())
+        Ok(())
     }
 }
 
@@ -182,11 +248,14 @@ pub mod tests {
     use {
         super::*,
         crate::genesis_utils::{create_genesis_config, create_genesis_config_with_leader},
-        solana_account::AccountSharedData,
+        agave_feature_set::FeatureSet,
+        solana_account::state_traits::StateMut,
         solana_pubkey as pubkey,
         solana_rent::Rent,
         solana_signer::Signer,
-        std::sync::RwLock,
+        solana_vote_interface::state::{VoteStateV4, VoteStateVersions},
+        std::sync::{Arc, RwLock},
+        test_case::test_case,
     };
 
     #[test]
@@ -196,12 +265,14 @@ pub mod tests {
         assert_eq!(bank.deposit_or_burn_fee(0), 0);
     }
 
-    #[test]
-    fn test_deposit_or_burn_fee() {
+    #[test_case(true; "custom_commission_collector")]
+    #[test_case(false; "no_custom_commission_collector")]
+    fn test_deposit_or_burn_fee(custom_commission_collector: bool) {
         #[derive(PartialEq)]
         enum Scenario {
             Normal,
             InvalidOwner,
+            RentPayingAccount,
         }
 
         struct TestCase {
@@ -217,37 +288,86 @@ pub mod tests {
         for test_case in [
             TestCase::new(Scenario::Normal),
             TestCase::new(Scenario::InvalidOwner),
+            TestCase::new(Scenario::RentPayingAccount),
         ] {
-            let mut genesis = create_genesis_config(0);
+            let initial_balance = 1000;
+            let mut genesis =
+                create_genesis_config_with_leader(0, &pubkey::new_rand(), initial_balance);
             let rent = Rent::default();
             let min_rent_exempt_balance = rent.minimum_balance(0);
             genesis.genesis_config.rent = rent; // Ensure rent is non-zero, as genesis_utils sets Rent::free by default
-            let bank = Bank::new_for_tests(&genesis.genesis_config);
+
+            // update collector id at genesis for invalid owner case
+            let maybe_collector_id = if custom_commission_collector
+                && (test_case.scenario == Scenario::InvalidOwner
+                    || test_case.scenario == Scenario::RentPayingAccount)
+            {
+                let collector_id = Pubkey::new_unique();
+                for (_, account) in genesis.genesis_config.accounts.iter_mut() {
+                    if account.owner == solana_sdk_ids::vote::id() {
+                        let mut vote_state =
+                            VoteStateV4::deserialize(account.data(), &Pubkey::default()).unwrap();
+                        vote_state.block_revenue_collector = collector_id;
+                        let versioned = VoteStateVersions::V4(Box::new(vote_state));
+                        account.set_state(&versioned).unwrap();
+                    }
+                }
+                Some(collector_id)
+            } else {
+                None
+            };
+
+            let mut bank = Bank::new_for_tests(&genesis.genesis_config);
+            let mut feature_set = FeatureSet::all_enabled();
+            if !custom_commission_collector {
+                feature_set.deactivate(&agave_feature_set::custom_commission_collector::id());
+            }
+            bank.feature_set = Arc::new(feature_set);
+
+            let collector_id = maybe_collector_id.unwrap_or(if custom_commission_collector {
+                bank.leader().vote_address
+            } else {
+                *bank.leader_id()
+            });
 
             let deposit = 100;
             let mut burn = 100;
 
             match test_case.scenario {
+                Scenario::RentPayingAccount => {
+                    // ensure that the account is rent-paying
+                    let account = AccountSharedData::new(1, 1_000, &Pubkey::new_unique());
+                    bank.store_account(&collector_id, &account);
+                }
                 Scenario::InvalidOwner => {
                     // ensure that account owner is invalid and fee distribution will fail
                     let account =
                         AccountSharedData::new(min_rent_exempt_balance, 0, &Pubkey::new_unique());
-                    bank.store_account(bank.leader_id(), &account);
+                    bank.store_account(&collector_id, &account);
                 }
                 Scenario::Normal => {
-                    let account =
-                        AccountSharedData::new(min_rent_exempt_balance, 0, &system_program::id());
-                    bank.store_account(bank.leader_id(), &account);
+                    // vote account is the recipient in the Normal case, nothing
+                    // else to do
+                    if !custom_commission_collector {
+                        let account = AccountSharedData::new(
+                            min_rent_exempt_balance,
+                            0,
+                            &system_program::id(),
+                        );
+                        bank.store_account(&collector_id, &account);
+                    }
                 }
             }
 
             let initial_burn = burn;
-            let initial_leader_id_balance = bank.get_balance(bank.leader_id());
+            let initial_collector_balance = bank.get_balance(&collector_id);
             burn += bank.deposit_or_burn_fee(deposit);
-            let new_leader_id_balance = bank.get_balance(bank.leader_id());
+            let new_collector_balance = bank.get_balance(&collector_id);
 
-            if test_case.scenario == Scenario::InvalidOwner {
-                assert_eq!(initial_leader_id_balance, new_leader_id_balance);
+            if test_case.scenario == Scenario::InvalidOwner
+                || test_case.scenario == Scenario::RentPayingAccount
+            {
+                assert_eq!(initial_collector_balance, new_collector_balance);
                 assert_eq!(initial_burn + deposit, burn);
                 let locked_rewards = bank.rewards.read().unwrap();
                 assert!(
@@ -255,7 +375,7 @@ pub mod tests {
                     "There should be no rewards distributed"
                 );
             } else {
-                assert_eq!(initial_leader_id_balance + deposit, new_leader_id_balance);
+                assert_eq!(initial_collector_balance + deposit, new_collector_balance);
 
                 assert_eq!(initial_burn, burn);
 
@@ -310,25 +430,53 @@ pub mod tests {
         );
     }
 
-    #[test]
-    fn test_deposit_fees_invalid_account_owner() {
+    #[test_case(true, Ok(160027074900); "allowed")]
+    #[test_case(false, Err(DepositFeeError::InvalidAccountOwner); "prohibited")]
+    fn test_deposit_fees_to_vote_account(
+        custom_commission_collector: bool,
+        expected: Result<u64, DepositFeeError>,
+    ) {
         let initial_balance = 1000;
         let genesis = create_genesis_config_with_leader(0, &pubkey::new_rand(), initial_balance);
-        let bank = Bank::new_for_tests(&genesis.genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis.genesis_config);
+        let mut feature_set = FeatureSet::all_enabled();
+        if !custom_commission_collector {
+            feature_set.deactivate(&agave_feature_set::custom_commission_collector::id());
+        }
+        bank.feature_set = Arc::new(feature_set);
+
         let pubkey = genesis.voting_keypair.pubkey();
         let deposit_amount = 500;
 
-        assert_eq!(
-            bank.deposit_fees(&pubkey, deposit_amount),
-            Err(DepositFeeError::InvalidAccountOwner),
-            "Expected an error due to invalid account owner"
-        );
+        assert_eq!(bank.deposit_fees(&pubkey, deposit_amount), expected,);
     }
 
     #[test]
-    fn test_distribute_transaction_fee_details_normal() {
-        let genesis = create_genesis_config(0);
+    fn test_deposit_fees_reserved_account() {
+        let initial_balance = 1000;
+        let genesis = create_genesis_config_with_leader(0, &pubkey::new_rand(), initial_balance);
+        let bank = Bank::new_for_tests(&genesis.genesis_config);
+        let deposit_amount = 500;
+
+        for id in bank.get_reserved_account_keys() {
+            assert!(matches!(
+                bank.deposit_fees(id, deposit_amount),
+                Err(DepositFeeError::ReservedCollector) | Err(DepositFeeError::InvalidAccountOwner),
+            ));
+        }
+    }
+
+    #[test_case(true; "custom_commission_collector")]
+    #[test_case(false; "no_custom_commission_collector")]
+    fn test_distribute_transaction_fee_details_normal(custom_commission_collector: bool) {
+        let initial_balance = 1000;
+        let genesis = create_genesis_config_with_leader(0, &pubkey::new_rand(), initial_balance);
         let mut bank = Bank::new_for_tests(&genesis.genesis_config);
+        let mut feature_set = FeatureSet::all_enabled();
+        if !custom_commission_collector {
+            feature_set.deactivate(&agave_feature_set::custom_commission_collector::id());
+        }
+        bank.feature_set = Arc::new(feature_set);
         let transaction_fee = 100;
         let priority_fee = 200;
         bank.collector_fee_details = RwLock::new(CollectorFeeDetails {
@@ -338,14 +486,20 @@ pub mod tests {
         let expected_burn = transaction_fee * bank.burn_percent() / 100;
         let expected_rewards = transaction_fee - expected_burn + priority_fee;
 
+        let collector_id = if custom_commission_collector {
+            bank.leader().vote_address
+        } else {
+            *bank.leader_id()
+        };
+
         let initial_capitalization = bank.capitalization();
-        let initial_leader_id_balance = bank.get_balance(bank.leader_id());
+        let initial_collector_balance = bank.get_balance(&collector_id);
         bank.distribute_transaction_fee_details();
-        let new_leader_id_balance = bank.get_balance(bank.leader_id());
+        let new_collector_balance = bank.get_balance(&collector_id);
 
         assert_eq!(
-            initial_leader_id_balance + expected_rewards,
-            new_leader_id_balance
+            initial_collector_balance + expected_rewards,
+            new_collector_balance
         );
         assert_eq!(
             initial_capitalization - expected_burn,
@@ -393,10 +547,17 @@ pub mod tests {
         );
     }
 
-    #[test]
-    fn test_distribute_transaction_fee_details_overflow_failure() {
-        let genesis = create_genesis_config(0);
+    #[test_case(true; "custom_commission_collector")]
+    #[test_case(false; "no_custom_commission_collector")]
+    fn test_distribute_transaction_fee_details_overflow_failure(custom_commission_collector: bool) {
+        let initial_balance = 1000;
+        let genesis = create_genesis_config_with_leader(0, &pubkey::new_rand(), initial_balance);
         let mut bank = Bank::new_for_tests(&genesis.genesis_config);
+        let mut feature_set = FeatureSet::all_enabled();
+        if !custom_commission_collector {
+            feature_set.deactivate(&agave_feature_set::custom_commission_collector::id());
+        }
+        bank.feature_set = Arc::new(feature_set);
         let transaction_fee = 100;
         let priority_fee = 200;
         bank.collector_fee_details = RwLock::new(CollectorFeeDetails {
@@ -404,16 +565,23 @@ pub mod tests {
             priority_fee,
         });
 
+        let collector_id = if custom_commission_collector {
+            bank.leader().vote_address
+        } else {
+            *bank.leader_id()
+        };
+
         // ensure that account balance will overflow and fee distribution will fail
-        let account = AccountSharedData::new(u64::MAX, 0, &system_program::id());
-        bank.store_account(bank.leader_id(), &account);
+        let mut account = bank.get_account(&collector_id).unwrap_or_default();
+        account.set_lamports(u64::MAX);
+        bank.store_account(&collector_id, &account);
 
         let initial_capitalization = bank.capitalization();
-        let initial_leader_id_balance = bank.get_balance(bank.leader_id());
+        let initial_collector_balance = bank.get_balance(&collector_id);
         bank.distribute_transaction_fee_details();
-        let new_leader_id_balance = bank.get_balance(bank.leader_id());
+        let new_collector_balance = bank.get_balance(&collector_id);
 
-        assert_eq!(initial_leader_id_balance, new_leader_id_balance);
+        assert_eq!(initial_collector_balance, new_collector_balance);
         assert_eq!(
             initial_capitalization - transaction_fee - priority_fee,
             bank.capitalization()

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -120,9 +120,7 @@ impl Bank {
         // schedule for the current epoch, which *DOES NOT* correspond to
         // `Bank::current_epoch_stakes()`.
         let feature_snapshot = self.feature_set.snapshot();
-        let collector_id = if feature_snapshot.custom_commission_collector
-            && feature_snapshot.vote_state_v4
-        {
+        let collector_id = if feature_snapshot.custom_commission_collector {
             self.epoch_stakes
                 .get(&self.epoch)
                 .and_then(|stakes| {

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -9,6 +9,7 @@ use {
     solana_runtime_transaction::{
         transaction_meta::TransactionConfiguration, transaction_with_meta::TransactionWithMeta,
     },
+    solana_sdk_ids::incinerator,
     solana_svm::rent_calculator::{get_account_rent_state, transition_allowed},
     solana_system_interface::program as system_program,
     std::{result::Result, sync::atomic::Ordering::Relaxed},
@@ -234,15 +235,19 @@ impl Bank {
             return Err(DepositFeeError::ReservedCollector);
         }
 
-        // TODO use SIMD-0392 feature
-        let relax_post_execution_balance_checks = false;
-        if !self
-            .rent_collector()
-            .rent
-            .is_exempt(account.lamports(), account.data().len())
-            && (!relax_post_execution_balance_checks || pre_lamports == 0)
-        {
-            return Err(DepositFeeError::InvalidRentPayingAccount);
+        // Don't perform rent check on the incinerator, so that the deposit
+        // always works. The incinerator is cleaned right after this step
+        if *collector_id != incinerator::id() {
+            // TODO use SIMD-0392 feature
+            let relax_post_execution_balance_checks = false;
+            if !self
+                .rent_collector()
+                .rent
+                .is_exempt(account.lamports(), account.data().len())
+                && (!relax_post_execution_balance_checks || pre_lamports == 0)
+            {
+                return Err(DepositFeeError::InvalidRentPayingAccount);
+            }
         }
 
         Ok(())
@@ -279,6 +284,9 @@ pub mod tests {
             Normal,
             InvalidOwner,
             RentPayingAccount,
+            NonDefault,
+            VoteAccount,
+            Incinerator,
         }
 
         struct TestCase {
@@ -295,7 +303,19 @@ pub mod tests {
             TestCase::new(Scenario::Normal),
             TestCase::new(Scenario::InvalidOwner),
             TestCase::new(Scenario::RentPayingAccount),
+            TestCase::new(Scenario::NonDefault),
+            TestCase::new(Scenario::VoteAccount),
+            TestCase::new(Scenario::Incinerator),
         ] {
+            if !custom_commission_collector {
+                // Some scenarios don't make sense without a custom collector
+                match test_case.scenario {
+                    Scenario::NonDefault | Scenario::VoteAccount | Scenario::Incinerator => {
+                        continue;
+                    }
+                    Scenario::Normal | Scenario::InvalidOwner | Scenario::RentPayingAccount => {}
+                }
+            }
             let initial_balance = 1000;
             let mut genesis =
                 create_genesis_config_with_leader(0, &pubkey::new_rand(), initial_balance);
@@ -303,22 +323,28 @@ pub mod tests {
             let min_rent_exempt_balance = rent.minimum_balance(0);
             genesis.genesis_config.rent = rent; // Ensure rent is non-zero, as genesis_utils sets Rent::free by default
 
-            // update collector id at genesis for invalid owner case
-            let maybe_collector_id = if custom_commission_collector
-                && (test_case.scenario == Scenario::InvalidOwner
-                    || test_case.scenario == Scenario::RentPayingAccount)
-            {
-                let collector_id = Pubkey::new_unique();
-                for (_, account) in genesis.genesis_config.accounts.iter_mut() {
+            // update collector id at genesis for some cases
+            let maybe_collector_id = if custom_commission_collector {
+                let mut maybe_collector_id = None;
+                for (address, account) in genesis.genesis_config.accounts.iter_mut() {
                     if account.owner == solana_sdk_ids::vote::id() {
                         let mut vote_state =
                             VoteStateV4::deserialize(account.data(), &Pubkey::default()).unwrap();
+                        let collector_id = match test_case.scenario {
+                            Scenario::Normal => vote_state.block_revenue_collector,
+                            Scenario::InvalidOwner
+                            | Scenario::RentPayingAccount
+                            | Scenario::NonDefault => Pubkey::new_unique(),
+                            Scenario::Incinerator => incinerator::id(),
+                            Scenario::VoteAccount => *address,
+                        };
                         vote_state.block_revenue_collector = collector_id;
+                        maybe_collector_id = Some(collector_id);
                         let versioned = VoteStateVersions::V4(Box::new(vote_state));
                         account.set_state(&versioned).unwrap();
                     }
                 }
-                Some(collector_id)
+                maybe_collector_id
             } else {
                 None
             };
@@ -347,17 +373,17 @@ pub mod tests {
                         AccountSharedData::new(min_rent_exempt_balance, 0, &Pubkey::new_unique());
                     bank.store_account(&collector_id, &account);
                 }
-                Scenario::Normal => {
-                    // vote account is the recipient in the Normal case, nothing
-                    // else to do
-                    if !custom_commission_collector {
-                        let account = AccountSharedData::new(
-                            min_rent_exempt_balance,
-                            0,
-                            &system_program::id(),
-                        );
-                        bank.store_account(&collector_id, &account);
-                    }
+                Scenario::VoteAccount => {
+                    // nothing to do, collector id already set, and vote account
+                    // already exists
+                }
+                Scenario::Incinerator => {
+                    // nothing to do, incinerator already exists
+                }
+                Scenario::NonDefault | Scenario::Normal => {
+                    let account =
+                        AccountSharedData::new(min_rent_exempt_balance, 0, &system_program::id());
+                    bank.store_account(&collector_id, &account);
                 }
             }
 
@@ -366,38 +392,42 @@ pub mod tests {
             burn += bank.deposit_or_burn_fee(deposit);
             let new_collector_balance = bank.get_balance(&collector_id);
 
-            if test_case.scenario == Scenario::InvalidOwner
-                || test_case.scenario == Scenario::RentPayingAccount
-            {
-                assert_eq!(initial_collector_balance, new_collector_balance);
-                assert_eq!(initial_burn + deposit, burn);
-                let locked_rewards = bank.rewards.read().unwrap();
-                assert!(
-                    locked_rewards.is_empty(),
-                    "There should be no rewards distributed"
-                );
-            } else {
-                assert_eq!(initial_collector_balance + deposit, new_collector_balance);
+            match test_case.scenario {
+                Scenario::InvalidOwner | Scenario::RentPayingAccount => {
+                    assert_eq!(initial_collector_balance, new_collector_balance);
+                    assert_eq!(initial_burn + deposit, burn);
+                    let locked_rewards = bank.rewards.read().unwrap();
+                    assert!(
+                        locked_rewards.is_empty(),
+                        "There should be no rewards distributed"
+                    );
+                }
+                Scenario::NonDefault
+                | Scenario::Normal
+                | Scenario::VoteAccount
+                | Scenario::Incinerator => {
+                    assert_eq!(initial_collector_balance + deposit, new_collector_balance);
 
-                assert_eq!(initial_burn, burn);
+                    assert_eq!(initial_burn, burn);
 
-                let locked_rewards = bank.rewards.read().unwrap();
-                assert_eq!(
-                    locked_rewards.len(),
-                    1,
-                    "There should be one reward distributed"
-                );
+                    let locked_rewards = bank.rewards.read().unwrap();
+                    assert_eq!(
+                        locked_rewards.len(),
+                        1,
+                        "There should be one reward distributed"
+                    );
 
-                let reward_info = &locked_rewards[0];
-                assert_eq!(
-                    reward_info.1.lamports, deposit as i64,
-                    "The reward amount should match the expected deposit"
-                );
-                assert_eq!(
-                    reward_info.1.reward_type,
-                    RewardType::Fee,
-                    "The reward type should be Fee"
-                );
+                    let reward_info = &locked_rewards[0];
+                    assert_eq!(
+                        reward_info.1.lamports, deposit as i64,
+                        "The reward amount should match the expected deposit"
+                    );
+                    assert_eq!(
+                        reward_info.1.reward_type,
+                        RewardType::Fee,
+                        "The reward type should be Fee"
+                    );
+                }
             }
         }
     }
@@ -471,17 +501,11 @@ pub mod tests {
         }
     }
 
-    #[test_case(true; "custom_commission_collector")]
-    #[test_case(false; "no_custom_commission_collector")]
-    fn test_distribute_transaction_fee_details_normal(custom_commission_collector: bool) {
+    #[test]
+    fn test_distribute_transaction_fee_details_normal() {
         let initial_balance = 1000;
         let genesis = create_genesis_config_with_leader(0, &pubkey::new_rand(), initial_balance);
         let mut bank = Bank::new_for_tests(&genesis.genesis_config);
-        let mut feature_set = FeatureSet::all_enabled();
-        if !custom_commission_collector {
-            feature_set.deactivate(&agave_feature_set::custom_commission_collector::id());
-        }
-        bank.feature_set = Arc::new(feature_set);
         let transaction_fee = 100;
         let priority_fee = 200;
         bank.collector_fee_details = RwLock::new(CollectorFeeDetails {
@@ -548,17 +572,11 @@ pub mod tests {
         );
     }
 
-    #[test_case(true; "custom_commission_collector")]
-    #[test_case(false; "no_custom_commission_collector")]
-    fn test_distribute_transaction_fee_details_overflow_failure(custom_commission_collector: bool) {
+    #[test]
+    fn test_distribute_transaction_fee_details_overflow_failure() {
         let initial_balance = 1000;
         let genesis = create_genesis_config_with_leader(0, &pubkey::new_rand(), initial_balance);
         let mut bank = Bank::new_for_tests(&genesis.genesis_config);
-        let mut feature_set = FeatureSet::all_enabled();
-        if !custom_commission_collector {
-            feature_set.deactivate(&agave_feature_set::custom_commission_collector::id());
-        }
-        bank.feature_set = Arc::new(feature_set);
         let transaction_fee = 100;
         let priority_fee = 200;
         bank.collector_fee_details = RwLock::new(CollectorFeeDetails {

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -432,11 +432,11 @@ pub mod tests {
         );
     }
 
-    #[test_case(true, Ok(160027074900); "allowed")]
+    #[test_case(true, Ok(()); "allowed")]
     #[test_case(false, Err(DepositFeeError::InvalidAccountOwner); "prohibited")]
     fn test_deposit_fees_to_vote_account(
         custom_commission_collector: bool,
-        expected: Result<u64, DepositFeeError>,
+        expected: Result<(), DepositFeeError>,
     ) {
         let initial_balance = 1000;
         let genesis = create_genesis_config_with_leader(0, &pubkey::new_rand(), initial_balance);
@@ -449,8 +449,11 @@ pub mod tests {
 
         let pubkey = genesis.voting_keypair.pubkey();
         let deposit_amount = 500;
-
-        assert_eq!(bank.deposit_fees(&pubkey, deposit_amount), expected,);
+        let pre_lamports = bank.get_balance(&pubkey);
+        assert_eq!(
+            expected.map(|_| pre_lamports.saturating_add(deposit_amount)),
+            bank.deposit_fees(&pubkey, deposit_amount)
+        );
     }
 
     #[test]

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -330,11 +330,7 @@ pub mod tests {
             }
             bank.feature_set = Arc::new(feature_set);
 
-            let collector_id = maybe_collector_id.unwrap_or(if custom_commission_collector {
-                bank.leader().vote_address
-            } else {
-                *bank.leader_id()
-            });
+            let collector_id = maybe_collector_id.unwrap_or(*bank.leader_id());
 
             let deposit = 100;
             let mut burn = 100;
@@ -492,11 +488,7 @@ pub mod tests {
         let expected_burn = transaction_fee * bank.burn_percent() / 100;
         let expected_rewards = transaction_fee - expected_burn + priority_fee;
 
-        let collector_id = if custom_commission_collector {
-            bank.leader().vote_address
-        } else {
-            *bank.leader_id()
-        };
+        let collector_id = *bank.leader_id();
 
         let initial_capitalization = bank.capitalization();
         let initial_collector_balance = bank.get_balance(&collector_id);
@@ -571,11 +563,7 @@ pub mod tests {
             priority_fee,
         });
 
-        let collector_id = if custom_commission_collector {
-            bank.leader().vote_address
-        } else {
-            *bank.leader_id()
-        };
+        let collector_id = *bank.leader_id();
 
         // ensure that account balance will overflow and fee distribution will fail
         let mut account = bank.get_account(&collector_id).unwrap_or_default();

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1448,6 +1448,10 @@ fn test_bank_tx_fee() {
 
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.set_fee_structure(&fee_structure);
+
+    let leader = *bank.leader();
+    let collector_id = leader.vote_address;
+
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
 
     let capitalization = bank.capitalization();
@@ -1460,7 +1464,7 @@ fn test_bank_tx_fee() {
         bank.last_blockhash(),
     );
 
-    let initial_balance = bank.get_balance(&leader.id);
+    let initial_balance = bank.get_balance(&collector_id);
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), arbitrary_transfer_amount);
     assert_eq!(
@@ -1468,11 +1472,11 @@ fn test_bank_tx_fee() {
         mint - arbitrary_transfer_amount - expected_fee_paid
     );
 
-    assert_eq!(bank.get_balance(&leader.id), initial_balance);
+    assert_eq!(bank.get_balance(&collector_id), initial_balance);
     goto_end_of_slot(bank.clone());
     assert_eq!(bank.signature_count(), 1);
     assert_eq!(
-        bank.get_balance(&leader.id),
+        bank.get_balance(&collector_id),
         initial_balance + expected_fee_collected
     ); // Leader collects fee after the bank is frozen
 
@@ -1486,7 +1490,7 @@ fn test_bank_tx_fee() {
     assert_eq!(
         *bank.rewards.read().unwrap(),
         vec![(
-            leader.id,
+            collector_id,
             RewardInfo {
                 reward_type: RewardType::Fee,
                 lamports: expected_fee_collected as i64,
@@ -1514,14 +1518,14 @@ fn test_bank_tx_fee() {
 
     // Profit! 2 transaction signatures processed at 3 lamports each
     assert_eq!(
-        bank.get_balance(&leader.id),
+        bank.get_balance(&collector_id),
         initial_balance + 2 * expected_fee_collected
     );
 
     assert_eq!(
         *bank.rewards.read().unwrap(),
         vec![(
-            leader.id,
+            collector_id,
             RewardInfo {
                 reward_type: RewardType::Fee,
                 lamports: expected_fee_collected as i64,
@@ -1549,6 +1553,9 @@ fn test_bank_tx_compute_unit_fee() {
 
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
+    let leader = *bank.leader();
+    let collector_id = leader.vote_address;
+
     let expected_fee_paid = calculate_test_fee(
         &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
         bank.fee_structure(),
@@ -1566,7 +1573,7 @@ fn test_bank_tx_compute_unit_fee() {
         bank.last_blockhash(),
     );
 
-    let initial_balance = bank.get_balance(&leader.id);
+    let initial_balance = bank.get_balance(&collector_id);
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), arbitrary_transfer_amount);
     assert_eq!(
@@ -1574,11 +1581,11 @@ fn test_bank_tx_compute_unit_fee() {
         mint - arbitrary_transfer_amount - expected_fee_paid
     );
 
-    assert_eq!(bank.get_balance(&leader.id), initial_balance);
+    assert_eq!(bank.get_balance(&collector_id), initial_balance);
     goto_end_of_slot(bank.clone());
     assert_eq!(bank.signature_count(), 1);
     assert_eq!(
-        bank.get_balance(&leader.id),
+        bank.get_balance(&collector_id),
         initial_balance + expected_fee_collected
     ); // Leader collects fee after the bank is frozen
 
@@ -1592,7 +1599,7 @@ fn test_bank_tx_compute_unit_fee() {
     assert_eq!(
         *bank.rewards.read().unwrap(),
         vec![(
-            leader.id,
+            collector_id,
             RewardInfo {
                 reward_type: RewardType::Fee,
                 lamports: expected_fee_collected as i64,
@@ -1620,14 +1627,14 @@ fn test_bank_tx_compute_unit_fee() {
 
     // Profit! 2 transaction signatures processed at 3 lamports each
     assert_eq!(
-        bank.get_balance(&leader.id),
+        bank.get_balance(&collector_id),
         initial_balance + 2 * expected_fee_collected
     );
 
     assert_eq!(
         *bank.rewards.read().unwrap(),
         vec![(
-            leader.id,
+            collector_id,
             RewardInfo {
                 reward_type: RewardType::Fee,
                 lamports: expected_fee_collected as i64,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1450,7 +1450,7 @@ fn test_bank_tx_fee() {
     bank.set_fee_structure(&fee_structure);
 
     let leader = *bank.leader();
-    let collector_id = leader.vote_address;
+    let collector_id = leader.id;
 
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
 
@@ -1554,7 +1554,7 @@ fn test_bank_tx_compute_unit_fee() {
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     let leader = *bank.leader();
-    let collector_id = leader.vote_address;
+    let collector_id = leader.id;
 
     let expected_fee_paid = calculate_test_fee(
         &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),


### PR DESCRIPTION
#### Problem

Vote state v4 allows for setting custom commission receiver addresses, but the block rewards commission collector is not respected.

#### Summary of changes

Update the block fee distribution logic to use the configured commission collector address.

NOTE: One check relies on the implementation of SIMD-0392, so this PR needs to wait until that feature is in the codebase.

~~Leaving in draft in case any CI issues come up, and potentially to wait for SIMD-0392's implementation to land in #9380~~