### PR TITLE
fix(ci): treat "already exists" as success in publish retry loop

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -73,6 +73,11 @@ for Cargo_toml in $Cargo_tomls; do
         break
       fi
 
+      if grep -q "already exists on crates.io index" <<< "$output"; then
+        echo "${crate_name} version already published, skipping"
+        break
+      fi
+
       if [ "$i" -lt "$numRetries" ]; then
         retry_after=$(sed -n 's/.*Please try again after \(.*\) or email.*/\1/p' <<< "$output")
         if [[ -n "$retry_after" ]]; then


### PR DESCRIPTION
#### Problem

The pre-publish check queries crates.io to skip already-published crates, but can return a false negative under rate limiting. When this happens, cargo publish fails with "already exists" and the retry loop exhausts all attempts before failing the release.

#### Summary of Changes

treat "already exists" as success in publish retry loop to continue the publish loop. 
