### PR TITLE
bank: add custom initialization logic for block and transaction tests

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6338,6 +6338,11 @@ impl Bank {
     /// (`prepare_for_block_execution`, partitioned rewards recalc) and
     /// snapshot fields (stakes loading, debug keys, accounts data size)
     /// that are irrelevant to individual transaction execution.
+    ///
+    /// Covers the full transaction processing pipeline including
+    /// transaction age/nonce checks, compute budget and limits
+    /// sanitization, transaction account loading, and instruction
+    /// processing (everything under `load_and_execute_transactions`).
     pub fn new_for_txn_tests(
         bank_rc: BankRc,
         fields: BankFieldsToDeserialize,
@@ -6370,6 +6375,10 @@ impl Bank {
     /// mid-distribution, and runs `prepare_for_block_execution` to
     /// complete the `_new_from_parent`-equivalent initialization
     /// (epoch processing, sysvar updates, LT hash cache).
+    ///
+    /// Covers epoch boundary processing, rewards distribution, LT and
+    /// bank hash calculation, sysvar updates, runtime transaction
+    /// processing, and the votes/stakes caches.
     pub fn new_for_block_tests(
         bank_rc: BankRc,
         fields: BankFieldsToDeserialize,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6333,16 +6333,15 @@ impl Bank {
     }
 
     /// Create a bank for transaction testing. Constructs the bank struct,
-    /// applies activated features, and fills missing sysvar cache entries
-    /// so transactions can execute. Skips block-level setup
-    /// (`prepare_for_block_execution`, partitioned rewards recalc) and
-    /// snapshot fields (stakes loading, debug keys, accounts data size)
-    /// that are irrelevant to individual transaction execution.
+    /// applies activated features, and fills missing sysvar cache entries.
+    /// Skips block-level setup (`prepare_for_block_execution`, partitioned
+    /// rewards recalc) and snapshot fields (stakes loading, debug keys,
+    /// accounts data size) that are irrelevant to individual transaction
+    /// execution.
     ///
-    /// Covers the full transaction processing pipeline including
-    /// transaction age/nonce checks, compute budget and limits
-    /// sanitization, transaction account loading, and instruction
-    /// processing (everything under `load_and_execute_transactions`).
+    /// **Important:** The returned bank must be inserted into a
+    /// [`BankForks`] before calling `load_and_execute_transactions`,
+    /// because the program cache requires a `ForkGraph` to be present.
     pub fn new_for_txn_tests(
         bank_rc: BankRc,
         fields: BankFieldsToDeserialize,
@@ -6376,9 +6375,9 @@ impl Bank {
     /// complete the `_new_from_parent`-equivalent initialization
     /// (epoch processing, sysvar updates, LT hash cache).
     ///
-    /// Covers epoch boundary processing, rewards distribution, LT and
-    /// bank hash calculation, sysvar updates, runtime transaction
-    /// processing, and the votes/stakes caches.
+    /// **Important:** The returned bank must be inserted into a
+    /// [`BankForks`] before calling `load_and_execute_transactions`,
+    /// because the program cache requires a `ForkGraph` to be present.
     pub fn new_for_block_tests(
         bank_rc: BankRc,
         fields: BankFieldsToDeserialize,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1843,11 +1843,13 @@ impl Bank {
         new
     }
 
-    fn load_rent_from_account_for_snapshot_load(bank_rc: &BankRc, ancestors: &Ancestors) -> Rent {
+    fn load_rent_from_account_for_snapshot_load(
+        accounts: &Accounts,
+        ancestors: &Ancestors,
+    ) -> Rent {
         // The serialized rent collector is deprecated. Instead, reconstruct from fields plus
         // the rent sysvar account state.
-        let rent_sysvar = bank_rc
-            .accounts
+        let rent_sysvar = accounts
             .load_with_fixed_root_do_not_populate_read_cache(ancestors, &sysvar::rent::id())
             .expect("snapshot must contain rent sysvar account")
             .0;
@@ -1866,7 +1868,7 @@ impl Bank {
         parent_capitalization: u64,
         parent_block_height: u64,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
-    ) -> PrepareBlockExecutionTimings {
+    ) -> PrepareBlockExecutionStats {
         let slot = self.slot;
 
         // Following code may touch AccountsDb, requiring proper ancestors
@@ -1928,7 +1930,7 @@ impl Bank {
                 num_accounts_modified_this_slot
             });
 
-        PrepareBlockExecutionTimings {
+        PrepareBlockExecutionStats {
             update_epoch_time_us,
             distribute_rewards_time_us,
             cache_preparation_time_us,
@@ -2015,7 +2017,7 @@ impl Bank {
         );
 
         let stakes_accounts_load_duration = now.elapsed();
-        let rent = Self::load_rent_from_account_for_snapshot_load(&bank_rc, &ancestors);
+        let rent = Self::load_rent_from_account_for_snapshot_load(&bank_rc.accounts, &ancestors);
         let mut bank = Self {
             rc: bank_rc,
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
@@ -6281,7 +6283,7 @@ impl Bank {
         let slot = fields.slot;
         let epoch = fields.epoch_schedule.get_epoch(slot);
         let ancestors = Ancestors::from(vec![slot]);
-        let rent = Self::load_rent_from_account_for_snapshot_load(&bank_rc, &ancestors);
+        let rent = Self::load_rent_from_account_for_snapshot_load(&bank_rc.accounts, &ancestors);
 
         let accounts = Accounts::new(Arc::clone(&bank_rc.accounts.accounts_db));
         let mut bank = Self::default_with_accounts(accounts);
@@ -6356,10 +6358,7 @@ impl Bank {
             0,                      /* Irrelevant to txn execution */
         );
 
-        // Apply activated features
         bank.apply_activated_features();
-
-        // Initialize sysvar cache
         bank.transaction_processor
             .fill_missing_sysvar_cache_entries(&bank);
 
@@ -6376,15 +6375,9 @@ impl Bank {
         fields: BankFieldsToDeserialize,
         feature_set: FeatureSet,
         epoch_stakes: HashMap<Epoch, VersionedEpochStakes>,
-        stakes: Stakes<
-            crate::stake_account::StakeAccount<solana_stake_interface::state::Delegation>,
-        >,
+        stakes: Stakes<StakeAccount<Delegation>>,
         accounts_data_size_initial: u64,
     ) -> Self {
-        assert_ne!(
-            fields.slot, 0,
-            "new_for_block_tests does not support genesis slot"
-        );
         let parent_epoch = fields.epoch_schedule.get_epoch(fields.parent_slot);
         let parent_capitalization = fields.capitalization;
         let leader =

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6283,81 +6283,51 @@ impl Bank {
         let ancestors = Ancestors::from(vec![slot]);
         let rent = Self::load_rent_from_account_for_snapshot_load(&bank_rc, &ancestors);
 
-        Self {
-            rc: bank_rc,
-            status_cache: Arc::<RwLock<BankStatusCache>>::default(),
-            blockhash_queue: RwLock::new(fields.blockhash_queue),
-            max_processing_age: MAX_PROCESSING_AGE,
-            ancestors,
-            hash: RwLock::new(fields.hash),
-            parent_hash: fields.parent_hash,
-            parent_slot: fields.parent_slot,
-            hard_forks: Arc::new(RwLock::new(fields.hard_forks)),
-            transaction_count: AtomicU64::new(fields.transaction_count),
-            non_vote_transaction_count_since_restart: AtomicU64::default(),
-            transaction_error_count: AtomicU64::default(),
-            transaction_entries_count: AtomicU64::default(),
-            transactions_per_entry_max: AtomicU64::default(),
-            entry_bytes_consumed: EntryBytesBudget::new(MAX_ENTRY_BYTES_PER_SLOT),
-            tick_height: AtomicU64::new(fields.tick_height),
-            signature_count: AtomicU64::new(fields.signature_count),
-            capitalization: AtomicU64::new(fields.capitalization),
-            max_tick_height: fields.max_tick_height,
-            hashes_per_tick: fields.hashes_per_tick,
-            ticks_per_slot: fields.ticks_per_slot,
-            ns_per_slot: fields.ns_per_slot,
-            genesis_creation_time: fields.genesis_creation_time,
-            slots_per_year: fields.slots_per_year,
-            slot,
-            bank_id: 0,
+        let accounts = Accounts::new(Arc::clone(&bank_rc.accounts.accounts_db));
+        let mut bank = Self::default_with_accounts(accounts);
+
+        bank.rc = bank_rc;
+        bank.blockhash_queue = RwLock::new(fields.blockhash_queue);
+        bank.ancestors = ancestors;
+        bank.hash = RwLock::new(fields.hash);
+        bank.parent_hash = fields.parent_hash;
+        bank.parent_slot = fields.parent_slot;
+        bank.hard_forks = Arc::new(RwLock::new(fields.hard_forks));
+        bank.transaction_count = AtomicU64::new(fields.transaction_count);
+        bank.tick_height = AtomicU64::new(fields.tick_height);
+        bank.signature_count = AtomicU64::new(fields.signature_count);
+        bank.capitalization = AtomicU64::new(fields.capitalization);
+        bank.max_tick_height = fields.max_tick_height;
+        bank.hashes_per_tick = fields.hashes_per_tick;
+        bank.ticks_per_slot = fields.ticks_per_slot;
+        bank.ns_per_slot = fields.ns_per_slot;
+        bank.genesis_creation_time = fields.genesis_creation_time;
+        bank.slots_per_year = fields.slots_per_year;
+        bank.slot = slot;
+        bank.epoch = epoch;
+        bank.block_height = fields.block_height;
+        bank.leader = leader;
+        bank.fee_rate_governor = fields.fee_rate_governor;
+        bank.rent_collector = RentCollector::new(
             epoch,
-            block_height: fields.block_height,
-            leader,
-            fee_rate_governor: fields.fee_rate_governor,
-            rent_collector: RentCollector::new(
-                epoch,
-                fields.epoch_schedule.clone(),
-                fields.slots_per_year,
-                rent,
-            ),
-            epoch_schedule: fields.epoch_schedule,
-            inflation: Arc::new(RwLock::new(fields.inflation)),
-            stakes_cache,
-            epoch_stakes,
-            is_delta: AtomicBool::new(fields.is_delta),
-            rewards: RwLock::new(vec![]),
-            cluster_type: Some(ClusterType::Development),
-            transaction_debug_keys: None, /* Irrelevant to txn execution */
-            transaction_log_collector_config: Arc::<RwLock<TransactionLogCollectorConfig>>::default(
-            ),
-            transaction_log_collector: Arc::<RwLock<TransactionLogCollector>>::default(),
-            feature_set: Arc::new(feature_set),
-            reserved_account_keys: Arc::<ReservedAccountKeys>::default(),
-            drop_callback: RwLock::new(OptionalDropCallback(None)),
-            freeze_started: AtomicBool::new(fields.hash != Hash::default()),
-            vote_only_bank: false,
-            cost_tracker: RwLock::new(CostTracker::default()),
-            accounts_data_size_initial,
-            accounts_data_size_delta_on_chain: AtomicI64::new(0),
-            accounts_data_size_delta_off_chain: AtomicI64::new(0),
-            epoch_reward_status: EpochRewardStatus::default(),
-            transaction_processor: TransactionBatchProcessor::new_uninitialized(slot, epoch),
-            check_program_deployment_slot: false,
-            // collector_fee_details is not serialized to snapshot
-            collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
-            compute_budget: None, /* Set in transaction processor init */
-            transaction_account_lock_limit: None,
-            fee_structure: FeeStructure::default(),
-            hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
-            accounts_lt_hash: Mutex::new(fields.accounts_lt_hash),
-            cache_for_accounts_lt_hash: DashMap::default(),
-            stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
-            block_id: RwLock::new(None),
-            bank_hash_stats: AtomicBankHashStats::new(&fields.bank_hash_stats),
-            epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
-            expected_bank_hash: RwLock::new(None),
-            block_component_processor: RwLock::new(BlockComponentProcessor::default()),
-        }
+            fields.epoch_schedule.clone(),
+            fields.slots_per_year,
+            rent,
+        );
+        bank.epoch_schedule = fields.epoch_schedule;
+        bank.inflation = Arc::new(RwLock::new(fields.inflation));
+        bank.stakes_cache = stakes_cache;
+        bank.epoch_stakes = epoch_stakes;
+        bank.is_delta = AtomicBool::new(fields.is_delta);
+        bank.cluster_type = Some(ClusterType::Development);
+        bank.feature_set = Arc::new(feature_set);
+        bank.freeze_started = AtomicBool::new(fields.hash != Hash::default());
+        bank.accounts_data_size_initial = accounts_data_size_initial;
+        bank.transaction_processor = TransactionBatchProcessor::new_uninitialized(slot, epoch);
+        bank.accounts_lt_hash = Mutex::new(fields.accounts_lt_hash);
+        bank.bank_hash_stats = AtomicBankHashStats::new(&fields.bank_hash_stats);
+
+        bank
     }
 
     /// Create a bank for transaction testing. Constructs the bank struct,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -204,6 +204,7 @@ use {
 #[cfg(feature = "dev-context-only-utils")]
 use {
     dashmap::DashSet,
+    qualifier_attr::{field_qualifiers, qualifiers},
     rayon::iter::{IntoParallelRefIterator, ParallelIterator},
     solana_accounts_db::accounts_db::{
         ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
@@ -326,6 +327,7 @@ pub struct BankRc {
 }
 
 impl BankRc {
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn new(accounts: Accounts) -> Self {
         Self {
             accounts: Arc::new(accounts),
@@ -460,6 +462,39 @@ impl TransactionLogCollector {
 /// new fields can be optionally serialized and optionally deserialized. At some point, the serialization and
 /// deserialization will use a new mechanism or otherwise be in sync more clearly.
 #[derive(Clone, Debug)]
+#[cfg_attr(
+    feature = "dev-context-only-utils",
+    field_qualifiers(
+        blockhash_queue(pub),
+        hash(pub),
+        parent_hash(pub),
+        parent_slot(pub),
+        hard_forks(pub),
+        transaction_count(pub),
+        tick_height(pub),
+        signature_count(pub),
+        capitalization(pub),
+        max_tick_height(pub),
+        hashes_per_tick(pub),
+        ticks_per_slot(pub),
+        ns_per_slot(pub),
+        genesis_creation_time(pub),
+        slots_per_year(pub),
+        slot(pub),
+        block_height(pub),
+        leader_id(pub),
+        fee_rate_governor(pub),
+        epoch_schedule(pub),
+        inflation(pub),
+        stakes(pub),
+        is_delta(pub),
+        accounts_data_len(pub),
+        versioned_epoch_stakes(pub),
+        accounts_lt_hash(pub),
+        bank_hash_stats(pub),
+        block_id(pub),
+    )
+)]
 pub struct BankFieldsToDeserialize {
     pub(crate) blockhash_queue: BlockhashQueue,
     pub(crate) hash: Hash,
@@ -1421,71 +1456,20 @@ impl Bank {
             new.ancestors = Ancestors::from(ancestors);
         });
 
-        // Following code may touch AccountsDb, requiring proper ancestors
-        let (_, update_epoch_time_us) = measure_us!({
-            if parent.epoch() < new.epoch() {
-                new.process_new_epoch(
-                    parent.epoch(),
-                    parent.slot(),
-                    parent.capitalization(),
-                    parent.block_height(),
-                    reward_calc_tracer,
-                );
-            } else {
-                // Save a snapshot of stakes for use in consensus and stake weighted networking
-                let leader_schedule_epoch = new.epoch_schedule().get_leader_schedule_epoch(slot);
-                new.update_epoch_stakes(leader_schedule_epoch);
-            }
-        });
-
-        let (_, distribute_rewards_time_us) =
-            measure_us!(new.distribute_partitioned_epoch_rewards());
-
-        let (_, cache_preparation_time_us) =
-            measure_us!(new.prepare_program_cache_for_upcoming_feature_set());
-
-        // Update sysvars before processing transactions
-        let (_, update_sysvars_time_us) = measure_us!({
-            new.update_slot_hashes();
-            new.update_stake_history(Some(parent.epoch()));
-            // Keep setting the tower clock sysvar till we have not migrated to Alpenglow.
-            if new.get_alpenglow_genesis_certificate().is_none() {
-                new.update_clock(Some(parent.epoch()));
-            }
-            new.update_last_restart_slot()
-        });
-
-        let (_, fill_sysvar_cache_time_us) = measure_us!(
-            new.transaction_processor
-                .fill_missing_sysvar_cache_entries(&new)
+        let prepare_timings = new.prepare_for_block_execution(
+            parent.epoch(),
+            parent.slot(),
+            parent.capitalization(),
+            parent.block_height(),
+            reward_calc_tracer,
         );
-
-        let (num_accounts_modified_this_slot, populate_cache_for_accounts_lt_hash_us) =
-            measure_us!({
-                // The cache for accounts lt hash needs to be made aware of accounts modified
-                // before transaction processing begins.  Otherwise we may calculate the wrong
-                // accounts lt hash due to having the wrong initial state of the account.  The
-                // lt hash cache's initial state must always be from an ancestor, and cannot be
-                // an intermediate state within this Bank's slot.  If the lt hash cache has the
-                // wrong initial account state, we'll mix out the wrong lt hash value, and thus
-                // have the wrong overall accounts lt hash, and diverge.
-                let accounts_modified_this_slot =
-                    new.rc.accounts.accounts_db.get_pubkeys_for_slot(slot);
-                let num_accounts_modified_this_slot = accounts_modified_this_slot.len();
-                for pubkey in accounts_modified_this_slot {
-                    new.cache_for_accounts_lt_hash
-                        .entry(pubkey)
-                        .or_insert(AccountsLtHashCacheValue::BankNew);
-                }
-                num_accounts_modified_this_slot
-            });
 
         time.stop();
         report_new_bank_metrics(
             slot,
             parent.slot(),
             new.block_height,
-            num_accounts_modified_this_slot,
+            prepare_timings.num_accounts_modified_this_slot,
             NewBankTimings {
                 bank_rc_creation_time_us,
                 total_elapsed_time_us: time.as_us(),
@@ -1500,12 +1484,13 @@ impl Bank {
                 transaction_log_collector_config_time_us,
                 feature_set_time_us,
                 ancestors_time_us,
-                update_epoch_time_us,
-                distribute_rewards_time_us,
-                cache_preparation_time_us,
-                update_sysvars_time_us,
-                fill_sysvar_cache_time_us,
-                populate_cache_for_accounts_lt_hash_us,
+                update_epoch_time_us: prepare_timings.update_epoch_time_us,
+                distribute_rewards_time_us: prepare_timings.distribute_rewards_time_us,
+                cache_preparation_time_us: prepare_timings.cache_preparation_time_us,
+                update_sysvars_time_us: prepare_timings.update_sysvars_time_us,
+                fill_sysvar_cache_time_us: prepare_timings.fill_sysvar_cache_time_us,
+                populate_cache_for_accounts_lt_hash_us: prepare_timings
+                    .populate_cache_for_accounts_lt_hash_us,
             },
         );
 
@@ -1858,6 +1843,102 @@ impl Bank {
         new
     }
 
+    fn load_rent_from_account_for_snapshot_load(bank_rc: &BankRc, ancestors: &Ancestors) -> Rent {
+        // The serialized rent collector is deprecated. Instead, reconstruct from fields plus
+        // the rent sysvar account state.
+        let rent_sysvar = bank_rc
+            .accounts
+            .load_with_fixed_root_do_not_populate_read_cache(ancestors, &sysvar::rent::id())
+            .expect("snapshot must contain rent sysvar account")
+            .0;
+        from_account::<sysvar::rent::Rent, _>(&rent_sysvar)
+            .expect("snapshot must contain well-formed rent sysvar account")
+    }
+
+    /// Complete bank initialization for block execution. Performs epoch
+    /// processing, sysvar updates, program cache preparation, and LT hash
+    /// cache population -- the post-construction sequence shared by
+    /// `_new_from_parent` and the block-test path.
+    fn prepare_for_block_execution(
+        &mut self,
+        parent_epoch: Epoch,
+        parent_slot: Slot,
+        parent_capitalization: u64,
+        parent_block_height: u64,
+        reward_calc_tracer: Option<impl RewardCalcTracer>,
+    ) -> PrepareBlockExecutionTimings {
+        let slot = self.slot;
+
+        // Following code may touch AccountsDb, requiring proper ancestors
+        let (_, update_epoch_time_us) = measure_us!({
+            if parent_epoch < self.epoch() {
+                self.process_new_epoch(
+                    parent_epoch,
+                    parent_slot,
+                    parent_capitalization,
+                    parent_block_height,
+                    reward_calc_tracer,
+                );
+            } else {
+                // Save a snapshot of stakes for use in consensus and stake weighted networking
+                let leader_schedule_epoch = self.epoch_schedule().get_leader_schedule_epoch(slot);
+                self.update_epoch_stakes(leader_schedule_epoch);
+            }
+        });
+
+        let (_, distribute_rewards_time_us) =
+            measure_us!(self.distribute_partitioned_epoch_rewards());
+
+        let (_, cache_preparation_time_us) =
+            measure_us!(self.prepare_program_cache_for_upcoming_feature_set());
+
+        // Update sysvars before processing transactions
+        let (_, update_sysvars_time_us) = measure_us!({
+            self.update_slot_hashes();
+            self.update_stake_history(Some(parent_epoch));
+            // Keep setting the tower clock sysvar till we have not migrated to Alpenglow.
+            if self.get_alpenglow_genesis_certificate().is_none() {
+                self.update_clock(Some(parent_epoch));
+            }
+            self.update_last_restart_slot()
+        });
+
+        let (_, fill_sysvar_cache_time_us) = measure_us!(
+            self.transaction_processor
+                .fill_missing_sysvar_cache_entries(self)
+        );
+
+        let (num_accounts_modified_this_slot, populate_cache_for_accounts_lt_hash_us) =
+            measure_us!({
+                // The cache for accounts lt hash needs to be made aware of accounts modified
+                // before transaction processing begins.  Otherwise we may calculate the wrong
+                // accounts lt hash due to having the wrong initial state of the account.  The
+                // lt hash cache's initial state must always be from an ancestor, and cannot be
+                // an intermediate state within this Bank's slot.  If the lt hash cache has the
+                // wrong initial account state, we'll mix out the wrong lt hash value, and thus
+                // have the wrong overall accounts lt hash, and diverge.
+                let accounts_modified_this_slot =
+                    self.rc.accounts.accounts_db.get_pubkeys_for_slot(slot);
+                let num_accounts_modified_this_slot = accounts_modified_this_slot.len();
+                for pubkey in accounts_modified_this_slot {
+                    self.cache_for_accounts_lt_hash
+                        .entry(pubkey)
+                        .or_insert(AccountsLtHashCacheValue::BankNew);
+                }
+                num_accounts_modified_this_slot
+            });
+
+        PrepareBlockExecutionTimings {
+            update_epoch_time_us,
+            distribute_rewards_time_us,
+            cache_preparation_time_us,
+            update_sysvars_time_us,
+            fill_sysvar_cache_time_us,
+            num_accounts_modified_this_slot,
+            populate_cache_for_accounts_lt_hash_us,
+        }
+    }
+
     /// Create a bank from explicit arguments and deserialized fields from snapshot
     pub(crate) fn new_from_snapshot(
         bank_rc: BankRc,
@@ -1934,17 +2015,7 @@ impl Bank {
         );
 
         let stakes_accounts_load_duration = now.elapsed();
-        // The serialized rent collector is deprecated. Instead, reconstruct from fields plus
-        // the rent sysvar account state.
-        let rent = {
-            let rent_sysvar = bank_rc
-                .accounts
-                .load_with_fixed_root_do_not_populate_read_cache(&ancestors, &sysvar::rent::id())
-                .expect("snapshot must contain rent sysvar account")
-                .0;
-            from_account::<sysvar::rent::Rent, _>(&rent_sysvar)
-                .expect("snapshot must contain well-formed rent sysvar account")
-        };
+        let rent = Self::load_rent_from_account_for_snapshot_load(&bank_rc, &ancestors);
         let mut bank = Self {
             rc: bank_rc,
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
@@ -6192,6 +6263,195 @@ impl fmt::Debug for Bank {
 
 #[cfg(feature = "dev-context-only-utils")]
 impl Bank {
+    /// Shared bank constructor used by `new_for_txn_tests` and
+    /// `new_for_block_tests`. Builds only the `Bank` struct from deserialized
+    /// fields with the supplied `leader`, `stakes_cache`, and
+    /// `accounts_data_size_initial`. All post-init (feature application,
+    /// sysvar cache fill, partitioned rewards recalc,
+    /// `prepare_for_block_execution`, etc.) is the caller's responsibility.
+    fn new_from_fields_for_tests(
+        bank_rc: BankRc,
+        fields: BankFieldsToDeserialize,
+        feature_set: FeatureSet,
+        epoch_stakes: HashMap<Epoch, VersionedEpochStakes>,
+        leader: SlotLeader,
+        stakes_cache: StakesCache,
+        accounts_data_size_initial: u64,
+    ) -> Self {
+        let slot = fields.slot;
+        let epoch = fields.epoch_schedule.get_epoch(slot);
+        let ancestors = Ancestors::from(vec![slot]);
+        let rent = Self::load_rent_from_account_for_snapshot_load(&bank_rc, &ancestors);
+
+        Self {
+            rc: bank_rc,
+            status_cache: Arc::<RwLock<BankStatusCache>>::default(),
+            blockhash_queue: RwLock::new(fields.blockhash_queue),
+            max_processing_age: MAX_PROCESSING_AGE,
+            ancestors,
+            hash: RwLock::new(fields.hash),
+            parent_hash: fields.parent_hash,
+            parent_slot: fields.parent_slot,
+            hard_forks: Arc::new(RwLock::new(fields.hard_forks)),
+            transaction_count: AtomicU64::new(fields.transaction_count),
+            non_vote_transaction_count_since_restart: AtomicU64::default(),
+            transaction_error_count: AtomicU64::default(),
+            transaction_entries_count: AtomicU64::default(),
+            transactions_per_entry_max: AtomicU64::default(),
+            entry_bytes_consumed: EntryBytesBudget::new(MAX_ENTRY_BYTES_PER_SLOT),
+            tick_height: AtomicU64::new(fields.tick_height),
+            signature_count: AtomicU64::new(fields.signature_count),
+            capitalization: AtomicU64::new(fields.capitalization),
+            max_tick_height: fields.max_tick_height,
+            hashes_per_tick: fields.hashes_per_tick,
+            ticks_per_slot: fields.ticks_per_slot,
+            ns_per_slot: fields.ns_per_slot,
+            genesis_creation_time: fields.genesis_creation_time,
+            slots_per_year: fields.slots_per_year,
+            slot,
+            bank_id: 0,
+            epoch,
+            block_height: fields.block_height,
+            leader,
+            fee_rate_governor: fields.fee_rate_governor,
+            rent_collector: RentCollector::new(
+                epoch,
+                fields.epoch_schedule.clone(),
+                fields.slots_per_year,
+                rent,
+            ),
+            epoch_schedule: fields.epoch_schedule,
+            inflation: Arc::new(RwLock::new(fields.inflation)),
+            stakes_cache,
+            epoch_stakes,
+            is_delta: AtomicBool::new(fields.is_delta),
+            rewards: RwLock::new(vec![]),
+            cluster_type: Some(ClusterType::Development),
+            transaction_debug_keys: None, /* Irrelevant to txn execution */
+            transaction_log_collector_config: Arc::<RwLock<TransactionLogCollectorConfig>>::default(
+            ),
+            transaction_log_collector: Arc::<RwLock<TransactionLogCollector>>::default(),
+            feature_set: Arc::new(feature_set),
+            reserved_account_keys: Arc::<ReservedAccountKeys>::default(),
+            drop_callback: RwLock::new(OptionalDropCallback(None)),
+            freeze_started: AtomicBool::new(fields.hash != Hash::default()),
+            vote_only_bank: false,
+            cost_tracker: RwLock::new(CostTracker::default()),
+            accounts_data_size_initial,
+            accounts_data_size_delta_on_chain: AtomicI64::new(0),
+            accounts_data_size_delta_off_chain: AtomicI64::new(0),
+            epoch_reward_status: EpochRewardStatus::default(),
+            transaction_processor: TransactionBatchProcessor::new_uninitialized(slot, epoch),
+            check_program_deployment_slot: false,
+            // collector_fee_details is not serialized to snapshot
+            collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
+            compute_budget: None, /* Set in transaction processor init */
+            transaction_account_lock_limit: None,
+            fee_structure: FeeStructure::default(),
+            hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
+            accounts_lt_hash: Mutex::new(fields.accounts_lt_hash),
+            cache_for_accounts_lt_hash: DashMap::default(),
+            stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
+            block_id: RwLock::new(None),
+            bank_hash_stats: AtomicBankHashStats::new(&fields.bank_hash_stats),
+            epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
+            expected_bank_hash: RwLock::new(None),
+            block_component_processor: RwLock::new(BlockComponentProcessor::default()),
+        }
+    }
+
+    /// Create a bank for transaction testing. Constructs the bank struct,
+    /// applies activated features, and fills missing sysvar cache entries
+    /// so transactions can execute. Skips block-level setup
+    /// (`prepare_for_block_execution`, partitioned rewards recalc) and
+    /// snapshot fields (stakes loading, debug keys, accounts data size)
+    /// that are irrelevant to individual transaction execution.
+    pub fn new_for_txn_tests(
+        bank_rc: BankRc,
+        fields: BankFieldsToDeserialize,
+        feature_set: FeatureSet,
+        epoch_stakes: HashMap<Epoch, VersionedEpochStakes>,
+    ) -> Self {
+        let leader = SlotLeader {
+            id: fields.leader_id,
+            vote_address: Pubkey::default(),
+        };
+        let mut bank = Self::new_from_fields_for_tests(
+            bank_rc,
+            fields,
+            feature_set,
+            epoch_stakes,
+            leader,
+            StakesCache::default(), /* Irrelevant for txn tests */
+            0,                      /* Irrelevant to txn execution */
+        );
+
+        // Apply activated features
+        bank.apply_activated_features();
+
+        // Initialize sysvar cache
+        bank.transaction_processor
+            .fill_missing_sysvar_cache_entries(&bank);
+
+        bank
+    }
+
+    /// Create a bank for block testing. Constructs the bank struct,
+    /// applies activated features, recalculates partitioned rewards if
+    /// mid-distribution, and runs `prepare_for_block_execution` to
+    /// complete the `_new_from_parent`-equivalent initialization
+    /// (epoch processing, sysvar updates, LT hash cache).
+    pub fn new_for_block_tests(
+        bank_rc: BankRc,
+        fields: BankFieldsToDeserialize,
+        feature_set: FeatureSet,
+        epoch_stakes: HashMap<Epoch, VersionedEpochStakes>,
+        stakes: Stakes<
+            crate::stake_account::StakeAccount<solana_stake_interface::state::Delegation>,
+        >,
+        accounts_data_size_initial: u64,
+    ) -> Self {
+        assert_ne!(
+            fields.slot, 0,
+            "new_for_block_tests does not support genesis slot"
+        );
+        let parent_epoch = fields.epoch_schedule.get_epoch(fields.parent_slot);
+        let parent_capitalization = fields.capitalization;
+        let leader =
+            Self::slot_leader_from_epoch_stakes(fields.slot, &fields.epoch_schedule, &epoch_stakes);
+
+        let mut bank = Self::new_from_fields_for_tests(
+            bank_rc,
+            fields,
+            feature_set,
+            epoch_stakes,
+            leader,
+            StakesCache::new(stakes),
+            accounts_data_size_initial,
+        );
+
+        bank.apply_activated_features();
+
+        // If booting mid-distribution, recalculate reward partitions from the
+        // EpochRewards sysvar (mirrors initialize_after_snapshot_restore).
+        bank.recalculate_partitioned_rewards_if_active(|| {
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("single-threaded rayon pool")
+        });
+
+        bank.prepare_for_block_execution(
+            parent_epoch,
+            bank.parent_slot,
+            parent_capitalization,
+            bank.block_height.saturating_sub(1),
+            null_tracer(),
+        );
+
+        bank
+    }
+
     pub fn wrap_with_bank_forks_for_tests(self) -> (Arc<Self>, Arc<RwLock<BankForks>>) {
         let bank_forks = BankForks::new_rw_arc(self);
         let bank = bank_forks.read().unwrap().root_bank();

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -48,6 +48,16 @@ pub(crate) struct NewBankTimings {
     pub(crate) populate_cache_for_accounts_lt_hash_us: u64,
 }
 
+pub(crate) struct PrepareBlockExecutionTimings {
+    pub(crate) update_epoch_time_us: u64,
+    pub(crate) distribute_rewards_time_us: u64,
+    pub(crate) cache_preparation_time_us: u64,
+    pub(crate) update_sysvars_time_us: u64,
+    pub(crate) fill_sysvar_cache_time_us: u64,
+    pub(crate) num_accounts_modified_this_slot: usize,
+    pub(crate) populate_cache_for_accounts_lt_hash_us: u64,
+}
+
 pub(crate) fn report_new_epoch_metrics(
     epoch: Epoch,
     slot: Slot,

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -48,7 +48,7 @@ pub(crate) struct NewBankTimings {
     pub(crate) populate_cache_for_accounts_lt_hash_us: u64,
 }
 
-pub(crate) struct PrepareBlockExecutionTimings {
+pub(crate) struct PrepareBlockExecutionStats {
     pub(crate) update_epoch_time_us: u64,
     pub(crate) distribute_rewards_time_us: u64,
     pub(crate) cache_preparation_time_us: u64,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11796,11 +11796,8 @@ fn test_calculate_and_set_block_id_for_dcou() {
 }
 
 /// Exercises `Bank::new_for_txn_tests` by constructing a bank from
-/// deserialized fields and executing a system transfer. Covers the
-/// full transaction processing pipeline including transaction
-/// age/nonce checks, requested compute budget and limits
-/// sanitization, transaction account loading, and instruction
-/// processing (everything under `load_and_execute_transactions`).
+/// deserialized fields, wrapping it in `BankForks` (required for the
+/// program cache's `ForkGraph`), and executing a system transfer.
 #[test]
 fn test_new_for_txn_tests_system_transfer() {
     let slot = 10;
@@ -11944,11 +11941,9 @@ fn test_new_for_txn_tests_system_transfer() {
 }
 
 /// Exercises `Bank::new_for_block_tests` by constructing a bank with
-/// vote/stake accounts, executing a system transfer, and verifying a
-/// deterministic bank hash. Covers epoch boundary processing,
-/// rewards distribution, LT and bank hash calculation, sysvar
-/// updates, runtime transaction processing, and the votes/stakes
-/// caches.
+/// vote/stake accounts, wrapping it in `BankForks` (required for the
+/// program cache's `ForkGraph`), executing a system transfer, and
+/// verifying a deterministic bank hash.
 #[test]
 fn test_new_for_block_tests_with_vote_account() {
     let slot = 10;

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11786,3 +11786,162 @@ fn test_calculate_and_set_block_id_for_dcou() {
         assert_eq!(bank.block_id(), Some(expected_block_id));
     }
 }
+
+#[test]
+fn test_new_for_txn_tests_system_transfer() {
+    use {
+        crate::{
+            epoch_stakes::VersionedEpochStakes,
+            stake_history::StakeHistory,
+            stakes::{DeserializableStakes, SerdeStakesToStakeFormat, Stakes},
+        },
+        solana_accounts_db::{
+            accounts::Accounts, accounts_db::AccountsDb, accounts_hash::AccountsLtHash,
+            blockhash_queue::BlockhashQueue,
+        },
+        solana_hard_forks::HardForks,
+        solana_inflation::Inflation,
+        solana_lattice_hash::lt_hash::LtHash,
+        solana_vote::vote_account::VoteAccounts,
+    };
+
+    let slot: Slot = 10;
+    let parent_slot: Slot = slot - 1;
+    let epoch_schedule = EpochSchedule::default();
+    let epoch = epoch_schedule.get_epoch(slot);
+    let lamports_per_signature: u64 = 5000;
+    let transfer_amount: u64 = 100_000;
+
+    let sender = Keypair::new();
+    let recipient = Pubkey::new_unique();
+
+    let mut blockhash_queue = BlockhashQueue::default();
+    let recent_blockhash = Hash::new_unique();
+    blockhash_queue.register_hash(&recent_blockhash, lamports_per_signature);
+
+    let accounts_db = AccountsDb::default_for_tests();
+    let accounts = Accounts::new(Arc::new(accounts_db));
+
+    let clock = solana_clock::Clock {
+        slot,
+        epoch,
+        ..solana_clock::Clock::default()
+    };
+    let rent = Rent::default();
+
+    let make_sysvar = |data: Vec<u8>| -> AccountSharedData {
+        let mut acct = AccountSharedData::new(1, data.len(), &solana_sdk_ids::sysvar::id());
+        acct.set_data_from_slice(&data);
+        acct
+    };
+
+    let owned_accounts: Vec<(Pubkey, AccountSharedData)> = vec![
+        (
+            sender.pubkey(),
+            AccountSharedData::new(1_000_000_000, 0, &system_program::id()),
+        ),
+        (
+            recipient,
+            AccountSharedData::new(1_000_000_000, 0, &system_program::id()),
+        ),
+        (
+            sysvar::clock::id(),
+            make_sysvar(bincode::serialize(&clock).unwrap()),
+        ),
+        (
+            sysvar::epoch_schedule::id(),
+            make_sysvar(bincode::serialize(&epoch_schedule).unwrap()),
+        ),
+        (
+            sysvar::rent::id(),
+            make_sysvar(bincode::serialize(&rent).unwrap()),
+        ),
+        (
+            solana_sdk_ids::sysvar::slot_hashes::id(),
+            make_sysvar(bincode::serialize(&solana_slot_hashes::SlotHashes::default()).unwrap()),
+        ),
+        (system_program::id(), {
+            let mut acct = AccountSharedData::new(1, 14, &native_loader::id());
+            acct.set_executable(true);
+            acct.set_data_from_slice(b"system_program");
+            acct
+        }),
+    ];
+
+    let refs: Vec<(&Pubkey, &AccountSharedData)> =
+        owned_accounts.iter().map(|(k, v)| (k, v)).collect();
+    accounts.store_accounts_seq((parent_slot, refs.as_slice()), None, None);
+    accounts.accounts_db.add_root(parent_slot);
+
+    let bank_rc = BankRc::new(accounts);
+
+    let mut epoch_stakes: HashMap<Epoch, VersionedEpochStakes> = HashMap::new();
+    for key in [epoch, epoch.saturating_add(1)] {
+        epoch_stakes.insert(
+            key,
+            VersionedEpochStakes::new(
+                SerdeStakesToStakeFormat::Stake(Stakes::<Stake>::default()),
+                key,
+            ),
+        );
+    }
+
+    let stakes = DeserializableStakes {
+        vote_accounts: VoteAccounts::default(),
+        stake_delegations: vec![],
+        unused: 0,
+        epoch,
+        stake_history: StakeHistory::default(),
+    };
+
+    let fields = BankFieldsToDeserialize {
+        blockhash_queue,
+        hash: Hash::default(),
+        parent_hash: Hash::default(),
+        parent_slot,
+        hard_forks: HardForks::default(),
+        transaction_count: 0,
+        tick_height: 0,
+        signature_count: 0,
+        capitalization: 0,
+        max_tick_height: 0,
+        hashes_per_tick: None,
+        ticks_per_slot: 0,
+        ns_per_slot: 0,
+        genesis_creation_time: 0,
+        slots_per_year: 0.0,
+        slot,
+        block_height: 0,
+        leader_id: Pubkey::default(),
+        fee_rate_governor: FeeRateGovernor::default(),
+        epoch_schedule: epoch_schedule.clone(),
+        inflation: Inflation::default(),
+        stakes,
+        versioned_epoch_stakes: vec![],
+        is_delta: false,
+        accounts_data_len: 0,
+        accounts_lt_hash: AccountsLtHash(LtHash::identity()),
+        bank_hash_stats: BankHashStats::default(),
+        block_id: None,
+    };
+
+    let bank = Bank::new_for_txn_tests(bank_rc, fields, FeatureSet::all_enabled(), epoch_stakes);
+    let bank_forks = BankForks::new_rw_arc(bank);
+    let bank = bank_forks.read().unwrap().root_bank();
+
+    assert_eq!(bank.slot(), slot);
+    assert_eq!(bank.epoch(), epoch);
+    assert_eq!(bank.last_blockhash(), recent_blockhash);
+
+    let tx = system_transaction::transfer(&sender, &recipient, transfer_amount, recent_blockhash);
+    let result = bank.process_transaction(&tx);
+    assert!(result.is_ok(), "transaction failed: {result:?}");
+
+    let sender_balance = bank.get_balance(&sender.pubkey());
+    let recipient_balance = bank.get_balance(&recipient);
+    assert_eq!(
+        sender_balance,
+        1_000_000_000 - transfer_amount - lamports_per_signature
+    );
+    assert_eq!(recipient_balance, 1_000_000_000 + transfer_amount);
+}

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11945,3 +11945,159 @@ fn test_new_for_txn_tests_system_transfer() {
     );
     assert_eq!(recipient_balance, 1_000_000_000 + transfer_amount);
 }
+
+#[test]
+fn test_new_for_block_tests_with_vote_account() {
+    use {
+        crate::{
+            epoch_stakes::VersionedEpochStakes,
+            stake_history::StakeHistory,
+            stakes::{DeserializableStakes, Stakes},
+        },
+        solana_accounts_db::{
+            accounts::Accounts, accounts_db::AccountsDb, accounts_hash::AccountsLtHash,
+            blockhash_queue::BlockhashQueue,
+        },
+        solana_hard_forks::HardForks,
+        solana_inflation::Inflation,
+        solana_lattice_hash::lt_hash::LtHash,
+        solana_vote::vote_account::{VoteAccount, VoteAccounts},
+    };
+
+    let slot: Slot = 10;
+    let parent_slot: Slot = slot - 1;
+    let epoch_schedule = EpochSchedule::default();
+    let epoch = epoch_schedule.get_epoch(slot);
+    let lamports_per_signature: u64 = 5000;
+
+    let make_sysvar = |data: Vec<u8>| -> AccountSharedData {
+        let mut acct = AccountSharedData::new(1, data.len(), &solana_sdk_ids::sysvar::id());
+        acct.set_data_from_slice(&data);
+        acct
+    };
+
+    let clock = solana_clock::Clock {
+        slot,
+        epoch,
+        ..solana_clock::Clock::default()
+    };
+    let rent = Rent::default();
+
+    let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
+        crate::stakes::tests::create_staked_node_accounts(1_000_000, &rent);
+    let vote_account_shared = vote_account.clone();
+    let stake_account_shared = stake_account.clone();
+
+    let vote_acct = VoteAccount::try_from(vote_account.clone()).unwrap();
+    let node_pubkey = *vote_acct.node_pubkey();
+
+    let mut blockhash_queue = BlockhashQueue::default();
+    let recent_blockhash = Hash::new_unique();
+    blockhash_queue.register_hash(&recent_blockhash, lamports_per_signature);
+
+    let accounts_db = AccountsDb::default_for_tests();
+    let accounts = Accounts::new(Arc::new(accounts_db));
+
+    let owned_accounts: Vec<(Pubkey, AccountSharedData)> = vec![
+        (vote_pubkey, vote_account_shared),
+        (stake_pubkey, stake_account_shared),
+        (
+            sysvar::clock::id(),
+            make_sysvar(bincode::serialize(&clock).unwrap()),
+        ),
+        (
+            sysvar::epoch_schedule::id(),
+            make_sysvar(bincode::serialize(&epoch_schedule).unwrap()),
+        ),
+        (
+            sysvar::rent::id(),
+            make_sysvar(bincode::serialize(&rent).unwrap()),
+        ),
+        (
+            solana_sdk_ids::sysvar::slot_hashes::id(),
+            make_sysvar(bincode::serialize(&solana_slot_hashes::SlotHashes::default()).unwrap()),
+        ),
+        (system_program::id(), {
+            let mut acct = AccountSharedData::new(1, 14, &native_loader::id());
+            acct.set_executable(true);
+            acct.set_data_from_slice(b"system_program");
+            acct
+        }),
+    ];
+
+    let accounts_data_size: u64 = owned_accounts
+        .iter()
+        .map(|(_, a)| a.data().len() as u64)
+        .sum();
+    let total_lamports: u64 = owned_accounts.iter().map(|(_, a)| a.lamports()).sum();
+
+    let refs: Vec<(&Pubkey, &AccountSharedData)> =
+        owned_accounts.iter().map(|(k, v)| (k, v)).collect();
+    accounts.store_accounts_seq((parent_slot, refs.as_slice()), None, None);
+    accounts.accounts_db.add_root(parent_slot);
+
+    let bank_rc = BankRc::new(accounts);
+
+    let vote_accounts_map: HashMap<Pubkey, (u64, VoteAccount)> =
+        HashMap::from([(vote_pubkey, (1_000_000, vote_acct))]);
+    let mut epoch_stakes: HashMap<Epoch, VersionedEpochStakes> = HashMap::new();
+    for key in [epoch, epoch.saturating_add(1)] {
+        epoch_stakes.insert(
+            key,
+            VersionedEpochStakes::new_for_tests(vote_accounts_map.clone(), key),
+        );
+    }
+
+    let stakes_deser = DeserializableStakes {
+        vote_accounts: VoteAccounts::default(),
+        stake_delegations: vec![],
+        unused: 0,
+        epoch,
+        stake_history: StakeHistory::default(),
+    };
+
+    let fields = BankFieldsToDeserialize {
+        blockhash_queue,
+        hash: Hash::default(),
+        parent_hash: Hash::default(),
+        parent_slot,
+        hard_forks: HardForks::default(),
+        transaction_count: 0,
+        tick_height: 64u64.saturating_mul(slot),
+        signature_count: 0,
+        capitalization: total_lamports,
+        max_tick_height: 64u64.saturating_mul(slot.saturating_add(1)),
+        hashes_per_tick: None,
+        ticks_per_slot: 64,
+        ns_per_slot: 0,
+        genesis_creation_time: 0,
+        slots_per_year: 0.0,
+        slot,
+        block_height: slot,
+        leader_id: node_pubkey,
+        fee_rate_governor: FeeRateGovernor::default(),
+        epoch_schedule: epoch_schedule.clone(),
+        inflation: Inflation::default(),
+        stakes: stakes_deser,
+        versioned_epoch_stakes: vec![],
+        is_delta: false,
+        accounts_data_len: 0,
+        accounts_lt_hash: AccountsLtHash(LtHash::identity()),
+        bank_hash_stats: BankHashStats::default(),
+        block_id: None,
+    };
+
+    let bank = Bank::new_for_block_tests(
+        bank_rc,
+        fields,
+        FeatureSet::all_enabled(),
+        epoch_stakes,
+        Stakes::<StakeAccount<Delegation>>::default(),
+        accounts_data_size,
+    );
+
+    assert_eq!(bank.slot(), slot);
+    assert_eq!(bank.epoch(), epoch);
+    assert!(bank.capitalization() > 0);
+    assert_eq!(bank.last_blockhash(), recent_blockhash);
+}

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11832,7 +11832,7 @@ fn test_new_for_txn_tests_system_transfer() {
         acct
     };
 
-    let owned_accounts = vec![
+    let owned_accounts = [
         (
             sender.pubkey(),
             AccountSharedData::new(1_000_000_000, 0, &system_program::id()),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9,6 +9,7 @@ use {
         bank::BankRc,
         bank_client::BankClient,
         bank_forks::BankForks,
+        epoch_stakes::VersionedEpochStakes,
         genesis_utils::{
             self, GenesisConfigInfo, ValidatorVoteKeypairs, activate_all_features,
             activate_feature, bootstrap_validator_stake_lamports,
@@ -20,7 +21,7 @@ use {
         serde_snapshot::fields_from_stream,
         stake_history::StakeHistory,
         stake_utils,
-        stakes::InvalidCacheEntryReason,
+        stakes::{DeserializableStakes, InvalidCacheEntryReason, SerdeStakesToStakeFormat, Stakes},
     },
     agave_feature_set::{self as feature_set, FeatureSet},
     agave_reserved_account_keys::ReservedAccount,
@@ -39,10 +40,13 @@ use {
     },
     solana_account_info::MAX_PERMITTED_DATA_INCREASE,
     solana_accounts_db::{
-        accounts::AccountAddressFilter,
+        accounts::{AccountAddressFilter, Accounts},
+        accounts_db::AccountsDb,
+        accounts_hash::AccountsLtHash,
         accounts_index::{AccountIndex, AccountSecondaryIndexes, IndexKey},
         accounts_scan::ScanError,
         ancestors::Ancestors,
+        blockhash_queue::BlockhashQueue,
     },
     solana_client_traits::SyncClient,
     solana_clock::{
@@ -63,9 +67,12 @@ use {
     solana_fee_calculator::FeeRateGovernor,
     solana_fee_structure::FeeStructure,
     solana_genesis_config::GenesisConfig,
+    solana_hard_forks::HardForks,
     solana_hash::Hash,
+    solana_inflation::Inflation,
     solana_instruction::{AccountMeta, Instruction, error::InstructionError},
     solana_keypair::{Keypair, keypair_from_seed},
+    solana_lattice_hash::lt_hash::LtHash,
     solana_loader_v3_interface::{
         get_program_data_address, instruction::UpgradeableLoaderInstruction,
         state::UpgradeableLoaderState,
@@ -118,6 +125,7 @@ use {
         versioned::VersionedTransaction,
     },
     solana_transaction_error::{TransactionError, TransactionResult as Result},
+    solana_vote::vote_account::{VoteAccount, VoteAccounts},
     solana_vote_interface::state::{BLS_PUBLIC_KEY_COMPRESSED_SIZE, TowerSync},
     solana_vote_program::{
         vote_instruction,
@@ -11787,30 +11795,20 @@ fn test_calculate_and_set_block_id_for_dcou() {
     }
 }
 
+/// Exercises `Bank::new_for_txn_tests` by constructing a bank from
+/// deserialized fields and executing a system transfer. Covers the
+/// full transaction processing pipeline including transaction
+/// age/nonce checks, requested compute budget and limits
+/// sanitization, transaction account loading, and instruction
+/// processing (everything under `load_and_execute_transactions`).
 #[test]
 fn test_new_for_txn_tests_system_transfer() {
-    use {
-        crate::{
-            epoch_stakes::VersionedEpochStakes,
-            stake_history::StakeHistory,
-            stakes::{DeserializableStakes, SerdeStakesToStakeFormat, Stakes},
-        },
-        solana_accounts_db::{
-            accounts::Accounts, accounts_db::AccountsDb, accounts_hash::AccountsLtHash,
-            blockhash_queue::BlockhashQueue,
-        },
-        solana_hard_forks::HardForks,
-        solana_inflation::Inflation,
-        solana_lattice_hash::lt_hash::LtHash,
-        solana_vote::vote_account::VoteAccounts,
-    };
-
-    let slot: Slot = 10;
-    let parent_slot: Slot = slot - 1;
+    let slot = 10;
+    let parent_slot = slot - 1;
     let epoch_schedule = EpochSchedule::default();
     let epoch = epoch_schedule.get_epoch(slot);
-    let lamports_per_signature: u64 = 5000;
-    let transfer_amount: u64 = 100_000;
+    let lamports_per_signature = 5000;
+    let transfer_amount = 100_000;
 
     let sender = Keypair::new();
     let recipient = Pubkey::new_unique();
@@ -11819,8 +11817,7 @@ fn test_new_for_txn_tests_system_transfer() {
     let recent_blockhash = Hash::new_unique();
     blockhash_queue.register_hash(&recent_blockhash, lamports_per_signature);
 
-    let accounts_db = AccountsDb::default_for_tests();
-    let accounts = Accounts::new(Arc::new(accounts_db));
+    let accounts = Accounts::new(Arc::new(AccountsDb::default_for_tests()));
 
     let clock = solana_clock::Clock {
         slot,
@@ -11829,13 +11826,13 @@ fn test_new_for_txn_tests_system_transfer() {
     };
     let rent = Rent::default();
 
-    let make_sysvar = |data: Vec<u8>| -> AccountSharedData {
+    let make_sysvar = |data: Vec<u8>| {
         let mut acct = AccountSharedData::new(1, data.len(), &solana_sdk_ids::sysvar::id());
         acct.set_data_from_slice(&data);
         acct
     };
 
-    let owned_accounts: Vec<(Pubkey, AccountSharedData)> = vec![
+    let owned_accounts = vec![
         (
             sender.pubkey(),
             AccountSharedData::new(1_000_000_000, 0, &system_program::id()),
@@ -11868,14 +11865,13 @@ fn test_new_for_txn_tests_system_transfer() {
         }),
     ];
 
-    let refs: Vec<(&Pubkey, &AccountSharedData)> =
-        owned_accounts.iter().map(|(k, v)| (k, v)).collect();
+    let refs: Vec<_> = owned_accounts.iter().map(|(k, v)| (k, v)).collect();
     accounts.store_accounts_seq((parent_slot, refs.as_slice()), None, None);
     accounts.accounts_db.add_root(parent_slot);
 
     let bank_rc = BankRc::new(accounts);
 
-    let mut epoch_stakes: HashMap<Epoch, VersionedEpochStakes> = HashMap::new();
+    let mut epoch_stakes = HashMap::new();
     for key in [epoch, epoch.saturating_add(1)] {
         epoch_stakes.insert(
             key,
@@ -11946,31 +11942,22 @@ fn test_new_for_txn_tests_system_transfer() {
     assert_eq!(recipient_balance, 1_000_000_000 + transfer_amount);
 }
 
+/// Exercises `Bank::new_for_block_tests` by constructing a bank with
+/// vote/stake accounts, executing a system transfer, and verifying a
+/// deterministic bank hash. Covers epoch boundary processing,
+/// rewards distribution, LT and bank hash calculation, sysvar
+/// updates, runtime transaction processing, and the votes/stakes
+/// caches.
 #[test]
 fn test_new_for_block_tests_with_vote_account() {
-    use {
-        crate::{
-            epoch_stakes::VersionedEpochStakes,
-            stake_history::StakeHistory,
-            stakes::{DeserializableStakes, Stakes},
-        },
-        solana_accounts_db::{
-            accounts::Accounts, accounts_db::AccountsDb, accounts_hash::AccountsLtHash,
-            blockhash_queue::BlockhashQueue,
-        },
-        solana_hard_forks::HardForks,
-        solana_inflation::Inflation,
-        solana_lattice_hash::lt_hash::LtHash,
-        solana_vote::vote_account::{VoteAccount, VoteAccounts},
-    };
-
-    let slot: Slot = 10;
-    let parent_slot: Slot = slot - 1;
+    let slot = 10;
+    let parent_slot = slot - 1;
     let epoch_schedule = EpochSchedule::default();
     let epoch = epoch_schedule.get_epoch(slot);
-    let lamports_per_signature: u64 = 5000;
+    let lamports_per_signature = 5000;
+    let transfer_amount = 100_000;
 
-    let make_sysvar = |data: Vec<u8>| -> AccountSharedData {
+    let make_sysvar = |data: Vec<u8>| {
         let mut acct = AccountSharedData::new(1, data.len(), &solana_sdk_ids::sysvar::id());
         acct.set_data_from_slice(&data);
         acct
@@ -11983,24 +11970,51 @@ fn test_new_for_block_tests_with_vote_account() {
     };
     let rent = Rent::default();
 
-    let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
-        crate::stakes::tests::create_staked_node_accounts(1_000_000, &rent);
-    let vote_account_shared = vote_account.clone();
-    let stake_account_shared = stake_account.clone();
+    let node_pubkey = Pubkey::from([1u8; 32]);
+    let vote_pubkey = Pubkey::from([2u8; 32]);
+    let stake_pubkey = Pubkey::from([3u8; 32]);
+    let sender = keypair_from_seed(&[4u8; 32]).unwrap();
+    let recipient = Pubkey::from([5u8; 32]);
+
+    let vote_account = vote_state::create_v4_account_with_authorized(
+        &node_pubkey,
+        &vote_pubkey,
+        [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
+        &vote_pubkey,
+        0,
+        &vote_pubkey,
+        0,
+        &node_pubkey,
+        1,
+    );
+    let stake_lamports = rent.minimum_balance(StakeStateV2::size_of()) + 1_000_000;
+    let stake_account = stake_utils::create_stake_account(
+        &stake_pubkey,
+        &vote_pubkey,
+        &vote_account,
+        &rent,
+        stake_lamports,
+    );
 
     let vote_acct = VoteAccount::try_from(vote_account.clone()).unwrap();
-    let node_pubkey = *vote_acct.node_pubkey();
 
+    let recent_blockhash = Hash::from([42u8; 32]);
     let mut blockhash_queue = BlockhashQueue::default();
-    let recent_blockhash = Hash::new_unique();
     blockhash_queue.register_hash(&recent_blockhash, lamports_per_signature);
 
-    let accounts_db = AccountsDb::default_for_tests();
-    let accounts = Accounts::new(Arc::new(accounts_db));
+    let accounts = Accounts::new(Arc::new(AccountsDb::default_for_tests()));
 
-    let owned_accounts: Vec<(Pubkey, AccountSharedData)> = vec![
-        (vote_pubkey, vote_account_shared),
-        (stake_pubkey, stake_account_shared),
+    let owned_accounts = vec![
+        (vote_pubkey, vote_account),
+        (stake_pubkey, stake_account),
+        (
+            sender.pubkey(),
+            AccountSharedData::new(1_000_000_000, 0, &system_program::id()),
+        ),
+        (
+            recipient,
+            AccountSharedData::new(1_000_000_000, 0, &system_program::id()),
+        ),
         (
             sysvar::clock::id(),
             make_sysvar(bincode::serialize(&clock).unwrap()),
@@ -12031,16 +12045,14 @@ fn test_new_for_block_tests_with_vote_account() {
         .sum();
     let total_lamports: u64 = owned_accounts.iter().map(|(_, a)| a.lamports()).sum();
 
-    let refs: Vec<(&Pubkey, &AccountSharedData)> =
-        owned_accounts.iter().map(|(k, v)| (k, v)).collect();
+    let refs: Vec<_> = owned_accounts.iter().map(|(k, v)| (k, v)).collect();
     accounts.store_accounts_seq((parent_slot, refs.as_slice()), None, None);
     accounts.accounts_db.add_root(parent_slot);
 
     let bank_rc = BankRc::new(accounts);
 
-    let vote_accounts_map: HashMap<Pubkey, (u64, VoteAccount)> =
-        HashMap::from([(vote_pubkey, (1_000_000, vote_acct))]);
-    let mut epoch_stakes: HashMap<Epoch, VersionedEpochStakes> = HashMap::new();
+    let vote_accounts_map = HashMap::from([(vote_pubkey, (1_000_000, vote_acct))]);
+    let mut epoch_stakes = HashMap::new();
     for key in [epoch, epoch.saturating_add(1)] {
         epoch_stakes.insert(
             key,
@@ -12095,9 +12107,29 @@ fn test_new_for_block_tests_with_vote_account() {
         Stakes::<StakeAccount<Delegation>>::default(),
         accounts_data_size,
     );
+    let bank_forks = BankForks::new_rw_arc(bank);
+    let bank = bank_forks.read().unwrap().root_bank();
 
     assert_eq!(bank.slot(), slot);
     assert_eq!(bank.epoch(), epoch);
     assert!(bank.capitalization() > 0);
     assert_eq!(bank.last_blockhash(), recent_blockhash);
+
+    let tx = system_transaction::transfer(&sender, &recipient, transfer_amount, recent_blockhash);
+    let result = bank.process_transaction(&tx);
+    assert!(result.is_ok(), "transaction failed: {result:?}");
+
+    let sender_balance = bank.get_balance(&sender.pubkey());
+    let recipient_balance = bank.get_balance(&recipient);
+    assert_eq!(
+        sender_balance,
+        1_000_000_000 - transfer_amount - lamports_per_signature
+    );
+    assert_eq!(recipient_balance, 1_000_000_000 + transfer_amount);
+
+    bank.freeze();
+    assert_eq!(
+        bank.hash().to_string(),
+        "8ZixvxzpQPr8zWvMyxoTsnFYFmUUKEytytyztDhgQ7oD"
+    );
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11866,7 +11866,8 @@ fn test_new_for_txn_tests_system_transfer() {
     ];
 
     let refs: Vec<_> = owned_accounts.iter().map(|(k, v)| (k, v)).collect();
-    accounts.store_accounts_seq((parent_slot, refs.as_slice()), None, None);
+    let ancestors = Ancestors::from(vec![parent_slot]);
+    accounts.store_accounts_seq((parent_slot, refs.as_slice()), None, &ancestors);
     accounts.accounts_db.add_root(parent_slot);
 
     let bank_rc = BankRc::new(accounts);
@@ -12039,14 +12040,15 @@ fn test_new_for_block_tests_with_vote_account() {
         }),
     ];
 
-    let accounts_data_size: u64 = owned_accounts
+    let accounts_data_size = owned_accounts
         .iter()
         .map(|(_, a)| a.data().len() as u64)
         .sum();
-    let total_lamports: u64 = owned_accounts.iter().map(|(_, a)| a.lamports()).sum();
+    let total_lamports = owned_accounts.iter().map(|(_, a)| a.lamports()).sum();
 
     let refs: Vec<_> = owned_accounts.iter().map(|(k, v)| (k, v)).collect();
-    accounts.store_accounts_seq((parent_slot, refs.as_slice()), None, None);
+    let ancestors = Ancestors::from(vec![parent_slot]);
+    accounts.store_accounts_seq((parent_slot, refs.as_slice()), None, &ancestors);
     accounts.accounts_db.add_root(parent_slot);
 
     let bank_rc = BankRc::new(accounts);


### PR DESCRIPTION
#### Problem
For testing Agave's block and transaction execution, we require custom bank entrypoints that allow for high throughput (no need to initialize both a parent and child bank to test the epoch boundary) and allow us to test a variety of cases including the epoch boundary and rewards distribution. The behavior from the existing entrypoints does not work because `new_from_snapshot` does not process epoch boundaries, and `new_from_parent` requires double bank initialization which significantly reduces throughput.

#### Summary of Changes
Introduce two new bank entrypoints, `new_for_txn_tests` and `new_for_block_tests`. `new_for_txn_tests` is minimal and is a strict subset of `new_from_snapshot`. `new_for_block_tests` is a combination between `new_from_parent` and `new_from_snapshot`, both initializing the bank and allowing execution of any slot in isolation (besides slot 0). To ensure production code gets tested effectively, `prepare_for_block_execution` now contains a majority of `new_from_parent`'s initialization code and is shared between `new_for_block_tests` and `new_from_parent`. The core logic for `new_from_parent` remains completely unchanged.

