### PR TITLE
Add --preserve-program-transactions to test validator

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -273,6 +273,12 @@ pub struct Blockstore {
     completed_slots_senders: Mutex<Vec<CompletedSlotsSender>>,
     pub lowest_cleanup_slot: RwLock<Slot>,
     pub slots_stats: SlotsStats,
+
+    /// Programs whose transaction history is preserved from compaction cleanup.
+    preserved_programs: Arc<HashSet<[u8; 32]>>,
+    /// Signatures of transactions involving preserved programs, shared with
+    /// the compaction filter.
+    preserved_signatures: Arc<RwLock<HashSet<[u8; 64]>>>,
 }
 
 pub struct IndexMetaWorkingSetEntry {
@@ -389,6 +395,9 @@ impl Blockstore {
         info!("Opening blockstore at {blockstore_path:?}");
         let db = Arc::new(Rocks::open(blockstore_path, options)?);
 
+        let preserved_programs = db.preserved_programs().clone();
+        let preserved_signatures = db.preserved_signatures().clone();
+
         let address_signatures_cf = db.column();
         let bank_hash_cf = db.column();
         let block_height_cf = db.column();
@@ -450,11 +459,60 @@ impl Blockstore {
             max_root,
             lowest_cleanup_slot: RwLock::<Slot>::default(),
             slots_stats: SlotsStats::default(),
+            preserved_programs,
+            preserved_signatures,
         };
         blockstore.cleanup_old_entries()?;
         blockstore.update_highest_primary_index_slot()?;
+        blockstore.rebuild_preserved_signatures();
 
         Ok(blockstore)
+    }
+
+    pub fn preserved_programs(&self) -> &Arc<HashSet<[u8; 32]>> {
+        &self.preserved_programs
+    }
+
+    pub fn preserved_signatures(&self) -> &Arc<RwLock<HashSet<[u8; 64]>>> {
+        &self.preserved_signatures
+    }
+
+    /// On restart, rebuild the set of preserved transaction signatures by
+    /// scanning the AddressSignatures CF for each preserved program pubkey.
+    fn rebuild_preserved_signatures(&self) {
+        if self.preserved_programs.is_empty() {
+            return;
+        }
+
+        let mut count = 0usize;
+        for program_bytes in self.preserved_programs.iter() {
+            let pubkey = Pubkey::from(*program_bytes);
+            // Iterate all AddressSignatures entries for this pubkey
+            let iter = self.address_signatures_cf.iter(IteratorMode::From(
+                (pubkey, 0, 0, Signature::default()),
+                IteratorDirection::Forward,
+            ));
+            if let Ok(iter) = iter {
+                for ((address, _slot, _tx_index, signature), _) in iter {
+                    if address != pubkey {
+                        break;
+                    }
+                    let sig_bytes: [u8; 64] = signature.as_ref().try_into().unwrap();
+                    self.preserved_signatures
+                        .write()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .insert(sig_bytes);
+                    count += 1;
+                }
+            }
+        }
+        if count > 0 {
+            info!(
+                "Rebuilt {} preserved transaction signatures for {} programs",
+                count,
+                self.preserved_programs.len()
+            );
+        }
     }
 
     pub fn open_with_signal(
@@ -11873,5 +11931,251 @@ pub mod tests {
             tx_status2.status,
             Err(TransactionError::InsufficientFundsForFee)
         );
+    }
+
+    /// Verify that transactions for a preserved program survive compaction
+    /// while normal program transactions are cleaned up. The ledger stays
+    /// small on disk for non-preserved data (default cleanup behavior) but
+    /// ALL transactions for the preserved program are retained indefinitely.
+    #[test]
+    fn test_preserve_program_transactions_survives_two_gc_passes() {
+        let preserved_program = Pubkey::new_unique();
+        let normal_program = Pubkey::new_unique();
+        let fee_payer = Pubkey::new_unique();
+
+        let options = BlockstoreOptions {
+            preserved_programs: [preserved_program.to_bytes()].into_iter().collect(),
+            ..BlockstoreOptions::default_for_tests()
+        };
+
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open_with_options(ledger_path.path(), options).unwrap();
+
+        // Write transactions across several old slots for both programs
+        let num_slots: u64 = 5;
+        let mut preserved_sigs = Vec::new();
+        let mut normal_sigs = Vec::new();
+
+        for slot in 1..=num_slots {
+            // -- Transaction involving the preserved program --
+            let p_sig = Signature::new_unique();
+            blockstore
+                .write_transaction_status(
+                    slot,
+                    p_sig,
+                    [(&fee_payer, true), (&preserved_program, false)].into_iter(),
+                    TransactionStatusMeta {
+                        fee: 100 + slot,
+                        status: Ok(()),
+                        ..TransactionStatusMeta::default()
+                    },
+                    0,
+                )
+                .unwrap();
+
+            // Track in preserved_signatures (mirrors TransactionStatusService)
+            blockstore
+                .preserved_signatures()
+                .write()
+                .unwrap()
+                .insert(p_sig.as_ref().try_into().unwrap());
+            preserved_sigs.push((p_sig, slot));
+
+            // Also write memos for the preserved transaction
+            blockstore
+                .write_transaction_memos(&p_sig, slot, "preserved memo".to_string())
+                .unwrap();
+
+            // -- Transaction NOT involving the preserved program --
+            let n_sig = Signature::new_unique();
+            blockstore
+                .write_transaction_status(
+                    slot,
+                    n_sig,
+                    [(&fee_payer, true), (&normal_program, false)].into_iter(),
+                    TransactionStatusMeta {
+                        fee: 200 + slot,
+                        status: Ok(()),
+                        ..TransactionStatusMeta::default()
+                    },
+                    1,
+                )
+                .unwrap();
+            normal_sigs.push((n_sig, slot));
+
+            blockstore
+                .write_transaction_memos(&n_sig, slot, "normal memo".to_string())
+                .unwrap();
+        }
+
+        // Sanity: all data is present before any compaction
+        for (sig, slot) in &preserved_sigs {
+            assert!(
+                blockstore
+                    .address_signatures_cf
+                    .get((preserved_program, *slot, 0u32, *sig))
+                    .unwrap()
+                    .is_some(),
+                "preserved AddressSignatures missing before compaction"
+            );
+            assert!(
+                blockstore
+                    .read_transaction_status((*sig, *slot))
+                    .unwrap()
+                    .is_some(),
+                "preserved TransactionStatus missing before compaction"
+            );
+            assert!(
+                blockstore
+                    .read_transaction_memos(*sig, *slot)
+                    .unwrap()
+                    .is_some(),
+                "preserved TransactionMemos missing before compaction"
+            );
+        }
+        for (sig, slot) in &normal_sigs {
+            assert!(
+                blockstore
+                    .address_signatures_cf
+                    .get((normal_program, *slot, 1u32, *sig))
+                    .unwrap()
+                    .is_some(),
+                "normal AddressSignatures missing before compaction"
+            );
+        }
+
+        // ======== First GC pass ========
+        // Set oldest_slot well beyond all written data
+        blockstore.db.set_oldest_slot_for_tests(num_slots + 100);
+        blockstore.db.set_clean_slot_0_for_tests(true);
+
+        // Trigger compaction on the three relevant CFs
+        blockstore.address_signatures_cf.compact();
+        blockstore.transaction_status_cf.compact();
+        blockstore.transaction_memos_cf.compact();
+
+        // Preserved program: AddressSignatures keyed by the program should survive
+        for (sig, slot) in &preserved_sigs {
+            assert!(
+                blockstore
+                    .address_signatures_cf
+                    .get((preserved_program, *slot, 0u32, *sig))
+                    .unwrap()
+                    .is_some(),
+                "preserved AddressSignatures lost after 1st GC (slot {slot})"
+            );
+        }
+
+        // Preserved program: TransactionStatus should survive (sig in preserved set)
+        for (sig, slot) in &preserved_sigs {
+            let status = blockstore.read_transaction_status((*sig, *slot)).unwrap();
+            assert!(
+                status.is_some(),
+                "preserved TransactionStatus lost after 1st GC (slot {slot})"
+            );
+            assert_eq!(status.unwrap().fee, 100 + slot);
+        }
+
+        // Preserved program: TransactionMemos should survive
+        for (sig, slot) in &preserved_sigs {
+            assert!(
+                blockstore
+                    .read_transaction_memos(*sig, *slot)
+                    .unwrap()
+                    .is_some(),
+                "preserved TransactionMemos lost after 1st GC (slot {slot})"
+            );
+        }
+
+        // Normal program: all data should be cleaned up
+        for (sig, slot) in &normal_sigs {
+            assert!(
+                blockstore
+                    .address_signatures_cf
+                    .get((normal_program, *slot, 1u32, *sig))
+                    .unwrap()
+                    .is_none(),
+                "normal AddressSignatures survived 1st GC (slot {slot})"
+            );
+            assert!(
+                blockstore
+                    .read_transaction_status((*sig, *slot))
+                    .unwrap()
+                    .is_none(),
+                "normal TransactionStatus survived 1st GC (slot {slot})"
+            );
+            assert!(
+                blockstore
+                    .read_transaction_memos(*sig, *slot)
+                    .unwrap()
+                    .is_none(),
+                "normal TransactionMemos survived 1st GC (slot {slot})"
+            );
+        }
+
+        // Fee-payer AddressSignatures entries are NOT preserved
+        // (even for preserved-program transactions)
+        for (sig, slot) in &preserved_sigs {
+            assert!(
+                blockstore
+                    .address_signatures_cf
+                    .get((fee_payer, *slot, 0u32, *sig))
+                    .unwrap()
+                    .is_none(),
+                "fee_payer AddressSignatures should not be preserved"
+            );
+        }
+
+        // ======== Second GC pass (higher oldest_slot) ========
+        blockstore.db.set_oldest_slot_for_tests(num_slots + 500);
+
+        blockstore.address_signatures_cf.compact();
+        blockstore.transaction_status_cf.compact();
+        blockstore.transaction_memos_cf.compact();
+
+        // Preserved program data STILL survives after second GC
+        for (sig, slot) in &preserved_sigs {
+            assert!(
+                blockstore
+                    .address_signatures_cf
+                    .get((preserved_program, *slot, 0u32, *sig))
+                    .unwrap()
+                    .is_some(),
+                "preserved AddressSignatures lost after 2nd GC (slot {slot})"
+            );
+            let status = blockstore.read_transaction_status((*sig, *slot)).unwrap();
+            assert!(
+                status.is_some(),
+                "preserved TransactionStatus lost after 2nd GC (slot {slot})"
+            );
+            assert_eq!(status.unwrap().fee, 100 + slot);
+
+            assert!(
+                blockstore
+                    .read_transaction_memos(*sig, *slot)
+                    .unwrap()
+                    .is_some(),
+                "preserved TransactionMemos lost after 2nd GC (slot {slot})"
+            );
+        }
+
+        // Normal program data still gone after second GC
+        for (sig, slot) in &normal_sigs {
+            assert!(
+                blockstore
+                    .address_signatures_cf
+                    .get((normal_program, *slot, 1u32, *sig))
+                    .unwrap()
+                    .is_none(),
+                "normal AddressSignatures reappeared after 2nd GC"
+            );
+            assert!(
+                blockstore
+                    .read_transaction_status((*sig, *slot))
+                    .unwrap()
+                    .is_none(),
+                "normal TransactionStatus reappeared after 2nd GC"
+            );
+        }
     }
 }

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -1038,4 +1038,223 @@ pub mod tests {
         let child_slot_meta = blockstore.meta(12).unwrap().unwrap();
         assert_eq!(child_slot_meta.parent_slot.unwrap(), 5);
     }
+
+    /// Simulates the full BlockstoreCleanupService path with preserved programs:
+    /// write data → set_max_expired_slot → compaction → verify preserved data survives
+    /// while normal data is cleaned up.
+    #[test]
+    fn test_cleanup_service_path_with_preserved_programs() {
+        use {
+            crate::blockstore_options::BlockstoreOptions, solana_pubkey::Pubkey,
+            solana_signature::Signature, solana_transaction_status::TransactionStatusMeta,
+        };
+
+        let preserved_program = Pubkey::new_unique();
+        let normal_program = Pubkey::new_unique();
+        let fee_payer = Pubkey::new_unique();
+
+        let options = BlockstoreOptions {
+            preserved_programs: [preserved_program.to_bytes()].into_iter().collect(),
+            ..BlockstoreOptions::default_for_tests()
+        };
+
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open_with_options(ledger_path.path(), options).unwrap();
+
+        // Write transactions across old slots
+        let num_slots = 10u64;
+        let mut preserved_sigs = Vec::new();
+        let mut normal_sigs = Vec::new();
+
+        for slot in 1..=num_slots {
+            let p_sig = Signature::new_unique();
+            blockstore
+                .write_transaction_status(
+                    slot,
+                    p_sig,
+                    [(&fee_payer, true), (&preserved_program, false)].into_iter(),
+                    TransactionStatusMeta {
+                        fee: 100 + slot,
+                        status: Ok(()),
+                        ..TransactionStatusMeta::default()
+                    },
+                    0,
+                )
+                .unwrap();
+            blockstore
+                .preserved_signatures()
+                .write()
+                .unwrap()
+                .insert(p_sig.as_ref().try_into().unwrap());
+            blockstore
+                .write_transaction_memos(&p_sig, slot, "preserved memo".to_string())
+                .unwrap();
+            preserved_sigs.push((p_sig, slot));
+
+            let n_sig = Signature::new_unique();
+            blockstore
+                .write_transaction_status(
+                    slot,
+                    n_sig,
+                    [(&fee_payer, true), (&normal_program, false)].into_iter(),
+                    TransactionStatusMeta {
+                        fee: 200 + slot,
+                        status: Ok(()),
+                        ..TransactionStatusMeta::default()
+                    },
+                    1,
+                )
+                .unwrap();
+            blockstore
+                .write_transaction_memos(&n_sig, slot, "normal memo".to_string())
+                .unwrap();
+            normal_sigs.push((n_sig, slot));
+        }
+
+        // Sanity: all data present
+        let total_status = blockstore
+            .transaction_status_cf
+            .iter(IteratorMode::Start)
+            .unwrap()
+            .count();
+        assert_eq!(total_status, (num_slots * 2) as usize);
+
+        let total_addr_sigs = blockstore
+            .address_signatures_cf
+            .iter(IteratorMode::Start)
+            .unwrap()
+            .count();
+        // Each tx writes entries for fee_payer + program = 2 keys × 2 txs × num_slots
+        assert_eq!(total_addr_sigs, (num_slots * 4) as usize);
+
+        // === First cleanup cycle (like BlockstoreCleanupService) ===
+        // set_max_expired_slot is what the cleanup service calls after purging shred slots
+        let purge_slot = num_slots + 50;
+        blockstore.set_max_expired_slot(purge_slot);
+
+        // Trigger compaction on the three special CFs
+        blockstore.transaction_status_cf.compact();
+        blockstore.address_signatures_cf.compact();
+        blockstore.transaction_memos_cf.compact();
+
+        // Preserved: TransactionStatus entries survive
+        for (sig, slot) in &preserved_sigs {
+            let status = blockstore.read_transaction_status((*sig, *slot)).unwrap();
+            assert!(
+                status.is_some(),
+                "preserved TransactionStatus lost after 1st cleanup (slot {slot})"
+            );
+            assert_eq!(status.unwrap().fee, 100 + slot);
+        }
+
+        // Preserved: AddressSignatures keyed by preserved_program survive
+        for (sig, slot) in &preserved_sigs {
+            assert!(
+                blockstore
+                    .address_signatures_cf
+                    .get((preserved_program, *slot, 0u32, *sig))
+                    .unwrap()
+                    .is_some(),
+                "preserved AddressSignatures lost after 1st cleanup (slot {slot})"
+            );
+        }
+
+        // Preserved: TransactionMemos survive
+        for (sig, slot) in &preserved_sigs {
+            assert!(
+                blockstore
+                    .read_transaction_memos(*sig, *slot)
+                    .unwrap()
+                    .is_some(),
+                "preserved TransactionMemos lost after 1st cleanup (slot {slot})"
+            );
+        }
+
+        // Normal: all data cleaned up
+        for (sig, slot) in &normal_sigs {
+            assert!(
+                blockstore
+                    .read_transaction_status((*sig, *slot))
+                    .unwrap()
+                    .is_none(),
+                "normal TransactionStatus survived 1st cleanup (slot {slot})"
+            );
+            assert!(
+                blockstore
+                    .address_signatures_cf
+                    .get((normal_program, *slot, 1u32, *sig))
+                    .unwrap()
+                    .is_none(),
+                "normal AddressSignatures survived 1st cleanup (slot {slot})"
+            );
+            assert!(
+                blockstore
+                    .read_transaction_memos(*sig, *slot)
+                    .unwrap()
+                    .is_none(),
+                "normal TransactionMemos survived 1st cleanup (slot {slot})"
+            );
+        }
+
+        // fee_payer entries cleaned up (not a preserved program)
+        for (sig, slot) in &preserved_sigs {
+            assert!(
+                blockstore
+                    .address_signatures_cf
+                    .get((fee_payer, *slot, 0u32, *sig))
+                    .unwrap()
+                    .is_none(),
+                "fee_payer AddressSignatures should not be preserved"
+            );
+        }
+
+        // === Second cleanup cycle (higher oldest_slot) ===
+        blockstore.set_max_expired_slot(purge_slot + 500);
+        blockstore.transaction_status_cf.compact();
+        blockstore.address_signatures_cf.compact();
+        blockstore.transaction_memos_cf.compact();
+
+        // Preserved data still survives
+        for (sig, slot) in &preserved_sigs {
+            let status = blockstore.read_transaction_status((*sig, *slot)).unwrap();
+            assert!(
+                status.is_some(),
+                "preserved TransactionStatus lost after 2nd cleanup (slot {slot})"
+            );
+            assert!(
+                blockstore
+                    .address_signatures_cf
+                    .get((preserved_program, *slot, 0u32, *sig))
+                    .unwrap()
+                    .is_some(),
+                "preserved AddressSignatures lost after 2nd cleanup (slot {slot})"
+            );
+            assert!(
+                blockstore
+                    .read_transaction_memos(*sig, *slot)
+                    .unwrap()
+                    .is_some(),
+                "preserved TransactionMemos lost after 2nd cleanup (slot {slot})"
+            );
+        }
+
+        // Count remaining entries: only preserved ones
+        let remaining_status = blockstore
+            .transaction_status_cf
+            .iter(IteratorMode::Start)
+            .unwrap()
+            .count();
+        assert_eq!(remaining_status, num_slots as usize);
+
+        // AddressSignatures: only preserved_program entries remain (fee_payer entries purged)
+        let remaining_addr_sigs: Vec<_> = blockstore
+            .address_signatures_cf
+            .iter(IteratorMode::Start)
+            .unwrap()
+            .collect();
+        assert_eq!(remaining_addr_sigs.len(), num_slots as usize);
+        for ((pubkey, _slot, _tx_idx, _sig), _val) in &remaining_addr_sigs {
+            assert_eq!(*pubkey, preserved_program);
+        }
+    }
 }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -38,7 +38,7 @@ use {
         path::{Path, PathBuf},
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
-            Arc,
+            Arc, RwLock,
         },
     },
 };
@@ -65,6 +65,13 @@ pub enum IteratorMode<Index> {
 struct OldestSlot {
     slot: Arc<AtomicU64>,
     clean_slot_0: Arc<AtomicBool>,
+    /// Program pubkeys whose transaction history should be preserved from
+    /// compaction-based cleanup (immutable after construction).
+    preserved_programs: Arc<HashSet<[u8; 32]>>,
+    /// Signatures of transactions that involve preserved programs, populated
+    /// during the write path and checked during compaction of
+    /// TransactionStatus and TransactionMemos columns.
+    preserved_signatures: Arc<RwLock<HashSet<[u8; 64]>>>,
 }
 
 impl OldestSlot {
@@ -102,6 +109,7 @@ pub(crate) struct Rocks {
     oldest_slot: OldestSlot,
     column_options: Arc<LedgerColumnOptions>,
     write_batch_perf_status: PerfSamplingStatus,
+    preserved_signatures: Arc<RwLock<HashSet<[u8; 64]>>>,
 }
 
 impl Rocks {
@@ -115,7 +123,13 @@ impl Rocks {
         if let Some(recovery_mode) = recovery_mode {
             db_options.set_wal_recovery_mode(recovery_mode.into());
         }
-        let oldest_slot = OldestSlot::default();
+        let preserved_programs = Arc::new(options.preserved_programs.clone());
+        let preserved_signatures = Arc::new(RwLock::new(HashSet::new()));
+        let oldest_slot = OldestSlot {
+            preserved_programs,
+            preserved_signatures: preserved_signatures.clone(),
+            ..OldestSlot::default()
+        };
         let cf_descriptors = Self::cf_descriptors(&path, &options, &oldest_slot);
         let column_options = Arc::from(options.column_options);
 
@@ -151,11 +165,30 @@ impl Rocks {
             oldest_slot,
             column_options,
             write_batch_perf_status: PerfSamplingStatus::default(),
+            preserved_signatures,
         };
 
         rocks.configure_compaction();
 
         Ok(rocks)
+    }
+
+    pub(crate) fn preserved_signatures(&self) -> &Arc<RwLock<HashSet<[u8; 64]>>> {
+        &self.preserved_signatures
+    }
+
+    pub(crate) fn preserved_programs(&self) -> &Arc<HashSet<[u8; 32]>> {
+        &self.oldest_slot.preserved_programs
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_oldest_slot_for_tests(&self, slot: Slot) {
+        self.oldest_slot.set(slot);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_clean_slot_0_for_tests(&self, clean: bool) {
+        self.oldest_slot.set_clean_slot_0(clean);
     }
 
     /// Create the column family (CF) descriptors necessary to open the database.
@@ -1035,6 +1068,67 @@ struct PurgedSlotFilter<C: Column + ColumnName> {
     clean_slot_0: bool,
     name: CString,
     _phantom: PhantomData<C>,
+    preserved_programs: Arc<HashSet<[u8; 32]>>,
+    preserved_signatures: Arc<RwLock<HashSet<[u8; 64]>>>,
+}
+
+impl<C: Column + ColumnName> PurgedSlotFilter<C> {
+    /// Check if this key belongs to a preserved program's transaction history
+    /// and should be kept even though its slot is below the cleanup threshold.
+    fn should_preserve(&self, key: &[u8]) -> bool {
+        if self.preserved_programs.is_empty() {
+            return false;
+        }
+
+        if C::NAME == columns::AddressSignatures::NAME {
+            // Current format (108 bytes): pubkey at 0..32
+            // Deprecated format (112 bytes): pubkey at 8..40
+            let pubkey_bytes: Option<[u8; 32]> = if key.len() == 108 {
+                key[0..32].try_into().ok()
+            } else if key.len() == 112 {
+                key[8..40].try_into().ok()
+            } else {
+                None
+            };
+            if let Some(pubkey_bytes) = pubkey_bytes {
+                return self.preserved_programs.contains(&pubkey_bytes);
+            }
+        } else if C::NAME == columns::TransactionStatus::NAME {
+            // Current format (72 bytes): signature at 0..64
+            // Deprecated format (80 bytes): signature at 8..72
+            let sig_bytes: Option<[u8; 64]> = if key.len() == 72 {
+                key[0..64].try_into().ok()
+            } else if key.len() == 80 {
+                key[8..72].try_into().ok()
+            } else {
+                None
+            };
+            if let Some(sig_bytes) = sig_bytes {
+                return self
+                    .preserved_signatures
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .contains(&sig_bytes);
+            }
+        } else if C::NAME == columns::TransactionMemos::NAME {
+            // Current format (72 bytes): signature at 0..64, slot at 64..72
+            // Deprecated format (64 bytes): signature at 0..64
+            let sig_bytes: Option<[u8; 64]> = if key.len() == 72 || key.len() == 64 {
+                key[0..64].try_into().ok()
+            } else {
+                None
+            };
+            if let Some(sig_bytes) = sig_bytes {
+                return self
+                    .preserved_signatures
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .contains(&sig_bytes);
+            }
+        }
+
+        false
+    }
 }
 
 impl<C: Column + ColumnName> CompactionFilter for PurgedSlotFilter<C> {
@@ -1042,7 +1136,10 @@ impl<C: Column + ColumnName> CompactionFilter for PurgedSlotFilter<C> {
         use rocksdb::CompactionDecision::*;
 
         let slot_in_key = C::slot(C::index(key));
-        if slot_in_key >= self.oldest_slot || (slot_in_key == 0 && !self.clean_slot_0) {
+        if slot_in_key >= self.oldest_slot
+            || (slot_in_key == 0 && !self.clean_slot_0)
+            || self.should_preserve(key)
+        {
             Keep
         } else {
             Remove
@@ -1076,6 +1173,8 @@ impl<C: Column + ColumnName> CompactionFilterFactory for PurgedSlotFilterFactory
             ))
             .unwrap(),
             _phantom: PhantomData,
+            preserved_programs: self.oldest_slot.preserved_programs.clone(),
+            preserved_signatures: self.oldest_slot.preserved_signatures.clone(),
         }
     }
 

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -1,7 +1,7 @@
 use {
     crate::blockstore_db::{default_num_compaction_threads, default_num_flush_threads},
     rocksdb::{DBCompressionType as RocksCompressionType, DBRecoveryMode},
-    std::num::NonZeroUsize,
+    std::{collections::HashSet, num::NonZeroUsize},
 };
 
 /// The subdirectory under ledger directory where the Blockstore lives
@@ -16,6 +16,9 @@ pub struct BlockstoreOptions {
     pub column_options: LedgerColumnOptions,
     pub num_rocksdb_compaction_threads: NonZeroUsize,
     pub num_rocksdb_flush_threads: NonZeroUsize,
+    /// Program pubkeys (as raw bytes) whose transaction history should be
+    /// preserved from compaction-based cleanup. Only used by the test validator.
+    pub preserved_programs: HashSet<[u8; 32]>,
 }
 
 impl Default for BlockstoreOptions {
@@ -29,6 +32,7 @@ impl Default for BlockstoreOptions {
             column_options: LedgerColumnOptions::default(),
             num_rocksdb_compaction_threads: default_num_compaction_threads(),
             num_rocksdb_flush_threads: default_num_flush_threads(),
+            preserved_programs: HashSet::new(),
         }
     }
 }

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -252,6 +252,24 @@ impl TransactionStatusService {
                             transaction_index,
                             batch,
                         )?;
+
+                        // Track signatures for preserved program transactions
+                        let preserved_programs = blockstore.preserved_programs();
+                        if !preserved_programs.is_empty() {
+                            let should_preserve = message
+                                .account_keys()
+                                .iter()
+                                .any(|key| preserved_programs.contains(&key.to_bytes()));
+                            if should_preserve {
+                                let sig_bytes: [u8; 64] =
+                                    transaction.signature().as_ref().try_into().unwrap();
+                                blockstore
+                                    .preserved_signatures()
+                                    .write()
+                                    .unwrap_or_else(|e| e.into_inner())
+                                    .insert(sig_bytes);
+                            }
+                        }
                     }
                 }
 

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -40,7 +40,8 @@ use {
     solana_instruction::{AccountMeta, Instruction},
     solana_keypair::{read_keypair_file, write_keypair_file, Keypair},
     solana_ledger::{
-        blockstore::create_new_ledger, blockstore_options::LedgerColumnOptions,
+        blockstore::create_new_ledger,
+        blockstore_options::{BlockstoreOptions, LedgerColumnOptions},
         create_new_tmp_ledger,
     },
     solana_loader_v3_interface::state::UpgradeableLoaderState,
@@ -150,6 +151,9 @@ pub struct TestValidatorGenesis {
     pub transaction_account_lock_limit: Option<usize>,
     pub geyser_plugin_manager: Arc<RwLock<GeyserPluginManager>>,
     admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
+    /// Programs whose transaction history should be preserved from ledger
+    /// cleanup (compaction).
+    pub preserve_transaction_programs: HashSet<Pubkey>,
 }
 
 impl Default for TestValidatorGenesis {
@@ -186,6 +190,7 @@ impl Default for TestValidatorGenesis {
             geyser_plugin_manager: Arc::new(RwLock::new(GeyserPluginManager::default())),
             admin_rpc_service_post_init:
                 Arc::<RwLock<Option<AdminRpcRequestMetadataPostInit>>>::default(),
+            preserve_transaction_programs: HashSet::<Pubkey>::default(),
         }
     }
 }
@@ -271,6 +276,11 @@ impl TestValidatorGenesis {
 
     pub fn rent(&mut self, rent: Rent) -> &mut Self {
         self.rent = rent;
+        self
+    }
+
+    pub fn preserve_transaction_programs(&mut self, programs: HashSet<Pubkey>) -> &mut Self {
+        self.preserve_transaction_programs = programs;
         self
     }
 
@@ -1220,6 +1230,14 @@ impl TestValidator {
             warp_slot: config.warp_slot,
             validator_exit: config.validator_exit.clone(),
             max_ledger_shreds: config.max_ledger_shreds,
+            blockstore_options: BlockstoreOptions {
+                preserved_programs: config
+                    .preserve_transaction_programs
+                    .iter()
+                    .map(|p| p.to_bytes())
+                    .collect(),
+                ..BlockstoreOptions::default_for_tests()
+            },
             no_wait_for_vote_to_start_leader: true,
             staked_nodes_overrides: config.staked_nodes_overrides.clone(),
             accounts_db_config,

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -377,6 +377,11 @@ fn main() {
 
     let features_to_deactivate = pubkeys_of(&matches, "deactivate_feature").unwrap_or_default();
 
+    let preserve_transaction_programs: HashSet<Pubkey> =
+        pubkeys_of(&matches, "preserve_program_transactions")
+            .map(|v| v.into_iter().collect())
+            .unwrap_or_default();
+
     if TestValidatorGenesis::ledger_exists(&ledger_path) {
         for (name, long) in &[
             ("bpf_program", "--bpf-program"),
@@ -482,7 +487,8 @@ fn main() {
             println!("Error: add_accounts_from_directories failed: {e}");
             exit(1);
         })
-        .deactivate_features(&features_to_deactivate);
+        .deactivate_features(&features_to_deactivate)
+        .preserve_transaction_programs(preserve_transaction_programs);
 
     genesis.rpc_config(JsonRpcConfig {
         enable_rpc_transaction_history: true,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -843,6 +843,19 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                      silently ignored",
                 ),
         )
+        .arg(
+            Arg::with_name("preserve_program_transactions")
+                .long("preserve-program-transactions")
+                .value_name("PROGRAM_ID")
+                .takes_value(true)
+                .validator(is_pubkey)
+                .multiple(true)
+                .help(
+                    "Preserve all transaction history for the specified program, preventing it \
+                     from being cleaned up by ledger compaction. May be specified multiple times \
+                     for different programs.",
+                ),
+        )
         .args(&pub_sub_config::args(/*test_validator:*/ true))
 }
 

--- a/validator/src/commands/run/args/blockstore_options.rs
+++ b/validator/src/commands/run/args/blockstore_options.rs
@@ -80,6 +80,7 @@ impl FromClapArgMatches for BlockstoreOptions {
             access_type: AccessType::Primary,
             num_rocksdb_compaction_threads: rocksdb_compaction_threads,
             num_rocksdb_flush_threads: rocksdb_flush_threads,
+            preserved_programs: Default::default(),
         })
     }
 }


### PR DESCRIPTION
#### Problem

The test validator's `BlockstoreCleanupService` truncates all ledger history (default 10,000 shreds) via slot-based purging. Developers testing programs that need full transaction history (e.g. for `getSignaturesForAddress` or `getTransaction`) lose old transactions after cleanup, making it impossible to verify historical queries during development.

#### Summary of Changes

- Add `--preserve-program-transactions <PROGRAM_ID>` CLI arg (repeatable) to `solana-test-validator`
- Modify RocksDB compaction filters (`PurgedSlotFilter`) to exempt `AddressSignatures`, `TransactionStatus`, and `TransactionMemos` entries for preserved programs
- Populate the preserved signatures set in `TransactionStatusService` during the write path
- Rebuild the preserved signatures set on startup by scanning `AddressSignatures`
- Add two comprehensive tests:
  - `test_preserve_program_transactions_survives_two_gc_passes` (blockstore-level compaction)
  - `test_cleanup_service_path_with_preserved_programs` (full cleanup service code path via `set_max_expired_slot`)

**Files modified (9):**

| File | Change |
|------|--------|
| `validator/src/cli.rs` | CLI arg definition |
| `validator/src/bin/solana-test-validator.rs` | Parse arg into `HashSet<Pubkey>` |
| `test-validator/src/lib.rs` | Config field + setter + pass to `ValidatorConfig` |
| `ledger/src/blockstore_options.rs` | `preserved_programs` field in `BlockstoreOptions` |
| `ledger/src/blockstore_db.rs` | `OldestSlot`, `PurgedSlotFilter`, `PurgedSlotFilterFactory` |
| `ledger/src/blockstore.rs` | Fields, getters, `rebuild_preserved_signatures()`, test |
| `ledger/src/blockstore/blockstore_purge.rs` | Integration test |
| `rpc/src/transaction_status_service.rs` | Populate `preserved_signatures` during write |
| `validator/src/commands/run/args/blockstore_options.rs` | Default for main validator |

**Usage:**
```bash
solana-test-validator --preserve-program-transactions <PROGRAM_ID_1> --preserve-program-transactions <PROGRAM_ID_2>
```

**Testing performed:**
- `cargo +nightly fmt -- --check`: clean
- `cargo clippy -p solana-ledger -p agave-validator -p solana-test-validator -p solana-rpc -- -D warnings`: clean
- All 12 blockstore_purge tests pass
- All 6 blockstore_db tests pass
- All 20 agave-validator blockstore_options tests pass
- Validator starts successfully both with and without the new flag