### PR TITLE
broadcast: send block header

### DIFF
--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -476,6 +476,14 @@ impl BlockComponent {
         Self::BlockMarker(marker)
     }
 
+    pub fn new_block_header(parent_slot: Slot, parent_block_id: Hash) -> Self {
+        let header = BlockHeaderV1 {
+            parent_slot,
+            parent_block_id,
+        };
+        Self::new_block_marker(VersionedBlockMarker::new_block_header(header))
+    }
+
     pub const fn as_marker(&self) -> Option<&VersionedBlockMarker> {
         match self {
             Self::BlockMarker(m) => Some(m),

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -55,6 +55,7 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { workspace = true }
+agave-votor-messages = { path = "../votor-messages", features = ["dev-context-only-utils"] }
 assert_matches = { workspace = true }
 bencher = { workspace = true }
 bs58 = { workspace = true }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -8,7 +8,7 @@ use {
     crate::cluster_nodes::ClusterNodesCache,
     agave_votor::event::VotorEventSender,
     agave_votor_messages::migration::MigrationStatus,
-    solana_entry::entry::Entry,
+    solana_entry::block_component::BlockComponent,
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::shred::{
@@ -45,6 +45,8 @@ pub struct StandardBroadcastRun {
     reed_solomon_cache: Arc<ReedSolomonCache>,
     migration_status: Arc<MigrationStatus>,
     votor_event_sender: VotorEventSender,
+    max_data_shreds_per_slot: u32,
+    max_code_shreds_per_slot: u32,
 }
 
 #[derive(Debug)]
@@ -83,6 +85,8 @@ impl StandardBroadcastRun {
             reed_solomon_cache: Arc::<ReedSolomonCache>::default(),
             migration_status,
             votor_event_sender,
+            max_data_shreds_per_slot: MAX_DATA_SHREDS_PER_SLOT as u32,
+            max_code_shreds_per_slot: MAX_CODE_SHREDS_PER_SLOT as u32,
         }
     }
 
@@ -163,7 +167,7 @@ impl StandardBroadcastRun {
                 // self.next_shred_index and self.next_code_index
                 .inspect(|shred| self.process_shreds_stats.record_shred(shred))
                 .collect();
-        if let Some(shred) = shreds.iter().max_by_key(|shred| shred.fec_set_index()) {
+        if let Some(shred) = shreds.last() {
             self.chained_merkle_root = shred.merkle_root().unwrap();
         }
         self.report_and_reset_stats(/*was_interrupted:*/ true);
@@ -171,23 +175,20 @@ impl StandardBroadcastRun {
         shreds
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn entries_to_shreds(
+    fn component_to_shreds(
         &mut self,
         keypair: &Keypair,
-        entries: &[Entry],
+        component: &BlockComponent,
         reference_tick: u8,
         is_slot_end: bool,
         process_stats: &mut ProcessShredsStats,
-        max_data_shreds_per_slot: u32,
-        max_code_shreds_per_slot: u32,
     ) -> std::result::Result<Vec<Shred>, BroadcastError> {
         let shreds: Vec<_> =
             Shredder::new(self.slot, self.parent, reference_tick, self.shred_version)
                 .unwrap()
-                .make_merkle_shreds_from_entries(
+                .make_merkle_shreds_from_component(
                     keypair,
-                    entries,
+                    component,
                     is_slot_end,
                     self.chained_merkle_root,
                     self.next_shred_index,
@@ -216,10 +217,10 @@ impl StandardBroadcastRun {
         if let Some(fec_set_root) = self.double_merkle_leaves.last() {
             self.chained_merkle_root = *fec_set_root;
         }
-        if self.next_shred_index > max_data_shreds_per_slot {
+        if self.next_shred_index > self.max_data_shreds_per_slot {
             return Err(BroadcastError::TooManyShreds);
         }
-        if self.next_code_index > max_code_shreds_per_slot {
+        if self.next_code_index > self.max_code_shreds_per_slot {
             return Err(BroadcastError::TooManyShreds);
         }
         Ok(shreds)
@@ -268,7 +269,7 @@ impl StandardBroadcastRun {
 
         let mut to_shreds_time = Measure::start("broadcast_to_shreds");
 
-        if self.slot != bank.slot() {
+        let maybe_send_header = if self.slot != bank.slot() {
             // Finish previous slot if it was interrupted.
             if !self.completed {
                 let shreds = self.finish_prev_slot(keypair, bank.ticks_per_slot() as u8);
@@ -301,7 +302,10 @@ impl StandardBroadcastRun {
 
             // Reinitialize state for this slot.
             self.reinitialize_state(blockstore, &bank, process_stats);
-        }
+            true
+        } else {
+            false
+        };
 
         // 2) Convert entries to shreds and coding shreds
         let is_last_in_slot = last_tick_height == bank.max_tick_height();
@@ -310,17 +314,37 @@ impl StandardBroadcastRun {
         let reference_tick = last_tick_height
             .saturating_add(bank.ticks_per_slot())
             .saturating_sub(bank.max_tick_height());
-        let shreds = self
-            .entries_to_shreds(
+
+        let mut header_shreds = if maybe_send_header
+            && self
+                .migration_status
+                .should_allow_block_markers(bank.slot())
+        {
+            let header = BlockComponent::new_block_header(self.parent, self.parent_block_id);
+            self.component_to_shreds(keypair, &header, reference_tick as u8, false, process_stats)
+                .unwrap()
+        } else {
+            vec![]
+        };
+
+        let entry_component =
+            BlockComponent::new_entry_batch(entries).expect("Received 0 length entry batch");
+        let entry_shreds = self
+            .component_to_shreds(
                 keypair,
-                &entries,
+                &entry_component,
                 reference_tick as u8,
                 is_last_in_slot,
                 process_stats,
-                MAX_DATA_SHREDS_PER_SLOT as u32,
-                MAX_CODE_SHREDS_PER_SLOT as u32,
             )
             .unwrap();
+
+        let shreds = if maybe_send_header {
+            header_shreds.extend(entry_shreds);
+            header_shreds
+        } else {
+            entry_shreds
+        };
         // Insert the first data shred synchronously so that blockstore stores
         // that the leader started this block. This must be done before the
         // blocks are sent out over the wire, so that the slots we have already
@@ -557,6 +581,7 @@ impl BroadcastRun for StandardBroadcastRun {
 mod test {
     use {
         super::*,
+        assert_matches::assert_matches,
         crossbeam_channel::unbounded,
         rand::Rng,
         solana_entry::entry::create_ticks,
@@ -574,6 +599,7 @@ mod test {
         solana_runtime::bank::Bank,
         solana_signer::Signer,
         std::{ops::Deref, sync::Arc, time::Duration},
+        test_case::test_case,
     };
 
     #[allow(clippy::type_complexity)]
@@ -655,25 +681,28 @@ mod test {
         assert!(shred.verify(&keypair.pubkey()));
     }
 
-    #[test]
-    fn test_slot_interrupt() {
+    #[test_case(MigrationStatus::default(), 1 ; "pre_migration")]
+    #[test_case(MigrationStatus::post_migration_status(), 2 ; "alpenglow_enabled")]
+    fn test_slot_interrupt(migration_status: MigrationStatus, shred_multiplier: u64) {
         // Setup
         let num_shreds_per_slot = DATA_SHREDS_PER_FEC_BLOCK as u64;
         let (blockstore, genesis_config, cluster_info, bank0, leader_keypair, socket, bank_forks) =
             setup(num_shreds_per_slot);
 
+        let bank1 = Arc::new(Bank::new_from_parent(bank0.clone(), *bank0.leader(), 1));
+
         // Insert 1 less than the number of ticks needed to finish the slot
         let ticks0 = create_ticks(genesis_config.ticks_per_slot - 1, 0, genesis_config.hash());
         let receive_results = ReceiveResults {
             entries: ticks0.clone(),
-            bank: bank0.clone(),
+            bank: bank1.clone(),
             last_tick_height: (ticks0.len() - 1) as u64,
         };
 
-        // Step 1: Make an incomplete transmission for slot 0
+        // Step 1: Make an incomplete transmission for slot 1
         let (votor_event_sender, _votor_event_receiver) = unbounded();
         let mut standard_broadcast_run =
-            StandardBroadcastRun::new(0, Arc::new(MigrationStatus::default()), votor_event_sender);
+            StandardBroadcastRun::new(0, Arc::new(migration_status), votor_event_sender);
         standard_broadcast_run
             .test_process_receive_results(
                 &leader_keypair,
@@ -684,14 +713,15 @@ mod test {
                 &bank_forks,
             )
             .unwrap();
+        // When alpenglow is enabled, new slots include both header and component shreds
         assert_eq!(
             standard_broadcast_run.next_shred_index as u64,
-            num_shreds_per_slot
+            shred_multiplier * num_shreds_per_slot
         );
-        assert_eq!(standard_broadcast_run.slot, 0);
+        assert_eq!(standard_broadcast_run.slot, 1);
         assert_eq!(standard_broadcast_run.parent, 0);
         // Make sure the slot is not complete
-        assert!(!blockstore.is_full(0));
+        assert!(!blockstore.is_full(1));
         // Modify the stats, should reset later
         standard_broadcast_run.process_shreds_stats.receive_elapsed = 10;
         // Broadcast stats should exist, and 1 batch should have been sent,
@@ -716,16 +746,24 @@ mod test {
                 .num_batches(),
             1
         );
-        // Try to fetch ticks from blockstore, nothing should break
-        assert_eq!(blockstore.get_slot_entries(0, 0).unwrap(), ticks0);
+        // Try to fetch ticks from blockstore, nothing should break.
+        // When headers are enabled, header shreds occupy the first num_shreds_per_slot indices,
+        // so entry data starts at that offset.
+        let header_shred_offset = (shred_multiplier - 1) * num_shreds_per_slot;
         assert_eq!(
-            blockstore.get_slot_entries(0, num_shreds_per_slot).unwrap(),
+            blockstore.get_slot_entries(1, header_shred_offset).unwrap(),
+            ticks0
+        );
+        assert_eq!(
+            blockstore
+                .get_slot_entries(1, shred_multiplier * num_shreds_per_slot)
+                .unwrap(),
             vec![],
         );
 
         // Step 2: Make a transmission for another bank that interrupts the transmission for
-        // slot 0
-        let bank2 = Arc::new(Bank::new_from_parent(bank0.clone(), *bank0.leader(), 2));
+        // slot 1
+        let bank2 = Arc::new(Bank::new_from_parent(bank1, *bank0.leader(), 2));
         let interrupted_slot = standard_broadcast_run.slot;
         // Interrupting the slot should cause the unfinished_slot and stats to reset
         let num_shreds = 1;
@@ -752,13 +790,14 @@ mod test {
             .unwrap();
 
         // The shred index should have reset to 0, which makes it possible for the
-        // index < the previous shred index for slot 0
+        // index < the previous shred index for slot 1
+        // When alpenglow is enabled, new slots include both header and component shreds
         assert_eq!(
             standard_broadcast_run.next_shred_index as usize,
-            DATA_SHREDS_PER_FEC_BLOCK
+            shred_multiplier as usize * DATA_SHREDS_PER_FEC_BLOCK
         );
         assert_eq!(standard_broadcast_run.slot, 2);
-        assert_eq!(standard_broadcast_run.parent, 0);
+        assert_eq!(standard_broadcast_run.parent, 1);
 
         // Check that the stats were reset as well
         assert_eq!(
@@ -785,9 +824,14 @@ mod test {
         );
 
         // Try to fetch the incomplete ticks from blockstore, should succeed
-        assert_eq!(blockstore.get_slot_entries(0, 0).unwrap(), ticks0);
         assert_eq!(
-            blockstore.get_slot_entries(0, num_shreds_per_slot).unwrap(),
+            blockstore.get_slot_entries(1, header_shred_offset).unwrap(),
+            ticks0
+        );
+        assert_eq!(
+            blockstore
+                .get_slot_entries(1, shred_multiplier * num_shreds_per_slot)
+                .unwrap(),
             vec![],
         );
     }
@@ -878,7 +922,7 @@ mod test {
     }
 
     #[test]
-    fn entries_to_shreds_max() {
+    fn test_component_to_shreds_max() {
         agave_logger::setup();
         let keypair = Keypair::new();
         let (votor_event_sender, _votor_event_receiver) = unbounded();
@@ -886,20 +930,16 @@ mod test {
             StandardBroadcastRun::new(0, Arc::new(MigrationStatus::default()), votor_event_sender);
         bs.slot = 1;
         bs.parent = 0;
+        bs.max_data_shreds_per_slot = 1000;
+        bs.max_code_shreds_per_slot = 1000;
         let entries = create_ticks(10_000, 1, solana_hash::Hash::default());
 
         let mut stats = ProcessShredsStats::default();
 
+        let component =
+            BlockComponent::new_entry_batch(entries[0..entries.len() - 2].to_vec()).unwrap();
         let (data, coding) = bs
-            .entries_to_shreds(
-                &keypair,
-                &entries[0..entries.len() - 2],
-                0,
-                false,
-                &mut stats,
-                1000,
-                1000,
-            )
+            .component_to_shreds(&keypair, &component, 0, false, &mut stats)
             .unwrap()
             .into_iter()
             .partition::<Vec<_>, _>(Shred::is_data);
@@ -907,8 +947,10 @@ mod test {
         assert!(!data.is_empty());
         assert!(!coding.is_empty());
 
-        let r = bs.entries_to_shreds(&keypair, &entries, 0, false, &mut stats, 10, 10);
-        info!("{r:?}");
+        bs.max_data_shreds_per_slot = 10;
+        bs.max_code_shreds_per_slot = 10;
+        let component = BlockComponent::new_entry_batch(entries).unwrap();
+        let r = bs.component_to_shreds(&keypair, &component, 0, false, &mut stats);
         assert_matches!(r, Err(BroadcastError::TooManyShreds));
     }
 }


### PR DESCRIPTION
Continuing from #11260 
Upstream of https://github.com/anza-xyz/alpenglow/pull/571

#### Problem
Alpenglow blocks require a block header which specifies the parent slot and the parent block id
The parent offset in shreds is not used in alpenglow and can be removed in the next shred format post release.

#### Summary of Changes
When disseminating data for a *new* slot in broadcast, insert a block header if this is an alpenglow block

