### PR TITLE
poh: record sends EntryMarker

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
+    "solana-entry/dev-context-only-utils",
     "solana-ledger/dev-context-only-utils",
     "solana-perf/dev-context-only-utils",
     "solana-runtime/dev-context-only-utils",

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -21,7 +21,10 @@ use {
     rand::{Rng, rng},
     rayon::prelude::*,
     solana_core::{banking_stage::BankingStage, banking_trace::BankingTracer},
-    solana_entry::entry::{Entry, next_hash},
+    solana_entry::{
+        entry::{Entry, next_hash},
+        entry_or_marker::EntryOrMarker,
+    },
     solana_genesis_config::GenesisConfig,
     solana_hash::Hash,
     solana_keypair::Keypair,
@@ -33,7 +36,7 @@ use {
     },
     solana_message::Message,
     solana_perf::packet::to_packet_batches,
-    solana_poh::poh_recorder::{WorkingBankEntry, create_test_recorder},
+    solana_poh::poh_recorder::{WorkingBankEntryOrMarker, create_test_recorder},
     solana_pubkey as pubkey,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_signature::Signature,
@@ -50,11 +53,13 @@ use {
     test::Bencher,
 };
 
-fn check_txs(receiver: &Arc<Receiver<WorkingBankEntry>>, ref_tx_count: usize) {
+fn check_txs(receiver: &Arc<Receiver<WorkingBankEntryOrMarker>>, ref_tx_count: usize) {
     let mut total = 0;
     let now = Instant::now();
     loop {
-        if let Ok((_bank, (entry, _tick_height))) = receiver.recv_timeout(Duration::new(1, 0)) {
+        if let Ok((_bank, (EntryOrMarker::Entry(entry), _tick_height))) =
+            receiver.recv_timeout(Duration::new(1, 0))
+        {
             total += entry.transactions.len();
         }
         if total >= ref_tx_count {

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -911,7 +911,10 @@ mod tests {
         agave_banking_stage_ingress_types::BankingPacketBatch,
         crossbeam_channel::unbounded,
         itertools::Itertools,
-        solana_entry::entry::{self, EntrySlice},
+        solana_entry::{
+            entry::{self, EntrySlice},
+            entry_or_marker::EntryOrMarker,
+        },
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::{
@@ -1084,7 +1087,7 @@ mod tests {
         // capture the entry receiver until we've received all our entries.
         let mut entries = Vec::with_capacity(100);
         loop {
-            if let Ok((_bank, (entry, _))) = entry_receiver.try_recv() {
+            if let Ok((_bank, (EntryOrMarker::Entry(entry), _))) = entry_receiver.try_recv() {
                 let tx_entry = !entry.transactions.is_empty();
                 entries.push(entry);
                 if tx_entry {
@@ -1111,7 +1114,7 @@ mod tests {
         entries.extend(
             entry_receiver
                 .iter()
-                .map(|(_bank, (entry, _tick_height))| entry),
+                .map(|(_bank, (entry_or_marker, _tick_height))| entry_or_marker.unwrap_entry()),
         );
 
         assert!(
@@ -1229,7 +1232,7 @@ mod tests {
         // check that the balance is what we expect.
         let entries: Vec<_> = entry_receiver
             .iter()
-            .map(|(_bank, (entry, _tick_height))| entry)
+            .map(|(_bank, (entry_or_marker, _tick_height))| entry_or_marker.unwrap_entry())
             .collect();
 
         let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -34,7 +34,7 @@ use {
         entry_notifier_service::EntryNotifierSender,
     },
     solana_poh::{
-        poh_recorder::{PohRecorder, WorkingBankEntry},
+        poh_recorder::{PohRecorder, WorkingBankEntryOrMarker},
         transaction_recorder::TransactionRecorder,
     },
     solana_pubkey::Pubkey,
@@ -110,7 +110,7 @@ impl Tpu {
         cluster_info: &Arc<ClusterInfo>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         transaction_recorder: TransactionRecorder,
-        entry_receiver: Receiver<WorkingBankEntry>,
+        entry_receiver: Receiver<WorkingBankEntryOrMarker>,
         retransmit_slots_receiver: Receiver<Slot>,
         sockets: TpuSockets,
         subscriptions: Option<Arc<RpcSubscriptions>>,

--- a/core/src/tpu_entry_notifier.rs
+++ b/core/src/tpu_entry_notifier.rs
@@ -1,8 +1,8 @@
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
-    solana_entry::entry::EntrySummary,
+    solana_entry::{entry::EntrySummary, entry_or_marker::EntryOrMarker},
     solana_ledger::entry_notifier_service::{EntryNotification, EntryNotifierSender},
-    solana_poh::poh_recorder::WorkingBankEntry,
+    solana_poh::poh_recorder::WorkingBankEntryOrMarker,
     std::{
         sync::{
             Arc,
@@ -19,9 +19,9 @@ pub(crate) struct TpuEntryNotifier {
 
 impl TpuEntryNotifier {
     pub(crate) fn new(
-        entry_receiver: Receiver<WorkingBankEntry>,
+        entry_receiver: Receiver<WorkingBankEntryOrMarker>,
         entry_notification_sender: EntryNotifierSender,
-        broadcast_entry_sender: Sender<WorkingBankEntry>,
+        broadcast_entry_sender: Sender<WorkingBankEntryOrMarker>,
         exit: Arc<AtomicBool>,
     ) -> Self {
         let thread_hdl = Builder::new()
@@ -54,14 +54,15 @@ impl TpuEntryNotifier {
 
     pub(crate) fn send_entry_notification(
         exit: Arc<AtomicBool>,
-        entry_receiver: &Receiver<WorkingBankEntry>,
+        entry_receiver: &Receiver<WorkingBankEntryOrMarker>,
         entry_notification_sender: &EntryNotifierSender,
-        broadcast_entry_sender: &Sender<WorkingBankEntry>,
+        broadcast_entry_sender: &Sender<WorkingBankEntryOrMarker>,
         current_slot: &mut u64,
         current_index: &mut usize,
         current_transaction_index: &mut usize,
     ) -> Result<(), RecvTimeoutError> {
-        let (bank, (entry, tick_height)) = entry_receiver.recv_timeout(Duration::from_secs(1))?;
+        let (bank, (entry_or_marker, tick_height)) =
+            entry_receiver.recv_timeout(Duration::from_secs(1))?;
         let slot = bank.slot();
         let index = if slot != *current_slot {
             *current_index = 0;
@@ -73,28 +74,31 @@ impl TpuEntryNotifier {
             *current_index
         };
 
-        let entry_summary = EntrySummary {
-            num_hashes: entry.num_hashes,
-            hash: entry.hash,
-            num_transactions: entry.transactions.len() as u64,
+        if let EntryOrMarker::Entry(ref entry) = entry_or_marker {
+            let entry_summary = EntrySummary {
+                num_hashes: entry.num_hashes,
+                hash: entry.hash,
+                num_transactions: entry.transactions.len() as u64,
+            };
+            if let Err(err) = entry_notification_sender.send(EntryNotification {
+                slot,
+                index,
+                entry: entry_summary,
+                starting_transaction_index: *current_transaction_index,
+            }) {
+                warn!(
+                    "Failed to send slot {slot:?} entry {index:?} from Tpu to \
+                     EntryNotifierService, error {err:?}",
+                );
+            }
+            *current_transaction_index += entry.transactions.len();
         };
-        if let Err(err) = entry_notification_sender.send(EntryNotification {
-            slot,
-            index,
-            entry: entry_summary,
-            starting_transaction_index: *current_transaction_index,
-        }) {
-            warn!(
-                "Failed to send slot {slot:?} entry {index:?} from Tpu to EntryNotifierService, \
-                 error {err:?}",
-            );
-        }
-        *current_transaction_index += entry.transactions.len();
 
-        if let Err(err) = broadcast_entry_sender.send((bank, (entry, tick_height))) {
+        if let Err(err) = broadcast_entry_sender.send((bank, (entry_or_marker, tick_height))) {
+            let index = *current_index;
             warn!(
-                "Failed to send slot {slot:?} entry {index:?} from Tpu to BroadcastStage, error \
-                 {err:?}",
+                "Failed to send slot {slot:?} entry/marker {index:?} from Tpu to BroadcastStage, \
+                 error {err:?}",
             );
             // If the BroadcastStage channel is closed, the validator has halted. Try to exit
             // gracefully.

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -18,7 +18,7 @@ use {
         replay_stage::{ReplayStage, TowerBFTStructures},
         unfrozen_gossip_verified_vote_hashes::UnfrozenGossipVerifiedVoteHashes,
     },
-    solana_entry::entry::Entry,
+    solana_entry::{entry::Entry, entry_or_marker::EntryOrMarker},
     solana_hash::Hash,
     solana_leader_schedule::SlotLeader,
     solana_ledger::{
@@ -290,8 +290,13 @@ fn test_scheduler_producing_blocks() {
     // Verify transactions are committed and poh-recorded
     assert_eq!(tpu_bank.transaction_count(), 1);
     assert_matches!(
-        signal_receiver.into_iter().find(|(_, (entry, _))| !entry.is_tick()),
-        Some((_, (Entry {transactions, ..}, _))) if transactions == [tx.to_versioned_transaction()]
+        signal_receiver.into_iter().find(|(_, (entry_or_marker, _))| {
+            match entry_or_marker {
+                EntryOrMarker::Entry(entry) => !entry.is_tick(),
+                EntryOrMarker::Marker(_) => false,
+            }
+        }),
+        Some((_, (EntryOrMarker::Entry(Entry {transactions, ..}), _))) if transactions == [tx.to_versioned_transaction()]
     );
 
     // Stop things.

--- a/entry/src/entry_or_marker.rs
+++ b/entry/src/entry_or_marker.rs
@@ -1,0 +1,42 @@
+//! Entry marker types for the PoH recording pipeline.
+//!
+//! This module defines `EntryOrMarker`, a wrapper type that allows both regular entries and block
+//! markers (headers, footers) to flow through the same PoH recording channel.
+use crate::{block_component::VersionedBlockMarker, entry::Entry};
+
+/// Wraps either a regular entry or a block metadata marker.
+///
+/// The PoH recorder uses this type to stream both transaction-containing entries and block markers
+/// through a unified channel to downstream consumers, e.g., broadcast stage.
+#[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum EntryOrMarker {
+    /// A regular entry containing transactions and/or ticks
+    Entry(Entry),
+    /// A block metadata marker (header or footer)
+    Marker(VersionedBlockMarker),
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl EntryOrMarker {
+    pub fn unwrap_entry(self) -> Entry {
+        match self {
+            Self::Entry(e) => e,
+            Self::Marker(marker) => panic!("Attempting to unwrap marker as entry {marker:?}"),
+        }
+    }
+}
+
+/// Converts an Entry into an EntryOrMarker.
+impl From<Entry> for EntryOrMarker {
+    fn from(entry: Entry) -> Self {
+        EntryOrMarker::Entry(entry)
+    }
+}
+
+/// Converts a VersionedBlockMarker into an EntryOrMarker.
+impl From<VersionedBlockMarker> for EntryOrMarker {
+    fn from(marker: VersionedBlockMarker) -> Self {
+        EntryOrMarker::Marker(marker)
+    }
+}

--- a/entry/src/lib.rs
+++ b/entry/src/lib.rs
@@ -2,4 +2,5 @@
 #![allow(clippy::arithmetic_side_effects)]
 pub mod block_component;
 pub mod entry;
+pub mod entry_or_marker;
 pub mod poh;

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -24,6 +24,7 @@ use {
     solana_clock::{BankId, Slot},
     solana_entry::{
         entry::Entry,
+        entry_or_marker::EntryOrMarker,
         poh::{Poh, PohEntry},
     },
     solana_hash::Hash,
@@ -57,7 +58,7 @@ pub enum PohRecorderError {
     MinHeightNotReached,
 
     #[error("send WorkingBankEntry error")]
-    SendError(#[from] SendError<WorkingBankEntry>),
+    SendError(#[from] Box<SendError<WorkingBankEntryOrMarker>>),
 
     #[error("channel full")]
     ChannelFull,
@@ -68,7 +69,7 @@ pub enum PohRecorderError {
 
 pub(crate) type Result<T> = std::result::Result<T, PohRecorderError>;
 
-pub type WorkingBankEntry = (Arc<Bank>, (Entry, u64));
+pub type WorkingBankEntryOrMarker = (Arc<Bank>, (EntryOrMarker, u64));
 
 #[derive(Debug)]
 pub struct RecordSummary {
@@ -176,7 +177,7 @@ pub struct PohRecorder {
     /// This field MUST be kept consistent with the `shared_leader_state` field.
     working_bank: Option<WorkingBank>,
     shared_leader_state: SharedLeaderState,
-    working_bank_sender: Sender<WorkingBankEntry>,
+    working_bank_sender: Sender<WorkingBankEntryOrMarker>,
     leader_last_tick_height: u64, // zero if none
     grace_ticks: u64,
     blockstore: Arc<Blockstore>,
@@ -210,7 +211,7 @@ impl PohRecorder {
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         poh_config: &PohConfig,
         is_exited: Arc<AtomicBool>,
-    ) -> (Self, Receiver<WorkingBankEntry>) {
+    ) -> (Self, Receiver<WorkingBankEntryOrMarker>) {
         let delay_leader_block_for_pending_fork = false;
         Self::new_with_clear_signal(
             tick_height,
@@ -240,7 +241,7 @@ impl PohRecorder {
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         poh_config: &PohConfig,
         is_exited: Arc<AtomicBool>,
-    ) -> (Self, Receiver<WorkingBankEntry>) {
+    ) -> (Self, Receiver<WorkingBankEntryOrMarker>) {
         let tick_number = 0;
         let poh = Arc::new(Mutex::new(Poh::new_with_slot_info(
             last_entry_hash,
@@ -356,20 +357,22 @@ impl PohRecorder {
             if mixed_in {
                 debug_assert_eq!(self.entries.len(), mixins.len());
                 for (entry, transactions) in self.entries.drain(..).zip(transaction_batches) {
-                    let (send_entry_res, send_batches_us) =
-                        measure_us!(self.working_bank_sender.send((
+                    let (send_entry_res, send_batches_us) = measure_us!(
+                        self.working_bank_sender.send((
                             working_bank.bank.clone(),
                             (
                                 Entry {
                                     num_hashes: entry.num_hashes,
                                     hash: entry.hash,
                                     transactions,
-                                },
+                                }
+                                .into(),
                                 tick_height, // `record_batches` guarantees that mixins are **not** split across ticks.
                             ),
-                        )));
+                        ))
+                    );
                     self.metrics.send_entry_us += send_batches_us;
-                    send_entry_res?;
+                    send_entry_res.map_err(Box::new)?;
                 }
 
                 return Ok(RecordSummary {
@@ -569,7 +572,7 @@ impl PohRecorder {
             .iter()
             .take_while(|x| x.1 <= working_bank.max_tick_height)
             .count();
-        let mut send_result: std::result::Result<(), SendError<WorkingBankEntry>> = Ok(());
+        let mut send_result: std::result::Result<(), SendError<WorkingBankEntryOrMarker>> = Ok(());
 
         if entry_count > 0 {
             trace!(
@@ -580,11 +583,14 @@ impl PohRecorder {
                 entry_count,
             );
 
-            for tick in &self.tick_cache[..entry_count] {
-                working_bank.bank.register_tick(&tick.0.hash);
+            for (entry, tick_height) in &self.tick_cache[..entry_count] {
+                working_bank.bank.register_tick(&entry.hash);
+
+                let tick = (EntryOrMarker::from(entry.clone()), *tick_height);
+
                 send_result = self
                     .working_bank_sender
-                    .send((working_bank.bank.clone(), tick.clone()));
+                    .send((working_bank.bank.clone(), tick));
                 if send_result.is_err() {
                     break;
                 }
@@ -976,7 +982,7 @@ fn do_create_test_recorder(
     PohController,
     TransactionRecorder,
     PohService,
-    Receiver<WorkingBankEntry>,
+    Receiver<WorkingBankEntryOrMarker>,
 ) {
     let leader_schedule_cache = match leader_schedule_cache {
         Some(provided_cache) => provided_cache,
@@ -1041,7 +1047,7 @@ pub fn create_test_recorder(
     PohController,
     TransactionRecorder,
     PohService,
-    Receiver<WorkingBankEntry>,
+    Receiver<WorkingBankEntryOrMarker>,
 ) {
     do_create_test_recorder(bank, blockstore, poh_config, leader_schedule_cache, false)
 }
@@ -1278,9 +1284,11 @@ mod tests {
 
         // Collect the tick entries produced.
         let mut entries = vec![];
-        while let Ok((_bank, (entry, _tick_height))) = entry_receiver.try_recv() {
-            assert!(entry.is_tick());
-            entries.push(entry);
+        while let Ok((_bank, (entry_or_marker, _tick_height))) = entry_receiver.try_recv() {
+            if let EntryOrMarker::Entry(entry) = entry_or_marker {
+                assert!(entry.is_tick());
+                entries.push(entry);
+            }
         }
 
         // Confirm correct number of entries received.
@@ -1542,11 +1550,11 @@ mod tests {
         //tick in the cache + entry
         for _ in 0..min_tick_height {
             let (_bank, (e, _tick_height)) = entry_receiver.recv().unwrap();
-            assert!(e.is_tick());
+            assert!(e.unwrap_entry().is_tick());
         }
 
         let (_bank, (e, _tick_height)) = entry_receiver.recv().unwrap();
-        assert!(!e.is_tick());
+        assert!(!e.unwrap_entry().is_tick());
     }
 
     #[test]
@@ -1583,7 +1591,7 @@ mod tests {
         );
         for _ in 0..num_ticks_to_max {
             let (_bank, (entry, _tick_height)) = entry_receiver.recv().unwrap();
-            assert!(entry.is_tick());
+            assert!(entry.unwrap_entry().is_tick());
         }
     }
 

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -23,7 +23,7 @@ use {
     solana_measure::measure::Measure,
     solana_metrics::inc_new_counter_error,
     solana_net_utils::SocketAddrSpace,
-    solana_poh::poh_recorder::WorkingBankEntry,
+    solana_poh::poh_recorder::WorkingBankEntryOrMarker,
     solana_pubkey::Pubkey,
     solana_runtime::{bank::MAX_LEADER_SCHEDULE_STAKES, bank_forks::BankForks},
     solana_streamer::sendmmsg::{SendPktsError, batch_send},
@@ -111,7 +111,7 @@ impl BroadcastStageType {
         &self,
         sock: Vec<UdpSocket>,
         cluster_info: Arc<ClusterInfo>,
-        receiver: Receiver<WorkingBankEntry>,
+        receiver: Receiver<WorkingBankEntryOrMarker>,
         retransmit_slots_receiver: Receiver<Slot>,
         exit_sender: Arc<AtomicBool>,
         blockstore: Arc<Blockstore>,
@@ -159,7 +159,7 @@ trait BroadcastRun {
         &mut self,
         keypair: &Keypair,
         blockstore: &Blockstore,
-        receiver: &Receiver<WorkingBankEntry>,
+        receiver: &Receiver<WorkingBankEntryOrMarker>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()>;
@@ -200,7 +200,7 @@ impl BroadcastStage {
     fn run(
         cluster_info: Arc<ClusterInfo>,
         blockstore: &Blockstore,
-        receiver: &Receiver<WorkingBankEntry>,
+        receiver: &Receiver<WorkingBankEntryOrMarker>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         mut broadcast_stage_run: impl BroadcastRun,
@@ -258,7 +258,7 @@ impl BroadcastStage {
     fn new(
         socks: Vec<UdpSocket>,
         cluster_info: Arc<ClusterInfo>,
-        receiver: Receiver<WorkingBankEntry>,
+        receiver: Receiver<WorkingBankEntryOrMarker>,
         retransmit_slots_receiver: Receiver<Slot>,
         exit: Arc<AtomicBool>,
         blockstore: Arc<Blockstore>,
@@ -542,7 +542,7 @@ pub mod test {
         agave_votor_messages::migration::MigrationStatus,
         crossbeam_channel::{bounded, unbounded},
         rand::Rng,
-        solana_entry::entry::create_ticks,
+        solana_entry::{entry::create_ticks, entry_or_marker::EntryOrMarker},
         solana_gossip::{cluster_info::ClusterInfo, node::Node},
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -682,7 +682,7 @@ pub mod test {
     fn setup_dummy_broadcast_service(
         leader_keypair: Arc<Keypair>,
         ledger_path: &Path,
-        entry_receiver: Receiver<WorkingBankEntry>,
+        entry_receiver: Receiver<WorkingBankEntryOrMarker>,
         retransmit_slots_receiver: Receiver<Slot>,
     ) -> MockBroadcastStage {
         // Make the database ledger
@@ -763,7 +763,7 @@ pub mod test {
             let ticks = create_ticks(max_tick_height - start_tick_height, 0, Hash::default());
             for (i, tick) in ticks.into_iter().enumerate() {
                 entry_sender
-                    .send((bank.clone(), (tick, i as u64 + 1)))
+                    .send((bank.clone(), (EntryOrMarker::Entry(tick), i as u64 + 1)))
                     .expect("Expect successful send to broadcast service");
             }
         }

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -5,7 +5,7 @@ use {
     agave_votor_messages::migration::MigrationStatus,
     crossbeam_channel::Sender,
     itertools::Itertools,
-    solana_entry::entry::Entry,
+    solana_entry::{block_component::BlockComponent, entry::Entry},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
@@ -40,7 +40,7 @@ pub(super) struct BroadcastDuplicatesRun {
     config: BroadcastDuplicatesConfig,
     current_slot: Slot,
     chained_merkle_root: Hash,
-    carryover_entry: Option<WorkingBankEntry>,
+    carryover_entry: Option<WorkingBankEntryOrMarker>,
     next_shred_index: u32,
     next_code_index: u32,
     shred_version: u16,
@@ -92,14 +92,14 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         &mut self,
         keypair: &Keypair,
         blockstore: &Blockstore,
-        receiver: &Receiver<WorkingBankEntry>,
+        receiver: &Receiver<WorkingBankEntryOrMarker>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
         let mut stats = ProcessShredsStats::default();
         let mut receive_results =
-            broadcast_utils::recv_slot_entries(receiver, &mut self.carryover_entry, &mut stats)?;
+            broadcast_utils::recv_slot_components(receiver, &mut self.carryover_entry, &mut stats)?;
         let bank = receive_results.bank.clone();
         let last_tick_height = receive_results.last_tick_height;
 
@@ -117,12 +117,14 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             self.num_slots_broadcasted += 1;
         }
 
-        if receive_results.entries.is_empty() {
+        let BlockComponent::EntryBatch(ref mut entries) = receive_results.component else {
+            // This test only TowerBFT implementation does not use block markers
             return Ok(());
-        }
-
+        };
+        // We are guarenteed by coalesce that this is not empty
+        assert!(!entries.is_empty());
         // Update the recent blockhash based on transactions in the entries
-        for entry in &receive_results.entries {
+        for entry in entries.iter() {
             if !entry.transactions.is_empty() {
                 self.recent_blockhash = Some(*entry.transactions[0].message.recent_blockhash());
                 break;
@@ -137,17 +139,17 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                 && self.num_slots_broadcasted.is_multiple_of(DUPLICATE_RATE)
                 && let Some(recent_blockhash) = self.recent_blockhash
             {
-                let entry_batch_len = receive_results.entries.len();
+                let entry_batch_len = entries.len();
                 let prev_entry_hash =
                     // Try to get second-to-last entry before last tick
                     if entry_batch_len > 1 {
-                        Some(receive_results.entries[entry_batch_len - 2].hash)
+                        Some(entries[entry_batch_len - 2].hash)
                     } else {
                         self.prev_entry_hash
                     };
 
                 if let Some(prev_entry_hash) = prev_entry_hash {
-                    let original_last_entry = receive_results.entries.pop().unwrap();
+                    let original_last_entry = entries.pop().unwrap();
 
                     // Last entry has to be a tick
                     assert!(original_last_entry.is_tick());
@@ -182,7 +184,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         self.prev_entry_hash = last_entries
             .as_ref()
             .map(|(original_last_entry, _)| original_last_entry.hash)
-            .or_else(|| receive_results.entries.last().map(|e| e.hash));
+            .or_else(|| entries.last().map(|e| e.hash));
 
         let shredder = Shredder::new(
             bank.slot(),
@@ -192,21 +194,16 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         )
         .expect("Expected to create a new shredder");
 
-        // Avoid generating an empty FEC set
-        let (data_shreds, coding_shreds) = if !receive_results.entries.is_empty() {
-            shredder.entries_to_merkle_shreds_for_tests(
-                keypair,
-                &receive_results.entries,
-                last_tick_height == bank.max_tick_height() && last_entries.is_none(),
-                self.chained_merkle_root,
-                self.next_shred_index,
-                self.next_code_index,
-                &self.reed_solomon_cache,
-                &mut stats,
-            )
-        } else {
-            (vec![], vec![])
-        };
+        let (data_shreds, coding_shreds) = shredder.component_to_merkle_shreds_for_tests(
+            keypair,
+            &receive_results.component,
+            last_tick_height == bank.max_tick_height() && last_entries.is_none(),
+            self.chained_merkle_root,
+            self.next_shred_index,
+            self.next_code_index,
+            &self.reed_solomon_cache,
+            &mut stats,
+        );
         if let Some(shred) = data_shreds.iter().max_by_key(|shred| shred.index()) {
             self.chained_merkle_root = shred.merkle_root().unwrap();
         }
@@ -216,9 +213,9 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         }
         let last_shreds =
             last_entries.map(|(original_last_entry, duplicate_extra_last_entries)| {
-                let (original_last_data_shred, _) = shredder.entries_to_merkle_shreds_for_tests(
+                let (original_last_data_shred, _) = shredder.component_to_merkle_shreds_for_tests(
                     keypair,
-                    &[original_last_entry],
+                    &BlockComponent::EntryBatch(vec![original_last_entry]),
                     true,
                     self.chained_merkle_root,
                     self.next_shred_index,
@@ -229,9 +226,9 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                 // Don't mark the last shred as last so that validators won't
                 // know that they've gotten all the shreds, and will continue
                 // trying to repair.
-                let (partition_last_data_shred, _) = shredder.entries_to_merkle_shreds_for_tests(
+                let (partition_last_data_shred, _) = shredder.component_to_merkle_shreds_for_tests(
                     keypair,
-                    &duplicate_extra_last_entries,
+                    &BlockComponent::EntryBatch(duplicate_extra_last_entries),
                     true,
                     self.chained_merkle_root,
                     self.next_shred_index,

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -4,13 +4,13 @@ use {
     agave_votor_messages::migration::MigrationStatus,
     crossbeam_channel::Receiver,
     solana_clock::Slot,
-    solana_entry::entry::Entry,
+    solana_entry::{block_component::BlockComponent, entry::Entry, entry_or_marker::EntryOrMarker},
     solana_hash::Hash,
     solana_ledger::{
         blockstore::Blockstore,
         shred::{self, ProcessShredsStats, get_data_shred_bytes_per_batch_typical},
     },
-    solana_poh::poh_recorder::WorkingBankEntry,
+    solana_poh::poh_recorder::WorkingBankEntryOrMarker,
     solana_runtime::bank::Bank,
     std::{
         sync::Arc,
@@ -22,7 +22,7 @@ use {
 const ENTRY_COALESCE_DURATION: Duration = Duration::from_millis(50);
 
 pub(super) struct ReceiveResults {
-    pub entries: Vec<Entry>,
+    pub component: BlockComponent,
     pub bank: Arc<Bank>,
     pub last_tick_height: u64,
 }
@@ -69,24 +69,54 @@ fn keep_coalescing_entries(
     true
 }
 
-pub(super) fn recv_slot_entries(
-    receiver: &Receiver<WorkingBankEntry>,
-    carryover_entry: &mut Option<WorkingBankEntry>,
+pub(super) fn recv_slot_components(
+    receiver: &Receiver<WorkingBankEntryOrMarker>,
+    carryover_entry: &mut Option<WorkingBankEntryOrMarker>,
     process_stats: &mut ProcessShredsStats,
 ) -> Result<ReceiveResults> {
+    loop {
+        if let Some(result) =
+            recv_slot_components_maybe_empty(receiver, carryover_entry, process_stats)?
+        {
+            return Ok(result);
+        }
+    }
+}
+
+fn recv_slot_components_maybe_empty(
+    receiver: &Receiver<WorkingBankEntryOrMarker>,
+    carryover_entry: &mut Option<WorkingBankEntryOrMarker>,
+    process_stats: &mut ProcessShredsStats,
+) -> Result<Option<ReceiveResults>> {
     let recv_start = Instant::now();
 
     // If there is a carryover entry, use it. Else, see if there is a new entry.
-    let (mut bank, (entry, mut last_tick_height)) = match carryover_entry.take() {
-        Some((bank, (entry, tick_height))) => (bank, (entry, tick_height)),
+    let (mut bank, (entry_or_marker, mut last_tick_height)) = match carryover_entry.take() {
+        Some((bank, (entry_or_marker, tick_height))) => (bank, (entry_or_marker, tick_height)),
         None => receiver.recv_timeout(Duration::new(1, 0))?,
     };
     assert!(last_tick_height <= bank.max_tick_height());
-    let mut entries = vec![entry];
 
-    // Drain the channel of entries.
+    let mut entries: Vec<Entry> = match entry_or_marker {
+        EntryOrMarker::Marker(marker) => {
+            // If the first thing is a block marker, return it immediately
+            process_stats.receive_elapsed = recv_start.elapsed().as_micros() as u64;
+
+            return Ok(Some(ReceiveResults {
+                component: BlockComponent::BlockMarker(marker),
+                bank,
+                last_tick_height,
+            }));
+        }
+        EntryOrMarker::Entry(entry) => {
+            vec![entry]
+        }
+    };
+
+    // Drain the channel of entries until we hit a marker or the slot ends
+    let mut hit_marker = false;
     while last_tick_height != bank.max_tick_height() {
-        let Ok((try_bank, (entry, tick_height))) = receiver.try_recv() else {
+        let Ok((try_bank, (next_entry_or_marker, tick_height))) = receiver.try_recv() else {
             break;
         };
         // If the bank changed, that implies the previous slot was interrupted and we do not have to
@@ -94,11 +124,25 @@ pub(super) fn recv_slot_entries(
         if try_bank.slot() != bank.slot() {
             warn!("Broadcast for slot: {} interrupted", bank.slot());
             entries.clear();
-            bank = try_bank;
+            last_tick_height = 0;
+            bank = try_bank.clone();
         }
-        last_tick_height = tick_height;
-        entries.push(entry);
-        assert!(last_tick_height <= bank.max_tick_height());
+        match next_entry_or_marker {
+            EntryOrMarker::Marker(ref _marker) => {
+                // If we hit a block marker, save it for next time and stop draining
+                *carryover_entry = Some((try_bank, (next_entry_or_marker, tick_height)));
+                hit_marker = true;
+                break;
+            }
+            EntryOrMarker::Entry(entry) => {
+                // Only update after confirming the entry is included in this batch.
+                last_tick_height = tick_height;
+
+                // Add the entry to our batch
+                entries.push(entry);
+                assert!(last_tick_height <= bank.max_tick_height());
+            }
+        }
     }
 
     let mut serialized_batch_byte_count = serialized_size(&entries)?;
@@ -117,16 +161,19 @@ pub(super) fn recv_slot_entries(
     // 1. We ticked through the entire slot.
     // 2. We hit the timeout.
     // 3. We're over the max data target.
-    // 4. We're "close enough" to tightly packing erasure batches.
+    // 4. We hit a block marker.
+    // 5. We're "close enough" to tightly packing erasure batches.
     let mut coalesce_start = Instant::now();
-    while keep_coalescing_entries(
-        last_tick_height,
-        bank.max_tick_height(),
-        serialized_batch_byte_count,
-        max_batch_byte_count,
-        process_stats,
-    ) {
-        let Ok((try_bank, (entry, tick_height))) =
+    while !hit_marker
+        && keep_coalescing_entries(
+            last_tick_height,
+            bank.max_tick_height(),
+            serialized_batch_byte_count,
+            max_batch_byte_count,
+            process_stats,
+        )
+    {
+        let Ok((try_bank, (entry_or_marker, tick_height))) =
             receiver.recv_deadline(coalesce_start + ENTRY_COALESCE_DURATION)
         else {
             process_stats.coalesce_exited_rcv_timeout += 1;
@@ -138,34 +185,51 @@ pub(super) fn recv_slot_entries(
             warn!("Broadcast for slot: {} interrupted", bank.slot());
             entries.clear();
             serialized_batch_byte_count = 8; // Vec len
+            last_tick_height = 0;
             bank = try_bank.clone();
             coalesce_start = Instant::now();
+            debug_assert!(carryover_entry.is_none());
         }
 
-        let entry_bytes = serialized_size(&entry)?;
-        if serialized_batch_byte_count + entry_bytes > max_batch_byte_count {
-            // This entry will push us over the batch byte limit. Save it for
-            // the next batch.
-            *carryover_entry = Some((try_bank, (entry, tick_height)));
-            process_stats.coalesce_exited_hit_max += 1;
-            break;
+        match entry_or_marker {
+            EntryOrMarker::Marker(ref _marker) => {
+                // If we hit a block marker, save it for next time and stop coalescing
+                *carryover_entry = Some((try_bank, (entry_or_marker, tick_height)));
+                break;
+            }
+            EntryOrMarker::Entry(entry) => {
+                let entry_bytes = serialized_size(&entry)?;
+
+                if serialized_batch_byte_count + entry_bytes > max_batch_byte_count {
+                    // This entry will push us over the batch byte limit. Save it for
+                    // the next batch.
+                    *carryover_entry = Some((try_bank, (entry.into(), tick_height)));
+                    process_stats.coalesce_exited_hit_max += 1;
+                    break;
+                }
+
+                // only update the last tick height after confirming we did
+                // not carry over the entry to the next batch.
+                last_tick_height = tick_height;
+
+                // Add the entry to the batch.
+                serialized_batch_byte_count += entry_bytes;
+                entries.push(entry);
+            }
         }
 
-        // only update the last tick height after confirming we did
-        // not carry over the entry to the next batch.
-        last_tick_height = tick_height;
-
-        // Add the entry to the batch.
-        serialized_batch_byte_count += entry_bytes;
-        entries.push(entry);
         assert!(last_tick_height <= bank.max_tick_height());
     }
     process_stats.receive_elapsed = recv_start.elapsed().as_micros() as u64;
     process_stats.coalesce_elapsed = coalesce_start.elapsed().as_micros() as u64;
-    Ok(ReceiveResults {
-        entries,
-        bank,
-        last_tick_height,
+
+    Ok(match entries.is_empty() {
+        true => None,
+        false => Some(ReceiveResults {
+            component: BlockComponent::EntryBatch(entries),
+            bank,
+            last_tick_height,
+        }),
     })
 }
 
@@ -219,6 +283,7 @@ mod tests {
     use {
         super::*,
         crossbeam_channel::unbounded,
+        solana_entry::entry_or_marker::EntryOrMarker,
         solana_genesis_config::GenesisConfig,
         solana_ledger::genesis_utils::{GenesisConfigInfo, create_genesis_config},
         solana_runtime::bank::SlotLeader,
@@ -253,7 +318,7 @@ mod tests {
     const MAX_TICK_HEIGHT: u64 = 10;
 
     #[test]
-    fn test_recv_slot_entries_1() {
+    fn test_recv_slot_components_1() {
         let (genesis_config, bank0, bank_forks, tx) = setup_test();
 
         let bank1 = Bank::new_from_parent_with_bank_forks(
@@ -270,25 +335,29 @@ mod tests {
             .map(|i| {
                 let entry = Entry::new(&last_hash, 1, vec![tx.clone()]);
                 last_hash = entry.hash;
-                s.send((bank1.clone(), (entry.clone(), i))).unwrap();
+                s.send((bank1.clone(), (EntryOrMarker::Entry(entry.clone()), i)))
+                    .unwrap();
                 entry
             })
             .collect();
 
         let mut res_entries = vec![];
         let mut last_tick_height = 0;
-        while let Ok(result) = recv_slot_entries(&r, &mut None, &mut ProcessShredsStats::default())
+        while let Ok(result) =
+            recv_slot_components(&r, &mut None, &mut ProcessShredsStats::default())
         {
             assert_eq!(result.bank.slot(), bank1.slot());
             last_tick_height = result.last_tick_height;
-            res_entries.extend(result.entries);
+            if let BlockComponent::EntryBatch(entries) = result.component {
+                res_entries.extend(entries);
+            }
         }
         assert_eq!(last_tick_height, bank1.max_tick_height());
         assert_eq!(res_entries, entries);
     }
 
     #[test]
-    fn test_recv_slot_entries_2() {
+    fn test_recv_slot_components_2() {
         let (genesis_config, bank0, bank_forks, tx) = setup_test();
 
         let bank1 = Bank::new_from_parent_with_bank_forks(
@@ -315,11 +384,15 @@ mod tests {
                 last_hash = entry.hash;
                 // Interrupt slot 1 right before the last tick
                 if tick_height == expected_last_height {
-                    s.send((bank2.clone(), (entry.clone(), tick_height)))
-                        .unwrap();
+                    s.send((
+                        bank2.clone(),
+                        (EntryOrMarker::Entry(entry.clone()), tick_height),
+                    ))
+                    .unwrap();
                     Some(entry)
                 } else {
-                    s.send((bank1.clone(), (entry, tick_height))).unwrap();
+                    s.send((bank1.clone(), (EntryOrMarker::Entry(entry), tick_height)))
+                        .unwrap();
                     None
                 }
             })
@@ -330,15 +403,170 @@ mod tests {
         let mut res_entries = vec![];
         let mut last_tick_height = 0;
         let mut bank_slot = 0;
-        while let Ok(result) = recv_slot_entries(&r, &mut None, &mut ProcessShredsStats::default())
+        while let Ok(result) =
+            recv_slot_components(&r, &mut None, &mut ProcessShredsStats::default())
         {
             bank_slot = result.bank.slot();
             last_tick_height = result.last_tick_height;
-            res_entries = result.entries;
+            if let BlockComponent::EntryBatch(entries) = result.component {
+                res_entries = entries;
+            }
         }
         assert_eq!(bank_slot, bank2.slot());
         assert_eq!(last_tick_height, expected_last_height);
         assert_eq!(res_entries, vec![last_entry]);
+    }
+
+    #[test]
+    fn test_marker_carryover_does_not_advance_last_tick_height() {
+        let (genesis_config, bank0, _bank_forks, tx) = setup_test();
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
+        let (s, r) = unbounded();
+        let max_tick = bank1.max_tick_height();
+
+        let mut last_hash = genesis_config.hash();
+        for tick in 1..=2 {
+            let entry = Entry::new(&last_hash, 1, vec![tx.clone()]);
+            last_hash = entry.hash;
+            s.send((bank1.clone(), (EntryOrMarker::Entry(entry), tick)))
+                .unwrap();
+        }
+
+        let marker = solana_entry::block_component::VersionedBlockMarker::new_block_header(
+            solana_entry::block_component::BlockHeaderV1 {
+                parent_slot: 0,
+                parent_block_id: Hash::default(),
+            },
+        );
+        s.send((bank1.clone(), (EntryOrMarker::Marker(marker), max_tick)))
+            .unwrap();
+
+        let mut carryover = None;
+        let result =
+            recv_slot_components(&r, &mut carryover, &mut ProcessShredsStats::default()).unwrap();
+
+        assert!(matches!(result.component, BlockComponent::EntryBatch(ref e) if e.len() == 2));
+        assert_eq!(result.last_tick_height, 2);
+        assert!(carryover.is_some());
+
+        let result =
+            recv_slot_components(&r, &mut carryover, &mut ProcessShredsStats::default()).unwrap();
+        assert!(matches!(result.component, BlockComponent::BlockMarker(_)));
+        assert_eq!(result.last_tick_height, max_tick);
+    }
+
+    #[test]
+    fn test_marker_preserves_entry_ordering() {
+        let (genesis_config, bank0, _bank_forks, tx) = setup_test();
+        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
+        let (s, r) = unbounded();
+
+        let mut last_hash = genesis_config.hash();
+
+        let entry1 = Entry::new(&last_hash, 1, vec![tx.clone()]);
+        last_hash = entry1.hash;
+        s.send((bank1.clone(), (EntryOrMarker::Entry(entry1.clone()), 1)))
+            .unwrap();
+
+        let marker = solana_entry::block_component::VersionedBlockMarker::new_block_header(
+            solana_entry::block_component::BlockHeaderV1 {
+                parent_slot: 0,
+                parent_block_id: Hash::default(),
+            },
+        );
+        s.send((bank1.clone(), (EntryOrMarker::Marker(marker), 2)))
+            .unwrap();
+
+        let entry2 = Entry::new(&last_hash, 1, vec![tx.clone()]);
+        s.send((bank1.clone(), (EntryOrMarker::Entry(entry2.clone()), 3)))
+            .unwrap();
+
+        let mut carryover = None;
+
+        // First call should return only entry1
+        let result =
+            recv_slot_components(&r, &mut carryover, &mut ProcessShredsStats::default()).unwrap();
+        assert!(matches!(result.component, BlockComponent::EntryBatch(ref e) if e.len() == 1));
+        if let BlockComponent::EntryBatch(ref entries) = result.component {
+            assert_eq!(entries[0], entry1);
+        }
+        assert_eq!(result.last_tick_height, 1);
+
+        // Second call should return the marker
+        let result =
+            recv_slot_components(&r, &mut carryover, &mut ProcessShredsStats::default()).unwrap();
+        assert!(matches!(result.component, BlockComponent::BlockMarker(_)));
+        assert_eq!(result.last_tick_height, 2);
+
+        // Third call should return entry2
+        let result =
+            recv_slot_components(&r, &mut carryover, &mut ProcessShredsStats::default()).unwrap();
+        assert!(matches!(result.component, BlockComponent::EntryBatch(ref e) if e.len() == 1));
+        if let BlockComponent::EntryBatch(ref entries) = result.component {
+            assert_eq!(entries[0], entry2);
+        }
+        assert_eq!(result.last_tick_height, 3);
+    }
+
+    #[test]
+    fn test_bank_change_then_marker_skips_empty_entry_batch() {
+        let (genesis_config, bank0, _bank_forks, tx) = setup_test();
+        let bank1 = Arc::new(Bank::new_from_parent(
+            bank0.clone(),
+            SlotLeader::default(),
+            1,
+        ));
+        let bank2 = Arc::new(Bank::new_from_parent(
+            bank1.clone(),
+            SlotLeader::default(),
+            2,
+        ));
+        let (s, r) = unbounded();
+
+        let mut last_hash = genesis_config.hash();
+
+        // Send one entry for bank1 with tick_height=5
+        let entry = Entry::new(&last_hash, 1, vec![tx.clone()]);
+        last_hash = entry.hash;
+        s.send((bank1.clone(), (EntryOrMarker::Entry(entry), 5)))
+            .unwrap();
+
+        // Bank changes to bank2, but the next item is a marker with tick_height=3 — this should
+        // leave entries empty after the clear. The stale last_tick_height (5, from bank1) must not
+        // leak into subsequent results.
+        let marker = solana_entry::block_component::VersionedBlockMarker::new_block_header(
+            solana_entry::block_component::BlockHeaderV1 {
+                parent_slot: 1,
+                parent_block_id: Hash::default(),
+            },
+        );
+        s.send((bank2.clone(), (EntryOrMarker::Marker(marker), 3)))
+            .unwrap();
+
+        // Ensure that the inner function returns None when the channel has no more items after the
+        // bank change + marker.
+        let mut carryover = None;
+        let result = recv_slot_components_maybe_empty(
+            &r,
+            &mut carryover,
+            &mut ProcessShredsStats::default(),
+        )
+        .unwrap();
+        assert!(result.is_none());
+        assert!(carryover.is_some());
+
+        // Now send a real entry for bank2 so recv_slot_components has something to return after
+        // skipping the empty batch.
+        let entry2 = Entry::new(&last_hash, 1, vec![tx.clone()]);
+        s.send((bank2.clone(), (EntryOrMarker::Entry(entry2.clone()), 2)))
+            .unwrap();
+
+        // Verify that the outer function skips the empty batch and returns the carried-over marker.
+        // last_tick_height must be 3 (from the marker), not 5 (stale value from bank1).
+        let result =
+            recv_slot_components(&r, &mut carryover, &mut ProcessShredsStats::default()).unwrap();
+        assert!(matches!(result.component, BlockComponent::BlockMarker(_)));
+        assert_eq!(result.last_tick_height, 3);
     }
 
     #[test]

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -27,7 +27,7 @@ pub struct StandardBroadcastRun {
     parent: Slot,
     parent_block_id: Hash,
     chained_merkle_root: Hash,
-    carryover_entry: Option<WorkingBankEntry>,
+    carryover_entry: Option<WorkingBankEntryOrMarker>,
     double_merkle_leaves: Vec<Hash>,
     next_shred_index: u32,
     next_code_index: u32,
@@ -262,7 +262,7 @@ impl StandardBroadcastRun {
         process_stats: &mut ProcessShredsStats,
     ) -> Result<()> {
         let ReceiveResults {
-            entries,
+            component,
             bank,
             last_tick_height,
         } = receive_results;
@@ -327,12 +327,10 @@ impl StandardBroadcastRun {
             vec![]
         };
 
-        let entry_component =
-            BlockComponent::new_entry_batch(entries).expect("Received 0 length entry batch");
-        let entry_shreds = self
+        let shreds = self
             .component_to_shreds(
                 keypair,
-                &entry_component,
+                &component,
                 reference_tick as u8,
                 is_last_in_slot,
                 process_stats,
@@ -340,10 +338,10 @@ impl StandardBroadcastRun {
             .unwrap();
 
         let shreds = if maybe_send_header {
-            header_shreds.extend(entry_shreds);
+            header_shreds.extend(shreds);
             header_shreds
         } else {
-            entry_shreds
+            shreds
         };
         // Insert the first data shred synchronously so that blockstore stores
         // that the leader started this block. This must be done before the
@@ -539,12 +537,12 @@ impl BroadcastRun for StandardBroadcastRun {
         &mut self,
         keypair: &Keypair,
         blockstore: &Blockstore,
-        receiver: &Receiver<WorkingBankEntry>,
+        receiver: &Receiver<WorkingBankEntryOrMarker>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         let mut process_stats = ProcessShredsStats::default();
-        let receive_results = broadcast_utils::recv_slot_entries(
+        let receive_results = broadcast_utils::recv_slot_components(
             receiver,
             &mut self.carryover_entry,
             &mut process_stats,
@@ -694,7 +692,7 @@ mod test {
         // Insert 1 less than the number of ticks needed to finish the slot
         let ticks0 = create_ticks(genesis_config.ticks_per_slot - 1, 0, genesis_config.hash());
         let receive_results = ReceiveResults {
-            entries: ticks0.clone(),
+            component: BlockComponent::EntryBatch(ticks0.clone()),
             bank: bank1.clone(),
             last_tick_height: (ticks0.len() - 1) as u64,
         };
@@ -774,7 +772,7 @@ mod test {
             genesis_config.hash(),
         );
         let receive_results = ReceiveResults {
-            entries: ticks1.clone(),
+            component: BlockComponent::EntryBatch(ticks1.clone()),
             bank: bank2,
             last_tick_height: (ticks1.len() - 1) as u64,
         };
@@ -851,7 +849,7 @@ mod test {
             let ticks = create_ticks(num_ticks, 0, genesis_config.hash());
             last_tick_height += (ticks.len() - 1) as u64;
             let receive_results = ReceiveResults {
-                entries: ticks,
+                component: BlockComponent::EntryBatch(ticks),
                 bank: bank.clone(),
                 last_tick_height,
             };
@@ -900,7 +898,7 @@ mod test {
         // Insert complete slot of ticks needed to finish the slot
         let ticks = create_ticks(genesis_config.ticks_per_slot, 0, genesis_config.hash());
         let receive_results = ReceiveResults {
-            entries: ticks.clone(),
+            component: BlockComponent::EntryBatch(ticks.clone()),
             bank: bank0,
             last_tick_height: ticks.len() as u64,
         };


### PR DESCRIPTION
Continuing from https://github.com/anza-xyz/agave/pull/11289
Upstream of https://github.com/anza-xyz/alpenglow/pull/543

#### Problem
Alpenglow blocks consist of regular entry batches as well as `BlockMarker` which are special metadata (header / footer / (rarely) update parent)

We need to upgrade the poh recorder `record` -> broadcast pipeline to accept `BlockMarker`

#### Summary of Changes
Add a new type `EntryMarker` allowing poh recorder to send entries or a `BlockMarker`. Augment coalesce code to detect and process `EntryMarker`:

1. Entries follow the standard coalesce to transform into an entry batch (`Vec<Entry>`)
2. In V1 `BlockMarker` takes an entire FEC set, so if we receive one terminate the current batch of entries and send the `BlockMarker`
3. In practice this is inconsequential - vast majority of alpenglow blocks only have a header and footer, so this "interruption" should only happen at the end of the block (header is not sent via poh recorder but instead directly in broadcast see #11887)
