### PR TITLE
blockstore: upgrade to `SlotMetaV3` and fill from header / update parent

### DIFF
--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -176,11 +176,12 @@ pub trait RepairHandler {
             .ok()??;
 
         let parent_slot = slot_meta.parent_slot?;
+        let parent_block_id = slot_meta.parent_block_id;
         let parent_proof = double_merkle_meta.get_parent_info_proof()?.to_vec();
 
         let response = BlockIdRepairResponse::ParentFecSetCount {
             fec_set_count: double_merkle_meta.fec_set_count(),
-            parent_info: (parent_slot, Hash::default()),
+            parent_info: (parent_slot, parent_block_id),
             parent_proof,
         };
         create_response_packet_batch(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -17,7 +17,7 @@ use {
         next_slots_iterator::NextSlotsIterator,
         shred::{
             self, DATA_SHREDS_PER_FEC_BLOCK, ErasureSetId, ProcessShredsStats, ReedSolomonCache,
-            Shred, ShredId, ShredType, Shredder,
+            Shred, ShredFlags, ShredId, ShredType, Shredder,
             merkle_tree::{MerkleTree, SIZE_OF_MERKLE_PROOF_ENTRY, get_proof_size},
         },
         slot_stats::{ShredSource, SlotsStats},
@@ -37,7 +37,9 @@ use {
     solana_address_lookup_table_interface::state::AddressLookupTable,
     solana_clock::{DEFAULT_TICKS_PER_SECOND, Slot, UnixTimestamp},
     solana_entry::{
-        block_component::BlockComponent,
+        block_component::{
+            BlockComponent, VersionedBlockHeader, VersionedBlockMarker, VersionedUpdateParent,
+        },
         entry::{Entry, MaxDataShredsLen, create_ticks},
     },
     solana_genesis_config::{DEFAULT_GENESIS_ARCHIVE, DEFAULT_GENESIS_FILE, GenesisConfig},
@@ -361,6 +363,101 @@ pub(crate) fn hashes_per_tick_for_ledger(genesis_config: &GenesisConfig) -> u64 
         return 0;
     };
     hashes_per_tick
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ParentInfo {
+    pub(crate) parent_slot: Slot,
+    pub(crate) parent_block_id: Hash,
+    pub(crate) replay_fec_set_index: u32,
+}
+
+impl ParentInfo {
+    fn from_slot_meta(slot_meta: &SlotMeta) -> Option<Self> {
+        let parent_slot = slot_meta.parent_slot?;
+        let parent_info = ParentInfo {
+            parent_slot,
+            parent_block_id: slot_meta.parent_block_id,
+            replay_fec_set_index: slot_meta.replay_fec_set_index,
+        };
+        (parent_info.populated_from_update_parent()
+            || parent_info.parent_block_id != Hash::default())
+        .then_some(parent_info)
+    }
+
+    /// Try to parse a `ParentInfo` from a block header in the first shred
+    /// (index 0) of a slot.
+    fn maybe_parse_block_header(current_shred: &Shred) -> Option<Self> {
+        // Block headers only occur at index 0
+        if current_shred.index() != 0 {
+            return None;
+        }
+
+        let shred_bytes = current_shred.payload();
+        let payload = shred::layout::get_data(shred_bytes).ok()?;
+
+        if !BlockComponent::infer_is_block_marker(payload).unwrap_or(false) {
+            return None;
+        }
+
+        let component: BlockComponent = wincode::deserialize(payload).ok()?;
+        let VersionedBlockMarker::V1(marker) = component.as_marker()?;
+        let VersionedBlockHeader::V1(header) = marker.as_block_header()?;
+
+        Some(ParentInfo {
+            parent_slot: header.parent_slot,
+            parent_block_id: header.parent_block_id,
+            replay_fec_set_index: 0,
+        })
+    }
+
+    /// Validate compatibility between two `ParentInfo` values.
+    ///
+    /// Returns `Ok(true)` if the new value should replace the previous one,
+    /// `Ok(false)` if it should not, or `Err` if they are incompatible.
+    fn should_write_parent_info(slot: Slot, new: &ParentInfo, prev: &ParentInfo) -> Result<bool> {
+        let (update_parent_info, block_header_parent_info, should_write) = match (
+            new.populated_from_block_header(),
+            prev.populated_from_block_header(),
+        ) {
+            // New is BlockHeader, prev is UpdateParent
+            // UpdateParent takes precedence, so don't overwrite
+            (true, false) => (prev, new, false),
+            // New is UpdateParent, prev is BlockHeader
+            // Validate and allow UpdateParent to replace BlockHeader
+            (false, true) => (new, prev, true),
+            // Both are the same type - ensure they match
+            _ => match new == prev {
+                true => return Ok(false),
+                false => return Err(BlockstoreError::BlockComponentMismatch(slot)),
+            },
+        };
+
+        // Validate that the UpdateParent is compatible with the BlockHeader
+        if update_parent_info.block() == block_header_parent_info.block() {
+            return Err(BlockstoreError::UpdateParentMatchesBlockHeader(slot));
+        }
+
+        if update_parent_info.parent_slot > block_header_parent_info.parent_slot {
+            return Err(BlockstoreError::UpdateParentSlotGreaterThanBlockHeader(
+                slot,
+            ));
+        }
+
+        Ok(should_write)
+    }
+
+    fn populated_from_update_parent(&self) -> bool {
+        self.replay_fec_set_index > 0
+    }
+
+    fn populated_from_block_header(&self) -> bool {
+        self.replay_fec_set_index == 0
+    }
+
+    fn block(&self) -> (Slot, Hash) {
+        (self.parent_slot, self.parent_block_id)
+    }
 }
 
 pub fn banking_trace_path(path: &Path) -> PathBuf {
@@ -854,6 +951,154 @@ impl Blockstore {
 
         let dmr: Hash = wincode::deserialize(&double_merkle_meta_bytes[0..HASH_BYTES])?;
         Ok(Some(dmr))
+    }
+
+    /// Returns the parent metadata carried by SlotMeta for the specified slot and location.
+    #[cfg(test)]
+    pub(crate) fn get_parent_info(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+    ) -> Result<Option<ParentInfo>> {
+        let slot_meta = self.meta_from_location(slot, location)?;
+        Ok(slot_meta.and_then(|slot_meta| ParentInfo::from_slot_meta(&slot_meta)))
+    }
+
+    /// Try to parse a `ParentInfo` from an `UpdateParent` block component at
+    /// an FEC set boundary.
+    ///
+    /// Two cases trigger parsing:
+    /// - (a) Current shred has `data_complete()` — look at the 0th shred of the
+    ///   NEXT FEC set for an `UpdateParent`.
+    /// - (b) Current shred is at index 0 of its FEC set (and index > 0) — check
+    ///   if the previous shred had `DATA_COMPLETE_SHRED`, and if so parse the
+    ///   current shred.
+    fn maybe_parse_update_parent(
+        &self,
+        current_shred: &Shred,
+        slot: Slot,
+        location: BlockLocation,
+        just_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+    ) -> Option<ParentInfo> {
+        let current_index = current_shred.index();
+        let fec_set_index = current_shred.fec_set_index();
+        let data_complete = current_shred.data_complete();
+
+        let (shred_bytes, target_fec_set_index) = if data_complete {
+            // Case (a): Current shred has DATA_COMPLETE=true (end of FEC set)
+            // Check the 0th shred in the NEXT FEC set for UpdateParent
+            let next_fec_set_index = fec_set_index + DATA_SHREDS_PER_FEC_BLOCK as u32;
+            let shred_id = ShredId::new(slot, next_fec_set_index, ShredType::Data);
+            let shred_bytes =
+                self.get_shred_from_just_inserted_or_db(just_inserted_shreds, shred_id, location);
+            (shred_bytes, next_fec_set_index)
+        } else if current_index.is_multiple_of(DATA_SHREDS_PER_FEC_BLOCK as u32)
+            && current_index > 0
+        {
+            // Case (b): Current shred is the 0th shred of the FEC set
+            // Check if the PREVIOUS shred had DATA_COMPLETE=true
+            let prev_shred_index = current_index - 1;
+            let shred_id = ShredId::new(slot, prev_shred_index, ShredType::Data);
+
+            let prev_payload =
+                self.get_shred_from_just_inserted_or_db(just_inserted_shreds, shred_id, location);
+
+            let shred_bytes = prev_payload
+                .and_then(|prev| shred::layout::get_flags(&prev).ok())
+                .and_then(|flags| {
+                    flags
+                        .contains(ShredFlags::DATA_COMPLETE_SHRED)
+                        .then(|| Cow::Borrowed(current_shred.payload()))
+                });
+
+            (shred_bytes, fec_set_index)
+        } else {
+            return None;
+        };
+
+        let shred_bytes = shred_bytes?;
+        let payload = shred::layout::get_data(&shred_bytes).ok()?;
+
+        if !BlockComponent::infer_is_block_marker(payload).unwrap_or(false) {
+            return None;
+        }
+
+        let component: BlockComponent = wincode::deserialize(payload).ok()?;
+        let VersionedBlockMarker::V1(marker) = component.as_marker()?;
+        let VersionedUpdateParent::V1(update_parent) = marker.as_update_parent()?;
+
+        Some(ParentInfo {
+            parent_slot: update_parent.new_parent_slot,
+            parent_block_id: update_parent.new_parent_block_id,
+            replay_fec_set_index: target_fec_set_index,
+        })
+    }
+
+    /// Orchestrates parsing and validation of `ParentInfo` during shred
+    /// insertion.
+    ///
+    /// Called at FEC set boundaries. Parses block headers and `UpdateParent`
+    /// markers, validates them against parent metadata in `SlotMeta`, and
+    /// marks the slot dead on conflict.
+    fn maybe_update_parent_info(
+        &self,
+        shred: &Shred,
+        location: BlockLocation,
+        slot_meta: &mut SlotMeta,
+        just_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+        write_batch: &mut WriteBatch,
+    ) -> Result<()> {
+        let slot = shred.slot();
+        let previous_parent_info = ParentInfo::from_slot_meta(slot_meta);
+
+        // Try to parse new ParentInfo from the current shred
+        let new_parent_info = match (shred.index(), previous_parent_info.as_ref()) {
+            // Always try to parse block header at index 0
+            (0, _) => ParentInfo::maybe_parse_block_header(shred),
+            // Try to parse UpdateParent only if we don't have one already
+            (_, Some(parent_info)) if parent_info.populated_from_block_header() => {
+                self.maybe_parse_update_parent(shred, slot, location, just_inserted_shreds)
+            }
+            (_, None) => {
+                self.maybe_parse_update_parent(shred, slot, location, just_inserted_shreds)
+            }
+            // previous_parent_info is UpdateParent; don't parse another one
+            _ => None,
+        };
+
+        let Some(new_parent_info) = new_parent_info else {
+            return Ok(());
+        };
+
+        // Validate new ParentInfo against previous (if both exist)
+        if let Some(prev) = previous_parent_info.as_ref() {
+            match ParentInfo::should_write_parent_info(slot, &new_parent_info, prev) {
+                Ok(true) => {}
+                Ok(false) => return Ok(()),
+                Err(e) => {
+                    if !matches!(location, BlockLocation::Original) {
+                        error!(
+                            "Shreds being inserted to the alternate column {location:?} for slot \
+                             {} have mismatching ParentInfo. Note that these shreds have reached \
+                             a confirmation threshold, and were fetched by block id repair which \
+                             does pre verification via merkle proofs before ingest. For a \
+                             mismatch to occur something has gone disastrously wrong and we might \
+                             not be able to recover. Marking the slot as dead.",
+                            shred.slot(),
+                        );
+                    }
+                    self.dead_slots_cf
+                        .put_in_batch(write_batch, slot, &true)
+                        .unwrap();
+                    return Err(e);
+                }
+            }
+        }
+
+        // Update parent metadata fields in SlotMeta.
+        slot_meta.update_from_parent_info(new_parent_info);
+
+        Ok(())
     }
 
     /// Check whether the specified slot is an orphan slot which does not
@@ -1600,11 +1845,11 @@ impl Blockstore {
     ) -> Result<Option<(Option<Slot>, Hash)>> {
         if let Some(working_entry) = slot_metas.and_then(|sm| sm.get(&(location, slot))) {
             // First check the tracker if available
-            let parent_slot = RefCell::borrow(&*working_entry.new_slot_meta).parent_slot;
-            Ok(Some((parent_slot, Hash::default())))
+            let entry = RefCell::borrow(&*working_entry.new_slot_meta);
+            Ok(Some((entry.parent_slot, entry.parent_block_id)))
         } else if let Some(meta) = self.meta_from_location(slot, location)? {
             // Fall back to DB
-            Ok(Some((meta.parent_slot, Hash::default())))
+            Ok(Some((meta.parent_slot, meta.parent_block_id)))
         } else {
             Ok(None)
         }
@@ -2329,6 +2574,24 @@ impl Blockstore {
                     return Err(InsertDataShredError::InvalidShred);
                 }
             }
+        }
+
+        // Validate parent meta before persisting the shred. If the shred
+        // contains conflicting parent information the slot is marked dead and
+        // the shred is not inserted.
+        if shred
+            .index()
+            .is_multiple_of(DATA_SHREDS_PER_FEC_BLOCK as u32)
+            || shred.data_complete()
+        {
+            self.maybe_update_parent_info(
+                &shred,
+                location,
+                slot_meta,
+                just_inserted_shreds,
+                write_batch,
+            )
+            .map_err(InsertDataShredError::BlockstoreError)?;
         }
 
         let completed_data_sets = self.insert_data_shred(
@@ -4892,8 +5155,7 @@ impl Blockstore {
         // Handle chaining for all the SlotMetas that were inserted into
         working_set.retain(|_, entry| entry.did_insert_occur);
         let mut new_chained_slots = HashMap::new();
-        let working_set_slots: Vec<_> = working_set.keys().collect();
-        for (location, slot) in working_set_slots {
+        for (location, slot) in working_set.keys() {
             if !matches!(location, BlockLocation::Original) {
                 // We do not perform SlotMeta chaining for alternate versions of slots.
                 // We only chain SlotMeta across the original column.
@@ -4904,6 +5166,13 @@ impl Blockstore {
             }
             self.handle_chaining_for_slot(write_batch, working_set, &mut new_chained_slots, *slot)?;
         }
+
+        // Handle reparenting from UpdateParent markers
+        self.update_chaining_for_updated_parent_slots(
+            write_batch,
+            working_set,
+            &mut new_chained_slots,
+        )?;
 
         // Write all the newly changed slots in new_chained_slots to the write_batch
         for (slot, meta) in new_chained_slots.iter() {
@@ -5017,6 +5286,109 @@ impl Blockstore {
                 new_chained_slots,
                 SlotMeta::set_parent_connected,
             )?;
+        }
+
+        Ok(())
+    }
+
+    /// Propagate `set_parent_connected` to all children of `slot_meta`.
+    fn propagate_parent_connected_to_children(
+        &self,
+        slot_meta: &Rc<RefCell<SlotMeta>>,
+        working_set: &HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
+        new_chained_slots: &mut HashMap<u64, Rc<RefCell<SlotMeta>>>,
+    ) -> Result<()> {
+        debug_assert!(slot_meta.borrow().is_connected());
+        self.traverse_children_mut(
+            slot_meta,
+            working_set,
+            new_chained_slots,
+            SlotMeta::set_parent_connected,
+        )
+    }
+
+    /// Handles chaining updates when an `UpdateParent` marker overrides a
+    /// previously set parent in `SlotMeta`.
+    fn update_chaining_for_updated_parent_slots(
+        &self,
+        write_batch: &mut WriteBatch,
+        working_set: &HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
+        new_chained_slots: &mut HashMap<u64, Rc<RefCell<SlotMeta>>>,
+    ) -> Result<()> {
+        // Process only existing slots in Original whose parent was updated by UpdateParent.
+        for (slot, slot_meta, old_parent_slot, new_parent_slot) in
+            working_set
+                .iter()
+                .filter_map(|(&(location, slot), slot_meta_entry)| {
+                    if !matches!(location, BlockLocation::Original) {
+                        return None;
+                    }
+
+                    let old_slot_meta = slot_meta_entry.old_slot_meta.as_ref()?;
+                    if old_slot_meta.is_orphan() {
+                        return None;
+                    }
+
+                    let new_slot_meta = slot_meta_entry.new_slot_meta.borrow();
+                    if new_slot_meta.populated_from_block_header() {
+                        return None;
+                    }
+
+                    let new_parent_slot = new_slot_meta.parent_slot?;
+                    let old_parent_slot = old_slot_meta.parent_slot?;
+                    (old_parent_slot != new_parent_slot).then_some((
+                        slot,
+                        slot_meta_entry.new_slot_meta.clone(),
+                        old_parent_slot,
+                        new_parent_slot,
+                    ))
+                })
+        {
+            slot_meta.borrow_mut().parent_slot = Some(new_parent_slot);
+
+            // Remove slot from old parent's next_slots if parent changed.
+            self.find_slot_meta_else_create(working_set, new_chained_slots, old_parent_slot)?
+                .borrow_mut()
+                .next_slots
+                .retain(|&s| s != slot);
+
+            // Add slot to new parent's next_slots.
+            let new_parent_meta =
+                self.find_slot_meta_else_create(working_set, new_chained_slots, new_parent_slot)?;
+            {
+                let mut new_parent = new_parent_meta.borrow_mut();
+                if !new_parent.next_slots.contains(&slot) {
+                    new_parent.next_slots.push(slot);
+                }
+            }
+
+            // If the new parent of `slot` is a newly inserted orphan, insert it into the orphans
+            // column family
+            if new_parent_meta.borrow().is_orphan() {
+                self.orphans_cf
+                    .put_in_batch(write_batch, new_parent_slot, &true)?;
+            }
+
+            // Propagate or clear connectivity based on new parent's state.
+            if new_parent_meta.borrow().is_connected() {
+                if !slot_meta.borrow().is_parent_connected() {
+                    let became_connected = slot_meta.borrow_mut().set_parent_connected();
+                    if became_connected {
+                        self.propagate_parent_connected_to_children(
+                            &slot_meta,
+                            working_set,
+                            new_chained_slots,
+                        )?;
+                    }
+                }
+            } else if slot_meta.borrow_mut().clear_parent_connected() {
+                self.traverse_children_mut(
+                    &slot_meta,
+                    working_set,
+                    new_chained_slots,
+                    SlotMeta::clear_parent_connected,
+                )?;
+            }
         }
 
         Ok(())
@@ -5851,7 +6223,7 @@ pub mod tests {
             InnerInstruction, InnerInstructions, Reward, Rewards, TransactionTokenBalance,
         },
         std::{cmp::Ordering, num::NonZeroUsize, time::Duration},
-        test_case::test_case,
+        test_case::{test_case, test_matrix},
     };
 
     // used for tests only
@@ -5884,6 +6256,111 @@ pub mod tests {
         assert_eq!(slot, meta.slot);
         assert!(meta.is_full());
         assert!(meta.next_slots.is_empty());
+    }
+
+    fn create_update_parent_shreds(
+        slot: Slot,
+        parent_slot: Slot,
+        parent_block_id: Hash,
+        shred_index: u32,
+        is_last_in_slot: bool,
+    ) -> Vec<Shred> {
+        use solana_entry::block_component::UpdateParentV1;
+        let component = VersionedBlockMarker::new_update_parent(UpdateParentV1 {
+            new_parent_slot: parent_slot,
+            new_parent_block_id: parent_block_id,
+        });
+        let component = BlockComponent::new_block_marker(component);
+
+        Shredder::new(slot, 0, 0, 0)
+            .unwrap()
+            .make_merkle_shreds_from_component(
+                &Keypair::new(),
+                &component,
+                is_last_in_slot,
+                Hash::new_unique(),
+                shred_index,
+                shred_index,
+                &ReedSolomonCache::default(),
+                &mut ProcessShredsStats::default(),
+            )
+            .collect()
+    }
+
+    fn create_block_header_shreds(
+        slot: Slot,
+        parent_slot: Slot,
+        parent_block_id: Hash,
+    ) -> Vec<Shred> {
+        use solana_entry::block_component::BlockHeaderV1;
+        let component = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+            parent_slot,
+            parent_block_id,
+        });
+        let component = BlockComponent::new_block_marker(component);
+
+        Shredder::new(slot, parent_slot, 0, 0)
+            .unwrap()
+            .make_merkle_shreds_from_component(
+                &Keypair::new(),
+                &component,
+                false,
+                Hash::new_unique(),
+                0,
+                0,
+                &ReedSolomonCache::default(),
+                &mut ProcessShredsStats::default(),
+            )
+            .collect()
+    }
+
+    fn verify_next_slots(blockstore: &Blockstore, parent_slot: Slot, expected: &[Slot]) {
+        let meta = blockstore.meta(parent_slot).unwrap();
+        let actual = meta.as_ref().map(|m| {
+            let mut slots = m.next_slots.clone();
+            slots.sort_unstable();
+            slots
+        });
+
+        let mut expected = expected.to_vec();
+        expected.sort_unstable();
+
+        match (actual, expected.is_empty()) {
+            (Some(actual), _) => assert_eq!(
+                actual, expected,
+                "Parent slot {parent_slot} next_slots mismatch",
+            ),
+            (None, false) => panic!("Slot {parent_slot} meta doesn't exist"),
+            (None, true) => {} // OK - no meta and no expected children
+        }
+    }
+
+    fn create_block_footer_shreds(slot: Slot, parent_slot: Slot, shred_index: u32) -> Vec<Shred> {
+        use solana_entry::block_component::BlockFooterV1;
+        let footer = BlockFooterV1 {
+            bank_hash: Hash::new_unique(),
+            block_producer_time_nanos: 0,
+            block_user_agent: vec![],
+            final_cert: None,
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        };
+        let component = VersionedBlockMarker::new_block_footer(footer);
+        let component = BlockComponent::new_block_marker(component);
+
+        Shredder::new(slot, parent_slot, 0, 0)
+            .unwrap()
+            .make_merkle_shreds_from_component(
+                &Keypair::new(),
+                &component,
+                true,
+                Hash::new_unique(),
+                shred_index,
+                shred_index,
+                &ReedSolomonCache::default(),
+                &mut ProcessShredsStats::default(),
+            )
+            .collect()
     }
 
     #[test]
@@ -12358,5 +12835,418 @@ pub mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[test_matrix([true, false], [
+        (990, 980, false, false), // update parent before block header -> not dead
+        (980, 990, false, true),  // update parent after block header -> dead
+        (990, 990, true, true),   // update parent == block header, same id -> dead
+        (990, 990, false, false), // update parent == block header, different id -> not dead
+    ])]
+    fn test_invalid_parent_info_marks_dead(block_header_first: bool, case: (u64, u64, bool, bool)) {
+        let (bh_parent_slot, up_parent_slot, same_block_id, expect_dead) = case;
+        let slot = 1000;
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let bh_block_id = Hash::new_unique();
+        let up_block_id = if same_block_id {
+            bh_block_id
+        } else {
+            Hash::new_unique()
+        };
+
+        let block_header_shreds = create_block_header_shreds(slot, bh_parent_slot, bh_block_id);
+        let update_parent_shreds =
+            create_update_parent_shreds(slot, up_parent_slot, up_block_id, 32, false);
+        let block_footer_shreds = create_block_footer_shreds(slot, bh_parent_slot, 64);
+
+        let shreds: Vec<Shred> = if block_header_first {
+            let mut s = block_header_shreds;
+            s.extend(update_parent_shreds);
+            s.extend(block_footer_shreds);
+            s
+        } else {
+            let mut s = update_parent_shreds;
+            s.extend(block_header_shreds);
+            s.extend(block_footer_shreds);
+            s
+        }
+        .into_iter()
+        .filter(|s| s.is_data())
+        .collect();
+
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+
+        assert_eq!(
+            blockstore.is_dead(slot),
+            expect_dead,
+            "block_header_first={block_header_first}, bh_parent={bh_parent_slot}, \
+             up_parent={up_parent_slot}, same_block_id={same_block_id}"
+        );
+        assert_eq!(
+            !blockstore.is_full(slot),
+            expect_dead,
+            "block_header_first={block_header_first}, bh_parent={bh_parent_slot}, \
+             up_parent={up_parent_slot}, same_block_id={same_block_id}"
+        );
+    }
+
+    #[test]
+    fn test_block_header_followed_by_update_parent() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let parent_5_id = Hash::new_unique();
+        blockstore
+            .insert_shreds(create_block_header_shreds(10, 5, parent_5_id), None, true)
+            .unwrap();
+
+        assert_eq!(blockstore.meta(10).unwrap().unwrap().parent_slot, Some(5));
+        verify_next_slots(&blockstore, 5, &[10]);
+
+        let parent_3_id = Hash::new_unique();
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds(10, 3, parent_3_id, 32, true),
+                None,
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(blockstore.meta(10).unwrap().unwrap().parent_slot, Some(3));
+
+        let parent_info = blockstore
+            .get_parent_info(10, BlockLocation::Original)
+            .unwrap()
+            .unwrap();
+        assert_eq!(parent_info.parent_slot, 3);
+        assert_eq!(parent_info.parent_block_id, parent_3_id);
+        assert!(parent_info.populated_from_update_parent());
+
+        verify_next_slots(&blockstore, 5, &[]);
+        verify_next_slots(&blockstore, 3, &[10]);
+    }
+
+    #[test]
+    fn test_update_parent_overrides_block_header() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        blockstore
+            .insert_shreds(
+                create_block_header_shreds(20, 18, Hash::new_unique()),
+                None,
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(blockstore.meta(20).unwrap().unwrap().parent_slot, Some(18));
+        verify_next_slots(&blockstore, 18, &[20]);
+
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds(20, 15, Hash::new_unique(), 32, true),
+                None,
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(blockstore.meta(20).unwrap().unwrap().parent_slot, Some(15));
+        verify_next_slots(&blockstore, 18, &[]);
+        verify_next_slots(&blockstore, 15, &[20]);
+    }
+
+    #[test]
+    fn test_reparenting_via_update_parent() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        blockstore
+            .insert_shreds(
+                create_block_header_shreds(30, 25, Hash::new_unique()),
+                None,
+                true,
+            )
+            .unwrap();
+        verify_next_slots(&blockstore, 25, &[30]);
+
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds(30, 22, Hash::new_unique(), 32, true),
+                None,
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(blockstore.meta(30).unwrap().unwrap().parent_slot, Some(22));
+        verify_next_slots(&blockstore, 25, &[]);
+        verify_next_slots(&blockstore, 22, &[30]);
+    }
+
+    #[test]
+    fn test_multiple_children_reparenting() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let parent_id = Hash::new_unique();
+        for slot in [41, 40, 42] {
+            blockstore
+                .insert_shreds(create_block_header_shreds(slot, 35, parent_id), None, true)
+                .unwrap();
+        }
+        verify_next_slots(&blockstore, 35, &[40, 41, 42]);
+
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds(41, 32, Hash::new_unique(), 32, true),
+                None,
+                true,
+            )
+            .unwrap();
+        verify_next_slots(&blockstore, 35, &[40, 42]);
+        verify_next_slots(&blockstore, 32, &[41]);
+
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds(40, 33, Hash::new_unique(), 32, true),
+                None,
+                true,
+            )
+            .unwrap();
+        verify_next_slots(&blockstore, 35, &[42]);
+        verify_next_slots(&blockstore, 33, &[40]);
+    }
+
+    #[test]
+    fn test_interleaved_shred_arrival() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        blockstore
+            .insert_shreds(
+                create_block_header_shreds(50, 48, Hash::new_unique()),
+                None,
+                true,
+            )
+            .unwrap();
+        assert_eq!(blockstore.meta(50).unwrap().unwrap().parent_slot, Some(48));
+
+        // Split update parent shreds across two batches
+        let mut update_shreds = create_update_parent_shreds(50, 45, Hash::new_unique(), 32, true);
+        let mid = update_shreds.len() / 2;
+        let first_half: Vec<_> = update_shreds.drain(..mid).collect();
+
+        blockstore.insert_shreds(first_half, None, true).unwrap();
+        blockstore.insert_shreds(update_shreds, None, true).unwrap();
+
+        assert_eq!(blockstore.meta(50).unwrap().unwrap().parent_slot, Some(45));
+        verify_next_slots(&blockstore, 48, &[]);
+        verify_next_slots(&blockstore, 45, &[50]);
+    }
+
+    #[test]
+    fn test_same_batch_block_header_then_update_parent() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let mut shreds = create_block_header_shreds(60, 55, Hash::new_unique());
+        shreds.extend(create_update_parent_shreds(
+            60,
+            52,
+            Hash::new_unique(),
+            32,
+            true,
+        ));
+
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+
+        // UpdateParent should take precedence
+        assert_eq!(blockstore.meta(60).unwrap().unwrap().parent_slot, Some(52));
+        verify_next_slots(&blockstore, 55, &[]);
+        verify_next_slots(&blockstore, 52, &[60]);
+    }
+
+    #[test]
+    fn test_same_batch_update_parent_then_block_header() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let mut shreds = create_update_parent_shreds(70, 65, Hash::new_unique(), 32, true);
+        shreds.extend(create_block_header_shreds(70, 68, Hash::new_unique()));
+
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+
+        // UpdateParent should take precedence regardless of insertion order
+        assert_eq!(blockstore.meta(70).unwrap().unwrap().parent_slot, Some(65));
+        verify_next_slots(&blockstore, 68, &[]);
+        verify_next_slots(&blockstore, 65, &[70]);
+    }
+
+    #[test]
+    fn test_update_parent_propagates_connectivity() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        // Slot 0 is connected when full
+        let (shreds, _) = make_slot_entries(0, 0, 5);
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+        assert!(blockstore.meta(0).unwrap().unwrap().is_connected());
+
+        // Slot 10 with BlockHeader pointing to disconnected parent
+        blockstore
+            .insert_shreds(
+                create_block_header_shreds(10, 5, Hash::new_unique()),
+                None,
+                true,
+            )
+            .unwrap();
+        assert!(!blockstore.meta(10).unwrap().unwrap().is_connected());
+
+        // UpdateParent switches to connected parent, slot becomes connected
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds(10, 0, Hash::new_unique(), 32, true),
+                None,
+                true,
+            )
+            .unwrap();
+
+        let meta = blockstore.meta(10).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(0));
+        assert!(meta.is_parent_connected());
+    }
+
+    #[test]
+    fn test_update_parent_propagates_connectivity_to_descendants() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        // Slot 0 is connected when full
+        let (shreds, _) = make_slot_entries(0, 0, 5);
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+
+        // Slot 100 starts incomplete with BlockHeader pointing to disconnected parent
+        blockstore
+            .insert_shreds(
+                create_block_header_shreds(100, 50, Hash::new_unique()),
+                None,
+                true,
+            )
+            .unwrap();
+        // Slots 200 and 300 are full, chained to 100
+        for (slot, parent) in [(200, 100), (300, 200)] {
+            let (shreds, _) = make_slot_entries(slot, parent, 5);
+            blockstore.insert_shreds(shreds, None, true).unwrap();
+        }
+        for slot in [100, 200, 300] {
+            assert!(!blockstore.meta(slot).unwrap().unwrap().is_connected());
+        }
+
+        // Reparent 100 to connected slot 0; connectivity propagates to 200 and 300
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds(100, 0, Hash::new_unique(), 32, true),
+                None,
+                true,
+            )
+            .unwrap();
+
+        // Slot 100 is incomplete, so only parent_connected
+        assert!(blockstore.meta(100).unwrap().unwrap().is_parent_connected());
+        // Slots 200 and 300 are full, so they become connected
+        for slot in [200, 300] {
+            assert!(blockstore.meta(slot).unwrap().unwrap().is_connected());
+        }
+    }
+
+    #[test]
+    fn test_update_parent_clears_connectivity() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        // Slot 0 and 5 are connected (full slots chained together)
+        let (shreds, _) = make_slot_entries(0, 0, 5);
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+        let (shreds, _) = make_slot_entries(5, 0, 5);
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+        assert!(blockstore.meta(5).unwrap().unwrap().is_connected());
+
+        // Slot 10 with BlockHeader pointing to connected parent 5
+        blockstore
+            .insert_shreds(
+                create_block_header_shreds(10, 5, Hash::new_unique()),
+                None,
+                true,
+            )
+            .unwrap();
+        let meta = blockstore.meta(10).unwrap().unwrap();
+        assert!(meta.is_parent_connected());
+
+        // Slot 20 chains to slot 10
+        let (shreds, _) = make_slot_entries(20, 10, 5);
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+
+        // UpdateParent switches slot 10 to disconnected parent 3
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds(10, 3, Hash::new_unique(), 32, true),
+                None,
+                true,
+            )
+            .unwrap();
+
+        let meta = blockstore.meta(10).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(3));
+        assert!(!meta.is_parent_connected());
+        assert!(!blockstore.meta(20).unwrap().unwrap().is_parent_connected());
+    }
+
+    #[test]
+    fn test_connectivity_does_not_propagate_through_incomplete_slot() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        // Slot 0 is the connected root
+        let (shreds, _) = make_slot_entries(0, 0, 5);
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+        assert!(blockstore.meta(0).unwrap().unwrap().is_connected());
+
+        // Slot 50 incomplete, pointing to disconnected parent 40
+        blockstore
+            .insert_shreds(
+                create_block_header_shreds(50, 40, Hash::new_unique()),
+                None,
+                true,
+            )
+            .unwrap();
+
+        // Full children chain from incomplete slot 50
+        let (shreds, _) = make_slot_entries(60, 50, 5);
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+        let (shreds, _) = make_slot_entries(70, 60, 5);
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+
+        for slot in [50, 60, 70] {
+            assert!(!blockstore.meta(slot).unwrap().unwrap().is_connected());
+        }
+
+        // Reparent slot 50 to connected slot 0, keeping it incomplete
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds(50, 0, Hash::new_unique(), 32, false),
+                None,
+                true,
+            )
+            .unwrap();
+
+        // Slot 50 incomplete: parent_connected but not connected
+        let meta_50 = blockstore.meta(50).unwrap().unwrap();
+        assert!(meta_50.is_parent_connected());
+        assert!(!meta_50.is_connected());
+
+        // Children stay disconnected since parent 50 is incomplete
+        assert!(!blockstore.meta(60).unwrap().unwrap().is_connected());
+        assert!(!blockstore.meta(70).unwrap().unwrap().is_connected());
     }
 }

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -886,7 +886,7 @@ impl TypedColumn for columns::DoubleMerkleMeta {
 mod tests {
     use {
         super::*,
-        crate::blockstore_meta::{ConnectedFlags, SlotMetaV3},
+        crate::blockstore_meta::{CompletedDataIndexes, ConnectedFlags},
         solana_hash::Hash,
         wincode,
     };
@@ -903,6 +903,8 @@ mod tests {
             next_slots: vec![43, 44],
             connected_flags: ConnectedFlags::CONNECTED | ConnectedFlags::PARENT_CONNECTED,
             completed_data_indexes: [0u32, 5, 10].into_iter().collect(),
+            parent_block_id: Hash::new_unique(),
+            replay_fec_set_index: 7,
         };
 
         let bytes = <columns::SlotMeta as TypedColumn>::serialize(&meta).unwrap();
@@ -911,8 +913,8 @@ mod tests {
     }
 
     #[test]
-    fn test_slot_meta_column_deserialize_v2_from_v3_bytes() {
-        let meta_v3 = SlotMetaV3 {
+    fn test_slot_meta_column_deserialize_from_v2_bytes() {
+        let v2 = blockstore_meta::SlotMetaV2 {
             slot: 42,
             consumed: 10,
             received: 15,
@@ -922,16 +924,58 @@ mod tests {
             next_slots: vec![43, 44],
             connected_flags: ConnectedFlags::CONNECTED | ConnectedFlags::PARENT_CONNECTED,
             completed_data_indexes: [0u32, 5, 10].into_iter().collect(),
+        };
+        let v2_bytes = wincode::serialize(&v2).unwrap();
+
+        let deserialized = <columns::SlotMeta as TypedColumn>::deserialize(&v2_bytes).unwrap();
+        let expected = blockstore_meta::SlotMeta {
+            slot: 42,
+            consumed: 10,
+            received: 15,
+            first_shred_timestamp: 1234567890,
+            last_index: Some(14),
+            parent_slot: Some(41),
+            next_slots: vec![43, 44],
+            connected_flags: ConnectedFlags::CONNECTED | ConnectedFlags::PARENT_CONNECTED,
+            completed_data_indexes: [0u32, 5, 10].into_iter().collect(),
+            ..Default::default()
+        };
+        assert_eq!(deserialized, expected);
+    }
+
+    #[test]
+    fn test_default_wincode_deserialize_handles_v2_bytes() {
+        let v2 = blockstore_meta::SlotMetaV2 {
+            slot: 1,
+            consumed: 0,
+            received: 0,
+            first_shred_timestamp: 0,
+            last_index: None,
+            parent_slot: Some(0),
+            next_slots: vec![],
+            connected_flags: ConnectedFlags::empty(),
+            completed_data_indexes: CompletedDataIndexes::default(),
+        };
+        let v2_bytes = wincode::serialize(&v2).unwrap();
+        let deserialized = wincode::deserialize::<blockstore_meta::SlotMeta>(&v2_bytes).unwrap();
+        assert_eq!(deserialized.parent_block_id, Hash::default());
+        assert_eq!(deserialized.replay_fec_set_index, 0);
+
+        let v3 = blockstore_meta::SlotMeta {
+            slot: 1,
+            consumed: 0,
+            received: 0,
+            first_shred_timestamp: 0,
+            last_index: None,
+            parent_slot: Some(0),
+            next_slots: vec![],
+            connected_flags: ConnectedFlags::empty(),
+            completed_data_indexes: CompletedDataIndexes::default(),
             parent_block_id: Hash::new_unique(),
             replay_fec_set_index: 7,
         };
-        let v3_bytes = wincode::serialize(&meta_v3).unwrap();
-
-        let expected = blockstore_meta::SlotMeta::from(meta_v3);
-
-        assert!(deserialize_reject_trailing::<blockstore_meta::SlotMeta>(&v3_bytes).is_err());
-
-        let deserialized = <columns::SlotMeta as TypedColumn>::deserialize(&v3_bytes).unwrap();
-        assert_eq!(expected, deserialized);
+        let v3_bytes = wincode::serialize(&v3).unwrap();
+        let deserialized = wincode::deserialize::<blockstore_meta::SlotMeta>(&v3_bytes).unwrap();
+        assert_eq!(deserialized, v3);
     }
 }

--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -77,6 +77,14 @@ pub enum BlockstoreError {
     },
     #[error(transparent)]
     ManualPurge(#[from] BlockstoreManualPurgeError),
+    #[error("update parent matches block header for slot {0}")]
+    UpdateParentMatchesBlockHeader(Slot),
+    #[error("update parent slot greater than block header for slot {0}")]
+    UpdateParentSlotGreaterThanBlockHeader(Slot),
+    #[error("unexpected block component")]
+    UnexpectedBlockComponent,
+    #[error("block component mismatch for slot {0}")]
+    BlockComponentMismatch(Slot),
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         bit_vec::BitVec,
+        blockstore::ParentInfo,
         shred::{
             self, DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, Shred, ShredType,
             merkle_tree::{SIZE_OF_MERKLE_PROOF_ENTRY, get_proof_size},
@@ -144,7 +145,7 @@ pub struct SlotMetaBase<T> {
     pub completed_data_indexes: T,
 }
 
-pub type SlotMeta = SlotMetaBase<CompletedDataIndexes>;
+pub type SlotMetaV2 = SlotMetaBase<CompletedDataIndexes>;
 
 /// SlotMetaV3 extends SlotMeta with two additional fields: `parent_block_id`
 /// and `replay_fec_set_index`. The SlotMeta type will continue to be used
@@ -153,7 +154,7 @@ pub type SlotMeta = SlotMetaBase<CompletedDataIndexes>;
 /// SlotMeta enables this software to read a Blockstore modified by a future
 /// version where the SlotMetaV3 format is persisted.
 #[derive(Clone, Debug, Default, SchemaRead, SchemaWrite, Eq, PartialEq)]
-pub(crate) struct SlotMetaV3 {
+pub struct SlotMetaV3 {
     pub slot: Slot,
     pub consumed: u64,
     pub received: u64,
@@ -168,38 +169,26 @@ pub(crate) struct SlotMetaV3 {
     pub completed_data_indexes: CompletedDataIndexes,
     /// The block id of the parent block.
     /// Populated from the block header / update parent marker.
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Hash>")]
     pub parent_block_id: Hash,
     /// The FEC set index from which replay should start for this block.
     /// Populated from the block header / update parent marker.
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<u32>")]
     pub replay_fec_set_index: u32,
 }
 
-impl From<SlotMetaV3> for SlotMeta {
-    fn from(v3: SlotMetaV3) -> Self {
-        SlotMeta {
-            slot: v3.slot,
-            consumed: v3.consumed,
-            received: v3.received,
-            first_shred_timestamp: v3.first_shred_timestamp,
-            last_index: v3.last_index,
-            parent_slot: v3.parent_slot,
-            next_slots: v3.next_slots,
-            connected_flags: v3.connected_flags,
-            completed_data_indexes: v3.completed_data_indexes,
-        }
-    }
-}
+pub type SlotMeta = SlotMetaV3;
 
 // Wincode implementation of serialize and deserialize for Option<u64>
 // where None is represented as u64::MAX; for backward compatibility.
 mod wincode_compat {
     use {
         super::*,
-        std::mem::MaybeUninit,
+        std::{marker::PhantomData, mem::MaybeUninit},
         wincode::{
-            ReadResult, WriteResult,
+            ReadError, ReadResult, WriteResult,
             config::ConfigCore,
-            io::{Reader, Writer},
+            io::{ReadError as IoReadError, Reader, Writer},
         },
     };
 
@@ -228,6 +217,49 @@ mod wincode_compat {
 
         fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
             <Slot as SchemaWrite<C>>::write(writer, &src.unwrap_or(Slot::MAX))
+        }
+    }
+
+    /// Deserializes using `T` normally, but returns `T::Dst::default()` if the
+    /// reader is exhausted (EOF). Useful for backward compatibility when
+    /// trailing fields are appended to persisted structs.
+    pub(crate) struct DefaultOnEmptyRead<T>(PhantomData<T>);
+
+    // TYPE_META intentionally left dynamic: decoding may read either 0 bytes
+    // (EOF fallback) or the full encoded representation.
+    unsafe impl<'de, C: ConfigCore, T> SchemaRead<'de, C> for DefaultOnEmptyRead<T>
+    where
+        T: SchemaRead<'de, C>,
+        T::Dst: Default,
+    {
+        type Dst = T::Dst;
+
+        fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+            match <T as SchemaRead<'de, C>>::read(reader, dst) {
+                Ok(()) => Ok(()),
+                Err(ReadError::Io(IoReadError::ReadSizeLimit(_))) => {
+                    dst.write(Self::Dst::default());
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    unsafe impl<C: ConfigCore, T> SchemaWrite<C> for DefaultOnEmptyRead<T>
+    where
+        T: SchemaWrite<C>,
+    {
+        type Src = T::Src;
+
+        const TYPE_META: wincode::TypeMeta = T::TYPE_META;
+
+        fn size_of(src: &Self::Src) -> WriteResult<usize> {
+            <T as SchemaWrite<C>>::size_of(src)
+        }
+
+        fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+            <T as SchemaWrite<C>>::write(writer, src)
         }
     }
 }
@@ -550,6 +582,17 @@ impl SlotMeta {
         self.is_connected()
     }
 
+    /// Clear the parent_connected and connected flags.
+    /// Returns true if the slot was previously parent-connected (signaling
+    /// that children need clearing too).
+    pub fn clear_parent_connected(&mut self) -> bool {
+        let was_parent_connected = self.is_parent_connected();
+        self.connected_flags
+            .set(ConnectedFlags::PARENT_CONNECTED, false);
+        self.connected_flags.set(ConnectedFlags::CONNECTED, false);
+        was_parent_connected
+    }
+
     /// Dangerous.
     #[cfg(feature = "dev-context-only-utils")]
     pub fn unset_parent(&mut self) {
@@ -579,6 +622,16 @@ impl SlotMeta {
 
     pub(crate) fn new_orphan(slot: Slot) -> Self {
         Self::new(slot, /*parent_slot:*/ None)
+    }
+
+    pub(crate) fn update_from_parent_info(&mut self, parent_info: ParentInfo) {
+        self.parent_slot = Some(parent_info.parent_slot);
+        self.parent_block_id = parent_info.parent_block_id;
+        self.replay_fec_set_index = parent_info.replay_fec_set_index;
+    }
+
+    pub(crate) fn populated_from_block_header(&self) -> bool {
+        self.replay_fec_set_index == 0
     }
 }
 

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -49,6 +49,13 @@ pub enum BlockComponentProcessorError {
     MultipleBlockFooters,
     #[error("Multiple block headers detected")]
     MultipleBlockHeaders,
+    #[error(
+        "Block header parent slot mismatch: header={header_parent_slot}, bank={bank_parent_slot}"
+    )]
+    HeaderParentSlotMismatch {
+        header_parent_slot: Slot,
+        bank_parent_slot: Slot,
+    },
     #[error("Multiple update parents detected")]
     MultipleUpdateParents,
     #[error("Nanosecond clock out of bounds")]
@@ -125,7 +132,7 @@ impl BlockComponentProcessor {
             // - once migration is fully enabled, or
             // - while we're still in the migration phase (to let us advance it)
             BlockMarkerV1::BlockHeader(header) if markers_fully_enabled || in_migration => {
-                self.on_header(header.inner())
+                self.on_header(header.inner(), bank.parent_slot())
             }
             BlockMarkerV1::GenesisCertificate(genesis_cert)
                 if markers_fully_enabled || in_migration =>
@@ -315,7 +322,8 @@ impl BlockComponentProcessor {
 
     fn on_header(
         &mut self,
-        _header: &VersionedBlockHeader,
+        header: &VersionedBlockHeader,
+        bank_parent_slot: Slot,
     ) -> Result<(), BlockComponentProcessorError> {
         if self.has_header {
             return Err(BlockComponentProcessorError::MultipleBlockHeaders);
@@ -323,6 +331,14 @@ impl BlockComponentProcessor {
 
         if self.update_parent.is_some() {
             return Err(BlockComponentProcessorError::SpuriousUpdateParent);
+        }
+
+        let VersionedBlockHeader::V1(header) = header;
+        if header.parent_slot != bank_parent_slot {
+            return Err(BlockComponentProcessorError::HeaderParentSlotMismatch {
+                header_parent_slot: header.parent_slot,
+                bank_parent_slot,
+            });
         }
 
         self.has_header = true;
@@ -502,10 +518,10 @@ mod tests {
         });
 
         // First header should succeed
-        assert!(processor.on_header(&header).is_ok());
+        assert!(processor.on_header(&header, 0).is_ok());
 
         // Second header should fail
-        let result = processor.on_header(&header);
+        let result = processor.on_header(&header, 0);
         assert_eq!(
             result,
             Err(BlockComponentProcessorError::MultipleBlockHeaders)
@@ -592,8 +608,25 @@ mod tests {
             parent_block_id: Hash::default(),
         });
 
-        processor.on_header(&header).unwrap();
+        processor.on_header(&header, 0).unwrap();
         assert!(processor.has_header);
+    }
+
+    #[test]
+    fn test_on_header_parent_slot_mismatch_error() {
+        let mut processor = BlockComponentProcessor::default();
+        let header = VersionedBlockHeader::V1(BlockHeaderV1 {
+            parent_slot: 2,
+            parent_block_id: Hash::default(),
+        });
+
+        assert_eq!(
+            processor.on_header(&header, 0),
+            Err(BlockComponentProcessorError::HeaderParentSlotMismatch {
+                header_parent_slot: 2,
+                bank_parent_slot: 0,
+            })
+        );
     }
 
     #[test]
@@ -612,6 +645,27 @@ mod tests {
             .on_marker(bank, parent, marker, None, &migration_status)
             .unwrap();
         assert!(processor.has_header);
+    }
+
+    #[test]
+    fn test_on_marker_rejects_header_parent_slot_mismatch() {
+        let migration_status = MigrationStatus::post_migration_status();
+        let mut processor = BlockComponentProcessor::default();
+        let marker = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+            parent_slot: 7, // mismatches bank.parent_slot() below (0)
+            parent_block_id: Hash::default(),
+        });
+
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
+
+        assert_eq!(
+            processor.on_marker(bank, parent, marker, None, &migration_status),
+            Err(BlockComponentProcessorError::HeaderParentSlotMismatch {
+                header_parent_slot: 7,
+                bank_parent_slot: 0,
+            })
+        );
     }
 
     #[test]
@@ -665,7 +719,7 @@ mod tests {
             parent_slot: 0,
             parent_block_id: Hash::default(),
         });
-        processor.on_header(&header).unwrap();
+        processor.on_header(&header, bank.parent_slot()).unwrap();
 
         // Process some entry batches (not full yet)
         assert!(processor.on_entry_batch(&migration_status, 1).is_ok());
@@ -1114,10 +1168,13 @@ mod tests {
     fn test_update_parent_after_header_abandoned_bank() {
         let mut processor = BlockComponentProcessor::default();
         processor
-            .on_header(&VersionedBlockHeader::V1(BlockHeaderV1 {
-                parent_slot: 0,
-                parent_block_id: Hash::default(),
-            }))
+            .on_header(
+                &VersionedBlockHeader::V1(BlockHeaderV1 {
+                    parent_slot: 0,
+                    parent_block_id: Hash::default(),
+                }),
+                0,
+            )
             .unwrap();
 
         let update_parent = VersionedUpdateParent::V1(UpdateParentV1 {
@@ -1165,7 +1222,7 @@ mod tests {
         });
 
         assert_eq!(
-            processor.on_header(&header),
+            processor.on_header(&header, 0),
             Err(BlockComponentProcessorError::SpuriousUpdateParent)
         );
     }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -405,7 +405,7 @@ impl StandardBroadcastRun {
                 let fec_set_count = self.double_merkle_leaves.len();
                 // Add the final leaf (parent info)
                 let parent_info_leaf =
-                    hashv(&[&self.parent.to_le_bytes(), Hash::default().as_bytes()]);
+                    hashv(&[&self.parent.to_le_bytes(), self.parent_block_id.as_bytes()]);
                 self.double_merkle_leaves.push(parent_info_leaf);
 
                 // Compute the double merkle root


### PR DESCRIPTION
Continuing from #11618 
Upstream of 

- https://github.com/anza-xyz/alpenglow/pull/590
- https://github.com/anza-xyz/alpenglow/pull/622
- https://github.com/anza-xyz/alpenglow/pull/653

#### Problem
We currently use slot meta v2 in blockstore, #11309 added forward compatible read support for `SlotMetaV3`, this PR completes the migration by switching all writes to the V3 format.

V3 introduces new fields `parent_block_id` and `replay_fec_set_index` and changes semantics about how `parent_slot` is populated to accommodate Alpenglow blocks.

#### Summary of Changes
Concretely:

1. Alpenglow blocks contain `BlockHeader` `BlockMarker`s (shred 0) as well as (rarely) `UpdateParent` block markers
2. For these blocks, we want the `parent_*` fields to be populated by

      - If the block only contains a `BlockHeader`, populate the `parent_*` fields to the values of the  header and set `replay_fec_set_index` to 0
      - If the block also contains a `UpdateParent`, populate the `parent_*` fields to the value of the `UpdateParent` and set `replay_fec_set_index` to the fec set that the `UpdateParent` was in
      - `UpdateParent` is used to say "ignore all shreds prior to this shred and start replay from here with this parent"
 3. We maintain compatibility with TowerBFT blocks without having to introduce feature flag logic in blockstore
 4. So we still continue to populate `parent_slot` from the first received shred - and then overwrite it if `BlockHeader` or `UpdateParent` is present
 5. TowerBFT blocks that add these `BlockMarkers` will fail as they will fail deserialization here https://github.com/anza-xyz/agave/blob/92facd6dc83d675b3f670ebceac0b7bbe5a23e30/ledger/src/blockstore_processor.rs#L1666 allowing us to keep blockstore logic feature flag free
 6. It's critical that the slot meta chaining logic is correct in case of alpenglow blocks:
      - For consistency in alpenglow we require that the `BlockHeader` specifies the same parent as the `PARENT_OFFSET` in the shreds
      - Thus it's not required that processing a `BlockHeader` has to call the update chaining path again.
      - If for whatever reason the `BlockHeader` did not specify the same parent as `PARENT_OFFSET` the block is later failed during replay in `block_component_processer.rs`
      - However `UpdateParent` can specify a new parent, thus we need to call the update chaining path again.
      - It's critical that we get this correct as otherwise `generate_new_bank_forks` will not work, so good to get some eyes that we haven't messed this up in a subtle way (we've done testing on clusters for this but might have missed something)
      - Once alpenglow is active we can remove `PARENT_OFFSET` entirely and remove the "first shred sets chaining" logic
7. `SlotMeta` chaining is *only* performed for slots in the `BlockLocation::Original` column. Although alpenglow will (hopefully never) need to fill `BlockLocation::Alternate` columns when repairing duplicate blocks, we do not need to chain these blocks. If a situation arises that we need to replay these blocks, we will first move them to the `BlockLocation::Original` column in #11753 