### PR TITLE
vote-program: drop VoteStateHandle impl for v3 state

### DIFF
--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -24,8 +24,7 @@ use {
         state::{
             BLS_PUBLIC_KEY_COMPRESSED_SIZE, BlockTimestamp, LandedVote, Lockout,
             MAX_EPOCH_CREDITS_HISTORY, MAX_LOCKOUT_HISTORY, VOTE_CREDITS_GRACE_SLOTS,
-            VOTE_CREDITS_MAXIMUM_PER_SLOT, VoteInit, VoteInitV2, VoteState1_14_11, VoteStateV3,
-            VoteStateV4, VoteStateVersions,
+            VOTE_CREDITS_MAXIMUM_PER_SLOT, VoteInit, VoteInitV2, VoteStateV4, VoteStateVersions,
         },
     },
     std::collections::VecDeque,
@@ -109,231 +108,6 @@ pub trait VoteStateHandle {
     ) -> Result<(), InstructionError>;
 
     fn has_bls_pubkey(&self) -> bool;
-}
-
-impl VoteStateHandle for VoteStateV3 {
-    fn authorized_withdrawer(&self) -> &Pubkey {
-        &self.authorized_withdrawer
-    }
-
-    fn set_authorized_withdrawer(&mut self, authorized_withdrawer: Pubkey) {
-        self.authorized_withdrawer = authorized_withdrawer;
-    }
-
-    #[cfg(test)]
-    fn authorized_voters(&self) -> &AuthorizedVoters {
-        &self.authorized_voters
-    }
-
-    fn set_new_authorized_voter<F>(
-        &mut self,
-        authorized_pubkey: &Pubkey,
-        current_epoch: Epoch,
-        target_epoch: Epoch,
-        bls_pubkey: Option<&[u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE]>,
-        verify: F,
-    ) -> Result<(), InstructionError>
-    where
-        F: Fn(Pubkey) -> Result<(), InstructionError>,
-    {
-        if bls_pubkey.is_some() {
-            // We should not be able to reach here because we only call this function
-            // when both Vote State V4 and BLS features are enabled.
-            // See `is_vote_authorize_with_bls_enabled` in vote_processor.rs.
-            return Err(InstructionError::InvalidAccountData);
-        }
-
-        let epoch_authorized_voter = self.get_and_update_authorized_voter(current_epoch)?;
-        verify(epoch_authorized_voter)?;
-
-        // The offset in slots `n` on which the target_epoch
-        // (default value `DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET`) is
-        // calculated is the number of slots available from the
-        // first slot `S` of an epoch in which to set a new voter for
-        // the epoch at `S` + `n`
-        if self.authorized_voters.contains(target_epoch) {
-            return Err(VoteError::TooSoonToReauthorize.into());
-        }
-
-        // Get the latest authorized_voter
-        let (latest_epoch, latest_authorized_pubkey) = self
-            .authorized_voters
-            .last()
-            .ok_or(InstructionError::InvalidAccountData)?;
-
-        // If we're not setting the same pubkey as authorized pubkey again,
-        // then update the list of prior voters to mark the expiration
-        // of the old authorized pubkey
-        if latest_authorized_pubkey != authorized_pubkey {
-            // Update the epoch ranges of authorized pubkeys that will be expired
-            let epoch_of_last_authorized_switch =
-                self.prior_voters.last().map(|range| range.2).unwrap_or(0);
-
-            // target_epoch must:
-            // 1) Be monotonically increasing due to the clock always
-            //    moving forward
-            // 2) not be equal to latest epoch otherwise this
-            //    function would have returned TooSoonToReauthorize error
-            //    above
-            if target_epoch <= *latest_epoch {
-                return Err(InstructionError::InvalidAccountData);
-            }
-
-            // Commit the new state
-            self.prior_voters.append((
-                *latest_authorized_pubkey,
-                epoch_of_last_authorized_switch,
-                target_epoch,
-            ));
-        }
-
-        self.authorized_voters
-            .insert(target_epoch, *authorized_pubkey);
-
-        Ok(())
-    }
-
-    fn get_and_update_authorized_voter(
-        &mut self,
-        current_epoch: Epoch,
-    ) -> Result<Pubkey, InstructionError> {
-        let pubkey = self
-            .authorized_voters
-            .get_and_cache_authorized_voter_for_epoch(current_epoch)
-            .ok_or(InstructionError::InvalidAccountData)?;
-        self.authorized_voters
-            .purge_authorized_voters(current_epoch);
-        Ok(pubkey)
-    }
-
-    fn commission(&self) -> u8 {
-        self.commission
-    }
-
-    fn set_commission(&mut self, commission: u8) {
-        self.commission = commission;
-    }
-
-    fn set_inflation_rewards_commission_bps(&mut self, _commission_bps: u16) {
-        // No-op. We can never reach this callsite, since SIMD-0291 depends on
-        // SIMD-0185: the activation of VoteStateV4.
-    }
-
-    fn set_block_revenue_commission_bps(&mut self, _commission_bps: u16) {
-        // No-op. We can never reach this callsite, since SIMD-0123 depends on
-        // SIMD-0185: the activation of VoteStateV4.
-    }
-
-    fn node_pubkey(&self) -> &Pubkey {
-        &self.node_pubkey
-    }
-
-    fn set_node_pubkey(&mut self, node_pubkey: Pubkey) {
-        self.node_pubkey = node_pubkey;
-    }
-
-    fn set_inflation_rewards_collector(&mut self, _collector: Pubkey) {
-        // No-op for v3: field does not exist.
-    }
-
-    fn set_block_revenue_collector(&mut self, _collector: Pubkey) {
-        // No-op for v3: field does not exist.
-    }
-
-    fn pending_delegator_rewards(&self) -> u64 {
-        // V3 doesn't have this field.
-        0
-    }
-
-    fn add_pending_delegator_rewards(&mut self, _amount: u64) -> Result<(), InstructionError> {
-        // No-op. We can never reach this callsite, since SIMD-0123 depends on
-        // SIMD-0185: the activation of VoteStateV4.
-        Ok(())
-    }
-
-    fn votes(&self) -> &VecDeque<LandedVote> {
-        &self.votes
-    }
-
-    fn votes_mut(&mut self) -> &mut VecDeque<LandedVote> {
-        &mut self.votes
-    }
-
-    fn set_votes(&mut self, votes: VecDeque<LandedVote>) {
-        self.votes = votes;
-    }
-
-    fn contains_slot(&self, candidate_slot: Slot) -> bool {
-        self.votes
-            .binary_search_by(|vote| vote.slot().cmp(&candidate_slot))
-            .is_ok()
-    }
-
-    fn last_lockout(&self) -> Option<&Lockout> {
-        self.votes.back().map(|vote| &vote.lockout)
-    }
-
-    fn last_voted_slot(&self) -> Option<Slot> {
-        self.last_lockout().map(|v| v.slot())
-    }
-
-    fn root_slot(&self) -> Option<Slot> {
-        self.root_slot
-    }
-
-    fn set_root_slot(&mut self, root_slot: Option<Slot>) {
-        self.root_slot = root_slot;
-    }
-
-    fn current_epoch(&self) -> Epoch {
-        if self.epoch_credits.is_empty() {
-            0
-        } else {
-            self.epoch_credits.last().unwrap().0
-        }
-    }
-
-    fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)> {
-        &self.epoch_credits
-    }
-
-    fn epoch_credits_mut(&mut self) -> &mut Vec<(Epoch, u64, u64)> {
-        &mut self.epoch_credits
-    }
-
-    fn last_timestamp(&self) -> &BlockTimestamp {
-        &self.last_timestamp
-    }
-
-    fn set_last_timestamp(&mut self, timestamp: BlockTimestamp) {
-        self.last_timestamp = timestamp;
-    }
-
-    fn set_vote_account_state(
-        self,
-        vote_account: &mut BorrowedInstructionAccount,
-    ) -> Result<(), InstructionError> {
-        // If the account is not large enough to store the vote state, then attempt a realloc to make it large enough.
-        // The realloc can only proceed if the vote account has balance sufficient for rent exemption at the new size.
-        if (vote_account.get_data().len() < VoteStateV3::size_of())
-            && (!vote_account.is_rent_exempt_at_data_length(VoteStateV3::size_of())
-                || vote_account
-                    .set_data_length(VoteStateV3::size_of())
-                    .is_err())
-        {
-            // Account cannot be resized to the size of a vote state as it will not be rent exempt, or failed to be
-            // resized for other reasons.  So store the V1_14_11 version.
-            return vote_account.set_state(&VoteStateVersions::V1_14_11(Box::new(
-                VoteState1_14_11::from(self),
-            )));
-        }
-        // Vote account is large enough to store the newest version of vote state
-        vote_account.set_state(&VoteStateVersions::V3(Box::new(self)))
-    }
-
-    fn has_bls_pubkey(&self) -> bool {
-        false
-    }
 }
 
 impl VoteStateHandle for VoteStateV4 {
@@ -1087,7 +861,10 @@ mod tests {
         },
         solana_vote_interface::{
             authorized_voters::AuthorizedVoters,
-            state::{BlockTimestamp, MAX_EPOCH_CREDITS_HISTORY, MAX_LOCKOUT_HISTORY, VoteInit},
+            state::{
+                BlockTimestamp, MAX_EPOCH_CREDITS_HISTORY, MAX_LOCKOUT_HISTORY, VoteInit,
+                VoteState1_14_11, VoteStateV3,
+            },
         },
         std::collections::VecDeque,
         test_case::test_case,
@@ -1119,21 +896,6 @@ mod tests {
         transaction_context
     }
 
-    fn get_max_sized_vote_state_v3() -> VoteStateV3 {
-        let mut authorized_voters = AuthorizedVoters::default();
-        for i in 0..=MAX_LEADER_SCHEDULE_EPOCH_OFFSET {
-            authorized_voters.insert(i, Pubkey::new_unique());
-        }
-
-        VoteStateV3 {
-            votes: VecDeque::from(vec![LandedVote::default(); MAX_LOCKOUT_HISTORY]),
-            root_slot: Some(u64::MAX),
-            epoch_credits: vec![(0, 0, 0); MAX_EPOCH_CREDITS_HISTORY],
-            authorized_voters,
-            ..Default::default()
-        }
-    }
-
     fn get_max_sized_vote_state_v4() -> VoteStateV4 {
         let mut authorized_voters = AuthorizedVoters::default();
         for i in 0..=MAX_LEADER_SCHEDULE_EPOCH_OFFSET {
@@ -1150,24 +912,16 @@ mod tests {
         }
     }
 
-    fn set_new_authorized_voter_and_assert<T: VoteStateHandle>(
-        vote_state: &mut T,
+    fn set_new_authorized_voter_and_assert(
+        vote_state: &mut VoteStateHandler,
         original_voter: Pubkey,
         epoch_offset: Epoch,
-        prior_voters_last_callback: Option<fn(&T) -> &(Pubkey, Epoch, Epoch)>,
     ) {
         let new_voter = Pubkey::new_unique();
         // Set a new authorized voter
         vote_state
             .set_new_authorized_voter(&new_voter, 0, epoch_offset, None, |_| Ok(()))
             .unwrap();
-
-        if let Some(prior_voters_last) = prior_voters_last_callback {
-            assert_eq!(
-                prior_voters_last(vote_state),
-                &(original_voter, 0, epoch_offset),
-            );
-        }
 
         // Trying to set authorized voter for same epoch again should fail
         assert_eq!(
@@ -1185,23 +939,11 @@ mod tests {
         vote_state
             .set_new_authorized_voter(&new_voter2, 3, 3 + epoch_offset, None, |_| Ok(()))
             .unwrap();
-        if let Some(prior_voters_last) = prior_voters_last_callback {
-            assert_eq!(
-                prior_voters_last(vote_state),
-                &(new_voter, epoch_offset, 3 + epoch_offset),
-            );
-        }
 
         let new_voter3 = Pubkey::new_unique();
         vote_state
             .set_new_authorized_voter(&new_voter3, 6, 6 + epoch_offset, None, |_| Ok(()))
             .unwrap();
-        if let Some(prior_voters_last) = prior_voters_last_callback {
-            assert_eq!(
-                prior_voters_last(vote_state),
-                &(new_voter2, 3 + epoch_offset, 6 + epoch_offset),
-            );
-        }
 
         // Check can set back to original voter
         vote_state
@@ -1256,38 +998,19 @@ mod tests {
         };
         let clock = Clock::default();
 
-        // Start with v3. We'll also check `prior_voters`.
-        let mut vote_state = VoteStateV3::new(&vote_init, &clock);
-        assert!(vote_state.prior_voters.last().is_none());
+        let mut vote_state = VoteStateHandler::new_v4(VoteStateV4::new_with_defaults(
+            &vote_pubkey,
+            &vote_init,
+            &clock,
+        ));
 
-        set_new_authorized_voter_and_assert(
-            &mut vote_state,
-            original_voter,
-            epoch_offset,
-            Some(|vote_state: &VoteStateV3| vote_state.prior_voters.last().unwrap()),
-        );
-
-        // Now try with v4. No `prior_voters` to check.
-        let mut vote_state = VoteStateV4::new_with_defaults(&vote_pubkey, &vote_init, &clock);
-
-        set_new_authorized_voter_and_assert(&mut vote_state, original_voter, epoch_offset, None);
+        set_new_authorized_voter_and_assert(&mut vote_state, original_voter, epoch_offset);
 
         // V4 removes the monotonicity constraint on target_epoch.
         // V3 rejects non-monotonic target epochs; V4 allows them.
         {
             let voter_a = Pubkey::new_unique();
             let voter_b = Pubkey::new_unique();
-
-            let mut v3 = VoteStateV3 {
-                authorized_voters: AuthorizedVoters::new(0, Pubkey::new_unique()),
-                ..Default::default()
-            };
-            v3.set_new_authorized_voter(&voter_a, 0, 10, None, |_| Ok(()))
-                .unwrap();
-            assert_eq!(
-                v3.set_new_authorized_voter(&voter_b, 0, 5, None, |_| Ok(())),
-                Err(InstructionError::InvalidAccountData)
-            );
 
             let mut v4 = VoteStateV4 {
                 authorized_voters: AuthorizedVoters::new(0, Pubkey::new_unique()),
@@ -1300,8 +1023,8 @@ mod tests {
         }
     }
 
-    fn assert_authorized_voter_is_locked_within_epoch<T: VoteStateHandle>(
-        vote_state: &mut T,
+    fn assert_authorized_voter_is_locked_within_epoch(
+        vote_state: &mut VoteStateHandler,
         original_voter: &Pubkey,
     ) {
         // Test that it's not possible to set a new authorized
@@ -1347,87 +1070,16 @@ mod tests {
         };
         let clock = Clock::default();
 
-        // First test v3.
-        let mut vote_state = VoteStateV3::new(&vote_init, &clock);
-        assert_authorized_voter_is_locked_within_epoch(&mut vote_state, &original_voter);
-
-        // Now v4.
-        let mut vote_state = VoteStateV4::new_with_defaults(&vote_pubkey, &vote_init, &clock);
+        let mut vote_state = VoteStateHandler::new_v4(VoteStateV4::new_with_defaults(
+            &vote_pubkey,
+            &vote_init,
+            &clock,
+        ));
         assert_authorized_voter_is_locked_within_epoch(&mut vote_state, &original_voter);
     }
 
     #[test]
-    fn test_get_and_update_authorized_voter_v3() {
-        let original_voter = Pubkey::new_unique();
-        let mut vote_state = VoteStateV3::new(
-            &VoteInit {
-                node_pubkey: original_voter,
-                authorized_voter: original_voter,
-                authorized_withdrawer: original_voter,
-                commission: 0,
-            },
-            &Clock::default(),
-        );
-
-        assert_eq!(vote_state.authorized_voters().len(), 1);
-        assert_eq!(
-            *vote_state.authorized_voters().first().unwrap().1,
-            original_voter
-        );
-
-        // If no new authorized voter was set, the same authorized voter
-        // is locked into the next epoch
-        assert_eq!(
-            vote_state.get_and_update_authorized_voter(1).unwrap(),
-            original_voter
-        );
-
-        // Try to get the authorized voter for epoch 5, implies
-        // the authorized voter for epochs 1-4 were unchanged
-        assert_eq!(
-            vote_state.get_and_update_authorized_voter(5).unwrap(),
-            original_voter
-        );
-
-        // Authorized voter for expired epoch 0..5 should have been
-        // purged and no longer queryable
-        assert_eq!(vote_state.authorized_voters().len(), 1);
-        for i in 0..5 {
-            assert!(
-                vote_state
-                    .authorized_voters()
-                    .get_authorized_voter(i)
-                    .is_none()
-            );
-        }
-
-        // Set an authorized voter change at slot 7
-        let new_authorized_voter = Pubkey::new_unique();
-        vote_state
-            .set_new_authorized_voter(&new_authorized_voter, 5, 7, None, |_| Ok(()))
-            .unwrap();
-
-        // Try to get the authorized voter for epoch 6, unchanged
-        assert_eq!(
-            vote_state.get_and_update_authorized_voter(6).unwrap(),
-            original_voter
-        );
-
-        // Try to get the authorized voter for epoch 7 and onwards, should
-        // be the new authorized voter
-        for i in 7..10 {
-            assert_eq!(
-                vote_state.get_and_update_authorized_voter(i).unwrap(),
-                new_authorized_voter
-            );
-        }
-        assert_eq!(vote_state.authorized_voters().len(), 1);
-    }
-
-    // v4 purging retains one extra epoch compared to v3.
-    // Besides that, the functionality should be the same.
-    #[test]
-    fn test_get_and_update_authorized_voter_v4() {
+    fn test_get_and_update_authorized_voter() {
         let vote_pubkey = Pubkey::new_unique();
         let original_voter = Pubkey::new_unique();
         let mut vote_state = VoteStateV4::new_with_defaults(
@@ -1558,27 +1210,18 @@ mod tests {
     }
 
     #[test_case(
-        VoteStateV3::size_of(),
-        get_max_sized_vote_state_v3(),
-        |vote_state, data| {
-            let versioned = VoteStateVersions::new_v3(vote_state);
-            VoteStateV3::serialize(&versioned, data).unwrap();
-        };
-        "VoteStateV3"
-    )]
-    #[test_case(
         VoteStateV4::size_of(),
-        get_max_sized_vote_state_v4(),
+        VoteStateHandler::new_v4(get_max_sized_vote_state_v4()),
         |vote_state, data| {
-            let versioned = VoteStateVersions::new_v4(vote_state);
+            let versioned = VoteStateVersions::new_v4(vote_state.unwrap_v4());
             VoteStateV4::serialize(&versioned, data).unwrap();
         };
         "VoteStateV4"
     )]
-    fn test_vote_state_max_size<T: Clone + VoteStateHandle>(
+    fn test_vote_state_max_size(
         max_size: usize,
-        mut vote_state: T,
-        verify_serialize: fn(T, &mut [u8]),
+        mut vote_state: VoteStateHandler,
+        verify_serialize: fn(VoteStateHandler, &mut [u8]),
     ) {
         let mut max_sized_data = vec![0; max_size];
         let (start_leader_schedule_epoch, _) = vote_state.authorized_voters().last().unwrap();


### PR DESCRIPTION
#### Problem
SIMD-0185 (Vote State V4) is active on all networks and the feature was cleaned up in #11759. We can further clean up the vote program a bit.

#### Summary of Changes
Drop the implementation of the `VoteStateHandle` trait for `VoteStateV3`, which cannot be a target version anymore.

Part of https://github.com/anza-xyz/agave/issues/10899