### PR TITLE
Reads version file when checking for incomplete bank snapshots

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -347,7 +347,42 @@ fn is_bank_snapshot_complete(bank_snapshot_dir: impl AsRef<Path>) -> bool {
     let version_path = bank_snapshot_dir
         .as_ref()
         .join(snapshot_paths::SNAPSHOT_VERSION_FILENAME);
-    version_path.is_file()
+
+    let Ok(version_file_info) = FileInfo::new_from_path(&version_path) else {
+        // failed to either open or query the file -- snapshot is incomplete
+        return false;
+    };
+
+    let Ok(version_str) = snapshot_version_from_file(version_file_info) else {
+        // failed to read from file -- snapshot is incomplete
+        return false;
+    };
+
+    let Ok(_snapshot_version) = SnapshotVersion::from_str(version_str.as_str()) else {
+        // invalid snapshot version -- snapshot is incomplete
+        return false;
+    };
+
+    // version file is good, so now check the serialized bank and status cache files
+    let Some(slot) = bank_snapshot_dir.as_ref().file_name() else {
+        return false;
+    };
+    let Some(slot) = slot.to_str() else {
+        return false;
+    };
+    for file_name in [slot, snapshot_paths::SNAPSHOT_STATUS_CACHE_FILENAME] {
+        let file_path = bank_snapshot_dir.as_ref().join(file_name);
+        let Ok(file_info) = FileInfo::new_from_path(file_path) else {
+            // failed to either open or query the file -- snapshot is incomplete
+            return false;
+        };
+        if file_info.size == 0 {
+            // file is empty -- snapshot is incomplete
+            return false;
+        }
+    }
+
+    true
 }
 
 /// Writes files that indicate the bank snapshot is loadable by fastboot
@@ -2714,5 +2749,70 @@ mod tests {
         // Set a very low maximum file size for deserialization
         // This should panic
         deserialize_obsolete_accounts(bank_snapshot_dir, 100).unwrap();
+    }
+
+    #[test]
+    fn test_is_bank_snapshot_complete() {
+        let temp_dir = TempDir::new().unwrap();
+        let slot = 123;
+        let bank_snapshot_dir = temp_dir.as_ref().join(slot.to_string());
+        fs::create_dir(&bank_snapshot_dir).unwrap();
+
+        let version_path = bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_VERSION_FILENAME);
+        let serialized_bank_path = bank_snapshot_dir.join(slot.to_string());
+        let status_cache_path =
+            bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_STATUS_CACHE_FILENAME);
+
+        // scenario 1: no version file
+        assert!(!is_bank_snapshot_complete(&bank_snapshot_dir));
+
+        // scenario 2: bad version file (too large)
+        let too_large = format!(
+            "{:v>width$}",
+            "hi",
+            width = (MAX_SNAPSHOT_VERSION_FILE_SIZE + 1) as usize,
+        );
+        fs::write(&version_path, too_large).unwrap();
+        assert!(!is_bank_snapshot_complete(&bank_snapshot_dir));
+
+        // scenario 3: bad version
+        fs::remove_file(&version_path).unwrap();
+        let bad_version = String::from("v0.0.0");
+        fs::write(&version_path, bad_version).unwrap();
+        assert!(!is_bank_snapshot_complete(&bank_snapshot_dir));
+
+        // scenario 4: empty version
+        fs::remove_file(&version_path).unwrap();
+        fs::File::create_new(&version_path).unwrap();
+        assert!(!is_bank_snapshot_complete(&bank_snapshot_dir));
+
+        // write a "good" version file so we can check the next file
+        fs::remove_file(&version_path).unwrap();
+        fs::write(&version_path, SnapshotVersion::default().as_str()).unwrap();
+
+        // scenario 5: no serialized bank file
+        assert!(!is_bank_snapshot_complete(&bank_snapshot_dir));
+
+        // scenario 6: empty serialized bank
+        fs::File::create_new(&serialized_bank_path).unwrap();
+        assert!(!is_bank_snapshot_complete(&bank_snapshot_dir));
+
+        // write a "good" serialized bank file so we can check the next file
+        fs::remove_file(&serialized_bank_path).unwrap();
+        fs::write(&serialized_bank_path, "serialized bank").unwrap();
+
+        // scenario 7: no status cache file
+        assert!(!is_bank_snapshot_complete(&bank_snapshot_dir));
+
+        // scenario 8: empty status cache
+        fs::File::create_new(&status_cache_path).unwrap();
+        assert!(!is_bank_snapshot_complete(&bank_snapshot_dir));
+
+        // write a "good" status cache file so we can check for all good
+        fs::remove_file(&status_cache_path).unwrap();
+        fs::write(&status_cache_path, "status cache").unwrap();
+
+        // scenario 9: all good
+        assert!(is_bank_snapshot_complete(bank_snapshot_dir));
     }
 }


### PR DESCRIPTION
#### Problem

`bv1` had a full system restart, and after bringing it back online, the validator crashed shortly after startup with this error:

```
[2026-04-11T15:54:58.939137722Z ERROR solana_core::snapshot_packager_service] Stopping SnapshotPackagerService! Fatal error while archiving snapshot package: failed to add bank snapshot for slot 412534077: bank snapshot dir already exists '/home/sol/ledger-snapshots/snapshots/412534077'
```

So there was an old snapshot dir still laying around, which caused taking a snapshot later for that same slot to fail.

Looking at the machine, the old snapshot dir was:

```
sol@bv1:~/ledger-snapshots$ ll 412534077/
total 8
drwxr-xr-x 2 sol sol 4096 Apr 11 15:32 ./
drwxr-xr-x 5 sol sol 4096 Apr 11 15:54 ../
-rw-r--r-- 1 sol sol    0 Apr 11 15:32 412534077
-rw-r--r-- 1 sol sol    0 Apr 11 15:32 full_snapshot_slot
-rw-r--r-- 1 sol sol    0 Apr 11 15:32 status_cache
-rw-r--r-- 1 sol sol    0 Apr 11 15:32 version
```

And the relevant things to see are all the files have zero bytes, so this old snapshot is invalid and should be purged.

At startup we do purge incomplete snapshots, but the check for "complete" is only if the `version` file exists or not. In this case, the version file does exist, but is not valid.


#### Summary of Changes

Update the "is complete" check to read the version file.