### PR TITLE
Remove max_root from get_with_and_then

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -315,10 +315,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         &self,
         pubkey: &Pubkey,
         ancestors: &Ancestors,
-        max_root: Option<Slot>,
+        _max_root: Option<Slot>,
         should_add_to_in_mem_cache: bool,
         callback: impl FnOnce(SlotListItem<T>) -> R,
     ) -> Option<R> {
+        let max_root = ancestors.min_slot();
         self.get_and_then(pubkey, |entry| {
             let callback_result = entry.and_then(|entry| {
                 self.get_account_info_with_and_then(entry, Some(ancestors), max_root, callback)


### PR DESCRIPTION
#### Problem
- get_with_and_then no longer needs max_root. The same functionality can be achieved by passing in an Ancestor list that only contains the previous max_root

#### Summary of Changes
- Remove it!

Fixes #
