### PR TITLE
runtime_transaction: remove bincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10092,7 +10092,6 @@ dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
  "agave-transaction-view",
- "bincode",
  "criterion",
  "rand 0.9.4",
  "solana-compute-budget-instruction",
@@ -10113,6 +10112,7 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error",
  "solana-vote-interface",
+ "wincode",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8689,7 +8689,6 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-transaction-view",
- "bincode",
  "solana-compute-budget-instruction",
  "solana-hash 4.3.0",
  "solana-message",
@@ -8700,6 +8699,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
+ "wincode",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8320,7 +8320,6 @@ version = "4.1.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-transaction-view",
- "bincode",
  "solana-compute-budget-instruction",
  "solana-hash 4.3.0",
  "solana-message",
@@ -8331,6 +8330,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
+ "wincode",
 ]
 
 [[package]]

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -23,7 +23,6 @@ dev-context-only-utils = ["solana-compute-budget-instruction/dev-context-only-ut
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-transaction-view = { workspace = true }
-bincode = { workspace = true }
 solana-compute-budget-instruction = { workspace = true }
 solana-hash = { workspace = true }
 solana-message = { workspace = true, features = ["blake3", "wincode"] }
@@ -31,9 +30,10 @@ solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true }
 solana-svm-transaction = { workspace = true }
-solana-transaction = { workspace = true, features = ["serde"] }
+solana-transaction = { workspace = true, features = ["wincode"] }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 agave-feature-set = { workspace = true }
@@ -47,7 +47,7 @@ solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-runtime-transaction = { path = ".", features = ["agave-unstable-api"] }
 solana-signer = { workspace = true }
-solana-system-interface = { workspace = true, features = ["bincode"] }
+solana-system-interface = { workspace = true, features = ["wincode"] }
 solana-system-transaction = { workspace = true }
 solana-transaction = { workspace = true, features = ["blake3"] }
 solana-vote-interface = { workspace = true }

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -153,7 +153,7 @@ impl TransactionWithMeta for RuntimeTransaction<SanitizedTransaction> {
     }
 
     fn serialized_size(&self) -> usize {
-        bincode::serialized_size(&self.to_versioned_transaction())
+        wincode::serialized_size(&self.to_versioned_transaction())
             .expect("versioned transaction serialization should succeed") as usize
     }
 }
@@ -391,8 +391,14 @@ mod tests {
         )
         .unwrap();
 
-        let expected = bincode::serialized_size(&transaction.to_versioned_transaction()).unwrap();
+        let expected = wincode::serialized_size(&transaction.to_versioned_transaction()).unwrap();
         assert_eq!(transaction.serialized_size(), expected as usize);
+        assert_eq!(
+            expected,
+            wincode::serialize(&transaction.to_versioned_transaction())
+                .unwrap()
+                .len() as u64
+        );
     }
 
     #[test]

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -260,7 +260,7 @@ mod tests {
                 1,
                 Hash::new_unique(),
             ));
-            bincode::serialize(&transaction).unwrap()
+            wincode::serialize(&transaction).unwrap()
         };
 
         let hash = Hash::new_unique();
@@ -296,7 +296,7 @@ mod tests {
             loaded_addresses: Option<LoadedAddresses>,
             reserved_account_keys: &HashSet<Pubkey>,
         ) {
-            let bytes = bincode::serialize(&original_transaction).unwrap();
+            let bytes = wincode::serialize(&original_transaction).unwrap();
             let transaction_view =
                 SanitizedTransactionView::try_new_sanitized(&bytes[..], true).unwrap();
             let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
@@ -363,7 +363,7 @@ mod tests {
             reserved_account_keys: &HashSet<Pubkey>,
         ) {
             let bytes =
-                bincode::serialize(&original_transaction.to_versioned_transaction()).unwrap();
+                wincode::serialize(&original_transaction.to_versioned_transaction()).unwrap();
             let transaction_view =
                 SanitizedTransactionView::try_new_sanitized(&bytes[..], true).unwrap();
             let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
@@ -445,7 +445,7 @@ mod tests {
     #[test]
     fn test_serialized_size() {
         let serialized_transaction =
-            bincode::serialize(&VersionedTransaction::from(system_transaction::transfer(
+            wincode::serialize(&VersionedTransaction::from(system_transaction::transfer(
                 &Keypair::new(),
                 &Pubkey::new_unique(),
                 1,


### PR DESCRIPTION
#### Problem
- txv1 not supported by bincode

#### Summary of Changes
- use wincode instead of bincode in runtime_transaction

Fixes #
