### PR TITLE
streamer: bump number of quic vote connection slots to 4096

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -596,7 +596,12 @@ impl ValidatorTpuConfig {
                 max_connections_per_ipaddr_per_min: 32,
                 ..Default::default()
             },
-            qos_config: SimpleQosConfig::default(),
+            qos_config: SimpleQosConfig {
+                // Way more than the size of our clusters. If some super low staked validators can not
+                // find room, it does not present a liveness issue.
+                max_staked_connections: 4096,
+                ..Default::default()
+            },
         };
 
         // Two threads is reasonable for tests; benches are free to set more

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -627,7 +627,12 @@ impl ValidatorTpuConfig {
                 max_connections_per_ipaddr_per_min: 32,
                 ..Default::default()
             },
-            qos_config: SimpleQosConfig::default(),
+            qos_config: SimpleQosConfig {
+                // Way more than the size of our clusters. If some super low staked validators can not
+                // find room, it does not present a liveness issue.
+                max_staked_connections: 4096,
+                ..Default::default()
+            },
         };
 
         // Two threads is reasonable for tests; benches are free to set more


### PR DESCRIPTION
#### Problem

- We can have > 2000 staked validators in TowerBFT
- QUIC vote connection pool is not big enough for that

#### Summary of Changes

- Bump to 4096

Fixes #3550
