### PR TITLE
run_manage_ancestor_requests sleep interval

### DIFF
--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -17,7 +17,7 @@ use {
     },
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender, unbounded},
     dashmap::{DashMap, mapref::entry::Entry::Occupied},
-    solana_clock::{DEFAULT_MS_PER_SLOT, Slot},
+    solana_clock::Slot,
     solana_gossip::{cluster_info::ClusterInfo, contact_info::Protocol, ping_pong::Pong},
     solana_keypair::{Keypair, Signer, signable::Signable},
     solana_ledger::blockstore::Blockstore,
@@ -623,7 +623,15 @@ impl AncestorHashesService {
                         &mut request_throttle,
                     );
 
-                    sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT));
+                    let sleep_duration = Duration::from_nanos_u128(
+                        repair_info
+                            .bank_forks
+                            .read()
+                            .unwrap()
+                            .root_bank()
+                            .ns_per_slot,
+                    );
+                    sleep(sleep_duration);
                 }
             })
             .unwrap()


### PR DESCRIPTION
#### Problem

Sleep interval in repair is hardcoded to 400ms const, preventing changes to slot duration

#### Summary of Changes

Make it fetch the slot duration from bank