### PR TITLE
repair: tag requests cache with location for blockstore insertion

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -1,8 +1,7 @@
 use {
     crate::{
-        banking_stage::BankingControlMsg,
-        cluster_slots_service::cluster_slots::ClusterSlots,
-        repair::{outstanding_requests::OutstandingRequests, serve_repair::ShredRepairType},
+        banking_stage::BankingControlMsg, cluster_slots_service::cluster_slots::ClusterSlots,
+        repair::repair_service::OutstandingShredRepairs,
     },
     solana_gossip::{cluster_info::ClusterInfo, node::NodeMultihoming},
     solana_ledger::blockstore::Blockstore,
@@ -83,7 +82,7 @@ pub struct AdminRpcRequestMetadataPostInit {
     pub repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
     pub notifies: Arc<RwLock<KeyUpdaters>>,
     pub repair_socket: Arc<UdpSocket>,
-    pub outstanding_repair_requests: Arc<RwLock<OutstandingRequests<ShredRepairType>>>,
+    pub outstanding_repair_requests: Arc<RwLock<OutstandingShredRepairs>>,
     pub cluster_slots: Arc<ClusterSlots>,
     pub node: Option<Arc<NodeMultihoming>>,
     pub banking_control_sender: mpsc::Sender<BankingControlMsg>,

--- a/core/src/repair/outstanding_requests.rs
+++ b/core/src/repair/outstanding_requests.rs
@@ -7,17 +7,28 @@ use {
 
 pub const DEFAULT_REQUEST_EXPIRATION_MS: u64 = 60_000;
 
-pub struct OutstandingRequests<T> {
-    requests: LruCache<Nonce, RequestStatus<T>>,
+pub struct OutstandingRequests<T, U = ()> {
+    requests: LruCache<Nonce, RequestStatus<T, U>>,
 }
 
-impl<T, S: ?Sized> OutstandingRequests<T>
+impl<T, S: ?Sized, U> OutstandingRequests<T, U>
 where
     T: RequestResponse<Response = S>,
 {
-    // Returns boolean indicating whether sufficient time has passed for a request with
-    // the given timestamp to be made
+    /// Add a request to the cache, returns the nonce to be sent with the repair request
+    /// and expected on the response.
     pub fn add_request(&mut self, request: T, now: u64) -> Nonce {
+        self.add_request_with_metadata(request, now, None)
+    }
+
+    /// Similar to `add_request` but additionally specifies an associated metadata
+    /// for the nonce that can be fetched with `fetch_metadata_for_nonce`.
+    pub fn add_request_with_metadata(
+        &mut self,
+        request: T,
+        now: u64,
+        metadata: Option<U>,
+    ) -> Nonce {
         let num_expected_responses = request.num_expected_responses();
         let nonce = rng().random_range(0..Nonce::MAX);
         self.requests.put(
@@ -26,49 +37,73 @@ where
                 expire_timestamp: now + DEFAULT_REQUEST_EXPIRATION_MS,
                 num_expected_responses,
                 request,
+                metadata,
             },
         );
         nonce
     }
 
+    /// Register a response to the request associated with `nonce`.
+    /// If there are no more expected responses to the request, return `None`
+    ///
+    /// Performs validation on the response, if:
+    /// - Request has expired
+    /// - Or validation fails
+    ///
+    /// Deletes the request from the cache
+    ///
+    /// Otherwise decrement the # of expected requests.
+    /// If the expected number of responses is now 0 and there is no metadata associated with the request,
+    /// delete the response.
+    ///
+    /// Finally return `success_fn(request)`
     pub fn register_response<R>(
         &mut self,
         nonce: u32,
         response: &S,
         now: u64,
-        // runs if the response was valid
         success_fn: impl Fn(&T) -> R,
     ) -> Option<R> {
-        let (response, should_delete) = self
-            .requests
-            .get_mut(&nonce)
-            .map(|status| {
-                if status.num_expected_responses > 0
-                    && now < status.expire_timestamp
-                    && status.request.verify_response(response)
-                {
-                    status.num_expected_responses -= 1;
-                    (
-                        Some(success_fn(&status.request)),
-                        status.num_expected_responses == 0,
-                    )
-                } else {
-                    (None, true)
-                }
-            })
-            .unwrap_or((None, false));
+        let mut should_delete = false;
+        let response = self.requests.get_mut(&nonce).and_then(|status| {
+            if status.num_expected_responses == 0 {
+                // No more expected responses
+                return None;
+            }
+
+            if now >= status.expire_timestamp || !status.request.verify_response(response) {
+                // Invalid/expired response should invalidate this nonce.
+                should_delete = true;
+                return None;
+            }
+
+            status.num_expected_responses -= 1;
+            if status.num_expected_responses == 0 && status.metadata.is_none() {
+                // No metadata, and no more expected responses safe to delete eagerly.
+                should_delete = true;
+            }
+            Some(success_fn(&status.request))
+        });
 
         if should_delete {
             self.requests
                 .pop(&nonce)
-                .expect("Delete must delete existing object");
+                .expect("request must exist when marked for deletion");
         }
-
         response
+    }
+
+    /// Fetches metadata associated with the nonce
+    pub fn fetch_metadata_for_nonce(&self, nonce: u32) -> Option<U>
+    where
+        U: Copy,
+    {
+        let status = self.requests.get(&nonce)?;
+        status.metadata
     }
 }
 
-impl<T> Default for OutstandingRequests<T> {
+impl<T, U> Default for OutstandingRequests<T, U> {
     fn default() -> Self {
         Self {
             requests: LruCache::new(16 * 1024),
@@ -76,23 +111,46 @@ impl<T> Default for OutstandingRequests<T> {
     }
 }
 
-pub struct RequestStatus<T> {
+pub struct RequestStatus<T, U> {
     expire_timestamp: u64,
     num_expected_responses: u32,
     request: T,
+    metadata: Option<U>,
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
     use {
-        super::*, crate::repair::serve_repair::ShredRepairType, solana_keypair::Keypair,
-        solana_ledger::shred::Shredder, solana_time_utils::timestamp,
+        super::*,
+        crate::repair::{request_response::RequestResponse, serve_repair::ShredRepairType},
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_ledger::{blockstore_meta::BlockLocation, shred::Shredder},
+        solana_time_utils::timestamp,
     };
+
+    #[derive(Clone, Copy)]
+    struct TestRequest {
+        expected_response: u8,
+        num_expected_responses: u32,
+    }
+
+    impl RequestResponse for TestRequest {
+        type Response = u8;
+
+        fn num_expected_responses(&self) -> u32 {
+            self.num_expected_responses
+        }
+
+        fn verify_response(&self, response: &Self::Response) -> bool {
+            self.expected_response == *response
+        }
+    }
 
     #[test]
     fn test_add_request() {
         let repair_type = ShredRepairType::Orphan(9);
-        let mut outstanding_requests = OutstandingRequests::default();
+        let mut outstanding_requests = OutstandingRequests::<ShredRepairType>::default();
         let nonce = outstanding_requests.add_request(repair_type, timestamp());
         let request_status = outstanding_requests.requests.get(&nonce).unwrap();
         assert_eq!(request_status.request, repair_type);
@@ -100,12 +158,13 @@ pub(crate) mod tests {
             request_status.num_expected_responses,
             repair_type.num_expected_responses()
         );
+        assert!(request_status.metadata.is_none());
     }
 
     #[test]
     fn test_timeout_expired_remove() {
         let repair_type = ShredRepairType::Orphan(9);
-        let mut outstanding_requests = OutstandingRequests::default();
+        let mut outstanding_requests = OutstandingRequests::<ShredRepairType>::default();
         let nonce = outstanding_requests.add_request(repair_type, timestamp());
         let keypair = Keypair::new();
         let shred = Shredder::single_shred_for_tests(0, &keypair);
@@ -113,8 +172,8 @@ pub(crate) mod tests {
         let expire_timestamp = outstanding_requests
             .requests
             .get(&nonce)
-            .unwrap()
-            .expire_timestamp;
+            .map(|status| status.expire_timestamp)
+            .unwrap();
 
         assert!(
             outstanding_requests
@@ -127,23 +186,23 @@ pub(crate) mod tests {
     #[test]
     fn test_register_response() {
         let repair_type = ShredRepairType::Orphan(9);
-        let mut outstanding_requests = OutstandingRequests::default();
+        let mut outstanding_requests = OutstandingRequests::<ShredRepairType>::default();
         let nonce = outstanding_requests.add_request(repair_type, timestamp());
         let keypair = Keypair::new();
         let shred = Shredder::single_shred_for_tests(0, &keypair);
         let mut expire_timestamp = outstanding_requests
             .requests
             .get(&nonce)
-            .unwrap()
-            .expire_timestamp;
+            .map(|status| status.expire_timestamp)
+            .unwrap();
         let mut num_expected_responses = outstanding_requests
             .requests
             .get(&nonce)
-            .unwrap()
-            .num_expected_responses;
+            .map(|status| status.num_expected_responses)
+            .unwrap();
         assert!(num_expected_responses > 1);
 
-        // Response that passes all checks should decrease num_expected_responses
+        // Response that passes all checks should decrease num_expected_responses.
         assert!(
             outstanding_requests
                 .register_response(nonce, shred.payload(), expire_timestamp - 1, |_| ())
@@ -159,7 +218,7 @@ pub(crate) mod tests {
             num_expected_responses
         );
 
-        // Response with incorrect nonce is ignored
+        // Response with incorrect nonce is ignored.
         assert!(
             outstanding_requests
                 .register_response(nonce + 1, shred.payload(), expire_timestamp - 1, |_| ())
@@ -180,7 +239,7 @@ pub(crate) mod tests {
         );
 
         // Response with timestamp over limit should remove status, preventing late
-        // responses from being accepted
+        // responses from being accepted.
         assert!(
             outstanding_requests
                 .register_response(nonce, shred.payload(), expire_timestamp, |_| ())
@@ -188,18 +247,19 @@ pub(crate) mod tests {
         );
         assert!(outstanding_requests.requests.get(&nonce).is_none());
 
-        // If number of outstanding requests hits zero, should also remove the entry
+        // If number of outstanding requests hits zero and there is no completion
+        // data, remove the entry.
         let nonce = outstanding_requests.add_request(repair_type, timestamp());
         expire_timestamp = outstanding_requests
             .requests
             .get(&nonce)
-            .unwrap()
-            .expire_timestamp;
+            .map(|status| status.expire_timestamp)
+            .unwrap();
         num_expected_responses = outstanding_requests
             .requests
             .get(&nonce)
-            .unwrap()
-            .num_expected_responses;
+            .map(|status| status.num_expected_responses)
+            .unwrap();
         assert!(num_expected_responses > 1);
         for _ in 0..num_expected_responses {
             assert!(outstanding_requests.requests.get(&nonce).is_some());
@@ -210,5 +270,45 @@ pub(crate) mod tests {
             );
         }
         assert!(outstanding_requests.requests.get(&nonce).is_none());
+    }
+
+    #[test]
+    fn test_fetch_metadata_for_registered_response_single_response_request() {
+        let mut outstanding_requests = OutstandingRequests::<TestRequest, BlockLocation>::default();
+        let now = timestamp();
+        let request = TestRequest {
+            expected_response: 42,
+            num_expected_responses: 1,
+        };
+        let block_id = Hash::new_unique();
+        let nonce = outstanding_requests.add_request_with_metadata(
+            request,
+            now,
+            Some(BlockLocation::Alternate { block_id }),
+        );
+
+        assert!(
+            outstanding_requests
+                .register_response(nonce, &42, now, |_| ())
+                .is_some()
+        );
+
+        // Duplicate responses should not remove metadata before consumption.
+        assert!(
+            outstanding_requests
+                .register_response(nonce, &42, now, |_| ())
+                .is_none()
+        );
+
+        assert_eq!(
+            outstanding_requests.fetch_metadata_for_nonce(nonce),
+            Some(BlockLocation::Alternate { block_id })
+        );
+        // Entry is lazily cleaned up by LRU, metadata still exists
+        assert!(outstanding_requests.requests.get(&nonce).is_some());
+        assert_eq!(
+            outstanding_requests.fetch_metadata_for_nonce(nonce),
+            Some(BlockLocation::Alternate { block_id })
+        );
     }
 }

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -29,6 +29,7 @@ use {
     solana_keypair::Signer,
     solana_ledger::{
         blockstore::{Blockstore, SlotMeta},
+        blockstore_meta::BlockLocation,
         shred,
     },
     solana_measure::measure::Measure,
@@ -82,7 +83,7 @@ pub type ConfirmedSlotsSender = CrossbeamSender<Vec<Slot>>;
 pub type ConfirmedSlotsReceiver = CrossbeamReceiver<Vec<Slot>>;
 pub type DumpedSlotsSender = CrossbeamSender<Vec<(Slot, Hash)>>;
 pub type DumpedSlotsReceiver = CrossbeamReceiver<Vec<(Slot, Hash)>>;
-pub type OutstandingShredRepairs = OutstandingRequests<ShredRepairType>;
+pub type OutstandingShredRepairs = OutstandingRequests<ShredRepairType, BlockLocation>;
 pub type PopularPrunedForksSender = CrossbeamSender<Vec<Slot>>;
 pub type PopularPrunedForksReceiver = CrossbeamReceiver<Vec<Slot>>;
 
@@ -973,7 +974,7 @@ impl RepairService {
         let nonce = outstanding_repair_requests
             .write()
             .unwrap()
-            .add_request(repair_request, timestamp());
+            .add_request_with_metadata(repair_request, timestamp(), Some(BlockLocation::Original));
 
         // Create repair request
         let header =
@@ -1102,7 +1103,16 @@ impl RepairService {
                 if let Some(repairs) = repairs {
                     let mut outstanding_requests = outstanding_requests.write().unwrap();
                     for repair_type in repairs {
-                        let nonce = outstanding_requests.add_request(repair_type, timestamp());
+                        let location = repair_type
+                            .block_id()
+                            .map_or(BlockLocation::Original, |block_id| {
+                                BlockLocation::Alternate { block_id }
+                            });
+                        let nonce = outstanding_requests.add_request_with_metadata(
+                            repair_type,
+                            timestamp(),
+                            Some(location),
+                        );
 
                         match serve_repair.map_repair_request(
                             &repair_type,

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -37,9 +37,12 @@ use {
     },
     solana_hash::{HASH_BYTES, Hash},
     solana_keypair::{Keypair, signable::Signable},
-    solana_ledger::shred::{
-        self, DATA_SHREDS_PER_FEC_BLOCK, MAX_FEC_SETS_PER_SLOT, Nonce, SIZE_OF_NONCE,
-        ShredFetchStats, ShredType, layout::get_merkle_root, merkle_tree,
+    solana_ledger::{
+        blockstore_meta::BlockLocation,
+        shred::{
+            self, DATA_SHREDS_PER_FEC_BLOCK, MAX_FEC_SETS_PER_SLOT, Nonce, SIZE_OF_NONCE,
+            ShredFetchStats, ShredType, layout::get_merkle_root, merkle_tree,
+        },
     },
     solana_net_utils::{SocketAddrSpace, token_bucket::TokenBucket},
     solana_packet::PACKET_DATA_SIZE,
@@ -124,6 +127,15 @@ impl ShredRepairType {
             | ShredRepairType::HighestShred(slot, _)
             | ShredRepairType::Shred(slot, _) => *slot,
             ShredRepairType::ShredForBlockId { slot, .. } => *slot,
+        }
+    }
+
+    pub fn block_id(&self) -> Option<Hash> {
+        match self {
+            ShredRepairType::ShredForBlockId { block_id, .. } => Some(*block_id),
+            ShredRepairType::Orphan(_)
+            | ShredRepairType::HighestShred(_, _)
+            | ShredRepairType::Shred(_, _) => None,
         }
     }
 }
@@ -1515,7 +1527,19 @@ impl ServeRepair {
             }
         };
         let peer = repair_peers.sample(&mut rand::rng());
-        let nonce = outstanding_requests.add_request(repair_request, timestamp());
+        let location = repair_request
+            .block_id()
+            // Eager repair uses the Original blockstore column,
+            // however block id based repair shreds must be inserted in the
+            // Alternate column
+            .map_or(BlockLocation::Original, |block_id| {
+                BlockLocation::Alternate { block_id }
+            });
+        let nonce = outstanding_requests.add_request_with_metadata(
+            repair_request,
+            timestamp(),
+            Some(location),
+        );
         let out = self.map_repair_request(
             &repair_request,
             &peer.pubkey,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -362,6 +362,15 @@ impl Tvu {
             fetch_receiver,
             retransmit_sender.clone(),
             verified_sender,
+            Arc::new({
+                let outstanding_repair_requests = outstanding_repair_requests.clone();
+                move |nonce| {
+                    outstanding_repair_requests
+                        .read()
+                        .unwrap()
+                        .fetch_metadata_for_nonce(nonce)
+                }
+            }),
             tvu_config.shred_sigverify_threads,
         );
 

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -171,7 +171,7 @@ fn run_check_duplicate(
 #[allow(clippy::too_many_arguments)]
 fn run_insert<F>(
     thread_pool: &ThreadPool,
-    verified_receiver: &Receiver<Vec<(shred::Payload, /*is_repaired:*/ bool)>>,
+    verified_receiver: &Receiver<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
     blockstore: &Blockstore,
     leader_schedule_cache: &LeaderScheduleCache,
     handle_duplicate: F,
@@ -191,12 +191,12 @@ where
     shred_receiver_elapsed.stop();
     ws_metrics.shred_receiver_elapsed_us += shred_receiver_elapsed.as_us();
     ws_metrics.run_insert_count += 1;
-    let handle_shred = |(shred, repair): (shred::Payload, bool)| {
+    let handle_shred = |(shred, repair, block_location): (shred::Payload, bool, BlockLocation)| {
         if repair {
             ws_metrics.num_repairs.fetch_add(1, Ordering::Relaxed);
         }
         let shred = Shred::new_from_serialized_shred(shred).ok()?;
-        Some((Cow::Owned(shred), repair, BlockLocation::Original))
+        Some((Cow::Owned(shred), repair, block_location))
     };
     let now = Instant::now();
     let shreds: Vec<_> = thread_pool.install(|| {
@@ -226,7 +226,7 @@ where
 }
 
 pub struct WindowServiceChannels {
-    pub verified_receiver: Receiver<Vec<(shred::Payload, /*is_repaired:*/ bool)>>,
+    pub verified_receiver: Receiver<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
     pub retransmit_sender: EvictingSender<Vec<shred::Payload>>,
     pub completed_data_sets_sender: Option<CompletedDataSetsSender>,
     pub duplicate_slots_sender: DuplicateSlotSender,
@@ -235,7 +235,7 @@ pub struct WindowServiceChannels {
 
 impl WindowServiceChannels {
     pub fn new(
-        verified_receiver: Receiver<Vec<(shred::Payload, /*is_repaired:*/ bool)>>,
+        verified_receiver: Receiver<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
         retransmit_sender: EvictingSender<Vec<shred::Payload>>,
         completed_data_sets_sender: Option<CompletedDataSetsSender>,
         duplicate_slots_sender: DuplicateSlotSender,
@@ -352,7 +352,7 @@ impl WindowService {
         exit: Arc<AtomicBool>,
         blockstore: Arc<Blockstore>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
-        verified_receiver: Receiver<Vec<(shred::Payload, /*is_repaired:*/ bool)>>,
+        verified_receiver: Receiver<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
         check_duplicate_sender: Sender<PossibleDuplicateShred>,
         completed_data_sets_sender: Option<CompletedDataSetsSender>,
         retransmit_sender: EvictingSender<Vec<shred::Payload>>,

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -11,6 +11,7 @@ use {
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
     solana_ledger::{
+        blockstore_meta::BlockLocation,
         leader_schedule_cache::LeaderScheduleCache,
         shred::{
             self,
@@ -22,7 +23,7 @@ use {
     solana_perf::{
         self,
         deduper::Deduper,
-        packet::{PacketBatch, PacketRefMut},
+        packet::{PacketBatch, PacketRef, PacketRefMut},
     },
     solana_pubkey::Pubkey,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
@@ -73,13 +74,16 @@ enum ResignError {
     Shred(#[from] shred::Error),
 }
 
+pub type RepairNonceLocationLookup = dyn Fn(shred::Nonce) -> Option<BlockLocation> + Send + Sync;
+
 pub fn spawn_shred_sigverify(
     cluster_info: Arc<ClusterInfo>,
     bank_forks: Arc<RwLock<BankForks>>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
     shred_fetch_receiver: Receiver<PacketBatch>,
     retransmit_sender: EvictingSender<Vec<shred::Payload>>,
-    verified_sender: Sender<Vec<(shred::Payload, /*is_repaired:*/ bool)>>,
+    verified_sender: Sender<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
+    repair_nonce_location_lookup: Arc<RepairNonceLocationLookup>,
     num_sigverify_threads: NonZeroUsize,
 ) -> JoinHandle<()> {
     let mut stats = ShredSigVerifyStats::new(Instant::now());
@@ -115,6 +119,7 @@ pub fn spawn_shred_sigverify(
                 &retransmit_sender,
                 &verified_sender,
                 &cluster_nodes_cache,
+                repair_nonce_location_lookup.as_ref(),
                 &cache,
                 &mut stats,
                 &mut shred_buffer,
@@ -143,8 +148,9 @@ fn run_shred_sigverify<const K: usize>(
     deduper: &Deduper<K, [u8]>,
     shred_fetch_receiver: &Receiver<PacketBatch>,
     retransmit_sender: &EvictingSender<Vec<shred::Payload>>,
-    verified_sender: &Sender<Vec<(shred::Payload, /*is_repaired:*/ bool)>>,
+    verified_sender: &Sender<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
     cluster_nodes_cache: &ClusterNodesCache<RetransmitStage>,
+    repair_nonce_location_lookup: &RepairNonceLocationLookup,
     cache: &RwLock<LruCache>,
     stats: &mut ShredSigVerifyStats,
     shred_buffer: &mut Vec<PacketBatch>,
@@ -237,20 +243,24 @@ fn run_shred_sigverify<const K: usize>(
         .flat_map(|batch| batch.iter())
         .filter(|packet| !packet.meta().discard())
         .filter_map(|packet| {
-            let shred = shred::layout::get_shred(packet)?.to_vec();
-            Some((shred, packet.meta().repair()))
+            extract_shred_and_location(packet, repair_nonce_location_lookup, stats)
         })
-        .partition_map(|(shred, repair)| {
-            if repair {
+        .partition_map(|(shred, location)| {
+            if let Some(location) = location {
                 // No need for Arc overhead here because repaired shreds are
                 // not retranmitted.
-                Either::Right(shred::Payload::from(shred))
+                Either::Right((
+                    shred::Payload::from(shred),
+                    /* is_repaired */ true,
+                    location,
+                ))
             } else {
                 // Share the payload between the retransmit-stage and the
                 // window-service.
                 Either::Left(shred::Payload::from(shred))
             }
         });
+
     // Repaired shreds are not retransmitted.
     stats.num_retransmit_shreds += shreds.len();
     if let Err(send_err) = retransmit_sender.try_send(shreds.clone()) {
@@ -264,14 +274,34 @@ fn run_shred_sigverify<const K: usize>(
     // Send all shreds to window service to be inserted into blockstore.
     let shreds = shreds
         .into_iter()
-        .map(|shred| (shred, /*is_repaired:*/ false));
-    let repairs = repairs
-        .into_iter()
-        .map(|shred| (shred, /*is_repaired:*/ true));
+        .map(|shred| (shred, /*is_repaired:*/ false, BlockLocation::Original));
     verified_sender.send(shreds.chain(repairs).collect())?;
     stats.elapsed_micros += now.elapsed().as_micros() as u64;
     shred_buffer.clear();
     Ok(())
+}
+
+/// Extracts shred bytes and, for repaired shreds, the location where the shred
+/// should be inserted into blockstore.
+fn extract_shred_and_location(
+    packet: PacketRef,
+    repair_nonce_location_lookup: &RepairNonceLocationLookup,
+    stats: &mut ShredSigVerifyStats,
+) -> Option<(Vec<u8>, Option<BlockLocation>)> {
+    let (shred, nonce) = shred::layout::get_shred_and_repair_nonce(packet)?;
+    let Some(nonce) = nonce else {
+        // Turbine shred.
+        return Some((shred.to_vec(), None));
+    };
+
+    // Repair shred.
+    if let Some(location) = repair_nonce_location_lookup(nonce) {
+        Some((shred.to_vec(), Some(location)))
+    } else {
+        // This indicates the request entry was evicted before consumption.
+        stats.num_unknown_block_location += 1;
+        None
+    }
 }
 
 /// Checks whether the shred in the given `packet` is of resigned variant. If
@@ -467,6 +497,9 @@ struct ShredSigVerifyStats {
     num_retranmitter_signature_verified: AtomicUsize,
     num_retransmit_stage_overflow_shreds: usize,
     num_retransmit_shreds: usize,
+    /// This means the OutstandingRequests cache is saturated and we
+    /// threw away a verified shred due to being unable to fetch the storage location
+    num_unknown_block_location: usize,
     num_unknown_slot_leader: AtomicUsize,
     num_unknown_turbine_parent: AtomicUsize,
     elapsed_micros: u64,
@@ -491,6 +524,7 @@ impl ShredSigVerifyStats {
             num_retranmitter_signature_verified: AtomicUsize::default(),
             num_retransmit_stage_overflow_shreds: 0usize,
             num_retransmit_shreds: 0usize,
+            num_unknown_block_location: 0usize,
             num_unknown_slot_leader: AtomicUsize::default(),
             num_unknown_turbine_parent: AtomicUsize::default(),
             elapsed_micros: 0u64,
@@ -534,6 +568,11 @@ impl ShredSigVerifyStats {
                 i64
             ),
             ("num_retransmit_shreds", self.num_retransmit_shreds, i64),
+            (
+                "num_unknown_block_location",
+                self.num_unknown_block_location,
+                i64
+            ),
             (
                 "num_unknown_slot_leader",
                 self.num_unknown_slot_leader.load(Ordering::Relaxed),


### PR DESCRIPTION
Upstream of https://github.com/anza-xyz/alpenglow/pull/357 *note* heavily modified see https://github.com/anza-xyz/agave/pull/11933#issuecomment-4248163222

### Problem
Shreds requested / received by the (yet to be upstreamed) `block_id_repair_service` need to be inserted in the alternate blockstore columns.

We need to maintain a repair nonce <> location lookup so that we insert the shred on receival appropriately.

#### Summary of Changes
Beef up `OutstandingRequests` such that it is able to track additional metadata. For shred repair this metadata is the `BlockLocation`. Existing eager repair will fill in `BlockLocation::Original` and the new alpenglow repair types use `BlockLocation::Alternate`.

We now register the response as usual pre sigverify, but the request remains in the `OutstandingRequests` cache until it is fetched post sigverify for the metadata. This metadata (the block location) is then forwarded along with the shred to window service for insertion to blockstore.