### PR TITLE
fix: SIMD-0449: use proper vm addr in pointer array

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1498,7 +1498,7 @@ pub mod validator_admission_ticket {
 }
 
 pub mod direct_account_pointers_in_program_input {
-    solana_pubkey::declare_id!("ptrXWLkSDMZZmZN8GAT6W5yW4EvYByfw6cRRHbXwQNS");
+    solana_pubkey::declare_id!("ptr9umikaeAS7ZBBp2fsfRhie16F1V2jCKA2y6gXNAK");
 }
 
 pub mod upgrade_bpf_stake_program_to_v5 {

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1635,12 +1635,12 @@ mod tests {
                 data,
                 region,
                 SerializedAccountMetadata {
+                    vm_addr: vm_addr as u64,
                     original_data_len: self.data.len(),
                     vm_key_addr: key_addr as u64,
                     vm_lamports_addr: lamports_addr as u64,
                     vm_owner_addr: owner_addr as u64,
                     vm_data_addr: data_addr as u64,
-                    vm_addr: vm_addr as u64,
                 },
             )
         }

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1640,6 +1640,7 @@ mod tests {
                     vm_lamports_addr: lamports_addr as u64,
                     vm_owner_addr: owner_addr as u64,
                     vm_data_addr: data_addr as u64,
+                    vm_addr: vm_addr as u64,
                 },
             )
         }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -298,6 +298,9 @@ pub struct SerializedAccountMetadata {
     pub vm_key_addr: u64,
     pub vm_lamports_addr: u64,
     pub vm_owner_addr: u64,
+    /// Address of the first byte of the serialized account record (the
+    /// `NON_DUP_MARKER`/duplicate-marker byte).
+    pub vm_addr: u64,
 }
 
 /// Main pipeline from runtime to program execution.

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -293,14 +293,14 @@ impl MemoryContext {
 
 #[derive(Debug, Clone)]
 pub struct SerializedAccountMetadata {
+    /// Address of the first byte of the serialized account record (the
+    /// `NON_DUP_MARKER`/duplicate-marker byte).
+    pub vm_addr: u64,
     pub original_data_len: usize,
     pub vm_data_addr: u64,
     pub vm_key_addr: u64,
     pub vm_lamports_addr: u64,
     pub vm_owner_addr: u64,
-    /// Address of the first byte of the serialized account record (the
-    /// `NON_DUP_MARKER`/duplicate-marker byte).
-    pub vm_addr: u64,
 }
 
 /// Main pipeline from runtime to program execution.

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -386,12 +386,12 @@ fn serialize_parameters_for_abiv0(
                 let rent_epoch = u64::MAX;
                 s.write::<u64>(rent_epoch.to_le());
                 accounts_metadata.push(SerializedAccountMetadata {
+                    vm_addr,
                     original_data_len: account.get_data().len(),
                     vm_key_addr,
                     vm_lamports_addr,
                     vm_owner_addr,
                     vm_data_addr,
-                    vm_addr,
                 });
             }
         };
@@ -554,12 +554,12 @@ fn serialize_parameters_for_abiv1(
                 let rent_epoch = u64::MAX;
                 s.write::<u64>(rent_epoch.to_le());
                 accounts_metadata.push(SerializedAccountMetadata {
+                    vm_addr,
                     original_data_len: borrowed_account.get_data().len(),
                     vm_key_addr,
                     vm_owner_addr,
                     vm_lamports_addr,
                     vm_data_addr,
-                    vm_addr,
                 });
             }
             SerializeAccount::Duplicate(position) => {

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -373,7 +373,7 @@ fn serialize_parameters_for_abiv0(
                 s.write(position as u8);
             }
             SerializeAccount::Account(_, mut account) => {
-                s.write::<u8>(NON_DUP_MARKER);
+                let vm_addr = s.write::<u8>(NON_DUP_MARKER);
                 s.write::<u8>(account.is_signer() as u8);
                 s.write::<u8>(account.is_writable() as u8);
                 let vm_key_addr = s.write_all(account.get_key().as_ref());
@@ -391,6 +391,7 @@ fn serialize_parameters_for_abiv0(
                     vm_lamports_addr,
                     vm_owner_addr,
                     vm_data_addr,
+                    vm_addr,
                 });
             }
         };
@@ -539,7 +540,7 @@ fn serialize_parameters_for_abiv1(
     for account in accounts {
         match account {
             SerializeAccount::Account(_, mut borrowed_account) => {
-                s.write::<u8>(NON_DUP_MARKER);
+                let vm_addr = s.write::<u8>(NON_DUP_MARKER);
                 s.write::<u8>(borrowed_account.is_signer() as u8);
                 s.write::<u8>(borrowed_account.is_writable() as u8);
                 #[expect(deprecated)]
@@ -558,6 +559,7 @@ fn serialize_parameters_for_abiv1(
                     vm_owner_addr,
                     vm_lamports_addr,
                     vm_data_addr,
+                    vm_addr,
                 });
             }
             SerializeAccount::Duplicate(position) => {
@@ -577,7 +579,7 @@ fn serialize_parameters_for_abiv1(
         s.fill_write(offset, 0)
             .map_err(|_| InstructionError::InvalidArgument)?;
         for entry in accounts_metadata.iter() {
-            s.write::<u64>(entry.vm_data_addr.to_le());
+            s.write::<u64>(entry.vm_addr.to_le());
         }
     }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8545,6 +8545,7 @@ dependencies = [
 name = "solana-sbf-rust-direct-account-pointers"
 version = "4.1.0-alpha.0"
 dependencies = [
+ "solana-account-info",
  "solana-account-view",
  "solana-address 2.6.0",
  "solana-cpi",

--- a/programs/sbf/rust/direct_account_pointers_in_program_input/Cargo.toml
+++ b/programs/sbf/rust/direct_account_pointers_in_program_input/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 crate-type = ["cdylib"]
 
 [dependencies]
+solana-account-info = { workspace = true }
 solana-account-view = { workspace = true }
 solana-address = { workspace = true }
 solana-cpi = { workspace = true }

--- a/programs/sbf/rust/direct_account_pointers_in_program_input/src/lib.rs
+++ b/programs/sbf/rust/direct_account_pointers_in_program_input/src/lib.rs
@@ -4,17 +4,20 @@
 #![allow(clippy::missing_safety_doc)]
 
 use {
-    core::{mem::size_of, ptr::with_exposed_provenance_mut, slice::from_raw_parts},
+    core::{
+        mem::{MaybeUninit, size_of},
+        ptr::with_exposed_provenance_mut,
+        slice::from_raw_parts,
+    },
+    solana_account_info::AccountInfo,
     solana_account_view::AccountView,
     solana_address::Address,
-    solana_program_error::{ProgramError, ProgramResult},
+    solana_program_entrypoint::deserialize_into,
+    solana_program_error::ProgramError,
 };
 
-/// `assert_eq(core::mem::align_of::<u128>(), 8)` is true for BPF but not
-/// for some host machines.
 const BPF_ALIGN_OF_U128: usize = 8;
 
-/// Align a pointer to the BPF alignment of [`u128`].
 macro_rules! align_pointer {
     ($ptr:ident) => {
         with_exposed_provenance_mut(
@@ -23,56 +26,46 @@ macro_rules! align_pointer {
     };
 }
 
+const MAX_ACCOUNTS: usize = 64;
+
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn entrypoint(program_input: *mut u8, instruction_data: *mut u8) -> u64 {
-    // First 8-bytes of program_input contains the number of accounts.
-    let accounts = program_input as *mut u64;
+pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
+    // First use the current entrypoint to read the actual accounts region
+    #[allow(clippy::declare_interior_mutable_const)]
+    const UNINIT: MaybeUninit<AccountInfo> = MaybeUninit::<AccountInfo>::uninit();
+    let mut uninit_infos = [UNINIT; MAX_ACCOUNTS];
 
-    let (program_id, accounts, instruction_data) = unsafe {
-        // The 8-bytes before the instruction data contains the length of
-        // the instruction data, even if the instruction data is empty.
-        let ix_data_len = *(instruction_data.sub(size_of::<u64>()) as *mut u64) as usize;
+    let (_program_id, num_accounts, instruction_data) =
+        unsafe { deserialize_into(input, &mut uninit_infos) };
+    let account_infos: &[AccountInfo] =
+        unsafe { from_raw_parts(uninit_infos.as_ptr() as *const AccountInfo, num_accounts) };
 
-        // The program_id is located right after the instruction data.
-        let program_id = &*(instruction_data.add(ix_data_len) as *const Address);
+    // Locate the SIMD-0449 additional pointer slice. It lives immediately
+    // after the program id, with up to 7 bytes of padding to reach 8-byte
+    // alignment.
+    let after_ix_data =
+        unsafe { (instruction_data.as_ptr() as *mut u8).add(instruction_data.len()) };
+    let after_program_id = unsafe { after_ix_data.add(size_of::<Address>()) };
+    let slice_ptr = align_pointer!(after_program_id) as *const AccountView;
+    let account_views: &[AccountView] = unsafe { from_raw_parts(slice_ptr, num_accounts) };
 
-        // The slice of account pointers is located right after the program_id.
-        let slice_ptr = instruction_data.add(ix_data_len + size_of::<Address>());
-        let accounts = from_raw_parts(
-            align_pointer!(slice_ptr) as *const AccountView,
-            *accounts as usize,
-        );
-
-        // The instruction data slice.
-        let instruction_data = from_raw_parts(instruction_data, ix_data_len);
-
-        (program_id, accounts, instruction_data)
-    };
-    match process_instruction(program_id, accounts, instruction_data) {
-        Ok(_) => solana_program_entrypoint::SUCCESS,
-        Err(e) => e.into(),
-    }
-}
-
-pub fn process_instruction(
-    _program_id: &Address,
-    accounts: &[AccountView],
-    _instruction_data: &[u8],
-) -> ProgramResult {
-    // The program expects the accounts to be duplicated in the input.
-    let non_duplicated = accounts.len() / 2;
-
-    for i in 0..non_duplicated {
-        let account = &accounts[i];
-        let duplicate = &accounts[i + non_duplicated];
-
-        if account != duplicate || account.address() != duplicate.address() {
-            return Err(ProgramError::InvalidAccountData);
+    // Check all account views from the additional pointer slice against their
+    // account info counterparts.
+    for (info, view) in account_infos.iter().zip(account_views.iter()) {
+        let mismatch = info.key != view.address()
+            || info.owner != view.owner()
+            || info.lamports() != view.lamports()
+            || info.is_signer != view.is_signer()
+            || info.is_writable != view.is_writable()
+            || info.executable != view.executable()
+            || info.data.borrow().len() != view.data_len();
+        if mismatch {
+            return ProgramError::Custom(1).into();
         }
     }
 
-    solana_cpi::set_return_data(&accounts.len().to_le_bytes());
-    Ok(())
+    solana_cpi::set_return_data(&num_accounts.to_le_bytes());
+    solana_program_entrypoint::SUCCESS
 }
 
 solana_program_entrypoint::custom_heap_default!();


### PR DESCRIPTION
#### Problem

Current implementation of SIMD-0449 is wrongly writing the account data pointer instead of the pointer to the start of the account metadata.

#### Summary of Changes

* Compute and write the pointer to the start of the account metadata.
* Update the test to validate that the account information is the same between parsing the account data and using the account pointers.
* Rekey the feature gate from `ptrXWLkSDMZZmZN8GAT6W5yW4EvYByfw6cRRHbXwQNS` to `ptr9umikaeAS7ZBBp2fsfRhie16F1V2jCKA2y6gXNAK`.

Note: The fix is from https://github.com/buffalojoec/solana/tree/direct-pointers-addr-bug