### PR TITLE
Tag a new release at the version bump, not before

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -130,7 +130,7 @@ Create a PR that makes the following updates to [CHANGELOG.md](https://github.co
 1. Dispatch [Bump Version](https://github.com/anza-xyz/agave/actions/workflows/bump-version.yml) pipeline to create the version bump PR.
 1. Verify CI checks pass. Verify that the change is correct: it only contains version bump changes and only expected version is changed. Approve it.
 1. Wait for approvals required to merge and merge it.
-1. Check out relevant branch, create release tag pointing to the commit right before the version bump change and push it. The release tag must exactly match the `version` field in `/Cargo.toml` prefixed by `v` that was before the version bump.
+1. Check out relevant branch, create release tag pointing to the version bump merge commit from the previous step. The release tag must exactly match the `version` field in `/Cargo.toml` prefixed by `v` from the version bump.
     ```
     git checkout v4.0
     git tag v4.0.1 123abc...


### PR DESCRIPTION
#### Problem

Our release process looks like this:
1. Bump the version to X.Y.Z.
2. Backport (potentially several) changes.
3. When we are ready, tag X.Y.Z release.
4. Bump the version to X.Y.Z+1. ...

Such order has several issues:
1. Release named at the step 3 is pre-defined already by the step 1 that usually happened at least a week ago. This is probably ok for patch releases, but not good for minor releases and stableness propagation (ALPHA -> BETA -> RC -> STABLE).
2. The code built from the branch at random point of time between 1 and 3 steps reports as `vX.Y.Z`. In reality the code may contain just a subset of backports done at the step 2. It confuses when we declare "at least vX.Y.Z required" as a binary built from the branch reports as `vX.Y.Z` but does not necessarily meet the criteria - it contains at least what is in the X.Y.Z-1 release.

#### Summary of Changes

The new proposed process will look like this:
1. The code is at the version X.Y.Z.
2. Backport (potentially several) changes.
3. When we are ready, bump the version to X.Y.Z+1.
4. Tag X.Y.Z+1 release at the exact version bump commit. ...

This order solves both issues:
1. We decide at step 3 what release will we cut: X.Y.Z+1 or stableness propagation release.
2. When the code built from the branch reports as `vX.Y.Z` then we know that it contains _at least_ what is in `vX.Y.Z` release.