### PR TITLE
vote-state: Default to identity for block rewards, vote for inflation rewards

### DIFF
--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -112,7 +112,7 @@ impl StakeReward {
             1000,
             &validator_voting_keypair.pubkey(),
             0,
-            &validator_voting_keypair.pubkey(),
+            &validator_pubkey,
             validator_stake_lamports,
         );
 

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -291,7 +291,7 @@ fn add_validator_accounts(
             bls_pubkey_compressed_bytes,
             identity_pubkey,
             u16::from(commission) * 100,
-            identity_pubkey,
+            vote_pubkey,
             0,
             identity_pubkey,
             vote_account_lamports,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2392,7 +2392,7 @@ fn main() {
                                 [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
                                 identity_pubkey,
                                 10000,
-                                identity_pubkey,
+                                vote_pubkey,
                                 0,
                                 identity_pubkey,
                                 rent.minimum_balance(VoteStateV4::size_of()).max(1),

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -228,7 +228,7 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64) {
         0,
         &vote_address,
         0,
-        &vote_address,
+        &node_address,
         1_000_000_000,
     );
     program_test.add_account(vote_address, vote_account.clone().into());

--- a/programs/sbf/tests/syscall_get_epoch_stake.rs
+++ b/programs/sbf/tests/syscall_get_epoch_stake.rs
@@ -50,20 +50,20 @@ fn test_syscall_get_epoch_stake() {
             .iter()
             .map(|keypair| {
                 let node_id = keypair.node_keypair.pubkey();
-                let authorized_voter = keypair.vote_keypair.pubkey();
+                let vote_pubkey = keypair.vote_keypair.pubkey();
                 let vote_account = VoteAccount::try_from(create_v4_account_with_authorized(
                     &node_id,
-                    &authorized_voter,
+                    &vote_pubkey,
                     [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
                     &node_id,
                     0,
-                    &node_id,
+                    &vote_pubkey,
                     0,
                     &node_id,
                     100,
                 ))
                 .unwrap();
-                (authorized_voter, (0, vote_account)) // No stake.
+                (vote_pubkey, (0, vote_account)) // No stake.
             })
             .collect::<HashMap<_, _>>(),
         0, // Leader schedule epoch 0

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -133,24 +133,26 @@ fn create_accounts() -> (
 fn create_test_account() -> (Pubkey, AccountSharedData) {
     let rent = Rent::default();
     let balance = rent.minimum_balance(VoteStateV3::size_of());
+    let node_pubkey = solana_pubkey::new_rand();
     let vote_pubkey = solana_pubkey::new_rand();
     (
         vote_pubkey,
         create_v4_account_with_authorized(
-            &solana_pubkey::new_rand(),
+            &node_pubkey,
             &vote_pubkey,
             [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &vote_pubkey,
             0,
             &vote_pubkey,
             0,
-            &vote_pubkey,
+            &node_pubkey,
             balance,
         ),
     )
 }
 
 fn create_test_account_with_authorized() -> (Pubkey, Pubkey, Pubkey, AccountSharedData) {
+    let node_pubkey = solana_pubkey::new_rand();
     let vote_pubkey = solana_pubkey::new_rand();
     let authorized_voter = solana_pubkey::new_rand();
     let authorized_withdrawer = solana_pubkey::new_rand();
@@ -160,14 +162,14 @@ fn create_test_account_with_authorized() -> (Pubkey, Pubkey, Pubkey, AccountShar
         authorized_voter,
         authorized_withdrawer,
         create_v4_account_with_authorized(
-            &solana_pubkey::new_rand(),
+            &node_pubkey,
             &authorized_voter,
             [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &authorized_withdrawer,
             0,
             &authorized_withdrawer,
             0,
-            &authorized_withdrawer,
+            &node_pubkey,
             100,
         ),
     )
@@ -731,15 +733,16 @@ impl BenchAuthorizeWithSeed {
             &withdrawer_owner,
         )
         .unwrap();
+        let node_pubkey = Pubkey::new_unique();
         let vote_account = create_v4_account_with_authorized(
-            &Pubkey::new_unique(),
+            &node_pubkey,
             &authorized_voter,
             [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &authorized_withdrawer,
             0,
             &authorized_withdrawer,
             0,
-            &authorized_withdrawer,
+            &node_pubkey,
             100,
         );
         let clock_account = account::create_account_shared_data_for_test(&clock);
@@ -823,15 +826,16 @@ impl BenchAuthorizeCheckedWithSeed {
             &withdrawer_owner,
         )
         .unwrap();
+        let node_pubkey = Pubkey::new_unique();
         let vote_account = create_v4_account_with_authorized(
-            &Pubkey::new_unique(),
+            &node_pubkey,
             &authorized_voter,
             [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
             &authorized_withdrawer,
             0,
             &authorized_withdrawer,
             0,
-            &authorized_withdrawer,
+            &node_pubkey,
             100,
         );
         let new_authority_pubkey = Pubkey::new_unique();

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -683,7 +683,7 @@ mod tests {
             0,
             &vote_pubkey,
             0,
-            &vote_pubkey,
+            &node_pubkey,
             balance,
         );
 
@@ -776,7 +776,7 @@ mod tests {
             0,
             authorized_withdrawer,
             0,
-            authorized_withdrawer,
+            &node_pubkey,
             100,
         )
     }
@@ -807,7 +807,7 @@ mod tests {
             0,
             &authorized_withdrawer,
             0,
-            &authorized_withdrawer,
+            &node_pubkey,
             100,
         );
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -4043,7 +4043,7 @@ mod tests {
             inflation_rewards_commission_bps,
             &authorized_withdrawer,
             0,
-            &authorized_withdrawer,
+            &node_pubkey,
             lamports,
         );
         assert_eq!(vote_account.lamports(), lamports);
@@ -4165,7 +4165,7 @@ mod tests {
             inflation_rewards_commission_bps,
             &authorized_withdrawer,
             0,
-            &authorized_withdrawer,
+            &node_pubkey,
             lamports,
         );
         assert_eq!(vote_account.lamports(), lamports);

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -422,7 +422,7 @@ mod tests {
             1000,
             &validator_vote_pubkey,
             0,
-            &validator_vote_pubkey,
+            &validator_pubkey,
             20,
         );
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -918,7 +918,7 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
         0,
         &vote_id,
         0,
-        &vote_id,
+        &node_pubkey,
         100,
     );
     let stake_id1 = solana_pubkey::new_rand();
@@ -1698,7 +1698,7 @@ fn test_readonly_accounts(relax_intrabatch_account_locks: bool) {
         0,
         &authorized_voter.pubkey(),
         0,
-        &authorized_voter.pubkey(),
+        &vote_pubkey0,
         100,
     );
     let vote_account1 = vote_state::create_v4_account_with_authorized(
@@ -1709,7 +1709,7 @@ fn test_readonly_accounts(relax_intrabatch_account_locks: bool) {
         0,
         &authorized_voter.pubkey(),
         0,
-        &authorized_voter.pubkey(),
+        &vote_pubkey1,
         100,
     );
     let vote_account2 = vote_state::create_v4_account_with_authorized(
@@ -1720,7 +1720,7 @@ fn test_readonly_accounts(relax_intrabatch_account_locks: bool) {
         0,
         &authorized_voter.pubkey(),
         0,
-        &authorized_voter.pubkey(),
+        &vote_pubkey2,
         100,
     );
     bank.store_account(&vote_pubkey0, &vote_account0);
@@ -9861,7 +9861,7 @@ fn test_rent_state_changes_sysvars() {
         0,
         &validator_voting_keypair.pubkey(),
         0,
-        &validator_voting_keypair.pubkey(),
+        &validator_pubkey,
         validator_stake_lamports,
     );
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1682,6 +1682,9 @@ fn test_readonly_accounts(relax_intrabatch_account_locks: bool) {
     let next_slot = bank.slot() + 1;
     let bank = Bank::new_from_parent(bank, SlotLeader::default(), next_slot);
 
+    let node_pubkey0 = solana_pubkey::new_rand();
+    let node_pubkey1 = solana_pubkey::new_rand();
+    let node_pubkey2 = solana_pubkey::new_rand();
     let vote_pubkey0 = solana_pubkey::new_rand();
     let vote_pubkey1 = solana_pubkey::new_rand();
     let vote_pubkey2 = solana_pubkey::new_rand();
@@ -1691,36 +1694,36 @@ fn test_readonly_accounts(relax_intrabatch_account_locks: bool) {
 
     // Create vote accounts
     let vote_account0 = vote_state::create_v4_account_with_authorized(
-        &vote_pubkey0,
+        &node_pubkey0,
         &authorized_voter.pubkey(),
         [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
         &authorized_voter.pubkey(),
         0,
-        &authorized_voter.pubkey(),
-        0,
         &vote_pubkey0,
+        0,
+        &node_pubkey0,
         100,
     );
     let vote_account1 = vote_state::create_v4_account_with_authorized(
-        &vote_pubkey1,
+        &node_pubkey1,
         &authorized_voter.pubkey(),
         [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
         &authorized_voter.pubkey(),
         0,
-        &authorized_voter.pubkey(),
-        0,
         &vote_pubkey1,
+        0,
+        &node_pubkey1,
         100,
     );
     let vote_account2 = vote_state::create_v4_account_with_authorized(
-        &vote_pubkey2,
+        &node_pubkey2,
         &authorized_voter.pubkey(),
         [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
         &authorized_voter.pubkey(),
         0,
-        &authorized_voter.pubkey(),
-        0,
         &vote_pubkey2,
+        0,
+        &node_pubkey2,
         100,
     );
     bank.store_account(&vote_pubkey0, &vote_account0);

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -246,7 +246,7 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
             0,
             &vote_pubkey,
             0,
-            &vote_pubkey,
+            &node_pubkey,
             vote_account_lamports,
         );
         let stake_account = Account::from(stake_utils::create_stake_account(
@@ -438,7 +438,7 @@ pub fn create_genesis_config_with_leader_ex_no_features(
         0,
         validator_vote_account_pubkey,
         0,
-        validator_vote_account_pubkey,
+        validator_pubkey,
         vote_account_lamports,
     );
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -634,7 +634,7 @@ pub(crate) mod tests {
             0,
             &vote_pubkey,
             0,
-            &vote_pubkey,
+            &node_pubkey,
             1,
         );
         let stake_pubkey = solana_pubkey::new_rand();
@@ -667,7 +667,7 @@ pub(crate) mod tests {
                 0,
                 vote_pubkey,
                 0,
-                vote_pubkey,
+                &node_pubkey,
                 1,
             ),
             rent,

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -219,7 +219,7 @@ mod tests {
                     0,
                     &vote_pubkey,
                     0,
-                    &vote_pubkey,
+                    &node_pubkey,
                     1_000_000_000,
                 ),
                 &Rent::default(),
@@ -281,7 +281,7 @@ mod tests {
                 commission_bps,
                 &vote_pubkey,
                 0,
-                &vote_pubkey,
+                &node_pubkey,
                 rng.random_range(0..1_000_000), // lamports
             );
             stakes_cache.check_and_store(&vote_pubkey, &vote_account, None);


### PR DESCRIPTION
#### Problem

As noticed in #11877, some of the tests look incorrect because we're using the vote account as the block reward collector account, which is inconsistent with the default from SIMD-185.

#### Summary of changes

Update usages of `create_v4_account*` to use the node identity as the block reward collector and the vote account as the inflation rewards collector.