### PR TITLE
Configure snapshot usage as load and generate when creating snapshots

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "solana-version",
  "solana-vote",
  "solana-vote-program",
+ "tempfile",
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -98,3 +98,4 @@ signal-hook = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
+tempfile = { workspace = true }

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -1,6 +1,7 @@
 use {
     crate::LEDGER_TOOL_DIRECTORY,
     agave_snapshots::{
+        SnapshotInterval,
         paths::{self as snapshot_paths, BANK_SNAPSHOTS_DIR},
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_hash::StartingSnapshotHashes,
@@ -174,12 +175,16 @@ pub fn load_and_process_ledger(
         }
         let usage = if arg_matches.is_present("no_snapshot") {
             SnapshotUsage::Disabled
+        } else if arg_matches.is_present("snapshot_slot") {
+            SnapshotUsage::LoadAndGenerate
         } else {
             SnapshotUsage::LoadOnly
         };
 
         SnapshotConfig {
             usage,
+            full_snapshot_archive_interval: SnapshotInterval::Disabled,
+            incremental_snapshot_archive_interval: SnapshotInterval::Disabled,
             full_snapshot_archives_dir,
             incremental_snapshot_archives_dir,
             bank_snapshots_dir,
@@ -603,5 +608,101 @@ pub(crate) fn get_access_type(process_options: &ProcessOptions) -> AccessType {
         UseSnapshotArchivesAtStartup::Always => AccessType::ReadOnly,
         UseSnapshotArchivesAtStartup::Never => AccessType::PrimaryForMaintenance,
         UseSnapshotArchivesAtStartup::WhenNewest => AccessType::PrimaryForMaintenance,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        agave_snapshots::{paths::BANK_SNAPSHOTS_DIR, snapshot_config::SnapshotConfig},
+        clap::{App, Arg},
+        solana_ledger::{
+            blockstore::Blockstore,
+            blockstore_options::{AccessType, BlockstoreOptions},
+            blockstore_processor::ProcessOptions,
+            genesis_utils::create_genesis_config,
+        },
+        solana_runtime::{bank::Bank, snapshot_bank_utils},
+        std::fs,
+        tempfile::TempDir,
+    };
+
+    /// Ensure that snapshot slot is properly loaded and set as latest_full_snapshot_slot in accounts db
+    /// when snapshot_slot is provided as an argument to load_and_process_ledger.
+    #[test]
+    fn test_load_and_process_ledger_sets_latest_full_snapshot_slot_when_snapshot_slot_present() {
+        let ledger_tmp = TempDir::new().unwrap();
+        let ledger_path = ledger_tmp.path();
+
+        let genesis_config = create_genesis_config(10_000).genesis_config;
+
+        // Create a bank from genesis and archive a full snapshot into the ledger directory.
+        let bank_snapshots_dir = ledger_path.join(BANK_SNAPSHOTS_DIR);
+        fs::create_dir_all(&bank_snapshots_dir).unwrap();
+        let bank = Bank::new_for_tests(&genesis_config);
+        bank.fill_bank_with_ticks_for_tests();
+        Bank::calculate_and_set_block_id_for_dcou(&bank);
+        let archive_format = SnapshotConfig::default().archive_format;
+        snapshot_bank_utils::bank_to_full_snapshot_archive(
+            &bank_snapshots_dir,
+            &bank,
+            None,
+            ledger_path,
+            ledger_path,
+            archive_format,
+        )
+        .unwrap();
+
+        // Open the blockstore so load_and_process_ledger can pass it to process_blockstore.
+        let blockstore = Arc::new(
+            Blockstore::open_with_options(
+                ledger_path,
+                BlockstoreOptions {
+                    access_type: AccessType::PrimaryForMaintenance,
+                    ..BlockstoreOptions::default()
+                },
+            )
+            .unwrap(),
+        );
+
+        // Setup the arguments such that a new snapshot will be generated from the loaded snapshot
+        let arg_matches = App::new("test")
+            .arg(
+                Arg::with_name("block_verification_method")
+                    .long("block-verification-method")
+                    .takes_value(true)
+                    .default_value("unified-scheduler"),
+            )
+            .arg(
+                Arg::with_name("snapshot_slot")
+                    .long("snapshot-slot")
+                    .takes_value(true),
+            )
+            .get_matches_from(vec!["test", "--snapshot-slot", "0"]);
+        let process_options = ProcessOptions {
+            halt_at_slot: Some(0),
+            ..ProcessOptions::default()
+        };
+
+        let LoadAndProcessLedgerOutput { bank_forks, .. } = load_and_process_ledger(
+            &arg_matches,
+            &genesis_config,
+            blockstore,
+            process_options,
+            None,
+        )
+        .unwrap();
+
+        let root_bank = bank_forks.read().unwrap().root_bank();
+
+        // Verify that latest_full_snapshot_slot is set, which matches the assert in main.rs
+        assert!(
+            root_bank
+                .accounts()
+                .accounts_db
+                .latest_full_snapshot_slot()
+                .is_some()
+        );
     }
 }

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -615,9 +615,7 @@ mod tests {
         agave_snapshots::{paths::BANK_SNAPSHOTS_DIR, snapshot_config::SnapshotConfig},
         clap::{App, Arg},
         solana_ledger::{
-            blockstore::Blockstore,
-            blockstore_options::{AccessType, BlockstoreOptions},
-            blockstore_processor::ProcessOptions,
+            blockstore::Blockstore, blockstore_processor::ProcessOptions,
             genesis_utils::create_genesis_config,
         },
         solana_runtime::{bank::Bank, snapshot_bank_utils},
@@ -652,16 +650,7 @@ mod tests {
         .unwrap();
 
         // Open the blockstore so load_and_process_ledger can pass it to process_blockstore.
-        let blockstore = Arc::new(
-            Blockstore::open_with_options(
-                ledger_path,
-                BlockstoreOptions {
-                    access_type: AccessType::PrimaryForMaintenance,
-                    ..BlockstoreOptions::default()
-                },
-            )
-            .unwrap(),
-        );
+        let blockstore = Arc::new(Blockstore::open(ledger_path).unwrap());
 
         // Setup the arguments such that a new snapshot will be generated from the loaded snapshot
         let arg_matches = App::new("test")

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -1,7 +1,6 @@
 use {
     crate::LEDGER_TOOL_DIRECTORY,
     agave_snapshots::{
-        SnapshotInterval,
         paths::{self as snapshot_paths, BANK_SNAPSHOTS_DIR},
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_hash::StartingSnapshotHashes,
@@ -183,12 +182,10 @@ pub fn load_and_process_ledger(
 
         SnapshotConfig {
             usage,
-            full_snapshot_archive_interval: SnapshotInterval::Disabled,
-            incremental_snapshot_archive_interval: SnapshotInterval::Disabled,
             full_snapshot_archives_dir,
             incremental_snapshot_archives_dir,
             bank_snapshots_dir,
-            ..SnapshotConfig::default()
+            ..SnapshotConfig::new_load_only()
         }
     };
 
@@ -680,16 +677,12 @@ mod tests {
                     .takes_value(true),
             )
             .get_matches_from(vec!["test", "--snapshot-slot", "0"]);
-        let process_options = ProcessOptions {
-            halt_at_slot: Some(0),
-            ..ProcessOptions::default()
-        };
 
         let LoadAndProcessLedgerOutput { bank_forks, .. } = load_and_process_ledger(
             &arg_matches,
             &genesis_config,
             blockstore,
-            process_options,
+            ProcessOptions::default(),
             None,
         )
         .unwrap();


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/issues/11935
When creating a snapshot from the ledger tool, the full snapshot slot is not set. 

#### Summary of Changes
- Set the full snapshot slot on first snapshot configuration
- Added a test to verify the fix
-**Note** that the full path cannot be done in a unit test as it requires running main from the ledger-tool. 

Tested independently by running the solana-test-validator for 120s and waiting for snapshots to be created.

Then:
```
agave-ledger-tool create-snapshot 339 --incremental --ledger test-ledger
```

Output without fix:
```
thread 'main' (869528) panicked at /private/tmp/agave-no-fix/ledger-tool/src/main.rs:2179:25:
assertion failed: bank.accounts().accounts_db.latest_full_snapshot_slot().is_some()
```

Output with fix:
```
datapoint: archive-snapshot-package slot=339i archive_format="TarZstd" duration_ms=1i incremental-snapshot-archive-size=42085i
Shred version: 1506
...
agave_ledger_tool ledger tool took 863ms
```


Fixes #
https://github.com/anza-xyz/agave/issues/11935

Bug is present on 4.0 and 3.1. Needs backporting. 