### PR TITLE
xdp: improve routing

### DIFF
--- a/xdp/src/netlink.rs
+++ b/xdp/src/netlink.rs
@@ -3,7 +3,7 @@
 use {
     libc::{
         AF_INET, AF_INET6, AF_NETLINK, IFLA_INFO_DATA, IFLA_INFO_KIND, IFLA_LINKINFO, MSG_DONTWAIT,
-        NDA_DST, NDA_LLADDR, NETLINK_EXT_ACK, NETLINK_ROUTE, NLA_ALIGNTO, NLA_TYPE_MASK,
+        MSG_TRUNC, NDA_DST, NDA_LLADDR, NETLINK_EXT_ACK, NETLINK_ROUTE, NLA_ALIGNTO, NLA_TYPE_MASK,
         NLM_F_DUMP, NLM_F_MULTI, NLM_F_REQUEST, NLMSG_DONE, NLMSG_ERROR, RTA_DST, RTA_GATEWAY,
         RTA_IIF, RTA_OIF, RTA_PREFSRC, RTA_PRIORITY, RTA_TABLE, RTM_GETLINK, RTM_GETNEIGH,
         RTM_GETROUTE, RTM_NEWLINK, RTM_NEWNEIGH, RTM_NEWROUTE, SO_RCVBUF, SOCK_RAW, SOL_NETLINK,
@@ -105,11 +105,10 @@ impl NetlinkSocket {
     }
 
     fn recv_with_flags(&self, flags: i32) -> Result<Vec<NetlinkMessage>, io::Error> {
-        // The theoretical max size of a single netlink message (including header) is 4GiB.
-        // See: https://elixir.bootlin.com/linux/v6.17.7/source/include/uapi/linux/netlink.h#L46
-        // However, in the kernel, the netlink message size is set to a page size.
-        // If the page size exceeds 8KiB, the netlink message size is capped to 8KiB
-        // See: https://elixir.bootlin.com/linux/v6.17.7/source/include/linux/netlink.h#L267
+        // The kernel returns NLMSG_GOODSIZE (8k) as the recommended max allocation for netlink
+        // responses. However that is not a hard cap, and netlink code can in theory return larger
+        // messages. Out of caution we allocate a larger buffer AND use MSG_TRUNC to detect if that
+        // is still not enough.
         let mut buf = [0u8; 8 * 1024]; // 8 KiB
         let mut messages = Vec::new();
         let mut multipart = true;
@@ -121,7 +120,7 @@ impl NetlinkSocket {
                     self.sock.as_raw_fd(),
                     buf.as_mut_ptr() as *mut _,
                     buf.len(),
-                    flags,
+                    flags | MSG_TRUNC,
                 )
             };
             if len < 0 {
@@ -132,6 +131,9 @@ impl NetlinkSocket {
             }
 
             let len = len as usize;
+            if len > buf.len() {
+                return Err(io::Error::other("netlink datagram truncated"));
+            }
             let mut offset = 0;
             while offset < len {
                 let message = NetlinkMessage::read(&buf[offset..])?;

--- a/xdp/src/netlink.rs
+++ b/xdp/src/netlink.rs
@@ -4,10 +4,11 @@ use {
     libc::{
         AF_INET, AF_INET6, AF_NETLINK, IFLA_INFO_DATA, IFLA_INFO_KIND, IFLA_LINKINFO, MSG_DONTWAIT,
         MSG_TRUNC, NDA_DST, NDA_LLADDR, NETLINK_EXT_ACK, NETLINK_ROUTE, NLA_ALIGNTO, NLA_TYPE_MASK,
-        NLM_F_DUMP, NLM_F_MULTI, NLM_F_REQUEST, NLMSG_DONE, NLMSG_ERROR, RTA_DST, RTA_GATEWAY,
-        RTA_IIF, RTA_OIF, RTA_PREFSRC, RTA_PRIORITY, RTA_TABLE, RTM_GETLINK, RTM_GETNEIGH,
-        RTM_GETROUTE, RTM_NEWLINK, RTM_NEWNEIGH, RTM_NEWROUTE, SO_RCVBUF, SOCK_RAW, SOL_NETLINK,
-        SOL_SOCKET, nlattr, nlmsgerr, nlmsghdr, recv, send, setsockopt, sockaddr_nl, socket,
+        NLM_F_DUMP, NLM_F_DUMP_INTR, NLM_F_MULTI, NLM_F_REQUEST, NLMSG_DONE, NLMSG_ERROR, RTA_DST,
+        RTA_GATEWAY, RTA_IIF, RTA_OIF, RTA_PREFSRC, RTA_PRIORITY, RTA_TABLE, RTM_GETLINK,
+        RTM_GETNEIGH, RTM_GETROUTE, RTM_NEWLINK, RTM_NEWNEIGH, RTM_NEWROUTE, SO_RCVBUF, SOCK_RAW,
+        SOL_NETLINK, SOL_SOCKET, nlattr, nlmsgerr, nlmsghdr, recv, send, setsockopt, sockaddr_nl,
+        socket,
     },
     std::{
         collections::HashMap,
@@ -139,6 +140,12 @@ impl NetlinkSocket {
                 let message = NetlinkMessage::read(&buf[offset..])?;
                 offset += align_to(message.header.nlmsg_len as usize, NLMSG_ALIGNTO as usize);
                 multipart = message.header.nlmsg_flags & NLM_F_MULTI as u16 != 0;
+                if message.header.nlmsg_flags & NLM_F_DUMP_INTR as u16 != 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Interrupted,
+                        "netlink dump interrupted",
+                    ));
+                }
                 match message.header.nlmsg_type as i32 {
                     NLMSG_ERROR => {
                         let err = message.error.unwrap();

--- a/xdp/src/netlink.rs
+++ b/xdp/src/netlink.rs
@@ -2,12 +2,12 @@
 
 use {
     libc::{
-        AF_INET, AF_INET6, AF_NETLINK, IFLA_INFO_DATA, IFLA_INFO_KIND, IFLA_LINKINFO, NDA_DST,
-        NDA_LLADDR, NETLINK_EXT_ACK, NETLINK_ROUTE, NLA_ALIGNTO, NLA_TYPE_MASK, NLM_F_DUMP,
-        NLM_F_MULTI, NLM_F_REQUEST, NLMSG_DONE, NLMSG_ERROR, RTA_DST, RTA_GATEWAY, RTA_IIF,
-        RTA_OIF, RTA_PREFSRC, RTA_PRIORITY, RTA_TABLE, RTM_GETLINK, RTM_GETNEIGH, RTM_GETROUTE,
-        RTM_NEWLINK, RTM_NEWNEIGH, RTM_NEWROUTE, SO_RCVBUF, SOCK_RAW, SOL_NETLINK, SOL_SOCKET,
-        nlattr, nlmsgerr, nlmsghdr, recv, send, setsockopt, sockaddr_nl, socket,
+        AF_INET, AF_INET6, AF_NETLINK, IFLA_INFO_DATA, IFLA_INFO_KIND, IFLA_LINKINFO, MSG_DONTWAIT,
+        NDA_DST, NDA_LLADDR, NETLINK_EXT_ACK, NETLINK_ROUTE, NLA_ALIGNTO, NLA_TYPE_MASK,
+        NLM_F_DUMP, NLM_F_MULTI, NLM_F_REQUEST, NLMSG_DONE, NLMSG_ERROR, RTA_DST, RTA_GATEWAY,
+        RTA_IIF, RTA_OIF, RTA_PREFSRC, RTA_PRIORITY, RTA_TABLE, RTM_GETLINK, RTM_GETNEIGH,
+        RTM_GETROUTE, RTM_NEWLINK, RTM_NEWNEIGH, RTM_NEWROUTE, SO_RCVBUF, SOCK_RAW, SOL_NETLINK,
+        SOL_SOCKET, nlattr, nlmsgerr, nlmsghdr, recv, send, setsockopt, sockaddr_nl, socket,
     },
     std::{
         collections::HashMap,
@@ -88,6 +88,23 @@ impl NetlinkSocket {
     }
 
     pub(crate) fn recv(&self) -> Result<Vec<NetlinkMessage>, io::Error> {
+        self.recv_with_flags(0)
+    }
+
+    pub(crate) fn recv_nonblocking(&self) -> Result<Option<Vec<NetlinkMessage>>, io::Error> {
+        match self.recv_with_flags(MSG_DONTWAIT) {
+            Ok(messages) => Ok(Some(messages)),
+            Err(e)
+                if e.raw_os_error()
+                    .is_some_and(|errno| errno == libc::EAGAIN || errno == libc::EWOULDBLOCK) =>
+            {
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn recv_with_flags(&self, flags: i32) -> Result<Vec<NetlinkMessage>, io::Error> {
         // The theoretical max size of a single netlink message (including header) is 4GiB.
         // See: https://elixir.bootlin.com/linux/v6.17.7/source/include/uapi/linux/netlink.h#L46
         // However, in the kernel, the netlink message size is set to a page size.
@@ -104,7 +121,7 @@ impl NetlinkSocket {
                     self.sock.as_raw_fd(),
                     buf.as_mut_ptr() as *mut _,
                     buf.len(),
-                    0,
+                    flags,
                 )
             };
             if len < 0 {

--- a/xdp/src/netlink.rs
+++ b/xdp/src/netlink.rs
@@ -3,12 +3,12 @@
 use {
     libc::{
         AF_INET, AF_INET6, AF_NETLINK, IFLA_INFO_DATA, IFLA_INFO_KIND, IFLA_LINKINFO, MSG_DONTWAIT,
-        MSG_TRUNC, NDA_DST, NDA_LLADDR, NETLINK_EXT_ACK, NETLINK_ROUTE, NLA_ALIGNTO, NLA_TYPE_MASK,
-        NLM_F_DUMP, NLM_F_DUMP_INTR, NLM_F_MULTI, NLM_F_REQUEST, NLMSG_DONE, NLMSG_ERROR, RTA_DST,
-        RTA_GATEWAY, RTA_IIF, RTA_OIF, RTA_PREFSRC, RTA_PRIORITY, RTA_TABLE, RTM_GETLINK,
-        RTM_GETNEIGH, RTM_GETROUTE, RTM_NEWLINK, RTM_NEWNEIGH, RTM_NEWROUTE, SO_RCVBUF, SOCK_RAW,
-        SOL_NETLINK, SOL_SOCKET, nlattr, nlmsgerr, nlmsghdr, recv, send, setsockopt, sockaddr_nl,
-        socket,
+        MSG_TRUNC, NDA_DST, NDA_LLADDR, NETLINK_EXT_ACK, NETLINK_GET_STRICT_CHK, NETLINK_ROUTE,
+        NLA_ALIGNTO, NLA_TYPE_MASK, NLM_F_DUMP, NLM_F_DUMP_INTR, NLM_F_MULTI, NLM_F_REQUEST,
+        NLMSG_DONE, NLMSG_ERROR, RTA_DST, RTA_GATEWAY, RTA_IIF, RTA_OIF, RTA_PREFSRC, RTA_PRIORITY,
+        RTA_TABLE, RTM_GETLINK, RTM_GETNEIGH, RTM_GETROUTE, RTM_NEWLINK, RTM_NEWNEIGH,
+        RTM_NEWROUTE, SO_RCVBUF, SOCK_RAW, SOL_NETLINK, SOL_SOCKET, nlattr, nlmsgerr, nlmsghdr,
+        recv, send, setsockopt, sockaddr_nl, socket,
     },
     std::{
         collections::HashMap,
@@ -57,18 +57,20 @@ impl NetlinkSocket {
         let sock = unsafe { OwnedFd::from_raw_fd(sock) };
 
         let enable = 1i32;
-        // Safety: libc wrapper
-        if unsafe {
-            setsockopt(
-                sock.as_raw_fd(),
-                SOL_NETLINK,
-                NETLINK_EXT_ACK,
-                &enable as *const _ as *const _,
-                mem::size_of::<i32>() as u32,
-            )
-        } < 0
-        {
-            return Err(io::Error::last_os_error());
+        for opt in [NETLINK_EXT_ACK, NETLINK_GET_STRICT_CHK] {
+            // Safety: libc wrapper
+            if unsafe {
+                setsockopt(
+                    sock.as_raw_fd(),
+                    SOL_NETLINK,
+                    opt,
+                    &enable as *const _ as *const _,
+                    mem::size_of::<i32>() as u32,
+                )
+            } < 0
+            {
+                return Err(io::Error::last_os_error());
+            }
         }
         Ok(Self { sock, _nl_pid: 0 })
     }
@@ -694,15 +696,9 @@ pub fn netlink_get_routes(family: u8, table: u32) -> Result<Vec<RouteEntry>, io:
         if msg.header.nlmsg_type != RTM_NEWROUTE {
             continue;
         }
-
-        if msg.data.len() < mem::size_of::<rtmsg>() {
-            continue;
-        }
-
         if let Some(route) = parse_rtm_newroute(&msg) {
-            // for compatibility reasons, it turns out the kernel ignores the rtm_table filter in
-            // the request unless NETLINK_GET_STRICT_CHK is set. Filter manually for now until we
-            // add support for strict checking and do enough testing.
+            // with strict checking, the kernel should return routes for the requested table only
+            debug_assert!(route.table == Some(table));
             if route.table == Some(table) {
                 routes.push(route);
             }
@@ -716,6 +712,7 @@ pub fn parse_rtm_newroute(msg: &NetlinkMessage) -> Option<RouteEntry> {
     if msg.data.len() < mem::size_of::<rtmsg>() {
         return None;
     }
+
     let rt_msg = unsafe { ptr::read_unaligned(msg.data.as_ptr() as *const rtmsg) };
     let Ok(attrs) = parse_attrs(&msg.data[mem::size_of::<rtmsg>()..]) else {
         return None;

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -10,7 +10,7 @@ use {
     log::warn,
     std::{
         cmp::Ordering,
-        io,
+        fmt, io,
         net::{IpAddr, Ipv4Addr},
     },
     thiserror::Error,
@@ -53,6 +53,17 @@ pub enum RouteTable {
     Local,
     Main,
     Other(u32),
+}
+
+impl std::fmt::Display for RouteTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Default => f.write_str("default"),
+            Self::Local => f.write_str("local"),
+            Self::Main => f.write_str("main"),
+            Self::Other(table) => write!(f, "{table}"),
+        }
+    }
 }
 
 impl From<RouteTable> for u32 {
@@ -394,6 +405,25 @@ pub struct Router {
     cached_gre_info: Vec<GreRouteInfo>,
 }
 
+struct RoutingTableDisplay<'a>(&'a [Route<Ipv4Addr>]);
+
+impl fmt::Display for RoutingTableDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0.is_empty() {
+            return f.write_str("<empty>");
+        }
+
+        for (i, route) in self.0.iter().enumerate() {
+            if i > 0 {
+                f.write_str("\n")?;
+            }
+            format_route(f, route)?;
+        }
+
+        Ok(())
+    }
+}
+
 impl Router {
     pub fn new() -> Result<Self, io::Error> {
         Self::from_tables(RoutingTables::from_netlink(RouteTable::Main)?)
@@ -430,6 +460,10 @@ impl Router {
         };
 
         Ok(router)
+    }
+
+    pub fn routing_table(&self) -> impl fmt::Display + '_ {
+        RoutingTableDisplay(self.routes.as_slice())
     }
 
     fn cached_gre_route_info(&self, if_index: u32) -> Option<&GreRouteInfo> {
@@ -564,6 +598,29 @@ impl Router {
             mac_addr,
         })
     }
+}
+
+fn format_route(f: &mut fmt::Formatter<'_>, route: &Route<Ipv4Addr>) -> fmt::Result {
+    match route.destination {
+        Some(destination) if route.dst_len == 32 => write!(f, "{destination}")?,
+        Some(destination) => write!(f, "{destination}/{}", route.dst_len)?,
+        None => f.write_str("default")?,
+    }
+
+    if let Some(gateway) = route.gateway {
+        write!(f, " via {gateway}")?;
+    }
+    if let Some(if_index) = route.out_if_index {
+        write!(f, " dev if{if_index}")?;
+    }
+    if let Some(preferred_src) = route.preferred_src {
+        write!(f, " src {preferred_src}")?;
+    }
+    if let Some(priority) = route.priority {
+        write!(f, " metric {priority}")?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -731,6 +788,40 @@ mod tests {
                 .all(|r| r.destination != Some(test_dst))
         );
         assert_eq!(tables.routes.iter().len(), before_routes_len);
+    }
+
+    #[test]
+    fn test_routing_table_display() {
+        let router = router_from_tables(
+            vec![],
+            vec![
+                Route {
+                    destination: Some(Ipv4Addr::new(10, 0, 0, 0)),
+                    gateway: Some(Ipv4Addr::new(192, 168, 1, 1)),
+                    preferred_src: Some(Ipv4Addr::new(192, 168, 1, 10)),
+                    out_if_index: Some(2),
+                    priority: Some(100),
+                    type_: 0,
+                    dst_len: 24,
+                },
+                Route {
+                    destination: None,
+                    gateway: Some(Ipv4Addr::new(192, 168, 1, 254)),
+                    preferred_src: None,
+                    out_if_index: Some(3),
+                    priority: None,
+                    type_: 0,
+                    dst_len: 0,
+                },
+            ],
+            vec![],
+        );
+
+        assert_eq!(
+            router.routing_table().to_string(),
+            "10.0.0.0/24 via 192.168.1.1 dev if2 src 192.168.1.10 metric 100\ndefault via \
+             192.168.1.254 dev if3"
+        );
     }
 
     #[test]

--- a/xdp/src/route_monitor.rs
+++ b/xdp/src/route_monitor.rs
@@ -173,8 +173,22 @@ impl RouteMonitorState {
     /// Resets the route monitor state by creating a new router and reinitializing
     /// the netlink socket. Used when errors occur to recover to a clean state
     fn reset(&mut self, atomic_router: &Arc<ArcSwap<Router>>) {
-        let tables = RoutingTables::from_netlink(self.tables.routes.table)
-            .expect("error creating RoutingTables");
+        let mut retries = 0;
+        let tables = loop {
+            if retries == 3 {
+                panic!("failed to build routing table after 3 attempts");
+            }
+
+            match RoutingTables::from_netlink(self.tables.routes.table) {
+                Ok(tables) => break tables,
+                Err(e) if e.kind() == ErrorKind::Interrupted => {
+                    warn!("interrupted while building routing table, retrying");
+                    thread::sleep(Duration::from_secs(1));
+                    retries += 1;
+                }
+                Err(e) => panic!("error creating RoutingTables: {e}"),
+            }
+        };
         let router = Router::from_tables(tables.clone()).expect("error creating Router");
         atomic_router.store(Arc::new(router));
         *self = Self::new(tables);

--- a/xdp/src/route_monitor.rs
+++ b/xdp/src/route_monitor.rs
@@ -1,10 +1,7 @@
 use {
     crate::{
-        netlink::{
-            NetlinkMessage, NetlinkSocket, parse_rtm_ifinfomsg, parse_rtm_newneigh,
-            parse_rtm_newroute,
-        },
-        route::{Router, RoutingTables},
+        netlink::{NetlinkMessage, NetlinkSocket, parse_rtm_newneigh, parse_rtm_newroute},
+        route::{RouteTable, Router, RoutingTables},
     },
     arc_swap::ArcSwap,
     libc::{
@@ -33,7 +30,7 @@ impl RouteMonitor {
     /// Publishes the updated routing table every `update_interval` if needed
     pub fn start<F: FnOnce() + Send + Sync + 'static>(
         atomic_router: Arc<ArcSwap<Router>>,
-        tables: RoutingTables,
+        route_table: RouteTable,
         exit: Arc<AtomicBool>,
         update_interval: Duration,
         on_thread_start: F,
@@ -44,7 +41,7 @@ impl RouteMonitor {
                 // MUST remain first to run here
                 on_thread_start();
 
-                let mut state = RouteMonitorState::new(tables);
+                let mut state = RouteMonitorState::new(route_table);
 
                 let timeout = Duration::from_millis(10);
                 while !exit.load(Ordering::Relaxed) {
@@ -70,6 +67,7 @@ impl RouteMonitor {
                     debug_assert!(ev & POLLNVAL == 0);
 
                     if (ev & (POLLHUP | POLLERR)) != 0 {
+                        // we get POLLERR if the socket overflows
                         error!(
                             "netlink poll error (revents={}{})",
                             if ev & POLLERR != 0 { "POLLERR " } else { "" },
@@ -89,11 +87,12 @@ impl RouteMonitor {
                                     warn!("netlink recv returned empty message list");
                                     continue;
                                 }
-                                state.dirty |=
-                                    Self::process_netlink_updates(&mut state.tables, &msgs);
+                                state.update(&msgs);
                             }
                             Ok(None) => break,
                             Err(e) => {
+                                // we get here if recv() catches ENOBUFS or if the returned buffer
+                                // exceeds NLMSG_GOODSIZE
                                 error!("netlink recv error: {e}");
                                 state.reset(&atomic_router);
                                 break;
@@ -104,94 +103,65 @@ impl RouteMonitor {
             })
             .unwrap()
     }
-
-    #[inline]
-    fn process_netlink_updates(tables: &mut RoutingTables, msgs: &[NetlinkMessage]) -> bool {
-        let mut dirty = false;
-        for m in msgs {
-            match m.header.nlmsg_type {
-                RTM_NEWROUTE => {
-                    if let Some(r) = parse_rtm_newroute(m) {
-                        dirty |= tables.upsert_route(r);
-                    }
-                }
-                RTM_DELROUTE => {
-                    if let Some(r) = parse_rtm_newroute(m) {
-                        dirty |= tables.remove_route(r);
-                    }
-                }
-                RTM_NEWNEIGH => {
-                    if let Some(n) = parse_rtm_newneigh(m, None) {
-                        if let Some(IpAddr::V4(_)) = n.destination {
-                            dirty |= tables.upsert_neighbor(n);
-                        }
-                    }
-                }
-                RTM_DELNEIGH => {
-                    if let Some(n) = parse_rtm_newneigh(m, None) {
-                        if let Some(IpAddr::V4(ip)) = n.destination {
-                            dirty |= tables.remove_neighbor(ip, n.ifindex as u32);
-                        }
-                    }
-                }
-                RTM_NEWLINK => {
-                    if let Some(interface_info) = parse_rtm_ifinfomsg(m) {
-                        dirty |= tables.upsert_interface(interface_info);
-                    }
-                }
-                RTM_DELLINK => {
-                    if let Some(interface_info) = parse_rtm_ifinfomsg(m) {
-                        dirty |= tables.remove_interface(interface_info.if_index);
-                    }
-                }
-                _ => {}
-            }
-        }
-        dirty
-    }
 }
 
 struct RouteMonitorState {
     sock: NetlinkSocket,
-    tables: RoutingTables,
+    route_table: RouteTable,
     dirty: bool,
     last_publish: Instant,
 }
 
 impl RouteMonitorState {
     /// Creates a new RouteMonitorState with a bounded netlink socket
-    fn new(tables: RoutingTables) -> Self {
+    fn new(route_table: RouteTable) -> Self {
         Self {
-            sock: NetlinkSocket::bind((RTMGRP_IPV4_ROUTE | RTMGRP_NEIGH | RTMGRP_LINK) as u32)
-                .expect("error creating netlink socket"),
-            tables,
+            sock: bind_socket(),
+            route_table,
             dirty: false,
             last_publish: Instant::now(),
         }
     }
 
-    /// Resets the route monitor state by creating a new router and reinitializing
-    /// the netlink socket. Used when errors occur to recover to a clean state
-    fn reset(&mut self, atomic_router: &Arc<ArcSwap<Router>>) {
-        let mut retries = 0;
-        let tables = loop {
-            if retries == 3 {
-                panic!("failed to build routing table after 3 attempts");
-            }
+    #[inline]
+    fn update(&mut self, msgs: &[NetlinkMessage]) {
+        self.dirty |= msgs.iter().any(|message| match message.header.nlmsg_type {
+            RTM_NEWROUTE | RTM_DELROUTE => parse_rtm_newroute(message)
+                .and_then(|route| route.table)
+                .is_some_and(|table| self.route_table == table.into()),
+            RTM_NEWNEIGH | RTM_DELNEIGH => parse_rtm_newneigh(message, None)
+                .is_some_and(|neighbor| matches!(neighbor.destination, Some(IpAddr::V4(_)))),
+            RTM_NEWLINK | RTM_DELLINK => true,
+            _ => false,
+        });
+    }
 
-            match RoutingTables::from_netlink(self.tables.routes.table) {
-                Ok(tables) => break tables,
-                Err(e) if e.kind() == ErrorKind::Interrupted => {
-                    warn!("interrupted while building routing table, retrying");
-                    thread::sleep(Duration::from_secs(1));
-                    retries += 1;
-                }
-                Err(e) => panic!("error creating RoutingTables: {e}"),
+    /// Resets the route monitor state by creating a new router and reinitializing
+    /// the netlink socket.
+    fn reset(&mut self, atomic_router: &Arc<ArcSwap<Router>>) {
+        // the most likely (albeit uncommon) way to get here is a huge burst of incoming
+        // notifications that causes the netlink socket to overflow. When that happens poll/recv
+        // return POLLERR/ENOBUFS, we detect that and recover by reloading the socket and the
+        // entire routing state.
+        self.sock = bind_socket();
+        let router = match rebuild_router(self.route_table) {
+            Ok(router) => router,
+            Err(e) => {
+                // If we fail to rebuild the router (unlikely but possible if route updates keep
+                // coming for more than 3s - see rebuild_router()), we don't reset
+                // self.pending_events so that we attempt to rebuild again on the next publish
+                // interval.
+                //
+                // We don't update self.last_publish as rebuild_router() will sleep between retries
+                // so there's no risk of getting in a tight retry/publish loop.
+                self.dirty = true;
+                warn!("failed to rebuild router from netlink during reset: {e}");
+                return;
             }
         };
-        let router = Router::from_tables(tables.clone()).expect("error creating Router");
         atomic_router.store(Arc::new(router));
-        *self = Self::new(tables);
+        self.dirty = false;
+        self.last_publish = Instant::now();
     }
 
     /// Publishes the updated router if there are new route/neighbor updates
@@ -202,12 +172,42 @@ impl RouteMonitorState {
         update_interval: Duration,
     ) {
         if self.dirty && self.last_publish.elapsed() >= update_interval {
-            match Router::from_tables(self.tables.clone()) {
-                Ok(router) => atomic_router.store(Arc::new(router)),
-                Err(e) => log::warn!("failed to build router before publish: {e:?}"),
+            match rebuild_router(self.route_table) {
+                Ok(router) => {
+                    atomic_router.store(Arc::new(router));
+                    self.dirty = false;
+                }
+                Err(e) => warn!("failed to rebuild router from netlink: {e}"),
             }
             self.last_publish = Instant::now();
-            self.dirty = false;
+        }
+    }
+}
+
+fn bind_socket() -> NetlinkSocket {
+    NetlinkSocket::bind((RTMGRP_IPV4_ROUTE | RTMGRP_NEIGH | RTMGRP_LINK) as u32)
+        // this should never fail unless there's a configuration bug (eg no perms)
+        .expect("failed to bind netlink socket")
+}
+
+fn rebuild_router(route_table: RouteTable) -> Result<Router, Error> {
+    let mut retries = 0u8;
+    loop {
+        if retries == 10 {
+            return Err(Error::new(
+                ErrorKind::Interrupted,
+                "failed to build routing table after 10 attempts",
+            ));
+        }
+
+        match RoutingTables::from_netlink(route_table) {
+            Ok(tables) => return Router::from_tables(tables),
+            Err(e) if e.kind() == ErrorKind::Interrupted => {
+                warn!("interrupted while building routing table, retrying");
+                thread::sleep(Duration::from_secs(1));
+                retries = retries.saturating_add(1);
+            }
+            Err(e) => return Err(e),
         }
     }
 }

--- a/xdp/src/route_monitor.rs
+++ b/xdp/src/route_monitor.rs
@@ -81,15 +81,23 @@ impl RouteMonitor {
                     if (ev & POLLIN) == 0 {
                         continue;
                     }
-                    // Drain channel
-                    match state.sock.recv() {
-                        Ok(msgs) => {
-                            state.dirty |= Self::process_netlink_updates(&mut state.tables, &msgs);
-                        }
-                        Err(e) => {
-                            error!("netlink recv error: {e}");
-                            state.reset(&atomic_router);
-                            continue;
+                    // drain the socket
+                    loop {
+                        match state.sock.recv_nonblocking() {
+                            Ok(Some(msgs)) => {
+                                if msgs.is_empty() {
+                                    warn!("netlink recv returned empty message list");
+                                    continue;
+                                }
+                                state.dirty |=
+                                    Self::process_netlink_updates(&mut state.tables, &msgs);
+                            }
+                            Ok(None) => break,
+                            Err(e) => {
+                                error!("netlink recv error: {e}");
+                                state.reset(&atomic_router);
+                                break;
+                            }
                         }
                     }
                 }

--- a/xdp/src/route_monitor.rs
+++ b/xdp/src/route_monitor.rs
@@ -108,8 +108,22 @@ impl RouteMonitor {
 struct RouteMonitorState {
     sock: NetlinkSocket,
     route_table: RouteTable,
-    dirty: bool,
+    pending_events: PendingEvents,
     last_publish: Instant,
+}
+
+#[derive(Default)]
+struct PendingEvents {
+    routes: usize,
+    neighbors: usize,
+    links: usize,
+    errors: usize,
+}
+
+impl PendingEvents {
+    fn is_empty(&self) -> bool {
+        self.routes == 0 && self.neighbors == 0 && self.links == 0 && self.errors == 0
+    }
 }
 
 impl RouteMonitorState {
@@ -118,22 +132,65 @@ impl RouteMonitorState {
         Self {
             sock: bind_socket(),
             route_table,
-            dirty: false,
+            pending_events: PendingEvents::default(),
             last_publish: Instant::now(),
         }
     }
 
     #[inline]
     fn update(&mut self, msgs: &[NetlinkMessage]) {
-        self.dirty |= msgs.iter().any(|message| match message.header.nlmsg_type {
-            RTM_NEWROUTE | RTM_DELROUTE => parse_rtm_newroute(message)
-                .and_then(|route| route.table)
-                .is_some_and(|table| self.route_table == table.into()),
-            RTM_NEWNEIGH | RTM_DELNEIGH => parse_rtm_newneigh(message, None)
-                .is_some_and(|neighbor| matches!(neighbor.destination, Some(IpAddr::V4(_)))),
-            RTM_NEWLINK | RTM_DELLINK => true,
-            _ => false,
-        });
+        for message in msgs {
+            match message.header.nlmsg_type {
+                RTM_NEWROUTE | RTM_DELROUTE => {
+                    let Some(route) = parse_rtm_newroute(message) else {
+                        continue;
+                    };
+                    if !route
+                        .table
+                        .is_some_and(|table| self.route_table == table.into())
+                    {
+                        continue;
+                    }
+                    self.pending_events.routes = self.pending_events.routes.saturating_add(1);
+                    debug!(
+                        "route monitor update {} table {} dst={:?}/{} gateway={:?} oif={:?} \
+                         priority={:?}",
+                        nlmsg_type_name(message.header.nlmsg_type),
+                        self.route_table,
+                        route.destination,
+                        route.dst_len,
+                        route.gateway,
+                        route.out_if_index,
+                        route.priority,
+                    );
+                }
+                RTM_NEWNEIGH | RTM_DELNEIGH => {
+                    let Some(neighbor) = parse_rtm_newneigh(message, None) else {
+                        continue;
+                    };
+                    if !matches!(neighbor.destination, Some(IpAddr::V4(_))) {
+                        continue;
+                    }
+                    self.pending_events.neighbors = self.pending_events.neighbors.saturating_add(1);
+                    debug!(
+                        "route monitor update {} neighbor={:?} ifindex={} state={} lladdr={:?}",
+                        nlmsg_type_name(message.header.nlmsg_type),
+                        neighbor.destination,
+                        neighbor.ifindex,
+                        neighbor.state,
+                        neighbor.lladdr,
+                    );
+                }
+                RTM_NEWLINK | RTM_DELLINK => {
+                    self.pending_events.links = self.pending_events.links.saturating_add(1);
+                    debug!(
+                        "route monitor update {}",
+                        nlmsg_type_name(message.header.nlmsg_type)
+                    );
+                }
+                _ => {}
+            }
+        }
     }
 
     /// Resets the route monitor state by creating a new router and reinitializing
@@ -144,6 +201,8 @@ impl RouteMonitorState {
         // return POLLERR/ENOBUFS, we detect that and recover by reloading the socket and the
         // entire routing state.
         self.sock = bind_socket();
+        self.pending_events.errors = self.pending_events.errors.saturating_add(1);
+        log_router_rebuild(self.route_table, &self.pending_events);
         let router = match rebuild_router(self.route_table) {
             Ok(router) => router,
             Err(e) => {
@@ -154,14 +213,13 @@ impl RouteMonitorState {
                 //
                 // We don't update self.last_publish as rebuild_router() will sleep between retries
                 // so there's no risk of getting in a tight retry/publish loop.
-                self.dirty = true;
                 warn!("failed to rebuild router from netlink during reset: {e}");
                 return;
             }
         };
         log_router_publish(self.route_table, &router);
         atomic_router.store(Arc::new(router));
-        self.dirty = false;
+        self.pending_events = PendingEvents::default();
         self.last_publish = Instant::now();
     }
 
@@ -172,12 +230,13 @@ impl RouteMonitorState {
         atomic_router: &Arc<ArcSwap<Router>>,
         update_interval: Duration,
     ) {
-        if self.dirty && self.last_publish.elapsed() >= update_interval {
+        if !self.pending_events.is_empty() && self.last_publish.elapsed() >= update_interval {
+            log_router_rebuild(self.route_table, &self.pending_events);
             match rebuild_router(self.route_table) {
                 Ok(router) => {
                     log_router_publish(self.route_table, &router);
                     atomic_router.store(Arc::new(router));
-                    self.dirty = false;
+                    self.pending_events = PendingEvents::default();
                 }
                 Err(e) => warn!("failed to rebuild router from netlink: {e}"),
             }
@@ -191,6 +250,29 @@ fn log_router_publish(route_table: RouteTable, router: &Router) {
         "published router table {route_table}:\n{}",
         router.routing_table()
     );
+}
+
+fn log_router_rebuild(route_table: RouteTable, pending_rebuild: &PendingEvents) {
+    info!(
+        "rebuilding router table {route_table}: route_events={} neighbor_events={} link_events={} \
+         error_events={}",
+        pending_rebuild.routes,
+        pending_rebuild.neighbors,
+        pending_rebuild.links,
+        pending_rebuild.errors,
+    );
+}
+
+fn nlmsg_type_name(nlmsg_type: u16) -> &'static str {
+    match nlmsg_type {
+        RTM_NEWROUTE => "RTM_NEWROUTE",
+        RTM_DELROUTE => "RTM_DELROUTE",
+        RTM_NEWNEIGH => "RTM_NEWNEIGH",
+        RTM_DELNEIGH => "RTM_DELNEIGH",
+        RTM_NEWLINK => "RTM_NEWLINK",
+        RTM_DELLINK => "RTM_DELLINK",
+        _ => "RTM_UNKNOWN",
+    }
 }
 
 fn bind_socket() -> NetlinkSocket {

--- a/xdp/src/route_monitor.rs
+++ b/xdp/src/route_monitor.rs
@@ -159,6 +159,7 @@ impl RouteMonitorState {
                 return;
             }
         };
+        log_router_publish(self.route_table, &router);
         atomic_router.store(Arc::new(router));
         self.dirty = false;
         self.last_publish = Instant::now();
@@ -174,6 +175,7 @@ impl RouteMonitorState {
         if self.dirty && self.last_publish.elapsed() >= update_interval {
             match rebuild_router(self.route_table) {
                 Ok(router) => {
+                    log_router_publish(self.route_table, &router);
                     atomic_router.store(Arc::new(router));
                     self.dirty = false;
                 }
@@ -182,6 +184,13 @@ impl RouteMonitorState {
             self.last_publish = Instant::now();
         }
     }
+}
+
+fn log_router_publish(route_table: RouteTable, router: &Router) {
+    debug!(
+        "published router table {route_table}:\n{}",
+        router.routing_table()
+    );
 }
 
 fn bind_socket() -> NetlinkSocket {

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -275,13 +275,13 @@ impl TransmitterBuilder {
         caps::drop(None, CapSet::Effective, CAP_NET_ADMIN).expect("drop CAP_NET_ADMIN capability");
 
         let tables = tables_result?;
-        let router = Router::from_tables(tables.clone())?;
+        let router = Router::from_tables(tables)?;
 
         // Use ArcSwap for lock-free updates of the routing table
         let atomic_router = Arc::new(ArcSwap::from_pointee(router));
         let route_monitor_handle = RouteMonitor::start(
             Arc::clone(&atomic_router),
-            tables,
+            RouteTable::Main,
             exit.clone(),
             ROUTE_MONITOR_UPDATE_INTERVAL,
             || {

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -196,6 +196,7 @@ impl TransmitterBuilder {
                 CapSet,
                 Capability::{CAP_BPF, CAP_NET_ADMIN, CAP_NET_RAW, CAP_PERFMON},
             },
+            log::debug,
             std::collections::HashSet,
         };
         let XdpConfig {
@@ -276,6 +277,11 @@ impl TransmitterBuilder {
 
         let tables = tables_result?;
         let router = Router::from_tables(tables)?;
+        debug!(
+            "published router table {}:\n{}",
+            RouteTable::Main,
+            router.routing_table()
+        );
 
         // Use ArcSwap for lock-free updates of the routing table
         let atomic_router = Arc::new(ArcSwap::from_pointee(router));


### PR DESCRIPTION
This fixes a few issues with routing:

- we weren't properly reading _all_ the queued messages when we detected that the netlink socket was readable
- we now pass MSG_TRUNC to netlink recvs so we can detect when a message is truncated
- we now handle NLM_F_DUMP_INTR in response to dump requests. The flag is set if routing state changes while we're requesting it, and is used to notify us that what we've read so far is stale and needs to be discarded 
- since netlink is lossy, instead of trying to keep our internal state in sync with the kernel state by tracking individual inserts/removes/updates, we now treat every change as a signal that our internal state is stale, and re-fetch the whole state from the kernel
- we now set NETLINK_GET_STRICT_CHK so that when we do fetch the state, we don't fetch a bunch of useless kernel-internal state we have no use for
- we now log when and why we rebuild

Not a small PR but all the changes are nice and split in self contained commits. 