### PR TITLE
security-policy: exclude loader v4

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -177,6 +177,9 @@ Alpenglow logic from a feature fork to agave master is currently underway. As
 such there are many partially migrated changes isolated to a few areas. These
 are disqualified from reports and bounties. Bugs in integration logic that impact
 the no-Alpenglow code path remain in scope
+* Loader V4 (the `loader-v4` crate and associated code paths). Loader V4 is
+being removed from the codebase and its feature ID has been stubbed out. Bugs
+relating to Loader V4 functionality are disqualified from reports and bounties.
 
 ### Eligibility:
 * Submissions _MUST_ include an exploit proof-of-concept to be considered eligible


### PR DESCRIPTION
#### Problem
Loader V4 is almost removed. It was stubbed out a while back. It should be clear it's not eligible for bug bounties.

#### Summary of Changes
Add Loader V4 to the "Out of Scope" section.