### PR TITLE
Assign version bump PR to the caller of the workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -67,10 +67,17 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.rest.pulls.create({
+            const pr = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `Bump version to ${process.env.NEW_VERSION}`,
               head: `version-bump-${process.env.NEW_VERSION}`,
               base: process.env.TARGET_BRANCH
+            })
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.data.number,
+              assignees: [context.actor],
             })


### PR DESCRIPTION
#### Problem

Our procedures usually expect that the person who starts the new release and bumps the version during it also reviews the version bump PR. That person does not have to be in the list of required approvers however and therefore not automatically notified about this PR, so they have to actively monitor the workflow and fish the PR from the output or from the list of pull requests in the repository.

#### Summary of Changes

Automatically assign the version bump PR to the Github account that dispatched the workflow. Github will notify this account then that they are assigned to this PR.