### PR TITLE
Upstreaming pending_safe_to_notar

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -16,7 +16,7 @@ use {
         generated_cert_types::GeneratedCertTypes,
     },
     agave_votor_messages::{
-        consensus_message::{Certificate, CertificateType, ConsensusMessage, VoteMessage},
+        consensus_message::{Block, Certificate, CertificateType, ConsensusMessage, VoteMessage},
         fraction::Fraction,
         migration::MigrationStatus,
         vote::{Vote, VoteType},
@@ -124,6 +124,11 @@ pub(crate) struct ConsensusPool {
     slot_stake_counters_map: BTreeMap<Slot, SlotStakeCounters>,
     /// Stores details about the genesis vote during the migration
     migration_status: Option<Arc<MigrationStatus>>,
+    /// Pending safe-to-notar blocks for intrawindow slots that need parent verification.
+    /// These are blocks that have reached the safe-to-notar threshold but are not the
+    /// first block in their leader window. They need to be verified that their parent
+    /// has a NotarizeFallback certificate before the SafeToNotar event can be emitted.
+    pending_safe_to_notar: Vec<Block>,
     /// The slot at which the state was last pruned.
     last_pruned_slot: Slot,
 }
@@ -160,6 +165,7 @@ impl ConsensusPool {
             slot_stake_counters_map: BTreeMap::new(),
             migration_status: None,
             generated_cert_types,
+            pending_safe_to_notar: vec![],
             last_pruned_slot: 0,
         }
     }
@@ -468,6 +474,7 @@ impl ConsensusPool {
                     entry_stake,
                     my_vote_pubkey == &validator_vote_key,
                     events,
+                    &mut self.pending_safe_to_notar,
                     &mut self.stats,
                 );
             }
@@ -573,6 +580,31 @@ impl ConsensusPool {
             .contains_key(&CertificateType::Skip(slot))
     }
 
+    /// Checks if a specific block has a NotarizeFallback certificate (or stronger).
+    /// This is used for verifying that an intrawindow block's parent has been certified.
+    pub(crate) fn block_has_notar_fallback_or_stronger(&self, block: Block) -> bool {
+        let (slot, block_id) = block;
+        self.completed_certificates
+            .contains_key(&CertificateType::NotarizeFallback(slot, block_id))
+            || self
+                .completed_certificates
+                .contains_key(&CertificateType::Notarize(slot, block_id))
+            || self
+                .completed_certificates
+                .contains_key(&CertificateType::FinalizeFast(slot, block_id))
+    }
+
+    /// Takes the pending safe-to-notar blocks that need parent verification.
+    /// The caller is responsible for processing these blocks.
+    pub(crate) fn take_pending_safe_to_notar(&mut self) -> Vec<Block> {
+        std::mem::take(&mut self.pending_safe_to_notar)
+    }
+
+    /// Used by consensus_pool_service to return blocks that it failed to process.
+    pub(crate) fn add_to_pending_safe_to_notar(&mut self, block: Block) {
+        self.pending_safe_to_notar.push(block);
+    }
+
     #[cfg(test)]
     fn make_start_leader_decision(
         &self,
@@ -624,6 +656,8 @@ impl ConsensusPool {
         self.vote_pools = self.vote_pools.split_off(&(root_slot, VoteType::Finalize));
         self.slot_stake_counters_map = self.slot_stake_counters_map.split_off(&root_slot);
         self.parent_ready_tracker.set_root(root_slot);
+        self.pending_safe_to_notar
+            .retain(|(slot, _)| *slot >= root_slot);
         self.last_pruned_slot = root_slot;
     }
 
@@ -1502,12 +1536,12 @@ mod tests {
         let bank = ctx.bank_forks.read().unwrap().root_bank();
         let (my_vote_key, _, _) = get_key_and_stakes(&bank, 0, 0).unwrap();
 
-        // Create bank 2
-        let slot = 2;
+        // Use slot 0 (first in leader window: 0 % 4 == 0) so SafeToNotar goes directly to events
+        let slot = 0;
         let block_id = Hash::new_unique();
 
         // Add a skip from myself.
-        let vote = Vote::new_skip_vote(2);
+        let vote = Vote::new_skip_vote(slot);
         let mut new_events = vec![];
         ctx.pool
             .add_message(
@@ -1521,7 +1555,7 @@ mod tests {
 
         // 40% notarized, should succeed
         for rank in 1..5 {
-            let vote = Vote::new_notarization_vote(2, block_id);
+            let vote = Vote::new_notarization_vote(slot, block_id);
             ctx.pool
                 .add_message(
                     &bank,
@@ -1540,19 +1574,26 @@ mod tests {
         }
         new_events.clear();
 
-        // Create bank 3
-        let slot = 3;
+        // Use slot 4 (first in leader window: 4 % 4 == 0) for the second part
+        let slot = 4;
         let block_id = Hash::new_unique();
 
         // Add 20% notarize, but no vote from myself, should fail
         for rank in 1..3 {
-            let vote = Vote::new_notarization_vote(3, block_id);
-            ctx.add_message(dummy_vote_message(&ctx.validators, &vote, rank));
+            let vote = Vote::new_notarization_vote(slot, block_id);
+            ctx.pool
+                .add_message(
+                    &bank,
+                    &Pubkey::new_unique(),
+                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    &mut new_events,
+                )
+                .unwrap();
         }
         assert!(new_events.is_empty());
 
         // Add a notarize from myself for some other block, but still not enough notar or skip, should fail.
-        let vote = Vote::new_notarization_vote(3, Hash::new_unique());
+        let vote = Vote::new_notarization_vote(slot, Hash::new_unique());
         ctx.pool
             .add_message(
                 &bank,
@@ -1564,9 +1605,9 @@ mod tests {
         assert!(new_events.is_empty());
 
         // Now add 40% skip, should succeed
-        // Funny thing is in this case we will also get SafeToSkip(3)
+        // Funny thing is in this case we will also get SafeToSkip(slot)
         for rank in 3..7 {
-            let vote = Vote::new_skip_vote(3);
+            let vote = Vote::new_skip_vote(slot);
             ctx.pool
                 .add_message(
                     &bank,
@@ -1594,7 +1635,7 @@ mod tests {
         // but not on the same block_id because we already sent the event
         let duplicate_block_id = Hash::new_unique();
         for rank in 7..9 {
-            let vote = Vote::new_notarization_vote(3, duplicate_block_id);
+            let vote = Vote::new_notarization_vote(slot, duplicate_block_id);
             ctx.pool
                 .add_message(
                     &bank,

--- a/votor/src/consensus_pool/slot_stake_counters.rs
+++ b/votor/src/consensus_pool/slot_stake_counters.rs
@@ -7,7 +7,8 @@ use {
         consensus_pool::stats::ConsensusPoolStats,
         event::VotorEvent,
     },
-    agave_votor_messages::{fraction::Fraction, vote::Vote},
+    agave_votor_messages::{consensus_message::Block, fraction::Fraction, vote::Vote},
+    solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
     solana_hash::Hash,
     std::{collections::BTreeMap, num::NonZeroU64},
 };
@@ -32,12 +33,19 @@ impl SlotStakeCounters {
         }
     }
 
-    pub fn add_vote(
+    /// Adds a vote and checks for safe-to-notar and safe-to-skip thresholds.
+    ///
+    /// For intrawindow blocks (slot % NUM_CONSECUTIVE_LEADER_SLOTS != 0), instead of
+    /// immediately emitting SafeToNotar events, we add them to `pending_safe_to_notar`
+    /// which will be processed later in the consensus pool service to verify parent
+    /// certification status.
+    pub(super) fn add_vote(
         &mut self,
         vote: &Vote,
         entry_stake: Stake,
         is_my_own_vote: bool,
         events: &mut Vec<VotorEvent>,
+        pending_safe_to_notar: &mut Vec<Block>,
         stats: &mut ConsensusPoolStats,
     ) {
         match vote {
@@ -63,13 +71,23 @@ impl SlotStakeCounters {
             return;
         }
         let slot = vote.slot();
+        let is_first_in_leader_window =
+            slot.is_multiple_of(NUM_CONSECUTIVE_LEADER_SLOTS) || slot == 1;
+
         // Check safe to notar
         for (block_id, stake) in &self.notarize_entry_total {
             if !self.safe_to_notar_sent.contains(block_id) && self.is_safe_to_notar(block_id, stake)
             {
-                events.push(VotorEvent::SafeToNotar((slot, *block_id)));
-                stats.event_safe_to_notarize = stats.event_safe_to_notarize.saturating_add(1);
                 self.safe_to_notar_sent.push(*block_id);
+
+                if is_first_in_leader_window {
+                    // First block in leader window - emit event immediately
+                    events.push(VotorEvent::SafeToNotar((slot, *block_id)));
+                    stats.event_safe_to_notarize = stats.event_safe_to_notarize.saturating_add(1);
+                } else {
+                    // Intrawindow block - add to pending for later processing
+                    pending_safe_to_notar.push((slot, *block_id));
+                }
             }
         }
         // Check safe to skip
@@ -136,21 +154,25 @@ mod tests {
     use {super::*, agave_votor_messages::vote::Vote};
 
     #[test]
-    fn test_safe_to_notar() {
+    fn test_safe_to_notar_first_in_leader_window() {
         let mut counters = SlotStakeCounters::new(100);
 
         let mut events = vec![];
+        let mut pending_safe_to_notar = vec![];
         let mut stats = ConsensusPoolStats::default();
-        let slot = 2;
+        // Use slot 0 which is first in leader window (0 % 4 == 0)
+        let slot = 0;
         // I voted for skip
         counters.add_vote(
             &Vote::new_skip_vote(slot),
             10,
             true,
             &mut events,
+            &mut pending_safe_to_notar,
             &mut stats,
         );
         assert!(events.is_empty());
+        assert!(pending_safe_to_notar.is_empty());
         assert_eq!(stats.event_safe_to_notarize, 0);
 
         // 40% of stake holders voted notarize
@@ -159,12 +181,15 @@ mod tests {
             40,
             false,
             &mut events,
+            &mut pending_safe_to_notar,
             &mut stats,
         );
+        // First in leader window goes to events directly
         assert_eq!(events.len(), 1);
         assert!(
             matches!(events[0], VotorEvent::SafeToNotar((s, block_id)) if s == slot && block_id == Hash::default())
         );
+        assert!(pending_safe_to_notar.is_empty());
         assert_eq!(stats.event_safe_to_notarize, 1);
         events.clear();
 
@@ -174,15 +199,19 @@ mod tests {
             20,
             false,
             &mut events,
+            &mut pending_safe_to_notar,
             &mut stats,
         );
         assert!(events.is_empty());
+        assert!(pending_safe_to_notar.is_empty());
         assert_eq!(stats.event_safe_to_notarize, 1);
 
-        // Reset counters
+        // Reset counters with slot 4 (first in next leader window)
         counters = SlotStakeCounters::new(100);
         events.clear();
+        pending_safe_to_notar.clear();
         stats = ConsensusPoolStats::default();
+        let slot = 4;
 
         // I voted for notarize b
         let hash_1 = Hash::new_unique();
@@ -191,9 +220,11 @@ mod tests {
             1,
             true,
             &mut events,
+            &mut pending_safe_to_notar,
             &mut stats,
         );
         assert!(events.is_empty());
+        assert!(pending_safe_to_notar.is_empty());
         assert_eq!(stats.event_safe_to_notarize, 0);
 
         // 25% of stake holders voted notarize b'
@@ -203,9 +234,11 @@ mod tests {
             25,
             false,
             &mut events,
+            &mut pending_safe_to_notar,
             &mut stats,
         );
         assert!(events.is_empty());
+        assert!(pending_safe_to_notar.is_empty());
         assert_eq!(stats.event_safe_to_notarize, 0);
 
         // 35% more of stake holders voted skip
@@ -214,13 +247,54 @@ mod tests {
             35,
             false,
             &mut events,
+            &mut pending_safe_to_notar,
             &mut stats,
         );
         assert_eq!(events.len(), 1);
         assert!(
             matches!(events[0], VotorEvent::SafeToNotar((s, block_id)) if s == slot && block_id == hash_2)
         );
+        assert!(pending_safe_to_notar.is_empty());
         assert_eq!(stats.event_safe_to_notarize, 1);
+    }
+
+    #[test]
+    fn test_safe_to_notar_intrawindow_block() {
+        let mut counters = SlotStakeCounters::new(100);
+
+        let mut events = vec![];
+        let mut pending_safe_to_notar = vec![];
+        let mut stats = ConsensusPoolStats::default();
+        // Use slot 2 which is NOT first in leader window (2 % 4 != 0)
+        let slot = 2;
+        // I voted for skip
+        counters.add_vote(
+            &Vote::new_skip_vote(slot),
+            10,
+            true,
+            &mut events,
+            &mut pending_safe_to_notar,
+            &mut stats,
+        );
+        assert!(events.is_empty());
+        assert!(pending_safe_to_notar.is_empty());
+
+        // 40% of stake holders voted notarize
+        let block_id = Hash::new_unique();
+        counters.add_vote(
+            &Vote::new_notarization_vote(slot, block_id),
+            40,
+            false,
+            &mut events,
+            &mut pending_safe_to_notar,
+            &mut stats,
+        );
+        // Intrawindow block goes to pending instead of events
+        assert!(events.is_empty());
+        assert_eq!(pending_safe_to_notar.len(), 1);
+        assert_eq!(pending_safe_to_notar[0], (slot, block_id));
+        // Stats are not updated for pending
+        assert_eq!(stats.event_safe_to_notarize, 0);
     }
 
     #[test]
@@ -228,6 +302,7 @@ mod tests {
         let mut counters = SlotStakeCounters::new(100);
 
         let mut events = vec![];
+        let mut pending_safe_to_notar = vec![];
         let mut stats = ConsensusPoolStats::default();
         let slot = 2;
         // I voted for notarize b
@@ -236,6 +311,7 @@ mod tests {
             10,
             true,
             &mut events,
+            &mut pending_safe_to_notar,
             &mut stats,
         );
         assert!(events.is_empty());
@@ -247,6 +323,7 @@ mod tests {
             40,
             false,
             &mut events,
+            &mut pending_safe_to_notar,
             &mut stats,
         );
         assert_eq!(events.len(), 1);
@@ -260,6 +337,7 @@ mod tests {
             20,
             false,
             &mut events,
+            &mut pending_safe_to_notar,
             &mut stats,
         );
         assert!(events.is_empty());
@@ -268,6 +346,7 @@ mod tests {
         // Reset counters
         counters = SlotStakeCounters::new(100);
         events.clear();
+        pending_safe_to_notar.clear();
         stats = ConsensusPoolStats::default();
 
         // I voted for notarize b, 10% of stake holders voted with me
@@ -277,6 +356,7 @@ mod tests {
             10,
             true,
             &mut events,
+            &mut pending_safe_to_notar,
             &mut stats,
         );
         // 20% of stake holders voted a different notarization b'
@@ -286,6 +366,7 @@ mod tests {
             20,
             false,
             &mut events,
+            &mut pending_safe_to_notar,
             &mut stats,
         );
         // 30% of stake holders voted skip
@@ -294,6 +375,7 @@ mod tests {
             30,
             false,
             &mut events,
+            &mut pending_safe_to_notar,
             &mut stats,
         );
         assert_eq!(events.len(), 1);
@@ -307,6 +389,7 @@ mod tests {
             10,
             false,
             &mut events,
+            &mut pending_safe_to_notar,
             &mut stats,
         );
         assert!(events.is_empty());

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -10,12 +10,12 @@ use {
         consensus_pool::{
             AddVoteError, ConsensusPool, parent_ready_tracker::BlockProductionParent,
         },
-        event::{LeaderWindowInfo, VotorEvent, VotorEventSender},
+        event::{LeaderWindowInfo, RepairEvent, RepairEventSender, VotorEvent, VotorEventSender},
         generated_cert_types::GeneratedCertTypes,
         voting_service::BLSOp,
     },
     agave_votor_messages::{
-        consensus_message::{Certificate, ConsensusMessage},
+        consensus_message::{Block, Certificate, ConsensusMessage},
         migration::MigrationStatus,
     },
     crossbeam_channel::{Receiver, Sender, TrySendError, select},
@@ -30,6 +30,7 @@ use {
     },
     stats::ConsensusPoolServiceStats,
     std::{
+        collections::HashSet,
         sync::{
             Arc, RwLock,
             atomic::{AtomicBool, Ordering},
@@ -56,6 +57,7 @@ pub(crate) struct ConsensusPoolContext {
     pub(crate) bls_sender: Sender<BLSOp>,
     pub(crate) event_sender: VotorEventSender,
     pub(crate) commitment_sender: Sender<CommitmentAggregationData>,
+    pub(crate) repair_event_sender: RepairEventSender,
 
     /// Used to communicate the highest finalization cert the pool has observed to the block creation loop.
     pub(crate) highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
@@ -216,6 +218,9 @@ impl ConsensusPoolService {
         // Kick off parent ready
         let mut kick_off_parent_ready = false;
 
+        // Track pending safe-to-notar blocks for intrawindow slots.
+        let mut pending_safe_to_notar = HashSet::new();
+
         // Ingest votes into certificate pool and notify voting loop of new events
         while !ctx.exit.load(Ordering::Relaxed) {
             // Kick off parent ready event, this either happens:
@@ -277,6 +282,15 @@ impl ConsensusPoolService {
                 }
             }
 
+            // Process pending safe-to-notar blocks for intrawindow slots
+            Self::process_pending_safe_to_notar(
+                &ctx,
+                &mut consensus_pool,
+                &mut pending_safe_to_notar,
+                &mut events,
+                &mut stats,
+            )?;
+
             if events
                 .drain(..)
                 .try_for_each(|event| ctx.event_sender.send(event))
@@ -285,6 +299,14 @@ impl ConsensusPoolService {
                 return Self::handle_channel_disconnected(&mut ctx, "event_sender");
             }
 
+            let wait_timeout = if pending_safe_to_notar.is_empty() {
+                Duration::from_secs(1)
+            } else {
+                // If there are pending blocks that are waiting for repair in order to emit
+                // SafeToNotar events, use a shorter timeout
+                Duration::from_millis(20)
+            };
+
             let messages: Vec<ConsensusMessage> = select! {
                 recv(ctx.consensus_message_receiver) -> msg => {
                     let Ok(first) = msg else {
@@ -292,7 +314,7 @@ impl ConsensusPoolService {
                     };
                     std::iter::once(first).chain(ctx.consensus_message_receiver.try_iter()).flatten().collect()
                 },
-                default(Duration::from_secs(1)) => continue
+                default(wait_timeout) => continue
             };
 
             for message in messages {
@@ -438,6 +460,89 @@ impl ConsensusPoolService {
         }
     }
 
+    /// Process pending safe-to-notar blocks for intrawindow slots.
+    ///
+    /// For each pending block:
+    /// 1. If it's new send a repair request
+    /// 2. If the slot is <= highest_finalized_slot, discard it
+    /// 3. Check if the block has been received in blockstore
+    /// 4. If received, verify the parent has a NotarizeFallback certificate
+    /// 5. If verified, emit SafeToNotar event and remove from pending
+    fn process_pending_safe_to_notar(
+        ctx: &ConsensusPoolContext,
+        consensus_pool: &mut ConsensusPool,
+        pending_safe_to_notar: &mut HashSet<Block>,
+        events: &mut Vec<VotorEvent>,
+        stats: &mut ConsensusPoolServiceStats,
+    ) -> Result<(), ()> {
+        // First, collect new pending blocks from the consensus pool and send them for repair
+        for block @ (slot, block_id) in consensus_pool.take_pending_safe_to_notar() {
+            if pending_safe_to_notar.insert(block) {
+                match ctx
+                    .repair_event_sender
+                    .try_send(RepairEvent::FetchBlock { slot, block_id })
+                {
+                    Ok(()) => (),
+                    Err(TrySendError::Full(event)) => {
+                        error!(
+                            "Repair event channel for event={event:?} is full. Will try event in \
+                             next iteration."
+                        );
+                        consensus_pool.add_to_pending_safe_to_notar(block);
+                    }
+                    Err(TrySendError::Disconnected(_)) => return Err(()),
+                }
+                stats.pending_safe_to_notar_repair_sent += 1;
+            }
+        }
+
+        let highest_finalized = consensus_pool.highest_finalized_slot().unwrap_or(0);
+
+        pending_safe_to_notar.retain(|&(slot, block_id)| {
+            // Discard if slot is at or below highest finalized
+            if slot <= highest_finalized {
+                return false;
+            }
+
+            // Check if we've received the full block in blockstore
+            let Some(location) = ctx
+                .blockstore
+                .get_block_location(slot, block_id)
+                .expect("Blockstore operations must succeed")
+            else {
+                // Block not yet received, keep waiting
+                return true;
+            };
+
+            // Block has been received, get the parent meta
+            let slot_meta = ctx
+                .blockstore
+                .meta_from_location(slot, location)
+                .expect("Blockstore operations must succeed")
+                .expect("SlotMeta must exist if block location is present");
+
+            let parent_block = (
+                slot_meta
+                    .parent_slot
+                    .expect("parent slot must exist for full blocks"),
+                slot_meta.parent_block_id,
+            );
+
+            // Check if the parent has a NotarizeFallback certificate (or stronger)
+            if consensus_pool.block_has_notar_fallback_or_stronger(parent_block) {
+                // All conditions met - emit SafeToNotar event
+                events.push(VotorEvent::SafeToNotar((slot, block_id)));
+                stats.pending_safe_to_notar_resolved += 1;
+                return false;
+            }
+
+            // Parent doesn't have the certificate yet, keep waiting
+            true
+        });
+
+        Ok(())
+    }
+
     pub(crate) fn join(self) -> thread::Result<()> {
         self.t_ingest.join()
     }
@@ -452,6 +557,7 @@ mod tests {
             consensus_message::{BLS_KEYPAIR_DERIVE_SEED, CertificateType, VoteMessage},
             vote::Vote,
         },
+        crossbeam_channel::unbounded,
         solana_bls_signatures::{
             BLS_SIGNATURE_AFFINE_SIZE, keypair::Keypair as BLSKeypair,
             signature::Signature as BLSSignature,
@@ -703,6 +809,7 @@ mod tests {
     #[test]
     fn test_send_produce_block_event() {
         let mut ctx = TestContext::default();
+        let (repair_event_sender, _repair_event_receiver) = unbounded();
 
         // Find when is the next leader slot for me (validator 0)
         let next_leader_slot = ctx
@@ -751,6 +858,7 @@ mod tests {
             event_sender: crossbeam_channel::unbounded().0,
             commitment_sender: ctx.commitment_sender.clone(),
             highest_finalized: ctx.highest_finalized.clone(),
+            repair_event_sender,
         };
 
         // Add a ParentReady event for the slot before our leader slot

--- a/votor/src/consensus_pool_service/stats.rs
+++ b/votor/src/consensus_pool_service/stats.rs
@@ -20,6 +20,8 @@ pub(super) struct ConsensusPoolServiceStats {
     pub(super) received_certificates: Saturating<usize>,
     pub(super) standstill: bool,
     pub(super) prune_old_state_called: Saturating<usize>,
+    pub(crate) pending_safe_to_notar_repair_sent: Saturating<usize>,
+    pub(crate) pending_safe_to_notar_resolved: Saturating<usize>,
     last_request_time: Instant,
 }
 
@@ -36,6 +38,8 @@ impl ConsensusPoolServiceStats {
             received_certificates: Saturating(0),
             standstill: false,
             prune_old_state_called: Saturating(0),
+            pending_safe_to_notar_repair_sent: Saturating(0),
+            pending_safe_to_notar_resolved: Saturating(0),
             last_request_time: Instant::now(),
         }
     }
@@ -52,7 +56,9 @@ impl ConsensusPoolServiceStats {
             received_certificates: Saturating(received_certificates),
             standstill,
             prune_old_state_called: Saturating(prune_old_state_called),
-            ..
+            pending_safe_to_notar_repair_sent: Saturating(pending_safe_to_notar_repair_sent),
+            pending_safe_to_notar_resolved: Saturating(pending_safe_to_notar_resolved),
+            last_request_time: _,
         } = self;
         datapoint_info!(
             "consensus_pool_service",
@@ -74,6 +80,16 @@ impl ConsensusPoolServiceStats {
             ("received_certificates", received_certificates, i64),
             ("in_standstill_bool", standstill, bool),
             ("prune_old_state_called", prune_old_state_called, i64),
+            (
+                "pending_safe_to_notar_repair_sent",
+                pending_safe_to_notar_repair_sent,
+                i64
+            ),
+            (
+                "pending_safe_to_notar_resolved",
+                pending_safe_to_notar_resolved,
+                i64
+            ),
         );
     }
 

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -190,7 +190,7 @@ impl Votor {
             highest_parent_ready,
             leader_window_info_sender,
             vote_history_storage,
-            repair_event_sender,
+            repair_event_sender: repair_event_sender.clone(),
         };
 
         let voting_context = VotingContext {
@@ -243,6 +243,7 @@ impl Votor {
             bls_sender,
             event_sender,
             commitment_sender,
+            repair_event_sender,
             highest_finalized,
         };
 


### PR DESCRIPTION
#### Problem

Now that we have upstreamed repair, we can track intra window slots pending safe to notar separately and trigger their processing out-of-band.


#### Summary of Changes

Upstreams the relevant bit of code from alpenglow to implement the feature.
