### PR TITLE
remove stateful QosService

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -41,7 +41,7 @@ use {
     solana_time_utils::AtomicInterval,
     solana_unified_scheduler_logic::SchedulingMode,
     std::{
-        num::{NonZeroU64, NonZeroUsize, Saturating},
+        num::{NonZeroU64, NonZeroUsize},
         ops::Deref,
         sync::{
             Arc, RwLock,
@@ -325,30 +325,6 @@ impl BankingStageStats {
             self.batch_packet_indexes_len.clear();
         }
     }
-}
-
-#[derive(Debug, Default)]
-pub struct BatchedTransactionDetails {
-    pub costs: BatchedTransactionCostDetails,
-    pub errors: BatchedTransactionErrorDetails,
-}
-
-#[derive(Debug, Default)]
-pub struct BatchedTransactionCostDetails {
-    pub batched_signature_cost: Saturating<u64>,
-    pub batched_write_lock_cost: Saturating<u64>,
-    pub batched_data_bytes_cost: Saturating<u64>,
-    pub batched_loaded_accounts_data_size_cost: Saturating<u64>,
-    pub batched_programs_execute_cost: Saturating<u64>,
-}
-
-#[derive(Debug, Default)]
-pub struct BatchedTransactionErrorDetails {
-    pub batched_retried_txs_per_block_limit_count: Saturating<u64>,
-    pub batched_retried_txs_per_vote_limit_count: Saturating<u64>,
-    pub batched_retried_txs_per_account_limit_count: Saturating<u64>,
-    pub batched_retried_txs_per_account_data_block_limit_count: Saturating<u64>,
-    pub batched_dropped_txs_per_account_data_total_limit_count: Saturating<u64>,
 }
 
 pub trait LikeClusterInfo: Send + Sync + 'static + Clone {

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -6,8 +6,7 @@ use qualifier_attr::qualifiers;
 use {
     self::{
         committer::Committer, consumer::Consumer, decision_maker::DecisionMaker,
-        qos_service::QosService, vote_packet_receiver::VotePacketReceiver,
-        vote_storage::VoteStorage,
+        vote_packet_receiver::VotePacketReceiver, vote_storage::VoteStorage,
     },
     crate::{
         banking_stage::{
@@ -553,7 +552,6 @@ impl BankingStage {
                 Consumer::new(
                     self.committer.clone(),
                     self.transaction_recorder.clone(),
-                    QosService::new(id),
                     self.log_messages_bytes_limit,
                 ),
                 finished_work_sender.clone(),
@@ -650,7 +648,6 @@ impl BankingStage {
         let consumer = Consumer::new(
             self.committer.clone(),
             self.transaction_recorder.clone(),
-            QosService::new(0),
             self.log_messages_bytes_limit,
         );
         let decision_maker = DecisionMaker::from(self.poh_recorder.read().unwrap().deref());
@@ -738,7 +735,6 @@ mod external {
                     Consumer::new(
                         self.committer.clone(),
                         self.transaction_recorder.clone(),
-                        QosService::new(id),
                         self.log_messages_bytes_limit,
                     ),
                     worker_to_pack,

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -2058,7 +2058,6 @@ mod tests {
         super::*,
         crate::banking_stage::{
             committer::Committer,
-            qos_service::QosService,
             scheduler_messages::{MaxAge, TransactionBatchId},
             tests::{create_slow_genesis_config, sanitize_transactions},
         },
@@ -2140,7 +2139,7 @@ mod tests {
 
         let (replay_vote_sender, replay_vote_receiver) = unbounded();
         let committer = Committer::new(None, replay_vote_sender, None);
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(committer, recorder, None);
         let shared_leader_state = SharedLeaderState::new(0, None, None);
 
         let (consume_sender, consume_receiver) = unbounded();

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -241,9 +241,6 @@ impl Consumer {
             bank,
         );
 
-        // reports qos service stats for this batch
-        self.qos_service.report_metrics(bank.slot());
-
         debug!(
             "bank: {} lock: {}us unlock: {}us txs_len: {}",
             bank.slot(),
@@ -346,25 +343,6 @@ impl Consumer {
             processed_counts,
             balance_collector,
         } = load_and_execute_transactions_output;
-
-        let actual_execute_time = execute_and_commit_timings
-            .execute_timings
-            .execute_accessories
-            .process_instructions
-            .total_us
-            .0;
-        let actual_executed_cu = processing_results
-            .iter()
-            .map(|processing_result| {
-                processing_result
-                    .as_ref()
-                    .map_or(0, |pr| pr.executed_units())
-            })
-            .sum();
-        self.qos_service
-            .accumulate_actual_execute_cu(actual_executed_cu);
-        self.qos_service
-            .accumulate_actual_execute_time(actual_execute_time);
 
         let transaction_counts = LeaderProcessedTransactionCounts {
             processed_count: processed_counts.processed_transactions_count,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -106,7 +106,6 @@ pub struct LeaderProcessedTransactionCounts {
 pub struct Consumer {
     committer: Committer,
     transaction_recorder: TransactionRecorder,
-    qos_service: QosService,
     log_messages_bytes_limit: Option<usize>,
 }
 
@@ -114,13 +113,11 @@ impl Consumer {
     pub fn new(
         committer: Committer,
         transaction_recorder: TransactionRecorder,
-        qos_service: QosService,
         log_messages_bytes_limit: Option<usize>,
     ) -> Self {
         Self {
             committer,
             transaction_recorder,
-            qos_service,
             log_messages_bytes_limit,
         }
     }
@@ -200,7 +197,7 @@ impl Consumer {
         let (
             (transaction_qos_cost_results, cost_model_throttled_transactions_count),
             cost_model_us,
-        ) = measure_us!(self.qos_service.select_and_accumulate_transaction_costs(
+        ) = measure_us!(QosService::select_and_accumulate_transaction_costs(
             bank,
             txs,
             pre_results
@@ -586,7 +583,7 @@ mod tests {
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(transaction_status_sender, replay_vote_sender, None);
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(committer, recorder, None);
 
         TestFrame {
             mint_keypair,
@@ -609,7 +606,7 @@ mod tests {
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(None, replay_vote_sender, None);
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(committer, recorder, None);
         consumer.process_and_record_transactions(&bank, &transactions)
     }
 

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -4,23 +4,15 @@
 //!
 
 use {
-    super::{
-        BatchedTransactionCostDetails, BatchedTransactionDetails, BatchedTransactionErrorDetails,
-        committer::CommitTransactionDetails,
-    },
+    super::{BatchedTransactionDetails, committer::CommitTransactionDetails},
     agave_feature_set::FeatureSet,
     solana_clock::Slot,
     solana_cost_model::{
         cost_model::CostModel, cost_tracker::UpdatedCosts, transaction_cost::TransactionCost,
     },
-    solana_measure::measure::Measure,
     solana_runtime::bank::Bank,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_transaction_error::TransactionError,
-    std::{
-        num::Saturating,
-        sync::atomic::{AtomicU64, Ordering},
-    },
 };
 
 mod transaction {
@@ -32,15 +24,11 @@ mod transaction {
 // Banking thread calls `report_metrics(slot)` at end of `process_and_record_transaction()`, or any time
 // it wants.
 //
-pub struct QosService {
-    metrics: QosServiceMetrics,
-}
+pub struct QosService {}
 
 impl QosService {
-    pub fn new(id: u32) -> Self {
-        Self {
-            metrics: QosServiceMetrics::new(id),
-        }
+    pub fn new(_id: u32) -> Self {
+        Self {}
     }
 
     /// Calculate cost of transactions, if not already filtered out, determine which ones to
@@ -80,21 +68,10 @@ impl QosService {
         transactions: impl Iterator<Item = &'a Tx>,
         pre_results: impl Iterator<Item = transaction::Result<()>>,
     ) -> Vec<transaction::Result<TransactionCost<'a, Tx>>> {
-        let mut compute_cost_time = Measure::start("compute_cost_time");
-        let txs_costs: Vec<_> = transactions
+        transactions
             .zip(pre_results)
             .map(|(tx, pre_result)| pre_result.map(|()| CostModel::calculate_cost(tx, feature_set)))
-            .collect();
-        compute_cost_time.stop();
-        self.metrics
-            .stats
-            .compute_cost_time
-            .fetch_add(compute_cost_time.as_us(), Ordering::Relaxed);
-        self.metrics
-            .stats
-            .compute_cost_count
-            .fetch_add(txs_costs.len() as u64, Ordering::Relaxed);
-        txs_costs
+            .collect()
     }
 
     /// Given a list of transactions and their costs, this function returns a corresponding
@@ -106,7 +83,6 @@ impl QosService {
         transactions_costs: impl Iterator<Item = transaction::Result<TransactionCost<'a, Tx>>>,
         bank: &Bank,
     ) -> (Vec<transaction::Result<TransactionCost<'a, Tx>>>, usize) {
-        let mut cost_tracking_time = Measure::start("cost_tracking_time");
         let mut cost_tracker = bank.write_cost_tracker().unwrap();
         let mut num_included = 0;
         let select_results = transactions
@@ -126,10 +102,6 @@ impl QosService {
                             updated_block_cost,
                             updated_costliest_account_cost
                         );
-                        self.metrics
-                            .stats
-                            .selected_txs_count
-                            .fetch_add(1, Ordering::Relaxed);
                         num_included += 1;
                         Ok(cost)
                     }
@@ -150,11 +122,6 @@ impl QosService {
             .collect();
         cost_tracker.add_transactions_in_flight(num_included);
 
-        cost_tracking_time.stop();
-        self.metrics
-            .stats
-            .cost_tracking_time
-            .fetch_add(cost_tracking_time.as_us(), Ordering::Relaxed);
         (select_results, num_included)
     }
 
@@ -237,103 +204,17 @@ impl QosService {
     }
 
     // metrics are reported by bank slot
-    pub fn report_metrics(&self, slot: Slot) {
-        self.metrics.report(slot);
-    }
+    pub fn report_metrics(&self, _slot: Slot) {}
 
     fn accumulate_estimated_transaction_costs(
         &self,
-        batched_transaction_details: &BatchedTransactionDetails,
+        _batched_transaction_details: &BatchedTransactionDetails,
     ) {
-        let &BatchedTransactionDetails {
-            costs:
-                BatchedTransactionCostDetails {
-                    batched_signature_cost: Saturating(batched_signature_cost),
-                    batched_write_lock_cost: Saturating(batched_write_lock_cost),
-                    batched_data_bytes_cost: Saturating(batched_data_bytes_cost),
-                    batched_loaded_accounts_data_size_cost:
-                        Saturating(batched_loaded_accounts_data_size_cost),
-                    batched_programs_execute_cost: Saturating(batched_programs_execute_cost),
-                },
-            errors:
-                BatchedTransactionErrorDetails {
-                    batched_retried_txs_per_block_limit_count:
-                        Saturating(batched_retried_txs_per_block_limit_count),
-                    batched_retried_txs_per_vote_limit_count:
-                        Saturating(batched_retried_txs_per_vote_limit_count),
-                    batched_retried_txs_per_account_limit_count:
-                        Saturating(batched_retried_txs_per_account_limit_count),
-                    batched_retried_txs_per_account_data_block_limit_count:
-                        Saturating(batched_retried_txs_per_account_data_block_limit_count),
-                    batched_dropped_txs_per_account_data_total_limit_count:
-                        Saturating(batched_dropped_txs_per_account_data_total_limit_count),
-                },
-        } = batched_transaction_details;
-        self.metrics
-            .stats
-            .estimated_signature_cu
-            .fetch_add(batched_signature_cost, Ordering::Relaxed);
-        self.metrics
-            .stats
-            .estimated_write_lock_cu
-            .fetch_add(batched_write_lock_cost, Ordering::Relaxed);
-        self.metrics
-            .stats
-            .estimated_data_bytes_cu
-            .fetch_add(batched_data_bytes_cost, Ordering::Relaxed);
-        self.metrics
-            .stats
-            .estimated_loaded_accounts_data_size_cu
-            .fetch_add(batched_loaded_accounts_data_size_cost, Ordering::Relaxed);
-        self.metrics
-            .stats
-            .estimated_programs_execute_cu
-            .fetch_add(batched_programs_execute_cost, Ordering::Relaxed);
-
-        self.metrics
-            .errors
-            .retried_txs_per_block_limit_count
-            .fetch_add(batched_retried_txs_per_block_limit_count, Ordering::Relaxed);
-        self.metrics
-            .errors
-            .retried_txs_per_vote_limit_count
-            .fetch_add(batched_retried_txs_per_vote_limit_count, Ordering::Relaxed);
-        self.metrics
-            .errors
-            .retried_txs_per_account_limit_count
-            .fetch_add(
-                batched_retried_txs_per_account_limit_count,
-                Ordering::Relaxed,
-            );
-        self.metrics
-            .errors
-            .retried_txs_per_account_data_block_limit_count
-            .fetch_add(
-                batched_retried_txs_per_account_data_block_limit_count,
-                Ordering::Relaxed,
-            );
-        self.metrics
-            .errors
-            .dropped_txs_per_account_data_total_limit_count
-            .fetch_add(
-                batched_dropped_txs_per_account_data_total_limit_count,
-                Ordering::Relaxed,
-            );
     }
 
-    pub fn accumulate_actual_execute_cu(&self, units: u64) {
-        self.metrics
-            .stats
-            .actual_programs_execute_cu
-            .fetch_add(units, Ordering::Relaxed);
-    }
+    pub fn accumulate_actual_execute_cu(&self, _units: u64) {}
 
-    pub fn accumulate_actual_execute_time(&self, micro_sec: u64) {
-        self.metrics
-            .stats
-            .actual_execute_time_us
-            .fetch_add(micro_sec, Ordering::Relaxed);
-    }
+    pub fn accumulate_actual_execute_time(&self, _micro_sec: u64) {}
 
     // rollup transaction cost details, eg signature_cost, write_lock_cost, data_bytes_cost and
     // execution_cost from the batch of transactions selected for block.
@@ -388,205 +269,6 @@ impl QosService {
     }
 }
 
-#[derive(Debug, Default)]
-struct QosServiceMetrics {
-    /// banking_stage creates one QosService instance per working threads, that is uniquely
-    /// identified by id. This field allows to categorize metrics for gossip votes, TPU votes
-    /// and other transactions.
-    id: String,
-
-    /// aggregate metrics per slot
-    slot: AtomicU64,
-
-    stats: QosServiceMetricsStats,
-    errors: QosServiceMetricsErrors,
-}
-
-#[derive(Debug, Default)]
-struct QosServiceMetricsStats {
-    /// accumulated time in micro-sec spent in computing transaction cost. It is the main performance
-    /// overhead introduced by cost_model
-    compute_cost_time: AtomicU64,
-
-    /// total number of transactions in the reporting period to be computed for their cost. It is
-    /// usually the number of sanitized transactions leader receives.
-    compute_cost_count: AtomicU64,
-
-    /// accumulated time in micro-sec spent in tracking each bank's cost. It is the second part of
-    /// overhead introduced
-    cost_tracking_time: AtomicU64,
-
-    /// number of transactions to be included in blocks
-    selected_txs_count: AtomicU64,
-
-    /// accumulated estimated signature Compute Unites to be packed into block
-    estimated_signature_cu: AtomicU64,
-
-    /// accumulated estimated write locks Compute Units to be packed into block
-    estimated_write_lock_cu: AtomicU64,
-
-    /// accumulated estimated instruction data Compute Units to be packed into block
-    estimated_data_bytes_cu: AtomicU64,
-
-    /// accumulated estimated loaded accounts data size cost to be packed into block
-    estimated_loaded_accounts_data_size_cu: AtomicU64,
-
-    /// accumulated estimated program Compute Units to be packed into block
-    estimated_programs_execute_cu: AtomicU64,
-
-    /// accumulated actual program Compute Units that have been packed into block
-    actual_programs_execute_cu: AtomicU64,
-
-    /// accumulated actual program execute micro-sec that have been packed into block
-    actual_execute_time_us: AtomicU64,
-}
-
-#[derive(Debug, Default)]
-struct QosServiceMetricsErrors {
-    /// number of transactions to be queued for retry due to their potential to breach block limit
-    retried_txs_per_block_limit_count: AtomicU64,
-
-    /// number of transactions to be queued for retry due to their potential to breach vote limit
-    retried_txs_per_vote_limit_count: AtomicU64,
-
-    /// number of transactions to be queued for retry due to their potential to breach writable
-    /// account limit
-    retried_txs_per_account_limit_count: AtomicU64,
-
-    /// number of transactions to be queued for retry due to their potential to breach account data
-    /// block limits
-    retried_txs_per_account_data_block_limit_count: AtomicU64,
-
-    /// number of transactions to be dropped due to their potential to breach account data total
-    /// limits
-    dropped_txs_per_account_data_total_limit_count: AtomicU64,
-}
-
-impl QosServiceMetrics {
-    pub fn new(id: u32) -> Self {
-        QosServiceMetrics {
-            id: id.to_string(),
-            ..QosServiceMetrics::default()
-        }
-    }
-
-    pub fn report(&self, bank_slot: Slot) {
-        if bank_slot != self.slot.load(Ordering::Relaxed) {
-            datapoint_info!(
-                "qos-service-stats",
-                "id" => self.id,
-                ("bank_slot", bank_slot, i64),
-                (
-                    "compute_cost_time",
-                    self.stats.compute_cost_time.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "compute_cost_count",
-                    self.stats.compute_cost_count.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "cost_tracking_time",
-                    self.stats.cost_tracking_time.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "selected_txs_count",
-                    self.stats.selected_txs_count.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "estimated_signature_cu",
-                    self.stats.estimated_signature_cu.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "estimated_write_lock_cu",
-                    self.stats
-                        .estimated_write_lock_cu
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "estimated_data_bytes_cu",
-                    self.stats
-                        .estimated_data_bytes_cu
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "estimated_loaded_accounts_data_size_cu",
-                    self.stats
-                        .estimated_loaded_accounts_data_size_cu
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "estimated_programs_execute_cu",
-                    self.stats
-                        .estimated_programs_execute_cu
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "actual_programs_execute_cu",
-                    self.stats
-                        .actual_programs_execute_cu
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "actual_execute_time_us",
-                    self.stats.actual_execute_time_us.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-            );
-            datapoint_info!(
-                "qos-service-errors",
-                "id" => self.id,
-                ("bank_slot", bank_slot, i64),
-                (
-                    "retried_txs_per_block_limit_count",
-                    self.errors
-                        .retried_txs_per_block_limit_count
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "retried_txs_per_vote_limit_count",
-                    self.errors
-                        .retried_txs_per_vote_limit_count
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "retried_txs_per_account_limit_count",
-                    self.errors
-                        .retried_txs_per_account_limit_count
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "retried_txs_per_account_data_block_limit_count",
-                    self.errors
-                        .retried_txs_per_account_data_block_limit_count
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "dropped_txs_per_account_data_total_limit_count",
-                    self.errors
-                        .dropped_txs_per_account_data_total_limit_count
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-            );
-            self.slot.store(bank_slot, Ordering::Relaxed);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use {
@@ -601,7 +283,7 @@ mod tests {
         solana_system_transaction as system_transaction,
         solana_vote::vote_transaction,
         solana_vote_program::vote_state::TowerSync,
-        std::sync::Arc,
+        std::{num::Saturating, sync::Arc},
     };
 
     #[test]

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -23,26 +23,21 @@ mod transaction {
 // Banking thread calls `report_metrics(slot)` at end of `process_and_record_transaction()`, or any time
 // it wants.
 //
-pub struct QosService {}
+pub struct QosService;
 
 impl QosService {
-    pub fn new(_id: u32) -> Self {
-        Self {}
-    }
-
     /// Calculate cost of transactions, if not already filtered out, determine which ones to
     /// include in the slot, and accumulate costs in the cost tracker.
     /// Returns a vector of results containing selected transaction costs, and the number of
     /// transactions that were *NOT* selected.
     pub fn select_and_accumulate_transaction_costs<'a, Tx: TransactionWithMeta>(
-        &self,
         bank: &Bank,
         transactions: &'a [Tx],
         pre_results: impl Iterator<Item = transaction::Result<()>>,
     ) -> (Vec<transaction::Result<TransactionCost<'a, Tx>>>, u64) {
         let transaction_costs =
-            self.compute_transaction_costs(&bank.feature_set, transactions.iter(), pre_results);
-        let (transactions_qos_cost_results, num_included) = self.select_transactions_per_cost(
+            Self::compute_transaction_costs(&bank.feature_set, transactions.iter(), pre_results);
+        let (transactions_qos_cost_results, num_included) = Self::select_transactions_per_cost(
             transactions.iter(),
             transaction_costs.into_iter(),
             bank,
@@ -59,7 +54,6 @@ impl QosService {
     // invoke cost_model to calculate cost for the given list of transactions that have not
     // been filtered out already.
     fn compute_transaction_costs<'a, Tx: TransactionWithMeta>(
-        &self,
         feature_set: &FeatureSet,
         transactions: impl Iterator<Item = &'a Tx>,
         pre_results: impl Iterator<Item = transaction::Result<()>>,
@@ -74,7 +68,6 @@ impl QosService {
     /// list of Results that indicate if a transaction is selected to be included in the current block,
     /// and a count of the number of transactions that would fit in the block
     fn select_transactions_per_cost<'a, Tx: TransactionWithMeta>(
-        &self,
         transactions: impl Iterator<Item = &'a Tx>,
         transactions_costs: impl Iterator<Item = transaction::Result<TransactionCost<'a, Tx>>>,
         bank: &Bank,
@@ -237,8 +230,7 @@ mod tests {
         );
         let txs = [transfer_tx.clone(), vote_tx.clone(), vote_tx, transfer_tx];
 
-        let qos_service = QosService::new(1);
-        let txs_costs = qos_service.compute_transaction_costs(
+        let txs_costs = QosService::compute_transaction_costs(
             &FeatureSet::all_enabled(),
             txs.iter(),
             std::iter::repeat(Ok(())),
@@ -284,8 +276,7 @@ mod tests {
         // make a vec of txs
         let txs = [transfer_tx.clone(), vote_tx.clone(), transfer_tx, vote_tx];
 
-        let qos_service = QosService::new(1);
-        let txs_costs = qos_service.compute_transaction_costs(
+        let txs_costs = QosService::compute_transaction_costs(
             &FeatureSet::all_enabled(),
             txs.iter(),
             std::iter::repeat(Ok(())),
@@ -298,7 +289,7 @@ mod tests {
             .unwrap()
             .set_limits(cost_limit, cost_limit, cost_limit, 0);
         let (results, num_selected) =
-            qos_service.select_transactions_per_cost(txs.iter(), txs_costs.into_iter(), &bank);
+            QosService::select_transactions_per_cost(txs.iter(), txs_costs.into_iter(), &bank);
         assert_eq!(num_selected, 2);
 
         // verify that first transfer tx and first vote are allowed
@@ -341,8 +332,7 @@ mod tests {
 
         // assert all tx_costs should be applied to cost_tracker if all execution_results are all committed
         {
-            let qos_service = QosService::new(1);
-            let txs_costs = qos_service.compute_transaction_costs(
+            let txs_costs = QosService::compute_transaction_costs(
                 &FeatureSet::all_enabled(),
                 txs.iter(),
                 std::iter::repeat(Ok(())),
@@ -352,7 +342,7 @@ mod tests {
                 .map(|cost| cost.as_ref().unwrap().sum())
                 .sum();
             let (qos_cost_results, _num_included) =
-                qos_service.select_transactions_per_cost(txs.iter(), txs_costs.into_iter(), &bank);
+                QosService::select_transactions_per_cost(txs.iter(), txs_costs.into_iter(), &bank);
             assert_eq!(
                 total_txs_cost,
                 bank.read_cost_tracker().unwrap().block_cost()
@@ -412,8 +402,7 @@ mod tests {
 
         // assert all tx_costs should be removed from cost_tracker if all execution_results are all Not Committed
         {
-            let qos_service = QosService::new(1);
-            let txs_costs = qos_service.compute_transaction_costs(
+            let txs_costs = QosService::compute_transaction_costs(
                 &FeatureSet::all_enabled(),
                 txs.iter(),
                 std::iter::repeat(Ok(())),
@@ -423,7 +412,7 @@ mod tests {
                 .map(|cost| cost.as_ref().unwrap().sum())
                 .sum();
             let (qos_cost_results, _num_included) =
-                qos_service.select_transactions_per_cost(txs.iter(), txs_costs.into_iter(), &bank);
+                QosService::select_transactions_per_cost(txs.iter(), txs_costs.into_iter(), &bank);
             assert_eq!(
                 total_txs_cost,
                 bank.read_cost_tracker().unwrap().block_cost()
@@ -466,8 +455,7 @@ mod tests {
 
         // assert only committed tx_costs are applied cost_tracker
         {
-            let qos_service = QosService::new(1);
-            let txs_costs = qos_service.compute_transaction_costs(
+            let txs_costs = QosService::compute_transaction_costs(
                 &FeatureSet::all_enabled(),
                 txs.iter(),
                 std::iter::repeat(Ok(())),
@@ -477,7 +465,7 @@ mod tests {
                 .map(|cost| cost.as_ref().unwrap().sum())
                 .sum();
             let (qos_cost_results, _num_included) =
-                qos_service.select_transactions_per_cost(txs.iter(), txs_costs.into_iter(), &bank);
+                QosService::select_transactions_per_cost(txs.iter(), txs_costs.into_iter(), &bank);
             assert_eq!(
                 total_txs_cost,
                 bank.read_cost_tracker().unwrap().block_cost()

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -4,9 +4,8 @@
 //!
 
 use {
-    super::{BatchedTransactionDetails, committer::CommitTransactionDetails},
+    super::committer::CommitTransactionDetails,
     agave_feature_set::FeatureSet,
-    solana_clock::Slot,
     solana_cost_model::{
         cost_model::CostModel, cost_tracker::UpdatedCosts, transaction_cost::TransactionCost,
     },
@@ -48,9 +47,6 @@ impl QosService {
             transaction_costs.into_iter(),
             bank,
         );
-        self.accumulate_estimated_transaction_costs(&Self::accumulate_batched_transaction_costs(
-            transactions_qos_cost_results.iter(),
-        ));
         let cost_model_throttled_transactions_count =
             transactions.len().saturating_sub(num_included) as u64;
 
@@ -202,71 +198,6 @@ impl QosService {
         });
         cost_tracker.sub_transactions_in_flight(num_included);
     }
-
-    // metrics are reported by bank slot
-    pub fn report_metrics(&self, _slot: Slot) {}
-
-    fn accumulate_estimated_transaction_costs(
-        &self,
-        _batched_transaction_details: &BatchedTransactionDetails,
-    ) {
-    }
-
-    pub fn accumulate_actual_execute_cu(&self, _units: u64) {}
-
-    pub fn accumulate_actual_execute_time(&self, _micro_sec: u64) {}
-
-    // rollup transaction cost details, eg signature_cost, write_lock_cost, data_bytes_cost and
-    // execution_cost from the batch of transactions selected for block.
-    fn accumulate_batched_transaction_costs<'a, Tx: TransactionWithMeta + 'a>(
-        transactions_costs: impl Iterator<Item = &'a transaction::Result<TransactionCost<'a, Tx>>>,
-    ) -> BatchedTransactionDetails {
-        let mut batched_transaction_details = BatchedTransactionDetails::default();
-        transactions_costs.for_each(|cost| match cost {
-            Ok(cost) => {
-                batched_transaction_details.costs.batched_signature_cost += cost.signature_cost();
-                batched_transaction_details.costs.batched_write_lock_cost += cost.write_lock_cost();
-                batched_transaction_details.costs.batched_data_bytes_cost +=
-                    u64::from(cost.data_bytes_cost());
-                batched_transaction_details
-                    .costs
-                    .batched_loaded_accounts_data_size_cost +=
-                    cost.loaded_accounts_data_size_cost();
-                batched_transaction_details
-                    .costs
-                    .batched_programs_execute_cost += cost.programs_execution_cost();
-            }
-            Err(transaction_error) => match transaction_error {
-                TransactionError::WouldExceedMaxBlockCostLimit => {
-                    batched_transaction_details
-                        .errors
-                        .batched_retried_txs_per_block_limit_count += 1;
-                }
-                TransactionError::WouldExceedMaxVoteCostLimit => {
-                    batched_transaction_details
-                        .errors
-                        .batched_retried_txs_per_vote_limit_count += 1;
-                }
-                TransactionError::WouldExceedMaxAccountCostLimit => {
-                    batched_transaction_details
-                        .errors
-                        .batched_retried_txs_per_account_limit_count += 1;
-                }
-                TransactionError::WouldExceedAccountDataBlockLimit => {
-                    batched_transaction_details
-                        .errors
-                        .batched_retried_txs_per_account_data_block_limit_count += 1;
-                }
-                TransactionError::WouldExceedAccountDataTotalLimit => {
-                    batched_transaction_details
-                        .errors
-                        .batched_dropped_txs_per_account_data_total_limit_count += 1;
-                }
-                _ => {}
-            },
-        });
-        batched_transaction_details
-    }
 }
 
 #[cfg(test)]
@@ -274,7 +205,6 @@ mod tests {
     use {
         super::*,
         itertools::Itertools,
-        solana_cost_model::transaction_cost::{UsageCostDetails, WritableKeysTransaction},
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_runtime::genesis_utils::{GenesisConfigInfo, create_genesis_config},
@@ -283,7 +213,7 @@ mod tests {
         solana_system_transaction as system_transaction,
         solana_vote::vote_transaction,
         solana_vote_program::vote_state::TowerSync,
-        std::{num::Saturating, sync::Arc},
+        std::sync::Arc,
     };
 
     #[test]
@@ -600,58 +530,5 @@ mod tests {
                 bank.read_cost_tracker().unwrap().transaction_count()
             );
         }
-    }
-
-    #[test]
-    fn test_accumulate_batched_transaction_costs() {
-        let signature_cost = 1;
-        let write_lock_cost = 2;
-        let data_bytes_cost = 3;
-        let programs_execution_cost = 10;
-        let num_txs = 4;
-
-        let dummy_transaction = WritableKeysTransaction::new(vec![]);
-        let tx_cost_results: Vec<_> = (0..num_txs)
-            .map(|n| {
-                if n % 2 == 0 {
-                    Ok(TransactionCost::Transaction(UsageCostDetails {
-                        transaction: &dummy_transaction,
-                        signature_cost,
-                        write_lock_cost,
-                        data_bytes_cost,
-                        programs_execution_cost,
-                        loaded_accounts_data_size_cost: 0,
-                        allocated_accounts_data_size: 0,
-                    }))
-                } else {
-                    Err(TransactionError::WouldExceedMaxBlockCostLimit)
-                }
-            })
-            .collect();
-        // should only accumulate half of the costs that are OK
-        let expected_signatures = signature_cost * (num_txs / 2);
-        let expected_write_locks = write_lock_cost * (num_txs / 2);
-        let expected_data_bytes = u64::from(data_bytes_cost) * (num_txs / 2);
-        let expected_programs_execution_costs = programs_execution_cost * (num_txs / 2);
-        let batched_transaction_details =
-            QosService::accumulate_batched_transaction_costs(tx_cost_results.iter());
-        assert_eq!(
-            Saturating(expected_signatures),
-            batched_transaction_details.costs.batched_signature_cost
-        );
-        assert_eq!(
-            Saturating(expected_write_locks),
-            batched_transaction_details.costs.batched_write_lock_cost
-        );
-        assert_eq!(
-            Saturating(expected_data_bytes),
-            batched_transaction_details.costs.batched_data_bytes_cost
-        );
-        assert_eq!(
-            Saturating(expected_programs_execution_costs),
-            batched_transaction_details
-                .costs
-                .batched_programs_execute_cost
-        );
     }
 }

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -574,7 +574,6 @@ mod tests {
         super::*,
         crate::banking_stage::{
             committer::Committer,
-            qos_service::QosService,
             tests::{create_slow_genesis_config, sanitize_transactions},
             vote_storage::tests::packet_from_slots,
         },
@@ -767,7 +766,7 @@ mod tests {
 
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let committer = Committer::new(None, replay_vote_sender, None);
-        let consumer = Consumer::new(committer, recorder, QosService::new(1), None);
+        let consumer = Consumer::new(committer, recorder, None);
 
         // Create and process a simple transfer transaction
         let pubkey = solana_pubkey::new_rand();


### PR DESCRIPTION
#### Problem
- state used to track metrics nobody looks at and are covered by other metrics (cost_tracker, worker errors, etc)

#### Summary of Changes
- remove metrics
- remove unused structs
- remove state from qos-service
	- now just a wrapper around cost-model/tracker 

Fixes #
