### PR TITLE
remove local cluster test

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -121,7 +121,6 @@ fn create_test_validator_keys(keypairs: &[&str]) -> Vec<(ValidatorKeys, bool)> {
 }
 
 /// Smoke-tests the `new_with_equal_stakes()` startup path for a single-node cluster.
-/// This does not cover the explicit config-driven constructor path.
 #[test]
 #[serial]
 fn test_local_cluster_start_and_exit() {
@@ -134,28 +133,6 @@ fn test_local_cluster_start_and_exit() {
         SocketAddrSpace::Unspecified,
     );
     assert_eq!(cluster.validators.len(), num_nodes);
-}
-
-/// Verifies that an explicitly customized `ClusterConfig` still boots cleanly.
-/// This covers config plumbing rather than the helper-based startup path.
-#[test]
-#[serial]
-fn test_local_cluster_start_and_exit_with_config() {
-    agave_logger::setup();
-    const NUM_NODES: usize = 1;
-    let mut config = ClusterConfig {
-        validator_configs: make_identical_validator_configs(
-            &ValidatorConfig::default_for_test(),
-            NUM_NODES,
-        ),
-        node_stakes: vec![DEFAULT_NODE_STAKE; NUM_NODES],
-        ticks_per_slot: 8,
-        slots_per_epoch: MINIMUM_SLOTS_PER_EPOCH,
-        stakers_slot_offset: MINIMUM_SLOTS_PER_EPOCH,
-        ..ClusterConfig::default()
-    };
-    let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
-    assert_eq!(cluster.validators.len(), NUM_NODES);
 }
 
 /// Baseline multi-node transaction propagation and confirmation across every validator.


### PR DESCRIPTION
#### Problem
`test_local_cluster_start_and_exit_with_config` isn't providing any additional test coverage and local cluster tests are expensive.

#### Summary of Changes

- Delete `test_local_cluster_start_and_exit_with_config`
- Rely on coverage from `test_local_cluster_start_and_exit` for basic smoke test and `test_two_unbalanced_stakes` for testing w/ non-default tick count (has added bonus of verifying tick count in ledger).
- Update comment for `test_local_cluster_start_and_exit` - calling out that it doesn't explicitly pass a config seems irrelevant (it passes it one level down the stack)