### PR TITLE
Remove set_dirty and replace with mark_dirty

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1132,7 +1132,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             "ref count should be one after cleaning all entries"
         );
 
-        entry.set_dirty(true);
+        entry.mark_dirty();
 
         // Return the last entry in the slot list, which is the only one
         *slot_list

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -59,7 +59,7 @@ impl<T: IndexValue> AccountMapEntry<T> {
         let previous = self.ref_count.fetch_add(1, Ordering::Release);
         // ensure ref count does not overflow
         assert_ne!(previous, RefCount::MAX);
-        self.set_dirty(true);
+        self.mark_dirty();
     }
 
     /// decrement the ref count by one
@@ -73,7 +73,7 @@ impl<T: IndexValue> AccountMapEntry<T> {
     /// return the refcount prior to the ref count change
     pub fn unref_by_count(&self, count: RefCount) -> RefCount {
         let previous = self.ref_count.fetch_sub(count, Ordering::Release);
-        self.set_dirty(true);
+        self.mark_dirty();
         assert!(
             previous >= count,
             "decremented ref count below zero: {self:?}"
@@ -85,8 +85,8 @@ impl<T: IndexValue> AccountMapEntry<T> {
         self.meta.dirty.load(Ordering::Acquire)
     }
 
-    pub fn set_dirty(&self, value: bool) {
-        self.meta.dirty.store(value, Ordering::Release)
+    pub fn mark_dirty(&self) {
+        self.meta.dirty.store(true, Ordering::Release)
     }
 
     /// set dirty to false, return true if was dirty

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -396,7 +396,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 entry.map(|entry| {
                     let result = user_fn(entry.slot_list_write_lock());
                     // note that to be safe here, we ALWAYS mark the entry as dirty
-                    entry.set_dirty(true);
+                    entry.mark_dirty();
                     result
                 }),
             )
@@ -414,7 +414,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         } else {
             slot_list.push((slot, new_entry));
         }
-        current.set_dirty(true);
+        current.mark_dirty();
     }
 
     pub fn upsert(
@@ -562,7 +562,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 current.unref_by_count(ref_count_change.unsigned_abs());
             }
         }
-        current.set_dirty(true);
+        current.mark_dirty();
         slot_list_len
     }
 
@@ -842,7 +842,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         // Step 4: Extract the data to perform disk update outside the lock
         //
         // Race condition handling: If a parallel operation dirties the item again after scanning,
-        // then we will set_dirty(true) and skip the disk update. The dirty flag will ensure the
+        // then we will mark_dirty() and skip the disk update. The dirty flag will ensure the
         // next flush picks up the item again. If the item becomes dirty during our disk write,
         // that's ok - the dirty flag will be picked up on the next flush and prevent us from
         // evicting the item from the cache.
@@ -871,13 +871,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         // re-check the ref count after locking the slot list
         if entry.ref_count() != 1 {
-            entry.set_dirty(true);
+            entry.mark_dirty();
             return ShouldFlush::No(ReasonToNotFlush::RefCount);
         }
 
         if slot_list.len() != 1 {
             // we only flush regular entries, i.e. slot list len == 1
-            entry.set_dirty(true);
+            entry.mark_dirty();
             return ShouldFlush::No(ReasonToNotFlush::SlotListLen);
         }
 
@@ -886,7 +886,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         if slot_list_elem.1.is_cached() {
             // we only flush regular entries, i.e. slot list does not contain any cached entries
-            entry.set_dirty(true);
+            entry.mark_dirty();
             return ShouldFlush::No(ReasonToNotFlush::SlotListCached);
         }
 
@@ -1947,7 +1947,7 @@ mod tests {
                     ref_count,
                     AccountMapEntryMeta::default(),
                 ));
-                entry.set_dirty(true);
+                entry.mark_dirty();
                 entry.set_age(age);
                 (Pubkey::new_unique(), entry)
             })
@@ -1959,7 +1959,7 @@ mod tests {
                     ref_count,
                     AccountMapEntryMeta::default(),
                 ));
-                entry.set_dirty(false);
+                assert!(!entry.dirty());
                 entry.set_age(age);
                 (Pubkey::new_unique(), entry)
             })
@@ -2044,7 +2044,7 @@ mod tests {
                     AccountMapEntryMeta::default(),
                 ));
                 if i % 2 == 0 {
-                    one_element_slot_list_entry.set_dirty(true);
+                    one_element_slot_list_entry.mark_dirty();
                 }
                 one_element_slot_list_entry.set_age(current_age);
                 (pk, one_element_slot_list_entry)
@@ -2093,7 +2093,7 @@ mod tests {
                 /*ref count*/ 1,
                 AccountMapEntryMeta::default(),
             );
-            entry.set_dirty(true);
+            entry.mark_dirty();
 
             let entry_for_flush = bucket.try_make_entry_for_flush(&entry, 0, 0);
             assert_eq!(entry_for_flush, ShouldFlush::Yes((slot, account_info)));
@@ -2106,7 +2106,7 @@ mod tests {
                 /*ref count*/ 1,
                 AccountMapEntryMeta::default(),
             );
-            entry.set_dirty(false);
+            assert!(!entry.dirty());
 
             let entry_for_flush = bucket.try_make_entry_for_flush(&entry, 0, 0);
             assert_eq!(entry_for_flush, ShouldFlush::No(ReasonToNotFlush::Clean),);
@@ -2131,7 +2131,7 @@ mod tests {
                 /*ref count*/ 2,
                 AccountMapEntryMeta::default(),
             );
-            entry.set_dirty(true);
+            entry.mark_dirty();
 
             let entry_for_flush = bucket.try_make_entry_for_flush(&entry, 0, 0);
             assert_eq!(entry_for_flush, ShouldFlush::No(ReasonToNotFlush::RefCount),);
@@ -2144,7 +2144,7 @@ mod tests {
                 /*ref count*/ 1,
                 AccountMapEntryMeta::default(),
             );
-            entry.set_dirty(true);
+            entry.mark_dirty();
 
             let entry_for_flush = bucket.try_make_entry_for_flush(&entry, 0, 0);
             assert_eq!(
@@ -2160,7 +2160,7 @@ mod tests {
                 /*ref count*/ 1,
                 AccountMapEntryMeta::default(),
             );
-            entry.set_dirty(true);
+            entry.mark_dirty();
 
             let entry_for_flush = bucket.try_make_entry_for_flush(&entry, 0, 0);
             assert_eq!(
@@ -2177,7 +2177,7 @@ mod tests {
                 /*ref count*/ 1,
                 AccountMapEntryMeta::default(),
             );
-            entry.set_dirty(true);
+            entry.mark_dirty();
 
             let entry_for_flush = bucket.try_make_entry_for_flush(&entry, 0, 0);
             assert_eq!(


### PR DESCRIPTION
#### Problem
Setting dirty to false only has test usages, the correct runtime usage is clear_dirty which does a CAS 

#### Summary of Changes
- Replace set_dirty(true) with mark_dirty()
- Replace callers of set_dirty(false) with assert, as dirty was already false in those cases. 

#### Note
This is building to the next PR which is to convert dirty to three states rather than a bool: Dirty, Flushing and Clean. This is required to allow flushing of entries in the foreground. Flushing entries in the foreground reduces overshoot on map size. 

Next PR (Not complete but for reference): https://github.com/anza-xyz/agave/pull/11988

Fixes #
