### PR TITLE
cost pacer: derive slot time

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -21,6 +21,7 @@ use {
         },
         validator::SchedulerPacing,
     },
+    solana_clock::DEFAULT_MS_PER_SLOT,
     solana_cost_model::cost_tracker::SharedBlockCost,
     solana_measure::measure_us,
     solana_runtime::{bank::Bank, bank_forks::SharableBanks},
@@ -52,8 +53,9 @@ impl Default for SchedulerConfig {
     }
 }
 
+const DEFAULT_SCHEDULER_PACING_NON_FILL_TIME_MILLIS: u64 = 50;
 pub(crate) const DEFAULT_SCHEDULER_PACING_FILL_TIME_MILLIS: NonZeroU64 =
-    NonZeroU64::new(350).unwrap();
+    NonZeroU64::new(DEFAULT_MS_PER_SLOT - DEFAULT_SCHEDULER_PACING_NON_FILL_TIME_MILLIS).unwrap();
 
 /// Controls packet and transaction flow into scheduler, and scheduling execution.
 pub(crate) struct SchedulerController<R, S>
@@ -167,8 +169,12 @@ where
                                 pacing_fill_time, b.ns_per_slot,
                             );
                             self.config.scheduler_pacing = SchedulerPacing::FillTimeMillis(
-                                NonZeroU64::new(b.ns_per_slot as u64 / 1_000_000)
-                                    .unwrap_or(NonZeroU64::new(1).unwrap()),
+                                NonZeroU64::new(
+                                    (b.ns_per_slot as u64 / 1_000_000).saturating_sub(
+                                        DEFAULT_SCHEDULER_PACING_NON_FILL_TIME_MILLIS,
+                                    ),
+                                )
+                                .unwrap_or(NonZeroU64::new(1).unwrap()),
                             );
                         }
                     }
@@ -635,8 +641,10 @@ mod tests {
             .unwrap_or_default()
         {}
         let now = Instant::now();
-        let slot_time =
-            Duration::from_nanos_u128(scheduler_controller.sharable_banks.working().ns_per_slot);
+        let slot_time = decision
+            .bank()
+            .map(|bank| Duration::from_nanos_u128(bank.ns_per_slot))
+            .unwrap();
         assert!(
             scheduler_controller
                 .process_transactions(
@@ -645,7 +653,9 @@ mod tests {
                         block_limit: u64::MAX,
                         shared_block_cost: SharedBlockCost::new(0),
                         detection_time: now.checked_sub(slot_time).unwrap(),
-                        fill_time: Some(slot_time.saturating_sub(Duration::from_millis(100))),
+                        fill_time: Some(slot_time.saturating_sub(Duration::from_millis(
+                            DEFAULT_SCHEDULER_PACING_NON_FILL_TIME_MILLIS
+                        ))),
                     }),
                     &now
                 )

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -635,6 +635,8 @@ mod tests {
             .unwrap_or_default()
         {}
         let now = Instant::now();
+        let slot_time =
+            Duration::from_nanos_u128(scheduler_controller.sharable_banks.working().ns_per_slot);
         assert!(
             scheduler_controller
                 .process_transactions(
@@ -642,8 +644,8 @@ mod tests {
                     Some(&CostPacer {
                         block_limit: u64::MAX,
                         shared_block_cost: SharedBlockCost::new(0),
-                        detection_time: now.checked_sub(Duration::from_millis(400)).unwrap(),
-                        fill_time: Some(Duration::from_millis(300)),
+                        detection_time: now.checked_sub(slot_time).unwrap(),
+                        fill_time: Some(slot_time.saturating_sub(Duration::from_millis(100))),
                     }),
                     &now
                 )


### PR DESCRIPTION
#### Problem

1. Cost Pacer scheduling testing appears to be using hard coded 400ms as an approximate slot time. Would be easy to change slot time and forget to update this.
2. We are using some ad-hoc hard coded assumptions around slot time and "non-fill" time in the production and testing paths
3. In the event slot time drops, the production path does not leave any non-fill time buffer

#### Summary of Changes
1. Derive slot time from working bank in `test_receive_then_schedule`
2. Introduce `DEFAULT_SCHEDULER_PACING_NON_FILL_TIME_MILLIS` to define the "non-fill" time as 50ms and use this consistently everywhere
3. Remove hard coded 350ms from the fill time and derive this value from `DEFAULT_MS_PER_SLOT` and `DEFAULT_SCHEDULER_PACING_NON_FILL_TIME_MILLIS`