### PR TITLE
Feat/reserve enough space for fee only

### DIFF
--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -5,7 +5,6 @@ pub use solana_program_runtime::execution_budget::{
 use {
     solana_fee_structure::FeeDetails,
     solana_program_runtime::execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
-    std::num::NonZeroU32,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -301,7 +300,7 @@ impl ComputeBudget {
 
     pub fn get_compute_budget_and_limits(
         &self,
-        loaded_accounts_data_size_limit: NonZeroU32,
+        loaded_accounts_data_size_limit: u32,
         fee_details: FeeDetails,
     ) -> SVMTransactionExecutionAndFeeBudgetLimits {
         SVMTransactionExecutionAndFeeBudgetLimits {

--- a/compute-budget/src/compute_budget_limits.rs
+++ b/compute-budget/src/compute_budget_limits.rs
@@ -48,7 +48,7 @@ impl ComputeBudgetLimits {
                 heap_size: self.updated_heap_bytes,
                 ..SVMTransactionExecutionBudget::new_with_defaults(simd_0268_active)
             },
-            loaded_accounts_data_size_limit,
+            loaded_accounts_data_size_limit: loaded_accounts_data_size_limit.get(),
             fee_details,
         }
     }

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -83,7 +83,22 @@ impl QosService {
         let mut compute_cost_time = Measure::start("compute_cost_time");
         let txs_costs: Vec<_> = transactions
             .zip(pre_results)
-            .map(|(tx, pre_result)| pre_result.map(|()| CostModel::calculate_cost(tx, feature_set)))
+            .map(|(tx, pre_result)| {
+                pre_result.map(|()| {
+                    let mut reserving_cost = CostModel::calculate_cost(tx, feature_set);
+
+                    if let TransactionCost::Transaction(ref mut usage_cost_details) = reserving_cost
+                    {
+                        // To maintain cost tracking consistency, reserve at least one page for
+                        // loading the fee payer account in fee-only fallback scenarios.
+                        usage_cost_details.loaded_accounts_data_size_cost = usage_cost_details
+                            .loaded_accounts_data_size_cost
+                            .max(CostModel::calculate_pages_cost(1));
+                    }
+
+                    reserving_cost
+                })
+            })
             .collect();
         compute_cost_time.stop();
         self.metrics

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -10,7 +10,6 @@ use {
     agave_feature_set::FeatureSet,
     solana_bincode::limited_deserialize,
     solana_compute_budget::compute_budget_limits::DEFAULT_HEAP_COST,
-    solana_fee_structure::FeeStructure,
     solana_pubkey::Pubkey,
     solana_runtime_transaction::transaction_meta::TransactionMeta,
     solana_sdk_ids::system_program,
@@ -185,7 +184,7 @@ impl CostModel {
                 Ok(config) => (
                     u64::from(config.compute_unit_limit),
                     Self::calculate_loaded_accounts_data_size_cost(
-                        config.loaded_accounts_data_size_limit.get(),
+                        config.loaded_accounts_data_size_limit,
                         feature_set,
                     ),
                 ),
@@ -200,11 +199,22 @@ impl CostModel {
         transaction.instruction_data_len() / (INSTRUCTION_DATA_BYTES_COST as u16)
     }
 
+    // rounding bytes into number of pages
+    fn calculate_pages_for_bytes(bytes: u32) -> u64 {
+        u64::from(bytes)
+            .saturating_add(solana_fee_structure::ACCOUNT_DATA_COST_PAGE_SIZE.saturating_sub(1))
+            .saturating_div(solana_fee_structure::ACCOUNT_DATA_COST_PAGE_SIZE)
+    }
+
+    pub fn calculate_pages_cost(num_pages: u64) -> u64 {
+        num_pages.saturating_mul(DEFAULT_HEAP_COST)
+    }
+
     pub fn calculate_loaded_accounts_data_size_cost(
         loaded_accounts_data_size: u32,
         _feature_set: &FeatureSet,
     ) -> u64 {
-        FeeStructure::calculate_memory_usage_cost(loaded_accounts_data_size, DEFAULT_HEAP_COST)
+        Self::calculate_pages_cost(Self::calculate_pages_for_bytes(loaded_accounts_data_size))
     }
 
     fn calculate_account_data_size_on_deserialized_system_instruction(

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -427,7 +427,7 @@ mod tests {
             // and it has default loaded_account_data_size
             let loaded_accounts_data_size_cost =
                 CostModel::calculate_loaded_accounts_data_size_cost(
-                    MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.into(),
+                    MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get(),
                     &feature_set,
                 );
             let vote_program_usage_details = UsageCostDetails {

--- a/program-runtime/src/execution_budget.rs
+++ b/program-runtime/src/execution_budget.rs
@@ -297,7 +297,7 @@ impl SVMTransactionExecutionCost {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SVMTransactionExecutionAndFeeBudgetLimits {
     pub budget: SVMTransactionExecutionBudget,
-    pub loaded_accounts_data_size_limit: NonZeroU32,
+    pub loaded_accounts_data_size_limit: u32,
     pub fee_details: FeeDetails,
 }
 
@@ -306,7 +306,7 @@ impl Default for SVMTransactionExecutionAndFeeBudgetLimits {
     fn default() -> Self {
         Self {
             budget: SVMTransactionExecutionBudget::default(),
-            loaded_accounts_data_size_limit: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
+            loaded_accounts_data_size_limit: MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get(),
             fee_details: FeeDetails::default(),
         }
     }

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -67,7 +67,7 @@ impl<T> TransactionMeta for RuntimeTransaction<T> {
             updated_heap_bytes: compute_budget_limits.updated_heap_bytes,
             compute_unit_limit: compute_budget_limits.compute_unit_limit,
             priority_fee_lamports: compute_budget_limits.get_prioritization_fee(),
-            loaded_accounts_data_size_limit: compute_budget_limits.loaded_accounts_bytes,
+            loaded_accounts_data_size_limit: compute_budget_limits.loaded_accounts_bytes.get(),
         })
     }
     fn instruction_data_len(&self) -> u16 {

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -370,9 +370,7 @@ mod tests {
             );
             assert_eq!(
                 loaded_accounts_bytes,
-                transaction_configuration
-                    .loaded_accounts_data_size_limit
-                    .get()
+                transaction_configuration.loaded_accounts_data_size_limit
             );
         }
     }

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -15,7 +15,7 @@ use {
     agave_feature_set::FeatureSet,
     solana_compute_budget_instruction::compute_budget_instruction_details::ComputeBudgetInstructionDetails,
     solana_hash::Hash, solana_message::TransactionSignatureDetails,
-    solana_transaction::TransactionError, std::num::NonZeroU32,
+    solana_transaction::TransactionError,
 };
 
 pub trait TransactionMeta {
@@ -43,7 +43,7 @@ pub struct TransactionConfiguration {
     pub updated_heap_bytes: u32,
     pub compute_unit_limit: u32,
     pub priority_fee_lamports: u64,
-    pub loaded_accounts_data_size_limit: NonZeroU32,
+    pub loaded_accounts_data_size_limit: u32,
 }
 
 impl TransactionConfiguration {

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -35,7 +35,6 @@ use {
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction_context::{IndexOfAccount, transaction_accounts::KeyedAccountSharedData},
     solana_transaction_error::{TransactionError, TransactionResult as Result},
-    std::num::NonZeroU32,
 };
 
 // Per SIMD-0186, all accounts are assigned a base size of 64 bytes to cover
@@ -81,8 +80,7 @@ impl Default for CheckedTransactionDetails {
             nonce_address: None,
             compute_budget_and_limits: SVMTransactionExecutionAndFeeBudgetLimits {
                 budget: SVMTransactionExecutionBudget::default(),
-                loaded_accounts_data_size_limit: NonZeroU32::new(32)
-                    .expect("Failed to set loaded_accounts_bytes"),
+                loaded_accounts_data_size_limit: 32,
                 fee_details: FeeDetails::default(),
             },
         }
@@ -105,7 +103,7 @@ impl CheckedTransactionDetails {
 pub(crate) struct ValidatedTransactionDetails {
     pub(crate) rollback_accounts: RollbackAccounts,
     pub(crate) compute_budget: SVMTransactionExecutionBudget,
-    pub(crate) loaded_accounts_bytes_limit: NonZeroU32,
+    pub(crate) loaded_accounts_bytes_limit: u32,
     pub(crate) fee_details: FeeDetails,
     pub(crate) loaded_fee_payer_account: LoadedTransactionAccount,
 }
@@ -117,7 +115,7 @@ impl Default for ValidatedTransactionDetails {
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),
             loaded_accounts_bytes_limit:
-                solana_program_runtime::execution_budget::MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
+                solana_program_runtime::execution_budget::MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get(),
             fee_details: FeeDetails::default(),
             loaded_fee_payer_account: LoadedTransactionAccount::default(),
         }
@@ -449,11 +447,10 @@ struct LoadedTransactionDataSize {
 }
 
 impl LoadedTransactionDataSize {
-    fn with_max_size(requested_loaded_accounts_data_size_limit: NonZeroU32) -> Self {
+    fn with_max_size(requested_loaded_accounts_data_size_limit: u32) -> Self {
         Self {
             loaded_accounts_data_size: 0,
-            requested_loaded_accounts_data_size_limit: requested_loaded_accounts_data_size_limit
-                .get(),
+            requested_loaded_accounts_data_size_limit,
         }
     }
 
@@ -1129,7 +1126,7 @@ mod tests {
     fn test_increase_calculated_data_size() {
         let mut error_metrics = TransactionErrorMetrics::default();
         let data_size: usize = 123;
-        let requested_data_size_limit = NonZeroU32::new(data_size as u32).unwrap();
+        let requested_data_size_limit = data_size as u32;
         let mut acc = LoadedTransactionDataSize::with_max_size(requested_data_size_limit);
 
         // OK - loaded data size is up to limit
@@ -1318,7 +1315,7 @@ mod tests {
         let mut error_metrics = TransactionErrorMetrics::default();
 
         let mut loaded_transaction_data_size =
-            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
+            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get());
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1372,7 +1369,7 @@ mod tests {
         let mut error_metrics = TransactionErrorMetrics::default();
 
         let mut loaded_transaction_data_size =
-            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
+            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get());
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1426,7 +1423,7 @@ mod tests {
         let mut error_metrics = TransactionErrorMetrics::default();
 
         let mut loaded_transaction_data_size =
-            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
+            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get());
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1473,7 +1470,7 @@ mod tests {
         let mut error_metrics = TransactionErrorMetrics::default();
 
         let mut loaded_transaction_data_size =
-            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
+            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get());
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1531,7 +1528,7 @@ mod tests {
         let mut error_metrics = TransactionErrorMetrics::default();
 
         let mut loaded_transaction_data_size =
-            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
+            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get());
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1603,7 +1600,7 @@ mod tests {
         let mut error_metrics = TransactionErrorMetrics::default();
 
         let mut loaded_transaction_data_size =
-            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
+            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get());
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1662,7 +1659,7 @@ mod tests {
         let mut error_metrics = TransactionErrorMetrics::default();
 
         let mut loaded_transaction_data_size =
-            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
+            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get());
 
         let sanitized_transaction = SanitizedTransaction::new_for_tests(
             sanitized_message,
@@ -1735,7 +1732,7 @@ mod tests {
         );
 
         let mut loaded_transaction_data_size =
-            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
+            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get());
 
         let result = load_transaction_accounts(
             &mut account_loader,
@@ -1825,7 +1822,7 @@ mod tests {
         );
 
         let mut loaded_transaction_data_size =
-            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
+            LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get());
 
         let result = load_transaction_accounts(
             &mut account_loader,
@@ -2469,7 +2466,7 @@ mod tests {
             assert!(expected_size <= MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get() as usize);
 
             let mut loaded_transaction_data_size =
-                LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES);
+                LoadedTransactionDataSize::with_max_size(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get());
 
             load_transaction_accounts(
                 &mut account_loader,


### PR DESCRIPTION
#### Problem

refactor the NonZero removal and cost model change #11853

#### Summary of Changes
two commits for two prs
1. remove NonZero type; refactor cost model function into two parts, one pub facing
2. make sure block packer reserves at least 1 page for loading fee payer, to keep cost tracking consistent when tx turned into fee-only, in which case its loaded_accounts_data_size is `0`

Fixes #
