### PR TITLE
timestamp test use default slot time

### DIFF
--- a/runtime/src/stake_weighted_timestamp.rs
+++ b/runtime/src/stake_weighted_timestamp.rs
@@ -98,13 +98,16 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    use {super::*, solana_account::Account, solana_native_token::LAMPORTS_PER_SOL};
+    use {
+        super::*, solana_account::Account, solana_clock::DEFAULT_MS_PER_SLOT,
+        solana_native_token::LAMPORTS_PER_SOL,
+    };
 
     #[test]
     fn test_calculate_stake_weighted_timestamp_uses_median() {
         let recent_timestamp: UnixTimestamp = 1_578_909_061;
         let slot = 5;
-        let slot_duration = Duration::from_millis(400);
+        let slot_duration = Duration::from_millis(DEFAULT_MS_PER_SLOT);
         let pubkey0 = solana_pubkey::new_rand();
         let pubkey1 = solana_pubkey::new_rand();
         let pubkey2 = solana_pubkey::new_rand();


### PR DESCRIPTION
#### Problem
`test_calculate_stake_weighted_timestamp_uses_median` is using hard coded 400ms slot time for testing timestamps. Makes it a little harder to catch this and update it if we change slot time in the future

#### Summary of Changes
use `DEFAULT_MS_PER_SLOT` instead