### PR TITLE
Votor timer manager use slot time

### DIFF
--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -67,9 +67,6 @@ pub const SAFE_TO_SKIP_THRESHOLD: Fraction = Fraction::from_percentage(40);
 /// Time bound assumed on network transmission delays during periods of synchrony.
 pub(crate) const DELTA: Duration = Duration::from_millis(250);
 
-/// Time the leader has for producing and sending the block.
-pub(crate) const DELTA_BLOCK: Duration = Duration::from_millis(400);
-
 /// Base timeout for when leader's first slice should arrive if they sent it immediately.
 pub(crate) const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
 

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -215,9 +215,11 @@ impl EventHandler {
         let should_set_timeouts = vctx.vote_history.add_parent_ready(slot, parent_block);
         Self::check_pending_blocks(my_pubkey, &mut local_context.pending_blocks, vctx, votes)?;
         if should_set_timeouts {
+            let delta_block =
+                Duration::from_nanos_u128(ctx.bank_forks.read().unwrap().root_bank().ns_per_slot);
             timer_manager
                 .write()
-                .set_timeouts(slot, local_context.standstill_slot);
+                .set_timeouts(slot, local_context.standstill_slot, delta_block);
             local_context.stats.timeout_set = local_context.stats.timeout_set.saturating_add(1);
         }
 

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -215,8 +215,7 @@ impl EventHandler {
         let should_set_timeouts = vctx.vote_history.add_parent_ready(slot, parent_block);
         Self::check_pending_blocks(my_pubkey, &mut local_context.pending_blocks, vctx, votes)?;
         if should_set_timeouts {
-            let delta_block =
-                Duration::from_nanos_u128(ctx.bank_forks.read().unwrap().root_bank().ns_per_slot);
+            let delta_block = Duration::from_nanos_u128(vctx.sharable_banks.root().ns_per_slot);
             timer_manager
                 .write()
                 .set_timeouts(slot, local_context.standstill_slot, delta_block);

--- a/votor/src/timer_manager.rs
+++ b/votor/src/timer_manager.rs
@@ -5,10 +5,7 @@ mod stats;
 mod timers;
 
 use {
-    crate::{
-        common::{DELTA_BLOCK, DELTA_TIMEOUT},
-        event::VotorEvent,
-    },
+    crate::{common::DELTA_TIMEOUT, event::VotorEvent},
     agave_votor_messages::migration::MigrationStatus,
     crossbeam_channel::Sender,
     parking_lot::RwLock as PlRwLock,
@@ -37,11 +34,7 @@ impl TimerManager {
         exit: Arc<AtomicBool>,
         migration_status: Arc<MigrationStatus>,
     ) -> Self {
-        let timers = Arc::new(PlRwLock::new(Timers::new(
-            DELTA_TIMEOUT,
-            DELTA_BLOCK,
-            event_sender,
-        )));
+        let timers = Arc::new(PlRwLock::new(Timers::new(DELTA_TIMEOUT, event_sender)));
         let handle = {
             let timers = Arc::clone(&timers);
             thread::spawn(move || {
@@ -64,10 +57,15 @@ impl TimerManager {
         Self { timers, handle }
     }
 
-    pub(crate) fn set_timeouts(&self, slot: Slot, standstill_slot: Option<Slot>) {
+    pub(crate) fn set_timeouts(
+        &self,
+        slot: Slot,
+        standstill_slot: Option<Slot>,
+        delta_block: Duration,
+    ) {
         self.timers
             .write()
-            .set_timeouts(slot, Instant::now(), standstill_slot);
+            .set_timeouts(slot, Instant::now(), standstill_slot, delta_block);
     }
 
     pub(crate) fn join(self) {
@@ -82,7 +80,10 @@ impl TimerManager {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::event::VotorEvent, crossbeam_channel::unbounded, std::time::Duration};
+    use {
+        super::*, crate::event::VotorEvent, crossbeam_channel::unbounded,
+        solana_clock::DEFAULT_MS_PER_SLOT, std::time::Duration,
+    };
 
     #[test]
     fn test_timer_manager() {
@@ -93,10 +94,11 @@ mod tests {
             exit.clone(),
             Arc::new(MigrationStatus::post_migration_status()),
         );
+        let delta_block = Duration::from_millis(DEFAULT_MS_PER_SLOT);
         let slot = 52;
         let start = Instant::now();
-        timer_manager.set_timeouts(slot, None);
-        // Should see two timeouts at DELTA_BLOCK and DELTA_TIMEOUT
+        timer_manager.set_timeouts(slot, None, delta_block);
+        // Should see two timeouts at delta_block and DELTA_TIMEOUT
         let mut timeouts_received = 0;
         while timeouts_received < 2 && Instant::now().duration_since(start) < Duration::from_secs(2)
         {
@@ -106,7 +108,7 @@ mod tests {
                     VotorEvent::Timeout(s) => {
                         assert_eq!(s, slot);
                         assert!(
-                            Instant::now().duration_since(start) >= DELTA_TIMEOUT + DELTA_BLOCK
+                            Instant::now().duration_since(start) >= DELTA_TIMEOUT + delta_block
                         );
                         timeouts_received += 1;
                     }

--- a/votor/src/timer_manager/timers.rs
+++ b/votor/src/timer_manager/timers.rs
@@ -300,8 +300,7 @@ mod tests {
         assert!(timers.progress(now).is_none());
         assert!(receiver.try_recv().unwrap_err().is_empty());
 
-        let delta_block = Duration::from_millis(DEFAULT_MS_PER_SLOT);
-        timers.set_timeouts(0, now, None, delta_block);
+        timers.set_timeouts(0, now, None, Duration::from_millis(DEFAULT_MS_PER_SLOT));
         while timers.progress(now).is_some() {
             now = now.checked_add(one_micro).unwrap();
         }

--- a/votor/src/timer_manager/timers.rs
+++ b/votor/src/timer_manager/timers.rs
@@ -146,7 +146,6 @@ impl TimerState {
 /// Maintains all active timer states for windows of slots.
 pub(super) struct Timers {
     delta_timeout: Duration,
-    delta_block: Duration,
     /// Timers are indexed by slots.
     timers: HashMap<Slot, TimerState>,
     /// A min heap based on the time the next timer state might be ready.
@@ -158,14 +157,9 @@ pub(super) struct Timers {
 }
 
 impl Timers {
-    pub(super) fn new(
-        delta_timeout: Duration,
-        delta_block: Duration,
-        event_sender: Sender<VotorEvent>,
-    ) -> Self {
+    pub(super) fn new(delta_timeout: Duration, event_sender: Sender<VotorEvent>) -> Self {
         Self {
             delta_timeout,
-            delta_block,
             timers: HashMap::new(),
             heap: BinaryHeap::new(),
             event_sender,
@@ -176,13 +170,19 @@ impl Timers {
     /// Call to set timeouts for a new window of slots.
     /// If `standstill_slot` is provided, timeouts are extended by 5% for each leader window
     /// since standstill started.
-    pub(super) fn set_timeouts(&mut self, slot: Slot, now: Instant, standstill_slot: Option<Slot>) {
+    pub(super) fn set_timeouts(
+        &mut self,
+        slot: Slot,
+        now: Instant,
+        standstill_slot: Option<Slot>,
+        delta_block: Duration,
+    ) {
         assert_eq!(self.heap.len(), self.timers.len());
         let timeout_multiplier = calculate_timeout_multiplier(slot, standstill_slot);
         let (timer, next_fire) = TimerState::new(
             slot,
             self.delta_timeout,
-            self.delta_block,
+            delta_block,
             now,
             timeout_multiplier,
         );
@@ -245,9 +245,8 @@ impl Timers {
 #[cfg(test)]
 mod tests {
     use {
-        super::*,
-        crate::common::{DELTA_BLOCK, DELTA_TIMEOUT},
-        crossbeam_channel::unbounded,
+        super::*, crate::common::DELTA_TIMEOUT, crossbeam_channel::unbounded,
+        solana_clock::DEFAULT_MS_PER_SLOT,
     };
 
     #[test]
@@ -297,11 +296,12 @@ mod tests {
         let one_micro = Duration::from_micros(1);
         let mut now = Instant::now();
         let (sender, receiver) = unbounded();
-        let mut timers = Timers::new(one_micro, one_micro, sender);
+        let mut timers = Timers::new(one_micro, sender);
         assert!(timers.progress(now).is_none());
         assert!(receiver.try_recv().unwrap_err().is_empty());
 
-        timers.set_timeouts(0, now, None);
+        let delta_block = Duration::from_millis(DEFAULT_MS_PER_SLOT);
+        timers.set_timeouts(0, now, None, delta_block);
         while timers.progress(now).is_some() {
             now = now.checked_add(one_micro).unwrap();
         }
@@ -392,8 +392,13 @@ mod tests {
         // Use a large multiplier that would exceed MAX_TIMEOUT
         let multiplier = 1000000.0;
 
-        let (mut timer_state, next_fire) =
-            TimerState::new(100, DELTA_TIMEOUT, DELTA_BLOCK, now, multiplier);
+        let (mut timer_state, next_fire) = TimerState::new(
+            100,
+            DELTA_TIMEOUT,
+            Duration::from_millis(DEFAULT_MS_PER_SLOT),
+            now,
+            multiplier,
+        );
 
         // The first timeout should be capped at MAX_TIMEOUT
         let expected_first_fire = now + Duration::from_secs(MAX_TIMEOUT_SECS as u64);


### PR DESCRIPTION
#### Problem
`DELTA_BLOCK` hard coded to 400ms and used in several places in Votor crate. Makes it impossible to switch slot time dynamically.

#### Summary of Changes
Give `TimerManager` a handle to shareable banks so we can derive the block time from the working bank