### PR TITLE
test get slot time from bank

### DIFF
--- a/core/src/epoch_specs.rs
+++ b/core/src/epoch_specs.rs
@@ -116,7 +116,7 @@ mod tests {
         assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
         assert_eq!(
             get_epoch_duration(&bank),
-            Duration::from_millis(num_slots * 400)
+            Duration::from_nanos(num_slots * bank.ns_per_slot as u64)
         );
         for slot in 1..32 {
             bank = Bank::new_from_parent_with_bank_forks(
@@ -129,7 +129,7 @@ mod tests {
             assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
             assert_eq!(
                 get_epoch_duration(&bank),
-                Duration::from_millis(num_slots * 400)
+                Duration::from_nanos(num_slots * bank.ns_per_slot as u64)
             );
         }
         let epoch = 1;
@@ -145,7 +145,7 @@ mod tests {
             assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
             assert_eq!(
                 get_epoch_duration(&bank),
-                Duration::from_millis(num_slots * 400)
+                Duration::from_nanos(num_slots * bank.ns_per_slot as u64)
             );
         }
         let epoch = 2;
@@ -161,7 +161,7 @@ mod tests {
             assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
             assert_eq!(
                 get_epoch_duration(&bank),
-                Duration::from_millis(num_slots * 400)
+                Duration::from_nanos(num_slots * bank.ns_per_slot as u64)
             );
         }
     }


### PR DESCRIPTION
#### Problem
`test_get_epoch_duration` using hard coded 400 for slot time

#### Summary of Changes
Grab the actual slot time from bank instead