### PR TITLE
replace AtomicBool dirty flag with DirtyState enum

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1,6 +1,7 @@
 mod account_map_entry;
 mod accounts_index_storage;
 mod bucket_map_holder;
+mod dirty_state;
 pub(crate) mod in_mem_accounts_index;
 mod iter;
 mod roots_tracker;

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -2,16 +2,14 @@ use {
     super::{
         AtomicRefCount, DiskIndexValue, IndexValue, RefCount, SlotList, SlotListItem,
         bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
+        dirty_state::{AtomicDirtyState, DirtyState},
     },
     crate::{account_info::AccountInfo, is_zero_lamport::IsZeroLamport},
     solana_clock::Slot,
     std::{
         fmt::Debug,
         ops::{Deref, DerefMut},
-        sync::{
-            RwLock, RwLockReadGuard, RwLockWriteGuard,
-            atomic::{AtomicBool, Ordering},
-        },
+        sync::{RwLock, RwLockReadGuard, RwLockWriteGuard, atomic::Ordering},
     },
 };
 
@@ -82,19 +80,23 @@ impl<T: IndexValue> AccountMapEntry<T> {
     }
 
     pub fn dirty(&self) -> bool {
-        self.meta.dirty.load(Ordering::Acquire)
+        self.meta.dirty.is_dirty()
+    }
+
+    pub fn is_evictable(&self) -> bool {
+        self.meta.dirty.is_evictable()
     }
 
     pub fn mark_dirty(&self) {
-        self.meta.dirty.store(true, Ordering::Release)
+        self.meta.dirty.mark_dirty();
     }
 
-    /// set dirty to false, return true if was dirty
-    pub fn clear_dirty(&self) -> bool {
-        self.meta
-            .dirty
-            .compare_exchange(true, false, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
+    pub fn begin_flush(&self) -> bool {
+        self.meta.dirty.begin_flush()
+    }
+
+    pub fn end_flush(&self) -> bool {
+        self.meta.dirty.end_flush()
     }
 
     pub fn age(&self) -> Age {
@@ -220,8 +222,8 @@ impl<T> DerefMut for SlotListWriteGuard<'_, T> {
 /// used to keep track of consistency with disk index
 #[derive(Debug, Default)]
 pub struct AccountMapEntryMeta {
-    /// true if entry in in-mem idx has changes and needs to be written to disk
-    dirty: AtomicBool,
+    /// Dirty flag tracking sync state with the disk index.
+    dirty: AtomicDirtyState,
     /// 'age' at which this entry should be purged from the cache (implements lru)
     age: AtomicAge,
 }
@@ -232,7 +234,7 @@ impl AccountMapEntryMeta {
         is_cached: bool,
     ) -> Self {
         AccountMapEntryMeta {
-            dirty: AtomicBool::new(true),
+            dirty: AtomicDirtyState::new(DirtyState::Dirty),
             age: AtomicAge::new(storage.future_age_to_flush(is_cached)),
         }
     }
@@ -240,7 +242,7 @@ impl AccountMapEntryMeta {
         storage: &BucketMapHolder<T, U>,
     ) -> Self {
         AccountMapEntryMeta {
-            dirty: AtomicBool::new(false),
+            dirty: AtomicDirtyState::new(DirtyState::Clean),
             age: AtomicAge::new(storage.future_age_to_flush(false)),
         }
     }

--- a/accounts-db/src/accounts_index/dirty_state.rs
+++ b/accounts-db/src/accounts_index/dirty_state.rs
@@ -1,0 +1,172 @@
+use std::sync::atomic::{AtomicU8, Ordering};
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirtyState {
+    /// Entry is in sync with the disk index. Safe to evict
+    Clean = 0,
+    /// Item is being flushed to the disk. Not safe to evict
+    Flushing = 1,
+    /// Entry has changes not yet written to disk. Not safe to evict
+    Dirty = 2,
+}
+
+impl From<u8> for DirtyState {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => Self::Clean,
+            1 => Self::Flushing,
+            2 => Self::Dirty,
+            _ => panic!("invalid value for DirtyState: {value}"),
+        }
+    }
+}
+
+/// Atomic wrapper for DirtyState, owning all state-transition operations
+#[derive(Debug)]
+pub struct AtomicDirtyState(AtomicU8);
+
+impl Default for AtomicDirtyState {
+    fn default() -> Self {
+        Self(AtomicU8::new(DirtyState::Clean as u8))
+    }
+}
+
+impl AtomicDirtyState {
+    pub fn new(state: DirtyState) -> Self {
+        Self(AtomicU8::new(state as u8))
+    }
+
+    pub fn load(&self) -> DirtyState {
+        DirtyState::from(self.0.load(Ordering::Acquire))
+    }
+
+    /// Returns true when the entry is Dirty or Flushing, and thus not safe to evict
+    pub fn is_dirty(&self) -> bool {
+        self.load() != DirtyState::Clean
+    }
+
+    /// Returns true when the entry is Clean and thus safe to evict
+    pub fn is_evictable(&self) -> bool {
+        self.load() == DirtyState::Clean
+    }
+
+    /// Mark the entry as Dirty, having changes that are not yet flushed to disk
+    pub fn mark_dirty(&self) {
+        self.0.store(DirtyState::Dirty as u8, Ordering::Release);
+    }
+
+    /// Transitions from Dirty to Flushing. Returns true if the transition succeeded
+    pub fn begin_flush(&self) -> bool {
+        self.0
+            .compare_exchange(
+                DirtyState::Dirty as u8,
+                DirtyState::Flushing as u8,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+
+    /// Transitions from Flushing to Clean. Returns true if the transition succeeded
+    pub fn end_flush(&self) -> bool {
+        self.0
+            .compare_exchange(
+                DirtyState::Flushing as u8,
+                DirtyState::Clean as u8,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, test_case::test_case};
+
+    #[test_case(DirtyState::Clean, false, true; "clean")]
+    #[test_case(DirtyState::Flushing, true, false; "flushing")]
+    #[test_case(DirtyState::Dirty, true, false; "dirty")]
+    fn test_state_properties(
+        state: DirtyState,
+        expected_is_dirty: bool,
+        expected_is_evictable: bool,
+    ) {
+        let s = AtomicDirtyState::new(state);
+        assert_eq!(s.is_dirty(), expected_is_dirty);
+        assert_eq!(s.is_evictable(), expected_is_evictable);
+    }
+
+    #[test]
+    fn default_is_clean() {
+        let s = AtomicDirtyState::default();
+        assert_eq!(s.load(), DirtyState::Clean);
+    }
+
+    #[test_case(DirtyState::Clean; "from_clean")]
+    #[test_case(DirtyState::Flushing; "from_flushing")]
+    #[test_case(DirtyState::Dirty; "from_dirty")]
+    fn test_mark_dirty(initial: DirtyState) {
+        let s = AtomicDirtyState::new(initial);
+        s.mark_dirty();
+        assert_eq!(s.load(), DirtyState::Dirty);
+    }
+
+    #[test_case(DirtyState::Dirty, true, DirtyState::Flushing; "from_dirty_succeeds")]
+    #[test_case(DirtyState::Clean, false, DirtyState::Clean; "from_clean_fails")]
+    #[test_case(DirtyState::Flushing, false, DirtyState::Flushing; "from_flushing_fails")]
+    fn test_begin_flush(initial: DirtyState, expected_return: bool, expected_state: DirtyState) {
+        let s = AtomicDirtyState::new(initial);
+        assert_eq!(s.begin_flush(), expected_return);
+        assert_eq!(s.load(), expected_state);
+    }
+
+    #[test_case(DirtyState::Flushing, true, DirtyState::Clean; "transitions_to_clean")]
+    #[test_case(DirtyState::Dirty, false, DirtyState::Dirty; "noop_when_dirty")]
+    #[test_case(DirtyState::Clean, false, DirtyState::Clean; "noop_when_clean")]
+    fn test_end_flush(initial: DirtyState, expected_return: bool, expected_state: DirtyState) {
+        let s = AtomicDirtyState::new(initial);
+        assert_eq!(s.end_flush(), expected_return);
+        assert_eq!(s.load(), expected_state);
+    }
+
+    #[test_case(0, DirtyState::Clean)]
+    #[test_case(1, DirtyState::Flushing)]
+    #[test_case(2, DirtyState::Dirty)]
+    fn test_from_u8(value: u8, expected: DirtyState) {
+        assert_eq!(DirtyState::from(value), expected);
+    }
+
+    #[test_case(3)]
+    #[test_case(255)]
+    #[should_panic(expected = "invalid value for DirtyState")]
+    fn test_from_u8_invalid(value: u8) {
+        let _ = DirtyState::from(value);
+    }
+
+    /// Normal Path: Dirty to Flushing to Clean
+    #[test]
+    fn test_flush_cycle_happy_path() {
+        let s = AtomicDirtyState::new(DirtyState::Dirty);
+        assert!(s.begin_flush());
+        assert_eq!(s.load(), DirtyState::Flushing);
+        assert!(s.end_flush());
+        assert_eq!(s.load(), DirtyState::Clean);
+    }
+
+    /// A write arriving while a flush is in-flight must not be lost.
+    ///
+    /// Sequence: Dirty -> Flushing (begin_flush), then a concurrent
+    /// write calls mark_dirty() -> Dirty, then the flush completes and
+    /// end_flush() must leave the entry Dirty for the next cycle.
+    #[test]
+    fn test_concurrent_write_during_flush_is_not_lost() {
+        let s = AtomicDirtyState::new(DirtyState::Dirty);
+        assert!(s.begin_flush());
+        s.mark_dirty(); // concurrent write while disk write is in-flight
+        assert_eq!(s.load(), DirtyState::Dirty);
+        assert!(!s.end_flush()); // disk write completes -- must not clear the new dirty
+        assert_eq!(s.load(), DirtyState::Dirty);
+    }
+}

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -827,8 +827,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// To be flushed, `entry` must be dirty and regular.
     /// ('regular' means ref count == 1 and slot list len == 1)
     ///
-    /// If yes can be flushed, then `entry`'s dirty flag will be cleared.
-    /// If no cannot be flushed, then `entry`'s dirty flag will remain set.
+    /// If yes can be flushed, then `entry`'s dirty state will be set to Flushing
+    /// If no cannot be flushed, then `entry`'s dirty state will remain Dirty.
     fn try_make_entry_for_flush(
         &self,
         entry: &AccountMapEntry<T>,
@@ -836,16 +836,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         ages_flushing_now: Age,
     ) -> ShouldFlush<SlotListItem<T>> {
         // Step 1: Perform the cheap checks on the entry
-        // Step 2: Clear the dirty flag
+        // Step 2: Transition Dirty -> Flushing
         // Step 3: Perform all the checks on the entry.
-        // - If any fail, set the dirty flag again, update stats, and return None.
+        // - If any fail, transition back to Dirty, update stats, and return None.
         // Step 4: Extract the data to perform disk update outside the lock
         //
-        // Race condition handling: If a parallel operation dirties the item again after scanning,
-        // then we will mark_dirty() and skip the disk update. The dirty flag will ensure the
-        // next flush picks up the item again. If the item becomes dirty during our disk write,
-        // that's ok - the dirty flag will be picked up on the next flush and prevent us from
-        // evicting the item from the cache.
+        // Race condition handling: if a concurrent write calls mark_dirty() while the entry
+        // is flushing, the dirty state will transition back to Dirty. end_flush() will
+        // then fail the transition to Clean and the entry remains Dirty after the write
 
         if !Self::should_evict_based_on_age(current_age, entry, ages_flushing_now) {
             // entry was bumped in age after initial scan for candidates
@@ -858,15 +856,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             return ShouldFlush::No(ReasonToNotFlush::RefCount);
         }
 
-        // assume we're going to flush this entry, so clear its dirty flag
-        let was_dirty = entry.clear_dirty();
-        if !was_dirty {
-            // entry is not dirty anymore, skip disk write
+        // Transition Dirty to Flushing.  Returns false if already Clean or Flushing
+        if !entry.begin_flush() {
             return ShouldFlush::No(ReasonToNotFlush::Clean);
         }
 
         // lock the slot list and then check *everything*
-        // if a check fails, do not flush, and set dirty flag again
+        // if a check fails, mark_dirty() aborts back to Dirty
         let slot_list = entry.slot_list_read_lock();
 
         // re-check the ref count after locking the slot list
@@ -890,7 +886,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             return ShouldFlush::No(ReasonToNotFlush::SlotListCached);
         }
 
-        // entry is ready to be flushed
+        // entry is ready to be flushed; caller must call end_flush() after disk write
         ShouldFlush::Yes(slot_list_elem)
     }
 
@@ -1201,7 +1197,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let mut flush_stats = DiskFlushStats::new();
 
         // Process each candidate to flush
-        // For each entry: lock map briefly, get entry, calculate disk value, release lock, then write to disk
+        // For each entry: lock map briefly, transition Dirty to Flushing, extract disk value,
+        // release lock, write to disk, re-lock to transition Flushing to Clean.
         let flush_update_measure = Measure::start("flush_update");
         for key in candidates_to_flush.0 {
             // Entry was dirty at scan time, need to write to disk
@@ -1246,6 +1243,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     Ok(_) => {
                         // successfully written to disk
                         flush_stats.flush_entries_updated_on_disk += 1;
+                        // Transition state from Flushing to Clean
+                        if let Some(entry) = self.map_internal.read().unwrap().get(&key) {
+                            entry.end_flush();
+                        }
                         break;
                     }
                     Err(err) => {
@@ -1288,10 +1289,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 if let Entry::Occupied(occupied) = map.entry(*k) {
                     let v = occupied.get();
 
-                    if v.dirty()
+                    if !v.is_evictable()
                         || !Self::should_evict_based_on_age(current_age, v, ages_flushing_now)
                     {
-                        // marked dirty or bumped in age after we looked above
+                        // dirty/flushing or bumped in age after we looked above
                         // these evictions will be handled in later passes (at later ages)
                         failed += 1;
                         continue;


### PR DESCRIPTION
#### Problem

Current dirty flag handling does not allow flush and evict to run in separate threads. The race condition is:

1. `flush_write_cache` finds a dirty entry and marks it clean, then starts the flush
2. The eviction thread evicts the now-clean entry from cache
3. A load finds no entry (or a stale one) — the in-memory version was evicted before the flush completed

**Two possible solutions:**

**Option 1 — Clear the dirty flag after flushing completes**

This introduces a different race:
1. Flush begins on any thread
2. `upsert` modifies the entry and marks it dirty
3. Flush completes and overwrites the dirty entry with a clean one

To resolve this, the flush thread would need to inspect the slot list to detect whether it changed during the flush.

**Option 2 — Explicit 3-state tracking (chosen approach)**

- Transition entry to `Flushing` when a flush begins
- Do not allow eviction of entries in `Dirty` or `Flushing` state
- CAS from `Flushing` → `Clean`; if another thread transitioned to `Dirty` in the meantime, the CAS fails and the dirty state is preserved

> **Note:** This does not protect against multiple threads writing to a single entry simultaneously.

---

#### Summary of Changes

- Added `DirtyState` enum with three variants: `Dirty` / `Flushing` / `Clean`
- Updated the background flush thread to use the new state transitions

---

#### Notes

Next PR will add an eviction path from `upsert`.

Builds upon https://github.com/anza-xyz/agave/pull/11976

Fixes #
