### PR TITLE
remove relax_intrabatch_account_locks

### DIFF
--- a/accounts-db/benches/bench_lock_accounts.rs
+++ b/accounts-db/benches/bench_lock_accounts.rs
@@ -66,20 +66,15 @@ fn create_test_transactions(lock_count: usize, read_conflicts: bool) -> Vec<Sani
 fn bench_entry_lock_accounts(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench_lock_accounts");
 
-    for (batch_size, lock_count, read_conflicts, relax_intrabatch_account_locks) in
-        iproduct!(BATCH_SIZES, LOCK_COUNTS, [false, true], [false, true])
+    for (batch_size, lock_count, read_conflicts) in
+        iproduct!(BATCH_SIZES, LOCK_COUNTS, [false, true])
     {
         let name = format!(
-            "batch_size_{batch_size}_locks_count_{lock_count}{}{}",
+            "batch_size_{batch_size}_locks_count_{lock_count}{}",
             if read_conflicts {
                 "_read_conflicts"
             } else {
                 ""
-            },
-            if relax_intrabatch_account_locks {
-                "_simd83"
-            } else {
-                "_old"
             },
         );
 
@@ -98,7 +93,6 @@ fn bench_entry_lock_accounts(c: &mut Criterion) {
                         black_box(batch.iter()),
                         batch_results.clone(),
                         MAX_TX_ACCOUNT_LOCKS,
-                        relax_intrabatch_account_locks,
                     );
                     accounts.unlock_accounts(batch.iter().zip(&results));
                 }

--- a/accounts-db/src/account_locks.rs
+++ b/accounts-db/src/account_locks.rs
@@ -16,26 +16,9 @@ pub struct AccountLocks {
 }
 
 impl AccountLocks {
-    /// Lock the account keys in `keys` for a transaction.
-    /// The bool in the tuple indicates if the account is writable.
-    /// Returns an error if any of the accounts are already locked in a way
-    /// that conflicts with the requested lock.
-    /// NOTE this is the pre-SIMD83 logic and can be removed once SIMD83 is active.
-    pub fn try_lock_accounts<'a>(
-        &mut self,
-        keys: impl Iterator<Item = (&'a Pubkey, bool)> + Clone,
-    ) -> TransactionResult<()> {
-        self.can_lock_accounts(keys.clone())?;
-        self.lock_accounts(keys);
-
-        Ok(())
-    }
-
     /// Lock accounts for all transactions in a batch which don't conflict
     /// with existing locks. Returns a vector of `TransactionResult` indicating
     /// success or failure for each transaction in the batch.
-    /// NOTE this is the SIMD83 logic; after the feature is active, it becomes
-    /// the only logic, and this note can be removed with the feature gate.
     pub fn try_lock_transaction_batch<'a>(
         &mut self,
         mut validated_batch_keys: Vec<
@@ -201,45 +184,6 @@ fn has_duplicates(account_keys: AccountKeys) -> bool {
 #[cfg(test)]
 mod tests {
     use {super::*, solana_message::v0::LoadedAddresses};
-
-    #[test]
-    fn test_account_locks() {
-        let mut account_locks = AccountLocks::default();
-
-        let key1 = Pubkey::new_unique();
-        let key2 = Pubkey::new_unique();
-
-        // Add write and read-lock.
-        let result = account_locks.try_lock_accounts([(&key1, true), (&key2, false)].into_iter());
-        assert!(result.is_ok());
-
-        // Try to add duplicate write-lock.
-        let result = account_locks.try_lock_accounts([(&key1, true)].into_iter());
-        assert_eq!(result, Err(TransactionError::AccountInUse));
-
-        // Try to add write lock on read-locked account.
-        let result = account_locks.try_lock_accounts([(&key2, true)].into_iter());
-        assert_eq!(result, Err(TransactionError::AccountInUse));
-
-        // Try to add read lock on write-locked account.
-        let result = account_locks.try_lock_accounts([(&key1, false)].into_iter());
-        assert_eq!(result, Err(TransactionError::AccountInUse));
-
-        // Add read lock on read-locked account.
-        let result = account_locks.try_lock_accounts([(&key2, false)].into_iter());
-        assert!(result.is_ok());
-
-        // Unlock write and read locks.
-        account_locks.unlock_accounts([(&key1, true), (&key2, false)].into_iter());
-
-        // No more remaining write-locks. Read-lock remains.
-        assert!(!account_locks.is_locked_write(&key1));
-        assert!(account_locks.is_locked_readonly(&key2));
-
-        // Unlock read lock.
-        account_locks.unlock_accounts([(&key2, false)].into_iter());
-        assert!(!account_locks.is_locked_readonly(&key2));
-    }
 
     #[test]
     fn test_validate_account_locks_valid_no_dynamic() {

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -483,7 +483,6 @@ impl Accounts {
         txs: impl Iterator<Item = &'a (impl SVMMessage + 'a)>,
         results: impl Iterator<Item = Result<()>>,
         tx_account_lock_limit: usize,
-        relax_intrabatch_account_locks: bool,
     ) -> Vec<Result<()>> {
         // Validate the account locks, then get keys and is_writable if successful validation.
         // We collect to fully evaluate before taking the account_locks mutex.
@@ -497,18 +496,7 @@ impl Accounts {
             .collect::<Vec<_>>();
 
         let account_locks = &mut self.account_locks.lock().unwrap();
-
-        if relax_intrabatch_account_locks {
-            account_locks.try_lock_transaction_batch(validated_batch_keys)
-        } else {
-            validated_batch_keys
-                .into_iter()
-                .map(|result_validated_tx_keys| match result_validated_tx_keys {
-                    Ok(validated_tx_keys) => account_locks.try_lock_accounts(validated_tx_keys),
-                    Err(e) => Err(e),
-                })
-                .collect()
-        }
+        account_locks.try_lock_transaction_batch(validated_batch_keys)
     }
 
     /// Once accounts are unlocked, new transactions that modify that state can enter the pipeline
@@ -634,7 +622,6 @@ mod tests {
             sync::atomic::{AtomicBool, AtomicU64, Ordering},
             thread, time,
         },
-        test_case::test_case,
     };
 
     fn new_sanitized_tx<T: Signers>(
@@ -816,9 +803,8 @@ mod tests {
         assert_eq!(loaded, vec![]);
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_lock_accounts_with_duplicates(relax_intrabatch_account_locks: bool) {
+    #[test]
+    fn test_lock_accounts_with_duplicates() {
         let accounts_db = AccountsDb::new_single_for_tests();
         let accounts = Accounts::new(Arc::new(accounts_db));
 
@@ -833,18 +819,13 @@ mod tests {
         };
 
         let tx = new_sanitized_tx(&[&keypair], message, Hash::default());
-        let results = accounts.lock_accounts(
-            [tx].iter(),
-            [Ok(())].into_iter(),
-            MAX_TX_ACCOUNT_LOCKS,
-            relax_intrabatch_account_locks,
-        );
+        let results =
+            accounts.lock_accounts([tx].iter(), [Ok(())].into_iter(), MAX_TX_ACCOUNT_LOCKS);
         assert_eq!(results[0], Err(TransactionError::AccountLoadedTwice));
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_lock_accounts_with_too_many_accounts(relax_intrabatch_account_locks: bool) {
+    #[test]
+    fn test_lock_accounts_with_too_many_accounts() {
         let accounts_db = AccountsDb::new_single_for_tests();
         let accounts = Accounts::new(Arc::new(accounts_db));
 
@@ -871,7 +852,6 @@ mod tests {
                 txs.iter(),
                 vec![Ok(()); txs.len()].into_iter(),
                 MAX_TX_ACCOUNT_LOCKS,
-                relax_intrabatch_account_locks,
             );
             assert_eq!(results, vec![Ok(())]);
             accounts.unlock_accounts(txs.iter().zip(&results));
@@ -898,15 +878,13 @@ mod tests {
                 txs.iter(),
                 vec![Ok(()); txs.len()].into_iter(),
                 MAX_TX_ACCOUNT_LOCKS,
-                relax_intrabatch_account_locks,
             );
             assert_eq!(results[0], Err(TransactionError::TooManyAccountLocks));
         }
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_accounts_locks(relax_intrabatch_account_locks: bool) {
+    #[test]
+    fn test_accounts_locks() {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
@@ -938,7 +916,6 @@ mod tests {
             [tx.clone()].iter(),
             [Ok(())].into_iter(),
             MAX_TX_ACCOUNT_LOCKS,
-            relax_intrabatch_account_locks,
         );
 
         assert_eq!(results0, vec![Ok(())]);
@@ -975,7 +952,6 @@ mod tests {
             txs.iter(),
             vec![Ok(()); txs.len()].into_iter(),
             MAX_TX_ACCOUNT_LOCKS,
-            relax_intrabatch_account_locks,
         );
         assert_eq!(
             results1,
@@ -1004,12 +980,8 @@ mod tests {
             instructions,
         );
         let tx = new_sanitized_tx(&[&keypair1], message, Hash::default());
-        let results2 = accounts.lock_accounts(
-            [tx].iter(),
-            [Ok(())].into_iter(),
-            MAX_TX_ACCOUNT_LOCKS,
-            relax_intrabatch_account_locks,
-        );
+        let results2 =
+            accounts.lock_accounts([tx].iter(), [Ok(())].into_iter(), MAX_TX_ACCOUNT_LOCKS);
         assert_eq!(
             results2,
             vec![Ok(())] // Now keypair1 account can be locked as writable
@@ -1025,9 +997,8 @@ mod tests {
         );
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_accounts_locks_multithreaded(relax_intrabatch_account_locks: bool) {
+    #[test]
+    fn test_accounts_locks_multithreaded() {
         let counter = Arc::new(AtomicU64::new(0));
         let exit = Arc::new(AtomicBool::new(false));
 
@@ -1079,7 +1050,6 @@ mod tests {
                     txs.iter(),
                     vec![Ok(()); txs.len()].into_iter(),
                     MAX_TX_ACCOUNT_LOCKS,
-                    relax_intrabatch_account_locks,
                 );
                 for result in results.iter() {
                     if result.is_ok() {
@@ -1099,7 +1069,6 @@ mod tests {
                 txs.iter(),
                 vec![Ok(()); txs.len()].into_iter(),
                 MAX_TX_ACCOUNT_LOCKS,
-                relax_intrabatch_account_locks,
             );
             if results[0].is_ok() {
                 let counter_value = counter_clone.clone().load(Ordering::Acquire);
@@ -1112,9 +1081,8 @@ mod tests {
         exit.store(true, Ordering::Relaxed);
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_demote_program_write_locks(relax_intrabatch_account_locks: bool) {
+    #[test]
+    fn test_demote_program_write_locks() {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
@@ -1142,12 +1110,8 @@ mod tests {
             instructions,
         );
         let tx = new_sanitized_tx(&[&keypair0], message, Hash::default());
-        let results0 = accounts.lock_accounts(
-            [tx].iter(),
-            [Ok(())].into_iter(),
-            MAX_TX_ACCOUNT_LOCKS,
-            relax_intrabatch_account_locks,
-        );
+        let results0 =
+            accounts.lock_accounts([tx].iter(), [Ok(())].into_iter(), MAX_TX_ACCOUNT_LOCKS);
 
         assert!(results0[0].is_ok());
         // Instruction program-id account demoted to readonly
@@ -1189,9 +1153,8 @@ mod tests {
         }
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_accounts_locks_with_results(relax_intrabatch_account_locks: bool) {
+    #[test]
+    fn test_accounts_locks_with_results() {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
@@ -1247,12 +1210,8 @@ mod tests {
             Ok(()),
         ];
 
-        let results = accounts.lock_accounts(
-            txs.iter(),
-            qos_results.into_iter(),
-            MAX_TX_ACCOUNT_LOCKS,
-            relax_intrabatch_account_locks,
-        );
+        let results =
+            accounts.lock_accounts(txs.iter(), qos_results.into_iter(), MAX_TX_ACCOUNT_LOCKS);
 
         assert_eq!(
             results,
@@ -1281,9 +1240,8 @@ mod tests {
         );
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_accounts_locks_intrabatch_conflicts(relax_intrabatch_account_locks: bool) {
+    #[test]
+    fn test_accounts_locks_intrabatch_conflicts() {
         let pubkey = Pubkey::new_unique();
         let account_data = AccountSharedData::new(1, 0, &Pubkey::default());
         let accounts_db = Arc::new(AccountsDb::new_single_for_tests());
@@ -1314,7 +1272,6 @@ mod tests {
             [w_tx.clone()].iter(),
             [Ok(())].into_iter(),
             MAX_TX_ACCOUNT_LOCKS,
-            relax_intrabatch_account_locks,
         );
 
         assert_eq!(results, vec![Ok(())]);
@@ -1324,7 +1281,6 @@ mod tests {
             [r_tx.clone()].iter(),
             [Ok(())].into_iter(),
             MAX_TX_ACCOUNT_LOCKS,
-            relax_intrabatch_account_locks,
         );
 
         assert_eq!(results, vec![Err(TransactionError::AccountInUse)]);
@@ -1334,40 +1290,29 @@ mod tests {
             [w_tx.clone()].iter(),
             [Ok(())].into_iter(),
             MAX_TX_ACCOUNT_LOCKS,
-            relax_intrabatch_account_locks,
         );
 
         assert_eq!(results, vec![Err(TransactionError::AccountInUse)]);
 
-        // wr conflict in-batch succeeds or fails based on feature
+        // wr conflict in-batch succeeds
         let accounts = Accounts::new(accounts_db.clone());
         let results = accounts.lock_accounts(
             [w_tx.clone(), r_tx.clone()].iter(),
             [Ok(()), Ok(())].into_iter(),
             MAX_TX_ACCOUNT_LOCKS,
-            relax_intrabatch_account_locks,
         );
 
-        if relax_intrabatch_account_locks {
-            assert_eq!(results, vec![Ok(()), Ok(())]);
-        } else {
-            assert_eq!(results, vec![Ok(()), Err(TransactionError::AccountInUse)]);
-        }
+        assert_eq!(results, vec![Ok(()), Ok(())]);
 
-        // ww conflict in-batch succeeds or fails based on feature
+        // ww conflict in-batch succeeds
         let accounts = Accounts::new(accounts_db);
         let results = accounts.lock_accounts(
             [w_tx, r_tx].iter(),
             [Ok(()), Ok(())].into_iter(),
             MAX_TX_ACCOUNT_LOCKS,
-            relax_intrabatch_account_locks,
         );
 
-        if relax_intrabatch_account_locks {
-            assert_eq!(results, vec![Ok(()), Ok(())]);
-        } else {
-            assert_eq!(results, vec![Ok(()), Err(TransactionError::AccountInUse)]);
-        }
+        assert_eq!(results, vec![Ok(()), Ok(())]);
     }
 
     #[test]

--- a/core/benches/scheduler.rs
+++ b/core/benches/scheduler.rs
@@ -218,7 +218,6 @@ fn timing_scheduler<T: ReceiveAndBuffer, S: Scheduler<T::Transaction>>(
                         .schedule(
                             black_box(&mut container),
                             u64::MAX, // no budget
-                            false,
                             bench_env.filter_1,
                             bench_env.filter_2,
                         )

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -2094,7 +2094,6 @@ mod tests {
             collections::HashSet,
             sync::{RwLock, atomic::AtomicBool},
         },
-        test_case::test_case,
     };
 
     // Helper struct to create tests that hold channels, files, etc.
@@ -2112,9 +2111,7 @@ mod tests {
         consumed_receiver: Receiver<FinishedConsumeWork<RuntimeTransaction<SanitizedTransaction>>>,
     }
 
-    fn setup_test_frame(
-        relax_intrabatch_account_locks: bool,
-    ) -> (
+    fn setup_test_frame() -> (
         TestFrame,
         ConsumeWorker<RuntimeTransaction<SanitizedTransaction>>,
     ) {
@@ -2125,14 +2122,11 @@ mod tests {
         } = create_slow_genesis_config(10_000);
         let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         // Warp to next epoch for MaxAge tests.
-        let mut bank = Bank::new_from_parent(
+        let bank = Bank::new_from_parent(
             bank.clone(),
             SlotLeader::new_unique(),
             bank.get_epoch_info().slots_in_epoch,
         );
-        if !relax_intrabatch_account_locks {
-            bank.deactivate_feature(&agave_feature_set::relax_intrabatch_account_locks::id());
-        }
         let bank = Arc::new(bank);
 
         let (record_sender, record_receiver) = record_channels(false);
@@ -2172,7 +2166,7 @@ mod tests {
 
     #[test]
     fn test_worker_consume_no_bank() {
-        let (test_frame, worker) = setup_test_frame(true);
+        let (test_frame, worker) = setup_test_frame();
         let TestFrame {
             mint_keypair,
             genesis_config,
@@ -2219,7 +2213,7 @@ mod tests {
 
     #[test]
     fn test_worker_consume_no_bank_drains_queue() {
-        let (test_frame, worker) = setup_test_frame(true);
+        let (test_frame, worker) = setup_test_frame();
         let TestFrame {
             mint_keypair,
             genesis_config,
@@ -2271,7 +2265,7 @@ mod tests {
 
     #[test]
     fn test_worker_consume_simple() {
-        let (mut test_frame, worker) = setup_test_frame(true);
+        let (mut test_frame, worker) = setup_test_frame();
         let TestFrame {
             mint_keypair,
             genesis_config,
@@ -2322,10 +2316,9 @@ mod tests {
         let _ = worker_thread.join().unwrap();
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_worker_consume_self_conflicting(relax_intrabatch_account_locks: bool) {
-        let (mut test_frame, worker) = setup_test_frame(relax_intrabatch_account_locks);
+    #[test]
+    fn test_worker_consume_self_conflicting() {
+        let (mut test_frame, worker) = setup_test_frame();
         let TestFrame {
             mint_keypair,
             genesis_config,
@@ -2374,15 +2367,7 @@ mod tests {
         assert_eq!(consumed.work.ids, vec![id1, id2]);
         assert_eq!(consumed.work.max_ages, vec![max_age, max_age]);
 
-        // id2 succeeds with simd83, or is retryable due to lock conflict without simd83
-        assert_eq!(
-            consumed.retryable_indexes,
-            if relax_intrabatch_account_locks {
-                vec![]
-            } else {
-                vec![RetryableIndex::new(1, true)]
-            }
-        );
+        assert_eq!(consumed.retryable_indexes, vec![]);
 
         drop(test_frame);
         let _ = worker_thread.join().unwrap();
@@ -2390,7 +2375,7 @@ mod tests {
 
     #[test]
     fn test_worker_consume_multiple_messages() {
-        let (mut test_frame, worker) = setup_test_frame(true);
+        let (mut test_frame, worker) = setup_test_frame();
         let TestFrame {
             mint_keypair,
             genesis_config,
@@ -2469,7 +2454,7 @@ mod tests {
 
     #[test]
     fn test_worker_ttl() {
-        let (mut test_frame, worker) = setup_test_frame(true);
+        let (mut test_frame, worker) = setup_test_frame();
         let TestFrame {
             mint_keypair,
             genesis_config,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -582,10 +582,7 @@ mod tests {
         consumer: Consumer,
     }
 
-    fn setup_test(
-        relax_intrabatch_account_locks: bool,
-        transaction_status_sender: Option<TransactionStatusSender>,
-    ) -> TestFrame {
+    fn setup_test(transaction_status_sender: Option<TransactionStatusSender>) -> TestFrame {
         agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
@@ -596,10 +593,7 @@ mod tests {
             &Pubkey::new_unique(),
             bootstrap_validator_stake_lamports(),
         );
-        let mut bank = Bank::new_for_tests(&genesis_config);
-        if !relax_intrabatch_account_locks {
-            bank.deactivate_feature(&agave_feature_set::relax_intrabatch_account_locks::id());
-        }
+        let bank = Bank::new_for_tests(&genesis_config);
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
 
         let (record_sender, mut record_receiver) = record_channels(false);
@@ -687,7 +681,7 @@ mod tests {
             bank_forks: _bank_forks,
             mut record_receiver,
             consumer,
-        } = setup_test(true, None);
+        } = setup_test(None);
 
         let pubkey = solana_pubkey::new_rand();
         let transactions = sanitize_transactions(vec![system_transaction::transfer(
@@ -773,7 +767,7 @@ mod tests {
             bank_forks: _bank_forks,
             record_receiver: _record_receiver,
             consumer,
-        } = setup_test(true, None);
+        } = setup_test(None);
         let pubkey = Pubkey::new_unique();
 
         // setup nonce account with a durable nonce different from the current
@@ -841,7 +835,7 @@ mod tests {
             bank_forks: _bank_forks,
             record_receiver: _record_receiver,
             consumer,
-        } = setup_test(true, None);
+        } = setup_test(None);
 
         let pubkey = solana_pubkey::new_rand();
         let transactions = {
@@ -882,18 +876,15 @@ mod tests {
         );
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_bank_process_and_record_transactions_cost_tracker(
-        relax_intrabatch_account_locks: bool,
-    ) {
+    #[test]
+    fn test_bank_process_and_record_transactions_cost_tracker() {
         let TestFrame {
             mint_keypair,
             bank,
             bank_forks: _bank_forks,
             record_receiver: _record_receiver,
             consumer,
-        } = setup_test(relax_intrabatch_account_locks, None);
+        } = setup_test(None);
 
         let pubkey = solana_pubkey::new_rand();
 
@@ -1013,21 +1004,16 @@ mod tests {
         assert_eq!(get_tx_count(), 2);
     }
 
-    #[test_case(false, false; "old::locked")]
-    #[test_case(false, true; "old::duplicate")]
-    #[test_case(true, false; "simd83::locked")]
-    #[test_case(true, true; "simd83::duplicate")]
-    fn test_bank_process_and_record_transactions_account_in_use(
-        relax_intrabatch_account_locks: bool,
-        use_duplicate_transaction: bool,
-    ) {
+    #[test_case(false; "locked")]
+    #[test_case(true; "duplicate")]
+    fn test_bank_process_and_record_transactions_account_in_use(use_duplicate_transaction: bool) {
         let TestFrame {
             mint_keypair,
             bank,
             bank_forks: _bank_forks,
             record_receiver: _record_receiver,
             consumer,
-        } = setup_test(relax_intrabatch_account_locks, None);
+        } = setup_test(None);
 
         let pubkey = solana_pubkey::new_rand();
         let pubkey1 = solana_pubkey::new_rand();
@@ -1050,10 +1036,9 @@ mod tests {
             use_duplicate_transaction
         );
 
-        // with simd83 and no duplicate, we take a cross-batch lock on an account to create a conflict
-        // with a duplicate transaction and simd83 it comes from message hash equality in the batch
-        // without simd83 the conflict comes from locks in batch
-        if relax_intrabatch_account_locks && !use_duplicate_transaction {
+        // with a duplicate transaction, we get a conflict from message hash equality in the batch
+        // with no duplicate, we must take a cross-batch lock on an account to create a conflict
+        if !use_duplicate_transaction {
             let conflicting_transaction =
                 sanitize_transactions(vec![system_transaction::transfer(
                     &Keypair::new(),
@@ -1084,8 +1069,8 @@ mod tests {
         );
         assert!(commit_transactions_result.is_ok());
 
-        // with simd3, duplicate transactions are not retryable
-        if relax_intrabatch_account_locks && use_duplicate_transaction {
+        // duplicate transactions are not retryable
+        if use_duplicate_transaction {
             assert_eq!(retryable_transaction_indexes, Vec::<_>::new());
         } else {
             assert_eq!(
@@ -1151,14 +1136,9 @@ mod tests {
         );
     }
 
-    #[test_case(false, false; "old::locked")]
-    #[test_case(false, true; "old::duplicate")]
-    #[test_case(true, false; "simd83::locked")]
-    #[test_case(true, true; "simd83::duplicate")]
-    fn test_process_transactions_account_in_use(
-        relax_intrabatch_account_locks: bool,
-        use_duplicate_transaction: bool,
-    ) {
+    #[test_case(false; "locked")]
+    #[test_case(true; "duplicate")]
+    fn test_process_transactions_account_in_use(use_duplicate_transaction: bool) {
         agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
@@ -1166,9 +1146,6 @@ mod tests {
             ..
         } = create_slow_genesis_config(10_000);
         let mut bank = Bank::new_for_tests(&genesis_config);
-        if !relax_intrabatch_account_locks {
-            bank.deactivate_feature(&agave_feature_set::relax_intrabatch_account_locks::id());
-        }
         bank.ns_per_slot = u128::MAX;
         let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
         // set cost tracker limits to MAX so it will not filter out TXs
@@ -1198,9 +1175,9 @@ mod tests {
             ..
         } = execute_transactions_for_test(bank, transactions);
 
-        // If SIMD-83 is enabled *and* the transactions are distinct, all are executed.
-        // In the three other cases, only one is executed. In all four cases, all are attempted.
-        let execution_count = if relax_intrabatch_account_locks && !use_duplicate_transaction {
+        // if the transactions are distinct, all are executed.
+        // otherwise, only one is executed. regardless, all are attempted.
+        let execution_count = if !use_duplicate_transaction {
             transactions_len
         } else {
             1
@@ -1225,22 +1202,12 @@ mod tests {
             execution_count
         );
 
-        // If SIMD-83 is enabled and the transactions are distinct, there are zero retryable (all executed).
-        // If SIMD-83 is enabled and the transactions are identical, there are zero retryable (marked AlreadyProcessed).
-        // If SIMD-83 is not enabled, all but the first are retryable (marked AccountInUse).
-        if relax_intrabatch_account_locks {
-            assert_eq!(
-                execute_and_commit_transactions_output.retryable_transaction_indexes,
-                Vec::<_>::new()
-            );
-        } else {
-            assert_eq!(
-                execute_and_commit_transactions_output.retryable_transaction_indexes,
-                (1..transactions_len)
-                    .map(|index| RetryableIndex::new(index, true))
-                    .collect::<Vec<_>>()
-            );
-        }
+        // If the transactions are distinct, there are zero retryable (all executed).
+        // If the transactions are identical, there are zero retryable (marked AlreadyProcessed).
+        assert_eq!(
+            execute_and_commit_transactions_output.retryable_transaction_indexes,
+            Vec::<_>::new()
+        );
     }
 
     #[test]
@@ -1251,7 +1218,7 @@ mod tests {
             bank_forks: _bank_forks,
             mut record_receiver,
             consumer,
-        } = setup_test(true, None);
+        } = setup_test(None);
 
         let pubkey = solana_pubkey::new_rand();
 
@@ -1323,7 +1290,7 @@ mod tests {
             bank_forks: _bank_forks,
             record_receiver: _record_receiver,
             consumer,
-        } = setup_test(true, tss);
+        } = setup_test(tss);
 
         let pubkey = solana_pubkey::new_rand();
         let pubkey1 = solana_pubkey::new_rand();
@@ -1394,7 +1361,7 @@ mod tests {
             bank_forks,
             mut record_receiver,
             consumer,
-        } = setup_test(true, tss);
+        } = setup_test(tss);
 
         let keypair = Keypair::new();
         let address_table_key = Pubkey::new_unique();

--- a/core/src/banking_stage/read_write_account_set.rs
+++ b/core/src/banking_stage/read_write_account_set.rs
@@ -41,12 +41,6 @@ impl ReadWriteAccountSet {
             })
     }
 
-    /// Clears the read and write sets
-    pub fn clear(&mut self) {
-        self.read_set.clear();
-        self.write_set.clear();
-    }
-
     /// Check if an account can be read-locked
     fn can_read(&self, pubkey: &Pubkey) -> bool {
         !self.write_set.contains(pubkey)

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -77,7 +77,6 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
         &mut self,
         container: &mut S,
         budget: u64,
-        relax_intrabatch_account_locks: bool,
         _pre_graph_filter: impl Fn(&[&Tx], &mut [bool]),
         pre_lock_filter: impl Fn(&TransactionState<Tx>) -> PreLockFilterAction,
     ) -> Result<SchedulingSummary, SchedulerError> {
@@ -142,17 +141,6 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                 panic!("transaction state must exist")
             };
 
-            // If there is a conflict with any of the transactions in the current batches,
-            // we should immediately send out the batches, so this transaction may be scheduled.
-            if !relax_intrabatch_account_locks
-                && !self
-                    .working_account_set
-                    .check_locks(transaction_state.transaction())
-            {
-                self.working_account_set.clear();
-                num_sent += self.common.send_batches()?;
-            }
-
             // Now check if the transaction can actually be scheduled.
             match try_schedule_transaction(
                 transaction_state,
@@ -183,12 +171,6 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                     max_age,
                     cost,
                 }) => {
-                    if !relax_intrabatch_account_locks {
-                        assert!(
-                            self.working_account_set.take_locks(&transaction),
-                            "locks must be available"
-                        );
-                    }
                     num_scheduled += 1;
                     self.common.batches.add_transaction_to_batch(
                         thread_id,
@@ -318,7 +300,6 @@ mod test {
         solana_system_interface::instruction as system_instruction,
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         std::borrow::Borrow,
-        test_case::test_case,
     };
 
     #[allow(clippy::type_complexity)]
@@ -431,7 +412,6 @@ mod test {
             scheduler.schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter
             ),
@@ -452,7 +432,6 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -475,7 +454,6 @@ mod test {
             .schedule(
                 &mut container,
                 0, // zero budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -502,7 +480,6 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -530,7 +507,6 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -558,7 +534,6 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -568,9 +543,8 @@ mod test {
         assert_eq!(collect_work(&work_receivers[0]).1, vec![vec![1], vec![0]]);
     }
 
-    #[test_case(true; "relax_intrabatch_account_locks_true")]
-    #[test_case(false; "relax_intrabatch_account_locks_false")]
-    fn test_schedule_single_threaded_conflict(relax_intrabatch_account_locks: bool) {
+    #[test]
+    fn test_schedule_single_threaded_conflict() {
         let (mut scheduler, work_receivers, _finished_work_sender) =
             create_test_frame(1, GreedySchedulerConfig::default());
         let pubkey = Pubkey::new_unique();
@@ -583,18 +557,13 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                relax_intrabatch_account_locks,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 2);
         assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
-        if relax_intrabatch_account_locks {
-            assert_eq!(collect_work(&work_receivers[0]).1, vec![vec![1, 0]]);
-        } else {
-            assert_eq!(collect_work(&work_receivers[0]).1, vec![vec![1], vec![0]]);
-        }
+        assert_eq!(collect_work(&work_receivers[0]).1, vec![vec![1, 0]]);
     }
 
     #[test]
@@ -608,7 +577,6 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -650,14 +618,13 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 3);
         assert_eq!(scheduling_summary.num_unschedulable_conflicts, 1);
-        assert_eq!(collect_work(&work_receivers[0]).1, [vec![3], vec![0]]);
+        assert_eq!(collect_work(&work_receivers[0]).1, [vec![3, 0]]);
         assert_eq!(collect_work(&work_receivers[1]).1, [vec![2]]);
     }
 
@@ -688,14 +655,13 @@ mod test {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
             .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 3);
         assert_eq!(scheduling_summary.num_unschedulable_threads, 3);
-        assert_eq!(collect_work(&work_receivers[0]).1, [vec![5], vec![4]]);
+        assert_eq!(collect_work(&work_receivers[0]).1, [vec![5, 4]]);
         assert_eq!(collect_work(&work_receivers[1]).1, [vec![0]]);
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -13,7 +13,6 @@ use {
     },
     crate::banking_stage::{
         consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH,
-        read_write_account_set::ReadWriteAccountSet,
         scheduler_messages::{ConsumeWork, FinishedConsumeWork},
     },
     agave_scheduling_utils::thread_aware_account_locks::{
@@ -47,7 +46,6 @@ impl Default for GreedySchedulerConfig {
 /// scheduled, up to the limits.
 pub struct GreedyScheduler<Tx: TransactionWithMeta> {
     common: SchedulingCommon<Tx>,
-    working_account_set: ReadWriteAccountSet,
     unschedulables: Vec<TransactionPriorityId>,
     config: GreedySchedulerConfig,
 }
@@ -60,7 +58,6 @@ impl<Tx: TransactionWithMeta> GreedyScheduler<Tx> {
         config: GreedySchedulerConfig,
     ) -> Self {
         Self {
-            working_account_set: ReadWriteAccountSet::default(),
             unschedulables: Vec::with_capacity(config.max_scanned_transactions_per_scheduling_pass),
             common: SchedulingCommon::new(
                 consume_work_senders,
@@ -185,7 +182,6 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                     if self.common.batches.transactions()[thread_id].len()
                         >= self.config.target_transactions_per_batch
                     {
-                        self.working_account_set.clear();
                         num_sent += self.common.send_batches()?;
                     }
 
@@ -204,7 +200,6 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
             }
         }
 
-        self.working_account_set.clear();
         num_sent += self.common.send_batches()?;
         let Saturating(num_scheduled) = num_scheduled;
         assert_eq!(

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -111,7 +111,6 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for PrioGraphScheduler<Tx> {
         &mut self,
         container: &mut S,
         budget: u64,
-        _relax_intrabatch_account_locks: bool,
         pre_graph_filter: impl Fn(&[&Tx], &mut [bool]),
         pre_lock_filter: impl Fn(&TransactionState<Tx>) -> PreLockFilterAction,
     ) -> Result<SchedulingSummary, SchedulerError> {
@@ -585,7 +584,6 @@ mod tests {
             scheduler.schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter
             ),
@@ -605,7 +603,6 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -627,7 +624,6 @@ mod tests {
             .schedule(
                 &mut container,
                 0, // zero budget. nothing should be scheduled
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -649,7 +645,6 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -672,7 +667,6 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -700,7 +694,6 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -747,7 +740,6 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -763,7 +755,6 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -783,7 +774,6 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )
@@ -812,7 +802,6 @@ mod tests {
             .schedule(
                 &mut container,
                 u64::MAX, // no budget
-                false,
                 test_pre_graph_filter,
                 test_pre_lock_filter,
             )

--- a/core/src/banking_stage/transaction_scheduler/scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler.rs
@@ -18,7 +18,6 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
         &mut self,
         container: &mut S,
         budget: u64,
-        relax_intrabatch_account_locks: bool,
         pre_graph_filter: impl Fn(&[&Tx], &mut [bool]),
         pre_lock_filter: impl Fn(&TransactionState<Tx>) -> PreLockFilterAction,
     ) -> Result<SchedulingSummary, SchedulerError>;

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -228,7 +228,6 @@ where
                 let (scheduling_summary, schedule_time_us) = measure_us!(self.scheduler.schedule(
                     &mut self.container,
                     scheduling_budget,
-                    bank.feature_set.snapshot().relax_intrabatch_account_locks,
                     |txs, results| {
                         Self::pre_graph_filter(txs, results, bank, bank.max_processing_age())
                     },

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -51,7 +51,6 @@ pub struct FeatureSnapshot {
     pub enable_sbpf_v3_deployment_and_execution: bool,
     pub deplete_cu_meter_on_vm_failure: bool,
     pub fix_alt_bn128_multiplication_input_length: bool,
-    pub relax_intrabatch_account_locks: bool,
     pub formalize_loaded_transaction_data_size: bool,
     pub alpenglow: bool,
     pub disable_zk_elgamal_proof_program: bool,
@@ -152,7 +151,6 @@ impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
             fix_alt_bn128_multiplication_input_length: is_active(
                 &fix_alt_bn128_multiplication_input_length::ID,
             ),
-            relax_intrabatch_account_locks: is_active(&relax_intrabatch_account_locks::ID),
             formalize_loaded_transaction_data_size: is_active(
                 &formalize_loaded_transaction_data_size::ID,
             ),

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2787,7 +2787,7 @@ pub mod tests {
             slice,
             sync::{Arc, Barrier, RwLock},
         },
-        test_case::{test_case, test_matrix},
+        test_case::test_matrix,
         trees::tr,
     };
 
@@ -4036,11 +4036,8 @@ pub mod tests {
         });
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_process_entries_2nd_entry_collision_with_self_and_error(
-        relax_intrabatch_account_locks: bool,
-    ) {
+    #[test]
+    fn test_process_entries_2nd_entry_collision_with_self_and_error() {
         agave_logger::setup();
 
         let GenesisConfigInfo {
@@ -4048,10 +4045,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(1000);
-        let mut bank = Bank::new_for_tests(&genesis_config);
-        if !relax_intrabatch_account_locks {
-            bank.deactivate_feature(&agave_feature_set::relax_intrabatch_account_locks::id());
-        }
+        let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
@@ -4139,18 +4133,12 @@ pub mod tests {
             bank.get_balance(&keypair3.pubkey()),
         ];
 
-        if relax_intrabatch_account_locks {
-            assert!(result.is_ok());
-            assert_eq!(balances, [0, 3, 3]);
-        } else {
-            assert!(result.is_err());
-            assert_eq!(balances, [2, 2, 2]);
-        }
+        assert!(result.is_ok());
+        assert_eq!(balances, [0, 3, 3]);
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_process_entry_duplicate_transaction(relax_intrabatch_account_locks: bool) {
+    #[test]
+    fn test_process_entry_duplicate_transaction() {
         agave_logger::setup();
 
         let GenesisConfigInfo {
@@ -4158,10 +4146,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(1000);
-        let mut bank = Bank::new_for_tests(&genesis_config);
-        if !relax_intrabatch_account_locks {
-            bank.deactivate_feature(&agave_feature_set::relax_intrabatch_account_locks::id());
-        }
+        let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
@@ -4204,11 +4189,7 @@ pub mod tests {
         ];
 
         assert_eq!(balances, [5, 5]);
-        if relax_intrabatch_account_locks {
-            assert_eq!(result, Err(TransactionError::AlreadyProcessed));
-        } else {
-            assert_eq!(result, Err(TransactionError::AccountInUse));
-        }
+        assert_eq!(result, Err(TransactionError::AlreadyProcessed));
     }
 
     #[test]
@@ -4518,18 +4499,14 @@ pub mod tests {
         );
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_update_transaction_statuses_fail(relax_intrabatch_account_locks: bool) {
+    #[test]
+    fn test_update_transaction_statuses_fail() {
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
             ..
         } = create_genesis_config(11_000);
-        let mut bank = Bank::new_for_tests(&genesis_config);
-        if !relax_intrabatch_account_locks {
-            bank.deactivate_feature(&agave_feature_set::relax_intrabatch_account_locks::id());
-        }
+        let bank = Bank::new_for_tests(&genesis_config);
         let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
@@ -4555,24 +4532,14 @@ pub mod tests {
             ],
         );
 
-        // succeeds with simd83, fails because of account locking conflict otherwise
         assert_eq!(
             process_entries_for_tests_without_scheduler(&bank, vec![entry_1_to_mint]),
-            if relax_intrabatch_account_locks {
-                Ok(())
-            } else {
-                Err(TransactionError::AccountInUse)
-            }
+            Ok(())
         );
 
-        // fails with simd83 as already processed, succeeds otherwise
         assert_eq!(
             bank.process_transaction(&test_tx),
-            if relax_intrabatch_account_locks {
-                Err(TransactionError::AlreadyProcessed)
-            } else {
-                Ok(())
-            }
+            Err(TransactionError::AlreadyProcessed)
         );
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3311,16 +3311,13 @@ impl Bank {
         tx_results: impl Iterator<Item = Result<()>>,
     ) -> Vec<Result<()>> {
         let tx_account_lock_limit = self.get_transaction_account_lock_limit();
-        let relax_intrabatch_account_locks =
-            self.feature_set.snapshot().relax_intrabatch_account_locks;
 
-        // with simd83 enabled, we must fail transactions that duplicate a prior message hash
-        // previously, conflicting account locks would fail such transactions as a side effect
+        // we must fail transactions that duplicate a prior message hash
         let mut batch_message_hashes = AHashSet::with_capacity(txs.len());
         let tx_results = tx_results
             .enumerate()
             .map(|(i, tx_result)| match tx_result {
-                Ok(()) if relax_intrabatch_account_locks => {
+                Ok(()) => {
                     // `HashSet::insert()` returns `true` when the value does *not* already exist
                     if batch_message_hashes.insert(txs[i].message_hash()) {
                         Ok(())
@@ -3328,16 +3325,12 @@ impl Bank {
                         Err(TransactionError::AlreadyProcessed)
                     }
                 }
-                Ok(()) => Ok(()),
                 Err(e) => Err(e),
             });
 
-        self.rc.accounts.lock_accounts(
-            txs.iter(),
-            tx_results,
-            tx_account_lock_limit,
-            relax_intrabatch_account_locks,
-        )
+        self.rc
+            .accounts
+            .lock_accounts(txs.iter(), tx_results, tx_account_lock_limit)
     }
 
     /// Prepare a locked transaction batch from a list of sanitized transactions.

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1139,17 +1139,15 @@ fn test_one_source_two_tx_one_batch() {
 
     assert_eq!(res.len(), 2);
     assert_eq!(res[0], Ok(()));
-    assert_eq!(res[1], Err(TransactionError::AccountInUse));
+    assert_eq!(res[1], Ok(()));
     assert_eq!(
         bank.get_balance(&mint_keypair.pubkey()),
-        LAMPORTS_PER_SOL - amount
+        LAMPORTS_PER_SOL - amount * 2
     );
     assert_eq!(bank.get_balance(&key1), amount);
-    assert_eq!(bank.get_balance(&key2), 0);
+    assert_eq!(bank.get_balance(&key2), amount);
     assert_eq!(bank.get_signature_status(&t1.signatures[0]), Some(Ok(())));
-    // TODO: Transactions that fail to pay a fee could be dropped silently.
-    // Non-instruction errors don't get logged in the signature cache
-    assert_eq!(bank.get_signature_status(&t2.signatures[0]), None);
+    assert_eq!(bank.get_signature_status(&t2.signatures[0]), Some(Ok(())));
 }
 
 #[test]
@@ -1665,19 +1663,14 @@ fn test_debits_before_credits() {
     assert_eq!(bank.non_vote_transaction_count_since_restart(), 1);
 }
 
-#[test_case(false; "old")]
-#[test_case(true; "simd83")]
-fn test_readonly_accounts(relax_intrabatch_account_locks: bool) {
+#[test]
+fn test_readonly_accounts() {
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,
         ..
     } = create_genesis_config_with_leader(500, &solana_pubkey::new_rand(), 0);
-    let mut bank = Bank::new_for_tests(&genesis_config);
-    if !relax_intrabatch_account_locks {
-        bank.deactivate_feature(&feature_set::relax_intrabatch_account_locks::id());
-    }
-
+    let bank = Bank::new_for_tests(&genesis_config);
     let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
     let next_slot = bank.slot() + 1;
     let bank = Bank::new_from_parent(bank, SlotLeader::default(), next_slot);
@@ -1774,16 +1767,9 @@ fn test_readonly_accounts(relax_intrabatch_account_locks: bool) {
     );
     let txs = [tx0, tx1];
     let results = bank.process_transactions(txs.iter());
-    // Whether an account can be locked as read-only and writable at the same time depends on features.
+    // An account can be locked as read-only and writable at the same time
     assert_eq!(results[0], Ok(()));
-    assert_eq!(
-        results[1],
-        if relax_intrabatch_account_locks {
-            Ok(())
-        } else {
-            Err(TransactionError::AccountInUse)
-        }
-    );
+    assert_eq!(results[1], Ok(()));
 }
 
 #[test]
@@ -8197,9 +8183,8 @@ fn test_vote_epoch_panic() {
     );
 }
 
-#[test_case(false; "old")]
-#[test_case(true; "simd83")]
-fn test_tx_log_order(relax_intrabatch_account_locks: bool) {
+#[test]
+fn test_tx_log_order() {
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,
@@ -8209,10 +8194,7 @@ fn test_tx_log_order(relax_intrabatch_account_locks: bool) {
         &Pubkey::new_unique(),
         bootstrap_validator_stake_lamports(),
     );
-    let mut bank = Bank::new_for_tests(&genesis_config);
-    if !relax_intrabatch_account_locks {
-        bank.deactivate_feature(&feature_set::relax_intrabatch_account_locks::id());
-    }
+    let bank = Bank::new_for_tests(&genesis_config);
     let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
     *bank.transaction_log_collector_config.write().unwrap() = TransactionLogCollectorConfig {
         mentioned_addresses: HashSet::new(),
@@ -8273,11 +8255,7 @@ fn test_tx_log_order(relax_intrabatch_account_locks: bool) {
             .unwrap()[2]
             .contains(&"failed".to_string())
     );
-    if relax_intrabatch_account_locks {
-        assert!(commit_results[2].is_ok());
-    } else {
-        assert!(commit_results[2].is_err());
-    }
+    assert!(commit_results[2].is_ok());
 
     let stored_logs = &bank.transaction_log_collector.read().unwrap().logs;
     let success_log_info = stored_logs
@@ -12054,8 +12032,7 @@ fn test_temporary_account_execute_and_commit() {
     // after the batch has executed.
 
     let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
-    let mut bank = Bank::new_for_tests(&genesis_config);
-    bank.activate_feature(&feature_set::relax_intrabatch_account_locks::ID);
+    let bank = Bank::new_for_tests(&genesis_config);
     let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
 
     let fee_calculator = genesis_config.fee_rate_governor.create_fee_calculator();
@@ -12126,8 +12103,7 @@ fn test_temporary_account_recreated_execute_and_commit() {
     // re-created in the final transaction and should be present in final state.
 
     let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
-    let mut bank = Bank::new_for_tests(&genesis_config);
-    bank.activate_feature(&feature_set::relax_intrabatch_account_locks::ID);
+    let bank = Bank::new_for_tests(&genesis_config);
     let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
 
     let fee_calculator = genesis_config.fee_rate_governor.create_fee_calculator();

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -120,13 +120,11 @@ mod tests {
         solana_system_transaction as system_transaction,
         solana_transaction::sanitized::SanitizedTransaction,
         solana_transaction_error::TransactionError,
-        test_case::test_case,
     };
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_transaction_batch(relax_intrabatch_account_locks: bool) {
-        let (bank, txs) = setup(false, relax_intrabatch_account_locks);
+    #[test]
+    fn test_transaction_batch() {
+        let (bank, txs) = setup(false);
 
         // Test getting locked accounts
         let batch = bank.prepare_sanitized_batch(&txs);
@@ -146,10 +144,9 @@ mod tests {
         assert!(batch2.lock_results().iter().all(|x| x.is_ok()));
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_simulation_batch(relax_intrabatch_account_locks: bool) {
-        let (bank, txs) = setup(false, relax_intrabatch_account_locks);
+    #[test]
+    fn test_simulation_batch() {
+        let (bank, txs) = setup(false);
 
         // Prepare batch without locks
         let batch = bank.prepare_unlocked_batch_from_single_tx(&txs[0]);
@@ -164,15 +161,10 @@ mod tests {
         assert!(batch3.lock_results().iter().all(|x| x.is_ok()));
     }
 
-    #[test_case(false; "old")]
-    #[test_case(true; "simd83")]
-    fn test_unlock_failures(relax_intrabatch_account_locks: bool) {
-        let (bank, txs) = setup(true, relax_intrabatch_account_locks);
-        let expected_lock_results = if relax_intrabatch_account_locks {
-            vec![Ok(()), Ok(()), Ok(())]
-        } else {
-            vec![Ok(()), Err(TransactionError::AccountInUse), Ok(())]
-        };
+    #[test]
+    fn test_unlock_failures() {
+        let (bank, txs) = setup(true);
+        let expected_lock_results = vec![Ok(()), Ok(()), Ok(())];
 
         // Test getting locked accounts
         let mut batch = bank.prepare_sanitized_batch(&txs);
@@ -194,20 +186,14 @@ mod tests {
         assert_eq!(batch2.lock_results, expected_lock_results,);
     }
 
-    fn setup(
-        insert_conflicting_tx: bool,
-        relax_intrabatch_account_locks: bool,
-    ) -> (Bank, Vec<RuntimeTransaction<SanitizedTransaction>>) {
+    fn setup(insert_conflicting_tx: bool) -> (Bank, Vec<RuntimeTransaction<SanitizedTransaction>>) {
         let dummy_leader_pubkey = solana_pubkey::new_rand();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
             ..
         } = create_genesis_config_with_leader(500, &dummy_leader_pubkey, 100);
-        let mut bank = Bank::new_for_tests(&genesis_config);
-        if !relax_intrabatch_account_locks {
-            bank.deactivate_feature(&agave_feature_set::relax_intrabatch_account_locks::id());
-        }
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let pubkey = solana_pubkey::new_rand();
         let keypair2 = Keypair::new();


### PR DESCRIPTION
#### Problem
`relax_intrabatch_account_locks` is now active on all clusters and can be removed from code paths

#### Summary of Changes
remove it
