### PR TITLE
unify legacy vote commission in display

### DIFF
--- a/account-decoder/src/parse_vote.rs
+++ b/account-decoder/src/parse_vote.rs
@@ -30,7 +30,10 @@ pub fn parse_vote(data: &[u8], vote_pubkey: &Pubkey) -> Result<VoteAccountType, 
     Ok(VoteAccountType::Vote(UiVoteState {
         node_pubkey: vote_state.node_pubkey.to_string(),
         authorized_withdrawer: vote_state.authorized_withdrawer.to_string(),
-        commission: (vote_state.inflation_rewards_commission_bps / 100) as u8,
+        commission: vote_state
+            .inflation_rewards_commission_bps
+            .div_ceil(100)
+            .min(u8::MAX as u16) as u8,
         votes,
         root_slot: vote_state.root_slot,
         authorized_voters,

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -1666,7 +1666,10 @@ pub async fn process_show_vote_account(
         authorized_voters: (&vote_state.authorized_voters).into(),
         authorized_withdrawer: vote_state.authorized_withdrawer.to_string(),
         credits: vote_state.credits(),
-        commission: (vote_state.inflation_rewards_commission_bps / 100) as u8,
+        commission: vote_state
+            .inflation_rewards_commission_bps
+            .div_ceil(100)
+            .min(u8::MAX as u16) as u8,
         root_slot: vote_state.root_slot,
         recent_timestamp: vote_state.last_timestamp.clone(),
         votes,


### PR DESCRIPTION
#### Problem
The values displayed for legacy inflation rewards `commission` can get totally clobbered for large basis points values if anyone sets a very large `u16` value for `inflation_rewards_comission_bps`. This is due to the fact that integer casts in Rust cause the underlying value to wrap around, not saturate.

This is purely a display issue in both RPC and CLI, not anything protocol-sensitive.

#### Summary of Changes
Follow the lead of `RpcVoteAccountInfo` and use ceiling division clamped to `u8::MAX` in all places where we still support the legacy `commission` field in display.