### PR TITLE
Cleanup VAT-Filtering

### DIFF
--- a/ci/_
+++ b/ci/_
@@ -5,8 +5,7 @@
 # |source| me
 #
 
-base_dir=$(realpath --strip "$(dirname "$0")/..")
-
+base_dir="$(cd "$(dirname "$0")/.." && pwd)"
 _() {
   if [[ $(pwd) = $base_dir ]]; then
     echo "--- $*" > /dev/stderr

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1094,6 +1094,7 @@ struct NewEpochBundle {
     rewards_calculation: Arc<PartitionedRewardsCalculation>,
     calculate_activated_stake_time_us: u64,
     update_rewards_with_thread_pool_time_us: u64,
+    vat_filterred_vote_accounts: VoteAccounts,
 }
 
 impl Bank {
@@ -1224,7 +1225,7 @@ impl Bank {
         // genesis needs stakes for all epochs up to the epoch implied by
         //  slot = 0 and genesis configuration
         {
-            let stakes = bank.get_top_epoch_stakes();
+            let stakes = bank.get_top_epoch_stakes(None);
             let stakes = SerdeStakesToStakeFormat::from(stakes);
             for epoch in 0..=bank.get_leader_schedule_epoch(bank.slot) {
                 bank.epoch_stakes
@@ -1445,7 +1446,7 @@ impl Bank {
             } else {
                 // Save a snapshot of stakes for use in consensus and stake weighted networking
                 let leader_schedule_epoch = new.epoch_schedule().get_leader_schedule_epoch(slot);
-                new.update_epoch_stakes(leader_schedule_epoch);
+                new.update_epoch_stakes(leader_schedule_epoch, None);
             }
             new.distribute_partitioned_epoch_rewards();
         });
@@ -1720,6 +1721,7 @@ impl Bank {
             rewards_calculation,
             calculate_activated_stake_time_us,
             update_rewards_with_thread_pool_time_us,
+            vat_filterred_vote_accounts: distribution_epoch_vote_accounts,
         }
     }
 
@@ -1752,6 +1754,7 @@ impl Bank {
             rewards_calculation,
             calculate_activated_stake_time_us,
             update_rewards_with_thread_pool_time_us,
+            vat_filterred_vote_accounts,
         } = self.compute_new_epoch_caches_and_rewards(
             &thread_pool,
             parent_epoch,
@@ -1764,8 +1767,9 @@ impl Bank {
 
         // Save a snapshot of stakes for use in consensus and stake weighted networking
         let leader_schedule_epoch = self.epoch_schedule.get_leader_schedule_epoch(slot);
-        let (_, update_epoch_stakes_time_us) =
-            measure_us!(self.update_epoch_stakes(leader_schedule_epoch));
+        let (_, update_epoch_stakes_time_us) = measure_us!(
+            self.update_epoch_stakes(leader_schedule_epoch, Some(&vat_filterred_vote_accounts))
+        );
 
         // Distribute rewards commission to vote accounts and cache stake rewards
         // for partitioned distribution in the upcoming slots.
@@ -1837,7 +1841,7 @@ impl Bank {
         parent.freeze();
         let parent_timestamp = parent.clock().unix_timestamp;
         let mut new = Bank::new_from_parent(parent, leader, slot);
-        new.update_epoch_stakes(new.epoch_schedule().get_epoch(slot));
+        new.update_epoch_stakes(new.epoch_schedule().get_epoch(slot), None);
         new.tick_height.store(new.max_tick_height(), Relaxed);
 
         let mut clock = new.clock();
@@ -2386,7 +2390,11 @@ impl Bank {
         from_account(&self.get_account(&sysvar::slot_history::id()).unwrap()).unwrap()
     }
 
-    fn update_epoch_stakes(&mut self, leader_schedule_epoch: Epoch) {
+    fn update_epoch_stakes(
+        &mut self,
+        leader_schedule_epoch: Epoch,
+        vat_filterred_vote_accounts: Option<&VoteAccounts>,
+    ) {
         // update epoch_stakes cache
         //  if my parent didn't populate for this staker's epoch, we've
         //  crossed a boundary
@@ -2396,7 +2404,7 @@ impl Bank {
                 // to ensure we retain the oldest epoch, if that epoch is 0.
                 epoch >= leader_schedule_epoch.saturating_sub(MAX_LEADER_SCHEDULE_STAKES - 1)
             });
-            let stakes = self.get_top_epoch_stakes();
+            let stakes = self.get_top_epoch_stakes(vat_filterred_vote_accounts);
             let stakes = SerdeStakesToStakeFormat::from(stakes);
             let new_epoch_stakes = VersionedEpochStakes::new(stakes, leader_schedule_epoch);
             info!(
@@ -6098,19 +6106,7 @@ impl Bank {
 
     fn maybe_filter_vote_accounts_for_vat(&self, vote_accounts: &VoteAccounts) -> VoteAccounts {
         if self.feature_set.snapshot().validator_admission_ticket {
-            let vote_account_rent_exempt_minimum = self
-                .rent_collector
-                .rent
-                .minimum_balance(VoteStateV4::size_of());
-            let minimum_vote_account_balance = if self.feature_set.snapshot().alpenglow {
-                // When alpenglow is active the minimum required balance is
-                // VAT + rent-exempt minimum for vote account.
-                vote_account_rent_exempt_minimum + VAT_TO_BURN_PER_EPOCH
-            } else {
-                // If alpenglow is not active, the minimum required balance is
-                // rent-exempt minimum.
-                vote_account_rent_exempt_minimum
-            };
+            let minimum_vote_account_balance = self.minimum_vote_account_balance_for_vat();
             vote_accounts
                 .clone_and_filter_for_vat(MAX_ALPENGLOW_VOTE_ACCOUNTS, minimum_vote_account_balance)
         } else {
@@ -6122,27 +6118,38 @@ impl Bank {
     /// See `VoteAccounts::clone_and_filter_for_vat` for the full criteria
     ///
     /// If the VAT feature is not active, return all stakes
-    pub fn get_top_epoch_stakes(&self) -> Stakes<StakeAccount<Delegation>> {
+    pub fn get_top_epoch_stakes(
+        &self,
+        vat_filterred_vote_accounts: Option<&VoteAccounts>,
+    ) -> Stakes<StakeAccount<Delegation>> {
+        let minimum_vote_account_balance = self.minimum_vote_account_balance_for_vat();
+
+        if self.feature_set.snapshot().validator_admission_ticket
+            && vat_filterred_vote_accounts.is_some()
+        {
+            self.stakes_cache.stakes().clone_and_filter_for_vat(
+                MAX_ALPENGLOW_VOTE_ACCOUNTS,
+                minimum_vote_account_balance,
+                vat_filterred_vote_accounts.unwrap().clone(),
+            )
+        } else {
+            self.stakes_cache.stakes().clone()
+        }
+    }
+
+    fn minimum_vote_account_balance_for_vat(&self) -> u64 {
         let vote_account_rent_exempt_minimum = self
             .rent_collector
             .rent
             .minimum_balance(VoteStateV4::size_of());
         let feature_snapshot = self.feature_set.snapshot();
-        let minimum_vote_account_balance = if feature_snapshot.alpenglow {
+        if feature_snapshot.alpenglow {
             // When alpenglow is active the minimum required balance is
             // VAT + rent-exempt minimum for vote account.
             vote_account_rent_exempt_minimum + VAT_TO_BURN_PER_EPOCH
         } else {
             // If alpenglow is not active, the minimum required balance is rent-exempt-minimum
             vote_account_rent_exempt_minimum
-        };
-
-        if feature_snapshot.validator_admission_ticket {
-            self.stakes_cache
-                .stakes()
-                .clone_and_filter_for_vat(MAX_ALPENGLOW_VOTE_ACCOUNTS, minimum_vote_account_balance)
-        } else {
-            self.stakes_cache.stakes().clone()
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6124,14 +6124,16 @@ impl Bank {
     ) -> Stakes<StakeAccount<Delegation>> {
         let minimum_vote_account_balance = self.minimum_vote_account_balance_for_vat();
 
-        if self.feature_set.snapshot().validator_admission_ticket
-            && vat_filterred_vote_accounts.is_some()
-        {
-            self.stakes_cache.stakes().clone_and_filter_for_vat(
-                MAX_ALPENGLOW_VOTE_ACCOUNTS,
-                minimum_vote_account_balance,
-                vat_filterred_vote_accounts.unwrap().clone(),
-            )
+        if self.feature_set.snapshot().validator_admission_ticket {
+            if let Some(vat_filterred_vote_accounts) = vat_filterred_vote_accounts {
+                return self.stakes_cache.stakes().clone_and_filter_for_vat(
+                    MAX_ALPENGLOW_VOTE_ACCOUNTS,
+                    minimum_vote_account_balance,
+                    vat_filterred_vote_accounts.clone(),
+                );
+            } else {
+                return self.stakes_cache.stakes().clone();
+            }
         } else {
             self.stakes_cache.stakes().clone()
         }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -8,8 +8,8 @@ use {
     },
     crate::{
         bank::{
-            RewardCalcTracer, RewardCalculationEvent, RewardCommission, RewardCommissions,
-            RewardsMetrics, null_tracer,
+            MAX_ALPENGLOW_VOTE_ACCOUNTS, RewardCalcTracer, RewardCalculationEvent,
+            RewardCommission, RewardCommissions, RewardsMetrics, null_tracer,
         },
         inflation_rewards::{
             points::{CalculationEnvironment, DelegatedVoteState, PointValue, calculate_points},
@@ -234,12 +234,13 @@ impl Bank {
 
         let (num_stake_accounts, num_vote_accounts) = {
             let stakes = self.stakes_cache.stakes();
-            let filtered_vote_accounts =
-                self.maybe_filter_vote_accounts_for_vat(stakes.vote_accounts());
-            (
-                stakes.stake_delegations().len(),
-                filtered_vote_accounts.len(),
-            )
+            let filtered_vote_accounts_len = stakes
+                .vote_accounts()
+                .iter()
+                .filter(|va| va.1.lamports() > self.minimum_vote_account_balance_for_vat())
+                .count()
+                .min(MAX_ALPENGLOW_VOTE_ACCOUNTS);
+            (stakes.stake_delegations().len(), filtered_vote_accounts_len)
         };
         self.capitalization
             .fetch_add(total_reward_commissions, Relaxed);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -366,12 +366,12 @@ fn test_bank_update_epoch_stakes() {
     assert_eq!(initial_epochs, vec![0, 1]);
 
     for existing_epoch in &initial_epochs {
-        bank.update_epoch_stakes(*existing_epoch);
+        bank.update_epoch_stakes(*existing_epoch, None);
         assert_eq!(bank.epoch_stake_keys(), initial_epochs);
     }
 
     for epoch in (initial_epochs.len() as Epoch)..(MAX_LEADER_SCHEDULE_STAKES - 1) {
-        bank.update_epoch_stakes(dbg!(epoch));
+        bank.update_epoch_stakes(dbg!(epoch), None);
         assert_eq!(bank.epoch_stakes.len() as Epoch, epoch + 1);
     }
 
@@ -384,7 +384,7 @@ fn test_bank_update_epoch_stakes() {
         )
     );
 
-    bank.update_epoch_stakes(MAX_LEADER_SCHEDULE_STAKES - 1);
+    bank.update_epoch_stakes(MAX_LEADER_SCHEDULE_STAKES - 1, None);
     assert_eq!(
         bank.epoch_stake_key_info(),
         (
@@ -394,7 +394,7 @@ fn test_bank_update_epoch_stakes() {
         )
     );
 
-    bank.update_epoch_stakes(MAX_LEADER_SCHEDULE_STAKES);
+    bank.update_epoch_stakes(MAX_LEADER_SCHEDULE_STAKES, None);
     assert_eq!(
         bank.epoch_stake_key_info(),
         (

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -184,8 +184,8 @@ pub struct Stakes<T: Clone> {
 impl<T: Clone> Stakes<T> {
     pub fn clone_and_filter_for_vat(
         &self,
-        max_vote_accounts: usize,
-        minimum_vote_account_balance: u64,
+        _max_vote_accounts: usize,
+        _minimum_vote_account_balance: u64,
         vote_accounts: VoteAccounts,
     ) -> Stakes<T> {
         Stakes {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -186,11 +186,10 @@ impl<T: Clone> Stakes<T> {
         &self,
         max_vote_accounts: usize,
         minimum_vote_account_balance: u64,
+        vote_accounts: VoteAccounts,
     ) -> Stakes<T> {
         Stakes {
-            vote_accounts: self
-                .vote_accounts
-                .clone_and_filter_for_vat(max_vote_accounts, minimum_vote_account_balance),
+            vote_accounts,
             epoch: self.epoch,
             // Do not need anything else for EpochStakes
             stake_delegations: ImblHashMap::new(),


### PR DESCRIPTION
#### Problem
VAT filtering currently is being calculated independently inside `compute_new_epoch_caches_and_rewards` and `update_epoch_stakes` while nothing enforcing them to be same.

#### Summary of Changes
* Compute the VAT-filtered “distribution vote accounts” once during `compute_new_epoch_caches_and_rewards`, and store it on `NewEpochBundle`
* Thread that precomputed vote-account snapshot into `update_epoch_stakes`, so `epoch_stakes` is built from the same distribution set used for rewards.
* Changed `get_top_epoch_stakes` to accept an optional precomputed filtered VoteAccounts, avoiding recomputation and keeping the epoch-boundary path consistent.
* Adjust `Stakes::clone_and_filter_for_vat` (in `runtime/src/stakes.rs`) to accept the already-filtered VoteAccounts when available, so epoch-stakes construction can reuse it directly.

#### Additional changes
As suggested in the [original issue](https://github.com/anza-xyz/agave/issues/11645), here few more refactoring in the code:
1.  in `‎runtime/src/bank/partitioned_epoch_rewards/calculation.rs`, change the code to calculate filtered vote account len from:
```rust
let filtered_vote_accounts_len = stakes
                .vote_accounts()
                .iter()
                .filter(|va| va.1.lamports() > self.minimum_vote_account_balance_for_vat())
                .count()
                .min(MAX_ALPENGLOW_VOTE_ACCOUNTS);
```
2. add a new function `Bank::minimum_vote_account_balance_for_vat()` for minimum balance calculation for vat

Closes #11645