### PR TITLE
gossip: Remove deprecated types from tests

### DIFF
--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -785,7 +785,7 @@ impl CrdsStats {
 mod tests {
     use {
         super::*,
-        crate::crds_data::{AccountsHashes, new_rand_timestamp},
+        crate::crds_data::{SnapshotHashes, new_rand_timestamp},
         rand::{Rng, rng},
         rayon::ThreadPoolBuilder,
         solana_keypair::Keypair,
@@ -1320,8 +1320,12 @@ mod tests {
         );
         assert_eq!(crds.get_shred_version(&pubkey), Some(8));
         // Add other crds values with the same pubkey.
-        let val = AccountsHashes::new_rand(&mut rng, Some(pubkey));
-        let val = CrdsData::AccountsHashes(val);
+        let val = CrdsData::SnapshotHashes(SnapshotHashes {
+            from: pubkey,
+            full: (0, solana_hash::Hash::default()),
+            incremental: vec![],
+            wallclock: 0,
+        });
         let val = CrdsValue::new_unsigned(val);
         assert_eq!(
             crds.insert(val, timestamp(), GossipRoute::LocalMessage),
@@ -1333,7 +1337,7 @@ mod tests {
         assert_eq!(crds.get::<&ContactInfo>(pubkey), None);
         assert_eq!(crds.get_shred_version(&pubkey), None);
         // Remove the remaining entry with the same pubkey.
-        crds.remove(&CrdsValueLabel::AccountsHashes(pubkey), timestamp());
+        crds.remove(&CrdsValueLabel::SnapshotHashes(pubkey), timestamp());
         assert_eq!(crds.get_records(&pubkey).count(), 0);
     }
 

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -261,9 +261,7 @@ pub(crate) mod tests {
         super::*,
         crate::{
             contact_info::ContactInfo,
-            crds_data::{
-                self, AccountsHashes, CrdsData, LowestSlot, SnapshotHashes, Vote as CrdsVote,
-            },
+            crds_data::{self, CrdsData, LowestSlot, SnapshotHashes, Vote as CrdsVote},
             duplicate_shred::{self, MAX_DUPLICATE_SHREDS, tests::new_rand_shred},
         },
         rand::Rng,
@@ -334,32 +332,6 @@ pub(crate) mod tests {
         };
         prune_data.sign(self_keypair);
         prune_data
-    }
-
-    #[test]
-    fn test_max_accounts_hashes_with_push_messages() {
-        let mut rng = rand::rng();
-        for _ in 0..256 {
-            let accounts_hash = AccountsHashes::new_rand(&mut rng, None);
-            let crds_value =
-                CrdsValue::new(CrdsData::AccountsHashes(accounts_hash), &Keypair::new());
-            let message = Protocol::PushMessage(Pubkey::new_unique(), vec![crds_value]);
-            let socket = new_rand_socket_addr(&mut rng);
-            assert!(Packet::from_data(Some(&socket), message).is_ok());
-        }
-    }
-
-    #[test]
-    fn test_max_accounts_hashes_with_pull_responses() {
-        let mut rng = rand::rng();
-        for _ in 0..256 {
-            let accounts_hash = AccountsHashes::new_rand(&mut rng, None);
-            let crds_value =
-                CrdsValue::new(CrdsData::AccountsHashes(accounts_hash), &Keypair::new());
-            let response = Protocol::PullResponse(Pubkey::new_unique(), vec![crds_value]);
-            let socket = new_rand_socket_addr(&mut rng);
-            assert!(Packet::from_data(Some(&socket), response).is_ok());
-        }
     }
 
     #[test]
@@ -580,20 +552,21 @@ pub(crate) mod tests {
     fn test_split_messages_packet_size() {
         // Test that if a value is smaller than payload size but too large to be wrapped in a vec
         // that it is still dropped
-        let mut value = CrdsValue::new_unsigned(CrdsData::AccountsHashes(AccountsHashes {
+        let mut incremental: Vec<(Slot, Hash)> = vec![];
+        let mut value = CrdsValue::new_unsigned(CrdsData::SnapshotHashes(SnapshotHashes {
             from: Pubkey::default(),
-            hashes: vec![],
+            full: (0, Hash::default()),
+            incremental: incremental.clone(),
             wallclock: 0,
         }));
-
-        let mut i = 0;
         while value.bincode_serialized_size() < PUSH_MESSAGE_MAX_PAYLOAD_SIZE {
-            value = CrdsValue::new_unsigned(CrdsData::AccountsHashes(AccountsHashes {
+            incremental.push((0, Hash::default()));
+            value = CrdsValue::new_unsigned(CrdsData::SnapshotHashes(SnapshotHashes {
                 from: Pubkey::default(),
-                hashes: vec![(0, Hash::default()); i],
+                full: (0, Hash::default()),
+                incremental: incremental.clone(),
                 wallclock: 0,
             }));
-            i += 1;
         }
         let split: Vec<_> =
             split_gossip_messages(PUSH_MESSAGE_MAX_PAYLOAD_SIZE, vec![value]).collect();


### PR DESCRIPTION
#### Problem

Currently some of our deprecated types are used in non-serialization tests.

#### Summary of Changes

Remove deprecated types from tests to simplify removal of said types.