### PR TITLE
vote: extend vote state view v4 frame tests

### DIFF
--- a/vote/src/vote_state_view/frame_v4.rs
+++ b/vote/src/vote_state_view/frame_v4.rs
@@ -316,6 +316,19 @@ mod tests {
         let inflation_rewards_collector = Pubkey::from([3; 32]);
         let block_revenue_collector = Pubkey::from([4; 32]);
         let pending_delegator_rewards = 42;
+        let bls_pubkey_compressed = [42u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE];
+        let authorized_voter = Pubkey::from([5; 32]);
+        let root_slot = 17u64;
+        let last_timestamp = BlockTimestamp {
+            slot: 100,
+            timestamp: 1_700_000_000,
+        };
+        let lockout = Lockout::new_with_confirmation_count(42, 3);
+        let landed_vote = LandedVote {
+            latency: 7,
+            lockout,
+        };
+        let epoch_credits = vec![(9u64, 100u64, 50u64)];
         let vote_state = VoteStateV4 {
             node_pubkey,
             authorized_withdrawer,
@@ -324,31 +337,147 @@ mod tests {
             inflation_rewards_collector,
             block_revenue_collector,
             pending_delegator_rewards,
-            ..VoteStateV4::default()
+            bls_pubkey_compressed: Some(bls_pubkey_compressed),
+            votes: VecDeque::from([landed_vote]),
+            root_slot: Some(root_slot),
+            authorized_voters: AuthorizedVoters::new(0, authorized_voter),
+            epoch_credits: epoch_credits.clone(),
+            last_timestamp: last_timestamp.clone(),
         };
         let versioned = VoteStateVersions::new_v4(vote_state);
         let bytes = bincode::serialize(&versioned).unwrap();
+        let frame = VoteStateFrameV4::try_new(&bytes).unwrap();
 
-        // Read node_pubkey at its offset.
+        // node_pubkey
         let offset = VoteStateFrameV4::node_pubkey_offset();
         assert_eq!(&bytes[offset..offset + 32], node_pubkey.as_ref());
 
-        // Read authorized_withdrawer at its offset.
+        // authorized_withdrawer
         let offset = VoteStateFrameV4::authorized_withdrawer_offset();
         assert_eq!(&bytes[offset..offset + 32], authorized_withdrawer.as_ref());
 
-        // Read inflation_rewards_commission at its offset.
+        // inflation_rewards_collector
+        let offset = VoteStateFrameV4::inflation_rewards_collector_offset();
+        assert_eq!(
+            &bytes[offset..offset + 32],
+            inflation_rewards_collector.as_ref()
+        );
+
+        // block_revenue_collector
+        let offset = VoteStateFrameV4::block_revenue_collector_offset();
+        assert_eq!(
+            &bytes[offset..offset + 32],
+            block_revenue_collector.as_ref()
+        );
+
+        // inflation_rewards_commission
         let offset = VoteStateFrameV4::inflation_rewards_commission_offset();
         assert_eq!(
             u16::from_le_bytes(bytes[offset..offset + 2].try_into().unwrap()),
             inflation_rewards_commission_bps
         );
 
-        // Read block_revenue_commission at its offset.
+        // block_revenue_commission
         let offset = VoteStateFrameV4::block_revenue_commission_offset();
         assert_eq!(
             u16::from_le_bytes(bytes[offset..offset + 2].try_into().unwrap()),
             block_revenue_commission_bps
+        );
+
+        // pending_delegator_rewards
+        let offset = VoteStateFrameV4::pending_delegator_rewards_offset();
+        assert_eq!(
+            u64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap()),
+            pending_delegator_rewards
+        );
+
+        // bls_pubkey_compressed
+        let offset = VoteStateFrameV4::bls_pubkey_compressed_offset();
+        assert_eq!(bytes[offset], 1);
+        assert_eq!(
+            &bytes[offset + 1..offset + 1 + BLS_PUBLIC_KEY_COMPRESSED_SIZE],
+            &bls_pubkey_compressed,
+        );
+
+        // votes: 8-byte length prefix + one LandedVote
+        let offset = frame.votes_offset();
+        assert_eq!(
+            u64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap()),
+            1
+        );
+        let item_offset = offset + 8;
+        assert_eq!(bytes[item_offset], landed_vote.latency);
+        assert_eq!(
+            u64::from_le_bytes(bytes[item_offset + 1..item_offset + 9].try_into().unwrap()),
+            lockout.slot()
+        );
+        assert_eq!(
+            u32::from_le_bytes(bytes[item_offset + 9..item_offset + 13].try_into().unwrap()),
+            lockout.confirmation_count()
+        );
+
+        // root_slot
+        let offset = frame.root_slot_offset();
+        assert_eq!(bytes[offset], 1);
+        assert_eq!(
+            u64::from_le_bytes(bytes[offset + 1..offset + 9].try_into().unwrap()),
+            root_slot
+        );
+
+        // authorized_voters: 8-byte length + one entry
+        let offset = frame.authorized_voters_offset();
+        assert_eq!(
+            u64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap()),
+            1
+        );
+        let entry_offset = offset + 8;
+        assert_eq!(
+            u64::from_le_bytes(bytes[entry_offset..entry_offset + 8].try_into().unwrap()),
+            0
+        );
+        assert_eq!(
+            &bytes[entry_offset + 8..entry_offset + 8 + 32],
+            authorized_voter.as_ref()
+        );
+
+        // epoch_credits: 8-byte length + one entry
+        let offset = frame.epoch_credits_offset();
+        assert_eq!(
+            u64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap()),
+            1
+        );
+        let (expected_epoch, expected_credits, expected_prev) = epoch_credits[0];
+        let entry_offset = offset + 8;
+        assert_eq!(
+            u64::from_le_bytes(bytes[entry_offset..entry_offset + 8].try_into().unwrap()),
+            expected_epoch
+        );
+        assert_eq!(
+            u64::from_le_bytes(
+                bytes[entry_offset + 8..entry_offset + 16]
+                    .try_into()
+                    .unwrap()
+            ),
+            expected_credits
+        );
+        assert_eq!(
+            u64::from_le_bytes(
+                bytes[entry_offset + 16..entry_offset + 24]
+                    .try_into()
+                    .unwrap()
+            ),
+            expected_prev
+        );
+
+        // last_timestamp
+        let offset = frame.last_timestamp_offset();
+        assert_eq!(
+            u64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap()),
+            last_timestamp.slot
+        );
+        assert_eq!(
+            i64::from_le_bytes(bytes[offset + 8..offset + 16].try_into().unwrap()),
+            last_timestamp.timestamp
         );
     }
 }


### PR DESCRIPTION
#### Problem
The v4 frame tests stop after the block collector, but they could be extended to cover all fields.

#### Summary of Changes
Widen the test to cover all fields.
