### PR TITLE
Fixes unused import warning on mac

### DIFF
--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -12,7 +12,6 @@ use {
     solana_sdk_ids::{
         bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4, native_loader,
     },
-    solana_svm_measure::measure::Measure,
     solana_svm_type_overrides::sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -244,7 +243,7 @@ impl ProgramCacheEntry {
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let entry_stats = ProgramStatistics::default();
         #[cfg(feature = "metrics")]
-        let load_elf_time = Measure::start("load_elf_time");
+        let load_elf_time = solana_svm_measure::measure::Measure::start("load_elf_time");
         let executable = Executable::load(elf_bytes, Arc::clone(&*program_runtime_environment))?;
 
         #[cfg(feature = "metrics")]
@@ -254,7 +253,7 @@ impl ProgramCacheEntry {
 
         if !reloading {
             #[cfg(feature = "metrics")]
-            let verify_code_time = Measure::start("verify_code_time");
+            let verify_code_time = solana_svm_measure::measure::Measure::start("verify_code_time");
             executable.verify::<RequisiteVerifier>()?;
             #[cfg(feature = "metrics")]
             {
@@ -264,7 +263,7 @@ impl ProgramCacheEntry {
 
         #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
         {
-            let jit_compile_time = Measure::start("jit_compile_time");
+            let jit_compile_time = solana_svm_measure::measure::Measure::start("jit_compile_time");
             executable.jit_compile()?;
             let jit_compile_time = jit_compile_time.end_as_us();
             entry_stats.jit_compiled(jit_compile_time);


### PR DESCRIPTION
#### Problem

On my macbook, I see this warning when building:

```
warning: unused import: `solana_svm_measure::measure::Measure`
  --> program-runtime/src/program_cache_entry.rs:15:5
   |
15 |     solana_svm_measure::measure::Measure,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

```

For the most part, uses of `Measure` is behind `#[cfg(feature = "metrics")]`. However, this one is not:

https://github.com/anza-xyz/agave/blob/06ddd6dc7091de7dd475f899066a0e64cce8a0dd/program-runtime/src/program_cache_entry.rs#L265-L275

This block doesn't run on non-x86 machines, e.g. mac on arm, which results in the unused import warning.


#### Summary of Changes

Fully qualify the use of `Measure`.