### PR TITLE
replay: remove reentrant locking in prune program cache

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2396,7 +2396,11 @@ fn load_frozen_forks(
                 root = new_root_bank.slot();
 
                 leader_schedule_cache.set_root(new_root_bank);
-                new_root_bank.prune_program_cache(root, new_root_bank.epoch());
+                new_root_bank.prune_program_cache(
+                    root,
+                    new_root_bank.epoch(),
+                    &bank_forks.read().unwrap(),
+                );
                 let _ = bank_forks
                     .write()
                     .unwrap()

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -478,16 +478,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         &mut self,
         new_root_slot: Slot,
         upcoming_environment: Option<ProgramRuntimeEnvironment>,
+        fork_graph: &FG,
     ) {
-        let Some(fork_graph) = self.fork_graph.clone() else {
-            error!("Program cache doesn't have fork graph.");
-            return;
-        };
-        let fork_graph = fork_graph.upgrade().unwrap();
-        let Ok(fork_graph) = fork_graph.read() else {
-            error!("Failed to lock fork graph for reading.");
-            return;
-        };
         match &mut self.index {
             IndexImplementation::V1 { entries, .. } => {
                 for second_level in entries.values_mut() {
@@ -1665,10 +1657,10 @@ pub(crate) mod tests {
 
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
-        cache.prune(0, None);
+        cache.prune(0, None, &fork_graph.read().unwrap());
         assert!(cache.get_flattened_entries_for_tests().is_empty());
 
-        cache.prune(10, None);
+        cache.prune(10, None, &fork_graph.read().unwrap());
         assert!(cache.get_flattened_entries_for_tests().is_empty());
 
         let mut cache = ProgramCache::<TestForkGraph>::new(0);
@@ -1678,10 +1670,10 @@ pub(crate) mod tests {
 
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
-        cache.prune(0, None);
+        cache.prune(0, None, &fork_graph.read().unwrap());
         assert!(cache.get_flattened_entries_for_tests().is_empty());
 
-        cache.prune(10, None);
+        cache.prune(10, None, &fork_graph.read().unwrap());
         assert!(cache.get_flattened_entries_for_tests().is_empty());
 
         let mut cache = ProgramCache::<TestForkGraph>::new(0);
@@ -1691,10 +1683,10 @@ pub(crate) mod tests {
 
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
-        cache.prune(0, None);
+        cache.prune(0, None, &fork_graph.read().unwrap());
         assert!(cache.get_flattened_entries_for_tests().is_empty());
 
-        cache.prune(10, None);
+        cache.prune(10, None, &fork_graph.read().unwrap());
         assert!(cache.get_flattened_entries_for_tests().is_empty());
 
         let mut cache = ProgramCache::<TestForkGraph>::new(0);
@@ -1703,10 +1695,10 @@ pub(crate) mod tests {
         }));
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
-        cache.prune(0, None);
+        cache.prune(0, None, &fork_graph.read().unwrap());
         assert!(cache.get_flattened_entries_for_tests().is_empty());
 
-        cache.prune(10, None);
+        cache.prune(10, None, &fork_graph.read().unwrap());
         assert!(cache.get_flattened_entries_for_tests().is_empty());
     }
 
@@ -1741,12 +1733,12 @@ pub(crate) mod tests {
         // Test that there are 2 entries for the program
         assert_eq!(cache.get_slot_versions_for_tests(&program1).len(), 2);
 
-        cache.prune(21, None);
+        cache.prune(21, None, &fork_graph.read().unwrap());
 
         // Test that prune didn't remove the entry, since environments are different.
         assert_eq!(cache.get_slot_versions_for_tests(&program1).len(), 2);
 
-        cache.prune(22, upcoming_environment);
+        cache.prune(22, upcoming_environment, &fork_graph.read().unwrap());
 
         // Test that prune removed 1 entry, since epoch changed
         assert_eq!(cache.get_slot_versions_for_tests(&program1).len(), 1);
@@ -1988,7 +1980,7 @@ pub(crate) mod tests {
         assert_eq!(tombstone.deployment_slot, 11);
         assert!(match_slot(&extracted, &program4, 5, 11));
 
-        cache.prune(5, None);
+        cache.prune(5, None, &fork_graph.read().unwrap());
 
         // Fork graph after pruning
         //                   0
@@ -2026,7 +2018,7 @@ pub(crate) mod tests {
         assert!(match_slot(&extracted, &program3, 25, 27));
         assert!(match_slot(&extracted, &program4, 5, 27));
 
-        cache.prune(15, None);
+        cache.prune(15, None, &fork_graph.read().unwrap());
 
         // Fork graph after pruning
         //                  0
@@ -2325,7 +2317,7 @@ pub(crate) mod tests {
         cache.assign_program(&env, program1, 0, new_test_entry(0, 1));
         cache.assign_program(&env, program1, 5, new_test_entry(5, 6));
 
-        cache.prune(10, None);
+        cache.prune(10, None, &fork_graph.read().unwrap());
 
         let mut missing = get_entries_to_load(&cache, 20, &[program1]);
         let mut extracted = ProgramCacheForTxBatch::new(20);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1621,7 +1621,12 @@ impl Bank {
         }
     }
 
-    pub fn prune_program_cache(&self, new_root_slot: Slot, new_root_epoch: Epoch) {
+    pub fn prune_program_cache(
+        &self,
+        new_root_slot: Slot,
+        new_root_epoch: Epoch,
+        bank_forks: &BankForks,
+    ) {
         let upcoming_environment = self
             .transaction_processor
             .epoch_boundary_preparation
@@ -1632,7 +1637,7 @@ impl Bank {
             .global_program_cache
             .write()
             .unwrap()
-            .prune(new_root_slot, upcoming_environment);
+            .prune(new_root_slot, upcoming_environment, bank_forks);
     }
 
     pub fn prune_program_cache_by_deployment_slot(&self, deployment_slot: Slot) {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10849,7 +10849,11 @@ fn test_feature_activation_loaded_programs_epoch_transition() {
             .global_program_cache
             .write()
             .unwrap();
-        program_cache.prune(bank.slot(), upcoming_environment);
+        program_cache.prune(
+            bank.slot(),
+            upcoming_environment,
+            &bank_forks.read().unwrap(),
+        );
 
         // Unload all (which is only the entry with the new environment)
         program_cache.sort_and_unload(percentage::Percentage::from(0));

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -489,7 +489,7 @@ impl BankForks {
 
     pub fn prune_program_cache(&self, root: Slot) {
         if let Some(root_bank) = self.banks.get(&root) {
-            root_bank.prune_program_cache(root, root_bank.epoch());
+            root_bank.prune_program_cache(root, root_bank.epoch(), self);
         }
     }
 


### PR DESCRIPTION
Upstream of https://github.com/anza-xyz/alpenglow/pull/227

#### Problem
In alpenglow rooting bank forks is no longer performed by the replay thread, but instead by the votor thread.
As part of rooting we prune the program cache. This exposed the following issue 
https://github.com/anza-xyz/agave/blob/2d279e16ba65c5c456621b84dbbcad722ac69d33/votor/src/root_utils.rs#L211

We grab the bank forks read lock in order to call `prune_program_cache()` , which in turn grabs the read lock again. 
https://github.com/anza-xyz/agave/blob/2d279e16ba65c5c456621b84dbbcad722ac69d33/program-runtime/src/loaded_programs.rs#L487

This can cause a deadlock if a writer requests the lock in between:

1. votor thread `set_bank_forks_root` acquires the read lock in order to call `prune_program_cache`
2. replay thread `generate_new_bank_forks` asks for the write lock and waits
3. `prune_program_cache` tries to acquire the read lock again during `fork_graph.read()`
4. Deadlock, as (3) will never complete due to the presence of (2)

To be clear this was always an issue, but we are safe pre alpenglow because the replay thread is also the one calling `set_bank_forks_root` and there are no other writers of `BankForks`

#### Summary of Changes
Have `prune_program_cache` pass in `BankForks` to avoid the reentrant locking
