### PR TITLE
Create `memory_context.rs`

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -13,8 +13,9 @@ use {
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_program_runtime::{
         create_vm,
-        invoke_context::{BpfAllocator, InvokeContext, MemoryContext},
+        invoke_context::{BpfAllocator, InvokeContext},
         loaded_programs::ProgramRuntimeEnvironment,
+        memory_context::MemoryContext,
         program_cache_entry::{
             DELAY_VISIBILITY_SLOT_OFFSET, ProgramCacheEntry, ProgramCacheEntryType,
         },

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -2,8 +2,9 @@
 
 use {
     crate::{
-        invoke_context::{InvokeContext, SerializedAccountMetadata},
+        invoke_context::InvokeContext,
         memory::{translate_slice, translate_type, translate_type_mut_for_cpi, translate_vm_slice},
+        memory_context::SerializedAccountMetadata,
         serialization::{create_memory_region_of_account, modify_memory_region_of_account},
     },
     solana_account_info::AccountInfo,
@@ -280,7 +281,7 @@ impl<'a> CallerAccount<'a> {
         check_aligned: bool,
         _vm_addr: u64,
         account_info: &solana_account_info::AccountInfo,
-        account_metadata: &crate::invoke_context::SerializedAccountMetadata,
+        account_metadata: &crate::memory_context::SerializedAccountMetadata,
     ) -> Result<CallerAccount<'a>, Error> {
         use crate::memory::{translate_type, translate_type_mut_for_cpi};
 
@@ -414,7 +415,7 @@ impl<'a> CallerAccount<'a> {
         check_aligned: bool,
         vm_addr: u64,
         account_info: &SolAccountInfo,
-        account_metadata: &crate::invoke_context::SerializedAccountMetadata,
+        account_metadata: &crate::memory_context::SerializedAccountMetadata,
     ) -> Result<CallerAccount<'a>, Error> {
         use crate::memory::translate_type_mut_for_cpi;
 
@@ -1364,8 +1365,9 @@ mod tests {
     use {
         super::*,
         crate::{
-            invoke_context::{BpfAllocator, MemoryContext, SerializedAccountMetadata},
+            invoke_context::BpfAllocator,
             memory::translate_type,
+            memory_context::{MemoryContext, SerializedAccountMetadata},
             with_mock_invoke_context_with_feature_set,
         },
         assert_matches::assert_matches,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -15,6 +15,7 @@ use {
         loaded_programs::{
             ProgramCacheForTxBatch, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
         },
+        memory_context::{MemoryContext, MemoryContexts},
         program_cache_entry::ProgramCacheEntryType,
         stable_log,
         sysvar_cache::SysvarCache,
@@ -28,7 +29,7 @@ use {
         error::{EbpfError, ProgramResult},
         memory_region::MemoryMapping,
         program::{BuiltinProgram, SBPFVersion},
-        vm::{Config, ContextObject, EbpfVm},
+        vm::{ContextObject, EbpfVm},
     },
     solana_sdk_ids::{
         bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4, native_loader,
@@ -213,94 +214,6 @@ impl ComputeMeter {
     pub fn mock_set_remaining(&self, remaining: u64) {
         self.0.set(remaining);
     }
-}
-
-pub struct MemoryContexts(Vec<MemoryContext>);
-
-impl MemoryContexts {
-    /// Set this instruction's [`MemoryContext`].
-    pub fn set_memory_context(
-        &mut self,
-        memory_context: MemoryContext,
-    ) -> Result<(), InstructionError> {
-        *self.0.last_mut().ok_or(InstructionError::CallDepth)? = memory_context;
-        Ok(())
-    }
-
-    /// Get current instruction's [`MemoryContext`]
-    pub fn memory_context(&self) -> Result<&MemoryContext, InstructionError> {
-        self.0.last().ok_or(InstructionError::CallDepth)
-    }
-
-    /// Get current instruction's [`MemoryContext`] for mutable use.
-    pub fn memory_context_mut(&mut self) -> Result<&mut MemoryContext, InstructionError> {
-        self.0.last_mut().ok_or(InstructionError::CallDepth)
-    }
-
-    pub fn memory_mapping(&self) -> Result<&MemoryMapping, InstructionError> {
-        let last_context = self.memory_context()?;
-        Ok(&last_context.memory_mapping)
-    }
-
-    pub fn memory_mapping_mut(&mut self) -> Result<&mut MemoryMapping, InstructionError> {
-        let last_context = self.memory_context_mut()?;
-        Ok(&mut last_context.memory_mapping)
-    }
-
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn mock_set_mapping(&mut self, memory_mapping: MemoryMapping) {
-        self.0 = vec![MemoryContext {
-            allocator: BpfAllocator::new(0),
-            accounts_metadata: vec![],
-            memory_mapping: Box::new(memory_mapping),
-        }];
-    }
-}
-
-/// This structure contains metadata about the memory for each instruction under execution.
-/// The BpfAllocator, accounts addresses in the guest and the memory mapping.
-pub struct MemoryContext {
-    pub allocator: BpfAllocator,
-    pub accounts_metadata: Vec<SerializedAccountMetadata>,
-    memory_mapping: Box<MemoryMapping>,
-}
-
-impl MemoryContext {
-    /// Creates a new memory context
-    pub fn new(
-        allocator: BpfAllocator,
-        accounts_metadata: Vec<SerializedAccountMetadata>,
-        memory_mapping: MemoryMapping,
-    ) -> Self {
-        Self {
-            allocator,
-            accounts_metadata,
-            memory_mapping: Box::new(memory_mapping),
-        }
-    }
-
-    /// Returns an empty dummy context used for builtin functions
-    pub(crate) fn empty() -> Self {
-        Self {
-            allocator: BpfAllocator::new(0),
-            accounts_metadata: Vec::new(),
-            memory_mapping: Box::new(
-                MemoryMapping::new(Vec::new(), &Config::default(), SBPFVersion::Reserved).unwrap(),
-            ),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct SerializedAccountMetadata {
-    /// Address of the first byte of the serialized account record (the
-    /// `NON_DUP_MARKER`/duplicate-marker byte).
-    pub vm_addr: u64,
-    pub original_data_len: usize,
-    pub vm_data_addr: u64,
-    pub vm_key_addr: u64,
-    pub vm_lamports_addr: u64,
-    pub vm_owner_addr: u64,
 }
 
 /// Main pipeline from runtime to program execution.

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -12,6 +12,7 @@ pub mod loaded_programs;
 pub mod loading_task;
 pub mod mem_pool;
 pub mod memory;
+pub mod memory_context;
 pub mod program_cache_entry;
 pub mod program_metrics;
 pub mod serialization;

--- a/program-runtime/src/memory_context.rs
+++ b/program-runtime/src/memory_context.rs
@@ -1,0 +1,93 @@
+use {
+    crate::invoke_context::BpfAllocator,
+    solana_instruction::error::InstructionError,
+    solana_sbpf::{memory_region::MemoryMapping, program::SBPFVersion, vm::Config},
+};
+
+pub struct MemoryContexts(pub Vec<MemoryContext>);
+
+impl MemoryContexts {
+    /// Set this instruction's [`MemoryContext`].
+    pub fn set_memory_context(
+        &mut self,
+        memory_context: MemoryContext,
+    ) -> Result<(), InstructionError> {
+        *self.0.last_mut().ok_or(InstructionError::CallDepth)? = memory_context;
+        Ok(())
+    }
+
+    /// Get current instruction's [`MemoryContext`]
+    pub fn memory_context(&self) -> Result<&MemoryContext, InstructionError> {
+        self.0.last().ok_or(InstructionError::CallDepth)
+    }
+
+    /// Get current instruction's [`MemoryContext`] for mutable use.
+    pub fn memory_context_mut(&mut self) -> Result<&mut MemoryContext, InstructionError> {
+        self.0.last_mut().ok_or(InstructionError::CallDepth)
+    }
+
+    pub fn memory_mapping(&self) -> Result<&MemoryMapping, InstructionError> {
+        let last_context = self.memory_context()?;
+        Ok(&last_context.memory_mapping)
+    }
+
+    pub fn memory_mapping_mut(&mut self) -> Result<&mut MemoryMapping, InstructionError> {
+        let last_context = self.memory_context_mut()?;
+        Ok(&mut last_context.memory_mapping)
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn mock_set_mapping(&mut self, memory_mapping: MemoryMapping) {
+        self.0 = vec![MemoryContext {
+            allocator: BpfAllocator::new(0),
+            accounts_metadata: vec![],
+            memory_mapping: Box::new(memory_mapping),
+        }];
+    }
+}
+
+/// This structure contains metadata about the memory for each instruction under execution.
+/// The BpfAllocator, accounts addresses in the guest and the memory mapping.
+pub struct MemoryContext {
+    pub allocator: BpfAllocator,
+    pub accounts_metadata: Vec<SerializedAccountMetadata>,
+    memory_mapping: Box<MemoryMapping>,
+}
+
+impl MemoryContext {
+    /// Creates a new memory context
+    pub fn new(
+        allocator: BpfAllocator,
+        accounts_metadata: Vec<SerializedAccountMetadata>,
+        memory_mapping: MemoryMapping,
+    ) -> Self {
+        Self {
+            allocator,
+            accounts_metadata,
+            memory_mapping: Box::new(memory_mapping),
+        }
+    }
+
+    /// Returns an empty dummy context used for builtin functions
+    pub(crate) fn empty() -> Self {
+        Self {
+            allocator: BpfAllocator::new(0),
+            accounts_metadata: Vec::new(),
+            memory_mapping: Box::new(
+                MemoryMapping::new(Vec::new(), &Config::default(), SBPFVersion::Reserved).unwrap(),
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SerializedAccountMetadata {
+    /// Address of the first byte of the serialized account record (the
+    /// `NON_DUP_MARKER`/duplicate-marker byte).
+    pub vm_addr: u64,
+    pub original_data_len: usize,
+    pub vm_data_addr: u64,
+    pub vm_key_addr: u64,
+    pub vm_lamports_addr: u64,
+    pub vm_owner_addr: u64,
+}

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
-    crate::invoke_context::SerializedAccountMetadata,
+    crate::memory_context::SerializedAccountMetadata,
     solana_instruction::error::InstructionError,
     solana_program_entrypoint::{BPF_ALIGN_OF_U128, MAX_PERMITTED_DATA_INCREASE, NON_DUP_MARKER},
     solana_pubkey::Pubkey,

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -5,8 +5,9 @@ use qualifier_attr::qualifiers;
 use {
     crate::{
         execution_budget::MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268,
-        invoke_context::{BpfAllocator, InvokeContext, MemoryContext, SerializedAccountMetadata},
+        invoke_context::{BpfAllocator, InvokeContext},
         mem_pool::VmMemoryPool,
+        memory_context::{MemoryContext, SerializedAccountMetadata},
         program_cache_entry::ProgramCacheEntry,
         serialization, stable_log,
     },

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2694,8 +2694,9 @@ mod tests {
         solana_program::program::check_type_assumptions,
         solana_program_runtime::{
             execution_budget::MAX_HEAP_FRAME_BYTES,
-            invoke_context::{BpfAllocator, InvokeContext, MemoryContext},
+            invoke_context::{BpfAllocator, InvokeContext},
             memory::address_is_aligned,
+            memory_context::MemoryContext,
             with_mock_invoke_context, with_mock_invoke_context_with_feature_set,
         },
         solana_sbpf::{


### PR DESCRIPTION
#### Problem

The memory context related structs and function will be expanded to handle ABIv2. To avoid cluttering `invoke_context.rs`, we can move those things to a new file.

#### Summary of Changes

Create a new file.
