### PR TITLE
Add ExecutionFlags to support replay

### DIFF
--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -68,6 +68,7 @@ impl Committer {
         balance_collector: Option<BalanceCollector>,
         execute_and_commit_timings: &mut LeaderExecuteAndCommitTimings,
         processed_counts: &ProcessedTransactionCounts,
+        transactions_verified: bool,
     ) -> (u64, Vec<CommitTransactionDetails>) {
         let (commit_results, commit_time_us) = measure_us!(bank.commit_transactions(
             batch.sanitized_transactions(),
@@ -100,7 +101,14 @@ impl Committer {
                 batch.sanitized_transactions(),
                 &commit_results,
                 Some(&self.replay_vote_sender),
-                ReplayVoteSendType::VerifiedExecuted,
+                if transactions_verified {
+                    ReplayVoteSendType::VerifiedExecuted
+                } else {
+                    ReplayVoteSendType::Executed {
+                        replay_bank_id: bank.bank_id(),
+                        replay_slot: bank.slot(),
+                    }
+                },
             );
 
             if let Some(prioritization_fee_cache) = self.prioritization_fee_cache.as_ref() {

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -126,6 +126,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
                 all_or_nothing: false,
                 skip_account_locks: false,
                 skip_cost_tracking: false,
+                skip_poh_recording: false,
             },
         );
         self.metrics.update_for_consume(&output);
@@ -398,6 +399,7 @@ pub(crate) mod external {
                 all_or_nothing: message.flags & execution_flags::ALL_OR_NOTHING != 0,
                 skip_account_locks: false,
                 skip_cost_tracking: false,
+                skip_poh_recording: false,
             };
             if execution_flags.all_or_nothing && translation_results.len() != transactions.len() {
                 self.send_execution_response(

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -124,6 +124,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             ExecutionFlags {
                 drop_on_failure: false,
                 all_or_nothing: false,
+                skip_account_locks: false,
             },
         );
         self.metrics.update_for_consume(&output);
@@ -394,6 +395,7 @@ pub(crate) mod external {
             let execution_flags = ExecutionFlags {
                 drop_on_failure: message.flags & execution_flags::DROP_ON_FAILURE != 0,
                 all_or_nothing: message.flags & execution_flags::ALL_OR_NOTHING != 0,
+                skip_account_locks: false,
             };
             if execution_flags.all_or_nothing && translation_results.len() != transactions.len() {
                 self.send_execution_response(

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -125,6 +125,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
                 drop_on_failure: false,
                 all_or_nothing: false,
                 skip_account_locks: false,
+                skip_cost_tracking: false,
             },
         );
         self.metrics.update_for_consume(&output);
@@ -396,6 +397,7 @@ pub(crate) mod external {
                 drop_on_failure: message.flags & execution_flags::DROP_ON_FAILURE != 0,
                 all_or_nothing: message.flags & execution_flags::ALL_OR_NOTHING != 0,
                 skip_account_locks: false,
+                skip_cost_tracking: false,
             };
             if execution_flags.all_or_nothing && translation_results.len() != transactions.len() {
                 self.send_execution_response(

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -64,6 +64,11 @@ pub struct ExecutionFlags {
     /// scheduled transactions with total cost within the block limits,
     /// or verifying it after execution.
     pub skip_cost_tracking: bool,
+
+    /// NOTE: Not currently exposed to scheduler-bindings.
+    /// Used to skip recording transactions into PoH.
+    /// This is useful for replay where we simply commit the transactions.
+    pub skip_poh_recording: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -170,6 +175,7 @@ impl Consumer {
                 all_or_nothing: false,
                 skip_account_locks: false,
                 skip_cost_tracking: false,
+                skip_poh_recording: false,
             },
         );
 
@@ -385,94 +391,88 @@ impl Consumer {
         let (freeze_lock, freeze_lock_us) = measure_us!(bank.freeze_lock());
         execute_and_commit_timings.freeze_lock_us = freeze_lock_us;
 
-        let reserved_bytes =
-            bank.entry_bytes_budget()
+        let starting_transaction_index = if flags.skip_poh_recording {
+            None
+        } else {
+            let reserved_bytes = bank
+                .entry_bytes_budget()
                 .reserve(entry_bytes)
                 .map_err(|err| match err {
                     EntryBytesReserveError::ExceedsSlotLimit => PohRecorderError::MaxHeightReached,
                 });
-        let (record_transactions_summary, record_us) = measure_us!(reserved_bytes.map(|_| {
-            self.transaction_recorder
-                .record_transactions(bank.bank_id(), processed_transactions)
-        }));
-        execute_and_commit_timings.record_us = record_us;
+            let (record_transactions_summary, record_us) = measure_us!(reserved_bytes.map(|_| {
+                self.transaction_recorder
+                    .record_transactions(bank.bank_id(), processed_transactions)
+            }));
+            execute_and_commit_timings.record_us = record_us;
 
-        let (recording_result, starting_transaction_index) = match record_transactions_summary {
-            Ok(summary) => {
-                execute_and_commit_timings.record_transactions_timings =
-                    RecordTransactionsTimings {
-                        processing_results_to_transactions_us: Saturating(
-                            processing_results_to_transactions_us,
-                        ),
-                        ..summary.record_transactions_timings
-                    };
-                (summary.result, summary.starting_transaction_index)
+            let (recording_result, starting_transaction_index) = match record_transactions_summary {
+                Ok(summary) => {
+                    execute_and_commit_timings.record_transactions_timings =
+                        RecordTransactionsTimings {
+                            processing_results_to_transactions_us: Saturating(
+                                processing_results_to_transactions_us,
+                            ),
+                            ..summary.record_transactions_timings
+                        };
+                    (summary.result, summary.starting_transaction_index)
+                }
+                Err(err) => (Err(err), None),
+            };
+
+            if let Err(recorder_err) = recording_result {
+                retryable_transaction_indexes.extend(
+                    processing_results.iter().enumerate().filter_map(
+                        |(index, processing_result)| {
+                            processing_result.was_processed().then_some(RetryableIndex {
+                                index,
+                                immediately_retryable: true, // recording errors are always immediately retryable
+                            })
+                        },
+                    ),
+                );
+
+                // retryable indexes are expected to be sorted - in this case the
+                // `extend` can cause that assumption to be violated.
+                retryable_transaction_indexes.sort_unstable();
+
+                return ExecuteAndCommitTransactionsOutput {
+                    transaction_counts,
+                    retryable_transaction_indexes,
+                    commit_transactions_result: Err(recorder_err),
+                    execute_and_commit_timings,
+                    error_counters,
+                };
             }
-            Err(err) => (Err(err), None),
+
+            starting_transaction_index
         };
 
-        if let Err(recorder_err) = recording_result {
-            retryable_transaction_indexes.extend(processing_results.iter().enumerate().filter_map(
-                |(index, processing_result)| {
-                    processing_result.was_processed().then_some(RetryableIndex {
-                        index,
-                        immediately_retryable: true, // recording errors are always immediately retryable
+        let (_, commit_transaction_statuses) = if processed_counts.processed_transactions_count != 0
+        {
+            self.committer.commit_transactions(
+                batch,
+                processing_results,
+                starting_transaction_index,
+                bank,
+                balance_collector,
+                &mut execute_and_commit_timings,
+                &processed_counts,
+            )
+        } else {
+            (
+                0,
+                processing_results
+                    .into_iter()
+                    .map(|processing_result| match processing_result {
+                        Ok(_) => unreachable!("processed transaction count is 0"),
+                        Err(err) => CommitTransactionDetails::NotCommitted(err),
                     })
-                },
-            ));
-
-            // retryable indexes are expected to be sorted - in this case the
-            // `extend` can cause that assumption to be violated.
-            retryable_transaction_indexes.sort_unstable();
-
-            return ExecuteAndCommitTransactionsOutput {
-                transaction_counts,
-                retryable_transaction_indexes,
-                commit_transactions_result: Err(recorder_err),
-                execute_and_commit_timings,
-                error_counters,
-            };
-        }
-
-        let (commit_time_us, commit_transaction_statuses) =
-            if processed_counts.processed_transactions_count != 0 {
-                self.committer.commit_transactions(
-                    batch,
-                    processing_results,
-                    starting_transaction_index,
-                    bank,
-                    balance_collector,
-                    &mut execute_and_commit_timings,
-                    &processed_counts,
-                )
-            } else {
-                (
-                    0,
-                    processing_results
-                        .into_iter()
-                        .map(|processing_result| match processing_result {
-                            Ok(_) => unreachable!("processed transaction count is 0"),
-                            Err(err) => CommitTransactionDetails::NotCommitted(err),
-                        })
-                        .collect(),
-                )
-            };
+                    .collect(),
+            )
+        };
 
         drop(freeze_lock);
-
-        debug!(
-            "bank: {} process_and_record_locked: {}us record: {}us commit: {}us txs_len: {}",
-            bank.slot(),
-            load_execute_us,
-            record_us,
-            commit_time_us,
-            batch.sanitized_transactions().len(),
-        );
-
-        debug!(
-            "execute_and_commit_transactions_locked: {:?}",
-            execute_and_commit_timings.execute_timings,
-        );
 
         debug_assert_eq!(
             transaction_counts.attempted_processing_count,
@@ -927,6 +927,7 @@ mod tests {
                 all_or_nothing: false,
                 skip_account_locks: true,
                 skip_cost_tracking: false,
+                skip_poh_recording: false,
             },
         );
 
@@ -952,6 +953,109 @@ mod tests {
         assert_eq!(transaction_results, vec![Ok(())]);
 
         bank.unlock_accounts(transactions.iter().zip(&transaction_results));
+    }
+
+    #[test]
+    fn test_bank_process_and_record_transactions_skip_poh_recording() {
+        let TestFrame {
+            mint_keypair,
+            bank,
+            bank_forks: _bank_forks,
+            mut record_receiver,
+            consumer,
+        } = setup_test(true, None);
+
+        let destination = Pubkey::new_unique();
+        let transactions = sanitize_transactions(vec![system_transaction::transfer(
+            &mint_keypair,
+            &destination,
+            1,
+            bank.last_blockhash(),
+        )]);
+        let max_ages = vec![MaxAge {
+            sanitized_epoch: bank.epoch(),
+            alt_invalidation_slot: bank.slot(),
+        }];
+
+        let process_transactions_batch_output = consumer.process_and_record_aged_transactions(
+            &bank,
+            &transactions,
+            &max_ages,
+            ExecutionFlags {
+                drop_on_failure: false,
+                all_or_nothing: false,
+                skip_account_locks: false,
+                skip_cost_tracking: false,
+                skip_poh_recording: true,
+            },
+        );
+
+        let ExecuteAndCommitTransactionsOutput {
+            transaction_counts,
+            commit_transactions_result,
+            retryable_transaction_indexes,
+            ..
+        } = process_transactions_batch_output.execute_and_commit_transactions_output;
+
+        assert_eq!(
+            transaction_counts,
+            LeaderProcessedTransactionCounts {
+                attempted_processing_count: 1,
+                processed_count: 1,
+                processed_with_successful_result_count: 1,
+            }
+        );
+        assert!(retryable_transaction_indexes.is_empty());
+        assert!(commit_transactions_result.is_ok());
+        assert_eq!(bank.get_balance(&destination), 1);
+
+        record_receiver.shutdown();
+        assert!(record_receiver.drain().next().is_none());
+
+        // Ensure that this works even with the recorder shutdown (replay)
+        let destination = Pubkey::new_unique();
+        let transactions = sanitize_transactions(vec![system_transaction::transfer(
+            &mint_keypair,
+            &destination,
+            1,
+            bank.last_blockhash(),
+        )]);
+        let max_ages = vec![MaxAge {
+            sanitized_epoch: bank.epoch(),
+            alt_invalidation_slot: bank.slot(),
+        }];
+
+        let process_transactions_batch_output = consumer.process_and_record_aged_transactions(
+            &bank,
+            &transactions,
+            &max_ages,
+            ExecutionFlags {
+                drop_on_failure: false,
+                all_or_nothing: false,
+                skip_account_locks: false,
+                skip_cost_tracking: false,
+                skip_poh_recording: true,
+            },
+        );
+
+        let ExecuteAndCommitTransactionsOutput {
+            transaction_counts,
+            commit_transactions_result,
+            retryable_transaction_indexes,
+            ..
+        } = process_transactions_batch_output.execute_and_commit_transactions_output;
+
+        assert_eq!(
+            transaction_counts,
+            LeaderProcessedTransactionCounts {
+                attempted_processing_count: 1,
+                processed_count: 1,
+                processed_with_successful_result_count: 1,
+            }
+        );
+        assert!(retryable_transaction_indexes.is_empty());
+        assert!(commit_transactions_result.is_ok());
+        assert_eq!(bank.get_balance(&destination), 1);
     }
 
     #[test_case(false; "old")]
@@ -1119,6 +1223,7 @@ mod tests {
                     all_or_nothing: false,
                     skip_account_locks: false,
                     skip_cost_tracking: false, // track costs
+                    skip_poh_recording: false,
                 },
             );
         let ExecuteAndCommitTransactionsOutput {
@@ -1151,6 +1256,7 @@ mod tests {
                 all_or_nothing: false,
                 skip_account_locks: false,
                 skip_cost_tracking: true,
+                skip_poh_recording: false,
             },
         );
 

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -52,6 +52,11 @@ pub struct ExecutionFlags {
     /// failing transactions to be committed. If both flags are set then any
     /// failing transaction will cause all transactions to be aborted.
     pub all_or_nothing: bool,
+
+    /// NOTE: Not currently exposed to scheduler-bindings.
+    /// Use to skip locking accounts - i.e. rely on the scheduler to have
+    /// scheduled transactions with no overlapping accounts.
+    pub skip_account_locks: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -156,6 +161,7 @@ impl Consumer {
             ExecutionFlags {
                 drop_on_failure: false,
                 all_or_nothing: false,
+                skip_account_locks: false,
             },
         );
 
@@ -208,6 +214,7 @@ impl Consumer {
         // same account state
         let (batch, lock_us) = measure_us!(bank.prepare_sanitized_batch_with_results(
             txs,
+            flags.skip_account_locks,
             transaction_qos_cost_results.iter().map(|r| match r {
                 Ok(_cost) => Ok(()),
                 Err(err) => Err(err.clone()),
@@ -855,6 +862,63 @@ mod tests {
                 1
             ])
         );
+    }
+
+    #[test]
+    fn test_bank_process_and_record_transactions_skip_account_locks_leaves_locks_unchanged() {
+        let TestFrame {
+            mint_keypair,
+            bank,
+            bank_forks: _bank_forks,
+            record_receiver: _record_receiver,
+            consumer,
+        } = setup_test(true, None);
+
+        let destination = Pubkey::new_unique();
+        let transactions = sanitize_transactions(vec![system_transaction::transfer(
+            &mint_keypair,
+            &destination,
+            1,
+            bank.last_blockhash(),
+        )]);
+        let max_ages = vec![MaxAge {
+            sanitized_epoch: bank.epoch(),
+            alt_invalidation_slot: bank.slot(),
+        }];
+
+        let process_transactions_batch_output = consumer.process_and_record_aged_transactions(
+            &bank,
+            &transactions,
+            &max_ages,
+            ExecutionFlags {
+                drop_on_failure: false,
+                all_or_nothing: false,
+                skip_account_locks: true,
+            },
+        );
+
+        let ExecuteAndCommitTransactionsOutput {
+            transaction_counts,
+            commit_transactions_result,
+            ..
+        } = process_transactions_batch_output.execute_and_commit_transactions_output;
+
+        assert_eq!(
+            transaction_counts,
+            LeaderProcessedTransactionCounts {
+                attempted_processing_count: 1,
+                processed_count: 1,
+                processed_with_successful_result_count: 1,
+            }
+        );
+        assert!(commit_transactions_result.is_ok());
+
+        // The executed transaction should remain lockable afterward, confirming the skip-locks
+        // path did not leave any account locks behind.
+        let transaction_results = bank.try_lock_accounts(&transactions);
+        assert_eq!(transaction_results, vec![Ok(())]);
+
+        bank.unlock_accounts(transactions.iter().zip(&transaction_results));
     }
 
     #[test_case(false; "old")]

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -6,6 +6,7 @@ use {
         scheduler_messages::MaxAge,
     },
     itertools::Itertools,
+    solana_cost_model::transaction_cost::TransactionCost,
     solana_fee::FeeFeatures,
     solana_measure::measure_us,
     solana_poh::{
@@ -38,7 +39,7 @@ const SERIALIZED_ENTRIES_OVERHEAD: u64 = {
     + 8 // Vec<Entry> length
 };
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct ExecutionFlags {
     /// Should failing transactions within the batch be dropped (no fee charged
     /// & not committed).
@@ -57,6 +58,12 @@ pub struct ExecutionFlags {
     /// Use to skip locking accounts - i.e. rely on the scheduler to have
     /// scheduled transactions with no overlapping accounts.
     pub skip_account_locks: bool,
+
+    /// NOTE: Not currently exposed to scheduler-bindings.
+    /// Used to skip cost-tracking - i.e. rely on the scheduler to have
+    /// scheduled transactions with total cost within the block limits,
+    /// or verifying it after execution.
+    pub skip_cost_tracking: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -162,6 +169,7 @@ impl Consumer {
                 drop_on_failure: false,
                 all_or_nothing: false,
                 skip_account_locks: false,
+                skip_cost_tracking: false,
             },
         );
 
@@ -203,10 +211,11 @@ impl Consumer {
         let (
             (transaction_qos_cost_results, cost_model_throttled_transactions_count),
             cost_model_us,
-        ) = measure_us!(QosService::select_and_accumulate_transaction_costs(
+        ) = measure_us!(Self::cost_tracker_reserve(
             bank,
             txs,
-            pre_results
+            pre_results,
+            flags.skip_cost_tracking
         ));
 
         // Only lock accounts for those transactions are selected for the block;
@@ -235,15 +244,17 @@ impl Consumer {
             ..
         } = execute_and_commit_transactions_output;
 
-        // Costs of all transactions are added to the cost_tracker before processing.
-        // To ensure accurate tracking of compute units, transactions that ultimately
-        // were not included in the block should have their cost removed, the rest
-        // should update with their actually consumed units.
-        QosService::remove_or_update_costs(
-            transaction_qos_cost_results.iter(),
-            commit_transactions_result.as_ref().ok(),
-            bank,
-        );
+        if !flags.skip_cost_tracking {
+            // Costs of all transactions are added to the cost_tracker before processing.
+            // To ensure accurate tracking of compute units, transactions that ultimately
+            // were not included in the block should have their cost removed, the rest
+            // should update with their actually consumed units.
+            QosService::remove_or_update_costs(
+                transaction_qos_cost_results.iter(),
+                commit_transactions_result.as_ref().ok(),
+                bank,
+            );
+        }
 
         debug!(
             "bank: {} lock: {}us unlock: {}us txs_len: {}",
@@ -504,6 +515,27 @@ impl Consumer {
             &bank.rent_collector().rent,
             fee,
         )
+    }
+
+    fn cost_tracker_reserve<'a, Tx: TransactionWithMeta>(
+        bank: &Bank,
+        transactions: &'a [Tx],
+        pre_results: impl Iterator<Item = Result<(), TransactionError>>,
+        skip_cost_tracking: bool,
+    ) -> (Vec<Result<TransactionCost<'a, Tx>, TransactionError>>, u64) {
+        if skip_cost_tracking {
+            // Skip tracking and only calculate the costs.
+            (
+                QosService::compute_transaction_costs(
+                    &bank.feature_set,
+                    transactions.iter(),
+                    pre_results,
+                ),
+                0, // no transactions throttled since we're skipping cost tracking
+            )
+        } else {
+            QosService::select_and_accumulate_transaction_costs(bank, transactions, pre_results)
+        }
     }
 }
 
@@ -894,6 +926,7 @@ mod tests {
                 drop_on_failure: false,
                 all_or_nothing: false,
                 skip_account_locks: true,
+                skip_cost_tracking: false,
             },
         );
 
@@ -1050,6 +1083,101 @@ mod tests {
 
         assert_eq!(get_block_cost(), expected_block_cost);
         assert_eq!(get_tx_count(), 2);
+    }
+
+    #[test]
+    fn test_bank_process_and_record_transactions_skip_cost_tracking() {
+        let TestFrame {
+            mint_keypair,
+            bank,
+            bank_forks: _bank_forks,
+            record_receiver: _record_receiver,
+            consumer,
+        } = setup_test(true, None);
+
+        let max_ages = vec![MaxAge {
+            sanitized_epoch: bank.epoch(),
+            alt_invalidation_slot: bank.slot(),
+        }];
+
+        let get_block_cost = || bank.read_cost_tracker().unwrap().block_cost();
+        let get_tx_count = || bank.read_cost_tracker().unwrap().transaction_count();
+
+        let tracked_transactions = sanitize_transactions(vec![system_transaction::transfer(
+            &mint_keypair,
+            &Pubkey::new_unique(),
+            1,
+            bank.last_blockhash(),
+        )]);
+        let tracked_process_transactions_batch_output = consumer
+            .process_and_record_aged_transactions(
+                &bank,
+                &tracked_transactions,
+                &max_ages,
+                ExecutionFlags {
+                    drop_on_failure: false,
+                    all_or_nothing: false,
+                    skip_account_locks: false,
+                    skip_cost_tracking: false, // track costs
+                },
+            );
+        let ExecuteAndCommitTransactionsOutput {
+            transaction_counts,
+            commit_transactions_result,
+            ..
+        } = tracked_process_transactions_batch_output.execute_and_commit_transactions_output;
+
+        assert_eq!(transaction_counts.processed_with_successful_result_count, 1);
+        assert!(commit_transactions_result.is_ok());
+
+        let tracked_block_cost = get_block_cost();
+        let tracked_tx_count = get_tx_count();
+        assert_ne!(tracked_block_cost, 0);
+        assert_eq!(tracked_tx_count, 1);
+
+        // Use new transactions so we do not hit status-cache
+        let transactions = sanitize_transactions(vec![system_transaction::transfer(
+            &mint_keypair,
+            &Pubkey::new_unique(),
+            1,
+            bank.last_blockhash(),
+        )]);
+        let process_transactions_batch_output = consumer.process_and_record_aged_transactions(
+            &bank,
+            &transactions,
+            &max_ages,
+            ExecutionFlags {
+                drop_on_failure: false,
+                all_or_nothing: false,
+                skip_account_locks: false,
+                skip_cost_tracking: true,
+            },
+        );
+
+        assert_eq!(
+            process_transactions_batch_output.cost_model_throttled_transactions_count,
+            0
+        );
+
+        let ExecuteAndCommitTransactionsOutput {
+            transaction_counts,
+            commit_transactions_result,
+            retryable_transaction_indexes,
+            ..
+        } = process_transactions_batch_output.execute_and_commit_transactions_output;
+
+        assert_eq!(
+            transaction_counts,
+            LeaderProcessedTransactionCounts {
+                attempted_processing_count: 1,
+                processed_count: 1,
+                processed_with_successful_result_count: 1,
+            }
+        );
+        assert!(retryable_transaction_indexes.is_empty());
+        assert!(commit_transactions_result.is_ok());
+        assert_eq!(get_block_cost(), tracked_block_cost); // no change
+        assert_eq!(get_tx_count(), tracked_tx_count);
     }
 
     #[test_case(false, false; "old::locked")]

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -458,6 +458,7 @@ impl Consumer {
                 balance_collector,
                 &mut execute_and_commit_timings,
                 &processed_counts,
+                true, // for block-production assume transactions are verified
             )
         } else {
             (

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -53,7 +53,7 @@ impl QosService {
 
     // invoke cost_model to calculate cost for the given list of transactions that have not
     // been filtered out already.
-    fn compute_transaction_costs<'a, Tx: TransactionWithMeta>(
+    pub fn compute_transaction_costs<'a, Tx: TransactionWithMeta>(
         feature_set: &FeatureSet,
         transactions: impl Iterator<Item = &'a Tx>,
         pre_results: impl Iterator<Item = transaction::Result<()>>,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3345,7 +3345,7 @@ impl Bank {
         &'a self,
         txs: &'b [Tx],
     ) -> TransactionBatch<'a, 'b, Tx> {
-        self.prepare_sanitized_batch_with_results(txs, txs.iter().map(|_| Ok(())))
+        self.prepare_sanitized_batch_with_results(txs, false, txs.iter().map(|_| Ok(())))
     }
 
     /// Prepare a locked transaction batch from a list of sanitized transactions, and their cost
@@ -3353,14 +3353,24 @@ impl Bank {
     pub fn prepare_sanitized_batch_with_results<'a, 'b, Tx: TransactionWithMeta>(
         &'a self,
         transactions: &'b [Tx],
+        skip_account_locks: bool,
         transaction_results: impl Iterator<Item = Result<()>>,
     ) -> TransactionBatch<'a, 'b, Tx> {
-        // this lock_results could be: Ok, AccountInUse, WouldExceedBlockMaxLimit or WouldExceedAccountMaxLimit
-        TransactionBatch::new(
-            self.try_lock_accounts_with_results(transactions, transaction_results),
-            self,
-            OwnedOrBorrowed::Borrowed(transactions),
-        )
+        if skip_account_locks {
+            let mut batch = TransactionBatch::new(
+                transaction_results.collect(),
+                self,
+                OwnedOrBorrowed::Borrowed(transactions),
+            );
+            batch.set_needs_unlock(false);
+            batch
+        } else {
+            TransactionBatch::new(
+                self.try_lock_accounts_with_results(transactions, transaction_results),
+                self,
+                OwnedOrBorrowed::Borrowed(transactions),
+            )
+        }
     }
 
     /// Prepare a transaction batch from a single transaction without locking accounts

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2113,6 +2113,43 @@ fn test_readonly_relaxed_locks() {
 }
 
 #[test]
+fn test_prepare_sanitized_batch_with_results_skip_account_locks_preserves_transaction_errors() {
+    let (genesis_config, mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
+    let bank = Bank::new_for_tests(&genesis_config);
+    let txs = vec![
+        RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+            &mint_keypair,
+            &Pubkey::new_unique(),
+            1,
+            bank.last_blockhash(),
+        )),
+        RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+            &mint_keypair,
+            &Pubkey::new_unique(),
+            1,
+            bank.last_blockhash(),
+        )),
+        RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+            &mint_keypair,
+            &Pubkey::new_unique(),
+            1,
+            bank.last_blockhash(),
+        )),
+    ];
+
+    let batch = bank.prepare_sanitized_batch_with_results(
+        &txs,
+        true,
+        [Ok(()), Err(TransactionError::AccountLoadedTwice), Ok(())].into_iter(),
+    );
+    assert_eq!(
+        batch.lock_results().as_slice(),
+        &[Ok(()), Err(TransactionError::AccountLoadedTwice), Ok(())]
+    );
+    assert!(!batch.needs_unlock());
+}
+
+#[test]
 fn test_bank_invalid_account_index() {
     let (genesis_config, mint_keypair) = create_genesis_config(1);
     let keypair = Keypair::new();


### PR DESCRIPTION
#### Problem
- Want to re-use same consumer (and external message types) for replay stage 

#### Summary of Changes
- Add ExecutionFlags to:
	- skip account locking: not strictly necessary, but since we do not need to worry about a jito thread in replay, this is useful to avoid overhead
	- skip cost tracking: skip cost tracking in the workers; scheduler can track this w/o lock-contention
	- skip poh recording: skip poh recording since that is not relevant to replay
- Add plumbing to support vote sender w/ unverified transactions
	- in replay signatures are verified asynchronously	 	

Fixes #
