### PR TITLE
feat(snapshots): enable direct io for snapshot and archive creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7795,6 +7795,7 @@ dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-bls-cert-verify",
  "agave-feature-set",
+ "agave-fs",
  "agave-logger",
  "agave-math-utils",
  "agave-reserved-account-keys",

--- a/accounts-db/src/utils.rs
+++ b/accounts-db/src/utils.rs
@@ -1,6 +1,5 @@
 use {
     agave_fs::{dirs, metadata::DirectIoSupport},
-    itertools::Itertools as _,
     log::*,
     solana_account::{AccountSharedData, ReadableAccount},
     solana_measure::measure_time,
@@ -164,28 +163,25 @@ pub fn create_account_shared_data(account: &impl ReadableAccount) -> AccountShar
     )
 }
 
-/// Check that given paths conform to requirements defined by `config`.
+/// Validates that all `paths` reside on filesystems that support direct I/O (`O_DIRECT`).
 ///
-/// Return `Err` if paths are impossible to access or do not support required features.
-///
-/// This functions validates that paths reside on filesystem supporting configured operations
-/// like direct-io. This allows providing meaningful error messages to user during startup
-/// instead of generating hard to diagnose errors during runtime.
+/// Returns a descriptive `Err` early at startup rather than letting silent failures surface
+/// at runtime. No-op when `use_direct_io` is `false`.
 pub fn validate_account_paths_for_direct_io(
     use_direct_io: bool,
-    accounts_paths: &[PathBuf],
-    account_snapshot_paths: &[PathBuf],
+    paths: impl IntoIterator<Item = impl AsRef<Path>>,
 ) -> io::Result<()> {
     if use_direct_io {
         let mut unsupported_paths = vec![];
-        for path in accounts_paths.iter().chain(account_snapshot_paths.iter()) {
+        for path in paths.into_iter() {
+            let path = path.as_ref();
             if agave_fs::metadata::check_direct_io_capability(path)? == DirectIoSupport::Unsupported
             {
-                unsupported_paths.push(path);
+                unsupported_paths.push(path.display().to_string());
             }
         }
         if !unsupported_paths.is_empty() {
-            let paths_str = unsupported_paths.into_iter().map(|p| p.display()).join(",");
+            let paths_str = unsupported_paths.join(",");
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
                 format!(

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -43,6 +43,7 @@ frozen-abi = [
 agave-banking-stage-ingress-types = { workspace = true }
 agave-bls-cert-verify = { workspace = true }
 agave-feature-set = { workspace = true }
+agave-fs = { workspace = true }
 agave-logger = { workspace = true }
 agave-math-utils = { workspace = true }
 agave-scheduler-bindings = { workspace = true }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,8 +1,7 @@
 mod snapshot_gossip_manager;
 use {
     agave_snapshots::{
-        SnapshotKind, paths as snapshot_paths, snapshot_config::SnapshotConfig,
-        snapshot_hash::StartingSnapshotHashes,
+        SnapshotKind, paths as snapshot_paths, snapshot_hash::StartingSnapshotHashes,
     },
     snapshot_gossip_manager::SnapshotGossipManager,
     solana_accounts_db::account_storage_entry::AccountStorageEntry,
@@ -63,10 +62,8 @@ impl SnapshotPackagerService {
                     if exit.load(Ordering::Relaxed) {
                         if let Some(teardown_state) = teardown_state {
                             info!("Received exit request, tearing down...");
-                            let (_, dur) = meas_dur!(Self::teardown(
-                                teardown_state,
-                                snapshot_controller.snapshot_config(),
-                            ));
+                            let (_, dur) =
+                                meas_dur!(Self::teardown(teardown_state, &snapshot_controller));
                             info!("Teardown completed in {dur:?}.");
                         }
                         break;
@@ -119,6 +116,7 @@ impl SnapshotPackagerService {
                     }
 
                     let archive_time = Instant::now();
+                    let io_setup = snapshot_controller.new_io_setup_state(false);
                     // Serializing the snapshot package is not allowed to fail, as archiving is
                     // not allowed to fail (see comment on archive_snapshot_package below
                     let bank_snapshot_info = snapshot_utils::serialize_snapshot(
@@ -127,6 +125,7 @@ impl SnapshotPackagerService {
                         snapshot_package.bank_snapshot_package,
                         snapshot_package.snapshot_storages.as_slice(),
                         exit_backpressure.is_none(),
+                        &io_setup,
                     );
 
                     let Ok(bank_snapshot_info) = bank_snapshot_info else {
@@ -151,6 +150,7 @@ impl SnapshotPackagerService {
                             &bank_snapshot_info.snapshot_dir,
                             snapshot_package.snapshot_storages,
                             snapshot_config,
+                            &io_setup,
                         ) {
                             error!(
                                 "Stopping {}! Fatal error while archiving snapshot package: {err}",
@@ -223,12 +223,15 @@ impl SnapshotPackagerService {
     }
 
     /// Performs final operations before gracefully shutting down
-    fn teardown(state: TeardownState, snapshot_config: &SnapshotConfig) {
+    fn teardown(state: TeardownState, snapshot_controller: &SnapshotController) {
+        let snapshot_config = snapshot_controller.snapshot_config();
         let TeardownState {
             snapshot_slot,
             snapshot_storages,
             bank_snapshot_package,
         } = state;
+
+        let io_setup = snapshot_controller.new_io_setup_state(true);
 
         if let Some(bank_snapshot_package) = bank_snapshot_package {
             info!("Serializing bank snapshot...");
@@ -239,6 +242,7 @@ impl SnapshotPackagerService {
                 bank_snapshot_package,
                 snapshot_storages.as_slice(),
                 false,
+                &io_setup,
             );
             if let Err(err) = result {
                 warn!(
@@ -297,6 +301,7 @@ impl SnapshotPackagerService {
             &bank_snapshot_dir,
             &snapshot_storages,
             snapshot_slot,
+            &io_setup,
         );
         if let Err(err) = result {
             warn!("Failed to serialize obsolete accounts: {err}");

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -239,13 +239,13 @@ impl SnapshotPackagerService {
         // Teardown, expedite IO using sqpoll thread, but fallback in case of error.
         // Also, don't use direct I/O, since data is likely going to be re-read soon after.
         let io_setup = IoSetupState::default()
-            .with_buffers_registered(snapshot_config.use_registered_io_uring_buffers)
-            .with_direct_io(false)
             .with_shared_sqpoll()
             .unwrap_or_else(|error| {
                 warn!("unable to use sqpoll for io-uring: {error}");
                 IoSetupState::default()
-            });
+            })
+            .with_buffers_registered(snapshot_config.use_registered_io_uring_buffers)
+            .with_direct_io(false);
 
         if let Some(bank_snapshot_package) = bank_snapshot_package {
             info!("Serializing bank snapshot...");

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,7 +1,9 @@
 mod snapshot_gossip_manager;
 use {
+    agave_fs::io_setup::IoSetupState,
     agave_snapshots::{
-        SnapshotKind, paths as snapshot_paths, snapshot_hash::StartingSnapshotHashes,
+        SnapshotKind, paths as snapshot_paths, snapshot_config::SnapshotConfig,
+        snapshot_hash::StartingSnapshotHashes,
     },
     snapshot_gossip_manager::SnapshotGossipManager,
     solana_accounts_db::account_storage_entry::AccountStorageEntry,
@@ -63,7 +65,7 @@ impl SnapshotPackagerService {
                         if let Some(teardown_state) = teardown_state {
                             info!("Received exit request, tearing down...");
                             let (_, dur) =
-                                meas_dur!(Self::teardown(teardown_state, &snapshot_controller));
+                                meas_dur!(Self::teardown(teardown_state, snapshot_config));
                             info!("Teardown completed in {dur:?}.");
                         }
                         break;
@@ -116,7 +118,7 @@ impl SnapshotPackagerService {
                     }
 
                     let archive_time = Instant::now();
-                    let io_setup = snapshot_controller.new_io_setup_state(false);
+                    let io_setup = Self::new_io_setup_state(snapshot_config, false);
                     // Serializing the snapshot package is not allowed to fail, as archiving is
                     // not allowed to fail (see comment on archive_snapshot_package below
                     let bank_snapshot_info = snapshot_utils::serialize_snapshot(
@@ -223,15 +225,14 @@ impl SnapshotPackagerService {
     }
 
     /// Performs final operations before gracefully shutting down
-    fn teardown(state: TeardownState, snapshot_controller: &SnapshotController) {
-        let snapshot_config = snapshot_controller.snapshot_config();
+    fn teardown(state: TeardownState, snapshot_config: &SnapshotConfig) {
         let TeardownState {
             snapshot_slot,
             snapshot_storages,
             bank_snapshot_package,
         } = state;
 
-        let io_setup = snapshot_controller.new_io_setup_state(true);
+        let io_setup = Self::new_io_setup_state(snapshot_config, true);
 
         if let Some(bank_snapshot_package) = bank_snapshot_package {
             info!("Serializing bank snapshot...");
@@ -314,6 +315,21 @@ impl SnapshotPackagerService {
         let result = snapshot_utils::mark_bank_snapshot_as_loadable(&bank_snapshot_dir);
         if let Err(err) = result {
             warn!("Failed to mark bank snapshot as loadable: {err}");
+        }
+    }
+
+    fn new_io_setup_state(snapshot_config: &SnapshotConfig, is_teardown: bool) -> IoSetupState {
+        let io_state = IoSetupState::default()
+            .with_buffers_registered(snapshot_config.use_registered_io_uring_buffers);
+        if is_teardown {
+            // Teardown, expedite IO using sqpoll thread, but fallback in case of error.
+            io_state.with_shared_sqpoll().unwrap_or_else(|error| {
+                warn!("unable to use sqpoll for io-uring: {error}");
+                Self::new_io_setup_state(snapshot_config, false)
+            })
+        } else {
+            // Regular operation, saved data is unlikely being read back soon, so allow direct-io.
+            io_state.with_direct_io(snapshot_config.use_direct_io)
         }
     }
 }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -118,7 +118,11 @@ impl SnapshotPackagerService {
                     }
 
                     let archive_time = Instant::now();
-                    let io_setup = Self::new_io_setup_state(snapshot_config, false);
+                    // Regular operation, saved data is unlikely being read back soon, so allow direct-io.
+                    let io_setup = IoSetupState::default()
+                        .with_buffers_registered(snapshot_config.use_registered_io_uring_buffers)
+                        .with_direct_io(snapshot_config.use_direct_io);
+
                     // Serializing the snapshot package is not allowed to fail, as archiving is
                     // not allowed to fail (see comment on archive_snapshot_package below
                     let bank_snapshot_info = snapshot_utils::serialize_snapshot(
@@ -232,7 +236,16 @@ impl SnapshotPackagerService {
             bank_snapshot_package,
         } = state;
 
-        let io_setup = Self::new_io_setup_state(snapshot_config, true);
+        // Teardown, expedite IO using sqpoll thread, but fallback in case of error.
+        // Also, don't use direct I/O, since data is likely going to be re-read soon after.
+        let io_setup = IoSetupState::default()
+            .with_buffers_registered(snapshot_config.use_registered_io_uring_buffers)
+            .with_direct_io(false)
+            .with_shared_sqpoll()
+            .unwrap_or_else(|error| {
+                warn!("unable to use sqpoll for io-uring: {error}");
+                IoSetupState::default()
+            });
 
         if let Some(bank_snapshot_package) = bank_snapshot_package {
             info!("Serializing bank snapshot...");
@@ -315,21 +328,6 @@ impl SnapshotPackagerService {
         let result = snapshot_utils::mark_bank_snapshot_as_loadable(&bank_snapshot_dir);
         if let Err(err) = result {
             warn!("Failed to mark bank snapshot as loadable: {err}");
-        }
-    }
-
-    fn new_io_setup_state(snapshot_config: &SnapshotConfig, is_teardown: bool) -> IoSetupState {
-        let io_state = IoSetupState::default()
-            .with_buffers_registered(snapshot_config.use_registered_io_uring_buffers);
-        if is_teardown {
-            // Teardown, expedite IO using sqpoll thread, but fallback in case of error.
-            io_state.with_shared_sqpoll().unwrap_or_else(|error| {
-                warn!("unable to use sqpoll for io-uring: {error}");
-                Self::new_io_setup_state(snapshot_config, false)
-            })
-        } else {
-            // Regular operation, saved data is unlikely being read back soon, so allow direct-io.
-            io_state.with_direct_io(snapshot_config.use_direct_io)
         }
     }
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2841,8 +2841,15 @@ fn cleanup_accounts_paths(config: &ValidatorConfig) {
 fn validate_account_paths(config: &ValidatorConfig) -> std::io::Result<()> {
     validate_account_paths_for_direct_io(
         config.snapshot_config.use_direct_io,
-        &config.account_paths,
-        &config.account_snapshot_paths,
+        config
+            .account_paths
+            .iter()
+            .chain(&config.account_snapshot_paths)
+            .chain([
+                &config.snapshot_config.full_snapshot_archives_dir,
+                &config.snapshot_config.incremental_snapshot_archives_dir,
+                &config.snapshot_config.bank_snapshots_dir,
+            ]),
     )
 }
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6862,6 +6862,7 @@ dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-bls-cert-verify",
  "agave-feature-set",
+ "agave-fs",
  "agave-logger",
  "agave-math-utils",
  "agave-scheduler-bindings",

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -267,8 +267,14 @@ pub fn load_and_process_ledger(
 
     validate_account_paths_for_direct_io(
         snapshot_config.use_direct_io,
-        &account_paths,
-        &account_snapshot_paths,
+        account_paths
+            .iter()
+            .chain(account_snapshot_paths.iter())
+            .chain([
+                &snapshot_config.full_snapshot_archives_dir,
+                &snapshot_config.incremental_snapshot_archives_dir,
+                &snapshot_config.bank_snapshots_dir,
+            ]),
     )
     .map_err(LoadAndProcessLedgerError::ValidateAccountPaths)?;
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6533,6 +6533,7 @@ dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-bls-cert-verify",
  "agave-feature-set",
+ "agave-fs",
  "agave-logger",
  "agave-math-utils",
  "agave-scheduler-bindings",

--- a/runtime/src/serde_snapshot/status_cache.rs
+++ b/runtime/src/serde_snapshot/status_cache.rs
@@ -33,6 +33,7 @@ pub fn serialize_status_cache(
 ) -> agave_snapshots::Result<u64> {
     snapshot_utils::serialize_snapshot_data_file(
         status_cache_path,
+        &IoSetupState::default(),
         |stream| {
             let snapshot_slot_deltas = slot_deltas
                 .iter()
@@ -65,7 +66,6 @@ pub fn serialize_status_cache(
             bincode::serialize_into(stream, &snapshot_slot_deltas)?;
             Ok(())
         },
-        &IoSetupState::default(),
     )
 }
 

--- a/runtime/src/serde_snapshot/status_cache.rs
+++ b/runtime/src/serde_snapshot/status_cache.rs
@@ -6,6 +6,7 @@ use shuttle::sync::Mutex;
 use std::sync::Mutex;
 use {
     crate::{bank::BankSlotDelta, snapshot_utils, status_cache::KeySlice},
+    agave_fs::io_setup::IoSetupState,
     bincode::{self, Options as _},
     serde::{Deserialize, Serialize},
     solana_clock::Slot,
@@ -30,38 +31,42 @@ pub fn serialize_status_cache(
     slot_deltas: &[BankSlotDelta],
     status_cache_path: &Path,
 ) -> agave_snapshots::Result<u64> {
-    snapshot_utils::serialize_snapshot_data_file(status_cache_path, |stream| {
-        let snapshot_slot_deltas = slot_deltas
-            .iter()
-            .map(|slot_delta| {
-                let status_map = slot_delta.2.lock().unwrap();
-                let snapshot_status_map = status_map
-                    .iter()
-                    .map(|(key, value)| {
-                        (
-                            *key,
+    snapshot_utils::serialize_snapshot_data_file(
+        status_cache_path,
+        |stream| {
+            let snapshot_slot_deltas = slot_deltas
+                .iter()
+                .map(|slot_delta| {
+                    let status_map = slot_delta.2.lock().unwrap();
+                    let snapshot_status_map = status_map
+                        .iter()
+                        .map(|(key, value)| {
                             (
-                                value.0,
-                                value
-                                    .1
-                                    .iter()
-                                    .map(|(key_slice, result)| {
-                                        (
-                                            *key_slice,
-                                            result.clone().map_err(SerdeTransactionError::from),
-                                        )
-                                    })
-                                    .collect::<Vec<_>>(),
-                            ),
-                        )
-                    })
-                    .collect::<HashMap<_, _>>();
-                (slot_delta.0, slot_delta.1, snapshot_status_map)
-            })
-            .collect::<Vec<_>>();
-        bincode::serialize_into(stream, &snapshot_slot_deltas)?;
-        Ok(())
-    })
+                                *key,
+                                (
+                                    value.0,
+                                    value
+                                        .1
+                                        .iter()
+                                        .map(|(key_slice, result)| {
+                                            (
+                                                *key_slice,
+                                                result.clone().map_err(SerdeTransactionError::from),
+                                            )
+                                        })
+                                        .collect::<Vec<_>>(),
+                                ),
+                            )
+                        })
+                        .collect::<HashMap<_, _>>();
+                    (slot_delta.0, slot_delta.1, snapshot_status_map)
+                })
+                .collect::<Vec<_>>();
+            bincode::serialize_into(stream, &snapshot_slot_deltas)?;
+            Ok(())
+        },
+        &IoSetupState::default(),
+    )
 }
 
 /// Deserializes the status cache from file at `status_cache_path`

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -733,12 +733,17 @@ pub fn bank_to_full_snapshot_archive(
 
     let snapshot_storages = snapshot_package.snapshot_storages;
 
+    let io_setup = IoSetupState::default()
+        .with_buffers_registered(snapshot_config.use_registered_io_uring_buffers)
+        .with_direct_io(snapshot_config.use_direct_io)
+        .with_shared_sqpoll()?;
     let bank_snapshot_info = snapshot_utils::serialize_snapshot(
         &snapshot_config.bank_snapshots_dir,
         snapshot_config.snapshot_version,
         snapshot_package.bank_snapshot_package,
         snapshot_storages.as_slice(),
         false, // we do not intend to fastboot, so skip flushing and hard linking the storages
+        &io_setup,
     )?;
 
     let snapshot_archive_info = snapshot_utils::archive_snapshot_package(
@@ -748,6 +753,7 @@ pub fn bank_to_full_snapshot_archive(
         bank_snapshot_info.snapshot_dir,
         snapshot_storages,
         &snapshot_config,
+        &io_setup,
     )?;
 
     Ok(FullSnapshotArchiveInfo::new(snapshot_archive_info))
@@ -800,12 +806,17 @@ pub fn bank_to_incremental_snapshot_archive(
 
     let snapshot_storages = snapshot_package.snapshot_storages;
 
+    let io_setup = IoSetupState::default()
+        .with_buffers_registered(snapshot_config.use_registered_io_uring_buffers)
+        .with_direct_io(snapshot_config.use_direct_io)
+        .with_shared_sqpoll()?;
     let bank_snapshot_info = snapshot_utils::serialize_snapshot(
         &snapshot_config.bank_snapshots_dir,
         snapshot_config.snapshot_version,
         snapshot_package.bank_snapshot_package,
         snapshot_storages.as_slice(),
         false, // we do not intend to fastboot, so skip flushing and hard linking the storages
+        &io_setup,
     )?;
 
     let snapshot_archive_info = snapshot_utils::archive_snapshot_package(
@@ -815,6 +826,7 @@ pub fn bank_to_incremental_snapshot_archive(
         bank_snapshot_info.snapshot_dir,
         snapshot_storages,
         &snapshot_config,
+        &io_setup,
     )?;
 
     Ok(IncrementalSnapshotArchiveInfo::new(
@@ -946,6 +958,7 @@ mod tests {
             bank_snapshot_package,
             snapshot_storages.as_slice(),
             should_flush_and_hard_link_storages,
+            &IoSetupState::default(),
         )?;
 
         Ok(())

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -5,7 +5,6 @@ use {
         },
         bank::{Bank, SquashTiming},
     },
-    agave_fs::io_setup::IoSetupState,
     agave_snapshots::{SnapshotInterval, snapshot_config::SnapshotConfig},
     log::*,
     solana_clock::Slot,
@@ -49,21 +48,6 @@ impl SnapshotController {
 
     pub fn snapshot_config(&self) -> &SnapshotConfig {
         &self.snapshot_config
-    }
-
-    pub fn new_io_setup_state(&self, is_teardown: bool) -> IoSetupState {
-        let io_state = IoSetupState::default()
-            .with_buffers_registered(self.snapshot_config.use_registered_io_uring_buffers);
-        if is_teardown {
-            // Teardown, expedite IO using sqpoll thread, but fallback in case of error.
-            io_state.with_shared_sqpoll().unwrap_or_else(|error| {
-                warn!("unable to use sqpoll for io-uring: {error}");
-                self.new_io_setup_state(false)
-            })
-        } else {
-            // Regular operation, saved data is unlikely being read back soon, so allow direct-io.
-            io_state.with_direct_io(self.snapshot_config.use_direct_io)
-        }
     }
 
     pub fn request_sender(&self) -> &SnapshotRequestSender {

--- a/runtime/src/snapshot_controller.rs
+++ b/runtime/src/snapshot_controller.rs
@@ -5,6 +5,7 @@ use {
         },
         bank::{Bank, SquashTiming},
     },
+    agave_fs::io_setup::IoSetupState,
     agave_snapshots::{SnapshotInterval, snapshot_config::SnapshotConfig},
     log::*,
     solana_clock::Slot,
@@ -48,6 +49,21 @@ impl SnapshotController {
 
     pub fn snapshot_config(&self) -> &SnapshotConfig {
         &self.snapshot_config
+    }
+
+    pub fn new_io_setup_state(&self, is_teardown: bool) -> IoSetupState {
+        let io_state = IoSetupState::default()
+            .with_buffers_registered(self.snapshot_config.use_registered_io_uring_buffers);
+        if is_teardown {
+            // Teardown, expedite IO using sqpoll thread, but fallback in case of error.
+            io_state.with_shared_sqpoll().unwrap_or_else(|error| {
+                warn!("unable to use sqpoll for io-uring: {error}");
+                self.new_io_setup_state(false)
+            })
+        } else {
+            // Regular operation, saved data is unlikely being read back soon, so allow direct-io.
+            io_state.with_direct_io(self.snapshot_config.use_direct_io)
+        }
     }
 
     pub fn request_sender(&self) -> &SnapshotRequestSender {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -486,6 +486,7 @@ pub fn archive_snapshot_package(
     bank_snapshot_dir: impl AsRef<Path>,
     mut snapshot_storages: Vec<Arc<AccountStorageEntry>>,
     snapshot_config: &SnapshotConfig,
+    io_setup: &IoSetupState,
 ) -> Result<SnapshotArchiveInfo> {
     let snapshot_archive_path = match snapshot_archive_kind {
         SnapshotArchiveKind::Full => snapshot_paths::build_full_snapshot_archive_path(
@@ -516,6 +517,7 @@ pub fn archive_snapshot_package(
         &bank_snapshot_dir,
         snapshot_archive_path,
         snapshot_config.archive_format,
+        io_setup,
     )?;
 
     Ok(snapshot_archive_info)
@@ -528,6 +530,7 @@ pub fn serialize_snapshot(
     bank_snapshot_package: BankSnapshotPackage,
     snapshot_storages: &[Arc<AccountStorageEntry>],
     should_flush_and_hard_link_storages: bool,
+    io_setup: &IoSetupState,
 ) -> Result<BankSnapshotInfo> {
     let BankSnapshotPackage {
         mut bank_fields,
@@ -579,7 +582,7 @@ pub fn serialize_snapshot(
             Ok(())
         };
         let (bank_snapshot_consumed_size, bank_serialize) = measure_time!(
-            serialize_snapshot_data_file(&bank_snapshot_path, bank_snapshot_serializer)
+            serialize_snapshot_data_file(&bank_snapshot_path, bank_snapshot_serializer, io_setup)
                 .map_err(|err| AddBankSnapshotError::SerializeBank(Box::new(err)))?,
             "bank serialize"
         );
@@ -612,10 +615,13 @@ pub fn serialize_snapshot(
                 );
 
                 let (_, serialize_obsolete_accounts_us) = measure_us!({
-                    write_obsolete_accounts_to_snapshot(&bank_snapshot_dir, snapshot_storages, slot)
-                        .map_err(|err| {
-                            AddBankSnapshotError::SerializeObsoleteAccounts(Box::new(err))
-                        })?
+                    write_obsolete_accounts_to_snapshot(
+                        &bank_snapshot_dir,
+                        snapshot_storages,
+                        slot,
+                        io_setup,
+                    )
+                    .map_err(|err| AddBankSnapshotError::SerializeObsoleteAccounts(Box::new(err)))?
                 });
 
                 mark_bank_snapshot_as_loadable(&bank_snapshot_dir)
@@ -720,6 +726,7 @@ pub fn write_obsolete_accounts_to_snapshot(
     bank_snapshot_dir: impl AsRef<Path>,
     snapshot_storages: &[Arc<AccountStorageEntry>],
     snapshot_slot: Slot,
+    io_setup: &IoSetupState,
 ) -> Result<u64> {
     let obsolete_accounts =
         SerdeObsoleteAccountsMap::new_from_storages(snapshot_storages, snapshot_slot);
@@ -727,6 +734,7 @@ pub fn write_obsolete_accounts_to_snapshot(
         bank_snapshot_dir,
         &obsolete_accounts,
         MAX_OBSOLETE_ACCOUNTS_FILE_SIZE,
+        io_setup,
     )
 }
 
@@ -734,12 +742,13 @@ fn serialize_obsolete_accounts(
     bank_snapshot_dir: impl AsRef<Path>,
     obsolete_accounts_map: &SerdeObsoleteAccountsMap,
     maximum_obsolete_accounts_file_size: u64,
+    io_setup: &IoSetupState,
 ) -> Result<u64> {
     let obsolete_accounts_path = bank_snapshot_dir
         .as_ref()
         .join(snapshot_paths::SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME);
     let mut file_stream = SizeLimitedWriter::new(
-        large_file_buf_writer(&obsolete_accounts_path, &IoSetupState::default())?,
+        large_file_buf_writer(&obsolete_accounts_path, io_setup)?,
         maximum_obsolete_accounts_file_size,
     );
 
@@ -778,7 +787,11 @@ fn deserialize_obsolete_accounts(
     )?)
 }
 
-pub fn serialize_snapshot_data_file<F>(data_file_path: &Path, serializer: F) -> Result<u64>
+pub fn serialize_snapshot_data_file<F>(
+    data_file_path: &Path,
+    serializer: F,
+    io_setup: &IoSetupState,
+) -> Result<u64>
 where
     F: FnOnce(&mut dyn Write) -> Result<()>,
 {
@@ -786,6 +799,7 @@ where
         data_file_path,
         MAX_SNAPSHOT_DATA_FILE_SIZE,
         serializer,
+        io_setup,
     )
 }
 
@@ -824,12 +838,13 @@ fn serialize_snapshot_data_file_capped<F>(
     data_file_path: &Path,
     maximum_file_size: u64,
     serializer: F,
+    io_setup: &IoSetupState,
 ) -> Result<u64>
 where
     F: FnOnce(&mut dyn Write) -> Result<()>,
 {
     let mut data_file_stream = SizeLimitedWriter::new(
-        large_file_buf_writer(data_file_path, &IoSetupState::default())?,
+        large_file_buf_writer(data_file_path, io_setup)?,
         maximum_file_size,
     );
     serializer(&mut data_file_stream).map_err(|err| {
@@ -1853,6 +1868,7 @@ mod tests {
                 serialize_into(stream, &2323_u32)?;
                 Ok(())
             },
+            &IoSetupState::default(),
         )
         .unwrap();
         assert_eq!(consumed_size, expected_consumed_size);
@@ -1869,6 +1885,7 @@ mod tests {
                 serialize_into(stream, &2323_u32)?;
                 Ok(())
             },
+            &IoSetupState::default(),
         );
         assert_matches!(result, Err(SnapshotError::Io(ref message)) if message.to_string().contains("bytes would exceed limit of"));
     }
@@ -1886,6 +1903,7 @@ mod tests {
                 serialize_into(stream, &expected_data)?;
                 Ok(())
             },
+            &IoSetupState::default(),
         )
         .unwrap();
 
@@ -1920,6 +1938,7 @@ mod tests {
                 serialize_into(stream, &expected_data)?;
                 Ok(())
             },
+            &IoSetupState::default(),
         )
         .unwrap();
 
@@ -1954,6 +1973,7 @@ mod tests {
                 serialize_into(&mut *stream, &expected_data)?;
                 Ok(())
             },
+            &IoSetupState::default(),
         )
         .unwrap();
 
@@ -2686,8 +2706,13 @@ mod tests {
         }
 
         // write obsolete accounts to snapshot
-        write_obsolete_accounts_to_snapshot(bank_snapshot_dir, &snapshot_storages, snapshot_slot)
-            .unwrap();
+        write_obsolete_accounts_to_snapshot(
+            bank_snapshot_dir,
+            &snapshot_storages,
+            snapshot_slot,
+            &IoSetupState::default(),
+        )
+        .unwrap();
 
         // Deserialize
         let deserialized_accounts =
@@ -2729,7 +2754,13 @@ mod tests {
             SerdeObsoleteAccountsMap::new_from_storages(&snapshot_storages, snapshot_slot);
 
         // Limit the file size to something low for the test
-        serialize_obsolete_accounts(bank_snapshot_dir, &obsolete_accounts, 100).unwrap();
+        serialize_obsolete_accounts(
+            bank_snapshot_dir,
+            &obsolete_accounts,
+            100,
+            &IoSetupState::default(),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -2755,8 +2786,13 @@ mod tests {
         }
 
         // Write obsolete accounts to snapshot
-        write_obsolete_accounts_to_snapshot(bank_snapshot_dir, &snapshot_storages, snapshot_slot)
-            .unwrap();
+        write_obsolete_accounts_to_snapshot(
+            bank_snapshot_dir,
+            &snapshot_storages,
+            snapshot_slot,
+            &IoSetupState::default(),
+        )
+        .unwrap();
 
         // Set a very low maximum file size for deserialization
         // This should panic

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -582,7 +582,7 @@ pub fn serialize_snapshot(
             Ok(())
         };
         let (bank_snapshot_consumed_size, bank_serialize) = measure_time!(
-            serialize_snapshot_data_file(&bank_snapshot_path, bank_snapshot_serializer, io_setup)
+            serialize_snapshot_data_file(&bank_snapshot_path, io_setup, bank_snapshot_serializer)
                 .map_err(|err| AddBankSnapshotError::SerializeBank(Box::new(err)))?,
             "bank serialize"
         );
@@ -789,8 +789,8 @@ fn deserialize_obsolete_accounts(
 
 pub fn serialize_snapshot_data_file<F>(
     data_file_path: &Path,
-    serializer: F,
     io_setup: &IoSetupState,
+    serializer: F,
 ) -> Result<u64>
 where
     F: FnOnce(&mut dyn Write) -> Result<()>,
@@ -798,8 +798,8 @@ where
     serialize_snapshot_data_file_capped::<F>(
         data_file_path,
         MAX_SNAPSHOT_DATA_FILE_SIZE,
-        serializer,
         io_setup,
+        serializer,
     )
 }
 
@@ -837,8 +837,8 @@ pub fn deserialize_snapshot_data_files<T: Sized>(
 fn serialize_snapshot_data_file_capped<F>(
     data_file_path: &Path,
     maximum_file_size: u64,
-    serializer: F,
     io_setup: &IoSetupState,
+    serializer: F,
 ) -> Result<u64>
 where
     F: FnOnce(&mut dyn Write) -> Result<()>,
@@ -1864,11 +1864,11 @@ mod tests {
         let consumed_size = serialize_snapshot_data_file_capped(
             &temp_dir.path().join("data-file"),
             expected_consumed_size,
+            &IoSetupState::default(),
             |stream| {
                 serialize_into(stream, &2323_u32)?;
                 Ok(())
             },
-            &IoSetupState::default(),
         )
         .unwrap();
         assert_eq!(consumed_size, expected_consumed_size);
@@ -1881,11 +1881,11 @@ mod tests {
         let result = serialize_snapshot_data_file_capped(
             &temp_dir.path().join("data-file"),
             expected_consumed_size - 1,
+            &IoSetupState::default(),
             |stream| {
                 serialize_into(stream, &2323_u32)?;
                 Ok(())
             },
-            &IoSetupState::default(),
         );
         assert_matches!(result, Err(SnapshotError::Io(ref message)) if message.to_string().contains("bytes would exceed limit of"));
     }
@@ -1899,11 +1899,11 @@ mod tests {
         serialize_snapshot_data_file_capped(
             &temp_dir.path().join("data-file"),
             expected_consumed_size,
+            &IoSetupState::default(),
             |stream| {
                 serialize_into(stream, &expected_data)?;
                 Ok(())
             },
-            &IoSetupState::default(),
         )
         .unwrap();
 
@@ -1934,11 +1934,11 @@ mod tests {
         serialize_snapshot_data_file_capped(
             &temp_dir.path().join("data-file"),
             expected_consumed_size,
+            &IoSetupState::default(),
             |stream| {
                 serialize_into(stream, &expected_data)?;
                 Ok(())
             },
-            &IoSetupState::default(),
         )
         .unwrap();
 
@@ -1968,12 +1968,12 @@ mod tests {
         serialize_snapshot_data_file_capped(
             &temp_dir.path().join("data-file"),
             expected_consumed_size * 2,
+            &IoSetupState::default(),
             |stream| {
                 serialize_into(&mut *stream, &expected_data)?;
                 serialize_into(&mut *stream, &expected_data)?;
                 Ok(())
             },
-            &IoSetupState::default(),
         )
         .unwrap();
 

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -29,6 +29,7 @@ pub fn archive_snapshot(
     bank_snapshot_dir: impl AsRef<Path>,
     archive_path: impl AsRef<Path>,
     archive_format: ArchiveFormat,
+    io_setup: &IoSetupState,
 ) -> Result<SnapshotArchiveInfo> {
     use ArchiveSnapshotPackageError as E;
     const ACCOUNTS_DIR: &str = "accounts";
@@ -88,7 +89,7 @@ pub fn archive_snapshot(
     ));
 
     {
-        let archive_writer = large_file_buf_writer(&staging_archive_path, &IoSetupState::default())
+        let archive_writer = large_file_buf_writer(&staging_archive_path, io_setup)
             .map_err(|err| E::CreateArchiveFile(err, staging_archive_path.clone()))?;
 
         let do_archive_files = |encoder: &mut dyn Write| -> std::result::Result<(), E> {


### PR DESCRIPTION
#### Problem
Creating snapshots and archiving them is IO intensive and may pollute kernel buffer cache with data that is typically not read anytime soon.

#### Summary of Changes
* pass through `SnapshotConfig` / `&IoSetupState` to functions doing snapshot serialization and archiving
* additionally enable sqpoll - on teardown, on creating archive from bank in ledger-tool / tests (`bank_to_full_snapshot_archive`  / `bank_to_incremental_snapshot_archive`)
* don't enable direct-io on tear-down, the written data is more likely to be re-read than not
