### PR TITLE
clippy(runtime): use map.values() instead of discarding key in flat_map

### DIFF
--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -556,8 +556,8 @@ pub(crate) mod tests {
             new_vote_accounts(num_nodes, num_vote_accounts_per_node, is_alpenglow);
 
         let expected_authorized_voters: HashMap<_, _> = vote_accounts_map
-            .iter()
-            .flat_map(|(_, vote_accounts)| {
+            .values()
+            .flat_map(|vote_accounts| {
                 vote_accounts
                     .iter()
                     .map(|v| (v.vote_account, v.authorized_voter))


### PR DESCRIPTION
#### Problem
```
error: iterating on a map's values
   --> runtime/src/epoch_stakes.rs:558:57
    |
558 |           let expected_authorized_voters: HashMap<_, _> = vote_accounts_map
    |  _________________________________________________________^
559 | |             .iter()
560 | |             .flat_map(|(_, vote_accounts)| {
561 | |                 vote_accounts
562 | |                     .iter()
563 | |                     .map(|v| (v.vote_account, v.authorized_voter))
564 | |             })
    | |______________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_kv_map
    = note: `-D clippy::iter-kv-map` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::iter_kv_map)]`
```

#### Summary of Changes
use `.values()`
