### PR TITLE
chore: switch rust toolchain to 1.95.0 and nightly 2026-02-28

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2026-01-18
+  nightly_version=2026-02-28
 fi
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.95.0"


### PR DESCRIPTION
#### Problem
rust 1.95.0 is out
https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/

#### Summary of Changes
* switch stable rust toolchain to 1.95.0
* switch nightly version to 2026-02-28 (last date tagged as 1.95.0)
