### PR TITLE
fix(ci): add influx creds to benchmark upload script

### DIFF
--- a/ci/upload-benchmark.sh
+++ b/ci/upload-benchmark.sh
@@ -81,7 +81,7 @@ while IFS= read -r line; do
     echo "datapoint: $datapoint"
 
     if [[ -z "$DRY_RUN" ]]; then
-      curl -s -X POST "${INFLUX_HOST}/write?db=${INFLUX_DB}" --data-binary "$datapoint"
+      curl -s -X POST "${INFLUX_HOST}/write?db=${INFLUX_DB}" -u "${INFLUX_USER}:${INFLUX_PASSWORD}" --data-binary "$datapoint"
     fi
   fi
 


### PR DESCRIPTION
#### Problem

Script is pushing metrics without credentials and will start failing once authentication is enabled on all influx nodes

#### Summary of Changes

Add the credentials to the `curl` invocation.

Fixes #
