### PR TITLE
startup replay: upstream migration status during startup

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -12,6 +12,7 @@ use {
     agave_votor::event::LeaderWindowInfo,
     crossbeam_channel::Receiver,
     solana_clock::Slot,
+    solana_entry::block_component::{BlockMarkerV1, GenesisCertificate, VersionedBlockMarker},
     solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
     solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
@@ -110,6 +111,9 @@ struct LeaderContext {
     // Metrics
     metrics: LoopMetrics,
     slot_metrics: SlotMetrics,
+
+    // Migration information
+    genesis_cert: GenesisCertificate,
 }
 
 #[derive(Default)]
@@ -175,6 +179,15 @@ fn start_loop(config: BlockCreationLoopConfig) {
         }
     };
 
+    let genesis_cert = bank_forks
+        .read()
+        .unwrap()
+        .migration_status()
+        .genesis_certificate()
+        .expect("Migration complete, genesis certificate must exist");
+    let genesis_cert = GenesisCertificate::try_from((*genesis_cert).clone())
+        .expect("Genesis certificate must be valid");
+
     info!("{my_pubkey}: PohService has shutdown, BlockCreationLoop is enabled");
 
     let mut ctx = LeaderContext {
@@ -194,6 +207,7 @@ fn start_loop(config: BlockCreationLoopConfig) {
         metrics: LoopMetrics::default(),
         slot_metrics: SlotMetrics::default(),
         highest_finalized,
+        genesis_cert,
     };
 
     // Setup poh
@@ -613,6 +627,11 @@ fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut L
     let tpu_bank = ctx.bank_forks.write().unwrap().insert(tpu_bank);
     let bank_id = tpu_bank.bank_id();
     ctx.poh_recorder.write().unwrap().set_bank(tpu_bank);
+
+    // If this is the first alpenglow block, emit the genesis certificate marker
+    maybe_include_genesis_certificate(parent_slot, ctx);
+
+    // Wakeup banking stage
     ctx.record_receiver.restart(bank_id);
     ctx.slot_metrics.reset(slot);
 
@@ -620,4 +639,34 @@ fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut L
         "{}: new fork:{} parent:{} (leader) root:{}",
         ctx.my_pubkey, slot, parent_slot, root_slot
     );
+}
+
+///  If this the very first alpenglow block, include the genesis certificate
+///  Note: if the alpenglow genesis is 0, then this is a test cluster with Alpenglow enabled
+///  by default. No need to put in the genesis marker as the genesis account is already populated
+///  during cluster creation.
+fn maybe_include_genesis_certificate(parent_slot: Slot, ctx: &LeaderContext) {
+    if parent_slot != ctx.genesis_cert.slot || parent_slot == 0 {
+        return;
+    }
+    let genesis_marker = VersionedBlockMarker::V1(BlockMarkerV1::new_genesis_certificate(
+        ctx.genesis_cert.clone(),
+    ));
+
+    let mut poh_recorder = ctx.poh_recorder.write().unwrap();
+    // Send the genesis certificate
+    poh_recorder
+        .send_marker(genesis_marker)
+        .expect("Max tick height cannot have been reached");
+
+    // Process the genesis certificate
+    let bank = poh_recorder.bank().expect("Bank cannot have been cleared");
+    let processor = bank.block_component_processor.read().unwrap();
+    processor
+        .on_genesis_certificate(
+            bank.clone(),
+            ctx.genesis_cert.clone(),
+            &ctx.bank_forks.read().unwrap().migration_status(),
+        )
+        .expect("Recording genesis certificate should not fail");
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2136,6 +2136,69 @@ fn process_bank_0(
     Ok(())
 }
 
+/// Clean up a failed slot and restart processing from the given genesis slot
+///
+/// `first_alpenglow_bank` is removed from runtime caches, and its dead status is reset
+/// `pending_slots` is the current child blocks left to be processed. We clear and update
+/// this with the children of `genesis_slot` instead.
+fn cleanup_and_populate_pending_from_alpenglow_genesis(
+    first_alpenglow_bank: &BankWithScheduler,
+    genesis_slot: Slot,
+    bank_forks: &RwLock<BankForks>,
+    blockstore: &Blockstore,
+    leader_schedule_cache: &LeaderScheduleCache,
+    pending_slots: &mut Vec<(SlotMeta, Bank, Hash)>,
+    opts: &ProcessOptions,
+    migration_status: &MigrationStatus,
+) -> result::Result<(), BlockstoreProcessorError> {
+    // `first_alpenglow_bank` was processed as a TowerBFT bank. Reset it.
+    let first_alpenglow_slot = first_alpenglow_bank.slot();
+    let root_bank = bank_forks.read().unwrap().root_bank();
+    root_bank
+        .remove_unrooted_slots(&[(first_alpenglow_bank.slot(), first_alpenglow_bank.bank_id())]);
+    root_bank.clear_slot_signatures(first_alpenglow_bank.slot());
+    root_bank.prune_program_cache_by_deployment_slot(first_alpenglow_bank.slot());
+
+    if blockstore.is_dead(first_alpenglow_slot) {
+        if blockstore.is_primary_access() {
+            blockstore.remove_dead_slot(first_alpenglow_slot).unwrap();
+        } else {
+            info!(
+                "First alpenglow slot {first_alpenglow_slot} won't be cleared from dead due to \
+                 being read-only blockstore access"
+            )
+        }
+    }
+
+    let genesis_slot_meta = blockstore
+        .meta(genesis_slot)
+        .map_err(|err| {
+            error!("Failed to load meta for slot {genesis_slot}: {err:?}");
+            BlockstoreProcessorError::FailedToLoadMeta
+        })?
+        .unwrap();
+
+    warn!(
+        "{}: load_frozen_forks() restart processing from {genesis_slot} treating further blocks \
+         as Alpenglow banks",
+        migration_status.my_pubkey()
+    );
+    // Clear current child bank frontier
+    pending_slots.clear();
+    // And queue up children of genesis instead
+    process_next_slots(
+        &bank_forks.read().unwrap().get(genesis_slot).unwrap(),
+        &genesis_slot_meta,
+        blockstore,
+        leader_schedule_cache,
+        pending_slots,
+        opts,
+        migration_status,
+    )?;
+
+    Ok(())
+}
+
 // Given a bank, add its children to the pending slots queue if those children slots are
 // complete
 fn process_next_slots(
@@ -2239,8 +2302,8 @@ fn load_frozen_forks(
     let mut root = bank_forks.read().unwrap().root();
     let max_root = std::cmp::max(root, blockstore_max_root);
     info!(
-        "load_frozen_forks() latest root from blockstore: {blockstore_max_root}, max_root: \
-         {max_root}",
+        "load_frozen_forks() bank forks root: {root}, latest root from blockstore: \
+         {blockstore_max_root}, max_root: {max_root}",
     );
 
     // The total number of slots processed
@@ -2323,8 +2386,37 @@ fn load_frozen_forks(
             ) {
                 assert!(bank_forks.write().unwrap().remove(bank.slot()).is_some());
                 if opts.abort_on_invalid_block {
-                    Err(error)?
+                    return Err(error);
                 }
+
+                // If this block was the first alpenglow block and advanced the migration phase, we can enable alpenglow.
+                //
+                // Note: since this code is all startup code we don't have to worry about shutting down `PohService` or any
+                // in flight activity of `ReplayStage`. This bank must have failed to freeze as it is an Alpenglow block
+                // being verified as a TowerBFT one.
+                //
+                // We are safe to cleanly transition to alpenglow here
+                if migration_status.is_ready_to_enable() {
+                    debug_assert!(matches!(
+                        error,
+                        BlockstoreProcessorError::InvalidBlock(BlockError::TooFewTicks),
+                    ));
+                    let genesis_slot = migration_status.enable_alpenglow_during_startup();
+
+                    // We need to clear pending_slots as it might contain Alpenglow blocks initialized as TowerBFT banks.
+                    // Clear and populate pending slots from alpenglow genesis
+                    cleanup_and_populate_pending_from_alpenglow_genesis(
+                        &bank,
+                        genesis_slot,
+                        bank_forks,
+                        blockstore,
+                        leader_schedule_cache,
+                        &mut pending_slots,
+                        opts,
+                        &migration_status,
+                    )?;
+                }
+
                 continue;
             }
             async_verification = progress.take_async_verification();
@@ -2388,7 +2480,11 @@ fn load_frozen_forks(
                 } else {
                     None
                 }
-            };
+            }.filter(|new_root_bank| {
+                // In the case that we've restarted while the migrationary period is going on but before alpenglow
+                // is enabled, don't root blocks past the migration slot
+                migration_status.should_root_during_startup(new_root_bank.slot())
+            });
             m.stop();
             voting_us += m.as_us();
 
@@ -2416,6 +2512,19 @@ fn load_frozen_forks(
                 all_banks.retain(|_, bank| bank.ancestors.contains_key(&root));
                 m.stop();
                 root_retain_us += m.as_us();
+
+                // If this root bank activated the feature flag, update migration status
+                if migration_status.is_pre_feature_activation() {
+                    if let Some(slot) = bank_forks
+                        .read()
+                        .unwrap()
+                        .root_bank()
+                        .feature_set
+                        .activated_slot(&agave_feature_set::alpenglow::id())
+                    {
+                        migration_status.record_feature_activation(slot);
+                    }
+                }
             }
 
             slots_processed += 1;

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -41,7 +41,7 @@ use {
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         bank_forks_utils,
-        blockstore::{Blockstore, entries_to_test_shreds},
+        blockstore::{Blockstore, PurgeType, entries_to_test_shreds},
         blockstore_processor::{self, ProcessOptions},
         leader_schedule_cache::LeaderScheduleCache,
         shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
@@ -6051,9 +6051,16 @@ fn test_alpenglow_imbalanced_stakes_catchup() {
     );
 }
 
-fn test_alpenglow_migration(num_nodes: usize) {
+fn test_alpenglow_migration(
+    num_nodes: usize,
+    test_name: &str,
+    leader_schedule: &[usize],
+) -> (
+    LocalCluster,
+    Vec<ValidatorKeys>,
+    /* migration slot */ Slot,
+) {
     agave_logger::setup_with_default(AG_DEBUG_LOG_FILTER);
-    let test_name = &format!("test_alpenglow_migration_{num_nodes}");
 
     let vote_listener_socket = bind_to_localhost_unique().unwrap();
     let vote_listener_addr = vote_listener_socket.try_clone().unwrap();
@@ -6064,17 +6071,11 @@ fn test_alpenglow_migration(num_nodes: usize) {
     });
     validator_config.wait_for_supermajority = Some(0);
 
-    let validator_keys = (0..num_nodes)
-        .map(|i| {
-            (
-                ValidatorKeys {
-                    node_keypair: Arc::new(keypair_from_seed(&[i as u8; 32]).unwrap()),
-                    vote_keypair: Arc::new(Keypair::new()),
-                },
-                true,
-            )
-        })
-        .collect::<Vec<_>>();
+    let (leader_schedule, keys) = create_custom_leader_schedule_with_random_keys(leader_schedule);
+
+    validator_config.fixed_leader_schedule = Some(FixedSchedule {
+        leader_schedule: Arc::new(leader_schedule),
+    });
     let node_stakes = vec![DEFAULT_NODE_STAKE; num_nodes];
 
     // We want the epochs to be as short as possible to reduce test time without being flaky.
@@ -6083,7 +6084,7 @@ fn test_alpenglow_migration(num_nodes: usize) {
     assert!(slots_per_epoch > MIGRATION_SLOT_OFFSET);
     let mut cluster_config = ClusterConfig {
         validator_configs: make_identical_validator_configs(&validator_config, num_nodes),
-        validator_keys: Some(validator_keys.clone()),
+        validator_keys: Some(keys.clone().into_iter().zip(iter::repeat(true)).collect()),
         node_stakes: node_stakes.clone(),
         slots_per_epoch,
         stakers_slot_offset: slots_per_epoch,
@@ -6172,6 +6173,7 @@ fn test_alpenglow_migration(num_nodes: usize) {
 
     // Additionally ensure that roots are being made
     cluster.check_for_new_roots(8, test_name, SocketAddrSpace::Unspecified);
+    (cluster, keys, migration_slot)
 }
 
 /// Single-node migration from legacy mode into Alpenglow after feature activation.
@@ -6179,7 +6181,7 @@ fn test_alpenglow_migration(num_nodes: usize) {
 #[test]
 #[serial]
 fn test_alpenglow_migration_1() {
-    test_alpenglow_migration(1)
+    test_alpenglow_migration(1, "test_alpenglow_migration_1", &[4]);
 }
 
 /// Multi-node migration into Alpenglow, including notarized-vote and root production
@@ -6187,5 +6189,69 @@ fn test_alpenglow_migration_1() {
 #[test]
 #[serial]
 fn test_alpenglow_migration_4() {
-    test_alpenglow_migration(4)
+    test_alpenglow_migration(4, "test_alpenglow_migration_4", &[4, 4, 4, 4]);
+}
+
+#[test]
+#[serial]
+fn test_alpenglow_restart_post_migration() {
+    let test_name = "test_alpenglow_restart_post_migration";
+
+    // Start a 2 node cluster and have it go through the migration
+    let (mut cluster, _, _) = test_alpenglow_migration(2, test_name, &[4, 4]);
+
+    // Now restart one of the nodes. This causes the cluster to temporarily halt
+    let node_pubkey = cluster.get_node_pubkeys()[0];
+    cluster.exit_restart_node(
+        &node_pubkey,
+        safe_clone_config(&cluster.validators.get(&node_pubkey).unwrap().config),
+        SocketAddrSpace::Unspecified,
+    );
+
+    // The restarted node will startup from genesis (0) so this test verifies the following:
+    // - When processing the feature flag activation during startup increment `PreFeatureActivation` ->  `Migration`
+    // - When processing the first alpenglow block during startup increment `Migration` -> `ReadyToEnable`
+    // - If we reach `ReadyToEnable` during startup, enable alpenglow
+    // - Ensure that during startup we set ticks correctly
+    cluster.check_for_new_roots(8, test_name, SocketAddrSpace::Unspecified);
+}
+
+#[test]
+#[serial]
+fn test_alpenglow_missed_migration_entirely() {
+    let test_name = "test_alpenglow_missed_migration_entirely";
+
+    // Start a 3 node cluster and have it go through the migration and root some slots
+    // Critical that the third node is not in the leader schedule, as since
+    // we clear blockstore later, we could end up producing duplicate blocks
+    let (mut cluster, validator_keys, migration_slot) =
+        test_alpenglow_migration(3, test_name, &[4, 4, 0]);
+
+    // Now kill the second node
+    let node_pubkey = validator_keys[2].node_keypair.pubkey();
+    let exit_info = cluster.exit_node(&node_pubkey);
+    let start_slot = migration_slot - 10;
+
+    // Clear blockstore to simulate the node partitioning before the migration period
+    info!("Clearing blockstore after slot {start_slot}");
+    {
+        let blockstore = Blockstore::open(&exit_info.info.ledger_path).unwrap();
+        let end_slot = blockstore.highest_slot().unwrap().unwrap();
+        blockstore.purge_from_next_slots(start_slot, end_slot);
+        blockstore
+            .purge_slots(start_slot, end_slot, PurgeType::Exact)
+            .unwrap();
+    }
+
+    // Restart the node.
+    // We have simulated the following situation:
+    // - Nodes 1 and 3 were enough to perform the migration. They finalized blocks after the migration
+    //   and are no longer broadcasting the GenesisCertificate.
+    // - Node 2 was completely partitioned off since 10 slots before the migration.
+    // - Node 2 now rejoins the network
+    // - It is able to use TowerBFT eager repair to fetch blocks, eventually it will see the
+    //   first Alpenglow block, attempt to process it as a TowerBFT block and switch to Alpenglow.
+    info!("Restarting node to a pre migration state");
+    cluster.restart_node(&node_pubkey, exit_info, SocketAddrSpace::Unspecified);
+    cluster.check_for_new_roots(8, test_name, SocketAddrSpace::Unspecified);
 }

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -23,6 +23,7 @@ use {
     log::*,
     solana_clock::{BankId, Slot},
     solana_entry::{
+        block_component::VersionedBlockMarker,
         entry::Entry,
         entry_or_marker::EntryOrMarker,
         poh::{Poh, PohEntry},
@@ -303,6 +304,24 @@ impl PohRecorder {
         )));
 
         self.leader_last_tick_height = leader_last_tick_height;
+    }
+
+    /// Send the block marker to be broadcast
+    pub fn send_marker(&mut self, marker: VersionedBlockMarker) -> Result<()> {
+        let tick_height = self.tick_height();
+        let working_bank = self
+            .working_bank
+            .as_mut()
+            .ok_or(PohRecorderError::MaxHeightReached)?;
+
+        self.working_bank_sender
+            .send((
+                working_bank.bank.clone(),
+                (EntryOrMarker::Marker(marker), tick_height),
+            ))
+            .unwrap();
+
+        Ok(())
     }
 
     // Returns the index of `transactions.first()` in the slot, if being tracked by WorkingBank


### PR DESCRIPTION
Upstreams https://github.com/anza-xyz/alpenglow/pull/608

#### Problem
If a node restarts during the migration period, or we want to use ledger tool across the migration slot range it currently doesn't work.
Startup replay is handled separately than steady state replay and doesn't contain the logic to update `MigrationStatus`

#### Summary of Changes
Upstream the changes to `load_frozen_forks` to match the steady state path. More details in the downstream PR 