### PR TITLE
deprecate BlockProductionMethod::CentralScheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Release channels have their own copy of this changelog:
 #### Deprecations
 * Using `minimal` for `--accounts-index-limit` is now deprecated.
 * `--account-shrink-path` is now deprecated.
-* `--block-production-method central-scheduler` is now deprecated and will be removed in a future release. Use `central-scheduler-greedy` instead.
 * `sbf-sdk.tar.bz2` is not included anymore in the Agave release tarball. The file will be made available in the new
   [`cargo-build-sbf`](https://github.com/anza-xyz/cargo-build-sbf) repository.
 #### Changes
@@ -122,6 +121,7 @@ prerelease version. The new interpretation is as follows:
 * `agave-validator exit` now saves bank state before exiting. This enables restarts from local state when snapshot generation is disabled.
 * Added `--accounts-index-limit` to specify the memory limit of the accounts index.
 * Snapshot archive unpacking now uses direct I/O by default to improve performance by bypassing the OS page cache. Use `--no-accounts-db-snapshots-direct-io` to opt out if your file system does not support `O_DIRECT`. Direct I/O will be extended to snapshot creation in a future release.
+* `--block-production-method central-scheduler` is now deprecated and will be removed in a future release. Use `central-scheduler-greedy` instead.
 ### CLI
 #### Breaking
 * Removed deprecated arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Release channels have their own copy of this changelog:
 #### Deprecations
 * Using `minimal` for `--accounts-index-limit` is now deprecated.
 * `--account-shrink-path` is now deprecated.
+* `--block-production-method central-scheduler` is now deprecated and will be removed in a future release. Use `central-scheduler-greedy` instead.
 * `sbf-sdk.tar.bz2` is not included anymore in the Agave release tarball. The file will be made available in the new
   [`cargo-build-sbf`](https://github.com/anza-xyz/cargo-build-sbf) repository.
 #### Changes

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -218,7 +218,7 @@ impl BlockProductionMethod {
         "Switch transaction scheduling method for producing ledger entries"
     }
 
-    pub fn warn_if_deprecated(&self) {
+    pub fn warn_if_deprecated_value(&self) {
         if matches!(self, Self::CentralScheduler) {
             warn!(
                 "`central-scheduler` is deprecated and will be removed in a future release; use \

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -217,6 +217,15 @@ impl BlockProductionMethod {
     pub fn cli_message() -> &'static str {
         "Switch transaction scheduling method for producing ledger entries"
     }
+
+    pub fn warn_if_deprecated(&self) {
+        if matches!(self, Self::CentralScheduler) {
+            warn!(
+                "`central-scheduler` is deprecated and will be removed in a future release; use \
+                 `central-scheduler-greedy` instead"
+            );
+        }
+    }
 }
 
 #[derive(

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -388,7 +388,7 @@ pub fn load_and_process_ledger(
         BlockProductionMethod
     )
     .unwrap_or_default();
-    block_production_method.warn_if_deprecated();
+    block_production_method.warn_if_deprecated_value();
     info!(
         "Using: block-verification-method: {block_verification_method}, block-production-method: \
          {block_production_method}",

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -388,6 +388,7 @@ pub fn load_and_process_ledger(
         BlockProductionMethod
     )
     .unwrap_or_default();
+    block_production_method.warn_if_deprecated();
     info!(
         "Using: block-verification-method: {block_verification_method}, block-production-method: \
          {block_production_method}",

--- a/validator/src/commands/manage_block_production/mod.rs
+++ b/validator/src/commands/manage_block_production/mod.rs
@@ -26,7 +26,7 @@ impl FromClapArgMatches for ManageBlockProductionArgs {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
         let block_production_method =
             value_t!(matches, "block_production_method", BlockProductionMethod).unwrap_or_default();
-        block_production_method.warn_if_deprecated();
+        block_production_method.warn_if_deprecated_value();
 
         Ok(ManageBlockProductionArgs {
             block_production_method,

--- a/validator/src/commands/manage_block_production/mod.rs
+++ b/validator/src/commands/manage_block_production/mod.rs
@@ -24,13 +24,12 @@ pub struct ManageBlockProductionArgs {
 
 impl FromClapArgMatches for ManageBlockProductionArgs {
     fn from_clap_arg_match(matches: &ArgMatches) -> Result<Self> {
+        let block_production_method =
+            value_t!(matches, "block_production_method", BlockProductionMethod).unwrap_or_default();
+        block_production_method.warn_if_deprecated();
+
         Ok(ManageBlockProductionArgs {
-            block_production_method: value_t!(
-                matches,
-                "block_production_method",
-                BlockProductionMethod
-            )
-            .unwrap_or_default(),
+            block_production_method,
             transaction_structure: value_t!(matches, "transaction_struct", TransactionStructure)
                 .unwrap_or_default(),
             num_workers: value_t!(matches, "block_production_num_workers", NonZeroUsize)

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -903,6 +903,9 @@ pub fn execute(
             i8
         ),
     };
+    validator_config
+        .block_production_method
+        .warn_if_deprecated();
 
     let vote_account = pubkey_of(matches, "vote_account").unwrap_or_else(|| {
         if !validator_config.voting_disabled {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -905,7 +905,7 @@ pub fn execute(
     };
     validator_config
         .block_production_method
-        .warn_if_deprecated();
+        .warn_if_deprecated_value();
 
     let vote_account = pubkey_of(matches, "vote_account").unwrap_or_else(|| {
         if !validator_config.voting_disabled {


### PR DESCRIPTION
#### Problem
- See #12009
- We no longer want to support users using prio-graph scheduler

#### Summary of Changes
- Add deprecation warnings for uses of central-scheduler

Fixes #
