### PR TITLE
admin_rpc: upstream send VotorEvent::SetIdentity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "agave-votor",
  "agave-xdp",
  "assert_cmd",
+ "assert_matches",
  "caps",
  "chrono",
  "clap 2.33.3",

--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -3,6 +3,7 @@ use {
         banking_stage::BankingControlMsg, cluster_slots_service::cluster_slots::ClusterSlots,
         repair::repair_service::OutstandingShredRepairs,
     },
+    agave_votor::event::VotorEventSender,
     solana_gossip::{cluster_info::ClusterInfo, node::NodeMultihoming},
     solana_ledger::blockstore::Blockstore,
     solana_pubkey::Pubkey,
@@ -88,4 +89,5 @@ pub struct AdminRpcRequestMetadataPostInit {
     pub banking_control_sender: mpsc::Sender<BankingControlMsg>,
     pub snapshot_controller: Arc<SnapshotController>,
     pub blockstore: Arc<Blockstore>,
+    pub votor_event_sender: VotorEventSender,
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1701,7 +1701,7 @@ impl Validator {
                 )
             }),
             cancel,
-            votor_event_sender,
+            votor_event_sender.clone(),
         );
 
         datapoint_info!(
@@ -1735,6 +1735,7 @@ impl Validator {
             banking_control_sender,
             snapshot_controller,
             blockstore: blockstore.clone(),
+            votor_event_sender,
         });
 
         Ok(Self {

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -102,6 +102,7 @@ libc = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
+assert_matches = { workspace = true }
 predicates = { workspace = true }
 pretty_assertions = { workspace = true }
 scopeguard = { workspace = true }

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1,4 +1,5 @@
 use {
+    agave_votor::event::VotorEvent,
     crossbeam_channel::Sender,
     jsonrpc_core::{BoxFuture, ErrorCode, MetaIoHandler, Metadata, Result},
     jsonrpc_core_client::{RpcError, transports::ipc},
@@ -911,6 +912,15 @@ impl AdminRpcImpl {
             post_init
                 .cluster_info
                 .set_keypair(Arc::new(identity_keypair));
+            post_init
+                .votor_event_sender
+                .send(VotorEvent::SetIdentity)
+                .map_err(|err| jsonrpc_core::error::Error {
+                    code: ErrorCode::InternalError,
+                    message: format!("Failed to send SetIdentity event: {err}").to_string(),
+                    data: None,
+                })?;
+
             warn!("Identity set to {new_identity}");
             Ok(())
         })
@@ -1044,6 +1054,8 @@ mod tests {
     use {
         super::*,
         agave_snapshots::snapshot_config::SnapshotConfig,
+        agave_votor::event::VotorEventSender,
+        assert_matches::assert_matches,
         crossbeam_channel::unbounded,
         serde_json::Value,
         solana_accounts_db::{
@@ -1077,6 +1089,7 @@ mod tests {
     #[derive(Default)]
     struct TestConfig {
         account_indexes: AccountSecondaryIndexes,
+        votor_event_sender: Option<VotorEventSender>,
     }
 
     struct RpcHandler {
@@ -1122,6 +1135,10 @@ mod tests {
             let vote_account = vote_keypair.pubkey();
             let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
             let repair_whitelist = Arc::new(RwLock::new(HashSet::new()));
+            let votor_event_sender = config.votor_event_sender.unwrap_or_else(|| {
+                let (votor_event_sender, _) = unbounded();
+                votor_event_sender
+            });
             let meta = AdminRpcRequestMetadata {
                 rpc_addr: None,
                 start_time: SystemTime::now(),
@@ -1147,6 +1164,7 @@ mod tests {
                     banking_control_sender: mpsc::channel(1).0,
                     snapshot_controller,
                     blockstore,
+                    votor_event_sender,
                 }))),
                 staked_nodes_overrides: Arc::new(RwLock::new(HashMap::new())),
                 rpc_to_plugin_manager_sender: None,
@@ -1175,7 +1193,11 @@ mod tests {
     // Bank but without validator.
     #[test]
     fn test_set_identity() {
-        let rpc = RpcHandler::start_with_config(TestConfig::default());
+        let (votor_event_sender, votor_event_receiver) = unbounded();
+        let rpc = RpcHandler::start_with_config(TestConfig {
+            account_indexes: AccountSecondaryIndexes::default(),
+            votor_event_sender: Some(votor_event_sender),
+        });
 
         let RpcHandler { io, meta, .. } = rpc;
 
@@ -1212,6 +1234,10 @@ mod tests {
             actual_validator_id,
             expected_validator_id.pubkey().to_string()
         );
+        let event = votor_event_receiver
+            .recv()
+            .expect("Failed to receive SetIdentity event");
+        assert_matches!(event, VotorEvent::SetIdentity);
     }
 
     struct TestValidatorWithAdminRpc {


### PR DESCRIPTION
upstream of https://github.com/anza-xyz/alpenglow/pull/363

#### Problem
The Votor event loop needs to know when the operator sets identity so that it can fetch the new vote history and start voting under the new identity.

#### Summary of Changes
when the `set-identity` cli is invoked, send over a `VotorEvent`
