### PR TITLE
xdp: resolve/touch neigh entries as they get used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,7 @@ dependencies = [
  "aya",
  "bytes",
  "caps",
+ "crossbeam-channel",
  "crossbeam-queue",
  "libc",
  "log",

--- a/ci/test-xdp.sh
+++ b/ci/test-xdp.sh
@@ -3,6 +3,9 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+# docker mounts /proc/sys read-only by default, but we need to override some keys
+mount -o remount,rw /proc/sys
+
 # The CI container runs as root for network namespace privileges. Keep
 # root-owned Cargo artifacts out of the mounted checkout.
 export CARGO_TARGET_DIR=/tmp/agave-xdp-target

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -485,6 +485,7 @@ dependencies = [
  "aya",
  "bytes",
  "caps",
+ "crossbeam-channel",
  "crossbeam-queue",
  "libc",
  "log",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "aya",
  "bytes",
  "caps",
+ "crossbeam-channel",
  "crossbeam-queue",
  "libc",
  "log",

--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -21,6 +21,7 @@ dev-context-only-utils = []
 agave-cpu-utils = { workspace = true }
 arc-swap = { workspace = true }
 bytes = { workspace = true }
+crossbeam-channel = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -14,6 +14,8 @@ pub mod gre;
 #[cfg(target_os = "linux")]
 pub(crate) mod lpm;
 #[cfg(target_os = "linux")]
+pub(crate) mod neighbors;
+#[cfg(target_os = "linux")]
 pub mod netlink;
 #[cfg(target_os = "linux")]
 pub mod packet;

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -7,6 +7,8 @@ pub mod gre;
 #[cfg(target_os = "linux")]
 pub(crate) mod lpm;
 #[cfg(target_os = "linux")]
+pub(crate) mod neighbors;
+#[cfg(target_os = "linux")]
 pub mod netlink;
 #[cfg(target_os = "linux")]
 pub mod packet;

--- a/xdp/src/neighbors.rs
+++ b/xdp/src/neighbors.rs
@@ -1,0 +1,280 @@
+#[cfg(target_os = "linux")]
+use {
+    crate::netlink::{NetlinkSocket, netlink_use_neighbor},
+    crossbeam_channel::{RecvTimeoutError, Sender},
+    log::{debug, warn},
+    std::{
+        collections::{HashMap, hash_map::Entry},
+        io,
+        net::Ipv4Addr,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        thread,
+        time::{Duration, Instant},
+    },
+};
+
+#[cfg(target_os = "linux")]
+const NEIGHBOR_USE_INTERVAL: Duration = Duration::from_secs(30);
+#[cfg(target_os = "linux")]
+const NEIGHBOR_MISS_COOLDOWN: Duration = Duration::from_secs(1);
+#[cfg(target_os = "linux")]
+const NEIGHBOR_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
+
+#[cfg(target_os = "linux")]
+#[derive(Clone)]
+/// Observes neighbors and keeps them fresh in the neigh table.
+///
+/// Linux expires neighbors from the neigh table after a certain idle time. When using regular
+/// sockets, the kernel automatically refreshes neighbors when sending packets to them. When using
+/// XDP, we need to explicitly keep them alive.
+pub(crate) struct NeighborsObserver {
+    sender: Sender<NeighborEvent>,
+    neighbors: HashMap<NeighborKey, NeighborState>,
+    next_sweep_at: Option<Instant>,
+}
+
+#[cfg(target_os = "linux")]
+impl NeighborsObserver {
+    fn new(sender: Sender<NeighborEvent>) -> Self {
+        Self {
+            sender,
+            neighbors: HashMap::new(),
+            next_sweep_at: None,
+        }
+    }
+
+    pub(crate) fn observe(&mut self, if_index: u32, ip: Ipv4Addr, is_resolved: bool) {
+        self.observe_at(if_index, ip, is_resolved, Instant::now());
+    }
+
+    fn observe_at(&mut self, if_index: u32, ip: Ipv4Addr, is_resolved: bool, now: Instant) {
+        let key = NeighborKey { if_index, ip };
+
+        sweep(&mut self.next_sweep_at, &mut self.neighbors, now);
+
+        match self.neighbors.entry(key) {
+            Entry::Vacant(entry) => {
+                if self
+                    .sender
+                    .try_send(NeighborEvent { key, is_resolved })
+                    .is_ok()
+                {
+                    entry.insert(NeighborState {
+                        last_touched_at: now,
+                    });
+                }
+            }
+            Entry::Occupied(mut entry) => {
+                let state = entry.get_mut();
+                if now.duration_since(state.last_touched_at) < min_interval(is_resolved) {
+                    return;
+                }
+
+                if self
+                    .sender
+                    .try_send(NeighborEvent { key, is_resolved })
+                    .is_ok()
+                {
+                    state.last_touched_at = now;
+                }
+            }
+        };
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct NeighborKey {
+    if_index: u32,
+    ip: Ipv4Addr,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Debug)]
+struct NeighborState {
+    last_touched_at: Instant,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Debug)]
+struct NeighborEvent {
+    key: NeighborKey,
+    is_resolved: bool,
+}
+
+#[cfg(target_os = "linux")]
+fn min_interval(is_resolved: bool) -> Duration {
+    if is_resolved {
+        NEIGHBOR_USE_INTERVAL
+    } else {
+        NEIGHBOR_MISS_COOLDOWN
+    }
+}
+
+#[cfg(target_os = "linux")]
+/// Submits USE requests for neighbors observed by the `NeighborsObserver`.
+///
+/// This is a separate thread since netlink requires CAP_NET_ADMIN and we don't want to require that
+/// capability for all the XDP senders.
+pub(crate) struct NeighborsRefresher {
+    socket: NetlinkSocket,
+    neighbors: HashMap<NeighborKey, NeighborState>,
+    next_sweep_at: Option<Instant>,
+}
+
+#[cfg(target_os = "linux")]
+impl NeighborsRefresher {
+    pub(crate) fn start<F: FnOnce() + Send + Sync + 'static>(
+        exit: Arc<AtomicBool>,
+        on_thread_start: F,
+    ) -> io::Result<(thread::JoinHandle<()>, NeighborsObserver)> {
+        const NEIGHBOR_MONITOR_RECV_TIMEOUT: Duration = Duration::from_millis(100);
+        const NEIGHBOR_REQUEST_CHANNEL_CAP: usize = 8192;
+
+        let (sender, receiver) = crossbeam_channel::bounded(NEIGHBOR_REQUEST_CHANNEL_CAP);
+        let handle = thread::Builder::new()
+            .name("solNeighMon".to_owned())
+            .spawn(move || {
+                on_thread_start();
+
+                let mut monitor = Self::new();
+                while !exit.load(Ordering::Relaxed) {
+                    match receiver.recv_timeout(NEIGHBOR_MONITOR_RECV_TIMEOUT) {
+                        Ok(event) => monitor.observe_event(event, Instant::now()),
+                        Err(RecvTimeoutError::Timeout) => {}
+                        Err(RecvTimeoutError::Disconnected) => return,
+                    }
+                }
+            })?;
+
+        Ok((handle, NeighborsObserver::new(sender)))
+    }
+
+    fn new() -> Self {
+        Self {
+            socket: NetlinkSocket::open().expect("failed to open netlink socket"),
+            neighbors: HashMap::new(),
+            next_sweep_at: None,
+        }
+    }
+
+    fn observe_event(&mut self, event: NeighborEvent, now: Instant) {
+        self.observe_at(event.key, event.is_resolved, now)
+    }
+
+    fn observe_at(&mut self, key: NeighborKey, is_resolved: bool, now: Instant) {
+        sweep(&mut self.next_sweep_at, &mut self.neighbors, now);
+
+        let ret = match self.neighbors.entry(key) {
+            Entry::Vacant(entry) => {
+                let ret = netlink_use_neighbor(&self.socket, key.if_index, key.ip).map(|_| true);
+                if ret.is_ok() {
+                    entry.insert(NeighborState {
+                        last_touched_at: now,
+                    });
+                }
+                ret
+            }
+            Entry::Occupied(mut entry) => {
+                let state = entry.get_mut();
+                if now.duration_since(state.last_touched_at) >= min_interval(is_resolved) {
+                    let ret =
+                        netlink_use_neighbor(&self.socket, key.if_index, key.ip).map(|_| true);
+                    if ret.is_ok() {
+                        state.last_touched_at = now;
+                    }
+                    ret
+                } else {
+                    Ok(false)
+                }
+            }
+        };
+        match ret {
+            Ok(true) => debug!("refreshed neighbor {} on if{}", key.ip, key.if_index),
+            Ok(false) => {}
+            Err(err) => {
+                warn!(
+                    "failed to request neighbor use {} on if{}: {}",
+                    key.ip, key.if_index, err
+                );
+                self.socket = NetlinkSocket::open().expect("failed to reopen netlink socket");
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn sweep(
+    next_sweep_at: &mut Option<Instant>,
+    neighbors: &mut HashMap<NeighborKey, NeighborState>,
+    now: Instant,
+) {
+    let next_sweep_at =
+        next_sweep_at.get_or_insert_with(|| now.checked_add(NEIGHBOR_IDLE_TIMEOUT).unwrap());
+    if now >= *next_sweep_at {
+        neighbors
+            .retain(|_, state| now.duration_since(state.last_touched_at) < NEIGHBOR_IDLE_TIMEOUT);
+        *next_sweep_at = now.checked_add(NEIGHBOR_IDLE_TIMEOUT).unwrap();
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use {
+        super::*,
+        crossbeam_channel::{Receiver, TryRecvError, bounded},
+    };
+
+    fn test_key() -> NeighborKey {
+        NeighborKey {
+            if_index: 7,
+            ip: Ipv4Addr::new(10, 0, 0, 7),
+        }
+    }
+
+    fn recv_event(receiver: &Receiver<NeighborEvent>) -> NeighborEvent {
+        receiver.try_recv().expect("expected neighbor event")
+    }
+
+    #[test]
+    fn observe_dedupes_within_resolved_cooldown() {
+        let (sender, receiver) = bounded(8);
+        let mut neighbors = NeighborsObserver::new(sender);
+        let key = test_key();
+        let now = Instant::now();
+
+        neighbors.observe_at(key.if_index, key.ip, true, now);
+        assert_eq!(recv_event(&receiver).key, key);
+
+        neighbors.observe_at(key.if_index, key.ip, true, now + Duration::from_secs(1));
+        assert!(matches!(receiver.try_recv(), Err(TryRecvError::Empty)));
+
+        neighbors.observe_at(key.if_index, key.ip, true, now + NEIGHBOR_USE_INTERVAL);
+        assert_eq!(recv_event(&receiver).key, key);
+    }
+
+    #[test]
+    fn observe_uses_shorter_cooldown_for_unresolved_neighbors() {
+        let (sender, receiver) = bounded(8);
+        let mut neighbors = NeighborsObserver::new(sender);
+        let key = test_key();
+        let now = Instant::now();
+
+        neighbors.observe_at(key.if_index, key.ip, false, now);
+        assert_eq!(recv_event(&receiver).key, key);
+
+        neighbors.observe_at(
+            key.if_index,
+            key.ip,
+            false,
+            now + Duration::from_millis(999),
+        );
+        assert!(matches!(receiver.try_recv(), Err(TryRecvError::Empty)));
+
+        neighbors.observe_at(key.if_index, key.ip, false, now + NEIGHBOR_MISS_COOLDOWN);
+        assert_eq!(recv_event(&receiver).key, key);
+    }
+}

--- a/xdp/src/neighbors.rs
+++ b/xdp/src/neighbors.rs
@@ -1,0 +1,279 @@
+use {
+    crate::netlink::{NetlinkSocket, netlink_use_neighbor},
+    crossbeam_channel::{RecvTimeoutError, Sender},
+    log::{debug, warn},
+    std::{
+        collections::{HashMap, hash_map::Entry},
+        io,
+        net::Ipv4Addr,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        thread,
+        time::{Duration, Instant},
+    },
+};
+
+const NEIGHBOR_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Intervals between neighbor refreshes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NeighborIntervals {
+    /// How often to request the kernel to touch a resolved neighbor so it doesn't go stale.
+    pub use_interval: Duration,
+    /// How often to try to resolve an unresolved neighbor.
+    pub miss_interval: Duration,
+}
+
+impl NeighborIntervals {
+    fn min_interval(self, is_resolved: bool) -> Duration {
+        if is_resolved {
+            self.use_interval
+        } else {
+            self.miss_interval
+        }
+    }
+}
+
+#[derive(Clone)]
+/// Observes neighbors and keeps them fresh in the neigh table.
+///
+/// Linux expires neighbors from the neigh table after a certain idle time. When using regular
+/// sockets, the kernel automatically refreshes neighbors when sending packets to them. When using
+/// XDP, we need to explicitly keep them alive.
+pub(crate) struct NeighborsObserver {
+    sender: Sender<NeighborEvent>,
+    intervals: NeighborIntervals,
+    neighbors: HashMap<NeighborKey, NeighborState>,
+    next_sweep_at: Option<Instant>,
+}
+
+impl NeighborsObserver {
+    fn new(sender: Sender<NeighborEvent>, intervals: NeighborIntervals) -> Self {
+        Self {
+            sender,
+            intervals,
+            neighbors: HashMap::new(),
+            next_sweep_at: None,
+        }
+    }
+
+    pub(crate) fn observe(&mut self, if_index: u32, ip: Ipv4Addr, is_resolved: bool) {
+        self.observe_at(if_index, ip, is_resolved, Instant::now());
+    }
+
+    fn observe_at(&mut self, if_index: u32, ip: Ipv4Addr, is_resolved: bool, now: Instant) {
+        let key = NeighborKey { if_index, ip };
+
+        sweep(&mut self.next_sweep_at, &mut self.neighbors, now);
+
+        match self.neighbors.entry(key) {
+            Entry::Vacant(entry) => {
+                if self
+                    .sender
+                    .try_send(NeighborEvent { key, is_resolved })
+                    .is_ok()
+                {
+                    entry.insert(NeighborState {
+                        last_touched_at: now,
+                    });
+                }
+            }
+            Entry::Occupied(mut entry) => {
+                let state = entry.get_mut();
+                if now.duration_since(state.last_touched_at)
+                    < self.intervals.min_interval(is_resolved)
+                {
+                    return;
+                }
+
+                if self
+                    .sender
+                    .try_send(NeighborEvent { key, is_resolved })
+                    .is_ok()
+                {
+                    state.last_touched_at = now;
+                }
+            }
+        };
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct NeighborKey {
+    if_index: u32,
+    ip: Ipv4Addr,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct NeighborState {
+    last_touched_at: Instant,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct NeighborEvent {
+    key: NeighborKey,
+    is_resolved: bool,
+}
+
+/// Submits USE requests for neighbors observed by the `NeighborsObserver`.
+///
+/// This is a separate thread since netlink requires CAP_NET_ADMIN and we don't want to require that
+/// capability for all the XDP senders.
+pub(crate) struct NeighborsRefresher {
+    socket: NetlinkSocket,
+    intervals: NeighborIntervals,
+    neighbors: HashMap<NeighborKey, NeighborState>,
+    next_sweep_at: Option<Instant>,
+}
+
+impl NeighborsRefresher {
+    pub(crate) fn start<F: FnOnce() + Send + Sync + 'static>(
+        exit: Arc<AtomicBool>,
+        intervals: NeighborIntervals,
+        on_thread_start: F,
+    ) -> io::Result<(thread::JoinHandle<()>, NeighborsObserver)> {
+        const NEIGHBOR_MONITOR_RECV_TIMEOUT: Duration = Duration::from_millis(100);
+        const NEIGHBOR_REQUEST_CHANNEL_CAP: usize = 8192;
+
+        let (sender, receiver) = crossbeam_channel::bounded(NEIGHBOR_REQUEST_CHANNEL_CAP);
+        let handle = thread::Builder::new()
+            .name("solNeighMon".to_owned())
+            .spawn(move || {
+                on_thread_start();
+
+                let mut monitor = Self::new(intervals);
+                while !exit.load(Ordering::Relaxed) {
+                    match receiver.recv_timeout(NEIGHBOR_MONITOR_RECV_TIMEOUT) {
+                        Ok(event) => monitor.observe_event(event, Instant::now()),
+                        Err(RecvTimeoutError::Timeout) => {}
+                        Err(RecvTimeoutError::Disconnected) => return,
+                    }
+                }
+            })?;
+
+        Ok((handle, NeighborsObserver::new(sender, intervals)))
+    }
+
+    fn new(intervals: NeighborIntervals) -> Self {
+        Self {
+            socket: NetlinkSocket::open().expect("failed to open netlink socket"),
+            intervals,
+            neighbors: HashMap::new(),
+            next_sweep_at: None,
+        }
+    }
+
+    fn observe_event(&mut self, event: NeighborEvent, now: Instant) {
+        self.observe_at(event.key, event.is_resolved, now)
+    }
+
+    fn observe_at(&mut self, key: NeighborKey, is_resolved: bool, now: Instant) {
+        sweep(&mut self.next_sweep_at, &mut self.neighbors, now);
+
+        let entry = self.neighbors.entry(key);
+        if let Entry::Occupied(entry) = &entry
+            && now.duration_since(entry.get().last_touched_at)
+                < self.intervals.min_interval(is_resolved)
+        {
+            return;
+        }
+
+        match netlink_use_neighbor(&self.socket, key.if_index, key.ip) {
+            Ok(()) => {
+                entry.insert_entry(NeighborState {
+                    last_touched_at: now,
+                });
+                debug!("refreshed neighbor {} on if{}", key.ip, key.if_index);
+            }
+            Err(err) => {
+                warn!(
+                    "failed to request neighbor use {} on if{}: {}",
+                    key.ip, key.if_index, err
+                );
+                self.socket = NetlinkSocket::open().expect("failed to reopen netlink socket");
+            }
+        }
+    }
+}
+
+fn sweep(
+    next_sweep_at: &mut Option<Instant>,
+    neighbors: &mut HashMap<NeighborKey, NeighborState>,
+    now: Instant,
+) {
+    let next_sweep_at =
+        next_sweep_at.get_or_insert_with(|| now.checked_add(NEIGHBOR_IDLE_TIMEOUT).unwrap());
+    if now >= *next_sweep_at {
+        neighbors
+            .retain(|_, state| now.duration_since(state.last_touched_at) < NEIGHBOR_IDLE_TIMEOUT);
+        *next_sweep_at = now.checked_add(NEIGHBOR_IDLE_TIMEOUT).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crossbeam_channel::{Receiver, TryRecvError, bounded},
+    };
+
+    fn test_key() -> NeighborKey {
+        NeighborKey {
+            if_index: 7,
+            ip: Ipv4Addr::new(10, 0, 0, 7),
+        }
+    }
+
+    fn recv_event(receiver: &Receiver<NeighborEvent>) -> NeighborEvent {
+        receiver.try_recv().expect("expected neighbor event")
+    }
+
+    #[test]
+    fn observe_dedupes_within_resolved_cooldown() {
+        let (sender, receiver) = bounded(8);
+        let intervals = NeighborIntervals {
+            use_interval: Duration::from_secs(30),
+            miss_interval: Duration::from_secs(1),
+        };
+        let mut neighbors = NeighborsObserver::new(sender, intervals);
+        let key = test_key();
+        let now = Instant::now();
+
+        neighbors.observe_at(key.if_index, key.ip, true, now);
+        assert_eq!(recv_event(&receiver).key, key);
+
+        neighbors.observe_at(key.if_index, key.ip, true, now + Duration::from_secs(1));
+        assert!(matches!(receiver.try_recv(), Err(TryRecvError::Empty)));
+
+        neighbors.observe_at(key.if_index, key.ip, true, now + intervals.use_interval);
+        assert_eq!(recv_event(&receiver).key, key);
+    }
+
+    #[test]
+    fn observe_uses_shorter_cooldown_for_unresolved_neighbors() {
+        let (sender, receiver) = bounded(8);
+        let intervals = NeighborIntervals {
+            use_interval: Duration::from_secs(30),
+            miss_interval: Duration::from_secs(1),
+        };
+        let mut neighbors = NeighborsObserver::new(sender, intervals);
+        let key = test_key();
+        let now = Instant::now();
+
+        neighbors.observe_at(key.if_index, key.ip, false, now);
+        assert_eq!(recv_event(&receiver).key, key);
+
+        neighbors.observe_at(
+            key.if_index,
+            key.ip,
+            false,
+            now + Duration::from_millis(999),
+        );
+        assert!(matches!(receiver.try_recv(), Err(TryRecvError::Empty)));
+
+        neighbors.observe_at(key.if_index, key.ip, false, now + intervals.miss_interval);
+        assert_eq!(recv_event(&receiver).key, key);
+    }
+}

--- a/xdp/src/netlink.rs
+++ b/xdp/src/netlink.rs
@@ -23,6 +23,12 @@ use {
 
 const NETLINK_RCVBUF_SIZE: i32 = 1 << 16;
 const NLA_HDR_LEN: usize = align_to(mem::size_of::<nlattr>(), NLA_ALIGNTO as usize);
+const NDA_FLAGS_EXT: u16 = 15;
+const NLM_F_ACK: u16 = 0x4;
+const NLM_F_REPLACE: u16 = 0x100;
+const NLM_F_CREATE: u16 = 0x400;
+const NTF_EXT_MANAGED: u32 = 1;
+const NTF_USE: u8 = 1;
 // GRE nested attributes (from include/uapi/linux/if_tunnel.h)
 const IFLA_GRE_LOCAL: u16 = 6;
 const IFLA_GRE_REMOTE: u16 = 7;
@@ -47,7 +53,7 @@ pub struct NetlinkSocket {
 }
 
 impl NetlinkSocket {
-    fn open() -> Result<Self, io::Error> {
+    pub(crate) fn open() -> Result<Self, io::Error> {
         // Safety: libc wrapper
         let sock = unsafe { socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE) };
         if sock < 0 {
@@ -508,6 +514,10 @@ pub struct NeighborEntry {
     pub ifindex: i32,
     // NUD_* state
     pub state: u16,
+    // NTF_* flags from ndmsg
+    pub flags: u8,
+    // NTF_EXT_* flags from NDA_FLAGS_EXT
+    pub flags_ext: u32,
 }
 
 impl NeighborEntry {
@@ -517,6 +527,12 @@ impl NeighborEntry {
             Some(IpAddr::V4(ip)) => Some((self.ifindex, ip)),
             _ => None,
         }
+    }
+
+    #[inline]
+    pub fn requires_refresh(&self) -> bool {
+        let blocked_states = libc::NUD_PERMANENT | libc::NUD_NOARP;
+        self.state & blocked_states == 0 && self.flags_ext & NTF_EXT_MANAGED == 0
     }
 }
 
@@ -528,7 +544,7 @@ struct ndmsg {
     _ndm_pad2: u16,
     ndm_ifindex: i32,
     ndm_state: u16,
-    _ndm_flags: u8,
+    ndm_flags: u8,
     _ndm_type: u8,
 }
 
@@ -536,6 +552,42 @@ struct ndmsg {
 struct NeighRequest {
     header: nlmsghdr,
     ndm: ndmsg,
+}
+
+pub fn netlink_use_neighbor(
+    sock: &NetlinkSocket,
+    if_index: u32,
+    ip: Ipv4Addr,
+) -> Result<(), io::Error> {
+    let req = build_use_neighbor_request(if_index, ip, 1);
+    sock.send(&req)?;
+    sock.recv()?;
+    Ok(())
+}
+
+fn build_use_neighbor_request(if_index: u32, ip: Ipv4Addr, seq: u32) -> Vec<u8> {
+    // Safety: NeighRequest is POD.
+    let mut req = unsafe { mem::zeroed::<NeighRequest>() };
+    let nlmsg_len = mem::size_of::<nlmsghdr>() + mem::size_of::<ndmsg>();
+    req.header = nlmsghdr {
+        nlmsg_len: nlmsg_len as u32,
+        nlmsg_flags: (NLM_F_REQUEST as u16) | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE,
+        nlmsg_type: RTM_NEWNEIGH,
+        nlmsg_pid: 0,
+        nlmsg_seq: seq,
+    };
+    req.ndm.ndm_family = AF_INET as u8;
+    req.ndm.ndm_ifindex = if_index as i32;
+    req.ndm.ndm_state = 0;
+    req.ndm.ndm_flags = NTF_USE;
+
+    let mut req_buf = bytes_of(&req)[..nlmsg_len].to_vec();
+    push_nlattr(&mut req_buf, NDA_DST, &ip.octets());
+
+    let header = unsafe { &mut *(req_buf.as_mut_ptr() as *mut nlmsghdr) };
+    header.nlmsg_len = req_buf.len() as u32;
+
+    req_buf
 }
 
 /// fetch the kernel's neighbor table (ARP/NDP cache)
@@ -601,6 +653,8 @@ pub fn parse_rtm_newneigh(msg: &NetlinkMessage, if_index: Option<u32>) -> Option
         lladdr: None,
         ifindex: nd_msg.ndm_ifindex,
         state: nd_msg.ndm_state,
+        flags: nd_msg.ndm_flags,
+        flags_ext: 0,
     };
     if let Some(dst_attr) = attrs.get(&NDA_DST) {
         neighbor.destination = parse_ip_address(dst_attr.data, nd_msg.ndm_family);
@@ -610,6 +664,13 @@ pub fn parse_rtm_newneigh(msg: &NetlinkMessage, if_index: Option<u32>) -> Option
             let mut mac = [0u8; 6];
             mac.copy_from_slice(&lladdr_attr.data[0..6]);
             neighbor.lladdr = Some(MacAddress(mac));
+        }
+    }
+    if let Some(flags_ext_attr) = attrs.get(&NDA_FLAGS_EXT) {
+        if flags_ext_attr.data.len() >= mem::size_of::<u32>() {
+            let mut flags_ext = [0; mem::size_of::<u32>()];
+            flags_ext.copy_from_slice(&flags_ext_attr.data[..mem::size_of::<u32>()]);
+            neighbor.flags_ext = u32::from_ne_bytes(flags_ext);
         }
     }
     Some(neighbor)

--- a/xdp/src/netlink.rs
+++ b/xdp/src/netlink.rs
@@ -27,6 +27,14 @@ const NLA_HDR_LEN: usize = align_to(mem::size_of::<nlattr>(), NLA_ALIGNTO as usi
 // MTU of the device (from include/uapi/linux/if_link.h)
 const IFLA_MTU: u16 = 4;
 
+const NDA_FLAGS_EXT: u16 = 15;
+const NLM_F_ACK: u16 = 0x4;
+const NLM_F_REPLACE: u16 = 0x100;
+const NLM_F_CREATE: u16 = 0x400;
+const NTF_EXT_LEARNED: u8 = 1 << 4;
+const NTF_EXT_MANAGED: u32 = 1;
+const NTF_EXT_VALIDATED: u32 = 1 << 2;
+const NTF_USE: u8 = 1;
 // GRE nested attributes (from include/uapi/linux/if_tunnel.h)
 const IFLA_GRE_LOCAL: u16 = 6;
 const IFLA_GRE_REMOTE: u16 = 7;
@@ -55,7 +63,7 @@ pub struct NetlinkSocket {
 }
 
 impl NetlinkSocket {
-    fn open() -> Result<Self, io::Error> {
+    pub(crate) fn open() -> Result<Self, io::Error> {
         // Safety: libc wrapper
         let sock = unsafe { socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE) };
         if sock < 0 {
@@ -552,6 +560,10 @@ pub struct NeighborEntry {
     pub ifindex: i32,
     // NUD_* state
     pub state: u16,
+    // NTF_* flags from ndmsg
+    pub flags: u8,
+    // NTF_EXT_* flags from NDA_FLAGS_EXT
+    pub flags_ext: u32,
 }
 
 impl NeighborEntry {
@@ -561,6 +573,13 @@ impl NeighborEntry {
             Some(IpAddr::V4(ip)) => Some((self.ifindex, ip)),
             _ => None,
         }
+    }
+
+    #[inline]
+    pub fn requires_refresh(&self) -> bool {
+        self.state & (libc::NUD_PERMANENT | libc::NUD_NOARP) == 0
+            && self.flags & NTF_EXT_LEARNED == 0
+            && self.flags_ext & (NTF_EXT_MANAGED | NTF_EXT_VALIDATED) == 0
     }
 }
 
@@ -572,7 +591,7 @@ struct ndmsg {
     _ndm_pad2: u16,
     ndm_ifindex: i32,
     ndm_state: u16,
-    _ndm_flags: u8,
+    ndm_flags: u8,
     _ndm_type: u8,
 }
 
@@ -580,6 +599,40 @@ struct ndmsg {
 struct NeighRequest {
     header: nlmsghdr,
     ndm: ndmsg,
+}
+
+pub fn netlink_use_neighbor(
+    sock: &NetlinkSocket,
+    if_index: u32,
+    ip: Ipv4Addr,
+) -> Result<(), io::Error> {
+    let req = {
+        // Safety: NeighRequest is POD.
+        let mut req = unsafe { mem::zeroed::<NeighRequest>() };
+        let nlmsg_len = mem::size_of::<nlmsghdr>() + mem::size_of::<ndmsg>();
+        req.header = nlmsghdr {
+            nlmsg_len: nlmsg_len as u32,
+            nlmsg_flags: (NLM_F_REQUEST as u16) | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE,
+            nlmsg_type: RTM_NEWNEIGH,
+            nlmsg_pid: 0,
+            nlmsg_seq: 1,
+        };
+        req.ndm.ndm_family = AF_INET as u8;
+        req.ndm.ndm_ifindex = if_index as i32;
+        req.ndm.ndm_state = 0;
+        req.ndm.ndm_flags = NTF_USE;
+
+        let mut req_buf = bytes_of(&req)[..nlmsg_len].to_vec();
+        push_nlattr(&mut req_buf, NDA_DST, &ip.octets());
+
+        let header = unsafe { &mut *(req_buf.as_mut_ptr() as *mut nlmsghdr) };
+        header.nlmsg_len = req_buf.len() as u32;
+
+        req_buf
+    };
+    sock.send(&req)?;
+    sock.recv()?;
+    Ok(())
 }
 
 /// fetch the kernel's neighbor table (ARP/NDP cache)
@@ -645,6 +698,8 @@ pub fn parse_rtm_newneigh(msg: &NetlinkMessage, if_index: Option<u32>) -> Option
         lladdr: None,
         ifindex: nd_msg.ndm_ifindex,
         state: nd_msg.ndm_state,
+        flags: nd_msg.ndm_flags,
+        flags_ext: 0,
     };
     if let Some(dst_attr) = attrs.get(&NDA_DST) {
         neighbor.destination = parse_ip_address(dst_attr.data, nd_msg.ndm_family);
@@ -655,6 +710,13 @@ pub fn parse_rtm_newneigh(msg: &NetlinkMessage, if_index: Option<u32>) -> Option
         let mut mac = [0u8; 6];
         mac.copy_from_slice(&lladdr_attr.data[0..6]);
         neighbor.lladdr = Some(MacAddress(mac));
+    }
+    if let Some(flags_ext_attr) = attrs.get(&NDA_FLAGS_EXT)
+        && flags_ext_attr.data.len() >= mem::size_of::<u32>()
+    {
+        let mut flags_ext = [0; mem::size_of::<u32>()];
+        flags_ext.copy_from_slice(&flags_ext_attr.data[..mem::size_of::<u32>()]);
+        neighbor.flags_ext = u32::from_ne_bytes(flags_ext);
     }
     Some(neighbor)
 }

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -38,6 +38,7 @@ pub struct GreRouteInfo {
     pub underlay_if_index: u32,
     pub underlay_ip_addr: Ipv4Addr,
     pub underlay_mac_addr: Option<MacAddress>,
+    pub underlay_neigh_requires_refresh: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -45,6 +46,7 @@ pub struct NextHop {
     pub mac_addr: Option<MacAddress>,
     pub ip_addr: IpAddr,
     pub if_index: u32,
+    pub neigh_requires_refresh: bool,
     pub preferred_src_ip: Option<Ipv4Addr>,
     pub gre: Option<GreRouteInfo>,
 }
@@ -216,11 +218,10 @@ impl Neighbors {
         self.neighbors.iter()
     }
 
-    fn lookup(&self, ip: IpAddr, if_index: u32) -> Option<&MacAddress> {
+    fn lookup(&self, ip: IpAddr, if_index: u32) -> Option<&NeighborEntry> {
         self.neighbors
             .iter()
             .find(|n| n.ifindex == if_index as i32 && n.destination == Some(ip))
-            .and_then(|n| n.lladdr.as_ref())
     }
 
     fn upsert(&mut self, new_neighbor: NeighborEntry) -> bool {
@@ -503,6 +504,7 @@ impl Router {
                     ip_addr: next_hop_ip,
                     if_index,
                     mac_addr: default_route.mac_addr,
+                    neigh_requires_refresh: default_route.neigh_requires_refresh,
                     preferred_src_ip,
                     gre: default_route.gre.clone(),
                 });
@@ -514,16 +516,19 @@ impl Router {
                 if_index,
                 ip_addr: next_hop_ip,
                 mac_addr: gre.underlay_mac_addr,
+                neigh_requires_refresh: gre.underlay_neigh_requires_refresh,
                 preferred_src_ip,
                 gre: Some(gre),
             });
         }
 
-        let mac_addr = self.neighbors.lookup(next_hop_ip, if_index).cloned();
+        let neighbor = self.neighbors.lookup(next_hop_ip, if_index);
+        let mac_addr = neighbor.and_then(|neighbor| neighbor.lladdr);
         Ok(NextHop {
             ip_addr: next_hop_ip,
             mac_addr,
             if_index,
+            neigh_requires_refresh: neighbor.is_none_or(NeighborEntry::requires_refresh),
             preferred_src_ip,
             gre: None,
         })
@@ -588,10 +593,10 @@ impl Router {
             return None;
         }
         let underlay_ip_addr = underlay_route.gateway.unwrap_or(remote);
-        let underlay_mac_addr = self
+        let underlay_neighbor = self
             .neighbors
-            .lookup(IpAddr::V4(underlay_ip_addr), underlay_if_index)
-            .copied();
+            .lookup(IpAddr::V4(underlay_ip_addr), underlay_if_index);
+        let underlay_mac_addr = underlay_neighbor.and_then(|neighbor| neighbor.lladdr);
 
         Some(GreRouteInfo {
             gre_if_index: interface.if_index,
@@ -599,6 +604,8 @@ impl Router {
             underlay_if_index,
             underlay_ip_addr,
             underlay_mac_addr,
+            underlay_neigh_requires_refresh: underlay_neighbor
+                .is_none_or(NeighborEntry::requires_refresh),
         })
     }
 }
@@ -631,7 +638,7 @@ mod tests {
     use {
         super::*,
         crate::netlink::{MacAddress, NeighborEntry, RouteEntry},
-        libc::{AF_INET, NUD_REACHABLE},
+        libc::{AF_INET, NUD_NOARP, NUD_PERMANENT, NUD_REACHABLE},
         std::net::{IpAddr, Ipv4Addr},
     };
 
@@ -710,12 +717,16 @@ mod tests {
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
             ifindex: 1,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }));
         assert!(tables.upsert_neighbor(NeighborEntry {
             destination: Some(IpAddr::V4(backup_gateway)),
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x02])),
             ifindex: 2,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }));
         assert!(tables.upsert_route(test_route_entry_with_priority(
             None,
@@ -747,6 +758,8 @@ mod tests {
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
             ifindex: 1,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         };
         assert!(tables.upsert_neighbor(neighbor));
 
@@ -781,6 +794,7 @@ mod tests {
         let next_hop = router.route_v4(test_dst).unwrap();
         assert_eq!(next_hop.if_index, 1);
         assert_eq!(next_hop.ip_addr, IpAddr::V4(gateway));
+        assert!(next_hop.neigh_requires_refresh);
 
         // Delete using same key should remove the route
         assert!(tables.remove_route(route.clone()));
@@ -839,6 +853,8 @@ mod tests {
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
             ifindex: 1,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         };
 
         // Upsert new neighbor and check that it was inserted and neighbors are dirty
@@ -909,6 +925,8 @@ mod tests {
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
             ifindex: 1,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }));
         assert!(tables.upsert_route(test_route_entry(
             Some(test_dst),
@@ -930,6 +948,7 @@ mod tests {
         let next_hop = router.route_v4(test_dst).unwrap();
         assert_eq!(next_hop.if_index, 1);
         assert_eq!(next_hop.ip_addr, IpAddr::V4(main_gateway));
+        assert!(next_hop.neigh_requires_refresh);
     }
 
     #[test]
@@ -944,6 +963,8 @@ mod tests {
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
             ifindex: 1,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }));
         assert!(tables.upsert_route(test_route_entry(
             Some(test_dst),
@@ -965,6 +986,7 @@ mod tests {
         let next_hop = router.route_v4(test_dst).unwrap();
         assert_eq!(next_hop.if_index, 1);
         assert_eq!(next_hop.ip_addr, IpAddr::V4(main_gateway));
+        assert!(next_hop.neigh_requires_refresh);
     }
 
     #[test]
@@ -985,12 +1007,16 @@ mod tests {
                 lladdr: Some(mac1),
                 ifindex: if_index_underlay,
                 state: NUD_REACHABLE,
+                flags: 0,
+                flags_ext: 0,
             },
             NeighborEntry {
                 destination: Some(IpAddr::V4(remote2)),
                 lladdr: Some(mac2),
                 ifindex: if_index_underlay,
                 state: NUD_REACHABLE,
+                flags: 0,
+                flags_ext: 0,
             },
         ];
 
@@ -1032,20 +1058,24 @@ mod tests {
         let hop1 = router.route_v4(gre_dest1).unwrap();
         assert_eq!(hop1.if_index, if_index_gre1 as u32);
         assert_eq!(hop1.mac_addr, Some(mac1));
+        assert!(hop1.neigh_requires_refresh);
         let gre1 = hop1.gre.as_ref().unwrap();
         assert_eq!(gre1.gre_if_index, if_index_gre1 as u32);
         assert_eq!(gre1.underlay_if_index, if_index_underlay as u32);
         assert_eq!(gre1.underlay_ip_addr, remote1);
         assert_eq!(gre1.underlay_mac_addr, Some(mac1));
+        assert!(gre1.underlay_neigh_requires_refresh);
 
         let hop2 = router.route_v4(gre_dest2).unwrap();
         assert_eq!(hop2.if_index, if_index_gre2 as u32);
         assert_eq!(hop2.mac_addr, Some(mac2));
+        assert!(hop2.neigh_requires_refresh);
         let gre2 = hop2.gre.as_ref().unwrap();
         assert_eq!(gre2.gre_if_index, if_index_gre2 as u32);
         assert_eq!(gre2.underlay_if_index, if_index_underlay as u32);
         assert_eq!(gre2.underlay_ip_addr, remote2);
         assert_eq!(gre2.underlay_mac_addr, Some(mac2));
+        assert!(gre2.underlay_neigh_requires_refresh);
     }
 
     #[test]
@@ -1061,6 +1091,8 @@ mod tests {
             lladdr: Some(mac),
             ifindex: if_index_underlay,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }];
 
         let routes = vec![
@@ -1098,20 +1130,24 @@ mod tests {
         let hop_default = router.default().unwrap();
         assert_eq!(hop_default.if_index, if_index_gre as u32);
         assert_eq!(hop_default.mac_addr, Some(mac));
+        assert!(hop_default.neigh_requires_refresh);
         let gre_default = hop_default.gre.as_ref().unwrap();
         assert_eq!(gre_default.gre_if_index, if_index_gre as u32);
         assert_eq!(gre_default.underlay_if_index, if_index_underlay as u32);
         assert_eq!(gre_default.underlay_ip_addr, remote);
         assert_eq!(gre_default.underlay_mac_addr, Some(mac));
+        assert!(gre_default.underlay_neigh_requires_refresh);
 
         let hop_route = router.route_v4(dest).unwrap();
         assert_eq!(hop_route.if_index, if_index_gre as u32);
         assert_eq!(hop_route.mac_addr, Some(mac));
+        assert!(hop_route.neigh_requires_refresh);
         let gre_route = hop_route.gre.as_ref().unwrap();
         assert_eq!(gre_route.gre_if_index, if_index_gre as u32);
         assert_eq!(gre_route.underlay_if_index, if_index_underlay as u32);
         assert_eq!(gre_route.underlay_ip_addr, remote);
         assert_eq!(gre_route.underlay_mac_addr, Some(mac));
+        assert!(gre_route.underlay_neigh_requires_refresh);
     }
 
     #[test]
@@ -1125,6 +1161,8 @@ mod tests {
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
             ifindex: 1,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }));
 
         assert!(tables.upsert_route(test_route_entry(
@@ -1168,6 +1206,7 @@ mod tests {
         let next_hop = router.default().unwrap();
         assert_eq!(next_hop.if_index, 1);
         assert_eq!(next_hop.ip_addr, IpAddr::V4(primary));
+        assert!(next_hop.neigh_requires_refresh);
 
         {
             let mut tables = tables.clone();
@@ -1184,6 +1223,7 @@ mod tests {
             let next_hop = router.default().unwrap();
             assert_eq!(next_hop.if_index, 1);
             assert_eq!(next_hop.ip_addr, IpAddr::V4(primary));
+            assert!(next_hop.neigh_requires_refresh);
         }
 
         let mut tables = tables;
@@ -1200,5 +1240,104 @@ mod tests {
         let next_hop = router.default().unwrap();
         assert_eq!(next_hop.if_index, 2);
         assert_eq!(next_hop.ip_addr, IpAddr::V4(backup));
+        assert!(next_hop.neigh_requires_refresh);
+    }
+
+    #[test]
+    fn test_permanent_neighbors_do_not_require_refresh() {
+        let test_dst = Ipv4Addr::new(10, 255, 255, 123);
+        let router = router_from_tables(
+            vec![NeighborEntry {
+                destination: Some(IpAddr::V4(test_dst)),
+                lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
+                ifindex: 1,
+                state: NUD_PERMANENT,
+                flags: 0,
+                flags_ext: 0,
+            }],
+            vec![test_route(Some(test_dst), 1)],
+            vec![],
+        );
+
+        let next_hop = router.route_v4(test_dst).unwrap();
+        assert_eq!(next_hop.ip_addr, IpAddr::V4(test_dst));
+        assert!(!next_hop.neigh_requires_refresh);
+    }
+
+    #[test]
+    fn test_noarp_neighbors_do_not_require_refresh() {
+        let gateway = Ipv4Addr::new(10, 255, 255, 1);
+        let test_dst = Ipv4Addr::new(10, 255, 255, 123);
+        let router = router_from_tables(
+            vec![NeighborEntry {
+                destination: Some(IpAddr::V4(gateway)),
+                lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
+                ifindex: 1,
+                state: NUD_NOARP,
+                flags: 0,
+                flags_ext: 0,
+            }],
+            vec![
+                test_route_entry(
+                    Some(test_dst),
+                    Some(gateway),
+                    1,
+                    32,
+                    u32::from(RouteTable::Main),
+                )
+                .try_into()
+                .unwrap(),
+            ],
+            vec![],
+        );
+
+        let next_hop = router.route_v4(test_dst).unwrap();
+        assert_eq!(next_hop.ip_addr, IpAddr::V4(gateway));
+        assert!(!next_hop.neigh_requires_refresh);
+    }
+
+    #[test]
+    fn test_gre_with_permanent_underlay_neighbor_does_not_require_refresh() {
+        let remote = Ipv4Addr::new(10, 0, 0, 1);
+        let gre_dest = Ipv4Addr::new(192, 168, 0, 1);
+        let if_index_underlay = 1;
+        let if_index_gre = 100;
+        let mac = MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01]);
+
+        let router = router_from_tables(
+            vec![NeighborEntry {
+                destination: Some(IpAddr::V4(remote)),
+                lladdr: Some(mac),
+                ifindex: if_index_underlay,
+                state: NUD_PERMANENT,
+                flags: 0,
+                flags_ext: 0,
+            }],
+            vec![
+                test_route(Some(remote), if_index_underlay as u32),
+                test_route(Some(gre_dest), if_index_gre as u32),
+            ],
+            vec![
+                InterfaceInfo {
+                    if_index: if_index_underlay as u32,
+                    gre_tunnel: None,
+                },
+                InterfaceInfo {
+                    if_index: if_index_gre as u32,
+                    gre_tunnel: Some(GreTunnelInfo {
+                        local: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)),
+                        remote: IpAddr::V4(remote),
+                        ttl: 0,
+                        tos: 0,
+                        pmtudisc: 0,
+                    }),
+                },
+            ],
+        );
+
+        let next_hop = router.route_v4(gre_dest).unwrap();
+        assert!(!next_hop.neigh_requires_refresh);
+        let gre = next_hop.gre.as_ref().unwrap();
+        assert!(!gre.underlay_neigh_requires_refresh);
     }
 }

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -33,9 +33,11 @@ pub enum RouteError {
 
 #[derive(Debug, Clone)]
 pub struct GreRouteInfo {
-    pub if_index: u32,
+    pub gre_if_index: u32,
     pub tunnel_info: GreTunnelInfo,
-    pub mac_addr: MacAddress,
+    pub underlay_if_index: u32,
+    pub underlay_ip_addr: Ipv4Addr,
+    pub underlay_mac_addr: Option<MacAddress>,
 }
 
 #[derive(Debug, Clone)]
@@ -469,7 +471,7 @@ impl Router {
     fn cached_gre_route_info(&self, if_index: u32) -> Option<&GreRouteInfo> {
         self.cached_gre_info
             .iter()
-            .find(|gre| gre.if_index == if_index)
+            .find(|gre| gre.gre_if_index == if_index)
     }
 
     fn gre_route_info(&self, if_index: u32) -> Option<GreRouteInfo> {
@@ -511,7 +513,7 @@ impl Router {
             return Ok(NextHop {
                 if_index,
                 ip_addr: next_hop_ip,
-                mac_addr: Some(gre.mac_addr),
+                mac_addr: gre.underlay_mac_addr,
                 preferred_src_ip,
                 gre: Some(gre),
             });
@@ -567,7 +569,6 @@ impl Router {
             IpAddr::V4(local) => local,
             IpAddr::V6(_) => return None,
         };
-        // Skip unconfigured tunnels (remote/local 0.0.0.0)
         if remote == Ipv4Addr::UNSPECIFIED || local == Ipv4Addr::UNSPECIFIED {
             return None;
         }
@@ -586,16 +587,18 @@ impl Router {
             );
             return None;
         }
-        let underlay_next_hop_ip = IpAddr::V4(underlay_route.gateway.unwrap_or(remote));
-        let mac_addr = self
+        let underlay_ip_addr = underlay_route.gateway.unwrap_or(remote);
+        let underlay_mac_addr = self
             .neighbors
-            .lookup(underlay_next_hop_ip, underlay_if_index)
-            .copied()?;
+            .lookup(IpAddr::V4(underlay_ip_addr), underlay_if_index)
+            .copied();
 
         Some(GreRouteInfo {
-            if_index: interface.if_index,
+            gre_if_index: interface.if_index,
             tunnel_info: tunnel_info.clone(),
-            mac_addr,
+            underlay_if_index,
+            underlay_ip_addr,
+            underlay_mac_addr,
         })
     }
 }
@@ -1029,18 +1032,20 @@ mod tests {
         let hop1 = router.route_v4(gre_dest1).unwrap();
         assert_eq!(hop1.if_index, if_index_gre1 as u32);
         assert_eq!(hop1.mac_addr, Some(mac1));
-        assert_eq!(
-            hop1.gre.as_ref().map(|gre| gre.if_index),
-            Some(if_index_gre1 as u32)
-        );
+        let gre1 = hop1.gre.as_ref().unwrap();
+        assert_eq!(gre1.gre_if_index, if_index_gre1 as u32);
+        assert_eq!(gre1.underlay_if_index, if_index_underlay as u32);
+        assert_eq!(gre1.underlay_ip_addr, remote1);
+        assert_eq!(gre1.underlay_mac_addr, Some(mac1));
 
         let hop2 = router.route_v4(gre_dest2).unwrap();
         assert_eq!(hop2.if_index, if_index_gre2 as u32);
         assert_eq!(hop2.mac_addr, Some(mac2));
-        assert_eq!(
-            hop2.gre.as_ref().map(|gre| gre.if_index),
-            Some(if_index_gre2 as u32)
-        );
+        let gre2 = hop2.gre.as_ref().unwrap();
+        assert_eq!(gre2.gre_if_index, if_index_gre2 as u32);
+        assert_eq!(gre2.underlay_if_index, if_index_underlay as u32);
+        assert_eq!(gre2.underlay_ip_addr, remote2);
+        assert_eq!(gre2.underlay_mac_addr, Some(mac2));
     }
 
     #[test]
@@ -1093,18 +1098,20 @@ mod tests {
         let hop_default = router.default().unwrap();
         assert_eq!(hop_default.if_index, if_index_gre as u32);
         assert_eq!(hop_default.mac_addr, Some(mac));
-        assert_eq!(
-            hop_default.gre.as_ref().map(|gre| gre.if_index),
-            Some(if_index_gre as u32)
-        );
+        let gre_default = hop_default.gre.as_ref().unwrap();
+        assert_eq!(gre_default.gre_if_index, if_index_gre as u32);
+        assert_eq!(gre_default.underlay_if_index, if_index_underlay as u32);
+        assert_eq!(gre_default.underlay_ip_addr, remote);
+        assert_eq!(gre_default.underlay_mac_addr, Some(mac));
 
         let hop_route = router.route_v4(dest).unwrap();
         assert_eq!(hop_route.if_index, if_index_gre as u32);
         assert_eq!(hop_route.mac_addr, Some(mac));
-        assert_eq!(
-            hop_route.gre.as_ref().map(|gre| gre.if_index),
-            Some(if_index_gre as u32)
-        );
+        let gre_route = hop_route.gre.as_ref().unwrap();
+        assert_eq!(gre_route.gre_if_index, if_index_gre as u32);
+        assert_eq!(gre_route.underlay_if_index, if_index_underlay as u32);
+        assert_eq!(gre_route.underlay_ip_addr, remote);
+        assert_eq!(gre_route.underlay_mac_addr, Some(mac));
     }
 
     #[test]

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -40,6 +40,7 @@ pub struct GreRouteInfo {
     pub underlay_if_index: u32,
     pub underlay_ip_addr: Ipv4Addr,
     pub underlay_mac_addr: Option<MacAddress>,
+    pub underlay_neigh_requires_refresh: bool,
 }
 
 /// VLAN encapsulation directive carried on a resolved NextHop.
@@ -64,6 +65,7 @@ pub struct NextHop {
     pub ip_addr: IpAddr,
     pub if_index: u32,
     pub mtu: u32,
+    pub neigh_requires_refresh: bool,
     pub preferred_src_ip: Option<Ipv4Addr>,
     pub gre: Option<GreRouteInfo>,
     pub vlan: Option<VlanRouteInfo>,
@@ -236,11 +238,10 @@ impl Neighbors {
         self.neighbors.iter()
     }
 
-    fn lookup(&self, ip: IpAddr, if_index: u32) -> Option<&MacAddress> {
+    fn lookup(&self, ip: IpAddr, if_index: u32) -> Option<&NeighborEntry> {
         self.neighbors
             .iter()
             .find(|n| n.ifindex == if_index as i32 && n.destination == Some(ip))
-            .and_then(|n| n.lladdr.as_ref())
     }
 
     fn upsert(&mut self, new_neighbor: NeighborEntry) -> bool {
@@ -502,7 +503,7 @@ impl Router {
     fn cached_gre_route_info(&self, if_index: u32) -> Option<&GreRouteInfo> {
         self.cached_gre_info
             .iter()
-            .find(|gre| gre.gre_if_index == if_index)
+            .find(|gre| gre.if_index == if_index)
     }
 
     fn gre_route_info(&self, if_index: u32) -> Option<GreRouteInfo> {
@@ -545,6 +546,7 @@ impl Router {
                 if_index,
                 mtu: default_route.mtu,
                 mac_addr: default_route.mac_addr,
+                neigh_requires_refresh: default_route.neigh_requires_refresh,
                 preferred_src_ip,
                 gre: default_route.gre.clone(),
                 vlan: default_route.vlan,
@@ -557,6 +559,7 @@ impl Router {
                 mtu: gre.underlay_mtu,
                 ip_addr: next_hop_ip,
                 mac_addr: gre.underlay_mac_addr,
+                neigh_requires_refresh: gre.underlay_neigh_requires_refresh,
                 preferred_src_ip,
                 gre: Some(gre),
                 vlan: None,
@@ -574,16 +577,21 @@ impl Router {
         // IPv4 multicast destinations map deterministically to a multicast MAC (RFC 1112 §6.4)
         // and never participate in ARP, so there is no neighbor entry to look up. Otherwise
         // consult the neighbor cache for the unicast MAC.
-        let mac_addr = if next_hop_v4.is_multicast() {
-            Some(ipv4_multicast_mac(next_hop_v4))
+        let (mac_addr, neigh_requires_refresh) = if next_hop_v4.is_multicast() {
+            (Some(ipv4_multicast_mac(next_hop_v4)), false)
         } else {
-            self.neighbors.lookup(next_hop_ip, if_index).cloned()
+            let neighbor = self.neighbors.lookup(next_hop_ip, if_index);
+            (
+                neighbor.and_then(|neighbor| neighbor.lladdr),
+                neighbor.is_none_or(NeighborEntry::requires_refresh),
+            )
         };
         Ok(NextHop {
             ip_addr: next_hop_ip,
             mac_addr,
             if_index,
             mtu,
+            neigh_requires_refresh,
             preferred_src_ip,
             gre: None,
             vlan,
@@ -651,10 +659,10 @@ impl Router {
             return None;
         }
         let underlay_ip_addr = underlay_route.gateway.unwrap_or(remote);
-        let underlay_mac_addr = self
+        let underlay_neighbor = self
             .neighbors
-            .lookup(IpAddr::V4(underlay_ip_addr), underlay_if_index)
-            .copied();
+            .lookup(IpAddr::V4(underlay_ip_addr), underlay_if_index);
+        let underlay_mac_addr = underlay_neighbor.and_then(|neighbor| neighbor.lladdr);
 
         Some(GreRouteInfo {
             if_index: interface.if_index,
@@ -664,6 +672,8 @@ impl Router {
             underlay_if_index,
             underlay_ip_addr,
             underlay_mac_addr,
+            underlay_neigh_requires_refresh: underlay_neighbor
+                .is_none_or(NeighborEntry::requires_refresh),
         })
     }
 }
@@ -704,7 +714,7 @@ mod tests {
     use {
         super::*,
         crate::netlink::{MacAddress, NeighborEntry, RouteEntry, VlanLinkInfo},
-        libc::{AF_INET, NUD_REACHABLE},
+        libc::{AF_INET, NUD_NOARP, NUD_PERMANENT, NUD_REACHABLE},
         std::net::{IpAddr, Ipv4Addr},
     };
 
@@ -797,12 +807,16 @@ mod tests {
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
             ifindex: 1,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }));
         assert!(tables.upsert_neighbor(NeighborEntry {
             destination: Some(IpAddr::V4(backup_gateway)),
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x02])),
             ifindex: 2,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }));
         assert!(tables.upsert_route(test_route_entry_with_priority(
             None,
@@ -841,6 +855,8 @@ mod tests {
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
             ifindex: 1,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         };
         assert!(tables.upsert_neighbor(neighbor));
 
@@ -875,6 +891,7 @@ mod tests {
         let next_hop = router.route_v4(test_dst).unwrap();
         assert_eq!(next_hop.if_index, 1);
         assert_eq!(next_hop.ip_addr, IpAddr::V4(gateway));
+        assert!(next_hop.neigh_requires_refresh);
 
         // Delete using same key should remove the route
         assert!(tables.remove_route(route.clone()));
@@ -946,6 +963,8 @@ mod tests {
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
             ifindex: 1,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         };
 
         // Upsert new neighbor and check that it was inserted and neighbors are dirty
@@ -1024,6 +1043,8 @@ mod tests {
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
             ifindex: 1,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }));
         assert!(tables.upsert_route(test_route_entry(
             Some(test_dst),
@@ -1045,6 +1066,7 @@ mod tests {
         let next_hop = router.route_v4(test_dst).unwrap();
         assert_eq!(next_hop.if_index, 1);
         assert_eq!(next_hop.ip_addr, IpAddr::V4(main_gateway));
+        assert!(next_hop.neigh_requires_refresh);
     }
 
     #[test]
@@ -1065,6 +1087,8 @@ mod tests {
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
             ifindex: 1,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }));
         assert!(tables.upsert_route(test_route_entry(
             Some(test_dst),
@@ -1086,6 +1110,7 @@ mod tests {
         let next_hop = router.route_v4(test_dst).unwrap();
         assert_eq!(next_hop.if_index, 1);
         assert_eq!(next_hop.ip_addr, IpAddr::V4(main_gateway));
+        assert!(next_hop.neigh_requires_refresh);
     }
 
     #[test]
@@ -1106,12 +1131,16 @@ mod tests {
                 lladdr: Some(mac1),
                 ifindex: if_index_underlay,
                 state: NUD_REACHABLE,
+                flags: 0,
+                flags_ext: 0,
             },
             NeighborEntry {
                 destination: Some(IpAddr::V4(remote2)),
                 lladdr: Some(mac2),
                 ifindex: if_index_underlay,
                 state: NUD_REACHABLE,
+                flags: 0,
+                flags_ext: 0,
             },
         ];
 
@@ -1160,6 +1189,7 @@ mod tests {
         assert_eq!(hop1.if_index, if_index_gre1 as u32);
         assert_eq!(hop1.mtu, DEFAULT_MTU_FOR_TESTS);
         assert_eq!(hop1.mac_addr, Some(mac1));
+        assert!(hop1.neigh_requires_refresh);
 
         let hop1_gre = hop1.gre.as_ref().unwrap();
         assert_eq!(hop1_gre.if_index, if_index_gre1 as u32);
@@ -1169,11 +1199,13 @@ mod tests {
         assert_eq!(hop1_gre.underlay_if_index, if_index_underlay as u32);
         assert_eq!(hop1_gre.underlay_ip_addr, remote1);
         assert_eq!(hop1_gre.underlay_mac_addr, Some(mac1));
+        assert!(hop1_gre.underlay_neigh_requires_refresh);
 
         let hop2 = router.route_v4(gre_dest2).unwrap();
         assert_eq!(hop2.if_index, if_index_gre2 as u32);
         assert_eq!(hop2.mtu, DEFAULT_MTU_FOR_TESTS);
         assert_eq!(hop2.mac_addr, Some(mac2));
+        assert!(hop2.neigh_requires_refresh);
 
         let hop2_gre = hop2.gre.as_ref().unwrap();
         assert_eq!(hop2_gre.if_index, if_index_gre2 as u32);
@@ -1183,6 +1215,7 @@ mod tests {
         assert_eq!(hop2_gre.underlay_if_index, if_index_underlay as u32);
         assert_eq!(hop2_gre.underlay_ip_addr, remote2);
         assert_eq!(hop2_gre.underlay_mac_addr, Some(mac2));
+        assert!(hop2_gre.underlay_neigh_requires_refresh);
     }
 
     #[test]
@@ -1198,6 +1231,8 @@ mod tests {
             lladdr: Some(mac),
             ifindex: if_index_underlay,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }];
 
         let routes = vec![
@@ -1240,6 +1275,7 @@ mod tests {
         assert_eq!(hop_default.if_index, if_index_gre as u32);
         assert_eq!(hop_default.mtu, DEFAULT_MTU_FOR_TESTS);
         assert_eq!(hop_default.mac_addr, Some(mac));
+        assert!(hop_default.neigh_requires_refresh);
 
         let hop_default_gre = hop_default.gre.as_ref().unwrap();
         assert_eq!(hop_default_gre.if_index, if_index_gre as u32);
@@ -1249,11 +1285,13 @@ mod tests {
         assert_eq!(hop_default_gre.underlay_if_index, if_index_underlay as u32);
         assert_eq!(hop_default_gre.underlay_ip_addr, remote);
         assert_eq!(hop_default_gre.underlay_mac_addr, Some(mac));
+        assert!(hop_default_gre.underlay_neigh_requires_refresh);
 
         let hop_route = router.route_v4(dest).unwrap();
         assert_eq!(hop_route.if_index, if_index_gre as u32);
         assert_eq!(hop_route.mtu, DEFAULT_MTU_FOR_TESTS);
         assert_eq!(hop_route.mac_addr, Some(mac));
+        assert!(hop_route.neigh_requires_refresh);
 
         let hop_route_gre = hop_route.gre.as_ref().unwrap();
         assert_eq!(hop_route_gre.if_index, if_index_gre as u32);
@@ -1263,6 +1301,7 @@ mod tests {
         assert_eq!(hop_route_gre.underlay_if_index, if_index_underlay as u32);
         assert_eq!(hop_route_gre.underlay_ip_addr, remote);
         assert_eq!(hop_route_gre.underlay_mac_addr, Some(mac));
+        assert!(hop_route_gre.underlay_neigh_requires_refresh);
     }
 
     #[test]
@@ -1282,6 +1321,8 @@ mod tests {
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
             ifindex: 1,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }));
 
         assert!(tables.upsert_route(test_route_entry(
@@ -1325,6 +1366,7 @@ mod tests {
         let next_hop = router.default().unwrap();
         assert_eq!(next_hop.if_index, 1);
         assert_eq!(next_hop.ip_addr, IpAddr::V4(primary));
+        assert!(next_hop.neigh_requires_refresh);
 
         {
             let mut tables = tables.clone();
@@ -1341,6 +1383,7 @@ mod tests {
             let next_hop = router.default().unwrap();
             assert_eq!(next_hop.if_index, 1);
             assert_eq!(next_hop.ip_addr, IpAddr::V4(primary));
+            assert!(next_hop.neigh_requires_refresh);
         }
 
         let mut tables = tables;
@@ -1357,6 +1400,119 @@ mod tests {
         let next_hop = router.default().unwrap();
         assert_eq!(next_hop.if_index, 2);
         assert_eq!(next_hop.ip_addr, IpAddr::V4(backup));
+        assert!(next_hop.neigh_requires_refresh);
+    }
+
+    #[test]
+    fn test_permanent_neighbors_do_not_require_refresh() {
+        let test_dst = Ipv4Addr::new(10, 255, 255, 123);
+        let router = router_from_tables(
+            vec![NeighborEntry {
+                destination: Some(IpAddr::V4(test_dst)),
+                lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
+                ifindex: 1,
+                state: NUD_PERMANENT,
+                flags: 0,
+                flags_ext: 0,
+            }],
+            vec![test_route(Some(test_dst), 1)],
+            vec![InterfaceInfo {
+                if_index: 1,
+                mtu: DEFAULT_MTU_FOR_TESTS,
+                gre_tunnel: None,
+                vlan_link: None,
+            }],
+        );
+
+        let next_hop = router.route_v4(test_dst).unwrap();
+        assert_eq!(next_hop.ip_addr, IpAddr::V4(test_dst));
+        assert!(!next_hop.neigh_requires_refresh);
+    }
+
+    #[test]
+    fn test_noarp_neighbors_do_not_require_refresh() {
+        let gateway = Ipv4Addr::new(10, 255, 255, 1);
+        let test_dst = Ipv4Addr::new(10, 255, 255, 123);
+        let router = router_from_tables(
+            vec![NeighborEntry {
+                destination: Some(IpAddr::V4(gateway)),
+                lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
+                ifindex: 1,
+                state: NUD_NOARP,
+                flags: 0,
+                flags_ext: 0,
+            }],
+            vec![
+                test_route_entry(
+                    Some(test_dst),
+                    Some(gateway),
+                    1,
+                    32,
+                    u32::from(RouteTable::Main),
+                )
+                .try_into()
+                .unwrap(),
+            ],
+            vec![InterfaceInfo {
+                if_index: 1,
+                mtu: DEFAULT_MTU_FOR_TESTS,
+                gre_tunnel: None,
+                vlan_link: None,
+            }],
+        );
+
+        let next_hop = router.route_v4(test_dst).unwrap();
+        assert_eq!(next_hop.ip_addr, IpAddr::V4(gateway));
+        assert!(!next_hop.neigh_requires_refresh);
+    }
+
+    #[test]
+    fn test_gre_with_permanent_underlay_neighbor_does_not_require_refresh() {
+        let remote = Ipv4Addr::new(10, 0, 0, 1);
+        let gre_dest = Ipv4Addr::new(192, 168, 0, 1);
+        let if_index_underlay = 1;
+        let if_index_gre = 100;
+        let mac = MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01]);
+
+        let router = router_from_tables(
+            vec![NeighborEntry {
+                destination: Some(IpAddr::V4(remote)),
+                lladdr: Some(mac),
+                ifindex: if_index_underlay,
+                state: NUD_PERMANENT,
+                flags: 0,
+                flags_ext: 0,
+            }],
+            vec![
+                test_route(Some(remote), if_index_underlay as u32),
+                test_route(Some(gre_dest), if_index_gre as u32),
+            ],
+            vec![
+                InterfaceInfo {
+                    if_index: if_index_underlay as u32,
+                    mtu: DEFAULT_MTU_FOR_TESTS,
+                    gre_tunnel: None,
+                    vlan_link: None,
+                },
+                InterfaceInfo {
+                    if_index: if_index_gre as u32,
+                    mtu: DEFAULT_MTU_FOR_TESTS,
+                    gre_tunnel: Some(GreTunnelInfo {
+                        local: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)),
+                        remote: IpAddr::V4(remote),
+                        ttl: 0,
+                        tos: 0,
+                        pmtudisc: 0,
+                    }),
+                    vlan_link: None,
+                },
+            ],
+        );
+
+        let next_hop = router.route_v4(gre_dest).unwrap();
+        assert!(!next_hop.neigh_requires_refresh);
+        let gre = next_hop.gre.as_ref().unwrap();
+        assert!(!gre.underlay_neigh_requires_refresh);
     }
 
     #[test]
@@ -1373,6 +1529,8 @@ mod tests {
             lladdr: Some(peer_mac),
             ifindex: vlan_if as i32,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }];
         let interfaces = vec![InterfaceInfo {
             if_index: vlan_if,
@@ -1419,12 +1577,16 @@ mod tests {
                 lladdr: Some(mac_a),
                 ifindex: vlan_if_a as i32,
                 state: NUD_REACHABLE,
+                flags: 0,
+                flags_ext: 0,
             },
             NeighborEntry {
                 destination: Some(IpAddr::V4(peer_b)),
                 lladdr: Some(mac_b),
                 ifindex: vlan_if_b as i32,
                 state: NUD_REACHABLE,
+                flags: 0,
+                flags_ext: 0,
             },
         ];
         let interfaces = vec![
@@ -1470,6 +1632,8 @@ mod tests {
             lladdr: Some(underlay_mac),
             ifindex: if_index_underlay as i32,
             state: NUD_REACHABLE,
+            flags: 0,
+            flags_ext: 0,
         }];
         let routes = vec![
             test_route(Some(remote), if_index_underlay),
@@ -1551,6 +1715,7 @@ mod tests {
             Some(MacAddress([0x01, 0x00, 0x5e, 0x00, 0x00, 0x03]))
         );
         assert_eq!(next_hop.if_index, if_index);
+        assert!(!next_hop.neigh_requires_refresh);
     }
 
     #[test]

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -37,7 +37,9 @@ pub struct GreRouteInfo {
     pub mtu: u32,
     pub underlay_mtu: u32,
     pub tunnel_info: GreTunnelInfo,
-    pub mac_addr: MacAddress,
+    pub underlay_if_index: u32,
+    pub underlay_ip_addr: Ipv4Addr,
+    pub underlay_mac_addr: Option<MacAddress>,
 }
 
 /// VLAN encapsulation directive carried on a resolved NextHop.
@@ -500,7 +502,7 @@ impl Router {
     fn cached_gre_route_info(&self, if_index: u32) -> Option<&GreRouteInfo> {
         self.cached_gre_info
             .iter()
-            .find(|gre| gre.if_index == if_index)
+            .find(|gre| gre.gre_if_index == if_index)
     }
 
     fn gre_route_info(&self, if_index: u32) -> Option<GreRouteInfo> {
@@ -554,7 +556,7 @@ impl Router {
                 if_index,
                 mtu: gre.underlay_mtu,
                 ip_addr: next_hop_ip,
-                mac_addr: Some(gre.mac_addr),
+                mac_addr: gre.underlay_mac_addr,
                 preferred_src_ip,
                 gre: Some(gre),
                 vlan: None,
@@ -630,7 +632,6 @@ impl Router {
             IpAddr::V4(local) => local,
             IpAddr::V6(_) => return None,
         };
-        // Skip unconfigured tunnels (remote/local 0.0.0.0)
         if remote == Ipv4Addr::UNSPECIFIED || local == Ipv4Addr::UNSPECIFIED {
             return None;
         }
@@ -649,18 +650,20 @@ impl Router {
             );
             return None;
         }
-        let underlay_next_hop_ip = IpAddr::V4(underlay_route.gateway.unwrap_or(remote));
-        let mac_addr = self
+        let underlay_ip_addr = underlay_route.gateway.unwrap_or(remote);
+        let underlay_mac_addr = self
             .neighbors
-            .lookup(underlay_next_hop_ip, underlay_if_index)
-            .copied()?;
+            .lookup(IpAddr::V4(underlay_ip_addr), underlay_if_index)
+            .copied();
 
         Some(GreRouteInfo {
             if_index: interface.if_index,
             mtu: interface.mtu,
             underlay_mtu: underlay_interface.mtu,
             tunnel_info: tunnel_info.clone(),
-            mac_addr,
+            underlay_if_index,
+            underlay_ip_addr,
+            underlay_mac_addr,
         })
     }
 }
@@ -1163,6 +1166,9 @@ mod tests {
         assert_eq!(hop1_gre.mtu, DEFAULT_MTU_FOR_TESTS - 100);
         assert_eq!(hop1_gre.underlay_mtu, DEFAULT_MTU_FOR_TESTS);
         assert_eq!(hop1.mtu, hop1_gre.underlay_mtu);
+        assert_eq!(hop1_gre.underlay_if_index, if_index_underlay as u32);
+        assert_eq!(hop1_gre.underlay_ip_addr, remote1);
+        assert_eq!(hop1_gre.underlay_mac_addr, Some(mac1));
 
         let hop2 = router.route_v4(gre_dest2).unwrap();
         assert_eq!(hop2.if_index, if_index_gre2 as u32);
@@ -1174,6 +1180,9 @@ mod tests {
         assert_eq!(hop2_gre.mtu, DEFAULT_MTU_FOR_TESTS + 100);
         assert_eq!(hop2_gre.underlay_mtu, DEFAULT_MTU_FOR_TESTS);
         assert_eq!(hop2.mtu, hop2_gre.underlay_mtu);
+        assert_eq!(hop2_gre.underlay_if_index, if_index_underlay as u32);
+        assert_eq!(hop2_gre.underlay_ip_addr, remote2);
+        assert_eq!(hop2_gre.underlay_mac_addr, Some(mac2));
     }
 
     #[test]
@@ -1237,6 +1246,9 @@ mod tests {
         assert_eq!(hop_default_gre.mtu, DEFAULT_MTU_FOR_TESTS - 100);
         assert_eq!(hop_default_gre.underlay_mtu, DEFAULT_MTU_FOR_TESTS);
         assert_eq!(hop_default.mtu, hop_default_gre.underlay_mtu);
+        assert_eq!(hop_default_gre.underlay_if_index, if_index_underlay as u32);
+        assert_eq!(hop_default_gre.underlay_ip_addr, remote);
+        assert_eq!(hop_default_gre.underlay_mac_addr, Some(mac));
 
         let hop_route = router.route_v4(dest).unwrap();
         assert_eq!(hop_route.if_index, if_index_gre as u32);
@@ -1248,6 +1260,9 @@ mod tests {
         assert_eq!(hop_route_gre.mtu, DEFAULT_MTU_FOR_TESTS - 100);
         assert_eq!(hop_route_gre.underlay_mtu, DEFAULT_MTU_FOR_TESTS);
         assert_eq!(hop_route.mtu, hop_route_gre.underlay_mtu);
+        assert_eq!(hop_route_gre.underlay_if_index, if_index_underlay as u32);
+        assert_eq!(hop_route_gre.underlay_ip_addr, remote);
+        assert_eq!(hop_route_gre.underlay_mac_addr, Some(mac));
     }
 
     #[test]

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -3,6 +3,7 @@ use {
     crate::{
         device::{NetworkDevice, QueueId},
         load_xdp_program,
+        neighbors::NeighborsObserver,
         route::{RouteTable, Router, RoutingTables},
         route_monitor::RouteMonitor,
         set_cpu_affinity,
@@ -180,6 +181,8 @@ pub struct TransmitterBuilder {
     tx_channel_cap: usize,
     maybe_ebpf: Option<Ebpf>,
     atomic_router: Arc<ArcSwap<Router>>,
+    neighbors: NeighborsObserver,
+    neighbors_monitor_handle: thread::JoinHandle<()>,
     route_monitor_handle: thread::JoinHandle<()>,
 }
 
@@ -192,6 +195,7 @@ impl TransmitterBuilder {
     #[cfg(target_os = "linux")]
     pub fn new(config: XdpConfig, exit: Arc<AtomicBool>) -> Result<Self, Box<dyn Error>> {
         use {
+            crate::neighbors::NeighborsRefresher,
             caps::{
                 CapSet,
                 Capability::{CAP_BPF, CAP_NET_ADMIN, CAP_NET_RAW, CAP_PERFMON},
@@ -283,6 +287,15 @@ impl TransmitterBuilder {
             router.routing_table()
         );
 
+        fn retain_cap_net_admin() {
+            // we need to retain CAP_NET_ADMIN in case the netlink socket needs reinitialized
+            let retained_caps = caps::CapsHashSet::from_iter([caps::Capability::CAP_NET_ADMIN]);
+            caps::set(None, caps::CapSet::Effective, &retained_caps)
+                .expect("linux allows effective capset to be set");
+            caps::set(None, caps::CapSet::Permitted, &retained_caps)
+                .expect("linux allows permitted capset to be set");
+        }
+
         // Use ArcSwap for lock-free updates of the routing table
         let atomic_router = Arc::new(ArcSwap::from_pointee(router));
         let route_monitor_handle = RouteMonitor::start(
@@ -291,15 +304,14 @@ impl TransmitterBuilder {
             exit.clone(),
             ROUTE_MONITOR_UPDATE_INTERVAL,
             || {
-                // we need to retain CAP_NET_ADMIN in case the netlink socket needs reinitialized
-                let retained_caps = caps::CapsHashSet::from_iter([caps::Capability::CAP_NET_ADMIN]);
-                caps::set(None, caps::CapSet::Effective, &retained_caps)
-                    .expect("linux allows effective capset to be set");
-                caps::set(None, caps::CapSet::Permitted, &retained_caps)
-                    .expect("linux allows permitted capset to be set");
+                retain_cap_net_admin();
                 info!("route monitor thread started");
             },
         );
+        let (neighbors_monitor_handle, neighbors) = NeighborsRefresher::start(exit, || {
+            retain_cap_net_admin();
+            info!("neighbors thread started");
+        })?;
 
         let maybe_ebpf = maybe_ebpf_result.transpose()?;
 
@@ -308,6 +320,8 @@ impl TransmitterBuilder {
             tx_channel_cap,
             maybe_ebpf,
             atomic_router,
+            neighbors,
+            neighbors_monitor_handle,
             route_monitor_handle,
         })
     }
@@ -329,11 +343,13 @@ impl TransmitterBuilder {
             tx_channel_cap,
             maybe_ebpf,
             atomic_router,
+            neighbors,
+            neighbors_monitor_handle,
             route_monitor_handle,
         } = self;
 
         let (drop_sender, drop_receiver) = crossbeam_channel::bounded(DROP_CHANNEL_CAP);
-        let mut threads = vec![route_monitor_handle];
+        let mut threads = vec![route_monitor_handle, neighbors_monitor_handle];
 
         threads.push(
             Builder::new()
@@ -363,6 +379,7 @@ impl TransmitterBuilder {
             let (sender, receiver) = crossbeam_channel::bounded(tx_channel_cap);
             let drop_sender = drop_sender.clone();
             let atomic_router = Arc::clone(&atomic_router);
+            let mut neighbors = neighbors.clone();
             threads.push(
                 Builder::new()
                     .name(format!("solTransmIO{i:02}"))
@@ -370,7 +387,28 @@ impl TransmitterBuilder {
                         tx_loop.run(receiver, drop_sender, move |ip| {
                             let r = atomic_router.load();
                             match ip {
-                                IpAddr::V4(ip) => r.route_v4(*ip).ok(),
+                                IpAddr::V4(ip) => {
+                                    let next_hop = r.route_v4(*ip).ok()?;
+                                    if next_hop.neigh_requires_refresh {
+                                        if let Some(gre) = next_hop.gre.as_ref() {
+                                            neighbors.observe(
+                                                gre.underlay_if_index,
+                                                gre.underlay_ip_addr,
+                                                gre.underlay_mac_addr.is_some(),
+                                            );
+                                        } else {
+                                            let IpAddr::V4(neighbor_ip) = next_hop.ip_addr else {
+                                                return None;
+                                            };
+                                            neighbors.observe(
+                                                next_hop.if_index,
+                                                neighbor_ip,
+                                                next_hop.mac_addr.is_some(),
+                                            );
+                                        }
+                                    }
+                                    Some(next_hop)
+                                }
                                 IpAddr::V6(_) => None,
                             }
                         })

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -1,5 +1,5 @@
 #[cfg(target_os = "linux")]
-pub use crate::tx_loop::TrySendError;
+pub use crate::{neighbors::NeighborIntervals, tx_loop::TrySendError};
 use {
     crate::ecn_codepoint::EcnCodepoint,
     bytes::Bytes,
@@ -15,6 +15,7 @@ use {
     crate::{
         device::{NetworkDevice, QueueId},
         load_xdp_program,
+        neighbors::NeighborsObserver,
         route::{RouteTable, Router, RoutingTables},
         route_monitor::RouteMonitor,
         tx_loop::{self, TxLoop, TxLoopBuilder, TxLoopConfigBuilder, TxPacket},
@@ -293,6 +294,8 @@ pub struct TransmitterBuilder {
     tx_channel_cap: usize,
     maybe_ebpf: Option<Ebpf>,
     atomic_router: Arc<ArcSwap<Router>>,
+    neighbors: NeighborsObserver,
+    neighbors_monitor_handle: thread::JoinHandle<()>,
     route_monitor_handle: thread::JoinHandle<()>,
 }
 
@@ -304,7 +307,24 @@ impl TransmitterBuilder {
 
     #[cfg(target_os = "linux")]
     pub fn new(config: XdpConfig, exit: Arc<AtomicBool>) -> Result<Self, Box<dyn Error>> {
+        Self::new_with_intervals(
+            config,
+            exit,
+            NeighborIntervals {
+                use_interval: Duration::from_secs(30),
+                miss_interval: Duration::from_secs(1),
+            },
+        )
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn new_with_intervals(
+        config: XdpConfig,
+        exit: Arc<AtomicBool>,
+        neighbor_intervals: NeighborIntervals,
+    ) -> Result<Self, Box<dyn Error>> {
         use {
+            crate::neighbors::NeighborsRefresher,
             caps::Capability::{CAP_BPF, CAP_NET_ADMIN, CAP_NET_RAW, CAP_PERFMON},
             log::debug,
             std::{collections::HashSet, io},
@@ -389,6 +409,15 @@ impl TransmitterBuilder {
             router.routing_table()
         );
 
+        fn retain_cap_net_admin() {
+            // we need to retain CAP_NET_ADMIN in case the netlink socket needs reinitialized
+            let retained_caps = caps::CapsHashSet::from_iter([caps::Capability::CAP_NET_ADMIN]);
+            caps::set(None, caps::CapSet::Effective, &retained_caps)
+                .expect("linux allows effective capset to be set");
+            caps::set(None, caps::CapSet::Permitted, &retained_caps)
+                .expect("linux allows permitted capset to be set");
+        }
+
         // Use ArcSwap for lock-free updates of the routing table
         let atomic_router = Arc::new(ArcSwap::from_pointee(router));
         let route_monitor_handle = RouteMonitor::start(
@@ -397,15 +426,15 @@ impl TransmitterBuilder {
             exit.clone(),
             ROUTE_MONITOR_UPDATE_INTERVAL,
             || {
-                // we need to retain CAP_NET_ADMIN in case the netlink socket needs reinitialized
-                let retained_caps = caps::CapsHashSet::from_iter([caps::Capability::CAP_NET_ADMIN]);
-                caps::set(None, caps::CapSet::Effective, &retained_caps)
-                    .expect("linux allows effective capset to be set");
-                caps::set(None, caps::CapSet::Permitted, &retained_caps)
-                    .expect("linux allows permitted capset to be set");
+                retain_cap_net_admin();
                 info!("route monitor thread started");
             },
         );
+        let (neighbors_monitor_handle, neighbors) =
+            NeighborsRefresher::start(exit, neighbor_intervals, || {
+                retain_cap_net_admin();
+                info!("neighbors thread started");
+            })?;
 
         let maybe_ebpf = maybe_ebpf_result.transpose()?;
 
@@ -414,6 +443,8 @@ impl TransmitterBuilder {
             tx_channel_cap,
             maybe_ebpf,
             atomic_router,
+            neighbors,
+            neighbors_monitor_handle,
             route_monitor_handle,
         })
     }
@@ -432,11 +463,13 @@ impl TransmitterBuilder {
             tx_channel_cap,
             maybe_ebpf,
             atomic_router,
+            neighbors,
+            neighbors_monitor_handle,
             route_monitor_handle,
         } = self;
 
         let drop_queue = Arc::new(ArrayQueue::new(DROP_CHANNEL_CAP));
-        let mut threads = vec![route_monitor_handle];
+        let mut threads = vec![route_monitor_handle, neighbors_monitor_handle];
 
         threads.push(
             Builder::new()
@@ -469,6 +502,7 @@ impl TransmitterBuilder {
             let (sender, receiver) = tx_loop::channel(tx_channel_cap);
             let drop_queue = Arc::clone(&drop_queue);
             let atomic_router = Arc::clone(&atomic_router);
+            let mut neighbors = neighbors.clone();
             threads.push(
                 Builder::new()
                     .name(format!("solTransmIO{i:02}"))
@@ -480,13 +514,7 @@ impl TransmitterBuilder {
                                     drop(item);
                                 }
                             },
-                            move |ip| {
-                                let r = atomic_router.load();
-                                match ip {
-                                    IpAddr::V4(ip) => r.route_v4(*ip).ok(),
-                                    IpAddr::V6(_) => None,
-                                }
-                            },
+                            move |ip| route(ip, &atomic_router.load(), &mut neighbors),
                         )
                     })
                     .unwrap(),
@@ -496,6 +524,34 @@ impl TransmitterBuilder {
 
         (Transmitter { threads }, XdpSender { senders })
     }
+}
+
+#[cfg(target_os = "linux")]
+fn route(
+    ip: &IpAddr,
+    router: &Router,
+    neighbors: &mut NeighborsObserver,
+) -> Option<crate::route::NextHop> {
+    let IpAddr::V4(ip) = ip else {
+        return None;
+    };
+
+    let next_hop = router.route_v4(*ip).ok()?;
+    if next_hop.neigh_requires_refresh {
+        if let Some(gre) = next_hop.gre.as_ref() {
+            neighbors.observe(
+                gre.underlay_if_index,
+                gre.underlay_ip_addr,
+                gre.underlay_mac_addr.is_some(),
+            );
+        } else {
+            let IpAddr::V4(neighbor_ip) = next_hop.ip_addr else {
+                return None;
+            };
+            neighbors.observe(next_hop.if_index, neighbor_ip, next_hop.mac_addr.is_some());
+        }
+    }
+    Some(next_hop)
 }
 
 impl Transmitter {

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -198,11 +198,11 @@ pub trait TxPacket {
 }
 
 impl<U: Umem> TxLoop<U> {
-    pub fn run<T: TxPacket, R: Fn(&IpAddr) -> Option<NextHop>>(
+    pub fn run<T: TxPacket, R: FnMut(&IpAddr) -> Option<NextHop>>(
         self,
         receiver: Receiver<T>,
         drop_sender: Sender<T>,
-        route_fn: R,
+        mut route_fn: R,
     ) {
         // How long we sleep waiting to receive shreds from the channel.
         const RECV_TIMEOUT: Duration = Duration::from_nanos(1000);

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -317,13 +317,24 @@ impl<U: Umem> TxLoop<U> {
                     };
 
                     if let Some(gre) = &next_hop.gre {
+                        let Some(dest_mac) = gre.underlay_mac_addr else {
+                            log::warn!(
+                                "dropping packet: GRE peer {addr} must be routed through {} on \
+                                 if{} which has no known MAC address",
+                                gre.underlay_ip_addr,
+                                gre.underlay_if_index
+                            );
+                            batched_packets -= 1;
+                            umem.release(frame.offset());
+                            continue;
+                        };
                         frame.set_len(gre_packet_size(len));
                         let packet = umem.map_frame_mut(&frame);
                         let inner_src_ip = next_hop.preferred_src_ip.as_ref().unwrap_or(src_ip);
                         if let Err(err) = construct_gre_packet(
                             packet,
                             &src_mac,
-                            &gre.mac_addr,
+                            &dest_mac,
                             inner_src_ip,
                             &dst_ip,
                             src_port,

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -325,12 +325,12 @@ impl<T> Receiver<T> for TxReceiver<T> {
 }
 
 impl<U: Umem> TxLoop<U> {
-    pub fn run<T, Rx, D, R>(self, receiver: Rx, mut drop_item: D, route_fn: R)
+    pub fn run<T, Rx, D, R>(self, receiver: Rx, mut drop_item: D, mut route_fn: R)
     where
         T: TxPacket,
         Rx: Receiver<T>,
         D: FnMut(T),
-        R: Fn(&IpAddr) -> Option<NextHop>,
+        R: FnMut(&IpAddr) -> Option<NextHop>,
     {
         // How long we sleep waiting to receive packets from the channel.
         const RECV_TIMEOUT: Duration = Duration::from_nanos(1000);

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -431,6 +431,17 @@ impl<U: Umem> TxLoop<U> {
                 };
 
                 if let Some(gre) = &next_hop.gre {
+                    let Some(dest_mac) = gre.underlay_mac_addr else {
+                        log::warn!(
+                            "dropping packet: GRE peer {addr} must be routed through {} on if{} \
+                             which has no known MAC address",
+                            gre.underlay_ip_addr,
+                            gre.underlay_if_index
+                        );
+                        umem.release(frame);
+                        continue;
+                    };
+
                     let l3_inner_packet_len = INNER_PACKET_HEADER_SIZE + len;
                     let l3_outer_gre_packet_len =
                         IP_HEADER_SIZE + GRE_HEADER_BASE_SIZE + l3_inner_packet_len;
@@ -468,7 +479,7 @@ impl<U: Umem> TxLoop<U> {
                     if let Err(err) = construct_gre_packet(
                         &mut packet,
                         &src_mac,
-                        &gre.mac_addr,
+                        &dest_mac,
                         inner_src_ip,
                         &dst_ip,
                         src_port,

--- a/xdp/tests/route_monitor.rs
+++ b/xdp/tests/route_monitor.rs
@@ -248,7 +248,7 @@ fn route_monitor_publishes_live_gre_route_updates() {
                         && next_hop.preferred_src_ip == Some(gre.overlay_ip)
                         && next_hop.gre.as_ref().is_some_and(|gre_route| {
                             gre_route.if_index == gre.if_index
-                                && gre_route.mac_addr == links.right_mac
+                                && gre_route.underlay_mac_addr == Some(links.right_mac)
                                 && gre_route.tunnel_info.local == IpAddr::V4(gre.local_ip)
                                 && gre_route.tunnel_info.remote == IpAddr::V4(gre.remote_ip)
                         }) =>

--- a/xdp/tests/router_snapshot.rs
+++ b/xdp/tests/router_snapshot.rs
@@ -35,7 +35,7 @@ fn router_snapshot_resolves_gre_routes_from_netlink() {
 
         let gre_route = next_hop.gre.as_ref().expect("route should use GRE");
         assert_eq!(gre_route.if_index, gre.if_index);
-        assert_eq!(gre_route.mac_addr, links.right_mac);
+        assert_eq!(gre_route.underlay_mac_addr, Some(links.right_mac));
         assert_eq!(gre_route.tunnel_info.local, IpAddr::V4(gre.local_ip));
         assert_eq!(gre_route.tunnel_info.remote, IpAddr::V4(gre.remote_ip));
         assert_eq!(gre_route.tunnel_info.ttl, 64);

--- a/xdp/tests/transmitter_smoke.rs
+++ b/xdp/tests/transmitter_smoke.rs
@@ -6,10 +6,11 @@ use {
     agave_cpu_utils::cpu_affinity,
     agave_xdp::{
         gre::packet::GRE_HEADER_BASE_SIZE,
-        netlink::MacAddress,
+        netlink::{MacAddress, netlink_get_neighbors},
         packet::{ETH_HEADER_SIZE, IP_HEADER_SIZE, UDP_HEADER_SIZE},
         transmitter::{
-            BytesTxPacket, QueueCpuBinding, Transmitter, TransmitterBuilder, XdpConfig, XdpSender,
+            BytesTxPacket, NeighborIntervals, QueueCpuBinding, Transmitter, TransmitterBuilder,
+            XdpConfig, XdpSender,
         },
     },
     bytes::Bytes,
@@ -22,8 +23,8 @@ use {
         },
     },
     std::{
-        io, mem,
-        net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+        fs, io, mem,
+        net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
         ops::Range,
         os::fd::{AsFd, AsRawFd, OwnedFd},
         sync::{
@@ -400,6 +401,152 @@ fn transmitter_sends_udp_payload_over_veth_in_copy_mode() {
             Duration::from_secs(3),
         )
         .expect("receive UDP frame from AF_XDP transmitter");
+    assert_eq!(received, payload.as_ref());
+}
+
+#[test]
+#[ignore = "requires root and network namespace privileges"]
+fn transmitter_resolves_neighbors() {
+    let cpu_id = transmitter_cpu();
+
+    let _netns = common::NetNsGuard::new().expect("create network namespace");
+    let links = common::setup_veth_pair_with_tx_queue_count(1);
+
+    // both veth endpoints are local, configure the peer to accept ARP from a local source address.
+    fs::write("/proc/sys/net/ipv4/conf/axdp1/accept_local", "1")
+        .expect("enable accept_local on veth peer");
+
+    let neighbor_intervals = NeighborIntervals {
+        use_interval: Duration::from_millis(100),
+        miss_interval: Duration::from_millis(10),
+    };
+    // how long before a neighbor entry is considered stale and needs to be touched again
+    fs::write(
+        "/proc/sys/net/ipv4/neigh/axdp0/base_reachable_time_ms",
+        "500",
+    )
+    .expect("shorten neighbor reachable time");
+    fs::write("/proc/sys/net/ipv4/neigh/axdp0/delay_first_probe_time", "0")
+        .expect("disable neighbor probe delay");
+
+    let receiver = PacketSocket::bind(links.right_if_index).expect("bind raw packet receiver");
+    let dst_port = 45_682;
+    let src_port = 12_348;
+    let destination = SocketAddr::V4(SocketAddrV4::new(links.right_ip, dst_port));
+
+    let exit = Arc::new(AtomicBool::new(false));
+    let config = XdpConfig::with_tx_channel_cap(
+        Some(common::LEFT_IFACE.to_string()),
+        vec![QueueCpuBinding {
+            queue: 0,
+            cpu: cpu_id,
+        }],
+        false,
+        TEST_TX_CHANNEL_CAP,
+    );
+    let (transmitter, sender) =
+        TransmitterBuilder::new_with_intervals(config, Arc::clone(&exit), neighbor_intervals)
+            .expect("build copy-mode transmitter")
+            .build();
+    let transmitter = TransmitterGuard::new(transmitter, sender, exit);
+
+    let neighbors = netlink_get_neighbors(None, libc::AF_INET as u8).expect("read neighbor table");
+    assert!(
+        neighbors.iter().all(|neighbor| {
+            neighbor.ifindex != links.left_if_index as i32
+                || neighbor.destination != Some(IpAddr::V4(links.right_ip))
+        }),
+        "neighbor unexpectedly exists before sending"
+    );
+
+    // this should resolve the neighbor. The packet is lost because the neighbor is not yet
+    // reachable.
+    let packet = BytesTxPacket::new(
+        SocketAddrV4::new(links.left_ip, src_port),
+        destination,
+        None,
+        Bytes::from_static(b"agave-xdp-neighbor-resolution"),
+    );
+    transmitter
+        .sender()
+        .try_send(0, packet)
+        .expect("queue packet to resolve neighbor");
+
+    common::wait_until(
+        "neighbor to become reachable",
+        Duration::from_secs(3),
+        || {
+            netlink_get_neighbors(None, libc::AF_INET as u8)
+                .expect("read neighbor table")
+                .into_iter()
+                .find(|neighbor| {
+                    neighbor.ifindex == links.left_if_index as i32
+                        && neighbor.destination == Some(IpAddr::V4(links.right_ip))
+                        && neighbor.lladdr == Some(links.right_mac)
+                        && neighbor.state & libc::NUD_REACHABLE != 0
+                })
+        },
+    );
+
+    // now wait for it to go stale
+    common::wait_until("neighbor to become stale", Duration::from_secs(3), || {
+        netlink_get_neighbors(None, libc::AF_INET as u8)
+            .expect("read neighbor table")
+            .into_iter()
+            .find(|neighbor| {
+                neighbor.ifindex == links.left_if_index as i32
+                    && neighbor.destination == Some(IpAddr::V4(links.right_ip))
+                    && neighbor.lladdr == Some(links.right_mac)
+                    && neighbor.state & libc::NUD_STALE != 0
+            })
+    });
+
+    // this should refresh
+    let payload = Bytes::from_static(b"agave-xdp-neighbor-touch");
+    let packet = BytesTxPacket::new(
+        SocketAddrV4::new(links.left_ip, src_port),
+        destination,
+        None,
+        payload.clone(),
+    );
+    transmitter
+        .sender()
+        .try_send(0, packet)
+        .expect("queue packet to touch stale neighbor");
+
+    common::wait_until(
+        "stale neighbor to be touched",
+        Duration::from_secs(3),
+        || {
+            netlink_get_neighbors(None, libc::AF_INET as u8)
+                .expect("read neighbor table")
+                .into_iter()
+                .find(|neighbor| {
+                    let touched = libc::NUD_DELAY | libc::NUD_PROBE | libc::NUD_REACHABLE;
+                    neighbor.ifindex == links.left_if_index as i32
+                        && neighbor.destination == Some(IpAddr::V4(links.right_ip))
+                        && neighbor.lladdr == Some(links.right_mac)
+                        && neighbor.state & touched != 0
+                })
+        },
+    );
+
+    let mut buf = [0u8; 2048];
+    let received = receiver
+        .recv_matching_udp(
+            &mut buf,
+            &ExpectedUdpPacket {
+                src_mac: links.left_mac,
+                dst_mac: links.right_mac,
+                src_ip: links.left_ip,
+                dst_ip: links.right_ip,
+                src_port,
+                dst_port,
+                payload: payload.as_ref(),
+            },
+            Duration::from_secs(3),
+        )
+        .expect("receive UDP frame after touching stale neighbor");
     assert_eq!(received, payload.as_ref());
 }
 


### PR DESCRIPTION
We use a mixed socket/XDP stack and currently rely on the socket code to resolve and keep neigh entries alive. 

This PR implements neigh resolution in agave-xdp itself so we don't have to rely on socket code. It resolves entries and keeps them alive as they are used. 