### PR TITLE
SIMD-0232: Respect inflation reward collector

### DIFF
--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -19,7 +19,7 @@ use {
 };
 
 #[derive(Error, Debug, PartialEq)]
-enum DepositFeeError {
+pub(super) enum DepositFeeError {
     #[error("fee account became rent paying")]
     InvalidRentPayingAccount,
     #[error("lamport overflow")]
@@ -228,7 +228,7 @@ impl Bank {
         Ok(account.lamports())
     }
 
-    fn check_collector_account(
+    pub(super) fn check_collector_account(
         collector_id: &Pubkey,
         pre_lamports: u64,
         account: &AccountSharedData,

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -454,6 +454,7 @@ impl Bank {
         new_rate_activation_epoch: Option<Epoch>,
         delay_commission_updates: bool,
         commission_rate_in_basis_points: bool,
+        custom_commission_collector: bool,
     ) -> Option<DelegationRewards> {
         // curry closure to add the contextual stake_pubkey
         let reward_calc_tracer = reward_calc_tracer.as_ref().map(|outer| {
@@ -522,13 +523,22 @@ impl Bank {
                     stake_reward,
                     commission_bps,
                 };
+                let (commission_pubkey, is_vote_account) = if custom_commission_collector {
+                    let commission_pubkey = *vote_state
+                        .inflation_rewards_collector()
+                        .unwrap_or(&vote_pubkey);
+                    (commission_pubkey, commission_pubkey == vote_pubkey)
+                } else {
+                    (vote_pubkey, true)
+                };
                 let reward_commission = RewardCommission {
                     commission_bps,
                     commission_lamports,
+                    is_vote_account,
                 };
                 Some(DelegationRewards {
                     stake_reward,
-                    commission_pubkey: vote_pubkey,
+                    commission_pubkey,
                     reward_commission,
                 })
             }
@@ -556,6 +566,7 @@ impl Bank {
         let feature_snapshot = self.feature_set.snapshot();
         let delay_commission_updates = feature_snapshot.delay_commission_updates;
         let commission_rate_in_basis_points = feature_snapshot.commission_rate_in_basis_points;
+        let custom_commission_collector = feature_snapshot.custom_commission_collector;
 
         let mut measure_redeem_rewards = Measure::start("redeem-rewards");
         // For N stake delegations, where N is >1,000,000, we produce:
@@ -587,6 +598,7 @@ impl Bank {
                                 new_warmup_cooldown_rate_epoch,
                                 delay_commission_updates,
                                 commission_rate_in_basis_points,
+                                custom_commission_collector,
                             )
                         });
                     let (stake_reward, maybe_reward_record) = match maybe_reward_record {
@@ -793,6 +805,12 @@ impl Bank {
         reward_commissions: &RewardCommissions,
         thread_pool: &ThreadPool,
     ) -> RewardCommissionAccounts {
+        let reserved_account_keys = &self.reserved_account_keys;
+        let rent = &self.rent_collector().rent;
+        let feature_snapshot = self.feature_set.snapshot();
+        let relax_post_exec_min_balance_check = feature_snapshot.relax_post_exec_min_balance_check;
+        let custom_commission_collector = feature_snapshot.custom_commission_collector;
+
         let accounts_with_rewards: Vec<_> = thread_pool.install(|| {
             reward_commissions
                 .par_iter()
@@ -802,23 +820,46 @@ impl Bank {
                         RewardCommission {
                             commission_bps,
                             commission_lamports,
+                            is_vote_account,
                             ..
                         },
                     )| {
-                        let Some(mut commission_account) =
-                            self.get_account_with_fixed_root_no_cache(commission_pubkey)
-                        else {
-                            debug!(
-                                "commission account {commission_pubkey} missing at distribution \
+                        let maybe_commission_account = self
+                            .get_account_with_fixed_root_no_cache(commission_pubkey);
+                        let mut commission_account = if custom_commission_collector {
+                            maybe_commission_account.unwrap_or_default()
+                        } else {
+                            let Some(commission_account) = maybe_commission_account else {
+                                debug!(
+                                    "commission account {commission_pubkey} missing at distribution \
                                  time"
-                            );
-                            return None;
+                                );
+                                return None;
+                            };
+                            commission_account
                         };
+                        let pre_lamports = commission_account.lamports();
                         if let Err(err) =
                             commission_account.checked_add_lamports(*commission_lamports)
                         {
                             debug!("reward redemption failed for {commission_pubkey}: {err:?}");
                             return None;
+                        }
+                        if !is_vote_account {
+                            if let Err(err) = Self::check_collector_account(
+                                commission_pubkey,
+                                pre_lamports,
+                                &commission_account,
+                                reserved_account_keys,
+                                rent,
+                                relax_post_exec_min_balance_check,
+                            ) {
+                                debug!(
+                                    "reward redemption failed for {commission_pubkey} due to \
+                                     commission account error: {err:?}"
+                                );
+                                return None;
+                            }
                         }
                         Some((
                             *commission_pubkey,
@@ -834,6 +875,7 @@ impl Bank {
                 )
                 .collect()
         });
+
         let total_reward_commission_lamports = accounts_with_rewards
             .iter()
             .map(|(_, info, _)| info.lamports as u64)
@@ -893,6 +935,7 @@ mod tests {
         solana_epoch_schedule::EpochSchedule,
         solana_keypair::Keypair,
         solana_native_token::LAMPORTS_PER_SOL,
+        solana_rent::Rent,
         solana_signer::Signer,
         solana_stake_interface::{
             stake_flags::StakeFlags,
@@ -1132,6 +1175,7 @@ mod tests {
         delegate_stake_amount: Option<u64>,
         new_commission: Option<u8>,
         earned_credits: Option<u64>,
+        new_inflation_rewards_collector: Option<Pubkey>,
     }
 
     fn recalculate_reward_commission_for_tests(
@@ -1165,19 +1209,34 @@ mod tests {
             null_tracer(),
             &mut RewardsMetrics::default(), // This is required, but not reporting anything at the moment
         );
-        reward_commissions.get(commission_pubkey).map(|rc| {
+        reward_commissions.get(commission_pubkey).and_then(|rc| {
+            let commission_account = bank.get_account(commission_pubkey).unwrap_or_default();
             // In the recalculation path, commissions have already been
             // distributed — so the current account balance already includes
             // them. We report that balance as the post_balance.
-            let post_balance = bank
-                .get_account(commission_pubkey)
-                .map(|a| a.lamports())
-                .unwrap_or(0);
-            RewardInfo {
-                reward_type: RewardType::Voting,
-                lamports: rc.commission_lamports as i64,
-                post_balance,
-                commission_bps: Some(rc.commission_bps),
+            let post_balance = commission_account.lamports();
+
+            // This is artificial, but mimics the actual distribution logic a
+            // bit better
+            if *commission_account.owner() != solana_vote_program::id()
+                && Bank::check_collector_account(
+                    commission_pubkey,
+                    post_balance.saturating_sub(rc.commission_lamports),
+                    &commission_account,
+                    &bank.reserved_account_keys,
+                    &bank.rent_collector().rent,
+                    true,
+                )
+                .is_err()
+            {
+                None
+            } else {
+                Some(RewardInfo {
+                    reward_type: RewardType::Voting,
+                    lamports: rc.commission_lamports as i64,
+                    post_balance,
+                    commission_bps: Some(rc.commission_bps),
+                })
             }
         })
     }
@@ -1269,6 +1328,12 @@ mod tests {
                 });
             }
 
+            if let Some(inflation_rewards_collector) = vote_op.new_inflation_rewards_collector {
+                modify_vote_state(&|vote_state: &mut VoteStateV4| {
+                    vote_state.inflation_rewards_collector = inflation_rewards_collector;
+                });
+            }
+
             if let Some(earned_credits) = vote_op.earned_credits {
                 modify_vote_state(&|vote_state: &mut VoteStateV4| {
                     let last_credits = vote_state
@@ -1293,28 +1358,37 @@ mod tests {
 
         for (vote_address, vote_op) in &op.vote_operations {
             let expected_commission = vote_op.expected_reward_commission;
+            // some tests delegate before the vote account exists
+            let collector_address = bank
+                .get_account(vote_address)
+                .map(|vote_account| {
+                    VoteStateV4::deserialize(vote_account.data(), vote_address)
+                        .unwrap()
+                        .inflation_rewards_collector
+                })
+                .unwrap_or(*vote_address);
             let recalculated_vote_reward =
-                recalculate_reward_commission_for_tests(&bank, vote_address);
+                recalculate_reward_commission_for_tests(&bank, &collector_address);
             let vote_reward = bank
                 .rewards
                 .read()
                 .unwrap()
                 .iter()
-                .find(|(address, _reward)| address == vote_address)
+                .find(|(address, _reward)| *address == collector_address)
                 .map(|(_address, reward)| *reward);
 
-            let prev_vote_balance = prev_bank
-                .get_account(vote_address)
+            let prev_collector_balance = prev_bank
+                .get_account(&collector_address)
                 .unwrap_or_default()
                 .lamports();
-            let vote_balance = bank.get_balance(vote_address);
+            let collector_balance = bank.get_balance(&collector_address);
 
             if let Some(expected_commission) = &expected_commission {
-                let reward_lamports = vote_balance - prev_vote_balance;
+                let reward_lamports = collector_balance - prev_collector_balance;
                 let expected_vote_reward = RewardInfo {
                     reward_type: RewardType::Voting,
                     lamports: reward_lamports as i64,
-                    post_balance: vote_balance,
+                    post_balance: collector_balance,
                     commission_bps: Some(*expected_commission as u16 * 100),
                 };
 
@@ -2141,6 +2215,7 @@ mod tests {
             RewardCommission {
                 commission_bps: 1_000,
                 commission_lamports: 50,
+                is_vote_account: true,
             },
             50,
         );
@@ -2149,6 +2224,7 @@ mod tests {
             RewardCommission {
                 commission_bps: 1_000,
                 commission_lamports: 50,
+                is_vote_account: true,
             },
             50,
         );
@@ -2157,6 +2233,7 @@ mod tests {
             RewardCommission {
                 commission_bps: 1_000,
                 commission_lamports: 30,
+                is_vote_account: true,
             },
             30,
         );
@@ -2165,6 +2242,7 @@ mod tests {
             RewardCommission {
                 commission_bps: 1_000,
                 commission_lamports: 50,
+                is_vote_account: true,
             },
             50,
         );
@@ -2492,6 +2570,7 @@ mod tests {
             RewardCommission {
                 commission_bps: 0,
                 commission_lamports: 1, // enough to overflow
+                is_vote_account: true,
             },
         );
         let result = bank.load_and_reward_commission_accounts(&reward_commissions, &thread_pool);
@@ -2518,6 +2597,7 @@ mod tests {
             RewardCommission {
                 commission_bps: 500,
                 commission_lamports,
+                is_vote_account: true,
             },
         );
 
@@ -2566,6 +2646,7 @@ mod tests {
                     RewardCommission {
                         commission_bps,
                         commission_lamports,
+                        is_vote_account: true,
                     },
                 );
                 let result =
@@ -2585,5 +2666,163 @@ mod tests {
                 assert_eq!(*pubkey_result, pubkey);
             }
         }
+    }
+
+    #[test]
+    fn test_inflation_rewards_collector() {
+        let GenesisConfigInfo {
+            mut genesis_config, ..
+        } = genesis_utils::create_genesis_config_with_leader(
+            1_000_000 * LAMPORTS_PER_SOL,
+            &Pubkey::new_unique(),
+            42 * LAMPORTS_PER_SOL,
+        );
+
+        genesis_config.rent = Rent::default();
+        genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
+
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        let vote_address = Pubkey::new_unique();
+
+        // Vote account just created
+        let mut bank = apply_epoch_operations(
+            bank,
+            bank_forks.as_ref(),
+            EpochOperations {
+                epoch: 0,
+                vote_operations: vec![(
+                    vote_address,
+                    VoteOperations {
+                        create_with_balance: Some(LAMPORTS_PER_SOL),
+                        new_commission: Some(1),
+                        earned_credits: Some(1000),
+                        delegate_stake_amount: Some(LAMPORTS_PER_SOL),
+                        ..VoteOperations::default()
+                    },
+                )],
+            },
+        );
+
+        for (epoch, (collector_address, maybe_account, expected_reward_commission)) in [
+            // system account with lamports, success
+            (
+                Pubkey::new_unique(),
+                Some(AccountSharedData::new(
+                    LAMPORTS_PER_SOL,
+                    0,
+                    &solana_sdk_ids::system_program::id(),
+                )),
+                Some(1),
+            ),
+            // vote account, success
+            (vote_address, None, Some(1)),
+            // incinerator, success
+            (solana_sdk_ids::incinerator::id(), None, Some(1)),
+            // non-rent-exempt system account with 1 lamport, success with relaxed checks
+            (
+                Pubkey::new_unique(),
+                Some(AccountSharedData::new(
+                    1,
+                    0,
+                    &solana_sdk_ids::system_program::id(),
+                )),
+                Some(1),
+            ),
+            // invalid owner, no commission
+            (
+                Pubkey::new_unique(),
+                Some(AccountSharedData::new(
+                    LAMPORTS_PER_SOL,
+                    0,
+                    &Pubkey::new_unique(),
+                )),
+                None,
+            ),
+            // reserved account, no commission
+            (solana_sdk_ids::native_loader::id(), None, None),
+            // non-rent-exempt system account, no commission
+            (Pubkey::new_unique(), None, None),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            if let Some(account) = maybe_account {
+                bank.store_account(&collector_address, &account);
+            }
+            println!("{epoch}");
+            bank = apply_epoch_operations(
+                bank,
+                bank_forks.as_ref(),
+                EpochOperations {
+                    epoch: epoch as u64 + 1,
+                    vote_operations: vec![(
+                        vote_address,
+                        VoteOperations {
+                            earned_credits: Some(1),
+                            new_inflation_rewards_collector: Some(collector_address),
+                            expected_reward_commission,
+                            ..VoteOperations::default()
+                        },
+                    )],
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn test_inflation_rewards_collector_becomes_rent_exempt() {
+        let GenesisConfigInfo {
+            mut genesis_config, ..
+        } = genesis_utils::create_genesis_config_with_leader(
+            1_000_000 * LAMPORTS_PER_SOL,
+            &Pubkey::new_unique(),
+            42 * LAMPORTS_PER_SOL,
+        );
+
+        genesis_config.rent = Rent::default();
+        genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
+
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        let vote_address = Pubkey::new_unique();
+
+        // Vote account just created
+        let bank = apply_epoch_operations(
+            bank,
+            bank_forks.as_ref(),
+            EpochOperations {
+                epoch: 0,
+                vote_operations: vec![(
+                    vote_address,
+                    VoteOperations {
+                        create_with_balance: Some(LAMPORTS_PER_SOL),
+                        new_commission: Some(100),
+                        earned_credits: Some(1000),
+                        delegate_stake_amount: Some(LAMPORTS_PER_SOL),
+                        new_inflation_rewards_collector: Some(Pubkey::new_unique()),
+                        ..VoteOperations::default()
+                    },
+                )],
+            },
+        );
+
+        // next epoch, get reward into new account
+        let epoch = bank.epoch();
+        apply_epoch_operations(
+            bank,
+            bank_forks.as_ref(),
+            EpochOperations {
+                epoch,
+                vote_operations: vec![(
+                    vote_address,
+                    VoteOperations {
+                        earned_credits: Some(1),
+                        expected_reward_commission: Some(100),
+                        ..VoteOperations::default()
+                    },
+                )],
+            },
+        );
     }
 }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -57,6 +57,16 @@ impl RewardsAccumulator {
         self.reward_commissions
             .entry(commission_pubkey)
             .and_modify(|dst_reward_commission| {
+                // If a commission account is used by multiple vote accounts,
+                // the reported `commission_bps` may be incorrect. To keep
+                // things simple and correct, don't report `commission_bps` if
+                // there's any variation.
+                if dst_reward_commission
+                    .commission_bps
+                    .is_some_and(|bps| Some(bps) != reward_commission.commission_bps)
+                {
+                    dst_reward_commission.commission_bps = None;
+                }
                 dst_reward_commission.commission_lamports = dst_reward_commission
                     .commission_lamports
                     .saturating_add(reward_commission.commission_lamports)
@@ -532,7 +542,7 @@ impl Bank {
                     (vote_pubkey, true)
                 };
                 let reward_commission = RewardCommission {
-                    commission_bps,
+                    commission_bps: Some(commission_bps),
                     commission_lamports,
                     is_vote_account,
                 };
@@ -824,15 +834,15 @@ impl Bank {
                             ..
                         },
                     )| {
-                        let maybe_commission_account = self
-                            .get_account_with_fixed_root_no_cache(commission_pubkey);
+                        let maybe_commission_account =
+                            self.get_account_with_fixed_root_no_cache(commission_pubkey);
                         let mut commission_account = if custom_commission_collector {
                             maybe_commission_account.unwrap_or_default()
                         } else {
                             let Some(commission_account) = maybe_commission_account else {
                                 debug!(
-                                    "commission account {commission_pubkey} missing at distribution \
-                                 time"
+                                    "commission account {commission_pubkey} missing at \
+                                     distribution time"
                                 );
                                 return None;
                             };
@@ -867,7 +877,7 @@ impl Bank {
                                 reward_type: RewardType::Voting,
                                 lamports: *commission_lamports as i64,
                                 post_balance: commission_account.lamports(),
-                                commission_bps: Some(*commission_bps),
+                                commission_bps: *commission_bps,
                             },
                             commission_account,
                         ))
@@ -1169,7 +1179,8 @@ mod tests {
 
     #[derive(Default)]
     struct VoteOperations {
-        expected_reward_commission: Option<u8>,
+        expect_reward: bool,
+        expected_reward_commission: Option<u16>,
         // ops to perform before epoch ends
         create_with_balance: Option<u64>,
         delegate_stake_amount: Option<u64>,
@@ -1235,7 +1246,7 @@ mod tests {
                     reward_type: RewardType::Voting,
                     lamports: rc.commission_lamports as i64,
                     post_balance,
-                    commission_bps: Some(rc.commission_bps),
+                    commission_bps: rc.commission_bps,
                 })
             }
         })
@@ -1357,7 +1368,6 @@ mod tests {
             Bank::new_from_parent_with_bank_forks(bank_forks, bank, SlotLeader::new_unique(), slot);
 
         for (vote_address, vote_op) in &op.vote_operations {
-            let expected_commission = vote_op.expected_reward_commission;
             // some tests delegate before the vote account exists
             let collector_address = bank
                 .get_account(vote_address)
@@ -1383,13 +1393,13 @@ mod tests {
                 .lamports();
             let collector_balance = bank.get_balance(&collector_address);
 
-            if let Some(expected_commission) = &expected_commission {
+            if vote_op.expect_reward {
                 let reward_lamports = collector_balance - prev_collector_balance;
                 let expected_vote_reward = RewardInfo {
                     reward_type: RewardType::Voting,
                     lamports: reward_lamports as i64,
                     post_balance: collector_balance,
-                    commission_bps: Some(*expected_commission as u16 * 100),
+                    commission_bps: vote_op.expected_reward_commission,
                 };
 
                 assert_eq!(
@@ -1480,7 +1490,8 @@ mod tests {
                         VoteOperations {
                             new_commission: Some(2),
                             earned_credits: Some(1000),
-                            expected_reward_commission: Some(expected_commission),
+                            expect_reward: true,
+                            expected_reward_commission: Some(expected_commission * 100),
                             ..VoteOperations::default()
                         },
                     )],
@@ -1499,7 +1510,8 @@ mod tests {
                     VoteOperations {
                         new_commission: Some(3),
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(expected_commission),
+                        expect_reward: true,
+                        expected_reward_commission: Some(expected_commission * 100),
                         ..VoteOperations::default()
                     },
                 )],
@@ -1552,7 +1564,8 @@ mod tests {
                         create_with_balance: Some(LAMPORTS_PER_SOL),
                         new_commission: Some(1),
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(1),
+                        expect_reward: true,
+                        expected_reward_commission: Some(100),
                         ..VoteOperations::default()
                     },
                 )],
@@ -1572,7 +1585,8 @@ mod tests {
                     VoteOperations {
                         new_commission: Some(2),
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(1),
+                        expect_reward: true,
+                        expected_reward_commission: Some(100),
                         ..VoteOperations::default()
                     },
                 )],
@@ -1589,7 +1603,8 @@ mod tests {
                     VoteOperations {
                         new_commission: Some(3),
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(1),
+                        expect_reward: true,
+                        expected_reward_commission: Some(100),
                         ..VoteOperations::default()
                     },
                 )],
@@ -1628,6 +1643,7 @@ mod tests {
                     VoteOperations {
                         new_commission: Some(1),
                         earned_credits: Some(1000),
+                        expect_reward: true,
                         expected_reward_commission: Some(0),
                         ..VoteOperations::default()
                     },
@@ -1647,6 +1663,7 @@ mod tests {
                     VoteOperations {
                         new_commission: Some(2),
                         earned_credits: Some(1000),
+                        expect_reward: true,
                         expected_reward_commission: Some(0),
                         ..VoteOperations::default()
                     },
@@ -1663,7 +1680,8 @@ mod tests {
                     genesis_vote_address,
                     VoteOperations {
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(1),
+                        expect_reward: true,
+                        expected_reward_commission: Some(100),
                         ..VoteOperations::default()
                     },
                 )],
@@ -1679,7 +1697,8 @@ mod tests {
                     genesis_vote_address,
                     VoteOperations {
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(2),
+                        expect_reward: true,
+                        expected_reward_commission: Some(200),
                         ..VoteOperations::default()
                     },
                 )],
@@ -1695,7 +1714,8 @@ mod tests {
                     genesis_vote_address,
                     VoteOperations {
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(2),
+                        expect_reward: true,
+                        expected_reward_commission: Some(200),
                         ..VoteOperations::default()
                     },
                 )],
@@ -1761,7 +1781,7 @@ mod tests {
         let vote_rewards = 0;
         let commission_bps = vote_state.inflation_rewards_commission_bps;
         assert_eq!(reward_commission.commission_lamports, vote_rewards);
-        assert_eq!(reward_commission.commission_bps, commission_bps);
+        assert_eq!(reward_commission.commission_bps, Some(commission_bps));
 
         assert_eq!(stake_reward_calculation.stake_rewards.num_rewards(), 1);
         let expected_reward = {
@@ -2213,7 +2233,7 @@ mod tests {
         accumulator1.add_reward(
             commission_pubkey_a,
             RewardCommission {
-                commission_bps: 1_000,
+                commission_bps: Some(1_000),
                 commission_lamports: 50,
                 is_vote_account: true,
             },
@@ -2222,7 +2242,7 @@ mod tests {
         accumulator1.add_reward(
             commission_pubkey_b,
             RewardCommission {
-                commission_bps: 1_000,
+                commission_bps: Some(1_000),
                 commission_lamports: 50,
                 is_vote_account: true,
             },
@@ -2231,7 +2251,7 @@ mod tests {
         accumulator2.add_reward(
             commission_pubkey_b,
             RewardCommission {
-                commission_bps: 1_000,
+                commission_bps: Some(1_000),
                 commission_lamports: 30,
                 is_vote_account: true,
             },
@@ -2240,7 +2260,7 @@ mod tests {
         accumulator2.add_reward(
             commission_pubkey_c,
             RewardCommission {
-                commission_bps: 1_000,
+                commission_bps: Some(1_000),
                 commission_lamports: 50,
                 is_vote_account: true,
             },
@@ -2253,28 +2273,28 @@ mod tests {
             .reward_commissions
             .get(&commission_pubkey_a)
             .unwrap();
-        assert_eq!(reward_commission_a_1.commission_bps, 1_000);
+        assert_eq!(reward_commission_a_1.commission_bps, Some(1_000));
         assert_eq!(reward_commission_a_1.commission_lamports, 50);
 
         let reward_commission_b_1 = accumulator1
             .reward_commissions
             .get(&commission_pubkey_b)
             .unwrap();
-        assert_eq!(reward_commission_b_1.commission_bps, 1_000);
+        assert_eq!(reward_commission_b_1.commission_bps, Some(1_000));
         assert_eq!(reward_commission_b_1.commission_lamports, 50);
 
         let reward_commission_b_2 = accumulator2
             .reward_commissions
             .get(&commission_pubkey_b)
             .unwrap();
-        assert_eq!(reward_commission_b_2.commission_bps, 1_000);
+        assert_eq!(reward_commission_b_2.commission_bps, Some(1_000));
         assert_eq!(reward_commission_b_2.commission_lamports, 30);
 
         let reward_commission_c_2 = accumulator2
             .reward_commissions
             .get(&commission_pubkey_c)
             .unwrap();
-        assert_eq!(reward_commission_c_2.commission_bps, 1_000);
+        assert_eq!(reward_commission_c_2.commission_bps, Some(1_000));
         assert_eq!(reward_commission_c_2.commission_lamports, 50);
 
         let accumulator = accumulator1.accumulate_into_larger(accumulator2);
@@ -2285,14 +2305,14 @@ mod tests {
             .reward_commissions
             .get(&commission_pubkey_a)
             .unwrap();
-        assert_eq!(reward_commission_a.commission_bps, 1_000);
+        assert_eq!(reward_commission_a.commission_bps, Some(1_000));
         assert_eq!(reward_commission_a.commission_lamports, 50);
 
         let reward_commission_b = accumulator
             .reward_commissions
             .get(&commission_pubkey_b)
             .unwrap();
-        assert_eq!(reward_commission_b.commission_bps, 1_000);
+        assert_eq!(reward_commission_b.commission_bps, Some(1_000));
         // sum of the reward commissions from both accumulators
         assert_eq!(reward_commission_b.commission_lamports, 80);
 
@@ -2300,7 +2320,7 @@ mod tests {
             .reward_commissions
             .get(&commission_pubkey_c)
             .unwrap();
-        assert_eq!(reward_commission_c.commission_bps, 1_000);
+        assert_eq!(reward_commission_c.commission_bps, Some(1_000));
         assert_eq!(reward_commission_c.commission_lamports, 50);
     }
 
@@ -2568,7 +2588,7 @@ mod tests {
         reward_commissions.insert(
             pubkey,
             RewardCommission {
-                commission_bps: 0,
+                commission_bps: Some(0),
                 commission_lamports: 1, // enough to overflow
                 is_vote_account: true,
             },
@@ -2595,7 +2615,7 @@ mod tests {
         reward_commissions.insert(
             pubkey,
             RewardCommission {
-                commission_bps: 500,
+                commission_bps: Some(500),
                 commission_lamports,
                 is_vote_account: true,
             },
@@ -2644,7 +2664,7 @@ mod tests {
                 reward_commissions.insert(
                     pubkey,
                     RewardCommission {
-                        commission_bps,
+                        commission_bps: Some(commission_bps),
                         commission_lamports,
                         is_vote_account: true,
                     },
@@ -2713,12 +2733,12 @@ mod tests {
                     0,
                     &solana_sdk_ids::system_program::id(),
                 )),
-                Some(1),
+                Some(100),
             ),
             // vote account, success
-            (vote_address, None, Some(1)),
+            (vote_address, None, Some(100)),
             // incinerator, success
-            (solana_sdk_ids::incinerator::id(), None, Some(1)),
+            (solana_sdk_ids::incinerator::id(), None, Some(100)),
             // non-rent-exempt system account with 1 lamport, success with relaxed checks
             (
                 Pubkey::new_unique(),
@@ -2727,7 +2747,7 @@ mod tests {
                     0,
                     &solana_sdk_ids::system_program::id(),
                 )),
-                Some(1),
+                Some(100),
             ),
             // invalid owner, no commission
             (
@@ -2750,7 +2770,6 @@ mod tests {
             if let Some(account) = maybe_account {
                 bank.store_account(&collector_address, &account);
             }
-            println!("{epoch}");
             bank = apply_epoch_operations(
                 bank,
                 bank_forks.as_ref(),
@@ -2761,6 +2780,7 @@ mod tests {
                         VoteOperations {
                             earned_credits: Some(1),
                             new_inflation_rewards_collector: Some(collector_address),
+                            expect_reward: expected_reward_commission.is_some(),
                             expected_reward_commission,
                             ..VoteOperations::default()
                         },
@@ -2818,10 +2838,94 @@ mod tests {
                     vote_address,
                     VoteOperations {
                         earned_credits: Some(1),
-                        expected_reward_commission: Some(100),
+                        expect_reward: true,
+                        expected_reward_commission: Some(10_000),
                         ..VoteOperations::default()
                     },
                 )],
+            },
+        );
+    }
+
+    #[test]
+    fn test_repeated_inflation_rewards_collector() {
+        let GenesisConfigInfo {
+            mut genesis_config, ..
+        } = genesis_utils::create_genesis_config_with_leader(
+            1_000_000 * LAMPORTS_PER_SOL,
+            &Pubkey::new_unique(),
+            42 * LAMPORTS_PER_SOL,
+        );
+
+        genesis_config.rent = Rent::default();
+        genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
+
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+
+        let collector_address = Pubkey::new_unique();
+        let vote1_address = Pubkey::new_unique();
+        let vote2_address = Pubkey::new_unique();
+        // Vote account just created
+        let bank = apply_epoch_operations(
+            bank,
+            bank_forks.as_ref(),
+            EpochOperations {
+                epoch: 0,
+                vote_operations: vec![
+                    (
+                        vote1_address,
+                        VoteOperations {
+                            create_with_balance: Some(LAMPORTS_PER_SOL),
+                            new_commission: Some(50),
+                            earned_credits: Some(1000),
+                            delegate_stake_amount: Some(LAMPORTS_PER_SOL),
+                            new_inflation_rewards_collector: Some(collector_address),
+                            ..VoteOperations::default()
+                        },
+                    ),
+                    (
+                        vote2_address,
+                        VoteOperations {
+                            create_with_balance: Some(LAMPORTS_PER_SOL),
+                            new_commission: Some(100),
+                            earned_credits: Some(1000),
+                            delegate_stake_amount: Some(LAMPORTS_PER_SOL),
+                            new_inflation_rewards_collector: Some(collector_address),
+                            ..VoteOperations::default()
+                        },
+                    ),
+                ],
+            },
+        );
+
+        // next epoch, get double reward into collector
+        let epoch = bank.epoch();
+        apply_epoch_operations(
+            bank,
+            bank_forks.as_ref(),
+            EpochOperations {
+                epoch,
+                vote_operations: vec![
+                    (
+                        vote1_address,
+                        VoteOperations {
+                            earned_credits: Some(1),
+                            expect_reward: true,
+                            expected_reward_commission: None,
+                            ..VoteOperations::default()
+                        },
+                    ),
+                    (
+                        vote2_address,
+                        VoteOperations {
+                            earned_credits: Some(1),
+                            expect_reward: true,
+                            expected_reward_commission: None,
+                            ..VoteOperations::default()
+                        },
+                    ),
+                ],
             },
         );
     }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -47,6 +47,18 @@ struct RewardsAccumulator {
     total_stake_rewards_lamports: u64,
 }
 
+/// If a commission account is used by multiple vote accounts, the reported
+/// `commission_bps` may be incorrect. To keep things simple and correct, don't
+/// report `commission_bps` if there's any variation.
+fn unset_commission_bps_if_different(src: &RewardCommission, dst: &mut RewardCommission) {
+    if dst
+        .commission_bps
+        .is_some_and(|bps| Some(bps) != src.commission_bps)
+    {
+        dst.commission_bps = None;
+    }
+}
+
 impl RewardsAccumulator {
     fn add_reward(
         &mut self,
@@ -57,16 +69,7 @@ impl RewardsAccumulator {
         self.reward_commissions
             .entry(commission_pubkey)
             .and_modify(|dst_reward_commission| {
-                // If a commission account is used by multiple vote accounts,
-                // the reported `commission_bps` may be incorrect. To keep
-                // things simple and correct, don't report `commission_bps` if
-                // there's any variation.
-                if dst_reward_commission
-                    .commission_bps
-                    .is_some_and(|bps| Some(bps) != reward_commission.commission_bps)
-                {
-                    dst_reward_commission.commission_bps = None;
-                }
+                unset_commission_bps_if_different(&reward_commission, dst_reward_commission);
                 dst_reward_commission.commission_lamports = dst_reward_commission
                     .commission_lamports
                     .saturating_add(reward_commission.commission_lamports)
@@ -95,6 +98,7 @@ impl RewardsAccumulator {
             dst.reward_commissions
                 .entry(commission_pubkey)
                 .and_modify(|dst_reward_commission: &mut RewardCommission| {
+                    unset_commission_bps_if_different(&reward_commission, dst_reward_commission);
                     dst_reward_commission.commission_lamports = dst_reward_commission
                         .commission_lamports
                         .saturating_add(reward_commission.commission_lamports)

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -153,6 +153,7 @@ pub(crate) enum EpochRewardPhase {
 pub(super) struct RewardCommission {
     pub(super) commission_bps: u16,
     pub(super) commission_lamports: u64,
+    pub(super) is_vote_account: bool,
 }
 
 pub(super) type RewardCommissions = HashMap<Pubkey, RewardCommission, PubkeyHasherBuilder>;

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -151,7 +151,7 @@ pub(crate) enum EpochRewardPhase {
 
 #[derive(Debug)]
 pub(super) struct RewardCommission {
-    pub(super) commission_bps: u16,
+    pub(super) commission_bps: Option<u16>,
     pub(super) commission_lamports: u64,
     pub(super) is_vote_account: bool,
 }


### PR DESCRIPTION
#### Problem

SIMD-0232 has been accepted, but not implemented. Specifically, the inflation rewards collector account set in VoteStateV4 is not respected during rewards payout.

#### Summary of changes

Pay out inflation rewards into the configured collector account, as specified in SIMD-0232.

~~NOTE: leaving in draft until #11877 lands, some refactoring is done, and tests pass~~