### PR TITLE
tx_loop: rethink logic for committing pending descriptors

### DIFF
--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -204,7 +204,7 @@ impl<U: Umem> TxLoop<U> {
         drop_sender: Sender<T>,
         route_fn: R,
     ) {
-        // How long we sleep waiting to receive shreds from the channel.
+        // How long we sleep waiting to receive packets from the channel.
         const RECV_TIMEOUT: Duration = Duration::from_nanos(1000);
 
         const MAX_TIMEOUTS: usize = 1;
@@ -235,6 +235,8 @@ impl<U: Umem> TxLoop<U> {
         // example if we have 3 packets to transmit to 2 destination addresses each, we have 6 batched
         // packets.
         let mut batched_packets = 0;
+        // How many descriptors are written into the TX ring but not yet committed.
+        let mut written_uncommitted = 0;
 
         let mut timeouts = 0;
         loop {
@@ -253,8 +255,8 @@ impl<U: Umem> TxLoop<U> {
                         thread::sleep(RECV_TIMEOUT);
                     } else {
                         timeouts = 0;
+                        commit_pending(&mut ring, &mut written_uncommitted);
                         // we haven't received anything in a while, kick the driver
-                        ring.commit();
                         kick(&ring);
                     }
                 }
@@ -266,16 +268,15 @@ impl<U: Umem> TxLoop<U> {
                 }
             };
 
-            // this is the number of packets after which we commit the ring and kick the driver if
-            // necessary
-            let mut chunk_remaining = BATCH_SIZE.min(batched_packets);
-
             for item in batched_items.drain(..) {
                 let src_addr = item.src_addr();
                 let src_ip = src_addr.ip();
                 let src_port = src_addr.port();
                 for addr in item.dst_addrs().as_ref() {
                     if ring.available() == 0 || umem.available() == 0 {
+                        commit_pending(&mut ring, &mut written_uncommitted);
+                        kick(&ring);
+
                         // loop until we have space for the next packet
                         loop {
                             completion.sync(true);
@@ -384,14 +385,11 @@ impl<U: Umem> TxLoop<U> {
                         .expect("failed to write to ring");
 
                     batched_packets -= 1;
-                    chunk_remaining -= 1;
+                    written_uncommitted += 1;
 
-                    // check if it's time to commit the ring and kick the driver
-                    if chunk_remaining == 0 {
-                        chunk_remaining = BATCH_SIZE.min(batched_packets);
-
-                        // commit new frames
-                        ring.commit();
+                    // check if it's time to publish descriptors and kick the driver
+                    if written_uncommitted >= BATCH_SIZE {
+                        commit_pending(&mut ring, &mut written_uncommitted);
                         kick(&ring);
                     }
                 }
@@ -400,6 +398,8 @@ impl<U: Umem> TxLoop<U> {
             debug_assert_eq!(batched_packets, 0);
         }
         assert_eq!(batched_packets, 0);
+        commit_pending(&mut ring, &mut written_uncommitted);
+        kick(&ring);
 
         // drain the ring
         while umem.available() < umem_tx_capacity || ring.available() < ring.capacity() {
@@ -420,6 +420,15 @@ impl<U: Umem> TxLoop<U> {
             kick(&ring);
         }
     }
+}
+
+#[inline(always)]
+fn commit_pending<F: Frame>(ring: &mut TxRing<F>, pending_uncommitted: &mut usize) {
+    if *pending_uncommitted == 0 {
+        return;
+    }
+    ring.commit();
+    *pending_uncommitted = 0;
 }
 
 // With some drivers, or always when we work in SKB mode, we need to explicitly kick the driver once


### PR DESCRIPTION
This PR resolves a problem leading to possible exhaustion of UMEM when drop rate of packets is high.

To illustrate the problem consider an example: if `batched_packets = 2`, `chunk_remaining = 2`. Assume the first packet succeeds, we write payload in the frame and write the ring. Now the second packet drops on missing MAC. Hence, we never reach `chunk_remaining == 0` and never commit ring. Kernel doesn't see transmit because producer index is not published (commit not called). UMEM frame is occupied, userspace ring capacity is reduced.

The solution is to track `pending_uncommitted` instead. If we follow the same example, with this change we will try to commit the uncommitted descriptors if ring/umem is full or when we exit the loop and do the final drain of uncommitted descriptors.