### PR TITLE
Stops setting tower clock once migrated to alpenglow

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1459,7 +1459,10 @@ impl Bank {
         let (_, update_sysvars_time_us) = measure_us!({
             new.update_slot_hashes();
             new.update_stake_history(Some(parent.epoch()));
-            new.update_clock(Some(parent.epoch()));
+            // Keep setting the tower clock sysvar till we have not migrated to Alpenglow.
+            if new.get_alpenglow_genesis_certificate().is_none() {
+                new.update_clock(Some(parent.epoch()));
+            }
             new.update_last_restart_slot()
         });
 


### PR DESCRIPTION
#### Problem

Currently, we continue updating the tower clock even after we have migrated to alpenglow.


#### Summary of Changes

Stops setting the tower clock once migration to alpenglow occurs.
