### PR TITLE
refactor: calculate snapshot_dir in archive from slot

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -121,16 +121,13 @@ impl SnapshotPackagerService {
                     let archive_time = Instant::now();
                     // Serializing the snapshot package is not allowed to fail, as archiving is
                     // not allowed to fail (see comment on archive_snapshot_package below
-                    let bank_snapshot_info = snapshot_utils::serialize_snapshot(
+                    if let Err(err) = snapshot_utils::serialize_snapshot(
                         &snapshot_config.bank_snapshots_dir,
                         snapshot_config.snapshot_version,
                         snapshot_package.bank_snapshot_package,
                         snapshot_package.snapshot_storages.as_slice(),
                         exit_backpressure.is_none(),
-                    );
-
-                    let Ok(bank_snapshot_info) = bank_snapshot_info else {
-                        let err = bank_snapshot_info.unwrap_err();
+                    ) {
                         error!(
                             "Stopping {}! Fatal error while serializing snapshot for slot \
                              {snapshot_slot}: {err}",
@@ -138,7 +135,7 @@ impl SnapshotPackagerService {
                         );
                         exit.store(true, Ordering::Relaxed);
                         break;
-                    };
+                    }
 
                     if let SnapshotKind::Archive(snapshot_archive_kind) = snapshot_kind {
                         // Archiving the snapshot package is not allowed to fail.
@@ -148,7 +145,6 @@ impl SnapshotPackagerService {
                             snapshot_archive_kind,
                             snapshot_slot,
                             snapshot_hash,
-                            &bank_snapshot_info.snapshot_dir,
                             snapshot_package.snapshot_storages,
                             snapshot_config,
                         ) {

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -718,7 +718,7 @@ pub fn bank_to_full_snapshot_archive(
 
     let snapshot_storages = snapshot_package.snapshot_storages;
 
-    let bank_snapshot_info = snapshot_utils::serialize_snapshot(
+    snapshot_utils::serialize_snapshot(
         &snapshot_config.bank_snapshots_dir,
         snapshot_config.snapshot_version,
         snapshot_package.bank_snapshot_package,
@@ -730,7 +730,6 @@ pub fn bank_to_full_snapshot_archive(
         snapshot_archive_kind,
         snapshot_package.slot,
         snapshot_package.hash,
-        bank_snapshot_info.snapshot_dir,
         snapshot_storages,
         &snapshot_config,
     )?;
@@ -785,7 +784,7 @@ pub fn bank_to_incremental_snapshot_archive(
 
     let snapshot_storages = snapshot_package.snapshot_storages;
 
-    let bank_snapshot_info = snapshot_utils::serialize_snapshot(
+    snapshot_utils::serialize_snapshot(
         &snapshot_config.bank_snapshots_dir,
         snapshot_config.snapshot_version,
         snapshot_package.bank_snapshot_package,
@@ -797,7 +796,6 @@ pub fn bank_to_incremental_snapshot_archive(
         snapshot_archive_kind,
         snapshot_package.slot,
         snapshot_package.hash,
-        bank_snapshot_info.snapshot_dir,
         snapshot_storages,
         &snapshot_config,
     )?;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -483,7 +483,6 @@ pub fn archive_snapshot_package(
     snapshot_archive_kind: SnapshotArchiveKind,
     snapshot_slot: Slot,
     snapshot_hash: SnapshotHash,
-    bank_snapshot_dir: impl AsRef<Path>,
     mut snapshot_storages: Vec<Arc<AccountStorageEntry>>,
     snapshot_config: &SnapshotConfig,
 ) -> Result<SnapshotArchiveInfo> {
@@ -513,7 +512,6 @@ pub fn archive_snapshot_package(
         snapshot_slot,
         snapshot_hash,
         snapshot_storages.as_slice(),
-        &bank_snapshot_dir,
         snapshot_archive_path,
         snapshot_config,
     )?;

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -27,7 +27,6 @@ pub fn archive_snapshot(
     snapshot_slot: Slot,
     snapshot_hash: SnapshotHash,
     snapshot_storages: &[Arc<AccountStorageEntry>],
-    bank_snapshot_dir: impl AsRef<Path>,
     archive_path: impl AsRef<Path>,
     snapshot_config: &SnapshotConfig,
 ) -> Result<SnapshotArchiveInfo> {
@@ -58,9 +57,11 @@ pub fn archive_snapshot(
         .map_err(|err| E::CreateSnapshotStagingDir(err, staging_snapshot_dir.clone()))?;
 
     // To be a source for symlinking and archiving, the path need to be an absolute path
-    let src_snapshot_dir = bank_snapshot_dir.as_ref().canonicalize().map_err(|err| {
-        E::CanonicalizeSnapshotSourceDir(err, bank_snapshot_dir.as_ref().to_path_buf())
-    })?;
+    let src_snapshot_dir =
+        paths::get_bank_snapshot_dir(&snapshot_config.bank_snapshots_dir, snapshot_slot);
+    let src_snapshot_dir = src_snapshot_dir
+        .canonicalize()
+        .map_err(|err| E::CanonicalizeSnapshotSourceDir(err, src_snapshot_dir))?;
     let staging_snapshot_file = staging_snapshot_dir.join(&slot_str);
     let src_snapshot_file = src_snapshot_dir.join(slot_str);
     symlink::symlink_file(&src_snapshot_file, &staging_snapshot_file)


### PR DESCRIPTION
#### Problem
`snapshot_utils::archive_snapshot_package` takes parameter `bank_snapshot_dir`, which is derivable from snapshot config + slot (using `agave_snapshots::paths::get_bank_snapshot_dir`), other parameters also passed through to `archive_snapshot_package`.

This redundancy
* makes it harder to understand the purpose of all parameters
* adds a bit of confusion, since parameter and snapshot config's field are both called `bank_snapshot_dir`
* opens up surface for mistakes/bugs, especially in tests - the passed directory path can be different than canonical and won't work when reading the snapshots, e.g.  `solana_runtime::snapshot_utils::get_bank_snapshots` will return dirs obtained with `paths::get_bank_snapshot_dir` instead of the actual one used for archiving)
 
#### Summary of Changes
* remove parameters from `snapshot_utils::archive_snapshot_package` and `agave_snapshots::archive::archive_snapshot`
* calculate snapshot source dir from config's `bank_snapshot_dir` + `snapshot_slot` in `agave_snapshots::archive::archive_snapshot`

This means less parameter threading, simpler call sites, tighter encapsulation of the snapshot directory path derivation, at the expense of relying on `paths::get_bank_snapshot_dir` to be used in the same way by both `snapshot_utils::serialize_snapshot` and `agave_snapshots::archive::archive_snapshot`