### PR TITLE
runtime: remove unused sort_results from get_all_accounts

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -440,7 +440,6 @@ impl Accounts {
         &self,
         ancestors: &Ancestors,
         bank_id: BankId,
-        sort_results: bool,
     ) -> ScanResult<Vec<PubkeyAccountSlot>> {
         let mut collector = Vec::new();
         self.accounts_db.scan_accounts(
@@ -455,10 +454,6 @@ impl Accounts {
             },
             &ScanConfig::default(),
         )?;
-        if sort_results {
-            // Avoid copying pubkeys (using Ord::cmp(a, b) silences clippy::unnecessary_sort_by).
-            collector.sort_unstable_by(|(addr_a, _, _), (addr_b, _, _)| Ord::cmp(addr_a, addr_b));
-        }
         Ok(collector)
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4670,10 +4670,8 @@ impl Bank {
     }
 
     /// Returns all the accounts this bank can load
-    pub fn get_all_accounts(&self, sort_results: bool) -> ScanResult<Vec<PubkeyAccountSlot>> {
-        self.rc
-            .accounts
-            .load_all(&self.ancestors, self.bank_id, sort_results)
+    pub fn get_all_accounts(&self) -> ScanResult<Vec<PubkeyAccountSlot>> {
+        self.rc.accounts.load_all(&self.ancestors, self.bank_id)
     }
 
     // Scans all the accounts this bank can load, applying `scan_func`
@@ -5983,7 +5981,7 @@ impl Bank {
     ///
     /// Only intended to be called by tests or when the number of accounts is small.
     pub fn calculate_accounts_data_size(&self) -> ScanResult<u64> {
-        let accounts = self.get_all_accounts(false)?;
+        let accounts = self.get_all_accounts()?;
         let accounts_data_size = accounts
             .into_iter()
             .map(|(_pubkey, account, _slot)| account.data().len() as u64)

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3295,7 +3295,7 @@ fn test_bank_get_program_accounts() {
     let (parent, _bank_forks) =
         Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
-    let genesis_accounts: Vec<_> = parent.get_all_accounts(false).unwrap();
+    let genesis_accounts: Vec<_> = parent.get_all_accounts().unwrap();
     assert!(
         genesis_accounts
             .iter()


### PR DESCRIPTION
#### Problem

  `Accounts::load_all()` and `Bank::get_all_accounts()` expose a `sort_results` parameter that is never used in practice (`false` at all call sites), leaving dead code and an unnecessary API surface.                                                                                                                                                            
                                                                                                                                                                                      
#### Summary of Changes                                                                                                                                                             
                                                                                                                                                                                      
  - Removed `sort_results` from `Accounts::load_all()`.                                                                                                                               
  - Removed `sort_results` from `Bank::get_all_accounts()`.                                                                                                                           
  - Deleted the unreachable sorting branch in `accounts-db/src/accounts.rs`.                                                                                                          
  - Updated all call sites and affected tests to use the new signatures.                                                                                                              
                                                                                                                                                                                      