### PR TITLE
Feat/block production cost model reserves min one page cost for loading accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7937,7 +7937,6 @@ dependencies = [
  "solana-compute-budget-interface",
  "solana-compute-budget-program",
  "solana-cost-model",
- "solana-fee-structure",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-hash 4.3.0",

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -60,7 +60,22 @@ impl QosService {
     ) -> Vec<transaction::Result<TransactionCost<'a, Tx>>> {
         transactions
             .zip(pre_results)
-            .map(|(tx, pre_result)| pre_result.map(|()| CostModel::calculate_cost(tx, feature_set)))
+            .map(|(tx, pre_result)| {
+                pre_result.map(|()| {
+                    let mut reserving_cost = CostModel::calculate_cost(tx, feature_set);
+
+                    if let TransactionCost::Transaction(ref mut usage_cost_details) = reserving_cost
+                    {
+                        // To maintain cost tracking consistency, reserve at least one page for
+                        // loading the fee payer account in fee-only fallback scenarios.
+                        usage_cost_details.loaded_accounts_data_size_cost = usage_cost_details
+                            .loaded_accounts_data_size_cost
+                            .max(CostModel::calculate_pages_cost(1));
+                    }
+
+                    reserving_cost
+                })
+            })
             .collect()
     }
 
@@ -518,5 +533,41 @@ mod tests {
                 bank.read_cost_tracker().unwrap().transaction_count()
             );
         }
+    }
+
+    #[test]
+    fn test_min_one_page_cost_reserved() {
+        let payer = Keypair::new();
+        let recipient = solana_pubkey::Pubkey::new_unique();
+
+        let transaction = solana_transaction::Transaction::new_unsigned(solana_message::Message::new(
+        &[
+            solana_compute_budget_interface::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(0),
+            solana_system_interface::instruction::transfer(&payer.pubkey(), &recipient, 1),
+        ],
+        Some(&payer.pubkey()),
+    ));
+
+        let txs = [RuntimeTransaction::from_transaction_for_tests(transaction)];
+        let tx_costs = QosService::compute_transaction_costs(
+            &FeatureSet::all_enabled(),
+            txs.iter(),
+            std::iter::repeat(Ok(())),
+        );
+
+        let tx_cost = tx_costs
+            .into_iter()
+            .next()
+            .expect("one tx cost")
+            .expect("tx cost should be computed");
+
+        let TransactionCost::Transaction(usage_cost_details) = tx_cost else {
+            panic!("expected TransactionCost::Transaction");
+        };
+
+        assert_eq!(
+            usage_cost_details.loaded_accounts_data_size_cost,
+            CostModel::calculate_pages_cost(1),
+        );
     }
 }

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -570,4 +570,107 @@ mod tests {
             CostModel::calculate_pages_cost(1),
         );
     }
+
+    #[test]
+    fn test_requested_zero_loaded_accounts_data_size_refund() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+
+        let payer = Keypair::new();
+        let recipient = solana_pubkey::Pubkey::new_unique();
+        let transaction = solana_transaction::Transaction::new_unsigned(solana_message::Message::new(
+        &[
+            solana_compute_budget_interface::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(0),
+            solana_system_interface::instruction::transfer(&payer.pubkey(), &recipient, 1),
+        ],
+        Some(&payer.pubkey()),
+        ));
+        let txs = [RuntimeTransaction::from_transaction_for_tests(transaction)];
+
+        {
+            let txs_costs = QosService::compute_transaction_costs(
+                &FeatureSet::all_enabled(),
+                txs.iter(),
+                std::iter::repeat(Ok(())),
+            );
+            let total_txs_cost: u64 = txs_costs
+                .iter()
+                .map(|cost| cost.as_ref().unwrap().sum())
+                .sum();
+            let (qos_cost_results, _num_included) =
+                QosService::select_transactions_per_cost(txs.iter(), txs_costs.into_iter(), &bank);
+            // transaction is committed with actual loaded account size == 0.
+            let committed_status: Vec<CommitTransactionDetails> = qos_cost_results
+                .iter()
+                .map(|tx_cost| CommitTransactionDetails::Committed {
+                    compute_units: tx_cost.as_ref().unwrap().programs_execution_cost(),
+                    loaded_accounts_data_size: 0,
+                    result: Ok(()),
+                    fee_payer_post_balance: 0,
+                })
+                .collect();
+            QosService::remove_or_update_costs(
+                qos_cost_results.iter(),
+                Some(&committed_status),
+                &bank,
+            );
+            // should refund cost of 1 page it over reserved
+            let final_txs_cost = total_txs_cost - CostModel::calculate_pages_cost(1);
+            assert_eq!(
+                final_txs_cost,
+                bank.read_cost_tracker().unwrap().block_cost()
+            );
+        }
+    }
+
+    #[test]
+    fn test_requested_zero_loaded_accounts_data_size_no_refund() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+
+        let payer = Keypair::new();
+        let recipient = solana_pubkey::Pubkey::new_unique();
+        let transaction = solana_transaction::Transaction::new_unsigned(solana_message::Message::new(
+        &[
+            solana_compute_budget_interface::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(0),
+            solana_system_interface::instruction::transfer(&payer.pubkey(), &recipient, 1),
+        ],
+        Some(&payer.pubkey()),
+        ));
+        let txs = [RuntimeTransaction::from_transaction_for_tests(transaction)];
+
+        {
+            let txs_costs = QosService::compute_transaction_costs(
+                &FeatureSet::all_enabled(),
+                txs.iter(),
+                std::iter::repeat(Ok(())),
+            );
+            let total_txs_cost: u64 = txs_costs
+                .iter()
+                .map(|cost| cost.as_ref().unwrap().sum())
+                .sum();
+            let (qos_cost_results, _num_included) =
+                QosService::select_transactions_per_cost(txs.iter(), txs_costs.into_iter(), &bank);
+            // transaction is committed with actual loaded account size == 1.
+            let committed_status: Vec<CommitTransactionDetails> = qos_cost_results
+                .iter()
+                .map(|tx_cost| CommitTransactionDetails::Committed {
+                    compute_units: tx_cost.as_ref().unwrap().programs_execution_cost(),
+                    loaded_accounts_data_size: 1,
+                    result: Ok(()),
+                    fee_payer_post_balance: 0,
+                })
+                .collect();
+            QosService::remove_or_update_costs(
+                qos_cost_results.iter(),
+                Some(&committed_status),
+                &bank,
+            );
+            // should be no refund, since the loaded size is same
+            assert_eq!(
+                total_txs_cost,
+                bank.read_cost_tracker().unwrap().block_cost()
+            );
+        }
+    }
 }

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -41,7 +41,6 @@ solana-clock = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-instruction = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
-solana-fee-structure = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -10,7 +10,6 @@ use {
     agave_feature_set::FeatureSet,
     solana_bincode::limited_deserialize,
     solana_compute_budget::compute_budget_limits::DEFAULT_HEAP_COST,
-    solana_fee_structure::FeeStructure,
     solana_pubkey::Pubkey,
     solana_runtime_transaction::transaction_meta::TransactionMeta,
     solana_sdk_ids::system_program,
@@ -21,6 +20,8 @@ use {
     },
     std::num::Saturating,
 };
+
+const ACCOUNT_DATA_COST_PAGE_SIZE: u64 = 32_u64.saturating_mul(1024);
 
 pub struct CostModel;
 
@@ -200,11 +201,22 @@ impl CostModel {
         transaction.instruction_data_len() / (INSTRUCTION_DATA_BYTES_COST as u16)
     }
 
+    /// Compute the number of pages needed to contain provided number of bytes.
+    fn calculate_pages_for_bytes(bytes: u32) -> u64 {
+        u64::from(bytes)
+            .saturating_add(ACCOUNT_DATA_COST_PAGE_SIZE.saturating_sub(1))
+            .saturating_div(ACCOUNT_DATA_COST_PAGE_SIZE)
+    }
+
+    pub fn calculate_pages_cost(num_pages: u64) -> u64 {
+        num_pages.saturating_mul(DEFAULT_HEAP_COST)
+    }
+
     pub fn calculate_loaded_accounts_data_size_cost(
         loaded_accounts_data_size: u32,
         _feature_set: &FeatureSet,
     ) -> u64 {
-        FeeStructure::calculate_memory_usage_cost(loaded_accounts_data_size, DEFAULT_HEAP_COST)
+        Self::calculate_pages_cost(Self::calculate_pages_for_bytes(loaded_accounts_data_size))
     }
 
     fn calculate_account_data_size_on_deserialized_system_instruction(
@@ -320,7 +332,6 @@ mod tests {
             },
         },
         solana_compute_budget_interface::ComputeBudgetInstruction,
-        solana_fee_structure::ACCOUNT_DATA_COST_PAGE_SIZE,
         solana_hash::Hash,
         solana_instruction::Instruction,
         solana_keypair::Keypair,
@@ -918,6 +929,8 @@ mod tests {
     #[test]
     fn test_zero_bytes() {
         // 0 bytes should result in 0 pages and 0 cost
+        assert_eq!(CostModel::calculate_pages_for_bytes(0), 0);
+        assert_eq!(CostModel::calculate_pages_cost(0), 0);
         assert_eq!(
             CostModel::calculate_loaded_accounts_data_size_cost(0, &FeatureSet::default()),
             0
@@ -926,35 +939,44 @@ mod tests {
 
     #[test]
     fn test_non_zero_bytes_single_page() {
+        let page_size = ACCOUNT_DATA_COST_PAGE_SIZE as u32;
+
         // Any non-zero bytes up to page_size should be 1 page
+        assert_eq!(CostModel::calculate_pages_for_bytes(1), 1);
+        assert_eq!(CostModel::calculate_pages_for_bytes(page_size), 1);
+
         assert_eq!(
             CostModel::calculate_loaded_accounts_data_size_cost(1, &FeatureSet::default()),
-            DEFAULT_HEAP_COST
+            CostModel::calculate_pages_cost(1)
         );
     }
 
     #[test]
     fn test_non_zero_bytes_multiple_pages() {
-        let page_size = solana_fee_structure::ACCOUNT_DATA_COST_PAGE_SIZE as u32;
+        let page_size = ACCOUNT_DATA_COST_PAGE_SIZE as u32;
 
         // Just over one page should round up to 2 pages
+        assert_eq!(CostModel::calculate_pages_for_bytes(page_size + 1), 2);
+
         assert_eq!(
             CostModel::calculate_loaded_accounts_data_size_cost(
                 page_size + 1,
                 &FeatureSet::default()
             ),
-            2 * DEFAULT_HEAP_COST
+            CostModel::calculate_pages_cost(2)
         );
     }
 
     #[test]
     fn test_exact_multiple_pages() {
-        let page_size = solana_fee_structure::ACCOUNT_DATA_COST_PAGE_SIZE as u32;
+        let page_size = ACCOUNT_DATA_COST_PAGE_SIZE as u32;
 
         let bytes = page_size * 3;
+        assert_eq!(CostModel::calculate_pages_for_bytes(bytes), 3);
+
         assert_eq!(
             CostModel::calculate_loaded_accounts_data_size_cost(bytes, &FeatureSet::default()),
-            3 * DEFAULT_HEAP_COST
+            CostModel::calculate_pages_cost(3)
         );
     }
 }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6994,7 +6994,6 @@ dependencies = [
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-compute-budget-interface",
- "solana-fee-structure",
  "solana-metrics",
  "solana-packet 4.1.0",
  "solana-pubkey 4.2.0",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6665,7 +6665,6 @@ dependencies = [
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-compute-budget-interface",
- "solana-fee-structure",
  "solana-metrics",
  "solana-packet 4.1.0",
  "solana-pubkey 4.2.0",


### PR DESCRIPTION
#### Problem

transactions request `0` loaded_accounts_data_size could still be packed as fee-only transactions. To keep consistency with cost model, qos-service should reserve at least one page to load fee payer accounts.

#### Summary of Changes
- commit 1: refactor cost model to do loaded_accounts_data_size_cost calc locally, remove dependency to fee-structure. Updated tests.
- commit 2: changes qos-service to reserve at least cost for one page for loaded_accounts_data_size_cost. add test.

Fixes #
