### PR TITLE
snapshot/paths: Return snapshot archive iterators instead of Vecs

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1007,11 +1007,12 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
         .unwrap();
 
         // Now get the same full snapshot on the LEADER that we just got from the validator
-        let mut leader_full_snapshots = snapshot_paths::get_full_snapshot_archives(
+        let mut leader_full_snapshots = snapshot_paths::full_snapshot_archives_iter(
             leader_snapshot_test_config
                 .full_snapshot_archives_dir
                 .path(),
-        );
+        )
+        .collect::<Vec<_>>();
         leader_full_snapshots.retain(|full_snapshot| {
             full_snapshot.slot() == validator_full_snapshot.slot()
                 && full_snapshot.hash() == validator_full_snapshot.hash()
@@ -1141,11 +1142,12 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 
     // Check to make sure that the full snapshot the validator created during startup is the same
     // or one greater than the snapshot the leader created.
-    let validator_full_snapshot_archives = snapshot_paths::get_full_snapshot_archives(
+    let validator_full_snapshot_archives = snapshot_paths::full_snapshot_archives_iter(
         validator_snapshot_test_config
             .full_snapshot_archives_dir
             .path(),
-    );
+    )
+    .collect::<Vec<_>>();
     info!("validator full snapshot archives: {validator_full_snapshot_archives:#?}");
     let validator_full_snapshot_archive_for_comparison = validator_full_snapshot_archives
         .into_iter()
@@ -5001,9 +5003,10 @@ fn test_boot_from_local_state() {
             );
             std::thread::yield_now();
         }
-        let other_full_snapshot_archives = snapshot_paths::get_full_snapshot_archives(
+        let other_full_snapshot_archives = snapshot_paths::full_snapshot_archives_iter(
             &other_validator_config.full_snapshot_archives_dir,
-        );
+        )
+        .collect::<Vec<_>>();
         debug!("validator{i} full snapshot archives: {other_full_snapshot_archives:?}");
         assert!(
             other_full_snapshot_archives
@@ -5026,9 +5029,11 @@ fn test_boot_from_local_state() {
                 .collect::<Vec<_>>(),
         );
 
-        let other_incremental_snapshot_archives = snapshot_paths::get_incremental_snapshot_archives(
-            &other_validator_config.incremental_snapshot_archives_dir,
-        );
+        let other_incremental_snapshot_archives =
+            snapshot_paths::incremental_snapshot_archives_iter(
+                &other_validator_config.incremental_snapshot_archives_dir,
+            )
+            .collect::<Vec<_>>();
         debug!(
             "validator{i} incremental snapshot archives: {other_incremental_snapshot_archives:?}"
         );
@@ -5116,12 +5121,14 @@ fn test_boot_from_local_state_missing_archive() {
     );
     debug!(
         "snapshot archives:\n\tfull: {:?}\n\tincr: {:?}",
-        snapshot_paths::get_full_snapshot_archives(
+        snapshot_paths::full_snapshot_archives_iter(
             validator_config.full_snapshot_archives_dir.path()
-        ),
-        snapshot_paths::get_incremental_snapshot_archives(
+        )
+        .collect::<Vec<_>>(),
+        snapshot_paths::incremental_snapshot_archives_iter(
             validator_config.incremental_snapshot_archives_dir.path()
-        ),
+        )
+        .collect::<Vec<_>>(),
     );
     info!("Waiting for validator to create snapshots... DONE");
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -25,7 +25,7 @@ use {
             HardLinkStoragesToSnapshotError, SnapshotError, SnapshotFastbootError,
             SnapshotNewFromDirError,
         },
-        paths::{self as snapshot_paths, get_incremental_snapshot_archives},
+        paths::{self as snapshot_paths, incremental_snapshot_archives_iter},
         snapshot_archive_info::{
             FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfo,
             SnapshotArchiveInfoGetter,
@@ -1580,7 +1580,8 @@ pub fn purge_old_snapshot_archives(
     );
 
     let mut full_snapshot_archives =
-        snapshot_paths::get_full_snapshot_archives(&full_snapshot_archives_dir);
+        snapshot_paths::full_snapshot_archives_iter(&full_snapshot_archives_dir)
+            .collect::<Vec<_>>();
     full_snapshot_archives.sort_unstable();
     full_snapshot_archives.reverse();
 
@@ -1627,7 +1628,7 @@ pub fn purge_old_snapshot_archives(
     );
     let mut incremental_snapshot_archives_by_base_slot = HashMap::<Slot, Vec<_>>::new();
     for incremental_snapshot_archive in
-        get_incremental_snapshot_archives(&incremental_snapshot_archives_dir)
+        incremental_snapshot_archives_iter(&incremental_snapshot_archives_dir)
     {
         incremental_snapshot_archives_by_base_slot
             .entry(incremental_snapshot_archive.base_slot())
@@ -1822,7 +1823,7 @@ mod tests {
         super::*,
         agave_snapshots::{
             paths::{
-                get_full_snapshot_archives, get_highest_full_snapshot_archive_slot,
+                full_snapshot_archives_iter, get_highest_full_snapshot_archive_slot,
                 get_highest_incremental_snapshot_archive_slot,
             },
             snapshot_config::{
@@ -2157,7 +2158,8 @@ mod tests {
             0,
         );
 
-        let snapshot_archives = get_full_snapshot_archives(full_snapshot_archives_dir);
+        let snapshot_archives =
+            full_snapshot_archives_iter(full_snapshot_archives_dir.path()).collect::<Vec<_>>();
         assert_eq!(snapshot_archives.len() as Slot, max_slot - min_slot);
     }
 
@@ -2180,7 +2182,8 @@ mod tests {
             0,
         );
 
-        let snapshot_archives = get_full_snapshot_archives(full_snapshot_archives_dir);
+        let snapshot_archives =
+            full_snapshot_archives_iter(full_snapshot_archives_dir.path()).collect::<Vec<_>>();
         assert_eq!(snapshot_archives.len() as Slot, max_slot - min_slot);
         assert!(snapshot_archives.iter().all(|info| info.is_remote()));
     }
@@ -2203,7 +2206,8 @@ mod tests {
         );
 
         let incremental_snapshot_archives =
-            get_incremental_snapshot_archives(incremental_snapshot_archives_dir);
+            incremental_snapshot_archives_iter(incremental_snapshot_archives_dir.path())
+                .collect::<Vec<_>>();
         assert_eq!(
             incremental_snapshot_archives.len() as Slot,
             (max_full_snapshot_slot - min_full_snapshot_slot)
@@ -2233,7 +2237,8 @@ mod tests {
         );
 
         let incremental_snapshot_archives =
-            get_incremental_snapshot_archives(incremental_snapshot_archives_dir);
+            incremental_snapshot_archives_iter(incremental_snapshot_archives_dir.path())
+                .collect::<Vec<_>>();
         assert_eq!(
             incremental_snapshot_archives.len() as Slot,
             (max_full_snapshot_slot - min_full_snapshot_slot)
@@ -2414,7 +2419,7 @@ mod tests {
                 NonZeroUsize::new(usize::MAX).unwrap(),
             );
             let mut full_snapshot_archives =
-                get_full_snapshot_archives(&full_snapshot_archives_dir);
+                full_snapshot_archives_iter(&full_snapshot_archives_dir).collect::<Vec<_>>();
             full_snapshot_archives.sort_unstable();
             assert_eq!(
                 full_snapshot_archives.len(),
@@ -2490,7 +2495,7 @@ mod tests {
 
         // Ensure correct number of full snapshot archives are purged/retained
         let mut remaining_full_snapshot_archives =
-            get_full_snapshot_archives(full_snapshot_archives_dir.path());
+            full_snapshot_archives_iter(full_snapshot_archives_dir.path()).collect::<Vec<_>>();
         assert_eq!(
             remaining_full_snapshot_archives.len(),
             maximum_full_snapshot_archives_to_retain.get(),
@@ -2504,7 +2509,8 @@ mod tests {
         // incremental snapshot archive is retained. This is accounted for by the
         // `+ maximum_full_snapshot_archives_to_retain.saturating_sub(1)`
         let mut remaining_incremental_snapshot_archives =
-            get_incremental_snapshot_archives(incremental_snapshot_archives_dir.path());
+            incremental_snapshot_archives_iter(incremental_snapshot_archives_dir.path())
+                .collect::<Vec<_>>();
         assert_eq!(
             remaining_incremental_snapshot_archives.len(),
             maximum_incremental_snapshot_archives_to_retain
@@ -2590,7 +2596,8 @@ mod tests {
         );
 
         let remaining_incremental_snapshot_archives =
-            get_incremental_snapshot_archives(incremental_snapshot_archives_dir.path());
+            incremental_snapshot_archives_iter(incremental_snapshot_archives_dir.path())
+                .collect::<Vec<_>>();
         assert!(remaining_incremental_snapshot_archives.is_empty());
     }
 

--- a/snapshots/src/paths.rs
+++ b/snapshots/src/paths.rs
@@ -160,50 +160,51 @@ pub fn get_bank_snapshot_dir(bank_snapshots_dir: impl AsRef<Path>, slot: Slot) -
         .join(get_snapshot_file_name(slot))
 }
 
-/// Walk down the snapshot archive to collect snapshot archive file info
-fn get_snapshot_archives<T, F>(snapshot_archives_dir: &Path, cb: F) -> Vec<T>
-where
-    F: Fn(PathBuf) -> Result<T>,
-{
-    let walk_dir = |dir: &Path| -> Vec<T> {
-        let entry_iter = fs::read_dir(dir);
-        match entry_iter {
-            Err(err) => {
+/// Walk down the snapshot archive to yield snapshot archive file info
+fn snapshot_archives_iter<T>(
+    snapshot_archives_dir: &Path,
+    cb: fn(PathBuf) -> Result<T>,
+) -> impl Iterator<Item = T> {
+    let remote_dir = build_snapshot_archives_remote_dir(snapshot_archives_dir);
+
+    [
+        Some(snapshot_archives_dir.to_path_buf()),
+        remote_dir.exists().then_some(remote_dir),
+    ]
+    .into_iter()
+    .flatten()
+    .flat_map(move |dir| {
+        fs::read_dir(&dir)
+            .map_err(|err| {
                 info!(
                     "Unable to read snapshot archives directory '{}': {err}",
                     dir.display(),
                 );
-                vec![]
-            }
-            Ok(entries) => entries
-                .filter_map(|entry| entry.map_or(None, |entry| cb(entry.path()).ok()))
-                .collect(),
-        }
-    };
-
-    let mut ret = walk_dir(snapshot_archives_dir);
-    let remote_dir = build_snapshot_archives_remote_dir(snapshot_archives_dir);
-    if remote_dir.exists() {
-        ret.append(&mut walk_dir(remote_dir.as_ref()));
-    }
-    ret
+                err
+            })
+            .ok()
+            .into_iter()
+            .flat_map(move |entries| {
+                entries.filter_map(move |entry| entry.ok().and_then(|entry| cb(entry.path()).ok()))
+            })
+    })
 }
 
-/// Get a list of the full snapshot archives from a directory
-pub fn get_full_snapshot_archives(
+/// Get an iterator of the full snapshot archives from a directory
+pub fn full_snapshot_archives_iter(
     full_snapshot_archives_dir: impl AsRef<Path>,
-) -> Vec<FullSnapshotArchiveInfo> {
-    get_snapshot_archives(
+) -> impl Iterator<Item = FullSnapshotArchiveInfo> {
+    snapshot_archives_iter(
         full_snapshot_archives_dir.as_ref(),
         FullSnapshotArchiveInfo::new_from_path,
     )
 }
 
-/// Get a list of the incremental snapshot archives from a directory
-pub fn get_incremental_snapshot_archives(
+/// Get the incremental snapshot archives from a directory
+pub fn incremental_snapshot_archives_iter(
     incremental_snapshot_archives_dir: impl AsRef<Path>,
-) -> Vec<IncrementalSnapshotArchiveInfo> {
-    get_snapshot_archives(
+) -> impl Iterator<Item = IncrementalSnapshotArchiveInfo> {
+    snapshot_archives_iter(
         incremental_snapshot_archives_dir.as_ref(),
         IncrementalSnapshotArchiveInfo::new_from_path,
     )
@@ -234,9 +235,7 @@ pub fn get_highest_incremental_snapshot_archive_slot(
 pub fn get_highest_full_snapshot_archive_info(
     full_snapshot_archives_dir: impl AsRef<Path>,
 ) -> Option<FullSnapshotArchiveInfo> {
-    let mut full_snapshot_archives = get_full_snapshot_archives(full_snapshot_archives_dir);
-    full_snapshot_archives.sort_unstable();
-    full_snapshot_archives.into_iter().next_back()
+    full_snapshot_archives_iter(full_snapshot_archives_dir).max()
 }
 
 /// Get the path for the incremental snapshot archive with the highest slot, for a given full
@@ -249,8 +248,7 @@ pub fn get_highest_incremental_snapshot_archive_info(
     // full snapshot slot as the value passed in, perform the filtering before sorting to avoid
     // doing unnecessary work.
     let mut incremental_snapshot_archives =
-        get_incremental_snapshot_archives(incremental_snapshot_archives_dir)
-            .into_iter()
+        incremental_snapshot_archives_iter(incremental_snapshot_archives_dir)
             .filter(|incremental_snapshot_archive_info| {
                 incremental_snapshot_archive_info.base_slot() == full_snapshot_slot
             })

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1130,13 +1130,12 @@ fn download_snapshots(
     }
 
     // Check and see if we've already got the full snapshot; if not, download it
-    if snapshot_paths::get_full_snapshot_archives(full_snapshot_archives_dir)
-        .into_iter()
-        .any(|snapshot_archive| {
+    if snapshot_paths::full_snapshot_archives_iter(full_snapshot_archives_dir).any(
+        |snapshot_archive| {
             snapshot_archive.slot() == full_snapshot_hash.0
                 && snapshot_archive.hash().0 == full_snapshot_hash.1
-        })
-    {
+        },
+    ) {
         info!(
             "Full snapshot archive already exists locally. Skipping download. slot: {}, hash: {}",
             full_snapshot_hash.0, full_snapshot_hash.1
@@ -1159,8 +1158,7 @@ fn download_snapshots(
     if bootstrap_config.incremental_snapshot_fetch {
         // Check and see if we've already got the incremental snapshot; if not, download it
         if let Some(incremental_snapshot_hash) = incremental_snapshot_hash {
-            if snapshot_paths::get_incremental_snapshot_archives(incremental_snapshot_archives_dir)
-                .into_iter()
+            if snapshot_paths::incremental_snapshot_archives_iter(incremental_snapshot_archives_dir)
                 .any(|snapshot_archive| {
                     snapshot_archive.slot() == incremental_snapshot_hash.0
                         && snapshot_archive.hash().0 == incremental_snapshot_hash.1


### PR DESCRIPTION
#### Problem

Callers of `get_snapshot_archives()`, `get_full_snapshot_archives()`, and `get_incremental_snapshot_archives()` only iterate over the results.

#### Summary of Changes

Avoid collecting into vectors up front and return iterators instead.