### PR TITLE
refactor: update delay leader block flag handling and add no-op option

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -458,6 +458,7 @@ impl ValidatorConfig {
             replay_transactions_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
             tvu_shred_sigverify_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
             tvu_bls_sigverify_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
+            // Keep tests on the lower-latency behavior unless they opt in explicitly.
             delay_leader_block_for_pending_fork: false,
             voting_service_test_override: None,
             repair_handler_type: RepairHandlerType::default(),

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1142,14 +1142,24 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
         Arg::with_name("delay_leader_block_for_pending_fork")
             .hidden(hidden_unless_forced())
             .long("delay-leader-block-for-pending-fork")
+            .conflicts_with("no_delay_leader_block_for_pending_fork")
             .takes_value(false)
             .help(
-                "Delay leader block creation while replaying a block which descends from the \
-                 current fork and has a lower slot than our next leader slot. If we don't delay \
-                 here, our new leader block will be on a different fork from the block we are \
-                 replaying and there is a high chance that the cluster will confirm that block's \
-                 fork rather than our leader block's fork because it was created before we \
-                 started creating ours.",
+                "Deprecated no-op: delay leader block creation while replaying a block which \
+                 descends from the current fork and has a lower slot than our next leader slot. \
+                 This behavior is now enabled by default. Use \
+                 --no-delay-leader-block-for-pending-fork to opt out.",
+            ),
+    )
+    .arg(
+        Arg::with_name("no_delay_leader_block_for_pending_fork")
+            .hidden(hidden_unless_forced())
+            .long("no-delay-leader-block-for-pending-fork")
+            .conflicts_with("delay_leader_block_for_pending_fork")
+            .takes_value(false)
+            .help(
+                "Disable delaying leader block creation while replaying a block which descends \
+                 from the current fork and has a lower slot than our next leader slot.",
             ),
     )
     .arg(
@@ -1792,5 +1802,27 @@ mod tests {
             vec!["--allow-private-addr"],
             expected_args,
         );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_no_delay_leader_block_for_pending_fork() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            delay_leader_block_for_pending_fork: false,
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec!["--no-delay-leader-block-for-pending-fork"],
+            expected_args,
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_conflicting_delay_leader_flags_is_error() {
+        verify_args_struct_by_command_run_with_identity_setup_is_error::<RunArgs>(vec![
+            "--delay-leader-block-for-pending-fork",
+            "--no-delay-leader-block-for-pending-fork",
+        ]);
     }
 }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1807,22 +1807,21 @@ mod tests {
     #[test]
     fn verify_args_struct_by_command_run_with_no_delay_leader_block_for_pending_fork() {
         let default_run_args = RunArgs::default();
-        let expected_args = RunArgs {
-            delay_leader_block_for_pending_fork: false,
-            ..default_run_args.clone()
-        };
         verify_args_struct_by_command_run_with_identity_setup(
-            default_run_args,
+            default_run_args.clone(),
             vec!["--no-delay-leader-block-for-pending-fork"],
-            expected_args,
+            default_run_args,
         );
     }
 
     #[test]
     fn verify_args_struct_by_command_run_with_conflicting_delay_leader_flags_is_error() {
-        verify_args_struct_by_command_run_with_identity_setup_is_error::<RunArgs>(vec![
+        verify_args_struct_by_command_run_is_error_with_identity_setup(
+            RunArgs::default(),
+            vec![
             "--delay-leader-block-for-pending-fork",
             "--no-delay-leader-block-for-pending-fork",
-        ]);
+            ],
+        );
     }
 }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -859,8 +859,11 @@ pub fn execute(
         replay_transactions_threads,
         tvu_shred_sigverify_threads: tvu_sigverify_threads,
         tvu_bls_sigverify_threads,
+        // Enabled by default: this evaluates to `true` when neither flag is present,
+        // and is only disabled by the explicit `no_delay_leader_block_for_pending_fork` flag.
         delay_leader_block_for_pending_fork: matches
-            .is_present("delay_leader_block_for_pending_fork"),
+            .is_present("delay_leader_block_for_pending_fork")
+            || !matches.is_present("no_delay_leader_block_for_pending_fork"),
         turbine_disabled: Arc::<AtomicBool>::default(),
         broadcast_stage_type: BroadcastStageType::Standard,
         block_verification_method: value_t_or_exit!(


### PR DESCRIPTION
## Summary

Enable `delay_leader_block_for_pending_fork` by default for validator runs, while preserving an explicit opt-out for operators.

This change:
- makes pending-fork leader delay the default runtime behavior
- keeps `--delay-leader-block-for-pending-fork` as a hidden compatibility no-op
- adds a hidden `--no-delay-leader-block-for-pending-fork` escape hatch
- adds CLI parser coverage for the new opt-out flag and for conflicting flag combinations
- leaves `ValidatorConfig::default_for_test()` unchanged so tests do not silently inherit the production behavior shift

## Why

I traced dead-slot behavior back to replay and fork timing, and this flag is one of the relevant mitigations already present in the codebase.

Before this change, validators only got the safer behavior if they explicitly enabled a hidden flag. That makes the mitigation easy to miss operationally. Flipping the default reduces the chance of producing a leader block on a fork that is likely to lose while still preserving a way to disable the behavior if needed.

## Behavior Change

Before:
- default behavior: do not delay for a pending fork
- `--delay-leader-block-for-pending-fork`: enable the delay

After:
- default behavior: delay for a pending fork
- `--delay-leader-block-for-pending-fork`: accepted for compatibility, but no longer changes behavior
- `--no-delay-leader-block-for-pending-fork`: explicitly disables the delay

## Implementation Notes

- `validator/src/commands/run/execute.rs` now treats the delay as enabled unless the explicit no-delay flag is present.
- `validator/src/commands/run/args.rs` adds the new hidden opt-out flag and marks the old hidden enable flag as a deprecated no-op.
- `core/src/validator.rs` keeps the test default at `false` with an explanatory comment to avoid broad test churn.

## Validation

- Added parser tests for:
  - `--no-delay-leader-block-for-pending-fork`
  - conflicting use of both delay flags
- Checked diagnostics on the touched files

