### PR TITLE
rpc: Fix short-circuit condition going into big-table

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1884,7 +1884,7 @@ impl JsonRpcRequestProcessor {
                 .collect()
         };
 
-        if results.len() < limit || !found_until {
+        if results.len() < limit || (until.is_some() && !found_until) {
             if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
                 let mut bigtable_before = before;
                 if !results.is_empty() {


### PR DESCRIPTION
#### Problem

While updating the bigtable fallback logic in #7937, we incorrectly short-circuited the check into bigtable. Currently, we always go into bigtable if `until` is not specified, even if we've hit the limit of transactions to return.

#### Summary of changes

Only respect `found_until` if `until` is provided.