### PR TITLE
Modify clean_and_unref_rooted_entries to use slot_list_mut code

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1099,55 +1099,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         removed || missing_in_accounts_index
     }
 
-    /// Clean the slot list by removing all slot_list items older than the max_slot
-    /// Decrease the reference count of the entry by the number of removed accounts.
-    /// Returns the slot and account_info of the remaining entry in the slot list
-    /// Note: This must only be called on startup, and reclaims
-    /// must be reclaimed.
-    fn clean_and_unref_slot_list_on_startup(
-        &self,
-        entry: &AccountMapEntry<T>,
-        reclaims: &mut ReclaimsSlotList<T>,
-    ) -> (u64, T) {
-        let mut slot_list = entry.slot_list_write_lock();
-        let max_slot = slot_list
-            .iter()
-            .map(|(slot, _account)| *slot)
-            .max()
-            .expect("Slot list has entries");
-
-        let mut reclaim_count = 0;
-
-        slot_list.retain_and_count(|(slot, value)| {
-            // keep the newest entry, and reclaim all others
-            if *slot < max_slot {
-                assert!(!value.is_cached(), "Unsafe to reclaim cached entries");
-                reclaims.push((*slot, *value));
-                reclaim_count += 1;
-                false
-            } else {
-                true
-            }
-        });
-
-        // Unref
-        entry.unref_by_count(reclaim_count);
-        assert_eq!(
-            entry.ref_count(),
-            1,
-            "ref count should be one after cleaning all entries"
-        );
-
-        entry.mark_dirty();
-
-        // Return the last entry in the slot list, which is the only one
-        *slot_list
-            .last()
-            .expect("Slot list should have at least one entry after cleaning")
-    }
-
     /// Cleans and unrefs all older rooted entries for each pubkey in the accounts index.
-    /// Calls passed in callback on the remaining slot entry
     /// All pubkeys must be from a single bin
     pub fn clean_and_unref_rooted_entries_by_bin(
         &self,
@@ -1161,11 +1113,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         };
 
         for pubkey in pubkeys_by_bin {
-            map.get_internal_inner(pubkey, |entry| {
-                let entry = entry.expect("Expected entry to exist in accounts index");
-                self.clean_and_unref_slot_list_on_startup(entry, &mut reclaims);
-                (false, ())
-            });
+            map.clean_and_unref_slot_list_on_startup(pubkey, &mut reclaims);
         }
         reclaims
     }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -428,7 +428,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 .expect("Slot list has entries");
 
             let mut reclaim_count = 0;
-            slot_list.retain_and_count(|(slot, value)| {
+            let count = slot_list.retain_and_count(|(slot, value)| {
                 // keep the newest entry, and reclaim all others
                 if *slot < max_slot {
                     assert!(!value.is_cached(), "Unsafe to reclaim cached entries");
@@ -439,6 +439,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     true
                 }
             });
+
+            assert_eq!(count, 1, "Slot list should have exactly one entry after cleaning");
 
             entry.unref_by_count(reclaim_count);
             assert_eq!(

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -440,7 +440,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 }
             });
 
-            assert_eq!(count, 1, "Slot list should have exactly one entry after cleaning");
+            assert_eq!(
+                count, 1,
+                "Slot list should have exactly one entry after cleaning"
+            );
 
             entry.unref_by_count(reclaim_count);
             assert_eq!(

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -382,25 +382,72 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         result
     }
 
-    /// call `user_fn` with a write lock of the slot list.
-    /// Note that whether `user_fn` modifies the slot list or not, the entry in the in-mem index will always
-    /// be marked as dirty. So, callers to this should ideally know they will be modifying the slot list.
-    pub fn slot_list_mut<RT>(
+    /// Convenience wrapper for slot_list_mut_with_entry that ignores the entry
+    pub(crate) fn slot_list_mut<RT>(
         &self,
         pubkey: &Pubkey,
         user_fn: impl FnOnce(SlotListWriteGuard<T>) -> RT,
+    ) -> Option<RT> {
+        self.slot_list_mut_with_entry(pubkey, |slot_list, _entry| user_fn(slot_list))
+    }
+
+    /// Call `user_fn` with a write lock of the slot list and the entry itself
+    /// Note that whether `user_fn` modifies the slot list or not, the entry in the in-mem index will always
+    /// be marked as dirty. So, callers to this should ideally know they will be modifying the slot list.
+    pub(crate) fn slot_list_mut_with_entry<RT>(
+        &self,
+        pubkey: &Pubkey,
+        user_fn: impl FnOnce(SlotListWriteGuard<T>, &AccountMapEntry<T>) -> RT,
     ) -> Option<RT> {
         self.get_internal_inner(pubkey, |entry| {
             (
                 true,
                 entry.map(|entry| {
-                    let result = user_fn(entry.slot_list_write_lock());
+                    let result = user_fn(entry.slot_list_write_lock(), entry);
                     // note that to be safe here, we ALWAYS mark the entry as dirty
                     entry.mark_dirty();
                     result
                 }),
             )
         })
+    }
+
+    /// Clean the slot list by removing all slot_list items older than the max_slot.
+    /// Decrease the reference count of the entry by the number of removed accounts.
+    /// Note: This must only be called on startup, and reclaims must be reclaimed.
+    pub(crate) fn clean_and_unref_slot_list_on_startup(
+        &self,
+        pubkey: &Pubkey,
+        reclaims: &mut ReclaimsSlotList<T>,
+    ) {
+        self.slot_list_mut_with_entry(pubkey, |mut slot_list, entry| {
+            let max_slot = slot_list
+                .iter()
+                .map(|(slot, _account)| *slot)
+                .max()
+                .expect("Slot list has entries");
+
+            let mut reclaim_count = 0;
+            slot_list.retain_and_count(|(slot, value)| {
+                // keep the newest entry, and reclaim all others
+                if *slot < max_slot {
+                    assert!(!value.is_cached(), "Unsafe to reclaim cached entries");
+                    reclaims.push((*slot, *value));
+                    reclaim_count += 1;
+                    false
+                } else {
+                    true
+                }
+            });
+
+            entry.unref_by_count(reclaim_count);
+            assert_eq!(
+                entry.ref_count(),
+                1,
+                "ref count should be one after cleaning all entries"
+            );
+        })
+        .expect("Expected entry to exist in accounts index");
     }
 
     /// Insert a cached entry into the accounts index


### PR DESCRIPTION
#### Problem
Spawned from: https://github.com/anza-xyz/agave/pull/12030#issuecomment-4284237879
clean_and_unref_rooted_entries logic is inconsistently placed with other slot list mutation code. 


#### Summary of Changes
- Move slot_list_mut code into slot_list_mut_with_entry
- Made slot_list_mut a wrapper around slot_list_mut_with_entry
- Move clean_and_unref_slot_list_on_startup to the in memory index and call slot_list_mut_with_entry

Just a refactoring. Ran back to back (with first, without second)
<img width="1679" height="414" alt="image" src="https://github.com/user-attachments/assets/dea7d479-57fe-4573-92ee-9e0e1a049213" />

Results with regards to timings  are identical. 

Fixes #
