### PR TITLE
chore(secpol): explicitly call out unsupported rpc environments

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -167,7 +167,10 @@ snapshot slot or genesis.
 * Issues involving maliciously crafted snapshots. Snapshots have historically been
 considered trust on first use and have many shortcomings with respect to consistency
 and verifiability as a result. An effort to improve this situation is actively underway
-* For the RPC DoS category, the following classes of issue are out of scope
+* The in-built RPC service is not intended to be directly exposed to untrusted clients.
+Any environments which require features like authentication and rate-limiting _*MUST*_ be
+deployed behind a reverse proxy or similar. For the RPC DoS category, the following
+classes of issue are out of scope
   * Those requiring a call rate greater than once per `CLUSTER_SLOT_TIME_TARGET / 2`
   * Those requiring calls from multiple clients
   * Those impacting getProgramAccounts, et al. without secondary indexes enabled and/or


### PR DESCRIPTION
#### Problem
the built in rpc service does not directly support features like authentication and rate-limiting. as such, we have always recommended that any environment which exposes it to untrusted clients implement those features by deploying the service behind a reverse proxy or similar

#### Summary of Changes
call out this situation in the out of scope section of the security policy