### PR TITLE
Config quic streamer receving max packet size; 

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -17,7 +17,7 @@ use {
     smallvec::SmallVec,
     solana_keypair::Keypair,
     solana_net_utils::token_bucket::TokenBucket,
-    solana_packet::{Meta, PACKET_DATA_SIZE},
+    solana_packet::Meta,
     solana_perf::packet::{BytesPacket, PacketBatch},
     solana_pubkey::Pubkey,
     solana_tls_utils::get_pubkey_from_tls_certificate,
@@ -151,7 +151,7 @@ where
 {
     let sockets: Vec<_> = sockets.into_iter().collect();
     info!("Start {name} quic server on {sockets:?}");
-    let (config, _) = configure_server(keypair)?;
+    let (config, _) = configure_server(keypair, &quic_server_params)?;
 
     let endpoints = sockets
         .into_iter()
@@ -507,6 +507,7 @@ async fn setup_connection<Q, C>(
                         new_connection,
                         stats,
                         server_params.wait_for_chunk_timeout,
+                        server_params.max_stream_data_bytes,
                         conn_context.clone(),
                         qos,
                         cancel_connection,
@@ -568,6 +569,7 @@ async fn handle_connection<Q, C>(
     connection: Connection,
     stats: Arc<StreamerStats>,
     wait_for_chunk_timeout: Duration,
+    max_stream_data_bytes: u32,
     context: C,
     qos: Arc<Q>,
     cancel: CancellationToken,
@@ -665,6 +667,7 @@ async fn handle_connection<Q, C>(
                 &packet_sender,
                 &stats,
                 peer_type,
+                max_stream_data_bytes,
             ) {
                 // The stream is finished, break out of the loop and close the stream.
                 Ok(StreamState::Finished) => {
@@ -721,14 +724,14 @@ fn handle_chunks(
     packet_sender: &Sender<PacketBatch>,
     stats: &StreamerStats,
     peer_type: ConnectionPeerType,
+    max_stream_data_bytes: u32,
 ) -> Result<StreamState, ()> {
     let n_chunks = chunks.len();
     for chunk in chunks {
         accum.meta.size += chunk.len();
-        if accum.meta.size > PACKET_DATA_SIZE {
-            // The stream window size is set to PACKET_DATA_SIZE, so one individual chunk can
-            // never exceed this size. A peer can send two chunks that together exceed the size
-            // tho, in which case we report the error.
+        if accum.meta.size > max_stream_data_bytes as usize {
+            // A peer can send multiple chunks that together exceed the
+            // configured maximum data bytes receivable over one stream; reject the stream in that case.
             stats.invalid_stream_size.fetch_add(1, Ordering::Relaxed);
             debug!("invalid stream size {}", accum.meta.size);
             return Err(());
@@ -1124,6 +1127,7 @@ pub mod test {
         quinn::{ApplicationClose, ConnectionError},
         solana_keypair::Keypair,
         solana_net_utils::sockets::bind_to_localhost_unique,
+        solana_packet::PACKET_DATA_SIZE,
         solana_signer::Signer,
         std::collections::HashMap,
         tokio::time::sleep,
@@ -2068,6 +2072,42 @@ pub mod test {
             _ => panic!("unexpected close"),
         }
         assert_eq!(stats.invalid_stream_size.load(Ordering::Relaxed), 1);
+        cancel.cancel();
+        join_handle.await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_client_connection_accepts_packet_up_to_configured_max_stream_data_bytes() {
+        let max_stream_data_bytes = PACKET_DATA_SIZE as u32 * 2;
+        let SpawnTestServerResult {
+            join_handle,
+            receiver,
+            server_address,
+            stats,
+            cancel,
+        } = setup_quic_server(
+            None,
+            QuicStreamerConfig {
+                stream_receive_window_size: max_stream_data_bytes,
+                max_stream_data_bytes,
+                ..QuicStreamerConfig::default_for_tests()
+            },
+            SwQosConfig::default(),
+        );
+
+        let client_connection = make_client_endpoint(&server_address, None).await;
+        let mut send_stream = client_connection.open_uni().await.unwrap();
+
+        let num_bytes = max_stream_data_bytes - 1;
+        send_stream
+            .write_all(&vec![42; num_bytes as usize])
+            .await
+            .unwrap();
+        send_stream.finish().unwrap();
+
+        check_received_packets(receiver, 1, num_bytes as usize).await;
+        assert_eq!(stats.invalid_stream_size.load(Ordering::Relaxed), 0);
+
         cancel.cancel();
         join_handle.await.unwrap();
     }

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -435,7 +435,7 @@ mod tests {
                 quic::{ConnectionTable, ConnectionTableType},
                 testing_utilities::get_client_config,
             },
-            quic::{StreamerStats, configure_server},
+            quic::{QuicStreamerConfig, StreamerStats, configure_server},
             streamer::StakedNodes,
         },
         quinn::Endpoint,
@@ -456,7 +456,8 @@ mod tests {
         client_keypair: &Keypair,
     ) -> (Connection, Endpoint, Endpoint) {
         // Create server endpoint
-        let (server_config, _) = configure_server(server_keypair).unwrap();
+        let (server_config, _) =
+            configure_server(server_keypair, &QuicStreamerConfig::default()).unwrap();
         let server_socket = bind_to_localhost_unique().expect("should bind - server");
         let server_addr = server_socket.local_addr().unwrap();
         let server_endpoint = Endpoint::new(

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -88,6 +88,7 @@ pub struct SpawnServerResult {
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
 pub(crate) fn configure_server(
     identity_keypair: &Keypair,
+    quic_server_params: &QuicStreamerConfig,
 ) -> Result<(ServerConfig, String), QuicServerError> {
     let (cert, priv_key) = new_dummy_x509_certificate(identity_keypair);
     let cert_chain_pem_parts = vec![Pem {
@@ -111,10 +112,7 @@ pub(crate) fn configure_server(
 
     // Set STREAM_MAX_DATA to fit at most 1 transaction.
     // This should match the maximal TX size.
-    config.stream_receive_window((PACKET_DATA_SIZE as u32).into());
-    // set the receive window really small initially to prevent the fresh connections
-    // from slamming us with traffic.
-    config.receive_window((PACKET_DATA_SIZE as u32).into());
+    config.stream_receive_window((quic_server_params.stream_receive_window_size).into());
     // disable uni_streams until handshake is complete
     config.max_concurrent_uni_streams(0u32.into());
     config.receive_window(CONNECTION_RECEIVE_WINDOW_BYTES);
@@ -155,11 +153,12 @@ pub enum QuicServerError {
 
 pub struct EndpointKeyUpdater {
     endpoints: Vec<Endpoint>,
+    quic_server_params: QuicStreamerConfig,
 }
 
 impl NotifyKeyUpdate for EndpointKeyUpdater {
     fn update_key(&self, key: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
-        let (config, _) = configure_server(key)?;
+        let (config, _) = configure_server(key, &self.quic_server_params)?;
         for endpoint in &self.endpoints {
             endpoint.set_server_config(Some(config.clone()));
         }
@@ -553,6 +552,10 @@ pub struct QuicStreamerConfig {
     pub max_connections_per_ipaddr_per_min: u64,
     pub wait_for_chunk_timeout: Duration,
     pub num_threads: NonZeroUsize,
+    /// Per-stream QUIC receive window (flow control limit).
+    pub stream_receive_window_size: u32,
+    /// Maximum total bytes allowed per stream (hard cap).
+    pub max_stream_data_bytes: u32,
 }
 
 #[derive(Clone)]
@@ -573,6 +576,8 @@ impl Default for QuicStreamerConfig {
             max_connections_per_ipaddr_per_min: DEFAULT_MAX_CONNECTIONS_PER_IPADDR_PER_MINUTE,
             wait_for_chunk_timeout: DEFAULT_WAIT_FOR_CHUNK_TIMEOUT,
             num_threads: NonZeroUsize::new(num_cpus::get().min(1)).expect("1 is non-zero"),
+            stream_receive_window_size: PACKET_DATA_SIZE as u32,
+            max_stream_data_bytes: PACKET_DATA_SIZE as u32,
         }
     }
 }
@@ -616,7 +621,7 @@ where
             sockets,
             keypair,
             packet_sender,
-            quic_server_params,
+            quic_server_params.clone(),
             qos,
             cancel,
         )
@@ -631,6 +636,7 @@ where
         .unwrap();
     let updater = EndpointKeyUpdater {
         endpoints: result.endpoints.clone(),
+        quic_server_params,
     };
     Ok(SpawnServerResult {
         endpoints: result.endpoints,


### PR DESCRIPTION
#### Problem

V1 transaction has size up to 4096B. Streamer currently block packets larger than PACKET_DATA_SIZE.

#### Summary of Changes
- extended `QuicStreamerConfig` to include parameters for `receive_window_size` and `max_packet_size`. they are defaulted to current value, eg `default` has no change to current behavior
- piped config to where quic receiving window size and max packet size are checked.
- add test for packet up to configured max size
- since we don't need to bring in v1 message size const, this pr makes no change to cargo.toml 

Fixes #
