### PR TITLE
shred: apply SIMD-0337 rules to recovered shreds

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -4,16 +4,38 @@ use {
     bencher::{Bencher, benchmark_group, benchmark_main},
     rand::Rng,
     solana_entry::entry::{Entry, create_ticks},
+    solana_epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_ledger::shred::{
-        CODING_SHREDS_PER_FEC_BLOCK, DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats,
-        ReedSolomonCache, Shred, Shredder, get_data_shred_bytes_per_batch_typical,
-        max_entries_per_n_shred, max_ticks_per_n_shreds, recover,
+    solana_ledger::{
+        genesis_utils::create_genesis_config,
+        shred::{
+            CODING_SHREDS_PER_FEC_BLOCK, DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats,
+            ReedSolomonCache, Shred, Shredder, filter::ShredRecoveryContext,
+            get_data_shred_bytes_per_batch_typical, max_entries_per_n_shred,
+            max_ticks_per_n_shreds,
+        },
     },
     solana_perf::test_tx,
-    std::hint::black_box,
+    solana_runtime::bank::Bank,
+    solana_streamer::evicting_sender::EvictingSender,
+    std::{hint::black_box, sync::Arc},
 };
+
+fn new_shred_recovery_context(shreds: &[Shred]) -> ShredRecoveryContext {
+    let mut genesis_config = create_genesis_config(1).genesis_config;
+    let shred_slot = shreds.first().map(Shred::slot).unwrap_or_default();
+    let slots_per_epoch = shred_slot.max(MINIMUM_SLOTS_PER_EPOCH);
+    genesis_config.epoch_schedule = EpochSchedule::custom(slots_per_epoch, slots_per_epoch, false);
+    let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
+    ShredRecoveryContext::new(
+        ReedSolomonCache::default(),
+        dummy_retransmit_sender,
+        root_bank,
+        shreds.first().map(Shred::version).unwrap_or_default(),
+    )
+}
 
 fn make_test_entry(txs_per_entry: u64) -> Entry {
     Entry {
@@ -184,11 +206,19 @@ fn bench_shredder_decoding(bencher: &mut Bencher) {
         )
         .partition(Shred::is_data);
     coding_shreds.truncate(CODING_SHREDS_PER_FEC_BLOCK);
+    let mut shred_recovery_context = new_shred_recovery_context(&coding_shreds);
 
     bencher.iter(|| {
-        for shred in recover(coding_shreds.clone(), &reed_solomon_cache).unwrap() {
-            black_box(shred.unwrap());
-        }
+        let mut recovered_shreds = Vec::new();
+        let mut recovered_data_shreds = Vec::new();
+        shred_recovery_context
+            .recover(
+                coding_shreds.clone(),
+                &mut recovered_shreds,
+                &mut recovered_data_shreds,
+            )
+            .unwrap();
+        black_box((recovered_shreds, recovered_data_shreds));
     })
 }
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -430,6 +430,7 @@ impl Tvu {
                 repair_info,
                 window_service_channels,
                 leader_schedule_cache.clone(),
+                tvu_config.shred_version,
                 outstanding_repair_requests,
             )
         };

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -19,12 +19,12 @@ use {
         blockstore::{Blockstore, BlockstoreInsertionMetrics, PossibleDuplicateShred},
         blockstore_meta::BlockLocation,
         leader_schedule_cache::LeaderScheduleCache,
-        shred::{self, ReedSolomonCache, Shred},
+        shred::{self, ReedSolomonCache, Shred, filter::ShredRecoveryContext},
     },
     solana_measure::measure::Measure,
     solana_metrics::inc_new_counter_error,
     solana_rayon_threadlimit::get_thread_count,
-    solana_runtime::bank_forks::BankForks,
+    solana_runtime::bank_forks::{BankForks, SharableBanks},
     solana_streamer::evicting_sender::EvictingSender,
     std::{
         borrow::Cow,
@@ -174,13 +174,12 @@ fn run_insert<F>(
     thread_pool: &ThreadPool,
     verified_receiver: &Receiver<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
     blockstore: &Blockstore,
+    shred_recovery_context: &mut ShredRecoveryContext,
     leader_schedule_cache: &LeaderScheduleCache,
     handle_duplicate: F,
     metrics: &mut BlockstoreInsertionMetrics,
     ws_metrics: &mut WindowServiceMetrics,
     completed_data_sets_sender: Option<&CompletedDataSetsSender>,
-    retransmit_sender: &EvictingSender<Vec<shred::Payload>>,
-    reed_solomon_cache: &ReedSolomonCache,
 ) -> Result<()>
 where
     F: Fn(PossibleDuplicateShred),
@@ -213,9 +212,8 @@ where
         shreds,
         Some(leader_schedule_cache),
         false, // is_trusted
-        retransmit_sender,
+        shred_recovery_context,
         &handle_duplicate,
-        reed_solomon_cache,
         metrics,
     )?;
 
@@ -267,6 +265,7 @@ impl WindowService {
         repair_info: RepairInfo,
         window_service_channels: WindowServiceChannels,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
+        shred_version: u16,
         outstanding_repair_requests: Arc<RwLock<OutstandingShredRepairs>>,
     ) -> WindowService {
         let cluster_info = repair_info.cluster_info.clone();
@@ -298,13 +297,16 @@ impl WindowService {
             blockstore.clone(),
             duplicate_receiver,
             duplicate_slots_sender,
-            bank_forks,
+            bank_forks.clone(),
         );
 
+        let sharable_banks = bank_forks.read().unwrap().sharable_banks();
         let t_insert = Self::start_window_insert_thread(
             exit,
             blockstore,
+            sharable_banks,
             leader_schedule_cache,
+            shred_version,
             verified_receiver,
             duplicate_sender,
             completed_data_sets_sender,
@@ -352,7 +354,9 @@ impl WindowService {
     fn start_window_insert_thread(
         exit: Arc<AtomicBool>,
         blockstore: Arc<Blockstore>,
+        sharable_banks: SharableBanks,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
+        shred_version: u16,
         verified_receiver: Receiver<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
         check_duplicate_sender: Sender<PossibleDuplicateShred>,
         completed_data_sets_sender: Option<CompletedDataSetsSender>,
@@ -382,19 +386,26 @@ impl WindowService {
                 let mut metrics = BlockstoreInsertionMetrics::default();
                 let mut ws_metrics = WindowServiceMetrics::default();
                 let mut last_print = Instant::now();
+                let mut shred_recovery_context = ShredRecoveryContext::new(
+                    reed_solomon_cache,
+                    retransmit_sender,
+                    sharable_banks.root(),
+                    shred_version,
+                );
 
                 while !exit.load(Ordering::Relaxed) {
+                    shred_recovery_context.maybe_update(sharable_banks.root());
+
                     if let Err(e) = run_insert(
                         &thread_pool,
                         &verified_receiver,
                         &blockstore,
+                        &mut shred_recovery_context,
                         &leader_schedule_cache,
                         handle_duplicate,
                         &mut metrics,
                         &mut ws_metrics,
                         completed_data_sets_sender.as_ref(),
-                        &retransmit_sender,
-                        &reed_solomon_cache,
                     ) {
                         ws_metrics.record_error(&e);
                         if Self::should_exit_on_error(e, &handle_error) {
@@ -409,6 +420,7 @@ impl WindowService {
                         ws_metrics = WindowServiceMetrics::default();
                         last_print = Instant::now();
                     }
+                    shred_recovery_context.maybe_submit_stats();
                 }
             })
             .unwrap()
@@ -570,14 +582,13 @@ mod test {
             blockstore.clone(),
             duplicate_shred_receiver,
             duplicate_slot_sender,
-            bank_forks,
+            bank_forks.clone(),
         );
 
         let handle_duplicate = |shred| {
             let _ = duplicate_shred_sender.send(shred);
         };
         let num_trials = 100;
-        let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
         for slot in 0..num_trials {
             let (shreds, _) = make_many_slot_entries(slot, 1, 10);
             let duplicate_index = 0;
@@ -591,14 +602,19 @@ mod test {
             let shreds = [&original_shred, &duplicate_shred]
                 .into_iter()
                 .map(|shred| (Cow::Borrowed(shred), /*is_repaired:*/ false));
+            let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
             blockstore
                 .insert_shreds_handle_duplicate(
                     shreds,
                     None,
                     false, // is_trusted
-                    &dummy_retransmit_sender,
+                    &mut ShredRecoveryContext::new(
+                        ReedSolomonCache::default(),
+                        dummy_retransmit_sender,
+                        bank_forks.read().unwrap().root_bank(),
+                        0, // shred_version
+                    ),
                     &handle_duplicate,
-                    &ReedSolomonCache::default(),
                     &mut BlockstoreInsertionMetrics::default(),
                 )
                 .unwrap();

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1370,7 +1370,7 @@ pub mod static_instruction_limit {
 }
 
 pub mod discard_unexpected_data_complete_shreds {
-    solana_pubkey::declare_id!("dcomRRWHXP1FVWPqi9Mm4oxJhF4ehC795SvAtUdA9os");
+    solana_pubkey::declare_id!("disCA4efguFL6Wqa4pGdG7jpjC7C5uiKzKnhEBqchBe");
 }
 
 pub mod vote_state_v4 {

--- a/ledger/benches/make_shreds_from_entries.rs
+++ b/ledger/benches/make_shreds_from_entries.rs
@@ -3,14 +3,37 @@ use {
     criterion::{Criterion, criterion_group, criterion_main},
     rand::Rng,
     solana_entry::entry::Entry,
+    solana_epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_ledger::shred::{self, ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
+    solana_ledger::{
+        genesis_utils::create_genesis_config,
+        shred::{
+            ProcessShredsStats, ReedSolomonCache, Shred, Shredder, filter::ShredRecoveryContext,
+        },
+    },
     solana_packet::PACKET_DATA_SIZE,
     solana_pubkey::Pubkey,
+    solana_runtime::bank::Bank,
+    solana_streamer::evicting_sender::EvictingSender,
     solana_transaction::Transaction,
-    std::{hint::black_box, iter::repeat_with},
+    std::{hint::black_box, iter::repeat_with, sync::Arc},
 };
+
+fn new_shred_recovery_context(shreds: &[Shred]) -> ShredRecoveryContext {
+    let mut genesis_config = create_genesis_config(1).genesis_config;
+    let shred_slot = shreds.first().map(Shred::slot).unwrap_or_default();
+    let slots_per_epoch = shred_slot.max(MINIMUM_SLOTS_PER_EPOCH);
+    genesis_config.epoch_schedule = EpochSchedule::custom(slots_per_epoch, slots_per_epoch, false);
+    let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
+    ShredRecoveryContext::new(
+        ReedSolomonCache::default(),
+        dummy_retransmit_sender,
+        root_bank,
+        shreds.first().map(Shred::version).unwrap_or_default(),
+    )
+}
 
 fn make_dummy_hash<R: Rng>(rng: &mut R) -> Hash {
     Hash::from(rng.random::<[u8; 32]>())
@@ -178,12 +201,18 @@ fn run_recover_shreds(
     let mut shreds = data;
     shreds.extend(code);
     c.bench_function(name, |b| {
+        let mut shred_recovery_context = new_shred_recovery_context(&shreds);
         b.iter(|| {
-            let recovered_shreds = shred::recover(shreds.clone(), &reed_solomon_cache)
-                .unwrap()
-                .collect::<Result<Vec<_>, _>>()
+            let mut recovered_shreds = Vec::new();
+            let mut recovered_data_shreds = Vec::new();
+            shred_recovery_context
+                .recover(
+                    shreds.clone(),
+                    &mut recovered_shreds,
+                    &mut recovered_data_shreds,
+                )
                 .unwrap();
-            black_box(recovered_shreds);
+            black_box((recovered_shreds, recovered_data_shreds));
         })
     });
 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -16,8 +16,9 @@ use {
         leader_schedule_cache::LeaderScheduleCache,
         next_slots_iterator::NextSlotsIterator,
         shred::{
-            self, DATA_SHREDS_PER_FEC_BLOCK, ErasureSetId, ProcessShredsStats, ReedSolomonCache,
-            Shred, ShredFlags, ShredId, ShredType, Shredder,
+            self, DATA_SHREDS_PER_FEC_BLOCK, ErasureSetId, Payload, ProcessShredsStats,
+            ReedSolomonCache, Shred, ShredFlags, ShredId, ShredType, Shredder,
+            filter::ShredRecoveryContext,
             merkle_tree::{MerkleTree, SIZE_OF_MERKLE_PROOF_ENTRY, get_proof_size},
         },
         slot_stats::{ShredSource, SlotsStats},
@@ -53,7 +54,6 @@ use {
     solana_signature::Signature,
     solana_signer::Signer,
     solana_storage_proto::{StoredExtendedRewards, StoredTransactionStatusMeta},
-    solana_streamer::{evicting_sender::EvictingSender, streamer::ChannelSend},
     solana_time_utils::timestamp,
     solana_transaction::{
         TransactionVerificationMode,
@@ -1293,20 +1293,22 @@ impl Blockstore {
         })
     }
 
-    /// Performs shred recovery for `erasure_meta`
+    /// Performs shred recovery for `erasure_meta`, applying shred sanitization and filters
+    /// to the recovered shreds.
     /// Note: that we do not do recovery on the Alternate shred columns
-    fn recover_shreds<'a>(
-        &'a self,
-        index: &'a Index,
-        erasure_meta: &'a ErasureMeta,
-        prev_inserted_shreds: &'a HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
-        reed_solomon_cache: &'a ReedSolomonCache,
-    ) -> std::result::Result<impl Iterator<Item = Shred> + 'a, shred::Error> {
+    fn recover_shreds(
+        &self,
+        index: &Index,
+        erasure_meta: &ErasureMeta,
+        prev_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+        shred_recovery_ctx: &mut ShredRecoveryContext,
+        recovered_shreds: &mut Vec<Payload>,
+        recovered_data_shreds: &mut Vec<Shred>,
+    ) -> std::result::Result<(), shred::Error> {
         // Find shreds for this erasure set and try recovery
         let data = self.get_recovery_data_shreds(index, erasure_meta, prev_inserted_shreds);
         let code = self.get_recovery_coding_shreds(index, erasure_meta, prev_inserted_shreds);
-        let shreds = shred::recover(data.chain(code), reed_solomon_cache)?;
-        Ok(shreds.filter_map(std::result::Result::ok))
+        shred_recovery_ctx.recover(data.chain(code), recovered_shreds, recovered_data_shreds)
     }
 
     /// Collects and reports [`BlockstoreRocksDbColumnFamilyMetrics`] for the
@@ -1477,20 +1479,26 @@ impl Blockstore {
         metrics.insert_shreds_elapsed_us += start.as_us();
     }
 
-    fn try_shred_recovery<'a>(
-        &'a self,
-        erasure_metas: &'a BTreeMap<ErasureSetId, WorkingEntry<ErasureMeta>>,
-        index_working_set: &'a HashMap<(BlockLocation, u64), IndexMetaWorkingSetEntry>,
-        prev_inserted_shreds: &'a HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
-        reed_solomon_cache: &'a ReedSolomonCache,
-    ) -> impl Iterator<Item = Shred> + 'a {
-        // Recovery rules:
-        // 1. Only try recovery around indexes for which new data or coding shreds are received
-        // 2. For new data shreds, check if an erasure set exists. If not, don't try recovery
-        // 3. Before trying recovery, check if enough number of shreds have been received
-        // 3a. Enough number of shreds = (#data + #coding shreds) > erasure.num_data
-        // 4. Only perform rceovery in the Original column
-        erasure_metas
+    /// Attempt shred recovery for erasure metas
+    /// Recovery rules:
+    /// 1. Only try recovery around indexes for which new data or coding shreds are received
+    /// 2. For new data shreds, check if an erasure set exists. If not, don't try recovery
+    /// 3. Before trying recovery, check if enough number of shreds have been received
+    ///    3a. Enough number of shreds = (#data + #coding shreds) > erasure.num_data
+    /// 4. Only perform rceovery in the Original column
+    ///
+    /// Returns (recovered_shreds, recovered_data_shreds)
+    fn try_shred_recovery(
+        &self,
+        erasure_metas: &BTreeMap<ErasureSetId, WorkingEntry<ErasureMeta>>,
+        index_working_set: &HashMap<(BlockLocation, u64), IndexMetaWorkingSetEntry>,
+        prev_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+        shred_recovery_ctx: &mut ShredRecoveryContext,
+    ) -> (
+        /* recovered_shreds */ Vec<Payload>,
+        /* recovered_data_shreds */ Vec<Shred>,
+    ) {
+        let erasure_metas_to_recover = erasure_metas
             .iter()
             .filter_map(|(erasure_set, working_erasure_meta)| {
                 let erasure_meta = working_erasure_meta.as_ref();
@@ -1501,17 +1509,32 @@ impl Blockstore {
                 let index = &index_meta_entry.index;
                 erasure_meta
                     .should_recover_shreds(index)
-                    .then(|| {
-                        self.recover_shreds(
-                            index,
-                            erasure_meta,
-                            prev_inserted_shreds,
-                            reed_solomon_cache,
-                        )
-                    })?
-                    .ok()
+                    .then_some((index, erasure_meta))
             })
-            .flatten()
+            .collect_vec();
+
+        let max_recovered_shreds = erasure_metas_to_recover.len() * DATA_SHREDS_PER_FEC_BLOCK;
+        let mut recovered_shreds = Vec::with_capacity(max_recovered_shreds);
+        let mut recovered_data_shreds = Vec::with_capacity(max_recovered_shreds);
+        for (index, erasure_meta) in erasure_metas_to_recover {
+            let _ = self
+                .recover_shreds(
+                    index,
+                    erasure_meta,
+                    prev_inserted_shreds,
+                    shred_recovery_ctx,
+                    &mut recovered_shreds,
+                    &mut recovered_data_shreds,
+                )
+                .inspect_err(|e| {
+                    info!(
+                        "Unable to perform shred recovery for slot {} fec set {}: {e:?}",
+                        index.slot,
+                        erasure_meta.fec_set_index()
+                    )
+                });
+        }
+        (recovered_shreds, recovered_data_shreds)
     }
 
     /// Attempts shred recovery and does the following for recovered data
@@ -1524,42 +1547,20 @@ impl Blockstore {
     fn handle_shred_recovery(
         &self,
         leader_schedule: Option<&LeaderScheduleCache>,
-        reed_solomon_cache: &ReedSolomonCache,
+        shred_recovery_context: &mut ShredRecoveryContext,
         shred_insertion_tracker: &mut ShredInsertionTracker,
-        retransmit_sender: &EvictingSender<Vec<shred::Payload>>,
         is_trusted: bool,
         metrics: &mut BlockstoreInsertionMetrics,
     ) {
         let mut start = Measure::start("Shred recovery");
-        let mut recovered_shreds = Vec::new();
-        let recovered_data_shreds: Vec<_> = self
-            .try_shred_recovery(
-                &shred_insertion_tracker.erasure_metas,
-                &shred_insertion_tracker.index_working_set,
-                &shred_insertion_tracker.just_inserted_shreds,
-                reed_solomon_cache,
-            )
-            .filter_map(|shred| {
-                // All shreds should be retransmitted, but because there are no
-                // more missing data shreds in the erasure batch, coding shreds
-                // are not stored in blockstore.
-                match shred.shred_type() {
-                    ShredType::Code => {
-                        // Don't need Arc overhead here!
-                        recovered_shreds.push(shred.into_payload());
-                        None
-                    }
-                    ShredType::Data => {
-                        // Verify that the cloning is cheap here.
-                        recovered_shreds.push(shred.payload().clone());
-                        Some(shred)
-                    }
-                }
-            })
-            .collect();
-        if !recovered_shreds.is_empty() {
-            let _ = retransmit_sender.try_send(recovered_shreds);
-        }
+        let (recovered_shreds, recovered_data_shreds) = self.try_shred_recovery(
+            &shred_insertion_tracker.erasure_metas,
+            &shred_insertion_tracker.index_working_set,
+            &shred_insertion_tracker.just_inserted_shreds,
+            shred_recovery_context,
+        );
+        shred_recovery_context.try_retransmit_shreds(recovered_shreds);
+
         metrics.num_recovered += recovered_data_shreds.len();
         for shred in recovered_data_shreds {
             let slot = shred.slot();
@@ -1946,17 +1947,14 @@ impl Blockstore {
     ///     pair to the `cf::Index` column family for each index_working_set_entry which insert did occur in this function call.
     ///
     /// Arguments:
-    ///  - `shreds`: the shreds to be inserted, alongside the location to insert.
-    ///  - `is_repaired`: a boolean vector aligned with `shreds` where each
-    ///    boolean indicates whether the corresponding shred is repaired or not.
+    ///  - `shreds`: the shreds to be inserted, alongside their repaired flag and
+    ///    insertion location.
     ///  - `leader_schedule`: the leader schedule
     ///  - `is_trusted`: whether the shreds come from a trusted source. If this
     ///    is set to true, then the function will skip the shred duplication and
     ///    integrity checks.
-    ///  - `retransmit_sender`: the sender for transmitting any recovered
-    ///    data shreds.
-    ///  - `handle_duplicate`: a function for handling shreds that have the same slot
-    ///    and index.
+    ///  - `shred_recovery_context`: recovery-time dependencies and policy for
+    ///    erasure recovery. `None` disables recovery.
     ///  - `metrics`: the metric for reporting detailed stats
     ///
     /// On success, the function returns an Ok result with a vector of
@@ -1975,10 +1973,7 @@ impl Blockstore {
         // retransmit channel either. Otherwise, if we are inserting shreds
         // from another leader, we need to try erasure recovery and retransmit
         // recovered shreds.
-        should_recover_shreds: Option<(
-            &ReedSolomonCache,
-            &EvictingSender<Vec<shred::Payload>>, // retransmit_sender
-        )>,
+        shred_recovery_context: Option<&mut ShredRecoveryContext>,
         metrics: &mut BlockstoreInsertionMetrics,
     ) -> Result<InsertResults> {
         let mut total_start = Measure::start("Total elapsed");
@@ -2000,12 +1995,11 @@ impl Blockstore {
             &mut shred_insertion_tracker,
             metrics,
         );
-        if let Some((reed_solomon_cache, retransmit_sender)) = should_recover_shreds {
+        if let Some(shred_recovery_context) = shred_recovery_context {
             self.handle_shred_recovery(
                 leader_schedule,
-                reed_solomon_cache,
+                shred_recovery_context,
                 &mut shred_insertion_tracker,
-                retransmit_sender,
                 is_trusted,
                 metrics,
             );
@@ -2052,6 +2046,7 @@ impl Blockstore {
 
     /// Simlar to `insert_shreds_at_location_handle_duplicate`  but always inserts
     /// shreds in the original column specified by `BlockLocation::Original`
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn insert_shreds_handle_duplicate<'a, F>(
         &self,
         shreds: impl IntoIterator<
@@ -2060,9 +2055,8 @@ impl Blockstore {
         >,
         leader_schedule: Option<&LeaderScheduleCache>,
         is_trusted: bool,
-        retransmit_sender: &EvictingSender<Vec<shred::Payload>>,
+        shred_recovery_context: &mut ShredRecoveryContext,
         handle_duplicate: &F,
-        reed_solomon_cache: &ReedSolomonCache,
         metrics: &mut BlockstoreInsertionMetrics,
     ) -> Result<Vec<CompletedDataSetInfo>>
     where
@@ -2074,9 +2068,8 @@ impl Blockstore {
                 .map(|(shred, is_repaired)| (shred, is_repaired, BlockLocation::Original)),
             leader_schedule,
             is_trusted,
-            retransmit_sender,
+            shred_recovery_context,
             handle_duplicate,
-            reed_solomon_cache,
             metrics,
         )
     }
@@ -2094,9 +2087,8 @@ impl Blockstore {
         >,
         leader_schedule: Option<&LeaderScheduleCache>,
         is_trusted: bool,
-        retransmit_sender: &EvictingSender<Vec<shred::Payload>>,
+        shred_recovery_context: &mut ShredRecoveryContext,
         handle_duplicate: &F,
-        reed_solomon_cache: &ReedSolomonCache,
         metrics: &mut BlockstoreInsertionMetrics,
     ) -> Result<Vec<CompletedDataSetInfo>>
     where
@@ -2109,7 +2101,7 @@ impl Blockstore {
             shreds,
             leader_schedule,
             is_trusted,
-            Some((reed_solomon_cache, retransmit_sender)),
+            Some(shred_recovery_context),
             metrics,
         )?;
 
@@ -2187,7 +2179,7 @@ impl Blockstore {
             shreds,
             leader_schedule,
             is_trusted,
-            None, // (reed_solomon_cache, retransmit_sender)
+            None, // Skip recovery for locally produced shreds.
             &mut BlockstoreInsertionMetrics::default(),
         )?;
         Ok(insert_results.completed_data_set_infos)
@@ -2219,7 +2211,7 @@ impl Blockstore {
                 )],
                 Some(leader_schedule),
                 false,
-                None, // (reed_solomon_cache, retransmit_sender)
+                None, // Skip recovery for this direct insertion path.
                 &mut BlockstoreInsertionMetrics::default(),
             )
             .unwrap();
@@ -6196,10 +6188,12 @@ pub mod tests {
         crate::{
             genesis_utils::{GenesisConfigInfo, create_genesis_config},
             shred::{
-                max_ticks_per_n_shreds,
+                ShredFlags, max_ticks_per_n_shreds,
+                merkle::finish_erasure_batch_for_tests,
                 merkle_tree::{SIZE_OF_MERKLE_PROOF_ENTRY, get_proof_size, verify_merkle_proof},
             },
         },
+        agave_feature_set::discard_unexpected_data_complete_shreds,
         assert_matches::assert_matches,
         crossbeam_channel::unbounded,
         rand::{rng, seq::SliceRandom},
@@ -6216,6 +6210,7 @@ pub mod tests {
         solana_shred_version::version_from_hash,
         solana_signature::Signature,
         solana_storage_proto::convert::generated,
+        solana_streamer::evicting_sender::EvictingSender,
         solana_transaction::Transaction,
         solana_transaction_context::transaction::TransactionReturnData,
         solana_transaction_error::TransactionError,
@@ -10857,6 +10852,8 @@ pub mod tests {
         let slot = 1;
         let (data_shreds, coding_shreds, leader_schedule_cache) =
             setup_erasure_shreds(slot, 0, 100);
+        let genesis_config = create_genesis_config(2).genesis_config;
+        let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
         let coding_shreds = coding_shreds.into_iter().map(|shred| {
@@ -10871,7 +10868,12 @@ pub mod tests {
                 coding_shreds,
                 Some(&leader_schedule_cache),
                 false, // is_trusted
-                Some((&ReedSolomonCache::default(), &dummy_retransmit_sender)),
+                Some(&mut ShredRecoveryContext::new(
+                    ReedSolomonCache::default(),
+                    dummy_retransmit_sender,
+                    root_bank,
+                    0, // shred_version
+                )),
                 &mut BlockstoreInsertionMetrics::default(),
             )
             .unwrap();
@@ -10888,6 +10890,113 @@ pub mod tests {
             );
         }
 
+        verify_index_integrity(&blockstore, slot);
+    }
+
+    #[test]
+    fn test_recovery_discards_unexpected_data_complete_shreds() {
+        const DATA_SHRED_FLAGS_OFFSET: usize = 85;
+
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let genesis_config = create_genesis_config(2).genesis_config;
+        let mut root_bank = Bank::new_for_tests(&genesis_config);
+        root_bank.activate_feature(&discard_unexpected_data_complete_shreds::id());
+        let root_bank = Arc::new(root_bank);
+        let slot = root_bank.get_slots_in_epoch(root_bank.epoch());
+        let reed_solomon_cache = ReedSolomonCache::default();
+        let (data_shreds, coding_shreds, leader_keypair, leader_schedule_cache) =
+            setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot_and_keypair(
+                slot,
+                0,
+                100,
+                0,
+                Hash::new_from_array(rand::rng().random()),
+                false, // is_last_in_slot
+            );
+        assert!(data_shreds.len() >= DATA_SHREDS_PER_FEC_BLOCK);
+        assert!(coding_shreds.len() >= DATA_SHREDS_PER_FEC_BLOCK);
+
+        let mut first_fec_set: Vec<_> = data_shreds[..DATA_SHREDS_PER_FEC_BLOCK]
+            .iter()
+            .cloned()
+            .chain(coding_shreds[..DATA_SHREDS_PER_FEC_BLOCK].iter().cloned())
+            .collect();
+        let chained_merkle_root = first_fec_set[0].chained_merkle_root().unwrap();
+
+        for shred in first_fec_set.iter_mut().take(DATA_SHREDS_PER_FEC_BLOCK) {
+            let mut payload = shred.payload().clone();
+            payload.as_mut()[DATA_SHRED_FLAGS_OFFSET] |= ShredFlags::DATA_COMPLETE_SHRED.bits();
+            *shred = Shred::new_from_serialized_shred(payload).unwrap();
+        }
+        finish_erasure_batch_for_tests(
+            &leader_keypair,
+            &mut first_fec_set,
+            chained_merkle_root,
+            &reed_solomon_cache,
+        )
+        .unwrap();
+
+        let (mut data_shreds, mut coding_shreds): (Vec<_>, Vec<_>) =
+            first_fec_set.into_iter().partition(Shred::is_data);
+        data_shreds.sort_unstable_by_key(Shred::index);
+        coding_shreds.sort_unstable_by_key(Shred::index);
+
+        let valid_data_shred = data_shreds.pop().unwrap();
+        let shreds: Vec<_> = std::iter::once(valid_data_shred.clone())
+            .chain(
+                coding_shreds
+                    .into_iter()
+                    .take(DATA_SHREDS_PER_FEC_BLOCK - 1),
+            )
+            .map(|shred| {
+                (
+                    Cow::Owned(shred),
+                    /*is_repaired:*/ false,
+                    BlockLocation::Original,
+                )
+            })
+            .collect();
+        let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
+        let mut metrics = BlockstoreInsertionMetrics::default();
+        blockstore
+            .do_insert_shreds(
+                shreds,
+                Some(&leader_schedule_cache),
+                false, // is_trusted
+                Some(&mut ShredRecoveryContext::new(
+                    reed_solomon_cache,
+                    dummy_retransmit_sender,
+                    root_bank,
+                    0, // shred_version
+                )),
+                &mut metrics,
+            )
+            .unwrap();
+
+        assert_eq!(metrics.num_recovered, 0);
+        assert_eq!(metrics.num_recovered_inserted, 0);
+        assert_eq!(metrics.num_recovered_failed_invalid, 0);
+
+        let index = blockstore.get_index(slot).unwrap().unwrap();
+        assert_eq!(index.data().num_shreds(), 1);
+        assert!(index.data().contains(u64::from(valid_data_shred.index())));
+        assert_eq!(
+            blockstore
+                .get_data_shred(slot, u64::from(valid_data_shred.index()))
+                .unwrap()
+                .unwrap(),
+            valid_data_shred.payload().as_ref(),
+        );
+        for shred in data_shreds {
+            assert!(
+                blockstore
+                    .get_data_shred(slot, u64::from(shred.index()))
+                    .unwrap()
+                    .is_none()
+            );
+        }
         verify_index_integrity(&blockstore, slot);
     }
 
@@ -11076,6 +11185,32 @@ pub mod tests {
         chained_merkle_root: Hash,
         is_last_in_slot: bool,
     ) -> (Vec<Shred>, Vec<Shred>, Arc<LeaderScheduleCache>) {
+        let (data_shreds, coding_shreds, _, leader_schedule_cache) =
+            setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot_and_keypair(
+                slot,
+                parent_slot,
+                num_entries,
+                fec_set_index,
+                chained_merkle_root,
+                is_last_in_slot,
+            );
+
+        (data_shreds, coding_shreds, leader_schedule_cache)
+    }
+
+    fn setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot_and_keypair(
+        slot: u64,
+        parent_slot: u64,
+        num_entries: u64,
+        fec_set_index: u32,
+        chained_merkle_root: Hash,
+        is_last_in_slot: bool,
+    ) -> (
+        Vec<Shred>,
+        Vec<Shred>,
+        Arc<Keypair>,
+        Arc<LeaderScheduleCache>,
+    ) {
         let entries = make_slot_entries_with_transactions(num_entries);
         let leader_keypair = Arc::new(Keypair::new());
         let shredder = Shredder::new(slot, parent_slot, 0, 0).unwrap();
@@ -11104,7 +11239,12 @@ pub mod tests {
         };
         leader_schedule_cache.set_fixed_leader_schedule(Some(fixed_schedule));
 
-        (data_shreds, coding_shreds, Arc::new(leader_schedule_cache))
+        (
+            data_shreds,
+            coding_shreds,
+            leader_keypair,
+            Arc::new(leader_schedule_cache),
+        )
     }
 
     fn verify_index_integrity(blockstore: &Blockstore, slot: u64) {

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -680,6 +680,10 @@ impl ErasureMeta {
         self.config
     }
 
+    pub(crate) fn fec_set_index(&self) -> u32 {
+        self.fec_set_index
+    }
+
     pub(crate) fn data_shreds_indices(&self) -> Range<u64> {
         let num_data = self.config.num_data as u64;
         let fec_set_index = u64::from(self.fec_set_index);

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -52,7 +52,6 @@
 pub(crate) use self::merkle_tree::PROOF_ENTRIES_FOR_32_32_BATCH;
 use {
     self::traits::{Shred as _, ShredData as _},
-    assert_matches::debug_assert_matches,
     bitflags::bitflags,
     num_enum::{IntoPrimitive, TryFromPrimitive},
     serde::{Deserialize, Serialize},
@@ -694,31 +693,6 @@ unsafe impl<'a, C: ConfigCore> SchemaRead<'a, C> for ShredVariant {
         dst.write(value);
         Ok(())
     }
-}
-
-pub fn recover<T: IntoIterator<Item = Shred>>(
-    shreds: T,
-    reed_solomon_cache: &ReedSolomonCache,
-) -> Result<impl Iterator<Item = Result<Shred, Error>> + use<T>, Error> {
-    let shreds = shreds
-        .into_iter()
-        .map(|shred| {
-            debug_assert_matches!(
-                shred.common_header().shred_variant,
-                ShredVariant::MerkleCode { .. } | ShredVariant::MerkleData { .. }
-            );
-            merkle::Shred::try_from(shred)
-        })
-        .collect::<Result<_, _>>()?;
-    // With Merkle shreds, leader signs the Merkle root of the erasure batch
-    // and all shreds within the same erasure batch have the same signature.
-    // For recovered shreds, the (unique) signature is copied from shreds which
-    // were received from turbine (or repair) and are already sig-verified.
-    // The same signature also verifies for recovered shreds because when
-    // reconstructing the Merkle tree for the erasure batch, we will obtain the
-    // same Merkle root.
-    let shreds = merkle::recover(shreds, reed_solomon_cache)?;
-    Ok(shreds.map(|shred| shred.map(Shred::from)))
 }
 
 pub fn max_ticks_per_n_shreds(num_shreds: u64, shred_data_size: Option<usize>) -> u64 {

--- a/ledger/src/shred/filter.rs
+++ b/ledger/src/shred/filter.rs
@@ -3,16 +3,19 @@
 
 use {
     super::{
-        DATA_SHREDS_PER_FEC_BLOCK, MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT,
-        ShredFetchStats, ShredFlags, ShredType, ShredVariant, layout,
+        DATA_SHREDS_PER_FEC_BLOCK, Error, MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT,
+        Payload, ReedSolomonCache, Shred, ShredFetchStats, ShredFlags, ShredType, ShredVariant,
+        layout, merkle,
     },
     crate::blockstore,
     agave_feature_set::discard_unexpected_data_complete_shreds,
+    assert_matches::debug_assert_matches,
     solana_clock::Slot,
     solana_epoch_schedule::EpochSchedule,
     solana_perf::packet::PacketRef,
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
+    solana_streamer::{evicting_sender::EvictingSender, streamer::ChannelSend},
     std::{
         sync::Arc,
         time::{Duration, Instant},
@@ -97,10 +100,6 @@ impl ShredFilterContext {
             // In the future as shred limit changes we can update self.max_*_shreds_per_slot based on root
             // bank as well
         }
-    }
-
-    pub fn stats_mut(&mut self) -> &mut ShredFetchStats {
-        &mut self.stats
     }
 
     pub fn maybe_submit_stats(&mut self, metric_name: &'static str, cadence: Duration) -> bool {
@@ -314,6 +313,114 @@ fn check_fixed_fec_set(index: u32, fec_set_index: u32) -> bool {
 /// This is checked during shred ingest with `enforce_fixed_fec_set` active.
 fn check_last_data_shred_index(index: u32) -> bool {
     (index + 1).is_multiple_of(DATA_SHREDS_PER_FEC_BLOCK as u32)
+}
+
+/// Holds the context to perform filtering on shred recovery
+pub struct ShredRecoveryContext {
+    /// Used to perform RS erasure code recovery
+    pub reed_solomon_cache: ReedSolomonCache,
+    /// Sender to retransmit the recovered shreds
+    retransmit_sender: EvictingSender<Vec<Payload>>,
+    /// Used for filtering recovered shreds
+    shred_filter_ctx: ShredFilterContext,
+}
+
+impl ShredRecoveryContext {
+    pub fn new(
+        reed_solomon_cache: ReedSolomonCache,
+        retransmit_sender: EvictingSender<Vec<Payload>>,
+        root_bank: Arc<Bank>,
+        shred_version: u16,
+    ) -> Self {
+        let shred_filter_ctx = ShredFilterContext::new(root_bank, shred_version);
+        Self {
+            reed_solomon_cache,
+            retransmit_sender,
+            shred_filter_ctx,
+        }
+    }
+
+    /// Periodically (no more than once per slot) update the context used for filtering
+    /// recovered shreds. This is not latency sensitive as feature flags and slot filtering windows
+    /// have an epoch order tolerance
+    pub fn maybe_update(&mut self, root_bank: Arc<Bank>) {
+        self.shred_filter_ctx.maybe_update(root_bank);
+    }
+
+    /// Submit stats at most every two seconds
+    pub fn maybe_submit_stats(&mut self) {
+        self.shred_filter_ctx
+            .maybe_submit_stats("shred-recovery", Duration::from_secs(2));
+    }
+
+    /// Recover shreds and apply filtering to the recovered shreds
+    pub fn recover<T: IntoIterator<Item = Shred>>(
+        &mut self,
+        shreds: T,
+        recovered_shreds: &mut Vec<Payload>,
+        recovered_data_shreds: &mut Vec<Shred>,
+    ) -> Result<(), Error> {
+        let shreds = shreds
+            .into_iter()
+            .map(|shred| {
+                debug_assert_matches!(
+                    shred.common_header().shred_variant,
+                    ShredVariant::MerkleCode { .. } | ShredVariant::MerkleData { .. }
+                );
+                merkle::Shred::try_from(shred)
+            })
+            .collect::<Result<_, _>>()?;
+
+        // With Merkle shreds, leader signs the Merkle root of the erasure batch
+        // and all shreds within the same erasure batch have the same signature.
+        // For recovered shreds, the (unique) signature is copied from shreds which
+        // were received from turbine (or repair) and are already sig-verified.
+        // The same signature also verifies for recovered shreds because when
+        // reconstructing the Merkle tree for the erasure batch, we will obtain the
+        // same Merkle root.
+        let shreds = merkle::recover(shreds, &self.reed_solomon_cache)?;
+        shreds
+            .filter_map(|shred| shred.ok().map(Shred::from))
+            .filter(|shred| !self.should_discard_shred(shred))
+            .for_each(|shred| {
+                // All shreds should be retransmitted, but because there are no
+                // more missing data shreds in the erasure batch, coding shreds
+                // are not stored in blockstore.
+                match shred.shred_type() {
+                    ShredType::Code => {
+                        // Don't need Arc overhead here!
+                        recovered_shreds.push(shred.into_payload());
+                    }
+                    ShredType::Data => {
+                        // Verify that the cloning is cheap here.
+                        recovered_shreds.push(shred.payload().clone());
+                        recovered_data_shreds.push(shred);
+                    }
+                }
+            });
+        Ok(())
+    }
+    /// Send recovered shreds for retransmit
+    pub fn try_retransmit_shreds(&self, recovered_shreds: Vec<Payload>) {
+        if !recovered_shreds.is_empty() {
+            let _ = self.retransmit_sender.try_send(recovered_shreds);
+        }
+    }
+
+    /// If SIMD-0337 is active, apply filtering rules to recovered shreds
+    pub fn should_discard_shred(&mut self, shred: &Shred) -> bool {
+        if !check_feature_activation(
+            self.shred_filter_ctx
+                .discard_unexpected_data_complete_shreds_feature_slot,
+            shred.slot(),
+            &self.shred_filter_ctx.epoch_schedule,
+        ) {
+            // Only apply filtering rules to recovered shreds when SIMD-0337 is active
+            return false;
+        }
+
+        self.shred_filter_ctx.should_discard_shred(shred.payload())
+    }
 }
 
 #[cfg(test)]

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1331,6 +1331,31 @@ fn finish_erasure_batch(
 }
 
 #[cfg(test)]
+pub(crate) fn finish_erasure_batch_for_tests(
+    keypair: &Keypair,
+    shreds: &mut [crate::shred::Shred],
+    chained_merkle_root: Hash,
+    reed_solomon_cache: &ReedSolomonCache,
+) -> Result<Hash, Error> {
+    let mut batch: Vec<_> = shreds
+        .iter()
+        .cloned()
+        .map(crate::shred::Shred::try_into)
+        .collect::<Result<_, _>>()?;
+    let chained_merkle_root = finish_erasure_batch(
+        None,
+        keypair,
+        &mut batch,
+        chained_merkle_root,
+        reed_solomon_cache,
+    )?;
+    for (dst, src) in shreds.iter_mut().zip(batch) {
+        *dst = crate::shred::Shred::from(src);
+    }
+    Ok(chained_merkle_root)
+}
+
+#[cfg(test)]
 mod test {
     use {
         super::*,

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -2,14 +2,20 @@
 use {
     solana_clock::Slot,
     solana_entry::entry::Entry,
+    solana_epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_ledger::shred::{
-        self, DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats, ReedSolomonCache, Shred, ShredData,
-        Shredder, max_entries_per_n_shred, max_entries_per_n_shred_last_or_not, recover,
-        verify_test_data_shred,
+    solana_ledger::{
+        genesis_utils::create_genesis_config,
+        shred::{
+            DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats, ReedSolomonCache, Shred, ShredData,
+            Shredder, filter::ShredRecoveryContext, max_entries_per_n_shred,
+            max_entries_per_n_shred_last_or_not, verify_test_data_shred,
+        },
     },
+    solana_runtime::bank::Bank,
     solana_signer::Signer,
+    solana_streamer::evicting_sender::EvictingSender,
     solana_system_transaction as system_transaction,
     std::{
         collections::{BTreeMap, HashSet},
@@ -20,6 +26,21 @@ use {
 };
 
 type IndexShredsMap = BTreeMap<u32, Vec<Shred>>;
+
+fn new_shred_recovery_context(shreds: &[Shred]) -> ShredRecoveryContext {
+    let mut genesis_config = create_genesis_config(1).genesis_config;
+    let shred_slot = shreds.first().map(Shred::slot).unwrap_or_default();
+    let slots_per_epoch = shred_slot.max(MINIMUM_SLOTS_PER_EPOCH);
+    genesis_config.epoch_schedule = EpochSchedule::custom(slots_per_epoch, slots_per_epoch, false);
+    let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
+    ShredRecoveryContext::new(
+        ReedSolomonCache::default(),
+        dummy_retransmit_sender,
+        root_bank,
+        shreds.first().map(Shred::version).unwrap_or_default(),
+    )
+}
 
 #[test_case(false)]
 #[test_case(true)]
@@ -84,10 +105,17 @@ fn test_multi_fec_block_coding(is_last_in_slot: bool) {
             .filter_map(|(i, b)| if i % 2 != 0 { Some(b.clone()) } else { None })
             .collect();
 
-        let recovered_data = recover(shred_info.clone(), &reed_solomon_cache)
-            .unwrap()
-            .map(|result| result.unwrap())
-            .filter(|shred| shred.is_data());
+        let mut shred_recovery_context = new_shred_recovery_context(&shred_info);
+        let mut recovered_shreds = Vec::new();
+        let mut recovered_data_shreds = Vec::new();
+        shred_recovery_context
+            .recover(
+                shred_info.clone(),
+                &mut recovered_shreds,
+                &mut recovered_data_shreds,
+            )
+            .unwrap();
+        let recovered_data = recovered_data_shreds.into_iter();
 
         for (i, recovered_shred) in recovered_data.enumerate() {
             let index = shred_start_index + (i * 2);
@@ -124,7 +152,6 @@ fn test_multi_fec_block_different_size_coding() {
         setup_different_sized_fec_blocks(slot, parent_slot, keypair.clone());
 
     let total_num_data_shreds: usize = fec_data.values().map(|x| x.len()).sum();
-    let reed_solomon_cache = ReedSolomonCache::default();
     // Test recovery
     for (fec_data_shreds, fec_coding_shreds) in fec_data.values().zip(fec_coding.values()) {
         let first_data_index = fec_data_shreds.first().unwrap().index() as usize;
@@ -134,13 +161,12 @@ fn test_multi_fec_block_different_size_coding() {
             .chain(fec_coding_shreds.iter().step_by(2))
             .cloned()
             .collect();
-        let recovered_data: Vec<Shred> = shred::recover(all_shreds, &reed_solomon_cache)
-            .unwrap()
-            .filter_map(|s| {
-                let s = s.unwrap();
-                s.is_data().then_some(s)
-            })
-            .collect();
+        let mut shred_recovery_context = new_shred_recovery_context(&all_shreds);
+        let mut recovered_shreds = Vec::new();
+        let mut recovered_data = Vec::new();
+        shred_recovery_context
+            .recover(all_shreds, &mut recovered_shreds, &mut recovered_data)
+            .unwrap();
         // Necessary in order to ensure the last shred in the slot
         // is part of the recovered set, and that the below `index`
         // calculation in the loop is correct


### PR DESCRIPTION
#### Problem
SIMD-0337 rules were only being applied to ingested shreds not recovered ones.

#### Summary of Changes
Apply the filtering to recovery as well and rekey the feature
