### PR TITLE
v4.0 - chore: bump vendored rustls-webpki for rustsec advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6331,8 +6331,7 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 [[package]]
 name = "rustls-webpki"
 version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+source = "git+https://github.com/anza-xyz/rustls-webpki?tag=anza-0.101.7-1#37e66ef34b2a3aabb82ec65ed7582ce689b9b43c"
 dependencies = [
  "ring",
  "untrusted",
@@ -6341,8 +6340,7 @@ dependencies = [
 [[package]]
 name = "rustls-webpki"
 version = "0.103.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+source = "git+https://github.com/anza-xyz/rustls-webpki?tag=anza-0.103.10-1#f4296cc9258f44b8aced868860f8fadc0fd70881"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -662,3 +662,5 @@ codegen-units = 1
 [patch.crates-io]
 # for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
+rustls-webpki = { git = "https://github.com/anza-xyz/rustls-webpki", tag = "anza-0.103.10-1" }
+rustls-webpki2 = { git = "https://github.com/anza-xyz/rustls-webpki", package = "rustls-webpki", tag = "anza-0.101.7-1" }

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -64,8 +64,30 @@ cargo_audit_ignores=(
   # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0049
   # Solution:  Upgrade to >=0.103.10
   #
-  # NOTE: we took the fix for 0.103.6 dependents. here we ignore for those on incompatible 0.101.7
+  # NOTE: we took the fix for 0.103.6 dependents. 0.101.7 is unaffected
   --ignore RUSTSEC-2026-0049
+
+  # Crate:     rustls-webpki
+  # Version:   0.101.7
+  # Title:     Name constraints for URI names were incorrectly accepted
+  # Date:      2026-04-14
+  # ID:        RUSTSEC-2026-0098
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0098
+  # Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
+  #
+  # AVAVE OK: we picked upstream fix atop our vendored branches
+  --ignore RUSTSEC-2026-0098
+
+  # Crate:     rustls-webpki
+  # Version:   0.101.7
+  # Title:     Name constraints were accepted for certificates asserting a wildcard name
+  # Date:      2026-04-14
+  # ID:        RUSTSEC-2026-0099
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0099
+  # Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
+  #
+  # AVAVE OK: we picked upstream fix atop our vendored branches
+  --ignore RUSTSEC-2026-0099
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem
RUSTSEC-2026-0098, RUSTSEC-2026-0099

#### Summary of Changes
bump our vendored tags