### PR TITLE
v3.1 - chore: bump vendored rustls-webpki for rustsec advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6515,8 +6515,7 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 [[package]]
 name = "rustls-webpki"
 version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+source = "git+https://github.com/anza-xyz/rustls-webpki?tag=anza-0.101.7-1#37e66ef34b2a3aabb82ec65ed7582ce689b9b43c"
 dependencies = [
  "ring",
  "untrusted",
@@ -6525,7 +6524,7 @@ dependencies = [
 [[package]]
 name = "rustls-webpki"
 version = "0.103.6"
-source = "git+https://github.com/anza-xyz/rustls-webpki?tag=anza-rustsec-2026-0049-0.103.6#aea57bff30e8085466e72ccaab42678100a92005"
+source = "git+https://github.com/anza-xyz/rustls-webpki?tag=anza-0.103.6-2#9a34ffb45c7d402536909d86b25c0d1adf0324f1"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -688,4 +688,5 @@ crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d
 # There is a similar override in `programs/sbf/Cargo.toml`.  Please keep both
 # comments and the overrides in sync.
 solana-curve25519 = { path = "curves/curve25519" }
-rustls-webpki = { git = "https://github.com/anza-xyz/rustls-webpki", tag = "anza-rustsec-2026-0049-0.103.6" }
+rustls-webpki = { git = "https://github.com/anza-xyz/rustls-webpki", tag = "anza-0.103.6-2" }
+rustls-webpki2 = { git = "https://github.com/anza-xyz/rustls-webpki", package = "rustls-webpki", tag = "anza-0.101.7-1" }

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -100,9 +100,30 @@ cargo_audit_ignores=(
   # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0049
   # Solution:  Upgrade to >=0.103.10
   #
-  # AGAVE OK: we patched the 0.103.6 release tag for corresponding dependents. here we
-  # ignore for those on incompatible 0.101.7
+  # AGAVE OK: we patched the 0.103.6 release tag for corresponding dependents. 0.101.7 is unaffected
   --ignore RUSTSEC-2026-0049
+
+  # Crate:     rustls-webpki
+  # Version:   0.101.7
+  # Title:     Name constraints for URI names were incorrectly accepted
+  # Date:      2026-04-14
+  # ID:        RUSTSEC-2026-0098
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0098
+  # Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
+  #
+  # AVAVE OK: we picked upstream fix atop our vendored branches
+  --ignore RUSTSEC-2026-0098
+
+  # Crate:     rustls-webpki
+  # Version:   0.101.7
+  # Title:     Name constraints were accepted for certificates asserting a wildcard name
+  # Date:      2026-04-14
+  # ID:        RUSTSEC-2026-0099
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0099
+  # Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
+  #
+  # AVAVE OK: we picked upstream fix atop our vendored branches
+  --ignore RUSTSEC-2026-0099
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem
RUSTSEC-2026-0098, RUSTSEC-2026-0099

#### Summary of Changes
bump our vendored tags