### PR TITLE
bump solana-loader-v3-interface to 7.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8870,9 +8870,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v3-interface"
-version = "6.1.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0538d4dbc9022e01616f1c58f2db98ece739c5d5ed4a2ef8737a953e76a2d4"
+checksum = "68029ab11d9c891d4ce23ada75745e40f983c5674af366f447b672569634231b"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -431,7 +431,7 @@ solana-lattice-hash = { path = "lattice-hash", version = "=4.1.0-alpha.0", featu
 solana-leader-schedule = { path = "leader-schedule", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-ledger = { path = "ledger", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-loader-v2-interface = "3.0.0"
-solana-loader-v3-interface = "6.1.1"
+solana-loader-v3-interface = "7.0.0"
 solana-loader-v4-interface = "3.1.0"
 solana-loader-v4-program = { path = "programs/loader-v4", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-local-cluster = { path = "local-cluster", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7717,9 +7717,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v3-interface"
-version = "6.1.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0538d4dbc9022e01616f1c58f2db98ece739c5d5ed4a2ef8737a953e76a2d4"
+checksum = "68029ab11d9c891d4ce23ada75745e40f983c5674af366f447b672569634231b"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -117,7 +117,7 @@ solana-instruction = "3.4.0"
 solana-instruction-error = "2.3.0"
 solana-keypair = "3.1.2"
 solana-ledger = { path = "../ledger", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-loader-v3-interface = "6.1.1"
+solana-loader-v3-interface = "7.0.0"
 solana-loader-v4-interface = "3.1.0"
 solana-loader-v4-program = { path = "../programs/loader-v4", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-local-cluster = { path = "../local-cluster", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -759,16 +759,6 @@ fn process_loader_upgradeable_instruction(
         UpgradeableLoaderInstruction::ExtendProgram { additional_bytes } => {
             common_extend_program(invoke_context, additional_bytes, false)?;
         }
-        UpgradeableLoaderInstruction::ExtendProgramChecked { .. } => {
-            // ExtendProgramChecked has been removed.
-            // This variant will be removed from the next interface release.
-            return Err(InstructionError::InvalidInstructionData);
-        }
-        UpgradeableLoaderInstruction::Migrate => {
-            // Loader V4 has been removed.
-            // This variant will be removed from the next interface release.
-            return Err(InstructionError::InvalidInstructionData);
-        }
     }
 
     Ok(())

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7375,9 +7375,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v3-interface"
-version = "6.1.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0538d4dbc9022e01616f1c58f2db98ece739c5d5ed4a2ef8737a953e76a2d4"
+checksum = "68029ab11d9c891d4ce23ada75745e40f983c5674af366f447b672569634231b"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -205,7 +205,7 @@ solana-fee-structure = "3.0.0"
 solana-hash = "4.3.0"
 solana-instruction = { workspace = true }
 solana-keypair = "3.1.2"
-solana-loader-v3-interface = "6.1.0"
+solana-loader-v3-interface = "7.0.0"
 solana-message = "4.1.0"
 solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = "4.2.0"

--- a/transaction-status/src/parse_bpf_loader.rs
+++ b/transaction-status/src/parse_bpf_loader.rs
@@ -187,39 +187,6 @@ pub fn parse_bpf_upgradeable_loader(
                 }),
             })
         }
-        UpgradeableLoaderInstruction::Migrate => {
-            check_num_bpf_upgradeable_loader_accounts(&instruction.accounts, 3)?;
-            Ok(ParsedInstructionEnum {
-                instruction_type: "migrate".to_string(),
-                info: json!({
-                    "programDataAccount": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "programAccount": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "authority": account_keys[instruction.accounts[2] as usize].to_string(),
-                }),
-            })
-        }
-        UpgradeableLoaderInstruction::ExtendProgramChecked { additional_bytes } => {
-            check_num_bpf_upgradeable_loader_accounts(&instruction.accounts, 3)?;
-            Ok(ParsedInstructionEnum {
-                instruction_type: "extendProgramChecked".to_string(),
-                info: json!({
-                    "additionalBytes": additional_bytes,
-                    "programDataAccount": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "programAccount": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "authority": account_keys[instruction.accounts[2] as usize].to_string(),
-                    "systemProgram": if instruction.accounts.len() > 3 {
-                        Some(account_keys[instruction.accounts[3] as usize].to_string())
-                    } else {
-                        None
-                    },
-                    "payerAccount": if instruction.accounts.len() > 4 {
-                        Some(account_keys[instruction.accounts[4] as usize].to_string())
-                    } else {
-                        None
-                    },
-                }),
-            })
-        }
     }
 }
 


### PR DESCRIPTION
#### Problem
Loader V3 interface v7.0.0 is out, which removes the `Migrate` and `ExtendProgramChecked` instructions.

#### Summary of Changes
Bump the dependency everywhere, fix breakage (only two places).