### PR TITLE
xdp: turn off fragmentation and handle MTU

### DIFF
--- a/xdp/src/gre/packet.rs
+++ b/xdp/src/gre/packet.rs
@@ -78,8 +78,6 @@ fn write_gre_outer_headers(
 ) -> Result<(), PacketError> {
     write_eth_header(packet, &gre_src_mac.0, &gre_dst_mac.0);
 
-    let dont_fragment = info.pmtudisc != 0;
-
     // Write outer IP header (protocol = GRE = 47)
     let gre_payload_len = GRE_HEADER_BASE_SIZE + inner_packet_len;
     let outer_ttl = (info.ttl != 0).then_some(info.ttl);
@@ -92,7 +90,9 @@ fn write_gre_outer_headers(
         &outer_remote,
         gre_payload_len as u16,
         IPPROTO_GRE as u8,
-        dont_fragment,
+        // GRE fragmentation is not supported. The outer IP header is always written with the Don't
+        // Fragment (DF) flag set.
+        true,
         outer_ttl,
         Some(info.tos),
     );

--- a/xdp/src/netlink.rs
+++ b/xdp/src/netlink.rs
@@ -23,6 +23,10 @@ use {
 
 const NETLINK_RCVBUF_SIZE: i32 = 1 << 16;
 const NLA_HDR_LEN: usize = align_to(mem::size_of::<nlattr>(), NLA_ALIGNTO as usize);
+
+// MTU of the device (from include/uapi/linux/if_link.h)
+const IFLA_MTU: u16 = 4;
+
 // GRE nested attributes (from include/uapi/linux/if_tunnel.h)
 const IFLA_GRE_LOCAL: u16 = 6;
 const IFLA_GRE_REMOTE: u16 = 7;
@@ -385,6 +389,7 @@ pub struct GreTunnelInfo {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InterfaceInfo {
     pub if_index: u32,
+    pub mtu: u32,
     pub gre_tunnel: Option<GreTunnelInfo>,
 }
 
@@ -442,10 +447,15 @@ pub(crate) fn parse_rtm_ifinfomsg(msg: &NetlinkMessage) -> Option<InterfaceInfo>
         return None;
     };
 
+    let mtu = attrs
+        .get(&IFLA_MTU)
+        .and_then(|a| u32_from_ne_bytes(a.data))?;
+
     // Parse GRE tunnel information if this is a GRE interface
     let gre_tunnel = parse_gre_tunnel_info_from_linkinfo(&attrs);
     Some(InterfaceInfo {
         if_index: ifi.ifi_index,
+        mtu,
         gre_tunnel,
     })
 }
@@ -739,11 +749,6 @@ pub fn parse_rtm_newroute(msg: &NetlinkMessage) -> Option<RouteEntry> {
         route.gateway = parse_ip_address(gateway_attr.data, rt_msg.rtm_family);
     }
 
-    let u32_from_ne_bytes = |data: &[u8]| -> Option<u32> {
-        data.get(..4)
-            .map(|data| u32::from_ne_bytes([data[0], data[1], data[2], data[3]]))
-    };
-
     if let Some(oif_attr) = attrs.get(&RTA_OIF) {
         route.out_if_index = u32_from_ne_bytes(oif_attr.data).map(|i| i as i32);
     }
@@ -772,4 +777,9 @@ fn push_nlattr<T>(buf: &mut Vec<u8>, attr_type: u16, value: &T) {
     buf.extend_from_slice(bytes_of(&attr));
     buf.extend_from_slice(bytes_of(value));
     buf.resize(buf.len() + (aligned_len - attr_len), 0);
+}
+
+fn u32_from_ne_bytes(data: &[u8]) -> Option<u32> {
+    let bytes: [u8; 4] = data.get(..4)?.try_into().ok()?;
+    Some(u32::from_ne_bytes(bytes))
 }

--- a/xdp/src/packet.rs
+++ b/xdp/src/packet.rs
@@ -63,7 +63,7 @@ pub fn write_ip_header_for_udp(
         dst_ip,
         payload_len,
         IPPROTO_UDP as u8,
-        false,
+        true,
         None,
         None,
     );

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -34,6 +34,8 @@ pub enum RouteError {
 #[derive(Debug, Clone)]
 pub struct GreRouteInfo {
     pub if_index: u32,
+    pub mtu: u32,
+    pub underlay_mtu: u32,
     pub tunnel_info: GreTunnelInfo,
     pub mac_addr: MacAddress,
 }
@@ -43,6 +45,7 @@ pub struct NextHop {
     pub mac_addr: Option<MacAddress>,
     pub ip_addr: IpAddr,
     pub if_index: u32,
+    pub mtu: u32,
     pub preferred_src_ip: Option<Ipv4Addr>,
     pub gre: Option<GreRouteInfo>,
 }
@@ -500,6 +503,7 @@ impl Router {
                 return Ok(NextHop {
                     ip_addr: next_hop_ip,
                     if_index,
+                    mtu: default_route.mtu,
                     mac_addr: default_route.mac_addr,
                     preferred_src_ip,
                     gre: default_route.gre.clone(),
@@ -510,6 +514,7 @@ impl Router {
         if let Some(gre) = self.gre_route_info(if_index) {
             return Ok(NextHop {
                 if_index,
+                mtu: gre.underlay_mtu,
                 ip_addr: next_hop_ip,
                 mac_addr: Some(gre.mac_addr),
                 preferred_src_ip,
@@ -517,11 +522,19 @@ impl Router {
             });
         }
 
+        let mtu = self
+            .interfaces
+            .iter()
+            .find(|interface| interface.if_index == if_index)
+            .map(|interface| interface.mtu)
+            .ok_or(RouteError::UnknownInterfaceIndex(if_index))?;
+
         let mac_addr = self.neighbors.lookup(next_hop_ip, if_index).cloned();
         Ok(NextHop {
             ip_addr: next_hop_ip,
             mac_addr,
             if_index,
+            mtu,
             preferred_src_ip,
             gre: None,
         })
@@ -594,6 +607,8 @@ impl Router {
 
         Some(GreRouteInfo {
             if_index: interface.if_index,
+            mtu: interface.mtu,
+            underlay_mtu: underlay_interface.mtu,
             tunnel_info: tunnel_info.clone(),
             mac_addr,
         })
@@ -631,6 +646,8 @@ mod tests {
         libc::{AF_INET, NUD_REACHABLE},
         std::net::{IpAddr, Ipv4Addr},
     };
+
+    const DEFAULT_MTU_FOR_TESTS: u32 = 1500;
 
     fn test_route(destination: Option<Ipv4Addr>, out_if_index: u32) -> Route<Ipv4Addr> {
         Route {
@@ -702,6 +719,16 @@ mod tests {
 
     fn dual_default_tables(primary_gateway: Ipv4Addr, backup_gateway: Ipv4Addr) -> RoutingTables {
         let mut tables = empty_tables();
+        assert!(tables.upsert_interface(InterfaceInfo {
+            if_index: 1,
+            mtu: DEFAULT_MTU_FOR_TESTS,
+            gre_tunnel: None,
+        }));
+        assert!(tables.upsert_interface(InterfaceInfo {
+            if_index: 2,
+            mtu: DEFAULT_MTU_FOR_TESTS,
+            gre_tunnel: None,
+        }));
         assert!(tables.upsert_neighbor(NeighborEntry {
             destination: Some(IpAddr::V4(primary_gateway)),
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
@@ -737,6 +764,12 @@ mod tests {
     fn test_router() {
         let mut tables = empty_tables();
         let before_routes_len = tables.routes.iter().len();
+
+        assert!(tables.upsert_interface(InterfaceInfo {
+            if_index: 1,
+            mtu: DEFAULT_MTU_FOR_TESTS,
+            gre_tunnel: None,
+        }));
 
         let gateway = Ipv4Addr::new(10, 255, 255, 1);
         let neighbor = NeighborEntry {
@@ -814,7 +847,18 @@ mod tests {
                     dst_len: 0,
                 },
             ],
-            vec![],
+            vec![
+                InterfaceInfo {
+                    if_index: 2,
+                    mtu: DEFAULT_MTU_FOR_TESTS,
+                    gre_tunnel: None,
+                },
+                InterfaceInfo {
+                    if_index: 3,
+                    mtu: DEFAULT_MTU_FOR_TESTS,
+                    gre_tunnel: None,
+                },
+            ],
         );
 
         assert_eq!(
@@ -858,6 +902,7 @@ mod tests {
         let test_if_index = 99999;
         let interface = InterfaceInfo {
             if_index: test_if_index,
+            mtu: DEFAULT_MTU_FOR_TESTS,
             gre_tunnel: None,
         };
 
@@ -901,6 +946,11 @@ mod tests {
         let main_table = u32::from(RouteTable::Main);
 
         let mut tables = empty_tables();
+        assert!(tables.upsert_interface(InterfaceInfo {
+            if_index: 1,
+            mtu: DEFAULT_MTU_FOR_TESTS,
+            gre_tunnel: None,
+        }));
         assert!(tables.upsert_neighbor(NeighborEntry {
             destination: Some(IpAddr::V4(main_gateway)),
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
@@ -936,6 +986,11 @@ mod tests {
         let main_table = u32::from(RouteTable::Main);
 
         let mut tables = empty_tables();
+        assert!(tables.upsert_interface(InterfaceInfo {
+            if_index: 1,
+            mtu: DEFAULT_MTU_FOR_TESTS,
+            gre_tunnel: None,
+        }));
         assert!(tables.upsert_neighbor(NeighborEntry {
             destination: Some(IpAddr::V4(main_gateway)),
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),
@@ -1001,10 +1056,12 @@ mod tests {
         let interfaces = vec![
             InterfaceInfo {
                 if_index: if_index_underlay as u32,
+                mtu: DEFAULT_MTU_FOR_TESTS,
                 gre_tunnel: None,
             },
             InterfaceInfo {
                 if_index: if_index_gre1 as u32,
+                mtu: DEFAULT_MTU_FOR_TESTS - 100,
                 gre_tunnel: Some(GreTunnelInfo {
                     local: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)),
                     remote: IpAddr::V4(remote1),
@@ -1015,6 +1072,7 @@ mod tests {
             },
             InterfaceInfo {
                 if_index: if_index_gre2 as u32,
+                mtu: DEFAULT_MTU_FOR_TESTS + 100,
                 gre_tunnel: Some(GreTunnelInfo {
                     local: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4)),
                     remote: IpAddr::V4(remote2),
@@ -1028,19 +1086,25 @@ mod tests {
         let router = router_from_tables(neighbors, routes, interfaces);
         let hop1 = router.route_v4(gre_dest1).unwrap();
         assert_eq!(hop1.if_index, if_index_gre1 as u32);
+        assert_eq!(hop1.mtu, DEFAULT_MTU_FOR_TESTS);
         assert_eq!(hop1.mac_addr, Some(mac1));
-        assert_eq!(
-            hop1.gre.as_ref().map(|gre| gre.if_index),
-            Some(if_index_gre1 as u32)
-        );
+
+        let hop1_gre = hop1.gre.as_ref().unwrap();
+        assert_eq!(hop1_gre.if_index, if_index_gre1 as u32);
+        assert_eq!(hop1_gre.mtu, DEFAULT_MTU_FOR_TESTS - 100);
+        assert_eq!(hop1_gre.underlay_mtu, DEFAULT_MTU_FOR_TESTS);
+        assert_eq!(hop1.mtu, hop1_gre.underlay_mtu);
 
         let hop2 = router.route_v4(gre_dest2).unwrap();
         assert_eq!(hop2.if_index, if_index_gre2 as u32);
+        assert_eq!(hop2.mtu, DEFAULT_MTU_FOR_TESTS);
         assert_eq!(hop2.mac_addr, Some(mac2));
-        assert_eq!(
-            hop2.gre.as_ref().map(|gre| gre.if_index),
-            Some(if_index_gre2 as u32)
-        );
+
+        let hop2_gre = hop2.gre.as_ref().unwrap();
+        assert_eq!(hop2_gre.if_index, if_index_gre2 as u32);
+        assert_eq!(hop2_gre.mtu, DEFAULT_MTU_FOR_TESTS + 100);
+        assert_eq!(hop2_gre.underlay_mtu, DEFAULT_MTU_FOR_TESTS);
+        assert_eq!(hop2.mtu, hop2_gre.underlay_mtu);
     }
 
     #[test]
@@ -1074,10 +1138,12 @@ mod tests {
         let interfaces = vec![
             InterfaceInfo {
                 if_index: if_index_underlay as u32,
+                mtu: DEFAULT_MTU_FOR_TESTS,
                 gre_tunnel: None,
             },
             InterfaceInfo {
                 if_index: if_index_gre as u32,
+                mtu: DEFAULT_MTU_FOR_TESTS - 100,
                 gre_tunnel: Some(GreTunnelInfo {
                     local: IpAddr::V4(Ipv4Addr::new(10, 1, 0, 1)),
                     remote: IpAddr::V4(remote),
@@ -1092,19 +1158,25 @@ mod tests {
 
         let hop_default = router.default().unwrap();
         assert_eq!(hop_default.if_index, if_index_gre as u32);
+        assert_eq!(hop_default.mtu, DEFAULT_MTU_FOR_TESTS);
         assert_eq!(hop_default.mac_addr, Some(mac));
-        assert_eq!(
-            hop_default.gre.as_ref().map(|gre| gre.if_index),
-            Some(if_index_gre as u32)
-        );
+
+        let hop_default_gre = hop_default.gre.as_ref().unwrap();
+        assert_eq!(hop_default_gre.if_index, if_index_gre as u32);
+        assert_eq!(hop_default_gre.mtu, DEFAULT_MTU_FOR_TESTS - 100);
+        assert_eq!(hop_default_gre.underlay_mtu, DEFAULT_MTU_FOR_TESTS);
+        assert_eq!(hop_default.mtu, hop_default_gre.underlay_mtu);
 
         let hop_route = router.route_v4(dest).unwrap();
         assert_eq!(hop_route.if_index, if_index_gre as u32);
+        assert_eq!(hop_route.mtu, DEFAULT_MTU_FOR_TESTS);
         assert_eq!(hop_route.mac_addr, Some(mac));
-        assert_eq!(
-            hop_route.gre.as_ref().map(|gre| gre.if_index),
-            Some(if_index_gre as u32)
-        );
+
+        let hop_route_gre = hop_route.gre.as_ref().unwrap();
+        assert_eq!(hop_route_gre.if_index, if_index_gre as u32);
+        assert_eq!(hop_route_gre.mtu, DEFAULT_MTU_FOR_TESTS - 100);
+        assert_eq!(hop_route_gre.underlay_mtu, DEFAULT_MTU_FOR_TESTS);
+        assert_eq!(hop_route.mtu, hop_route_gre.underlay_mtu);
     }
 
     #[test]
@@ -1113,6 +1185,11 @@ mod tests {
         let default_gateway = Ipv4Addr::new(10, 0, 0, 1);
 
         let mut tables = empty_tables();
+        assert!(tables.upsert_interface(InterfaceInfo {
+            if_index: 1,
+            mtu: DEFAULT_MTU_FOR_TESTS,
+            gre_tunnel: None,
+        }));
         assert!(tables.upsert_neighbor(NeighborEntry {
             destination: Some(IpAddr::V4(default_gateway)),
             lladdr: Some(MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01])),

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -3,7 +3,10 @@
 use {
     crate::{
         device::{DeviceQueue, NetworkDevice, QueueId, RingSizes, TxCompletionRing},
-        gre::{construct_gre_packet, gre_packet_size},
+        gre::{
+            construct_gre_packet, gre_packet_size,
+            packet::{GRE_HEADER_BASE_SIZE, INNER_PACKET_HEADER_SIZE},
+        },
         netlink::MacAddress,
         packet::{
             ETH_HEADER_SIZE, IP_HEADER_SIZE, UDP_HEADER_SIZE, write_eth_header,
@@ -98,6 +101,9 @@ impl TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
             "starting xdp loop on {} queue {queue_id:?} cpu {cpu_id}",
             dev.name()
         );
+
+        // We don't support MTUs larger than page size due to AF_XDP limitations in single-buffer
+        // mode and a possible workaround might be to use multi-buffer TX.
 
         // some drivers require frame_size=page_size
         let frame_size = unsafe { sysconf(_SC_PAGESIZE) } as usize;
@@ -227,6 +233,7 @@ impl<U: Umem> TxLoop<U> {
 
         let umem = socket.umem();
         let umem_tx_capacity = umem.available();
+        let umem_frame_size = umem.frame_size();
 
         // Local buffer where we store packets before sending them.
         let mut batched_items = Vec::with_capacity(BATCH_SIZE);
@@ -318,7 +325,38 @@ impl<U: Umem> TxLoop<U> {
                     };
 
                     if let Some(gre) = &next_hop.gre {
-                        frame.set_len(gre_packet_size(len));
+                        let l3_inner_packet_len = INNER_PACKET_HEADER_SIZE + len;
+                        let l3_outer_gre_packet_len =
+                            IP_HEADER_SIZE + GRE_HEADER_BASE_SIZE + l3_inner_packet_len;
+
+                        if l3_inner_packet_len > gre.mtu as usize
+                            || l3_outer_gre_packet_len > next_hop.mtu as usize
+                        {
+                            log::warn!(
+                                "dropping packet: GRE payload exceeds MTU for {addr}: L3 inner \
+                                 packet length {l3_inner_packet_len}, L3 outer GRE packet length \
+                                 {l3_outer_gre_packet_len}, MTU: {mtu}, underlay_mtu: \
+                                 {underlay_mtu}.",
+                                mtu = gre.mtu,
+                                underlay_mtu = next_hop.mtu
+                            );
+                            batched_packets -= 1;
+                            umem.release(frame.offset());
+                            continue;
+                        }
+
+                        let packet_len = gre_packet_size(len);
+                        if packet_len > umem_frame_size {
+                            log::warn!(
+                                "dropping packet: GRE packet size {packet_len} exceeds frame size \
+                                 {umem_frame_size} for {addr}"
+                            );
+                            batched_packets -= 1;
+                            umem.release(frame.offset());
+                            continue;
+                        }
+
+                        frame.set_len(packet_len);
                         let packet = umem.map_frame_mut(&frame);
                         let inner_src_ip = next_hop.preferred_src_ip.as_ref().unwrap_or(src_ip);
                         if let Err(err) = construct_gre_packet(
@@ -350,9 +388,32 @@ impl<U: Umem> TxLoop<U> {
                             continue;
                         };
 
+                        let l3_packet_len = IP_HEADER_SIZE + UDP_HEADER_SIZE + len;
+                        if l3_packet_len > next_hop.mtu as usize {
+                            log::warn!(
+                                "dropping packet: packet size {l3_packet_len} exceeds MTU {mtu} \
+                                 for {addr}",
+                                mtu = next_hop.mtu
+                            );
+                            batched_packets -= 1;
+                            umem.release(frame.offset());
+                            continue;
+                        }
+
                         const PACKET_HEADER_SIZE: usize =
                             ETH_HEADER_SIZE + IP_HEADER_SIZE + UDP_HEADER_SIZE;
-                        frame.set_len(PACKET_HEADER_SIZE + len);
+                        let packet_len = PACKET_HEADER_SIZE + len;
+                        if packet_len > umem_frame_size {
+                            log::warn!(
+                                "dropping packet: packet size {packet_len} exceeds frame size \
+                                 {umem_frame_size} for {addr}"
+                            );
+                            batched_packets -= 1;
+                            umem.release(frame.offset());
+                            continue;
+                        }
+
+                        frame.set_len(packet_len);
                         let packet = umem.map_frame_mut(&frame);
 
                         // write the payload first as it's needed for checksum calculation (if enabled)


### PR DESCRIPTION
#### Problem

XDP TX currently allows IP fragmentation, which is unnecessary. Once fragmentation is disabled, packets must be checked before transmit so they fit the interface MTU and frame size.

#### Summary of Changes

* Turn off fragmentation in inner/outer IP headers.
* Disable fragmentation for inner and outer IP headers.
* Parse interface MTU from netlink link attributes and propagate it through interface metadata to `tx_loop`.
* Drop packets that exceed the GRE payload limit, interface MTU, or frame size.



