### PR TITLE
perf(fs): track remaining bytes in current buf instead of end pos

### DIFF
--- a/fs/src/io_uring/sequential_file_reader.rs
+++ b/fs/src/io_uring/sequential_file_reader.rs
@@ -287,7 +287,7 @@ impl<'a> SequentialFileReader<'a> {
         // Always reset in-file and in-buffer state
         state.current_offset = 0;
         state.current_buf_pos = 0;
-        state.current_buf_len = 0;
+        state.current_buf_remaining = 0;
         state.left_to_consume = 0;
 
         if removed_file.had_scheduled_reads() {
@@ -372,19 +372,22 @@ impl<'a> SequentialFileReader<'a> {
             let current_buf = &mut self.ring.context_mut().get_mut(state.current_buf_index);
             match current_buf {
                 ReadBufState::Full { buf, eof_pos } => {
-                    if state.current_buf_len == 0 {
-                        state.current_buf_len = eof_pos.unwrap_or(buf.len());
+                    if state.current_buf_remaining == 0 && state.current_buf_pos == 0 {
+                        // Initialize consuming new buffer.
+                        state.current_buf_remaining = eof_pos.unwrap_or(buf.len());
                         if state.left_to_consume > 0 {
+                            // Skip any bytes remaining from previous unfulfilled consumes.
                             let consumed = state
                                 .left_to_consume
-                                .min((state.current_buf_len - state.current_buf_pos) as usize);
+                                .min(state.current_buf_remaining as usize);
                             state.left_to_consume -= consumed;
-                            state.current_buf_pos += consumed as u32;
+                            state.current_buf_pos += consumed as IoSize;
+                            state.current_buf_remaining -= consumed as IoSize;
                         }
                     }
 
                     // Note: we might have consumed whole buf from `left_to_consume`
-                    if state.current_buf_pos < state.current_buf_len {
+                    if state.current_buf_remaining > 0 {
                         // We have some data available.
                         return Ok(true);
                     }
@@ -432,15 +435,13 @@ impl<'a> Read for SequentialFileReader<'a> {
 
 impl<'a> BufRead for SequentialFileReader<'a> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
-        if self.state.current_buf_pos == self.state.current_buf_len
-            && !self.wait_current_buf_full()?
-        {
+        if self.state.current_buf_remaining == 0 && !self.wait_current_buf_full()? {
             return Ok(&[]);
         }
 
         // At this point we must have data or be at EOF.
         let current_buf = self.ring.context().get_fast(self.state.current_buf_index);
-        Ok(current_buf.slice(self.state.current_buf_pos, self.state.current_buf_len))
+        Ok(current_buf.slice(self.state.current_buf_pos, self.state.current_buf_remaining))
     }
 
     fn consume(&mut self, amt: usize) {
@@ -521,8 +522,8 @@ struct SequentialFileReaderState {
     current_buf_index: u16,
     /// Position in buffer (pointed by `current_buf_index`) to consume data from
     current_buf_pos: IoSize,
-    /// Cached length of the current buffer (0 until `wait_current_buf_full` initializes it)
-    current_buf_len: IoSize,
+    /// Remaining bytes in the current buffer (0 until `wait_current_buf_full` initializes it)
+    current_buf_remaining: IoSize,
     /// File offset of the next `fill_buf()` buffer available to consume
     current_offset: FileSize,
 
@@ -541,11 +542,13 @@ impl SequentialFileReaderState {
         }
         self.current_offset += amt as FileSize;
 
-        let unconsumed_buf_len = (self.current_buf_len - self.current_buf_pos) as usize;
-        if amt <= unconsumed_buf_len {
+        let unconsumed_buf_len = self.current_buf_remaining as usize;
+        if let Some(new_remaining) = unconsumed_buf_len.checked_sub(amt) {
             self.current_buf_pos += amt as IoSize;
+            self.current_buf_remaining = new_remaining as IoSize;
         } else {
-            self.current_buf_pos = self.current_buf_len;
+            self.current_buf_pos += self.current_buf_remaining;
+            self.current_buf_remaining = 0;
             // Keep track of any bytes left to consume beyond current buffer, they will be
             // accounted for during next `wait_current_buf_full` call.
             self.left_to_consume += amt - unconsumed_buf_len;
@@ -586,7 +589,7 @@ impl SequentialFileReaderState {
         self.current_buf_index = (self.current_buf_index + 1) % num_bufs;
         self.current_buf_pos = 0;
         // Buffer might still be reading, len will be intialized on first `wait_current_buf_full`
-        self.current_buf_len = 0;
+        self.current_buf_remaining = 0;
     }
 
     /// Returns `true` if there are no more buffers available for reading.
@@ -702,14 +705,13 @@ impl ReadBufState {
     }
 
     #[inline]
-    fn slice(&self, start_pos: IoSize, end_pos: IoSize) -> &[u8] {
+    fn slice(&self, start_pos: IoSize, len: IoSize) -> &[u8] {
         match self {
             Self::Full { buf, eof_pos } => {
-                debug_assert!(eof_pos.unwrap_or(buf.len()) >= end_pos);
-                let limit = (end_pos - start_pos) as usize;
+                debug_assert!(eof_pos.unwrap_or(buf.len()) >= start_pos + len);
                 // Safety: `limit` is at most `buf.len() - start_pos` (as asserted for `end_pos`),
                 // so the slice is valid given buffer's validity
-                unsafe { slice::from_raw_parts(buf.as_ptr().add(start_pos as usize), limit) }
+                unsafe { slice::from_raw_parts(buf.as_ptr().add(start_pos as usize), len as usize) }
             }
             Self::Uninit(_) | Self::Reading => {
                 unreachable!("must call as_slice only on full buffer")


### PR DESCRIPTION
#### Problem
`SequentialFileReader` used as wincode reader is slower than `std::io::BufReader`, there are a couple of reasons, which should be optimized. Starting with some marginal, but clear to adjust issues.

`SequentialFileReader` is caching current buf length (which otherwise requires checking read buf state variant `Full` and its `eof_pos` field) for fast checks if current position reached the end. This could be even more useful if it tracked remaining bytes, such that:
* checking if current buf has data is one load + cmp to 0 instead of 2 loads comparing equality
* obtaining a slice of current buffer doesn't require subtracing pos from end_pos, `slice::from_raw_parts` takes length of the resulting slice, so remaining bytes can be used directly there

Additionally, current code has a slight code smell around handling uninitialized `current_buf_*` state (on startup or after consuming whole buffer and once new buffer becomes `Full`) in `wait_current_buf_full` - it only compared len to 0 and accounted for buf pos to be non-zero, which is not an allowed state.

#### Summary of Changes
* remove `current_buf_len` tracking len of all data in current buf and replace with `current_buf_remaining` that tracks available bytes to consume from current buf - this is a (tiny) perf optimization
* handle initialization of `current_buf_*` only when both vars are 0, otherwise pass through to obtain next buf or exit if eof reached