### PR TITLE
SIMD-0392: Add feature for other affected logic

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -85,6 +85,7 @@ pub struct FeatureSnapshot {
     pub upgrade_bpf_stake_program_to_v5: bool,
     pub loader_v3_minimum_extend_program_size: bool,
     pub enable_sha512_syscall: bool,
+    pub relax_post_exec_min_balance_check: bool,
 }
 
 impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
@@ -198,6 +199,7 @@ impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
                 &loader_v3_minimum_extend_program_size::ID,
             ),
             enable_sha512_syscall: is_active(&enable_sha512_syscall::ID),
+            relax_post_exec_min_balance_check: is_active(&relax_post_exec_min_balance_check::ID),
         }
     }
 }
@@ -362,6 +364,7 @@ impl FeatureSet {
                 .direct_account_pointers_in_program_input,
             loader_v3_minimum_extend_program_size: snapshot.loader_v3_minimum_extend_program_size,
             enable_sha512_syscall: snapshot.enable_sha512_syscall,
+            relax_post_exec_min_balance_check: snapshot.relax_post_exec_min_balance_check,
         }
     }
 }
@@ -1523,6 +1526,10 @@ pub mod enable_sha512_syscall {
     solana_pubkey::declare_id!("s512oDwgx8hjMnaQjXfqqrZroVj4HvC6TkN3iSSWXCh");
 }
 
+pub mod relax_post_exec_min_balance_check {
+    solana_pubkey::declare_id!("DEJmsCntuYqbXtL5z5TxbaxJXFUJAFjf7TqWSF7YWjQg");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2568,6 +2575,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
             "SIMD-0431: Loader V3 minimum extend program size",
         ),
         (enable_sha512_syscall::id(), "SIMD-0512: SHA512 Syscall"),
+        (
+            relax_post_exec_min_balance_check::id(),
+            "SIMD-0392: Relaxation of post-execution min_balance check",
+        ),
         /*************** ADD NEW FEATURES HERE ***************/
         /***** ADD NEW FEATURE BOOL TO `FeatureSnapshot` *****/
     ]

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -194,7 +194,7 @@ impl Bank {
                     &account,
                     &self.reserved_account_keys,
                     &self.rent_collector().rent,
-                    false, // TODO Pass SIMD-0392 feature
+                    feature_snapshot.relax_post_exec_min_balance_check,
                 )?;
             }
         } else {

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -51,6 +51,7 @@ pub struct SVMFeatureSet {
     pub direct_account_pointers_in_program_input: bool,
     pub loader_v3_minimum_extend_program_size: bool,
     pub enable_sha512_syscall: bool,
+    pub relax_post_exec_min_balance_check: bool,
 }
 
 impl SVMFeatureSet {
@@ -106,6 +107,7 @@ impl SVMFeatureSet {
             direct_account_pointers_in_program_input: true,
             loader_v3_minimum_extend_program_size: true,
             enable_sha512_syscall: true,
+            relax_post_exec_min_balance_check: true,
         }
     }
 }


### PR DESCRIPTION
#### Problem

SIMD-0392 (relax post-exec min balance checks) affects the behavior of SIMD-0232 (custom collector accounts), because we don't need such strict minimum balance checks.

The feature is being added in #9380, but logic for SIMD-0232 was added in #11877 which would change with SIMD-0392 implemented.

#### Summary of changes

Add the feature, and use it in the affected SIMD-0232 logic.

#9380 will need to rebased on this.