### PR TITLE
Feat/block v1 at scheduler

### DIFF
--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -268,6 +268,10 @@ impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction
 
 #[cfg(feature = "dev-context-only-utils")]
 impl solana_svm_transaction::svm_transaction::SVMTransaction for WritableKeysTransaction {
+    fn version(&self) -> solana_transaction::versioned::TransactionVersion {
+        unimplemented!("WritableKeysTransaction::version")
+    }
+
     fn signature(&self) -> &solana_signature::Signature {
         unimplemented!("WritableKeysTransaction::signature")
     }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -336,6 +336,7 @@ dependencies = [
  "solana-short-vec",
  "solana-signature",
  "solana-svm-transaction",
+ "solana-transaction",
  "solana-transaction-context",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -243,6 +243,7 @@ dependencies = [
  "solana-short-vec",
  "solana-signature",
  "solana-svm-transaction",
+ "solana-transaction",
  "solana-transaction-context",
 ]
 

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -24,7 +24,7 @@ use {
         svm_message::{SVMMessage, SVMStaticMessage},
         svm_transaction::SVMTransaction,
     },
-    solana_transaction::TransactionError,
+    solana_transaction::{TransactionError, versioned::TransactionVersion},
 };
 
 mod sdk_transactions;
@@ -165,6 +165,10 @@ impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
 }
 
 impl<T: SVMTransaction> SVMTransaction for RuntimeTransaction<T> {
+    fn version(&self) -> TransactionVersion {
+        self.transaction.version()
+    }
+
     fn signature(&self) -> &Signature {
         self.transaction.signature()
     }

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -15,6 +15,7 @@ use {
         transaction_error_metrics::TransactionErrorMetrics,
     },
     solana_svm_transaction::svm_message::SVMMessage,
+    solana_transaction::versioned::TransactionVersion,
     solana_transaction_error::{TransactionError, TransactionResult},
 };
 
@@ -69,9 +70,11 @@ impl Bank {
         collect_processed_slots: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> (Vec<TransactionCheckResult>, Option<Vec<Option<Slot>>>) {
+        let lock_results = self.filter_v1_transactions(sanitized_txs, lock_results);
+
         let lock_results = self.check_age_and_compute_budget_limits(
             sanitized_txs,
-            lock_results,
+            &lock_results,
             max_age,
             error_counters,
         );
@@ -81,6 +84,25 @@ impl Bank {
             collect_processed_slots,
             error_counters,
         )
+    }
+
+    fn filter_v1_transactions<Tx: TransactionWithMeta>(
+        &self,
+        sanitized_txs: &[impl core::borrow::Borrow<Tx>],
+        lock_results: &[TransactionResult<()>],
+    ) -> Vec<TransactionResult<()>> {
+        // Discard v1 transactions until support is added.
+        sanitized_txs
+            .iter()
+            .zip(lock_results)
+            .map(|(tx, lock_result)| match lock_result {
+                Err(err) => Err(err.clone()),
+                Ok(()) if tx.borrow().version() == TransactionVersion::Number(1) => {
+                    Err(TransactionError::UnsupportedVersion)
+                }
+                Ok(()) => Ok(()),
+            })
+            .collect()
     }
 
     fn check_age_and_compute_budget_limits<Tx: TransactionWithMeta>(
@@ -267,9 +289,12 @@ impl Bank {
 mod tests {
     use {
         super::*,
-        crate::bank::tests::{
-            get_nonce_blockhash, get_nonce_data_from_account, new_sanitized_message,
-            setup_nonce_with_bank,
+        crate::bank::{
+            ReservedAccountKeys,
+            tests::{
+                get_nonce_blockhash, get_nonce_data_from_account, new_sanitized_message,
+                setup_nonce_with_bank,
+            },
         },
         solana_account::state_traits::StateMut,
         solana_hash::Hash,
@@ -279,13 +304,16 @@ mod tests {
             SimpleAddressLoader, VersionedMessage,
             compiled_instruction::CompiledInstruction,
             v0::{self, LoadedAddresses, MessageAddressTableLookup},
+            v1,
         },
         solana_nonce::{state::State as NonceState, versions::Versions as NonceVersions},
+        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_signer::Signer,
         solana_system_interface::{
             instruction::{self as system_instruction, SystemInstruction},
             program as system_program,
         },
+        solana_transaction::{sanitized::MessageHash, versioned::VersionedTransaction},
         std::collections::HashSet,
     };
 
@@ -474,5 +502,126 @@ mod tests {
             bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce()),
             None,
         );
+    }
+
+    fn make_test_tx(version: TransactionVersion) -> impl TransactionWithMeta {
+        let payer = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        let recent_blockhash = Hash::new_unique();
+        let ix = system_instruction::transfer(&payer.pubkey(), &recipient, 1);
+
+        let message = match version {
+            TransactionVersion::LEGACY => {
+                VersionedMessage::Legacy(Message::new(&[ix], Some(&payer.pubkey())))
+            }
+            TransactionVersion::Number(0) => VersionedMessage::V0(
+                v0::Message::try_compile(&payer.pubkey(), &[ix], &[], recent_blockhash).unwrap(),
+            ),
+            TransactionVersion::Number(1) => VersionedMessage::V1(
+                v1::Message::try_compile(&payer.pubkey(), &[ix], recent_blockhash).unwrap(),
+            ),
+            TransactionVersion::Number(other) => {
+                panic!("unsupported test transaction version: {other}")
+            }
+        };
+
+        let tx = VersionedTransaction::try_new(message, &[&payer]).unwrap();
+        // Note: enabled loader is needed to create v0 runtime-transaction
+        let address_loader =
+            solana_message::SimpleAddressLoader::Enabled(solana_message::v0::LoadedAddresses {
+                writable: vec![],
+                readonly: vec![],
+            });
+        let rt = RuntimeTransaction::try_create(
+            tx,
+            MessageHash::Compute,
+            None,
+            address_loader,
+            &ReservedAccountKeys::empty_key_set(),
+            true,
+        );
+        rt.unwrap()
+    }
+
+    #[test]
+    fn test_filter_v1_transactions_keeps_existing_errors() {
+        let txs = vec![
+            make_test_tx(TransactionVersion::LEGACY),
+            make_test_tx(TransactionVersion::Number(0)),
+            make_test_tx(TransactionVersion::Number(1)),
+        ];
+        let lock_results = vec![
+            Err(TransactionError::AccountInUse),
+            Err(TransactionError::TooManyAccountLocks),
+            Err(TransactionError::WouldExceedMaxBlockCostLimit),
+        ];
+
+        let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
+
+        assert!(matches!(filtered[0], Err(TransactionError::AccountInUse)));
+        assert!(matches!(
+            filtered[1],
+            Err(TransactionError::TooManyAccountLocks)
+        ));
+        assert!(matches!(
+            filtered[2],
+            Err(TransactionError::WouldExceedMaxBlockCostLimit)
+        ));
+    }
+
+    #[test]
+    fn test_filter_v1_transactions_rejects_v1_with_ok_lock_result() {
+        let txs = vec![make_test_tx(TransactionVersion::Number(1))];
+        let lock_results = vec![Ok(())];
+
+        let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
+
+        assert_eq!(filtered.len(), 1);
+        assert!(matches!(
+            filtered[0],
+            Err(TransactionError::UnsupportedVersion)
+        ));
+    }
+
+    #[test]
+    fn test_filter_v1_transactions_keeps_legacy_and_v0_ok() {
+        let txs = vec![
+            make_test_tx(TransactionVersion::LEGACY),
+            make_test_tx(TransactionVersion::Number(0)),
+        ];
+        let lock_results = vec![Ok(()), Ok(())];
+
+        let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
+
+        assert_eq!(filtered, vec![Ok(()), Ok(())]);
+    }
+
+    #[test]
+    fn test_filter_v1_transactions_mixed_results() {
+        let txs = vec![
+            make_test_tx(TransactionVersion::LEGACY),
+            make_test_tx(TransactionVersion::Number(1)),
+            make_test_tx(TransactionVersion::Number(0)),
+            make_test_tx(TransactionVersion::Number(1)),
+        ];
+        let lock_results = vec![
+            Ok(()),
+            Ok(()),
+            Err(TransactionError::AccountInUse),
+            Err(TransactionError::TooManyAccountLocks),
+        ];
+
+        let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
+
+        assert!(matches!(filtered[0], Ok(())));
+        assert!(matches!(
+            filtered[1],
+            Err(TransactionError::UnsupportedVersion)
+        ));
+        assert!(matches!(filtered[2], Err(TransactionError::AccountInUse)));
+        assert!(matches!(
+            filtered[3],
+            Err(TransactionError::TooManyAccountLocks)
+        ));
     }
 }

--- a/svm-transaction/src/svm_transaction.rs
+++ b/svm-transaction/src/svm_transaction.rs
@@ -1,8 +1,14 @@
-use {crate::svm_message::SVMMessage, solana_signature::Signature};
+use {
+    crate::svm_message::SVMMessage, solana_signature::Signature,
+    solana_transaction::versioned::TransactionVersion,
+};
 
 mod sanitized_transaction;
 
 pub trait SVMTransaction: SVMMessage {
+    /// Get the transaction version.
+    fn version(&self) -> TransactionVersion;
+
     /// Get the first signature of the message.
     fn signature(&self) -> &Signature;
 

--- a/svm-transaction/src/svm_transaction/sanitized_transaction.rs
+++ b/svm-transaction/src/svm_transaction/sanitized_transaction.rs
@@ -1,9 +1,19 @@
 use {
-    crate::svm_transaction::SVMTransaction, solana_signature::Signature,
-    solana_transaction::sanitized::SanitizedTransaction,
+    crate::svm_transaction::SVMTransaction,
+    solana_message::SanitizedMessage,
+    solana_signature::Signature,
+    solana_transaction::{sanitized::SanitizedTransaction, versioned::TransactionVersion},
 };
 
 impl SVMTransaction for SanitizedTransaction {
+    fn version(&self) -> TransactionVersion {
+        match self.message() {
+            SanitizedMessage::Legacy(_) => TransactionVersion::LEGACY,
+            SanitizedMessage::V0(_) => TransactionVersion::Number(0),
+            SanitizedMessage::V1(_) => TransactionVersion::Number(1),
+        }
+    }
+
     fn signature(&self) -> &Signature {
         SanitizedTransaction::signature(self)
     }

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -22,6 +22,7 @@ solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true }
 solana-signature = { workspace = true }
 solana-svm-transaction = { workspace = true }
+solana-transaction = { workspace = true }
 solana-transaction-context = { workspace = true }
 
 [dev-dependencies]

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -235,6 +235,10 @@ impl<D: TransactionData> SVMMessage for ResolvedTransactionView<D> {
 }
 
 impl<D: TransactionData> SVMTransaction for ResolvedTransactionView<D> {
+    fn version(&self) -> solana_transaction::versioned::TransactionVersion {
+        self.view.version().into()
+    }
+
     fn signature(&self) -> &Signature {
         &self.view.signatures()[0]
     }

--- a/transaction-view/src/transaction_version.rs
+++ b/transaction-view/src/transaction_version.rs
@@ -7,3 +7,13 @@ pub enum TransactionVersion {
     V0 = 0,
     V1 = 1,
 }
+
+impl From<TransactionVersion> for solana_transaction::versioned::TransactionVersion {
+    fn from(version: TransactionVersion) -> Self {
+        match version {
+            TransactionVersion::Legacy => Self::LEGACY,
+            TransactionVersion::V0 => Self::Number(0),
+            TransactionVersion::V1 => Self::Number(1),
+        }
+    }
+}


### PR DESCRIPTION
#### Problem

Should block txv1 entering into block production before it's support is enabled.

#### Summary of Changes
- check transaction version, block `v1` at `check_transaction()`.

Fixes #
