### PR TITLE
runtime: Avoid incremental stakes cache updates in `process_genesis_config`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2781,7 +2781,7 @@ impl Bank {
                 "{pubkey} repeated in genesis config"
             );
             let account_shared_data = create_account_shared_data(account);
-            self.store_account(pubkey, &account_shared_data);
+            self.store_account_without_stakes_cache(pubkey, &account_shared_data);
             self.capitalization.fetch_add(account.lamports(), Relaxed);
             self.accounts_data_size_initial += account.data().len() as u64;
         }
@@ -2792,9 +2792,14 @@ impl Bank {
                 "{pubkey} repeated in genesis config"
             );
             let account_shared_data = create_account_shared_data(account);
-            self.store_account(pubkey, &account_shared_data);
+            self.store_account_without_stakes_cache(pubkey, &account_shared_data);
             self.accounts_data_size_initial += account.data().len() as u64;
         }
+
+        self.stakes_cache = StakesCache::new(Stakes::new_from_accounts_for_genesis(
+            self.new_warmup_cooldown_rate_epoch(),
+            genesis_config.accounts.iter(),
+        ));
 
         // After storing genesis accounts, the bank stakes cache will be warmed
         // up and can be used to set the leader id to the highest staked
@@ -4291,6 +4296,18 @@ impl Bank {
     /// Uses `store_accounts`, which works on a vector of accounts.
     pub fn store_account(&self, pubkey: &Pubkey, account: &AccountSharedData) {
         self.store_accounts((self.slot(), &[(pubkey, account)][..]))
+    }
+
+    fn store_account_without_stakes_cache(&self, pubkey: &Pubkey, account: &AccountSharedData) {
+        self.store_accounts_without_stakes_cache((self.slot(), &[(pubkey, account)][..]))
+    }
+
+    fn store_accounts_without_stakes_cache<'a>(&self, accounts: impl StorableAccounts<'a>) {
+        assert!(!self.freeze_started());
+        self.update_bank_hash_stats(&accounts);
+        self.rc
+            .accounts
+            .store_accounts_par(accounts, None, Some(&self.ancestors));
     }
 
     pub fn store_accounts<'a>(&self, accounts: impl StorableAccounts<'a>) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4298,18 +4298,6 @@ impl Bank {
         self.store_accounts((self.slot(), &[(pubkey, account)][..]))
     }
 
-    fn store_account_without_stakes_cache(&self, pubkey: &Pubkey, account: &AccountSharedData) {
-        self.store_accounts_without_stakes_cache((self.slot(), &[(pubkey, account)][..]))
-    }
-
-    fn store_accounts_without_stakes_cache<'a>(&self, accounts: impl StorableAccounts<'a>) {
-        assert!(!self.freeze_started());
-        self.update_bank_hash_stats(&accounts);
-        self.rc
-            .accounts
-            .store_accounts_par(accounts, None, Some(&self.ancestors));
-    }
-
     pub fn store_accounts<'a>(&self, accounts: impl StorableAccounts<'a>) {
         assert!(!self.freeze_started());
         let mut m = Measure::start("stakes_cache.check_and_store");
@@ -4335,6 +4323,18 @@ impl Bank {
             .stats
             .stakes_cache_check_and_store_us
             .fetch_add(m.as_us(), Relaxed);
+    }
+
+    fn store_account_without_stakes_cache(&self, pubkey: &Pubkey, account: &AccountSharedData) {
+        self.store_accounts_without_stakes_cache((self.slot(), &[(pubkey, account)][..]))
+    }
+
+    fn store_accounts_without_stakes_cache<'a>(&self, accounts: impl StorableAccounts<'a>) {
+        assert!(!self.freeze_started());
+        self.update_bank_hash_stats(&accounts);
+        self.rc
+            .accounts
+            .store_accounts_par(accounts, None, &self.ancestors);
     }
 
     pub fn force_flush_accounts_cache(&self) {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -16,7 +16,7 @@ use {
         program as stake_program,
         state::{Delegation, StakeActivationStatus},
     },
-    solana_vote::vote_account::{VoteAccount, VoteAccounts},
+    solana_vote::vote_account::{VoteAccount, VoteAccounts, VoteAccountsHashMap},
     solana_vote_interface::state::VoteStateVersions,
     std::{
         collections::HashMap,
@@ -236,6 +236,55 @@ impl<T: Clone> Stakes<T> {
 }
 
 impl Stakes<StakeAccount> {
+    pub(crate) fn new_from_accounts_for_genesis<'a, T: ReadableAccount + 'a>(
+        new_rate_activation_epoch: Option<Epoch>,
+        accounts: impl IntoIterator<Item = (&'a Pubkey, &'a T)>,
+    ) -> Self {
+        let stake_history = StakeHistory::default();
+        let mut vote_accounts = VoteAccountsHashMap::default();
+        let mut delegated_stakes: HashMap<Pubkey, u64> = HashMap::default();
+        let mut stake_delegations = ImblHashMap::new();
+        let epoch = 0;
+
+        for (pubkey, account) in accounts {
+            if account.lamports() == 0 {
+                continue;
+            }
+
+            if solana_vote_program::check_id(account.owner()) {
+                if VoteStateVersions::is_correct_size_and_initialized(account.data()) {
+                    if let Ok(vote_account) =
+                        VoteAccount::try_from(create_account_shared_data(account))
+                    {
+                        vote_accounts.insert(*pubkey, (0, vote_account));
+                    }
+                }
+            } else if stake_program::check_id(account.owner()) {
+                if let Ok(stake_account) =
+                    StakeAccount::try_from(create_account_shared_data(account))
+                {
+                    let delegation = stake_account.delegation();
+                    let stake = delegation.stake(epoch, &stake_history, new_rate_activation_epoch);
+                    *delegated_stakes.entry(delegation.voter_pubkey).or_default() += stake;
+                    stake_delegations.insert(*pubkey, stake_account);
+                }
+            }
+        }
+
+        let mut vote_accounts = VoteAccounts::from(Arc::new(vote_accounts));
+        for (vote_pubkey, stake) in delegated_stakes {
+            vote_accounts.add_stake(&vote_pubkey, stake);
+        }
+
+        Self {
+            vote_accounts,
+            stake_delegations,
+            unused: 0,
+            epoch,
+            stake_history,
+        }
+    }
+
     /// Creates a Stake<StakeAccount> from DeserializableStakes<Delegation> by loading the
     /// full account state for respective stake pubkeys. get_account function
     /// should return the account at the respective slot where stakes where


### PR DESCRIPTION
#### Problem

`Bank::process_genesis_config` was inserting accounts both to accounts-db and stakes cache one by one. This way is not optimal, and it was the primary reason behind `Bank::new_for_tests` being extremely slow.

This was visible mainly in the `epoch_turnover` benchmark, which was taking 153s to execute. The epoch boundary, that is actually being measured by the bechmark, takes miliseconds, but preparing a bank with 1,000 voters and 1,000,000 delegations is what took this entire time.

```
$ time target/release/deps/epoch_turnover-8052477413673af9 1000_votes_1000000_stakes
Gnuplot not found, using plotters backend
Testing bench_epoch_turnover/1000_votes_1000000_stakes
Success

Testing bench_epoch_rewards_period/1000_votes_1000000_stakes
Success

153.87user 6.42system 2:14.34elapsed 119%CPU (0avgtext+0avgdata 4773244maxresident)k
0inputs+0outputs (0major+2976539minor)pagefaults 0swaps
```

#### Summary of Changes

Improve that by inserting accounts only into accounts-db first, then initializing the stakes cache separately.

This brings visible improvement, the entire benchmark takes now 46s:

```
$ time target/release/deps/epoch_turnover-76b5932756e73ccb 1000_votes_1000000_stakes                                                                                                                                                             Gnuplot not found, using plotters backend
Testing bench_epoch_turnover/1000_votes_1000000_stakes
Success

Testing bench_epoch_rewards_period/1000_votes_1000000_stakes
Success

46.56user 7.40system 0:28.44elapsed 189%CPU (0avgtext+0avgdata 4818048maxresident)k
0inputs+0outputs (0major+3492471minor)pagefaults 0swaps
```