### PR TITLE
Block txv1 entering block production until support is ready

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -953,6 +953,10 @@ pub(crate) mod external {
                         check_response.included_slot =
                             included_slot.expect("included_slot must be set for already processed");
                     }
+                    Err(TransactionError::UnsupportedVersion) => {
+                        check_response.status_check_flags |=
+                            status_check_flags::UNSUPPORTED_VERSION;
+                    }
                     _ => {}
                 }
             }

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -15,6 +15,7 @@ use {
         transaction_error_metrics::TransactionErrorMetrics,
     },
     solana_svm_transaction::svm_message::SVMMessage,
+    solana_transaction::versioned::TransactionVersion,
     solana_transaction_error::{TransactionError, TransactionResult},
 };
 
@@ -69,9 +70,11 @@ impl Bank {
         collect_processed_slots: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> (Vec<TransactionCheckResult>, Option<Vec<Option<Slot>>>) {
+        let lock_results = self.filter_v1_transactions(sanitized_txs, lock_results);
+
         let lock_results = self.check_age_and_compute_budget_limits(
             sanitized_txs,
-            lock_results,
+            &lock_results,
             max_age,
             error_counters,
         );
@@ -81,6 +84,25 @@ impl Bank {
             collect_processed_slots,
             error_counters,
         )
+    }
+
+    fn filter_v1_transactions<Tx: TransactionWithMeta>(
+        &self,
+        sanitized_txs: &[impl core::borrow::Borrow<Tx>],
+        lock_results: &[TransactionResult<()>],
+    ) -> Vec<TransactionResult<()>> {
+        // Discard v1 transactions until support is added.
+        sanitized_txs
+            .iter()
+            .zip(lock_results)
+            .map(|(tx, lock_result)| match lock_result {
+                Err(err) => Err(err.clone()),
+                Ok(()) if tx.borrow().version() == TransactionVersion::Number(1) => {
+                    Err(TransactionError::UnsupportedVersion)
+                }
+                Ok(()) => Ok(()),
+            })
+            .collect()
     }
 
     fn check_age_and_compute_budget_limits<Tx: TransactionWithMeta>(
@@ -267,9 +289,12 @@ impl Bank {
 mod tests {
     use {
         super::*,
-        crate::bank::tests::{
-            get_nonce_blockhash, get_nonce_data_from_account, new_sanitized_message,
-            setup_nonce_with_bank,
+        crate::bank::{
+            ReservedAccountKeys,
+            tests::{
+                get_nonce_blockhash, get_nonce_data_from_account, new_sanitized_message,
+                setup_nonce_with_bank,
+            },
         },
         solana_account::state_traits::StateMut,
         solana_hash::Hash,
@@ -279,13 +304,16 @@ mod tests {
             SimpleAddressLoader, VersionedMessage,
             compiled_instruction::CompiledInstruction,
             v0::{self, LoadedAddresses, MessageAddressTableLookup},
+            v1,
         },
         solana_nonce::{state::State as NonceState, versions::Versions as NonceVersions},
+        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_signer::Signer,
         solana_system_interface::{
             instruction::{self as system_instruction, SystemInstruction},
             program as system_program,
         },
+        solana_transaction::{sanitized::MessageHash, versioned::VersionedTransaction},
         std::collections::HashSet,
     };
 
@@ -474,5 +502,126 @@ mod tests {
             bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce()),
             None,
         );
+    }
+
+    fn make_test_tx(version: TransactionVersion) -> impl TransactionWithMeta {
+        let payer = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        let recent_blockhash = Hash::new_unique();
+        let ix = system_instruction::transfer(&payer.pubkey(), &recipient, 1);
+
+        let message = match version {
+            TransactionVersion::LEGACY => {
+                VersionedMessage::Legacy(Message::new(&[ix], Some(&payer.pubkey())))
+            }
+            TransactionVersion::Number(0) => VersionedMessage::V0(
+                v0::Message::try_compile(&payer.pubkey(), &[ix], &[], recent_blockhash).unwrap(),
+            ),
+            TransactionVersion::Number(1) => VersionedMessage::V1(
+                v1::Message::try_compile(&payer.pubkey(), &[ix], recent_blockhash).unwrap(),
+            ),
+            TransactionVersion::Number(other) => {
+                panic!("unsupported test transaction version: {other}")
+            }
+        };
+
+        let tx = VersionedTransaction::try_new(message, &[&payer]).unwrap();
+        // Note: enabled loader is needed to create v0 runtime-transaction
+        let address_loader =
+            solana_message::SimpleAddressLoader::Enabled(solana_message::v0::LoadedAddresses {
+                writable: vec![],
+                readonly: vec![],
+            });
+        let rt = RuntimeTransaction::try_create(
+            tx,
+            MessageHash::Compute,
+            None,
+            address_loader,
+            &ReservedAccountKeys::empty_key_set(),
+            true,
+        );
+        rt.unwrap()
+    }
+
+    #[test]
+    fn test_filter_v1_transactions_keeps_existing_errors() {
+        let txs = vec![
+            make_test_tx(TransactionVersion::LEGACY),
+            make_test_tx(TransactionVersion::Number(0)),
+            make_test_tx(TransactionVersion::Number(1)),
+        ];
+        let lock_results = vec![
+            Err(TransactionError::AccountInUse),
+            Err(TransactionError::TooManyAccountLocks),
+            Err(TransactionError::WouldExceedMaxBlockCostLimit),
+        ];
+
+        let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
+
+        assert!(matches!(filtered[0], Err(TransactionError::AccountInUse)));
+        assert!(matches!(
+            filtered[1],
+            Err(TransactionError::TooManyAccountLocks)
+        ));
+        assert!(matches!(
+            filtered[2],
+            Err(TransactionError::WouldExceedMaxBlockCostLimit)
+        ));
+    }
+
+    #[test]
+    fn test_filter_v1_transactions_rejects_v1_with_ok_lock_result() {
+        let txs = vec![make_test_tx(TransactionVersion::Number(1))];
+        let lock_results = vec![Ok(())];
+
+        let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
+
+        assert_eq!(filtered.len(), 1);
+        assert!(matches!(
+            filtered[0],
+            Err(TransactionError::UnsupportedVersion)
+        ));
+    }
+
+    #[test]
+    fn test_filter_v1_transactions_keeps_legacy_and_v0_ok() {
+        let txs = vec![
+            make_test_tx(TransactionVersion::LEGACY),
+            make_test_tx(TransactionVersion::Number(0)),
+        ];
+        let lock_results = vec![Ok(()), Ok(())];
+
+        let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
+
+        assert_eq!(filtered, vec![Ok(()), Ok(())]);
+    }
+
+    #[test]
+    fn test_filter_v1_transactions_mixed_results() {
+        let txs = vec![
+            make_test_tx(TransactionVersion::LEGACY),
+            make_test_tx(TransactionVersion::Number(1)),
+            make_test_tx(TransactionVersion::Number(0)),
+            make_test_tx(TransactionVersion::Number(1)),
+        ];
+        let lock_results = vec![
+            Ok(()),
+            Ok(()),
+            Err(TransactionError::AccountInUse),
+            Err(TransactionError::TooManyAccountLocks),
+        ];
+
+        let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
+
+        assert!(matches!(filtered[0], Ok(())));
+        assert!(matches!(
+            filtered[1],
+            Err(TransactionError::UnsupportedVersion)
+        ));
+        assert!(matches!(filtered[2], Err(TransactionError::AccountInUse)));
+        assert!(matches!(
+            filtered[3],
+            Err(TransactionError::TooManyAccountLocks)
+        ));
     }
 }

--- a/scheduler-bindings/src/lib.rs
+++ b/scheduler-bindings/src/lib.rs
@@ -452,6 +452,9 @@ pub mod worker_message_types {
         pub const ALREADY_PROCESSED: u8 = 1 << 3;
         /// Flag set if status checks failed due to an invalid nonce state.
         pub const INVALID_NONCE: u8 = 1 << 4;
+        /// Flag set if status checks failed due to unsupported version of
+        /// transaction was received.
+        pub const UNSUPPORTED_VERSION: u8 = 1 << 5;
     }
 
     pub mod fee_payer_balance_flags {


### PR DESCRIPTION
#### Problem

Should block `txv1` entering into block production before it's support is enabled.

#### Summary of Changes
- check transaction version, block v1 at check_transaction().

Fixes #
