### PR TITLE
runtime: load commission accounts at distribution time

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1775,7 +1775,7 @@ impl Bank {
                 parent_slot,
                 parent_height,
                 &rewards_calculation,
-                &rewards_metrics,
+                &mut rewards_metrics,
                 &thread_pool,
             ));
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1769,14 +1769,15 @@ impl Bank {
 
         // Distribute rewards commission to vote accounts and cache stake rewards
         // for partitioned distribution in the upcoming slots.
-        let epoch_validator_rewards = self.begin_partitioned_rewards(
-            parent_epoch,
-            parent_slot,
-            parent_height,
-            &rewards_calculation,
-            &rewards_metrics,
-            &thread_pool,
-        );
+        let (epoch_validator_rewards, begin_partitioned_rewards_time_us) =
+            measure_us!(self.begin_partitioned_rewards(
+                parent_epoch,
+                parent_slot,
+                parent_height,
+                &rewards_calculation,
+                &rewards_metrics,
+                &thread_pool,
+            ));
 
         // the vote reward account state should be created at the epoch boundary in which we
         // activate alpenglow as it will need info from the previous epoch.
@@ -1799,6 +1800,7 @@ impl Bank {
                 calculate_activated_stake_time_us,
                 update_epoch_stakes_time_us,
                 update_rewards_with_thread_pool_time_us,
+                begin_partitioned_rewards_time_us,
             },
             rewards_metrics,
         );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1775,6 +1775,7 @@ impl Bank {
             parent_height,
             &rewards_calculation,
             &rewards_metrics,
+            &thread_pool,
         );
 
         // the vote reward account state should be created at the epoch boundary in which we

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -23,7 +23,7 @@ pub(crate) struct RewardsMetrics {
     pub(crate) redeem_rewards_us: u64,
     pub(crate) store_stake_accounts_us: AtomicU64,
     pub(crate) store_commission_accounts_us: AtomicU64,
-    pub(crate) load_and_reward_commission_accounts_us: AtomicU64,
+    pub(crate) load_and_reward_commission_accounts_us: u64,
 }
 
 pub(crate) struct NewBankTimings {
@@ -104,7 +104,7 @@ pub(crate) fn report_new_epoch_metrics(
         ),
         (
             "load_and_reward_commission_accounts_us",
-            metrics.load_and_reward_commission_accounts_us.load(Relaxed),
+            metrics.load_and_reward_commission_accounts_us,
             i64
         ),
     );

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -14,6 +14,7 @@ pub(crate) struct NewEpochTimings {
     pub(crate) calculate_activated_stake_time_us: u64,
     pub(crate) update_epoch_stakes_time_us: u64,
     pub(crate) update_rewards_with_thread_pool_time_us: u64,
+    pub(crate) begin_partitioned_rewards_time_us: u64,
 }
 
 #[derive(Debug, Default)]
@@ -22,6 +23,7 @@ pub(crate) struct RewardsMetrics {
     pub(crate) redeem_rewards_us: u64,
     pub(crate) store_stake_accounts_us: AtomicU64,
     pub(crate) store_commission_accounts_us: AtomicU64,
+    pub(crate) load_and_reward_commission_accounts_us: AtomicU64,
 }
 
 pub(crate) struct NewBankTimings {
@@ -80,6 +82,11 @@ pub(crate) fn report_new_epoch_metrics(
             i64
         ),
         (
+            "begin_partitioned_rewards_us",
+            timings.begin_partitioned_rewards_time_us,
+            i64
+        ),
+        (
             "calculate_points_us",
             metrics.calculate_points_us.load(Relaxed),
             i64
@@ -93,6 +100,11 @@ pub(crate) fn report_new_epoch_metrics(
         (
             "store_commission_accounts_us",
             metrics.store_commission_accounts_us.load(Relaxed),
+            i64
+        ),
+        (
+            "load_and_reward_commission_accounts_us",
+            metrics.load_and_reward_commission_accounts_us.load(Relaxed),
             i64
         ),
     );

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -2,9 +2,9 @@ use {
     super::{
         Bank, CachedVoteAccounts, CalculateValidatorRewardsResult, EpochRewardCalculateParamInfo,
         FilteredStakeDelegations, PartitionedRewardsCalculation, PartitionedStakeReward,
-        PartitionedStakeRewards, REWARD_CALCULATION_NUM_BLOCKS, RewardCommissionAccounts,
-        RewardCommissionAccountsStorable, StakeRewardCalculation,
-        epoch_rewards_hasher::hash_rewards_into_partitions,
+        PartitionedStakeRewards, REWARD_CALCULATION_NUM_BLOCKS, RewardCommission,
+        RewardCommissionAccounts, RewardCommissionAccountsStorable, RewardCommissions,
+        StakeRewardCalculation, epoch_rewards_hasher::hash_rewards_into_partitions,
     },
     crate::{
         bank::{RewardCalcTracer, RewardCalculationEvent, RewardsMetrics, null_tracer},
@@ -22,18 +22,15 @@ use {
         ThreadPool,
         iter::{IndexedParallelIterator, ParallelIterator},
     },
-    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
+    solana_account::{ReadableAccount, WritableAccount},
     solana_clock::{Epoch, Slot},
     solana_measure::{measure::Measure, measure_us},
     solana_native_token::LAMPORTS_PER_SOL,
-    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
+    solana_pubkey::Pubkey,
     solana_reward_info::RewardType,
     solana_stake_interface::{stake_history::StakeHistory, state::Delegation},
     solana_sysvar::epoch_rewards::EpochRewards,
-    std::{
-        collections::HashMap,
-        sync::{Arc, atomic::Ordering::Relaxed},
-    },
+    std::sync::{Arc, atomic::Ordering::Relaxed},
 };
 
 #[derive(Debug)]
@@ -42,15 +39,6 @@ struct DelegationRewards {
     commission_pubkey: Pubkey,
     reward_commission: RewardCommission,
 }
-
-#[derive(Debug)]
-struct RewardCommission {
-    commission_account: AccountSharedData,
-    commission_bps: u16,
-    commission_lamports: u64,
-}
-
-type RewardCommissions = HashMap<Pubkey, RewardCommission, PubkeyHasherBuilder>;
 
 #[derive(Default)]
 struct RewardsAccumulator {
@@ -878,7 +866,7 @@ mod tests {
         },
         solana_vote_program::vote_state::{self, create_bls_proof_of_possession},
         std::{
-            collections::HashSet,
+            collections::{HashMap, HashSet},
             sync::{Arc, RwLock, RwLockReadGuard},
         },
         test_case::test_case,

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -514,10 +514,8 @@ impl Bank {
                     stake_reward,
                     commission_bps,
                 };
-                let vote_account = vote_account.into();
                 let reward_commission = RewardCommission {
                     commission_bps,
-                    commission_account: vote_account,
                     commission_lamports,
                 };
                 Some(DelegationRewards {
@@ -902,52 +900,39 @@ mod tests {
         test_case::test_case,
     };
 
-    impl RewardCommission {
-        pub fn new_random() -> Self {
-            let mut rng = rand::rng();
-
-            let commission_balance = rng.random_range(1..200);
-            let commission_bps: u16 = rng.random_range(100..2_000);
-
-            let mut commission_account = AccountSharedData::default();
-            commission_account.set_lamports(commission_balance);
-
-            Self {
-                commission_account,
-                commission_bps,
-                commission_lamports: rng.random_range(1..200),
-            }
-        }
-    }
-
     #[test]
     fn test_store_commission_accounts_partitioned() {
         let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
         let bank = Bank::new_for_tests(&genesis_config);
 
         let num_reward_commissions = 100;
-        let reward_commissions = (0..num_reward_commissions)
-            .map(|_| (Pubkey::new_unique(), RewardCommission::new_random()))
-            .collect::<Vec<_>>();
-
-        let mut reward_commission_accounts = RewardCommissionAccounts::default();
-        reward_commissions
-            .iter()
-            .for_each(|(commission_pubkey, reward_commission)| {
+        let mut rng = rand::rng();
+        let entries: Vec<(Pubkey, RewardInfo, AccountSharedData)> = (0..num_reward_commissions)
+            .map(|_| {
+                let commission_balance = rng.random_range(1..200);
+                let commission_bps: u16 = rng.random_range(100..2_000);
+                let commission_lamports: u64 = rng.random_range(1..200);
+                let mut commission_account = AccountSharedData::default();
+                commission_account.set_lamports(commission_balance);
                 let info = RewardInfo {
                     reward_type: RewardType::Voting,
-                    lamports: reward_commission.commission_lamports as i64,
-                    post_balance: reward_commission.commission_lamports,
-                    commission_bps: Some(reward_commission.commission_bps),
+                    lamports: commission_lamports as i64,
+                    post_balance: commission_lamports,
+                    commission_bps: Some(commission_bps),
                 };
-                reward_commission_accounts.accounts_with_rewards.push((
-                    *commission_pubkey,
-                    info,
-                    reward_commission.commission_account.clone(),
-                ));
-                reward_commission_accounts.total_reward_commission_lamports +=
-                    reward_commission.commission_lamports;
-            });
+                (Pubkey::new_unique(), info, commission_account)
+            })
+            .collect();
+
+        let mut reward_commission_accounts = RewardCommissionAccounts::default();
+        for (commission_pubkey, info, commission_account) in &entries {
+            reward_commission_accounts.accounts_with_rewards.push((
+                *commission_pubkey,
+                *info,
+                commission_account.clone(),
+            ));
+            reward_commission_accounts.total_reward_commission_lamports += info.lamports as u64;
+        }
 
         let metrics = RewardsMetrics::default();
 
@@ -958,25 +943,20 @@ mod tests {
             reward_commission_accounts.accounts_with_rewards.len()
         );
         assert_eq!(
-            reward_commissions
+            entries
                 .iter()
-                .map(|(_, reward_commission)| reward_commission.commission_lamports)
+                .map(|(_, info, _)| info.lamports as u64)
                 .sum::<u64>(),
             total_reward_commissions
         );
 
         // load accounts to make sure they were stored correctly
-        reward_commissions
-            .iter()
-            .for_each(|(commission_pubkey, reward_commission)| {
-                let loaded_account = bank
-                    .load_slow_with_fixed_root(&bank.ancestors, commission_pubkey)
-                    .unwrap();
-                assert!(accounts_equal(
-                    &loaded_account.0,
-                    &reward_commission.commission_account
-                ));
-            });
+        for (commission_pubkey, _, commission_account) in &entries {
+            let loaded_account = bank
+                .load_slow_with_fixed_root(&bank.ancestors, commission_pubkey)
+                .unwrap();
+            assert!(accounts_equal(&loaded_account.0, commission_account));
+        }
     }
 
     #[test]
@@ -2144,18 +2124,12 @@ mod tests {
         let mut accumulator2 = RewardsAccumulator::default();
 
         let commission_pubkey_a = Pubkey::new_unique();
-        let commission_account_a = AccountSharedData::default();
-
         let commission_pubkey_b = Pubkey::new_unique();
-        let commission_account_b = AccountSharedData::default();
-
         let commission_pubkey_c = Pubkey::new_unique();
-        let commission_account_c = AccountSharedData::default();
 
         accumulator1.add_reward(
             commission_pubkey_a,
             RewardCommission {
-                commission_account: commission_account_a.clone(),
                 commission_bps: 1_000,
                 commission_lamports: 50,
             },
@@ -2164,7 +2138,6 @@ mod tests {
         accumulator1.add_reward(
             commission_pubkey_b,
             RewardCommission {
-                commission_account: commission_account_b.clone(),
                 commission_bps: 1_000,
                 commission_lamports: 50,
             },
@@ -2173,7 +2146,6 @@ mod tests {
         accumulator2.add_reward(
             commission_pubkey_b,
             RewardCommission {
-                commission_account: commission_account_b,
                 commission_bps: 1_000,
                 commission_lamports: 30,
             },
@@ -2182,7 +2154,6 @@ mod tests {
         accumulator2.add_reward(
             commission_pubkey_c,
             RewardCommission {
-                commission_account: commission_account_c,
                 commission_bps: 1_000,
                 commission_lamports: 50,
             },
@@ -2510,7 +2481,6 @@ mod tests {
         reward_commissions.insert(
             pubkey,
             RewardCommission {
-                commission_account: AccountSharedData::default(),
                 commission_bps: 0,
                 commission_lamports: 1, // enough to overflow
             },
@@ -2534,7 +2504,6 @@ mod tests {
                 reward_commissions.insert(
                     pubkey,
                     RewardCommission {
-                        commission_account: AccountSharedData::default(),
                         commission_bps,
                         commission_lamports,
                     },

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -20,7 +20,7 @@ use {
     log::{debug, info},
     rayon::{
         ThreadPool,
-        iter::{IndexedParallelIterator, ParallelIterator},
+        iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
     },
     solana_account::{ReadableAccount, WritableAccount},
     solana_clock::{Epoch, Slot},
@@ -111,9 +111,14 @@ impl Bank {
         parent_block_height: u64,
         rewards_calculation: &PartitionedRewardsCalculation,
         rewards_metrics: &RewardsMetrics,
+        thread_pool: &ThreadPool,
     ) -> u64 {
-        let distributed_rewards =
-            self.distribute_reward_commissions(parent_epoch, rewards_calculation, rewards_metrics);
+        let distributed_rewards = self.distribute_reward_commissions(
+            parent_epoch,
+            rewards_calculation,
+            rewards_metrics,
+            thread_pool,
+        );
 
         let slot = self.slot();
         let distribution_starting_block_height =
@@ -207,6 +212,7 @@ impl Bank {
         prev_epoch: Epoch,
         rewards_calculation: &PartitionedRewardsCalculation,
         rewards_metrics: &RewardsMetrics,
+        thread_pool: &ThreadPool,
     ) -> u64 {
         let PartitionedRewardsCalculation {
             reward_commissions,
@@ -220,7 +226,8 @@ impl Bank {
         // from the store. This is intentionally deferred from calculation
         // time so that any intervening account mutations (e.g. VAT burns in
         // `update_epoch_stakes`) are reflected.
-        let reward_commission_accounts = self.materialize_commission_accounts(reward_commissions);
+        let reward_commission_accounts =
+            self.materialize_commission_accounts(reward_commissions, thread_pool);
         let total_reward_commissions = reward_commission_accounts.total_reward_commission_lamports;
         self.store_commission_accounts_partitioned(&reward_commission_accounts, rewards_metrics);
         self.update_reward_commissions(&reward_commission_accounts);
@@ -778,41 +785,56 @@ impl Bank {
     fn materialize_commission_accounts(
         &self,
         reward_commissions: &RewardCommissions,
+        thread_pool: &ThreadPool,
     ) -> RewardCommissionAccounts {
-        let mut result = RewardCommissionAccounts {
-            accounts_with_rewards: Vec::with_capacity(reward_commissions.len()),
-            total_reward_commission_lamports: 0,
-        };
-        for (
-            commission_pubkey,
-            RewardCommission {
-                commission_bps,
-                commission_lamports,
-                ..
-            },
-        ) in reward_commissions
-        {
-            let Some(mut commission_account) = self.get_account(commission_pubkey) else {
-                debug!("commission account {commission_pubkey} missing at distribution time");
-                continue;
-            };
-            if let Err(err) = commission_account.checked_add_lamports(*commission_lamports) {
-                debug!("reward redemption failed for {commission_pubkey}: {err:?}");
-                continue;
-            }
-            result.accounts_with_rewards.push((
-                *commission_pubkey,
-                RewardInfo {
-                    reward_type: RewardType::Voting,
-                    lamports: *commission_lamports as i64,
-                    post_balance: commission_account.lamports(),
-                    commission_bps: Some(*commission_bps),
-                },
-                commission_account,
-            ));
-            result.total_reward_commission_lamports += commission_lamports;
+        let accounts_with_rewards: Vec<_> = thread_pool.install(|| {
+            reward_commissions
+                .par_iter()
+                .filter_map(
+                    |(
+                        commission_pubkey,
+                        RewardCommission {
+                            commission_bps,
+                            commission_lamports,
+                            ..
+                        },
+                    )| {
+                        let Some(mut commission_account) = self.get_account(commission_pubkey)
+                        else {
+                            debug!(
+                                "commission account {commission_pubkey} missing at distribution \
+                                 time"
+                            );
+                            return None;
+                        };
+                        if let Err(err) =
+                            commission_account.checked_add_lamports(*commission_lamports)
+                        {
+                            debug!("reward redemption failed for {commission_pubkey}: {err:?}");
+                            return None;
+                        }
+                        Some((
+                            *commission_pubkey,
+                            RewardInfo {
+                                reward_type: RewardType::Voting,
+                                lamports: *commission_lamports as i64,
+                                post_balance: commission_account.lamports(),
+                                commission_bps: Some(*commission_bps),
+                            },
+                            commission_account,
+                        ))
+                    },
+                )
+                .collect()
+        });
+        let total_reward_commission_lamports = accounts_with_rewards
+            .iter()
+            .map(|(_, info, _)| info.lamports as u64)
+            .sum();
+        RewardCommissionAccounts {
+            accounts_with_rewards,
+            total_reward_commission_lamports,
         }
-        result
     }
 
     fn update_reward_commissions(&self, reward_commission_accounts: &RewardCommissionAccounts) {
@@ -2469,8 +2491,9 @@ mod tests {
     fn test_materialize_commission_accounts_empty() {
         let (genesis_config, _mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
         let bank = Bank::new_for_tests(&genesis_config);
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let reward_commissions = RewardCommissions::default();
-        let result = bank.materialize_commission_accounts(&reward_commissions);
+        let result = bank.materialize_commission_accounts(&reward_commissions, &thread_pool);
         assert!(result.accounts_with_rewards.is_empty());
     }
 
@@ -2478,6 +2501,7 @@ mod tests {
     fn test_materialize_commission_accounts_overflow() {
         let (genesis_config, _mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
         let bank = Bank::new_for_tests(&genesis_config);
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let pubkey = solana_pubkey::new_rand();
         let mut commission_account = AccountSharedData::default();
         commission_account.set_lamports(u64::MAX);
@@ -2491,7 +2515,7 @@ mod tests {
                 commission_lamports: 1, // enough to overflow
             },
         );
-        let result = bank.materialize_commission_accounts(&reward_commissions);
+        let result = bank.materialize_commission_accounts(&reward_commissions, &thread_pool);
         assert!(result.accounts_with_rewards.is_empty());
     }
 
@@ -2499,6 +2523,7 @@ mod tests {
     fn test_materialize_commission_accounts_normal() {
         let (genesis_config, _mint_keypair) = create_genesis_config(1_000 * LAMPORTS_PER_SOL);
         let bank = Bank::new_for_tests(&genesis_config);
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let pubkey = solana_pubkey::new_rand();
         for commission_bps in [0, 100] {
             for commission_lamports in 0..2 {
@@ -2514,7 +2539,8 @@ mod tests {
                         commission_lamports,
                     },
                 );
-                let result = bank.materialize_commission_accounts(&reward_commissions);
+                let result =
+                    bank.materialize_commission_accounts(&reward_commissions, &thread_pool);
                 assert_eq!(result.accounts_with_rewards.len(), 1);
                 let (pubkey_result, rewards, account) = &result.accounts_with_rewards[0];
                 _ = commission_account.checked_add_lamports(commission_lamports);

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -222,12 +222,12 @@ impl Bank {
             ..
         } = rewards_calculation;
 
-        // Materialize commission accounts by reading current account state
-        // from the store. This is intentionally deferred from calculation
-        // time so that any intervening account mutations (e.g. VAT burns in
+        // Load the commission accounts and apply their rewards.
+        // This is intentionally deferred from calculation time so that any
+        // intervening account mutations (e.g. VAT burns in
         // `update_epoch_stakes`) are reflected.
         let reward_commission_accounts =
-            self.materialize_commission_accounts(reward_commissions, thread_pool);
+            self.load_and_reward_commission_accounts(reward_commissions, thread_pool);
         let total_reward_commissions = reward_commission_accounts.total_reward_commission_lamports;
         self.store_commission_accounts_partitioned(&reward_commission_accounts, rewards_metrics);
         self.update_reward_commissions(&reward_commission_accounts);
@@ -780,7 +780,7 @@ impl Bank {
     /// fetched, ensuring we always see the latest balances — including any
     /// intervening account mutations (e.g. VAT burns in `update_epoch_stakes`)
     /// that happen between calculation and distribution.
-    fn materialize_commission_accounts(
+    fn load_and_reward_commission_accounts(
         &self,
         reward_commissions: &RewardCommissions,
         thread_pool: &ThreadPool,
@@ -2459,17 +2459,17 @@ mod tests {
     }
 
     #[test]
-    fn test_materialize_commission_accounts_empty() {
+    fn test_load_and_reward_commission_accounts_empty() {
         let (genesis_config, _mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
         let bank = Bank::new_for_tests(&genesis_config);
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let reward_commissions = RewardCommissions::default();
-        let result = bank.materialize_commission_accounts(&reward_commissions, &thread_pool);
+        let result = bank.load_and_reward_commission_accounts(&reward_commissions, &thread_pool);
         assert!(result.accounts_with_rewards.is_empty());
     }
 
     #[test]
-    fn test_materialize_commission_accounts_overflow() {
+    fn test_load_and_reward_commission_accounts_overflow() {
         let (genesis_config, _mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
         let bank = Bank::new_for_tests(&genesis_config);
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
@@ -2485,12 +2485,12 @@ mod tests {
                 commission_lamports: 1, // enough to overflow
             },
         );
-        let result = bank.materialize_commission_accounts(&reward_commissions, &thread_pool);
+        let result = bank.load_and_reward_commission_accounts(&reward_commissions, &thread_pool);
         assert!(result.accounts_with_rewards.is_empty());
     }
 
     #[test]
-    fn test_materialize_commission_accounts_normal() {
+    fn test_load_and_reward_commission_accounts_normal() {
         let (genesis_config, _mint_keypair) = create_genesis_config(1_000 * LAMPORTS_PER_SOL);
         let bank = Bank::new_for_tests(&genesis_config);
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
@@ -2509,7 +2509,7 @@ mod tests {
                     },
                 );
                 let result =
-                    bank.materialize_commission_accounts(&reward_commissions, &thread_pool);
+                    bank.load_and_reward_commission_accounts(&reward_commissions, &thread_pool);
                 assert_eq!(result.accounts_with_rewards.len(), 1);
                 let (pubkey_result, rewards, account) = &result.accounts_with_rewards[0];
                 _ = commission_account.checked_add_lamports(commission_lamports);

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -797,7 +797,8 @@ impl Bank {
                             ..
                         },
                     )| {
-                        let Some(mut commission_account) = self.get_account(commission_pubkey)
+                        let Some(mut commission_account) =
+                            self.get_account_with_fixed_root_no_cache(commission_pubkey)
                         else {
                             debug!(
                                 "commission account {commission_pubkey} missing at distribution \

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -226,8 +226,17 @@ impl Bank {
         // This is intentionally deferred from calculation time so that any
         // intervening account mutations (e.g. VAT burns in
         // `update_epoch_stakes`) are reflected.
-        let reward_commission_accounts =
-            self.load_and_reward_commission_accounts(reward_commissions, thread_pool);
+        let (reward_commission_accounts, load_and_reward_commission_accounts_us) =
+            measure_us!(self.load_and_reward_commission_accounts(reward_commissions, thread_pool));
+        rewards_metrics
+            .load_and_reward_commission_accounts_us
+            .fetch_add(load_and_reward_commission_accounts_us, Relaxed);
+        info!(
+            "load_and_reward_commission_accounts: input_count={} output_count={} elapsed_us={}",
+            reward_commissions.len(),
+            reward_commission_accounts.accounts_with_rewards.len(),
+            load_and_reward_commission_accounts_us,
+        );
         let total_reward_commissions = reward_commission_accounts.total_reward_commission_lamports;
         self.store_commission_accounts_partitioned(&reward_commission_accounts, rewards_metrics);
         self.update_reward_commissions(&reward_commission_accounts);

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -2490,6 +2490,57 @@ mod tests {
     }
 
     #[test]
+    fn test_load_and_reward_commission_accounts_reflects_vat_burn() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000 * LAMPORTS_PER_SOL);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+        let pubkey = solana_pubkey::new_rand();
+
+        let pre_burn_balance = 10 * crate::bank::VAT_TO_BURN_PER_EPOCH;
+        let commission_lamports = 12_345;
+
+        // Commission is planned against the pre-burn account state.
+        let mut commission_account = AccountSharedData::default();
+        commission_account.set_lamports(pre_burn_balance);
+        bank.store_account_and_update_capitalization(&pubkey, &commission_account);
+        let mut reward_commissions = RewardCommissions::default();
+        reward_commissions.insert(
+            pubkey,
+            RewardCommission {
+                commission_bps: 500,
+                commission_lamports,
+            },
+        );
+
+        // Simulate the VAT burn that would run in `update_epoch_stakes`
+        // between reward calculation and distribution.
+        let post_burn_balance = pre_burn_balance - crate::bank::VAT_TO_BURN_PER_EPOCH;
+        let mut burned_account = commission_account.clone();
+        burned_account.set_lamports(post_burn_balance);
+        bank.store_account_and_update_capitalization(&pubkey, &burned_account);
+
+        let result = bank.load_and_reward_commission_accounts(&reward_commissions, &thread_pool);
+
+        assert_eq!(result.accounts_with_rewards.len(), 1);
+        let (pubkey_result, reward_info, account) = &result.accounts_with_rewards[0];
+        assert_eq!(*pubkey_result, pubkey);
+        // Commission is credited on top of the post-burn balance, not the
+        // pre-burn snapshot captured at calculation time.
+        let expected_post_balance = post_burn_balance + commission_lamports;
+        assert_eq!(account.lamports(), expected_post_balance);
+        assert_eq!(
+            *reward_info,
+            RewardInfo {
+                reward_type: RewardType::Voting,
+                lamports: commission_lamports as i64,
+                post_balance: expected_post_balance,
+                commission_bps: Some(500),
+            }
+        );
+        assert_eq!(result.total_reward_commission_lamports, commission_lamports);
+    }
+
+    #[test]
     fn test_load_and_reward_commission_accounts_normal() {
         let (genesis_config, _mint_keypair) = create_genesis_config(1_000 * LAMPORTS_PER_SOL);
         let bank = Bank::new_for_tests(&genesis_config);

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -110,7 +110,7 @@ impl Bank {
         parent_slot: Slot,
         parent_block_height: u64,
         rewards_calculation: &PartitionedRewardsCalculation,
-        rewards_metrics: &RewardsMetrics,
+        rewards_metrics: &mut RewardsMetrics,
         thread_pool: &ThreadPool,
     ) -> u64 {
         let distributed_rewards = self.distribute_reward_commissions(
@@ -211,7 +211,7 @@ impl Bank {
         &mut self,
         prev_epoch: Epoch,
         rewards_calculation: &PartitionedRewardsCalculation,
-        rewards_metrics: &RewardsMetrics,
+        rewards_metrics: &mut RewardsMetrics,
         thread_pool: &ThreadPool,
     ) -> u64 {
         let PartitionedRewardsCalculation {
@@ -228,9 +228,8 @@ impl Bank {
         // `update_epoch_stakes`) are reflected.
         let (reward_commission_accounts, load_and_reward_commission_accounts_us) =
             measure_us!(self.load_and_reward_commission_accounts(reward_commissions, thread_pool));
-        rewards_metrics
-            .load_and_reward_commission_accounts_us
-            .fetch_add(load_and_reward_commission_accounts_us, Relaxed);
+        rewards_metrics.load_and_reward_commission_accounts_us =
+            load_and_reward_commission_accounts_us;
         info!(
             "load_and_reward_commission_accounts: input_count={} output_count={} elapsed_us={}",
             reward_commissions.len(),

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -112,20 +112,19 @@ impl Bank {
         rewards_calculation: &PartitionedRewardsCalculation,
         rewards_metrics: &RewardsMetrics,
     ) -> u64 {
-        self.distribute_reward_commissions(parent_epoch, rewards_calculation, rewards_metrics);
+        let distributed_rewards =
+            self.distribute_reward_commissions(parent_epoch, rewards_calculation, rewards_metrics);
 
         let slot = self.slot();
         let distribution_starting_block_height =
             self.block_height() + REWARD_CALCULATION_NUM_BLOCKS;
 
         let PartitionedRewardsCalculation {
-            reward_commission_accounts,
             stake_rewards,
             point_value,
             ..
         } = rewards_calculation;
 
-        let distributed_rewards = reward_commission_accounts.total_reward_commission_lamports;
         let stake_rewards = Arc::clone(&stake_rewards.stake_rewards);
 
         let num_partitions = self.get_reward_distribution_num_blocks(&stake_rewards);
@@ -202,23 +201,29 @@ impl Bank {
         rewards_calculation
     }
 
+    /// Returns the total amount of commission lamports distributed.
     pub(in crate::bank) fn distribute_reward_commissions(
         &mut self,
         prev_epoch: Epoch,
         rewards_calculation: &PartitionedRewardsCalculation,
         rewards_metrics: &RewardsMetrics,
-    ) {
+    ) -> u64 {
         let PartitionedRewardsCalculation {
-            reward_commission_accounts,
+            reward_commissions,
             stake_rewards,
             capitalization,
             point_value,
             ..
         } = rewards_calculation;
 
+        // Materialize commission accounts by reading current account state
+        // from the store. This is intentionally deferred from calculation
+        // time so that any intervening account mutations (e.g. VAT burns in
+        // `update_epoch_stakes`) are reflected.
+        let reward_commission_accounts = self.materialize_commission_accounts(reward_commissions);
         let total_reward_commissions = reward_commission_accounts.total_reward_commission_lamports;
-        self.store_commission_accounts_partitioned(reward_commission_accounts, rewards_metrics);
-        self.update_reward_commissions(reward_commission_accounts);
+        self.store_commission_accounts_partitioned(&reward_commission_accounts, rewards_metrics);
+        self.update_reward_commissions(&reward_commission_accounts);
 
         let StakeRewardCalculation {
             total_stake_rewards_lamports,
@@ -263,6 +268,8 @@ impl Bank {
             ("num_stake_accounts", num_stake_accounts, i64),
             ("num_vote_accounts", num_vote_accounts, i64),
         );
+
+        total_reward_commissions
     }
 
     fn store_commission_accounts_partitioned(
@@ -299,7 +306,7 @@ impl Bank {
             self.calculate_epoch_inflation_rewards(capitalization, rewarded_epoch);
 
         let CalculateValidatorRewardsResult {
-            reward_commission_accounts,
+            reward_commissions,
             stake_reward_calculation: stake_rewards,
             point_value,
         } = self
@@ -321,7 +328,7 @@ impl Bank {
         );
 
         PartitionedRewardsCalculation {
-            reward_commission_accounts,
+            reward_commissions,
             stake_rewards,
             capitalization,
             point_value,
@@ -349,7 +356,7 @@ impl Bank {
             metrics,
         )
         .map(|point_value| {
-            let (reward_commission_accounts, stake_reward_calculation) = self
+            let (reward_commissions, stake_reward_calculation) = self
                 .calculate_stake_rewards_and_commissions(
                     stake_history,
                     stake_delegations,
@@ -361,7 +368,7 @@ impl Bank {
                     metrics,
                 );
             CalculateValidatorRewardsResult {
-                reward_commission_accounts,
+                reward_commissions,
                 stake_reward_calculation,
                 point_value,
             }
@@ -531,7 +538,7 @@ impl Bank {
         thread_pool: &ThreadPool,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         metrics: &mut RewardsMetrics,
-    ) -> (RewardCommissionAccounts, StakeRewardCalculation) {
+    ) -> (RewardCommissions, StakeRewardCalculation) {
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
         let feature_snapshot = self.feature_set.snapshot();
         let delay_commission_updates = feature_snapshot.delay_commission_updates;
@@ -621,12 +628,11 @@ impl Bank {
         unsafe {
             stake_rewards.assume_init(num_stake_rewards);
         }
-        let reward_commission_accounts = Self::calculate_commission_accounts(reward_commissions);
         measure_redeem_rewards.stop();
         metrics.redeem_rewards_us = measure_redeem_rewards.as_us();
 
         (
-            reward_commission_accounts,
+            reward_commissions,
             StakeRewardCalculation {
                 stake_rewards: Arc::new(stake_rewards),
                 total_stake_rewards_lamports,
@@ -764,15 +770,14 @@ impl Bank {
         (stake_rewards, partition_indices)
     }
 
-    /// Convert computed RewardCommissions to RewardCommissionAccounts for storing.
-    ///
-    /// This function processes reward commissions and consolidates them into a
-    /// single structure containing the pubkey, reward info, and updated account
-    /// data for each commission account. The resulting structure is optimized
-    /// for storage by combining previously separate rewards and accounts
-    /// vectors into a single accounts_with_rewards vector.
-    fn calculate_commission_accounts(
-        reward_commissions: RewardCommissions,
+    /// Load each planned commission account from the store and apply its
+    /// reward. This is the single point where commission account data is
+    /// fetched, ensuring we always see the latest balances — including any
+    /// intervening account mutations (e.g. VAT burns in `update_epoch_stakes`)
+    /// that happen between calculation and distribution.
+    fn materialize_commission_accounts(
+        &self,
+        reward_commissions: &RewardCommissions,
     ) -> RewardCommissionAccounts {
         let mut result = RewardCommissionAccounts {
             accounts_with_rewards: Vec::with_capacity(reward_commissions.len()),
@@ -781,24 +786,27 @@ impl Bank {
         for (
             commission_pubkey,
             RewardCommission {
-                mut commission_account,
                 commission_bps,
                 commission_lamports,
+                ..
             },
         ) in reward_commissions
         {
-            if let Err(err) = commission_account.checked_add_lamports(commission_lamports) {
+            let Some(mut commission_account) = self.get_account(commission_pubkey) else {
+                debug!("commission account {commission_pubkey} missing at distribution time");
+                continue;
+            };
+            if let Err(err) = commission_account.checked_add_lamports(*commission_lamports) {
                 debug!("reward redemption failed for {commission_pubkey}: {err:?}");
                 continue;
             }
-
             result.accounts_with_rewards.push((
-                commission_pubkey,
+                *commission_pubkey,
                 RewardInfo {
                     reward_type: RewardType::Voting,
-                    lamports: commission_lamports as i64,
+                    lamports: *commission_lamports as i64,
                     post_balance: commission_account.lamports(),
-                    commission_bps: Some(commission_bps),
+                    commission_bps: Some(*commission_bps),
                 },
                 commission_account,
             ));
@@ -866,7 +874,7 @@ mod tests {
         },
         solana_vote_program::vote_state::{self, create_bls_proof_of_possession},
         std::{
-            collections::{HashMap, HashSet},
+            collections::HashSet,
             sync::{Arc, RwLock, RwLockReadGuard},
         },
         test_case::test_case,
@@ -1011,20 +1019,16 @@ mod tests {
             &mut rewards_metrics,
         );
 
-        let reward_commission_accounts = &calculated_rewards
-            .as_ref()
-            .unwrap()
-            .reward_commission_accounts;
+        let reward_commissions = &calculated_rewards.as_ref().unwrap().reward_commissions;
         let stake_rewards = &calculated_rewards
             .as_ref()
             .unwrap()
             .stake_reward_calculation;
 
-        let total_reward_commissions: u64 = reward_commission_accounts
-            .accounts_with_rewards
-            .iter()
-            .map(|(_, reward_info, _)| reward_info.lamports)
-            .sum::<i64>() as u64;
+        let total_reward_commissions: u64 = reward_commissions
+            .values()
+            .map(|rc| rc.commission_lamports)
+            .sum();
 
         // assert that total rewards matches the sum of reward commissions and stake rewards
         assert_eq!(
@@ -1140,7 +1144,7 @@ mod tests {
             cached_vote_accounts,
         } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
 
-        let (reward_commission_accounts, ..) = bank.calculate_stake_rewards_and_commissions(
+        let (reward_commissions, ..) = bank.calculate_stake_rewards_and_commissions(
             &stake_history,
             &stake_delegations,
             cached_vote_accounts,
@@ -1150,11 +1154,21 @@ mod tests {
             null_tracer(),
             &mut RewardsMetrics::default(), // This is required, but not reporting anything at the moment
         );
-        reward_commission_accounts
-            .accounts_with_rewards
-            .into_iter()
-            .find(|(reward_address, ..)| reward_address == commission_pubkey)
-            .map(|(_, reward, _)| reward)
+        reward_commissions.get(commission_pubkey).map(|rc| {
+            // In the recalculation path, commissions have already been
+            // distributed — so the current account balance already includes
+            // them. We report that balance as the post_balance.
+            let post_balance = bank
+                .get_account(commission_pubkey)
+                .map(|a| a.lamports())
+                .unwrap_or(0);
+            RewardInfo {
+                reward_type: RewardType::Voting,
+                lamports: rc.commission_lamports as i64,
+                post_balance,
+                commission_bps: Some(rc.commission_bps),
+            }
+        })
     }
 
     fn apply_epoch_operations(
@@ -1657,23 +1671,12 @@ mod tests {
             .0;
         let vote_state = VoteStateV4::deserialize(vote_account.data(), vote_pubkey).unwrap();
 
-        assert_eq!(vote_rewards_accounts.accounts_with_rewards.len(), 1);
-        let (vote_pubkey_from_result, rewards, account) =
-            &vote_rewards_accounts.accounts_with_rewards[0];
+        assert_eq!(vote_rewards_accounts.len(), 1);
+        let reward_commission = vote_rewards_accounts.get(vote_pubkey).unwrap();
         let vote_rewards = 0;
         let commission_bps = vote_state.inflation_rewards_commission_bps;
-        assert_eq!(account.lamports(), vote_account.lamports());
-        assert!(accounts_equal(account, &vote_account));
-        assert_eq!(
-            *rewards,
-            RewardInfo {
-                reward_type: RewardType::Voting,
-                lamports: vote_rewards as i64,
-                post_balance: vote_account.lamports(),
-                commission_bps: Some(commission_bps),
-            }
-        );
-        assert_eq!(vote_pubkey_from_result, vote_pubkey);
+        assert_eq!(reward_commission.commission_lamports, vote_rewards);
+        assert_eq!(reward_commission.commission_bps, commission_bps);
 
         assert_eq!(stake_reward_calculation.stake_rewards.num_rewards(), 1);
         let expected_reward = {
@@ -2345,21 +2348,14 @@ mod tests {
         let cache = bank.epoch_rewards_calculation_cache.lock().unwrap();
         assert_eq!(cache.len(), expected_cache_len);
         let partitioned = cache.get(&bank.parent_hash()).unwrap().as_ref();
-        let RewardCommissionAccounts {
-            accounts_with_rewards,
-            total_reward_commission_lamports,
-            ..
-        } = &partitioned.reward_commission_accounts;
+        let reward_commissions = &partitioned.reward_commissions;
         let StakeRewardCalculation {
             stake_rewards,
             total_stake_rewards_lamports,
             ..
         } = &partitioned.stake_rewards;
         let point_value = &partitioned.point_value;
-        let voters: HashSet<_> = accounts_with_rewards
-            .iter()
-            .map(|(pubkey, _reward, _acc)| *pubkey)
-            .collect();
+        let voters: HashSet<_> = reward_commissions.keys().copied().collect();
         let stakers: HashSet<_> = stake_rewards
             .rewards
             .iter()
@@ -2368,8 +2364,12 @@ mod tests {
             .collect();
         assert_eq!(expected_voters, &voters);
         assert_eq!(expected_stakers, &stakers);
+        let total_reward_commission_lamports: u64 = reward_commissions
+            .values()
+            .map(|rc| rc.commission_lamports)
+            .sum();
         assert_eq!(
-            *total_reward_commission_lamports,
+            total_reward_commission_lamports,
             expected_reward_commissions
         );
         assert_eq!(*total_stake_rewards_lamports, expected_stake_rewards);
@@ -2466,47 +2466,55 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_commission_accounts_empty() {
-        let reward_commissions = HashMap::default();
-        let result = Bank::calculate_commission_accounts(reward_commissions);
+    fn test_materialize_commission_accounts_empty() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let reward_commissions = RewardCommissions::default();
+        let result = bank.materialize_commission_accounts(&reward_commissions);
         assert!(result.accounts_with_rewards.is_empty());
     }
 
     #[test]
-    fn test_calculate_commission_accounts_overflow() {
-        let mut reward_commissions = HashMap::default();
+    fn test_materialize_commission_accounts_overflow() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
+        let bank = Bank::new_for_tests(&genesis_config);
         let pubkey = solana_pubkey::new_rand();
         let mut commission_account = AccountSharedData::default();
         commission_account.set_lamports(u64::MAX);
+        bank.store_account_and_update_capitalization(&pubkey, &commission_account);
+        let mut reward_commissions = RewardCommissions::default();
         reward_commissions.insert(
             pubkey,
             RewardCommission {
-                commission_account,
+                commission_account: AccountSharedData::default(),
                 commission_bps: 0,
                 commission_lamports: 1, // enough to overflow
             },
         );
-        let result = Bank::calculate_commission_accounts(reward_commissions);
+        let result = bank.materialize_commission_accounts(&reward_commissions);
         assert!(result.accounts_with_rewards.is_empty());
     }
 
     #[test]
-    fn test_calculate_commission_accounts_normal() {
+    fn test_materialize_commission_accounts_normal() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000 * LAMPORTS_PER_SOL);
+        let bank = Bank::new_for_tests(&genesis_config);
         let pubkey = solana_pubkey::new_rand();
         for commission_bps in [0, 100] {
             for commission_lamports in 0..2 {
-                let mut reward_commissions = HashMap::default();
                 let mut commission_account = AccountSharedData::default();
                 commission_account.set_lamports(1);
+                bank.store_account_and_update_capitalization(&pubkey, &commission_account);
+                let mut reward_commissions = RewardCommissions::default();
                 reward_commissions.insert(
                     pubkey,
                     RewardCommission {
-                        commission_account: commission_account.clone(),
+                        commission_account: AccountSharedData::default(),
                         commission_bps,
                         commission_lamports,
                     },
                 );
-                let result = Bank::calculate_commission_accounts(reward_commissions);
+                let result = bank.materialize_commission_accounts(&reward_commissions);
                 assert_eq!(result.accounts_with_rewards.len(), 1);
                 let (pubkey_result, rewards, account) = &result.accounts_with_rewards[0];
                 _ = commission_account.checked_add_lamports(commission_lamports);

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -16,10 +16,10 @@ use {
         storable_accounts::{AccountForStorage, StorableAccounts},
     },
     solana_clock::Slot,
-    solana_pubkey::Pubkey,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_stake_interface::state::{Delegation, Stake},
     solana_vote::vote_account::VoteAccounts,
-    std::{mem::MaybeUninit, sync::Arc},
+    std::{collections::HashMap, mem::MaybeUninit, sync::Arc},
 };
 
 /// Number of blocks for reward calculation and storing vote accounts.
@@ -148,6 +148,15 @@ pub(crate) enum EpochRewardPhase {
     Calculation(StartBlockHeightAndRewards),
     Distribution(StartBlockHeightAndPartitionedRewards),
 }
+
+#[derive(Debug)]
+pub(super) struct RewardCommission {
+    pub(super) commission_account: AccountSharedData,
+    pub(super) commission_bps: u16,
+    pub(super) commission_lamports: u64,
+}
+
+pub(super) type RewardCommissions = HashMap<Pubkey, RewardCommission, PubkeyHasherBuilder>;
 
 #[derive(Debug, Default)]
 pub(super) struct RewardCommissionAccounts {

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -151,6 +151,7 @@ pub(crate) enum EpochRewardPhase {
 
 #[derive(Debug)]
 pub(super) struct RewardCommission {
+    #[allow(dead_code)] // We'll remove this later.
     pub(super) commission_account: AccountSharedData,
     pub(super) commission_bps: u16,
     pub(super) commission_lamports: u64,
@@ -233,7 +234,7 @@ pub(super) struct StakeRewardCalculation {
 
 #[derive(Debug)]
 struct CalculateValidatorRewardsResult {
-    reward_commission_accounts: RewardCommissionAccounts,
+    reward_commissions: RewardCommissions,
     stake_reward_calculation: StakeRewardCalculation,
     point_value: PointValue,
 }
@@ -241,7 +242,7 @@ struct CalculateValidatorRewardsResult {
 impl Default for CalculateValidatorRewardsResult {
     fn default() -> Self {
         Self {
-            reward_commission_accounts: RewardCommissionAccounts::default(),
+            reward_commissions: RewardCommissions::default(),
             stake_reward_calculation: StakeRewardCalculation::default(),
             point_value: PointValue {
                 points: 0,
@@ -317,7 +318,7 @@ pub(super) struct EpochRewardCalculateParamInfo<'a> {
 /// side effects.
 #[derive(Debug)]
 pub(super) struct PartitionedRewardsCalculation {
-    reward_commission_accounts: RewardCommissionAccounts,
+    reward_commissions: RewardCommissions,
     stake_rewards: StakeRewardCalculation,
     capitalization: u64,
     point_value: PointValue,

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -151,8 +151,6 @@ pub(crate) enum EpochRewardPhase {
 
 #[derive(Debug)]
 pub(super) struct RewardCommission {
-    #[allow(dead_code)] // We'll remove this later.
-    pub(super) commission_account: AccountSharedData,
     pub(super) commission_bps: u16,
     pub(super) commission_lamports: u64,
 }


### PR DESCRIPTION
#### Problem
As stated in #11614, audit findings revealed that commission account balances (vote accounts) were being loaded before VAT was burned, so their balances at distribution time were stale.

Ashwin's PR reloaded all the accounts before distributing commissions, to catch any balance changes, but we can actually just defer the account loads until distribution time.

#### Summary of Changes
Calculate commission rewards using `RewardCommission` entries throughout the commission calculation phase without actually loading or modifying the account. Then, right before distribution, "materialize" the accounts by loading all of them within a `par_iter` and updating their balances with the distributed commissions.

Finally, drop `commission_account` from `RewardCommission` since it's no longer required nor is it plumbed around the calculation phase.