### PR TITLE
Prevent external scheduler panics from crashing the validator

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -732,6 +732,7 @@ mod external {
                     Builder::new()
                         .name(format!("solECoWorker{id:02}"))
                         .spawn(move || {
+                            solana_metrics::mark_thread_nonfatal();
                             if let Err(err) = consume_worker.run(pack_to_worker) {
                                 error!("External consume worker error; err={err}");
                             }

--- a/core/src/banking_stage/progress_tracker.rs
+++ b/core/src/banking_stage/progress_tracker.rs
@@ -27,6 +27,7 @@ pub fn spawn(
     std::thread::Builder::new()
         .name("solProgTrker".to_string())
         .spawn(move || {
+            solana_metrics::mark_thread_nonfatal();
             ProgressTracker::new(exit, shared_leader_state, worker_metrics, ticks_per_slot)
                 .run(&mut producer);
         })

--- a/core/src/banking_stage/tpu_to_pack.rs
+++ b/core/src/banking_stage/tpu_to_pack.rs
@@ -40,6 +40,7 @@ pub fn spawn(
     std::thread::Builder::new()
         .name("solTpu2Pack".to_string())
         .spawn(move || {
+            solana_metrics::mark_thread_nonfatal();
             tpu_to_pack(exit, shutdown_signal, receivers, allocator, producer);
         })
         .unwrap()

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod counter;
 pub mod datapoint;
 pub mod metrics;
-pub use crate::metrics::{flush, query, set_host_id, set_panic_hook, submit};
+pub use crate::metrics::{flush, mark_thread_nonfatal, query, set_host_id, set_panic_hook, submit};
 use std::sync::{
     Arc,
     atomic::{AtomicU64, Ordering},

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -8,6 +8,7 @@ use {
     solana_cluster_type::ClusterType,
     solana_sha256_hasher::hash,
     std::{
+        cell::Cell,
         cmp,
         collections::HashMap,
         convert::Into,
@@ -510,6 +511,17 @@ pub fn flush() {
     agent.flush();
 }
 
+thread_local! {
+    /// Per-thread flag: when true, the panic hook skips `process::exit(1)`.
+    static NONFATAL_ON_PANIC: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Exempt the current thread from the `set_panic_hook` process exit.
+/// The panic is still recorded, but the spawner is responsible for recovery.
+pub fn mark_thread_nonfatal() {
+    NONFATAL_ON_PANIC.with(|flag| flag.set(true));
+}
+
 /// Hook the panic handler to generate a data point on each panic
 pub fn set_panic_hook(program: &'static str, version: Option<String>) {
     static SET_HOOK: Once = Once::new();
@@ -537,6 +549,10 @@ pub fn set_panic_hook(program: &'static str, version: Option<String>) {
             // Flush metrics immediately
             flush();
 
+            // Don't exit on panic in threads marked nonfatal.
+            if NONFATAL_ON_PANIC.with(|flag| flag.get()) {
+                return;
+            }
             // Exit cleanly so the process don't limp along in a half-dead state
             std::process::exit(1);
         }));


### PR DESCRIPTION
## Problem

The `solana-metrics` panic hook calls `std::process::exit(1)` on any thread panic. However, the banking stage's external scheduler threads are meant to be tracked and recovered on failure, so the banking stage can re-spawn under the internal scheduler. The panic hook makes the recovery path unreachable and takes down the whole validator.

## Reproducing

1. Start `agave-validator` with `--enable-scheduler-bindings`
2. Connect an external scheduler
3. Scheduler allocates a valid transaction: num_static_account_keys = 5, instruction references account index 3.
4. Scheduler submits a PackToWorkerMessage pointing at the allocation.
5. Worker sanitizes. Index 3 < 5 passes.
6. Scheduler frees the allocation (or overwrites it in place) so the next read sees num_static_account_keys = 2.
7. A subsequent bounds-checked access by the worker at index 3 panics.
8. The panic hook calls process::exit(1), killing the entire validator process due to an external scheduler failure

## Proposed changes

* Add `mark_thread_nonfatal()` to `solana-metrics`, backed by a per-thread `Cell<bool>` defaulting to `false`
* In `set_panic_hook`, skip `process::exit(1)` for threads marked nonfatal
* Call `mark_thread_nonfatal()` at the top of each external-scheduler worker closure

## Verification

I have verified this works against the [Reproducing](#reproducing) case. No unit tests added due to the simplicity of the logic.

