### PR TITLE
rayon-threadlimit: remove deprecated get_max_thread_count

### DIFF
--- a/rayon-threadlimit/src/lib.rs
+++ b/rayon-threadlimit/src/lib.rs
@@ -21,13 +21,3 @@ static MAX_RAYON_THREADS: std::sync::LazyLock<usize> = std::sync::LazyLock::new(
 pub fn get_thread_count() -> usize {
     *MAX_RAYON_THREADS
 }
-
-#[deprecated(
-    since = "3.0.0",
-    note = "The solana-rayon-threadlimit crate will be removed, use num_cpus::get() or something \
-            similar instead"
-)]
-pub fn get_max_thread_count() -> usize {
-    #[allow(deprecated)]
-    get_thread_count().saturating_mul(2)
-}


### PR DESCRIPTION
#### Problem
`get_max_thread_count` has been marked `#[deprecated(since = "3.0.0")]` with
the note that the `solana-rayon-threadlimit` crate will be removed and
callers should use `num_cpus::get()` or similar instead. No code in the
workspace still calls it, so the deprecated function is dead weight.

#### Summary of Changes
- Delete `get_max_thread_count` from `rayon-threadlimit/src/lib.rs`.
- No behavior change; `get_thread_count` and `MAX_RAYON_THREADS` are unchanged.