### PR TITLE
Clarify ownership in words instead of diagram

### DIFF
--- a/scheduler-bindings/src/lib.rs
+++ b/scheduler-bindings/src/lib.rs
@@ -47,6 +47,16 @@
 //!   back to the external scheduler process. This passes back the results
 //!   of processing the transactions.
 //!
+//! Ownership and pointer lifetime rule:
+//! - Sending a message that contains offsets or pointers to memory transfers
+//!   ownership of that memory to the receiver for the lifetime defined by the
+//!   protocol.
+//! - The sender must treat that memory as not owned until ownership is
+//!   explicitly returned by a later message, if any. In particular, the sender
+//!   must not free or modify that memory while it is not owned.
+//! - If the protocol does not return the memory to the sender, the receiver is
+//!   responsible for freeing it.
+//!
 
 /// Reference to a transaction that can shared safely across processes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
#### Problem
- memory ownership is documented elsewhere (diagram and words)
- want a single place to point to

#### Summary of Changes
- clarify ownership in bindings

Fixes #
