### PR TITLE
[SigVeirfy] batch verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8096,6 +8096,7 @@ dependencies = [
  "agave-reserved-account-keys",
  "agave-votor-messages",
  "assert_matches",
+ "criterion",
  "crossbeam-channel",
  "dlopen2",
  "log",

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -49,6 +49,7 @@ wincode = { workspace = true }
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
+criterion = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
 solana-entry = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
@@ -60,3 +61,7 @@ solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-transaction = { workspace = true, features = ["verify"] }
+
+[[bench]]
+name = "verify_signatures"
+harness = false

--- a/entry/benches/verify_signatures.rs
+++ b/entry/benches/verify_signatures.rs
@@ -1,0 +1,83 @@
+use {
+    agave_reserved_account_keys::ReservedAccountKeys,
+    criterion::{Criterion, Throughput, criterion_group, criterion_main},
+    solana_entry::entry::{Entry, UnverifiedSignatures, validate_and_hash_transactions},
+    solana_hash::Hash,
+    solana_keypair::Keypair,
+    solana_message::SimpleAddressLoader,
+    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_signer::Signer,
+    solana_system_transaction::transfer,
+    solana_transaction::{
+        sanitized::{MessageHash, SanitizedTransaction},
+        versioned::VersionedTransaction,
+    },
+    solana_transaction_error::TransactionResult as Result,
+    std::hint::black_box,
+};
+
+fn build_unverified_signatures(num_transactions: usize) -> UnverifiedSignatures {
+    let thread_pool = solana_entry::entry::thread_pool_for_benches();
+    let hash = Hash::default();
+    let keypair = Keypair::new();
+    let transactions = (0..num_transactions)
+        .map(|lamports| transfer(&keypair, &keypair.pubkey(), lamports as u64, hash))
+        .collect();
+    let entries = vec![Entry::new(&hash, 0, transactions)];
+
+    let validate_transaction = move |versioned_tx: VersionedTransaction,
+                                     message_bytes: &[u8]|
+          -> Result<RuntimeTransaction<SanitizedTransaction>> {
+        RuntimeTransaction::try_create(
+            versioned_tx,
+            MessageHash::Precomputed(solana_message::VersionedMessage::hash_raw_message(
+                message_bytes,
+            )),
+            None,
+            SimpleAddressLoader::Disabled,
+            &ReservedAccountKeys::empty_key_set(),
+            true,
+        )
+    };
+
+    validate_and_hash_transactions(
+        entries,
+        num_transactions,
+        &thread_pool,
+        validate_transaction,
+    )
+    .expect("transaction validation should succeed")
+    .unverified_signatures
+}
+
+fn bench_verify_signatures(c: &mut Criterion) {
+    for num_transactions in [1, 32, 256, 1024, 4096] {
+        let unverified_signatures = build_unverified_signatures(num_transactions);
+        let mut group = c.benchmark_group("entry_verify_signatures");
+        group.throughput(Throughput::Elements(num_transactions as u64));
+
+        group.bench_function(format!("single_loop/{num_transactions}_txs"), |bencher| {
+            bencher.iter(|| {
+                black_box(&unverified_signatures)
+                    .verify_single_loop_for_benches()
+                    .expect("signatures should verify");
+            });
+        });
+
+        group.bench_function(
+            format!("extract_then_verify/{num_transactions}_txs"),
+            |bencher| {
+                bencher.iter(|| {
+                    black_box(&unverified_signatures)
+                        .verify()
+                        .expect("signatures should verify");
+                });
+            },
+        );
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_verify_signatures);
+criterion_main!(benches);

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -188,6 +188,26 @@ struct TxVerificationData {
     serialized_message: Vec<u8>,
 }
 
+/// TODO: we will move this API into solana-sdk.
+fn batch_verify<'a>(
+    signatures: impl Iterator<Item = &'a Signature>,
+    pubkeys: impl Iterator<Item = &'a Address>,
+    serialized_messages: impl Iterator<Item = &'a [u8]>,
+) -> Result<()> {
+    signatures
+        .zip(pubkeys)
+        .zip(serialized_messages)
+        .collect::<Vec<_>>()
+        .into_par_iter()
+        .try_for_each(|((signature, pubkey), serialized_message)| {
+            if signature.verify(pubkey.as_ref(), serialized_message) {
+                Ok(())
+            } else {
+                Err(TransactionError::SignatureFailure)
+            }
+        })
+}
+
 pub struct UnverifiedSignatures {
     signatures: Vec<TxVerificationData>,
 }
@@ -200,6 +220,34 @@ impl UnverifiedSignatures {
     }
 
     pub fn verify(&self) -> Result<()> {
+        let signatures = self.signatures.iter().flat_map(|tx_signatures| {
+            tx_signatures
+                .signatures
+                .iter()
+                .take(tx_signatures.signer_pubkeys.len())
+        });
+        let pubkeys = self.signatures.iter().flat_map(|tx_signatures| {
+            tx_signatures
+                .signer_pubkeys
+                .iter()
+                .take(tx_signatures.signatures.len())
+        });
+        let serialized_messages = self.signatures.iter().flat_map(|tx_signatures| {
+            std::iter::repeat_n(
+                tx_signatures.serialized_message.as_slice(),
+                tx_signatures
+                    .signatures
+                    .len()
+                    .min(tx_signatures.signer_pubkeys.len()),
+            )
+        });
+
+        batch_verify(signatures, pubkeys, serialized_messages)
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    /// todo: this function is for benches only and will be removed after we move the batch verify logic to sdk
+    pub fn verify_single_loop_for_benches(&self) -> Result<()> {
         self.signatures.par_iter().try_for_each(|tx_signatures| {
             if tx_signatures
                 .signatures

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -189,23 +189,14 @@ struct TxVerificationData {
 }
 
 /// TODO: we will move this API into solana-sdk.
-fn batch_verify<'a>(
-    signatures: impl Iterator<Item = &'a Signature>,
-    pubkeys: impl Iterator<Item = &'a Address>,
-    serialized_messages: impl Iterator<Item = &'a [u8]>,
-) -> Result<()> {
-    signatures
-        .zip(pubkeys)
-        .zip(serialized_messages)
-        .collect::<Vec<_>>()
+#[inline]
+pub fn batch_verify<'a, I>(items: I) -> bool
+where
+    I: IntoParallelIterator<Item = (&'a Signature, &'a Address, &'a [u8])>,
+{
+    items
         .into_par_iter()
-        .try_for_each(|((signature, pubkey), serialized_message)| {
-            if signature.verify(pubkey.as_ref(), serialized_message) {
-                Ok(())
-            } else {
-                Err(TransactionError::SignatureFailure)
-            }
-        })
+        .all(|(signature, pubkey, message)| signature.verify(pubkey.as_ref(), message))
 }
 
 pub struct UnverifiedSignatures {
@@ -220,29 +211,18 @@ impl UnverifiedSignatures {
     }
 
     pub fn verify(&self) -> Result<()> {
-        let signatures = self.signatures.iter().flat_map(|tx_signatures| {
-            tx_signatures
-                .signatures
-                .iter()
-                .take(tx_signatures.signer_pubkeys.len())
-        });
-        let pubkeys = self.signatures.iter().flat_map(|tx_signatures| {
-            tx_signatures
-                .signer_pubkeys
-                .iter()
-                .take(tx_signatures.signatures.len())
-        });
-        let serialized_messages = self.signatures.iter().flat_map(|tx_signatures| {
-            std::iter::repeat_n(
-                tx_signatures.serialized_message.as_slice(),
-                tx_signatures
-                    .signatures
-                    .len()
-                    .min(tx_signatures.signer_pubkeys.len()),
-            )
+        let verification_items = self.signatures.par_iter().flat_map_iter(|tx| {
+            let message = tx.serialized_message.as_slice();
+            let len = tx.signatures.len();
+
+            (0..len).map(move |i| (&tx.signatures[i], &tx.signer_pubkeys[i], message))
         });
 
-        batch_verify(signatures, pubkeys, serialized_messages)
+        if batch_verify(verification_items) {
+            Ok(())
+        } else {
+            Err(TransactionError::SignatureFailure)
+        }
     }
 
     #[cfg(feature = "dev-context-only-utils")]


### PR DESCRIPTION
#### Problem

We want to extract the `(signature, pk, message)` tuple and later on use a `batch_verify` API in SDK to verify them in batch.

#### Performance impact
| Transactions | Single Loop Time | Extract Then Verify Time | Difference |
|---:|---:|---:|---:|
| 1 | 29.530 µs | 29.563 µs | +0.11% |
| 32 | 166.02 µs | 167.65 µs | +0.98% |
| 256 | 438.08 µs | 438.76 µs | +0.16% |
| 1024 | 1.2506 ms | 1.2522 ms | +0.13% |
| 4096 | 4.2714 ms | 4.2755 ms | +0.10% |

