### PR TITLE
chore: Move metric names to their structs

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -57,9 +57,11 @@ struct WindowServiceMetrics {
 }
 
 impl WindowServiceMetrics {
-    fn report_metrics(&self, metric_name: &'static str) {
+    const NAME: &str = "recv-window-insert-shreds";
+
+    fn report_metrics(&self) {
         datapoint_info!(
-            metric_name,
+            Self::NAME,
             (
                 "handle_packets_elapsed_us",
                 self.handle_packets_elapsed_us,
@@ -399,9 +401,9 @@ impl WindowService {
                     }
 
                     if last_print.elapsed().as_secs() > 2 {
-                        metrics.report_metrics("blockstore-insert-shreds");
+                        metrics.report_metrics();
                         metrics = BlockstoreInsertionMetrics::default();
-                        ws_metrics.report_metrics("recv-window-insert-shreds");
+                        ws_metrics.report_metrics();
                         ws_metrics = WindowServiceMetrics::default();
                         last_print = Instant::now();
                     }

--- a/ledger/src/blockstore_metrics.rs
+++ b/ledger/src/blockstore_metrics.rs
@@ -44,9 +44,11 @@ pub struct BlockstoreInsertionMetrics {
 }
 
 impl BlockstoreInsertionMetrics {
-    pub fn report_metrics(&self, metric_name: &'static str) {
+    const NAME: &str = "blockstore-insert-shreds";
+
+    pub fn report_metrics(&self) {
         datapoint_info!(
-            metric_name,
+            Self::NAME,
             ("num_shreds", self.num_shreds as i64, i64),
             ("total_elapsed_us", self.total_elapsed_us as i64, i64),
             (


### PR DESCRIPTION
#### Problem
These metric structs are particular to a single place in the codebase yet take the datapoint name as a function parameters. This adds an extra layer of indirection when searching the codebase for metric/field names

#### Summary of Changes
Move name to struct definition