### PR TITLE
feat: bump solana-stake-interface=3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10460,9 +10460,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd714713337a7f5b513e02119f484fb9b7e056c6ce74af30e70505f2e62b64b7"
+checksum = "f49eb5c77484214c3484921e2cdda79d185373118b5458c1b2df0f1a04c3bc30"
 dependencies = [
  "borsh",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -498,7 +498,7 @@ solana-signer-store = "0.1.0"
 solana-slot-hashes = "3.0.1"
 solana-slot-history = "3.0.0"
 solana-stable-layout = "3.0.1"
-solana-stake-interface = "3.0.0"
+solana-stake-interface = "3.1.0"
 solana-storage-bigtable = { path = "storage-bigtable", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-storage-proto = { path = "storage-proto", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-streamer = { path = "streamer", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }

--- a/account-decoder/src/parse_stake.rs
+++ b/account-decoder/src/parse_stake.rs
@@ -54,6 +54,7 @@ pub struct UiMeta {
 impl From<Meta> for UiMeta {
     fn from(meta: Meta) -> Self {
         Self {
+            #[expect(deprecated)]
             rent_exempt_reserve: meta.rent_exempt_reserve.to_string(),
             authorized: meta.authorized.into(),
             lockup: meta.lockup.into(),

--- a/account-decoder/src/parse_stake.rs
+++ b/account-decoder/src/parse_stake.rs
@@ -46,6 +46,11 @@ pub struct UiStakeAccount {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct UiMeta {
+    #[deprecated(
+        since = "4.1.0",
+        note = "Stake account rent must be calculated via the `Rent` sysvar. This value will \
+                cease to be correct once lamports-per-byte is adjusted."
+    )]
     pub rent_exempt_reserve: StringAmount,
     pub authorized: UiAuthorized,
     pub lockup: UiLockup,

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -168,6 +168,7 @@ fn create_stake_account(
 
     let meta = Meta {
         authorized: Authorized::auto(authorized),
+        #[expect(deprecated)]
         rent_exempt_reserve,
         ..Meta::default()
     };

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1671,6 +1671,10 @@ pub async fn process_show_stakes(
              Ensure that the account was fetched using a binary encoding.",
         );
         if let Ok(stake_state) = stake_account.state() {
+            let rent_exempt_balance = rpc_client
+                .get_minimum_balance_for_rent_exemption(stake_account.data.len())
+                .await?;
+
             match stake_state {
                 StakeStateV2::Initialized(_) if vote_account_pubkeys.is_empty() => {
                     stake_accounts.push(CliKeyedStakeState {
@@ -1682,6 +1686,7 @@ pub async fn process_show_stakes(
                             &stake_history,
                             &clock,
                             new_rate_activation_epoch,
+                            rent_exempt_balance,
                             false,
                         ),
                     });
@@ -1699,6 +1704,7 @@ pub async fn process_show_stakes(
                             &stake_history,
                             &clock,
                             new_rate_activation_epoch,
+                            rent_exempt_balance,
                             false,
                         ),
                     });

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2441,12 +2441,14 @@ pub fn build_stake_state(
     stake_history: &StakeHistory,
     clock: &Clock,
     new_rate_activation_epoch: Option<Epoch>,
+    rent_exempt_reserve: u64,
     use_csv: bool,
 ) -> CliStakeState {
     match stake_state {
         StakeStateV2::Stake(
             Meta {
-                rent_exempt_reserve,
+                #[expect(deprecated)]
+                    rent_exempt_reserve: _,
                 authorized,
                 lockup,
             },
@@ -2494,7 +2496,7 @@ pub fn build_stake_state(
                 lockup,
                 use_lamports_unit,
                 current_epoch,
-                rent_exempt_reserve: Some(*rent_exempt_reserve),
+                rent_exempt_reserve: Some(rent_exempt_reserve),
                 active_stake: u64_some_if_not_zero(effective),
                 activating_stake: u64_some_if_not_zero(activating),
                 deactivating_stake: u64_some_if_not_zero(deactivating),
@@ -2512,7 +2514,8 @@ pub fn build_stake_state(
             ..CliStakeState::default()
         },
         StakeStateV2::Initialized(Meta {
-            rent_exempt_reserve,
+            #[expect(deprecated)]
+                rent_exempt_reserve: _,
             authorized,
             lockup,
         }) => {
@@ -2528,7 +2531,7 @@ pub fn build_stake_state(
                 authorized: Some(authorized.into()),
                 lockup,
                 use_lamports_unit,
-                rent_exempt_reserve: Some(*rent_exempt_reserve),
+                rent_exempt_reserve: Some(rent_exempt_reserve),
                 ..CliStakeState::default()
             }
         }
@@ -2728,7 +2731,9 @@ pub async fn get_account_stake_state(
                 &agave_feature_set::reduce_stake_warmup_cooldown::id(),
             )
             .await?;
-
+            let rent_exempt_balance = rpc_client
+                .get_minimum_balance_for_rent_exemption(stake_account.data.len())
+                .await?;
             let mut state = build_stake_state(
                 stake_account.lamports,
                 &stake_state,
@@ -2736,6 +2741,7 @@ pub async fn get_account_stake_state(
                 &stake_history,
                 &clock,
                 new_rate_activation_epoch,
+                rent_exempt_balance,
                 use_csv,
             );
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8996,9 +8996,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd714713337a7f5b513e02119f484fb9b7e056c6ce74af30e70505f2e62b64b7"
+checksum = "f49eb5c77484214c3484921e2cdda79d185373118b5458c1b2df0f1a04c3bc30"
 dependencies = [
  "borsh",
  "num-traits",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9354,9 +9354,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd714713337a7f5b513e02119f484fb9b7e056c6ce74af30e70505f2e62b64b7"
+checksum = "f49eb5c77484214c3484921e2cdda79d185373118b5458c1b2df0f1a04c3bc30"
 dependencies = [
  "num-traits",
  "serde",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -158,7 +158,7 @@ solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version
 solana-sdk-ids = "=3.1.0"
 solana-secp256k1-recover = "=3.1.1"
 solana-sha256-hasher = { version = "=3.1.0", features = ["sha2"] }
-solana-stake-interface = { version = "=3.0.0", features = ["bincode"] }
+solana-stake-interface = { version = "=3.1.0", features = ["bincode"] }
 solana-svm = { path = "../../svm", version = "=4.1.0-alpha.0" }
 solana-svm-feature-set = { path = "../../svm-feature-set", version = "=4.1.0-alpha.0" }
 solana-svm-test-harness-instr = { path = "../../svm-test-harness/instr", version = "=4.1.0-alpha.0" }

--- a/runtime/benches/epoch_turnover.rs
+++ b/runtime/benches/epoch_turnover.rs
@@ -44,6 +44,7 @@ fn create_stake_account(vote_pubkey: &Pubkey, rent_exempt_reserve: u64) -> Accou
     let total_lamports = rent_exempt_reserve + DELEGATED_STAKE_LAMPORTS;
 
     let meta = Meta {
+        #[expect(deprecated)]
         rent_exempt_reserve,
         ..Meta::default()
     };

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1216,6 +1216,7 @@ mod tests {
 
                 let meta = Meta {
                     authorized: Authorized::auto(&Pubkey::new_unique()),
+                    #[expect(deprecated)]
                     rent_exempt_reserve,
                     ..Meta::default()
                 };

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -595,6 +595,7 @@ pub fn create_lockup_stake_account(
         .set_state(&StakeStateV2::Initialized(Meta {
             authorized: *authorized,
             lockup: *lockup,
+            #[expect(deprecated)]
             rent_exempt_reserve,
         }))
         .expect("set_state");

--- a/runtime/src/stake_utils.rs
+++ b/runtime/src/stake_utils.rs
@@ -48,6 +48,7 @@ pub fn create_stake_account(
 
     let meta = Meta {
         authorized: Authorized::auto(authorized),
+        #[expect(deprecated)]
         rent_exempt_reserve,
         ..Meta::default()
     };


### PR DESCRIPTION
#### Problem
`solana-stake-interface` has new version that deprectates `Meta::rent_exempt_reserve`

#### Summary of Changes
* bump dependency in agave including programs/sbf
* annotate use of `Meta::rent_exempt_reserve` with expected deprecation
  * when it's populated, it is filled with the value from rent collector already
  * change `cli` to ignore the value from account and override with value obtained from rpc
 
Note: conversion of `Meta` to `UiMeta` is still passing through the deprecated value - supposedly this should remain one-to-one view of the underlying data, but it requires additional attention.