### PR TITLE
perf(fs): split consume_or_skip from consume in FileBufRead

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -39,7 +39,7 @@ use {
         self,
         convert::TryFrom,
         fs::{File, OpenOptions, remove_file},
-        io::{self, BufRead, Seek, SeekFrom, Write},
+        io::{self, Seek, SeekFrom, Write},
         mem::{self, MaybeUninit},
         path::{Path, PathBuf},
         ptr, slice,
@@ -1055,7 +1055,7 @@ impl AppendVec {
                             stored_size,
                         };
                         callback(account);
-                        reader.consume(stored_size);
+                        reader.consume_or_skip(stored_size);
                         // restore default required buffer size
                         min_buf_len = STORE_META_OVERHEAD;
                     } else {
@@ -1238,7 +1238,7 @@ impl AppendVec {
                         offset,
                         stored_size,
                     });
-                    reader.consume(stored_size);
+                    reader.consume_or_skip(stored_size);
                 }
             }
         }

--- a/fs/src/buffered_reader.rs
+++ b/fs/src/buffered_reader.rs
@@ -77,6 +77,15 @@ pub trait FileBufRead<'a>: BufRead {
     /// This offset represents the position within the underlying file where data
     /// will be consumed from.
     fn get_file_offset(&self) -> FileSize;
+
+    /// Advance the offset by `amt` bytes, potentially skipping past the current buffer
+    /// into the underlying file.
+    ///
+    /// Unlike `BufRead::consume`, `amt` is not constrained by the size of the buffer
+    /// returned by `fill_buf` — any bytes beyond what is currently buffered are skipped
+    /// by advancing the file read offset, so the next `fill_buf` starts at the correct
+    /// position.
+    fn consume_or_skip(&mut self, n: usize);
 }
 
 /// An extension of the `BufRead` trait for readers that require stronger control
@@ -160,6 +169,16 @@ impl<'a, const N: usize> FileBufRead<'a> for BufferedReader<'a, N> {
             self.file_last_offset + self.buf_valid_bytes.start as FileSize
         }
     }
+
+    fn consume_or_skip(&mut self, amt: usize) {
+        if self.buf_valid_bytes.len() >= amt {
+            self.buf_valid_bytes.start += amt;
+        } else {
+            let additional_amount_to_skip = amt - self.buf_valid_bytes.len();
+            self.buf_valid_bytes = 0..0;
+            self.file_offset_of_next_read += additional_amount_to_skip as FileSize;
+        }
+    }
 }
 
 impl<const N: usize> BufferedReader<'_, N> {
@@ -218,7 +237,7 @@ impl<const N: usize> io::Read for BufferedReader<'_, N> {
         )?;
         let filled_len = bytes_read + available_len;
         // Buffer was successfully filled, drop buffered data and move offset.
-        self.consume(filled_len);
+        self.consume_or_skip(filled_len);
         Ok(filled_len)
     }
 }
@@ -233,19 +252,16 @@ impl<const N: usize> BufRead for BufferedReader<'_, N> {
         Ok(self.valid_slice())
     }
 
-    /// Advance the offset by `amt` to a `file` position where next `fill_buf` buffer should
-    /// start at.
+    /// Advance the buffer position by `amt`, clamped to the end of the currently buffered data.
     ///
-    /// Note that `amt` is not constrained by the size of the buffer returned by `fill_buf`
-    /// and can be thus used to seek/skip reads from the underlying file.
+    /// This follows the standard `BufRead::consume` contract: `amt` must not exceed the buffer
+    /// length returned by the preceding `fill_buf`. To skip bytes beyond the current buffer,
+    /// use [`FileBufRead::consume_or_skip`] instead.
     fn consume(&mut self, amt: usize) {
-        if self.buf_valid_bytes.len() >= amt {
-            self.buf_valid_bytes.start += amt;
-        } else {
-            let additional_amount_to_skip = amt - self.buf_valid_bytes.len();
-            self.buf_valid_bytes = 0..0;
-            self.file_offset_of_next_read += additional_amount_to_skip as FileSize;
-        }
+        self.buf_valid_bytes.start = self
+            .buf_valid_bytes
+            .end
+            .min(self.buf_valid_bytes.start + amt)
     }
 }
 
@@ -344,6 +360,17 @@ impl<'a, R: FileBufRead<'a>> FileBufRead<'a> for BufReaderWithOverflow<R> {
 
     fn get_file_offset(&self) -> FileSize {
         self.reader.get_file_offset() - self.overflow_buf.len() as FileSize
+    }
+
+    fn consume_or_skip(&mut self, mut amt: usize) {
+        let overflow_len = self.overflow_buf.len();
+        if overflow_len > 0 {
+            amt = amt
+                .checked_sub(overflow_len)
+                .expect("should consume all previously required bytes");
+            self.overflow_buf.clear();
+        }
+        self.reader.consume_or_skip(amt);
     }
 }
 
@@ -519,7 +546,7 @@ mod tests {
         // Consume the data and attempt read next 16 bytes, expect to hit `valid_len`, and only read 14 bytes
         let mut advance = 16;
         let mut required_data_len = 16;
-        reader.consume(advance);
+        reader.consume_or_skip(advance);
         let offset = reader.get_file_offset();
         expected_offset += advance as FileSize;
         assert_eq!(offset, expected_offset);
@@ -534,7 +561,7 @@ mod tests {
         // Continue reading should yield EOF.
         advance = 14;
         required_data_len = 16;
-        reader.consume(advance);
+        reader.consume_or_skip(advance);
         let offset = reader.get_file_offset();
         expected_offset += advance as FileSize;
         assert_eq!(offset, expected_offset);
@@ -549,7 +576,7 @@ mod tests {
         // Move the offset passed `valid_len`, expect to hit EOF.
         advance = 1;
         required_data_len = 8;
-        reader.consume(advance);
+        reader.consume_or_skip(advance);
         let offset = reader.get_file_offset();
         expected_offset += advance as FileSize;
         assert_eq!(offset, expected_offset);
@@ -564,7 +591,7 @@ mod tests {
         // Move the offset passed file_len, expect to hit EOF.
         advance = 3;
         required_data_len = 8;
-        reader.consume(advance);
+        reader.consume_or_skip(advance);
         let offset = reader.get_file_offset();
         expected_offset += advance as FileSize;
         assert_eq!(offset, expected_offset);
@@ -723,7 +750,7 @@ mod tests {
         assert_eq!(&slice[..required_len], &bytes[..required_len]);
 
         // Consume part of the buffer to simulate partial reading
-        reader.consume(required_len);
+        reader.consume_or_skip(required_len);
 
         // Case 2: required_len > buffer_size (overflow required)
         let required_len = BUFFER_SIZE + 8;
@@ -734,7 +761,7 @@ mod tests {
         assert_eq!(slice, &bytes[8..8 + required_len]);
 
         // Consume everything to reach EOF
-        reader.consume(required_len);
+        reader.consume_or_skip(required_len);
 
         // Case 3: required_len larger than remaining data (expect UnexpectedEof)
         let required_len = 64;
@@ -766,7 +793,7 @@ mod tests {
         let buf = reader.fill_buf().unwrap();
         assert_eq!(buf, &bytes[0..BUFFER_SIZE]);
 
-        reader.consume(8);
+        reader.consume_or_skip(8);
         let mut buf = [0; 8];
         assert_eq!(reader.read(&mut buf).unwrap(), 8);
         assert_eq!(buf, &bytes[8..BUFFER_SIZE]);

--- a/fs/src/io_uring/sequential_file_reader.rs
+++ b/fs/src/io_uring/sequential_file_reader.rs
@@ -428,7 +428,7 @@ impl<'a> Read for SequentialFileReader<'a> {
             return Ok(0); // EOF or empty `buf`
         }
         buf[..bytes_to_read].copy_from_slice(&available[..bytes_to_read]);
-        self.consume(bytes_to_read);
+        self.state.consume_in_current_buf(bytes_to_read);
         Ok(bytes_to_read)
     }
 }
@@ -444,8 +444,9 @@ impl<'a> BufRead for SequentialFileReader<'a> {
         Ok(current_buf.slice(self.state.current_buf_pos, self.state.current_buf_remaining))
     }
 
+    #[inline]
     fn consume(&mut self, amt: usize) {
-        self.state.consume(amt);
+        self.state.consume_in_current_buf(amt);
     }
 }
 
@@ -470,6 +471,10 @@ impl<'a> FileBufRead<'a> for SequentialFileReader<'a> {
 
     fn get_file_offset(&self) -> FileSize {
         self.state.current_offset
+    }
+
+    fn consume_or_skip(&mut self, amt: usize) {
+        self.state.consume_or_skip(amt);
     }
 }
 
@@ -536,7 +541,14 @@ struct SequentialFileReaderState {
 }
 
 impl SequentialFileReaderState {
-    fn consume(&mut self, amt: usize) {
+    #[inline]
+    fn consume_in_current_buf(&mut self, amt: usize) {
+        self.current_offset += amt as FileSize;
+        self.current_buf_pos += amt as IoSize;
+        self.current_buf_remaining -= amt as IoSize;
+    }
+
+    fn consume_or_skip(&mut self, amt: usize) {
         if amt == 0 || self.files.is_empty() {
             return;
         }
@@ -1069,18 +1081,18 @@ mod tests {
         assert_eq!(reader.fill_buf().unwrap(), &pattern[..512]);
         assert_eq!(0, reader.get_file_offset());
 
-        reader.consume(600);
+        reader.consume_or_skip(600);
         assert_eq!(600, reader.get_file_offset());
         assert_eq!(reader.fill_buf().unwrap(), &pattern[600..1024]);
 
-        reader.consume(400);
+        reader.consume_or_skip(400);
         assert_eq!(1000, reader.get_file_offset());
         assert_eq!(reader.fill_buf().unwrap(), &pattern[1000..1024]);
 
-        reader.consume(25);
+        reader.consume_or_skip(25);
         assert_eq!(reader.fill_buf().unwrap(), &pattern[1025..1536]);
 
-        reader.consume(2000);
+        reader.consume_or_skip(2000);
         assert_eq!(reader.fill_buf().unwrap(), &pattern[3025..3072]);
     }
 


### PR DESCRIPTION
#### Problem
`SequentialFileReader` implements extended `consume` semantics provided by `agave_fs::buffered_reader::BufferedReader`, i.e. it allows specifying amount beyond slice size returned by `fill_buf`. In tight loops calling `fill_buf + consume`, e.g. using wincode that calls `read_exact`, this brings significant performance penalty due to branching / data dependency in `state.consume` checking if amount is larger than current buf remaining bytes.

Adjusting the contract of `BufRead` implicitly like that isn't the cleanest way to structure code anyway.

Note: at the moment `SequentialFileReader` isn't used in contexts requiring this functionality, so in theory this could just be removed completely, but in foreseeable future it should still be useful to replace current reader in accounts-db with io-uring reader.

#### Summary of Changes
* introduce `consume_or_skip` to `FileBufRead`
* make `consume` in all readers follow `BufRead` semantics more closely
* update accounts-db to use `consume_or_skip`

##### Performance measurements
On test runs decoding obsolete accounts file (~75MB) using wincode + io_uring buf reader (bottleneck is `take_array` -> `read_exact` called extensively) this change improves total deserialization time from 100ms to 80ms.
