### PR TITLE
refactor(snapshots): remove SnapshotConfig from archive functions

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -515,7 +515,7 @@ pub fn archive_snapshot_package(
         snapshot_storages.as_slice(),
         &bank_snapshot_dir,
         snapshot_archive_path,
-        snapshot_config,
+        snapshot_config.archive_format,
     )?;
 
     Ok(snapshot_archive_info)

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -1,8 +1,7 @@
 use {
     crate::{
         ArchiveFormat, Result, SnapshotArchiveKind, error::ArchiveSnapshotPackageError, paths,
-        snapshot_archive_info::SnapshotArchiveInfo, snapshot_config::SnapshotConfig,
-        snapshot_hash::SnapshotHash,
+        snapshot_archive_info::SnapshotArchiveInfo, snapshot_hash::SnapshotHash,
     },
     agave_fs::buffered_writer::large_file_buf_writer,
     log::info,
@@ -29,7 +28,7 @@ pub fn archive_snapshot(
     snapshot_storages: &[Arc<AccountStorageEntry>],
     bank_snapshot_dir: impl AsRef<Path>,
     archive_path: impl AsRef<Path>,
-    snapshot_config: &SnapshotConfig,
+    archive_format: ArchiveFormat,
 ) -> Result<SnapshotArchiveInfo> {
     use ArchiveSnapshotPackageError as E;
     const ACCOUNTS_DIR: &str = "accounts";
@@ -81,7 +80,6 @@ pub fn archive_snapshot(
     })?;
 
     // Tar the staging directory into the archive at `staging_archive_path`
-    let archive_format = snapshot_config.archive_format;
     let staging_archive_path = tar_dir.join(format!(
         "{}{}.{}",
         staging_dir_prefix,


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/12014 propagated `SnapshotConfig` to `archive` function, but since we want to pass `IoSetupState` there anyway, it isn't necessary.

#### Summary of Changes
Bring back `archive_format` parameter instead of `SnapshotConfig`.