### PR TITLE
XDP by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ Release channels have their own copy of this changelog:
   `getLatestBlockhash` response together with its context (notably `context.slot`).
 ### Validator
 #### Breaking
+* XDP transmit in SKB (copy) mode is now enabled by default on Linux. The validator requires
+  `CAP_NET_ADMIN` and `CAP_NET_RAW` capabilities (plus `CAP_BPF` and `CAP_PERFMON` for
+  `--xdp-zero-copy`). Pass `--no-xdp` to fall back to UDP sockets. The XDP CPU
+  core is auto-selected to avoid overlapping the PoH core; passing `--xdp-cpu-cores`
+  with a core that conflicts with the PoH core is an error.
 #### Deprecations
 * `--accounts-db-access-storages-method` is now deprecated and a no-op (the `mmap` value was
   deprecated in v4.0.0; mmap mode has now been removed entirely). The flag is still accepted for

--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ $ ./cargo build
 > [!NOTE]
 > Note that this builds a debug version that is **not suitable for running a testnet or mainnet validator**. Please read [`docs/src/cli/install.md`](docs/src/cli/install.md#build-from-source) for instructions to build a release version for test and production uses.
 
+## **4. Grant capabilities for XDP (Linux-only).**
+
+XDP transmit is enabled on Linux by default and requires extra capabilities. After building, grant them to the validator binary:
+
+```bash
+$ sudo setcap 'cap_net_admin,cap_net_raw+eip' <path-to-agave-validator-binary>
+```
+
+For XDP zero-copy mode (`--xdp-zero-copy`), additional capabilities are needed:
+
+```bash
+$ sudo setcap 'cap_net_admin,cap_net_raw,cap_bpf,cap_perfmon+eip' <path-to-agave-validator-binary>
+```
+
 # Testing
 
 **Run the test suite:**

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -144,6 +144,7 @@ args+=(
   --no-wait-for-vote-to-start-leader
   --full-rpc-api
   --allow-private-addr
+  --no-xdp
 )
 default_arg --gossip-port 8001
 default_arg --log -

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -10,6 +10,7 @@ args=(
   --max-genesis-archive-unpacked-size 1073741824
   --no-poh-speed-test
   --no-os-network-limits-test
+  --no-xdp
 )
 airdrops_enabled=1
 node_sol=500 # 500 SOL: number of SOL to airdrop the node for transaction fees and vote account rent exemption (ignored if airdrops_enabled=0)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -121,6 +121,7 @@ args=(
   --require-tower
   --no-wait-for-vote-to-start-leader
   --no-os-network-limits-test
+  --no-xdp
 )
 # shellcheck disable=SC2086
 agave-validator "${args[@]}" $SOLANA_RUN_SH_VALIDATOR_ARGS &

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -176,12 +176,11 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .takes_value(true)
             .value_name("CPU_LIST")
             .conflicts_with("xdp_cpu_cores")
+            .conflicts_with("no_xdp")
             .validator(|value| {
                 validate_cpu_ranges(value, "--experimental-retransmit-xdp-cpu-cores")
             })
-            .help(
-                "Enable XDP retransmit on the specified CPU cores. Use --xdp-cpu-cores instead",
-            ),
+            .help("CPU cores to reserve for XDP. Use --xdp-cpu-cores instead"),
         replaced_by: "xdp-cpu-cores",
     );
     add_arg!(
@@ -191,8 +190,8 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .takes_value(true)
             .value_name("INTERFACE")
             .conflicts_with("xdp_interface")
-            .requires("experimental_retransmit_xdp_cpu_cores")
-            .help("Network interface to use for XDP retransmit. Use --xdp-interface instead"),
+            .conflicts_with("no_xdp")
+            .help("Network interface to use for XDP. Use --xdp-interface instead"),
         replaced_by: "xdp-interface",
     );
     add_arg!(
@@ -201,7 +200,7 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .long("experimental-retransmit-xdp-zero-copy")
             .takes_value(false)
             .conflicts_with("xdp_zero_copy")
-            .requires("experimental_retransmit_xdp_cpu_cores")
+            .conflicts_with("no_xdp")
             .help("Enable XDP zero copy. Use --xdp-zero-copy instead"),
         replaced_by: "xdp-zero-copy",
     );

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1211,27 +1211,40 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help(DefaultSchedulerPool::cli_message()),
     )
     .arg(
+        Arg::with_name("no_xdp")
+            .long("no-xdp")
+            .takes_value(false)
+            .help("Disable XDP transmit and fall back to UDP sockets"),
+    )
+    .arg(
         Arg::with_name("xdp_interface")
             .long("xdp-interface")
             .takes_value(true)
             .value_name("INTERFACE")
-            .requires("xdp_cpu_cores")
-            .help("Network interface to use for XDP"),
+            .conflicts_with("no_xdp")
+            .help(
+                "Network interface to use for XDP transmit. Auto-detected from default route if \
+                 not specified",
+            ),
     )
     .arg(
         Arg::with_name("xdp_cpu_cores")
             .long("xdp-cpu-cores")
             .takes_value(true)
             .value_name("CPU_LIST")
+            .conflicts_with("no_xdp")
             .validator(|value| validate_cpu_ranges(value, "--xdp-cpu-cores"))
-            .help("Use the specified CPU cores for XDP"),
+            .help(
+                "CPU cores to reserve for XDP transmit (e.g. \"2-4,7\"). Defaults to 1 \
+                 auto-selected core",
+            ),
     )
     .arg(
         Arg::with_name("xdp_zero_copy")
             .long("xdp-zero-copy")
             .takes_value(false)
-            .requires("xdp_cpu_cores")
-            .help("Enable XDP zero copy. Requires hardware support"),
+            .conflicts_with("no_xdp")
+            .help("Enable XDP zero copy mode. Requires hardware and driver support"),
     )
     .args(&pub_sub_config::args(/*test_validator:*/ false))
     .args(&json_rpc_config::args())

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -83,7 +83,10 @@ use {
     },
 };
 #[cfg(target_os = "linux")]
-use {agave_xdp::transmitter::XdpConfig, solana_clap_utils::input_parsers::parse_cpu_ranges};
+use {
+    agave_cpu_utils::cpu_affinity, agave_xdp::transmitter::XdpConfig,
+    solana_clap_utils::input_parsers::parse_cpu_ranges,
+};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Operation {
@@ -164,30 +167,11 @@ pub fn execute(
             Err(format!("invalid entrypoint address: {addr}"))?;
         }
     }
+    // XDP is not needed for init — it only initializes the ledger and exits.
+    // Also, init drops all Linux capabilities in main() so XDP setup would fail.
     #[cfg(target_os = "linux")]
-    let xdp_transmit_config = if let Some(xdp_cpu_cores) = matches
-        .value_of("xdp_cpu_cores")
-        .or_else(|| matches.value_of("experimental_retransmit_xdp_cpu_cores"))
-    {
-        let xdp_interface = matches
-            .value_of("xdp_interface")
-            .or_else(|| matches.value_of("experimental_retransmit_xdp_interface"));
-        let xdp_zero_copy = matches.is_present("xdp_zero_copy")
-            || matches.is_present("experimental_retransmit_xdp_zero_copy");
-        let config = XdpConfig::new(
-            xdp_interface,
-            parse_cpu_ranges(xdp_cpu_cores).unwrap(),
-            xdp_zero_copy,
-        );
-        if bind_addresses.len() > 1 {
-            Err(String::from(
-                "--xdp-cpu-cores cannot be used in a multihoming context",
-            ))?;
-        }
-        Some(config)
-    } else {
-        None
-    };
+    let xdp_transmit_config: Option<XdpConfig> =
+        build_xdp_config(matches, &operation, &bind_addresses)?;
 
     let dynamic_port_range =
         solana_net_utils::parse_port_range(matches.value_of("dynamic_port_range").unwrap())
@@ -1391,4 +1375,142 @@ fn new_snapshot_config(
     }
 
     Ok(snapshot_config)
+}
+
+#[cfg(target_os = "linux")]
+fn build_xdp_config(
+    matches: &ArgMatches,
+    operation: &Operation,
+    bind_addresses: &BindIpAddrs,
+) -> Result<Option<XdpConfig>, String> {
+    if matches.is_present("no_xdp") || *operation == Operation::Initialize {
+        return Ok(None);
+    }
+    if bind_addresses.len() > 1 {
+        return Err(
+            "XDP cannot be used in a multihoming context; pass --no-xdp to disable XDP".to_string(),
+        );
+    }
+    let xdp_interface = matches
+        .value_of("xdp_interface")
+        .or_else(|| matches.value_of("experimental_retransmit_xdp_interface"));
+    let xdp_zero_copy = matches.is_present("xdp_zero_copy")
+        || matches.is_present("experimental_retransmit_xdp_zero_copy");
+    let poh_pinned_cpu_core = value_of(matches, "poh_pinned_cpu_core")
+        .or_else(|| value_of(matches, "experimental_poh_pinned_cpu_core"))
+        .or(poh_service::DEFAULT_PINNED_CPU_CORE);
+    let xdp_cpu_cores = matches
+        .value_of("xdp_cpu_cores")
+        .or_else(|| matches.value_of("experimental_retransmit_xdp_cpu_cores"));
+    let cpus = if let Some(cpu_str) = xdp_cpu_cores {
+        let parsed =
+            parse_cpu_ranges(cpu_str).expect("clap validator already accepted this CPU list");
+        if let Some(poh_core) = poh_pinned_cpu_core {
+            if parsed.contains(&poh_core) {
+                return Err(format!(
+                    "--xdp-cpu-cores includes PoH core {poh_core}; XDP and PoH must not share a \
+                     CPU core"
+                ));
+            }
+        }
+        Some(parsed)
+    } else {
+        // Auto-select a single core, avoiding the PoH core.
+        match cpu_affinity(None) {
+            Ok(allowed) => {
+                match allowed
+                    .iter()
+                    .rev()
+                    .map(|cpu| **cpu)
+                    .find(|cpu| Some(*cpu) != poh_pinned_cpu_core)
+                {
+                    Some(cpu) => Some(vec![cpu]),
+                    None => {
+                        return Err(format!(
+                            "XDP requires a dedicated CPU core separate from PoH (core \
+                             {poh_pinned_cpu_core:?}), but none is available. Pass --no-xdp to \
+                             disable XDP."
+                        ));
+                    }
+                }
+            }
+            Err(e) => {
+                return Err(format!(
+                    "failed to query CPU affinity: {e}. Pass --no-xdp to disable XDP, or provide \
+                     --xdp-cpu-cores explicitly."
+                ));
+            }
+        }
+    };
+    Ok(cpus.map(|cpus| {
+        info!("XDP enabled on CPU cores: {cpus:?}");
+        XdpConfig::new(xdp_interface, cpus, xdp_zero_copy)
+    }))
+}
+
+#[cfg(all(target_os = "linux", test))]
+mod xdp_tests {
+    use {
+        super::*,
+        crate::{cli::DefaultArgs, commands::run::args::add_args},
+        solana_net_utils::multihomed_sockets::BindIpAddrs,
+        std::net::{IpAddr, Ipv4Addr},
+    };
+
+    fn single_ip_bind() -> BindIpAddrs {
+        BindIpAddrs::new(vec![Ipv4Addr::UNSPECIFIED.into()]).unwrap()
+    }
+
+    fn multihoming_bind() -> BindIpAddrs {
+        BindIpAddrs::new(vec![
+            IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
+            IpAddr::V4(Ipv4Addr::new(2, 2, 2, 2)),
+        ])
+        .unwrap()
+    }
+
+    #[test]
+    fn test_no_xdp_flag_disables_xdp() {
+        let default_args = DefaultArgs::default();
+        let app = add_args(clap::App::new("agave-validator"), &default_args);
+        let matches = app.get_matches_from(vec!["agave-validator", "--no-xdp"]);
+        let result = build_xdp_config(&matches, &Operation::Run, &single_ip_bind());
+        assert!(result.unwrap().is_none(), "--no-xdp must disable XDP");
+    }
+
+    #[test]
+    fn test_init_disables_xdp() {
+        let default_args = DefaultArgs::default();
+        let app = add_args(clap::App::new("agave-validator"), &default_args);
+        let matches = app.get_matches_from(vec!["agave-validator"]);
+        let result = build_xdp_config(&matches, &Operation::Initialize, &single_ip_bind());
+        assert!(result.unwrap().is_none(), "init operation must disable XDP");
+    }
+
+    #[test]
+    fn test_multihoming_is_error() {
+        let default_args = DefaultArgs::default();
+        let app = add_args(clap::App::new("agave-validator"), &default_args);
+        let matches = app.get_matches_from(vec!["agave-validator"]);
+        let result = build_xdp_config(&matches, &Operation::Run, &multihoming_bind());
+        assert!(
+            result.unwrap_err().contains("multihoming"),
+            "multihoming context must produce an error"
+        );
+    }
+
+    #[test]
+    fn test_explicit_xdp_core_conflicts_with_poh_core_is_error() {
+        let default_args = DefaultArgs::default();
+        let app = add_args(clap::App::new("agave-validator"), &default_args);
+        let poh_core = solana_poh::poh_service::DEFAULT_PINNED_CPU_CORE
+            .unwrap_or(0)
+            .to_string();
+        let matches = app.get_matches_from(vec!["agave-validator", "--xdp-cpu-cores", &poh_core]);
+        let result = build_xdp_config(&matches, &Operation::Run, &single_ip_bind());
+        assert!(
+            result.unwrap_err().contains("PoH core"),
+            "XDP core overlapping PoH core must produce an error"
+        );
+    }
 }

--- a/validator/tests/cli.rs
+++ b/validator/tests/cli.rs
@@ -25,6 +25,7 @@ fn test_use_the_same_path_for_accounts_and_snapshots() {
         "--log",
         "-",
         "--no-voting",
+        "--no-xdp",
         "--accounts",
         temp_dir_str,
         "--snapshots",


### PR DESCRIPTION
#### Problem

XDP should not be experimental anymore https://discord.com/channels/428295358100013066/478692221441409024/1496253676891930865

#### Summary of Changes

- Enable by default for agave-validator
- Still disabled for multinode and test-validator (since those are expected to run on localhost)

#### Testing

- This is currently running on an a staked testnet node DZ6m64cghUKgVcvsFgAb3NDaeEyRpuMSK8hwqETndNTS