### PR TITLE
refactor(runtime): share IoSetupState during snapshot unarchive

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -25,7 +25,7 @@ use {
             rebuild_storages_from_snapshot_dir, verify_and_unarchive_snapshots,
         },
     },
-    agave_fs::dirs,
+    agave_fs::{dirs, io_setup::IoSetupState},
     agave_snapshots::{
         SnapshotArchiveKind, SnapshotKind,
         error::{
@@ -83,6 +83,10 @@ pub fn bank_fields_from_snapshot_archives(
 
     let account_paths = vec![temp_accounts_dir.path().to_path_buf()];
 
+    let io_setup = IoSetupState::default()
+        .with_shared_sqpoll()?
+        .with_direct_io(accounts_db_config.snapshots_use_direct_io)
+        .with_buffers_registered(accounts_db_config.use_registered_io_uring_buffers);
     let (
         UnarchivedSnapshots {
             full_unpacked_snapshots_dir_and_version,
@@ -96,6 +100,7 @@ pub fn bank_fields_from_snapshot_archives(
         incremental_snapshot_archive_info.as_ref(),
         &account_paths,
         accounts_db_config,
+        &io_setup,
     )?;
 
     bank_fields_from_snapshots(
@@ -162,6 +167,10 @@ pub fn bank_from_snapshot_archives(
             )
     );
 
+    let io_setup = IoSetupState::default()
+        .with_shared_sqpoll()?
+        .with_direct_io(accounts_db_config.snapshots_use_direct_io)
+        .with_buffers_registered(accounts_db_config.use_registered_io_uring_buffers);
     let (
         UnarchivedSnapshots {
             full_storage: mut storage,
@@ -182,6 +191,7 @@ pub fn bank_from_snapshot_archives(
         incremental_snapshot_archive_info,
         account_paths,
         &accounts_db_config,
+        &io_setup,
     )?;
 
     if let Some(incremental_storage) = incremental_storage {

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -99,7 +99,7 @@ pub fn bank_fields_from_snapshot_archives(
         &full_snapshot_archive_info,
         incremental_snapshot_archive_info.as_ref(),
         &account_paths,
-        accounts_db_config,
+        accounts_db_config.storage_access,
         &io_setup,
     )?;
 
@@ -190,7 +190,7 @@ pub fn bank_from_snapshot_archives(
         full_snapshot_archive_info,
         incremental_snapshot_archive_info,
         account_paths,
-        &accounts_db_config,
+        accounts_db_config.storage_access,
         &io_setup,
     )?;
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1048,16 +1048,12 @@ pub fn verify_and_unarchive_snapshots(
     incremental_snapshot_archive_info: Option<&IncrementalSnapshotArchiveInfo>,
     account_paths: &[PathBuf],
     accounts_db_config: &AccountsDbConfig,
+    io_setup: &IoSetupState,
 ) -> Result<(UnarchivedSnapshots, UnarchivedSnapshotsGuard)> {
     check_are_snapshots_compatible(
         full_snapshot_archive_info,
         incremental_snapshot_archive_info,
     )?;
-
-    let io_setup = IoSetupState::default()
-        .with_shared_sqpoll()?
-        .with_direct_io(accounts_db_config.snapshots_use_direct_io)
-        .with_buffers_registered(accounts_db_config.use_registered_io_uring_buffers);
 
     let next_append_vec_id = Arc::new(AtomicAccountsFileId::new(0));
     let UnarchivedSnapshot {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -41,7 +41,7 @@ use {
     solana_accounts_db::{
         account_storage::AccountStorageMap,
         account_storage_entry::AccountStorageEntry,
-        accounts_db::{AccountsDbConfig, AtomicAccountsFileId},
+        accounts_db::AtomicAccountsFileId,
         accounts_file::{AccountsFile, StorageAccess},
         utils::{ACCOUNTS_RUN_DIR, ACCOUNTS_SNAPSHOT_DIR, move_and_async_delete_path},
     },
@@ -1047,7 +1047,7 @@ pub fn verify_and_unarchive_snapshots(
     full_snapshot_archive_info: &FullSnapshotArchiveInfo,
     incremental_snapshot_archive_info: Option<&IncrementalSnapshotArchiveInfo>,
     account_paths: &[PathBuf],
-    accounts_db_config: &AccountsDbConfig,
+    storage_access: StorageAccess,
     io_setup: &IoSetupState,
 ) -> Result<(UnarchivedSnapshots, UnarchivedSnapshotsGuard)> {
     check_are_snapshots_compatible(
@@ -1072,8 +1072,8 @@ pub fn verify_and_unarchive_snapshots(
         full_snapshot_archive_info.archive_format(),
         next_append_vec_id.clone(),
         None,
-        accounts_db_config,
-        &io_setup,
+        storage_access,
+        io_setup,
     )?;
 
     let (
@@ -1100,8 +1100,8 @@ pub fn verify_and_unarchive_snapshots(
             incremental_snapshot_archive_info.archive_format(),
             next_append_vec_id.clone(),
             Some(incremental_snapshot_archive_info.base_slot()),
-            accounts_db_config,
-            &io_setup,
+            storage_access,
+            io_setup,
         )?;
         (
             Some(unpack_dir),
@@ -1283,6 +1283,7 @@ fn create_snapshot_meta_files_for_unarchived_snapshot(unpack_dir: impl AsRef<Pat
 /// Perform the common tasks when unarchiving a snapshot.  Handles creating the temporary
 /// directories, untaring, reading the version file, and then returning those fields plus the
 /// rebuilt storage
+#[allow(clippy::too_many_arguments)]
 fn unarchive_snapshot(
     bank_snapshots_dir: impl AsRef<Path>,
     unpacked_snapshots_dir_prefix: &'static str,
@@ -1292,7 +1293,7 @@ fn unarchive_snapshot(
     archive_format: ArchiveFormat,
     next_append_vec_id: Arc<AtomicAccountsFileId>,
     base_slot: Option<Slot>,
-    accounts_db_config: &AccountsDbConfig,
+    storage_access: StorageAccess,
     io_setup: &IoSetupState,
 ) -> Result<UnarchivedSnapshot> {
     let unpack_dir = tempfile::Builder::new()
@@ -1331,7 +1332,7 @@ fn unarchive_snapshot(
                         num_rebuilder_threads,
                         next_append_vec_id,
                         SnapshotFrom::Archive,
-                        accounts_db_config.storage_access,
+                        storage_access,
                         None,
                     )?,
                     measure_name

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1054,6 +1054,11 @@ pub fn verify_and_unarchive_snapshots(
         incremental_snapshot_archive_info,
     )?;
 
+    let io_setup = IoSetupState::default()
+        .with_shared_sqpoll()?
+        .with_direct_io(accounts_db_config.snapshots_use_direct_io)
+        .with_buffers_registered(accounts_db_config.use_registered_io_uring_buffers);
+
     let next_append_vec_id = Arc::new(AtomicAccountsFileId::new(0));
     let UnarchivedSnapshot {
         unpack_dir: full_unpack_dir,
@@ -1072,6 +1077,7 @@ pub fn verify_and_unarchive_snapshots(
         next_append_vec_id.clone(),
         None,
         accounts_db_config,
+        &io_setup,
     )?;
 
     let (
@@ -1099,6 +1105,7 @@ pub fn verify_and_unarchive_snapshots(
             next_append_vec_id.clone(),
             Some(incremental_snapshot_archive_info.base_slot()),
             accounts_db_config,
+            &io_setup,
         )?;
         (
             Some(unpack_dir),
@@ -1290,69 +1297,68 @@ fn unarchive_snapshot(
     next_append_vec_id: Arc<AtomicAccountsFileId>,
     base_slot: Option<Slot>,
     accounts_db_config: &AccountsDbConfig,
+    io_setup: &IoSetupState,
 ) -> Result<UnarchivedSnapshot> {
     let unpack_dir = tempfile::Builder::new()
         .prefix(unpacked_snapshots_dir_prefix)
         .tempdir_in(bank_snapshots_dir)?;
     let unpacked_snapshots_dir = unpack_dir.path().join(snapshot_paths::BANK_SNAPSHOTS_DIR);
 
-    let io_setup = IoSetupState::default()
-        .with_shared_sqpoll()?
-        .with_direct_io(accounts_db_config.snapshots_use_direct_io)
-        .with_buffers_registered(accounts_db_config.use_registered_io_uring_buffers);
-
     let (file_sender, file_receiver) = crossbeam_channel::unbounded();
-    let unarchive_handle = streaming_unarchive_snapshot(
-        file_sender,
-        account_paths.to_vec(),
-        unpack_dir.path().to_path_buf(),
-        snapshot_archive_path.as_ref().to_path_buf(),
-        archive_format,
-        io_setup,
-    );
+    thread::scope(|scope| {
+        let unarchive_handle = streaming_unarchive_snapshot(
+            scope,
+            file_sender,
+            account_paths.to_vec(),
+            unpack_dir.path().to_path_buf(),
+            snapshot_archive_path.as_ref().to_path_buf(),
+            archive_format,
+            io_setup,
+        );
 
-    let num_rebuilder_threads = num_cpus::get_physical().saturating_sub(1).max(1);
-    let snapshot_result = snapshot_fields_from_files(&file_receiver).and_then(
-        |SnapshotFieldsBundle {
-             snapshot_version,
-             bank_fields,
-             accounts_db_fields,
-             append_vec_files,
-             ..
-         }| {
-            let snapshot_storage_lengths =
-                accounts_db_fields.get_storage_lengths_for_snapshot_slots(base_slot)?;
-            let (storage, measure_untar) = measure_time!(
-                SnapshotStorageRebuilder::spawn_rebuilder_threads(
-                    snapshot_storage_lengths,
-                    append_vec_files,
-                    file_receiver,
-                    num_rebuilder_threads,
-                    next_append_vec_id,
-                    SnapshotFrom::Archive,
-                    accounts_db_config.storage_access,
-                    None,
-                )?,
-                measure_name
-            );
-            info!("{measure_untar}");
-            create_snapshot_meta_files_for_unarchived_snapshot(&unpack_dir)?;
+        let num_rebuilder_threads = num_cpus::get_physical().saturating_sub(1).max(1);
+        let snapshot_result = snapshot_fields_from_files(&file_receiver).and_then(
+            |SnapshotFieldsBundle {
+                 snapshot_version,
+                 bank_fields,
+                 accounts_db_fields,
+                 append_vec_files,
+                 ..
+             }| {
+                let snapshot_storage_lengths =
+                    accounts_db_fields.get_storage_lengths_for_snapshot_slots(base_slot)?;
+                let (storage, measure_untar) = measure_time!(
+                    SnapshotStorageRebuilder::spawn_rebuilder_threads(
+                        snapshot_storage_lengths,
+                        append_vec_files,
+                        file_receiver,
+                        num_rebuilder_threads,
+                        next_append_vec_id,
+                        SnapshotFrom::Archive,
+                        accounts_db_config.storage_access,
+                        None,
+                    )?,
+                    measure_name
+                );
+                info!("{measure_untar}");
+                create_snapshot_meta_files_for_unarchived_snapshot(&unpack_dir)?;
 
-            Ok(UnarchivedSnapshot {
-                unpack_dir,
-                storage,
-                bank_fields,
-                accounts_db_fields,
-                unpacked_snapshots_dir_and_version: UnpackedSnapshotsDirAndVersion {
-                    unpacked_snapshots_dir,
-                    snapshot_version,
-                },
-                measure_untar,
-            })
-        },
-    );
-    unarchive_handle.join().unwrap()?;
-    snapshot_result
+                Ok(UnarchivedSnapshot {
+                    unpack_dir,
+                    storage,
+                    bank_fields,
+                    accounts_db_fields,
+                    unpacked_snapshots_dir_and_version: UnpackedSnapshotsDirAndVersion {
+                        unpacked_snapshots_dir,
+                        snapshot_version,
+                    },
+                    measure_untar,
+                })
+            },
+        );
+        unarchive_handle.join().unwrap()?;
+        snapshot_result
+    })
 }
 
 /// Spawn thread that streams snapshot dir files across channel

--- a/snapshots/src/unarchive.rs
+++ b/snapshots/src/unarchive.rs
@@ -10,7 +10,7 @@ use {
         fs,
         io::{self, BufRead, BufReader},
         path::{Path, PathBuf},
-        thread::{self, JoinHandle},
+        thread::{self, Scope, ScopedJoinHandle},
         time::Instant,
     },
 };
@@ -25,14 +25,15 @@ const MAX_SNAPSHOT_READER_BUF_SIZE: usize = 128 * 1024 * 1024;
 const MAX_UNPACK_WRITE_BUF_SIZE: usize = 512 * 1024 * 1024;
 
 /// Streams unpacked files across channel
-pub fn streaming_unarchive_snapshot(
+pub fn streaming_unarchive_snapshot<'scope, 'env: 'scope>(
+    scope: &'scope Scope<'scope, 'env>,
     file_sender: Sender<FileInfo>,
     account_paths: Vec<PathBuf>,
     ledger_dir: PathBuf,
     snapshot_archive_path: PathBuf,
     archive_format: ArchiveFormat,
-    io_setup: IoSetupState,
-) -> JoinHandle<Result<(), UnpackError>> {
+    io_setup: &'env IoSetupState,
+) -> ScopedJoinHandle<'scope, Result<(), UnpackError>> {
     let do_unpack = move |archive_path: &Path| {
         let (decompressor, file_creator) = {
             // Bound the buffers based on input archive size (decompression multiplies content size,
@@ -42,10 +43,10 @@ pub fn streaming_unarchive_snapshot(
             let write_buf_size = MAX_UNPACK_WRITE_BUF_SIZE.min(archive_size);
 
             let decompressor =
-                decompressed_tar_reader(archive_format, archive_path, read_buf_size, &io_setup)?;
+                decompressed_tar_reader(archive_format, archive_path, read_buf_size, io_setup)?;
             (
                 decompressor,
-                file_creator(write_buf_size, &io_setup, move |file_info| {
+                file_creator(write_buf_size, io_setup, move |file_info| {
                     let result = file_sender.send(file_info);
                     if let Err(err) = result {
                         panic!(
@@ -69,7 +70,7 @@ pub fn streaming_unarchive_snapshot(
 
     thread::Builder::new()
         .name("solTarUnpack".to_string())
-        .spawn(move || {
+        .spawn_scoped(scope, move || {
             do_unpack(&snapshot_archive_path)
                 .map_err(|err| UnpackError::Unpack(Box::new(err), snapshot_archive_path))
         })


### PR DESCRIPTION
#### Problem
We use accounts_db_config to setup unarchiving the snapshot data by creating `IoSetupState` down in `unarchive_snapshot` function. In order to widen scope of shared io state and reduce exposure of `AccountsDbConfig` into functions only caring about unarchiving we can consume necessary parts of config and create `IoSetupState` higher in the call hierarchy. 

#### Summary of Changes
* crate `IoSetupState` in `bank_from_snapshot_archives` (this will also enable using the same io state for deserialization in the future)
* share the same `&IoSetupState` across both calls to `unarchive_snapshot` - requires a bit of `thread::scope` trickery, because `IoSetupState` doesn't support cloning
* replace `accounts_db_config` parameters with `storage_access`, which is not the only use of the config
