### PR TITLE
syscall: error early on get_sysvar unaligned stores

### DIFF
--- a/syscalls/src/sysvar.rs
+++ b/syscalls/src/sysvar.rs
@@ -14,6 +14,16 @@ fn get_sysvar<T: std::fmt::Debug + SysvarSerialize + Clone>(
         .saturating_add(size_of::<T>() as u64);
     invoke_context.compute_meter.consume_checked(amount)?;
 
+    // If a test case contains a program that is owned by the deprecated
+    // bpf loader but also contains get_sysvar syscalls, the store into the
+    // host memory will segfault due to unaligned accesses. However, this has
+    // no consensus impact because this loader was deprecated before the get_sysvar
+    // syscall was activated.
+    let check_aligned = invoke_context.get_check_aligned();
+    if !check_aligned {
+        return Err(SyscallError::UnalignedPointer.into());
+    }
+
     if var_addr >= ebpf::MM_INPUT_START
         && invoke_context
             .get_feature_set()
@@ -22,7 +32,6 @@ fn get_sysvar<T: std::fmt::Debug + SysvarSerialize + Clone>(
         return Err(SyscallError::InvalidPointer.into());
     }
 
-    let check_aligned = invoke_context.get_check_aligned();
     let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
     translate_mut!(
         memory_mapping,
@@ -188,6 +197,16 @@ declare_builtin_function!(
             .saturating_add(std::cmp::max(sysvar_buf_cost, mem_op_base_cost));
         invoke_context.compute_meter.consume_checked(cost)?;
 
+        // If a test case contains a program that is owned by the deprecated
+        // bpf loader but also contains get_sysvar syscalls, the store into the
+        // host memory will segfault due to unaligned accesses. However, this has
+        // no consensus impact because this loader was deprecated before the get_sysvar
+        // syscall was activated.
+        let check_aligned = invoke_context.get_check_aligned();
+        if !check_aligned {
+            return Err(SyscallError::UnalignedPointer.into());
+        }
+
         if var_addr >= ebpf::MM_INPUT_START
             && invoke_context
                 .get_feature_set()
@@ -196,7 +215,6 @@ declare_builtin_function!(
             return Err(SyscallError::InvalidPointer.into());
         }
 
-        let check_aligned = invoke_context.get_check_aligned();
         let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         // Abort: "Not all bytes in VM memory range `[var_addr, var_addr + length)` are writable."
         translate_mut!(


### PR DESCRIPTION
#### Problem

When testing VM execution against Firedancer, there may be test cases where the `get_sysvar` helper method is reached through the deprecated bpf loader (when a v1 program contains a sysvar-related syscall), which, in production, is technically not possible because the syscall was only enabled after that bpf loader version was deprecated. The store into the unaligned memory triggers a segfault here. It's extremely difficult to try to constrain the fuzzer from not generating these inputs. The simplest solution is to return an error if trying to perform an unaligned memory store in the `get_sysvar` codepaths. 

#### Summary of Changes

Add an alignment check at the top of the syscalls to reject any inputs where the memory mapping is unaligned.

Fixes #

Gracefully handles unaligned memory accesses with loader v1-owned programs that invoke sysvar-related syscalls.