### PR TITLE
vote-program: UpdateCommissionCollector: add number of accounts check and test coverage

### DIFF
--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -389,6 +389,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 return Err(InstructionError::InvalidInstructionData);
             }
 
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let new_collector = read_new_collector_account(&instruction_context, &me, 1)?;
 
             let rent = invoke_context
@@ -1871,7 +1872,29 @@ mod tests {
         );
         assert_eq!(
             get_commission_collector(&accounts[0], CommissionKind::InflationRewards),
-            original_inflation_collector
+            original_inflation_collector, // Unchanged
+        );
+        assert_eq!(
+            get_commission_collector(&accounts[0], CommissionKind::BlockRevenue),
+            original_block_revenue_collector, // Unchanged
+        );
+
+        // Should fail - fewer than 2 account inputs (SIMD-0232).
+        let too_few_instruction_accounts = vec![AccountMeta {
+            pubkey: vote_pubkey,
+            is_signer: false,
+            is_writable: true,
+        }];
+        let accounts = process_instruction(
+            features,
+            &instruction_data,
+            transaction_accounts.clone(),
+            too_few_instruction_accounts,
+            Err(InstructionError::MissingAccount),
+        );
+        assert_eq!(
+            get_commission_collector(&accounts[0], CommissionKind::InflationRewards),
+            original_inflation_collector, // Unchanged
         );
         assert_eq!(
             get_commission_collector(&accounts[0], CommissionKind::BlockRevenue),

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -389,7 +389,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 return Err(InstructionError::InvalidInstructionData);
             }
 
-            instruction_context.check_number_of_instruction_accounts(2)?;
+            instruction_context.check_number_of_instruction_accounts(3)?;
             let new_collector = read_new_collector_account(&instruction_context, &me, 1)?;
 
             let rent = invoke_context
@@ -1855,6 +1855,80 @@ mod tests {
             vote_pubkey
         );
 
+        // Should pass - all three accounts can alias.
+        let aliased_vote_account =
+            create_test_account_with_provided_authorized(&vote_pubkey, &vote_pubkey);
+        let aliased_original_inflation_collector =
+            get_commission_collector(&aliased_vote_account, CommissionKind::InflationRewards);
+        let aliased_original_block_revenue_collector =
+            get_commission_collector(&aliased_vote_account, CommissionKind::BlockRevenue);
+        let aliased_transaction_accounts = vec![
+            (vote_pubkey, aliased_vote_account),
+            (
+                sysvar::rent::id(),
+                account::create_account_shared_data_for_test(&rent),
+            ),
+        ];
+        let aliased_instruction_accounts = vec![
+            AccountMeta {
+                pubkey: vote_pubkey, // Vote account
+                is_signer: false,
+                is_writable: true,
+            },
+            AccountMeta {
+                pubkey: vote_pubkey, // New collector
+                is_signer: false,
+                is_writable: true,
+            },
+            AccountMeta {
+                pubkey: vote_pubkey, // Authorized withdrawer
+                is_signer: true,     // (Signer)
+                is_writable: false,
+            },
+        ];
+
+        // InflationRewards (triple alias)
+        let instruction_data = serialize(&VoteInstruction::UpdateCommissionCollector(
+            CommissionKind::InflationRewards,
+        ))
+        .unwrap();
+        let accounts = process_instruction(
+            features,
+            &instruction_data,
+            aliased_transaction_accounts.clone(),
+            aliased_instruction_accounts.clone(),
+            Ok(()),
+        );
+        assert_eq!(
+            get_commission_collector(&accounts[0], CommissionKind::InflationRewards),
+            vote_pubkey
+        );
+        assert_eq!(
+            get_commission_collector(&accounts[0], CommissionKind::BlockRevenue),
+            aliased_original_block_revenue_collector, // Unchanged
+        );
+
+        // BlockRevenue (triple alias)
+        let instruction_data = serialize(&VoteInstruction::UpdateCommissionCollector(
+            CommissionKind::BlockRevenue,
+        ))
+        .unwrap();
+        let accounts = process_instruction(
+            features,
+            &instruction_data,
+            aliased_transaction_accounts,
+            aliased_instruction_accounts,
+            Ok(()),
+        );
+        assert_eq!(
+            get_commission_collector(&accounts[0], CommissionKind::InflationRewards),
+            aliased_original_inflation_collector, // Unchanged
+        );
+        assert_eq!(
+            get_commission_collector(&accounts[0], CommissionKind::BlockRevenue),
+            vote_pubkey
+        );
+
         // Should fail - SIMD-0232 disabled.
         let instruction_data = serialize(&VoteInstruction::UpdateCommissionCollector(
             CommissionKind::InflationRewards,
@@ -1879,7 +1953,7 @@ mod tests {
             original_block_revenue_collector, // Unchanged
         );
 
-        // Should fail - fewer than 2 account inputs (SIMD-0232).
+        // Should fail - fewer than 3 account inputs (SIMD-0232).
         let too_few_instruction_accounts = vec![AccountMeta {
             pubkey: vote_pubkey,
             is_signer: false,

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -4174,6 +4174,73 @@ mod tests {
     }
 
     #[test]
+    fn test_update_validator_identity_preserves_custom_block_revenue_collector() {
+        // SIMD-0232 enabled.
+        //
+        // Once a validator has set a custom block_revenue_collector, rotating
+        // the validator identity via UpdateValidatorIdentity must NOT clobber
+        // the custom collector.
+        let custom_commission_collector_enabled = true;
+
+        let vote_pubkey = solana_pubkey::new_rand();
+        let mut vote_state = vote_state_new_for_test(&vote_pubkey, VoteStateTargetVersion::V4);
+        let node_pubkey = *vote_state.node_pubkey();
+        let withdrawer_pubkey = *vote_state.authorized_withdrawer();
+
+        // Seed a custom block_revenue_collector distinct from the node identity.
+        let custom_collector = solana_pubkey::new_rand();
+        vote_state.set_block_revenue_collector(custom_collector);
+
+        let serialized = vote_state.serialize();
+        let serialized_len = serialized.len();
+        let rent = Rent::default();
+        let lamports = rent.minimum_balance(serialized_len);
+        let mut vote_account = AccountSharedData::new(lamports, serialized_len, &id());
+        vote_account.set_data_from_slice(&serialized);
+
+        let processor_account = AccountSharedData::new(0, 0, &solana_sdk_ids::native_loader::id());
+        let mut transaction_context = TransactionContext::new(
+            vec![(id(), processor_account), (node_pubkey, vote_account)],
+            rent,
+            0,
+            0,
+            1,
+        );
+        transaction_context
+            .configure_top_level_instruction_for_tests(
+                0,
+                vec![InstructionAccount::new(1, false, true)],
+                vec![],
+            )
+            .unwrap();
+        let instruction_context = transaction_context.get_next_instruction_context().unwrap();
+        let mut borrowed_account = instruction_context
+            .try_borrow_instruction_account(0)
+            .unwrap();
+
+        let new_node_pubkey = solana_pubkey::new_rand();
+        let signers: HashSet<Pubkey> = vec![withdrawer_pubkey, new_node_pubkey]
+            .into_iter()
+            .collect();
+
+        update_validator_identity(
+            &mut borrowed_account,
+            VoteStateTargetVersion::V4,
+            &new_node_pubkey,
+            &signers,
+            custom_commission_collector_enabled,
+        )
+        .unwrap();
+
+        // node_pubkey updated, but block_revenue_collector preserved.
+        let vote_state =
+            VoteStateV4::deserialize(borrowed_account.get_data(), &new_node_pubkey).unwrap();
+        assert_eq!(vote_state.node_pubkey, new_node_pubkey);
+        assert_eq!(vote_state.block_revenue_collector, custom_collector);
+        assert_ne!(vote_state.block_revenue_collector, new_node_pubkey);
+    }
+
+    #[test]
     fn test_get_and_update_authorized_voter_v4_with_bls() {
         let vote_account_pubkey = Pubkey::new_unique();
         let (bls_pubkey, bls_proof_of_possession) =
@@ -4385,6 +4452,39 @@ mod tests {
                 NewCommissionCollector::NewAccount(borrowed_collector)
                     .validate_and_resolve_key(&borrowed_vote, &rent),
                 Ok(collector_pubkey),
+            );
+        }
+
+        // Success: Incinerator is an accepted collector (SIMD-0232 explicitly
+        // allows it — funds sent to the incinerator are burned at end-of-block).
+        {
+            // Imagine the incinerator is temporarily holding funds at the time
+            // of the invocation.
+            let incinerator_account =
+                AccountSharedData::new(rent.minimum_balance(0), 0, &system_program::id());
+            let transaction_context = new_transaction_context(
+                vec![
+                    (id(), processor_account.clone()),
+                    (vote_pubkey, vote_account.clone()),
+                    (solana_sdk_ids::incinerator::id(), incinerator_account),
+                ],
+                vec![
+                    InstructionAccount::new(1, false, true),
+                    InstructionAccount::new(2, false, true),
+                ],
+                &rent,
+            );
+            let instruction_context = transaction_context.get_next_instruction_context().unwrap();
+            let borrowed_vote = instruction_context
+                .try_borrow_instruction_account(0)
+                .unwrap();
+            let borrowed_collector = instruction_context
+                .try_borrow_instruction_account(1)
+                .unwrap();
+            assert_eq!(
+                NewCommissionCollector::NewAccount(borrowed_collector)
+                    .validate_and_resolve_key(&borrowed_vote, &rent),
+                Ok(solana_sdk_ids::incinerator::id()),
             );
         }
 
@@ -4639,6 +4739,138 @@ mod tests {
                 vote_pubkey,
             );
         }
+
+        // V3 -> V4 auto-conversion side-effect: updating one collector against a
+        // V3-serialized account causes the "other" collector to be written as
+        // its V4 default (inflation_rewards_collector = vote_pubkey,
+        // block_revenue_collector = node_pubkey), per try_convert_to_vote_state_v4.
+        {
+            let v3 = get_max_sized_vote_state_v3();
+            let v3_node_pubkey = v3.node_pubkey;
+            let v3_withdrawer = v3.authorized_withdrawer;
+            let v3_vote_pubkey = solana_pubkey::new_rand();
+
+            let v4_size = VoteStateV4::size_of();
+            let mut account_data = vec![0u8; v4_size];
+            bincode::serialize_into(&mut account_data[..], &VoteStateVersions::V3(Box::new(v3)))
+                .unwrap();
+            let mut v3_vote_account =
+                AccountSharedData::new(rent.minimum_balance(v4_size), v4_size, &id());
+            v3_vote_account.set_data_from_slice(&account_data);
+
+            let v3_signers: HashSet<Pubkey> = vec![v3_withdrawer].into_iter().collect();
+
+            let transaction_context = new_transaction_context(
+                vec![
+                    (id(), processor_account.clone()),
+                    (v3_vote_pubkey, v3_vote_account),
+                    (new_collector, collector_account.clone()),
+                ],
+                vec![
+                    InstructionAccount::new(1, false, true),
+                    InstructionAccount::new(2, false, true),
+                ],
+                &rent,
+            );
+            let instruction_context = transaction_context.get_next_instruction_context().unwrap();
+            let mut borrowed_vote_account = instruction_context
+                .try_borrow_instruction_account(0)
+                .unwrap();
+
+            update_commission_collector(
+                &mut borrowed_vote_account,
+                target_version,
+                NewCommissionCollector::NewAccount(
+                    instruction_context
+                        .try_borrow_instruction_account(1)
+                        .unwrap(),
+                ),
+                CommissionKind::InflationRewards,
+                &v3_signers,
+                &rent,
+            )
+            .unwrap();
+
+            // The updated field reflects the caller's new collector.
+            assert_eq!(
+                get_commission_collector(&borrowed_vote_account, CommissionKind::InflationRewards),
+                new_collector,
+            );
+            // The *other* field was reset to its V4-conversion default
+            // (block_revenue_collector = node_pubkey from the V3 source).
+            assert_eq!(
+                get_commission_collector(&borrowed_vote_account, CommissionKind::BlockRevenue),
+                v3_node_pubkey,
+            );
+        }
+
+        // Should fail - deserialization error paths.
+        //
+        // All four variants produce `InvalidAccountData`:
+        // * V0_23_5 is explicitly unsupported
+        // * V1_14_11, V3, and V4 fail if state is bad
+        let run_with_account_data = |bytes: Vec<u8>| -> Result<(), InstructionError> {
+            let mut bad_vote_account =
+                AccountSharedData::new(rent.minimum_balance(bytes.len()), bytes.len(), &id());
+            bad_vote_account.set_data_from_slice(&bytes);
+            let transaction_context = new_transaction_context(
+                vec![
+                    (id(), processor_account.clone()),
+                    (vote_pubkey, bad_vote_account),
+                    (new_collector, collector_account.clone()),
+                ],
+                vec![
+                    InstructionAccount::new(1, false, true),
+                    InstructionAccount::new(2, false, true),
+                ],
+                &rent,
+            );
+            let instruction_context = transaction_context.get_next_instruction_context().unwrap();
+            let mut borrowed_vote_account = instruction_context
+                .try_borrow_instruction_account(0)
+                .unwrap();
+            update_commission_collector(
+                &mut borrowed_vote_account,
+                target_version,
+                NewCommissionCollector::NewAccount(
+                    instruction_context
+                        .try_borrow_instruction_account(1)
+                        .unwrap(),
+                ),
+                CommissionKind::InflationRewards,
+                &signers,
+                &rent,
+            )
+        };
+        let variant_with_short_body = |variant: u32| -> Vec<u8> {
+            let mut bytes = vec![0u8; 8];
+            bytes[..4].copy_from_slice(&variant.to_le_bytes());
+            bytes
+        };
+
+        // Should fail - V0_23_5 not supported.
+        assert_eq!(
+            run_with_account_data(variant_with_short_body(0)),
+            Err(InstructionError::InvalidAccountData),
+        );
+
+        // Should fail - Invalid V1_14_11 state.
+        assert_eq!(
+            run_with_account_data(variant_with_short_body(1)),
+            Err(InstructionError::InvalidAccountData),
+        );
+
+        // Should fail - Invalid V3 state.
+        assert_eq!(
+            run_with_account_data(variant_with_short_body(2)),
+            Err(InstructionError::InvalidAccountData),
+        );
+
+        // Should fail - Invalid V4 state.
+        assert_eq!(
+            run_with_account_data(variant_with_short_body(3)),
+            Err(InstructionError::InvalidAccountData),
+        );
 
         // Should fail - authorized withdrawer didn't sign.
         {


### PR DESCRIPTION
#### Problem
SIMD-0232 explicitly states to first check the number of accounts, which we do in other Vote program instructions via `instruction_context.check_number_of_instruction_accounts`.

We can also add some more test coverage to `UpdateCommissionCollector`.

#### Summary of Changes
For defense-in-depth, explicitly check the number of accounts at the top of the dispatch.

Note: this is not even a behavioral change, since `check_number_of_instruction_accounts` returns `MissingAccount` just like `get_key_of_instruction_account`.

Also, add some missing test coverage to for the `UpdateCommissionCollector` instruction, which I felt would be useful to cover.