### PR TITLE
[ABIv2] Refactor `MemoryContexts` to deal with ABIv2

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -541,7 +541,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
 
     invoke_context
         .memory_contexts
-        .set_memory_context(MemoryContext::new(
+        .set_memory_context_abi_v1(MemoryContext::new(
             BpfAllocator::new(heap_size as u64),
             account_lengths,
             memory_mapping,

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1906,8 +1906,16 @@ mod tests {
             aligned_memory_mapping: false,
             ..Config::default()
         };
-        *invoke_context.memory_contexts.memory_mapping_mut().unwrap() =
+        let mapping =
             unsafe { MemoryMapping::new(vec![region], &config, SBPFVersion::V3).unwrap() };
+        invoke_context
+            .memory_contexts
+            .set_memory_context_abi_v1(MemoryContext::new(
+                BpfAllocator::new(0),
+                Vec::new(),
+                mapping,
+            ))
+            .unwrap();
 
         let signers = translate_signers_rust(&program_id, vm_addr, 1, &invoke_context).unwrap();
         assert_eq!(signers[0], derived_key);

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1034,7 +1034,7 @@ where
     // only outside syscalls
     let accounts_metadata = &invoke_context
         .memory_contexts
-        .memory_context()
+        .memory_context_abi_v1()
         .unwrap()
         .accounts_metadata;
 
@@ -1875,7 +1875,7 @@ mod tests {
             unsafe { MemoryMapping::new(vec![region], &config, SBPFVersion::V3).unwrap() };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let ins = translate_instruction_rust(vm_addr, &invoke_context).unwrap();
         assert_eq!(ins.program_id, program_id);
@@ -1943,7 +1943,7 @@ mod tests {
 
         invoke_context
             .memory_contexts
-            .set_memory_context(MemoryContext::new(
+            .set_memory_context_abi_v1(MemoryContext::new(
                 BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
                 vec![account_metadata],
                 memory_mapping,
@@ -2035,7 +2035,7 @@ mod tests {
 
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         let check_aligned = invoke_context.get_check_aligned();
         let memory_mapping = invoke_context.memory_contexts.memory_mapping().unwrap();
         let caller_account = CallerAccount::from_account_info(
@@ -2094,7 +2094,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let mut caller_account = mock_caller_account.caller_account();
         let instruction_context = invoke_context
@@ -2157,7 +2157,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let data_slice = mock_caller_account.data_slice();
         let len_ptr = unsafe {

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -15,7 +15,7 @@ use {
         loaded_programs::{
             ProgramCacheForTxBatch, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
         },
-        memory_context::MemoryContexts,
+        memory_context::{MemoryContext, MemoryContexts},
         program_cache_entry::ProgramCacheEntryType,
         stable_log,
         sysvar_cache::SysvarCache,
@@ -29,7 +29,7 @@ use {
         error::{EbpfError, ProgramResult},
         memory_region::MemoryMapping,
         program::{BuiltinProgram, SBPFVersion},
-        vm::{ContextObject, EbpfVm},
+        vm::{Config, ContextObject, EbpfVm},
     },
     solana_sdk_ids::{
         bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4, native_loader,
@@ -296,7 +296,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             }
         }
 
-        self.memory_contexts.push();
+        self.memory_contexts.push_placeholder();
         self.transaction_context.push()
     }
 
@@ -607,6 +607,12 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         stable_log::program_invoke(&logger, &program_id, self.get_stack_height());
         let pre_remaining_units = self.get_remaining();
         // For now, only built-ins are invoked from here, so the VM and its Config are irrelevant.
+        self.memory_contexts
+            .set_memory_context_abi_v1(MemoryContext::new(
+                BpfAllocator::new(0),
+                Vec::new(),
+                MemoryMapping::new(Vec::new(), &Config::default(), SBPFVersion::Reserved).unwrap(),
+            ))?;
         let mut vm = EbpfVm::new(
             Arc::clone(
                 &**self

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -611,7 +611,12 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             .set_memory_context_abi_v1(MemoryContext::new(
                 BpfAllocator::new(0),
                 Vec::new(),
-                MemoryMapping::new(Vec::new(), &Config::default(), SBPFVersion::Reserved).unwrap(),
+                // SAFETY:
+                // This path invokes a builtin program, so this mapping is never used.
+                unsafe {
+                    MemoryMapping::new(Vec::new(), &Config::default(), SBPFVersion::Reserved)
+                        .unwrap()
+                },
             ))?;
         let mut vm = EbpfVm::new(
             Arc::clone(

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -15,7 +15,7 @@ use {
         loaded_programs::{
             ProgramCacheForTxBatch, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
         },
-        memory_context::{MemoryContext, MemoryContexts},
+        memory_context::MemoryContexts,
         program_cache_entry::ProgramCacheEntryType,
         stable_log,
         sysvar_cache::SysvarCache,
@@ -262,7 +262,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             compute_meter: ComputeMeter(Cell::new(compute_budget.compute_unit_limit)),
             total_nested_exec_time: Duration::ZERO,
             timings: ExecuteDetailsTimings::default(),
-            memory_contexts: MemoryContexts(Vec::new()),
+            memory_contexts: MemoryContexts::new(),
             register_traces: Vec::new(),
             #[cfg(feature = "sbpf-debugger")]
             debug_port: None,
@@ -296,13 +296,13 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             }
         }
 
-        self.memory_contexts.0.push(MemoryContext::empty());
+        self.memory_contexts.push();
         self.transaction_context.push()
     }
 
     /// Pop a stack frame from the invocation stack
     pub(crate) fn pop(&mut self) -> Result<(), InstructionError> {
-        self.memory_contexts.0.pop();
+        self.memory_contexts.pop();
         self.transaction_context.pop()
     }
 

--- a/program-runtime/src/memory_context.rs
+++ b/program-runtime/src/memory_context.rs
@@ -4,45 +4,96 @@ use {
     solana_sbpf::{memory_region::MemoryMapping, program::SBPFVersion, vm::Config},
 };
 
-pub struct MemoryContexts(pub Vec<MemoryContext>);
+enum MemoryContextType {
+    ABIv1(MemoryContext),
+    ABIv2,
+}
+
+pub struct MemoryContexts {
+    contexts: Vec<MemoryContextType>,
+    abiv2_mappings: Box<MemoryMapping>,
+}
 
 impl MemoryContexts {
+    pub(crate) fn new() -> Self {
+        Self {
+            contexts: Vec::new(),
+            abiv2_mappings: Box::new(
+                MemoryMapping::new(Vec::new(), &Config::default(), SBPFVersion::Reserved).unwrap(),
+            ),
+        }
+    }
+
     /// Set this instruction's [`MemoryContext`].
-    pub fn set_memory_context(
+    pub fn set_memory_context_abi_v1(
         &mut self,
         memory_context: MemoryContext,
     ) -> Result<(), InstructionError> {
-        *self.0.last_mut().ok_or(InstructionError::CallDepth)? = memory_context;
+        *self
+            .contexts
+            .last_mut()
+            .ok_or(InstructionError::CallDepth)? = MemoryContextType::ABIv1(memory_context);
         Ok(())
     }
 
     /// Get current instruction's [`MemoryContext`]
-    pub fn memory_context(&self) -> Result<&MemoryContext, InstructionError> {
-        self.0.last().ok_or(InstructionError::CallDepth)
+    pub fn memory_context_abi_v1(&self) -> Result<&MemoryContext, InstructionError> {
+        match self.contexts.last().ok_or(InstructionError::CallDepth)? {
+            MemoryContextType::ABIv1(ctx) => Ok(ctx),
+            MemoryContextType::ABIv2 => Err(InstructionError::InvalidAccountData),
+        }
     }
 
     /// Get current instruction's [`MemoryContext`] for mutable use.
-    pub fn memory_context_mut(&mut self) -> Result<&mut MemoryContext, InstructionError> {
-        self.0.last_mut().ok_or(InstructionError::CallDepth)
+    pub fn memory_context_mut_abi_v1(&mut self) -> Result<&mut MemoryContext, InstructionError> {
+        match self
+            .contexts
+            .last_mut()
+            .ok_or(InstructionError::CallDepth)?
+        {
+            MemoryContextType::ABIv1(ctx) => Ok(ctx),
+            MemoryContextType::ABIv2 => Err(InstructionError::ProgramEnvironmentSetupFailure),
+        }
     }
 
     pub fn memory_mapping(&self) -> Result<&MemoryMapping, InstructionError> {
-        let last_context = self.memory_context()?;
-        Ok(&last_context.memory_mapping)
+        let mapping = match self.contexts.last().ok_or(InstructionError::CallDepth)? {
+            MemoryContextType::ABIv1(ctx) => &ctx.memory_mapping,
+            MemoryContextType::ABIv2 => &self.abiv2_mappings,
+        };
+
+        Ok(mapping)
     }
 
     pub fn memory_mapping_mut(&mut self) -> Result<&mut MemoryMapping, InstructionError> {
-        let last_context = self.memory_context_mut()?;
-        Ok(&mut last_context.memory_mapping)
+        let mapping = match self
+            .contexts
+            .last_mut()
+            .ok_or(InstructionError::CallDepth)?
+        {
+            MemoryContextType::ABIv1(ctx) => &mut ctx.memory_mapping,
+            MemoryContextType::ABIv2 => &mut self.abiv2_mappings,
+        };
+
+        Ok(mapping)
     }
 
     #[cfg(feature = "dev-context-only-utils")]
-    pub fn mock_set_mapping(&mut self, memory_mapping: MemoryMapping) {
-        self.0 = vec![MemoryContext {
+    pub fn mock_set_mapping_abi_v1(&mut self, memory_mapping: MemoryMapping) {
+        self.contexts = vec![MemoryContextType::ABIv1(MemoryContext {
             allocator: BpfAllocator::new(0),
             accounts_metadata: vec![],
             memory_mapping: Box::new(memory_mapping),
-        }];
+        })];
+    }
+
+    pub fn push(&mut self) {
+        // We are only pushing a placeholder to be configured later
+        self.contexts.push(MemoryContextType::ABIv2);
+    }
+
+    pub fn pop(&mut self) {
+        self.contexts.pop();
     }
 }
 
@@ -65,18 +116,6 @@ impl MemoryContext {
             allocator,
             accounts_metadata,
             memory_mapping: Box::new(memory_mapping),
-        }
-    }
-
-    /// Returns an empty dummy context used for builtin functions
-    pub(crate) fn empty() -> Self {
-        Self {
-            allocator: BpfAllocator::new(0),
-            accounts_metadata: Vec::new(),
-            memory_mapping: Box::new(unsafe {
-                // SAFETY: no memory regions specified.
-                MemoryMapping::new(Vec::new(), &Config::default(), SBPFVersion::Reserved).unwrap()
-            }),
         }
     }
 }

--- a/program-runtime/src/memory_context.rs
+++ b/program-runtime/src/memory_context.rs
@@ -11,14 +11,14 @@ enum MemoryContextType {
 
 pub struct MemoryContexts {
     contexts: Vec<MemoryContextType>,
-    abiv2_mappings: Box<MemoryMapping>,
+    abi_v2_mapping: Box<MemoryMapping>,
 }
 
 impl MemoryContexts {
     pub(crate) fn new() -> Self {
         Self {
             contexts: Vec::new(),
-            abiv2_mappings: Box::new(
+            abi_v2_mapping: Box::new(
                 MemoryMapping::new(Vec::new(), &Config::default(), SBPFVersion::Reserved).unwrap(),
             ),
         }
@@ -59,7 +59,7 @@ impl MemoryContexts {
     pub fn memory_mapping(&self) -> Result<&MemoryMapping, InstructionError> {
         let mapping = match self.contexts.last().ok_or(InstructionError::CallDepth)? {
             MemoryContextType::ABIv1(ctx) => &ctx.memory_mapping,
-            MemoryContextType::ABIv2 => &self.abiv2_mappings,
+            MemoryContextType::ABIv2 => &self.abi_v2_mapping,
         };
 
         Ok(mapping)
@@ -72,7 +72,7 @@ impl MemoryContexts {
             .ok_or(InstructionError::CallDepth)?
         {
             MemoryContextType::ABIv1(ctx) => &mut ctx.memory_mapping,
-            MemoryContextType::ABIv2 => &mut self.abiv2_mappings,
+            MemoryContextType::ABIv2 => &mut self.abi_v2_mapping,
         };
 
         Ok(mapping)

--- a/program-runtime/src/memory_context.rs
+++ b/program-runtime/src/memory_context.rs
@@ -1,26 +1,21 @@
 use {
-    crate::invoke_context::BpfAllocator,
-    solana_instruction::error::InstructionError,
-    solana_sbpf::{memory_region::MemoryMapping, program::SBPFVersion, vm::Config},
+    crate::invoke_context::BpfAllocator, solana_instruction::error::InstructionError,
+    solana_sbpf::memory_region::MemoryMapping,
 };
 
 enum MemoryContextType {
     ABIv1(MemoryContext),
-    ABIv2,
+    Placeholder,
 }
 
 pub struct MemoryContexts {
     contexts: Vec<MemoryContextType>,
-    abi_v2_mapping: Box<MemoryMapping>,
 }
 
 impl MemoryContexts {
     pub(crate) fn new() -> Self {
         Self {
             contexts: Vec::new(),
-            abi_v2_mapping: Box::new(
-                MemoryMapping::new(Vec::new(), &Config::default(), SBPFVersion::Reserved).unwrap(),
-            ),
         }
     }
 
@@ -40,26 +35,29 @@ impl MemoryContexts {
     pub fn memory_context_abi_v1(&self) -> Result<&MemoryContext, InstructionError> {
         match self.contexts.last().ok_or(InstructionError::CallDepth)? {
             MemoryContextType::ABIv1(ctx) => Ok(ctx),
-            MemoryContextType::ABIv2 => Err(InstructionError::InvalidAccountData),
+            MemoryContextType::Placeholder => Err(InstructionError::ProgramEnvironmentSetupFailure),
         }
     }
 
     /// Get current instruction's [`MemoryContext`] for mutable use.
     pub fn memory_context_mut_abi_v1(&mut self) -> Result<&mut MemoryContext, InstructionError> {
-        match self
+        let context = self
             .contexts
             .last_mut()
-            .ok_or(InstructionError::CallDepth)?
-        {
+            .ok_or(InstructionError::CallDepth)?;
+
+        match context {
             MemoryContextType::ABIv1(ctx) => Ok(ctx),
-            MemoryContextType::ABIv2 => Err(InstructionError::ProgramEnvironmentSetupFailure),
+            MemoryContextType::Placeholder => Err(InstructionError::ProgramEnvironmentSetupFailure),
         }
     }
 
     pub fn memory_mapping(&self) -> Result<&MemoryMapping, InstructionError> {
         let mapping = match self.contexts.last().ok_or(InstructionError::CallDepth)? {
             MemoryContextType::ABIv1(ctx) => &ctx.memory_mapping,
-            MemoryContextType::ABIv2 => &self.abi_v2_mapping,
+            MemoryContextType::Placeholder => {
+                return Err(InstructionError::ProgramEnvironmentSetupFailure);
+            }
         };
 
         Ok(mapping)
@@ -72,7 +70,9 @@ impl MemoryContexts {
             .ok_or(InstructionError::CallDepth)?
         {
             MemoryContextType::ABIv1(ctx) => &mut ctx.memory_mapping,
-            MemoryContextType::ABIv2 => &mut self.abi_v2_mapping,
+            MemoryContextType::Placeholder => {
+                return Err(InstructionError::ProgramEnvironmentSetupFailure);
+            }
         };
 
         Ok(mapping)
@@ -87,9 +87,9 @@ impl MemoryContexts {
         })];
     }
 
-    pub fn push(&mut self) {
+    pub fn push_placeholder(&mut self) {
         // We are only pushing a placeholder to be configured later
-        self.contexts.push(MemoryContextType::ABIv2);
+        self.contexts.push(MemoryContextType::Placeholder);
     }
 
     pub fn pop(&mut self) {

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -170,7 +170,7 @@ unsafe fn set_memory_context<'b>(
 
     invoke_context
         .memory_contexts
-        .set_memory_context(MemoryContext::new(
+        .set_memory_context_abi_v1(MemoryContext::new(
             BpfAllocator::new(heap_size as u64),
             accounts_metadata,
             memory_mapping,
@@ -465,7 +465,7 @@ pub fn execute<'a, 'b: 'a>(
             parameter_bytes,
             &invoke_context
                 .memory_contexts
-                .memory_context()?
+                .memory_context_abi_v1()?
                 .accounts_metadata,
         )
     }

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -781,7 +781,7 @@ declare_builtin_function!(
         let Ok(layout) = Layout::from_size_align(size as usize, align) else {
             return Ok(0);
         };
-        let allocator = &mut invoke_context.memory_contexts.memory_context_mut()?.allocator;
+        let allocator = &mut invoke_context.memory_contexts.memory_context_mut_abi_v1()?.allocator;
         if free_addr == 0 {
             match allocator.alloc(layout) {
                 Ok(addr) => Ok(addr),
@@ -3043,7 +3043,7 @@ mod tests {
             unsafe { MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap() };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         let result = SyscallAbort::rust(&mut invoke_context, 0, 0, 0, 0, 0);
         result.unwrap();
     }
@@ -3068,7 +3068,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         invoke_context
             .compute_meter
             .mock_set_remaining(string.len() as u64 - 1);
@@ -3118,7 +3118,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(400 - 1);
         let result = SyscallLog::rust(
             &mut invoke_context,
@@ -3182,7 +3182,7 @@ mod tests {
             unsafe { MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap() };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         let result = SyscallLogU64::rust(&mut invoke_context, 1, 2, 3, 4, 5);
         result.unwrap();
 
@@ -3213,7 +3213,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let result = SyscallLogPubkey::rust(
             &mut invoke_context,
@@ -3259,7 +3259,7 @@ mod tests {
             let mapping = unsafe { MemoryMapping::new(regions, &config, SBPFVersion::V3).unwrap() };
             $invoke_context
                 .memory_contexts
-                .set_memory_context(MemoryContext::new(
+                .set_memory_context_abi_v1(MemoryContext::new(
                     BpfAllocator::new(solana_program_entrypoint::HEAP_LENGTH as u64),
                     Vec::new(),
                     mapping,
@@ -3384,7 +3384,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(
             (invoke_context.get_execution_cost().sha256_base_cost
                 + invoke_context.get_execution_cost().mem_op_base_cost.max(
@@ -3470,7 +3470,7 @@ mod tests {
 
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(
             (invoke_context
                 .get_execution_cost()
@@ -3545,7 +3545,7 @@ mod tests {
 
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(
             (invoke_context
                 .get_execution_cost()
@@ -3634,7 +3634,7 @@ mod tests {
 
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(
             (invoke_context
                 .get_execution_cost()
@@ -3787,7 +3787,7 @@ mod tests {
 
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(
             (invoke_context
                 .get_execution_cost()
@@ -3955,7 +3955,7 @@ mod tests {
 
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(
             invoke_context
                 .get_execution_cost()
@@ -4052,7 +4052,7 @@ mod tests {
         // test Edwards
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(500_000);
         let result = SyscallCurveMultiscalarMultiplication::rust(
             &mut invoke_context,
@@ -4238,7 +4238,7 @@ mod tests {
             };
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
 
             let result =
                 SyscallGetClockSysvar::rust(&mut invoke_context, got_clock_obj_va, 0, 0, 0, 0);
@@ -4299,7 +4299,7 @@ mod tests {
             };
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
 
             let result = SyscallGetEpochScheduleSysvar::rust(
                 &mut invoke_context,
@@ -4361,7 +4361,7 @@ mod tests {
             };
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
 
             let result = SyscallGetFeesSysvar::rust(&mut invoke_context, got_fees_va, 0, 0, 0, 0);
             assert_eq!(result.unwrap(), 0);
@@ -4398,7 +4398,7 @@ mod tests {
             };
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
 
             let result =
                 SyscallGetRentSysvar::rust(&mut invoke_context, got_rent_obj_va, 0, 0, 0, 0);
@@ -4453,7 +4453,7 @@ mod tests {
             };
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
 
             let result = SyscallGetEpochRewardsSysvar::rust(
                 &mut invoke_context,
@@ -4519,7 +4519,7 @@ mod tests {
             };
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
 
             let result = SyscallGetLastRestartSlotSysvar::rust(
                 &mut invoke_context,
@@ -4608,7 +4608,7 @@ mod tests {
             };
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
 
             let result = SyscallGetSysvar::rust(
                 &mut invoke_context,
@@ -4672,7 +4672,7 @@ mod tests {
             };
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
 
             let result = SyscallGetSysvar::rust(
                 &mut invoke_context,
@@ -4731,7 +4731,7 @@ mod tests {
             };
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
 
             // Abort: "Not all bytes in VM memory range `[sysvar_id, sysvar_id + 32)` are readable."
             let e = SyscallGetSysvar::rust(
@@ -4838,7 +4838,7 @@ mod tests {
             with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
 
             // "`1` if `offset + length` is greater than the length of the sysvar data."
             let result = SyscallGetSysvar::rust(
@@ -4917,7 +4917,7 @@ mod tests {
             unsafe { MemoryMapping::new(regions, &config, SBPFVersion::V3).unwrap() };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let result = syscall(
             invoke_context,
@@ -4989,7 +4989,7 @@ mod tests {
         prepare_mockup!(invoke_context, program_id, bpf_loader::id());
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let result =
             SyscallSetReturnData::rust(&mut invoke_context, SRC_VA, data.len() as u64, 0, 0, 0);
@@ -5104,7 +5104,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         let processed_sibling_instruction =
             unsafe { &mut *memory.as_mut_ptr().cast::<ProcessedSiblingInstruction>() };
         processed_sibling_instruction.data_len = 1;
@@ -5280,7 +5280,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         let processed_sibling_instruction =
             unsafe { &mut *memory.as_mut_ptr().cast::<ProcessedSiblingInstruction>() };
         processed_sibling_instruction.data_len = 2;
@@ -6040,7 +6040,7 @@ mod tests {
 
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
             let budget = invoke_context.get_execution_cost();
             invoke_context.compute_meter.mock_set_remaining(
                 budget.syscall_base_cost
@@ -6079,7 +6079,7 @@ mod tests {
             };
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
             let budget = invoke_context.get_execution_cost();
             invoke_context.compute_meter.mock_set_remaining(
                 budget.syscall_base_cost
@@ -6144,7 +6144,7 @@ mod tests {
             unsafe { MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap() };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let result =
             SyscallGetEpochStake::rust(&mut invoke_context, null_pointer_var, 0, 0, 0, 0).unwrap();
@@ -6218,7 +6218,7 @@ mod tests {
             };
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
 
             let result =
                 SyscallGetEpochStake::rust(&mut invoke_context, vote_address_var, 0, 0, 0, 0);
@@ -6248,7 +6248,7 @@ mod tests {
             };
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
 
             let result =
                 SyscallGetEpochStake::rust(&mut invoke_context, vote_address_var, 0, 0, 0, 0)
@@ -6280,7 +6280,7 @@ mod tests {
             };
             invoke_context
                 .memory_contexts
-                .mock_set_mapping(memory_mapping);
+                .mock_set_mapping_abi_v1(memory_mapping);
 
             let result =
                 SyscallGetEpochStake::rust(&mut invoke_context, vote_address_var, 0, 0, 0, 0)
@@ -6347,7 +6347,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let result = SyscallMemcmp::rust(&mut invoke_context, src_a, src_b, 4, 0x300000000, 0);
         result.unwrap();
@@ -6379,7 +6379,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let result = SyscallMemmove::rust(&mut invoke_context, dst, src, 4, 0, 0);
         result.unwrap();
@@ -6404,7 +6404,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let result = SyscallMemset::rust(&mut invoke_context, dst, value, 4, 0, 0);
         result.unwrap();
@@ -6429,7 +6429,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let result = SyscallMemcpy::rust(&mut invoke_context, dst, src, 4, 0, 0);
         assert_matches!(
@@ -6456,7 +6456,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let result = SyscallMemcpy::rust(&mut invoke_context, dst, src, 4, 0, 0);
         assert_access_violation!(result, fault_address, 4);
@@ -6482,7 +6482,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let result = SyscallMemset::rust(&mut invoke_context, dst, 0, 4, 0, 0);
         assert_access_violation!(result, dst, 4);
@@ -6503,7 +6503,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let result = SyscallMemcmp::rust(
             &mut invoke_context,
@@ -6604,7 +6604,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let bls12_381_g1_add_cost = invoke_context.get_execution_cost().bls12_381_g1_add_cost;
         invoke_context
@@ -6725,7 +6725,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let bls12_381_g1_subtract_cost = invoke_context
             .get_execution_cost()
@@ -6841,7 +6841,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let bls12_381_g1_multiply_cost = invoke_context
             .get_execution_cost()
@@ -6995,7 +6995,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let bls12_381_g2_add_cost = invoke_context.get_execution_cost().bls12_381_g2_add_cost;
         invoke_context
@@ -7148,7 +7148,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let bls12_381_g2_subtract_cost = invoke_context
             .get_execution_cost()
@@ -7285,7 +7285,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let bls12_381_g2_multiply_cost = invoke_context
             .get_execution_cost()
@@ -7406,7 +7406,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let bls12_381_one_pair_cost = invoke_context.get_execution_cost().bls12_381_one_pair_cost;
         invoke_context
@@ -7513,7 +7513,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let bls12_381_one_pair_cost = invoke_context.get_execution_cost().bls12_381_one_pair_cost;
         invoke_context
@@ -7595,7 +7595,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let bls12_381_g2_decompress_cost = invoke_context
             .get_execution_cost()
@@ -7707,7 +7707,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let bls12_381_g2_decompress_cost = invoke_context
             .get_execution_cost()
@@ -7786,7 +7786,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let bls12_381_g1_validate_cost = invoke_context
             .get_execution_cost()
@@ -7875,7 +7875,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
 
         let bls12_381_g2_validate_cost = invoke_context
             .get_execution_cost()

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -7981,7 +7981,7 @@ mod tests {
         };
         invoke_context
             .memory_contexts
-            .mock_set_mapping(memory_mapping);
+            .mock_set_mapping_abi_v1(memory_mapping);
         invoke_context.compute_meter.mock_set_remaining(
             (invoke_context.get_execution_cost().sha256_base_cost
                 + invoke_context.get_execution_cost().mem_op_base_cost.max(


### PR DESCRIPTION
#### Problem

This PR is the a split from https://github.com/anza-xyz/agave/pull/12063. The idea here is to allow `MemoryContexts` to deal with ABIv2 memory mappings.

#### Summary of Changes

1. Rename `set_memory_context` to `set_memory_context_abi_v1`.
2. Rename `memory_context` to `memory_context_abi_v1`, including the mutable version as well.