### PR TITLE
deps: Migrate from tiny-bip39 to canonical upstream bip39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,9 +1320,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "serde",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1339,6 +1352,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+dependencies = [
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -3348,6 +3370,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hidapi"
 version = "2.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5031,16 +5062,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
-]
-
-[[package]]
 name = "pcap-file"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5540,7 +5561,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -5561,7 +5582,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -6035,12 +6056,6 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -7304,6 +7319,7 @@ name = "solana-clap-utils"
 version = "4.2.0-alpha.0"
 dependencies = [
  "assert_matches",
+ "bip39",
  "bs58",
  "chrono",
  "clap 2.33.3",
@@ -7326,7 +7342,6 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "tempfile",
  "thiserror 2.0.18",
- "tiny-bip39",
  "uriparse",
  "url 2.5.8",
 ]
@@ -7336,6 +7351,7 @@ name = "solana-clap-v3-utils"
 version = "4.2.0-alpha.0"
 dependencies = [
  "assert_matches",
+ "bip39",
  "chrono",
  "clap 3.2.23",
  "five8",
@@ -7360,7 +7376,6 @@ dependencies = [
  "solana-zk-sdk 5.0.1",
  "tempfile",
  "thiserror 2.0.18",
- "tiny-bip39",
  "uriparse",
  "url 2.5.8",
 ]
@@ -7374,6 +7389,7 @@ dependencies = [
  "agave-votor-messages",
  "assert_matches",
  "bincode",
+ "bip39",
  "bs58",
  "clap 2.33.3",
  "console 0.16.3",
@@ -7447,7 +7463,6 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 2.0.18",
- "tiny-bip39",
  "tokio",
  "wincode",
 ]
@@ -8648,6 +8663,7 @@ name = "solana-keygen"
 version = "4.2.0-alpha.0"
 dependencies = [
  "agave-votor-messages",
+ "bip39",
  "bs58",
  "clap 3.2.23",
  "dirs-next",
@@ -8666,7 +8682,6 @@ dependencies = [
  "solana-signer",
  "solana-version",
  "tempfile",
- "tiny-bip39",
 ]
 
 [[package]]
@@ -10188,7 +10203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
 dependencies = [
  "hmac 0.12.1",
- "pbkdf2 0.11.0",
+ "pbkdf2",
  "sha2 0.10.9",
 ]
 
@@ -12206,23 +12221,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-bip39"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
-dependencies = [
- "once_cell",
- "pbkdf2 0.12.2",
- "rand 0.8.6",
- "rustc-hash 1.1.0",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "unicode-normalization",
- "wasm-bindgen",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,6 +202,7 @@ aya-ebpf = "0.1.1"
 base64 = "0.22.1"
 bencher = "0.1.5"
 bincode = "1.3.3"
+bip39 = { version = "2.2.2", features = ["rand", "all-languages"] }
 bitflags = { version = "2.11.1" }
 bitvec = { version = "1.0.1", features = ["serde"] }
 blake3 = "1.8.5"
@@ -546,7 +547,6 @@ tarpc = "0.29.0"
 tempfile = "3.27.0"
 test-case = "3.3.1"
 thiserror = "2.0.18"
-tiny-bip39 = "2.0.0"
 tokio = "1.52.3"
 tokio-serde = "0.8"
 tokio-stream = "0.1.18"

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -19,6 +19,7 @@ name = "solana_clap_utils"
 agave-unstable-api = []
 
 [dependencies]
+bip39 = { workspace = true }
 bs58 = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["default"] }
 clap = { version = "2.33.0", default-features = false, features = ["suggestions"] }
@@ -39,7 +40,6 @@ solana-seed-phrase = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 thiserror = { workspace = true }
-tiny-bip39 = { workspace = true }
 uriparse = { workspace = true }
 url = { workspace = true }
 

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -15,7 +15,7 @@ use {
         input_parsers::{STDOUT_OUTFILE_TOKEN, pubkeys_sigs_of},
         offline::{SIGN_ONLY_ARG, SIGNER_ARG},
     },
-    bip39::{Language, Mnemonic, Seed},
+    bip39::{Language, Mnemonic},
     clap::ArgMatches,
     rpassword::prompt_password,
     solana_derivation_path::{DerivationPath, DerivationPathError},
@@ -1065,15 +1065,15 @@ pub fn keypair_from_seed_phrase(
         let parse_language_fn = || {
             for language in &[
                 Language::English,
-                Language::ChineseSimplified,
-                Language::ChineseTraditional,
+                Language::SimplifiedChinese,
+                Language::TraditionalChinese,
                 Language::Japanese,
                 Language::Spanish,
                 Language::Korean,
                 Language::French,
                 Language::Italian,
             ] {
-                if let Ok(mnemonic) = Mnemonic::from_phrase(&sanitized, *language) {
+                if let Ok(mnemonic) = Mnemonic::parse_in(*language, &sanitized) {
                     return Ok(mnemonic);
                 }
             }
@@ -1081,11 +1081,11 @@ pub fn keypair_from_seed_phrase(
         };
         let mnemonic = parse_language_fn()?;
         let passphrase = prompt_passphrase(&passphrase_prompt)?;
-        let seed = Seed::new(&mnemonic, &passphrase);
+        let seed = mnemonic.to_seed(&passphrase);
         if legacy {
-            keypair_from_seed(seed.as_bytes())?
+            keypair_from_seed(&seed)?
         } else {
-            keypair_from_seed_and_derivation_path(seed.as_bytes(), derivation_path)?
+            keypair_from_seed_and_derivation_path(&seed, derivation_path)?
         }
     };
 

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -20,6 +20,7 @@ agave-unstable-api = []
 elgamal = ["dep:solana-zk-sdk"]
 
 [dependencies]
+bip39 = { workspace = true }
 chrono = { workspace = true, features = ["default"] }
 clap = { version = "3.2.23", default-features = false, features = ["cargo", "std", "suggestions"] }
 five8 = { workspace = true }
@@ -42,7 +43,6 @@ solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-zk-sdk = { workspace = true, optional = true }
 thiserror = { workspace = true }
-tiny-bip39 = { workspace = true }
 uriparse = { workspace = true }
 url = { workspace = true }
 

--- a/clap-v3-utils/src/keygen/mnemonic.rs
+++ b/clap-v3-utils/src/keygen/mnemonic.rs
@@ -85,8 +85,8 @@ pub fn acquire_language(matches: &ArgMatches) -> Language {
     let language_name = LANGUAGE_ARG.name;
     match matches.get_one::<String>(language_name).unwrap().as_str() {
         "english" => Language::English,
-        "chinese-simplified" => Language::ChineseSimplified,
-        "chinese-traditional" => Language::ChineseTraditional,
+        "chinese-simplified" => Language::SimplifiedChinese,
+        "chinese-traditional" => Language::TraditionalChinese,
         "japanese" => Language::Japanese,
         "spanish" => Language::Spanish,
         "korean" => Language::Korean,
@@ -101,8 +101,8 @@ pub fn try_get_language(matches: &ArgMatches) -> Result<Option<Language>, Box<dy
         .try_get_one::<String>(LANGUAGE_ARG.name)?
         .map(|language| match language.as_str() {
             "english" => Language::English,
-            "chinese-simplified" => Language::ChineseSimplified,
-            "chinese-traditional" => Language::ChineseTraditional,
+            "chinese-simplified" => Language::SimplifiedChinese,
+            "chinese-traditional" => Language::TraditionalChinese,
             "japanese" => Language::Japanese,
             "spanish" => Language::Spanish,
             "korean" => Language::Korean,

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -17,7 +17,7 @@ use {
         input_parsers::signer::{SignerSource, SignerSourceKind, try_pubkeys_sigs_of},
         offline::{SIGN_ONLY_ARG, SIGNER_ARG},
     },
-    bip39::{Language, Mnemonic, Seed},
+    bip39::{Language, Mnemonic},
     clap::ArgMatches,
     rpassword::prompt_password,
     solana_derivation_path::DerivationPath,
@@ -1186,15 +1186,15 @@ fn encodable_key_from_seed_phrase<K: EncodableKey + SeedDerivable>(
         let parse_language_fn = || {
             for language in &[
                 Language::English,
-                Language::ChineseSimplified,
-                Language::ChineseTraditional,
+                Language::SimplifiedChinese,
+                Language::TraditionalChinese,
                 Language::Japanese,
                 Language::Spanish,
                 Language::Korean,
                 Language::French,
                 Language::Italian,
             ] {
-                if let Ok(mnemonic) = Mnemonic::from_phrase(&sanitized, *language) {
+                if let Ok(mnemonic) = Mnemonic::parse_in(*language, &sanitized) {
                     return Ok(mnemonic);
                 }
             }
@@ -1202,11 +1202,11 @@ fn encodable_key_from_seed_phrase<K: EncodableKey + SeedDerivable>(
         };
         let mnemonic = parse_language_fn()?;
         let passphrase = prompt_passphrase(&passphrase_prompt)?;
-        let seed = Seed::new(&mnemonic, &passphrase);
+        let seed = mnemonic.to_seed(&passphrase);
         if legacy {
-            K::from_seed(seed.as_bytes())?
+            K::from_seed(&seed)?
         } else {
-            K::from_seed_and_derivation_path(seed.as_bytes(), derivation_path)?
+            K::from_seed_and_derivation_path(&seed, derivation_path)?
         }
     };
     Ok(key)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,6 +31,7 @@ agave-feature-set = { workspace = true }
 agave-logger = { workspace = true }
 agave-votor-messages = { workspace = true }
 bincode = { workspace = true }
+bip39 = { workspace = true }
 bs58 = { workspace = true }
 clap = { workspace = true }
 console = { workspace = true }
@@ -93,7 +94,6 @@ solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
 spl-memo-interface = { workspace = true }
 thiserror = { workspace = true }
-tiny-bip39 = { workspace = true }
 tokio = { workspace = true }
 wincode = { workspace = true }
 

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -12,7 +12,7 @@ use {
         feature::{CliFeatureStatus, status_from_account},
     },
     agave_feature_set::{FEATURE_NAMES, FeatureSet},
-    bip39::{Language, Mnemonic, MnemonicType, Seed},
+    bip39::{Language, Mnemonic},
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand},
     log::*,
     solana_account::state_traits::StateMut,
@@ -3259,15 +3259,15 @@ async fn send_deploy_messages(
 fn create_ephemeral_keypair()
 -> Result<(usize, bip39::Mnemonic, Keypair), Box<dyn std::error::Error>> {
     const WORDS: usize = 12;
-    let mnemonic = Mnemonic::new(MnemonicType::for_word_count(WORDS)?, Language::English);
-    let seed = Seed::new(&mnemonic, "");
-    let new_keypair = keypair_from_seed(seed.as_bytes())?;
+    let mnemonic = Mnemonic::generate_in(Language::English, WORDS)?;
+    let seed = mnemonic.to_seed("");
+    let new_keypair = keypair_from_seed(&seed)?;
 
     Ok((WORDS, mnemonic, new_keypair))
 }
 
 fn report_ephemeral_mnemonic(words: usize, mnemonic: bip39::Mnemonic, ephemeral_pubkey: &Pubkey) {
-    let phrase: &str = mnemonic.phrase();
+    let phrase = mnemonic.to_string();
     let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
     eprintln!("{divider}\nRecover the intermediate account's ephemeral keypair file with");
     eprintln!("`solana-keygen recover` and the following {words}-word seed phrase:");

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -1144,9 +1144,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+dependencies = [
+ "hex-conservative",
 ]
 
 [[package]]
@@ -2878,6 +2900,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4407,16 +4438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
-]
-
-[[package]]
 name = "pem"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4798,7 +4819,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -4819,7 +4840,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -5272,12 +5293,6 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -6363,6 +6378,7 @@ dependencies = [
 name = "solana-clap-utils"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "bip39",
  "bs58",
  "chrono",
  "clap",
@@ -6383,7 +6399,6 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "thiserror 2.0.18",
- "tiny-bip39",
  "uriparse",
  "url 2.5.8",
 ]
@@ -8555,7 +8570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
 dependencies = [
  "hmac 0.12.1",
- "pbkdf2 0.11.0",
+ "pbkdf2",
  "sha2 0.10.9",
 ]
 
@@ -10260,23 +10275,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-bip39"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
-dependencies = [
- "once_cell",
- "pbkdf2 0.12.2",
- "rand 0.8.6",
- "rustc-hash 1.1.0",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "unicode-normalization",
- "wasm-bindgen",
- "zeroize",
 ]
 
 [[package]]

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -24,6 +24,7 @@ remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
 agave-votor-messages = { workspace = true }
+bip39 = { workspace = true }
 bs58 = { workspace = true, features = ["std"] }
 clap = { version = "3.1.5", default-features = false, features = ["cargo", "std", "suggestions"] }
 dirs-next = { workspace = true }
@@ -41,7 +42,6 @@ solana-remote-wallet = { workspace = true }
 solana-seed-derivable = { workspace = true }
 solana-signer = "=3.0.0"
 solana-version = { workspace = true }
-tiny-bip39 = { workspace = true }
 
 [dev-dependencies]
 solana-pubkey = { workspace = true, features = ["rand"] }

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
     agave_votor_messages::consensus_message::BLS_KEYPAIR_DERIVE_SEED,
-    bip39::{Mnemonic, MnemonicType, Seed},
+    bip39::Mnemonic,
     clap::{
         Arg, ArgAction, ArgMatches, Command, builder::ValueParser, crate_description, crate_name,
         value_parser,
@@ -570,7 +570,6 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             }
 
             let word_count = try_get_word_count(matches)?.unwrap();
-            let mnemonic_type = MnemonicType::for_word_count(word_count)?;
             let language = try_get_language(matches)?.unwrap();
 
             let silent = matches.try_contains_id("silent")?;
@@ -580,14 +579,15 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
 
             let derivation_path = acquire_derivation_path(matches)?;
 
-            let mnemonic = Mnemonic::new(mnemonic_type, language);
+            let mnemonic = Mnemonic::generate_in(language, word_count)
+                .map_err(|e| format!("Unable to generate mnemonic: {e}"))?;
             let (passphrase, passphrase_message) = acquire_passphrase_and_message(matches)
                 .map_err(|err| format!("Unable to acquire passphrase: {err}"))?;
 
-            let seed = Seed::new(&mnemonic, &passphrase);
+            let seed = mnemonic.to_seed(&passphrase);
             let keypair = match derivation_path {
-                Some(_) => keypair_from_seed_and_derivation_path(seed.as_bytes(), derivation_path),
-                None => keypair_from_seed(seed.as_bytes()),
+                Some(_) => keypair_from_seed_and_derivation_path(&seed, derivation_path),
+                None => keypair_from_seed(&seed),
             }?;
 
             if let Some(outfile) = outfile {
@@ -596,7 +596,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             }
 
             if !silent {
-                let phrase: &str = mnemonic.phrase();
+                let phrase = mnemonic.to_string();
                 let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
                 println!(
                     "{}\npubkey: {}\n{}\nSave this seed phrase{} to recover your new \
@@ -605,7 +605,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                     keypair.pubkey(),
                     &divider,
                     passphrase_message,
-                    phrase,
+                    &phrase,
                     &divider
                 );
             }
@@ -709,7 +709,6 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             let derivation_path = acquire_derivation_path(matches)?;
 
             let word_count = try_get_word_count(matches)?.unwrap();
-            let mnemonic_type = MnemonicType::for_word_count(word_count)?;
             let language = try_get_language(matches)?.unwrap();
 
             let (passphrase, passphrase_message) = if use_mnemonic {
@@ -777,17 +776,18 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                                 );
                             }
                             let (keypair, phrase) = if use_mnemonic {
-                                let mnemonic = Mnemonic::new(mnemonic_type, language);
-                                let seed = Seed::new(&mnemonic, &passphrase);
+                                let mnemonic = Mnemonic::generate_in(language, word_count)
+                                    .expect("CLI word count is always a valid BIP39 length");
+                                let seed = mnemonic.to_seed(&passphrase);
                                 let keypair = match derivation_path {
                                     Some(_) => keypair_from_seed_and_derivation_path(
-                                        seed.as_bytes(),
+                                        &seed,
                                         derivation_path.clone(),
                                     ),
-                                    None => keypair_from_seed(seed.as_bytes()),
+                                    None => keypair_from_seed(&seed),
                                 }
                                 .unwrap();
-                                (keypair, mnemonic.phrase().to_string())
+                                (keypair, mnemonic.to_string())
                             } else {
                                 (Keypair::new(), "".to_string())
                             };

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1114,9 +1114,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+dependencies = [
+ "hex-conservative",
 ]
 
 [[package]]
@@ -2777,6 +2799,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4348,16 +4379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
-]
-
-[[package]]
 name = "pem"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4723,7 +4744,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -4744,7 +4765,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -5180,12 +5201,6 @@ name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -6226,6 +6241,7 @@ dependencies = [
 name = "solana-clap-utils"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "bip39",
  "bs58",
  "chrono",
  "clap",
@@ -6246,7 +6262,6 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "thiserror 2.0.18",
- "tiny-bip39",
  "uriparse",
  "url 2.5.8",
 ]
@@ -9093,7 +9108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
 dependencies = [
  "hmac 0.12.1",
- "pbkdf2 0.11.0",
+ "pbkdf2",
  "sha2 0.10.9",
 ]
 
@@ -10791,23 +10806,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-bip39"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
-dependencies = [
- "once_cell",
- "pbkdf2 0.12.2",
- "rand 0.8.6",
- "rustc-hash 1.1.0",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "unicode-normalization",
- "wasm-bindgen",
- "zeroize",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
tiny-bip39 is no longer being maintained. Use a more canonical bip39 source

#### Summary of Changes

* Use bip39