### PR TITLE
shred: refactor and encapsulate shred filter logic

### DIFF
--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -2,18 +2,11 @@
 
 use {
     crate::repair::{repair_service::OutstandingShredRepairs, serve_repair::ServeRepair},
-    agave_feature_set::FeatureSet,
-    solana_clock::Slot,
-    solana_epoch_schedule::EpochSchedule,
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
-    solana_ledger::shred::{self, ShredFetchStats, should_discard_shred},
+    solana_ledger::shred::{self, filter::ShredFilterContext},
     solana_perf::packet::{PacketBatch, PacketBatchRecycler, PacketFlags, PacketRef},
-    solana_pubkey::Pubkey,
-    solana_runtime::{
-        bank::Bank,
-        bank_forks::{BankForks, SharableBanks},
-    },
+    solana_runtime::bank_forks::{BankForks, SharableBanks},
     solana_streamer::{
         evicting_sender::EvictingSender,
         streamer::{self, ChannelSend, PacketBatchReceiver, StreamerReceiveStats},
@@ -25,7 +18,7 @@ use {
             atomic::{AtomicBool, Ordering},
         },
         thread::{self, Builder, JoinHandle},
-        time::{Duration, Instant},
+        time::Duration,
     },
 };
 
@@ -48,45 +41,6 @@ struct RepairContext {
     outstanding_repair_requests: Arc<RwLock<OutstandingShredRepairs>>,
 }
 
-struct ShredFilterContext {
-    last_updated: Instant,
-    last_root: u64,
-    slots_per_epoch: u64,
-    feature_set: Arc<FeatureSet>,
-    epoch_schedule: EpochSchedule,
-    keypair: Option<Arc<Keypair>>,
-}
-
-impl ShredFilterContext {
-    // When running with very short epochs (e.g. for testing), we want to avoid
-    // filtering out shreds that we actually need. This value was chosen empirically
-    // because it's large enough to protect against observed short epoch problems
-    // while being small enough to keep the overhead small on deduper, blockstore,
-    // etc.
-    const MAX_SHRED_DISTANCE_MINIMUM: u64 = 500;
-
-    fn new(root_bank: Arc<Bank>, repair_context: Option<&RepairContext>) -> ShredFilterContext {
-        Self {
-            last_updated: Instant::now(),
-            last_root: root_bank.slot(),
-            slots_per_epoch: root_bank.get_slots_in_epoch(root_bank.epoch()),
-            feature_set: root_bank.feature_set.clone(),
-            epoch_schedule: root_bank.epoch_schedule().clone(),
-            keypair: repair_context.as_ref().copied().map(RepairContext::keypair),
-        }
-    }
-
-    fn maybe_update(&mut self, root_bank: Arc<Bank>, repair_context: Option<&RepairContext>) {
-        if self.last_updated.elapsed().as_nanos() > root_bank.ns_per_slot {
-            *self = Self::new(root_bank, repair_context);
-        }
-    }
-
-    fn max_slot(&self) -> u64 {
-        self.last_root + Self::MAX_SHRED_DISTANCE_MINIMUM.max(2 * self.slots_per_epoch)
-    }
-}
-
 impl ShredFetchStage {
     // updates packets received on a channel and sends them on another channel
     fn modify_packets(
@@ -106,22 +60,22 @@ impl ShredFetchStage {
             repair_context.is_some()
         );
         const STATS_SUBMIT_CADENCE: Duration = Duration::from_secs(1);
-        let mut shred_filter_ctx = ShredFilterContext::new(sharable_banks.root(), repair_context);
-        let mut stats = ShredFetchStats::default();
+        let mut shred_filter_ctx = ShredFilterContext::new(sharable_banks.root(), shred_version);
+        let repair_keypair = repair_context.map(RepairContext::keypair);
 
         for mut packet_batch in recvr {
-            shred_filter_ctx.maybe_update(sharable_banks.root(), repair_context);
-            stats.shred_count += packet_batch.len();
+            shred_filter_ctx.maybe_update(sharable_banks.root());
+            shred_filter_ctx.stats.shred_count += packet_batch.len();
 
             if let Some(repair_context) = repair_context {
                 debug_assert_eq!(flags, PacketFlags::REPAIR);
-                debug_assert!(shred_filter_ctx.keypair.is_some());
-                if let Some(ref keypair) = shred_filter_ctx.keypair {
+                debug_assert!(repair_keypair.is_some());
+                if let Some(ref keypair) = repair_keypair {
                     ServeRepair::handle_repair_response_pings(
                         &repair_context.repair_socket,
                         keypair,
                         &mut packet_batch,
-                        &mut stats,
+                        &mut shred_filter_ctx.stats,
                     );
                 }
                 // Discard packets if repair nonce does not verify.
@@ -147,33 +101,15 @@ impl ShredFetchStage {
 
             // Filter out shreds that are way too far in the future to avoid the
             // overhead of having to hold onto them.
-            let max_slot = shred_filter_ctx.max_slot();
-            let discard_unexpected_data_complete_shreds = |shred_slot| {
-                check_feature_activation(
-                    &agave_feature_set::discard_unexpected_data_complete_shreds::id(),
-                    shred_slot,
-                    &shred_filter_ctx.feature_set,
-                    &shred_filter_ctx.epoch_schedule,
-                )
-            };
             let turbine_disabled = turbine_disabled.load(Ordering::Relaxed);
             for mut packet in packet_batch.iter_mut().filter(|p| !p.meta().discard()) {
-                if turbine_disabled
-                    || should_discard_shred(
-                        packet.as_ref(),
-                        shred_filter_ctx.last_root,
-                        max_slot,
-                        shred_version,
-                        discard_unexpected_data_complete_shreds,
-                        &mut stats,
-                    )
-                {
+                if turbine_disabled || shred_filter_ctx.should_discard_packet(packet.as_ref()) {
                     packet.meta_mut().set_discard(true);
                 } else {
                     packet.meta_mut().flags.insert(flags);
                 }
             }
-            if stats.maybe_submit(name, STATS_SUBMIT_CADENCE) {
+            if shred_filter_ctx.maybe_submit_stats(name, STATS_SUBMIT_CADENCE) {
                 if let Some(stats) = recvr_stats.as_ref() {
                     stats.report();
                 }
@@ -181,7 +117,7 @@ impl ShredFetchStage {
             if let Err(send_err) = sendr.try_send(packet_batch) {
                 match send_err {
                     crossbeam_channel::TrySendError::Full(v) => {
-                        stats.overflow_shreds += v.len();
+                        shred_filter_ctx.stats.overflow_shreds += v.len();
                     }
                     _ => unreachable!("EvictingSender holds on to both ends of the channel"),
                 }
@@ -332,22 +268,4 @@ fn verify_repair_nonce(
     outstanding_repair_requests
         .register_response(nonce, shred, now, |_| ())
         .is_some()
-}
-
-// Returns true if the feature is effective for the shred slot.
-#[must_use]
-fn check_feature_activation(
-    feature: &Pubkey,
-    shred_slot: Slot,
-    feature_set: &FeatureSet,
-    epoch_schedule: &EpochSchedule,
-) -> bool {
-    match feature_set.activated_slot(feature) {
-        None => false,
-        Some(feature_slot) => {
-            let feature_epoch = epoch_schedule.get_epoch(feature_slot);
-            let shred_epoch = epoch_schedule.get_epoch(shred_slot);
-            feature_epoch < shred_epoch
-        }
-    }
 }

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -26,7 +26,6 @@ use {
     solana_rayon_threadlimit::get_thread_count,
     solana_runtime::bank_forks::BankForks,
     solana_streamer::evicting_sender::EvictingSender,
-    solana_turbine::cluster_nodes,
     std::{
         borrow::Cow,
         net::UdpSocket,
@@ -121,7 +120,7 @@ fn run_check_duplicate(
             root_bank = bank_forks.read().unwrap().root_bank();
         }
         let shred_slot = shred.slot();
-        let validate_chained_block_id = cluster_nodes::check_feature_activation(
+        let validate_chained_block_id = shred::filter::check_feature_activation_from_bank(
             &feature_set::validate_chained_block_id::id(),
             shred_slot,
             &root_bank,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -52,7 +52,6 @@
 pub(crate) use self::merkle_tree::PROOF_ENTRIES_FOR_32_32_BATCH;
 use {
     self::traits::{Shred as _, ShredData as _},
-    crate::blockstore::{self},
     assert_matches::debug_assert_matches,
     bitflags::bitflags,
     num_enum::{IntoPrimitive, TryFromPrimitive},
@@ -60,7 +59,6 @@ use {
     solana_clock::Slot,
     solana_entry::entry::{Entry, create_ticks},
     solana_hash::Hash,
-    solana_perf::packet::PacketRef,
     solana_pubkey::Pubkey,
     solana_sha256_hasher::hashv,
     solana_signature::{SIGNATURE_BYTES, Signature},
@@ -81,10 +79,13 @@ pub use {
     },
     crate::shredder::{ReedSolomonCache, Shredder},
 };
+#[cfg(test)]
+use {rand::Rng, rayon::ThreadPoolBuilder};
 #[cfg(any(test, feature = "dev-context-only-utils"))]
 use {solana_keypair::Keypair, solana_perf::packet::Packet, solana_signer::Signer};
 
 mod common;
+pub mod filter;
 pub mod merkle;
 pub mod merkle_tree;
 mod payload;
@@ -720,196 +721,6 @@ pub fn recover<T: IntoIterator<Item = Shred>>(
     Ok(shreds.map(|shred| shred.map(Shred::from)))
 }
 
-// Accepts shreds in the slot range [root + 1, max_slot].
-#[must_use]
-pub fn should_discard_shred<'a, P>(
-    packet: P,
-    root: Slot,
-    max_slot: Slot,
-    shred_version: u16,
-    discard_unexpected_data_complete_shreds: impl Fn(Slot) -> bool,
-    stats: &mut ShredFetchStats,
-) -> bool
-where
-    P: Into<PacketRef<'a>>,
-{
-    should_discard_shred_with_custom_shred_limits(
-        packet,
-        root,
-        max_slot,
-        shred_version,
-        discard_unexpected_data_complete_shreds,
-        |_| MAX_DATA_SHREDS_PER_SLOT as u32,
-        |_| MAX_CODE_SHREDS_PER_SLOT as u32,
-        stats,
-    )
-}
-
-#[must_use]
-pub fn should_discard_shred_with_custom_shred_limits<'a, P>(
-    packet: P,
-    root: Slot,
-    max_slot: Slot,
-    shred_version: u16,
-    discard_unexpected_data_complete_shreds: impl Fn(Slot) -> bool,
-    max_data_shreds_per_slot: impl Fn(Slot) -> u32,
-    max_code_shreds_per_slot: impl Fn(Slot) -> u32,
-    stats: &mut ShredFetchStats,
-) -> bool
-where
-    P: Into<PacketRef<'a>>,
-{
-    debug_assert!(root < max_slot);
-    let Some(shred) = layout::get_shred(packet) else {
-        stats.index_overrun += 1;
-        return true;
-    };
-    match layout::get_version(shred) {
-        None => {
-            stats.index_overrun += 1;
-            return true;
-        }
-        Some(version) => {
-            if version != shred_version {
-                stats.shred_version_mismatch += 1;
-                return true;
-            }
-        }
-    }
-    let Ok(shred_variant) = layout::get_shred_variant(shred) else {
-        stats.bad_shred_type += 1;
-        return true;
-    };
-    let slot = match layout::get_slot(shred) {
-        Some(slot) => {
-            if slot > max_slot {
-                stats.slot_out_of_range += 1;
-                return true;
-            }
-            slot
-        }
-        None => {
-            stats.slot_bad_deserialize += 1;
-            return true;
-        }
-    };
-    let Some(index) = layout::get_index(shred) else {
-        stats.index_bad_deserialize += 1;
-        return true;
-    };
-    let Some(fec_set_index) = layout::get_fec_set_index(shred) else {
-        stats.fec_set_index_bad_deserialize += 1;
-        return true;
-    };
-
-    match ShredType::from(shred_variant) {
-        ShredType::Code => {
-            if index >= max_code_shreds_per_slot(slot) {
-                stats.index_out_of_bounds += 1;
-                return true;
-            }
-            if slot <= root {
-                stats.slot_out_of_range += 1;
-                return true;
-            }
-
-            let Ok(erasure_config) = layout::get_erasure_config(shred) else {
-                stats.erasure_config_bad_deserialize += 1;
-                return true;
-            };
-
-            if !erasure_config.is_fixed() {
-                stats.misaligned_erasure_config += 1;
-                return true;
-            }
-        }
-        ShredType::Data => {
-            if index >= max_data_shreds_per_slot(slot) {
-                stats.index_out_of_bounds += 1;
-                return true;
-            }
-            let Some(parent_offset) = layout::get_parent_offset(shred) else {
-                stats.bad_parent_offset += 1;
-                return true;
-            };
-            let Some(parent) = slot.checked_sub(Slot::from(parent_offset)) else {
-                stats.bad_parent_offset += 1;
-                return true;
-            };
-            if !blockstore::verify_shred_slots(slot, parent, root) {
-                stats.slot_out_of_range += 1;
-                return true;
-            }
-
-            let Ok(shred_flags) = layout::get_flags(shred) else {
-                stats.shred_flags_bad_deserialize += 1;
-                return true;
-            };
-
-            let expected_data_complete_index = fec_set_index
-                .checked_add(DATA_SHREDS_PER_FEC_BLOCK as u32)
-                .and_then(|index| index.checked_sub(1));
-            if shred_flags.contains(ShredFlags::DATA_COMPLETE_SHRED)
-                && (expected_data_complete_index != Some(index))
-            {
-                stats.unexpected_data_complete_shred += 1;
-
-                if discard_unexpected_data_complete_shreds(slot) {
-                    return true;
-                }
-            }
-
-            if shred_flags.contains(ShredFlags::LAST_SHRED_IN_SLOT)
-                && !check_last_data_shred_index(index)
-            {
-                stats.misaligned_last_data_index += 1;
-                return true;
-            }
-        }
-    }
-
-    if !check_fixed_fec_set(index, fec_set_index) {
-        stats.misaligned_fec_set += 1;
-        return true;
-    }
-
-    match shred_variant {
-        ShredVariant::MerkleCode { .. } => {
-            stats.num_shreds_merkle_code_chained =
-                stats.num_shreds_merkle_code_chained.saturating_add(1);
-        }
-        ShredVariant::MerkleData { .. } => {
-            stats.num_shreds_merkle_data_chained =
-                stats.num_shreds_merkle_data_chained.saturating_add(1);
-        }
-    }
-    false
-}
-
-/// Returns true if `index` and `fec_set_index` are valid under the assumption that
-/// all erasure sets contain exactly `DATA_SHREDS_PER_FEC_BLOCK` data and coding shreds:
-/// - `index` is between `fec_set_index` and `fec_set_index + DATA_SHREDS_PER_FEC_BLOCK`
-/// - `fec_set_index` is a multiple of `DATA_SHREDS_PER_FEC_BLOCK`
-fn check_fixed_fec_set(index: u32, fec_set_index: u32) -> bool {
-    let Some(fec_set_end_exclusive) = fec_set_index.checked_add(DATA_SHREDS_PER_FEC_BLOCK as u32)
-    else {
-        return false;
-    };
-    index >= fec_set_index
-        && index < fec_set_end_exclusive
-        && fec_set_index.is_multiple_of(DATA_SHREDS_PER_FEC_BLOCK as u32)
-}
-
-/// Returns true if `index` of the last data shred is valid under the assumption that
-/// all erasure sets contain exactly `DATA_SHREDS_PER_FEC_BLOCK` data and coding shreds:
-/// - `index + 1` must be a multiple of `DATA_SHREDS_PER_FEC_BLOCK`
-///
-/// Note: this check is critical to verify that the last fec set is sufficiently sized.
-/// This is checked during shred ingest with `enforce_fixed_fec_set` active.
-fn check_last_data_shred_index(index: u32) -> bool {
-    (index + 1).is_multiple_of(DATA_SHREDS_PER_FEC_BLOCK as u32)
-}
-
 pub fn max_ticks_per_n_shreds(num_shreds: u64, shred_data_size: Option<usize>) -> u64 {
     let ticks = create_ticks(1, 0, Hash::default());
     max_entries_per_n_shred(&ticks[0], num_shreds, shred_data_size)
@@ -991,65 +802,63 @@ pub fn verify_test_data_shred(
 }
 
 #[cfg(test)]
+pub(crate) fn make_merkle_shreds_for_tests<R: Rng>(
+    rng: &mut R,
+    slot: Slot,
+    data_size: usize,
+    is_last_in_slot: bool,
+) -> Result<Vec<merkle::Shred>, Error> {
+    let thread_pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
+    let chained_merkle_root = Hash::new_from_array(rng.random());
+    let parent_offset = rng.random_range(1..=u16::try_from(slot).unwrap_or(u16::MAX));
+    let parent_slot = slot.checked_sub(u64::from(parent_offset)).unwrap();
+    let mut data = vec![0u8; data_size];
+    let fec_set_index = rng.random_range(0..21) * DATA_SHREDS_PER_FEC_BLOCK as u32;
+    rng.fill(&mut data[..]);
+    merkle::make_shreds_from_data(
+        &thread_pool,
+        &Keypair::new(),
+        chained_merkle_root,
+        &data[..],
+        slot,
+        parent_slot,
+        rng.random(),            // shred_version
+        rng.random_range(1..64), // reference_tick
+        is_last_in_slot,
+        fec_set_index, // next_shred_index
+        fec_set_index, // next_code_index
+        &ReedSolomonCache::default(),
+        &mut ProcessShredsStats::default(),
+    )
+}
+
+#[cfg(test)]
 mod tests {
     use {
         super::*,
         assert_matches::assert_matches,
-        itertools::Itertools,
-        rand::Rng,
         rand_chacha::{ChaChaRng, rand_core::SeedableRng},
-        rayon::ThreadPoolBuilder,
         solana_keypair::keypair_from_seed,
-        std::io::{Cursor, Seek, SeekFrom, Write},
         test_case::test_case,
     };
 
-    const SIZE_OF_SHRED_INDEX: usize = 4;
-    const SIZE_OF_SHRED_SLOT: usize = 8;
-    const SIZE_OF_SHRED_VARIANT: usize = 1;
-    const SIZE_OF_VERSION: usize = 2;
-    const SIZE_OF_FEC_SET_INDEX: usize = 4;
-    const SIZE_OF_PARENT_OFFSET: usize = 2;
+    pub(super) const SIZE_OF_SHRED_INDEX: usize = 4;
+    pub(super) const SIZE_OF_SHRED_SLOT: usize = 8;
+    pub(super) const SIZE_OF_SHRED_VARIANT: usize = 1;
+    pub(super) const SIZE_OF_VERSION: usize = 2;
+    pub(super) const SIZE_OF_FEC_SET_INDEX: usize = 4;
+    pub(super) const SIZE_OF_PARENT_OFFSET: usize = 2;
 
-    const OFFSET_OF_SHRED_VARIANT: usize = SIZE_OF_SIGNATURE;
-    const OFFSET_OF_SHRED_SLOT: usize = SIZE_OF_SIGNATURE + SIZE_OF_SHRED_VARIANT;
-    const OFFSET_OF_SHRED_INDEX: usize = OFFSET_OF_SHRED_SLOT + SIZE_OF_SHRED_SLOT;
-    const OFFSET_OF_FEC_SET_INDEX: usize =
+    pub(super) const OFFSET_OF_SHRED_VARIANT: usize = SIZE_OF_SIGNATURE;
+    pub(super) const OFFSET_OF_SHRED_SLOT: usize = SIZE_OF_SIGNATURE + SIZE_OF_SHRED_VARIANT;
+    pub(super) const OFFSET_OF_SHRED_INDEX: usize = OFFSET_OF_SHRED_SLOT + SIZE_OF_SHRED_SLOT;
+    pub(super) const OFFSET_OF_FEC_SET_INDEX: usize =
         OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX + SIZE_OF_VERSION;
-    const OFFSET_OF_NUM_DATA: usize = OFFSET_OF_FEC_SET_INDEX + SIZE_OF_FEC_SET_INDEX;
+    pub(super) const OFFSET_OF_NUM_DATA: usize = OFFSET_OF_FEC_SET_INDEX + SIZE_OF_FEC_SET_INDEX;
 
-    const OFFSET_OF_PARENT_OFFSET: usize = OFFSET_OF_FEC_SET_INDEX + SIZE_OF_FEC_SET_INDEX;
-    const OFFSET_OF_SHRED_FLAGS: usize = OFFSET_OF_PARENT_OFFSET + SIZE_OF_PARENT_OFFSET;
-
-    pub(super) fn make_merkle_shreds_for_tests<R: Rng>(
-        rng: &mut R,
-        slot: Slot,
-        data_size: usize,
-        is_last_in_slot: bool,
-    ) -> Result<Vec<merkle::Shred>, Error> {
-        let thread_pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
-        let chained_merkle_root = Hash::new_from_array(rng.random());
-        let parent_offset = rng.random_range(1..=u16::try_from(slot).unwrap_or(u16::MAX));
-        let parent_slot = slot.checked_sub(u64::from(parent_offset)).unwrap();
-        let mut data = vec![0u8; data_size];
-        let fec_set_index = rng.random_range(0..21) * DATA_SHREDS_PER_FEC_BLOCK as u32;
-        rng.fill(&mut data[..]);
-        merkle::make_shreds_from_data(
-            &thread_pool,
-            &Keypair::new(),
-            chained_merkle_root,
-            &data[..],
-            slot,
-            parent_slot,
-            rng.random(),            // shred_version
-            rng.random_range(1..64), // reference_tick
-            is_last_in_slot,
-            fec_set_index, // next_shred_index
-            fec_set_index, // next_code_index
-            &ReedSolomonCache::default(),
-            &mut ProcessShredsStats::default(),
-        )
-    }
+    pub(super) const OFFSET_OF_PARENT_OFFSET: usize =
+        OFFSET_OF_FEC_SET_INDEX + SIZE_OF_FEC_SET_INDEX;
+    pub(super) const OFFSET_OF_SHRED_FLAGS: usize = OFFSET_OF_PARENT_OFFSET + SIZE_OF_PARENT_OFFSET;
 
     #[test]
     fn test_shred_constants() {
@@ -1141,457 +950,6 @@ mod tests {
                 parent_offset: 1000
             })
         );
-    }
-
-    #[test_case(true ; "last_in_slot")]
-    #[test_case(false ; "not_last_in_slot")]
-    fn test_should_discard_shred(is_last_in_slot: bool) {
-        agave_logger::setup();
-        let mut rng = rand::rng();
-        let slot = 18_291;
-        let shreds = make_merkle_shreds_for_tests(
-            &mut rng,
-            slot,
-            1200 * 5, // data_size
-            is_last_in_slot,
-        )
-        .unwrap();
-        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
-        assert_eq!(shreds.iter().map(Shred::fec_set_index).dedup().count(), 1);
-
-        assert_matches!(shreds[0].shred_type(), ShredType::Data);
-        let parent_slot = shreds[0].parent().unwrap();
-        let shred_version = shreds[0].common_header().version;
-
-        let root = rng.random_range(0..parent_slot);
-        let max_slot = slot + rng.random_range(1..65536);
-        let mut packet = Packet::default();
-
-        // Data shred sanity checks!
-        {
-            let shred = shreds.first().unwrap();
-            assert_eq!(shred.shred_type(), ShredType::Data);
-            shred.copy_to_packet(&mut packet);
-            let mut stats = ShredFetchStats::default();
-            assert!(!should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats
-            ));
-        }
-        {
-            let mut packet = packet.clone();
-            let mut stats = ShredFetchStats::default();
-            packet.meta_mut().size = OFFSET_OF_SHRED_VARIANT;
-            assert!(should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats
-            ));
-            assert_eq!(stats.index_overrun, 1);
-
-            packet.meta_mut().size = OFFSET_OF_SHRED_INDEX;
-            assert!(should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats
-            ));
-            assert_eq!(stats.index_overrun, 2);
-
-            packet.meta_mut().size = OFFSET_OF_SHRED_INDEX + 1;
-            assert!(should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats
-            ));
-            assert_eq!(stats.index_overrun, 3);
-
-            packet.meta_mut().size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX - 1;
-            assert!(should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats
-            ));
-            assert_eq!(stats.index_overrun, 4);
-
-            packet.meta_mut().size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX + 2;
-            assert!(should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats
-            ));
-            assert_eq!(stats.index_overrun, 5);
-        }
-        {
-            let mut stats = ShredFetchStats::default();
-            assert!(should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version.wrapping_add(1),
-                |_| false,
-                &mut stats
-            ));
-            assert_eq!(stats.shred_version_mismatch, 1);
-        }
-        {
-            let mut stats = ShredFetchStats::default();
-            assert!(should_discard_shred(
-                &packet,
-                parent_slot + 1, // root
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats
-            ));
-            assert_eq!(stats.slot_out_of_range, 1);
-        }
-        {
-            let parent_offset = 0u16;
-            {
-                let mut cursor = Cursor::new(packet.buffer_mut());
-                cursor.seek(SeekFrom::Start(83)).unwrap();
-                cursor.write_all(&parent_offset.to_le_bytes()).unwrap();
-            }
-            assert_eq!(
-                layout::get_parent_offset(packet.data(..).unwrap()),
-                Some(parent_offset)
-            );
-            let mut stats = ShredFetchStats::default();
-            assert!(should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats
-            ));
-            assert_eq!(stats.slot_out_of_range, 1);
-        }
-        {
-            let parent_offset = u16::try_from(slot + 1).unwrap();
-            {
-                let mut cursor = Cursor::new(packet.buffer_mut());
-                cursor.seek(SeekFrom::Start(83)).unwrap();
-                cursor.write_all(&parent_offset.to_le_bytes()).unwrap();
-            }
-            assert_eq!(
-                layout::get_parent_offset(packet.data(..).unwrap()),
-                Some(parent_offset)
-            );
-            let mut stats = ShredFetchStats::default();
-            assert!(should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats
-            ));
-            assert_eq!(stats.bad_parent_offset, 1);
-        }
-        {
-            let index = u32::MAX - 10;
-            {
-                let mut cursor = Cursor::new(packet.buffer_mut());
-                cursor
-                    .seek(SeekFrom::Start(OFFSET_OF_SHRED_INDEX as u64))
-                    .unwrap();
-                cursor.write_all(&index.to_le_bytes()).unwrap();
-            }
-            assert_eq!(layout::get_index(packet.data(..).unwrap()), Some(index));
-            let mut stats = ShredFetchStats::default();
-            assert!(should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| true,
-                &mut stats
-            ));
-            assert_eq!(stats.index_out_of_bounds, 1);
-        }
-
-        // Coding shred sanity checks!
-        {
-            let shred = shreds.last().unwrap();
-            assert_eq!(shred.shred_type(), ShredType::Code);
-            shreds.last().unwrap().copy_to_packet(&mut packet);
-            let mut stats = ShredFetchStats::default();
-            assert!(!should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats
-            ));
-        }
-        {
-            let mut stats = ShredFetchStats::default();
-            assert!(should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version.wrapping_add(1),
-                |_| false,
-                &mut stats
-            ));
-            assert_eq!(stats.shred_version_mismatch, 1);
-        }
-        {
-            let mut stats = ShredFetchStats::default();
-            assert!(should_discard_shred(
-                &packet,
-                slot, // root
-                max_slot,
-                shred_version,
-                |_| true,
-                &mut stats
-            ));
-            assert_eq!(stats.slot_out_of_range, 1);
-        }
-        {
-            let index = u32::try_from(MAX_CODE_SHREDS_PER_SLOT).unwrap();
-            {
-                let mut cursor = Cursor::new(packet.buffer_mut());
-                cursor
-                    .seek(SeekFrom::Start(OFFSET_OF_SHRED_INDEX as u64))
-                    .unwrap();
-                cursor.write_all(&index.to_le_bytes()).unwrap();
-            }
-            assert_eq!(layout::get_index(packet.data(..).unwrap()), Some(index));
-            let mut stats = ShredFetchStats::default();
-            assert!(should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats
-            ));
-            assert_eq!(stats.index_out_of_bounds, 1);
-        }
-    }
-
-    #[test]
-    fn test_should_discard_shred_fec_set_checks() {
-        agave_logger::setup();
-        let mut rng = rand::rng();
-        let slot = 18_291;
-        let shreds = make_merkle_shreds_for_tests(
-            &mut rng,
-            slot,
-            1200 * 5, // data_size
-            false,    // is_last_in_slot
-        )
-        .unwrap();
-        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
-        assert_eq!(shreds.iter().map(Shred::fec_set_index).dedup().count(), 1);
-
-        assert_matches!(shreds[0].shred_type(), ShredType::Data);
-        let parent_slot = shreds[0].parent().unwrap();
-        let shred_version = shreds[0].common_header().version;
-        let root = rng.random_range(0..parent_slot);
-        let max_slot = slot + rng.random_range(1..65536);
-
-        // fec_set_index not multiple of 32
-        {
-            let mut packet = Packet::default();
-            shreds[0].copy_to_packet(&mut packet);
-
-            let bad_fec_set_index = 5u32;
-            {
-                let mut cursor = Cursor::new(packet.buffer_mut());
-                cursor
-                    .seek(SeekFrom::Start(OFFSET_OF_FEC_SET_INDEX as u64))
-                    .unwrap();
-                cursor.write_all(&bad_fec_set_index.to_le_bytes()).unwrap();
-            }
-
-            let mut stats = ShredFetchStats::default();
-            let should_discard = should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats,
-            );
-            assert!(should_discard);
-            assert_eq!(stats.misaligned_fec_set, 1);
-        }
-
-        // index not in range [fec_set_index, fec_set_index + 32)
-        {
-            let mut packet = Packet::default();
-            shreds[0].copy_to_packet(&mut packet);
-
-            let fec_set_index = 64u32; // Multiple of 32
-            let bad_index = 100u32; // Outside [64, 96)
-            {
-                let mut cursor = Cursor::new(packet.buffer_mut());
-                cursor
-                    .seek(SeekFrom::Start(OFFSET_OF_SHRED_INDEX as u64))
-                    .unwrap();
-                cursor.write_all(&bad_index.to_le_bytes()).unwrap();
-                cursor
-                    .seek(SeekFrom::Start(OFFSET_OF_FEC_SET_INDEX as u64))
-                    .unwrap();
-                cursor.write_all(&fec_set_index.to_le_bytes()).unwrap();
-            }
-
-            let mut stats = ShredFetchStats::default();
-            let should_discard = should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats,
-            );
-            assert!(should_discard);
-            assert_eq!(stats.misaligned_fec_set, 1);
-        }
-
-        // bad erasure config 16:32
-        {
-            let code_shred = shreds
-                .iter()
-                .find(|s| s.shred_type() == ShredType::Code)
-                .unwrap();
-            let mut packet = Packet::default();
-            code_shred.copy_to_packet(&mut packet);
-
-            let bad_num_data = 16u16;
-            {
-                let mut cursor = Cursor::new(packet.buffer_mut());
-                cursor
-                    .seek(SeekFrom::Start(OFFSET_OF_NUM_DATA as u64))
-                    .unwrap();
-                cursor.write_all(&bad_num_data.to_le_bytes()).unwrap();
-            }
-
-            let mut stats = ShredFetchStats::default();
-            let should_discard = should_discard_shred(
-                &packet,
-                root,
-                max_slot,
-                shred_version,
-                |_| false,
-                &mut stats,
-            );
-            assert!(should_discard);
-            assert_eq!(stats.misaligned_erasure_config, 1);
-        }
-
-        // data shred with LAST_SHRED_IN_SLOT flag on shred 30
-        let shreds = make_merkle_shreds_for_tests(
-            &mut rng,
-            slot,
-            1200 * 5, // data_size
-            true,     // is_last_in_slot
-        )
-        .unwrap();
-        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
-        let parent_slot = shreds[0].parent().unwrap();
-        let shred_version = shreds[0].common_header().version;
-        let root = rng.random_range(0..parent_slot);
-        let data_shreds: Vec<_> = shreds
-            .iter()
-            .filter(|s| s.shred_type() == ShredType::Data)
-            .collect();
-        let last_data_shred = data_shreds.last().unwrap();
-        assert!(last_data_shred.last_in_slot());
-        let mut packet = Packet::default();
-        last_data_shred.copy_to_packet(&mut packet);
-
-        let bad_last_index = 30u32;
-        let fec_set_index = 0u32;
-        {
-            let mut cursor = Cursor::new(packet.buffer_mut());
-            cursor
-                .seek(SeekFrom::Start(OFFSET_OF_SHRED_INDEX as u64))
-                .unwrap();
-            cursor.write_all(&bad_last_index.to_le_bytes()).unwrap();
-            cursor
-                .seek(SeekFrom::Start(OFFSET_OF_FEC_SET_INDEX as u64))
-                .unwrap();
-            cursor.write_all(&fec_set_index.to_le_bytes()).unwrap();
-        }
-
-        let mut stats = ShredFetchStats::default();
-        let should_discard = should_discard_shred(
-            &packet,
-            root,
-            max_slot,
-            shred_version,
-            |_| false,
-            &mut stats,
-        );
-        assert!(should_discard);
-        assert_eq!(stats.misaligned_last_data_index, 1);
-    }
-
-    #[test]
-    fn test_should_discard_shred_with_custom_shred_limits() {
-        agave_logger::setup();
-
-        // Create some shreds
-        let mut rng = rand::rng();
-        let slot = 42;
-        let shreds = make_merkle_shreds_for_tests(&mut rng, slot, 10_000, false).unwrap();
-
-        // Grab the first shred in packet form
-        let shred = Shred::from(shreds[0].clone());
-        let index = shred.common_header().index;
-        let shred_version = shred.common_header().version;
-        let mut packet = Packet::default();
-        shred.copy_to_packet(&mut packet);
-
-        // Verify index in bounds passes the discard check.
-        assert!(!should_discard_shred_with_custom_shred_limits(
-            &packet,
-            0,        // root
-            slot + 1, // max_slot
-            shred_version,
-            |_| false,
-            |_| index + 1,
-            |_| index + 1,
-            &mut ShredFetchStats::default(),
-        ));
-
-        // Verify index out of bounds is rejected.
-        let mut stats = ShredFetchStats::default();
-        assert!(should_discard_shred_with_custom_shred_limits(
-            &packet,
-            0,        // root
-            slot + 1, // max_slot
-            shred_version,
-            |_| false,
-            |_| index,
-            |_| index,
-            &mut stats,
-        ));
-        assert_eq!(stats.index_out_of_bounds, 1);
     }
 
     // Asserts that ShredType is backward compatible with u8.
@@ -2025,84 +1383,5 @@ mod tests {
             assert!(shred.is_shred_duplicate(&other));
             assert!(other.is_shred_duplicate(shred));
         }
-    }
-
-    #[test]
-    fn test_data_complete_shred_index_validation() {
-        agave_logger::setup();
-        let mut rng = rand::rng();
-        let slot = 18_291;
-        let shreds = make_merkle_shreds_for_tests(
-            &mut rng,
-            slot,
-            1200 * 5, // data_size
-            false,    // is_last_in_slot
-        )
-        .unwrap();
-        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
-
-        let data_shred = shreds
-            .iter()
-            .find(|s| s.shred_type() == ShredType::Data)
-            .unwrap();
-
-        let parent_slot = data_shred.parent().unwrap();
-        let shred_version = data_shred.common_header().version;
-        let root = rng.random_range(0..parent_slot);
-        let max_slot = slot + rng.random_range(1..65536);
-
-        // Test case where DATA_COMPLETE_SHRED flag is set but index is not at expected position
-        let mut packet = Packet::default();
-        data_shred.copy_to_packet(&mut packet);
-
-        let fec_set_index = 64u32;
-        let wrong_index = fec_set_index + 10; // Should be fec_set_index + 31 for DATA_COMPLETE_SHRED
-
-        // Modify the packet to have DATA_COMPLETE_SHRED flag with wrong index
-        {
-            let mut cursor = Cursor::new(packet.buffer_mut());
-            cursor
-                .seek(SeekFrom::Start(OFFSET_OF_SHRED_INDEX as u64))
-                .unwrap();
-            cursor.write_all(&wrong_index.to_le_bytes()).unwrap();
-            cursor
-                .seek(SeekFrom::Start(OFFSET_OF_FEC_SET_INDEX as u64))
-                .unwrap();
-            cursor.write_all(&fec_set_index.to_le_bytes()).unwrap();
-
-            // Flags offset is at 85, where:
-            //
-            //     85 = SIZE_OF_COMMON_SHRED_HEADER (83) + size of parent offset (i.e., 2)
-            //
-            // See the top-level comments, which articulate data shred layout, for more details.
-            cursor
-                .seek(SeekFrom::Start(OFFSET_OF_SHRED_FLAGS as u64))
-                .unwrap(); // flags offset
-            cursor
-                .write_all(&[ShredFlags::DATA_COMPLETE_SHRED.bits()])
-                .unwrap();
-        }
-
-        let mut stats = ShredFetchStats::default();
-        let should_discard =
-            should_discard_shred(&packet, root, max_slot, shred_version, |_| true, &mut stats);
-        assert!(should_discard);
-        assert_eq!(stats.unexpected_data_complete_shred, 1);
-
-        // Test case where DATA_COMPLETE_SHRED flag is set with correct index
-        let correct_index = fec_set_index + DATA_SHREDS_PER_FEC_BLOCK as u32 - 1;
-        {
-            let mut cursor = Cursor::new(packet.buffer_mut());
-            cursor
-                .seek(SeekFrom::Start(OFFSET_OF_SHRED_INDEX as u64))
-                .unwrap();
-            cursor.write_all(&correct_index.to_le_bytes()).unwrap();
-        }
-
-        let mut stats = ShredFetchStats::default();
-        let should_discard =
-            should_discard_shred(&packet, root, max_slot, shred_version, |_| true, &mut stats);
-        assert!(!should_discard);
-        assert_eq!(stats.unexpected_data_complete_shred, 0);
     }
 }

--- a/ledger/src/shred/filter.rs
+++ b/ledger/src/shred/filter.rs
@@ -1,0 +1,727 @@
+//! Relevant structures and filtering logic to be applied to ingested and recovered shreds.
+//! as well as shred level feature flag detection
+
+use {
+    super::{
+        DATA_SHREDS_PER_FEC_BLOCK, MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT,
+        ShredFetchStats, ShredFlags, ShredType, ShredVariant, layout,
+    },
+    crate::blockstore,
+    agave_feature_set::discard_unexpected_data_complete_shreds,
+    solana_clock::Slot,
+    solana_epoch_schedule::EpochSchedule,
+    solana_perf::packet::PacketRef,
+    solana_pubkey::Pubkey,
+    solana_runtime::bank::Bank,
+    std::{
+        sync::Arc,
+        time::{Duration, Instant},
+    },
+};
+
+pub struct ShredFilterContext {
+    last_updated: Instant,
+
+    // Fields for slot range filtering updated via the root bank
+    root: Slot,
+    max_slot: Slot,
+    epoch_schedule: EpochSchedule,
+
+    // Static from startup, filter out shreds of invalid version
+    shred_version: u16,
+
+    // Whether to discard shreds that are not end of FEC set
+    // but specify DATA_COMPLETE
+    discard_unexpected_data_complete_shreds_feature_slot: Option<Slot>,
+
+    // The shred limits per slot. At the moment these are hard coded
+    // In the future we could replace these with feature activation
+    // slots to case on what the limits should be
+    max_data_shreds_per_slot: u32,
+    max_code_shreds_per_slot: u32,
+
+    pub stats: ShredFetchStats,
+}
+
+impl ShredFilterContext {
+    pub fn new(root_bank: Arc<Bank>, shred_version: u16) -> Self {
+        Self::new_with_custom_shred_limits(
+            root_bank,
+            shred_version,
+            MAX_DATA_SHREDS_PER_SLOT as u32,
+            MAX_CODE_SHREDS_PER_SLOT as u32,
+        )
+    }
+
+    pub fn new_with_custom_shred_limits(
+        root_bank: Arc<Bank>,
+        shred_version: u16,
+        max_data_shreds_per_slot: u32,
+        max_code_shreds_per_slot: u32,
+    ) -> Self {
+        let root = root_bank.slot();
+        let max_slot = max_shred_slot(root, root_bank.get_slots_in_epoch(root_bank.epoch()));
+        let discard_unexpected_data_complete_shreds_feature_slot = root_bank
+            .feature_set
+            .activated_slot(&discard_unexpected_data_complete_shreds::id());
+
+        Self {
+            last_updated: Instant::now(),
+            root,
+            max_slot,
+            epoch_schedule: root_bank.epoch_schedule().clone(),
+            shred_version,
+            discard_unexpected_data_complete_shreds_feature_slot,
+            max_data_shreds_per_slot,
+            max_code_shreds_per_slot,
+            stats: ShredFetchStats::default(),
+        }
+    }
+
+    /// Periodically update filtering context based on the root bank (no more than once per slot)
+    /// This is done to amortize the cost over multiple shreds, and delay in updating is completely
+    /// acceptable as max shred / feature flag filtering has tolerance on the order of an epoch.
+    pub fn maybe_update(&mut self, root_bank: Arc<Bank>) {
+        if self.last_updated.elapsed().as_nanos() > root_bank.ns_per_slot {
+            self.last_updated = Instant::now();
+            self.root = root_bank.slot();
+            self.max_slot =
+                max_shred_slot(self.root, root_bank.get_slots_in_epoch(root_bank.epoch()));
+            debug_assert!(self.root < self.max_slot);
+
+            self.epoch_schedule = root_bank.epoch_schedule().clone();
+            self.discard_unexpected_data_complete_shreds_feature_slot = root_bank
+                .feature_set
+                .activated_slot(&discard_unexpected_data_complete_shreds::id());
+
+            // In the future as shred limit changes we can update self.max_*_shreds_per_slot based on root
+            // bank as well
+        }
+    }
+
+    pub fn stats_mut(&mut self) -> &mut ShredFetchStats {
+        &mut self.stats
+    }
+
+    pub fn maybe_submit_stats(&mut self, metric_name: &'static str, cadence: Duration) -> bool {
+        self.stats.maybe_submit(metric_name, cadence)
+    }
+
+    #[must_use]
+    pub fn should_discard_packet<'a, P>(&mut self, packet: P) -> bool
+    where
+        P: Into<PacketRef<'a>>,
+    {
+        let Some(shred) = layout::get_shred(packet) else {
+            self.stats.index_overrun += 1;
+            return true;
+        };
+        self.should_discard_shred(shred)
+    }
+
+    #[must_use]
+    pub fn should_discard_shred(&mut self, shred: &[u8]) -> bool {
+        match layout::get_version(shred) {
+            None => {
+                self.stats.index_overrun += 1;
+                return true;
+            }
+            Some(version) => {
+                if version != self.shred_version {
+                    self.stats.shred_version_mismatch += 1;
+                    return true;
+                }
+            }
+        }
+        let Ok(shred_variant) = layout::get_shred_variant(shred) else {
+            self.stats.bad_shred_type += 1;
+            return true;
+        };
+        let slot = match layout::get_slot(shred) {
+            Some(slot) => {
+                if slot > self.max_slot {
+                    self.stats.slot_out_of_range += 1;
+                    return true;
+                }
+                slot
+            }
+            None => {
+                self.stats.slot_bad_deserialize += 1;
+                return true;
+            }
+        };
+        let Some(index) = layout::get_index(shred) else {
+            self.stats.index_bad_deserialize += 1;
+            return true;
+        };
+        let Some(fec_set_index) = layout::get_fec_set_index(shred) else {
+            self.stats.fec_set_index_bad_deserialize += 1;
+            return true;
+        };
+
+        match ShredType::from(shred_variant) {
+            ShredType::Code => {
+                if index >= self.max_code_shreds_per_slot {
+                    self.stats.index_out_of_bounds += 1;
+                    return true;
+                }
+                if slot <= self.root {
+                    self.stats.slot_out_of_range += 1;
+                    return true;
+                }
+
+                let Ok(erasure_config) = layout::get_erasure_config(shred) else {
+                    self.stats.erasure_config_bad_deserialize += 1;
+                    return true;
+                };
+
+                if !erasure_config.is_fixed() {
+                    self.stats.misaligned_erasure_config += 1;
+                    return true;
+                }
+            }
+            ShredType::Data => {
+                if index >= self.max_data_shreds_per_slot {
+                    self.stats.index_out_of_bounds += 1;
+                    return true;
+                }
+                let Some(parent_offset) = layout::get_parent_offset(shred) else {
+                    self.stats.bad_parent_offset += 1;
+                    return true;
+                };
+                let Some(parent) = slot.checked_sub(Slot::from(parent_offset)) else {
+                    self.stats.bad_parent_offset += 1;
+                    return true;
+                };
+                if !blockstore::verify_shred_slots(slot, parent, self.root) {
+                    self.stats.slot_out_of_range += 1;
+                    return true;
+                }
+
+                let Ok(shred_flags) = layout::get_flags(shred) else {
+                    self.stats.shred_flags_bad_deserialize += 1;
+                    return true;
+                };
+
+                let expected_data_complete_index = fec_set_index
+                    .checked_add(DATA_SHREDS_PER_FEC_BLOCK as u32)
+                    .and_then(|index| index.checked_sub(1));
+                if shred_flags.contains(ShredFlags::DATA_COMPLETE_SHRED)
+                    && (expected_data_complete_index != Some(index))
+                {
+                    self.stats.unexpected_data_complete_shred += 1;
+
+                    if check_feature_activation(
+                        self.discard_unexpected_data_complete_shreds_feature_slot,
+                        slot,
+                        &self.epoch_schedule,
+                    ) {
+                        return true;
+                    }
+                }
+
+                if shred_flags.contains(ShredFlags::LAST_SHRED_IN_SLOT)
+                    && !check_last_data_shred_index(index)
+                {
+                    self.stats.misaligned_last_data_index += 1;
+                    return true;
+                }
+            }
+        }
+
+        if !check_fixed_fec_set(index, fec_set_index) {
+            self.stats.misaligned_fec_set += 1;
+            return true;
+        }
+
+        match shred_variant {
+            ShredVariant::MerkleCode { .. } => {
+                self.stats.num_shreds_merkle_code_chained =
+                    self.stats.num_shreds_merkle_code_chained.saturating_add(1);
+            }
+            ShredVariant::MerkleData { .. } => {
+                self.stats.num_shreds_merkle_data_chained =
+                    self.stats.num_shreds_merkle_data_chained.saturating_add(1);
+            }
+        }
+        false
+    }
+}
+
+/// Returns true if the feature is effective for the shred slot.
+/// Note: unlike normal feature flags, shred feature flags take effect 1 epoch after activation.
+#[must_use]
+pub fn check_feature_activation_from_bank(
+    feature: &Pubkey,
+    shred_slot: Slot,
+    root_bank: &Bank,
+) -> bool {
+    check_feature_activation(
+        root_bank.feature_set.activated_slot(feature),
+        shred_slot,
+        root_bank.epoch_schedule(),
+    )
+}
+
+/// Returns true if the feature is effective for the shred slot.
+/// Note: unlike normal feature flags, shred feature flags take effect 1 epoch after activation.
+#[must_use]
+pub fn check_feature_activation(
+    feature_slot: Option<Slot>,
+    shred_slot: Slot,
+    epoch_schedule: &EpochSchedule,
+) -> bool {
+    let Some(feature_slot) = feature_slot else {
+        return false;
+    };
+
+    let feature_epoch = epoch_schedule.get_epoch(feature_slot);
+    let shred_epoch = epoch_schedule.get_epoch(shred_slot);
+    feature_epoch < shred_epoch
+}
+
+/// The maximum shred slot we allow for ingest given a current `root` slot.
+fn max_shred_slot(root: Slot, slots_per_epoch: Slot) -> Slot {
+    // When running with very short epochs (e.g. for testing), we want to avoid
+    // filtering out shreds that we actually need. This value was chosen empirically
+    // because it's large enough to protect against observed short epoch problems
+    // while being small enough to keep the overhead small on deduper, blockstore,
+    // etc.
+    const MAX_SHRED_DISTANCE_MINIMUM: Slot = 500;
+    // Allow shreds up to 2 epochs into the future to support catching up to the tip of the cluster.
+    root.saturating_add(MAX_SHRED_DISTANCE_MINIMUM.max(2 * slots_per_epoch))
+}
+
+/// Returns true if `index` and `fec_set_index` are valid under the assumption that
+/// all erasure sets contain exactly `DATA_SHREDS_PER_FEC_BLOCK` data and coding shreds:
+/// - `index` is between `fec_set_index` and `fec_set_index + DATA_SHREDS_PER_FEC_BLOCK`
+/// - `fec_set_index` is a multiple of `DATA_SHREDS_PER_FEC_BLOCK`
+fn check_fixed_fec_set(index: u32, fec_set_index: u32) -> bool {
+    let Some(fec_set_end_exclusive) = fec_set_index.checked_add(DATA_SHREDS_PER_FEC_BLOCK as u32)
+    else {
+        return false;
+    };
+    index >= fec_set_index
+        && index < fec_set_end_exclusive
+        && fec_set_index.is_multiple_of(DATA_SHREDS_PER_FEC_BLOCK as u32)
+}
+
+/// Returns true if `index` of the last data shred is valid under the assumption that
+/// all erasure sets contain exactly `DATA_SHREDS_PER_FEC_BLOCK` data and coding shreds:
+/// - `index + 1` must be a multiple of `DATA_SHREDS_PER_FEC_BLOCK`
+///
+/// Note: this check is critical to verify that the last fec set is sufficiently sized.
+/// This is checked during shred ingest with `enforce_fixed_fec_set` active.
+fn check_last_data_shred_index(index: u32) -> bool {
+    (index + 1).is_multiple_of(DATA_SHREDS_PER_FEC_BLOCK as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{
+            super::{Shred, make_merkle_shreds_for_tests},
+            *,
+        },
+        crate::{genesis_utils::create_genesis_config, shred::tests::*},
+        assert_matches::assert_matches,
+        itertools::Itertools,
+        solana_leader_schedule::SlotLeader,
+        solana_perf::packet::Packet,
+        solana_runtime::bank::Bank,
+        std::{
+            io::{Cursor, Seek, SeekFrom, Write},
+            sync::Arc,
+        },
+        test_case::test_case,
+    };
+
+    fn new_test_bank(slot: Slot, discard_unexpected_data_complete_shreds: bool) -> Arc<Bank> {
+        let genesis_config = create_genesis_config(1).genesis_config;
+        let mut bank = Bank::new_for_tests(&genesis_config);
+        let feature_id = agave_feature_set::discard_unexpected_data_complete_shreds::id();
+        bank.deactivate_feature(&feature_id);
+        if discard_unexpected_data_complete_shreds {
+            bank.activate_feature(&feature_id);
+        }
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+        if slot == 0 {
+            bank
+        } else {
+            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), slot)
+        }
+    }
+
+    #[test_case(true ; "last_in_slot")]
+    #[test_case(false ; "not_last_in_slot")]
+    fn test_should_discard_shred(is_last_in_slot: bool) {
+        agave_logger::setup();
+        let mut rng = rand::rng();
+        let slot = 200;
+        let shreds = make_merkle_shreds_for_tests(
+            &mut rng,
+            slot,
+            1200 * 5, // data_size
+            is_last_in_slot,
+        )
+        .unwrap();
+        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
+        assert_eq!(shreds.iter().map(Shred::fec_set_index).dedup().count(), 1);
+
+        assert_matches!(shreds[0].shred_type(), ShredType::Data);
+        let parent_slot = shreds[0].parent().unwrap();
+        let shred_version = shreds[0].common_header().version;
+
+        let root_bank = new_test_bank(0, false);
+        let parent_exceeded_root_bank = new_test_bank(parent_slot + 1, false);
+        let slot_root_bank = new_test_bank(slot, false);
+        let mut packet = Packet::default();
+
+        {
+            let shred = shreds.first().unwrap();
+            assert_eq!(shred.shred_type(), ShredType::Data);
+            shred.copy_to_packet(&mut packet);
+            let mut shred_filter_context =
+                ShredFilterContext::new(root_bank.clone(), shred_version);
+            assert!(!shred_filter_context.should_discard_packet(&packet));
+        }
+        {
+            let mut packet = packet.clone();
+            let mut shred_filter_context =
+                ShredFilterContext::new(root_bank.clone(), shred_version);
+            packet.meta_mut().size = OFFSET_OF_SHRED_VARIANT;
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.index_overrun, 1);
+
+            packet.meta_mut().size = OFFSET_OF_SHRED_INDEX;
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.index_overrun, 2);
+
+            packet.meta_mut().size = OFFSET_OF_SHRED_INDEX + 1;
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.index_overrun, 3);
+
+            packet.meta_mut().size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX - 1;
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.index_overrun, 4);
+
+            packet.meta_mut().size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX + 2;
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.index_overrun, 5);
+        }
+        {
+            let mut shred_filter_context =
+                ShredFilterContext::new(root_bank.clone(), shred_version.wrapping_add(1));
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.shred_version_mismatch, 1);
+        }
+        {
+            let mut shred_filter_context =
+                ShredFilterContext::new(parent_exceeded_root_bank.clone(), shred_version);
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.slot_out_of_range, 1);
+        }
+        {
+            let parent_offset = 0u16;
+            {
+                let mut cursor = Cursor::new(packet.buffer_mut());
+                cursor.seek(SeekFrom::Start(83)).unwrap();
+                cursor.write_all(&parent_offset.to_le_bytes()).unwrap();
+            }
+            assert_eq!(
+                layout::get_parent_offset(packet.data(..).unwrap()),
+                Some(parent_offset)
+            );
+            let mut shred_filter_context =
+                ShredFilterContext::new(root_bank.clone(), shred_version);
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.slot_out_of_range, 1);
+        }
+        {
+            let parent_offset = u16::try_from(slot + 1).unwrap();
+            {
+                let mut cursor = Cursor::new(packet.buffer_mut());
+                cursor.seek(SeekFrom::Start(83)).unwrap();
+                cursor.write_all(&parent_offset.to_le_bytes()).unwrap();
+            }
+            assert_eq!(
+                layout::get_parent_offset(packet.data(..).unwrap()),
+                Some(parent_offset)
+            );
+            let mut shred_filter_context =
+                ShredFilterContext::new(root_bank.clone(), shred_version);
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.bad_parent_offset, 1);
+        }
+        {
+            let index = u32::MAX - 10;
+            {
+                let mut cursor = Cursor::new(packet.buffer_mut());
+                cursor
+                    .seek(SeekFrom::Start(OFFSET_OF_SHRED_INDEX as u64))
+                    .unwrap();
+                cursor.write_all(&index.to_le_bytes()).unwrap();
+            }
+            assert_eq!(layout::get_index(packet.data(..).unwrap()), Some(index));
+            let mut shred_filter_context =
+                ShredFilterContext::new(root_bank.clone(), shred_version);
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.index_out_of_bounds, 1);
+        }
+
+        {
+            let shred = shreds.last().unwrap();
+            assert_eq!(shred.shred_type(), ShredType::Code);
+            shreds.last().unwrap().copy_to_packet(&mut packet);
+            let mut shred_filter_context =
+                ShredFilterContext::new(root_bank.clone(), shred_version);
+            assert!(!shred_filter_context.should_discard_packet(&packet));
+        }
+        {
+            let mut shred_filter_context =
+                ShredFilterContext::new(root_bank.clone(), shred_version.wrapping_add(1));
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.shred_version_mismatch, 1);
+        }
+        {
+            let mut shred_filter_context =
+                ShredFilterContext::new(slot_root_bank.clone(), shred_version);
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.slot_out_of_range, 1);
+        }
+        {
+            let index = u32::try_from(MAX_CODE_SHREDS_PER_SLOT).unwrap();
+            {
+                let mut cursor = Cursor::new(packet.buffer_mut());
+                cursor
+                    .seek(SeekFrom::Start(OFFSET_OF_SHRED_INDEX as u64))
+                    .unwrap();
+                cursor.write_all(&index.to_le_bytes()).unwrap();
+            }
+            assert_eq!(layout::get_index(packet.data(..).unwrap()), Some(index));
+            let mut shred_filter_context =
+                ShredFilterContext::new(root_bank.clone(), shred_version);
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.index_out_of_bounds, 1);
+        }
+    }
+
+    #[test]
+    fn test_should_discard_shred_fec_set_checks() {
+        agave_logger::setup();
+        let mut rng = rand::rng();
+        let slot = 200;
+        let shreds = make_merkle_shreds_for_tests(
+            &mut rng,
+            slot,
+            1200 * 5, // data_size
+            false,    // is_last_in_slot
+        )
+        .unwrap();
+        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
+        assert_eq!(shreds.iter().map(Shred::fec_set_index).dedup().count(), 1);
+
+        assert_matches!(shreds[0].shred_type(), ShredType::Data);
+        let shred_version = shreds[0].common_header().version;
+        let root_bank = new_test_bank(0, false);
+
+        {
+            let mut packet = Packet::default();
+            shreds[0].copy_to_packet(&mut packet);
+
+            let bad_fec_set_index = 5u32;
+            {
+                let mut cursor = Cursor::new(packet.buffer_mut());
+                cursor
+                    .seek(SeekFrom::Start(OFFSET_OF_FEC_SET_INDEX as u64))
+                    .unwrap();
+                cursor.write_all(&bad_fec_set_index.to_le_bytes()).unwrap();
+            }
+
+            let mut shred_filter_context =
+                ShredFilterContext::new(root_bank.clone(), shred_version);
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.misaligned_fec_set, 1);
+        }
+
+        {
+            let mut packet = Packet::default();
+            shreds[0].copy_to_packet(&mut packet);
+
+            let fec_set_index = 64u32;
+            let bad_index = 100u32;
+            {
+                let mut cursor = Cursor::new(packet.buffer_mut());
+                cursor
+                    .seek(SeekFrom::Start(OFFSET_OF_SHRED_INDEX as u64))
+                    .unwrap();
+                cursor.write_all(&bad_index.to_le_bytes()).unwrap();
+                cursor
+                    .seek(SeekFrom::Start(OFFSET_OF_FEC_SET_INDEX as u64))
+                    .unwrap();
+                cursor.write_all(&fec_set_index.to_le_bytes()).unwrap();
+            }
+
+            let mut shred_filter_context =
+                ShredFilterContext::new(root_bank.clone(), shred_version);
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.misaligned_fec_set, 1);
+        }
+
+        {
+            let code_shred = shreds
+                .iter()
+                .find(|s| s.shred_type() == ShredType::Code)
+                .unwrap();
+            let mut packet = Packet::default();
+            code_shred.copy_to_packet(&mut packet);
+
+            let bad_num_data = 16u16;
+            {
+                let mut cursor = Cursor::new(packet.buffer_mut());
+                cursor
+                    .seek(SeekFrom::Start(OFFSET_OF_NUM_DATA as u64))
+                    .unwrap();
+                cursor.write_all(&bad_num_data.to_le_bytes()).unwrap();
+            }
+
+            let mut shred_filter_context =
+                ShredFilterContext::new(root_bank.clone(), shred_version);
+            assert!(shred_filter_context.should_discard_packet(&packet));
+            assert_eq!(shred_filter_context.stats.misaligned_erasure_config, 1);
+        }
+
+        let shreds = make_merkle_shreds_for_tests(
+            &mut rng,
+            slot,
+            1200 * 5, // data_size
+            true,     // is_last_in_slot
+        )
+        .unwrap();
+        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
+        let shred_version = shreds[0].common_header().version;
+        let data_shreds: Vec<_> = shreds
+            .iter()
+            .filter(|s| s.shred_type() == ShredType::Data)
+            .collect();
+        let last_data_shred = data_shreds.last().unwrap();
+        assert!(last_data_shred.last_in_slot());
+        let mut packet = Packet::default();
+        last_data_shred.copy_to_packet(&mut packet);
+
+        let bad_last_index = 30u32;
+        let fec_set_index = 0u32;
+        {
+            let mut cursor = Cursor::new(packet.buffer_mut());
+            cursor
+                .seek(SeekFrom::Start(OFFSET_OF_SHRED_INDEX as u64))
+                .unwrap();
+            cursor.write_all(&bad_last_index.to_le_bytes()).unwrap();
+            cursor
+                .seek(SeekFrom::Start(OFFSET_OF_FEC_SET_INDEX as u64))
+                .unwrap();
+            cursor.write_all(&fec_set_index.to_le_bytes()).unwrap();
+        }
+
+        let mut shred_filter_context = ShredFilterContext::new(root_bank.clone(), shred_version);
+        assert!(shred_filter_context.should_discard_packet(&packet));
+        assert_eq!(shred_filter_context.stats.misaligned_last_data_index, 1);
+    }
+
+    #[test]
+    fn test_should_discard_shred_with_custom_shred_limits() {
+        agave_logger::setup();
+
+        let mut rng = rand::rng();
+        let root_bank = new_test_bank(0, false);
+        let slot = 42;
+        let shreds = make_merkle_shreds_for_tests(&mut rng, slot, 10_000, false).unwrap();
+
+        let shred = Shred::from(shreds[0].clone());
+        let index = shred.common_header().index;
+        let shred_version = shred.common_header().version;
+        let mut packet = Packet::default();
+        shred.copy_to_packet(&mut packet);
+
+        let mut shred_filter_context = ShredFilterContext::new_with_custom_shred_limits(
+            root_bank.clone(),
+            shred_version,
+            index + 1,
+            index + 1,
+        );
+        assert!(!shred_filter_context.should_discard_packet(&packet));
+
+        let mut shred_filter_context = ShredFilterContext::new_with_custom_shred_limits(
+            root_bank,
+            shred_version,
+            index,
+            index,
+        );
+        assert!(shred_filter_context.should_discard_packet(&packet));
+        assert_eq!(shred_filter_context.stats.index_out_of_bounds, 1);
+    }
+
+    #[test]
+    fn test_data_complete_shred_index_validation() {
+        agave_logger::setup();
+        let mut rng = rand::rng();
+        let root_bank = new_test_bank(0, true);
+        let slot = root_bank.get_slots_in_epoch(root_bank.epoch());
+        let shreds = make_merkle_shreds_for_tests(
+            &mut rng,
+            slot,
+            1200 * 5, // data_size
+            false,    // is_last_in_slot
+        )
+        .unwrap();
+        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
+
+        let data_shred = shreds
+            .iter()
+            .find(|s| s.shred_type() == ShredType::Data)
+            .unwrap();
+
+        let shred_version = data_shred.common_header().version;
+
+        let mut packet = Packet::default();
+        data_shred.copy_to_packet(&mut packet);
+
+        let fec_set_index = 64u32;
+        let wrong_index = fec_set_index + 10;
+
+        {
+            let mut cursor = Cursor::new(packet.buffer_mut());
+            cursor
+                .seek(SeekFrom::Start(OFFSET_OF_SHRED_INDEX as u64))
+                .unwrap();
+            cursor.write_all(&wrong_index.to_le_bytes()).unwrap();
+            cursor
+                .seek(SeekFrom::Start(OFFSET_OF_FEC_SET_INDEX as u64))
+                .unwrap();
+            cursor.write_all(&fec_set_index.to_le_bytes()).unwrap();
+            cursor
+                .seek(SeekFrom::Start(OFFSET_OF_SHRED_FLAGS as u64))
+                .unwrap();
+            cursor
+                .write_all(&[ShredFlags::DATA_COMPLETE_SHRED.bits()])
+                .unwrap();
+        }
+
+        let mut shred_filter_context = ShredFilterContext::new(root_bank.clone(), shred_version);
+        assert!(shred_filter_context.should_discard_packet(&packet));
+        assert_eq!(shred_filter_context.stats.unexpected_data_complete_shred, 1);
+
+        let correct_index = fec_set_index + DATA_SHREDS_PER_FEC_BLOCK as u32 - 1;
+        {
+            let mut cursor = Cursor::new(packet.buffer_mut());
+            cursor
+                .seek(SeekFrom::Start(OFFSET_OF_SHRED_INDEX as u64))
+                .unwrap();
+            cursor.write_all(&correct_index.to_le_bytes()).unwrap();
+        }
+
+        let mut shred_filter_context = ShredFilterContext::new(root_bank, shred_version);
+        assert!(!shred_filter_context.should_discard_packet(&packet));
+        assert_eq!(shred_filter_context.stats.unexpected_data_complete_shred, 0);
+    }
+}

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -411,9 +411,7 @@ pub(crate) fn corrupt_packet<R: Rng>(
 mod tests {
     use {
         super::*,
-        crate::shred::{
-            SHREDS_PER_FEC_BLOCK, tests::make_merkle_shreds_for_tests, traits::ShredData,
-        },
+        crate::shred::{SHREDS_PER_FEC_BLOCK, make_merkle_shreds_for_tests, traits::ShredData},
         assert_matches::assert_matches,
         rand::Rng,
         solana_perf::packet::PacketFlags,

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -17,7 +17,7 @@ use {
         weighted_shuffle::WeightedShuffle,
     },
     solana_keypair::Keypair,
-    solana_ledger::shred::ShredId,
+    solana_ledger::shred::{ShredId, filter::check_feature_activation_from_bank},
     solana_native_token::LAMPORTS_PER_SOL,
     solana_net_utils::SocketAddrSpace,
     solana_pubkey::Pubkey,
@@ -582,7 +582,7 @@ impl<T: 'static> ClusterNodesCache<T> {
             let cache = self.cache.read().unwrap();
             get_epoch_entry(&cache, epoch, self.ttl)
         };
-        let use_cha_cha_8 = check_feature_activation(
+        let use_cha_cha_8 = check_feature_activation_from_bank(
             &feature_set::switch_to_chacha8_turbine::ID,
             shred_slot,
             root_bank,
@@ -715,20 +715,6 @@ pub fn make_test_cluster<R: Rng>(
         }
     }
     (nodes, stakes, cluster_info)
-}
-
-// Returns true if the feature is effective for the shred slot.
-#[must_use]
-pub fn check_feature_activation(feature: &Pubkey, shred_slot: Slot, root_bank: &Bank) -> bool {
-    match root_bank.feature_set.activated_slot(feature) {
-        None => false,
-        Some(feature_slot) => {
-            let epoch_schedule = root_bank.epoch_schedule();
-            let feature_epoch = epoch_schedule.get_epoch(feature_slot);
-            let shred_epoch = epoch_schedule.get_epoch(shred_slot);
-            feature_epoch < shred_epoch
-        }
-    }
 }
 
 #[cfg(test)]

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        cluster_nodes::{ClusterNodesCache, DATA_PLANE_FANOUT, check_feature_activation},
+        cluster_nodes::{ClusterNodesCache, DATA_PLANE_FANOUT},
         retransmit_stage::RetransmitStage,
     },
     agave_feature_set as feature_set,
@@ -338,7 +338,7 @@ fn maybe_verify_and_resign_packet(
                 .fetch_add(1, Ordering::Relaxed);
             if shred::layout::get_slot(shred)
                 .map(|slot| {
-                    check_feature_activation(
+                    shred::filter::check_feature_activation_from_bank(
                         &feature_set::verify_retransmitter_signature::id(),
                         slot,
                         root_bank,


### PR DESCRIPTION
#### Problem
The `should_discard_shred` path could use some love and care

#### Summary of Changes
Create a new filter module in shred and make a more ergonomic setup there.
Makes #12075 (applying `should_discard_shred` during erasure recovery) more sane