### PR TITLE
core: Fix reporting interval on several metrics

### DIFF
--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -145,7 +145,8 @@ impl ClusterSlotsService {
                 process_cluster_slots_updates_elapsed.as_us(),
             );
 
-            if last_stats.elapsed().as_secs() > 2 {
+            const REPORT_INTERVAL: Duration = Duration::from_secs(2);
+            if last_stats.elapsed() > REPORT_INTERVAL {
                 datapoint_info!(
                     "cluster_slots_service-timing",
                     (

--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -19,7 +19,7 @@ use {
             BTreeMap, BTreeSet, HashMap, HashSet, VecDeque, btree_set::Iter, hash_map::Entry,
         },
         sync::{Arc, RwLock},
-        time::Instant,
+        time::{Duration, Instant},
     },
 };
 
@@ -27,7 +27,7 @@ pub type ForkWeight = u64;
 pub type SlotHashKey = (Slot, Hash);
 type UpdateOperations = BTreeMap<(SlotHashKey, UpdateLabel), UpdateOperation>;
 
-const MAX_ROOT_PRINT_SECONDS: u64 = 30;
+const MAX_ROOT_PRINT_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord)]
 enum UpdateLabel {
@@ -448,7 +448,7 @@ impl HeaviestSubtreeForkChoice {
     }
 
     pub fn maybe_print_state(&mut self) {
-        if self.last_root_time.elapsed().as_secs() > MAX_ROOT_PRINT_SECONDS {
+        if self.last_root_time.elapsed() > MAX_ROOT_PRINT_INTERVAL {
             self.print_state();
             self.last_root_time = Instant::now();
         }

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -86,6 +86,8 @@ struct AncestorHashesResponsesStats {
 }
 
 impl AncestorHashesResponsesStats {
+    const REPORT_INTERVAL: Duration = Duration::from_secs(2);
+
     fn report(&mut self) {
         datapoint_info!(
             "ancestor_hashes_responses",
@@ -115,6 +117,8 @@ impl Default for AncestorRepairRequestsStats {
 }
 
 impl AncestorRepairRequestsStats {
+    const REPORT_INTERVAL: Duration = Duration::from_secs(2);
+
     fn report(&mut self) {
         let slot_to_count: Vec<_> = self
             .ancestor_requests
@@ -124,7 +128,7 @@ impl AncestorRepairRequestsStats {
             .collect();
 
         let repair_total = self.ancestor_requests.count;
-        if self.last_report.elapsed().as_secs() > 2 && repair_total > 0 {
+        if self.last_report.elapsed() > Self::REPORT_INTERVAL && repair_total > 0 {
             info!("ancestor_repair_requests_stats: {slot_to_count:?}");
             datapoint_info!(
                 "ancestor-repair",
@@ -248,7 +252,7 @@ impl AncestorHashesService {
                             return;
                         }
                     };
-                    if last_stats_report.elapsed().as_secs() > 2 {
+                    if last_stats_report.elapsed() > AncestorHashesResponsesStats::REPORT_INTERVAL {
                         stats.report();
                         last_stats_report = Instant::now();
                     }

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -149,8 +149,10 @@ impl Default for RepairMetrics {
 }
 
 impl RepairMetrics {
+    const REPORT_INTERVAL: Duration = Duration::from_secs(2);
+
     pub fn maybe_report(&mut self) {
-        if self.last_report.elapsed().as_secs() > 2 {
+        if self.last_report.elapsed() > Self::REPORT_INTERVAL {
             self.stats.report();
             self.timing.report();
             self.best_repairs_stats.report();

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1273,7 +1273,9 @@ impl ServeRepair {
                             return;
                         }
                     };
-                    if last_print.elapsed().as_secs() > 2 {
+
+                    const REPORT_INTERVAL: Duration = Duration::from_secs(2);
+                    if last_print.elapsed() > REPORT_INTERVAL {
                         self.report_reset_stats(&mut stats);
                         last_print = Instant::now();
                     }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -76,6 +76,8 @@ struct SigVerifierStats {
 }
 
 impl SigVerifierStats {
+    const REPORT_INTERVAL: Duration = Duration::from_secs(2);
+
     fn maybe_report_and_reset(&mut self, name: &'static str) {
         // No need to report a datapoint if no batches/packets received
         if self.total_batches == 0 {
@@ -323,7 +325,7 @@ impl SigVerifyStage {
                             _ => error!("{e:?}"),
                         }
                     }
-                    if last_print.elapsed().as_secs() > 2 {
+                    if last_print.elapsed() > SigVerifierStats::REPORT_INTERVAL {
                         stats.maybe_report_and_reset(metrics_name);
                         last_print = Instant::now();
                     }

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -378,9 +378,12 @@ impl WindowService {
                 let handle_duplicate = |possible_duplicate_shred| {
                     let _ = check_duplicate_sender.send(possible_duplicate_shred);
                 };
+
+                const METRICS_REPORTING_INTERVAL: Duration = Duration::from_secs(2);
                 let mut metrics = BlockstoreInsertionMetrics::default();
                 let mut ws_metrics = WindowServiceMetrics::default();
                 let mut last_print = Instant::now();
+
                 while !exit.load(Ordering::Relaxed) {
                     if let Err(e) = run_insert(
                         &thread_pool,
@@ -400,7 +403,7 @@ impl WindowService {
                         }
                     }
 
-                    if last_print.elapsed().as_secs() > 2 {
+                    if last_print.elapsed() > METRICS_REPORTING_INTERVAL {
                         metrics.report_metrics();
                         metrics = BlockstoreInsertionMetrics::default();
                         ws_metrics.report_metrics();


### PR DESCRIPTION
#### Problem
Several datapoints claim to report on 2s interval, but check when they should emit based on Duration::as_secs() > 2. Duration::as_secs() returns an integer so that comparison will only return true once at least 3 seconds have elapsed.

#### Summary of Changes
Switch to use a Duration on the rhs to actually report on 2s intervals

#### Backport Intention
I have rediscovered this several times over the past couple years; I think it is finally time to fix it. One issue with adjusting the timing intervals is many metrics are reported as sums / not normalized. So, dropping from a 3s interval (now) to 2s interval might give the false appearance of improvements.

For that reason, I'd like to BP to v4.0 and v3.1 for the sake of comparison between branches