### PR TITLE
refactor: move snapshot IO options from AccountsDbConfig to SnapshotConfig

### DIFF
--- a/accounts-db/src/accounts_db/accounts_db_config.rs
+++ b/accounts-db/src/accounts_db/accounts_db_config.rs
@@ -41,12 +41,6 @@ pub struct AccountsDbConfig {
     pub num_background_threads: Option<NonZeroUsize>,
     /// Number of threads for foreground operations (`thread_pool_foreground`)
     pub num_foreground_threads: Option<NonZeroUsize>,
-    /// Whether to register buffers as *fixed* in io_uring
-    ///
-    /// Requires memlock ulimit higher than sum of buffer sizes registered at the same time.
-    pub use_registered_io_uring_buffers: bool,
-    /// Enables direct I/O for operations on snapshots, their archives and contents being unpacked
-    pub snapshots_use_direct_io: bool,
 }
 
 pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
@@ -68,8 +62,6 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormalTest,
     num_background_threads: None,
     num_foreground_threads: None,
-    use_registered_io_uring_buffers: true,
-    snapshots_use_direct_io: true,
 };
 
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
@@ -91,6 +83,4 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormal,
     num_background_threads: None,
     num_foreground_threads: None,
-    use_registered_io_uring_buffers: true,
-    snapshots_use_direct_io: true,
 };

--- a/accounts-db/src/utils.rs
+++ b/accounts-db/src/utils.rs
@@ -1,5 +1,4 @@
 use {
-    crate::accounts_db::AccountsDbConfig,
     agave_fs::{dirs, metadata::DirectIoSupport},
     itertools::Itertools as _,
     log::*,
@@ -173,11 +172,11 @@ pub fn create_account_shared_data(account: &impl ReadableAccount) -> AccountShar
 /// like direct-io. This allows providing meaningful error messages to user during startup
 /// instead of generating hard to diagnose errors during runtime.
 pub fn validate_account_paths_for_direct_io(
-    config: &AccountsDbConfig,
+    use_direct_io: bool,
     accounts_paths: &[PathBuf],
     account_snapshot_paths: &[PathBuf],
 ) -> io::Result<()> {
-    if config.snapshots_use_direct_io {
+    if use_direct_io {
         let mut unsupported_paths = vec![];
         for path in accounts_paths.iter().chain(account_snapshot_paths.iter()) {
             if agave_fs::metadata::check_direct_io_capability(path)? == DirectIoSupport::Unsupported

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2840,7 +2840,7 @@ fn cleanup_accounts_paths(config: &ValidatorConfig) {
 
 fn validate_account_paths(config: &ValidatorConfig) -> std::io::Result<()> {
     validate_account_paths_for_direct_io(
-        &config.accounts_db_config,
+        config.snapshot_config.use_direct_io,
         &config.account_paths,
         &config.account_snapshot_paths,
     )

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -132,9 +132,9 @@ fn restore_from_snapshot(
 
     let deserialized_bank = snapshot_bank_utils::bank_from_snapshot_archives(
         account_paths,
-        &snapshot_config.bank_snapshots_dir,
         &full_snapshot_archive_info,
         None,
+        snapshot_config,
         old_genesis_config,
         &RuntimeConfig::default(),
         None,
@@ -533,10 +533,8 @@ fn restore_from_snapshots_and_check_banks_are_equal(
     genesis_config: &GenesisConfig,
 ) -> agave_snapshots::Result<()> {
     let (deserialized_bank, ..) = snapshot_bank_utils::bank_from_latest_snapshot_archives(
-        &snapshot_config.bank_snapshots_dir,
-        &snapshot_config.full_snapshot_archives_dir,
-        &snapshot_config.incremental_snapshot_archives_dir,
         &[accounts_dir],
+        snapshot_config,
         genesis_config,
         &RuntimeConfig::default(),
         None,
@@ -724,10 +722,8 @@ fn test_snapshots_with_background_services() {
     let (_tmp_dir, temporary_accounts_dir) = create_tmp_accounts_dir_for_tests();
     let snapshot_config = snapshot_controller.snapshot_config();
     let (deserialized_bank, ..) = snapshot_bank_utils::bank_from_latest_snapshot_archives(
-        &snapshot_config.bank_snapshots_dir,
-        &snapshot_config.full_snapshot_archives_dir,
-        &snapshot_config.incremental_snapshot_archives_dir,
         &[temporary_accounts_dir],
+        snapshot_config,
         &snapshot_test_config.genesis_config_info.genesis_config,
         &RuntimeConfig::default(),
         None,

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -19,7 +19,6 @@ use {
     },
     solana_cli_output::CliAccountNewConfig,
     solana_clock::Slot,
-    solana_core::resource_limits,
     solana_ledger::{
         blockstore_processor::ProcessOptions,
         use_snapshot_archives_at_startup::{self, UseSnapshotArchivesAtStartup},
@@ -384,10 +383,6 @@ pub fn get_accounts_db_config(
         scan_filter_for_shrinking,
         num_background_threads: None,
         num_foreground_threads: None,
-        use_registered_io_uring_buffers: resource_limits::check_memlock_limit_for_disk_io(
-            solana_accounts_db::accounts_db::TOTAL_IO_URING_BUFFERS_SIZE_LIMIT,
-        ),
-        snapshots_use_direct_io: !arg_matches.is_present("no_accounts_db_snapshots_direct_io"),
     }
 }
 

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -8,12 +8,18 @@ use {
     clap::{ArgMatches, value_t, value_t_or_exit, values_t_or_exit},
     crossbeam_channel::unbounded,
     log::*,
-    solana_accounts_db::utils::{
-        create_all_accounts_run_and_snapshot_dirs, move_and_async_delete_path_contents,
-        validate_account_paths_for_direct_io,
+    solana_accounts_db::{
+        accounts_db::TOTAL_IO_URING_BUFFERS_SIZE_LIMIT,
+        utils::{
+            create_all_accounts_run_and_snapshot_dirs, move_and_async_delete_path_contents,
+            validate_account_paths_for_direct_io,
+        },
     },
     solana_clock::Slot,
-    solana_core::validator::{BlockProductionMethod, BlockVerificationMethod},
+    solana_core::{
+        resource_limits,
+        validator::{BlockProductionMethod, BlockVerificationMethod},
+    },
     solana_genesis_config::GenesisConfig,
     solana_genesis_utils::open_genesis_config,
     solana_geyser_plugin_manager::geyser_plugin_service::{
@@ -181,6 +187,10 @@ pub fn load_and_process_ledger(
             full_snapshot_archives_dir,
             incremental_snapshot_archives_dir,
             bank_snapshots_dir,
+            use_direct_io: !arg_matches.is_present("no_accounts_db_snapshots_direct_io"),
+            use_registered_io_uring_buffers: resource_limits::check_memlock_limit_for_disk_io(
+                TOTAL_IO_URING_BUFFERS_SIZE_LIMIT,
+            ),
             ..SnapshotConfig::new_load_only()
         }
     };
@@ -256,7 +266,7 @@ pub fn load_and_process_ledger(
     let account_paths = account_run_paths;
 
     validate_account_paths_for_direct_io(
-        &process_options.accounts_db_config,
+        snapshot_config.use_direct_io,
         &account_paths,
         &account_snapshot_paths,
     )

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -217,9 +217,9 @@ pub fn try_load_bank_forks_from_snapshot(
 
         snapshot_bank_utils::bank_from_snapshot_archives(
             account_paths,
-            &snapshot_config.bank_snapshots_dir,
             &full_snapshot_archive_info,
             incremental_snapshot_archive_info.as_ref(),
+            snapshot_config,
             genesis_config,
             &process_options.runtime_config,
             process_options.debug_keys.clone(),

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -907,9 +907,9 @@ mod tests {
         };
         let roundtrip_bank = snapshot_bank_utils::bank_from_snapshot_archives(
             &[accounts_dir],
-            &bank_snapshots_dir,
             &snapshot,
             None,
+            &snapshot_config,
             &genesis_config,
             &RuntimeConfig::default(),
             None,
@@ -1005,9 +1005,9 @@ mod tests {
         let (_accounts_tempdir, accounts_dir) = snapshot_utils::create_tmp_accounts_dir_for_tests();
         let roundtrip_bank = snapshot_bank_utils::bank_from_snapshot_archives(
             &[accounts_dir],
-            &bank_snapshots_dir,
             &snapshot,
             None,
+            &snapshot_config,
             &genesis_config,
             &RuntimeConfig::default(),
             None,

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -2183,9 +2183,9 @@ pub(crate) mod tests {
         // Restore the bank from the snapshot and run checks.
         let roundtrip_bank = bank_from_snapshot_archives(
             &[accounts_dir],
-            bank_snapshots_dir.path(),
             &full_snapshot_archive_info,
             None,
+            &snapshot_config,
             &genesis_config,
             &RuntimeConfig::default(),
             None,

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -322,9 +322,9 @@ mod tests {
         // Deserialize
         let dbank = snapshot_bank_utils::bank_from_snapshot_archives(
             &[accounts_dir],
-            bank_snapshots_dir.path(),
             &snapshot_archive_info,
             None,
+            &snapshot_config,
             &genesis_config,
             &RuntimeConfig::default(),
             None,

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -9,6 +9,7 @@ use {
         },
     },
     agave_snapshots::SnapshotVersion,
+    solana_accounts_db::accounts_file::StorageAccess,
     tempfile::TempDir,
 };
 use {
@@ -55,7 +56,7 @@ use {
     std::{
         collections::{HashMap, HashSet},
         ops::RangeInclusive,
-        path::{Path, PathBuf},
+        path::PathBuf,
         sync::{Arc, atomic::AtomicBool},
     },
 };
@@ -65,7 +66,7 @@ use {
 #[cfg(feature = "dev-context-only-utils")]
 pub fn bank_fields_from_snapshot_archives(
     snapshot_config: &SnapshotConfig,
-    accounts_db_config: &AccountsDbConfig,
+    storage_access: StorageAccess,
 ) -> agave_snapshots::Result<BankFieldsToDeserialize> {
     let full_snapshot_archive_info =
         get_highest_full_snapshot_archive_info(&snapshot_config.full_snapshot_archives_dir)
@@ -87,8 +88,8 @@ pub fn bank_fields_from_snapshot_archives(
 
     let io_setup = IoSetupState::default()
         .with_shared_sqpoll()?
-        .with_direct_io(accounts_db_config.snapshots_use_direct_io)
-        .with_buffers_registered(accounts_db_config.use_registered_io_uring_buffers);
+        .with_direct_io(snapshot_config.use_direct_io)
+        .with_buffers_registered(snapshot_config.use_registered_io_uring_buffers);
     let (
         UnarchivedSnapshots {
             full_unpacked_snapshots_dir_and_version,
@@ -101,7 +102,7 @@ pub fn bank_fields_from_snapshot_archives(
         &full_snapshot_archive_info,
         incremental_snapshot_archive_info.as_ref(),
         &account_paths,
-        accounts_db_config.storage_access,
+        storage_access,
         &io_setup,
     )?;
 
@@ -171,8 +172,8 @@ pub fn bank_from_snapshot_archives(
 
     let io_setup = IoSetupState::default()
         .with_shared_sqpoll()?
-        .with_direct_io(accounts_db_config.snapshots_use_direct_io)
-        .with_buffers_registered(accounts_db_config.use_registered_io_uring_buffers);
+        .with_direct_io(snapshot_config.use_direct_io)
+        .with_buffers_registered(snapshot_config.use_registered_io_uring_buffers);
     let (
         UnarchivedSnapshots {
             full_storage: mut storage,
@@ -855,7 +856,9 @@ mod tests {
         solana_system_transaction as system_transaction,
         solana_transaction::sanitized::SanitizedTransaction,
         std::{
-            fs, slice,
+            fs,
+            path::Path,
+            slice,
             sync::{Arc, atomic::Ordering},
         },
         test_case::test_case,
@@ -1665,14 +1668,8 @@ mod tests {
 
         bank_to_incremental_snapshot_archive(&snapshot_config, &bank2, full_snapshot_slot).unwrap();
 
-        let bank_fields = bank_fields_from_snapshot_archives(
-            &snapshot_config,
-            &AccountsDbConfig {
-                storage_access,
-                ..ACCOUNTS_DB_CONFIG_FOR_TESTING
-            },
-        )
-        .unwrap();
+        let bank_fields =
+            bank_fields_from_snapshot_archives(&snapshot_config, storage_access).unwrap();
         assert_eq!(bank_fields.slot, bank2.slot());
         assert_eq!(bank_fields.parent_slot, bank2.parent_slot());
     }

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -64,17 +64,19 @@ use {
 /// epoch schedule, etc.
 #[cfg(feature = "dev-context-only-utils")]
 pub fn bank_fields_from_snapshot_archives(
-    full_snapshot_archives_dir: impl AsRef<Path>,
-    incremental_snapshot_archives_dir: impl AsRef<Path>,
+    snapshot_config: &SnapshotConfig,
     accounts_db_config: &AccountsDbConfig,
 ) -> agave_snapshots::Result<BankFieldsToDeserialize> {
     let full_snapshot_archive_info =
-        get_highest_full_snapshot_archive_info(&full_snapshot_archives_dir).ok_or_else(|| {
-            SnapshotError::NoSnapshotArchives(full_snapshot_archives_dir.as_ref().to_path_buf())
-        })?;
+        get_highest_full_snapshot_archive_info(&snapshot_config.full_snapshot_archives_dir)
+            .ok_or_else(|| {
+                SnapshotError::NoSnapshotArchives(
+                    snapshot_config.full_snapshot_archives_dir.clone(),
+                )
+            })?;
 
     let incremental_snapshot_archive_info = get_highest_incremental_snapshot_archive_info(
-        &incremental_snapshot_archives_dir,
+        &snapshot_config.incremental_snapshot_archives_dir,
         full_snapshot_archive_info.slot(),
     );
 
@@ -140,9 +142,9 @@ fn bank_fields_from_snapshots(
 #[expect(clippy::too_many_arguments)]
 pub fn bank_from_snapshot_archives(
     account_paths: &[PathBuf],
-    bank_snapshots_dir: impl AsRef<Path>,
     full_snapshot_archive_info: &FullSnapshotArchiveInfo,
     incremental_snapshot_archive_info: Option<&IncrementalSnapshotArchiveInfo>,
+    snapshot_config: &SnapshotConfig,
     genesis_config: &GenesisConfig,
     runtime_config: &RuntimeConfig,
     debug_keys: Option<Arc<HashSet<Pubkey>>>,
@@ -186,7 +188,7 @@ pub fn bank_from_snapshot_archives(
         },
         _guard,
     ) = verify_and_unarchive_snapshots(
-        bank_snapshots_dir,
+        &snapshot_config.bank_snapshots_dir,
         full_snapshot_archive_info,
         incremental_snapshot_archive_info,
         account_paths,
@@ -297,14 +299,13 @@ pub fn bank_from_snapshot_archives(
 
 /// Rebuild bank from snapshot archives
 ///
-/// This function searches `full_snapshot_archives_dir` and `incremental_snapshot_archives_dir` for
-/// the highest full snapshot and highest corresponding incremental snapshot, then rebuilds the bank.
+/// This function searches `snapshot_config.full_snapshot_archives_dir` and
+/// `snapshot_config.incremental_snapshot_archives_dir` for the highest full snapshot and
+/// highest corresponding incremental snapshot, then rebuilds the bank.
 #[expect(clippy::too_many_arguments)]
 pub fn bank_from_latest_snapshot_archives(
-    bank_snapshots_dir: impl AsRef<Path>,
-    full_snapshot_archives_dir: impl AsRef<Path>,
-    incremental_snapshot_archives_dir: impl AsRef<Path>,
     account_paths: &[PathBuf],
+    snapshot_config: &SnapshotConfig,
     genesis_config: &GenesisConfig,
     runtime_config: &RuntimeConfig,
     debug_keys: Option<Arc<HashSet<Pubkey>>>,
@@ -321,20 +322,23 @@ pub fn bank_from_latest_snapshot_archives(
     Option<IncrementalSnapshotArchiveInfo>,
 )> {
     let full_snapshot_archive_info =
-        get_highest_full_snapshot_archive_info(&full_snapshot_archives_dir).ok_or_else(|| {
-            SnapshotError::NoSnapshotArchives(full_snapshot_archives_dir.as_ref().to_path_buf())
-        })?;
+        get_highest_full_snapshot_archive_info(&snapshot_config.full_snapshot_archives_dir)
+            .ok_or_else(|| {
+                SnapshotError::NoSnapshotArchives(
+                    snapshot_config.full_snapshot_archives_dir.clone(),
+                )
+            })?;
 
     let incremental_snapshot_archive_info = get_highest_incremental_snapshot_archive_info(
-        &incremental_snapshot_archives_dir,
+        &snapshot_config.incremental_snapshot_archives_dir,
         full_snapshot_archive_info.slot(),
     );
 
     let bank = bank_from_snapshot_archives(
         account_paths,
-        bank_snapshots_dir.as_ref(),
         &full_snapshot_archive_info,
         incremental_snapshot_archive_info.as_ref(),
+        snapshot_config,
         genesis_config,
         runtime_config,
         debug_keys,
@@ -969,9 +973,9 @@ mod tests {
 
         let roundtrip_bank = bank_from_snapshot_archives(
             &[accounts_dir],
-            bank_snapshots_dir.path(),
             &snapshot_archive_info,
             None,
+            &snapshot_config,
             &genesis_config,
             &RuntimeConfig::default(),
             None,
@@ -1050,9 +1054,9 @@ mod tests {
 
         let roundtrip_bank = bank_from_snapshot_archives(
             &[accounts_dir],
-            bank_snapshots_dir.path(),
             &full_snapshot_archive_info,
             None,
+            &snapshot_config,
             &genesis_config,
             &RuntimeConfig::default(),
             None,
@@ -1152,9 +1156,9 @@ mod tests {
 
         let roundtrip_bank = bank_from_snapshot_archives(
             &[accounts_dir],
-            bank_snapshots_dir.path(),
             &full_snapshot_archive_info,
             None,
+            &snapshot_config,
             &genesis_config,
             &RuntimeConfig::default(),
             None,
@@ -1266,9 +1270,9 @@ mod tests {
 
         let roundtrip_bank = bank_from_snapshot_archives(
             &[accounts_dir],
-            bank_snapshots_dir.path(),
             &full_snapshot_archive_info,
             Some(&incremental_snapshot_archive_info),
+            &snapshot_config,
             &genesis_config,
             &RuntimeConfig::default(),
             None,
@@ -1366,10 +1370,8 @@ mod tests {
         bank_to_incremental_snapshot_archive(&snapshot_config, &bank4, full_snapshot_slot).unwrap();
 
         let (deserialized_bank, ..) = bank_from_latest_snapshot_archives(
-            &bank_snapshots_dir,
-            &full_snapshot_archives_dir,
-            &incremental_snapshot_archives_dir,
             &[accounts_dir],
+            &snapshot_config,
             &genesis_config,
             &RuntimeConfig::default(),
             None,
@@ -1408,12 +1410,11 @@ mod tests {
             bank_to_full_snapshot_archive(&snapshot_config, &bank).unwrap();
 
         let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
-        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let error = bank_from_snapshot_archives(
             &[accounts_dir],
-            &bank_snapshots_dir,
             &full_snapshot_archive_info,
             None,
+            &snapshot_config,
             &genesis_config,
             &RuntimeConfig::default(),
             None,
@@ -1546,9 +1547,9 @@ mod tests {
                 .unwrap();
         let deserialized_bank = bank_from_snapshot_archives(
             slice::from_ref(&accounts_dir),
-            bank_snapshots_dir.path(),
             &full_snapshot_archive_info,
             Some(&incremental_snapshot_archive_info),
+            &snapshot_config,
             &genesis_config,
             &RuntimeConfig::default(),
             None,
@@ -1596,9 +1597,9 @@ mod tests {
 
         let deserialized_bank = bank_from_snapshot_archives(
             &[accounts_dir],
-            bank_snapshots_dir.path(),
             &full_snapshot_archive_info,
             Some(&incremental_snapshot_archive_info),
+            &snapshot_config,
             &genesis_config,
             &RuntimeConfig::default(),
             None,
@@ -1665,8 +1666,7 @@ mod tests {
         bank_to_incremental_snapshot_archive(&snapshot_config, &bank2, full_snapshot_slot).unwrap();
 
         let bank_fields = bank_fields_from_snapshot_archives(
-            &all_snapshots_dir,
-            &all_snapshots_dir,
+            &snapshot_config,
             &AccountsDbConfig {
                 storage_access,
                 ..ACCOUNTS_DB_CONFIG_FOR_TESTING
@@ -2015,12 +2015,11 @@ mod tests {
             bank_to_full_snapshot_archive(&snapshot_config, &bank3).unwrap();
 
         let accounts_dir = tempfile::TempDir::new().unwrap();
-        let other_bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let deserialized_bank = bank_from_snapshot_archives(
             &[accounts_dir.path().to_path_buf()],
-            other_bank_snapshots_dir.path(),
             &full_snapshot_archive_info,
             None,
+            &snapshot_config,
             &genesis_config,
             &RuntimeConfig::default(),
             None,

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -650,9 +650,9 @@ mod tests {
         };
         let roundtrip_bank = snapshot_bank_utils::bank_from_snapshot_archives(
             &[accounts_dir],
-            &bank_snapshots_dir,
             &snapshot,
             None,
+            &snapshot_config,
             &genesis_config_info.genesis_config,
             &RuntimeConfig::default(),
             None,

--- a/snapshots/src/snapshot_config.rs
+++ b/snapshots/src/snapshot_config.rs
@@ -78,7 +78,7 @@ impl Default for SnapshotConfig {
             maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             maximum_incremental_snapshot_archives_to_retain:
                 DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            use_direct_io: false,
+            use_direct_io: true,
             use_registered_io_uring_buffers: true,
         }
     }

--- a/snapshots/src/snapshot_config.rs
+++ b/snapshots/src/snapshot_config.rs
@@ -48,6 +48,14 @@ pub struct SnapshotConfig {
     /// Maximum number of incremental snapshot archives to retain
     /// NOTE: Incremental snapshots will only be kept for the latest full snapshot
     pub maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
+
+    /// Use `O_DIRECT` flag for IO operations.
+    pub use_direct_io: bool,
+
+    /// Whether to register buffers as *fixed* in io_uring for IO operations.
+    ///
+    /// Requires memlock ulimit higher than sum of buffer sizes registered at the same time.
+    pub use_registered_io_uring_buffers: bool,
 }
 
 impl Default for SnapshotConfig {
@@ -70,6 +78,8 @@ impl Default for SnapshotConfig {
             maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             maximum_incremental_snapshot_archives_to_retain:
                 DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            use_direct_io: false,
+            use_registered_io_uring_buffers: true,
         }
     }
 }

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1087,8 +1087,6 @@ impl TestValidator {
             index: Some(AccountsIndexConfig::default()),
             account_indexes: Some(config.rpc_config.account_indexes.clone()),
             scan_filter_for_shrinking: ScanFilter::All,
-            use_registered_io_uring_buffers: false,
-            snapshots_use_direct_io: false,
             ..ACCOUNTS_DB_CONFIG_FOR_TESTING
         };
 
@@ -1135,6 +1133,7 @@ impl TestValidator {
                 bank_snapshots_dir: ledger_path.join(BANK_SNAPSHOTS_DIR),
                 full_snapshot_archives_dir: ledger_path.to_path_buf(),
                 incremental_snapshot_archives_dir: ledger_path.to_path_buf(),
+                use_registered_io_uring_buffers: false,
                 ..SnapshotConfig::default()
             },
             warp_slot: config.warp_slot,

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1134,6 +1134,7 @@ impl TestValidator {
                 full_snapshot_archives_dir: ledger_path.to_path_buf(),
                 incremental_snapshot_archives_dir: ledger_path.to_path_buf(),
                 use_registered_io_uring_buffers: false,
+                use_direct_io: false,
                 ..SnapshotConfig::default()
             },
             warp_slot: config.warp_slot,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -721,10 +721,6 @@ pub fn execute(
         scan_filter_for_shrinking,
         num_background_threads: Some(accounts_db_background_threads),
         num_foreground_threads: Some(accounts_db_foreground_threads),
-        use_registered_io_uring_buffers: resource_limits::check_memlock_limit_for_disk_io(
-            solana_accounts_db::accounts_db::TOTAL_IO_URING_BUFFERS_SIZE_LIMIT,
-        ),
-        snapshots_use_direct_io: !matches.is_present("no_accounts_db_snapshots_direct_io"),
     };
 
     let on_start_geyser_plugin_config_files = if matches.is_present("geyser_plugin_config") {
@@ -1386,6 +1382,10 @@ fn new_snapshot_config(
         snapshot_version,
         maximum_full_snapshot_archives_to_retain,
         maximum_incremental_snapshot_archives_to_retain,
+        use_registered_io_uring_buffers: resource_limits::check_memlock_limit_for_disk_io(
+            solana_accounts_db::accounts_db::TOTAL_IO_URING_BUFFERS_SIZE_LIMIT,
+        ),
+        use_direct_io: !matches.is_present("no_accounts_db_snapshots_direct_io"),
     };
 
     if !is_snapshot_config_valid(&snapshot_config) {


### PR DESCRIPTION
#### Problem
Functions that load a bank from snapshot archives (`bank_from_snapshot_archives`, `bank_from_latest_snapshot_archives`, `bank_fields_from_snapshot_archives`) accept explicit directory path parameters (`bank_snapshots_dir`, `full_snapshot_archives_dir`, `incremental_snapshot_archives_dir`) that are available on the `SnapshotConfig`, which can be passed to them directly.
Having snapshot config at hand enables cleaning up IO options controlling direct I/O (`O_DIRECT`) and io_uring buffer registration for snapshot operations, which are in `AccountsDbConfig` despite only being relevant to preparing data for accounts-db during snapshot archive unpacking.

#### Summary of Changes
* Commit 1 - pass `SnapshotConfig` instead of explicit path params - removes `bank_snapshots_dir`, `full_snapshot_archives_dir`, and `incremental_snapshot_archives_dir` parameters from `bank_from_snapshot_archives`, `bank_from_latest_snapshot_archives`, and `bank_fields_from_snapshot_archives`; callers now pass `&SnapshotConfig` and the functions read paths directly from it
* Commit 2 - move IO options from `AccountsDbConfig` to `SnapshotConfig`
  - add `use_direct_io: bool` and `use_registered_io_uring_buffers: bool` to `SnapshotConfig` (defaults: `true` / `true` except test-validator)
  - remove the same fields from `AccountsDbConfig` and its `FOR_TESTING`/`FOR_BENCHMARKS` constants
  - change `validate_account_paths_for_direct_io` to take `use_direct_io: bool` directly instead of `&AccountsDbConfig`
  - wire the fields from `SnapshotConfig` in the validator, ledger-tool, and test-validator; `io_setup` construction inside `bank_from_snapshot_archives` / `bank_fields_from_snapshot_archives` now reads from `snapshot_config`

(those could be split into 2 PRs, but since second commit provides context/motivation for the first, it should be fine to merge together)