### PR TITLE
Adds old store fn param to shrinking_in_progress()

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -189,13 +189,21 @@ impl AccountStorage {
     pub(crate) fn shrinking_in_progress(
         &self,
         slot: Slot,
+        old_store: Arc<AccountStorageEntry>,
         new_store: Arc<AccountStorageEntry>,
     ) -> ShrinkInProgress<'_> {
-        let shrinking_store = Arc::clone(
+        assert_eq!(new_store.slot(), slot);
+        assert_eq!(old_store.slot(), slot);
+        assert_eq!(
             self.map
                 .get(&slot)
-                .expect("no pre-existing storage for shrinking slot")
-                .value(),
+                .expect("pre-existing storage for shrinking slot")
+                .value()
+                .id(),
+            old_store.id(),
+            "store being shrunk not found in account storage map! slot: {slot}, old store: \
+             {old_store:?}, new store: {new_store:?}, entry in account storage map at slot: {:?}",
+            self.map.get(&slot).unwrap().value(),
         );
 
         // insert 'new_store' into 'shrink_in_progress_map'
@@ -212,7 +220,7 @@ impl AccountStorage {
             storage: self,
             slot,
             new_store,
-            old_store: shrinking_store,
+            old_store,
         }
     }
 
@@ -691,8 +699,9 @@ mod tests {
         let (_temp_dir1, sample_to_shrink) =
             new_test_storage_with(slot, id_to_shrink, storage_access);
         let (_temp_dir2, sample) = new_test_storage_with(slot, id_shrunk, storage_access);
-        storage.map.insert(slot, sample_to_shrink);
-        let shrinking_in_progress = storage.shrinking_in_progress(slot, sample.clone());
+        storage.map.insert(slot, sample_to_shrink.clone());
+        let shrinking_in_progress =
+            storage.shrinking_in_progress(slot, sample_to_shrink.clone(), sample.clone());
         assert!(storage.map.contains_key(&slot));
         assert_eq!(id_to_shrink, storage.map.get(&slot).unwrap().id());
         assert_eq!(
@@ -710,17 +719,17 @@ mod tests {
         assert!(storage.map.contains_key(&slot));
         assert_eq!(id_shrunk, storage.map.get(&slot).unwrap().id());
         assert!(storage.shrink_in_progress_map.read().unwrap().is_empty());
-        storage.shrinking_in_progress(slot, sample);
+        storage.shrinking_in_progress(slot, sample.clone(), sample);
     }
 
     #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
     #[test_case(StorageAccess::File)]
-    #[should_panic(expected = "no pre-existing storage for shrinking slot")]
+    #[should_panic(expected = "pre-existing storage for shrinking slot")]
     fn test_shrinking_in_progress_fail1(storage_access: StorageAccess) {
         // nothing in slot currently
         let (_temp_dir, sample) = new_test_storage(storage_access);
         let storage = AccountStorage::default();
-        storage.shrinking_in_progress(0, sample);
+        storage.shrinking_in_progress(0, sample.clone(), sample);
     }
 
     #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
@@ -736,7 +745,7 @@ mod tests {
             .write()
             .unwrap()
             .insert(0, sample.clone());
-        storage.shrinking_in_progress(0, sample);
+        storage.shrinking_in_progress(0, sample.clone(), sample);
     }
 
     #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
@@ -747,9 +756,10 @@ mod tests {
         let (_temp_dir1, sample_to_shrink) = new_test_storage(storage_access);
         let (_temp_dir2, sample) = new_test_storage(storage_access);
         let storage = AccountStorage::default();
-        storage.map.insert(0, sample_to_shrink);
-        let _shrinking_in_progress = storage.shrinking_in_progress(0, sample.clone());
-        storage.shrinking_in_progress(0, sample);
+        storage.map.insert(0, sample_to_shrink.clone());
+        let _shrinking_in_progress =
+            storage.shrinking_in_progress(0, sample_to_shrink.clone(), sample.clone());
+        storage.shrinking_in_progress(0, sample_to_shrink, sample);
     }
 
     #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2873,8 +2873,11 @@ impl AccountsDb {
 
         let mut stats_sub = ShrinkStatsSub::default();
         let mut rewrite_elapsed = Measure::start("rewrite_elapsed");
-        let (shrink_in_progress, time_us) =
-            measure_us!(self.get_store_for_shrink(slot, shrink_collect.alive_total_bytes as u64));
+        let (shrink_in_progress, time_us) = measure_us!(self.get_store_for_shrink(
+            slot,
+            Arc::clone(&store),
+            shrink_collect.alive_total_bytes as u64
+        ));
         stats_sub.create_and_insert_store_elapsed_us = Saturating(time_us);
 
         // here, we're writing back alive_accounts. That should be an atomic operation
@@ -3002,9 +3005,15 @@ impl AccountsDb {
     }
 
     /// return a store that can contain 'size' bytes
-    pub fn get_store_for_shrink(&self, slot: Slot, size: u64) -> ShrinkInProgress<'_> {
+    pub fn get_store_for_shrink(
+        &self,
+        slot: Slot,
+        old_store: Arc<AccountStorageEntry>,
+        size: u64,
+    ) -> ShrinkInProgress<'_> {
         let shrunken_store = self.create_store(slot, size, "shrink", self.shrink_paths.as_slice());
-        self.storage.shrinking_in_progress(slot, shrunken_store)
+        self.storage
+            .shrinking_in_progress(slot, old_store, shrunken_store)
     }
 
     // Reads all accounts in given slot's AppendVecs and filter only to alive,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -5027,7 +5027,7 @@ fn test_mark_dirty_dead_stores() {
         let size = 1;
         let old_store = db.create_and_insert_store(slot, size, "test");
         let old_id = old_store.id();
-        let shrink_in_progress = db.get_store_for_shrink(slot, 100);
+        let shrink_in_progress = db.get_store_for_shrink(slot, old_store, 100);
         let dead_storages =
             db.mark_dirty_dead_stores(slot, add_dirty_stores, Some(shrink_in_progress), false);
         assert!(db.storage.get_slot_storage_entry(slot).is_some());

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -557,8 +557,12 @@ impl AccountsDb {
         write_ancient_accounts: &mut WriteAncientAccounts<'b>,
     ) {
         let target_slot = accounts_to_write.target_slot();
+        let old_store = self
+            .storage
+            .get_slot_storage_entry_shrinking_in_progress_ok(target_slot)
+            .expect("ancient shrink target slot must already have a storage");
         let (shrink_in_progress, create_and_insert_store_elapsed_us) =
-            measure_us!(self.get_store_for_shrink(target_slot, bytes));
+            measure_us!(self.get_store_for_shrink(target_slot, old_store, bytes));
         let (store_accounts_timing, rewrite_elapsed_us) = measure_us!(self.store_accounts_frozen(
             accounts_to_write,
             shrink_in_progress.new_storage(),
@@ -1584,9 +1588,13 @@ mod tests {
                         if all_slots_shrunk {
                             // make it look like each of the slots was shrunk
                             slots.clone().for_each(|slot| {
+                                let old_store = db
+                                    .storage
+                                    .get_slot_storage_entry_shrinking_in_progress_ok(slot)
+                                    .unwrap();
                                 write_ancient_accounts
                                     .shrinks_in_progress
-                                    .insert(slot, db.get_store_for_shrink(slot, 1));
+                                    .insert(slot, db.get_store_for_shrink(slot, old_store, 1));
                             });
                         }
 

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -306,10 +306,11 @@ impl<'a> SnapshotMinimizer<'a> {
 
         let mut shrink_in_progress = None;
         if total_bytes > 0 {
-            shrink_in_progress = Some(
-                self.accounts_db()
-                    .get_store_for_shrink(slot, total_bytes as u64),
-            );
+            shrink_in_progress = Some(self.accounts_db().get_store_for_shrink(
+                slot,
+                Arc::clone(storage),
+                total_bytes as u64,
+            ));
             let new_storage = shrink_in_progress.as_ref().unwrap().new_storage();
 
             let accounts = [(slot, &keep_accounts[..])];


### PR DESCRIPTION
#### Problem

`AccountStorage::shrinking_in_progress()` takes in a slot to shrink, but that's it. If we want to support multiple storages per slot, having only the slot is insufficient to disambiguate which storage to shrink if there are more than one at that slot.


#### Summary of Changes

Update `AccountStorage::shrinking_in_progress()` to take the old storage itself, instead of doing an additional lookup (redundant, since we already have the storage...). This way when there may be multiple storages in a slot, we are explicit about which storage is being shrunk.