### PR TITLE
accounts-db: add config option for readonly cache shard count

### DIFF
--- a/accounts-db/benches/read_only_accounts_cache.rs
+++ b/accounts-db/benches/read_only_accounts_cache.rs
@@ -65,6 +65,7 @@ fn bench_read_only_accounts_cache(c: &mut Criterion) {
             AccountsDb::DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_LO,
             AccountsDb::DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_HI,
             AccountsDb::DEFAULT_READ_ONLY_CACHE_EVICT_SAMPLE_SIZE,
+            AccountsDb::DEFAULT_READ_ONLY_CACHE_NUM_SHARDS,
         ));
 
         for (pubkey, account) in accounts.iter() {
@@ -185,6 +186,7 @@ fn bench_read_only_accounts_cache_eviction(
             max_data_size_lo,
             max_data_size_hi,
             AccountsDb::DEFAULT_READ_ONLY_CACHE_EVICT_SAMPLE_SIZE,
+            AccountsDb::DEFAULT_READ_ONLY_CACHE_NUM_SHARDS,
         ));
 
         // Fill up the cache.

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1033,6 +1033,15 @@ impl AccountsDb {
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     const DEFAULT_READ_ONLY_CACHE_EVICT_SAMPLE_SIZE: usize = 8;
 
+    /// Number of read-only cache shards. Using 2^16 (65 536) shards keeps the
+    /// count a power of two and roughly matches the number of cached accounts
+    /// we observe on mainnet-beta. The average load is still ~1 account per
+    /// shard (collisions are common), but compared with the default
+    /// `num_cpus * 4` shards - where we saw hot shards carrying ~200
+    /// accounts - this dramatically lowers contention.
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+    const DEFAULT_READ_ONLY_CACHE_NUM_SHARDS: usize = 65536;
+
     pub fn new_with_config(
         paths: Vec<PathBuf>,
         accounts_db_config: AccountsDbConfig,
@@ -1063,6 +1072,9 @@ impl AccountsDb {
         let read_cache_evict_sample_size = accounts_db_config
             .read_cache_evict_sample_size
             .unwrap_or(Self::DEFAULT_READ_ONLY_CACHE_EVICT_SAMPLE_SIZE);
+        let read_cache_num_shards = accounts_db_config
+            .read_cache_num_shards
+            .unwrap_or(Self::DEFAULT_READ_ONLY_CACHE_NUM_SHARDS);
 
         // Increase the stack for foreground threads
         // rayon needs a lot of stack
@@ -1112,6 +1124,7 @@ impl AccountsDb {
                 read_cache_size.0,
                 read_cache_size.1,
                 read_cache_evict_sample_size,
+                read_cache_num_shards,
             ),
             write_cache_limit_bytes: accounts_db_config.write_cache_limit_bytes,
             partitioned_epoch_rewards_config: accounts_db_config.partitioned_epoch_rewards_config,

--- a/accounts-db/src/accounts_db/accounts_db_config.rs
+++ b/accounts-db/src/accounts_db/accounts_db_config.rs
@@ -26,6 +26,9 @@ pub struct AccountsDbConfig {
     /// The number of elements that will be randomly sampled at eviction time,
     /// the oldest of which will get evicted.
     pub read_cache_evict_sample_size: Option<usize>,
+    /// Number of shards for the read-only accounts cache's DashMap.
+    /// Must be a power of two. If None, defaults to 65536.
+    pub read_cache_num_shards: Option<usize>,
     pub write_cache_limit_bytes: Option<u64>,
     /// if None, ancient append vecs are set to ANCIENT_APPEND_VEC_DEFAULT_OFFSET
     /// Some(offset) means include slots up to (max_slot - (slots_per_epoch - 'offset'))
@@ -51,6 +54,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     read_cache_limit_bytes: None,
     read_cache_evict_sample_size: None,
+    read_cache_num_shards: None,
     write_cache_limit_bytes: None,
     ancient_append_vec_offset: None,
     ancient_storage_ideal_size: None,
@@ -72,6 +76,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     read_cache_limit_bytes: None,
     read_cache_evict_sample_size: None,
+    read_cache_num_shards: None,
     write_cache_limit_bytes: None,
     ancient_append_vec_offset: None,
     ancient_storage_ideal_size: None,

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -30,13 +30,6 @@ use {
 const CACHE_ENTRY_SIZE: usize =
     size_of::<ReadOnlyAccountCacheEntry>() + size_of::<ReadOnlyCacheKey>();
 
-/// Number of cache shards. Using 2^16 (65 536) shards keeps the count a power
-/// of two and roughly matches the number of cached accounts we observe on
-/// mainnet-beta. The average load is still ~1 account per shard (collisions are
-/// common), but compared with the default `num_cpus * 4` shards - where we saw
-/// hot shards carrying ~200 accounts - this dramatically lowers contention.
-const NUM_SHARDS: usize = 65536;
-
 type ReadOnlyCacheKey = Pubkey;
 
 #[derive(Debug)]
@@ -120,12 +113,17 @@ impl ReadOnlyAccountsCache {
         max_data_size_lo: usize,
         max_data_size_hi: usize,
         evict_sample_size: usize,
+        num_shards: usize,
     ) -> Self {
         assert!(max_data_size_lo <= max_data_size_hi);
         assert!(evict_sample_size > 0);
+        assert!(
+            num_shards.is_power_of_two(),
+            "num_shards must be a power of two, got {num_shards}"
+        );
         let cache = Arc::new(DashMap::with_hasher_and_shard_amount(
             AHashRandomState::default(),
-            NUM_SHARDS,
+            num_shards,
         ));
         let data_size = Arc::new(AtomicUsize::default());
         let cache_len = Arc::new(AtomicUsize::default());
@@ -538,6 +536,7 @@ mod tests {
             MAX_CACHE_SIZE,
             usize::MAX, // <-- do not evict in the background
             evict_sample_size,
+            8,
         );
         let slots: Vec<Slot> = repeat_with(|| rng.random_range(0..1000)).take(5).collect();
         let pubkeys: Vec<Pubkey> = repeat_with(|| {
@@ -599,7 +598,8 @@ mod tests {
         const ACCOUNT_DATA_SIZE: usize = 200;
         const MAX_ENTRIES: usize = 7;
         const MAX_CACHE_SIZE: usize = MAX_ENTRIES * (CACHE_ENTRY_SIZE + ACCOUNT_DATA_SIZE);
-        let cache = ReadOnlyAccountsCache::new(MAX_CACHE_SIZE, MAX_CACHE_SIZE, evict_sample_size);
+        let cache =
+            ReadOnlyAccountsCache::new(MAX_CACHE_SIZE, MAX_CACHE_SIZE, evict_sample_size, 8);
 
         for i in 0..MAX_ENTRIES {
             let pubkey = Pubkey::new_unique();
@@ -640,6 +640,7 @@ mod tests {
             usize::MAX,
             usize::MAX,
             1, /* evictions never trigger */
+            8,
         );
 
         let pubkeys: Vec<_> = (0..NUM_ACCOUNTS).map(|_| Pubkey::new_unique()).collect();

--- a/accounts-db/tests/read_only_accounts_cache.rs
+++ b/accounts-db/tests/read_only_accounts_cache.rs
@@ -1,7 +1,10 @@
 use {
     rand::{SeedableRng, rngs::SmallRng},
     solana_account::{Account, AccountSharedData},
-    solana_accounts_db::read_only_accounts_cache::{CACHE_ENTRY_SIZE, ReadOnlyAccountsCache},
+    solana_accounts_db::{
+        accounts_db::AccountsDb,
+        read_only_accounts_cache::{CACHE_ENTRY_SIZE, ReadOnlyAccountsCache},
+    },
     solana_pubkey::Pubkey,
     std::{collections::HashSet, sync::atomic::Ordering},
     test_case::test_matrix,
@@ -28,6 +31,7 @@ fn test_read_only_accounts_cache_eviction(num_accounts: (usize, usize), evict_sa
         max_cache_size,
         usize::MAX, // <-- do not evict in the background
         evict_sample_size,
+        AccountsDb::DEFAULT_READ_ONLY_CACHE_NUM_SHARDS,
     );
     let data = vec![0u8; DATA_SIZE];
     let mut newer_half = HashSet::new();

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -366,6 +366,7 @@ pub fn get_accounts_db_config(
         shrink_ratio: AccountShrinkThreshold::default(),
         read_cache_limit_bytes: None,
         read_cache_evict_sample_size: None,
+        read_cache_num_shards: None,
         write_cache_limit_bytes: None,
         ancient_append_vec_offset: value_t!(arg_matches, "accounts_db_ancient_append_vecs", i64)
             .ok(),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -703,6 +703,7 @@ pub fn execute(
         shrink_ratio,
         read_cache_limit_bytes,
         read_cache_evict_sample_size: None,
+        read_cache_num_shards: None,
         write_cache_limit_bytes: value_t!(matches, "accounts_db_cache_limit_mb", u64)
             .ok()
             .map(|mb| mb * MB as u64),


### PR DESCRIPTION
#### Problem
Transaction and block test execution speed is 50% dominated by a call to `DashMap::with_hasher_and_shard_amount` within the readonly accounts cache (which defaults to 65536 entries), largely over-provisioned for small, self-contained tests. Adding a config option allows us to choose a smaller default value from our testing harnesses.

#### Summary of Changes
Make the number of shards in the readonly accounts cache configurable via `AccountsDbConfig`
