### PR TITLE
Sigverify: Remove Rayon

### DIFF
--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -171,7 +171,7 @@ fn bench_shrink_sigverify_stage_core(bencher: &mut Bencher, discard_factor: i32)
         let mut verify_time = Measure::start("sigverify_batch_time");
         threadpool.install(|| sigverify::ed25519_verify(&mut batches, false, num_valid_packets));
         verify_time.stop();
-        black_box(sigverify::count_valid_packets(&batches));
+        black_box(&batches);
 
         c += 1;
         total_verify_time += verify_time.as_us();

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -169,7 +169,7 @@ fn bench_shrink_sigverify_stage_core(bencher: &mut Bencher, discard_factor: i32)
         let mut batches = batches0.clone();
 
         let mut verify_time = Measure::start("sigverify_batch_time");
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_valid_packets);
+        threadpool.install(|| sigverify::ed25519_verify(&mut batches, false, num_valid_packets));
         verify_time.stop();
         black_box(sigverify::count_valid_packets(&batches));
 

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -524,7 +524,6 @@ impl ClusterInfoVoteListener {
         // Votes should already be filtered by this point.
         threadpool.install(|| {
             sigverify::ed25519_verify(
-                threadpool,
                 &mut packet_batches,
                 /*reject_non_vote=*/ false,
                 votes.len(),

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -522,12 +522,14 @@ impl ClusterInfoVoteListener {
         let mut packet_batches = packet::to_packet_batches(&votes, 1);
 
         // Votes should already be filtered by this point.
-        sigverify::ed25519_verify(
-            threadpool,
-            &mut packet_batches,
-            /*reject_non_vote=*/ false,
-            votes.len(),
-        );
+        threadpool.install(|| {
+            sigverify::ed25519_verify(
+                threadpool,
+                &mut packet_batches,
+                /*reject_non_vote=*/ false,
+                votes.len(),
+            );
+        });
         let root_bank = sharable_banks.root();
         let epoch_schedule = root_bank.epoch_schedule();
         votes

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -9,11 +9,13 @@ use {
     crossbeam_channel::{Receiver, Sender, TrySendError, bounded},
     solana_measure::measure::Measure,
     solana_perf::{packet::PacketBatch, sigverify},
-    std::sync::{
-        Arc,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+    std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        thread::{Builder, JoinHandle},
     },
-    std::thread::{Builder, JoinHandle},
 };
 
 pub struct TransactionSigVerifier {
@@ -141,13 +143,9 @@ impl TransactionSigVerifier {
         } = task;
 
         let mut verify_time = Measure::start("sigverify_batch_time");
-        sigverify::ed25519_verify_serial(
-            core::slice::from_mut(&mut batch),
-            reject_non_vote,
-            valid_packets,
-        );
+        sigverify::ed25519_verify_serial(&mut batch, reject_non_vote, valid_packets);
         verify_time.stop();
-        let num_valid_packets = sigverify::count_valid_packets(core::slice::from_ref(&batch));
+        let num_valid_packets = sigverify::count_valid_packets(&batch);
 
         let banking_packet_batch = BankingPacketBatch::new(vec![batch]);
         if let Some(forward_stage_sender) = forward_stage_sender {

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -6,24 +6,35 @@ pub use solana_perf::sigverify::{count_packets_in_batches, ed25519_verify};
 use {
     crate::{banking_trace::BankingPacketSender, sigverify_stage::SigVerifyServiceError},
     agave_banking_stage_ingress_types::BankingPacketBatch,
-    crossbeam_channel::{Sender, TrySendError},
+    crossbeam_channel::{Receiver, Sender, TrySendError, bounded},
     solana_measure::measure::Measure,
-    solana_perf::{
-        packet::PacketBatch,
-        sigverify::{self},
-    },
+    solana_perf::{packet::PacketBatch, sigverify},
     std::sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
+    std::thread::{Builder, JoinHandle},
 };
 
 pub struct TransactionSigVerifier {
-    thread_pool: Arc<rayon::ThreadPool>,
-    banking_stage_sender: BankingPacketSender,
-    forward_stage_sender: Option<Sender<(BankingPacketBatch, bool)>>,
-    reject_non_vote: bool,
+    exit: Arc<AtomicBool>,
+    worker_sender: Sender<VerifyTask>,
+    worker_hdls: Vec<JoinHandle<()>>,
+    worker_count: usize,
 }
+
+struct VerifyTask {
+    batch: PacketBatch,
+    valid_packets: usize,
+    in_flight_count: Arc<AtomicUsize>,
+    total_valid_packets: Arc<AtomicUsize>,
+    total_verify_time_us: Arc<AtomicUsize>,
+}
+
+const CAPACITY_PER_THREAD: usize = {
+    15_000 // ~15k packets per second throughput
+    * 2 // 2 seconds worth
+};
 
 impl TransactionSigVerifier {
     pub fn new_reject_non_vote(
@@ -31,9 +42,7 @@ impl TransactionSigVerifier {
         packet_sender: BankingPacketSender,
         forward_stage_sender: Option<Sender<(BankingPacketBatch, bool)>>,
     ) -> Self {
-        let mut new_self = Self::new(thread_pool, packet_sender, forward_stage_sender);
-        new_self.reject_non_vote = true;
-        new_self
+        Self::new_with_mode(thread_pool, packet_sender, forward_stage_sender, true)
     }
 
     pub fn new(
@@ -41,68 +50,180 @@ impl TransactionSigVerifier {
         banking_stage_sender: BankingPacketSender,
         forward_stage_sender: Option<Sender<(BankingPacketBatch, bool)>>,
     ) -> Self {
-        Self {
+        Self::new_with_mode(
             thread_pool,
             banking_stage_sender,
             forward_stage_sender,
-            reject_non_vote: false,
+            false,
+        )
+    }
+
+    fn new_with_mode(
+        thread_pool: Arc<rayon::ThreadPool>,
+        banking_stage_sender: BankingPacketSender,
+        forward_stage_sender: Option<Sender<(BankingPacketBatch, bool)>>,
+        reject_non_vote: bool,
+    ) -> Self {
+        let worker_count = thread_pool.current_num_threads();
+        let exit = Arc::new(AtomicBool::new(false));
+        let (worker_sender, worker_receiver) =
+            bounded(worker_count.saturating_mul(CAPACITY_PER_THREAD));
+        let worker_hdls = Self::spawn_workers(
+            worker_count,
+            worker_receiver,
+            banking_stage_sender.clone(),
+            forward_stage_sender.clone(),
+            exit.clone(),
+            reject_non_vote,
+        );
+        Self {
+            exit,
+            worker_sender,
+            worker_hdls,
+            worker_count,
         }
+    }
+
+    fn spawn_workers(
+        worker_count: usize,
+        worker_receiver: Receiver<VerifyTask>,
+        banking_stage_sender: BankingPacketSender,
+        forward_stage_sender: Option<Sender<(BankingPacketBatch, bool)>>,
+        exit: Arc<AtomicBool>,
+        reject_non_vote: bool,
+    ) -> Vec<JoinHandle<()>> {
+        (0..worker_count)
+            .map(|i| {
+                let worker_receiver = worker_receiver.clone();
+                let banking_stage_sender = banking_stage_sender.clone();
+                let forward_stage_sender = forward_stage_sender.clone();
+                let exit = exit.clone();
+                Builder::new()
+                    .name(format!(
+                        "{}{i:02}",
+                        if reject_non_vote {
+                            "solSigVerVote"
+                        } else {
+                            "solSigVer"
+                        }
+                    ))
+                    .spawn(move || {
+                        while let Ok(task) = worker_receiver.recv() {
+                            if exit.load(Ordering::Acquire) {
+                                break;
+                            }
+                            Self::run_task(
+                                task,
+                                &banking_stage_sender,
+                                &forward_stage_sender,
+                                reject_non_vote,
+                            );
+                        }
+                    })
+                    .expect("new sigverify worker thread")
+            })
+            .collect()
+    }
+
+    fn run_task(
+        task: VerifyTask,
+        banking_stage_sender: &BankingPacketSender,
+        forward_stage_sender: &Option<Sender<(BankingPacketBatch, bool)>>,
+        reject_non_vote: bool,
+    ) {
+        let VerifyTask {
+            mut batch,
+            valid_packets,
+            in_flight_count,
+            total_valid_packets,
+            total_verify_time_us,
+            ..
+        } = task;
+
+        let mut verify_time = Measure::start("sigverify_batch_time");
+        sigverify::ed25519_verify_serial(
+            core::slice::from_mut(&mut batch),
+            reject_non_vote,
+            valid_packets,
+        );
+        verify_time.stop();
+        let num_valid_packets = sigverify::count_valid_packets(core::slice::from_ref(&batch));
+
+        let banking_packet_batch = BankingPacketBatch::new(vec![batch]);
+        if let Some(forward_stage_sender) = forward_stage_sender {
+            if let Err(err) = banking_stage_sender.send(banking_packet_batch.clone()) {
+                error!("sigverify send failed: {err:?}");
+                in_flight_count.fetch_sub(valid_packets, Ordering::Release);
+                return;
+            }
+            if let Err(TrySendError::Full(_)) =
+                forward_stage_sender.try_send((banking_packet_batch, reject_non_vote))
+            {
+                warn!("forwarding stage channel is full, dropping packets.");
+            }
+        } else if let Err(err) = banking_stage_sender.send(banking_packet_batch) {
+            error!("sigverify send failed: {err:?}");
+            in_flight_count.fetch_sub(valid_packets, Ordering::Release);
+            return;
+        }
+
+        total_valid_packets.fetch_add(num_valid_packets, Ordering::Relaxed);
+        total_verify_time_us.fetch_add(verify_time.as_us() as usize, Ordering::Relaxed);
+        in_flight_count.fetch_sub(valid_packets, Ordering::Release);
     }
 
     pub(crate) fn verify_and_send_packets(
         &mut self,
         batches: Vec<PacketBatch>,
-        valid_packets: usize,
         in_flight_count: Arc<AtomicUsize>,
         total_valid_packets: Arc<AtomicUsize>,
         total_verify_time_us: Arc<AtomicUsize>,
     ) -> Result<(), SigVerifyServiceError> {
-        let banking_stage_sender = self.banking_stage_sender.clone();
-        let forward_stage_sender = self.forward_stage_sender.clone();
-        let reject_non_vote = self.reject_non_vote;
+        for batch in batches {
+            let valid_packets = batch
+                .iter()
+                .filter(|packet| !packet.meta().discard())
+                .count();
+            in_flight_count.fetch_add(valid_packets, Ordering::Release);
 
-        in_flight_count.fetch_add(valid_packets, Ordering::Release);
-
-        self.thread_pool.spawn(move || {
-            let mut verify_time = Measure::start("sigverify_batch_time");
-            let mut batches = batches;
-            sigverify::ed25519_verify(&mut batches, reject_non_vote, valid_packets);
-            verify_time.stop();
-            let num_valid_packets = sigverify::count_valid_packets(&batches);
-
-            let banking_packet_batch = BankingPacketBatch::new(batches);
-            if let Some(forward_stage_sender) = &forward_stage_sender {
-                if let Err(err) = banking_stage_sender.send(banking_packet_batch.clone()) {
-                    error!("sigverify send failed: {err:?}");
-                    in_flight_count.fetch_sub(valid_packets, Ordering::Release);
-                    return;
-                }
-                if let Err(TrySendError::Full(_)) =
-                    forward_stage_sender.try_send((banking_packet_batch, reject_non_vote))
-                {
-                    warn!("forwarding stage channel is full, dropping packets.");
-                }
-            } else if let Err(err) = banking_stage_sender.send(banking_packet_batch) {
-                error!("sigverify send failed: {err:?}");
+            let task = VerifyTask {
+                batch,
+                valid_packets,
+                in_flight_count: in_flight_count.clone(),
+                total_valid_packets: total_valid_packets.clone(),
+                total_verify_time_us: total_verify_time_us.clone(),
+            };
+            if self.worker_sender.send(task).is_err() {
+                error!("sigverify worker queue closed unexpectedly");
                 in_flight_count.fetch_sub(valid_packets, Ordering::Release);
-                return;
             }
-
-            total_valid_packets.fetch_add(num_valid_packets, Ordering::Relaxed);
-            total_verify_time_us.fetch_add(verify_time.as_us() as usize, Ordering::Relaxed);
-            in_flight_count.fetch_sub(valid_packets, Ordering::Release);
-        });
+        }
 
         Ok(())
     }
 
     pub(crate) fn capacity(&self) -> usize {
-        const CAPACITY_PER_THREAD: usize = {
-            15_000 // ~15k packets per second throughput
-            * 2 // 2 seconds worth
-        };
-        self.thread_pool
-            .current_num_threads()
-            .saturating_mul(CAPACITY_PER_THREAD)
+        self.worker_count.saturating_mul(CAPACITY_PER_THREAD)
+    }
+}
+
+impl Drop for TransactionSigVerifier {
+    fn drop(&mut self) {
+        self.exit.store(true, Ordering::Release);
+        for _ in 0..self.worker_count {
+            let _ = self.worker_sender.send(VerifyTask {
+                batch: PacketBatch::from(solana_perf::packet::BytesPacketBatch::default()),
+                valid_packets: 0,
+                in_flight_count: Arc::new(AtomicUsize::new(0)),
+                total_valid_packets: Arc::new(AtomicUsize::new(0)),
+                total_verify_time_us: Arc::new(AtomicUsize::new(0)),
+            });
+        }
+        for worker_hdl in self.worker_hdls.drain(..) {
+            if let Err(err) = worker_hdl.join() {
+                let _ = err;
+                debug!("sigverify worker thread exited with panic");
+            }
+        }
     }
 }

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -57,7 +57,6 @@ impl TransactionSigVerifier {
         total_valid_packets: Arc<AtomicUsize>,
         total_verify_time_us: Arc<AtomicUsize>,
     ) -> Result<(), SigVerifyServiceError> {
-        let thread_pool = self.thread_pool.clone();
         let banking_stage_sender = self.banking_stage_sender.clone();
         let forward_stage_sender = self.forward_stage_sender.clone();
         let reject_non_vote = self.reject_non_vote;
@@ -67,7 +66,7 @@ impl TransactionSigVerifier {
         self.thread_pool.spawn(move || {
             let mut verify_time = Measure::start("sigverify_batch_time");
             let mut batches = batches;
-            sigverify::ed25519_verify(&thread_pool, &mut batches, reject_non_vote, valid_packets);
+            sigverify::ed25519_verify(&mut batches, reject_non_vote, valid_packets);
             verify_time.stop();
             let num_valid_packets = sigverify::count_valid_packets(&batches);
 

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -215,12 +215,8 @@ impl SigVerifyStage {
             let discard_or_dedup_fail =
                 deduper::dedup_packets_and_count_discards(deduper, &mut batches) as usize;
             dedup_time.stop();
-            let num_unique = num_packets.saturating_sub(discard_or_dedup_fail);
-            let num_packets_to_verify = num_unique;
-
             verifier.verify_and_send_packets(
                 batches,
-                num_packets_to_verify,
                 in_flight_count.clone(),
                 stats.total_valid_packets.clone(),
                 stats.total_verify_time_us.clone(),

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -31,7 +31,7 @@ fn bench_sigverify_simple(b: &mut Bencher) {
 
     // verify packets
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        threadpool.install(|| sigverify::ed25519_verify(&mut batches, false, num_packets));
     })
 }
 
@@ -56,7 +56,7 @@ fn bench_sigverify_low_packets_small_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE - 1;
     let mut batches = gen_batches(false, 1, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        threadpool.install(|| sigverify::ed25519_verify(&mut batches, false, num_packets));
     })
 }
 
@@ -65,7 +65,7 @@ fn bench_sigverify_low_packets_large_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE - 1;
     let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        threadpool.install(|| sigverify::ed25519_verify(&mut batches, false, num_packets));
     })
 }
 
@@ -74,7 +74,7 @@ fn bench_sigverify_medium_packets_small_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE * 8;
     let mut batches = gen_batches(false, 1, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        threadpool.install(|| sigverify::ed25519_verify(&mut batches, false, num_packets));
     })
 }
 
@@ -83,7 +83,7 @@ fn bench_sigverify_medium_packets_large_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE * 8;
     let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        threadpool.install(|| sigverify::ed25519_verify(&mut batches, false, num_packets));
     })
 }
 
@@ -92,7 +92,7 @@ fn bench_sigverify_high_packets_small_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE * 32;
     let mut batches = gen_batches(false, 1, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        threadpool.install(|| sigverify::ed25519_verify(&mut batches, false, num_packets));
     })
 }
 
@@ -102,7 +102,7 @@ fn bench_sigverify_high_packets_large_batch(b: &mut Bencher) {
     let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
     // verify packets
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        threadpool.install(|| sigverify::ed25519_verify(&mut batches, false, num_packets));
     })
 }
 
@@ -146,7 +146,7 @@ fn bench_sigverify_uneven(b: &mut Bencher) {
 
     // verify packets
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        threadpool.install(|| sigverify::ed25519_verify(&mut batches, false, num_packets));
     })
 }
 

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -106,18 +106,16 @@ fn is_simple_vote_transaction_view<D: TransactionData>(view: &SanitizedTransacti
 }
 
 pub fn ed25519_verify(
-    thread_pool: &rayon::ThreadPool,
+    _thread_pool: &rayon::ThreadPool,
     batches: &mut [PacketBatch],
     reject_non_vote: bool,
     packet_count: usize,
 ) {
     debug!("CPU ECDSA for {packet_count}");
-    thread_pool.install(|| {
-        batches.par_iter_mut().flatten().for_each(|mut packet| {
-            if !packet.meta().discard() && !verify_packet(&mut packet, reject_non_vote) {
-                packet.meta_mut().set_discard(true);
-            }
-        });
+    batches.par_iter_mut().flatten().for_each(|mut packet| {
+        if !packet.meta().discard() && !verify_packet(&mut packet, reject_non_vote) {
+            packet.meta_mut().set_discard(true);
+        }
     });
 }
 

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -105,12 +105,7 @@ fn is_simple_vote_transaction_view<D: TransactionData>(view: &SanitizedTransacti
     *program_id == solana_sdk_ids::vote::id()
 }
 
-pub fn ed25519_verify(
-    _thread_pool: &rayon::ThreadPool,
-    batches: &mut [PacketBatch],
-    reject_non_vote: bool,
-    packet_count: usize,
-) {
+pub fn ed25519_verify(batches: &mut [PacketBatch], reject_non_vote: bool, packet_count: usize) {
     debug!("CPU ECDSA for {packet_count}");
     batches.par_iter_mut().flatten().for_each(|mut packet| {
         if !packet.meta().discard() && !verify_packet(&mut packet, reject_non_vote) {
@@ -434,7 +429,7 @@ mod tests {
     fn ed25519_verify(batches: &mut [PacketBatch]) {
         let threadpool = threadpool_for_tests();
         let packet_count = sigverify::count_packets_in_batches(batches);
-        sigverify::ed25519_verify(&threadpool, batches, false, packet_count);
+        threadpool.install(|| sigverify::ed25519_verify(batches, false, packet_count));
     }
 
     #[test]

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -66,11 +66,8 @@ pub fn count_packets_in_batches(batches: &[PacketBatch]) -> usize {
     batches.iter().map(|batch| batch.len()).sum()
 }
 
-pub fn count_valid_packets<'a>(batches: impl IntoIterator<Item = &'a PacketBatch>) -> usize {
-    batches
-        .into_iter()
-        .map(|batch| batch.into_iter().filter(|p| !p.meta().discard()).count())
-        .sum()
+pub fn count_valid_packets(batch: &PacketBatch) -> usize {
+    batch.into_iter().filter(|p| !p.meta().discard()).count()
 }
 
 fn is_simple_vote_transaction_view<D: TransactionData>(view: &SanitizedTransactionView<D>) -> bool {
@@ -114,17 +111,11 @@ pub fn ed25519_verify(batches: &mut [PacketBatch], reject_non_vote: bool, packet
     });
 }
 
-pub fn ed25519_verify_serial(
-    batches: &mut [PacketBatch],
-    reject_non_vote: bool,
-    packet_count: usize,
-) {
+pub fn ed25519_verify_serial(batch: &mut PacketBatch, reject_non_vote: bool, packet_count: usize) {
     debug!("CPU ECDSA for {packet_count}");
-    for batch in batches {
-        for mut packet in batch.iter_mut() {
-            if !packet.meta().discard() && !verify_packet(&mut packet, reject_non_vote) {
-                packet.meta_mut().set_discard(true);
-            }
+    for mut packet in batch.iter_mut() {
+        if !packet.meta().discard() && !verify_packet(&mut packet, reject_non_vote) {
+            packet.meta_mut().set_discard(true);
         }
     }
 }

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -114,6 +114,21 @@ pub fn ed25519_verify(batches: &mut [PacketBatch], reject_non_vote: bool, packet
     });
 }
 
+pub fn ed25519_verify_serial(
+    batches: &mut [PacketBatch],
+    reject_non_vote: bool,
+    packet_count: usize,
+) {
+    debug!("CPU ECDSA for {packet_count}");
+    for batch in batches {
+        for mut packet in batch.iter_mut() {
+            if !packet.meta().discard() && !verify_packet(&mut packet, reject_non_vote) {
+                packet.meta_mut().set_discard(true);
+            }
+        }
+    }
+}
+
 pub fn mark_disabled(batches: &mut [PacketBatch], r: &[Vec<u8>]) {
     for (batch, v) in batches.iter_mut().zip(r) {
         for (mut pkt, f) in batch.iter_mut().zip(v) {


### PR DESCRIPTION
#### Problem
- Rayon does not make sense for how we're using it in SigVerify

#### Summary of Changes
- Use worker thread pool with sent tasks

Fixes #
