### PR TITLE
v4.0 - chore: bump rustls-webpki vendor tags for RUSTSEC-2026-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6331,7 +6331,7 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 [[package]]
 name = "rustls-webpki"
 version = "0.101.7"
-source = "git+https://github.com/anza-xyz/rustls-webpki?tag=anza-0.101.7-1#37e66ef34b2a3aabb82ec65ed7582ce689b9b43c"
+source = "git+https://github.com/anza-xyz/rustls-webpki?tag=anza-0.101.7-2#33eddb8e3258c606eca2ecb9e8e9abce18895f78"
 dependencies = [
  "ring",
  "untrusted",
@@ -6340,7 +6340,7 @@ dependencies = [
 [[package]]
 name = "rustls-webpki"
 version = "0.103.10"
-source = "git+https://github.com/anza-xyz/rustls-webpki?tag=anza-0.103.10-1#f4296cc9258f44b8aced868860f8fadc0fd70881"
+source = "git+https://github.com/anza-xyz/rustls-webpki?tag=anza-0.103.10-2#9f20a9c6e8d9c74191a8a4e2d1819843f5485966"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -662,5 +662,5 @@ codegen-units = 1
 [patch.crates-io]
 # for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
-rustls-webpki = { git = "https://github.com/anza-xyz/rustls-webpki", tag = "anza-0.103.10-1" }
-rustls-webpki2 = { git = "https://github.com/anza-xyz/rustls-webpki", package = "rustls-webpki", tag = "anza-0.101.7-1" }
+rustls-webpki = { git = "https://github.com/anza-xyz/rustls-webpki", tag = "anza-0.103.10-2" }
+rustls-webpki2 = { git = "https://github.com/anza-xyz/rustls-webpki", package = "rustls-webpki", tag = "anza-0.101.7-2" }

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -88,6 +88,17 @@ cargo_audit_ignores=(
   #
   # AVAVE OK: we picked upstream fix atop our vendored branches
   --ignore RUSTSEC-2026-0099
+
+  # Crate:     rustls-webpki
+  # Version:   0.101.7
+  # Title:     Reachable panic in certificate revocation list parsing
+  # Date:      2026-04-22
+  # ID:        RUSTSEC-2026-0104
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0104
+  # Solution:  Upgrade to >=0.103.13, <0.104.0-alpha.1 OR >=0.104.0-alpha.7
+  #
+  # AGAVE OK: vendored the upstream fix again
+  --ignore RUSTSEC-2026-0104
 )
 scripts/cargo-for-all-lock-files.sh audit "${cargo_audit_ignores[@]}" | $dep_tree_filter
 # we want the `cargo audit` exit code, not `$dep_tree_filter`'s


### PR DESCRIPTION
#### Problem
https://rustsec.org/advisories/RUSTSEC-2026-0104

#### Summary of Changes
https://github.com/anza-xyz/rustls-webpki/compare/anza-0.101.7-1...anza-0.101.7-2
https://github.com/anza-xyz/rustls-webpki/compare/anza-0.103.10-1...anza-0.103.10-2