### PR TITLE
validator: Register SIGUSR1 handler earlier

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -301,9 +301,19 @@ pub struct GeneratorConfig {
     pub starting_keypairs: Arc<Vec<Keypair>>,
 }
 
+#[derive(Clone, Debug)]
+pub struct ValidatorLogConfig {
+    /// The destination file for validator logs
+    pub logfile: PathBuf,
+    /// A flag to indicate that a logrotate rotation has occurred and that the
+    /// logfile should be reopened. The flag itself is toggled when the process
+    /// receives the SIGUSR1 signal
+    pub logrotate_flag: Arc<AtomicBool>,
+}
+
 pub struct ValidatorConfig {
-    /// The destination file for validator logs; `stderr` is used if `None`
-    pub logfile: Option<PathBuf>,
+    /// Log messages go to `stderr` if `None`
+    pub log_config: Option<ValidatorLogConfig>,
     pub expected_genesis_hash: Option<Hash>,
     pub expected_bank_hash: Option<Hash>,
     pub expected_shred_version: Option<u16>,
@@ -386,7 +396,7 @@ pub struct ValidatorConfig {
 impl ValidatorConfig {
     pub fn default_for_test() -> Self {
         Self {
-            logfile: None,
+            log_config: None,
             expected_genesis_hash: None,
             expected_bank_hash: None,
             expected_shred_version: None,
@@ -616,12 +626,11 @@ impl ValidatorTpuConfig {
 }
 
 pub struct Validator {
-    /// The destination file for validator logs; `stderr` is used if `None`
-    #[cfg_attr(not(unix), allow(dead_code))]
-    logfile: Option<PathBuf>,
     /// A global flag to indicate communicate shutdown between threads
     exit: Arc<AtomicBool>,
     validator_exit: Arc<RwLock<Exit>>,
+    #[cfg_attr(not(unix), allow(dead_code))]
+    log_config: Option<ValidatorLogConfig>,
     json_rpc_service: Option<JsonRpcService>,
     pubsub_service: Option<PubSubService>,
     rpc_completed_slots_service: Option<JoinHandle<()>>,
@@ -1732,7 +1741,7 @@ impl Validator {
         });
 
         Ok(Self {
-            logfile: config.logfile.clone(),
+            log_config: config.log_config.clone(),
             exit,
             stats_reporter_service,
             gossip_service,
@@ -1765,41 +1774,39 @@ impl Validator {
         })
     }
 
-    /// Register and listen for signals that the validator will act on. Also,
-    /// monitor the validator's exit flag incase a shutdown has been initated
-    /// by one of the validator threads
-    pub fn listen_for_signals(&self) -> Result<()> {
-        // Reopen the logfile when the SIGUSR1 signal is received; this provides
-        // a hook for working with logrotate
-        let sigusr1_flag = Arc::new(AtomicBool::new(false));
+    /// Register a signal handler to toggle the returned `AtomicBool` when the
+    /// `SIGUSR1` signal is received. The `SIGUSR1` signal provides a hook for
+    /// the validator to support logrotate
+    pub fn register_logrotate_signal_handler() -> Result<Arc<AtomicBool>> {
+        let flag = Arc::new(AtomicBool::new(false));
         #[cfg(unix)]
         {
-            if self.logfile.is_some() {
-                signal_hook::flag::register(libc::SIGUSR1, sigusr1_flag.clone())?;
-            }
+            signal_hook::flag::register(libc::SIGUSR1, flag.clone())?;
         }
+        Ok(flag)
+    }
 
+    /// Monitor registered signal handlers and the validator's exit flag
+    pub fn listen_for_signals(&self) -> Result<()> {
         info!("Validator::listen_for_signals() has started");
         loop {
             if self.exit.load(Ordering::Relaxed) {
                 break;
             }
 
-            if sigusr1_flag.load(Ordering::Relaxed) {
-                #[cfg(unix)]
-                {
-                    if let Some(logfile) = self.logfile.as_ref() {
-                        info!("Received SIGUSR1, reopening {}", logfile.display());
-                        agave_logger::redirect_stderr(logfile);
-                        // Reset the flag to `false` to allow detection of the
-                        // signal again and to avoid hitting this case every
-                        // iteration
-                        sigusr1_flag.store(false, Ordering::Relaxed);
-                    }
-                }
-                #[cfg(not(unix))]
-                {
-                    unreachable!("The SIGUSR1 signal is only handled on unix systems");
+            #[cfg(unix)]
+            if let Some(ValidatorLogConfig {
+                logfile,
+                logrotate_flag,
+            }) = self.log_config.as_ref()
+            {
+                if logrotate_flag.load(Ordering::Relaxed) {
+                    info!("Received SIGUSR1, reopening {}", logfile.display());
+                    agave_logger::redirect_stderr(logfile);
+                    // Reset the flag to `false` to allow detection of the
+                    // signal again and to avoid hitting this case every
+                    // iteration
+                    logrotate_flag.store(false, Ordering::Relaxed);
                 }
             }
 

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -6,7 +6,7 @@ use {
 
 pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
     ValidatorConfig {
-        logfile: config.logfile.clone(),
+        log_config: config.log_config.clone(),
         expected_genesis_hash: config.expected_genesis_hash,
         expected_bank_hash: config.expected_bank_hash,
         expected_shred_version: config.expected_shred_version,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -45,7 +45,8 @@ use {
         tpu::MAX_VOTES_PER_SECOND,
         validator::{
             BlockProductionMethod, BlockVerificationMethod, SchedulerPacing, Validator,
-            ValidatorConfig, ValidatorStartProgress, ValidatorTpuConfig, is_snapshot_config_valid,
+            ValidatorConfig, ValidatorLogConfig, ValidatorStartProgress, ValidatorTpuConfig,
+            is_snapshot_config_valid,
         },
     },
     solana_genesis_utils::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
@@ -127,11 +128,20 @@ pub fn execute(
     let identity_keypair = Arc::new(run_args.identity_keypair);
 
     let logfile = run_args.logfile;
-    if let Some(logfile) = logfile.as_ref() {
+    let log_config = if let Some(ref logfile) = logfile {
         println!("log file: {}", logfile.display());
-    }
-    let use_progress_bar = logfile.is_none();
-    agave_logger::initialize_logging(logfile.clone());
+        let logrotate_flag = Validator::register_logrotate_signal_handler()?;
+
+        Some(ValidatorLogConfig {
+            logfile: logfile.clone(),
+            logrotate_flag,
+        })
+    } else {
+        None
+    };
+    let use_progress_bar = log_config.is_none();
+    agave_logger::initialize_logging(logfile);
+
     cli::warn_for_deprecated_arguments(matches);
 
     info!("{} {}", crate_name!(), solana_version);
@@ -787,7 +797,7 @@ pub fn execute(
     );
 
     let mut validator_config = ValidatorConfig {
-        logfile,
+        log_config,
         require_tower: matches.is_present("require_tower"),
         tower_storage,
         vote_history_storage,


### PR DESCRIPTION
#### Problem
The validator is configured to listen for SIGUSR1 and reopen logfile when received to support logrotate. The default for unix is to terminate the process if that signal is sent without a handler registered.

Some previous cleanup shifted the signal handler registration to after Validator::new() completes. For normal operation, this is a narrow time window so a node would be unlikely to hit this often. However, Validator::new() not finishing for a while would increase the chances of the unhandled signal bringing the process down. One such case where this may happen is if the validator is waiting for supermajority

#### Summary of Changes
Shift the signal handler registration earlier in the process. Logrotate won't take effect until Validator::new() completes, but it will be handled when it gets there and most importantly, the process won't be killed