### PR TITLE
feat(fs): expose IoSetupState to callers of large_file_buf_writer

### DIFF
--- a/fs/src/buffered_writer.rs
+++ b/fs/src/buffered_writer.rs
@@ -1,5 +1,5 @@
 use {
-    crate::FileSize,
+    crate::{FileSize, io_setup::IoSetupState},
     std::{fs, io, path::Path},
 };
 
@@ -18,24 +18,25 @@ const DEFAULT_BUF_WRITER_BUFFER_SIZE: usize = 2 * 1024 * 1024;
 /// Return a buffered writer for creating a new file at `path`
 ///
 /// The returned writer is using a buffer size tuned for writing large files to disks.
-pub fn large_file_buf_writer(path: impl AsRef<Path>) -> io::Result<impl io::Write> {
+/// `io_setup` controls the I/O configuration (e.g. direct I/O, shared sqpoll).
+pub fn large_file_buf_writer(
+    path: impl AsRef<Path>,
+    io_setup: &IoSetupState,
+) -> io::Result<impl io::Write> {
     #[cfg(target_os = "linux")]
     {
         assert!(agave_io_uring::io_uring_supported());
         use {
-            crate::{
-                io_setup::IoSetupState,
-                io_uring::{
-                    file_creator::IoUringFileCreatorBuilder, file_writer::IoUringFileWriter,
-                },
+            crate::io_uring::{
+                file_creator::IoUringFileCreatorBuilder, file_writer::IoUringFileWriter,
             },
             std::sync::Arc,
         };
 
-        let io_setup = IoSetupState::default();
         let file_creator = IoUringFileCreatorBuilder::new()
             .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
             .write_with_direct_io(io_setup.use_direct_io)
+            .shared_sqpoll(io_setup.shared_sqpoll_fd())
             .build(DEFAULT_IO_URING_BUFFER_SIZE, |_| None)?;
 
         IoUringFileWriter::new(
@@ -53,6 +54,7 @@ pub fn large_file_buf_writer(path: impl AsRef<Path>) -> io::Result<impl io::Writ
 
     #[cfg(not(target_os = "linux"))]
     {
+        let _ = io_setup;
         let file = fs::File::create(path)?;
 
         Ok(io::BufWriter::with_capacity(

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -739,7 +739,7 @@ fn serialize_obsolete_accounts(
         .as_ref()
         .join(snapshot_paths::SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME);
     let mut file_stream = SizeLimitedWriter::new(
-        large_file_buf_writer(&obsolete_accounts_path)?,
+        large_file_buf_writer(&obsolete_accounts_path, &IoSetupState::default())?,
         maximum_obsolete_accounts_file_size,
     );
 
@@ -828,8 +828,10 @@ fn serialize_snapshot_data_file_capped<F>(
 where
     F: FnOnce(&mut dyn Write) -> Result<()>,
 {
-    let mut data_file_stream =
-        SizeLimitedWriter::new(large_file_buf_writer(data_file_path)?, maximum_file_size);
+    let mut data_file_stream = SizeLimitedWriter::new(
+        large_file_buf_writer(data_file_path, &IoSetupState::default())?,
+        maximum_file_size,
+    );
     serializer(&mut data_file_stream).map_err(|err| {
         IoError::other(format!(
             "unable to serialize snapshot data to file '{}': {err}",

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -3,7 +3,7 @@ use {
         ArchiveFormat, Result, SnapshotArchiveKind, error::ArchiveSnapshotPackageError, paths,
         snapshot_archive_info::SnapshotArchiveInfo, snapshot_hash::SnapshotHash,
     },
-    agave_fs::buffered_writer::large_file_buf_writer,
+    agave_fs::{buffered_writer::large_file_buf_writer, io_setup::IoSetupState},
     log::info,
     solana_accounts_db::{
         account_storage::AccountStoragesOrderer, account_storage_entry::AccountStorageEntry,
@@ -88,7 +88,7 @@ pub fn archive_snapshot(
     ));
 
     {
-        let archive_writer = large_file_buf_writer(&staging_archive_path)
+        let archive_writer = large_file_buf_writer(&staging_archive_path, &IoSetupState::default())
             .map_err(|err| E::CreateArchiveFile(err, staging_archive_path.clone()))?;
 
         let do_archive_files = |encoder: &mut dyn Write| -> std::result::Result<(), E> {


### PR DESCRIPTION
#### Problem
`large_file_buf_writer` creates its own `IoSetupState::default()` internally, making it impossible for callers to influence I/O configuration.

#### Summary of Changes
Expose the parameter so callers can pass their own setup. All existing callers pass `&IoSetupState::default()` to preserve current behavior.
