### PR TITLE
breaking(scheduler-bindings): ProgressMessage epoch & latest_blockhash

### DIFF
--- a/core/src/banking_stage/progress_tracker.rs
+++ b/core/src/banking_stage/progress_tracker.rs
@@ -119,15 +119,17 @@ impl ProgressTracker {
 
             ProgressMessage {
                 leader_state: agave_scheduler_bindings::LEADER_READY,
-                current_slot: working_bank.slot(),
-                next_leader_slot: next_leader_range_start,
-                leader_range_end: next_leader_range_end,
-                remaining_cost_units: self.remaining_block_cost(),
                 current_slot_progress: progress(
                     working_bank.slot(),
                     tick_height,
                     self.ticks_per_slot,
                 ),
+                epoch: working_bank.epoch(),
+                current_slot: working_bank.slot(),
+                next_leader_slot: next_leader_range_start,
+                leader_range_end: next_leader_range_end,
+                remaining_cost_units: self.remaining_block_cost(),
+                latest_blockhash: working_bank.last_blockhash().to_bytes(),
             }
         } else {
             let current_slot = slot_from_tick_height(tick_height, self.ticks_per_slot);
@@ -144,11 +146,13 @@ impl ProgressTracker {
 
             ProgressMessage {
                 leader_state,
+                current_slot_progress: progress(current_slot, tick_height, self.ticks_per_slot),
+                epoch: 0,
                 current_slot,
                 next_leader_slot: next_leader_range_start,
                 leader_range_end: next_leader_range_end,
                 remaining_cost_units: 0,
-                current_slot_progress: progress(current_slot, tick_height, self.ticks_per_slot),
+                latest_blockhash: [0; 32],
             }
         };
 
@@ -181,8 +185,9 @@ fn slot_from_tick_height(tick_height: u64, ticks_per_slot: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, solana_clock::DEFAULT_TICKS_PER_SLOT, solana_poh::poh_recorder::LeaderState,
-        solana_runtime::bank::Bank,
+        super::*, solana_clock::DEFAULT_TICKS_PER_SLOT,
+        solana_epoch_schedule::MINIMUM_SLOTS_PER_EPOCH, solana_leader_schedule::SlotLeader,
+        solana_poh::poh_recorder::LeaderState, solana_runtime::bank::Bank,
     };
 
     #[test]
@@ -204,6 +209,8 @@ mod tests {
         assert_eq!(message.current_slot_progress, 0);
         assert_eq!(message.next_leader_slot, u64::MAX);
         assert_eq!(message.leader_range_end, u64::MAX);
+        assert_eq!(message.epoch, 0);
+        assert_eq!(message.latest_blockhash, [0; 32]);
 
         let expected_tick_height = 2 * ticks_per_slot;
         shared_leader_state.store(Arc::new(LeaderState::new(
@@ -219,6 +226,8 @@ mod tests {
         assert_eq!(message.next_leader_slot, u64::MAX);
         assert_eq!(message.leader_range_end, u64::MAX);
         assert_eq!(message.current_slot_progress, 0);
+        assert_eq!(message.epoch, 0);
+        assert_eq!(message.latest_blockhash, [0; 32]);
 
         // Next leader slot is in the future - should be NOT_LEADER.
         shared_leader_state.store(Arc::new(LeaderState::new(
@@ -234,6 +243,8 @@ mod tests {
         assert_eq!(message.next_leader_slot, 4);
         assert_eq!(message.leader_range_end, 7);
         assert_eq!(message.current_slot_progress, 0);
+        assert_eq!(message.epoch, 0);
+        assert_eq!(message.latest_blockhash, [0; 32]);
 
         // In leader slot but no bank yet - should be LEADER_STARTING.
         // leader_first_tick_height is at start of slot 4, and we're at tick_height
@@ -255,10 +266,12 @@ mod tests {
         assert_eq!(message.next_leader_slot, 4);
         assert_eq!(message.leader_range_end, 7);
         assert_eq!(message.current_slot_progress, 1);
+        assert_eq!(message.epoch, 0);
+        assert_eq!(message.latest_blockhash, [0; 32]);
 
-        let bank = Arc::new(Bank::new_for_tests(
-            &solana_genesis_config::create_genesis_config(1).0,
-        ));
+        let (bank, _bank_forks) =
+            Bank::new_for_tests(&solana_genesis_config::create_genesis_config(1).0)
+                .wrap_with_bank_forks_for_tests();
         shared_leader_state.store(Arc::new(LeaderState::new(
             Some(bank.clone()),
             bank.tick_height(),
@@ -275,6 +288,8 @@ mod tests {
         assert_eq!(message.next_leader_slot, 4);
         assert_eq!(message.leader_range_end, 7);
         assert_eq!(message.current_slot_progress, 0);
+        assert_eq!(message.epoch, bank.epoch());
+        assert_eq!(message.latest_blockhash, bank.last_blockhash().to_bytes());
 
         bank.fill_bank_with_ticks_for_tests();
         assert!(bank.is_complete());
@@ -291,6 +306,34 @@ mod tests {
         assert_eq!(message.next_leader_slot, 4);
         assert_eq!(message.leader_range_end, 7);
         assert_eq!(message.current_slot_progress, 100);
+        assert_eq!(message.epoch, bank.epoch());
+        assert_eq!(message.latest_blockhash, bank.last_blockhash().to_bytes());
+
+        // Child bank past the first epoch boundary - epoch should advance.
+        let child_bank = Arc::new(Bank::new_from_parent(
+            bank,
+            SlotLeader::new_unique(),
+            MINIMUM_SLOTS_PER_EPOCH,
+        ));
+        assert_eq!(child_bank.epoch(), 1);
+        shared_leader_state.store(Arc::new(LeaderState::new(
+            Some(child_bank.clone()),
+            child_bank.tick_height(),
+            Some(MINIMUM_SLOTS_PER_EPOCH),
+            Some((MINIMUM_SLOTS_PER_EPOCH, MINIMUM_SLOTS_PER_EPOCH + 3)),
+        )));
+        let (message, tick_height) = progress_tracker.produce_progress_message();
+        assert_eq!(tick_height, child_bank.tick_height());
+        assert_eq!(message.leader_state, agave_scheduler_bindings::LEADER_READY);
+        assert_eq!(message.current_slot, child_bank.slot());
+        assert_eq!(message.next_leader_slot, MINIMUM_SLOTS_PER_EPOCH);
+        assert_eq!(message.leader_range_end, MINIMUM_SLOTS_PER_EPOCH + 3);
+        assert_eq!(message.current_slot_progress, 0);
+        assert_eq!(message.epoch, child_bank.epoch());
+        assert_eq!(
+            message.latest_blockhash,
+            child_bank.last_blockhash().to_bytes()
+        );
     }
 
     #[test]

--- a/scheduler-bindings/src/lib.rs
+++ b/scheduler-bindings/src/lib.rs
@@ -183,6 +183,11 @@ pub struct ProgressMessage {
     /// - To check if within a leader slot: `leader_state != NOT_LEADER`.
     /// - To check if transactions can be processed: `leader_state == LEADER_READY`.
     pub leader_state: u8,
+    /// Progress through the current slot in percentage.
+    pub current_slot_progress: u8,
+    /// The current epoch of the working bank.
+    /// Only valid if `leader_state == LEADER_READY`, otherwise zeroed.
+    pub epoch: u64,
     /// The current slot.
     pub current_slot: u64,
     /// Next known leader slot or u64::MAX if unknown.
@@ -198,8 +203,9 @@ pub struct ProgressMessage {
     /// i.e. block_limit - current_cost_units_used.
     /// Only valid if currently leader, otherwise the value is undefined.
     pub remaining_cost_units: u64,
-    /// Progress through the current slot in percentage.
-    pub current_slot_progress: u8,
+    /// The latest blockhash of the working bank.
+    /// Only valid if `leader_state == LEADER_READY`, otherwise zeroed.
+    pub latest_blockhash: [u8; 32],
 }
 
 /// Maximum number of transactions allowed in a [`PackToWorkerMessage`].

--- a/scheduling-utils/src/bridge/bindings.rs
+++ b/scheduling-utils/src/bridge/bindings.rs
@@ -75,11 +75,13 @@ where
 
             progress: ProgressMessage {
                 leader_state: 0,
+                current_slot_progress: 0,
+                epoch: 0,
                 current_slot: 0,
                 next_leader_slot: u64::MAX,
                 leader_range_end: u64::MAX,
                 remaining_cost_units: 0,
-                current_slot_progress: 0,
+                latest_blockhash: [0; 32],
             },
             runtime: RuntimeState {
                 feature_set: FeatureSet::all_enabled(),

--- a/scheduling-utils/src/handshake/tests.rs
+++ b/scheduling-utils/src/handshake/tests.rs
@@ -29,11 +29,13 @@ fn message_passing_on_all_queues() {
     };
     let progress_tracker = ProgressMessage {
         leader_state: agave_scheduler_bindings::LEADER_READY,
+        current_slot_progress: 32,
+        epoch: 7,
         current_slot: 3,
         next_leader_slot: 12,
         leader_range_end: 16,
         remaining_cost_units: 12_000_000,
-        current_slot_progress: 32,
+        latest_blockhash: [42; 32],
     };
     let pack_to_worker = PackToWorkerMessage {
         flags: 123,


### PR DESCRIPTION

## Problem

External scheduler implementations connected via `scheduler-bindings` need the working bank's epoch and a valid blockhash to construct transactions during leader slots - notably Jito Tip payments. Neither is currently exposed through the scheduler bindings.

## Proposed changes

- Add `epoch: u64` and `latest_blockhash: [u8; 32]` to `ProgressMessage` in `scheduler-bindings`. These fields are only populated from the working bank when `leader_state == LEADER_READY`.
- Pair u8's in `ProgressMessage` to reduce padding bytes.

## Testing

- Extended `test_progress_tracker_produce_progress_message` with a LEADER_READY case at non-zero epoch (child bank at `MINIMUM_SLOTS_PER_EPOCH`) and asserts for the new fields in every state.
- Updated `scheduling-utils::handshake::tests::message_passing_on_all_queues` to round-trip the new fields.


## Breaking change

`#[repr(C)]` layout of `ProgressMessage` changes (field additions + `current_slot_progress` reorder). The `agave-unstable-api` feature gate on `scheduler-bindings` pre-authorizes breaking changes of this form; no version bump or CHANGELOG entry required, matching precedent (`3432d0bed2`, `5c56e1b3d1`).

## Follow-ups

- Computing `epoch` outside `LEADER_READY` would require significantly more plumbing. Deferred until a concrete need for non-leader epoch updates is demonstrated.

- The `latest_blockhash` is unavailable without a bank. Broader access to the whole valid BlockhashQueue is a larger project and does not belong in `ProgressMessage`.
