### PR TITLE
vote-program: refactor deposit_delegator_rewards and add more tests

### DIFF
--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -4959,6 +4959,26 @@ mod tests {
             DEPOSIT_DELEGATOR_REWARDS_COMPUTE_UNITS,
         );
 
+        // Fail - source account has fewer lamports than the deposit.
+        let underfunded_source_account =
+            AccountSharedData::new(deposit_amount - 1, 0, &solana_sdk_ids::system_program::id());
+        process_instruction_with_cu_check(
+            VoteProgramFeatures::all_enabled(),
+            &instruction_data,
+            vec![
+                (vote_pubkey, vote_account_v4.clone()),
+                (source_pubkey, underfunded_source_account),
+                (
+                    solana_sdk_ids::system_program::id(),
+                    AccountSharedData::new(0, 0, &solana_sdk_ids::native_loader::id()),
+                ),
+            ],
+            instruction_accounts.clone(),
+            // SystemError::ResultWithNegativeLamports.
+            Err(InstructionError::Custom(1)),
+            DEPOSIT_DELEGATOR_REWARDS_COMPUTE_UNITS,
+        );
+
         // Fail - deposit overflow.
         let deposit_amount = 100_000;
         let mut vote_account_near_max = vote_account_v4.clone();

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -421,7 +421,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
 
             instruction_context.check_number_of_instruction_accounts(2)?;
             drop(me);
-            vote_state::deposit_delegator_rewards(invoke_context, deposit)
+            vote_state::deposit_delegator_rewards(invoke_context, 0, 1, deposit, &signers)
         }
     }
 });

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -934,24 +934,22 @@ pub fn update_commission_collector<S: std::hash::BuildHasher>(
 }
 
 /// Deposit delegator rewards into a vote account (SIMD-0123).
-pub fn deposit_delegator_rewards(
+pub fn deposit_delegator_rewards<S: std::hash::BuildHasher>(
     invoke_context: &mut InvokeContext,
+    vote_account_index: IndexOfAccount,
+    sender_account_index: IndexOfAccount,
     deposit: u64,
+    signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    const VOTE_ACCOUNT_INDEX: IndexOfAccount = 0;
-    const SENDER_ACCOUNT_INDEX: IndexOfAccount = 1;
-
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
 
-    // Source account must be a transaction-level signer.
-    if !instruction_context.is_instruction_account_signer(SENDER_ACCOUNT_INDEX)? {
-        return Err(InstructionError::MissingRequiredSignature);
-    }
-
-    let vote_address = *instruction_context.get_key_of_instruction_account(VOTE_ACCOUNT_INDEX)?;
+    let vote_address = *instruction_context.get_key_of_instruction_account(vote_account_index)?;
     let source_address =
-        *instruction_context.get_key_of_instruction_account(SENDER_ACCOUNT_INDEX)?;
+        *instruction_context.get_key_of_instruction_account(sender_account_index)?;
+
+    // Source account must sign the transfer.
+    verify_authorized_signer(&source_address, signers)?;
 
     // SIMD-0123 states we must validate the vote account deserializes to a v4
     // *before* attempting CPI, then update the `pending_delegator_rewards`
@@ -961,7 +959,7 @@ pub fn deposit_delegator_rewards(
     // later, since we know only lamports will change.
     let mut vote_state = {
         let vote_account =
-            instruction_context.try_borrow_instruction_account(VOTE_ACCOUNT_INDEX)?;
+            instruction_context.try_borrow_instruction_account(vote_account_index)?;
 
         // Can't use `get_vote_state_handler_checked`, since it will convert
         // the underlying vote state to v4.
@@ -984,7 +982,7 @@ pub fn deposit_delegator_rewards(
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let mut vote_account =
-        instruction_context.try_borrow_instruction_account(VOTE_ACCOUNT_INDEX)?;
+        instruction_context.try_borrow_instruction_account(vote_account_index)?;
 
     vote_state.add_pending_delegator_rewards(deposit)?;
     vote_state.set_vote_account_state(&mut vote_account)


### PR DESCRIPTION
#### Problem
The `deposit_delegator_rewards` helper in `vote_state/mod.rs` diverged from the pattern of the rest of `vote_state/mod.rs` and I also thought of one more test case to add to the already sizable test coverage.

#### Summary of Changes
Refactor `deposit_delegator_rewards` a bit - mainly to use the existing `verify_authorized_signer` helper - and add the test case.