### PR TITLE
chore(deps): bump message and transaction to swap wincode/short-vec feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-hash 4.3.0",
  "solana-pubkey 4.2.0",
+ "solana-short-vec",
  "solana-signer-store",
  "tempfile",
  "thiserror 2.0.18",
@@ -9035,9 +9036,9 @@ dependencies = [
 
 [[package]]
 name = "solana-message"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3349552a323d44d8936b81f003ea7a2fea8566684ebf0dc25d34ad4df2b103"
+checksum = "a634d1db65a393d4e87ec49ef97c8dfb12201e2ba9e5faf87ff34e632f29e509"
 dependencies = [
  "blake3",
  "lazy_static",
@@ -10344,6 +10345,7 @@ dependencies = [
  "serde_core",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "wincode",
 ]
 
 [[package]]
@@ -11120,9 +11122,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6aefe6edf26c6daa57f6caa1af119083abeaaf177a4ba38b4b492ca2ff2f7fd"
+checksum = "a98253cefd62dea714b67926d3d918c3b9f7d66993f1f2322ac7549ea991dc3e"
 dependencies = [
  "serde",
  "serde_derive",
@@ -13056,7 +13058,6 @@ dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
- "solana-short-vec",
  "thiserror 2.0.18",
  "wincode-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -436,7 +436,7 @@ solana-loader-v4-program = { path = "programs/loader-v4", version = "=4.1.0-alph
 solana-local-cluster = { path = "local-cluster", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-measure = { path = "measure", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-merkle-tree = { path = "merkle-tree", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-message = "4.1.0"
+solana-message = "4.1.1"
 solana-metrics = { path = "metrics", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-msg = "3.1.0"
 solana-native-token = "3.0.0"
@@ -520,7 +520,7 @@ solana-time-utils = "3.0.0"
 solana-tls-utils = { path = "tls-utils", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-tpu-client = { path = "tpu-client", version = "=4.1.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-tpu-client-next = { path = "tpu-client-next", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-transaction = "4.1.0"
+solana-transaction = "4.1.1"
 solana-transaction-context = { path = "transaction-context", version = "=4.1.0-alpha.0", features = ["agave-unstable-api", "bincode"] }
 solana-transaction-error = "3.2.0"
 solana-transaction-status = { path = "transaction-status", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
@@ -577,7 +577,7 @@ unwrap_none = "0.1.2"
 uriparse = "0.6.4"
 url = "2.5.8"
 winapi = "0.3.8"
-wincode = { version = "0.5.3", features = ["derive", "solana-short-vec"] }
+wincode = { version = "0.5.3", features = ["derive"] }
 winreg = "0.55"
 x509-parser = "0.18.1"
 zstd = "0.13.3"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -400,6 +400,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-hash 4.3.0",
  "solana-pubkey 4.2.0",
+ "solana-short-vec",
  "solana-signer-store",
  "thiserror 2.0.18",
  "wincode",
@@ -7854,9 +7855,9 @@ dependencies = [
 
 [[package]]
 name = "solana-message"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3349552a323d44d8936b81f003ea7a2fea8566684ebf0dc25d34ad4df2b103"
+checksum = "a634d1db65a393d4e87ec49ef97c8dfb12201e2ba9e5faf87ff34e632f29e509"
 dependencies = [
  "blake3",
  "lazy_static",
@@ -8898,6 +8899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb8cc883fc7b8ce4a7814cb1441b48c06437049ec11847005cf63bcfa85c546"
 dependencies = [
  "serde_core",
+ "wincode",
 ]
 
 [[package]]
@@ -9564,9 +9566,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6aefe6edf26c6daa57f6caa1af119083abeaaf177a4ba38b4b492ca2ff2f7fd"
+checksum = "a98253cefd62dea714b67926d3d918c3b9f7d66993f1f2322ac7549ea991dc3e"
 dependencies = [
  "serde",
  "serde_derive",
@@ -11416,7 +11418,6 @@ dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
- "solana-short-vec",
  "thiserror 2.0.18",
  "wincode-derive",
 ]

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -43,13 +43,13 @@ solana-clap-utils = { workspace = true }
 solana-config-interface = { version = "=2.0.0", features = ["bincode"] }
 solana-hash = "=4.3.0"
 solana-keypair = "=3.1.2"
-solana-message = "=4.1.0"
+solana-message = "=4.1.1"
 solana-pubkey = { version = "=4.2.0", default-features = false }
 solana-rpc-client = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-signature = { version = "=3.4.0", default-features = false }
 solana-signer = "=3.0.0"
-solana-transaction = { version = "=4.1.0", features = ["wincode"] }
+solana-transaction = { version = "=4.1.1", features = ["wincode"] }
 solana-version = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -35,7 +35,7 @@ solana-cli-config = { workspace = true }
 solana-derivation-path = { workspace = true }
 solana-instruction = { version = "=3.4.0", features = ["bincode"] }
 solana-keypair = "=3.1.2"
-solana-message = { version = "=4.1.0", features = ["wincode"] }
+solana-message = { version = "=4.1.1", features = ["wincode"] }
 solana-pubkey = { version = "=4.2.0", default-features = false }
 solana-remote-wallet = { workspace = true }
 solana-seed-derivable = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-hash 4.3.0",
  "solana-pubkey 4.2.0",
+ "solana-short-vec",
  "solana-signer-store",
  "thiserror 2.0.18",
  "wincode",
@@ -7444,9 +7445,9 @@ dependencies = [
 
 [[package]]
 name = "solana-message"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3349552a323d44d8936b81f003ea7a2fea8566684ebf0dc25d34ad4df2b103"
+checksum = "a634d1db65a393d4e87ec49ef97c8dfb12201e2ba9e5faf87ff34e632f29e509"
 dependencies = [
  "blake3",
  "lazy_static",
@@ -9256,6 +9257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb8cc883fc7b8ce4a7814cb1441b48c06437049ec11847005cf63bcfa85c546"
 dependencies = [
  "serde_core",
+ "wincode",
 ]
 
 [[package]]
@@ -9875,9 +9877,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6aefe6edf26c6daa57f6caa1af119083abeaaf177a4ba38b4b492ca2ff2f7fd"
+checksum = "a98253cefd62dea714b67926d3d918c3b9f7d66993f1f2322ac7549ea991dc3e"
 dependencies = [
  "serde",
  "serde_derive",
@@ -11695,7 +11697,6 @@ dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
- "solana-short-vec",
  "thiserror 2.0.18",
  "wincode-derive",
 ]

--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -38,6 +38,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-hash = { workspace = true, features = ["serde", "copy", "decode", "wincode"] }
 solana-pubkey = { workspace = true }
+solana-short-vec = { workspace = true, features = ["wincode"] }
 solana-signer-store = { workspace = true }
 thiserror = { workspace = true }
 wincode = { workspace = true }

--- a/votor-messages/src/reward_certificate.rs
+++ b/votor-messages/src/reward_certificate.rs
@@ -6,9 +6,10 @@ use {
     solana_clock::Slot,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
+    solana_short_vec::ShortU16,
     solana_signer_store::EncodeError,
     thiserror::Error,
-    wincode::{SchemaRead, SchemaWrite, containers::Vec as WincodeVec, len::ShortU16, pod_wrapper},
+    wincode::{SchemaRead, SchemaWrite, containers::Vec as WincodeVec, pod_wrapper},
 };
 
 // Use `BLSSignatureCompressed` directly once `BLSSignature` wincode support


### PR DESCRIPTION
#### Problem
wincode provided solana-short-vec impl through feature, which cause circular dependency (https://github.com/anza-xyz/wincode/issues/303). Now:
* `solana-short-vec` provides its own wincode impl
* `solana-message` and `solana-transaction` have versions, which do not force `wincode`'s old impl

#### Summary of Changes
* bump `solana-message = "4.1.1"`
* bump `solana-transaction = "4.1.1"`
* disable wincode's `solana-short-vec` feature
* code update to use `ShortU16` directly from `solana-short-vec`

