### PR TITLE
Remove Rayon from SigverifyStage

### DIFF
--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -9,10 +9,7 @@ use {
         distr::{Distribution, Uniform},
         rng,
     },
-    solana_core::{
-        banking_trace::BankingTracer, sigverify::TransactionSigVerifier,
-        sigverify_stage::SigVerifyStage,
-    },
+    solana_core::{banking_trace::BankingTracer, sigverify_stage::SigVerifyStage},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_measure::measure::Measure,
@@ -23,7 +20,7 @@ use {
     },
     solana_signer::Signer,
     solana_system_transaction as system_transaction,
-    std::{borrow::Cow, hint::black_box, sync::Arc, time::Instant},
+    std::{borrow::Cow, hint::black_box, num::NonZeroUsize, sync::Arc, time::Instant},
 };
 
 /// Orphan rules workaround that allows for implementation of `TDynBenchFn`.
@@ -74,13 +71,19 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
     agave_logger::setup();
     trace!("start");
     let (packet_s, packet_r) = unbounded();
+    let (vote_packet_s, vote_packet_r) = unbounded();
     let (verified_s, verified_r) = BankingTracer::channel_for_test();
-    let verifier = TransactionSigVerifier::new(
-        Arc::new(sigverify::threadpool_for_benches()),
+    let (tpu_vote_s, _tpu_vote_r) = BankingTracer::channel_for_test();
+    let (forward_stage_s, _forward_stage_r) = unbounded();
+    let (stage, gossip_sigverify_handle) = SigVerifyStage::new(
+        packet_r,
+        vote_packet_r,
         verified_s,
-        None,
+        tpu_vote_s,
+        forward_stage_s,
+        NonZeroUsize::new(sigverify::threadpool_for_benches().current_num_threads()).unwrap(),
+        false,
     );
-    let stage = SigVerifyStage::new(packet_r, verifier, "solSigVerBench", "bench");
     let packet_s = packet_s;
     let packet_s_for_bench = packet_s.clone();
     let verified_r_for_bench = verified_r.clone();
@@ -119,6 +122,8 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
     });
     // This will wait for all packets to make it through sigverify.
     drop(packet_s);
+    drop(vote_packet_s);
+    drop(gossip_sigverify_handle);
     stage.join().unwrap();
 }
 

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -5,13 +5,12 @@ use {
         optimistic_confirmation_verifier::OptimisticConfirmationVerifier,
         replay_stage::DUPLICATE_THRESHOLD,
         result::{Error, Result},
-        sigverify,
+        sigverify_stage::GossipSigVerifyHandle,
     },
     agave_banking_stage_ingress_types::BankingPacketBatch,
     agave_votor_messages::migration::MigrationStatus,
     crossbeam_channel::{Receiver, RecvTimeoutError, Select, Sender, unbounded},
     log::*,
-    rayon::ThreadPool,
     solana_clock::{BankId, Slot},
     solana_gossip::{
         cluster_info::{ClusterInfo, GOSSIP_SLEEP_MILLIS},
@@ -425,7 +424,7 @@ impl ClusterInfoVoteListener {
     pub fn new(
         exit: Arc<AtomicBool>,
         cluster_info: Arc<ClusterInfo>,
-        sigverify_threadpool: Arc<ThreadPool>,
+        gossip_sigverify_handle: GossipSigVerifyHandle,
         verified_packets_sender: BankingPacketSender,
         vote_tracker: Arc<VoteTracker>,
         bank_forks: Arc<RwLock<BankForks>>,
@@ -447,7 +446,7 @@ impl ClusterInfoVoteListener {
                     let _ = Self::recv_loop(
                         exit,
                         &cluster_info,
-                        sigverify_threadpool,
+                        gossip_sigverify_handle,
                         sharable_banks,
                         verified_packets_sender,
                         verified_vote_transactions_sender,
@@ -493,7 +492,7 @@ impl ClusterInfoVoteListener {
     fn recv_loop(
         exit: Arc<AtomicBool>,
         cluster_info: &ClusterInfo,
-        sigverify_threadpool: Arc<ThreadPool>,
+        mut gossip_sigverify_handle: GossipSigVerifyHandle,
         sharable_banks: SharableBanks,
         verified_packets_sender: BankingPacketSender,
         verified_vote_transactions_sender: VerifiedVoteTransactionsSender,
@@ -504,7 +503,7 @@ impl ClusterInfoVoteListener {
             inc_new_counter_debug!("cluster_info_vote_listener-recv_count", votes.len());
             if !votes.is_empty() {
                 let (vote_txs, packets) =
-                    Self::verify_votes(votes, &sigverify_threadpool, &sharable_banks);
+                    Self::verify_votes(votes, &mut gossip_sigverify_handle, &sharable_banks)?;
                 verified_vote_transactions_sender.send(vote_txs)?;
                 verified_packets_sender.send(BankingPacketBatch::new(packets))?;
             }
@@ -513,28 +512,32 @@ impl ClusterInfoVoteListener {
         Ok(())
     }
 
-    #[allow(clippy::type_complexity)]
     fn verify_votes(
         votes: Vec<Transaction>,
-        threadpool: &ThreadPool,
+        gossip_sigverify_handle: &mut GossipSigVerifyHandle,
+        sharable_banks: &SharableBanks,
+    ) -> Result<(Vec<Transaction>, Vec<PacketBatch>)> {
+        let packet_batches = packet::to_packet_batches(&votes, 1);
+        let (votes, packet_batches) =
+            gossip_sigverify_handle.verify_and_receive_votes(votes, packet_batches)?;
+        Ok(Self::filter_verified_votes(
+            votes,
+            packet_batches,
+            sharable_banks,
+        ))
+    }
+
+    fn filter_verified_votes(
+        votes: Vec<Transaction>,
+        packet_batches: Vec<PacketBatch>,
         sharable_banks: &SharableBanks,
     ) -> (Vec<Transaction>, Vec<PacketBatch>) {
-        let mut packet_batches = packet::to_packet_batches(&votes, 1);
-
-        // Votes should already be filtered by this point.
-        sigverify::ed25519_verify(
-            threadpool,
-            &mut packet_batches,
-            /*reject_non_vote=*/ false,
-            votes.len(),
-        );
         let root_bank = sharable_banks.root();
         let epoch_schedule = root_bank.epoch_schedule();
         votes
             .into_iter()
             .zip(packet_batches)
             .filter(|(_, packet_batch)| {
-                // to_packet_batches() above splits into 1 packet long batches
                 assert_eq!(packet_batch.len(), 1);
                 !packet_batch.get(0).unwrap().meta().discard()
             })
@@ -988,13 +991,16 @@ mod tests {
         },
     };
 
-    // Convenience wrapper for `ClusterInfoVoteListener::verify_votes()`
-    fn verify_votes(
+    // Avoid setting up sigverify stage.
+    fn test_verify_votes(
         votes: Vec<Transaction>,
         sharable_banks: &SharableBanks,
     ) -> (Vec<Transaction>, Vec<PacketBatch>) {
-        let threadpool = sigverify::threadpool_for_tests();
-        ClusterInfoVoteListener::verify_votes(votes, &threadpool, sharable_banks)
+        let mut packet_batches = packet::to_packet_batches(&votes, 1);
+        packet_batches
+            .iter_mut()
+            .for_each(|packet_batch| sigverify::ed25519_verify_serial(packet_batch, true));
+        ClusterInfoVoteListener::filter_verified_votes(votes, packet_batches, sharable_banks)
     }
 
     #[test]
@@ -1942,14 +1948,9 @@ mod tests {
         let bank_forks = BankForks::new_rw_arc(bank);
         let sharable_banks = bank_forks.read().unwrap().sharable_banks();
         let votes = vec![];
-        let (vote_txs, packets) = verify_votes(votes, &sharable_banks);
+        let (vote_txs, packet_batches) = test_verify_votes(votes, &sharable_banks);
         assert!(vote_txs.is_empty());
-        assert!(packets.is_empty());
-    }
-
-    fn verify_packets_len(packets: &[PacketBatch], ref_value: usize) {
-        let num_packets: usize = packets.iter().map(|pb| pb.len()).sum();
-        assert_eq!(num_packets, ref_value);
+        assert!(packet_batches.is_empty());
     }
 
     fn test_vote_tx(
@@ -1985,9 +1986,9 @@ mod tests {
         let sharable_banks = bank_forks.read().unwrap().sharable_banks();
         let vote_tx = test_vote_tx(voting_keypairs.first(), hash);
         let votes = vec![vote_tx];
-        let (vote_txs, packets) = verify_votes(votes, &sharable_banks);
+        let (vote_txs, packet_batches) = test_verify_votes(votes, &sharable_banks);
         assert_eq!(vote_txs.len(), 1);
-        verify_packets_len(&packets, 1);
+        assert_eq!(packet_batches.len(), 1);
     }
 
     #[test]
@@ -2013,9 +2014,9 @@ mod tests {
         let mut bad_vote = vote_tx.clone();
         bad_vote.signatures[0] = Signature::default();
         let votes = vec![vote_tx.clone(), bad_vote, vote_tx];
-        let (vote_txs, packets) = verify_votes(votes, &sharable_banks);
+        let (vote_txs, packet_batches) = test_verify_votes(votes, &sharable_banks);
         assert_eq!(vote_txs.len(), 2);
-        verify_packets_len(&packets, 2);
+        assert_eq!(packet_batches.len(), 2);
     }
 
     #[test]

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -965,6 +965,7 @@ impl ClusterInfoVoteListener {
 mod tests {
     use {
         super::*,
+        crate::sigverify::GossipVerifiedVoteBatch,
         itertools::Itertools,
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -991,16 +992,43 @@ mod tests {
         },
     };
 
+    fn pre_send_for_tests(
+        verified_vote_sender: &Sender<GossipVerifiedVoteBatch>,
+        votes: &[Transaction],
+    ) {
+        let mut packet_batches = packet::to_packet_batches(votes, 1);
+        packet_batches
+            .iter_mut()
+            .for_each(|packet_batch| sigverify::ed25519_verify_serial(packet_batch, true));
+        // There is no worker thread in these tests, so preload the verified
+        // responses that verify_votes() will receive after it sends work.
+        votes
+            .iter()
+            .cloned()
+            .zip(packet_batches)
+            .for_each(|(transaction, packet_batch)| {
+                verified_vote_sender
+                    .send(GossipVerifiedVoteBatch {
+                        transactions: vec![transaction],
+                        packet_batch,
+                    })
+                    .unwrap();
+            });
+    }
+
     // Avoid setting up sigverify stage.
     fn test_verify_votes(
         votes: Vec<Transaction>,
         sharable_banks: &SharableBanks,
     ) -> (Vec<Transaction>, Vec<PacketBatch>) {
-        let mut packet_batches = packet::to_packet_batches(&votes, 1);
-        packet_batches
-            .iter_mut()
-            .for_each(|packet_batch| sigverify::ed25519_verify_serial(packet_batch, true));
-        ClusterInfoVoteListener::filter_verified_votes(votes, packet_batches, sharable_banks)
+        let (worker_sender, _worker_receiver) = unbounded();
+        let (verified_vote_sender, verified_vote_receiver) = unbounded();
+        let mut gossip_sigverify_handle =
+            GossipSigVerifyHandle::new_for_tests(worker_sender, verified_vote_receiver);
+
+        pre_send_for_tests(&verified_vote_sender, &votes);
+        ClusterInfoVoteListener::verify_votes(votes, &mut gossip_sigverify_handle, sharable_banks)
+            .unwrap()
     }
 
     #[test]

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1009,7 +1009,7 @@ mod tests {
             .for_each(|(transaction, packet_batch)| {
                 verified_vote_sender
                     .send(GossipVerifiedVoteBatch {
-                        transactions: vec![transaction],
+                        transaction,
                         packet_batch,
                     })
                     .unwrap();

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -2,108 +2,317 @@
 //! By default, signatures are verified in parallel using all available CPU
 //! cores.
 
-pub use solana_perf::sigverify::{count_packets_in_batches, ed25519_verify};
 use {
     crate::{banking_trace::BankingPacketSender, sigverify_stage::SigVerifyServiceError},
     agave_banking_stage_ingress_types::BankingPacketBatch,
-    crossbeam_channel::{Sender, TrySendError},
-    solana_measure::measure::Measure,
+    crossbeam_channel::{Receiver, Sender, TrySendError, bounded},
+    solana_measure::measure_us,
     solana_perf::{
         packet::PacketBatch,
         sigverify::{self},
     },
-    std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
+    solana_transaction::Transaction,
+    std::{
+        num::NonZeroUsize,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        thread::JoinHandle,
+        time::Duration,
     },
 };
 
-pub struct TransactionSigVerifier {
-    thread_pool: Arc<rayon::ThreadPool>,
-    banking_stage_sender: BankingPacketSender,
-    forward_stage_sender: Option<Sender<(BankingPacketBatch, bool)>>,
-    reject_non_vote: bool,
+pub(crate) struct TransactionSigVerifier {
+    worker_sender: Sender<TransactionVerifyTask>,
+}
+
+struct TransactionVerifyTask {
+    batch: PacketBatch,
+}
+
+struct GossipVerifyTask {
+    batch: PacketBatch,
+    transaction: Transaction,
+}
+
+pub(crate) struct GossipVerifiedVoteBatch {
+    pub(crate) transactions: Vec<Transaction>,
+    pub(crate) packet_batch: PacketBatch,
+}
+
+#[derive(Clone)]
+pub(crate) struct SigVerifyWorkerStats {
+    pub(crate) total_valid_packets: Arc<AtomicUsize>,
+    pub(crate) total_verify_time_us: Arc<AtomicUsize>,
 }
 
 impl TransactionSigVerifier {
-    pub fn new_reject_non_vote(
-        thread_pool: Arc<rayon::ThreadPool>,
-        packet_sender: BankingPacketSender,
-        forward_stage_sender: Option<Sender<(BankingPacketBatch, bool)>>,
-    ) -> Self {
-        let mut new_self = Self::new(thread_pool, packet_sender, forward_stage_sender);
-        new_self.reject_non_vote = true;
-        new_self
-    }
-
-    pub fn new(
-        thread_pool: Arc<rayon::ThreadPool>,
-        banking_stage_sender: BankingPacketSender,
-        forward_stage_sender: Option<Sender<(BankingPacketBatch, bool)>>,
-    ) -> Self {
-        Self {
-            thread_pool,
-            banking_stage_sender,
-            forward_stage_sender,
-            reject_non_vote: false,
-        }
+    fn new(worker_sender: Sender<TransactionVerifyTask>) -> Self {
+        Self { worker_sender }
     }
 
     pub(crate) fn verify_and_send_packets(
         &mut self,
         batches: Vec<PacketBatch>,
-        valid_packets: usize,
-        in_flight_count: Arc<AtomicUsize>,
-        total_valid_packets: Arc<AtomicUsize>,
-        total_verify_time_us: Arc<AtomicUsize>,
-    ) -> Result<(), SigVerifyServiceError> {
-        let thread_pool = self.thread_pool.clone();
-        let banking_stage_sender = self.banking_stage_sender.clone();
-        let forward_stage_sender = self.forward_stage_sender.clone();
-        let reject_non_vote = self.reject_non_vote;
-
-        in_flight_count.fetch_add(valid_packets, Ordering::Release);
-
-        self.thread_pool.spawn(move || {
-            let mut verify_time = Measure::start("sigverify_batch_time");
-            let mut batches = batches;
-            sigverify::ed25519_verify(&thread_pool, &mut batches, reject_non_vote, valid_packets);
-            verify_time.stop();
-            let num_valid_packets = sigverify::count_valid_packets(&batches);
-
-            let banking_packet_batch = BankingPacketBatch::new(batches);
-            if let Some(forward_stage_sender) = &forward_stage_sender {
-                if let Err(err) = banking_stage_sender.send(banking_packet_batch.clone()) {
-                    error!("sigverify send failed: {err:?}");
-                    in_flight_count.fetch_sub(valid_packets, Ordering::Release);
-                    return;
+    ) -> Result<usize, SigVerifyServiceError> {
+        let mut dropped_packets = 0;
+        for batch in batches {
+            match self.worker_sender.try_send(TransactionVerifyTask { batch }) {
+                Ok(()) => {}
+                Err(TrySendError::Full(task)) => {
+                    dropped_packets += task.batch.len();
                 }
-                if let Err(TrySendError::Full(_)) =
-                    forward_stage_sender.try_send((banking_packet_batch, reject_non_vote))
-                {
-                    warn!("forwarding stage channel is full, dropping packets.");
+                Err(TrySendError::Disconnected(_)) => {
+                    return Err(SigVerifyServiceError::WorkerQueueClosed);
                 }
-            } else if let Err(err) = banking_stage_sender.send(banking_packet_batch) {
-                error!("sigverify send failed: {err:?}");
-                in_flight_count.fetch_sub(valid_packets, Ordering::Release);
-                return;
             }
+        }
 
-            total_valid_packets.fetch_add(num_valid_packets, Ordering::Relaxed);
-            total_verify_time_us.fetch_add(verify_time.as_us() as usize, Ordering::Relaxed);
-            in_flight_count.fetch_sub(valid_packets, Ordering::Release);
+        Ok(dropped_packets)
+    }
+}
+
+pub(crate) struct GossipSigVerifier {
+    worker_sender: Sender<GossipVerifyTask>,
+}
+
+impl GossipSigVerifier {
+    pub(crate) fn verify_and_send_votes(
+        &self,
+        votes: Vec<Transaction>,
+        packet_batches: Vec<PacketBatch>,
+    ) -> Result<usize, SigVerifyServiceError> {
+        assert_eq!(votes.len(), packet_batches.len());
+
+        let num_votes = votes.len();
+        let mut num_sent = 0;
+        for (transaction, batch) in votes.into_iter().zip(packet_batches) {
+            match self
+                .worker_sender
+                .try_send(GossipVerifyTask { batch, transaction })
+            {
+                Ok(()) => {
+                    num_sent += 1;
+                }
+                Err(TrySendError::Full(_)) => {
+                    warn!(
+                        "gossip sigverify worker queue is full, dropping {} votes.",
+                        num_votes.saturating_sub(num_sent)
+                    );
+                    break;
+                }
+                Err(TrySendError::Disconnected(_)) => {
+                    return Err(SigVerifyServiceError::WorkerQueueClosed);
+                }
+            }
+        }
+
+        Ok(num_sent)
+    }
+}
+
+/// Work queues are kept separate so that a spam on TPU
+/// will not lead to us dropping votes.
+const SIGVERIFY_WORK_CHANNEL_SIZE: usize = 50_000;
+
+#[derive(Clone)]
+struct WorkerPoolChannels {
+    non_vote_receiver: Receiver<TransactionVerifyTask>,
+    tpu_vote_receiver: Receiver<TransactionVerifyTask>,
+    gossip_receiver: Receiver<GossipVerifyTask>,
+    non_vote_banking_sender: BankingPacketSender,
+    tpu_vote_banking_sender: BankingPacketSender,
+    gossip_verified_vote_sender: Sender<GossipVerifiedVoteBatch>,
+    forward_stage_sender: Sender<(BankingPacketBatch, bool)>,
+    non_vote_stats: SigVerifyWorkerStats,
+    tpu_vote_stats: SigVerifyWorkerStats,
+}
+
+pub(crate) struct SigVerifyWorkerPool {
+    exit: Arc<AtomicBool>,
+    non_vote_sender: Sender<TransactionVerifyTask>,
+    tpu_vote_sender: Sender<TransactionVerifyTask>,
+    gossip_sender: Sender<GossipVerifyTask>,
+    worker_hdls: Vec<JoinHandle<()>>,
+}
+
+impl Drop for SigVerifyWorkerPool {
+    fn drop(&mut self) {
+        self.exit.store(true, Ordering::Relaxed);
+        self.worker_hdls.drain(..).for_each(|hdl| {
+            let _ = hdl.join();
         });
+    }
+}
 
-        Ok(())
+impl SigVerifyWorkerPool {
+    pub(crate) fn new(
+        num_workers: NonZeroUsize,
+        non_vote_banking_sender: BankingPacketSender,
+        tpu_vote_banking_sender: BankingPacketSender,
+        gossip_verified_vote_sender: Sender<GossipVerifiedVoteBatch>,
+        forward_stage_sender: Sender<(BankingPacketBatch, bool)>,
+        forward_non_votes: bool,
+        non_vote_stats: SigVerifyWorkerStats,
+        tpu_vote_stats: SigVerifyWorkerStats,
+    ) -> Self {
+        let (non_vote_sender, non_vote_receiver) = bounded(SIGVERIFY_WORK_CHANNEL_SIZE);
+        let (tpu_vote_sender, tpu_vote_receiver) = bounded(SIGVERIFY_WORK_CHANNEL_SIZE);
+        let (gossip_sender, gossip_receiver) = bounded(SIGVERIFY_WORK_CHANNEL_SIZE);
+        let channels = WorkerPoolChannels {
+            non_vote_receiver,
+            tpu_vote_receiver,
+            gossip_receiver,
+            non_vote_banking_sender,
+            tpu_vote_banking_sender,
+            gossip_verified_vote_sender,
+            forward_stage_sender,
+            non_vote_stats,
+            tpu_vote_stats,
+        };
+        let exit = Arc::new(AtomicBool::new(false));
+        let worker_hdls = (0..num_workers.get())
+            .map(|idx| {
+                let exit = exit.clone();
+                let channels = channels.clone();
+
+                std::thread::Builder::new()
+                    .name(format!("solSigVerify{idx:02}"))
+                    .spawn(move || Self::worker(exit, channels, forward_non_votes))
+                    .expect("failed to spawn sigverify worker thread")
+            })
+            .collect();
+        Self {
+            exit,
+            non_vote_sender,
+            tpu_vote_sender,
+            gossip_sender,
+            worker_hdls,
+        }
     }
 
-    pub(crate) fn capacity(&self) -> usize {
-        const CAPACITY_PER_THREAD: usize = {
-            15_000 // ~15k packets per second throughput
-            * 2 // 2 seconds worth
-        };
-        self.thread_pool
-            .current_num_threads()
-            .saturating_mul(CAPACITY_PER_THREAD)
+    pub(crate) fn non_vote_verifier(&self) -> TransactionSigVerifier {
+        TransactionSigVerifier::new(self.non_vote_sender.clone())
+    }
+
+    pub(crate) fn tpu_vote_verifier(&self) -> TransactionSigVerifier {
+        TransactionSigVerifier::new(self.tpu_vote_sender.clone())
+    }
+
+    pub(crate) fn gossip_verifier(&self) -> GossipSigVerifier {
+        GossipSigVerifier {
+            worker_sender: self.gossip_sender.clone(),
+        }
+    }
+
+    fn worker(exit: Arc<AtomicBool>, channels: WorkerPoolChannels, forward_non_votes: bool) {
+        while !exit.load(Ordering::Relaxed) {
+            let should_continue = crossbeam_channel::select! {
+                recv(&channels.non_vote_receiver) -> maybe_work => {
+                    match maybe_work {
+                        Ok(work) => Self::run_transaction_task(
+                            work,
+                            false,
+                            &channels.non_vote_banking_sender,
+                            &channels.forward_stage_sender,
+                            forward_non_votes,
+                            false,
+                            &channels.non_vote_stats,
+                        ),
+                        Err(_) => false,
+                    }
+                }
+                recv(&channels.tpu_vote_receiver) -> maybe_work => {
+                    match maybe_work {
+                        Ok(work) => Self::run_transaction_task(
+                            work,
+                            true,
+                            &channels.tpu_vote_banking_sender,
+                            &channels.forward_stage_sender,
+                            true,
+                            true,
+                            &channels.tpu_vote_stats,
+                        ),
+                        Err(_) => false,
+                    }
+                }
+                recv(&channels.gossip_receiver) -> maybe_work => {
+                    match maybe_work {
+                        Ok(work) => Self::run_gossip_task(
+                            work,
+                            &channels.gossip_verified_vote_sender,
+                        ),
+                        Err(_) => false,
+                    }
+                }
+                default(Duration::from_millis(10)) => { true }
+            };
+
+            if !should_continue {
+                return;
+            }
+        }
+    }
+
+    fn run_transaction_task(
+        mut work: TransactionVerifyTask,
+        reject_non_vote: bool,
+        banking_stage_sender: &BankingPacketSender,
+        forward_stage_sender: &Sender<(BankingPacketBatch, bool)>,
+        should_forward: bool,
+        is_tpu_vote: bool,
+        stats: &SigVerifyWorkerStats,
+    ) -> bool {
+        let (_, verify_time_us) = measure_us!(sigverify::ed25519_verify_serial(
+            &mut work.batch,
+            reject_non_vote
+        ));
+        let num_valid_packets = sigverify::count_valid_packets(std::iter::once(&work.batch));
+        stats
+            .total_valid_packets
+            .fetch_add(num_valid_packets, Ordering::Relaxed);
+        stats
+            .total_verify_time_us
+            .fetch_add(verify_time_us as usize, Ordering::Relaxed);
+
+        let banking_packet_batch = BankingPacketBatch::new(vec![work.batch]);
+        if let Err(err) = banking_stage_sender.send(banking_packet_batch.clone()) {
+            error!("sigverify send failed: {err:?}");
+            return false;
+        }
+        if should_forward {
+            Self::try_forward(forward_stage_sender, banking_packet_batch, is_tpu_vote);
+        }
+
+        true
+    }
+
+    fn run_gossip_task(
+        mut work: GossipVerifyTask,
+        verified_vote_sender: &Sender<GossipVerifiedVoteBatch>,
+    ) -> bool {
+        sigverify::ed25519_verify_serial(&mut work.batch, true);
+
+        if let Err(err) = verified_vote_sender.send(GossipVerifiedVoteBatch {
+            transactions: vec![work.transaction],
+            packet_batch: work.batch,
+        }) {
+            debug!("gossip sigverify response send failed: {err:?}");
+        }
+
+        true
+    }
+
+    fn try_forward(
+        forward_stage_sender: &Sender<(BankingPacketBatch, bool)>,
+        banking_packet_batch: BankingPacketBatch,
+        is_tpu_vote: bool,
+    ) {
+        if let Err(TrySendError::Full(_)) =
+            forward_stage_sender.try_send((banking_packet_batch, is_tpu_vote))
+        {
+            warn!("forwarding stage channel is full, dropping packets.");
+        }
     }
 }

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -37,7 +37,7 @@ pub(crate) struct GossipVerifyTask {
 }
 
 pub(crate) struct GossipVerifiedVoteBatch {
-    pub(crate) transactions: Vec<Transaction>,
+    pub(crate) transaction: Transaction,
     pub(crate) packet_batch: PacketBatch,
 }
 
@@ -307,7 +307,7 @@ impl SigVerifyWorkerPool {
         sigverify::ed25519_verify_serial(&mut work.batch, true);
 
         if let Err(err) = verified_vote_sender.send(GossipVerifiedVoteBatch {
-            transactions: vec![work.transaction],
+            transaction: work.transaction,
             packet_batch: work.batch,
         }) {
             debug!("gossip sigverify response send failed: {err:?}");

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -52,7 +52,7 @@ impl TransactionSigVerifier {
         Self { worker_sender }
     }
 
-    pub(crate) fn verify_and_send_packets(
+    pub(crate) fn send_packets_to_worker_pool(
         &mut self,
         batches: Vec<PacketBatch>,
     ) -> Result<usize, SigVerifyServiceError> {
@@ -78,7 +78,7 @@ pub(crate) struct GossipSigVerifier {
 }
 
 impl GossipSigVerifier {
-    pub(crate) fn verify_and_send_votes(
+    pub(crate) fn send_votes_to_worker_pool(
         &self,
         votes: Vec<Transaction>,
         packet_batches: Vec<PacketBatch>,

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -31,7 +31,7 @@ struct TransactionVerifyTask {
     batch: PacketBatch,
 }
 
-struct GossipVerifyTask {
+pub(crate) struct GossipVerifyTask {
     batch: PacketBatch,
     transaction: Transaction,
 }
@@ -78,6 +78,11 @@ pub(crate) struct GossipSigVerifier {
 }
 
 impl GossipSigVerifier {
+    #[cfg(test)]
+    pub(crate) fn new_for_tests(worker_sender: Sender<GossipVerifyTask>) -> Self {
+        Self { worker_sender }
+    }
+
     pub(crate) fn send_votes_to_worker_pool(
         &self,
         votes: Vec<Transaction>,

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -210,50 +210,53 @@ impl SigVerifyWorkerPool {
 
     fn worker(exit: Arc<AtomicBool>, channels: WorkerPoolChannels, forward_non_votes: bool) {
         while !exit.load(Ordering::Relaxed) {
-            let should_continue = crossbeam_channel::select! {
-                recv(&channels.non_vote_receiver) -> maybe_work => {
-                    match maybe_work {
-                        Ok(work) => Self::run_transaction_task(
-                            work,
-                            false,
-                            &channels.non_vote_banking_sender,
-                            &channels.forward_stage_sender,
-                            forward_non_votes,
-                            false,
-                            &channels.non_vote_stats,
-                        ),
-                        Err(_) => false,
-                    }
-                }
-                recv(&channels.tpu_vote_receiver) -> maybe_work => {
-                    match maybe_work {
-                        Ok(work) => Self::run_transaction_task(
-                            work,
-                            true,
-                            &channels.tpu_vote_banking_sender,
-                            &channels.forward_stage_sender,
-                            true,
-                            true,
-                            &channels.tpu_vote_stats,
-                        ),
-                        Err(_) => false,
-                    }
-                }
-                recv(&channels.gossip_receiver) -> maybe_work => {
-                    match maybe_work {
-                        Ok(work) => Self::run_gossip_task(
-                            work,
-                            &channels.gossip_verified_vote_sender,
-                        ),
-                        Err(_) => false,
-                    }
-                }
-                default(Duration::from_millis(10)) => { true }
-            };
-
-            if !should_continue {
-                return;
+            if !Self::worker_iteration(&channels, forward_non_votes) {
+                break;
             }
+        }
+    }
+
+    /// Returns false if some channel connection is disconnected.
+    fn worker_iteration(channels: &WorkerPoolChannels, forward_non_votes: bool) -> bool {
+        crossbeam_channel::select! {
+            recv(&channels.non_vote_receiver) -> maybe_work => {
+                match maybe_work {
+                    Ok(work) => Self::run_transaction_task(
+                        work,
+                        false,
+                        &channels.non_vote_banking_sender,
+                        &channels.forward_stage_sender,
+                        forward_non_votes,
+                        false,
+                        &channels.non_vote_stats,
+                    ),
+                    Err(_) => false,
+                }
+            }
+            recv(&channels.tpu_vote_receiver) -> maybe_work => {
+                match maybe_work {
+                    Ok(work) => Self::run_transaction_task(
+                        work,
+                        true,
+                        &channels.tpu_vote_banking_sender,
+                        &channels.forward_stage_sender,
+                        true,
+                        true,
+                        &channels.tpu_vote_stats,
+                    ),
+                    Err(_) => false,
+                }
+            }
+            recv(&channels.gossip_receiver) -> maybe_work => {
+                match maybe_work {
+                    Ok(work) => Self::run_gossip_task(
+                        work,
+                        &channels.gossip_verified_vote_sender,
+                    ),
+                    Err(_) => false,
+                }
+            }
+            default(Duration::from_millis(10)) => { true }
         }
     }
 

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -141,7 +141,9 @@ impl Drop for SigVerifyWorkerPool {
     fn drop(&mut self) {
         self.exit.store(true, Ordering::Relaxed);
         self.worker_hdls.drain(..).for_each(|hdl| {
-            let _ = hdl.join();
+            if let Err(err) = hdl.join() {
+                error!("sigverify worker encountered unexpected error: {err:?}");
+            }
         });
     }
 }

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -112,9 +112,11 @@ impl GossipSigVerifier {
     }
 }
 
-/// Work queues are kept separate so that a spam on TPU
-/// will not lead to us dropping votes.
-const SIGVERIFY_WORK_CHANNEL_SIZE: usize = 50_000;
+// Work queues are kept separate so that a spam on TPU
+// will not lead to us dropping votes.
+const SIGVERIFY_NON_VOTE_WORK_CHANNEL_SIZE: usize = 50_000;
+const SIGVERIFY_TPU_VOTE_WORK_CHANNEL_SIZE: usize = 5_000; // channel is batches not individual packets
+const SIGVERIFY_GOSSIP_VOTE_WORK_CHANNEL_SIZE: usize = 50_000;
 
 #[derive(Clone)]
 struct WorkerPoolChannels {
@@ -159,9 +161,9 @@ impl SigVerifyWorkerPool {
         non_vote_stats: SigVerifyWorkerStats,
         tpu_vote_stats: SigVerifyWorkerStats,
     ) -> Self {
-        let (non_vote_sender, non_vote_receiver) = bounded(SIGVERIFY_WORK_CHANNEL_SIZE);
-        let (tpu_vote_sender, tpu_vote_receiver) = bounded(SIGVERIFY_WORK_CHANNEL_SIZE);
-        let (gossip_sender, gossip_receiver) = bounded(SIGVERIFY_WORK_CHANNEL_SIZE);
+        let (non_vote_sender, non_vote_receiver) = bounded(SIGVERIFY_NON_VOTE_WORK_CHANNEL_SIZE);
+        let (tpu_vote_sender, tpu_vote_receiver) = bounded(SIGVERIFY_TPU_VOTE_WORK_CHANNEL_SIZE);
+        let (gossip_sender, gossip_receiver) = bounded(SIGVERIFY_GOSSIP_VOTE_WORK_CHANNEL_SIZE);
         let channels = WorkerPoolChannels {
             non_vote_receiver,
             tpu_vote_receiver,

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -5,17 +5,25 @@
 //! transaction. All processing is done on the CPU by default.
 
 use {
-    crate::sigverify::TransactionSigVerifier,
+    crate::{
+        banking_trace::BankingPacketSender,
+        sigverify::{
+            GossipSigVerifier, GossipVerifiedVoteBatch, SigVerifyWorkerPool, SigVerifyWorkerStats,
+            TransactionSigVerifier,
+        },
+    },
+    agave_banking_stage_ingress_types::BankingPacketBatch,
     core::time::Duration,
-    crossbeam_channel::{Receiver, RecvTimeoutError},
+    crossbeam_channel::{Receiver, RecvTimeoutError, Sender, unbounded},
     solana_measure::measure::Measure,
     solana_perf::{
         deduper::{self, Deduper},
         packet::PacketBatch,
     },
     solana_streamer::streamer::{self, StreamerError},
-    solana_time_utils as timing,
+    solana_transaction::Transaction,
     std::{
+        num::NonZeroUsize,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -30,12 +38,21 @@ use {
 pub enum SigVerifyServiceError {
     #[error("streamer error")]
     Streamer(#[from] StreamerError),
+    #[error("sigverify worker queue closed")]
+    WorkerQueueClosed,
 }
 
 type Result<T> = std::result::Result<T, SigVerifyServiceError>;
 
 pub struct SigVerifyStage {
-    thread_hdl: JoinHandle<()>,
+    non_vote_thread_hdl: JoinHandle<()>,
+    tpu_vote_thread_hdl: JoinHandle<()>,
+    _worker_pool: SigVerifyWorkerPool,
+}
+
+pub struct GossipSigVerifyHandle {
+    verifier: GossipSigVerifier,
+    verified_vote_receiver: Receiver<GossipVerifiedVoteBatch>,
 }
 
 #[derive(Default)]
@@ -167,13 +184,67 @@ impl SigVerifierStats {
 impl SigVerifyStage {
     pub fn new(
         packet_receiver: Receiver<PacketBatch>,
-        verifier: TransactionSigVerifier,
-        thread_name: &'static str,
-        metrics_name: &'static str,
-    ) -> Self {
-        let thread_hdl =
-            Self::verifier_service(packet_receiver, verifier, thread_name, metrics_name);
-        Self { thread_hdl }
+        vote_packet_receiver: Receiver<PacketBatch>,
+        non_vote_sender: BankingPacketSender,
+        tpu_vote_sender: BankingPacketSender,
+        forward_stage_sender: Sender<(BankingPacketBatch, bool)>,
+        num_workers: NonZeroUsize,
+        forward_non_votes: bool,
+    ) -> (Self, GossipSigVerifyHandle) {
+        let (gossip_verified_vote_sender, verified_vote_receiver) = unbounded();
+        let non_vote_stats = SigVerifierStats::default();
+        let tpu_vote_stats = SigVerifierStats::default();
+        let worker_pool = SigVerifyWorkerPool::new(
+            num_workers,
+            non_vote_sender,
+            tpu_vote_sender,
+            gossip_verified_vote_sender,
+            forward_stage_sender,
+            forward_non_votes,
+            SigVerifyWorkerStats {
+                total_valid_packets: non_vote_stats.total_valid_packets.clone(),
+                total_verify_time_us: non_vote_stats.total_verify_time_us.clone(),
+            },
+            SigVerifyWorkerStats {
+                total_valid_packets: tpu_vote_stats.total_valid_packets.clone(),
+                total_verify_time_us: tpu_vote_stats.total_verify_time_us.clone(),
+            },
+        );
+        let non_vote_thread_hdl = Self::verifier_service(
+            packet_receiver,
+            worker_pool.non_vote_verifier(),
+            "solSigVerTpu",
+            "tpu-verifier",
+            non_vote_stats,
+        );
+        let tpu_vote_thread_hdl = Self::verifier_service(
+            vote_packet_receiver,
+            worker_pool.tpu_vote_verifier(),
+            "solSigVerTpuVot",
+            "tpu-vote-verifier",
+            tpu_vote_stats,
+        );
+        let gossip_sigverify_handle = GossipSigVerifyHandle {
+            verifier: worker_pool.gossip_verifier(),
+            verified_vote_receiver,
+        };
+
+        (
+            Self {
+                non_vote_thread_hdl,
+                tpu_vote_thread_hdl,
+                _worker_pool: worker_pool,
+            },
+            gossip_sigverify_handle,
+        )
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        let non_vote_result = self.non_vote_thread_hdl.join();
+        let tpu_vote_result = self.tpu_vote_thread_hdl.join();
+        non_vote_result?;
+        tpu_vote_result?;
+        Ok(())
     }
 
     fn verifier<const K: usize>(
@@ -181,21 +252,12 @@ impl SigVerifyStage {
         recvr: &Receiver<PacketBatch>,
         verifier: &mut TransactionSigVerifier,
         stats: &mut SigVerifierStats,
-        in_flight_count: &Arc<AtomicUsize>,
     ) -> Result<()> {
         const SOFT_RECEIVE_CAP: usize = 5_000;
         let (mut batches, num_packets, recv_duration) =
             streamer::recv_packet_batches(recvr, SOFT_RECEIVE_CAP)?;
 
-        // If we're already at capacity immediately drop the packets
-        let mut should_drop = false;
-        if in_flight_count.load(Ordering::Relaxed) >= verifier.capacity() {
-            stats.total_dropped_on_capacity += num_packets;
-            should_drop = true;
-        }
-
         let batches_len = batches.len();
-
         stats
             .recv_batches_us_hist
             .increment(recv_duration.as_micros() as u64)
@@ -205,39 +267,17 @@ impl SigVerifyStage {
         stats.total_batches += batches_len;
         stats.total_packets += num_packets;
 
-        if !should_drop {
-            debug!(
-                "@{:?} verifier: verifying: {}",
-                timing::timestamp(),
-                num_packets,
-            );
-            let mut dedup_time = Measure::start("sigverify_dedup_time");
-            let discard_or_dedup_fail =
-                deduper::dedup_packets_and_count_discards(deduper, &mut batches) as usize;
-            dedup_time.stop();
-            let num_unique = num_packets.saturating_sub(discard_or_dedup_fail);
-            let num_packets_to_verify = num_unique;
-
-            verifier.verify_and_send_packets(
-                batches,
-                num_packets_to_verify,
-                in_flight_count.clone(),
-                stats.total_valid_packets.clone(),
-                stats.total_verify_time_us.clone(),
-            )?;
-            debug!(
-                "@{:?} verifier: done. batches: {} packets: {}",
-                timing::timestamp(),
-                batches_len,
-                num_packets
-            );
-            stats
-                .dedup_packets_pp_us_hist
-                .increment(dedup_time.as_us() / (num_packets as u64))
-                .unwrap();
-            stats.total_dedup += discard_or_dedup_fail;
-            stats.total_dedup_time_us += dedup_time.as_us() as usize;
-        }
+        let mut dedup_time = Measure::start("sigverify_dedup_time");
+        let discard_or_dedup_fail =
+            deduper::dedup_packets_and_count_discards(deduper, &mut batches) as usize;
+        dedup_time.stop();
+        stats.total_dropped_on_capacity += verifier.verify_and_send_packets(batches)?;
+        stats
+            .dedup_packets_pp_us_hist
+            .increment(dedup_time.as_us() / (num_packets as u64))
+            .unwrap();
+        stats.total_dedup += discard_or_dedup_fail;
+        stats.total_dedup_time_us += dedup_time.as_us() as usize;
 
         Ok(())
     }
@@ -247,8 +287,8 @@ impl SigVerifyStage {
         mut verifier: TransactionSigVerifier,
         thread_name: &'static str,
         metrics_name: &'static str,
+        mut stats: SigVerifierStats,
     ) -> JoinHandle<()> {
-        let mut stats = SigVerifierStats::default();
         let mut last_print = Instant::now();
         const MAX_DEDUPER_AGE: Duration = Duration::from_secs(2);
         const DEDUPER_FALSE_POSITIVE_RATE: f64 = 0.001;
@@ -258,18 +298,13 @@ impl SigVerifyStage {
             .spawn(move || {
                 let mut rng = rand::rng();
                 let mut deduper = Deduper::<2, [u8]>::new(&mut rng, DEDUPER_NUM_BITS);
-                let in_flight_count = Arc::new(AtomicUsize::new(0));
                 loop {
                     if deduper.maybe_reset(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, MAX_DEDUPER_AGE) {
                         stats.num_deduper_saturations += 1;
                     }
-                    if let Err(e) = Self::verifier(
-                        &deduper,
-                        &packet_receiver,
-                        &mut verifier,
-                        &mut stats,
-                        &in_flight_count,
-                    ) {
+                    if let Err(e) =
+                        Self::verifier(&deduper, &packet_receiver, &mut verifier, &mut stats)
+                    {
                         match e {
                             SigVerifyServiceError::Streamer(StreamerError::RecvTimeout(
                                 RecvTimeoutError::Disconnected,
@@ -288,9 +323,37 @@ impl SigVerifyStage {
             })
             .unwrap()
     }
+}
 
-    pub fn join(self) -> thread::Result<()> {
-        self.thread_hdl.join()
+impl GossipSigVerifyHandle {
+    /// Submit gossip votes for signature verification and collect the corresponding responses.
+    ///
+    /// This takes `&mut self` because responses for all submitted gossip tasks share one receiver.
+    /// Allowing concurrent callers would make it possible for one caller to consume another caller's
+    /// verification results.
+    pub(crate) fn verify_and_receive_votes(
+        &mut self,
+        votes: Vec<Transaction>,
+        packet_batches: Vec<PacketBatch>,
+    ) -> std::result::Result<(Vec<Transaction>, Vec<PacketBatch>), crossbeam_channel::RecvError>
+    {
+        let num_batches = match self.verifier.verify_and_send_votes(votes, packet_batches) {
+            Ok(num_batches) => num_batches,
+            Err(err) => {
+                error!("gossip sigverify enqueue failed: {err:?}");
+                return Ok((Vec::new(), Vec::new()));
+            }
+        };
+        let mut verified_vote_txs = Vec::with_capacity(num_batches);
+        let mut verified_packet_batches = Vec::with_capacity(num_batches);
+
+        for _ in 0..num_batches {
+            let verified_vote_batch = self.verified_vote_receiver.recv()?;
+            verified_vote_txs.extend(verified_vote_batch.transactions);
+            verified_packet_batches.push(verified_vote_batch.packet_batch);
+        }
+
+        Ok((verified_vote_txs, verified_packet_batches))
     }
 }
 
@@ -298,10 +361,9 @@ impl SigVerifyStage {
 mod tests {
     use {
         super::*,
-        crate::{banking_trace::BankingTracer, sigverify::TransactionSigVerifier},
+        crate::banking_trace::BankingTracer,
         crossbeam_channel::unbounded,
-        solana_perf::{packet::to_packet_batches, sigverify, test_tx::test_tx},
-        std::sync::Arc,
+        solana_perf::{packet::to_packet_batches, test_tx::test_tx},
     };
 
     fn gen_batches(
@@ -332,10 +394,19 @@ mod tests {
         agave_logger::setup();
         trace!("start");
         let (packet_s, packet_r) = unbounded();
+        let (vote_packet_s, vote_packet_r) = unbounded();
         let (verified_s, verified_r) = BankingTracer::channel_for_test();
-        let threadpool = Arc::new(sigverify::threadpool_for_tests());
-        let verifier = TransactionSigVerifier::new(threadpool, verified_s, None);
-        let stage = SigVerifyStage::new(packet_r, verifier, "solSigVerTest", "test");
+        let (tpu_vote_s, _tpu_vote_r) = BankingTracer::channel_for_test();
+        let (forward_stage_s, _forward_stage_r) = unbounded();
+        let (stage, gossip_sigverify_handle) = SigVerifyStage::new(
+            packet_r,
+            vote_packet_r,
+            verified_s,
+            tpu_vote_s,
+            forward_stage_s,
+            NonZeroUsize::new(4).unwrap(),
+            false,
+        );
 
         let now = Instant::now();
         let packets_per_batch = 128;
@@ -354,11 +425,11 @@ mod tests {
             assert_eq!(batch.len(), packets_per_batch);
             packet_s.send(batch).unwrap();
         }
-        let mut packet_s = Some(packet_s);
         let mut valid_received = 0;
         trace!("sent: {sent_len}");
+        drop(packet_s);
         loop {
-            if let Ok(verifieds) = verified_r.recv() {
+            if let Ok(verifieds) = verified_r.recv_timeout(Duration::from_secs(30)) {
                 valid_received += verifieds
                     .iter()
                     .map(|batch| batch.iter().filter(|p| !p.meta().discard()).count())
@@ -367,11 +438,8 @@ mod tests {
                 break;
             }
 
-            // Check if all the sent batches have been picked up by sigverify stage.
-            // Drop sender to exit the loop on next receive call, once the channel is
-            // drained.
-            if packet_s.as_ref().map(|s| s.is_empty()).unwrap_or(true) {
-                packet_s.take();
+            if valid_received >= if use_same_tx { 1 } else { total_packets } {
+                break;
             }
         }
         trace!("received: {valid_received}");
@@ -381,6 +449,8 @@ mod tests {
         } else {
             assert_eq!(valid_received, total_packets);
         }
+        drop(vote_packet_s);
+        drop(gossip_sigverify_handle);
         stage.join().unwrap();
     }
 }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -47,6 +47,7 @@ type Result<T> = std::result::Result<T, SigVerifyServiceError>;
 pub struct SigVerifyStage {
     non_vote_thread_hdl: JoinHandle<()>,
     tpu_vote_thread_hdl: JoinHandle<()>,
+    // pool held so workers stay alive. If dropped, workers in pool shut down.
     _worker_pool: SigVerifyWorkerPool,
 }
 

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -271,7 +271,7 @@ impl SigVerifyStage {
         let discard_or_dedup_fail =
             deduper::dedup_packets_and_count_discards(deduper, &mut batches) as usize;
         dedup_time.stop();
-        stats.total_dropped_on_capacity += verifier.verify_and_send_packets(batches)?;
+        stats.total_dropped_on_capacity += verifier.send_packets_to_worker_pool(batches)?;
         stats
             .dedup_packets_pp_us_hist
             .increment(dedup_time.as_us() / (num_packets as u64))
@@ -337,7 +337,10 @@ impl GossipSigVerifyHandle {
         packet_batches: Vec<PacketBatch>,
     ) -> std::result::Result<(Vec<Transaction>, Vec<PacketBatch>), crossbeam_channel::RecvError>
     {
-        let num_batches = match self.verifier.verify_and_send_votes(votes, packet_batches) {
+        let num_batches = match self
+            .verifier
+            .send_votes_to_worker_pool(votes, packet_batches)
+        {
             Ok(num_batches) => num_batches,
             Err(err) => {
                 error!("gossip sigverify enqueue failed: {err:?}");

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -327,6 +327,17 @@ impl SigVerifyStage {
 }
 
 impl GossipSigVerifyHandle {
+    #[cfg(test)]
+    pub(crate) fn new_for_tests(
+        worker_sender: Sender<crate::sigverify::GossipVerifyTask>,
+        verified_vote_receiver: Receiver<GossipVerifiedVoteBatch>,
+    ) -> Self {
+        Self {
+            verifier: GossipSigVerifier::new_for_tests(worker_sender),
+            verified_vote_receiver,
+        }
+    }
+
     /// Submit gossip votes for signature verification and collect the corresponding responses.
     ///
     /// This takes `&mut self` because responses for all submitted gossip tasks share one receiver.

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -364,7 +364,7 @@ impl GossipSigVerifyHandle {
 
         for _ in 0..num_batches {
             let verified_vote_batch = self.verified_vote_receiver.recv()?;
-            verified_vote_txs.extend(verified_vote_batch.transactions);
+            verified_vote_txs.push(verified_vote_batch.transaction);
             verified_packet_batches.push(verified_vote_batch.packet_batch);
         }
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -18,7 +18,6 @@ use {
             ForwardAddressGetter, ForwardingClientConfig, SpawnForwardingStageResult,
             spawn_forwarding_stage,
         },
-        sigverify::TransactionSigVerifier,
         sigverify_stage::SigVerifyStage,
         staked_nodes_updater_service::StakedNodesUpdaterService,
         tpu_entry_notifier::TpuEntryNotifier,
@@ -90,11 +89,10 @@ const TPU_CHANNEL_SIZE: usize = 50_000;
 
 pub struct Tpu {
     fetch_stage: FetchStage,
+    cluster_info_vote_listener: ClusterInfoVoteListener,
     sigverify_stage: SigVerifyStage,
-    vote_sigverify_stage: SigVerifyStage,
     banking_stage: BankingStageHandle,
     forwarding_stage: JoinHandle<()>,
-    cluster_info_vote_listener: ClusterInfoVoteListener,
     broadcast_stage: BroadcastStage,
     tpu_quic_t: thread::JoinHandle<()>,
     tpu_forwards_quic_t: thread::JoinHandle<()>,
@@ -260,41 +258,20 @@ impl Tpu {
 
         let (forward_stage_sender, forward_stage_receiver) = bounded(1024);
 
-        let sigverify_threadpool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(tpu_sigverify_threads.get())
-                .thread_name(|i| format!("solSigVerify{i:02}"))
-                .build()
-                .expect("new rayon threadpool"),
+        let (sigverify_stage, gossip_sigverify_handle) = SigVerifyStage::new(
+            packet_receiver,
+            vote_packet_receiver,
+            non_vote_sender,
+            tpu_vote_sender,
+            forward_stage_sender.clone(),
+            tpu_sigverify_threads,
+            enable_block_production_forwarding,
         );
-
-        let sigverify_stage = {
-            let verifier = TransactionSigVerifier::new(
-                sigverify_threadpool.clone(),
-                non_vote_sender,
-                enable_block_production_forwarding.then(|| forward_stage_sender.clone()),
-            );
-            SigVerifyStage::new(packet_receiver, verifier, "solSigVerTpu", "tpu-verifier")
-        };
-
-        let vote_sigverify_stage = {
-            let verifier = TransactionSigVerifier::new_reject_non_vote(
-                sigverify_threadpool.clone(),
-                tpu_vote_sender,
-                Some(forward_stage_sender),
-            );
-            SigVerifyStage::new(
-                vote_packet_receiver,
-                verifier,
-                "solSigVerTpuVot",
-                "tpu-vote-verifier",
-            )
-        };
 
         let cluster_info_vote_listener = ClusterInfoVoteListener::new(
             exit.clone(),
             cluster_info.clone(),
-            sigverify_threadpool,
+            gossip_sigverify_handle,
             gossip_vote_sender,
             vote_tracker,
             bank_forks.clone(),
@@ -377,11 +354,10 @@ impl Tpu {
 
         Self {
             fetch_stage,
+            cluster_info_vote_listener,
             sigverify_stage,
-            vote_sigverify_stage,
             banking_stage,
             forwarding_stage,
-            cluster_info_vote_listener,
             broadcast_stage,
             tpu_quic_t,
             tpu_forwards_quic_t,
@@ -395,9 +371,8 @@ impl Tpu {
     pub fn join(self) -> thread::Result<()> {
         let results = vec![
             self.fetch_stage.join(),
-            self.sigverify_stage.join(),
-            self.vote_sigverify_stage.join(),
             self.cluster_info_vote_listener.join(),
+            self.sigverify_stage.join(),
             self.banking_stage.join(),
             self.forwarding_stage.join(),
             self.staked_nodes_updater_service.join(),

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -256,7 +256,7 @@ impl Tpu {
         )
         .unwrap();
 
-        let (forward_stage_sender, forward_stage_receiver) = bounded(1024);
+        let (forward_stage_sender, forward_stage_receiver) = bounded(50_000);
 
         let (sigverify_stage, gossip_sigverify_handle) = SigVerifyStage::new(
             packet_receiver,

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -121,6 +121,14 @@ pub fn ed25519_verify(
     });
 }
 
+pub fn ed25519_verify_serial(batch: &mut PacketBatch, reject_non_vote: bool) {
+    for mut packet in batch.iter_mut() {
+        if !packet.meta().discard() && !verify_packet(&mut packet, reject_non_vote) {
+            packet.meta_mut().set_discard(true);
+        }
+    }
+}
+
 pub fn mark_disabled(batches: &mut [PacketBatch], r: &[Vec<u8>]) {
     for (batch, v) in batches.iter_mut().zip(r) {
         for (mut pkt, f) in batch.iter_mut().zip(v) {


### PR DESCRIPTION
#### Problem
- Rayon is not good for how we use it in sigverify

#### Summary of Changes
- Explicit sigverify thread pool (std::thread) that pops work from channel(s)
- Separate input channels for each use (tpu, tpu-vote, gossip-vote)  

Fixes #
