### PR TITLE
Updates `final_slot` in vote account even if the vote accounts didn't earn rewards

### DIFF
--- a/programs/vote/src/vote_state/handler.rs
+++ b/programs/vote/src/vote_state/handler.rs
@@ -242,7 +242,7 @@ impl VoteStateHandler {
         }
     }
 
-    pub(crate) fn last_voted_slot(&self) -> Option<Slot> {
+    pub fn last_voted_slot(&self) -> Option<Slot> {
         self.last_lockout().map(|v| v.slot())
     }
 

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -8,20 +8,58 @@ use {
     solana_vote::vote_account::VoteAccount,
     solana_vote_interface::state::{LandedVote, Lockout},
     solana_vote_program::vote_state::handler::VoteStateHandler,
-    std::collections::{HashSet, VecDeque},
+    std::collections::{HashMap, HashSet, VecDeque, hash_map::Entry},
     thiserror::Error,
 };
 
 pub mod epoch_inflation_account_state;
 
 /// Different types of errors that can happen when calculating and paying voting reward.
+///
+/// These errors should cause the processing of the bank to fail.
 #[derive(Debug, Error)]
 pub enum CalcVoteRewardUpdateVoteStatesError {
-    #[error("missing EpochInflationAccountState for current slot {current_slot}")]
-    MissingEpochInflationAccountState { current_slot: Slot },
+    #[error("allocating accounts failed with {0}")]
+    AllocateAccounts(#[from] AllocateAccountsError),
+    #[error("Processing reward state failed with {0}")]
+    RewardState(#[from] RewardStateError),
+}
+
+/// Different types of error that happen when allocating memory for storing updated accounts.
+///
+/// These errors should cause the processing of the bank to fail.
+#[derive(Debug, Error)]
+pub enum AllocateAccountsError {
+    #[error("did not find rank map for final_slot={final_slot} in current_slot={current_slot}")]
+    FinalCert {
+        current_slot: Slot,
+        final_slot: Slot,
+    },
+    #[error("did not find rank map for reward_slot={reward_slot} in current_slot={current_slot}")]
+    RewardCert {
+        current_slot: Slot,
+        reward_slot: Slot,
+    },
+}
+
+/// Different types of error that happen when looking up state to process the reward cert.
+///
+/// These errors should cause the processing of the bank to fail.
+#[derive(Debug, Error)]
+pub enum RewardStateError {
     #[error("missing epoch stakes for reward_slot {reward_slot} in current_slot {current_slot}")]
     MissingEpochStakes {
         reward_slot: Slot,
+        current_slot: Slot,
+    },
+    #[error("missing EpochInflationAccountState for current slot {current_slot}")]
+    MissingEpochInflationAccountState { current_slot: Slot },
+    #[error(
+        "missing validator stake info for reward epoch {reward_epoch} in current_slot \
+         {current_slot}"
+    )]
+    NoEpochValidatorStake {
+        reward_epoch: Epoch,
         current_slot: Slot,
     },
     #[error(
@@ -32,144 +70,375 @@ pub enum CalcVoteRewardUpdateVoteStatesError {
         reward_slot: Slot,
         current_slot: Slot,
     },
-    #[error(
-        "missing validator stake info for reward epoch {reward_epoch} in current_slot \
-         {current_slot}"
-    )]
-    NoEpochValidatorStake {
-        reward_epoch: Epoch,
-        current_slot: Slot,
-    },
+}
+
+/// Data needed to operate on `VoteStateHandler`.
+struct VoteState {
+    /// The pubkey of the vote account.
+    vote_pubkey: Pubkey,
+    /// Reference to actual `VoteStateHandler`.
+    handler: VoteStateHandler,
+    /// How many lamports were stored in the account.
+    lamports: u64,
+    /// How much space the account takes up.
+    space: usize,
+    /// Who owns the account.
+    owner: Pubkey,
+}
+
+impl VoteState {
+    fn try_new(
+        vote_accounts: &HashMap<Pubkey, (u64, VoteAccount)>,
+        vote_pubkey: Pubkey,
+    ) -> Option<Self> {
+        let Some((_, account)) = vote_accounts.get(&vote_pubkey) else {
+            info!("did not find vote account for vote_pubkey={vote_pubkey}");
+            return None;
+        };
+        let versions = match bincode::deserialize(account.account().data()) {
+            Ok(s) => s,
+            Err(e) => {
+                info!("bincode::deserialize for vote_pubkey={vote_pubkey} failed with {e}");
+                return None;
+            }
+        };
+        let handler = match VoteStateHandler::try_new_from_vote_state_versions(versions) {
+            Ok(h) => h,
+            Err(e) => {
+                info!("VoteStateHandler::try_new() for vote_pubkey={vote_pubkey} failed with {e}");
+                return None;
+            }
+        };
+        Some(Self {
+            vote_pubkey,
+            handler,
+            lamports: account.lamports(),
+            space: account.account().data().len(),
+            owner: *account.owner(),
+        })
+    }
+
+    fn serialize(self) -> Option<(Pubkey, AccountSharedData)> {
+        let mut updated_account = AccountSharedData::new(self.lamports, self.space, &self.owner);
+        match self
+            .handler
+            .serialize_into(updated_account.data_as_mut_slice())
+        {
+            Ok(()) => Some((self.vote_pubkey, updated_account)),
+            Err(e) => {
+                info!(
+                    "serializing account vote_pubkey={} failed with {e}",
+                    self.vote_pubkey
+                );
+                None
+            }
+        }
+    }
+}
+
+/// Common state required to pay rewards.
+#[derive(Debug)]
+struct RewardState<'a> {
+    /// The epoch in which the reward was paid into the vote account.
+    current_epoch: Epoch,
+    /// The slot in which the reward was earned.
+    reward_slot: Slot,
+    /// Validators present in the reward cert.
+    reward_validators: &'a HashSet<Pubkey>,
+    /// The slot in which the reward is being paid into the vote account.
+    current_slot: Slot,
+    /// The pubkey of the validator that will receive the leader rewards.
+    leader_vote_pubkey: Pubkey,
+    /// Vote accounts at reward slot.
+    accounts: &'a HashMap<Pubkey, (u64, VoteAccount)>,
+    /// Total stake at `reward_slot`.
+    total_stake: u64,
+    /// inflation state at `reward_slot`.
+    epoch_inflation_state: EpochInflationState,
+}
+
+impl<'a> RewardState<'a> {
+    fn try_new(
+        bank: &'a Bank,
+        reward_slot: Slot,
+        reward_validators: &'a HashSet<Pubkey>,
+    ) -> Result<Self, RewardStateError> {
+        let current_slot = bank.slot();
+        let epoch_stakes = bank.epoch_stakes_from_slot(reward_slot).ok_or(
+            RewardStateError::MissingEpochStakes {
+                reward_slot,
+                current_slot,
+            },
+        )?;
+        let accounts = epoch_stakes.stakes().vote_accounts().as_ref();
+        let total_stake = epoch_stakes.total_stake();
+        // This assumes that if the epoch_schedule ever changes, the new schedule will maintain correct
+        // info about older slots as well.
+        let reward_epoch = bank.epoch_schedule.get_epoch(reward_slot);
+        let epoch_inflation_state = {
+            let epoch_inflation_account_state = EpochInflationAccountState::new_from_bank(bank);
+            // This function should only be called after alpenglow is active and the slot in the the epoch
+            // that activated Alpenglow should have created the account.
+            debug_assert!(epoch_inflation_account_state.is_some());
+            epoch_inflation_account_state
+                .ok_or(RewardStateError::MissingEpochInflationAccountState { current_slot })?
+                .get_epoch_state(reward_epoch)
+                .ok_or(RewardStateError::NoEpochValidatorStake {
+                    reward_epoch,
+                    current_slot,
+                })?
+        };
+        Ok(Self {
+            current_epoch: bank.epoch(),
+            reward_slot,
+            reward_validators,
+            current_slot,
+            leader_vote_pubkey: bank.leader().vote_address,
+            accounts,
+            total_stake,
+            epoch_inflation_state,
+        })
+    }
+
+    /// Calculates rewards for the `validator`.
+    ///
+    /// On success also increments `total_leader_reward` with the leader's share.
+    fn calculate_reward(
+        &self,
+        validator: Pubkey,
+        accumulating_leader_reward: &mut u64,
+    ) -> Result<u64, RewardStateError> {
+        let (reward_slot_validator_stake, _) =
+            self.accounts
+                .get(&validator)
+                .ok_or(RewardStateError::MissingRewardSlotValidator {
+                    pubkey: validator,
+                    reward_slot: self.reward_slot,
+                    current_slot: self.current_slot,
+                })?;
+        let (validator_reward, leader_reward) = calculate_reward(
+            &self.epoch_inflation_state,
+            self.total_stake,
+            *reward_slot_validator_stake,
+        );
+        *accumulating_leader_reward = accumulating_leader_reward.saturating_add(leader_reward);
+        Ok(validator_reward)
+    }
+
+    fn update_votes(&self, vote_state: &mut VoteState) {
+        debug_assert!(self.reward_validators.contains(&vote_state.vote_pubkey));
+        let latest_voted_slot = self
+            .reward_slot
+            .max(vote_state.handler.last_voted_slot().unwrap_or(0))
+            .max(vote_state.handler.root_slot().unwrap_or(0));
+        vote_state.handler.set_votes(VecDeque::from([LandedVote {
+            lockout: Lockout::new(latest_voted_slot),
+            latency: 0,
+        }]));
+    }
+
+    fn update_account(
+        &self,
+        vote_state: &mut VoteState,
+        accumulating_leader_reward: &mut u64,
+    ) -> Result<bool, RewardStateError> {
+        if self.reward_validators.contains(&vote_state.vote_pubkey) {
+            self.update_votes(vote_state);
+            let reward =
+                self.calculate_reward(vote_state.vote_pubkey, accumulating_leader_reward)?;
+            if reward != 0 {
+                vote_state
+                    .handler
+                    .increment_credits(self.current_epoch, reward);
+            }
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Assumes that `Self::update_account` was already called and pays the additional
+    /// `leader_rewards` to the account.
+    #[must_use]
+    fn update_leader(&self, vote_state: &mut VoteState, leader_reward: u64) -> bool {
+        debug_assert_eq!(vote_state.vote_pubkey, self.leader_vote_pubkey);
+        if leader_reward != 0 {
+            vote_state
+                .handler
+                .increment_credits(self.current_epoch, leader_reward);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Common state required to update root_slot on the vote account.
+#[derive(Debug)]
+struct FinalCertState<'a> {
+    signers: &'a HashSet<Pubkey>,
+    final_slot: Slot,
+}
+
+impl<'a> FinalCertState<'a> {
+    /// Updates the `root_slot` and the `votes` fields in the `VoteStateHandler`.
+    #[must_use]
+    fn update_account(&self, vote_state: &mut VoteState) -> bool {
+        if self.signers.contains(&vote_state.vote_pubkey) {
+            vote_state.handler.set_root_slot(Some(self.final_slot));
+            let latest_voted_slot = vote_state
+                .handler
+                .last_voted_slot()
+                .unwrap_or(self.final_slot)
+                .max(self.final_slot);
+            // If a validator is included in the finalization cert, it must have voted for it.
+            // So even if the reward cert is absent, we can still update votes.
+            vote_state.handler.set_votes(VecDeque::from([LandedVote {
+                lockout: Lockout::new(latest_voted_slot),
+                latency: 0,
+            }]));
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Allocates storage for updated accounts.
+fn allocate_updated_accounts(
+    bank: &Bank,
+    reward_cert: &Option<ValidatedRewardCert>,
+    final_cert_input: &Option<(&HashSet<Pubkey>, Slot)>,
+) -> Result<Option<HashMap<Pubkey, VoteState>>, AllocateAccountsError> {
+    let max_validators = match (&reward_cert, &final_cert_input) {
+        (None, None) => return Ok(None),
+        (Some(cert), None) => {
+            // Adding one in the off chance that the current leader is not in the cert.
+            cert.validators().len() + 1
+        }
+        (None, Some((signers, _))) => signers.len(),
+        (Some(reward_cert), Some((_, slot))) => {
+            // Both finalization cert and reward cert are present.  Instead of computing overlap,
+            // use max validators.
+            let final_cert_slot_max_validators = bank
+                .get_rank_map(*slot)
+                .ok_or(AllocateAccountsError::FinalCert {
+                    current_slot: bank.slot(),
+                    final_slot: *slot,
+                })?
+                .len();
+            let reward_cert_slot_max_validators = bank
+                .get_rank_map(reward_cert.slot())
+                .ok_or(AllocateAccountsError::RewardCert {
+                    current_slot: bank.slot(),
+                    reward_slot: reward_cert.slot(),
+                })?
+                .len();
+            final_cert_slot_max_validators.max(reward_cert_slot_max_validators)
+        }
+    };
+    Ok(Some(HashMap::with_capacity(max_validators)))
+}
+
+fn update_accounts(
+    reward_state: &Option<RewardState>,
+    final_cert_state: &Option<FinalCertState>,
+    vote_accounts: &HashMap<Pubkey, (u64, VoteAccount)>,
+    mut updated_accounts: HashMap<Pubkey, VoteState>,
+    validators: impl Iterator<Item = Pubkey>,
+) -> Result<Vec<(Pubkey, AccountSharedData)>, CalcVoteRewardUpdateVoteStatesError> {
+    let mut leader_reward = 0;
+    for validator in validators {
+        let Some(mut vote_state) = VoteState::try_new(vote_accounts, validator) else {
+            continue;
+        };
+        let account_updated = match (reward_state, final_cert_state) {
+            (None, None) => false,
+            (Some(state), None) => state.update_account(&mut vote_state, &mut leader_reward)?,
+            (None, Some(state)) => state.update_account(&mut vote_state),
+            (Some(reward_state), Some(final_state)) => {
+                let reward_updated =
+                    reward_state.update_account(&mut vote_state, &mut leader_reward)?;
+                let final_cert_updated = final_state.update_account(&mut vote_state);
+                reward_updated || final_cert_updated
+            }
+        };
+        if account_updated {
+            updated_accounts.insert(vote_state.vote_pubkey, vote_state);
+        }
+    }
+
+    // all validators have been processed, can pay leader rewards now.
+    if let Some(state) = &reward_state {
+        match updated_accounts.entry(state.leader_vote_pubkey) {
+            Entry::Occupied(e) => {
+                let _ = state.update_leader(e.into_mut(), leader_reward);
+            }
+            Entry::Vacant(e) => {
+                if let Some(mut vote_state) =
+                    VoteState::try_new(vote_accounts, state.leader_vote_pubkey)
+                {
+                    if state.update_leader(&mut vote_state, leader_reward) {
+                        e.insert(vote_state);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(updated_accounts
+        .into_values()
+        .filter_map(|vote_state| vote_state.serialize())
+        .collect())
 }
 
 /// Calculates voting rewards based on the `reward_cert` and updates fields in the vote account
-/// based on the calculated rewards and the `final_cert`.
+/// based on the calculated rewards and the `final_cert_input`.
 pub(super) fn calc_vote_rewards_update_vote_states(
     bank: &Bank,
     reward_cert: Option<ValidatedRewardCert>,
     final_cert_input: Option<(&HashSet<Pubkey>, Slot)>,
 ) -> Result<(), CalcVoteRewardUpdateVoteStatesError> {
-    let (reward_slot, validators_to_reward) = if let Some(reward_cert) = reward_cert {
-        reward_cert.into_parts()
-    } else {
+    let Some(updated_accounts) = allocate_updated_accounts(bank, &reward_cert, &final_cert_input)?
+    else {
         return Ok(());
     };
+    let reward_state = match &reward_cert {
+        Some(c) => Some(RewardState::try_new(bank, c.slot(), c.validators())?),
+        None => None,
+    };
+    let final_cert_state = final_cert_input.map(|(signers, final_slot)| FinalCertState {
+        signers,
+        final_slot,
+    });
+    let vote_accounts = bank.vote_accounts();
 
-    let current_slot = bank.slot();
-    let (reward_slot_accounts, reward_slot_total_stake) = {
-        let epoch_stakes = bank.epoch_stakes_from_slot(reward_slot).ok_or(
-            CalcVoteRewardUpdateVoteStatesError::MissingEpochStakes {
-                reward_slot,
-                current_slot,
-            },
-        )?;
-        (
-            epoch_stakes.stakes().vote_accounts().as_ref(),
-            epoch_stakes.total_stake(),
-        )
+    let updated_accounts = match (&reward_state, &final_cert_state) {
+        (None, None) => return Ok(()),
+        (Some(state), None) => update_accounts(
+            &reward_state,
+            &final_cert_state,
+            &vote_accounts,
+            updated_accounts,
+            state.reward_validators.iter().cloned(),
+        )?,
+        (None, Some(state)) => update_accounts(
+            &reward_state,
+            &final_cert_state,
+            &vote_accounts,
+            updated_accounts,
+            state.signers.iter().cloned(),
+        )?,
+        (Some(r_state), Some(f_state)) => update_accounts(
+            &reward_state,
+            &final_cert_state,
+            &vote_accounts,
+            updated_accounts,
+            r_state.reward_validators.union(f_state.signers).cloned(),
+        )?,
     };
 
-    // This assumes that if the epoch_schedule ever changes, the new schedule will maintain correct
-    // info about older slots as well.
-    let reward_epoch = bank.epoch_schedule.get_epoch(reward_slot);
-    let epoch_state = {
-        let epoch_inflation_account_state = EpochInflationAccountState::new_from_bank(bank);
-        // This function should only be called after alpenglow is active and the slot in the the epoch
-        // that activated Alpenglow should have created the account.
-        debug_assert!(epoch_inflation_account_state.is_some());
-        epoch_inflation_account_state
-            .ok_or(
-                CalcVoteRewardUpdateVoteStatesError::MissingEpochInflationAccountState {
-                    current_slot,
-                },
-            )?
-            .get_epoch_state(reward_epoch)
-            .ok_or(CalcVoteRewardUpdateVoteStatesError::NoEpochValidatorStake {
-                reward_epoch,
-                current_slot,
-            })?
-    };
-
-    let current_vote_accounts = bank.vote_accounts();
-    let current_slot_leader_vote_pubkey = bank.leader().vote_address;
-    // Adding 1 to capacity in case the current leader was not in the aggregate and paying it
-    // triggers a reallocation.
-    let mut paid_vote_accounts = Vec::with_capacity(validators_to_reward.len().saturating_add(1));
-    let mut total_leader_reward = 0u64;
-    let current_epoch = bank.epoch();
-    for validator_to_reward in validators_to_reward {
-        let (reward_slot_validator_stake, _) =
-            reward_slot_accounts.get(&validator_to_reward).ok_or(
-                CalcVoteRewardUpdateVoteStatesError::MissingRewardSlotValidator {
-                    pubkey: validator_to_reward,
-                    reward_slot,
-                    current_slot,
-                },
-            )?;
-        let (validator_reward, add_leader_reward) = calculate_reward(
-            &epoch_state,
-            reward_slot_total_stake,
-            *reward_slot_validator_stake,
-        );
-        total_leader_reward = total_leader_reward.saturating_add(add_leader_reward);
-
-        if current_slot_leader_vote_pubkey == validator_to_reward {
-            // Current slot's leader's node pubkey is associated with exactly one vote
-            // pubkey and this reward is for this vote pubkey.  The reward will be paid.
-            // However, we haven't finished calculating the total rewards for the leader yet.
-            // `total_leader_reward` be paid at the end of the function.
-            total_leader_reward = total_leader_reward.saturating_add(validator_reward);
-            continue;
-        }
-
-        // The reward was not for a vote pubkey associated with the current slot's leader's node pubkey.
-        // We can pay it into the vote account immediately.
-        let Some((_, current_slot_account)) = current_vote_accounts.get(&validator_to_reward)
-        else {
-            info!(
-                "validator {validator_to_reward} was present for reward_slot {reward_slot} but is \
-                 absent for current_slot {current_slot}"
-            );
-            continue;
-        };
-        if let Some(account_data) = update_vote_account(
-            current_epoch,
-            reward_slot,
-            current_slot_account,
-            validator_to_reward,
-            validator_reward,
-            &final_cert_input,
-        ) {
-            paid_vote_accounts.push((validator_to_reward, account_data));
-        }
-    }
-
-    // We have computed the final `total_leader_rewards` now.  We can pay it into the leader's
-    // vote account.
-    if total_leader_reward != 0 {
-        match current_vote_accounts.get(&current_slot_leader_vote_pubkey) {
-            Some((_, leader_account)) => {
-                if let Some(account_data) = update_vote_account(
-                    current_epoch,
-                    reward_slot,
-                    leader_account,
-                    current_slot_leader_vote_pubkey,
-                    total_leader_reward,
-                    &final_cert_input,
-                ) {
-                    paid_vote_accounts.push((current_slot_leader_vote_pubkey, account_data));
-                }
-            }
-            None => {
-                info!(
-                    "Current slot {current_slot}'s leader's account \
-                     {current_slot_leader_vote_pubkey} not found.  It will not be paid."
-                )
-            }
-        }
-    }
-
-    bank.store_accounts((current_slot, paid_vote_accounts.as_slice()));
+    bank.store_accounts((bank.slot(), updated_accounts.as_slice()));
     Ok(())
 }
 
@@ -201,78 +470,6 @@ fn calculate_reward(
     (validator_reward_lamports, leader_reward_lamports)
 }
 
-/// Deserializes the state from the `account` and updates various fields in it.
-///
-/// If successful, returns the `AccountSharedData` that can be stored back into a `Bank`.
-fn update_vote_account(
-    current_epoch: Epoch,
-    reward_slot: Slot,
-    account: &VoteAccount,
-    validator_vote_pubkey: Pubkey,
-    reward: u64,
-    final_cert_input: &Option<(&HashSet<Pubkey>, Slot)>,
-) -> Option<AccountSharedData> {
-    let versions = bincode::deserialize(account.account().data()).ok()?;
-    let mut handle = VoteStateHandler::try_new_from_vote_state_versions(versions).ok()?;
-    update_vote_state(
-        &mut handle,
-        reward_slot,
-        current_epoch,
-        reward,
-        validator_vote_pubkey,
-        final_cert_input,
-    );
-    let mut paid_account = AccountSharedData::new(
-        account.lamports(),
-        account.account().data().len(),
-        account.owner(),
-    );
-    handle
-        .serialize_into(paid_account.data_as_mut_slice())
-        .ok()?;
-    Some(paid_account)
-}
-
-/// Updates `epoch_credits`, `root_slot`, and `votes` in vote state using the rewards and finalization
-/// certificates from the footer.
-///
-/// `epoch_credits` are updated to record the rewards that the vote account has earned.
-///
-/// Downstream tooling expects these fields to be be set:
-/// - `root_slot`, a validator's latest finalized & replayed slot
-/// - `votes`, a validator's latest vote
-///
-/// `votes` is consumed for health monitoring, we require it to be within `DELINQUENT_VALIDATOR_SLOT_DISTANCE`
-/// of the tip of the chain to be considered healthy.
-///
-/// `root_slot` is similarly used by various tooling (e.g. stake delegation) to determine whether the validator
-/// is healthy to interact with  and also is required to be within `DELINQUENT_VALIDATOR_SLOT_DISTANCE` of the tip.
-///
-/// Until we overhaul vote state we continue populating these two fields similar to TowerBFT:
-/// - `root_slot` is populated from the footer finalization certificate
-/// - `votes` is populated from the footer rewards aggregate
-fn update_vote_state(
-    handle: &mut VoteStateHandler,
-    reward_slot: Slot,
-    reward_epoch: Epoch,
-    reward: u64,
-    validator_vote_pubkey: Pubkey,
-    final_cert_input: &Option<(&HashSet<Pubkey>, Slot)>,
-) {
-    handle.increment_credits(reward_epoch, reward);
-    if let Some((signers, slot)) = final_cert_input {
-        if signers.contains(&validator_vote_pubkey) {
-            handle.set_root_slot(Some(*slot));
-        }
-    }
-
-    let latest_root_or_reward = handle.root_slot().unwrap_or(reward_slot).max(reward_slot);
-    handle.set_votes(VecDeque::from([LandedVote {
-        lockout: Lockout::new(latest_root_or_reward),
-        latency: 0,
-    }]));
-}
-
 #[cfg(test)]
 mod tests {
     use {
@@ -282,7 +479,6 @@ mod tests {
             genesis_utils::{
                 ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
             },
-            test_utils::new_rand_vote_account,
             validated_block_finalization::ValidatedBlockFinalizationCert,
         },
         agave_votor_messages::{
@@ -333,7 +529,7 @@ mod tests {
     fn build_fast_finalization_cert(
         bank: &Bank,
         signing_ranks: &[usize],
-    ) -> (HashSet<Pubkey>, Slot) {
+    ) -> ValidatedBlockFinalizationCert {
         let slot = bank.slot();
         let block_id = Hash::new_unique();
         let cert_type = CertificateType::FinalizeFast(slot, block_id);
@@ -349,9 +545,7 @@ mod tests {
             signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap,
         };
-        let (signers, cert, _) =
-            ValidatedBlockFinalizationCert::from_validated_fast(cert, bank).into_parts();
-        (signers, cert.cert_type.slot())
+        ValidatedBlockFinalizationCert::from_validated_fast(cert, bank)
     }
 
     #[test]
@@ -385,18 +579,6 @@ mod tests {
         assert_eq!(got_epoch, epoch);
         assert_eq!(got_final_credits, credits);
         assert_eq!(got_initial_credits, 0);
-    }
-
-    #[test]
-    fn pay_reward_works() {
-        let account =
-            VoteAccount::try_from(new_rand_vote_account(&mut rand::rng(), None, true)).unwrap();
-        let epoch = 1234;
-        let reward = 3453423;
-        let account_shared_data =
-            update_vote_account(epoch, 0, &account, Pubkey::default(), reward, &None).unwrap();
-        let vote_state = vote_state_from_account(&account_shared_data);
-        assert_eq!(reward, vote_state.epoch_credits().last().unwrap().1);
     }
 
     fn calc_reward_for_test(
@@ -534,8 +716,9 @@ mod tests {
                 })
                 .unwrap()
         };
-        let (final_cert_signers, final_cert_slot) =
-            build_fast_finalization_cert(&bank, &[cert_rank]);
+        let final_cert = build_fast_finalization_cert(&bank, &[cert_rank]);
+        let (signers, finalize_cert, _) = final_cert.clone().into_parts();
+        let final_cert_input = Some((&signers, finalize_cert.cert_type.slot()));
 
         calc_vote_rewards_update_vote_states(
             &bank,
@@ -543,16 +726,16 @@ mod tests {
                 reward_slot,
                 vec![target_vote_pubkey],
             )),
-            Some((&final_cert_signers, final_cert_slot)),
+            final_cert_input,
         )
         .unwrap();
 
         let handle = vote_state_from_bank(&bank, &target_vote_pubkey);
-        assert_eq!(handle.root_slot(), Some(final_cert_slot));
+        assert_eq!(handle.root_slot(), Some(final_cert.slot()));
         assert_eq!(handle.votes().len(), 1);
         assert_eq!(
             handle.votes().front().unwrap().lockout.slot(),
-            final_cert_slot.max(reward_slot)
+            final_cert.slot().max(reward_slot)
         );
     }
 
@@ -601,8 +784,9 @@ mod tests {
                 })
                 .unwrap()
         };
-        let (final_cert_signers, final_cert_slot) =
-            build_fast_finalization_cert(&bank, &[cert_rank]);
+        let final_cert = build_fast_finalization_cert(&bank, &[cert_rank]);
+        let (signers, finalize_cert, _) = final_cert.into_parts();
+        let final_cert_input = Some((&signers, finalize_cert.cert_type.slot()));
 
         calc_vote_rewards_update_vote_states(
             &bank,
@@ -610,7 +794,7 @@ mod tests {
                 reward_slot,
                 vec![target_vote_pubkey],
             )),
-            Some((&final_cert_signers, final_cert_slot)),
+            final_cert_input,
         )
         .unwrap();
 

--- a/runtime/src/validated_block_finalization.rs
+++ b/runtime/src/validated_block_finalization.rs
@@ -300,11 +300,6 @@ impl ValidatedBlockFinalizationCert {
         )
     }
 
-    /// Returns true when the provided vote account pubkey is in the finalization certificate.
-    pub fn was_signed_by(&self, vote_pubkey: &Pubkey) -> bool {
-        self.signers.contains(vote_pubkey)
-    }
-
     /// Returns the data needed to calculating and paying vote rewards.
     pub fn vote_rewards_input(&self) -> (&HashSet<Pubkey>, Slot) {
         (&self.signers, self.slot())
@@ -314,7 +309,7 @@ impl ValidatedBlockFinalizationCert {
     ///
     /// For slow finalization, returns (signers, finalize_cert, Some(notarize_cert)).
     /// For fast finalization, returns (signers, fast_finalize_cert, None).
-    pub fn into_parts(self) -> (HashSet<Pubkey>, Certificate, Option<Certificate>) {
+    pub(crate) fn into_parts(self) -> (HashSet<Pubkey>, Certificate, Option<Certificate>) {
         let signers = self.signers;
         let (final_cert, notar_cert) = match self.kind {
             ValidatedBlockFinalizationCertKind::Finalize {

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -67,6 +67,7 @@ fn extract_slot(
 }
 
 /// Struct built by validating incoming reward certs.
+#[derive(Debug, Clone)]
 pub struct ValidatedRewardCert {
     /// List of validators that were present in the reward certs.
     validators: HashSet<Pubkey>,
@@ -131,9 +132,12 @@ impl ValidatedRewardCert {
         }))
     }
 
-    /// Returns the validators that were extracted from the reward certs.
-    pub(crate) fn into_parts(self) -> (Slot, HashSet<Pubkey>) {
-        (self.reward_slot, self.validators)
+    pub(crate) fn slot(&self) -> Slot {
+        self.reward_slot
+    }
+
+    pub(crate) fn validators(&self) -> &HashSet<Pubkey> {
+        &self.validators
     }
 
     #[cfg(test)]


### PR DESCRIPTION
#### Problem

There is a bug in how `vote_reward.rs` currently works.  If no reward cert was presented, then the function is NOP.  This is a problem as then the function doesn't handle the finalization cert.  

Further, the function iterates over the validators in the reward cert and updates the root_slot for them.  So if there are validators in the finalization cert that are not in the reward cert, their root slot will also not be updated.


#### Summary of Changes

This PR fixes the above problem.  It makes the following changes:

- validated reward cert stores the validators in a hashset so it matches how validators are stored in the finalization cert and we can efficiently evaluate group membership.
- vote_reward.rs has undergone a big refactor so that now when we update a vote account, we can optionally ask it to update the reward related state or the final_slot related state.
- then vote_reward.rs updates the intersection of the two set of validators and then it updates the differences of the two groups.
