### PR TITLE
Bump `solana-bls-signatures` to `3.3.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7177,9 +7177,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bls-signatures"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3d8a6e1a009bddbdbfe13ee6ff206c16afa9f8fae7d04612d779ac2254ad5f"
+checksum = "654ea8d31bbb4b0b9c28f9c545edb32691de27d4e2fc0e252c1ff47da50c5f2a"
 dependencies = [
  "base64 0.22.1",
  "blst",
@@ -7200,6 +7200,8 @@ dependencies = [
  "solana-signer",
  "subtle",
  "thiserror 2.0.18",
+ "wincode",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -368,7 +368,7 @@ solana-big-mod-exp = "3.0.0"
 solana-bincode = "3.1.0"
 solana-blake3-hasher = "3.1.0"
 solana-bloom = { path = "bloom", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
-solana-bls-signatures = { version = "3.2.0", features = ["serde"] }
+solana-bls-signatures = { version = "3.3.0", features = ["serde"] }
 solana-bls12-381-syscall = { path = "bls12-381-syscall", version = "=4.1.0-alpha.0", features = ["agave-unstable-api"] }
 solana-bn254 = "3.2.1"
 solana-borsh = "3.0.2"

--- a/bls-cert-verify/benches/cert_verify.rs
+++ b/bls-cert-verify/benches/cert_verify.rs
@@ -8,7 +8,8 @@ use {
     bitvec::vec::BitVec,
     criterion::{BenchmarkId, Criterion, criterion_group, criterion_main},
     solana_bls_signatures::{
-        keypair::Keypair as BlsKeypair, pubkey::PubkeyAffine as BlsPubkeyAffine,
+        keypair::Keypair as BlsKeypair,
+        pubkey::{PopVerified, PubkeyAffine as BlsPubkeyAffine},
         signature::Signature as BlsSignature,
     },
     solana_hash::Hash,
@@ -107,7 +108,8 @@ fn bench_verify_cert(c: &mut Criterion) {
         let keypairs = create_bls_keypairs(size);
 
         // Pre-calculate public keys to simulate efficient Bank lookup
-        let pubkeys: Vec<BlsPubkeyAffine> = keypairs.iter().map(|kp| kp.public).collect();
+        let pubkeys: Vec<PopVerified<BlsPubkeyAffine>> =
+            keypairs.iter().map(|kp| kp.public).collect();
         let pubkeys_ref = &pubkeys;
 
         // Base2 Setup

--- a/bls-cert-verify/src/cert_verify.rs
+++ b/bls-cert-verify/src/cert_verify.rs
@@ -6,10 +6,12 @@ use {
         vote::Vote,
     },
     bitvec::vec::BitVec,
-    rayon::{iter::IntoParallelRefIterator, join},
+    rayon::iter::IntoParallelRefIterator,
     solana_bls_signatures::{
         BlsError, PubkeyProjective, Signature as BlsSignature, SignatureProjective,
-        VerifiablePubkey, pubkey::PubkeyAffine as BlsPubkeyAffine, signature::AsSignatureAffine,
+        VerifySignature,
+        pubkey::{AggregatePubkey, PopVerified, PubkeyAffine as BlsPubkeyAffine},
+        signature::AsSignatureAffine,
     },
     solana_signer_store::{DecodeError, Decoded, decode},
     thiserror::Error,
@@ -64,7 +66,7 @@ pub enum Error {
 pub fn verify_certificate(
     cert: &Certificate,
     max_validators: usize,
-    mut rank_map: impl FnMut(usize) -> Option<(u64, BlsPubkeyAffine)>,
+    mut rank_map: impl FnMut(usize) -> Option<(u64, PopVerified<BlsPubkeyAffine>)>,
 ) -> Result<u64, Error> {
     let mut total_stake = 0u64;
 
@@ -137,7 +139,7 @@ pub fn verify_base2<S: AsSignatureAffine>(
     signature: &S,
     ranks: &[u8],
     max_validators: usize,
-    rank_map: impl FnMut(usize) -> Option<BlsPubkeyAffine>,
+    rank_map: impl FnMut(usize) -> Option<PopVerified<BlsPubkeyAffine>>,
 ) -> Result<(), Error> {
     let ranks = decode(ranks, max_validators).map_err(Error::Decode)?;
     let ranks = match ranks {
@@ -151,7 +153,7 @@ fn verify_single_vote_signature<S: AsSignatureAffine>(
     payload: &[u8],
     signature: &S,
     ranks: &BitVec<u8>,
-    rank_map: impl FnMut(usize) -> Option<BlsPubkeyAffine>,
+    rank_map: impl FnMut(usize) -> Option<PopVerified<BlsPubkeyAffine>>,
 ) -> Result<(), Error> {
     let pubkeys = collect_pubkeys(ranks, rank_map)?;
     let agg_pubkey = aggregate_pubkeys(&pubkeys)?;
@@ -170,7 +172,7 @@ fn verify_base3(
     signature: &BlsSignature,
     ranks: &[u8],
     max_validators: usize,
-    mut rank_map: impl FnMut(usize) -> Option<BlsPubkeyAffine>,
+    mut rank_map: impl FnMut(usize) -> Option<PopVerified<BlsPubkeyAffine>>,
 ) -> Result<(), Error> {
     let ranks = decode(ranks, max_validators).map_err(Error::Decode)?;
     match ranks {
@@ -185,27 +187,31 @@ fn verify_base3(
             if primary_pubkeys.is_empty() {
                 let agg_pubkey = aggregate_pubkeys(&fallback_pubkeys)?;
                 Ok(agg_pubkey.verify_signature(signature, fallback_payload)?)
+            } else if fallback_pubkeys.is_empty() {
+                let agg_pubkey = aggregate_pubkeys(&primary_pubkeys)?;
+                Ok(agg_pubkey.verify_signature(signature, payload)?)
             } else {
+                let mut all_pubkeys = Vec::with_capacity(
+                    primary_pubkeys.len().saturating_add(fallback_pubkeys.len()),
+                );
+                all_pubkeys.extend_from_slice(&primary_pubkeys);
+                all_pubkeys.extend_from_slice(&fallback_pubkeys);
+
+                let mut all_messages = Vec::with_capacity(all_pubkeys.len());
+                all_messages.resize(primary_pubkeys.len(), payload);
+                all_messages.resize(all_pubkeys.len(), fallback_payload);
+
                 if rayon::current_num_threads() < THREAD_POOL_THRESHOLD {
-                    let primary_agg = PubkeyProjective::aggregate(primary_pubkeys.iter())?;
-                    let fallback_agg = PubkeyProjective::aggregate(fallback_pubkeys.iter())?;
-                    let pubkeys = [primary_agg, fallback_agg];
-                    let messages = [payload, fallback_payload].into_iter();
                     Ok(SignatureProjective::verify_distinct_aggregated(
-                        pubkeys.iter(),
+                        all_pubkeys.iter(),
                         signature,
-                        messages,
+                        all_messages.into_iter(),
                     )?)
                 } else {
-                    let (primary_agg_res, fallback_agg_res) = join(
-                        || PubkeyProjective::par_aggregate(primary_pubkeys.par_iter()),
-                        || PubkeyProjective::par_aggregate(fallback_pubkeys.par_iter()),
-                    );
-                    let pubkeys = [primary_agg_res?, fallback_agg_res?];
                     Ok(SignatureProjective::par_verify_distinct_aggregated(
-                        &pubkeys,
+                        &all_pubkeys,
                         signature,
-                        &[payload, fallback_payload],
+                        &all_messages,
                     )?)
                 }
             }
@@ -214,7 +220,9 @@ fn verify_base3(
 }
 
 /// Aggregates a slice of public keys into a single projective public key.
-pub fn aggregate_pubkeys(pubkeys: &[BlsPubkeyAffine]) -> Result<PubkeyProjective, Error> {
+pub fn aggregate_pubkeys(
+    pubkeys: &[PopVerified<BlsPubkeyAffine>],
+) -> Result<AggregatePubkey<PubkeyProjective>, Error> {
     if rayon::current_num_threads() < THREAD_POOL_THRESHOLD {
         PubkeyProjective::aggregate(pubkeys.iter()).map_err(Error::VerifySig)
     } else {
@@ -225,8 +233,8 @@ pub fn aggregate_pubkeys(pubkeys: &[BlsPubkeyAffine]) -> Result<PubkeyProjective
 /// Collects public keys sequentially based on the provided ranks bitmap.
 pub fn collect_pubkeys(
     ranks: &BitVec<u8>,
-    mut rank_map: impl FnMut(usize) -> Option<BlsPubkeyAffine>,
-) -> Result<Vec<BlsPubkeyAffine>, Error> {
+    mut rank_map: impl FnMut(usize) -> Option<PopVerified<BlsPubkeyAffine>>,
+) -> Result<Vec<PopVerified<BlsPubkeyAffine>>, Error> {
     let mut pubkeys = Vec::with_capacity(ranks.count_ones());
     for rank in ranks.iter_ones() {
         let pubkey = rank_map(rank).ok_or(Error::MissingRank)?;
@@ -356,7 +364,7 @@ mod test {
 
         let cert = Certificate {
             cert_type,
-            signature: BLSSignature::default(), // Use a default/wrong signature
+            signature: BLSSignature([0; 192]), // Use a default/wrong signature
             bitmap: encoded_bitmap,
         };
         assert_eq!(

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -438,8 +438,8 @@ mod tests {
 
     #[test]
     fn test_bls_pubkeys_of() {
-        let bls_pubkey1: BLSPubkey = BLSKeypair::new().public.into();
-        let bls_pubkey2: BLSPubkey = BLSKeypair::new().public.into();
+        let bls_pubkey1: BLSPubkey = BLSKeypair::new().public.into_inner().into();
+        let bls_pubkey2: BLSPubkey = BLSKeypair::new().public.into_inner().into();
         let bls_pubkey1_compressed: BLSPubkeyCompressed = bls_pubkey1.try_into().unwrap();
         let bls_pubkey2_compressed: BLSPubkeyCompressed = bls_pubkey2.try_into().unwrap();
         let matches = app().get_matches_from(vec![

--- a/core/benches/bls_vote_sigverify.rs
+++ b/core/benches/bls_vote_sigverify.rs
@@ -7,9 +7,7 @@ use {
     agave_votor_messages::{consensus_message::VoteMessage, vote::Vote},
     criterion::{BatchSize, Criterion, criterion_group, criterion_main},
     rayon::{ThreadPool, ThreadPoolBuilder},
-    solana_bls_signatures::{
-        Keypair as BLSKeypair, PreparedHashedMessage, Pubkey as BLSPubkey, VerifiablePubkey,
-    },
+    solana_bls_signatures::{Keypair as BLSKeypair, PreparedHashedMessage, VerifySignature},
     solana_core::bls_sigverify::{
         bls_vote_sigverify::{
             VotePayload, aggregate_pubkeys_by_payload, aggregate_signatures,
@@ -97,7 +95,7 @@ fn bench_verify_single_signature(c: &mut Criterion) {
     let keypair = BLSKeypair::new();
     let msg = b"benchmark_message_payload";
     let sig = keypair.sign(msg);
-    let pubkey: BLSPubkey = keypair.public.into();
+    let pubkey = keypair.public;
 
     group.bench_function("1_item", |b| {
         b.iter(|| {
@@ -116,7 +114,7 @@ fn bench_verify_single_signature_with_prepared_message(c: &mut Criterion) {
     let keypair = BLSKeypair::new();
     let msg = b"benchmark_message_payload";
     let sig = keypair.sign(msg);
-    let pubkey: BLSPubkey = keypair.public.into();
+    let pubkey = keypair.public;
     let prepared_msg = PreparedHashedMessage::new(msg);
 
     group.bench_function("1_item", |b| {

--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -20,7 +20,7 @@ use {
     },
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TryRecvError},
     rayon::{ThreadPool, ThreadPoolBuilder},
-    solana_bls_signatures::pubkey::PubkeyAffine as BlsPubkeyAffine,
+    solana_bls_signatures::pubkey::{PopVerified, PubkeyAffine as BlsPubkeyAffine},
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::leader_schedule_cache::LeaderScheduleCache,
@@ -269,7 +269,7 @@ impl SigVerifier {
         &mut self,
         vote: &VoteMessage,
         root_bank: &Bank,
-    ) -> Option<(Pubkey, BlsPubkeyAffine)> {
+    ) -> Option<(Pubkey, PopVerified<BlsPubkeyAffine>)> {
         let root_slot = root_bank.slot();
         let Some(rank_map) = root_bank.get_rank_map(vote.vote.slot()) else {
             self.stats.discard_vote_no_epoch_stakes += 1;
@@ -343,7 +343,7 @@ mod tests {
         },
         bitvec::prelude::{BitVec, Lsb0},
         crossbeam_channel::{Receiver, TryRecvError},
-        solana_bls_signatures::{Signature, Signature as BLSSignature},
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature},
         solana_epoch_schedule::EpochSchedule,
         solana_gossip::contact_info::ContactInfo,
         solana_hash::Hash,
@@ -462,7 +462,7 @@ mod tests {
     ) -> VoteMessage {
         let bls_keypair = &validator_keypairs[rank].bls_keypair;
         let payload = wincode::serialize(&vote).expect("Failed to serialize vote");
-        let signature: BLSSignature = bls_keypair.sign(&payload).into();
+        let signature: Signature = bls_keypair.sign(&payload).into();
         VoteMessage {
             vote,
             signature,
@@ -623,7 +623,7 @@ mod tests {
         // Send a packet with invalid rank
         let messages_invalid_rank = vec![ConsensusMessage::Vote(VoteMessage {
             vote: Vote::new_finalization_vote(5),
-            signature: Signature::default(),
+            signature: Signature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             rank: 1000, // Invalid rank
         })];
         ctx.verifier
@@ -720,7 +720,7 @@ mod tests {
         for (i, validator_keypair) in ctx.validator_keypairs.iter().enumerate().take(num_votes) {
             let rank = i as u16;
             let bls_keypair = &validator_keypair.bls_keypair;
-            let signature: BLSSignature = bls_keypair.sign(&vote_payload).into();
+            let signature: Signature = bls_keypair.sign(&vote_payload).into();
             let consensus_message = ConsensusMessage::Vote(VoteMessage {
                 vote,
                 signature,
@@ -1147,7 +1147,7 @@ mod tests {
 
         let cert = Certificate {
             cert_type,
-            signature: BLSSignature::default(), // Use a default/wrong signature
+            signature: Signature([0; BLS_SIGNATURE_AFFINE_SIZE]), // Use a default/wrong signature
             bitmap: encoded_bitmap,
         };
         let consensus_message = ConsensusMessage::Certificate(cert);
@@ -1175,7 +1175,7 @@ mod tests {
         for (i, validator_keypair) in ctx.validator_keypairs.iter().enumerate().take(num_votes) {
             let rank = i as u16;
             let bls_keypair = &validator_keypair.bls_keypair;
-            let signature: BLSSignature = bls_keypair.sign(&vote_payload).into();
+            let signature: Signature = bls_keypair.sign(&vote_payload).into();
             let consensus_message = ConsensusMessage::Vote(VoteMessage {
                 vote,
                 signature,
@@ -1232,7 +1232,7 @@ mod tests {
         let vote = Vote::new_skip_vote(42);
         let vote_payload = wincode::serialize(&vote).unwrap();
         let bls_keypair = &ctx.validator_keypairs[0].bls_keypair;
-        let signature: BLSSignature = bls_keypair.sign(&vote_payload).into();
+        let signature: Signature = bls_keypair.sign(&vote_payload).into();
 
         let consensus_message = ConsensusMessage::Vote(VoteMessage {
             vote,
@@ -1304,7 +1304,7 @@ mod tests {
         let vote = Vote::new_skip_vote(2);
         let vote_payload = wincode::serialize(&vote).unwrap();
         let bls_keypair = &validator_keypairs[0].bls_keypair;
-        let signature: BLSSignature = bls_keypair.sign(&vote_payload).into();
+        let signature: Signature = bls_keypair.sign(&vote_payload).into();
         let consensus_message_vote = ConsensusMessage::Vote(VoteMessage {
             vote,
             signature,
@@ -1482,7 +1482,7 @@ mod tests {
                     &(0..7).collect::<Vec<_>>(),
                 );
                 if invalid_indexes.contains(&i) {
-                    cert.signature = BLSSignature::default();
+                    cert.signature = Signature([0; BLS_SIGNATURE_AFFINE_SIZE]);
                 }
                 (ConsensusMessage::Certificate(cert), Pubkey::new_unique())
             })

--- a/core/src/bls_sigverify/bls_vote_sigverify.rs
+++ b/core/src/bls_sigverify/bls_vote_sigverify.rs
@@ -20,7 +20,7 @@ use {
     },
     solana_bls_signatures::{
         BlsError, PreparedHashedMessage,
-        pubkey::{PubkeyAffine as BlsPubkeyAffine, PubkeyProjective, VerifiablePubkey},
+        pubkey::{PopVerified, PubkeyAffine as BlsPubkeyAffine, PubkeyProjective, VerifySignature},
         signature::SignatureProjective,
     },
     solana_clock::Slot,
@@ -42,7 +42,7 @@ const PREPARED_PAYLOAD_CACHE_DISTINCT_VOTE_THRESHOLD_PERCENT: usize = 90;
 #[derive(Clone, Debug)]
 pub(super) struct VotePayload {
     pub vote_message: VoteMessage,
-    pub bls_pubkey: BlsPubkeyAffine,
+    pub bls_pubkey: PopVerified<BlsPubkeyAffine>,
     pub pubkey: Pubkey,
     pub remote_pubkey: Pubkey,
     pub prepared_payload: Option<Arc<PreparedHashedMessage>>,
@@ -338,10 +338,10 @@ fn aggregate_pubkeys_by_payload(
 ) -> (
     Vec<Vote>,
     Vec<PreparedHashedMessage>,
-    Result<Vec<PubkeyProjective>, BlsError>,
+    Result<Vec<PopVerified<PubkeyProjective>>, BlsError>,
 ) {
     debug_assert!(current_thread_index().is_some());
-    let mut grouped_votes: HashMap<&Vote, Vec<&BlsPubkeyAffine>> = HashMap::new();
+    let mut grouped_votes: HashMap<&Vote, Vec<&PopVerified<BlsPubkeyAffine>>> = HashMap::new();
 
     for v in votes {
         grouped_votes
@@ -358,9 +358,10 @@ fn aggregate_pubkeys_by_payload(
         .into_par_iter()
         .filter_map(|(vote, pubkeys)| {
             wincode::serialize(vote).ok().map(|serialized_vote| {
-                // TODO(sam): https://github.com/anza-xyz/alpenglow/issues/708
-                // should improve public key aggregation drastically (more than 80%)
-                let pubkey = PubkeyProjective::par_aggregate(pubkeys.into_par_iter());
+                // converting aggregate pubkey to `PopVerified` is safe here
+                // since the pubkeys are all PoP verified in the vote account
+                let pubkey = PubkeyProjective::par_aggregate(pubkeys.into_par_iter())
+                    .map(|agg| unsafe { PopVerified::new_unchecked(*agg) });
                 (*vote, PreparedHashedMessage::new(&serialized_vote), pubkey)
             })
         })

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6479,9 +6479,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bls-signatures"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3d8a6e1a009bddbdbfe13ee6ff206c16afa9f8fae7d04612d779ac2254ad5f"
+checksum = "654ea8d31bbb4b0b9c28f9c545edb32691de27d4e2fc0e252c1ff47da50c5f2a"
 dependencies = [
  "base64 0.22.1",
  "blst",
@@ -6500,6 +6500,8 @@ dependencies = [
  "solana-signer",
  "subtle",
  "thiserror 2.0.18",
+ "wincode",
+ "zeroize",
 ]
 
 [[package]]

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -291,7 +291,9 @@ impl FinalCertificate {
             slot: 1234567890,
             block_id: Hash::new_from_array([1u8; 32]),
             final_aggregate: VotesAggregate {
-                signature: BLSSignatureCompressed::default(),
+                signature: BLSSignatureCompressed(
+                    [0; solana_bls_signatures::BLS_SIGNATURE_COMPRESSED_SIZE],
+                ),
                 bitmap: vec![42; 64],
             },
             notar_aggregate: None,
@@ -554,7 +556,10 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for BlockComponent {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, std::iter::repeat_n, wincode::config::DEFAULT_PREALLOCATION_SIZE_LIMIT};
+    use {
+        super::*, solana_bls_signatures::BLS_SIGNATURE_AFFINE_SIZE, std::iter::repeat_n,
+        wincode::config::DEFAULT_PREALLOCATION_SIZE_LIMIT,
+    };
 
     fn mock_entries(n: usize) -> Vec<Entry> {
         repeat_n(Entry::default(), n).collect()
@@ -593,7 +598,7 @@ mod tests {
         let cert = GenesisCertificate {
             slot: 999,
             block_id: Hash::new_unique(),
-            bls_signature: BLSSignature::default(),
+            bls_signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: vec![1, 2, 3],
         };
         let bytes = wincode::serialize(&cert).unwrap();

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -1369,7 +1369,7 @@ mod tests {
 
         let generate_bls_pubkey = || {
             if add_bls_pubkey {
-                let bls_pubkey: BLSPubkey = BLSKeypair::new().public.into();
+                let bls_pubkey: BLSPubkey = BLSKeypair::new().public.into_inner().into();
                 if use_compressed_pubkey {
                     let bls_pubkey_compressed: BLSPubkeyCompressed = bls_pubkey.try_into().unwrap();
                     Some(bls_pubkey_compressed.to_string())

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -538,7 +538,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
         ("bls_pubkey", matches) => {
             let keypair = get_keypair_from_matches(matches, config, &mut wallet_manager)?;
             let bls_keypair = BLSKeypair::derive_from_signer(&keypair, BLS_KEYPAIR_DERIVE_SEED)?;
-            let bls_pubkey: BLSPubkey = bls_keypair.public.into();
+            let bls_pubkey: BLSPubkey = bls_keypair.public.into_inner().into();
 
             if matches.try_contains_id("outfile")? {
                 let outfile = matches.get_one::<String>("outfile").unwrap();
@@ -1292,7 +1292,7 @@ mod tests {
     fn test_read_write_bls_pubkey() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
         let filename = "test_bls_pubkey.json";
         let bls_keypair = BLSKeypair::new();
-        let bls_pubkey: BLSPubkey = bls_keypair.public.into();
+        let bls_pubkey: BLSPubkey = bls_keypair.public.into_inner().into();
         write_bls_pubkey_file(filename, bls_pubkey)?;
         let read = read_bls_pubkey_file(filename)?;
         assert_eq!(read, bls_pubkey);
@@ -1323,7 +1323,7 @@ mod tests {
         let bls_keypair =
             BLSKeypair::derive_from_signer(&my_keypair, BLS_KEYPAIR_DERIVE_SEED).unwrap();
         let read_bls_pubkey = read_bls_pubkey_file(&outfile_path).unwrap();
-        assert_eq!(read_bls_pubkey, bls_keypair.public.into());
+        assert_eq!(read_bls_pubkey, bls_keypair.public.into_inner().into());
     }
 
     #[test]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6150,9 +6150,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bls-signatures"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3d8a6e1a009bddbdbfe13ee6ff206c16afa9f8fae7d04612d779ac2254ad5f"
+checksum = "654ea8d31bbb4b0b9c28f9c545edb32691de27d4e2fc0e252c1ff47da50c5f2a"
 dependencies = [
  "base64 0.22.1",
  "blst",
@@ -6171,6 +6171,8 @@ dependencies = [
  "solana-signer",
  "subtle",
  "thiserror 2.0.18",
+ "wincode",
+ "zeroize",
 ]
 
 [[package]]

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -756,7 +756,7 @@ mod tests {
         },
         assert_matches::assert_matches,
         solana_account::Account,
-        solana_bls_signatures::Signature as BLSSignature,
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_clock::UnixTimestamp,
         solana_epoch_schedule::EpochSchedule,
         solana_keypair::Keypair,
@@ -852,7 +852,7 @@ mod tests {
         let ff_activation_slot = 5;
         let genesis_cert = Certificate {
             cert_type: CertificateType::Finalize(1),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: vec![],
         };
 
@@ -932,7 +932,7 @@ mod tests {
         let mut bank = Bank::new_from_parent(root_bank, SlotLeader::default(), 10);
         let genesis_cert = Certificate {
             cert_type: CertificateType::Finalize(1),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: vec![],
         };
         bank.activate_feature(&agave_feature_set::alpenglow::id());

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -294,7 +294,7 @@ mod tests {
         bitvec::prelude::*,
         rand::seq::IndexedRandom,
         solana_account::ReadableAccount,
-        solana_bls_signatures::Signature as BLSSignature,
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_epoch_schedule::EpochSchedule,
         solana_genesis_config::GenesisConfig,
         solana_hash::Hash,
@@ -333,7 +333,7 @@ mod tests {
 
         let cert = Certificate {
             cert_type,
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap,
         };
         ValidatedBlockFinalizationCert::from_validated_fast(cert, bank)

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -7,7 +7,7 @@ use {
         de::{SeqAccess, Visitor},
     },
     solana_bls_signatures::pubkey::{
-        PubkeyAffine as BLSPubkeyAffine, PubkeyCompressed as BLSPubkeyCompressed,
+        PopVerified, PubkeyAffine as BLSPubkeyAffine, PubkeyCompressed as BLSPubkeyCompressed,
     },
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
@@ -34,7 +34,7 @@ pub struct BLSPubkeyStakeEntry {
     /// The identity of the validator specified in the vote account
     pub node_pubkey: Pubkey,
     /// The bls pubkey of the validator specified in the vote account
-    pub bls_pubkey: BLSPubkeyAffine,
+    pub bls_pubkey: PopVerified<BLSPubkeyAffine>,
     /// The stake of the validator
     pub stake: u64,
 }
@@ -66,11 +66,14 @@ impl solana_frozen_abi::abi_example::AbiExample for BLSPubkeyToRankMap {
 
 pub(crate) fn bls_pubkey_compressed_bytes_to_bls_pubkey(
     bls_pubkey_compressed_bytes: [u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
-) -> Option<(BLSPubkeyCompressed, BLSPubkeyAffine)> {
+) -> Option<(BLSPubkeyCompressed, PopVerified<BLSPubkeyAffine>)> {
     let bls_pubkey_compressed: BLSPubkeyCompressed =
         bincode::deserialize(&bls_pubkey_compressed_bytes).ok()?;
     let bls_pubkey_affine = BLSPubkeyAffine::try_from(bls_pubkey_compressed).ok()?;
-    Some((bls_pubkey_compressed, bls_pubkey_affine))
+    // It is safe to use `new_unchecked` here because data coming from the vote
+    // state has already had its PoP verified.
+    let bls_pubkey_pop_verified = unsafe { PopVerified::new_unchecked(bls_pubkey_affine) };
+    Some((bls_pubkey_compressed, bls_pubkey_pop_verified))
 }
 
 impl BLSPubkeyToRankMap {
@@ -136,7 +139,7 @@ impl BLSPubkeyToRankMap {
         self.rank_map.len()
     }
 
-    pub fn get_rank(&self, bls_pubkey: &BLSPubkeyAffine) -> Option<&u16> {
+    pub fn get_rank(&self, bls_pubkey: &PopVerified<BLSPubkeyAffine>) -> Option<&u16> {
         let bls_pubkey_compressed = BLSPubkeyCompressed(bls_pubkey.to_bytes_compressed());
         self.rank_map.get(&bls_pubkey_compressed)
     }
@@ -498,7 +501,7 @@ pub(crate) mod tests {
                     iter::repeat_with(|| {
                         let authorized_voter = solana_pubkey::new_rand();
                         let bls_pubkey_compressed: BLSPubkeyCompressed =
-                            BLSKeypair::new().public.into();
+                            (*BLSKeypair::new().public).into();
                         let bls_pubkey_compressed_serialized =
                             bincode::serialize(&bls_pubkey_compressed)
                                 .unwrap()

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -16,8 +16,8 @@ use {
     log::*,
     solana_account::{Account, AccountSharedData, ReadableAccount, state_traits::StateMut},
     solana_bls_signatures::{
-        Pubkey as BLSPubkey, Signature as BLSSignature, keypair::Keypair as BLSKeypair,
-        pubkey::PubkeyCompressed as BLSPubkeyCompressed,
+        BLS_SIGNATURE_AFFINE_SIZE, Pubkey as BLSPubkey, Signature as BLSSignature,
+        keypair::Keypair as BLSKeypair, pubkey::PubkeyCompressed as BLSPubkeyCompressed,
     },
     solana_clock::Epoch,
     solana_cluster_type::ClusterType,
@@ -322,7 +322,7 @@ pub fn activate_all_features_alpenglow(genesis_config: &mut GenesisConfig) {
     // so we add a fake genesis certificate.
     let cert = Certificate {
         cert_type: CertificateType::Genesis(0, Hash::default()),
-        signature: BLSSignature::default(),
+        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
         bitmap: Vec::default(),
     };
     let cert_size = bincode::serialized_size(&cert).unwrap();

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -26,7 +26,7 @@ pub fn new_rand_vote_account<R: Rng>(
     let mut account = AccountSharedData::new(rng.random(), VoteStateV4::size_of(), &owner);
 
     let bls_pubkey_compressed = set_bls_pubkey.then(|| {
-        let bls_pubkey: BLSPubkeyCompressed = BLSKeypair::new().public.into();
+        let bls_pubkey: BLSPubkeyCompressed = (*BLSKeypair::new().public).into();
         let bls_pubkey_buffer = bincode::serialize(&bls_pubkey).unwrap();
         bls_pubkey_buffer.try_into().unwrap()
     });

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -199,7 +199,7 @@ mod tests {
             .iter()
             .map(|k| {
                 (
-                    BLSPubkeyCompressed::from(k.bls_keypair.public),
+                    BLSPubkeyCompressed::from(*k.bls_keypair.public),
                     k.bls_keypair.clone(),
                 )
             })
@@ -221,7 +221,7 @@ mod tests {
             .map(|index| {
                 let pubkey_affine = rank_map.get_pubkey_stake_entry(index).unwrap().bls_pubkey;
                 keypair_map
-                    .get(&BLSPubkeyCompressed::from(pubkey_affine))
+                    .get(&BLSPubkeyCompressed::from(*pubkey_affine))
                     .unwrap()
             })
             .collect::<Vec<_>>();

--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -61,7 +61,10 @@ use {
     },
 };
 #[cfg(feature = "dev-context-only-utils")]
-use {solana_bls_signatures::Signature as BLSSignature, solana_hash::Hash};
+use {
+    solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
+    solana_hash::Hash,
+};
 
 /// The slot offset post feature flag activation to begin the migration.
 /// Epoch boundaries induce heavy computation often resulting in forks. It's best to decouple the migration period
@@ -340,7 +343,7 @@ impl MigrationStatus {
     pub fn post_migration_status() -> Self {
         let genesis_certificate = Certificate {
             cert_type: CertificateType::Genesis(0, Hash::default()),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: vec![],
         };
         Self::new(MigrationPhase::AlpenglowEnabled {

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -686,7 +686,7 @@ mod tests {
         agave_votor_messages::consensus_message::{BLS_KEYPAIR_DERIVE_SEED, VoteMessage},
         bitvec::vec::BitVec,
         solana_bls_signatures::{
-            Pubkey as BLSPubkey, Signature as BLSSignature, VerifiableSignature,
+            BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature, VerifiableSignature,
             keypair::Keypair as BLSKeypair,
         },
         solana_clock::Slot,
@@ -1068,7 +1068,7 @@ mod tests {
         if vote.is_finalize() {
             let notarize_cert = Certificate {
                 cert_type: CertificateType::Notarize(vote.slot(), Hash::default()),
-                signature: BLSSignature::default(),
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: dummy_bitmap(),
             };
             ctx.add_message(ConsensusMessage::Certificate(notarize_cert));
@@ -1137,7 +1137,7 @@ mod tests {
 
         let cert = Certificate {
             cert_type,
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
 
@@ -1146,7 +1146,7 @@ mod tests {
         if matches!(cert_type, CertificateType::Finalize(slot) if slot == 5) {
             let notarize_cert = Certificate {
                 cert_type: CertificateType::Notarize(5, Hash::default()),
-                signature: BLSSignature::default(),
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: dummy_bitmap(),
             };
             ctx.add_message(ConsensusMessage::Certificate(notarize_cert));
@@ -1213,7 +1213,7 @@ mod tests {
                 ConsensusMessage::Vote(VoteMessage {
                     vote: Vote::new_skip_vote(5),
                     rank: 100,
-                    signature: BLSSignature::default(),
+                    signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 }),
                 &mut vec![]
             ),
@@ -1740,7 +1740,7 @@ mod tests {
         // Add a skip cert on slot 1 and finalize cert on slot 2
         let cert_1 = Certificate {
             cert_type: CertificateType::Skip(1),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.pool
@@ -1753,7 +1753,7 @@ mod tests {
             .unwrap();
         let cert_2 = Certificate {
             cert_type: CertificateType::FinalizeFast(2, Hash::new_unique()),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.pool
@@ -1794,7 +1794,7 @@ mod tests {
         let cert_type = CertificateType::Notarize(2, Hash::new_unique());
         let cert = ConsensusMessage::Certificate(Certificate {
             cert_type,
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         });
         assert!(
@@ -1814,13 +1814,13 @@ mod tests {
         // Add notar-fallback cert on 3 and finalize cert on 4
         let cert_3 = Certificate {
             cert_type: CertificateType::NotarizeFallback(3, Hash::new_unique()),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_3));
         let cert_4 = Certificate {
             cert_type: CertificateType::Finalize(4),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_4));
@@ -1835,7 +1835,7 @@ mod tests {
         // Add Notarize cert on 5
         let cert_5 = Certificate {
             cert_type: CertificateType::Notarize(5, Hash::new_unique()),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_5));
@@ -1843,7 +1843,7 @@ mod tests {
         // Add Finalize cert on 5
         let cert_5_finalize = Certificate {
             cert_type: CertificateType::Finalize(5),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_5_finalize));
@@ -1851,7 +1851,7 @@ mod tests {
         // Add FinalizeFast cert on 5
         let cert_5 = Certificate {
             cert_type: CertificateType::FinalizeFast(5, Hash::new_unique()),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_5));
@@ -1866,7 +1866,7 @@ mod tests {
         // Now add Notarize cert on 6
         let cert_6 = Certificate {
             cert_type: CertificateType::Notarize(6, Hash::new_unique()),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_6));
@@ -1881,14 +1881,14 @@ mod tests {
         // Add another Finalize cert on 6
         let cert_6_finalize = Certificate {
             cert_type: CertificateType::Finalize(6),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_6_finalize));
         // Add a NotarizeFallback cert on 6
         let cert_6_notarize_fallback = Certificate {
             cert_type: CertificateType::NotarizeFallback(6, Hash::new_unique()),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_6_notarize_fallback));
@@ -1904,7 +1904,7 @@ mod tests {
         // Add another skip on 7
         let cert_7 = Certificate {
             cert_type: CertificateType::Skip(7),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_7));
@@ -1923,13 +1923,13 @@ mod tests {
         // Add Finalize then Notarize cert on 8
         let cert_8_finalize = Certificate {
             cert_type: CertificateType::Finalize(8),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_8_finalize));
         let cert_8_notarize = Certificate {
             cert_type: CertificateType::Notarize(8, Hash::new_unique()),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_8_notarize));
@@ -1954,7 +1954,7 @@ mod tests {
         for slot in 1..=3 {
             let cert = Certificate {
                 cert_type: CertificateType::Notarize(slot, hash),
-                signature: BLSSignature::default(),
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: dummy_bitmap(),
             };
             ctx.pool
@@ -1982,7 +1982,7 @@ mod tests {
         for slot in 4..=7 {
             let cert = Certificate {
                 cert_type: CertificateType::FinalizeFast(slot, hash),
-                signature: BLSSignature::default(),
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: dummy_bitmap(),
             };
             ctx.pool
@@ -2010,14 +2010,14 @@ mod tests {
         for slot in 8..=10 {
             let cert = Certificate {
                 cert_type: CertificateType::NotarizeFallback(slot, hash),
-                signature: BLSSignature::default(),
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: dummy_bitmap(),
             };
             ctx.add_message(ConsensusMessage::Certificate(cert));
         }
         let cert = Certificate {
             cert_type: CertificateType::FinalizeFast(11, hash),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.pool
@@ -2056,12 +2056,11 @@ mod tests {
         let bls_keypair =
             BLSKeypair::derive_from_signer(validator_vote_keypair, BLS_KEYPAIR_DERIVE_SEED)
                 .unwrap();
-        let bls_pubkey: BLSPubkey = bls_keypair.public.into();
 
         let signed_message = bincode::serialize(&vote).unwrap();
         vote_message
             .signature
-            .verify(&bls_pubkey, &signed_message)
+            .verify(&bls_keypair.public, &signed_message)
             .expect("vote message signature should verify");
     }
 
@@ -2073,7 +2072,7 @@ mod tests {
         let cert_type = CertificateType::NotarizeFallback(slot, hash);
         let cert = Certificate {
             cert_type,
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert));

--- a/votor/src/consensus_pool/certificate_builder.rs
+++ b/votor/src/consensus_pool/certificate_builder.rs
@@ -275,8 +275,9 @@ mod tests {
             vote::Vote,
         },
         solana_bls_signatures::{
-            Keypair as BLSKeypair, PreparedHashedMessage, PubkeyProjective as BLSPubkeyProjective,
-            Signature as BLSSignature, SignatureProjective, VerifiablePubkey,
+            BLS_SIGNATURE_AFFINE_SIZE, Keypair as BLSKeypair, PreparedHashedMessage,
+            PubkeyProjective as BLSPubkeyProjective, Signature as BLSSignature,
+            SignatureProjective, VerifySignature,
         },
         solana_hash::Hash,
         solana_signer_store::{Decoded, decode},
@@ -413,7 +414,7 @@ mod tests {
         // Test bls error
         let message_with_invalid_signature = VoteMessage {
             vote,
-            signature: BLSSignature::default(), // Invalid signature
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]), // Invalid signature
             rank: 1,
         };
         assert_eq!(

--- a/votor/src/consensus_pool/vote_pool.rs
+++ b/votor/src/consensus_pool/vote_pool.rs
@@ -132,7 +132,7 @@ mod test {
     use {
         super::*,
         agave_votor_messages::{consensus_message::VoteMessage, vote::Vote},
-        solana_bls_signatures::Signature as BLSSignature,
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
     };
 
     #[test]
@@ -141,7 +141,7 @@ mod test {
         let vote = Vote::new_skip_vote(5);
         let vote_message = VoteMessage {
             vote,
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             rank: 1,
         };
         let my_pubkey = Pubkey::new_unique();
@@ -167,7 +167,7 @@ mod test {
         let vote = Vote::new_notarization_vote(3, block_id);
         let vote = VoteMessage {
             vote,
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             rank: 1,
         };
         assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), Some(10));
@@ -196,7 +196,7 @@ mod test {
                 let vote = Vote::new_notarization_fallback_vote(7, Hash::new_unique());
                 VoteMessage {
                     vote,
-                    signature: BLSSignature::default(),
+                    signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                     rank: 1,
                 }
             })

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -452,7 +452,8 @@ mod tests {
             vote::Vote,
         },
         solana_bls_signatures::{
-            keypair::Keypair as BLSKeypair, signature::Signature as BLSSignature,
+            BLS_SIGNATURE_AFFINE_SIZE, keypair::Keypair as BLSKeypair,
+            signature::Signature as BLSSignature,
         },
         solana_gossip::cluster_info::ClusterInfo,
         solana_hash::Hash,
@@ -651,7 +652,7 @@ mod tests {
         let target_slot = 3;
         let skip_certificate = Certificate {
             cert_type: CertificateType::Skip(target_slot),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: vec![],
         };
         events.clear();
@@ -713,7 +714,7 @@ mod tests {
         for slot in 1..next_leader_slot.0 {
             let skip_certificate = Certificate {
                 cert_type: CertificateType::Skip(slot),
-                signature: BLSSignature::default(),
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: vec![],
             };
 
@@ -783,12 +784,12 @@ mod tests {
         let certificates = vec![
             Arc::new(Certificate {
                 cert_type: CertificateType::Skip(1),
-                signature: BLSSignature::default(),
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: vec![],
             }),
             Arc::new(Certificate {
                 cert_type: CertificateType::Skip(2),
-                signature: BLSSignature::default(),
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: vec![],
             }),
         ];
@@ -823,7 +824,7 @@ mod tests {
 
         let certificates = vec![Arc::new(Certificate {
             cert_type: CertificateType::Skip(1),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: vec![],
         })];
 
@@ -840,7 +841,7 @@ mod tests {
 
         let certificates = vec![Arc::new(Certificate {
             cert_type: CertificateType::Skip(1),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: vec![],
         })];
 

--- a/votor/src/consensus_rewards/entry.rs
+++ b/votor/src/consensus_rewards/entry.rs
@@ -161,7 +161,7 @@ mod tests {
             .iter()
             .map(|k| {
                 (
-                    BlsPubkeyCompressed::from(k.bls_keypair.public),
+                    BlsPubkeyCompressed::from(k.bls_keypair.public.into_inner()),
                     k.bls_keypair.clone(),
                 )
             })
@@ -186,7 +186,7 @@ mod tests {
             .map(|index| {
                 let pubkey_affine = rank_map.get_pubkey_stake_entry(index).unwrap().bls_pubkey;
                 keypair_map
-                    .get(&BlsPubkeyCompressed::from(pubkey_affine))
+                    .get(&BlsPubkeyCompressed::from(*pubkey_affine))
                     .unwrap()
                     .clone()
             })

--- a/votor/src/consensus_rewards/entry/notar_entry.rs
+++ b/votor/src/consensus_rewards/entry/notar_entry.rs
@@ -99,6 +99,7 @@ mod tests {
             get_rank_map_keypairs, new_vote, validate_bitmap,
         },
         agave_votor_messages::{consensus_message::VoteMessage, vote::Vote},
+        solana_bls_signatures::signature::BLS_SIGNATURE_AFFINE_SIZE,
         solana_hash::Hash,
     };
 
@@ -114,7 +115,7 @@ mod tests {
         let notar = Vote::new_notarization_vote(slot, blockid0);
         let invalid_vote = VoteMessage {
             vote: notar,
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             rank,
         };
         entry

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -254,7 +254,7 @@ mod tests {
             consensus_message::{Certificate, CertificateType, ConsensusMessage, VoteMessage},
             vote::Vote,
         },
-        solana_bls_signatures::Signature as BLSSignature,
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
         solana_keypair::Keypair,
         solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
@@ -324,25 +324,25 @@ mod tests {
     #[test_case(BLSOp::PushVote {
         message: Arc::new(ConsensusMessage::Vote(VoteMessage {
             vote: Vote::new_skip_vote(5),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             rank: 1,
         })),
         slot: 5,
         saved_vote_history: SavedVoteHistoryVersions::Current(SavedVoteHistory::default()),
     }, ConsensusMessage::Vote(VoteMessage {
         vote: Vote::new_skip_vote(5),
-        signature: BLSSignature::default(),
+        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
         rank: 1,
     }))]
     #[test_case(BLSOp::PushCertificate {
         certificate: Arc::new(Certificate {
             cert_type: CertificateType::Skip(5),
-            signature: BLSSignature::default(),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: Vec::new(),
         }),
     }, ConsensusMessage::Certificate(Certificate {
         cert_type: CertificateType::Skip(5),
-        signature: BLSSignature::default(),
+        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
         bitmap: Vec::new(),
     }))]
     fn test_send_message(bls_op: BLSOp, expected_message: ConsensusMessage) {


### PR DESCRIPTION
#### Problem

Bump `solana-bls-signatures` crate to v3.3.0

#### Summary of Changes

There were a couple of API changes. The two most prominent ones are:
- `Signature` type does not implement `Default` any more, so I manually created all-zero signatures
- Introduction of `PopVerified` type

But addressing these were pretty straightforward.