### PR TITLE
accounts-db: use condvar to wake evictor thread on drop instead of polling sleep

### DIFF
--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -18,8 +18,8 @@ use {
     std::{
         mem::ManuallyDrop,
         sync::{
-            Arc,
-            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+            Arc, Condvar, Mutex,
+            atomic::{AtomicU64, AtomicUsize, Ordering},
         },
         thread,
         time::{Duration, Instant},
@@ -80,6 +80,15 @@ struct AtomicReadOnlyCacheStats {
     evictor_wakeup_count_productive: AtomicU64,
 }
 
+/// Shared state between the cache and its evictor thread, used to signal
+/// the evictor to wake up early (e.g. on drop) instead of waiting for
+/// the full polling interval to elapse.
+#[derive(Debug)]
+struct EvictorControl {
+    exit: Mutex<bool>,
+    wake: Condvar,
+}
+
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 #[derive(Debug)]
 pub(crate) struct ReadOnlyAccountsCache {
@@ -100,8 +109,9 @@ pub(crate) struct ReadOnlyAccountsCache {
     ///
     /// Evict from the cache in the background.
     evictor_thread_handle: ManuallyDrop<thread::JoinHandle<()>>,
-    /// Flag to stop the evictor
-    evictor_exit_flag: Arc<AtomicBool>,
+    /// Condvar-based control to stop the evictor without waiting for
+    /// the full sleep interval to elapse.
+    evictor_control: Arc<EvictorControl>,
 }
 
 impl ReadOnlyAccountsCache {
@@ -121,9 +131,12 @@ impl ReadOnlyAccountsCache {
         let cache_len = Arc::new(AtomicUsize::default());
         let stats = Arc::new(AtomicReadOnlyCacheStats::default());
         let timer = Instant::now();
-        let evictor_exit_flag = Arc::new(AtomicBool::new(false));
+        let evictor_control = Arc::new(EvictorControl {
+            exit: Mutex::new(false),
+            wake: Condvar::new(),
+        });
         let evictor_thread_handle = Self::spawn_evictor(
-            evictor_exit_flag.clone(),
+            evictor_control.clone(),
             max_data_size_lo,
             max_data_size_hi,
             data_size.clone(),
@@ -143,7 +156,7 @@ impl ReadOnlyAccountsCache {
             stats,
             timer,
             evictor_thread_handle: ManuallyDrop::new(evictor_thread_handle),
-            evictor_exit_flag,
+            evictor_control,
         }
     }
 
@@ -286,7 +299,7 @@ impl ReadOnlyAccountsCache {
 
     /// Spawns the background thread to handle evictions
     fn spawn_evictor(
-        exit: Arc<AtomicBool>,
+        control: Arc<EvictorControl>,
         max_data_size_lo: usize,
         max_data_size_hi: usize,
         data_size: Arc<AtomicUsize>,
@@ -301,13 +314,18 @@ impl ReadOnlyAccountsCache {
                 info!("AccountsReadCacheEvictor has started");
                 let mut rng = SmallRng::from_os_rng();
                 loop {
-                    if exit.load(Ordering::Relaxed) {
+                    // Wait up to 100 ms, or until the exit flag is set.
+                    // 100 ms is already four times per slot, which should be plenty.
+                    let exit_flag = control.exit.lock().unwrap();
+                    let (exit_flag, _) = control
+                        .wake
+                        .wait_timeout_while(exit_flag, Duration::from_millis(100), |exit| !*exit)
+                        .unwrap();
+                    if *exit_flag {
                         break;
                     }
+                    drop(exit_flag);
 
-                    // We shouldn't need to evict often, so sleep to reduce the frequency.
-                    // 100 ms is already four times per slot, which should be plenty.
-                    thread::sleep(Duration::from_millis(100));
                     stats
                         .evictor_wakeup_count_all
                         .fetch_add(1, Ordering::Relaxed);
@@ -444,7 +462,11 @@ impl ReadOnlyAccountsCache {
 
 impl Drop for ReadOnlyAccountsCache {
     fn drop(&mut self) {
-        self.evictor_exit_flag.store(true, Ordering::Relaxed);
+        {
+            let mut exit_flag = self.evictor_control.exit.lock().unwrap();
+            *exit_flag = true;
+        }
+        self.evictor_control.wake.notify_one();
         // SAFETY: We are dropping, so we will never use `evictor_thread_handle` again.
         let evictor_thread_handle = unsafe { ManuallyDrop::take(&mut self.evictor_thread_handle) };
         evictor_thread_handle


### PR DESCRIPTION
#### Problem
The `ReadOnlyAccountsCache` evictor thread uses `thread::sleep(100ms)` in a polling loop, checked by an `AtomicBool` exit flag. When the cache is dropped, it sets the flag and joins the thread, but the thread won't notice until it wakes from its current sleep. This means `Drop` blocks for up to 100ms.
This is particularly problematic for short-lived `AccountsDb` instances (e.g. in fuzzers or tests), where the 100ms drop latency dominates total runtime.

#### Summary of Changes
Replace the `AtomicBool` exit flag + `thread::sleep` polling with a `Condvar` + `Mutex<bool>` pair (`EvictorControl`). The evictor thread now uses `Condvar::wait_timeout(100ms)` instead of `thread::sleep(100ms)`, preserving the same wakeup cadence under normal operation. On drop, `notify_one()` is called after setting the exit flag, which immediately wakes the evictor thread so `join()` returns near-instantly.

