### PR TITLE
cli: improve validator-info commands

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1716,6 +1716,7 @@ impl fmt::Display for CliValidatorInfoVec {
 pub struct CliValidatorInfo {
     pub identity_pubkey: String,
     pub info_pubkey: String,
+    pub is_signed: bool,
     pub info: Map<String, Value>,
 }
 
@@ -1726,6 +1727,7 @@ impl fmt::Display for CliValidatorInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln_name_value(f, "Validator Identity:", &self.identity_pubkey)?;
         writeln_name_value(f, "  Info Address:", &self.info_pubkey)?;
+
         for (key, value) in self.info.iter() {
             writeln_name_value(
                 f,
@@ -1733,6 +1735,14 @@ impl fmt::Display for CliValidatorInfo {
                 value.as_str().unwrap_or("?"),
             )?;
         }
+
+        if !self.is_signed {
+            writeln!(
+                f,
+                "/!\\ This validator info account is NOT verified as owned by the validator"
+            )?;
+        }
+
         Ok(())
     }
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -294,7 +294,7 @@ pub enum CliCommand {
     },
     // Validator Info Commands
     GetValidatorInfo(Option<Pubkey>),
-    SetValidatorInfo {
+    PublishValidatorInfo {
         validator_info: Value,
         force_keybase: bool,
         info_pubkey: Option<Pubkey>,
@@ -726,7 +726,7 @@ pub fn parse_command(
         // Validator Info Commands
         ("validator-info", Some(matches)) => match matches.subcommand() {
             ("publish", Some(matches)) => {
-                parse_validator_info_command(matches, default_signer, wallet_manager)
+                parse_publish_validator_info_command(matches, default_signer, wallet_manager)
             }
             ("get", Some(matches)) => parse_get_validator_info_command(matches),
             _ => unreachable!(),
@@ -1413,13 +1413,13 @@ pub async fn process_command(config: &CliConfig<'_>) -> ProcessResult {
             process_get_validator_info(&rpc_client, config, *info_pubkey).await
         }
         // Publish validator info
-        CliCommand::SetValidatorInfo {
+        CliCommand::PublishValidatorInfo {
             validator_info,
             force_keybase,
             info_pubkey,
             compute_unit_price,
         } => {
-            process_set_validator_info(
+            process_publish_validator_info(
                 &rpc_client,
                 config,
                 validator_info,

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -129,20 +129,20 @@ fn parse_args(matches: &ArgMatches<'_>) -> Value {
 }
 
 fn parse_validator_info(
-    pubkey: &Pubkey,
     account: &Account,
-) -> Result<(Pubkey, Map<String, serde_json::value::Value>), Box<dyn error::Error>> {
+) -> Option<(Pubkey, bool, Map<String, serde_json::value::Value>)> {
     if account.owner != solana_config_interface::id() {
-        return Err(format!("{pubkey} is not a validator info account").into());
+        return None;
     }
-    let key_list: ConfigKeys = deserialize(&account.data)?;
-    if !key_list.keys.is_empty() {
-        let (validator_pubkey, _) = key_list.keys[1];
-        let validator_info_string: String = deserialize(get_config_data(&account.data)?)?;
-        let validator_info: Map<_, _> = serde_json::from_str(&validator_info_string)?;
-        Ok((validator_pubkey, validator_info))
+    let key_list: ConfigKeys = deserialize(&account.data).ok()?;
+    if key_list.keys.len() > 1 {
+        let (validator_pubkey, is_signed) = key_list.keys[1];
+        let validator_info_string: String =
+            get_config_data(&account.data).and_then(deserialize).ok()?;
+        let validator_info: Map<_, _> = serde_json::from_str(&validator_info_string).ok()?;
+        Some((validator_pubkey, is_signed, validator_info))
     } else {
-        Err(format!("{pubkey} could not be parsed as a validator info account").into())
+        None
     }
 }
 
@@ -242,7 +242,7 @@ impl ValidatorInfoSubCommands for App<'_, '_> {
     }
 }
 
-pub fn parse_validator_info_command(
+pub fn parse_publish_validator_info_command(
     matches: &ArgMatches<'_>,
     default_signer: &DefaultSigner,
     wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
@@ -252,7 +252,7 @@ pub fn parse_validator_info_command(
     // Prepare validator info
     let validator_info = parse_args(matches);
     Ok(CliCommandInfo {
-        command: CliCommand::SetValidatorInfo {
+        command: CliCommand::PublishValidatorInfo {
             validator_info,
             force_keybase: matches.is_present("force"),
             info_pubkey,
@@ -271,7 +271,7 @@ pub fn parse_get_validator_info_command(
     ))
 }
 
-pub async fn process_set_validator_info(
+pub async fn process_publish_validator_info(
     rpc_client: &RpcClient,
     config: &CliConfig<'_>,
     validator_info: &Value,
@@ -316,8 +316,10 @@ pub async fn process_set_validator_info(
                 Err(_) => false,
             },
         )
-        .find(|(pubkey, account)| {
-            let (validator_pubkey, _) = parse_validator_info(pubkey, account).unwrap();
+        .find(|(_, account)| {
+            let Some((validator_pubkey, true, _)) = parse_validator_info(account) else {
+                return false;
+            };
             validator_pubkey == config.signers[0].pubkey()
         });
 
@@ -456,18 +458,23 @@ pub async fn process_get_validator_info(
     };
 
     let mut validator_info_list: Vec<CliValidatorInfo> = vec![];
-    if validator_info.is_empty() {
-        println!("No validator info accounts found");
-    }
     for (validator_info_pubkey, validator_info_account) in validator_info.iter() {
-        let (validator_pubkey, validator_info) =
-            parse_validator_info(validator_info_pubkey, validator_info_account)?;
-        validator_info_list.push(CliValidatorInfo {
-            identity_pubkey: validator_pubkey.to_string(),
-            info_pubkey: validator_info_pubkey.to_string(),
-            info: validator_info,
-        });
+        let Some((validator_pubkey, is_signed, validator_info)) =
+            parse_validator_info(validator_info_account)
+        else {
+            continue;
+        };
+
+        if config.verbose || is_signed {
+            validator_info_list.push(CliValidatorInfo {
+                identity_pubkey: validator_pubkey.to_string(),
+                info_pubkey: validator_info_pubkey.to_string(),
+                is_signed,
+                info: validator_info,
+            });
+        }
     }
+
     Ok(config
         .output_format
         .formatted_string(&CliValidatorInfoVec::new(validator_info_list)))
@@ -594,32 +601,24 @@ mod tests {
         let data = serialize(&(config, validator_info)).unwrap();
 
         assert_eq!(
-            parse_validator_info(
-                &Pubkey::default(),
-                &Account {
-                    owner: solana_config_interface::id(),
-                    data,
-                    ..Account::default()
-                }
-            )
+            parse_validator_info(&Account {
+                owner: solana_config_interface::id(),
+                data,
+                ..Account::default()
+            })
             .unwrap(),
-            (pubkey, info)
+            (pubkey, true, info)
         );
     }
 
     #[test]
     fn test_parse_validator_info_not_validator_info_account() {
         assert!(
-            parse_validator_info(
-                &Pubkey::default(),
-                &Account {
-                    owner: solana_pubkey::new_rand(),
-                    ..Account::default()
-                }
-            )
-            .unwrap_err()
-            .to_string()
-            .contains("is not a validator info account")
+            parse_validator_info(&Account {
+                owner: solana_pubkey::new_rand(),
+                ..Account::default()
+            })
+            .is_none()
         );
     }
 
@@ -632,17 +631,12 @@ mod tests {
         let data = serialize(&(config, validator_info)).unwrap();
 
         assert!(
-            parse_validator_info(
-                &Pubkey::default(),
-                &Account {
-                    owner: solana_config_interface::id(),
-                    data,
-                    ..Account::default()
-                },
-            )
-            .unwrap_err()
-            .to_string()
-            .contains("could not be parsed as a validator info account")
+            parse_validator_info(&Account {
+                owner: solana_config_interface::id(),
+                data,
+                ..Account::default()
+            },)
+            .is_none()
         );
     }
 

--- a/cli/tests/validator_info.rs
+++ b/cli/tests/validator_info.rs
@@ -50,7 +50,7 @@ async fn test_publish(compute_unit_price: Option<u64>) {
         &config_validator.signers[0].pubkey()
     );
 
-    config_validator.command = CliCommand::SetValidatorInfo {
+    config_validator.command = CliCommand::PublishValidatorInfo {
         validator_info: json!({ "name": "test" }),
         force_keybase: true,
         info_pubkey: None,


### PR DESCRIPTION
#### Problem
i was learning about how validator-info works because i might use it for svsp and consequently learned anyone can open these accounts, which the cli does not handle well

it does speak well to the kindheartedness of our users that it doesnt seem anyone has ever done this tho

#### Summary of Changes

* check signer in `validator-info get`. hide unsigned in non-verbose mode, print with warning in verbose
* check signer in `validator-info publish` and skip unsigned entries when selecting an existing info
* fix bug where `publish` would break given a malformed validator info
* fix bug where all commands would break if anyone created a one-key validator info
* normalize naming of `publish` functions/types