### PR TITLE
rekey SIMD-0387

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1428,7 +1428,7 @@ pub mod alt_bn128_little_endian {
 }
 
 pub mod bls_pubkey_management_in_vote_account {
-    solana_pubkey::declare_id!("2uxQgtKa2ECHGs67Zdj7dgmzn2w9HiqhdcedwCWfYzzq");
+    solana_pubkey::declare_id!("AnAP9zPV4KL7czAPQbFhpDKV2tx7g4UGNbK9wvXwjaRo");
 }
 
 pub mod relax_programdata_account_check_migration {


### PR DESCRIPTION
#### Problem
Now that the BLS signatures library was bumped in https://github.com/anza-xyz/agave/pull/12184, we have to re-key SIMD-0387, which enables BLS pubkey management (and proof-of-possession verification) in the Vote program.

#### Summary of Changes
Re-key SIMD-0387.