### PR TITLE
Revalidate BCL leader bank insertion

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -5,10 +5,7 @@
 //!
 //! Once alpenglow is active, this is the only thread that will touch the [`PohRecorder`].
 use {
-    crate::{
-        banking_trace::BankingTracer,
-        replay_stage::{Finalizer, ReplayStage},
-    },
+    crate::{banking_trace::BankingTracer, replay_stage::Finalizer},
     agave_votor::event::LeaderWindowInfo,
     agave_votor_messages::reward_certificate::{BuildRewardCertsRequest, BuildRewardCertsResponse},
     crossbeam_channel::{Receiver, Sender},
@@ -28,7 +25,7 @@ use {
     solana_rpc::{rpc_subscriptions::RpcSubscriptions, slot_status_notifier::SlotStatusNotifier},
     solana_runtime::{
         bank::{Bank, NewBankOptions},
-        bank_forks::BankForks,
+        bank_forks::{BankForks, InsertBankError},
         block_component_processor::BlockComponentProcessor,
         installed_scheduler_pool::BankWithScheduler,
         leader_schedule_utils::{last_of_consecutive_leader_slots, leader_slot_index},
@@ -156,19 +153,7 @@ enum StartLeaderError {
 
     /// BankForks changed after leader-bank creation started.
     #[error("Leader bank {0} became stale before insertion: {1}")]
-    StaleLeaderBank(/* leader slot */ Slot, InsertLeaderBankError),
-}
-
-#[derive(Debug, Error, PartialEq, Eq)]
-enum InsertLeaderBankError {
-    #[error("slot {0} is already rooted")]
-    AlreadyRooted(Slot),
-
-    #[error("already contains bank for leader slot {0}")]
-    AlreadyHaveBank(Slot),
-
-    #[error("parent slot {parent_slot} for leader slot {slot} is no longer in BankForks")]
-    StaleParent { slot: Slot, parent_slot: Slot },
+    StaleLeaderBank(/* leader slot */ Slot, InsertBankError),
 }
 
 /// The block creation loop.
@@ -672,17 +657,22 @@ fn maybe_start_leader(
     Ok(())
 }
 
-/// Creates and inserts the leader bank `slot` of this window with
-/// parent `parent_bank`
+/// Builds the leader bank for `slot`, then commits it into `BankForks`.
+///
+/// The `parent_bank` was selected from an earlier `BankForks` read. Because bank
+/// construction happens outside the `BankForks` write lock, the fork graph can
+/// change before the new leader bank is ready to be published. The final insert
+/// must therefore go through `commit_leader_bank()`, which revalidates the fork
+/// state at the commit point.
 fn create_and_insert_leader_bank(
     slot: Slot,
     parent_bank: Arc<Bank>,
     ctx: &mut LeaderContext,
-) -> Result<(), InsertLeaderBankError> {
+) -> Result<(), InsertBankError> {
     let parent_slot = parent_bank.slot();
-    let root_slot = ctx.bank_forks.read().unwrap().root();
+    let root_slot_at_start = ctx.bank_forks.read().unwrap().root();
     trace!(
-        "{}: Creating and inserting leader slot {slot} parent {parent_slot} root {root_slot}",
+        "{}: Creating and inserting leader slot {slot} parent {parent_slot} root {root_slot_at_start}",
         ctx.my_pubkey
     );
 
@@ -720,13 +710,10 @@ fn create_and_insert_leader_bank(
         reset_poh_recorder(&parent_bank, ctx);
     }
 
-    let tpu_bank = ReplayStage::new_bank_from_parent_with_notify(
+    let tpu_bank = Bank::new_from_parent_with_options(
         parent_bank.clone(),
-        slot,
-        root_slot,
         leader,
-        ctx.rpc_subscriptions.as_deref(),
-        &ctx.slot_status_notifier,
+        slot,
         NewBankOptions::default(),
     );
     // make sure parent is frozen for finalized hashes via the above
@@ -737,13 +724,14 @@ fn create_and_insert_leader_bank(
         &parent_bank.hash(),
     );
 
-    // Insert the bank
-    let tpu_bank = insert_leader_bank(&ctx.bank_forks, tpu_bank)?;
+    let (tpu_bank, root_slot) = commit_leader_bank(&ctx.bank_forks, tpu_bank)?;
     let bank_id = tpu_bank.bank_id();
     ctx.poh_recorder.write().unwrap().set_bank(tpu_bank);
 
     // If this is the first alpenglow block, emit the genesis certificate marker
     maybe_include_genesis_certificate(parent_slot, ctx);
+
+    notify_created_leader_bank(slot, parent_slot, root_slot, ctx);
 
     // Wakeup banking stage
     ctx.record_receiver.restart(bank_id);
@@ -756,24 +744,37 @@ fn create_and_insert_leader_bank(
     Ok(())
 }
 
-fn insert_leader_bank(
+/// Commits a freshly-created BCL leader bank into `BankForks`.
+///
+/// This is the last correctness gate before BCL publishes side effects for the
+/// leader bank. `BankForks::try_insert()` owns the structural validation while
+/// this helper owns the lock boundary and returns the committed root used for
+/// created-bank notifications.
+///
+/// On success, this function performs the insert and returns the scheduler
+/// wrapper created by `BankForks::insert()`. On failure, it leaves `BankForks`
+/// unchanged so the caller can treat the bank as stale work and avoid notifying
+/// or waking downstream producers for a fork that will be rejected.
+fn commit_leader_bank(
     bank_forks: &RwLock<BankForks>,
     tpu_bank: Bank,
-) -> Result<BankWithScheduler, InsertLeaderBankError> {
-    let slot = tpu_bank.slot();
-    let parent_slot = tpu_bank.parent_slot();
+) -> Result<(BankWithScheduler, Slot), InsertBankError> {
     let mut bank_forks = bank_forks.write().unwrap();
-    let root = bank_forks.root();
-    if slot <= root {
-        return Err(InsertLeaderBankError::AlreadyRooted(slot));
+    let tpu_bank = bank_forks.try_insert(tpu_bank)?;
+    let root_slot = bank_forks.root();
+    Ok((tpu_bank, root_slot))
+}
+
+fn notify_created_leader_bank(slot: Slot, parent_slot: Slot, root_slot: Slot, ctx: &LeaderContext) {
+    if let Some(rpc_subscriptions) = ctx.rpc_subscriptions.as_deref() {
+        rpc_subscriptions.notify_slot(slot, parent_slot, root_slot);
     }
-    if bank_forks.get(slot).is_some() {
-        return Err(InsertLeaderBankError::AlreadyHaveBank(slot));
+    if let Some(slot_status_notifier) = &ctx.slot_status_notifier {
+        slot_status_notifier
+            .read()
+            .unwrap()
+            .notify_created_bank(slot, parent_slot);
     }
-    if bank_forks.get(parent_slot).is_none() {
-        return Err(InsertLeaderBankError::StaleParent { slot, parent_slot });
-    }
-    Ok(bank_forks.insert(tpu_bank))
 }
 
 ///  If this the very first alpenglow block, include the genesis certificate
@@ -819,6 +820,8 @@ mod tests {
     const COMPETING_LEADER_SLOT: Slot = 2;
     const CHILD_OF_STALE_PARENT_SLOT: Slot = 3;
 
+    // Test a tiny fork graph where slot 1 and slot 2 compete as children of
+    // genesis. Rooting slot 2 prunes slot 1, making a bank built on slot 1 stale.
     struct TestForks {
         bank_forks: Arc<RwLock<BankForks>>,
     }
@@ -845,8 +848,9 @@ mod tests {
             )
         }
 
-        fn insert_leader_bank(&self, parent_slot: Slot, slot: Slot) -> BankWithScheduler {
-            insert_leader_bank(&self.bank_forks, self.leader_bank(parent_slot, slot)).unwrap()
+        fn try_insert_leader_bank(&self, parent_slot: Slot, slot: Slot) -> BankWithScheduler {
+            let bank = self.leader_bank(parent_slot, slot);
+            self.bank_forks.write().unwrap().try_insert(bank).unwrap()
         }
 
         fn set_root(&self, slot: Slot) {
@@ -869,11 +873,11 @@ mod tests {
     fn assert_rejected_without_changing_forks(
         forks: &TestForks,
         bank: Bank,
-        expected_error: InsertLeaderBankError,
+        expected_error: InsertBankError,
     ) {
         let slot = bank.slot();
         let before = forks.fork_state_for(slot);
-        match insert_leader_bank(&forks.bank_forks, bank) {
+        match forks.bank_forks.write().unwrap().try_insert(bank) {
             Ok(bank) => panic!("unexpectedly inserted leader bank {}", bank.slot()),
             Err(error) => assert_eq!(error, expected_error),
         }
@@ -881,56 +885,67 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_leader_bank_accepts_current_parent() {
+    fn test_try_insert_leader_bank_accepts_current_parent() {
         let forks = TestForks::new();
 
-        let inserted_bank = forks.insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
+        // A bank built on the current root is valid and becomes the working bank.
+        let inserted_bank = forks.try_insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
 
         assert_eq!(inserted_bank.slot(), FIRST_LEADER_SLOT);
         assert_eq!(forks.working_slot(), FIRST_LEADER_SLOT);
     }
 
     #[test]
-    fn test_insert_leader_bank_rejects_duplicate_slot() {
+    fn test_try_insert_leader_bank_rejects_duplicate_slot() {
         let forks = TestForks::new();
-        forks.insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
+        forks.try_insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
 
+        // Another leader bank for the same slot would replace existing fork
+        // state, so the commit gate rejects it.
         assert_rejected_without_changing_forks(
             &forks,
             forks.leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT),
-            InsertLeaderBankError::AlreadyHaveBank(FIRST_LEADER_SLOT),
+            InsertBankError::AlreadyExists(FIRST_LEADER_SLOT),
         );
     }
 
     #[test]
-    fn test_insert_leader_bank_rejects_already_rooted_slot() {
+    fn test_try_insert_leader_bank_rejects_already_rooted_slot() {
         let forks = TestForks::new();
         let bank_built_before_its_slot_was_rooted =
             forks.leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
-        forks.insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
+        forks.try_insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
         forks.set_root(FIRST_LEADER_SLOT);
 
+        // The bank was valid when built, but the slot became rooted before the
+        // final insert. Publishing it again would move BankForks backward.
         assert_rejected_without_changing_forks(
             &forks,
             bank_built_before_its_slot_was_rooted,
-            InsertLeaderBankError::AlreadyRooted(FIRST_LEADER_SLOT),
+            InsertBankError::AlreadyRooted {
+                slot: FIRST_LEADER_SLOT,
+                root: FIRST_LEADER_SLOT,
+            },
         );
     }
 
     #[test]
-    fn test_insert_leader_bank_rejects_stale_parent() {
+    fn test_try_insert_leader_bank_rejects_stale_parent() {
         let forks = TestForks::new();
-        forks.insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
-        forks.insert_leader_bank(GENESIS_SLOT, COMPETING_LEADER_SLOT);
+        forks.try_insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
+        forks.try_insert_leader_bank(GENESIS_SLOT, COMPETING_LEADER_SLOT);
 
         let bank_built_on_pruned_parent =
             forks.leader_bank(FIRST_LEADER_SLOT, CHILD_OF_STALE_PARENT_SLOT);
         forks.set_root(COMPETING_LEADER_SLOT);
 
+        // The child bank was built from a parent snapshot that is no longer in
+        // BankForks. The final insert must reject the stale parent, not reattach
+        // the pruned fork.
         assert_rejected_without_changing_forks(
             &forks,
             bank_built_on_pruned_parent,
-            InsertLeaderBankError::StaleParent {
+            InsertBankError::MissingParent {
                 slot: CHILD_OF_STALE_PARENT_SLOT,
                 parent_slot: FIRST_LEADER_SLOT,
             },

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -30,6 +30,7 @@ use {
         bank::{Bank, NewBankOptions},
         bank_forks::BankForks,
         block_component_processor::BlockComponentProcessor,
+        installed_scheduler_pool::BankWithScheduler,
         leader_schedule_utils::{last_of_consecutive_leader_slots, leader_slot_index},
         validated_block_finalization::ValidatedBlockFinalizationCert,
     },
@@ -152,6 +153,22 @@ enum StartLeaderError {
         /* parent ready slot */ Slot,
         /* leader slot */ Slot,
     ),
+
+    /// BankForks changed after leader-bank creation started.
+    #[error("Leader bank {0} became stale before insertion: {1}")]
+    StaleLeaderBank(/* leader slot */ Slot, InsertLeaderBankError),
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+enum InsertLeaderBankError {
+    #[error("slot {0} is already rooted")]
+    AlreadyRooted(Slot),
+
+    #[error("already contains bank for leader slot {0}")]
+    AlreadyHaveBank(Slot),
+
+    #[error("parent slot {parent_slot} for leader slot {slot} is no longer in BankForks")]
+    StaleParent { slot: Slot, parent_slot: Slot },
 }
 
 /// The block creation loop.
@@ -627,6 +644,7 @@ fn start_leader_wait_for_parent_replay(
 /// If checks pass we return `Ok(())` and:
 /// - Reset poh to the `parent_slot`
 /// - Create a new bank for `slot` with parent `parent_slot`
+/// - Revalidate the root, slot, and parent under the BankForks write lock
 /// - Insert into bank_forks and poh recorder
 fn maybe_start_leader(
     slot: Slot,
@@ -649,13 +667,18 @@ fn maybe_start_leader(
     }
 
     // Create and insert the bank
-    create_and_insert_leader_bank(slot, parent_bank, ctx);
+    create_and_insert_leader_bank(slot, parent_bank, ctx)
+        .map_err(|err| StartLeaderError::StaleLeaderBank(slot, err))?;
     Ok(())
 }
 
 /// Creates and inserts the leader bank `slot` of this window with
 /// parent `parent_bank`
-fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut LeaderContext) {
+fn create_and_insert_leader_bank(
+    slot: Slot,
+    parent_bank: Arc<Bank>,
+    ctx: &mut LeaderContext,
+) -> Result<(), InsertLeaderBankError> {
     let parent_slot = parent_bank.slot();
     let root_slot = ctx.bank_forks.read().unwrap().root();
     trace!(
@@ -715,7 +738,7 @@ fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut L
     );
 
     // Insert the bank
-    let tpu_bank = ctx.bank_forks.write().unwrap().insert(tpu_bank);
+    let tpu_bank = insert_leader_bank(&ctx.bank_forks, tpu_bank)?;
     let bank_id = tpu_bank.bank_id();
     ctx.poh_recorder.write().unwrap().set_bank(tpu_bank);
 
@@ -730,6 +753,27 @@ fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut L
         "{}: new fork:{} parent:{} (leader) root:{}",
         ctx.my_pubkey, slot, parent_slot, root_slot
     );
+    Ok(())
+}
+
+fn insert_leader_bank(
+    bank_forks: &RwLock<BankForks>,
+    tpu_bank: Bank,
+) -> Result<BankWithScheduler, InsertLeaderBankError> {
+    let slot = tpu_bank.slot();
+    let parent_slot = tpu_bank.parent_slot();
+    let mut bank_forks = bank_forks.write().unwrap();
+    let root = bank_forks.root();
+    if slot <= root {
+        return Err(InsertLeaderBankError::AlreadyRooted(slot));
+    }
+    if bank_forks.get(slot).is_some() {
+        return Err(InsertLeaderBankError::AlreadyHaveBank(slot));
+    }
+    if bank_forks.get(parent_slot).is_none() {
+        return Err(InsertLeaderBankError::StaleParent { slot, parent_slot });
+    }
+    Ok(bank_forks.insert(tpu_bank))
 }
 
 ///  If this the very first alpenglow block, include the genesis certificate
@@ -760,4 +804,136 @@ fn maybe_include_genesis_certificate(parent_slot: Slot, ctx: &LeaderContext) {
             &ctx.bank_forks.read().unwrap().migration_status(),
         )
         .expect("Recording genesis certificate should not fail");
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, solana_clock::BankId, solana_ledger::genesis_utils::create_genesis_config,
+        solana_runtime::bank::SlotLeader,
+    };
+
+    const TEST_GENESIS_LAMPORTS: u64 = 10_000;
+    const GENESIS_SLOT: Slot = 0;
+    const FIRST_LEADER_SLOT: Slot = 1;
+    const COMPETING_LEADER_SLOT: Slot = 2;
+    const CHILD_OF_STALE_PARENT_SLOT: Slot = 3;
+
+    struct TestForks {
+        bank_forks: Arc<RwLock<BankForks>>,
+    }
+
+    impl TestForks {
+        fn new() -> Self {
+            let genesis = create_genesis_config(TEST_GENESIS_LAMPORTS);
+            let genesis_bank = Bank::new_for_tests(&genesis.genesis_config);
+            Self {
+                bank_forks: BankForks::new_rw_arc(genesis_bank),
+            }
+        }
+
+        fn bank(&self, slot: Slot) -> Option<Arc<Bank>> {
+            self.bank_forks.read().unwrap().get(slot)
+        }
+
+        fn leader_bank(&self, parent_slot: Slot, slot: Slot) -> Bank {
+            Bank::new_from_parent(
+                self.bank(parent_slot)
+                    .expect("test parent slot should exist"),
+                SlotLeader::default(),
+                slot,
+            )
+        }
+
+        fn insert_leader_bank(&self, parent_slot: Slot, slot: Slot) -> BankWithScheduler {
+            insert_leader_bank(&self.bank_forks, self.leader_bank(parent_slot, slot)).unwrap()
+        }
+
+        fn set_root(&self, slot: Slot) {
+            self.bank_forks.write().unwrap().set_root(slot, None, None);
+        }
+
+        fn working_slot(&self) -> Slot {
+            self.bank_forks.read().unwrap().working_bank().slot()
+        }
+
+        fn fork_state_for(&self, slot: Slot) -> (usize, Option<BankId>) {
+            let bank_forks = self.bank_forks.read().unwrap();
+            (
+                bank_forks.len(),
+                bank_forks.get(slot).map(|bank| bank.bank_id()),
+            )
+        }
+    }
+
+    fn assert_rejected_without_changing_forks(
+        forks: &TestForks,
+        bank: Bank,
+        expected_error: InsertLeaderBankError,
+    ) {
+        let slot = bank.slot();
+        let before = forks.fork_state_for(slot);
+        match insert_leader_bank(&forks.bank_forks, bank) {
+            Ok(bank) => panic!("unexpectedly inserted leader bank {}", bank.slot()),
+            Err(error) => assert_eq!(error, expected_error),
+        }
+        assert_eq!(forks.fork_state_for(slot), before);
+    }
+
+    #[test]
+    fn test_insert_leader_bank_accepts_current_parent() {
+        let forks = TestForks::new();
+
+        let inserted_bank = forks.insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
+
+        assert_eq!(inserted_bank.slot(), FIRST_LEADER_SLOT);
+        assert_eq!(forks.working_slot(), FIRST_LEADER_SLOT);
+    }
+
+    #[test]
+    fn test_insert_leader_bank_rejects_duplicate_slot() {
+        let forks = TestForks::new();
+        forks.insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
+
+        assert_rejected_without_changing_forks(
+            &forks,
+            forks.leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT),
+            InsertLeaderBankError::AlreadyHaveBank(FIRST_LEADER_SLOT),
+        );
+    }
+
+    #[test]
+    fn test_insert_leader_bank_rejects_already_rooted_slot() {
+        let forks = TestForks::new();
+        let bank_built_before_its_slot_was_rooted =
+            forks.leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
+        forks.insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
+        forks.set_root(FIRST_LEADER_SLOT);
+
+        assert_rejected_without_changing_forks(
+            &forks,
+            bank_built_before_its_slot_was_rooted,
+            InsertLeaderBankError::AlreadyRooted(FIRST_LEADER_SLOT),
+        );
+    }
+
+    #[test]
+    fn test_insert_leader_bank_rejects_stale_parent() {
+        let forks = TestForks::new();
+        forks.insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
+        forks.insert_leader_bank(GENESIS_SLOT, COMPETING_LEADER_SLOT);
+
+        let bank_built_on_pruned_parent =
+            forks.leader_bank(FIRST_LEADER_SLOT, CHILD_OF_STALE_PARENT_SLOT);
+        forks.set_root(COMPETING_LEADER_SLOT);
+
+        assert_rejected_without_changing_forks(
+            &forks,
+            bank_built_on_pruned_parent,
+            InsertLeaderBankError::StaleParent {
+                slot: CHILD_OF_STALE_PARENT_SLOT,
+                parent_slot: FIRST_LEADER_SLOT,
+            },
+        );
+    }
 }

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -997,7 +997,7 @@ mod tests {
         forks.set_root(COMPETING_LEADER_SLOT);
 
         let before = forks.fork_state_for(CHILD_OF_STALE_PARENT_SLOT);
-        let publish_side_effects_were_called = AtomicBool::new(false);
+        let mut publish_side_effects_were_called = false;
 
         assert_eq!(
             commit_and_publish_leader_bank(
@@ -1006,7 +1006,7 @@ mod tests {
                 |_bank, _root_slot| {
                     // This publisher is where BCL assigns PoH, emits created-bank
                     // notifications, wakes BankingStage, and resets slot metrics.
-                    publish_side_effects_were_called.store(true, Ordering::Relaxed);
+                    publish_side_effects_were_called = true;
                 },
             ),
             Err(InsertBankError::MissingParent {
@@ -1017,7 +1017,7 @@ mod tests {
 
         assert_eq!(forks.fork_state_for(CHILD_OF_STALE_PARENT_SLOT), before);
         assert!(
-            !publish_side_effects_were_called.load(Ordering::Relaxed),
+            !publish_side_effects_were_called,
             "stale leader bank must not publish PoH, notification, or record-receiver side effects"
         );
     }

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -724,18 +724,11 @@ fn create_and_insert_leader_bank(
         &parent_bank.hash(),
     );
 
-    let (tpu_bank, root_slot) = commit_leader_bank(&ctx.bank_forks, tpu_bank)?;
-    let bank_id = tpu_bank.bank_id();
-    ctx.poh_recorder.write().unwrap().set_bank(tpu_bank);
-
-    // If this is the first alpenglow block, emit the genesis certificate marker
-    maybe_include_genesis_certificate(parent_slot, ctx);
-
-    notify_created_leader_bank(slot, parent_slot, root_slot, ctx);
-
-    // Wakeup banking stage
-    ctx.record_receiver.restart(bank_id);
-    ctx.slot_metrics.reset(slot);
+    let bank_forks = ctx.bank_forks.clone();
+    let root_slot =
+        commit_and_publish_leader_bank(&bank_forks, tpu_bank, |tpu_bank, root_slot| {
+            publish_committed_leader_bank(slot, parent_slot, tpu_bank, root_slot, ctx);
+        })?;
 
     info!(
         "{}: new fork:{} parent:{} (leader) root:{}",
@@ -763,6 +756,44 @@ fn commit_leader_bank(
     let tpu_bank = bank_forks.try_insert(tpu_bank)?;
     let root_slot = bank_forks.root();
     Ok((tpu_bank, root_slot))
+}
+
+/// Commits the leader bank, then runs the caller's post-commit publisher.
+///
+/// The publisher owns the side effects that expose the committed leader bank to
+/// PoH, downstream notifications, BankingStage, and per-slot metrics. It must
+/// only run after `BankForks::try_insert()` accepts the bank, so stale work
+/// cannot be published as the active leader bank.
+fn commit_and_publish_leader_bank<F>(
+    bank_forks: &RwLock<BankForks>,
+    tpu_bank: Bank,
+    publish: F,
+) -> Result<Slot, InsertBankError>
+where
+    F: FnOnce(BankWithScheduler, Slot),
+{
+    let (tpu_bank, root_slot) = commit_leader_bank(bank_forks, tpu_bank)?;
+    publish(tpu_bank, root_slot);
+    Ok(root_slot)
+}
+
+fn publish_committed_leader_bank(
+    slot: Slot,
+    parent_slot: Slot,
+    tpu_bank: BankWithScheduler,
+    root_slot: Slot,
+    ctx: &mut LeaderContext,
+) {
+    let bank_id = tpu_bank.bank_id();
+    ctx.poh_recorder.write().unwrap().set_bank(tpu_bank);
+    // If this is the first alpenglow block, emit the genesis certificate marker
+    maybe_include_genesis_certificate(parent_slot, ctx);
+
+    notify_created_leader_bank(slot, parent_slot, root_slot, ctx);
+
+    // Wakeup banking stage
+    ctx.record_receiver.restart(bank_id);
+    ctx.slot_metrics.reset(slot);
 }
 
 fn notify_created_leader_bank(slot: Slot, parent_slot: Slot, root_slot: Slot, ctx: &LeaderContext) {
@@ -912,19 +943,20 @@ mod tests {
     #[test]
     fn test_try_insert_leader_bank_rejects_already_rooted_slot() {
         let forks = TestForks::new();
-        let bank_built_before_its_slot_was_rooted =
+        let bank_built_before_root_moved_past_its_slot =
             forks.leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
-        forks.try_insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
-        forks.set_root(FIRST_LEADER_SLOT);
+        forks.try_insert_leader_bank(GENESIS_SLOT, COMPETING_LEADER_SLOT);
+        forks.set_root(COMPETING_LEADER_SLOT);
 
-        // The bank was valid when built, but the slot became rooted before the
-        // final insert. Publishing it again would move BankForks backward.
+        // The bank was valid when built, but a different fork rooted past its
+        // slot before the final insert. Publishing it would move BankForks
+        // backward.
         assert_rejected_without_changing_forks(
             &forks,
-            bank_built_before_its_slot_was_rooted,
+            bank_built_before_root_moved_past_its_slot,
             InsertBankError::AlreadyRooted {
                 slot: FIRST_LEADER_SLOT,
-                root: FIRST_LEADER_SLOT,
+                root: COMPETING_LEADER_SLOT,
             },
         );
     }
@@ -949,6 +981,44 @@ mod tests {
                 slot: CHILD_OF_STALE_PARENT_SLOT,
                 parent_slot: FIRST_LEADER_SLOT,
             },
+        );
+    }
+
+    #[test]
+    fn test_stale_leader_bank_commit_does_not_publish_side_effects() {
+        let forks = TestForks::new();
+        forks.try_insert_leader_bank(GENESIS_SLOT, FIRST_LEADER_SLOT);
+        forks.try_insert_leader_bank(GENESIS_SLOT, COMPETING_LEADER_SLOT);
+
+        // BCL can build a leader bank from a parent snapshot that is valid at
+        // construction time, then lose the parent before the commit point.
+        let bank_built_on_parent_before_it_was_pruned =
+            forks.leader_bank(FIRST_LEADER_SLOT, CHILD_OF_STALE_PARENT_SLOT);
+        forks.set_root(COMPETING_LEADER_SLOT);
+
+        let before = forks.fork_state_for(CHILD_OF_STALE_PARENT_SLOT);
+        let publish_side_effects_were_called = AtomicBool::new(false);
+
+        assert_eq!(
+            commit_and_publish_leader_bank(
+                &forks.bank_forks,
+                bank_built_on_parent_before_it_was_pruned,
+                |_bank, _root_slot| {
+                    // This publisher is where BCL assigns PoH, emits created-bank
+                    // notifications, wakes BankingStage, and resets slot metrics.
+                    publish_side_effects_were_called.store(true, Ordering::Relaxed);
+                },
+            ),
+            Err(InsertBankError::MissingParent {
+                slot: CHILD_OF_STALE_PARENT_SLOT,
+                parent_slot: FIRST_LEADER_SLOT,
+            })
+        );
+
+        assert_eq!(forks.fork_state_for(CHILD_OF_STALE_PARENT_SLOT), before);
+        assert!(
+            !publish_side_effects_were_called.load(Ordering::Relaxed),
+            "stale leader bank must not publish PoH, notification, or record-receiver side effects"
         );
     }
 }

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -298,6 +298,27 @@ impl BankForks {
         Ok(self.insert(bank))
     }
 
+    /// Validates that `bank` is still safe to insert into the current fork graph.
+    ///
+    /// This is structural validation, not full bank or consensus validation. It
+    /// is meant for banks that were built from a `BankForks` snapshot outside the
+    /// write lock. By the time the bank is ready to be committed, the root may
+    /// have moved, another bank for the same slot may have been inserted, or the
+    /// selected parent may no longer be usable.
+    ///
+    /// The accepted shape is:
+    /// - the bank's slot is above the current root,
+    /// - no bank for that slot already exists,
+    /// - the parent is still present, and
+    /// - the parent is the root or a descendant of the root.
+    ///
+    /// The last condition is stricter than parent presence. `BankForks` may
+    /// retain ancestors below the local root for commitment/RPC queries, but
+    /// those retained ancestors are not valid parents for new work.
+    ///
+    /// The caller must hold the `BankForks` write lock from this validation
+    /// through insertion. Otherwise another writer could change the fork graph
+    /// between the check and the insert.
     fn validate_insert(&self, bank: &Bank) -> Result<(), InsertBankError> {
         let slot = bank.slot();
         let parent_slot = bank.parent_slot();
@@ -311,6 +332,9 @@ impl BankForks {
         if !self.banks.contains_key(&parent_slot) {
             return Err(InsertBankError::MissingParent { slot, parent_slot });
         }
+        // Parent presence alone is not enough. Retained ancestors below root can
+        // remain in `BankForks` for commitment queries, but new work must build
+        // on the root or one of its descendants.
         if !self.is_on_rooted_fork(parent_slot, root) {
             return Err(InsertBankError::ParentNotOnRootedFork {
                 slot,

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -23,6 +23,7 @@ use {
         sync::{Arc, RwLock},
         time::Instant,
     },
+    thiserror::Error,
 };
 
 /// Convenience type since often root/working banks are fetched together.
@@ -85,6 +86,18 @@ pub struct BankForks {
     /// The status tracker for the Alpenglow migration. Initialized via either
     /// the genesis or snapshot bank and then updated via block replay.
     migration_status: Arc<MigrationStatus>,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum InsertBankError {
+    #[error("slot {slot} is already rooted at {root}")]
+    AlreadyRooted { slot: Slot, root: Slot },
+
+    #[error("already contains bank for slot {0}")]
+    AlreadyExists(Slot),
+
+    #[error("parent slot {parent_slot} for slot {slot} is no longer in BankForks")]
+    MissingParent { slot: Slot, parent_slot: Slot },
 }
 
 impl Index<u64> for BankForks {
@@ -257,6 +270,35 @@ impl BankForks {
 
     pub fn insert(&mut self, bank: Bank) -> BankWithScheduler {
         self.insert_with_scheduling_mode(SchedulingMode::BlockVerification, bank)
+    }
+
+    /// Inserts a bank only if the current fork graph still accepts it.
+    ///
+    /// This checked insert is intended for banks built from a `BankForks`
+    /// snapshot outside the write lock. By the time the caller is ready to
+    /// publish the bank, another writer may have rooted past the slot, inserted
+    /// the same slot, or pruned the selected parent. In those cases, returning a
+    /// structured error lets the caller discard stale work without panicking or
+    /// mutating `BankForks`.
+    pub fn try_insert(&mut self, bank: Bank) -> Result<BankWithScheduler, InsertBankError> {
+        self.validate_insert(&bank)?;
+        Ok(self.insert(bank))
+    }
+
+    fn validate_insert(&self, bank: &Bank) -> Result<(), InsertBankError> {
+        let slot = bank.slot();
+        let parent_slot = bank.parent_slot();
+        let root = self.root();
+        if slot <= root {
+            return Err(InsertBankError::AlreadyRooted { slot, root });
+        }
+        if self.banks.contains_key(&slot) {
+            return Err(InsertBankError::AlreadyExists(slot));
+        }
+        if !self.banks.contains_key(&parent_slot) {
+            return Err(InsertBankError::MissingParent { slot, parent_slot });
+        }
+        Ok(())
     }
 
     pub fn insert_with_scheduling_mode(

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -88,16 +88,28 @@ pub struct BankForks {
     migration_status: Arc<MigrationStatus>,
 }
 
+/// Errors returned by checked BankForks insertion.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum InsertBankError {
+    /// The bank's slot is at or below the current root.
     #[error("slot {slot} is already rooted at {root}")]
     AlreadyRooted { slot: Slot, root: Slot },
 
+    /// BankForks already contains a bank for the bank's slot.
     #[error("already contains bank for slot {0}")]
     AlreadyExists(Slot),
 
+    /// The bank's parent is not present in BankForks.
     #[error("parent slot {parent_slot} for slot {slot} is no longer in BankForks")]
     MissingParent { slot: Slot, parent_slot: Slot },
+
+    /// The bank's parent is present, but not on the current rooted fork.
+    #[error("parent slot {parent_slot} for slot {slot} is not on rooted fork {root}")]
+    ParentNotOnRootedFork {
+        slot: Slot,
+        parent_slot: Slot,
+        root: Slot,
+    },
 }
 
 impl Index<u64> for BankForks {
@@ -272,7 +284,8 @@ impl BankForks {
         self.insert_with_scheduling_mode(SchedulingMode::BlockVerification, bank)
     }
 
-    /// Inserts a bank only if the current fork graph still accepts it.
+    /// Inserts a bank with the same scheduling mode as [`Self::insert`], only
+    /// if the current fork graph still accepts it.
     ///
     /// This checked insert is intended for banks built from a `BankForks`
     /// snapshot outside the write lock. By the time the caller is ready to
@@ -298,7 +311,22 @@ impl BankForks {
         if !self.banks.contains_key(&parent_slot) {
             return Err(InsertBankError::MissingParent { slot, parent_slot });
         }
+        if !self.is_on_rooted_fork(parent_slot, root) {
+            return Err(InsertBankError::ParentNotOnRootedFork {
+                slot,
+                parent_slot,
+                root,
+            });
+        }
         Ok(())
+    }
+
+    fn is_on_rooted_fork(&self, slot: Slot, root: Slot) -> bool {
+        slot == root
+            || self
+                .descendants
+                .get(&root)
+                .is_some_and(|descendants| descendants.contains(&slot))
     }
 
     pub fn insert_with_scheduling_mode(
@@ -1265,6 +1293,62 @@ mod tests {
                 (6, vec![])
             ])
         );
+    }
+
+    #[test]
+    fn test_try_insert_rejects_parent_retained_below_root() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let bank_forks = BankForks::new_rw_arc(bank);
+
+        extend_bank_forks(bank_forks.clone(), &[(0, 1), (1, 2)]);
+        bank_forks.write().unwrap().set_root(
+            2,
+            None,    // snapshot_controller
+            Some(1), // highest confirmed root
+        );
+
+        // Slot 1 is intentionally retained below the local root for commitment
+        // queries, but it is no longer a valid parent for new work.
+        assert!(bank_forks.read().unwrap().get(1).is_some());
+        assert_eq!(bank_forks.read().unwrap().root(), 2);
+
+        let bank_built_on_retained_ancestor = Bank::new_from_parent(
+            bank_forks.read().unwrap().get(1).unwrap(),
+            SlotLeader::default(),
+            3,
+        );
+        let before = {
+            let bank_forks = bank_forks.read().unwrap();
+            (
+                bank_forks.len(),
+                bank_forks.get(3).map(|bank| bank.bank_id()),
+            )
+        };
+
+        match bank_forks
+            .write()
+            .unwrap()
+            .try_insert(bank_built_on_retained_ancestor)
+        {
+            Ok(bank) => panic!("unexpectedly inserted bank {}", bank.slot()),
+            Err(error) => assert_eq!(
+                error,
+                InsertBankError::ParentNotOnRootedFork {
+                    slot: 3,
+                    parent_slot: 1,
+                    root: 2,
+                }
+            ),
+        }
+        let after = {
+            let bank_forks = bank_forks.read().unwrap();
+            (
+                bank_forks.len(),
+                bank_forks.get(3).map(|bank| bank.bank_id()),
+            )
+        };
+        assert_eq!(after, before);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a checked `BankForks` insertion path for BCL-created leader banks.
- Revalidate leader bank insertion under the `BankForks` write lock before BCL publishes committed-bank side effects.
- Reject stale work when the leader slot is already rooted, already exists, the selected parent was pruned, or the selected parent is only retained below the root for commitment queries.

## Context
BCL selects a parent from `BankForks`, then builds the leader bank outside the `BankForks` write lock. During that window, another writer can root, insert, or prune forks. Without a commit-time check, duplicate insertion can panic, a bank built on stale fork state can be inserted, and downstream publication can run for a bank that should be rejected.

This change treats those cases as stale BCL work. It hardens a structurally possible TOCTOU window, but it does not prove this interleaving is happening in production. It also does not claim every BCL side effect is post-commit: parent PoH reset and banking trace recording can still happen before the final insert. The fenced effects are the ones that publish the committed leader bank to PoH, created-bank notifications, BankingStage, and per-slot metrics.

## Design Notes
- Structural insertion validation belongs in `BankForks`, not only in the BCL call site.
- `try_insert()` mirrors `insert()` scheduling behavior and validates before mutating `BankForks`.
- Parent presence is not enough: a parent retained below the local root for commitment queries is not a valid parent for new work.
- PoH `set_bank`, RPC/slot-status notification, record-receiver wakeup, and slot-metric reset run only after successful insertion.
- Existing unchecked `insert()` remains for existing callers; BCL uses the checked path where stale publish side effects matter.

## Test Plan
- `git diff --check`
- `rustfmt --check runtime/src/bank_forks.rs core/src/block_creation_loop.rs`
  - Passed with existing stable-rustfmt warnings for unstable formatting options.
- `cargo test -p solana-runtime bank_forks`
- `cargo test -p solana-core block_creation_loop::tests`

## Remaining Gap
The tests pin the core fork-graph and publish-fence invariants, but they are not a deterministic full-thread interleaving test for BCL/replay timing. This is still an OCC-style hardening step, not the final single-writer/controller design.
