### PR TITLE
Introduces channels to help populate block footers

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -10,7 +10,8 @@ use {
         replay_stage::{Finalizer, ReplayStage},
     },
     agave_votor::event::LeaderWindowInfo,
-    crossbeam_channel::Receiver,
+    agave_votor_messages::reward_certificate::{BuildRewardCertsRequest, BuildRewardCertsResponse},
+    crossbeam_channel::{Receiver, Sender},
     solana_clock::Slot,
     solana_entry::block_component::{
         BlockFooterV1, BlockMarkerV1, GenesisCertificate, VersionedBlockMarker,
@@ -93,6 +94,11 @@ pub struct BlockCreationLoopConfig {
 
     // Channel to receive RecordReceiver from PohService
     pub record_receiver_receiver: Receiver<RecordReceiver>,
+
+    /// Channel to send the request to build reward certs.
+    pub build_reward_certs_sender: Sender<BuildRewardCertsRequest>,
+    /// Channel to receive the built reward certs.
+    pub reward_certs_receiver: Receiver<BuildRewardCertsResponse>,
 }
 
 struct LeaderContext {
@@ -111,6 +117,10 @@ struct LeaderContext {
     slot_status_notifier: Option<SlotStatusNotifier>,
     banking_tracer: Arc<BankingTracer>,
     replay_highest_frozen: Arc<ReplayHighestFrozen>,
+    #[allow(dead_code)]
+    build_reward_certs_sender: Sender<BuildRewardCertsRequest>,
+    #[allow(dead_code)]
+    reward_certs_receiver: Receiver<BuildRewardCertsResponse>,
 
     // Metrics
     metrics: LoopMetrics,
@@ -165,6 +175,8 @@ fn start_loop(config: BlockCreationLoopConfig) {
         replay_highest_frozen,
         record_receiver_receiver,
         highest_finalized,
+        build_reward_certs_sender,
+        reward_certs_receiver,
     } = config;
 
     // Similar to Votor, if this loop dies kill the validator
@@ -208,6 +220,8 @@ fn start_loop(config: BlockCreationLoopConfig) {
         slot_status_notifier,
         banking_tracer,
         replay_highest_frozen,
+        build_reward_certs_sender,
+        reward_certs_receiver,
         metrics: LoopMetrics::default(),
         slot_metrics: SlotMetrics::default(),
         highest_finalized,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -111,12 +111,6 @@ pub struct Tvu {
     bls_sigverify_threads: Option<(JoinHandle<()>, JoinHandle<()>)>,
     votor: Votor,
     commitment_service: AggregateCommitmentService,
-
-    // TODO: these will be used when the block component processor is upstreamed
-    #[allow(dead_code)]
-    reward_certs_receiver: Receiver<BuildRewardCertsResponse>,
-    #[allow(dead_code)]
-    build_reward_certs_sender: Sender<BuildRewardCertsRequest>,
 }
 
 pub struct TvuSockets {
@@ -179,6 +173,10 @@ pub struct AlpenglowInitializationState {
     // For BLS voting service
     pub bls_connection_cache: Arc<ConnectionCache>,
     pub voting_service_test_override: Option<VotingServiceOverride>,
+
+    // For rewards
+    pub reward_certs_sender: Sender<BuildRewardCertsResponse>,
+    pub build_reward_certs_receiver: Receiver<BuildRewardCertsRequest>,
 }
 
 impl Tvu {
@@ -255,6 +253,8 @@ impl Tvu {
             bls_connection_cache,
             voting_service_test_override,
             highest_finalized,
+            build_reward_certs_receiver,
+            reward_certs_sender,
         } = votor_init;
 
         // streamer and sigverify for A2A BLS messages
@@ -456,11 +456,6 @@ impl Tvu {
                 rpc_subscriptions.clone(),
             );
 
-        // TODO: when the block component processor is upstreamed,
-        // it will use the unused channels below.
-        let (reward_certs_sender, reward_certs_receiver) = bounded(MAX_ALPENGLOW_PACKET_NUM);
-        let (build_reward_certs_sender, build_reward_certs_receiver) =
-            bounded(MAX_ALPENGLOW_PACKET_NUM);
         let votor_config = VotorConfig {
             exit: exit.clone(),
             vote_account: *vote_account,
@@ -620,13 +615,6 @@ impl Tvu {
             bls_sigverify_threads,
             votor,
             commitment_service,
-            // TODO: these two channels are here temporarily and will be removed when the block
-            // component processor is upstreamed from the Alpenglow repo which will consume them.
-            // We need some place to store them temporarily so that they are not dropped.
-            // Dropping them causes interacting with the other ends in the BlsSigverifier to fail
-            // which causes the sigverifier to exit which resulting in various tests to fail.
-            reward_certs_receiver,
-            build_reward_certs_sender,
         })
     }
 
@@ -795,6 +783,8 @@ pub mod tests {
                 thread::sleep(Duration::from_secs(1));
             }
         });
+        let (reward_certs_sender, _reward_certs_receiver) = bounded(1);
+        let (_build_reward_certs_sender, build_reward_certs_receiver) = bounded(1);
 
         let tvu = Tvu::new(
             &vote_keypair.pubkey(),
@@ -862,6 +852,8 @@ pub mod tests {
                 bls_connection_cache: Arc::new(bls_connection_cache),
                 voting_service_test_override: None,
                 highest_finalized: Arc::new(RwLock::new(None)),
+                build_reward_certs_receiver,
+                reward_certs_sender,
             },
         )
         .expect("assume success");

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1447,7 +1447,12 @@ impl Validator {
 
         let replay_highest_frozen = Arc::new(ReplayHighestFrozen::default());
         let highest_parent_ready = Arc::new(RwLock::default());
+        // Shared state for highest finalized certificates (updated by Votor, read by block creation loop)
         let highest_finalized = Arc::new(RwLock::new(None));
+        // There will only ever be a single msg in flight so bound channel for [`BuildRewardCertsRequest`] to 1 message.
+        let (build_reward_certs_sender, build_reward_certs_receiver) = bounded(1);
+        // There will only ever be a single msg in flight so bound channel for [`BuildRewardCertsResponse`] to 1 message.
+        let (reward_certs_sender, reward_certs_receiver) = bounded(1);
 
         let block_creation_loop_config = BlockCreationLoopConfig {
             exit: exit.clone(),
@@ -1464,6 +1469,8 @@ impl Validator {
             replay_highest_frozen: replay_highest_frozen.clone(),
             record_receiver_receiver,
             highest_finalized: highest_finalized.clone(),
+            build_reward_certs_sender,
+            reward_certs_receiver,
         };
         let block_creation_loop = BlockCreationLoop::new(block_creation_loop_config);
 
@@ -1608,6 +1615,8 @@ impl Validator {
                 bls_connection_cache,
                 voting_service_test_override: config.voting_service_test_override.clone(),
                 highest_finalized,
+                build_reward_certs_receiver,
+                reward_certs_sender,
             },
         )
         .map_err(ValidatorError::Other)?;


### PR DESCRIPTION
#### Problem

When the block producer wants to produce a block, it needs to populate with a block footer which includes reward certs.  


#### Summary of Changes

This is a small PR to introduce the channels in the right place in the block creation loop so that it can request and get the reward certs to insert into the block footer.

This is an attempt to break https://github.com/anza-xyz/agave/pull/12049/ into smaller digestible PRs to make it easier to review and land.