### PR TITLE
poh recorder sends block footer

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -497,17 +497,7 @@ fn record_and_complete_block(
     );
 
     drop(bank);
-
-    let dummy_footer = BlockFooterV1 {
-        bank_hash: Hash::default(),
-        block_producer_time_nanos: 0,
-        block_user_agent: format!("agave/{}", version!()).into_bytes(),
-        final_cert: None,
-        skip_reward_cert: None,
-        notar_reward_cert: None,
-    };
-    w_poh_recorder.tick_alpenglow(max_tick_height, dummy_footer);
-
+    w_poh_recorder.tick_alpenglow(max_tick_height, footer);
     Ok(())
 }
 

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -12,7 +12,9 @@ use {
     agave_votor::event::LeaderWindowInfo,
     crossbeam_channel::Receiver,
     solana_clock::Slot,
-    solana_entry::block_component::{BlockMarkerV1, GenesisCertificate, VersionedBlockMarker},
+    solana_entry::block_component::{
+        BlockFooterV1, BlockMarkerV1, GenesisCertificate, VersionedBlockMarker,
+    },
     solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
     solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
@@ -29,6 +31,7 @@ use {
         leader_schedule_utils::{last_of_consecutive_leader_slots, leader_slot_index},
         validated_block_finalization::ValidatedBlockFinalizationCert,
     },
+    solana_version::version,
     stats::{LoopMetrics, SlotMetrics},
     std::{
         sync::{
@@ -419,7 +422,16 @@ fn record_and_complete_block(
     bank.set_tick_height(max_tick_height - 1);
     // Write the single tick for this slot
     drop(bank);
-    w_poh_recorder.tick_alpenglow(max_tick_height);
+
+    let dummy_footer = BlockFooterV1 {
+        bank_hash: Hash::default(),
+        block_producer_time_nanos: 0,
+        block_user_agent: format!("agave/{}", version!()).into_bytes(),
+        final_cert: None,
+        skip_reward_cert: None,
+        notar_reward_cert: None,
+    };
+    w_poh_recorder.tick_alpenglow(max_tick_height, dummy_footer);
 
     Ok(())
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2397,10 +2397,6 @@ fn load_frozen_forks(
                 //
                 // We are safe to cleanly transition to alpenglow here
                 if migration_status.is_ready_to_enable() {
-                    debug_assert!(matches!(
-                        error,
-                        BlockstoreProcessorError::InvalidBlock(BlockError::TooFewTicks),
-                    ));
                     let genesis_slot = migration_status.enable_alpenglow_during_startup();
 
                     // We need to clear pending_slots as it might contain Alpenglow blocks initialized as TowerBFT banks.

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -23,7 +23,7 @@ use {
     log::*,
     solana_clock::{BankId, Slot},
     solana_entry::{
-        block_component::VersionedBlockMarker,
+        block_component::{BlockFooterV1, VersionedBlockMarker},
         entry::Entry,
         entry_or_marker::EntryOrMarker,
         poh::{Poh, PohEntry},
@@ -42,7 +42,7 @@ use {
             Arc, Mutex, RwLock,
             atomic::{AtomicBool, AtomicU64, Ordering},
         },
-        time::Instant,
+        time::{Duration, Instant},
     },
     thiserror::Error,
 };
@@ -349,7 +349,7 @@ impl PohRecorder {
         }
 
         loop {
-            let (flush_cache_res, flush_cache_us) = measure_us!(self.flush_cache(false));
+            let (flush_cache_res, flush_cache_us) = measure_us!(self.flush_cache(false, None));
             self.metrics.flush_cache_no_tick_us += flush_cache_us;
             flush_cache_res?;
 
@@ -436,7 +436,7 @@ impl PohRecorder {
                 self.tick_height(),
             ));
 
-            let (_flush_res, flush_cache_and_tick_us) = measure_us!(self.flush_cache(true));
+            let (_flush_res, flush_cache_and_tick_us) = measure_us!(self.flush_cache(true, None));
             self.metrics.flush_cache_tick_us += flush_cache_and_tick_us;
         }
     }
@@ -480,7 +480,21 @@ impl PohRecorder {
 
         // TODO: adjust the working_bank.start time based on number of ticks
         // that have already elapsed based on current tick height.
-        let _ = self.flush_cache(false);
+        let _ = self.flush_cache(false, None);
+    }
+
+    fn notify_replay_wakeup(&self) {
+        if let Some(signal) = &self.clear_bank_signal {
+            match signal.try_send(true) {
+                Ok(()) => {}
+                Err(TrySendError::Full(_)) => {
+                    trace!("replay wake up signal channel is full.")
+                }
+                Err(TrySendError::Disconnected(_)) => {
+                    trace!("replay wake up signal channel is disconnected.")
+                }
+            }
+        }
     }
 
     /// Clears the working bank.
@@ -520,17 +534,7 @@ impl PohRecorder {
             );
         }
 
-        if let Some(ref signal) = self.clear_bank_signal {
-            match signal.try_send(true) {
-                Ok(_) => {}
-                Err(TrySendError::Full(_)) => {
-                    trace!("replay wake up signal channel is full.")
-                }
-                Err(TrySendError::Disconnected(_)) => {
-                    trace!("replay wake up signal channel is disconnected.")
-                }
-            }
-        }
+        self.notify_replay_wakeup();
     }
 
     /// Returns tick_height - does not update the internal state for tick_height.
@@ -568,10 +572,70 @@ impl PohRecorder {
         tick_height
     }
 
+    /// Waits for the bank to freeze and sends the block footer with the bank hash.
+    /// Returns:
+    /// - Ok(()): Footer sent successfully
+    /// - Err(None): Bank freeze timeout (caller should break without updating send_result)
+    /// - Err(Some(e)): Send failed (caller should update send_result and break)
+    fn wait_for_freeze_and_send_footer(
+        &self,
+        mut footer: BlockFooterV1,
+        working_bank: &WorkingBank,
+    ) -> std::result::Result<(), Option<Box<SendError<WorkingBankEntryOrMarker>>>> {
+        // Wake replay as soon as the slot reaches max tick height so it can freeze the bank
+        // before we block on the footer/bank-hash handoff.
+        self.notify_replay_wakeup();
+
+        // Wait for the bank to be frozen with timeout
+        // TODO: change this to use DELTA_BLOCK from votor instead.
+        let start = Instant::now();
+        while !working_bank.bank.is_frozen() && !self.is_exited.load(Ordering::Relaxed) {
+            if start.elapsed() > Duration::from_millis(400) {
+                break;
+            }
+            std::hint::spin_loop();
+        }
+
+        // If the bank still isn't frozen, we've timed out
+        if !working_bank.bank.is_frozen() {
+            if self.is_exited.load(Ordering::Relaxed) {
+                return Err(None);
+            }
+            error!(
+                "slot = {} block production failure. bank freezing timed out.",
+                working_bank.bank.slot()
+            );
+            return Err(None);
+        }
+
+        // Send out the block footer - we now have the bank hash
+        footer.bank_hash = working_bank.bank.hash();
+
+        let footer = VersionedBlockMarker::new_block_footer(footer);
+        let footer_entry_marker = (
+            EntryOrMarker::Marker(footer),
+            working_bank.max_tick_height - 1,
+        );
+
+        match self
+            .working_bank_sender
+            .send((working_bank.bank.clone(), footer_entry_marker))
+        {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                error!(
+                    "slot = {} block production failure. failed to broadcast footer",
+                    working_bank.bank.slot()
+                );
+                Err(Some(Box::new(err)))
+            }
+        }
+    }
+
     // Flush cache will delay flushing the cache for a bank until it past the WorkingBank::min_tick_height
     // On a record flush will flush the cache at the WorkingBank::min_tick_height, since a record
     // occurs after the min_tick_height was generated
-    fn flush_cache(&mut self, tick: bool) -> Result<()> {
+    fn flush_cache(&mut self, tick: bool, footer: Option<BlockFooterV1>) -> Result<()> {
         // check_tick_height is called before flush cache, so it cannot overrun the bank
         // so a bank that is so late that it's slot fully generated before it starts recording
         // will fail instead of broadcasting any ticks
@@ -591,7 +655,7 @@ impl PohRecorder {
             .iter()
             .take_while(|x| x.1 <= working_bank.max_tick_height)
             .count();
-        let mut send_result: std::result::Result<(), SendError<WorkingBankEntryOrMarker>> = Ok(());
+        let mut send_result = Ok(());
 
         if entry_count > 0 {
             trace!(
@@ -605,11 +669,24 @@ impl PohRecorder {
             for (entry, tick_height) in &self.tick_cache[..entry_count] {
                 working_bank.bank.register_tick(&entry.hash);
 
+                if let Some(footer) = footer.clone() {
+                    match self.wait_for_freeze_and_send_footer(footer, working_bank) {
+                        Ok(()) => {}        // Continue processing
+                        Err(None) => break, // Timeout - break without updating send_result
+                        Err(Some(e)) => {
+                            // Send failed - update send_result and break
+                            send_result = Err(e);
+                            break;
+                        }
+                    }
+                }
+
                 let tick = (EntryOrMarker::from(entry.clone()), *tick_height);
 
                 send_result = self
                     .working_bank_sender
-                    .send((working_bank.bank.clone(), tick));
+                    .send((working_bank.bank.clone(), tick))
+                    .map_err(Box::new);
                 if send_result.is_err() {
                     break;
                 }
@@ -941,7 +1018,7 @@ impl PohRecorder {
         self.clear_bank(true);
     }
 
-    pub fn tick_alpenglow(&mut self, slot_max_tick_height: u64) {
+    pub fn tick_alpenglow(&mut self, slot_max_tick_height: u64, footer: BlockFooterV1) {
         let (poh_entry, tick_lock_contention_us) = measure_us!({
             let mut poh_l = self.poh.lock().unwrap();
             poh_l.tick()
@@ -970,7 +1047,8 @@ impl PohRecorder {
                     .load(Ordering::Acquire),
             ));
 
-            let (_flush_res, flush_cache_and_tick_us) = measure_us!(self.flush_cache(true));
+            let (_flush_res, flush_cache_and_tick_us) =
+                measure_us!(self.flush_cache(true, Some(footer)));
             self.metrics.flush_cache_tick_us += flush_cache_and_tick_us;
         }
     }


### PR DESCRIPTION
#### Problem

We need to march towards populating blocks with a footer.


#### Summary of Changes

This PR updates the poh recorder so that it waits till the bank freezes, sets the hash on the footer and then sends it out.

This is an attempt to break https://github.com/anza-xyz/agave/pull/12049 into smaller digestible PRs to make it easier to review and land.