### PR TITLE
Refactoring needed to fix vote_reward not always updating `final_slot` in the vote state

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -348,7 +348,7 @@ fn skew_block_producer_time_nanos(
 /// The bank_hash field is left as default and will be filled in after the bank freezes.
 fn produce_block_footer(
     bank: &Bank,
-    highest_finalized: &RwLock<Option<ValidatedBlockFinalizationCert>>,
+    highest_finalized: Option<&ValidatedBlockFinalizationCert>,
 ) -> BlockFooterV1 {
     let mut block_producer_time_nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -375,11 +375,7 @@ fn produce_block_footer(
     }
 
     // Convert finalization certs into block marker
-    let final_cert = highest_finalized
-        .read()
-        .unwrap()
-        .as_ref()
-        .map(ValidatedBlockFinalizationCert::to_final_certificate);
+    let final_cert = highest_finalized.map(ValidatedBlockFinalizationCert::to_final_certificate);
 
     BlockFooterV1 {
         bank_hash: Hash::default(),
@@ -500,15 +496,20 @@ fn record_and_complete_block(
     bank.set_tick_height(max_tick_height - 1);
     // Write the single tick for this slot
 
-    let footer = produce_block_footer(&bank, &ctx.highest_finalized);
+    let footer = {
+        let guard = ctx.highest_finalized.read().unwrap();
+        let footer = produce_block_footer(&bank, guard.as_ref());
+        let final_cert_input = guard.as_ref().map(|c| c.vote_rewards_input());
 
-    BlockComponentProcessor::update_bank_with_footer_fields(
-        &bank,
-        footer.block_producer_time_nanos as i64,
-        Hash::default(), // Banks we produce do not need the bank hash mismatch check
-        None,
-        ctx.highest_finalized.read().unwrap().as_ref(),
-    );
+        BlockComponentProcessor::update_bank_with_footer_fields(
+            &bank,
+            footer.block_producer_time_nanos as i64,
+            Hash::default(), // Banks we produce do not need the bank hash mismatch check
+            None,
+            final_cert_input,
+        );
+        footer
+    };
 
     drop(bank);
     w_poh_recorder.tick_alpenglow(max_tick_height, footer);

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         bank::Bank,
-        block_component_processor::vote_reward::calculate_and_pay_voting_reward_and_update_vote_state,
+        block_component_processor::vote_reward::calc_vote_rewards_update_vote_states,
         validated_block_finalization::{
             BlockFinalizationCertError, ValidatedBlockFinalizationCert,
         },
@@ -21,7 +21,7 @@ use {
     },
     solana_hash::Hash,
     solana_pubkey::Pubkey,
-    std::{num::NonZeroU64, sync::Arc},
+    std::{collections::HashSet, num::NonZeroU64, sync::Arc},
     thiserror::Error,
 };
 
@@ -260,31 +260,44 @@ impl BlockComponentProcessor {
             notar_reward_cert,
         } = footer;
 
-        let reward_slot_and_validators =
+        let reward_cert =
             match ValidatedRewardCert::try_new(&bank, &skip_reward_cert, &notar_reward_cert) {
-                Ok(c) => Some(c.into_parts()),
+                Ok(c) => Some(c),
                 Err(ValidatedRewardCertError::Empty) => None,
                 Err(e) => return Err(e.into()),
             };
-        let validated_final_cert = final_cert
+        let final_cert = final_cert
             .map(|final_cert| {
                 ValidatedBlockFinalizationCert::try_from_footer(final_cert, &bank)
                     .map_err(BlockComponentProcessorError::InvalidFinalizationCertificate)
             })
             .transpose()?;
 
+        let (footer_input, pool_input) = match final_cert {
+            None => (None, None),
+            Some(cert) => {
+                let (signers, finalize_cert, notarize_cert) = cert.into_parts();
+                let final_slot = finalize_cert.cert_type.slot();
+                (
+                    Some((signers, final_slot)),
+                    Some((finalize_cert, notarize_cert)),
+                )
+            }
+        };
+
         Self::update_bank_with_footer_fields(
             &bank,
             block_producer_time_nanos as i64,
             bank_hash,
-            reward_slot_and_validators,
-            validated_final_cert.as_ref(),
+            reward_cert,
+            footer_input
+                .as_ref()
+                .map(|(validators, slot)| (validators, *slot)),
         );
 
         // Send finalization cert(s) to consensus pool
-        if let Some(validated) = validated_final_cert {
+        if let Some((finalize_cert, notarize_cert)) = pool_input {
             if let Some(sender) = finalization_cert_sender {
-                let (finalize_cert, notarize_cert) = validated.into_certificates();
                 if let Some(notarize_cert) = notarize_cert {
                     let _ = sender
                         .send(vec![ConsensusMessage::from(notarize_cert)])
@@ -392,18 +405,13 @@ impl BlockComponentProcessor {
         bank: &Bank,
         block_producer_time_nanos: i64,
         bank_hash: Hash,
-        reward_slot_and_validators: Option<(Slot, Vec<Pubkey>)>,
-        final_cert: Option<&ValidatedBlockFinalizationCert>,
+        reward_cert: Option<ValidatedRewardCert>,
+        final_cert_input: Option<(&HashSet<Pubkey>, Slot)>,
     ) {
         // Update clock sysvar
         bank.update_clock_from_footer(block_producer_time_nanos);
 
-        calculate_and_pay_voting_reward_and_update_vote_state(
-            bank,
-            reward_slot_and_validators,
-            final_cert,
-        )
-        .unwrap();
+        calc_vote_rewards_update_vote_states(bank, reward_cert, final_cert_input).unwrap();
         // Record expected bank hash from footer for later verification when the bank is frozen.
         bank.set_expected_bank_hash(bank_hash);
     }

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{bank::Bank, validated_block_finalization::ValidatedBlockFinalizationCert},
+    crate::{bank::Bank, validated_reward_certificate::ValidatedRewardCert},
     epoch_inflation_account_state::{EpochInflationAccountState, EpochInflationState},
     log::info,
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
@@ -8,7 +8,7 @@ use {
     solana_vote::vote_account::VoteAccount,
     solana_vote_interface::state::{LandedVote, Lockout},
     solana_vote_program::vote_state::handler::VoteStateHandler,
-    std::collections::VecDeque,
+    std::collections::{HashSet, VecDeque},
     thiserror::Error,
 };
 
@@ -16,7 +16,7 @@ pub mod epoch_inflation_account_state;
 
 /// Different types of errors that can happen when calculating and paying voting reward.
 #[derive(Debug, PartialEq, Eq, Error)]
-pub enum PayVoteRewardError {
+pub(super) enum Error {
     #[error("missing EpochInflationAccountState for current slot {current_slot}")]
     MissingEpochInflationAccountState { current_slot: Slot },
     #[error("missing epoch stakes for reward_slot {reward_slot} in current_slot {current_slot}")]
@@ -42,34 +42,27 @@ pub enum PayVoteRewardError {
     },
 }
 
-/// Calculates voting rewards and updates vote state fields for rewarded validators.
-///
-/// This is a NOP if [`reward_slot_and_validators`] is [`None`].
-///
-/// The reward slot is in the past relative to the current slot and hence might be in a different
-/// epoch than the current epoch and may have different validator sets and stakes, etc.
-/// This function must compute rewards using the stakes in the reward slot and pay them using the
-/// stakes in the current slot.
-///
-/// Additionally we also update vote-state `votes` and `root_slot` fields from the footer
-/// reward and finalization certificate
-pub(super) fn calculate_and_pay_voting_reward_and_update_vote_state(
+/// Calculates voting rewards based on the `reward_cert` and updates fields in the vote account
+/// based on the calculated rewards and the `final_cert`.
+pub(super) fn calc_vote_rewards_update_vote_states(
     bank: &Bank,
-    reward_slot_and_validators: Option<(Slot, Vec<Pubkey>)>,
-    final_cert: Option<&ValidatedBlockFinalizationCert>,
-) -> Result<(), PayVoteRewardError> {
-    let Some((reward_slot, validators_to_reward)) = reward_slot_and_validators else {
+    reward_cert: Option<ValidatedRewardCert>,
+    final_cert_input: Option<(&HashSet<Pubkey>, Slot)>,
+) -> Result<(), Error> {
+    let (reward_slot, validators_to_reward) = if let Some(reward_cert) = reward_cert {
+        reward_cert.into_parts()
+    } else {
         return Ok(());
     };
 
     let current_slot = bank.slot();
     let (reward_slot_accounts, reward_slot_total_stake) = {
-        let epoch_stakes = bank.epoch_stakes_from_slot(reward_slot).ok_or(
-            PayVoteRewardError::MissingEpochStakes {
-                reward_slot,
-                current_slot,
-            },
-        )?;
+        let epoch_stakes =
+            bank.epoch_stakes_from_slot(reward_slot)
+                .ok_or(Error::MissingEpochStakes {
+                    reward_slot,
+                    current_slot,
+                })?;
         (
             epoch_stakes.stakes().vote_accounts().as_ref(),
             epoch_stakes.total_stake(),
@@ -85,9 +78,9 @@ pub(super) fn calculate_and_pay_voting_reward_and_update_vote_state(
         // that activated Alpenglow should have created the account.
         debug_assert!(epoch_inflation_account_state.is_some());
         epoch_inflation_account_state
-            .ok_or(PayVoteRewardError::MissingEpochInflationAccountState { current_slot })?
+            .ok_or(Error::MissingEpochInflationAccountState { current_slot })?
             .get_epoch_state(reward_epoch)
-            .ok_or(PayVoteRewardError::NoEpochValidatorStake {
+            .ok_or(Error::NoEpochValidatorStake {
                 reward_epoch,
                 current_slot,
             })?
@@ -103,7 +96,7 @@ pub(super) fn calculate_and_pay_voting_reward_and_update_vote_state(
     for validator_to_reward in validators_to_reward {
         let (reward_slot_validator_stake, _) = reward_slot_accounts
             .get(&validator_to_reward)
-            .ok_or(PayVoteRewardError::MissingRewardSlotValidator {
+            .ok_or(Error::MissingRewardSlotValidator {
                 pubkey: validator_to_reward,
                 reward_slot,
                 current_slot,
@@ -140,7 +133,7 @@ pub(super) fn calculate_and_pay_voting_reward_and_update_vote_state(
             current_slot_account,
             validator_to_reward,
             validator_reward,
-            final_cert,
+            &final_cert_input,
         ) {
             paid_vote_accounts.push((validator_to_reward, account_data));
         }
@@ -157,7 +150,7 @@ pub(super) fn calculate_and_pay_voting_reward_and_update_vote_state(
                     leader_account,
                     current_slot_leader_vote_pubkey,
                     total_leader_reward,
-                    final_cert,
+                    &final_cert_input,
                 ) {
                     paid_vote_accounts.push((current_slot_leader_vote_pubkey, account_data));
                 }
@@ -212,7 +205,7 @@ fn update_vote_account(
     account: &VoteAccount,
     validator_vote_pubkey: Pubkey,
     reward: u64,
-    final_cert: Option<&ValidatedBlockFinalizationCert>,
+    final_cert_input: &Option<(&HashSet<Pubkey>, Slot)>,
 ) -> Option<AccountSharedData> {
     let versions = bincode::deserialize(account.account().data()).ok()?;
     let mut handle = VoteStateHandler::try_new_from_vote_state_versions(versions).ok()?;
@@ -222,7 +215,7 @@ fn update_vote_account(
         current_epoch,
         reward,
         validator_vote_pubkey,
-        final_cert,
+        final_cert_input,
     );
     let mut paid_account = AccountSharedData::new(
         account.lamports(),
@@ -259,12 +252,12 @@ fn update_vote_state(
     reward_epoch: Epoch,
     reward: u64,
     validator_vote_pubkey: Pubkey,
-    final_cert: Option<&ValidatedBlockFinalizationCert>,
+    final_cert_input: &Option<(&HashSet<Pubkey>, Slot)>,
 ) {
     handle.increment_credits(reward_epoch, reward);
-    if let Some(final_cert) = final_cert {
-        if final_cert.was_signed_by(&validator_vote_pubkey) {
-            handle.set_root_slot(Some(final_cert.slot()));
+    if let Some((signers, slot)) = final_cert_input {
+        if signers.contains(&validator_vote_pubkey) {
+            handle.set_root_slot(Some(*slot));
         }
     }
 
@@ -320,7 +313,7 @@ mod tests {
     fn build_fast_finalization_cert(
         bank: &Bank,
         signing_ranks: &[usize],
-    ) -> ValidatedBlockFinalizationCert {
+    ) -> (HashSet<Pubkey>, Slot) {
         let slot = bank.slot();
         let block_id = Hash::new_unique();
         let cert_type = CertificateType::FinalizeFast(slot, block_id);
@@ -336,7 +329,9 @@ mod tests {
             signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap,
         };
-        ValidatedBlockFinalizationCert::from_validated_fast(cert, bank)
+        let (signers, cert, _) =
+            ValidatedBlockFinalizationCert::from_validated_fast(cert, bank).into_parts();
+        (signers, cert.cert_type.slot())
     }
 
     #[test]
@@ -379,7 +374,7 @@ mod tests {
         let epoch = 1234;
         let reward = 3453423;
         let account_shared_data =
-            update_vote_account(epoch, 0, &account, Pubkey::default(), reward, None).unwrap();
+            update_vote_account(epoch, 0, &account, Pubkey::default(), reward, &None).unwrap();
         let vote_state = vote_state_from_account(&account_shared_data);
         assert_eq!(reward, vote_state.epoch_credits().last().unwrap().1);
     }
@@ -440,9 +435,12 @@ mod tests {
         let bank = Bank::new_from_parent(prev_bank.clone(), slot_leader, current_slot);
         let reward_slot = current_slot - NUM_SLOTS_FOR_REWARD;
 
-        calculate_and_pay_voting_reward_and_update_vote_state(
+        calc_vote_rewards_update_vote_states(
             &bank,
-            Some((reward_slot, validator_pubkeys_to_reward.clone())),
+            Some(ValidatedRewardCert::new_for_tests(
+                reward_slot,
+                validator_pubkeys_to_reward.clone(),
+            )),
             None,
         )
         .unwrap();
@@ -518,21 +516,25 @@ mod tests {
                 })
                 .unwrap()
         };
-        let final_cert = build_fast_finalization_cert(&bank, &[cert_rank]);
+        let (final_cert_signers, final_cert_slot) =
+            build_fast_finalization_cert(&bank, &[cert_rank]);
 
-        calculate_and_pay_voting_reward_and_update_vote_state(
+        calc_vote_rewards_update_vote_states(
             &bank,
-            Some((reward_slot, vec![target_vote_pubkey])),
-            Some(&final_cert),
+            Some(ValidatedRewardCert::new_for_tests(
+                reward_slot,
+                vec![target_vote_pubkey],
+            )),
+            Some((&final_cert_signers, final_cert_slot)),
         )
         .unwrap();
 
         let handle = vote_state_from_bank(&bank, &target_vote_pubkey);
-        assert_eq!(handle.root_slot(), Some(final_cert.slot()));
+        assert_eq!(handle.root_slot(), Some(final_cert_slot));
         assert_eq!(handle.votes().len(), 1);
         assert_eq!(
             handle.votes().front().unwrap().lockout.slot(),
-            final_cert.slot().max(reward_slot)
+            final_cert_slot.max(reward_slot)
         );
     }
 
@@ -582,12 +584,16 @@ mod tests {
                 })
                 .unwrap()
         };
-        let final_cert = build_fast_finalization_cert(&bank, &[cert_rank]);
+        let (final_cert_signers, final_cert_slot) =
+            build_fast_finalization_cert(&bank, &[cert_rank]);
 
-        calculate_and_pay_voting_reward_and_update_vote_state(
+        calc_vote_rewards_update_vote_states(
             &bank,
-            Some((reward_slot, vec![target_vote_pubkey])),
-            Some(&final_cert),
+            Some(ValidatedRewardCert::new_for_tests(
+                reward_slot,
+                vec![target_vote_pubkey],
+            )),
+            Some((&final_cert_signers, final_cert_slot)),
         )
         .unwrap();
 
@@ -639,9 +645,12 @@ mod tests {
         let bank = Bank::new_from_parent(prev_bank.clone(), slot_leader, current_slot);
         let reward_slot = current_slot - NUM_SLOTS_FOR_REWARD;
 
-        calculate_and_pay_voting_reward_and_update_vote_state(
+        calc_vote_rewards_update_vote_states(
             &bank,
-            Some((reward_slot, vec![vote_pubkey])),
+            Some(ValidatedRewardCert::new_for_tests(
+                reward_slot,
+                vec![vote_pubkey],
+            )),
             None,
         )
         .unwrap();

--- a/runtime/src/validated_block_finalization.rs
+++ b/runtime/src/validated_block_finalization.rs
@@ -305,18 +305,25 @@ impl ValidatedBlockFinalizationCert {
         self.signers.contains(vote_pubkey)
     }
 
-    /// Consumes self and returns the contained certificates.
+    /// Returns the data needed to calculating and paying vote rewards.
+    pub fn vote_rewards_input(&self) -> (&HashSet<Pubkey>, Slot) {
+        (&self.signers, self.slot())
+    }
+
+    /// Consumes self and returns the contained certificates and the signers.
     ///
-    /// For slow finalization, returns (finalize_cert, Some(notarize_cert)).
-    /// For fast finalization, returns (fast_finalize_cert, None).
-    pub fn into_certificates(self) -> (Certificate, Option<Certificate>) {
-        match self.kind {
+    /// For slow finalization, returns (signers, finalize_cert, Some(notarize_cert)).
+    /// For fast finalization, returns (signers, fast_finalize_cert, None).
+    pub fn into_parts(self) -> (HashSet<Pubkey>, Certificate, Option<Certificate>) {
+        let signers = self.signers;
+        let (final_cert, notar_cert) = match self.kind {
             ValidatedBlockFinalizationCertKind::Finalize {
                 finalize_cert,
                 notarize_cert,
             } => (finalize_cert, Some(notarize_cert)),
             ValidatedBlockFinalizationCertKind::FastFinalize(cert) => (cert, None),
-        }
+        };
+        (signers, final_cert, notar_cert)
     }
 
     /// Converts this validated certificate into a [`FinalCertificate`] for inclusion in a block footer.

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -8,6 +8,7 @@ use {
     solana_bls_signatures::BlsError,
     solana_clock::Slot,
     solana_pubkey::Pubkey,
+    std::collections::HashSet,
     thiserror::Error,
 };
 
@@ -68,9 +69,9 @@ fn extract_slot(
 }
 
 /// Struct built by validating incoming reward certs.
-pub(crate) struct ValidatedRewardCert {
+pub struct ValidatedRewardCert {
     /// List of validators that were present in the reward certs.
-    validators: Vec<Pubkey>,
+    validators: HashSet<Pubkey>,
     /// The slot the reward certs refer to
     reward_slot: Slot,
 }
@@ -90,11 +91,11 @@ impl ValidatedRewardCert {
             .ok_or(Error::NoRankMap)?
             .bls_pubkey_to_rank_map();
         let max_validators = rank_map.len();
-        let mut validators = Vec::with_capacity(max_validators);
+        let mut validators = HashSet::with_capacity(max_validators);
 
         let mut rank_map = |ind: usize| {
             rank_map.get_pubkey_stake_entry(ind).map(|entry| {
-                validators.push(entry.vote_account_pubkey);
+                validators.insert(entry.vote_account_pubkey);
                 entry.bls_pubkey
             })
         };
@@ -133,8 +134,17 @@ impl ValidatedRewardCert {
     }
 
     /// Returns the validators that were extracted from the reward certs.
-    pub(crate) fn into_parts(self) -> (Slot, Vec<Pubkey>) {
+    pub(crate) fn into_parts(self) -> (Slot, HashSet<Pubkey>) {
         (self.reward_slot, self.validators)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_tests(reward_slot: Slot, validators: Vec<Pubkey>) -> Self {
+        let validators = validators.into_iter().collect();
+        Self {
+            reward_slot,
+            validators,
+        }
     }
 }
 

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -61,6 +61,7 @@ pub(crate) struct ConsensusPoolContext {
     pub(crate) event_sender: VotorEventSender,
     pub(crate) commitment_sender: Sender<CommitmentAggregationData>,
 
+    /// Used to communicate the highest finalization cert the pool has observed to the block creation loop.
     pub(crate) highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
 }
 


### PR DESCRIPTION
#### Problem
There is a bug in how `vote_reward.rs` currently works.  If no reward cert was presented, then the function is NOP.  This is a problem as then the function doesn't handle the finalization cert.  

Further, the function iterates over the validators in the reward cert and updates the root_slot for them.  So if there are validators in the finalization cert that are not in the reward cert, their root slot will also not be updated.


#### Summary of Changes

This PR fixes doesn't actually fix the above problem but introduces the following refactoring to help us fix the bug.  The actual bug fix is planned to be done in https://github.com/anza-xyz/agave/pull/12183.


- validated reward cert stores the validators in a hashset so it matches how validators are stored in the finalization cert and we can efficiently evaluate group membership.
- minor changes to validated block finalization cert so that we can get the inputs for vote_reward.rs and the certs to send to the consensus pool without introducing any cloning.
- Renamed `calculate_and_pay_voting_reward_and_update_vote_state` to `calc_vote_rewards_update_vote_states` which is shorter and more "correct".
- `calc_vote_rewards_update_vote_states` doesn't take the finalization cert to avoid cloning.
- to reduce cloning, the block creation loop `take`s the highest finalized cert from the lock shared with the consensus pool service.  And since all the users of this lock are only ever taking the write lock, changed the lock to a mutex.
