### PR TITLE
fix(rpc): return error when leader schedule not found for validator

### DIFF
--- a/rpc-client-api/src/custom_error.rs
+++ b/rpc-client-api/src/custom_error.rs
@@ -30,6 +30,7 @@ pub const JSON_RPC_SERVER_ERROR_SLOT_NOT_EPOCH_BOUNDARY: i64 = -32018;
 pub const JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE: i64 = -32019;
 pub const JSON_RPC_SERVER_ERROR_FILTER_TRANSACTION_NOT_FOUND: i64 = -32020;
 pub const JSON_RPC_SERVER_ERROR_NO_SLOT_HISTORY: i64 = -32021;
+pub const JSON_RPC_SERVER_ERROR_LEADER_SCHEDULE_IDENTITY_NOT_FOUND: i64 = -32022;
 
 #[derive(Error, Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -86,6 +87,8 @@ pub enum RpcCustomError {
     FilterTransactionNotFound { signature: String },
     #[error("NoSlotHistory")]
     NoSlotHistory,
+    #[error("LeaderScheduleIdentityNotFound")]
+    LeaderScheduleIdentityNotFound { identity: String },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -273,6 +276,15 @@ impl From<RpcCustomError> for Error {
             RpcCustomError::NoSlotHistory => Self {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_NO_SLOT_HISTORY),
                 message: "No slot history".to_string(),
+                data: None,
+            },
+            RpcCustomError::LeaderScheduleIdentityNotFound { identity } => Self {
+                code: ErrorCode::ServerError(
+                    JSON_RPC_SERVER_ERROR_LEADER_SCHEDULE_IDENTITY_NOT_FOUND,
+                ),
+                message: format!(
+                    "Node {identity} was not in the leader schedule for specified epoch"
+                ),
                 data: None,
             },
         }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2960,28 +2960,23 @@ pub mod rpc_minimal {
 
             debug!("get_leader_schedule rpc request received: {slot:?}");
 
-            let get_leader_schedule_result = if let Some(leader_schedule) = meta
-            .leader_schedule_cache
-            .get_epoch_leader_schedule(epoch)
-            .map(|leader_schedule| {
-                let mut schedule_by_identity =
-                    solana_runtime::leader_schedule_utils::leader_schedule_by_identity(
-                        leader_schedule
-                            .get_slot_leaders()
-                            .map(|slot_leader| &slot_leader.id)
-                            .enumerate(),
-                    );
-                if let Some(identity) = config.identity {
-                    schedule_by_identity.retain(|k, _| *k == identity);
-                }
-                schedule_by_identity
-            }) && !leader_schedule.is_empty() {
-                Some(leader_schedule)
-            } else {
-                None
-            };
-
-            Ok(get_leader_schedule_result)
+            Ok(meta
+                .leader_schedule_cache
+                .get_epoch_leader_schedule(epoch)
+                .map(|leader_schedule| {
+                    let mut schedule_by_identity =
+                        solana_runtime::leader_schedule_utils::leader_schedule_by_identity(
+                            leader_schedule
+                                .get_slot_leaders()
+                                .map(|slot_leader| &slot_leader.id)
+                                .enumerate(),
+                        );
+                    if let Some(identity) = config.identity {
+                        schedule_by_identity.retain(|k, _| *k == identity);
+                    }
+                    schedule_by_identity
+                })
+                .filter(|schedule_by_identity| !schedule_by_identity.is_empty()))
         }
     }
 }
@@ -5515,7 +5510,7 @@ pub mod tests {
         );
         let result: Option<RpcLeaderSchedule> =
             parse_success_result(rpc.handle_request_sync(request));
-        let expected = Some(HashMap::default());
+        let expected = None;
         assert_eq!(result, expected);
     }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2960,7 +2960,7 @@ pub mod rpc_minimal {
 
             debug!("get_leader_schedule rpc request received: {slot:?}");
 
-            Ok(meta
+            if let Some(leader_schedule) = meta
                 .leader_schedule_cache
                 .get_epoch_leader_schedule(epoch)
                 .map(|leader_schedule| {
@@ -2975,7 +2975,14 @@ pub mod rpc_minimal {
                         schedule_by_identity.retain(|k, _| *k == identity);
                     }
                     schedule_by_identity
-                }))
+                })
+            {
+                Ok(Some(leader_schedule))
+            } else {
+                Err(Error::invalid_params(format!(
+                    "Unable to fetch leader schedule for slot: {slot}"
+                )))
+            }
         }
     }
 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2960,29 +2960,28 @@ pub mod rpc_minimal {
 
             debug!("get_leader_schedule rpc request received: {slot:?}");
 
-            if let Some(leader_schedule) = meta
-                .leader_schedule_cache
-                .get_epoch_leader_schedule(epoch)
-                .map(|leader_schedule| {
-                    let mut schedule_by_identity =
-                        solana_runtime::leader_schedule_utils::leader_schedule_by_identity(
-                            leader_schedule
-                                .get_slot_leaders()
-                                .map(|slot_leader| &slot_leader.id)
-                                .enumerate(),
-                        );
-                    if let Some(identity) = config.identity {
-                        schedule_by_identity.retain(|k, _| *k == identity);
-                    }
-                    schedule_by_identity
-                })
-            {
-                Ok(Some(leader_schedule))
+            let get_leader_schedule_result = if let Some(leader_schedule) = meta
+            .leader_schedule_cache
+            .get_epoch_leader_schedule(epoch)
+            .map(|leader_schedule| {
+                let mut schedule_by_identity =
+                    solana_runtime::leader_schedule_utils::leader_schedule_by_identity(
+                        leader_schedule
+                            .get_slot_leaders()
+                            .map(|slot_leader| &slot_leader.id)
+                            .enumerate(),
+                    );
+                if let Some(identity) = config.identity {
+                    schedule_by_identity.retain(|k, _| *k == identity);
+                }
+                schedule_by_identity
+            }) && !leader_schedule.is_empty() {
+                Some(leader_schedule)
             } else {
-                Err(Error::invalid_params(format!(
-                    "Unable to fetch leader schedule for slot: {slot}"
-                )))
-            }
+                None
+            };
+
+            Ok(get_leader_schedule_result)
         }
     }
 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2971,7 +2971,7 @@ pub mod rpc_minimal {
 
             debug!("get_leader_schedule rpc request received: {slot:?}");
 
-            Ok(meta
+            let schedule_by_identity = meta
                 .leader_schedule_cache
                 .get_epoch_leader_schedule(epoch)
                 .map(|leader_schedule| {
@@ -2982,11 +2982,20 @@ pub mod rpc_minimal {
                                 .map(|slot_leader| &slot_leader.id)
                                 .enumerate(),
                         );
-                    if let Some(identity) = config.identity {
-                        schedule_by_identity.retain(|k, _| *k == identity);
+                    if let Some(ref identity) = config.identity {
+                        schedule_by_identity.retain(|k, _| k == identity);
                     }
                     schedule_by_identity
-                }))
+                });
+
+            if let Some(identity) = config.identity
+                && let Some(scheduled_by_identity) = &schedule_by_identity
+                && scheduled_by_identity.is_empty()
+            {
+                return Err(RpcCustomError::LeaderScheduleIdentityNotFound { identity }.into());
+            }
+
+            Ok(schedule_by_identity)
         }
     }
 }
@@ -4620,6 +4629,7 @@ pub mod tests {
         solana_rpc_client_api::{
             custom_error::{
                 JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE,
+                JSON_RPC_SERVER_ERROR_LEADER_SCHEDULE_IDENTITY_NOT_FOUND,
                 JSON_RPC_SERVER_ERROR_TRANSACTION_HISTORY_NOT_AVAILABLE,
                 JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION,
             },
@@ -5545,14 +5555,15 @@ pub mod tests {
         let expected: Option<RpcLeaderSchedule> = None;
         assert_eq!(result, expected);
 
-        let request = create_test_request(
-            "getLeaderSchedule",
-            Some(json!([{"identity": Pubkey::new_unique().to_string() }])),
+        let identity = Pubkey::new_unique().to_string();
+        let request =
+            create_test_request("getLeaderSchedule", Some(json!([{"identity": identity }])));
+        let response = parse_failure_response(rpc.handle_request_sync(request));
+        let expected = (
+            JSON_RPC_SERVER_ERROR_LEADER_SCHEDULE_IDENTITY_NOT_FOUND,
+            format!("Node {identity} was not in the leader schedule for specified epoch"),
         );
-        let result: Option<RpcLeaderSchedule> =
-            parse_success_result(rpc.handle_request_sync(request));
-        let expected = Some(HashMap::default());
-        assert_eq!(result, expected);
+        assert_eq!(response, expected);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Calling the `getLeaderSchedule` rpc method with an invalid pubkey returns `{"jsonrpc":"2.0","result":{},"id":1}`.

#### Summary of Changes
Adds Err handling when `get_epoch_leader_schedule(epoch)` returns None

Some context for the issue: https://github.com/anza-xyz/agave/issues/6845#issuecomment-3097511362