### PR TITLE
chore: Move Validator::new() argument into ValidatorConfig

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -327,6 +327,7 @@ pub struct ValidatorConfig {
     pub repair_validators: Option<HashSet<Pubkey>>, // None = repair from all
     pub repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>, // Empty = repair with all
     pub gossip_validators: Option<HashSet<Pubkey>>, // None = gossip with all
+    pub should_check_duplicate_instance: bool,
     pub max_genesis_archive_unpacked_size: u64,
     /// Run PoH, transaction signature and other transaction verification during blockstore
     /// processing.
@@ -405,6 +406,7 @@ impl ValidatorConfig {
             new_hard_forks: None,
             known_validators: None,
             repair_validators: None,
+            should_check_duplicate_instance: true,
             repair_whitelist: Arc::new(RwLock::new(HashSet::default())),
             gossip_validators: None,
             max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
@@ -659,7 +661,6 @@ impl Validator {
         authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
         cluster_entrypoints: Vec<ContactInfo>,
         config: &ValidatorConfig,
-        should_check_duplicate_instance: bool,
         rpc_to_plugin_manager_receiver: Option<Receiver<GeyserPluginManagerRequest>>,
         start_progress: Arc<RwLock<ValidatorStartProgress>>,
         socket_addr_space: SocketAddrSpace,
@@ -676,7 +677,6 @@ impl Validator {
             authorized_voter_keypairs,
             cluster_entrypoints,
             config,
-            should_check_duplicate_instance,
             rpc_to_plugin_manager_receiver,
             start_progress,
             socket_addr_space,
@@ -696,7 +696,6 @@ impl Validator {
         authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
         cluster_entrypoints: Vec<ContactInfo>,
         config: &ValidatorConfig,
-        should_check_duplicate_instance: bool,
         rpc_to_plugin_manager_receiver: Option<Receiver<GeyserPluginManagerRequest>>,
         start_progress: Arc<RwLock<ValidatorStartProgress>>,
         socket_addr_space: SocketAddrSpace,
@@ -1392,7 +1391,7 @@ impl Validator {
             Some(epoch_specs),
             node.sockets.gossip.clone(),
             config.gossip_validators.clone(),
-            should_check_duplicate_instance,
+            config.should_check_duplicate_instance,
             Some(stats_reporter_sender.clone()),
             exit.clone(),
         );
@@ -2915,7 +2914,6 @@ mod tests {
             Arc::new(RwLock::new(vec![voting_keypair])),
             vec![leader_node.info],
             &config,
-            true, // should_check_duplicate_instance
             None, // rpc_to_plugin_manager_receiver
             start_progress.clone(),
             SocketAddrSpace::Unspecified,
@@ -3134,7 +3132,6 @@ mod tests {
                     Arc::new(RwLock::new(vec![Arc::new(vote_account_keypair)])),
                     vec![leader_node.info.clone()],
                     &config,
-                    true, // should_check_duplicate_instance.
                     None, // rpc_to_plugin_manager_receiver
                     Arc::new(RwLock::new(ValidatorStartProgress::default())),
                     SocketAddrSpace::Unspecified,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -454,7 +454,6 @@ impl LocalCluster {
                 Arc::new(RwLock::new(vec![leader_vote_keypair.clone()])),
                 vec![],
                 &leader_config,
-                true, // should_check_duplicate_instance
                 None, // rpc_to_plugin_manager_receiver
                 Arc::new(RwLock::new(ValidatorStartProgress::default())),
                 socket_addr_space,
@@ -662,7 +661,6 @@ impl LocalCluster {
             Arc::new(RwLock::new(vec![voting_keypair.clone()])),
             vec![self.entry_point_info.clone()],
             &config,
-            true, // should_check_duplicate_instance
             None, // rpc_to_plugin_manager_receiver
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
@@ -728,7 +726,6 @@ impl LocalCluster {
                 Arc::new(RwLock::new(vec![leader_vote_keypair.clone()])),
                 vec![],
                 &leader_config,
-                true, // should_check_duplicate_instance
                 None, // rpc_to_plugin_manager_receiver
                 Arc::new(RwLock::new(ValidatorStartProgress::default())),
                 socket_addr_space,
@@ -789,7 +786,6 @@ impl LocalCluster {
                     Arc::new(RwLock::new(vec![voting_keypair.clone()])),
                     entry_points,
                     &config,
-                    true, // should_check_duplicate_instance
                     None, // rpc_to_plugin_manager_receiver
                     Arc::new(RwLock::new(ValidatorStartProgress::default())),
                     socket_addr_space,
@@ -1420,7 +1416,6 @@ impl Cluster for LocalCluster {
             Arc::new(RwLock::new(vec![validator_info.voting_keypair.clone()])),
             entry_point_infos,
             &safe_clone_config(&cluster_validator_info.config),
-            true, // should_check_duplicate_instance
             None, // rpc_to_plugin_manager_receiver
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -27,6 +27,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         wait_for_supermajority: config.wait_for_supermajority,
         new_hard_forks: config.new_hard_forks.clone(),
         known_validators: config.known_validators.clone(),
+        should_check_duplicate_instance: config.should_check_duplicate_instance,
         repair_validators: config.repair_validators.clone(),
         repair_whitelist: config.repair_whitelist.clone(),
         gossip_validators: config.gossip_validators.clone(),

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1159,7 +1159,6 @@ impl TestValidator {
             config.authorized_voter_keypairs.clone(),
             vec![],
             &validator_config,
-            true, // should_check_duplicate_instance
             rpc_to_plugin_manager_receiver,
             config.start_progress.clone(),
             socket_addr_space,

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1292,7 +1292,6 @@ mod tests {
                 authorized_voter_keypairs,
                 vec![leader_node.info],
                 &validator_config,
-                true, // should_check_duplicate_instance
                 None, // rpc_to_plugin_manager_receiver
                 start_progress.clone(),
                 SocketAddrSpace::Unspecified,

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -560,7 +560,6 @@ pub fn rpc_bootstrap(
     do_port_check: bool,
     use_progress_bar: bool,
     maximum_local_snapshot_age: Slot,
-    should_check_duplicate_instance: bool,
     start_progress: &Arc<RwLock<ValidatorStartProgress>>,
     minimal_snapshot_download_speed: f32,
     maximum_snapshot_download_abort: u64,
@@ -610,7 +609,7 @@ pub fn rpc_bootstrap(
                     .expected_shred_version
                     .expect("expected_shred_version should not be None"),
                 validator_config.gossip_validators.clone(),
-                should_check_duplicate_instance,
+                validator_config.should_check_duplicate_instance,
                 socket_addr_space,
             ));
         }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -810,6 +810,7 @@ pub fn execute(
         wait_for_supermajority: value_t!(matches, "wait_for_supermajority", Slot).ok(),
         known_validators: run_args.known_validators,
         repair_validators,
+        should_check_duplicate_instance: true,
         repair_whitelist,
         repair_handler_type: RepairHandlerType::default(),
         gossip_validators,
@@ -1034,7 +1035,6 @@ pub fn execute(
             .incremental_snapshot_archives_dir,
     );
 
-    let should_check_duplicate_instance = true;
     if !cluster_entrypoints.is_empty() {
         bootstrap::rpc_bootstrap(
             &node,
@@ -1048,7 +1048,6 @@ pub fn execute(
             do_port_check,
             use_progress_bar,
             maximum_local_snapshot_age,
-            should_check_duplicate_instance,
             &start_progress,
             minimal_snapshot_download_speed,
             maximum_snapshot_download_abort,
@@ -1127,7 +1126,6 @@ pub fn execute(
         authorized_voter_keypairs,
         cluster_entrypoints,
         &validator_config,
-        should_check_duplicate_instance,
         rpc_to_plugin_manager_receiver,
         start_progress,
         run_args.socket_addr_space,


### PR DESCRIPTION
#### Problem
Validator::new() has too many arguments:
https://github.com/anza-xyz/agave/blob/be7866f31fc49a142ed640f5ec59327c6b115d6e/core/src/validator.rs#L652-L654

#### Summary of Changes
Shift the `should_check_duplicate_instance` argument into `ValidatorConfig`
