### PR TITLE
CI - Bypass deployment of SBPFv0 in tests

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8649,6 +8649,7 @@ dependencies = [
  "solana-perf",
  "solana-poh-config",
  "solana-precompile-error",
+ "solana-program-binaries",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
  "solana-rayon-threadlimit",

--- a/program-binaries/src/lib.rs
+++ b/program-binaries/src/lib.rs
@@ -75,7 +75,11 @@ static CORE_BPF_PROGRAMS: &[(Pubkey, Option<Pubkey>, &[u8])] = &[
 /// Returns a tuple `(Pubkey, Account)` for a BPF program, where the key is the
 /// provided program ID and the account is a valid BPF Loader program account
 /// containing the ELF.
-fn bpf_loader_program_account(program_id: &Pubkey, elf: &[u8], rent: &Rent) -> (Pubkey, Account) {
+pub fn bpf_loader_program_account(
+    program_id: &Pubkey,
+    elf: &[u8],
+    rent: &Rent,
+) -> (Pubkey, Account) {
     (
         *program_id,
         Account {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8280,6 +8280,7 @@ dependencies = [
  "solana-perf",
  "solana-poh-config",
  "solana-precompile-error",
+ "solana-program-binaries",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
  "solana-rayon-threadlimit",

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -815,30 +815,13 @@ fn test_program_sbf_invoke_sanity() {
         } = create_genesis_config(50);
 
         let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        let invoke_program_id = create_program(&bank, &bpf_loader_upgradeable::id(), program.1);
+        let invoked_program_id = create_program(&bank, &bpf_loader_upgradeable::id(), program.2);
+        let noop_program_id = create_program(&bank, &bpf_loader_upgradeable::id(), program.3);
         let mut bank_client = BankClient::new_shared(bank.clone());
-        let authority_keypair = Keypair::new();
-
-        let (_bank, invoke_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
-            program.1,
-        );
-        let (_bank, invoked_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
-            program.2,
-        );
-        let (bank, noop_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
-            program.3,
-        );
+        let bank = bank_client
+            .advance_slot(1, &bank_forks, SlotLeader::default())
+            .unwrap();
 
         let argument_keypair = Keypair::new();
         let account = AccountSharedData::new(42, 100, &invoke_program_id);
@@ -1794,16 +1777,15 @@ fn test_program_sbf_instruction_introspection() {
     } = create_genesis_config(50_000);
 
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let mut bank_client = BankClient::new_shared(bank.clone());
-    let authority_keypair = Keypair::new();
-
-    let (_bank, program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
+    let program_id = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
         "solana_sbf_rust_instruction_introspection",
     );
+    let mut bank_client = BankClient::new_shared(bank.clone());
+    let bank = bank_client
+        .advance_slot(1, &bank_forks, SlotLeader::default())
+        .unwrap();
 
     // Passing transaction
     let account_metas = vec![
@@ -2755,16 +2737,15 @@ fn test_program_sbf_realloc() {
             feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-        let mut bank_client = BankClient::new_shared(bank.clone());
-        let authority_keypair = Keypair::new();
-
-        let (bank, program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
+        let program_id = create_program(
+            &bank,
+            &bpf_loader_upgradeable::id(),
             "solana_sbf_rust_realloc",
         );
+        let mut bank_client = BankClient::new_shared(bank.clone());
+        let bank = bank_client
+            .advance_slot(1, &bank_forks, SlotLeader::default())
+            .unwrap();
 
         let mut bump = 0;
         let keypair = Keypair::new();
@@ -3172,23 +3153,20 @@ fn test_program_sbf_realloc_invoke() {
     let signer = &[&mint_keypair];
 
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let mut bank_client = BankClient::new_shared(bank.clone());
-    let authority_keypair = Keypair::new();
-
-    let (_bank, realloc_program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
+    let realloc_program_id = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
         "solana_sbf_rust_realloc",
     );
-    let (bank, realloc_invoke_program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
+    let realloc_invoke_program_id = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
         "solana_sbf_rust_realloc_invoke",
     );
+    let mut bank_client = BankClient::new_shared(bank.clone());
+    let bank = bank_client
+        .advance_slot(1, &bank_forks, SlotLeader::default())
+        .unwrap();
 
     let mut bump = 0;
     let keypair = Keypair::new();
@@ -3825,37 +3803,27 @@ fn test_program_sbf_processed_inner_instruction() {
     } = create_genesis_config(50);
 
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let mut bank_client = BankClient::new_shared(bank.clone());
-    let authority_keypair = Keypair::new();
-
-    let (_bank, sibling_program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
+    let sibling_program_id = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
         "solana_sbf_rust_sibling_instructions",
     );
-    let (_bank, sibling_inner_program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
+    let sibling_inner_program_id = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
         "solana_sbf_rust_sibling_inner_instructions",
     );
-    let (_bank, noop_program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
-        "solana_sbf_rust_noop",
-    );
-    let (_bank, invoke_and_return_program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
+    let noop_program_id =
+        create_program(&bank, &bpf_loader_upgradeable::id(), "solana_sbf_rust_noop");
+    let invoke_and_return_program_id = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
         "solana_sbf_rust_invoke_and_return",
     );
+    let mut bank_client = BankClient::new_shared(bank.clone());
+    bank_client
+        .advance_slot(1, &bank_forks, SlotLeader::default())
+        .unwrap();
 
     let instruction2 = Instruction::new_with_bytes(
         noop_program_id,
@@ -3926,17 +3894,11 @@ fn test_program_fees() {
     };
     bank.set_fee_structure(&fee_structure);
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-    let feature_set = bank.feature_set.clone();
+    let program_id = create_program(&bank, &bpf_loader_upgradeable::id(), "solana_sbf_rust_noop");
     let mut bank_client = BankClient::new_shared(bank.clone());
-    let authority_keypair = Keypair::new();
-
-    let (_bank, program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
-        "solana_sbf_rust_noop",
-    );
+    let bank = bank_client
+        .advance_slot(1, &bank_forks, SlotLeader::default())
+        .unwrap();
 
     let pre_balance = bank_client.get_balance(&mint_keypair.pubkey()).unwrap();
     let message = Message::new(
@@ -3949,6 +3911,7 @@ fn test_program_fees() {
         &ReservedAccountKeys::empty_key_set(),
     )
     .unwrap();
+    let feature_set = bank.feature_set.clone();
     let prioritization_fee = process_compute_budget_instructions(
         SVMStaticMessage::program_instructions_iter(&sanitized_message),
         &feature_set,
@@ -4061,30 +4024,25 @@ fn test_cpi_account_ownership_writability() {
 
         bank.feature_set = Arc::new(feature_set);
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-        let mut bank_client = BankClient::new_shared(bank);
-        let authority_keypair = Keypair::new();
-
-        let (_bank, invoke_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
+        let invoke_program_id = create_program(
+            &bank,
+            &bpf_loader_upgradeable::id(),
             "solana_sbf_rust_invoke",
         );
-        let (_bank, invoked_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
+        let invoked_program_id = create_program(
+            &bank,
+            &bpf_loader_upgradeable::id(),
             "solana_sbf_rust_invoked",
         );
-        let (bank, realloc_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
+        let realloc_program_id = create_program(
+            &bank,
+            &bpf_loader_upgradeable::id(),
             "solana_sbf_rust_realloc",
         );
+        let mut bank_client = BankClient::new_shared(bank.clone());
+        let bank = bank_client
+            .advance_slot(1, &bank_forks, SlotLeader::default())
+            .unwrap();
 
         let account_keypair = Keypair::new();
 
@@ -4263,22 +4221,16 @@ fn test_cpi_account_data_updates() {
         }
 
         bank.feature_set = Arc::new(feature_set);
-        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-        let mut bank_client = BankClient::new_shared(bank);
-        let authority_keypair = Keypair::new();
 
-        let (_bank, invoke_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+        let invoke_program_id = create_program(
+            &bank,
+            &bpf_loader_upgradeable::id(),
             "solana_sbf_rust_invoke",
         );
-        let (bank, realloc_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
+        let realloc_program_id = create_program(
+            &bank,
+            &bpf_loader_upgradeable::id(),
             "solana_sbf_rust_realloc",
         );
         let deprecated_program_id = create_program(
@@ -4286,6 +4238,10 @@ fn test_cpi_account_data_updates() {
             &bpf_loader_deprecated::id(),
             "solana_sbf_rust_deprecated_loader",
         );
+        let mut bank_client = BankClient::new_shared(bank.clone());
+        let bank = bank_client
+            .advance_slot(1, &bank_forks, SlotLeader::default())
+            .unwrap();
 
         let account_keypair = Keypair::new();
         let mint_pubkey = mint_keypair.pubkey();
@@ -4515,8 +4471,6 @@ fn test_cpi_invalid_account_info_pointers() {
 
     let bank = Bank::new_for_tests(&genesis_config);
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-    let mut bank_client = BankClient::new_shared(bank);
-    let authority_keypair = Keypair::new();
 
     let account_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -4527,41 +4481,28 @@ fn test_cpi_invalid_account_info_pointers() {
 
     let mut program_ids: Vec<Pubkey> = Vec::with_capacity(2);
 
-    #[allow(unused_mut)]
-    let mut bank;
     #[cfg(feature = "sbf_rust")]
     {
-        let (new_bank, invoke_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
+        let invoke_program_id = create_program(
+            &bank,
+            &bpf_loader_upgradeable::id(),
             "solana_sbf_rust_invoke",
         );
         account_metas.push(AccountMeta::new_readonly(invoke_program_id, false));
         program_ids.push(invoke_program_id);
-        #[allow(unused)]
-        {
-            bank = new_bank;
-        }
     }
 
     #[cfg(feature = "sbf_c")]
     {
-        let (new_bank, c_invoke_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
-            "invoke",
-        );
+        let c_invoke_program_id = create_program(&bank, &bpf_loader_upgradeable::id(), "invoke");
         account_metas.push(AccountMeta::new_readonly(c_invoke_program_id, false));
         program_ids.push(c_invoke_program_id);
-        #[allow(unused)]
-        {
-            bank = new_bank;
-        }
     }
+
+    let mut bank_client = BankClient::new_shared(bank.clone());
+    let bank = bank_client
+        .advance_slot(1, &bank_forks, SlotLeader::default())
+        .unwrap();
 
     for invoke_program_id in &program_ids {
         for ix in [
@@ -4602,15 +4543,15 @@ fn test_deplete_cost_meter_with_access_violation() {
 
     let bank = Bank::new_for_tests(&genesis_config);
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-    let mut bank_client = BankClient::new_shared(bank.clone());
-    let authority_keypair = Keypair::new();
-    let (bank, invoke_program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        bank_forks.as_ref(),
-        &mint_keypair,
-        &authority_keypair,
+    let invoke_program_id = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
         "solana_sbf_rust_invoke",
     );
+    let mut bank_client = BankClient::new_shared(bank.clone());
+    let bank = bank_client
+        .advance_slot(1, &bank_forks, SlotLeader::default())
+        .unwrap();
 
     let account_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -4714,16 +4655,16 @@ fn test_deny_access_beyond_current_length() {
             feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-        let mut bank_client = BankClient::new_shared(bank);
-        let authority_keypair = Keypair::new();
-
-        let (bank, invoke_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
+        let invoke_program_id = create_program(
+            &bank,
+            &bpf_loader_upgradeable::id(),
             "solana_sbf_rust_invoke",
         );
+        let mut bank_client = BankClient::new_shared(bank.clone());
+        let bank = bank_client
+            .advance_slot(1, &bank_forks, SlotLeader::default())
+            .unwrap();
+
         let account = AccountSharedData::new(42, 0, &invoke_program_id);
         let readonly_account_keypair = Keypair::new();
         let writable_account_keypair = Keypair::new();
@@ -4784,16 +4725,15 @@ fn test_deny_executable_write() {
             feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-        let mut bank_client = BankClient::new_shared(bank);
-        let authority_keypair = Keypair::new();
-
-        let (_bank, invoke_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
+        let invoke_program_id = create_program(
+            &bank,
+            &bpf_loader_upgradeable::id(),
             "solana_sbf_rust_invoke",
         );
+        let mut bank_client = BankClient::new_shared(bank.clone());
+        bank_client
+            .advance_slot(1, &bank_forks, SlotLeader::default())
+            .unwrap();
 
         let account_keypair = Keypair::new();
         let mint_pubkey = mint_keypair.pubkey();
@@ -4841,16 +4781,15 @@ fn test_update_callee_account() {
             feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-        let mut bank_client = BankClient::new_shared(bank.clone());
-        let authority_keypair = Keypair::new();
-
-        let (bank, invoke_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
+        let invoke_program_id = create_program(
+            &bank,
+            &bpf_loader_upgradeable::id(),
             "solana_sbf_rust_invoke",
         );
+        let mut bank_client = BankClient::new_shared(bank.clone());
+        let bank = bank_client
+            .advance_slot(1, &bank_forks, SlotLeader::default())
+            .unwrap();
 
         let account_keypair = Keypair::new();
 
@@ -5128,16 +5067,11 @@ fn test_account_info_in_account() {
             }
 
             let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+            let invoke_program_id = create_program(&bank, &bpf_loader_upgradeable::id(), program);
             let mut bank_client = BankClient::new_shared(bank.clone());
-            let authority_keypair = Keypair::new();
-
-            let (bank, invoke_program_id) = load_upgradeable_program_and_advance_slot(
-                &mut bank_client,
-                &bank_forks,
-                &mint_keypair,
-                &authority_keypair,
-                program,
-            );
+            let bank = bank_client
+                .advance_slot(1, &bank_forks, SlotLeader::default())
+                .unwrap();
 
             let account_keypair = Keypair::new();
 
@@ -5191,16 +5125,15 @@ fn test_account_info_rc_in_account() {
         }
 
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-        let mut bank_client = BankClient::new_shared(bank.clone());
-        let authority_keypair = Keypair::new();
-
-        let (bank, invoke_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
+        let invoke_program_id = create_program(
+            &bank,
+            &bpf_loader_upgradeable::id(),
             "solana_sbf_rust_invoke",
         );
+        let mut bank_client = BankClient::new_shared(bank.clone());
+        let bank = bank_client
+            .advance_slot(1, &bank_forks, SlotLeader::default())
+            .unwrap();
 
         let account_keypair = Keypair::new();
 
@@ -5282,23 +5215,20 @@ fn test_clone_account_data() {
     feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
 
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+    let invoke_program_id = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
+        "solana_sbf_rust_invoke",
+    );
+    let invoke_program_id2 = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
+        "solana_sbf_rust_invoke",
+    );
     let mut bank_client = BankClient::new_shared(bank.clone());
-    let authority_keypair = Keypair::new();
-
-    let (_bank, invoke_program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
-        "solana_sbf_rust_invoke",
-    );
-    let (bank, invoke_program_id2) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
-        "solana_sbf_rust_invoke",
-    );
+    let bank = bank_client
+        .advance_slot(1, &bank_forks, SlotLeader::default())
+        .unwrap();
 
     let account_keypair = Keypair::new();
 
@@ -5417,16 +5347,15 @@ fn test_stack_heap_zeroed() {
     let bank = Bank::new_for_tests(&genesis_config);
 
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-    let mut bank_client = BankClient::new_shared(bank);
-    let authority_keypair = Keypair::new();
-
-    let (bank, invoke_program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
+    let invoke_program_id = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
         "solana_sbf_rust_invoke",
     );
+    let mut bank_client = BankClient::new_shared(bank.clone());
+    let bank = bank_client
+        .advance_slot(1, &bank_forks, SlotLeader::default())
+        .unwrap();
 
     let account_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
@@ -5483,16 +5412,15 @@ fn test_function_call_args() {
     } = create_genesis_config(100_123_456_789);
 
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let mut bank_client = BankClient::new_shared(bank);
-    let authority_keypair = Keypair::new();
-
-    let (bank, program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
+    let program_id = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
         "solana_sbf_rust_call_args",
     );
+    let mut bank_client = BankClient::new_shared(bank.clone());
+    let bank = bank_client
+        .advance_slot(1, &bank_forks, SlotLeader::default())
+        .unwrap();
 
     #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug)]
     struct Test128 {
@@ -5636,22 +5564,20 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
 
         bank.feature_set = Arc::new(feature_set);
         let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-        let mut bank_client = BankClient::new_shared(bank);
-        let authority_keypair = Keypair::new();
-
-        let (bank, upgradeable_program_id) = load_upgradeable_program_and_advance_slot(
-            &mut bank_client,
-            &bank_forks,
-            &mint_keypair,
-            &authority_keypair,
+        let upgradeable_program_id = create_program(
+            &bank,
+            &bpf_loader_upgradeable::id(),
             "solana_sbf_rust_account_mem",
         );
-
         let deprecated_program_id = create_program(
             &bank,
             &bpf_loader_deprecated::id(),
             "solana_sbf_rust_account_mem_deprecated",
         );
+        let mut bank_client = BankClient::new_shared(bank.clone());
+        let bank = bank_client
+            .advance_slot(1, &bank_forks, SlotLeader::default())
+            .unwrap();
 
         let mint_pubkey = mint_keypair.pubkey();
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,6 +22,7 @@ dev-context-only-utils = [
     "agave-feature-set/dev-context-only-utils",
     "agave-votor-messages/dev-context-only-utils",
     "solana-accounts-db/dev-context-only-utils",
+    "solana-program-binaries",
     "solana-svm/dev-context-only-utils",
     "solana-runtime-transaction/dev-context-only-utils",
     "solana-vote/dev-context-only-utils",
@@ -137,6 +138,7 @@ solana-packet = { workspace = true }
 solana-perf = { workspace = true }
 solana-poh-config = { workspace = true }
 solana-precompile-error = { workspace = true }
+solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"], optional = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rayon-threadlimit = { workspace = true }
@@ -193,7 +195,6 @@ proptest = { workspace = true }
 solana-accounts-db = { path = "../accounts-db", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-builtins = { path = "../builtins", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-instruction-error = { workspace = true }
-solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-runtime = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -2,7 +2,7 @@
 use {
     crate::{bank::Bank, bank_client::BankClient, bank_forks::BankForks},
     serde::Serialize,
-    solana_account::{AccountSharedData, WritableAccount},
+    solana_account::AccountSharedData,
     solana_client_traits::{Client, SyncClient},
     solana_clock::Clock,
     solana_instruction::{AccountMeta, Instruction},
@@ -10,7 +10,12 @@ use {
     solana_leader_schedule::SlotLeader,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_message::Message,
+    solana_program_binaries::{
+        bpf_loader_program_account, bpf_loader_upgradeable_program_accounts,
+    },
     solana_pubkey::Pubkey,
+    solana_rent::Rent,
+    solana_sdk_ids::bpf_loader_upgradeable,
     solana_signer::Signer,
     std::{
         env,
@@ -51,14 +56,20 @@ pub fn load_program_from_file(name: &str) -> Vec<u8> {
 pub fn create_program(bank: &Bank, loader_id: &Pubkey, name: &str) -> Pubkey {
     let program_id = Pubkey::new_unique();
     let elf = load_program_from_file(name);
-    let mut program_account = AccountSharedData::new(1, elf.len(), loader_id);
-    program_account
-        .data_as_mut_slice()
-        .get_mut(..)
-        .unwrap()
-        .copy_from_slice(&elf);
-    program_account.set_executable(true);
-    bank.store_account(&program_id, &program_account);
+    let rent = Rent::default();
+    if bpf_loader_upgradeable::check_id(loader_id) {
+        let [(_, program_account), (programdata_id, programdata_account)] =
+            bpf_loader_upgradeable_program_accounts(&program_id, &elf, &rent);
+        bank.store_account(&program_id, &AccountSharedData::from(program_account));
+        bank.store_account(
+            &programdata_id,
+            &AccountSharedData::from(programdata_account),
+        );
+    } else {
+        let (_, mut program_account) = bpf_loader_program_account(&program_id, &elf, &rent);
+        program_account.owner = *loader_id;
+        bank.store_account(&program_id, &AccountSharedData::from(program_account));
+    }
     program_id
 }
 


### PR DESCRIPTION
#### Problem

Deployment of SBPFv0 will be disabled, thus we will have to switch to direct account creation, like we did for loader-v1 and loader-v2 when their deployments were disabled.

Preparation for https://github.com/anza-xyz/agave/pull/10880.

#### Summary of Changes

- Adds loader-v3 support to `loader_utils::create_program()`.
- Switches from `loader_utils::load_upgradeable_program_and_advance_slot()` to `loader_utils::create_program()` where possible.