### PR TITLE
ci: pin and verify codecov uploader in Docker image

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -6,7 +6,8 @@ ARG \
   RUST_NIGHTLY_VERSION= \
   NODE_MAJOR= \
   SCCACHE_VERSION= \
-  GRCOV_VERSION=
+  GRCOV_VERSION= \
+  CODECOV_VERSION=
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -26,6 +27,7 @@ RUN \
   if [ -z "$NODE_MAJOR" ]; then echo "ERROR: The NODE_MAJOR argument is required!" && exit 1; fi && \
   if [ -z "$SCCACHE_VERSION" ]; then echo "ERROR: The SCCACHE_VERSION argument is required!" && exit 1; fi && \
   if [ -z "$GRCOV_VERSION" ]; then echo "ERROR: The GRCOV_VERSION argument is required!" && exit 1; fi && \
+  if [ -z "$CODECOV_VERSION" ]; then echo "ERROR: The CODECOV_VERSION argument is required!" && exit 1; fi && \
   apt-get update && \
   apt-get install --no-install-recommends -y \
   # basic
@@ -121,8 +123,11 @@ RUN \
   mv ./grcov $CARGO_HOME/bin && \
   rm grcov-x86_64-unknown-linux-musl.tar.bz2 && \
   # codecov
-  curl -Os https://uploader.codecov.io/latest/linux/codecov && \
+  curl -Os "https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov" && \
+  curl -Os "https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov.SHA256SUM" && \
+  sha256sum -c codecov.SHA256SUM && \
   chmod +x codecov && \
   mv codecov /usr/bin && \
+  rm codecov.SHA256SUM && \
   # clean lists
   rm -rf /var/lib/apt/lists/*

--- a/ci/docker/build.sh
+++ b/ci/docker/build.sh
@@ -22,6 +22,7 @@ docker build "${platform[@]}" \
   --build-arg "NODE_MAJOR=${CI_DOCKER_ARG_NODE_MAJOR}" \
   --build-arg "SCCACHE_VERSION=${CI_DOCKER_ARG_SCCACHE_VERSION}" \
   --build-arg "GRCOV_VERSION=${CI_DOCKER_ARG_GRCOV_VERSION}" \
+  --build-arg "CODECOV_VERSION=${CI_DOCKER_ARG_CODECOV_VERSION}" \
   -t "$CI_DOCKER_IMAGE" .
 
 docker push "$CI_DOCKER_IMAGE"

--- a/ci/docker/env.sh
+++ b/ci/docker/env.sh
@@ -16,6 +16,7 @@ export CI_DOCKER_ARG_RUST_NIGHTLY_VERSION="${rust_nightly}"
 export CI_DOCKER_ARG_NODE_MAJOR=24
 export CI_DOCKER_ARG_SCCACHE_VERSION=v0.9.1
 export CI_DOCKER_ARG_GRCOV_VERSION=v0.8.18
+export CI_DOCKER_ARG_CODECOV_VERSION=v0.8.0
 
 hash_vars=(
   "$(cat "${ci_docker_env_sh_here}/Dockerfile")"
@@ -25,6 +26,7 @@ hash_vars=(
   "${CI_DOCKER_ARG_NODE_MAJOR}"
   "${CI_DOCKER_ARG_SCCACHE_VERSION}"
   "${CI_DOCKER_ARG_GRCOV_VERSION}"
+  "${CI_DOCKER_ARG_CODECOV_VERSION}"
 )
 hash_input=$(IFS="_"; echo "${hash_vars[*]}")
 ci_docker_hash=$(echo -n "${hash_input}" | sha256sum | head -c 8)


### PR DESCRIPTION
 #### Problem
                                                                                                                                                                                      
  The CI Docker image installs the Codecov uploader from a mutable `latest` URL without any integrity check, then places the binary directly in `/usr/bin`, which weakens supply-chain safety and build reproducibility.                                                                                                                                                   
                                                                                                                                                                                      
  #### Summary of Changes
                                                                                                                                                                                      
  - Added a required `CODECOV_VERSION` build arg to pin the uploader version.                                                                                                         
  - Replaced `https://uploader.codecov.io/latest/linux/codecov` with a versioned URL.                                                                                                 
  - Downloaded `codecov.SHA256SUM` and verified the binary with `sha256sum -c` before install.                                                                                        
  - Wired `CODECOV_VERSION` through `ci/docker/env.sh` and `ci/docker/build.sh`.                                                                                                      
                                                                                                                                                                                      
  Fixes #11554