### PR TITLE
chore(poh): move benchmarks to bencher 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9255,6 +9255,7 @@ dependencies = [
  "agave-votor-messages",
  "arc-swap",
  "assert_matches",
+ "bencher",
  "bincode",
  "criterion",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9305,6 +9305,7 @@ dependencies = [
  "agave-votor-messages",
  "arc-swap",
  "assert_matches",
+ "bencher",
  "bincode",
  "criterion",
  "crossbeam-channel",

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -45,6 +45,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
+bencher = { workspace = true }
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
@@ -62,6 +63,11 @@ jemallocator = { workspace = true }
 
 [[bench]]
 name = "poh"
+harness = false
+
+[[bench]]
+name = "poh_verify"
+harness = false
 
 [[bench]]
 name = "transaction_recorder"

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -48,6 +48,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
+bencher = { workspace = true }
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
@@ -65,6 +66,11 @@ jemallocator = { workspace = true }
 
 [[bench]]
 name = "poh"
+harness = false
+
+[[bench]]
+name = "poh_verify"
+harness = false
 
 [[bench]]
 name = "transaction_recorder"

--- a/poh/benches/poh.rs
+++ b/poh/benches/poh.rs
@@ -1,9 +1,7 @@
-// This bench attempts to justify the value of `solana_core::poh_service::NUM_HASHES_PER_BATCH`
-
-#![feature(test)]
-extern crate test;
+// This bench attempts to justify the value of `solana_poh::poh_service::DEFAULT_HASHES_PER_BATCH`.
 
 use {
+    bencher::{Bencher, benchmark_group, benchmark_main},
     solana_entry::poh::Poh,
     solana_hash::Hash,
     solana_ledger::{
@@ -18,11 +16,13 @@ use {
     solana_runtime::bank::Bank,
     solana_sha256_hasher::hash,
     solana_transaction::sanitized::SanitizedTransaction,
-    std::sync::{
-        Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+    std::{
+        hint::black_box,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, Ordering},
+        },
     },
-    test::Bencher,
 };
 
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
@@ -31,35 +31,32 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 const NUM_HASHES: u64 = 30_000; // Should require ~10ms on a 2017 MacBook Pro
 
-#[bench]
 // No locking.  Fastest.
-fn bench_poh_hash(bencher: &mut Bencher) {
+fn bench_poh_hash(b: &mut Bencher) {
     let mut poh = Poh::new(Hash::default(), None);
-    bencher.iter(|| {
+    b.iter(|| {
         poh.hash(NUM_HASHES);
     })
 }
 
-#[bench]
 // Lock on each iteration.  Slowest.
-fn bench_arc_mutex_poh_hash(bencher: &mut Bencher) {
+fn bench_arc_mutex_poh_hash(b: &mut Bencher) {
     let poh = Arc::new(Mutex::new(Poh::new(Hash::default(), None)));
-    bencher.iter(|| {
+    b.iter(|| {
         for _ in 0..NUM_HASHES {
             poh.lock().unwrap().hash(1);
         }
     })
 }
 
-#[bench]
 // Acquire lock every NUM_HASHES_PER_BATCH iterations.
 // Speed should be close to bench_poh_hash() if NUM_HASHES_PER_BATCH is set well.
-fn bench_arc_mutex_poh_batched_hash(bencher: &mut Bencher) {
+fn bench_arc_mutex_poh_batched_hash(b: &mut Bencher) {
     let poh = Arc::new(Mutex::new(Poh::new(Hash::default(), Some(NUM_HASHES))));
     //let exit = Arc::new(AtomicBool::new(false));
     let exit = Arc::new(AtomicBool::new(true));
 
-    bencher.iter(|| {
+    b.iter(|| {
         // NOTE: This block attempts to look as close as possible to `PohService::tick_producer()`
         loop {
             if poh.lock().unwrap().hash(DEFAULT_HASHES_PER_BATCH) {
@@ -72,17 +69,15 @@ fn bench_arc_mutex_poh_batched_hash(bencher: &mut Bencher) {
     })
 }
 
-#[bench]
 // Worst case transaction record delay due to batch hashing at NUM_HASHES_PER_BATCH
-fn bench_poh_lock_time_per_batch(bencher: &mut Bencher) {
+fn bench_poh_lock_time_per_batch(b: &mut Bencher) {
     let mut poh = Poh::new(Hash::default(), None);
-    bencher.iter(|| {
+    b.iter(|| {
         poh.hash(DEFAULT_HASHES_PER_BATCH);
     })
 }
 
-#[bench]
-fn bench_poh_recorder_record(bencher: &mut Bencher) {
+fn bench_poh_recorder_record(b: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore =
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger");
@@ -116,20 +111,19 @@ fn bench_poh_recorder_record(bencher: &mut Bencher) {
     ];
 
     let txs: Vec<_> = txs.iter().map(|tx| tx.to_versioned_transaction()).collect();
-    bencher.iter(|| {
+    b.iter(|| {
         let _record_result = poh_recorder
             .record(
                 bank.slot(),
-                vec![test::black_box(h1)],
-                vec![test::black_box(txs.clone())],
+                vec![black_box(h1)],
+                vec![black_box(txs.clone())],
             )
             .unwrap();
     });
     poh_recorder.tick();
 }
 
-#[bench]
-fn bench_poh_recorder_set_bank(bencher: &mut Bencher) {
+fn bench_poh_recorder_set_bank(b: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore =
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger");
@@ -148,9 +142,20 @@ fn bench_poh_recorder_set_bank(bencher: &mut Bencher) {
         &PohConfig::default(),
         Arc::new(AtomicBool::default()),
     );
-    bencher.iter(|| {
+    b.iter(|| {
         poh_recorder.set_bank_for_test(bank.clone());
         poh_recorder.tick();
         poh_recorder.clear_bank_for_test();
     });
 }
+
+benchmark_group!(
+    benches,
+    bench_arc_mutex_poh_batched_hash,
+    bench_arc_mutex_poh_hash,
+    bench_poh_hash,
+    bench_poh_lock_time_per_batch,
+    bench_poh_recorder_record,
+    bench_poh_recorder_set_bank
+);
+benchmark_main!(benches);

--- a/poh/benches/poh.rs
+++ b/poh/benches/poh.rs
@@ -32,17 +32,17 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 const NUM_HASHES: u64 = 30_000; // Should require ~10ms on a 2017 MacBook Pro
 
 // No locking.  Fastest.
-fn bench_poh_hash(b: &mut Bencher) {
+fn bench_poh_hash(bencher: &mut Bencher) {
     let mut poh = Poh::new(Hash::default(), None);
-    b.iter(|| {
+    bencher.iter(|| {
         poh.hash(NUM_HASHES);
     })
 }
 
 // Lock on each iteration.  Slowest.
-fn bench_arc_mutex_poh_hash(b: &mut Bencher) {
+fn bench_arc_mutex_poh_hash(bencher: &mut Bencher) {
     let poh = Arc::new(Mutex::new(Poh::new(Hash::default(), None)));
-    b.iter(|| {
+    bencher.iter(|| {
         for _ in 0..NUM_HASHES {
             poh.lock().unwrap().hash(1);
         }
@@ -51,12 +51,12 @@ fn bench_arc_mutex_poh_hash(b: &mut Bencher) {
 
 // Acquire lock every NUM_HASHES_PER_BATCH iterations.
 // Speed should be close to bench_poh_hash() if NUM_HASHES_PER_BATCH is set well.
-fn bench_arc_mutex_poh_batched_hash(b: &mut Bencher) {
+fn bench_arc_mutex_poh_batched_hash(bencher: &mut Bencher) {
     let poh = Arc::new(Mutex::new(Poh::new(Hash::default(), Some(NUM_HASHES))));
     //let exit = Arc::new(AtomicBool::new(false));
     let exit = Arc::new(AtomicBool::new(true));
 
-    b.iter(|| {
+    bencher.iter(|| {
         // NOTE: This block attempts to look as close as possible to `PohService::tick_producer()`
         loop {
             if poh.lock().unwrap().hash(DEFAULT_HASHES_PER_BATCH) {
@@ -70,14 +70,14 @@ fn bench_arc_mutex_poh_batched_hash(b: &mut Bencher) {
 }
 
 // Worst case transaction record delay due to batch hashing at NUM_HASHES_PER_BATCH
-fn bench_poh_lock_time_per_batch(b: &mut Bencher) {
+fn bench_poh_lock_time_per_batch(bencher: &mut Bencher) {
     let mut poh = Poh::new(Hash::default(), None);
-    b.iter(|| {
+    bencher.iter(|| {
         poh.hash(DEFAULT_HASHES_PER_BATCH);
     })
 }
 
-fn bench_poh_recorder_record(b: &mut Bencher) {
+fn bench_poh_recorder_record(bencher: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore =
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger");
@@ -111,7 +111,7 @@ fn bench_poh_recorder_record(b: &mut Bencher) {
     ];
 
     let txs: Vec<_> = txs.iter().map(|tx| tx.to_versioned_transaction()).collect();
-    b.iter(|| {
+    bencher.iter(|| {
         let _record_result = poh_recorder
             .record(bank.slot(), black_box(h1), black_box(txs.clone()))
             .unwrap();
@@ -119,7 +119,7 @@ fn bench_poh_recorder_record(b: &mut Bencher) {
     poh_recorder.tick();
 }
 
-fn bench_poh_recorder_set_bank(b: &mut Bencher) {
+fn bench_poh_recorder_set_bank(bencher: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore =
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger");
@@ -138,7 +138,7 @@ fn bench_poh_recorder_set_bank(b: &mut Bencher) {
         &PohConfig::default(),
         Arc::new(AtomicBool::default()),
     );
-    b.iter(|| {
+    bencher.iter(|| {
         poh_recorder.set_bank_for_test(bank.clone());
         poh_recorder.tick();
         poh_recorder.clear_bank_for_test();

--- a/poh/benches/poh.rs
+++ b/poh/benches/poh.rs
@@ -1,9 +1,7 @@
-// This bench attempts to justify the value of `solana_core::poh_service::NUM_HASHES_PER_BATCH`
-
-#![feature(test)]
-extern crate test;
+// This bench attempts to justify the value of `solana_poh::poh_service::DEFAULT_HASHES_PER_BATCH`.
 
 use {
+    bencher::{Bencher, benchmark_group, benchmark_main},
     solana_entry::poh::Poh,
     solana_hash::Hash,
     solana_ledger::{
@@ -18,11 +16,13 @@ use {
     solana_runtime::bank::Bank,
     solana_sha256_hasher::hash,
     solana_transaction::sanitized::SanitizedTransaction,
-    std::sync::{
-        Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+    std::{
+        hint::black_box,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, Ordering},
+        },
     },
-    test::Bencher,
 };
 
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
@@ -31,35 +31,32 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 const NUM_HASHES: u64 = 30_000; // Should require ~10ms on a 2017 MacBook Pro
 
-#[bench]
 // No locking.  Fastest.
-fn bench_poh_hash(bencher: &mut Bencher) {
+fn bench_poh_hash(b: &mut Bencher) {
     let mut poh = Poh::new(Hash::default(), None);
-    bencher.iter(|| {
+    b.iter(|| {
         poh.hash(NUM_HASHES);
     })
 }
 
-#[bench]
 // Lock on each iteration.  Slowest.
-fn bench_arc_mutex_poh_hash(bencher: &mut Bencher) {
+fn bench_arc_mutex_poh_hash(b: &mut Bencher) {
     let poh = Arc::new(Mutex::new(Poh::new(Hash::default(), None)));
-    bencher.iter(|| {
+    b.iter(|| {
         for _ in 0..NUM_HASHES {
             poh.lock().unwrap().hash(1);
         }
     })
 }
 
-#[bench]
 // Acquire lock every NUM_HASHES_PER_BATCH iterations.
 // Speed should be close to bench_poh_hash() if NUM_HASHES_PER_BATCH is set well.
-fn bench_arc_mutex_poh_batched_hash(bencher: &mut Bencher) {
+fn bench_arc_mutex_poh_batched_hash(b: &mut Bencher) {
     let poh = Arc::new(Mutex::new(Poh::new(Hash::default(), Some(NUM_HASHES))));
     //let exit = Arc::new(AtomicBool::new(false));
     let exit = Arc::new(AtomicBool::new(true));
 
-    bencher.iter(|| {
+    b.iter(|| {
         // NOTE: This block attempts to look as close as possible to `PohService::tick_producer()`
         loop {
             if poh.lock().unwrap().hash(DEFAULT_HASHES_PER_BATCH) {
@@ -72,17 +69,15 @@ fn bench_arc_mutex_poh_batched_hash(bencher: &mut Bencher) {
     })
 }
 
-#[bench]
 // Worst case transaction record delay due to batch hashing at NUM_HASHES_PER_BATCH
-fn bench_poh_lock_time_per_batch(bencher: &mut Bencher) {
+fn bench_poh_lock_time_per_batch(b: &mut Bencher) {
     let mut poh = Poh::new(Hash::default(), None);
-    bencher.iter(|| {
+    b.iter(|| {
         poh.hash(DEFAULT_HASHES_PER_BATCH);
     })
 }
 
-#[bench]
-fn bench_poh_recorder_record(bencher: &mut Bencher) {
+fn bench_poh_recorder_record(b: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore =
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger");
@@ -116,20 +111,15 @@ fn bench_poh_recorder_record(bencher: &mut Bencher) {
     ];
 
     let txs: Vec<_> = txs.iter().map(|tx| tx.to_versioned_transaction()).collect();
-    bencher.iter(|| {
+    b.iter(|| {
         let _record_result = poh_recorder
-            .record(
-                bank.slot(),
-                test::black_box(h1),
-                test::black_box(txs.clone()),
-            )
+            .record(bank.slot(), black_box(h1), black_box(txs.clone()))
             .unwrap();
     });
     poh_recorder.tick();
 }
 
-#[bench]
-fn bench_poh_recorder_set_bank(bencher: &mut Bencher) {
+fn bench_poh_recorder_set_bank(b: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore =
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger");
@@ -148,9 +138,20 @@ fn bench_poh_recorder_set_bank(bencher: &mut Bencher) {
         &PohConfig::default(),
         Arc::new(AtomicBool::default()),
     );
-    bencher.iter(|| {
+    b.iter(|| {
         poh_recorder.set_bank_for_test(bank.clone());
         poh_recorder.tick();
         poh_recorder.clear_bank_for_test();
     });
 }
+
+benchmark_group!(
+    benches,
+    bench_arc_mutex_poh_batched_hash,
+    bench_arc_mutex_poh_hash,
+    bench_poh_hash,
+    bench_poh_lock_time_per_batch,
+    bench_poh_recorder_record,
+    bench_poh_recorder_set_bank
+);
+benchmark_main!(benches);

--- a/poh/benches/poh_verify.rs
+++ b/poh/benches/poh_verify.rs
@@ -1,14 +1,11 @@
-#![feature(test)]
-extern crate test;
-
 use {
+    bencher::{Bencher, benchmark_group, benchmark_main},
     solana_entry::entry::{self, Entry, EntrySlice, next_entry_mut},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_sha256_hasher::hash,
     solana_signer::Signer,
     solana_system_transaction::transfer,
-    test::Bencher,
 };
 
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
@@ -18,8 +15,7 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 const NUM_HASHES: u64 = 400;
 const NUM_ENTRIES: usize = 800;
 
-#[bench]
-fn bench_poh_verify_ticks(bencher: &mut Bencher) {
+fn bench_poh_verify_ticks(b: &mut Bencher) {
     agave_logger::setup();
     let thread_pool = entry::thread_pool_for_benches();
 
@@ -32,13 +28,12 @@ fn bench_poh_verify_ticks(bencher: &mut Bencher) {
         ticks.push(next_entry_mut(&mut cur_hash, NUM_HASHES, vec![]));
     }
 
-    bencher.iter(|| {
+    b.iter(|| {
         assert!(ticks.verify(&start_hash, &thread_pool).status());
     })
 }
 
-#[bench]
-fn bench_poh_verify_transaction_entries(bencher: &mut Bencher) {
+fn bench_poh_verify_transaction_entries(b: &mut Bencher) {
     let thread_pool = entry::thread_pool_for_benches();
 
     let zero = Hash::default();
@@ -54,7 +49,14 @@ fn bench_poh_verify_transaction_entries(bencher: &mut Bencher) {
         ticks.push(next_entry_mut(&mut cur_hash, NUM_HASHES, vec![tx]));
     }
 
-    bencher.iter(|| {
+    b.iter(|| {
         assert!(ticks.verify(&start_hash, &thread_pool).status());
     })
 }
+
+benchmark_group!(
+    benches,
+    bench_poh_verify_ticks,
+    bench_poh_verify_transaction_entries
+);
+benchmark_main!(benches);

--- a/poh/benches/poh_verify.rs
+++ b/poh/benches/poh_verify.rs
@@ -15,7 +15,7 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 const NUM_HASHES: u64 = 400;
 const NUM_ENTRIES: usize = 800;
 
-fn bench_poh_verify_ticks(b: &mut Bencher) {
+fn bench_poh_verify_ticks(bencher: &mut Bencher) {
     agave_logger::setup();
     let thread_pool = entry::thread_pool_for_benches();
 
@@ -28,12 +28,12 @@ fn bench_poh_verify_ticks(b: &mut Bencher) {
         ticks.push(next_entry_mut(&mut cur_hash, NUM_HASHES, vec![]));
     }
 
-    b.iter(|| {
+    bencher.iter(|| {
         assert!(ticks.verify(&start_hash, &thread_pool).status());
     })
 }
 
-fn bench_poh_verify_transaction_entries(b: &mut Bencher) {
+fn bench_poh_verify_transaction_entries(bencher: &mut Bencher) {
     let thread_pool = entry::thread_pool_for_benches();
 
     let zero = Hash::default();
@@ -49,7 +49,7 @@ fn bench_poh_verify_transaction_entries(b: &mut Bencher) {
         ticks.push(next_entry_mut(&mut cur_hash, NUM_HASHES, vec![tx]));
     }
 
-    b.iter(|| {
+    bencher.iter(|| {
         assert!(ticks.verify(&start_hash, &thread_pool).status());
     })
 }


### PR DESCRIPTION
#### Fixes
Part of the migration for [this issue](https://github.com/anza-xyz/agave/issues/5931)

#### Summary of Changes
Moved benchmarks to bencher 0.1.5.
