### PR TITLE
chore(runtime): use workspace solana-program-binaries

### DIFF
--- a/ci/xtask/src/commands/generate_pipeline.rs
+++ b/ci/xtask/src/commands/generate_pipeline.rs
@@ -205,6 +205,7 @@ pub async fn generate_pull_request_pipeline(pr_number: u64) -> Result<buildkite:
         pipeline.add_step(default_stable_sbf_step());
         pipeline.add_step(default_shuttle_step());
         pipeline.add_step(default_coverage_step(3));
+        pipeline.add_step(default_crate_publish_test_step());
     }
 
     Ok(pipeline)

--- a/ci/xtask/src/commands/generate_pipeline.rs
+++ b/ci/xtask/src/commands/generate_pipeline.rs
@@ -205,7 +205,6 @@ pub async fn generate_pull_request_pipeline(pr_number: u64) -> Result<buildkite:
         pipeline.add_step(default_stable_sbf_step());
         pipeline.add_step(default_shuttle_step());
         pipeline.add_step(default_coverage_step(3));
-        pipeline.add_step(default_crate_publish_test_step());
     }
 
     Ok(pipeline)

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -138,7 +138,7 @@ solana-packet = { workspace = true }
 solana-perf = { workspace = true }
 solana-poh-config = { workspace = true }
 solana-precompile-error = { workspace = true }
-solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"], optional = true }
+solana-program-binaries = { workspace = true, optional = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rayon-threadlimit = { workspace = true }


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/pull/12205 introduced `solana-program-binaries` to `solana-runtime`. however, it uses `path` which will be removed during publishing and cause the publish process to fail

like:
https://buildkite.com/anza/agave/builds/47977#019dd033-1e05-4838-87e8-23b15ca44dbc/L513

#### Summary of Changes

use workspace = true