### PR TITLE
feat: adapt memory layout to enable wincode zero-copy

### DIFF
--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -215,12 +215,14 @@ pub struct BlockFooterV1 {
     pub notar_reward_cert: Option<NotarRewardCertificate>,
 }
 
+#[repr(C)]
 #[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
 pub struct BlockHeaderV1 {
     pub parent_slot: Slot,
     pub parent_block_id: Hash,
 }
 
+#[repr(C)]
 #[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
 pub struct UpdateParentV1 {
     pub new_parent_slot: Slot,

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -297,6 +297,7 @@ mod wincode_compat_cast {
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, SchemaRead, SchemaWrite)]
 pub(crate) struct ErasureConfig {
     pub(crate) num_data: usize,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -278,6 +278,7 @@ struct DataShredHeader {
 }
 
 /// The coding shred header has FEC information
+#[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 struct CodingShredHeader {
     num_data_shreds: u16,

--- a/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
+++ b/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
@@ -22,6 +22,7 @@ static VOTE_REWARD_ACCOUNT_ADDR: LazyLock<Pubkey> = LazyLock::new(|| {
 });
 
 /// The per epoch info stored in the off curve account.
+#[repr(C)]
 #[derive(Debug, Clone, PartialEq, Eq, SchemaRead, SchemaWrite, Deserialize, Serialize)]
 pub(super) struct EpochInflationState {
     /// The rewards (in lamports) that would be paid to a validator whose stake is equal to the

--- a/votor-messages/src/vote.rs
+++ b/votor-messages/src/vote.rs
@@ -186,6 +186,7 @@ impl From<GenesisVote> for Vote {
 }
 
 /// A notarization vote
+#[repr(C)]
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
@@ -212,6 +213,7 @@ pub struct NotarizationVote {
 }
 
 /// A finalization vote
+#[repr(C)]
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
@@ -238,6 +240,7 @@ pub struct FinalizationVote {
 /// A skip vote
 /// Represents a range of slots to skip
 /// inclusive on both ends
+#[repr(C)]
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
@@ -262,6 +265,7 @@ pub struct SkipVote {
 }
 
 /// A notarization fallback vote
+#[repr(C)]
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
@@ -288,6 +292,7 @@ pub struct NotarizationFallbackVote {
 }
 
 /// A skip fallback vote
+#[repr(C)]
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
@@ -312,6 +317,7 @@ pub struct SkipFallbackVote {
 }
 
 /// A genesis vote. Only used during the migration from TowerBFT
+#[repr(C)]
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),


### PR DESCRIPTION
#### Problem
Structs containing byte arrays or static integer types are eligible for zero-copy optimizations, as long as they are marked with `repr(C)` (or `repr(transparent)`) attribute.
There are some in agave, which just miss the attribute.

#### Summary of Changes
Add `#[repr(C)]` to a couple of structs.
