### PR TITLE
storage-bigtable: replace compress_best with compress_zstd_or_none

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10500,7 +10500,6 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bzip2",
- "enum-iterator",
  "flate2",
  "futures 0.3.32",
  "goauth",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9017,7 +9017,6 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bzip2",
- "enum-iterator",
  "flate2",
  "futures 0.3.32",
  "goauth",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9374,7 +9374,6 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "bzip2",
- "enum-iterator",
  "flate2",
  "futures 0.3.32",
  "goauth",

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -24,7 +24,6 @@ agave-reserved-account-keys = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
 bzip2 = { workspace = true }
-enum-iterator = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }
 goauth = { workspace = true }

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         CredentialType,
         access_token::{AccessToken, Scope},
-        compression::{compress_best, decompress},
+        compression::{compress_default, decompress},
         root_ca_certificate,
     },
     hyper_util::client::legacy::connect::{HttpConnector, proxy::Tunnel},
@@ -880,7 +880,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         let mut bytes_written = 0;
         let mut new_row_data = vec![];
         for (row_key, data) in cells {
-            let data = compress_best(&bincode::serialize(&data).unwrap())?;
+            let data = compress_default(&bincode::serialize(&data).unwrap())?;
             bytes_written += data.len();
             new_row_data.push((row_key, vec![("bin".to_string(), data)]));
         }
@@ -902,7 +902,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         for (row_key, data) in cells {
             let mut buf = Vec::with_capacity(data.encoded_len());
             data.encode(&mut buf).unwrap();
-            let data = compress_best(&buf)?;
+            let data = compress_default(&buf)?;
             bytes_written += data.len();
             new_row_data.push((row_key, vec![("proto".to_string(), data)]));
         }
@@ -1080,7 +1080,7 @@ mod tests {
             block_time: Some(1_234_567_890),
             block_height: Some(1),
         };
-        let bincode_block = compress_best(
+        let bincode_block = compress_default(
             &bincode::serialize::<StoredConfirmedBlock>(&expected_block.clone().into()).unwrap(),
         )
         .unwrap();
@@ -1088,7 +1088,7 @@ mod tests {
         let protobuf_block = confirmed_block_into_protobuf(expected_block.clone());
         let mut buf = Vec::with_capacity(protobuf_block.encoded_len());
         protobuf_block.encode(&mut buf).unwrap();
-        let protobuf_block = compress_best(&buf).unwrap();
+        let protobuf_block = compress_default(&buf).unwrap();
 
         let deserialized = deserialize_protobuf_or_bincode_cell_data::<
             StoredConfirmedBlock,

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         CredentialType,
         access_token::{AccessToken, Scope},
-        compression::{compress_default, decompress},
+        compression::{compress_zstd_or_none, decompress},
         root_ca_certificate,
     },
     hyper_util::client::legacy::connect::{HttpConnector, proxy::Tunnel},
@@ -880,7 +880,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         let mut bytes_written = 0;
         let mut new_row_data = vec![];
         for (row_key, data) in cells {
-            let data = compress_default(&bincode::serialize(&data).unwrap())?;
+            let data = compress_zstd_or_none(&bincode::serialize(&data).unwrap())?;
             bytes_written += data.len();
             new_row_data.push((row_key, vec![("bin".to_string(), data)]));
         }
@@ -902,7 +902,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         for (row_key, data) in cells {
             let mut buf = Vec::with_capacity(data.encoded_len());
             data.encode(&mut buf).unwrap();
-            let data = compress_default(&buf)?;
+            let data = compress_zstd_or_none(&buf)?;
             bytes_written += data.len();
             new_row_data.push((row_key, vec![("proto".to_string(), data)]));
         }
@@ -1080,7 +1080,7 @@ mod tests {
             block_time: Some(1_234_567_890),
             block_height: Some(1),
         };
-        let bincode_block = compress_default(
+        let bincode_block = compress_zstd_or_none(
             &bincode::serialize::<StoredConfirmedBlock>(&expected_block.clone().into()).unwrap(),
         )
         .unwrap();
@@ -1088,7 +1088,7 @@ mod tests {
         let protobuf_block = confirmed_block_into_protobuf(expected_block.clone());
         let mut buf = Vec::with_capacity(protobuf_block.encoded_len());
         protobuf_block.encode(&mut buf).unwrap();
-        let protobuf_block = compress_default(&buf).unwrap();
+        let protobuf_block = compress_zstd_or_none(&buf).unwrap();
 
         let deserialized = deserialize_protobuf_or_bincode_cell_data::<
             StoredConfirmedBlock,

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         CredentialType,
         access_token::{AccessToken, Scope},
-        compression::{CompressionMethod, compress, compress_default, decompress},
+        compression::{compress_default, decompress},
         root_ca_certificate,
     },
     hyper_util::client::legacy::connect::{HttpConnector, proxy::Tunnel},
@@ -880,11 +880,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         let mut bytes_written = 0;
         let mut new_row_data = vec![];
         for (row_key, data) in cells {
-            // Bincode payloads are tens of bytes; compression framing overhead would inflate them.
-            let data = compress(
-                CompressionMethod::NoCompression,
-                &bincode::serialize(&data).unwrap(),
-            )?;
+            let data = compress_default(&bincode::serialize(&data).unwrap())?;
             bytes_written += data.len();
             new_row_data.push((row_key, vec![("bin".to_string(), data)]));
         }

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         CredentialType,
         access_token::{AccessToken, Scope},
-        compression::{compress_default, decompress},
+        compression::{CompressionMethod, compress, compress_default, decompress},
         root_ca_certificate,
     },
     hyper_util::client::legacy::connect::{HttpConnector, proxy::Tunnel},
@@ -880,7 +880,11 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         let mut bytes_written = 0;
         let mut new_row_data = vec![];
         for (row_key, data) in cells {
-            let data = compress_default(&bincode::serialize(&data).unwrap())?;
+            // Bincode payloads are tens of bytes; compression framing overhead would inflate them.
+            let data = compress(
+                CompressionMethod::NoCompression,
+                &bincode::serialize(&data).unwrap(),
+            )?;
             bytes_written += data.len();
             new_row_data.push((row_key, vec![("bin".to_string(), data)]));
         }

--- a/storage-bigtable/src/compression.rs
+++ b/storage-bigtable/src/compression.rs
@@ -1,9 +1,6 @@
-use {
-    enum_iterator::{Sequence, all},
-    std::io::{self, BufReader, Read, Write},
-};
+use std::io::{self, BufReader, Read, Write};
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, Sequence)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum CompressionMethod {
     NoCompression,
     Bzip2,
@@ -66,16 +63,8 @@ pub fn compress(method: CompressionMethod, data: &[u8]) -> Result<Vec<u8>, io::E
     Ok(compressed_data)
 }
 
-pub fn compress_best(data: &[u8]) -> Result<Vec<u8>, io::Error> {
-    let mut candidates = vec![];
-    for method in all::<CompressionMethod>() {
-        candidates.push(compress(method, data)?);
-    }
-
-    Ok(candidates
-        .into_iter()
-        .min_by(|a, b| a.len().cmp(&b.len()))
-        .unwrap())
+pub fn compress_default(data: &[u8]) -> Result<Vec<u8>, io::Error> {
+    compress(CompressionMethod::Zstd, data)
 }
 
 #[cfg(test)]
@@ -86,7 +75,7 @@ mod test {
     fn test_compress_uncompress() {
         let data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         assert_eq!(
-            decompress(&compress_best(&data).expect("compress_best")).expect("decompress"),
+            decompress(&compress_default(&data).expect("compress_default")).expect("decompress"),
             data
         );
     }
@@ -94,6 +83,6 @@ mod test {
     #[test]
     fn test_compress() {
         let data = vec![0; 256];
-        assert!(compress_best(&data).expect("compress_best").len() < data.len());
+        assert!(compress_default(&data).expect("compress_default").len() < data.len());
     }
 }

--- a/storage-bigtable/src/compression.rs
+++ b/storage-bigtable/src/compression.rs
@@ -63,8 +63,16 @@ pub fn compress(method: CompressionMethod, data: &[u8]) -> Result<Vec<u8>, io::E
     Ok(compressed_data)
 }
 
+// Below this size, compression framing overhead typically exceeds any savings.
+const COMPRESSION_MIN_SIZE: usize = 128;
+
 pub fn compress_default(data: &[u8]) -> Result<Vec<u8>, io::Error> {
-    compress(CompressionMethod::Zstd, data)
+    let method = if data.len() < COMPRESSION_MIN_SIZE {
+        CompressionMethod::NoCompression
+    } else {
+        CompressionMethod::Zstd
+    };
+    compress(method, data)
 }
 
 #[cfg(test)]

--- a/storage-bigtable/src/compression.rs
+++ b/storage-bigtable/src/compression.rs
@@ -63,16 +63,10 @@ pub fn compress(method: CompressionMethod, data: &[u8]) -> Result<Vec<u8>, io::E
     Ok(compressed_data)
 }
 
-// Below this size, compression framing overhead typically exceeds any savings.
-const COMPRESSION_MIN_SIZE: usize = 128;
-
-pub fn compress_default(data: &[u8]) -> Result<Vec<u8>, io::Error> {
-    let method = if data.len() < COMPRESSION_MIN_SIZE {
-        CompressionMethod::NoCompression
-    } else {
-        CompressionMethod::Zstd
-    };
-    compress(method, data)
+pub fn compress_zstd_or_none(data: &[u8]) -> Result<Vec<u8>, io::Error> {
+    let zstd = compress(CompressionMethod::Zstd, data)?;
+    let none = compress(CompressionMethod::NoCompression, data)?;
+    Ok(if zstd.len() < none.len() { zstd } else { none })
 }
 
 #[cfg(test)]
@@ -83,7 +77,8 @@ mod test {
     fn test_compress_uncompress() {
         let data = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         assert_eq!(
-            decompress(&compress_default(&data).expect("compress_default")).expect("decompress"),
+            decompress(&compress_zstd_or_none(&data).expect("compress_zstd_or_none"))
+                .expect("decompress"),
             data
         );
     }
@@ -91,6 +86,11 @@ mod test {
     #[test]
     fn test_compress() {
         let data = vec![0; 256];
-        assert!(compress_default(&data).expect("compress_default").len() < data.len());
+        assert!(
+            compress_zstd_or_none(&data)
+                .expect("compress_zstd_or_none")
+                .len()
+                < data.len()
+        );
     }
 }


### PR DESCRIPTION
#### Problem

Mainnet bigtable upload rate is ~2 slot/s vs chain ~2.5 slot/s causing the bigtable upload to lag behind the tip, with the gap increasing indefinitely.

`compress_best` runs all four compression methods on every table cell and keps the smallest output. Bzip2-best is the slowest of the four and dominates per-cell CPU. 

Each block emits one MutateRows per table and the `tx-by-addr` table has one row per writable account per slot which translates to thousands of rows per block on mainnet. Before uploading, each row's cell data is compressed individually.

All compression ran inline on the async upload path, leading to TCP connections showing the `app_limited` flag as they were waiting for data to come.

#### Summary of Changes

Replace `compress_best` with `compress_zstd_or_none` which compresses with zstd and NoCompression and keeps the shorter output. Decompression code path unchanged.

Tested changes on one of the warehouse nodes and showing a ~5x speedup of uploads.