### PR TITLE
CI - Bypass deployment of SBPFv0 in tests (part 2)

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -9,8 +9,7 @@
 
 #[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
 use solana_runtime::loader_utils::{
-    create_program, load_upgradeable_buffer, load_upgradeable_program_and_advance_slot,
-    set_upgrade_authority, upgrade_program,
+    load_upgradeable_program_and_advance_slot, set_upgrade_authority, upgrade_program,
 };
 #[cfg(feature = "sbf_rust")]
 use {

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -7,6 +7,11 @@
 #![allow(clippy::unnecessary_cast)]
 #![allow(clippy::uninlined_format_args)]
 
+#[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
+use solana_runtime::loader_utils::{
+    create_program, load_upgradeable_buffer, load_upgradeable_program_and_advance_slot,
+    set_upgrade_authority, upgrade_program,
+};
 #[cfg(feature = "sbf_rust")]
 use {
     agave_feature_set::{self as feature_set, FeatureSet},
@@ -39,10 +44,7 @@ use {
             GenesisConfigInfo, bootstrap_validator_stake_lamports, create_genesis_config,
             create_genesis_config_with_leader, create_genesis_config_with_leader_ex,
         },
-        loader_utils::{
-            create_program, load_upgradeable_buffer, load_upgradeable_program_and_advance_slot,
-            set_upgrade_authority, upgrade_program,
-        },
+        loader_utils::{create_program, load_upgradeable_buffer},
     },
     solana_sbf_rust_invoke_dep::*,
     solana_sbf_rust_realloc_dep::*,
@@ -2102,7 +2104,7 @@ fn test_program_sbf_invoke_stable_genesis_and_bank() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
 fn test_program_sbf_invoke_in_same_tx_as_deployment() {
     agave_logger::setup();
 
@@ -2192,7 +2194,7 @@ fn test_program_sbf_invoke_in_same_tx_as_deployment() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
 fn test_program_sbf_invoke_in_same_tx_as_redeployment() {
     agave_logger::setup();
 
@@ -2278,7 +2280,7 @@ fn test_program_sbf_invoke_in_same_tx_as_redeployment() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
 fn test_program_sbf_invoke_in_same_tx_as_undeployment() {
     agave_logger::setup();
 
@@ -2502,7 +2504,7 @@ fn test_program_sbf_c_dup() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
 fn test_program_sbf_upgrade() {
     agave_logger::setup();
 
@@ -2567,7 +2569,7 @@ fn test_program_sbf_upgrade() {
 }
 
 #[test]
-#[cfg(feature = "sbf_rust")]
+#[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
 fn test_program_sbf_upgrade_via_cpi() {
     agave_logger::setup();
 

--- a/programs/sbf/tests/simulation.rs
+++ b/programs/sbf/tests/simulation.rs
@@ -3,16 +3,16 @@
 use {
     agave_validator::test_validator::*,
     solana_instruction::{AccountMeta, Instruction},
-    solana_keypair::Keypair,
     solana_message::Message,
     solana_pubkey::Pubkey,
     solana_runtime::{
-        bank::Bank,
+        bank::{Bank, SlotLeader},
         bank_client::BankClient,
         genesis_utils::{GenesisConfigInfo, create_genesis_config},
-        loader_utils::load_upgradeable_program_and_advance_slot,
+        loader_utils::create_program,
     },
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_sdk_ids::bpf_loader_upgradeable,
     solana_signer::Signer,
     solana_sysvar::{clock, slot_history},
     solana_transaction::Transaction,
@@ -29,15 +29,15 @@ fn test_no_panic_banks_client() {
         ..
     } = create_genesis_config(50);
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let mut bank_client = BankClient::new_shared(bank.clone());
-    let authority_keypair = Keypair::new();
-    let (bank, program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        bank_forks.as_ref(),
-        &mint_keypair,
-        &authority_keypair,
+    let program_id = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
         "solana_sbf_rust_simulation",
     );
+    let mut bank_client = BankClient::new_shared(bank.clone());
+    let bank = bank_client
+        .advance_slot(1, &bank_forks, SlotLeader::default())
+        .unwrap();
     bank.freeze();
 
     let instruction = Instruction::new_with_bincode(

--- a/programs/sbf/tests/syscall_get_epoch_stake.rs
+++ b/programs/sbf/tests/syscall_get_epoch_stake.rs
@@ -2,18 +2,18 @@
 
 use {
     solana_instruction::{AccountMeta, Instruction},
-    solana_keypair::Keypair,
     solana_message::Message,
     solana_runtime::{
-        bank::Bank,
+        bank::{Bank, SlotLeader},
         bank_client::BankClient,
         epoch_stakes::VersionedEpochStakes,
         genesis_utils::{
             GenesisConfigInfo, ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts,
         },
-        loader_utils::load_upgradeable_program_and_advance_slot,
+        loader_utils::create_program,
     },
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_sdk_ids::bpf_loader_upgradeable,
     solana_signer::Signer,
     solana_transaction::Transaction,
     solana_vote::vote_account::VoteAccount,
@@ -71,16 +71,15 @@ fn test_syscall_get_epoch_stake() {
     bank.set_epoch_stakes_for_test(0, epoch_stakes_epoch_0);
 
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-    let mut bank_client = BankClient::new_shared(bank);
-
-    let authority_keypair = Keypair::new();
-    let (bank, program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
+    let program_id = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
         "solana_sbf_syscall_get_epoch_stake",
     );
+    let mut bank_client = BankClient::new_shared(bank.clone());
+    let bank = bank_client
+        .advance_slot(1, &bank_forks, SlotLeader::default())
+        .unwrap();
     bank.freeze();
 
     let instruction = Instruction::new_with_bytes(

--- a/programs/sbf/tests/sysvar.rs
+++ b/programs/sbf/tests/sysvar.rs
@@ -3,19 +3,21 @@
 use {
     agave_feature_set::disable_fees_sysvar,
     solana_instruction::{AccountMeta, Instruction},
-    solana_keypair::Keypair,
     solana_message::Message,
     solana_pubkey::Pubkey,
     solana_runtime::{
-        bank::Bank,
+        bank::{Bank, SlotLeader},
         bank_client::BankClient,
         genesis_utils::{GenesisConfigInfo, create_genesis_config},
-        loader_utils::load_upgradeable_program_and_advance_slot,
+        loader_utils::create_program,
     },
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
-    solana_sdk_ids::sysvar::{
-        clock, epoch_schedule, instructions, recent_blockhashes, rent, slot_hashes, slot_history,
-        stake_history,
+    solana_sdk_ids::{
+        bpf_loader_upgradeable,
+        sysvar::{
+            clock, epoch_schedule, instructions, recent_blockhashes, rent, slot_hashes,
+            slot_history, stake_history,
+        },
     },
     solana_signer::Signer,
     solana_stake_interface::stake_history::{StakeHistory, StakeHistoryEntry},
@@ -60,15 +62,15 @@ fn test_sysvar_syscalls() {
     bank.set_sysvar_for_tests(&stake_history);
 
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-    let mut bank_client = BankClient::new_shared(bank);
-    let authority_keypair = Keypair::new();
-    let (bank, program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        bank_forks.as_ref(),
-        &mint_keypair,
-        &authority_keypair,
+    let program_id = create_program(
+        &bank,
+        &bpf_loader_upgradeable::id(),
         "solana_sbf_rust_sysvar",
     );
+    let mut bank_client = BankClient::new_shared(bank.clone());
+    let bank = bank_client
+        .advance_slot(1, &bank_forks, SlotLeader::default())
+        .unwrap();
     let dummy_account_key = Pubkey::new_unique();
     bank.store_account(
         &dummy_account_key,


### PR DESCRIPTION
#### Problem

#12205 missed a few places where tests still deployed older SBPF versions via loader-v3 instructions.

#### Summary of Changes

- Restricts deployment tests to SBPFv3.
- Switches from `load_upgradeable_program_and_advance_slot()` to `create_program()` where possible.