### PR TITLE
alpenglow: account for PohService during startup migration

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2391,10 +2391,7 @@ fn load_frozen_forks(
 
                 // If this block was the first alpenglow block and advanced the migration phase, we can enable alpenglow.
                 //
-                // Note: since this code is all startup code we don't have to worry about shutting down `PohService` or any
-                // in flight activity of `ReplayStage`. This bank must have failed to freeze as it is an Alpenglow block
-                // being verified as a TowerBFT one.
-                //
+                // This bank must have failed to freeze as it is an Alpenglow block being verified as a TowerBFT one.
                 // We are safe to cleanly transition to alpenglow here
                 if migration_status.is_ready_to_enable() {
                     let genesis_slot = migration_status.enable_alpenglow_during_startup();
@@ -2853,10 +2850,12 @@ pub mod tests {
             },
             shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
         },
+        agave_votor_messages::consensus_message::{Certificate, CertificateType},
         assert_matches::assert_matches,
         rand::{Rng, rng},
         rayon::ThreadPoolBuilder,
         solana_account::{AccountSharedData, WritableAccount},
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_cost_model::transaction_cost::TransactionCost,
         solana_entry::{
             block_component::{BlockComponent, BlockFooterV1, BlockHeaderV1, VersionedBlockMarker},
@@ -2896,11 +2895,61 @@ pub mod tests {
         std::{
             collections::BTreeSet,
             slice,
-            sync::{Arc, Barrier, RwLock},
+            sync::{Arc, Barrier, RwLock, atomic::Ordering},
+            thread,
         },
         test_case::test_matrix,
         trees::tr,
     };
+
+    /// Generate a dummy alpenglow genesis certificate
+    fn genesis_certificate(slot: Slot, block_id: Hash) -> Arc<Certificate> {
+        Arc::new(Certificate {
+            cert_type: CertificateType::Genesis(slot, block_id),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        })
+    }
+
+    /// Generate a dummy `MigrationStatus` in the `ReadyToEnable` phase
+    fn ready_to_enable_migration_status(genesis_slot: Slot, block_id: Hash) -> MigrationStatus {
+        let migration_status = MigrationStatus::default();
+        let migration_slot = migration_status.record_feature_activation(0);
+        assert!(genesis_slot < migration_slot);
+        migration_status.set_genesis_block((genesis_slot, block_id));
+        migration_status.set_genesis_certificate(genesis_certificate(genesis_slot, block_id));
+        assert!(migration_status.is_ready_to_enable());
+        migration_status
+    }
+
+    #[test]
+    fn test_startup_replay_enable_waits_for_poh_service_when_started() {
+        let genesis_slot = 1;
+        let block_id = Hash::new_from_array([7; solana_hash::HASH_BYTES]);
+        let migration_status = Arc::new(ready_to_enable_migration_status(genesis_slot, block_id));
+        let poh_service = {
+            let migration_status = Arc::clone(&migration_status);
+            migration_status.set_poh_service_started();
+            thread::spawn(move || {
+                while !migration_status.shutdown_poh.load(Ordering::Acquire) {
+                    thread::yield_now();
+                }
+                migration_status.poh_service_is_shutting_down();
+            })
+        };
+
+        assert_eq!(
+            migration_status.enable_alpenglow_during_startup(),
+            genesis_slot
+        );
+        poh_service.join().unwrap();
+
+        assert!(migration_status.is_alpenglow_enabled());
+        assert_eq!(
+            migration_status.wait_for_migration_or_exit(&AtomicBool::new(false)),
+            Some((genesis_slot, block_id))
+        );
+    }
 
     fn test_process_blockstore(
         genesis_config: &GenesisConfig,

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -107,6 +107,7 @@ impl PohService {
         migration_status: Arc<MigrationStatus>,
         record_receiver_sender: Sender<RecordReceiver>,
     ) -> Self {
+        migration_status.set_poh_service_started();
         let poh_config = poh_config.clone();
         let tick_producer = Builder::new()
             .name("solPohTickProd".to_string())

--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -301,6 +301,9 @@ pub struct MigrationStatus {
     /// Flag indicating whether we should shutdown Poh
     pub shutdown_poh: AtomicBool,
 
+    /// Flag indicating whether PohService has been started.
+    poh_service_started: AtomicBool,
+
     /// The current phase of the migration we are in
     phase: RwLock<MigrationPhase>,
 
@@ -333,6 +336,7 @@ impl MigrationStatus {
         Self {
             my_pubkey: RwLock::default(),
             shutdown_poh: AtomicBool::new(is_alpenglow_enabled),
+            poh_service_started: AtomicBool::new(false),
             phase: RwLock::new(phase),
             migration_wait: (Mutex::new(is_alpenglow_enabled), Condvar::new()),
         }
@@ -409,6 +413,11 @@ impl MigrationStatus {
         let my_pubkey = self.my_pubkey();
         let phase = self.phase.read().unwrap();
         warn!("{my_pubkey}: Alpenglow migration phase {phase:?}");
+    }
+
+    /// Record that PohService has started and must be coordinated with when enabling Alpenglow.
+    pub fn set_poh_service_started(&self) {
+        self.poh_service_started.store(true, Ordering::Release);
     }
 
     dispatch!(pub fn is_pre_feature_activation(&self) -> bool);
@@ -641,7 +650,7 @@ impl MigrationStatus {
         condvar.notify_all();
     }
 
-    /// Enables alpenglow in the startup pathway. This is pre `PohService` so we can do this from a single thread.
+    /// Enables alpenglow in the startup pathway.
     /// Returns the genesis slot
     ///
     /// Transition the phase from `ReadyToEnable` to `AlpenglowEnabled`
@@ -657,6 +666,15 @@ impl MigrationStatus {
         };
 
         let genesis_slot = genesis_cert.cert_type.slot();
+        if self.poh_service_started.load(Ordering::Acquire) {
+            // If `PohService` is started, use the full enable pathway
+            // We do not respect the exit flag during startup replay
+            let exit = AtomicBool::new(false);
+            self.enable_alpenglow(&exit);
+            return genesis_slot;
+        }
+
+        // If `PohService` has not yet started, enable in this single thread
         self.shutdown_poh.store(true, Ordering::Release);
         *self.phase.write().unwrap() = MigrationPhase::AlpenglowEnabled { genesis_cert };
         let (is_alpenglow_enabled, _condvar) = &self.migration_wait;


### PR DESCRIPTION
#### Problem
Depending on validator configuration, `PohService` could already be active during startup replay.

Startup replay erroneously assumes that `PohService` is not yet active, and uses the single thread version of enable.
This can cause issues if `PohService` is already active, as it will observe:

- startup replay moves `ReadyToEnable -> AlpenglowEnabled` (single thread no `PohService` coordination)
- as a result `shutdown_poh` gets set
- `PohService` sees `shutdown_poh` assumes `ReplayStage` has asked it to shutdown
- While shutting down it calls `poh_service_is_shutting_down` which assumes the phase must be exactly `ReadyToEnable`
- panic

#### Summary of Changes
If `PohService` is active use the full `enable_alpenglow` path instead, which properly coordinates `PohService` shutting down.

Add a test which would have failed without this change