### PR TITLE
potentially ignore `Standstill` and `ProduceWindow` events

### DIFF
--- a/votor/src/event.rs
+++ b/votor/src/event.rs
@@ -90,8 +90,8 @@ impl VotorEvent {
                 slot: s,
                 parent_block: _,
             } => s <= &root,
-            VotorEvent::ProduceWindow(_) => false,
-            VotorEvent::Standstill(_) => false,
+            VotorEvent::Standstill(s) => s < &root,
+            VotorEvent::ProduceWindow(info) => info.start_slot <= root,
             VotorEvent::SetIdentity => false,
         }
     }


### PR DESCRIPTION
#### Problem
Some `VotorEvent` variants always returned `false` on `should_ignore()` even though there seem to be valid conditions for them to be ignored similar to the other variants.

#### Summary of Changes
- Ignore `VotorEvent::Standstill` if a newer slot has been finalized after the standstill was triggered.
- Ignore `VotorEvent::ProduceWindow` if a slot within or after the leader window has been finalized. 
