### PR TITLE
offset next timeout from previous one, not from current time

### DIFF
--- a/votor/src/timer_manager/timers.rs
+++ b/votor/src/timer_manager/timers.rs
@@ -101,7 +101,7 @@ impl TimerState {
                     return None;
                 }
                 let slot = *window.front().unwrap();
-                let new_timeout = now.checked_add(*scaled_delta_block).unwrap();
+                let new_timeout = timeout.checked_add(*scaled_delta_block).unwrap();
                 *self = Self::WaitDeltaBlock {
                     window: window.to_owned(),
                     timeout: new_timeout,
@@ -123,7 +123,7 @@ impl TimerState {
                 match window.front() {
                     None => *self = Self::Done,
                     Some(_next_slot) => {
-                        *timeout = now.checked_add(*scaled_delta_block).unwrap();
+                        *timeout = timeout.checked_add(*scaled_delta_block).unwrap();
                     }
                 }
                 ret


### PR DESCRIPTION
#### Problem
In `TimerState::progress()`, the new timeouts are currently being set to `now.checked_add(...)`, i.e., as an offset of the current time. So, if the current time is 10ms after the previous timeout fired, we set the next timeout 10ms too late.

#### Summary of Changes
Instead set the timers to `timeout.checked_add(...)`, i.e., just offset from the previous timer regardless of when exactly we call `TimerState::progress()`.