### PR TITLE
remove unused `const VOTE_THRESHOLD_SIZE`

### DIFF
--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -12,8 +12,6 @@ use {
     thiserror::Error,
 };
 
-pub const VOTE_THRESHOLD_SIZE: f64 = 2f64 / 3f64;
-
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub enum VoteHistoryVersions {
     Current(VoteHistory),


### PR DESCRIPTION
#### Problem
The constant `VOTE_THRESHOLD_SIZE` in Votor's `vote_history.rs` does not seem to be used anywhere and its value of 2/3 has no apparent use in Alpenglow's Votor.

#### Summary of Changes
Removed `const VOTE_THRESHOLD_SIZE`.