### PR TITLE
ci: restore merkle shred test skips in coverage

### DIFF
--- a/ci/xtask/src/commands/generate_pipeline.rs
+++ b/ci/xtask/src/commands/generate_pipeline.rs
@@ -180,14 +180,21 @@ pub async fn generate_pull_request_pipeline(pr_number: u64) -> Result<buildkite:
 
     pipeline.add_step(buildkite::Step::Wait(buildkite::WaitStep {}));
 
-    if changed_files.iter().any(|file| {
+    let rust_changed = changed_files.iter().any(|file| {
         file.ends_with("Cargo.toml")
             || file.ends_with("Cargo.lock")
             || file.ends_with(".rs")
             || file.ends_with("rust-toolchain.toml")
             || file.ends_with("ci/rust-version.sh")
             || file.ends_with("ci/docker/Dockerfile")
-    }) {
+    });
+    let coverage_scripts_changed = changed_files.iter().any(|file| {
+        file.ends_with("scripts/coverage.sh")
+            || file.ends_with("ci/test-coverage.sh")
+            || file.starts_with("ci/coverage/")
+    });
+
+    if rust_changed {
         pipeline.add_step(default_checks_step());
         pipeline.add_step(default_feature_check_step(5));
         pipeline.add_step(default_miri_step());
@@ -204,6 +211,8 @@ pub async fn generate_pull_request_pipeline(pr_number: u64) -> Result<buildkite:
 
         pipeline.add_step(default_stable_sbf_step());
         pipeline.add_step(default_shuttle_step());
+        pipeline.add_step(default_coverage_step(3));
+    } else if coverage_scripts_changed {
         pipeline.add_step(default_coverage_step(3));
     }
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -50,26 +50,29 @@ export RUSTFLAGS="--cfg curve25519_dalek_backend=\"serial\" $RUSTFLAGS"
 export LLVM_PROFILE_FILE="$here/../target/cov/${COMMIT_HASH}/profraw/default-%p-%m.profraw"
 
 if [[ -z $1 ]]; then
-  EXTRA_ARGS=(
+  PACKAGES=(
     --features frozen-abi
     --lib
     --all
     --exclude solana-local-cluster
-    --
-    --skip shred::merkle::test::test_make_shreds_from_data::
-    --skip shred::merkle::test::test_make_shreds_from_data_rand::
-    --skip shred::merkle::test::test_recover_merkle_shreds::
   )
 else
-  EXTRA_ARGS=("$@")
+  PACKAGES=("$@")
 fi
+
+# Skip merkle shred tests that blow up coverage CI runtime (see #804, #812).
+TEST_ARGS=(
+  --skip shred::merkle::test::test_make_shreds_from_data::
+  --skip shred::merkle::test::test_make_shreds_from_data_rand::
+  --skip shred::merkle::test::test_recover_merkle_shreds::
+)
 
 # Most verbose log level (trace) is enabled for all solana code to make log!
 # macro code green always. Also, forcibly discard the vast amount of log by
 # redirecting the stderr altogether on CI, where all tests are run unlike
 # developing.
 RUST_LOG="solana=trace,agave=trace,$RUST_LOG" INTERCEPT_OUTPUT=/dev/null "$here/../ci/intercept.sh" \
-  cargo +"$rust_nightly" test --target-dir "$here/../target/cov" "${EXTRA_ARGS[@]}"
+  cargo +"$rust_nightly" test --target-dir "$here/../target/cov" "${PACKAGES[@]}" -- "${TEST_ARGS[@]}"
 
 # Generate test reports
 echo "--- grcov"


### PR DESCRIPTION
#### Problem

#9025 folded the `TEST_ARGS` array into a caller-overridable array. 
This results in the coverage test script dropping the `--skip` flags and inflates the coverage test time (see #804 and #812 ). 

#### Summary of Changes

Split the arrays again so skips always apply.
Update buildkite generator to include the coverage script changes in the coverage tests.

Fixes #

https://github.com/anza-xyz/devops/issues/930