### PR TITLE
Add firebam client id

### DIFF
--- a/version/src/client_ids.rs
+++ b/version/src/client_ids.rs
@@ -10,6 +10,7 @@ pub enum ClientId {
     Firedancer,
     AgaveBam,
     Sig,
+    FireBam,
     // If new variants are added, update From<u16> and TryFrom<ClientId>.
     Unknown(u16),
 }
@@ -25,6 +26,7 @@ impl fmt::Display for ClientId {
             Self::Firedancer => write!(f, "Firedancer"),
             Self::AgaveBam => write!(f, "AgaveBam"),
             Self::Sig => write!(f, "Sig"),
+            Self::FireBam => write!(f, "FireBam"),
             Self::Unknown(id) => write!(f, "Unknown({id})"),
         }
     }
@@ -41,6 +43,7 @@ impl From<u16> for ClientId {
             5u16 => Self::Firedancer,
             6u16 => Self::AgaveBam,
             7u16 => Self::Sig,
+            12u16 => Self::FireBam,
             _ => Self::Unknown(client),
         }
     }
@@ -59,7 +62,9 @@ impl TryFrom<ClientId> for u16 {
             ClientId::Firedancer => Ok(5u16),
             ClientId::AgaveBam => Ok(6u16),
             ClientId::Sig => Ok(7u16),
+            ClientId::FireBam => Ok(12u16),
             ClientId::Unknown(client @ 0u16..=7u16) => Err(format!("Invalid client: {client}")),
+            ClientId::Unknown(client @ 12u16) => Err(format!("Invalid client: {client}")),
             ClientId::Unknown(client) => Ok(client),
         }
     }
@@ -86,7 +91,11 @@ mod test {
         assert_eq!(ClientId::from(5u16), ClientId::Firedancer);
         assert_eq!(ClientId::from(6u16), ClientId::AgaveBam);
         assert_eq!(ClientId::from(7u16), ClientId::Sig);
-        for client in 8u16..=u16::MAX {
+        assert_eq!(ClientId::from(12u16), ClientId::FireBam);
+        for client in 8u16..=11u16 {
+            assert_eq!(ClientId::from(client), ClientId::Unknown(client));
+        }
+        for client in 13u16..=u16::MAX {
             assert_eq!(ClientId::from(client), ClientId::Unknown(client));
         }
         assert_eq!(u16::try_from(ClientId::SolanaLabs), Ok(0u16));
@@ -97,13 +106,21 @@ mod test {
         assert_eq!(u16::try_from(ClientId::Firedancer), Ok(5u16));
         assert_eq!(u16::try_from(ClientId::AgaveBam), Ok(6u16));
         assert_eq!(u16::try_from(ClientId::Sig), Ok(7u16));
+        assert_eq!(u16::try_from(ClientId::FireBam), Ok(12u16));
         for client in 0..=7u16 {
             assert_eq!(
                 u16::try_from(ClientId::Unknown(client)),
                 Err(format!("Invalid client: {client}"))
             );
         }
-        for client in 8u16..=u16::MAX {
+        assert_eq!(
+            u16::try_from(ClientId::Unknown(12u16)),
+            Err("Invalid client: 12".to_string())
+        );
+        for client in 8u16..=11u16 {
+            assert_eq!(u16::try_from(ClientId::Unknown(client)), Ok(client));
+        }
+        for client in 13u16..=u16::MAX {
             assert_eq!(u16::try_from(ClientId::Unknown(client)), Ok(client));
         }
     }
@@ -118,6 +135,7 @@ mod test {
         assert_eq!(format!("{}", ClientId::Firedancer), "Firedancer");
         assert_eq!(format!("{}", ClientId::AgaveBam), "AgaveBam");
         assert_eq!(format!("{}", ClientId::Sig), "Sig");
+        assert_eq!(format!("{}", ClientId::FireBam), "FireBam");
         assert_eq!(format!("{}", ClientId::Unknown(0)), "Unknown(0)");
         assert_eq!(format!("{}", ClientId::Unknown(u16::MAX)), "Unknown(65535)");
     }


### PR DESCRIPTION
## Summary
- Adds FireBam to the version client ID enum as ID 12.
- Updates conversions and display formatting so ID 12 is recognized instead of reported as unknown.
- Extends client ID tests for the reserved gaps around ID 12.

## Validation
- cargo test -p solana-version --features agave-unstable-api