### PR TITLE
ci: fix crate publish test

### DIFF
--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -90,7 +90,7 @@ rand = { workspace = true }
 shuttle = { workspace = true }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api"] }
 solana-clock = { workspace = true }
-solana-compute-budget = { workspace = true }
+solana-compute-budget = { path = "../compute-budget", features = ["agave-unstable-api"] }
 solana-compute-budget-interface = { workspace = true }
 solana-compute-budget-program = { path = "../programs/compute-budget", features = ["agave-unstable-api"] }
 solana-ed25519-program = { workspace = true }
@@ -110,8 +110,8 @@ solana-signature = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-svm = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils", "svm-internal"] }
-solana-syscalls = { workspace = true }
-solana-system-program = { workspace = true }
+solana-syscalls = { path = "../syscalls", features = ["agave-unstable-api"] }
+solana-system-program = { path = "../programs/system", features = ["agave-unstable-api"] }
 solana-system-transaction = { workspace = true }
 solana-sysvar = { workspace = true }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }


### PR DESCRIPTION
#### Problem

we removed loader-v4 in #11990 and it changed the publish order. the failure reason is similar to https://github.com/anza-xyz/agave/pull/10874

(my mistake for not having a ci to protect this. let's fix it for now and I'll prioritize adding proper tests)

#### Summary of Changes

use path in dev-dependencies