### PR TITLE
Fix: core tests

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -183,7 +183,7 @@ bitvec = { workspace = true }
 criterion = { workspace = true }
 serial_test = { workspace = true }
 solana-account = { workspace = true, features = ["dev-context-only-utils"] }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api"] }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api", "svm-internal"] }
 solana-client = { path = "../client", features = ["dev-context-only-utils"] }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-interface = { workspace = true }


### PR DESCRIPTION
#### Problem
- core tests no longer compiler after #11990
- Removed svm-internal depedency: https://github.com/anza-xyz/agave/pull/11990/changes#diff-245bc911112abf84223979c6b5e8a314e200a5b7bf8e5bf8b35b35a407c28e04L32 

#### Summary of Changes
- Add svm-internal feature on `solana-bpf-loader-program` in `core`

Fixes #
