### PR TITLE
add feature gate for txv1

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -86,6 +86,7 @@ pub struct FeatureSnapshot {
     pub loader_v3_minimum_extend_program_size: bool,
     pub enable_sha512_syscall: bool,
     pub relax_post_exec_min_balance_check: bool,
+    pub enable_tx_v1: bool,
 }
 
 impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
@@ -200,6 +201,7 @@ impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
             ),
             enable_sha512_syscall: is_active(&enable_sha512_syscall::ID),
             relax_post_exec_min_balance_check: is_active(&relax_post_exec_min_balance_check::ID),
+            enable_tx_v1: is_active(&enable_tx_v1::ID),
         }
     }
 }
@@ -365,6 +367,7 @@ impl FeatureSet {
             loader_v3_minimum_extend_program_size: snapshot.loader_v3_minimum_extend_program_size,
             enable_sha512_syscall: snapshot.enable_sha512_syscall,
             relax_post_exec_min_balance_check: snapshot.relax_post_exec_min_balance_check,
+            enable_tx_v1: snapshot.enable_tx_v1,
         }
     }
 }
@@ -1534,6 +1537,10 @@ pub mod relax_post_exec_min_balance_check {
     solana_pubkey::declare_id!("DEJmsCntuYqbXtL5z5TxbaxJXFUJAFjf7TqWSF7YWjQg");
 }
 
+pub mod enable_tx_v1 {
+    solana_pubkey::declare_id!("txv1hPU76QFBVeq3942jJ65e9Em2xbdbCJrzX8sM4U4");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2587,6 +2594,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
             relax_post_exec_min_balance_check::id(),
             "SIMD-0392: Relaxation of post-execution min_balance check",
         ),
+        (enable_tx_v1::id(), "SIMD-0385: Transaction V1"),
         /*************** ADD NEW FEATURES HERE ***************/
         /***** ADD NEW FEATURE BOOL TO `FeatureSnapshot` *****/
     ]

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -367,7 +367,6 @@ impl FeatureSet {
             loader_v3_minimum_extend_program_size: snapshot.loader_v3_minimum_extend_program_size,
             enable_sha512_syscall: snapshot.enable_sha512_syscall,
             relax_post_exec_min_balance_check: snapshot.relax_post_exec_min_balance_check,
-            enable_tx_v1: snapshot.enable_tx_v1,
         }
     }
 }

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -31,11 +31,6 @@ fn verify_packet(packet: &mut PacketRefMut, reject_non_vote: bool) -> bool {
             return false;
         };
 
-        // Discard v1 transactions until support is added.
-        if matches!(view.version(), TransactionVersion::V1) {
-            return false;
-        }
-
         let is_simple_vote_tx = is_simple_vote_transaction_view(&view);
         if reject_non_vote && !is_simple_vote_tx {
             (is_simple_vote_tx, false)
@@ -359,9 +354,10 @@ mod tests {
         let tx = test_tx();
         let mut data = bincode::serialize(&tx).unwrap();
 
-        // set message version to 1
+        // Set message version to 2. V1 is supported by transaction-view and
+        // allowed through sigverify; bank performs the feature gate check.
         const MESSAGE_OFFSET: usize = 1 + core::mem::size_of::<Signature>();
-        data[MESSAGE_OFFSET] = MESSAGE_VERSION_PREFIX + 1;
+        data[MESSAGE_OFFSET] = MESSAGE_VERSION_PREFIX + 2;
 
         let mut packet = BytesPacket::from_bytes(None, Bytes::from(data));
         assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4960,8 +4960,10 @@ impl Bank {
         tx: VersionedTransaction,
         verification_mode: TransactionVerificationMode,
     ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
-        // Discard v1 transactions until support is added.
-        if tx.version() == TransactionVersion::Number(1) {
+        // Discard v1 transactions until feature gate is activated.
+        if !self.feature_set.snapshot().enable_tx_v1
+            && tx.version() == TransactionVersion::Number(1)
+        {
             return Err(TransactionError::UnsupportedVersion);
         }
 
@@ -4981,10 +4983,17 @@ impl Bank {
         serialized_message: &[u8],
         verification_mode: TransactionVerificationMode,
     ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
-        // Discard v1 transactions until support is added.
-        if tx.version() == TransactionVersion::Number(1) {
+        // Discard v1 transactions until feature gate is activated.
+        let enable_tx_v1 = self.feature_set.snapshot().enable_tx_v1;
+        if !enable_tx_v1 && tx.version() == TransactionVersion::Number(1) {
             return Err(TransactionError::UnsupportedVersion);
         }
+        let max_transaction_size = match tx.version() {
+            TransactionVersion::Number(1) if enable_tx_v1 => {
+                solana_message::v1::MAX_TRANSACTION_SIZE
+            }
+            _ => PACKET_DATA_SIZE,
+        } as u64;
 
         let enable_instruction_account_limit =
             self.feature_set.snapshot().limit_instruction_accounts;
@@ -4994,7 +5003,7 @@ impl Bank {
         let sanitized_tx = {
             let size =
                 wincode::serialized_size(&tx).map_err(|_| TransactionError::SanitizeFailure)?;
-            if size > PACKET_DATA_SIZE as u64 {
+            if size > max_transaction_size {
                 return Err(TransactionError::SanitizeFailure);
             }
 

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -91,13 +91,16 @@ impl Bank {
         sanitized_txs: &[impl core::borrow::Borrow<Tx>],
         lock_results: &[TransactionResult<()>],
     ) -> Vec<TransactionResult<()>> {
-        // Discard v1 transactions until support is added.
+        // Discard v1 transactions until feature gate is activated.
         sanitized_txs
             .iter()
             .zip(lock_results)
             .map(|(tx, lock_result)| match lock_result {
                 Err(err) => Err(err.clone()),
-                Ok(()) if tx.borrow().version() == TransactionVersion::Number(1) => {
+                Ok(())
+                    if !self.feature_set.snapshot().enable_tx_v1
+                        && tx.borrow().version() == TransactionVersion::Number(1) =>
+                {
                     Err(TransactionError::UnsupportedVersion)
                 }
                 Ok(()) => Ok(()),
@@ -581,6 +584,18 @@ mod tests {
             filtered[0],
             Err(TransactionError::UnsupportedVersion)
         ));
+    }
+
+    #[test]
+    fn test_filter_v1_transactions_keeps_v1_when_feature_enabled() {
+        let txs = vec![make_test_tx(TransactionVersion::Number(1))];
+        let lock_results = vec![Ok(())];
+        let mut bank = Bank::default_for_tests();
+        bank.activate_feature(&agave_feature_set::enable_tx_v1::id());
+
+        let filtered = bank.filter_v1_transactions(&txs, &lock_results);
+
+        assert_eq!(filtered, vec![Ok(())]);
     }
 
     #[test]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -71,7 +71,8 @@ use {
         state::UpgradeableLoaderState,
     },
     solana_message::{
-        Message, MessageHeader, SanitizedMessage, compiled_instruction::CompiledInstruction,
+        Message, MessageHeader, SanitizedMessage, VersionedMessage,
+        compiled_instruction::CompiledInstruction, v0, v1,
     },
     solana_native_token::LAMPORTS_PER_SOL,
     solana_nonce::{self as nonce, state::DurableNonce},
@@ -114,6 +115,7 @@ use {
     solana_system_transaction as system_transaction, solana_sysvar as sysvar,
     solana_transaction::{
         Transaction, TransactionVerificationMode, sanitized::SanitizedTransaction,
+        versioned::VersionedTransaction,
     },
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     solana_vote_interface::state::{BLS_PUBLIC_KEY_COMPRESSED_SIZE, TowerSync},
@@ -8442,6 +8444,66 @@ fn test_verify_transactions_packet_data_size() {
                 .is_ok(),
         );
     }
+}
+
+#[test]
+fn test_verify_transactions_tx_v1_size_gate_does_not_relax_legacy_or_v0() {
+    let GenesisConfigInfo { genesis_config, .. } =
+        create_genesis_config_with_leader(42, &solana_pubkey::new_rand(), 42);
+    let mut bank = Bank::new_for_tests(&genesis_config);
+    bank.activate_feature(&feature_set::enable_tx_v1::id());
+
+    let recent_blockhash = Hash::new_unique();
+    let keypair = Keypair::new();
+    let pubkey = keypair.pubkey();
+    let make_instructions = |size| {
+        std::iter::repeat_with(|| system_instruction::transfer(&pubkey, &Pubkey::new_unique(), 1))
+            .take(size)
+            .collect::<Vec<_>>()
+    };
+    let make_legacy_transaction = |size| {
+        let ixs = make_instructions(size);
+        let message = Message::new(&ixs, Some(&pubkey));
+        VersionedTransaction::from(Transaction::new(&[&keypair], message, recent_blockhash))
+    };
+    let make_v0_transaction = |size| {
+        let ixs = make_instructions(size);
+        let message = v0::Message::try_compile(&pubkey, &ixs, &[], recent_blockhash).unwrap();
+        VersionedTransaction::try_new(VersionedMessage::V0(message), &[&keypair]).unwrap()
+    };
+    let make_v1_transaction = |size| {
+        let ixs = make_instructions(size);
+        let message = v1::Message::try_compile(&pubkey, &ixs, recent_blockhash).unwrap();
+        VersionedTransaction::try_new(VersionedMessage::V1(message), &[&keypair]).unwrap()
+    };
+    let oversized_but_tx_v1_sized = |make_transaction: &dyn Fn(usize) -> VersionedTransaction| {
+        (1..=64)
+            .map(make_transaction)
+            .find(|tx| {
+                let size = wincode::serialized_size(tx).unwrap();
+                size > PACKET_DATA_SIZE as u64
+                    && size <= solana_message::v1::MAX_TRANSACTION_SIZE as u64
+            })
+            .expect("test transaction with size between packet and tx v1 limits")
+    };
+
+    let legacy_tx = oversized_but_tx_v1_sized(&make_legacy_transaction);
+    assert_matches!(
+        bank.verify_transaction(legacy_tx, TransactionVerificationMode::FullVerification),
+        Err(TransactionError::SanitizeFailure)
+    );
+
+    let v0_tx = oversized_but_tx_v1_sized(&make_v0_transaction);
+    assert_matches!(
+        bank.verify_transaction(v0_tx, TransactionVerificationMode::FullVerification),
+        Err(TransactionError::SanitizeFailure)
+    );
+
+    let v1_tx = oversized_but_tx_v1_sized(&make_v1_transaction);
+    assert!(
+        bank.verify_transaction(v1_tx, TransactionVerificationMode::FullVerification)
+            .is_ok()
+    );
 }
 
 #[test]

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -52,6 +52,7 @@ pub struct SVMFeatureSet {
     pub loader_v3_minimum_extend_program_size: bool,
     pub enable_sha512_syscall: bool,
     pub relax_post_exec_min_balance_check: bool,
+    pub enable_tx_v1: bool,
 }
 
 impl SVMFeatureSet {
@@ -108,6 +109,7 @@ impl SVMFeatureSet {
             loader_v3_minimum_extend_program_size: true,
             enable_sha512_syscall: true,
             relax_post_exec_min_balance_check: true,
+            enable_tx_v1: true,
         }
     }
 }

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -52,7 +52,6 @@ pub struct SVMFeatureSet {
     pub loader_v3_minimum_extend_program_size: bool,
     pub enable_sha512_syscall: bool,
     pub relax_post_exec_min_balance_check: bool,
-    pub enable_tx_v1: bool,
 }
 
 impl SVMFeatureSet {
@@ -109,7 +108,6 @@ impl SVMFeatureSet {
             loader_v3_minimum_extend_program_size: true,
             enable_sha512_syscall: true,
             relax_post_exec_min_balance_check: true,
-            enable_tx_v1: true,
         }
     }
 }


### PR DESCRIPTION
#### Problem

Need feature Gate to enabled txv1

#### Summary of Changes
- add feature gate
- use feature gate at bank to check transaction at entrances of replay and block production
- remove hard fail from sigverify. note: feature gate at sigverify will be in a separate PR.

Fixes #
