### PR TITLE
chore: bump shaq version to 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6589,9 +6589,9 @@ dependencies = [
 
 [[package]]
 name = "shaq"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34483a45b522d9b15cc1031536718acb3f2d94f7bc09d7156a3e8d173dfdffe"
+checksum = "f70af47ac33fc236ff3d3185a60d0821622475415a6f3aa8378d50eed158913b"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -344,7 +344,7 @@ serde_json = "1.0.149"
 serde_with = { version = "3.18.0", default-features = false }
 serde_yaml = "0.9.34"
 serial_test = "3.4.0"
-shaq = { version = "2.0.0" }
+shaq = { version = "3.0.0" }
 shuttle = "0.7.1"
 signal-hook = "0.4.4"
 siphasher = "1.0.2"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -5922,9 +5922,9 @@ dependencies = [
 
 [[package]]
 name = "shaq"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34483a45b522d9b15cc1031536718acb3f2d94f7bc09d7156a3e8d173dfdffe"
+checksum = "f70af47ac33fc236ff3d3185a60d0821622475415a6f3aa8378d50eed158913b"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5646,9 +5646,9 @@ dependencies = [
 
 [[package]]
 name = "shaq"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34483a45b522d9b15cc1031536718acb3f2d94f7bc09d7156a3e8d173dfdffe"
+checksum = "f70af47ac33fc236ff3d3185a60d0821622475415a6f3aa8378d50eed158913b"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",


### PR DESCRIPTION
#### Problem
- shaq 3.0.0 includes several changes caught by auditors
	- no security risks, but want to keep shaq at latest for version bump of scheduler bindings

#### Summary of Changes
- Use shaq version 3.0.0

Fixes #
