### PR TITLE
chore: bump rts-alloc version to 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6075,9 +6075,9 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ced2d9fa1303e8c6814fe3fceb6599951e17622088df430ed6de039930cb9b"
+checksum = "eddfcbcf855d5fa999ae18a991204dca661237b6e6fda7c4cb06bd97ad0b3af2"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -332,7 +332,7 @@ reqwest = { version = "0.12.28", default-features = false }
 reqwest-middleware = "0.4.2"
 rolling-file = "0.2.0"
 rpassword = "7.5"
-rts-alloc = { version = "3.0.0" }
+rts-alloc = { version = "4.0.0" }
 rustls = { version = "0.23.40", features = ["std"], default-features = false }
 scopeguard = "1.2.0"
 semver = "1.0.28"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -5463,9 +5463,9 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ced2d9fa1303e8c6814fe3fceb6599951e17622088df430ed6de039930cb9b"
+checksum = "eddfcbcf855d5fa999ae18a991204dca661237b6e6fda7c4cb06bd97ad0b3af2"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5219,9 +5219,9 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ced2d9fa1303e8c6814fe3fceb6599951e17622088df430ed6de039930cb9b"
+checksum = "eddfcbcf855d5fa999ae18a991204dca661237b6e6fda7c4cb06bd97ad0b3af2"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",


### PR DESCRIPTION
#### Problem
- rts-alloc 4.0.0 includes several changes caught by auditors
	- no security risks, but want to keep rts-alloc at latest for version bump of scheduler bindings

#### Summary of Changes
- Use rts-alloc version 4.0.0

Fixes #
