### PR TITLE
turbine: use bounded channels in broadcast

### DIFF
--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -11,7 +11,7 @@ use {
         cluster_nodes::{ClusterNodes, ClusterNodesCache},
     },
     agave_votor::event::VotorEventSender,
-    crossbeam_channel::{Receiver, RecvError, RecvTimeoutError, Sender, unbounded},
+    crossbeam_channel::{Receiver, RecvError, RecvTimeoutError, Sender, bounded},
     itertools::Itertools,
     solana_clock::{NUM_CONSECUTIVE_LEADER_SLOTS, Slot},
     solana_gossip::{
@@ -20,7 +20,9 @@ use {
     },
     solana_keypair::Keypair,
     solana_ledger::{
-        blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache, shred::Shred,
+        blockstore::Blockstore,
+        leader_schedule_cache::LeaderScheduleCache,
+        shred::{MAX_FEC_SETS_PER_SLOT, Shred},
     },
     solana_measure::measure::Measure,
     solana_metrics::inc_new_counter_error,
@@ -58,6 +60,13 @@ const _: () = const {
 };
 const CLUSTER_NODES_CACHE_NUM_EPOCH_CAP: usize = MAX_LEADER_SCHEDULE_STAKES as usize;
 const CLUSTER_NODES_CACHE_TTL: Duration = Duration::from_secs(5);
+
+// Capacity in batches. One batch typically packs 1-2 FEC sets worth of bytes
+// (see get_target_batch_bytes_default), so this is at least 4 slots' worth of
+// broadcast traffic. Filling the channel means the consumer (blockstore record
+// or socket transmit) has fallen at least 4 slots behind, which means we've
+// been skipped already.
+const BROADCAST_CHANNEL_CAPACITY: usize = MAX_FEC_SETS_PER_SLOT as usize * 4;
 
 pub(crate) type RecordReceiver = Receiver<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>;
 pub(crate) type TransmitReceiver = Receiver<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>;
@@ -274,8 +283,8 @@ impl BroadcastStage {
         mut broadcast_stage_run: impl BroadcastRun + Send + 'static + Clone,
         xdp_sender: Option<XdpSender>,
     ) -> Self {
-        let (socket_sender, socket_receiver) = unbounded();
-        let (blockstore_sender, blockstore_receiver) = unbounded();
+        let (socket_sender, socket_receiver) = bounded(BROADCAST_CHANNEL_CAPACITY);
+        let (blockstore_sender, blockstore_receiver) = bounded(BROADCAST_CHANNEL_CAPACITY);
         let bs_run = broadcast_stage_run.clone();
 
         let socket_sender_ = socket_sender.clone();

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -11,7 +11,9 @@ use {
         cluster_nodes::{ClusterNodes, ClusterNodesCache},
     },
     agave_votor::event::VotorEventSender,
-    crossbeam_channel::{Receiver, RecvError, RecvTimeoutError, Sender, bounded},
+    crossbeam_channel::{
+        Receiver, RecvError, RecvTimeoutError, SendError, Sender, TrySendError, bounded,
+    },
     itertools::Itertools,
     solana_clock::{NUM_CONSECUTIVE_LEADER_SLOTS, Slot},
     solana_gossip::{
@@ -70,6 +72,44 @@ const BROADCAST_CHANNEL_CAPACITY: usize = MAX_FEC_SETS_PER_SLOT as usize * 4;
 
 pub(crate) type RecordReceiver = Receiver<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>;
 pub(crate) type TransmitReceiver = Receiver<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>;
+
+/// Try to send into a bounded channel. If the channel is full,
+/// log an error and fall back to a blocking send so shreds are not dropped.
+/// A full channel means there is something very wrong with our node,
+/// so we want a loud signal but must preserve shreds so the validator
+/// does not start repairing its own blocks.
+fn try_send_or_block<T>(
+    sender: &Sender<T>,
+    msg: T,
+    channel_name: &str,
+) -> std::result::Result<(), SendError<T>> {
+    match sender.try_send(msg) {
+        Ok(()) => Ok(()),
+        Err(TrySendError::Full(msg)) => {
+            error!("The channel to {channel_name} is full, node is resource starved!");
+            sender.send(msg)
+        }
+        Err(TrySendError::Disconnected(msg)) => Err(SendError(msg)),
+    }
+}
+
+/// Fan a batch of shreds out to both the blockstore record path and the
+/// network transmit path. Each leg uses [`try_send_or_block`] so any full
+/// channel is logged loudly but never drops shreds.
+#[allow(clippy::type_complexity)]
+pub(crate) fn dispatch_shreds(
+    blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
+    socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
+    shreds: Arc<Vec<Shred>>,
+    batch_info: Option<BroadcastShredBatchInfo>,
+) -> std::result::Result<(), SendError<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>> {
+    try_send_or_block(
+        blockstore_sender,
+        (shreds.clone(), batch_info.clone()),
+        "blockstore",
+    )?;
+    try_send_or_block(socket_sender, (shreds, batch_info), "network egress")
+}
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -427,7 +467,7 @@ impl BroadcastStage {
                     .all(|shred| shred.slot() == new_retransmit_slot)
             );
             if !data_shreds.is_empty() {
-                socket_sender.send((data_shreds, None))?;
+                try_send_or_block(socket_sender, (data_shreds, None), "network egress")?;
             }
 
             let coding_shreds = Arc::new(
@@ -442,7 +482,7 @@ impl BroadcastStage {
                     .all(|shred| shred.slot() == new_retransmit_slot)
             );
             if !coding_shreds.is_empty() {
-                socket_sender.send((coding_shreds, None))?;
+                try_send_or_block(socket_sender, (coding_shreds, None), "network egress")?;
             }
         }
 

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -263,8 +263,6 @@ impl BroadcastRun for BroadcastDuplicatesRun {
 
         if !data_shreds.is_empty() {
             let data_shreds = Arc::new(data_shreds);
-            blockstore_sender.send((data_shreds.clone(), None))?;
-
             // 3) Start broadcast step
             info!(
                 "{} Sending good shreds for slot {} to network",
@@ -272,7 +270,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                 data_shreds.first().unwrap().slot()
             );
             assert!(data_shreds.iter().all(|shred| shred.slot() == bank.slot()));
-            socket_sender.send((data_shreds, None))?;
+            dispatch_shreds(blockstore_sender, socket_sender, data_shreds, None)?;
         }
 
         // Special handling of last shred to cause partition
@@ -294,9 +292,6 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             let original_last_data_shred = Arc::new(original_last_data_shred);
             let partition_last_data_shred = Arc::new(partition_last_data_shred);
 
-            // Store the original shreds that this node replayed
-            blockstore_sender.send((original_last_data_shred.clone(), None))?;
-
             assert!(
                 original_last_data_shred
                     .iter()
@@ -311,7 +306,15 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             if let Some(duplicate_slot_sender) = &self.config.duplicate_slot_sender {
                 let _ = duplicate_slot_sender.send(bank.slot());
             }
-            socket_sender.send((original_last_data_shred, None))?;
+            // Store the original shreds that this node replayed;
+            dispatch_shreds(
+                blockstore_sender,
+                socket_sender,
+                original_last_data_shred,
+                None,
+            )?;
+            // the partition shreds go only over the wire to create the duplicate slot.
+            // blocking here is ok since this is only ever used in tests.
             socket_sender.send((partition_last_data_shred, None))?;
         }
 

--- a/turbine/src/broadcast_stage/broadcast_metrics.rs
+++ b/turbine/src/broadcast_stage/broadcast_metrics.rs
@@ -307,7 +307,7 @@ mod test {
             let slot_broadcast_stats = Arc::new(Mutex::new(SlotBroadcastStats::default()));
             let num_threads = 5;
             let slot = 0;
-            let (sender, receiver) = unbounded();
+            let (sender, receiver) = bounded(1024);
             let thread_handles: Vec<_> = (0..num_threads)
                 .map(|i| {
                     let slot_broadcast_stats = slot_broadcast_stats.clone();

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -305,8 +305,8 @@ impl StandardBroadcastRun {
         receive_results: ReceiveResults,
         bank_forks: &RwLock<BankForks>,
     ) -> Result<()> {
-        let (bsend, brecv) = unbounded();
-        let (ssend, srecv) = unbounded();
+        let (bsend, brecv) = bounded(BROADCAST_CHANNEL_CAPACITY);
+        let (ssend, srecv) = bounded(BROADCAST_CHANNEL_CAPACITY);
         self.process_receive_results(
             keypair,
             blockstore,
@@ -362,8 +362,8 @@ impl StandardBroadcastRun {
                     was_interrupted: true,
                 });
                 let shreds = Arc::new(shreds);
-                socket_sender.send((shreds.clone(), batch_info.clone()))?;
-                blockstore_sender.send((shreds, batch_info))?;
+                blockstore_sender.send((shreds.clone(), batch_info.clone()))?;
+                socket_sender.send((shreds, batch_info))?;
             }
             // If blockstore already has shreds for this slot,
             // it should not recreate the slot:
@@ -463,8 +463,8 @@ impl StandardBroadcastRun {
 
         let shreds = Arc::new(shreds);
         debug_assert!(shreds.iter().all(|shred| shred.slot() == bank.slot()));
-        socket_sender.send((shreds.clone(), batch_info.clone()))?;
-        blockstore_sender.send((shreds, batch_info))?;
+        blockstore_sender.send((shreds.clone(), batch_info.clone()))?;
+        socket_sender.send((shreds, batch_info))?;
 
         coding_send_time.stop();
 

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -362,8 +362,7 @@ impl StandardBroadcastRun {
                     was_interrupted: true,
                 });
                 let shreds = Arc::new(shreds);
-                blockstore_sender.send((shreds.clone(), batch_info.clone()))?;
-                socket_sender.send((shreds, batch_info))?;
+                dispatch_shreds(blockstore_sender, socket_sender, shreds, batch_info)?;
             }
             // If blockstore already has shreds for this slot,
             // it should not recreate the slot:
@@ -463,8 +462,7 @@ impl StandardBroadcastRun {
 
         let shreds = Arc::new(shreds);
         debug_assert!(shreds.iter().all(|shred| shred.slot() == bank.slot()));
-        blockstore_sender.send((shreds.clone(), batch_info.clone()))?;
-        socket_sender.send((shreds, batch_info))?;
+        dispatch_shreds(blockstore_sender, socket_sender, shreds, batch_info)?;
 
         coding_send_time.stop();
 


### PR DESCRIPTION
#### Problem

- Unbounded channels must go

#### Summary of Changes

- Replace unbounded ones with bounded in turbine broadcast. 
- Provision 4 slots worth of capacity for the broadcast channels to ensure they never back up under normal load. If they do fill up (broadcast or blockstore insert did not manage to clear backlog before start of next leader window), validator will stall (but at this point it is clearly broken anyway, so does not matter).
