### PR TITLE
add enable-tx-v1 feature gate at sigverify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9262,6 +9262,7 @@ dependencies = [
  "solana-vote-program",
  "test-case",
  "tikv-jemallocator",
+ "wincode",
 ]
 
 [[package]]

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -18,6 +18,7 @@ use {
         sigverify,
         test_tx::test_tx,
     },
+    solana_runtime::{bank::Bank, genesis_utils::create_genesis_config},
     solana_signer::Signer,
     solana_system_transaction as system_transaction,
     std::{borrow::Cow, hint::black_box, num::NonZeroUsize, sync::Arc, time::Instant},
@@ -70,6 +71,9 @@ fn bench_sigverify_stage_without_same_tx(bencher: &mut Bencher) {
 fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
     agave_logger::setup();
     trace!("start");
+    let (_bank, bank_forks) =
+        Bank::new_with_bank_forks_for_tests(&create_genesis_config(1).genesis_config);
+    let sharable_banks = bank_forks.read().unwrap().sharable_banks();
     let (packet_s, packet_r) = unbounded();
     let (vote_packet_s, vote_packet_r) = unbounded();
     let (verified_s, verified_r) = BankingTracer::channel_for_test();
@@ -83,6 +87,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
         forward_stage_s,
         NonZeroUsize::new(sigverify::threadpool_for_benches().current_num_threads()).unwrap(),
         false,
+        sharable_banks,
     );
     let packet_s = packet_s;
     let packet_s_for_bench = packet_s.clone();
@@ -174,7 +179,7 @@ fn bench_shrink_sigverify_stage_core(bencher: &mut Bencher, discard_factor: i32)
         let mut batches = batches0.clone();
 
         let mut verify_time = Measure::start("sigverify_batch_time");
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_valid_packets);
+        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_valid_packets, false);
         verify_time.stop();
         black_box(sigverify::count_valid_packets(&batches));
 

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -999,7 +999,7 @@ mod tests {
         let mut packet_batches = packet::to_packet_batches(votes, 1);
         packet_batches
             .iter_mut()
-            .for_each(|packet_batch| sigverify::ed25519_verify_serial(packet_batch, true));
+            .for_each(|packet_batch| sigverify::ed25519_verify_serial(packet_batch, true, false));
         // There is no worker thread in these tests, so preload the verified
         // responses that verify_votes() will receive after it sends work.
         votes

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -997,6 +997,7 @@ mod tests {
         votes: &[Transaction],
     ) {
         let mut packet_batches = packet::to_packet_batches(votes, 1);
+        // Gossip votes are legacy Transaction values, not tx-v1 packets.
         packet_batches
             .iter_mut()
             .for_each(|packet_batch| sigverify::ed25519_verify_serial(packet_batch, true, false));

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -11,6 +11,7 @@ use {
         packet::PacketBatch,
         sigverify::{self},
     },
+    solana_runtime::bank_forks::SharableBanks,
     solana_transaction::Transaction,
     std::{
         num::NonZeroUsize,
@@ -132,6 +133,7 @@ struct WorkerPoolChannels {
     tpu_vote_banking_sender: BankingPacketSender,
     gossip_verified_vote_sender: Sender<GossipVerifiedVoteBatch>,
     forward_stage_sender: Sender<(BankingPacketBatch, bool)>,
+    sharable_banks: SharableBanks,
     non_vote_stats: SigVerifyWorkerStats,
     tpu_vote_stats: SigVerifyWorkerStats,
 }
@@ -163,6 +165,7 @@ impl SigVerifyWorkerPool {
         gossip_verified_vote_sender: Sender<GossipVerifiedVoteBatch>,
         forward_stage_sender: Sender<(BankingPacketBatch, bool)>,
         forward_non_votes: bool,
+        sharable_banks: SharableBanks,
         non_vote_stats: SigVerifyWorkerStats,
         tpu_vote_stats: SigVerifyWorkerStats,
     ) -> Self {
@@ -177,6 +180,7 @@ impl SigVerifyWorkerPool {
             tpu_vote_banking_sender,
             gossip_verified_vote_sender,
             forward_stage_sender,
+            sharable_banks,
             non_vote_stats,
             tpu_vote_stats,
         };
@@ -235,6 +239,7 @@ impl SigVerifyWorkerPool {
                         &channels.forward_stage_sender,
                         forward_non_votes,
                         false,
+                        &channels.sharable_banks,
                         &channels.non_vote_stats,
                     ),
                     Err(_) => false,
@@ -249,6 +254,7 @@ impl SigVerifyWorkerPool {
                         &channels.forward_stage_sender,
                         true,
                         true,
+                        &channels.sharable_banks,
                         &channels.tpu_vote_stats,
                     ),
                     Err(_) => false,
@@ -274,11 +280,14 @@ impl SigVerifyWorkerPool {
         forward_stage_sender: &Sender<(BankingPacketBatch, bool)>,
         should_forward: bool,
         is_tpu_vote: bool,
+        sharable_banks: &SharableBanks,
         stats: &SigVerifyWorkerStats,
     ) -> bool {
+        let enable_tx_v1 = sharable_banks.working().feature_set.snapshot().enable_tx_v1;
         let (_, verify_time_us) = measure_us!(sigverify::ed25519_verify_serial(
             &mut work.batch,
-            reject_non_vote
+            reject_non_vote,
+            enable_tx_v1,
         ));
         let num_valid_packets = sigverify::count_valid_packets(std::iter::once(&work.batch));
         stats
@@ -304,7 +313,7 @@ impl SigVerifyWorkerPool {
         mut work: GossipVerifyTask,
         verified_vote_sender: &Sender<GossipVerifiedVoteBatch>,
     ) -> bool {
-        sigverify::ed25519_verify_serial(&mut work.batch, true);
+        sigverify::ed25519_verify_serial(&mut work.batch, true, false);
 
         if let Err(err) = verified_vote_sender.send(GossipVerifiedVoteBatch {
             transaction: work.transaction,

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -313,6 +313,7 @@ impl SigVerifyWorkerPool {
         mut work: GossipVerifyTask,
         verified_vote_sender: &Sender<GossipVerifiedVoteBatch>,
     ) -> bool {
+        // Gossip votes are legacy Transaction values, not tx-v1 packets.
         sigverify::ed25519_verify_serial(&mut work.batch, true, false);
 
         if let Err(err) = verified_vote_sender.send(GossipVerifiedVoteBatch {

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -20,6 +20,7 @@ use {
         deduper::{self, Deduper},
         packet::PacketBatch,
     },
+    solana_runtime::bank_forks::SharableBanks,
     solana_streamer::streamer::{self, StreamerError},
     solana_transaction::Transaction,
     std::{
@@ -193,6 +194,7 @@ impl SigVerifyStage {
         forward_stage_sender: Sender<(BankingPacketBatch, bool)>,
         num_workers: NonZeroUsize,
         forward_non_votes: bool,
+        sharable_banks: SharableBanks,
     ) -> (Self, GossipSigVerifyHandle) {
         let (gossip_verified_vote_sender, verified_vote_receiver) = unbounded();
         let non_vote_stats = SigVerifierStats::default();
@@ -204,6 +206,7 @@ impl SigVerifyStage {
             gossip_verified_vote_sender,
             forward_stage_sender,
             forward_non_votes,
+            sharable_banks,
             SigVerifyWorkerStats {
                 total_valid_packets: non_vote_stats.total_valid_packets.clone(),
                 total_verify_time_us: non_vote_stats.total_verify_time_us.clone(),
@@ -380,8 +383,30 @@ mod tests {
         super::*,
         crate::banking_trace::BankingTracer,
         crossbeam_channel::unbounded,
-        solana_perf::{packet::to_packet_batches, test_tx::test_tx},
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_message::{VersionedMessage, v1},
+        solana_perf::{
+            packet::{BytesPacket, BytesPacketBatch, to_packet_batches},
+            test_tx::test_tx,
+        },
+        solana_pubkey::Pubkey,
+        solana_runtime::{bank::Bank, genesis_utils::create_genesis_config},
+        solana_signer::Signer,
+        solana_system_interface::instruction as system_instruction,
+        solana_transaction::versioned::VersionedTransaction,
+        test_case::test_case,
     };
+
+    fn test_tx_v1() -> VersionedTransaction {
+        let payer = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        let instruction = system_instruction::transfer(&payer.pubkey(), &recipient, 1);
+        let message =
+            v1::Message::try_compile(&payer.pubkey(), &[instruction], Hash::new_unique()).unwrap();
+
+        VersionedTransaction::try_new(VersionedMessage::V1(message), &[&payer]).unwrap()
+    }
 
     fn gen_batches(
         use_same_tx: bool,
@@ -410,6 +435,9 @@ mod tests {
     fn test_sigverify_stage(use_same_tx: bool) {
         agave_logger::setup();
         trace!("start");
+        let (_bank, bank_forks) =
+            Bank::new_with_bank_forks_for_tests(&create_genesis_config(1).genesis_config);
+        let sharable_banks = bank_forks.read().unwrap().sharable_banks();
         let (packet_s, packet_r) = unbounded();
         let (vote_packet_s, vote_packet_r) = unbounded();
         let (verified_s, verified_r) = BankingTracer::channel_for_test();
@@ -423,6 +451,7 @@ mod tests {
             forward_stage_s,
             NonZeroUsize::new(4).unwrap(),
             false,
+            sharable_banks,
         );
 
         let now = Instant::now();
@@ -467,6 +496,55 @@ mod tests {
             assert_eq!(valid_received, total_packets);
         }
         drop(vote_packet_s);
+        drop(gossip_sigverify_handle);
+        stage.join().unwrap();
+    }
+
+    #[test_case(false, false; "tx_v1_disabled")]
+    #[test_case(true, true; "tx_v1_enabled")]
+    fn test_sigverify_stage_tx_v1_feature_gate(enable_tx_v1: bool, expected_valid: bool) {
+        let genesis_config = create_genesis_config(1).genesis_config;
+        let mut bank = Bank::new_for_tests(&genesis_config);
+        if enable_tx_v1 {
+            bank.activate_feature(&agave_feature_set::enable_tx_v1::id());
+        } else {
+            bank.deactivate_feature(&agave_feature_set::enable_tx_v1::id());
+        }
+        let (_bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+        let sharable_banks = bank_forks.read().unwrap().sharable_banks();
+        let (packet_s, packet_r) = unbounded();
+        let (vote_packet_s, vote_packet_r) = unbounded();
+        let (verified_s, verified_r) = BankingTracer::channel_for_test();
+        let (tpu_vote_s, _tpu_vote_r) = BankingTracer::channel_for_test();
+        let (forward_stage_s, _forward_stage_r) = unbounded();
+        let (stage, gossip_sigverify_handle) = SigVerifyStage::new(
+            packet_r,
+            vote_packet_r,
+            verified_s,
+            tpu_vote_s,
+            forward_stage_s,
+            NonZeroUsize::new(1).unwrap(),
+            false,
+            sharable_banks,
+        );
+
+        let mut bytes_batch = BytesPacketBatch::with_capacity(1);
+        bytes_batch.push(BytesPacket::from_bytes(
+            None,
+            wincode::serialize(&test_tx_v1()).unwrap(),
+        ));
+        packet_s.send(PacketBatch::from(bytes_batch)).unwrap();
+        drop(packet_s);
+        drop(vote_packet_s);
+
+        let verified_batch = verified_r.recv_timeout(Duration::from_secs(30)).unwrap();
+        assert_eq!(verified_batch.len(), 1);
+        assert_eq!(verified_batch[0].len(), 1);
+        assert_eq!(
+            !verified_batch[0].get(0).unwrap().meta().discard(),
+            expected_valid
+        );
+
         drop(gossip_sigverify_handle);
         stage.join().unwrap();
     }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -267,6 +267,7 @@ impl Tpu {
             forward_stage_sender.clone(),
             tpu_sigverify_threads,
             enable_block_production_forwarding,
+            bank_forks.read().unwrap().sharable_banks(),
         );
 
         let cluster_info_vote_listener = ClusterInfoVoteListener::new(

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -27,6 +27,7 @@ dev-context-only-utils = [
     "dep:solana-vote-program",
     "dep:solana-vote",
     "solana-hash/atomic",
+    "solana-transaction/wincode",
 ]
 frozen-abi = [
     "dep:solana-frozen-abi",
@@ -83,6 +84,7 @@ bencher = { workspace = true }
 rand_chacha = { workspace = true }
 solana-perf = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 test-case = { workspace = true }
+wincode = { workspace = true }
 
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dev-dependencies]
 jemallocator = { workspace = true }

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -31,7 +31,7 @@ fn bench_sigverify_simple(b: &mut Bencher) {
 
     // verify packets
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets, false);
     })
 }
 
@@ -56,7 +56,7 @@ fn bench_sigverify_low_packets_small_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE - 1;
     let mut batches = gen_batches(false, 1, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets, false);
     })
 }
 
@@ -65,7 +65,7 @@ fn bench_sigverify_low_packets_large_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE - 1;
     let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets, false);
     })
 }
 
@@ -74,7 +74,7 @@ fn bench_sigverify_medium_packets_small_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE * 8;
     let mut batches = gen_batches(false, 1, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets, false);
     })
 }
 
@@ -83,7 +83,7 @@ fn bench_sigverify_medium_packets_large_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE * 8;
     let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets, false);
     })
 }
 
@@ -92,7 +92,7 @@ fn bench_sigverify_high_packets_small_batch(b: &mut Bencher) {
     let num_packets = sigverify::VERIFY_PACKET_CHUNK_SIZE * 32;
     let mut batches = gen_batches(false, 1, num_packets);
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets, false);
     })
 }
 
@@ -102,7 +102,7 @@ fn bench_sigverify_high_packets_large_batch(b: &mut Bencher) {
     let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
     // verify packets
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets, false);
     })
 }
 
@@ -146,7 +146,7 @@ fn bench_sigverify_uneven(b: &mut Bencher) {
 
     // verify packets
     b.iter(|| {
-        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets);
+        sigverify::ed25519_verify(&threadpool, &mut batches, false, num_packets, false);
     })
 }
 

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -16,7 +16,7 @@ pub const VERIFY_PACKET_CHUNK_SIZE: usize = 128;
 /// Returns true if the signature on the packet verifies.
 /// Caller must do packet.set_discard(true) if this returns false.
 #[must_use]
-fn verify_packet(packet: &mut PacketRefMut, reject_non_vote: bool) -> bool {
+fn verify_packet(packet: &mut PacketRefMut, reject_non_vote: bool, enable_tx_v1: bool) -> bool {
     // If this packet was already marked as discard, drop it
     if packet.meta().discard() {
         return false;
@@ -30,6 +30,10 @@ fn verify_packet(packet: &mut PacketRefMut, reject_non_vote: bool) -> bool {
         let Ok(view) = SanitizedTransactionView::try_new_sanitized(data, true) else {
             return false;
         };
+
+        if !enable_tx_v1 && matches!(view.version(), TransactionVersion::V1) {
+            return false;
+        }
 
         let is_simple_vote_tx = is_simple_vote_transaction_view(&view);
         if reject_non_vote && !is_simple_vote_tx {
@@ -105,20 +109,23 @@ pub fn ed25519_verify(
     batches: &mut [PacketBatch],
     reject_non_vote: bool,
     packet_count: usize,
+    enable_tx_v1: bool,
 ) {
     debug!("CPU ECDSA for {packet_count}");
     thread_pool.install(|| {
         batches.par_iter_mut().flatten().for_each(|mut packet| {
-            if !packet.meta().discard() && !verify_packet(&mut packet, reject_non_vote) {
+            if !packet.meta().discard()
+                && !verify_packet(&mut packet, reject_non_vote, enable_tx_v1)
+            {
                 packet.meta_mut().set_discard(true);
             }
         });
     });
 }
 
-pub fn ed25519_verify_serial(batch: &mut PacketBatch, reject_non_vote: bool) {
+pub fn ed25519_verify_serial(batch: &mut PacketBatch, reject_non_vote: bool, enable_tx_v1: bool) {
     for mut packet in batch.iter_mut() {
-        if !packet.meta().discard() && !verify_packet(&mut packet, reject_non_vote) {
+        if !packet.meta().discard() && !verify_packet(&mut packet, reject_non_vote, enable_tx_v1) {
             packet.meta_mut().set_discard(true);
         }
     }
@@ -176,6 +183,7 @@ mod tests {
         solana_pubkey::Pubkey,
         solana_signature::Signature,
         solana_signer::Signer,
+        solana_system_interface::instruction as system_instruction,
         solana_transaction::{Transaction, versioned::VersionedTransaction},
         test_case::test_case,
     };
@@ -195,6 +203,20 @@ mod tests {
         )
         .unwrap();
         VersionedTransaction::try_new(VersionedMessage::V0(message), &[&payer]).unwrap()
+    }
+
+    fn test_tx_v1() -> VersionedTransaction {
+        let payer = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        let instruction = system_instruction::transfer(&payer.pubkey(), &recipient, 1);
+        let message = solana_message::v1::Message::try_compile(
+            &payer.pubkey(),
+            &[instruction],
+            Hash::new_unique(),
+        )
+        .unwrap();
+
+        VersionedTransaction::try_new(VersionedMessage::V1(message), &[&payer]).unwrap()
     }
 
     #[test]
@@ -232,7 +254,11 @@ mod tests {
         let actual_num_sigs = 5;
 
         let mut packet = packet_from_num_sigs(required_num_sigs, actual_num_sigs);
-        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
+        assert!(!sigverify::verify_packet(
+            &mut packet.as_mut(),
+            false,
+            false
+        ));
     }
 
     #[test]
@@ -245,7 +271,11 @@ mod tests {
         data.truncate(2);
 
         let mut packet = BytesPacket::from_bytes(None, Bytes::from(data));
-        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
+        assert!(!sigverify::verify_packet(
+            &mut packet.as_mut(),
+            false,
+            false
+        ));
     }
 
     #[test]
@@ -259,7 +289,7 @@ mod tests {
         tx.message.header.num_required_signatures = NUM_SIG as u8;
         let mut packet = BytesPacket::from_data(None, tx).unwrap();
 
-        assert!(!verify_packet(&mut packet.as_mut(), false));
+        assert!(!verify_packet(&mut packet.as_mut(), false, false));
 
         packet.meta_mut().set_discard(false);
         let mut batches = generate_packet_batches(&packet, 1, 1);
@@ -290,7 +320,7 @@ mod tests {
 
         let mut packet = BytesPacket::from_data(None, tx).unwrap();
 
-        assert!(!verify_packet(&mut packet.as_mut(), false));
+        assert!(!verify_packet(&mut packet.as_mut(), false, false));
 
         packet.meta_mut().set_discard(false);
         let mut batches = generate_packet_batches(&packet, 1, 1);
@@ -307,7 +337,11 @@ mod tests {
         data[0] = 0x7f;
 
         let mut packet = BytesPacket::from_bytes(None, Bytes::from(data));
-        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
+        assert!(!sigverify::verify_packet(
+            &mut packet.as_mut(),
+            false,
+            false
+        ));
     }
 
     #[test]
@@ -322,7 +356,11 @@ mod tests {
         data[3] = 0xff;
 
         let mut packet = BytesPacket::from_bytes(None, Bytes::from(data));
-        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
+        assert!(!sigverify::verify_packet(
+            &mut packet.as_mut(),
+            false,
+            false
+        ));
     }
 
     #[test]
@@ -336,7 +374,11 @@ mod tests {
         data[PUBKEY_OFFSET] = 0x7f;
 
         let mut packet = BytesPacket::from_bytes(None, Bytes::from(data));
-        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
+        assert!(!sigverify::verify_packet(
+            &mut packet.as_mut(),
+            false,
+            false
+        ));
     }
 
     #[test]
@@ -354,7 +396,11 @@ mod tests {
         let mut tx = Transaction::new_unsigned(message);
         tx.signatures = vec![Signature::default()];
         let mut packet = BytesPacket::from_data(None, tx).unwrap();
-        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
+        assert!(!sigverify::verify_packet(
+            &mut packet.as_mut(),
+            false,
+            false
+        ));
     }
 
     #[test]
@@ -362,13 +408,17 @@ mod tests {
         let tx = test_tx();
         let mut data = bincode::serialize(&tx).unwrap();
 
-        // Set message version to 2. V1 is supported by transaction-view and
-        // allowed through sigverify; bank performs the feature gate check.
+        // Set message version to 2. V1 is supported by transaction-view, but
+        // still explicitly feature-gated by sigverify.
         const MESSAGE_OFFSET: usize = 1 + core::mem::size_of::<Signature>();
         data[MESSAGE_OFFSET] = MESSAGE_VERSION_PREFIX + 2;
 
         let mut packet = BytesPacket::from_bytes(None, Bytes::from(data));
-        assert!(!sigverify::verify_packet(&mut packet.as_mut(), false));
+        assert!(!sigverify::verify_packet(
+            &mut packet.as_mut(),
+            false,
+            false
+        ));
     }
 
     fn generate_bytes_packet_batches(
@@ -440,7 +490,7 @@ mod tests {
     fn ed25519_verify(batches: &mut [PacketBatch]) {
         let threadpool = threadpool_for_tests();
         let packet_count = sigverify::count_packets_in_batches(batches);
-        sigverify::ed25519_verify(&threadpool, batches, false, packet_count);
+        sigverify::ed25519_verify(&threadpool, batches, false, packet_count, false);
     }
 
     #[test]
@@ -646,8 +696,20 @@ mod tests {
         };
 
         assert_eq!(
-            sigverify::verify_packet(&mut packet.as_mut(), false),
+            sigverify::verify_packet(&mut packet.as_mut(), false, false),
             !too_many_ixs
+        );
+    }
+
+    #[test_case(false, false; "tx_v1_disabled")]
+    #[test_case(true, true; "tx_v1_enabled")]
+    fn test_verify_packet_tx_v1_feature_gate(enable_tx_v1: bool, expected: bool) {
+        let tx = test_tx_v1();
+        let mut packet = BytesPacket::from_bytes(None, wincode::serialize(&tx).unwrap());
+
+        assert_eq!(
+            verify_packet(&mut packet.as_mut(), false, enable_tx_v1),
+            expected,
         );
     }
 }


### PR DESCRIPTION
#### Problem

Can filter out tx v1 if feature gate is enabled.

#### Summary of Changes
- plumbing `SharableBanks` to sigverify
- discard txv1 is feature gate isn't enabled.

Fixes #
