### PR TITLE
scheduler priority floor mechanism (load-shedding via published priority floor)

### DIFF
--- a/banking-stage-ingress-types/src/lib.rs
+++ b/banking-stage-ingress-types/src/lib.rs
@@ -1,5 +1,44 @@
 #![cfg(feature = "agave-unstable-api")]
-use {crossbeam_channel::Receiver, solana_perf::packet::PacketBatch, std::sync::Arc};
+use {
+    crossbeam_channel::Receiver,
+    solana_perf::packet::PacketBatch,
+    std::sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 pub type BankingPacketBatch = Arc<Vec<PacketBatch>>;
 pub type BankingPacketReceiver = Receiver<BankingPacketBatch>;
+
+/// Priority floor shared from the banking-stage scheduler to sigverify.
+///
+/// When saturated, the scheduler publishes the queue-min transaction's
+/// priority. Sigverify drops at-or-below-floor arrivals.
+/// In practice, transactions always have non-zero priorities.
+#[derive(Debug)]
+pub struct SchedulerPriorityFloor(AtomicU64);
+
+impl SchedulerPriorityFloor {
+    pub fn new() -> Self {
+        Self(AtomicU64::new(0))
+    }
+
+    pub fn set(&self, floor: u64) {
+        self.0.store(floor, Ordering::Relaxed);
+    }
+
+    pub fn clear(&self) {
+        self.set(0);
+    }
+
+    pub fn get(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for SchedulerPriorityFloor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -88,6 +88,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
         NonZeroUsize::new(sigverify::threadpool_for_benches().current_num_threads()).unwrap(),
         false,
         sharable_banks,
+        None,
     );
     let packet_s = packet_s;
     let packet_s_for_bench = packet_s.clone();

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -12,7 +12,7 @@ use {
         },
         validator::BlockProductionMethod,
     },
-    agave_banking_stage_ingress_types::BankingPacketBatch,
+    agave_banking_stage_ingress_types::{BankingPacketBatch, SchedulerPriorityFloor},
     agave_votor_messages::migration::MigrationStatus,
     assert_matches::assert_matches,
     bincode::deserialize_from,
@@ -855,6 +855,7 @@ impl BankingSimulator {
             bank_forks.clone(),
             None,
             Arc::default(),
+            Arc::new(SchedulerPriorityFloor::default()),
         );
 
         let (&_slot, &raw_base_event_time) = freeze_time_by_slot

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -18,7 +18,7 @@ use {
         },
         validator::BlockProductionMethod,
     },
-    agave_banking_stage_ingress_types::BankingPacketReceiver,
+    agave_banking_stage_ingress_types::{BankingPacketReceiver, SchedulerPriorityFloor},
     crossbeam_channel::{Receiver, Sender, unbounded},
     futures::{StreamExt, stream::FuturesUnordered},
     histogram::Histogram,
@@ -336,6 +336,7 @@ pub struct BankingStage {
     committer: Committer,
     log_messages_bytes_limit: Option<usize>,
     filter_keys: Arc<HashSet<Pubkey>>,
+    priority_floor: Arc<SchedulerPriorityFloor>,
     threads: FuturesUnordered<NamedTask<std::thread::Result<()>>>,
 }
 
@@ -357,6 +358,7 @@ impl BankingStage {
         bank_forks: Arc<RwLock<BankForks>>,
         prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
         filter_keys: Arc<HashSet<Pubkey>>,
+        priority_floor: Arc<SchedulerPriorityFloor>,
     ) -> BankingStageHandle {
         let committer = Committer::new(
             transaction_status_sender,
@@ -379,6 +381,7 @@ impl BankingStage {
             committer,
             log_messages_bytes_limit,
             filter_keys,
+            priority_floor,
             threads: FuturesUnordered::default(),
         };
 
@@ -556,6 +559,7 @@ impl BankingStage {
             finished_work_receiver,
             GreedySchedulerConfig::default(),
         );
+        let priority_floor = self.priority_floor.clone();
         let exit = exit.clone();
         let shutdown_signal = self.banking_shutdown_signal.clone();
         threads.push(
@@ -570,6 +574,7 @@ impl BankingStage {
                         sharable_banks,
                         scheduler,
                         worker_metrics,
+                        priority_floor,
                     );
 
                     match scheduler_controller.run() {
@@ -911,6 +916,7 @@ mod tests {
             bank_forks,
             None,
             Arc::default(),
+            Arc::new(SchedulerPriorityFloor::new()),
         );
         drop(non_vote_sender);
         drop(tpu_vote_sender);
@@ -972,6 +978,7 @@ mod tests {
             bank_forks, // keep a local-copy of bank-forks so worker threads do not lose weak access to bank-forks
             None,
             Arc::default(),
+            Arc::new(SchedulerPriorityFloor::new()),
         );
 
         // good tx, and no verify
@@ -1127,6 +1134,7 @@ mod tests {
                 bank_forks,
                 None,
                 Arc::default(),
+                Arc::new(SchedulerPriorityFloor::new()),
             );
 
             // wait for banking_stage to eat the packets
@@ -1281,6 +1289,7 @@ mod tests {
             bank_forks,
             None,
             Arc::default(),
+            Arc::new(SchedulerPriorityFloor::new()),
         );
 
         let keypairs = (0..100).map(|_| Keypair::new()).collect_vec();

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -20,6 +20,7 @@ use {
         },
         validator::SchedulerPacing,
     },
+    agave_banking_stage_ingress_types::SchedulerPriorityFloor,
     solana_clock::DEFAULT_MS_PER_SLOT,
     solana_cost_model::cost_tracker::SharedBlockCost,
     solana_measure::measure_us,
@@ -36,6 +37,13 @@ use {
 };
 
 const CHECK_CHUNK: usize = 128;
+
+/// Publish the priority floor once the scheduler's retained transaction buffer is
+/// this full. Capacity is enforced on the buffer, not just the priority queue:
+/// scheduled transactions still occupy buffer space until workers finish them.
+const SATURATION_BUFFER_PCT: u8 = 99;
+/// Clear the priority floor once the retained buffer drains below this watermark.
+const DESATURATION_BUFFER_PCT: u8 = 95;
 
 #[derive(Clone)]
 pub struct SchedulerConfig {
@@ -55,6 +63,56 @@ impl Default for SchedulerConfig {
 const DEFAULT_SCHEDULER_PACING_NON_FILL_TIME_MILLIS: u64 = 50;
 pub(crate) const DEFAULT_SCHEDULER_PACING_FILL_TIME_MILLIS: NonZeroU64 =
     NonZeroU64::new(DEFAULT_MS_PER_SLOT - DEFAULT_SCHEDULER_PACING_NON_FILL_TIME_MILLIS).unwrap();
+
+/// Detects saturation and publishes the priority floor for dropping low-priority transactions upstream.
+struct SaturationState {
+    priority_floor: Arc<SchedulerPriorityFloor>,
+    saturated: bool,
+    saturation_watermark: usize,
+    desaturation_watermark: usize,
+}
+
+impl SaturationState {
+    fn new(priority_floor: Arc<SchedulerPriorityFloor>, container_capacity: usize) -> Self {
+        let saturation_watermark =
+            container_capacity.saturating_mul(SATURATION_BUFFER_PCT as usize) / 100;
+        let desaturation_watermark =
+            container_capacity.saturating_mul(DESATURATION_BUFFER_PCT as usize) / 100;
+        Self {
+            priority_floor,
+            saturated: false,
+            saturation_watermark,
+            desaturation_watermark,
+        }
+    }
+
+    /// Update the saturation state.
+    fn update(&mut self, buffer_size: usize, num_dropped_on_capacity: usize) -> bool {
+        if self.saturated {
+            if buffer_size < self.desaturation_watermark && num_dropped_on_capacity == 0 {
+                self.saturated = false;
+            }
+        } else if buffer_size >= self.saturation_watermark || num_dropped_on_capacity > 0 {
+            self.saturated = true;
+        }
+
+        self.saturated
+    }
+
+    /// Publish the priority floor.
+    fn publish_floor(&self, floor: u64) {
+        self.priority_floor.set(floor);
+    }
+}
+
+impl Drop for SaturationState {
+    fn drop(&mut self) {
+        // The priority floor outlives individual scheduler controllers (it's
+        // shared with sigverify). Clear it on tear-down so a stale floor
+        // from this controller can't keep sigverify dropping packets.
+        self.priority_floor.clear();
+    }
+}
 
 /// Controls packet and transaction flow into scheduler, and scheduling execution.
 pub(crate) struct SchedulerController<R, S>
@@ -88,6 +146,8 @@ where
     recheck_cursor: Option<TransactionPriorityId>,
     /// Recheck IDs scratch space.
     recheck_chunk: Vec<TransactionPriorityId>,
+    /// Saturation detection and priority floor publication.
+    saturation_state: SaturationState,
 }
 
 impl<R, S> SchedulerController<R, S>
@@ -103,14 +163,18 @@ where
         sharable_banks: SharableBanks,
         scheduler: S,
         worker_metrics: Vec<Arc<ConsumeWorkerMetrics>>,
+        priority_floor: Arc<SchedulerPriorityFloor>,
     ) -> Self {
+        priority_floor.clear();
+        let container_capacity = TOTAL_BUFFERED_PACKETS;
+        let saturation_state = SaturationState::new(priority_floor, container_capacity);
         Self {
             exit,
             config,
             decision_maker,
             receive_and_buffer,
             sharable_banks,
-            container: R::Container::with_capacity(TOTAL_BUFFERED_PACKETS),
+            container: R::Container::with_capacity(container_capacity),
             scheduler,
             count_metrics: SchedulerCountMetrics::default(),
             timing_metrics: SchedulerTimingMetrics::default(),
@@ -118,6 +182,7 @@ where
             scheduling_details: SchedulingDetails::default(),
             recheck_cursor: None,
             recheck_chunk: Vec::with_capacity(CHECK_CHUNK),
+            saturation_state,
         }
     }
 
@@ -195,7 +260,7 @@ where
                     timing_metrics.clean_time_us += clean_time_us;
                 });
             }
-            self.receive_and_buffer_packets(&decision).map_err(|_| {
+            let receiving_stats = self.receive_and_buffer_packets(&decision).map_err(|_| {
                 SchedulerError::DisconnectedRecvChannel("receive and buffer disconnected")
             })?;
             // Report metrics only if there is data.
@@ -205,6 +270,7 @@ where
             self.count_metrics.update(|count_metrics| {
                 count_metrics.update_priority_stats(priority_min_max);
             });
+            self.update_scheduler_priority_floor(receiving_stats.num_dropped_on_capacity);
             self.count_metrics
                 .maybe_report_and_reset_interval(should_report);
             self.timing_metrics
@@ -263,6 +329,27 @@ where
         };
 
         Ok(scheduled)
+    }
+
+    /// Update the scheduler priority floor.
+    ///
+    /// Semantics: when the retained scheduler buffer is nearly full, drop
+    /// arrivals that are at-or-below the current queue-min priority, i.e. no
+    /// better than what the bounded scheduler candidate set would evict.
+    fn update_scheduler_priority_floor(&mut self, num_dropped_on_capacity: usize) {
+        let buffer_size = self.container.buffer_size();
+        let saturated = self
+            .saturation_state
+            .update(buffer_size, num_dropped_on_capacity);
+        let priority_floor = if saturated {
+            self.container
+                .get_min_max_priority()
+                .map_or(0, |(min, _)| min)
+        } else {
+            0
+        };
+
+        self.saturation_state.publish_floor(priority_floor);
     }
 
     /// Clears the transaction state container.
@@ -547,6 +634,7 @@ mod tests {
             bank_forks.read().unwrap().sharable_banks(),
             scheduler,
             vec![], // no actual workers with metrics to report, this can be empty
+            Arc::new(SchedulerPriorityFloor::default()),
         );
 
         (test_frame, scheduler_controller)
@@ -993,5 +1081,95 @@ mod tests {
             .map(|tx| tx.message_hash())
             .collect_vec();
         assert_eq!(message_hashes, vec![&tx1_hash]);
+    }
+}
+
+#[cfg(test)]
+mod saturation_state_tests {
+    use super::*;
+
+    fn saturation_watermark() -> usize {
+        TOTAL_BUFFERED_PACKETS.saturating_mul(SATURATION_BUFFER_PCT as usize) / 100
+    }
+
+    fn desaturation_watermark() -> usize {
+        TOTAL_BUFFERED_PACKETS.saturating_mul(DESATURATION_BUFFER_PCT as usize) / 100
+    }
+
+    fn make_state() -> (SaturationState, Arc<SchedulerPriorityFloor>) {
+        let priority_floor = Arc::new(SchedulerPriorityFloor::new());
+        let state = SaturationState::new(priority_floor.clone(), TOTAL_BUFFERED_PACKETS);
+        (state, priority_floor)
+    }
+
+    #[test]
+    fn starts_unsaturated() {
+        let (mut state, floor) = make_state();
+        assert!(!state.update(0, 0));
+        assert_eq!(floor.get(), 0);
+    }
+
+    #[test]
+    fn does_not_enter_when_buffer_below_saturation_watermark() {
+        let (mut state, floor) = make_state();
+        assert!(!state.update(saturation_watermark() - 1, 0));
+        assert_eq!(floor.get(), 0);
+    }
+
+    #[test]
+    fn enters_when_buffer_reaches_saturation_watermark() {
+        let (mut state, _floor) = make_state();
+        assert!(state.update(saturation_watermark(), 0));
+    }
+
+    #[test]
+    fn enters_on_capacity_drops_even_below_watermark() {
+        // Direct trigger: any on-capacity drop saturates regardless of
+        // buffer-watermark — invariant to future changes in the trim policy.
+        let (mut state, _floor) = make_state();
+        assert!(state.update(0, 1));
+    }
+
+    #[test]
+    fn publish_floor_writes_value() {
+        let (state, floor) = make_state();
+        state.publish_floor(42);
+        assert_eq!(floor.get(), 42);
+    }
+
+    #[test]
+    fn stays_saturated_at_desaturation_watermark() {
+        let (mut state, _floor) = make_state();
+        assert!(state.update(saturation_watermark(), 0));
+        assert!(state.update(desaturation_watermark(), 0));
+    }
+
+    #[test]
+    fn exits_when_buffer_drops_below_desaturation_watermark() {
+        let (mut state, _floor) = make_state();
+        assert!(state.update(saturation_watermark(), 0));
+        assert!(!state.update(desaturation_watermark() - 1, 0));
+    }
+
+    #[test]
+    fn stays_saturated_on_drops_even_below_desaturation_watermark() {
+        // Direct trigger keeps us saturated even if the buffer has drained,
+        // because drops in the same tick mean we still need backpressure.
+        let (mut state, _floor) = make_state();
+        assert!(state.update(saturation_watermark(), 0));
+        assert!(state.update(desaturation_watermark() - 1, 1));
+    }
+
+    #[test]
+    fn drop_clears_floor() {
+        // The floor outlives the controller (it's shared with sigverify), so
+        // tear-down must clear any stale value.
+        let floor = Arc::new(SchedulerPriorityFloor::new());
+        {
+            let state = SaturationState::new(floor.clone(), TOTAL_BUFFERED_PACKETS);
+            state.publish_floor(123);
+            assert_eq!(floor.get(), 123);
+        }
+        assert_eq!(floor.get(), 0);
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -188,7 +188,7 @@ impl SchedulerCountMetricsInner {
             ),
             ("num_dropped_on_capacity", num_dropped_on_capacity, i64),
             ("min_priority", self.get_min_priority(), i64),
-            ("max_priority", self.get_max_priority(), i64)
+            ("max_priority", self.get_max_priority(), i64),
         );
         if let Some(slot) = slot {
             datapoint.add_field_i64("slot", slot as i64);

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -3,8 +3,11 @@
 //! cores.
 
 use {
-    crate::{banking_trace::BankingPacketSender, sigverify_stage::SigVerifyServiceError},
-    agave_banking_stage_ingress_types::BankingPacketBatch,
+    crate::{
+        banking_trace::BankingPacketSender, sigverify_stage::SigVerifyServiceError,
+        transaction_priority::calculate_priority_from_bytes,
+    },
+    agave_banking_stage_ingress_types::{BankingPacketBatch, SchedulerPriorityFloor},
     crossbeam_channel::{Receiver, Sender, TrySendError, bounded},
     solana_measure::measure_us,
     solana_perf::{
@@ -12,7 +15,7 @@ use {
         packet::PacketBatch,
         sigverify::{self},
     },
-    solana_runtime::bank_forks::SharableBanks,
+    solana_runtime::{bank::Bank, bank_forks::SharableBanks},
     solana_transaction::Transaction,
     std::{
         num::NonZeroUsize,
@@ -47,6 +50,8 @@ pub(crate) struct SigVerifyWorkerStats {
     pub(crate) max_pre_send_len: Arc<AtomicUsize>,
     /// Count of sends where the EvictingSender had to drop a batch to make room.
     pub(crate) eviction_drops: Arc<AtomicUsize>,
+    pub(crate) total_dropped_below_priority_floor: Arc<AtomicUsize>,
+    pub(crate) total_priority_floor_time_us: Arc<AtomicUsize>,
 }
 
 #[derive(Clone)]
@@ -54,6 +59,12 @@ pub(crate) struct SigVerifyWorkerState {
     banking_stage_sender: BankingPacketSender,
     deduper: Arc<Deduper<2, [u8]>>,
     stats: SigVerifyWorkerStats,
+    /// Scheduler-published priority floor: when saturated, the scheduler publishes
+    /// the queue-min transaction's priority and workers drop at-or-below-floor
+    /// arrivals here, ahead of signature verification. `None` disables the
+    /// check (e.g. for the vote worker, which is governed by a separate
+    /// priority policy in banking stage).
+    priority_floor: Option<Arc<SchedulerPriorityFloor>>,
 }
 
 impl SigVerifyWorkerState {
@@ -61,11 +72,13 @@ impl SigVerifyWorkerState {
         banking_stage_sender: BankingPacketSender,
         deduper: Arc<Deduper<2, [u8]>>,
         stats: SigVerifyWorkerStats,
+        priority_floor: Option<Arc<SchedulerPriorityFloor>>,
     ) -> Self {
         Self {
             banking_stage_sender,
             deduper,
             stats,
+            priority_floor,
         }
     }
 }
@@ -279,7 +292,33 @@ impl SigVerifyWorkerPool {
             .total_dedup_time_us
             .fetch_add(dedup_time_us as usize, Ordering::Relaxed);
 
-        let enable_tx_v1 = sharable_banks.working().feature_set.snapshot().enable_tx_v1;
+        let working_bank = sharable_banks.working();
+
+        if let Some(floor) = state.priority_floor.as_ref() {
+            let floor = floor.get();
+            if floor > 0 {
+                let ((dropped, all_below), priority_floor_time_us) = measure_us!(
+                    apply_priority_floor_to_batch(&mut batch, floor, &working_bank)
+                );
+                state
+                    .stats
+                    .total_priority_floor_time_us
+                    .fetch_add(priority_floor_time_us as usize, Ordering::Relaxed);
+                if dropped > 0 {
+                    state
+                        .stats
+                        .total_dropped_below_priority_floor
+                        .fetch_add(dropped, Ordering::Relaxed);
+                }
+                if all_below {
+                    // Entire batch went below-floor: nothing left to verify or
+                    // forward.
+                    return true;
+                }
+            }
+        }
+
+        let enable_tx_v1 = working_bank.feature_set.snapshot().enable_tx_v1;
         let (_, verify_time_us) = measure_us!(sigverify::ed25519_verify_serial(
             &mut batch,
             reject_non_vote,
@@ -354,4 +393,39 @@ impl SigVerifyWorkerPool {
             warn!("forwarding stage channel is full, dropping packets.");
         }
     }
+}
+
+/// Apply the scheduler-published priority floor to a single batch in place.
+///
+/// Below-floor packets are marked `discard`. Returns `(dropped, all_below)`,
+/// where `dropped` is the number of packets newly marked and `all_below` is
+/// true iff no useful packets remain in the batch (so the caller can skip
+/// downstream work for this batch entirely).
+fn apply_priority_floor_to_batch(
+    batch: &mut PacketBatch,
+    floor: u64,
+    bank: &Bank,
+) -> (usize, bool) {
+    let mut dropped: usize = 0;
+    let mut any_kept = false;
+    for mut packet in batch.iter_mut() {
+        if packet.meta().discard() {
+            continue;
+        }
+        let Some(data) = packet.data(..) else {
+            // Zero-length or otherwise unreadable: leave to downstream
+            // stages to reject.
+            any_kept = true;
+            continue;
+        };
+        // Unparseable packets are kept and left for downstream rejection.
+        match calculate_priority_from_bytes(bank, data) {
+            Some(priority) if priority <= floor => {
+                packet.meta_mut().set_discard(true);
+                dropped = dropped.saturating_add(1);
+            }
+            _ => any_kept = true,
+        }
+    }
+    (dropped, !any_kept)
 }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -12,7 +12,7 @@ use {
             SigVerifyWorkerSenders, SigVerifyWorkerState, SigVerifyWorkerStats,
         },
     },
-    agave_banking_stage_ingress_types::BankingPacketBatch,
+    agave_banking_stage_ingress_types::{BankingPacketBatch, SchedulerPriorityFloor},
     core::time::Duration,
     crossbeam_channel::{Receiver, Sender, unbounded},
     solana_perf::{deduper::Deduper, packet::PacketBatch},
@@ -65,6 +65,8 @@ struct SigVerifierStats {
     max_pre_send_len: Arc<AtomicUsize>,
     /// Count of sends in which the EvictingSender had to drop a batch.
     eviction_drops: Arc<AtomicUsize>,
+    total_dropped_below_priority_floor: Arc<AtomicUsize>,
+    total_priority_floor_time_us: Arc<AtomicUsize>,
 }
 
 struct ServicerState {
@@ -110,13 +112,24 @@ impl SigVerifierStats {
                 i64
             ),
             (
+                "total_dropped_below_priority_floor",
+                self.total_dropped_below_priority_floor
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "total_priority_floor_time_us",
+                self.total_priority_floor_time_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
                 "total_valid_packets",
-                self.total_valid_packets.swap(0, Ordering::Relaxed) as i64,
+                self.total_valid_packets.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "total_verify_time_us",
-                self.total_verify_time_us.swap(0, Ordering::Relaxed) as i64,
+                self.total_verify_time_us.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
@@ -143,6 +156,7 @@ impl SigVerifyStage {
         num_workers: NonZeroUsize,
         forward_non_votes: bool,
         sharable_banks: SharableBanks,
+        scheduler_priority_floor: Option<Arc<SchedulerPriorityFloor>>,
     ) -> (Self, GossipSigVerifyHandle) {
         let (gossip_verified_vote_sender, verified_vote_receiver) = unbounded();
         let non_vote_stats = SigVerifierStats::default();
@@ -173,7 +187,14 @@ impl SigVerifyStage {
                     total_verify_time_us: non_vote_stats.total_verify_time_us.clone(),
                     max_pre_send_len: non_vote_stats.max_pre_send_len.clone(),
                     eviction_drops: non_vote_stats.eviction_drops.clone(),
+                    total_dropped_below_priority_floor: non_vote_stats
+                        .total_dropped_below_priority_floor
+                        .clone(),
+                    total_priority_floor_time_us: non_vote_stats
+                        .total_priority_floor_time_us
+                        .clone(),
                 },
+                scheduler_priority_floor,
             ),
             SigVerifyWorkerState::new(
                 tpu_vote_sender,
@@ -187,7 +208,14 @@ impl SigVerifyStage {
                     total_verify_time_us: tpu_vote_stats.total_verify_time_us.clone(),
                     max_pre_send_len: tpu_vote_stats.max_pre_send_len.clone(),
                     eviction_drops: tpu_vote_stats.eviction_drops.clone(),
+                    total_dropped_below_priority_floor: tpu_vote_stats
+                        .total_dropped_below_priority_floor
+                        .clone(),
+                    total_priority_floor_time_us: tpu_vote_stats
+                        .total_priority_floor_time_us
+                        .clone(),
                 },
+                None, // votes are not dropped for priority-floor
             ),
         );
         let servicer_thread_hdl = Self::servicer(
@@ -396,6 +424,7 @@ mod tests {
             NonZeroUsize::new(4).unwrap(),
             false,
             sharable_banks,
+            None,
         );
 
         let now = Instant::now();
@@ -470,6 +499,7 @@ mod tests {
             NonZeroUsize::new(1).unwrap(),
             false,
             sharable_banks,
+            None,
         );
 
         let mut bytes_batch = BytesPacketBatch::with_capacity(1);

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -23,6 +23,7 @@ use {
         tpu_entry_notifier::TpuEntryNotifier,
         validator::{BlockProductionMethod, GeneratorConfig},
     },
+    agave_banking_stage_ingress_types::SchedulerPriorityFloor,
     agave_votor::event::VotorEventSender,
     agave_xdp::transmitter::XdpSender,
     crossbeam_channel::{Receiver, bounded, unbounded},
@@ -268,6 +269,11 @@ impl Tpu {
 
         let (forward_stage_sender, forward_stage_receiver) = bounded(50_000);
 
+        // Shared between sigverify and scheduler. The scheduler publishes
+        // a priority floor under saturation; sigverify reads it and drops
+        // below-floor packets ahead of signature verification.
+        let scheduler_priority_floor = Arc::new(SchedulerPriorityFloor::new());
+
         let (sigverify_stage, gossip_sigverify_handle) = SigVerifyStage::new(
             packet_receiver,
             vote_packet_receiver,
@@ -277,6 +283,7 @@ impl Tpu {
             tpu_sigverify_threads,
             enable_block_production_forwarding,
             bank_forks.read().unwrap().sharable_banks(),
+            Some(scheduler_priority_floor.clone()),
         );
 
         let cluster_info_vote_listener = ClusterInfoVoteListener::new(
@@ -311,6 +318,7 @@ impl Tpu {
             bank_forks.clone(),
             prioritization_fee_cache,
             filter_keys,
+            scheduler_priority_floor,
         );
 
         #[cfg(unix)]

--- a/core/src/transaction_priority.rs
+++ b/core/src/transaction_priority.rs
@@ -1,9 +1,14 @@
 use {
+    agave_transaction_view::transaction_view::SanitizedTransactionView,
     solana_cost_model::cost_model::CostModel,
-    solana_runtime::bank::Bank,
+    solana_fee::FeeFeatures,
+    solana_runtime::bank::{Bank, CollectorFeeDetails},
     solana_runtime_transaction::{
-        transaction_meta::TransactionConfiguration, transaction_with_meta::TransactionWithMeta,
+        runtime_transaction::RuntimeTransaction,
+        transaction_meta::{TransactionConfiguration, TransactionMeta},
     },
+    solana_svm_transaction::svm_message::SVMStaticMessage,
+    solana_transaction::sanitized::MessageHash,
 };
 
 /// Calculate priority and cost for a transaction:
@@ -24,13 +29,21 @@ use {
 /// from user input. They should never be zero.
 /// Any difference in the prioritization is negligible for
 /// the current transaction costs.
-pub(crate) fn calculate_priority_and_cost(
+pub(crate) fn calculate_priority_and_cost<Tx: TransactionMeta + SVMStaticMessage>(
     bank: &Bank,
-    transaction: &impl TransactionWithMeta,
+    transaction: &Tx,
     transaction_configuration: &TransactionConfiguration,
 ) -> (u64, u64) {
     let cost = CostModel::calculate_cost(transaction, &bank.feature_set).sum();
-    let reward = bank.calculate_reward_for_transaction(transaction, transaction_configuration);
+    let fee_details = solana_fee::calculate_fee_details(
+        transaction,
+        bank.fee_structure().lamports_per_signature,
+        transaction_configuration.priority_fee_lamports,
+        FeeFeatures::from(bank.feature_set.as_ref()),
+    );
+    let reward = bank
+        .calculate_reward_and_burn_fee_details(&CollectorFeeDetails::from(fee_details))
+        .get_deposit();
 
     // We need a multiplier here to avoid rounding down too aggressively.
     // For many transactions, the cost will be greater than the fees in terms of raw lamports.
@@ -44,4 +57,136 @@ pub(crate) fn calculate_priority_and_cost(
             .saturating_div(cost.saturating_add(1)),
         cost,
     )
+}
+
+/// Evaluate raw packet bytes against the pf-floor, returning the computed
+/// priority.
+///
+/// Returns `None` if the bytes don't parse as a valid transaction, in which
+/// case the caller should leave the packet to downstream stages to reject.
+pub(crate) fn calculate_priority_from_bytes(bank: &Bank, data: &[u8]) -> Option<u64> {
+    let enable_instruction_accounts_limit = bank.feature_set.snapshot().limit_instruction_accounts;
+    let view = SanitizedTransactionView::try_new_sanitized(data, enable_instruction_accounts_limit)
+        .ok()?;
+    let runtime_tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
+        view,
+        MessageHash::Compute,
+        None,
+    )
+    .ok()?;
+    let transaction_configuration = runtime_tx
+        .transaction_configuration(&bank.feature_set)
+        .ok()?;
+    let (priority, _cost) =
+        calculate_priority_and_cost(bank, &runtime_tx, &transaction_configuration);
+
+    Some(priority)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_compute_budget_interface::ComputeBudgetInstruction,
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_ledger::genesis_utils::{GenesisConfigInfo, create_genesis_config},
+        solana_message::Message,
+        solana_pubkey::Pubkey,
+        solana_signer::Signer,
+        solana_system_interface::instruction as system_instruction,
+        solana_transaction::{Transaction, versioned::VersionedTransaction},
+        std::sync::Arc,
+    };
+
+    fn test_bank_with_lamports_per_signature(lamports_per_signature: u64) -> (Arc<Bank>, Keypair) {
+        let GenesisConfigInfo {
+            mut genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(u64::MAX);
+        if lamports_per_signature > 0 {
+            genesis_config.fee_rate_governor =
+                solana_fee_calculator::FeeRateGovernor::new(lamports_per_signature, 0);
+        }
+        let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        (bank, mint_keypair)
+    }
+
+    fn test_bank() -> (Arc<Bank>, Keypair) {
+        test_bank_with_lamports_per_signature(0)
+    }
+
+    fn make_tx_bytes(mint: &Keypair, recent_blockhash: Hash, compute_unit_price: u64) -> Vec<u8> {
+        let to = Pubkey::new_unique();
+        let transfer = system_instruction::transfer(&mint.pubkey(), &to, 1);
+        let prioritization = ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price);
+        let message = Message::new(&[transfer, prioritization], Some(&mint.pubkey()));
+        let tx = Transaction::new(&[mint], message, recent_blockhash);
+        bincode::serialize(&VersionedTransaction::from(tx)).unwrap()
+    }
+
+    fn priority_from(bank: &Bank, bytes: &[u8]) -> u64 {
+        calculate_priority_from_bytes(bank, bytes).unwrap()
+    }
+
+    #[test]
+    fn priority_from_bytes_returns_none_for_garbage() {
+        let (bank, _) = test_bank();
+        assert!(calculate_priority_from_bytes(&bank, &[]).is_none());
+        assert!(calculate_priority_from_bytes(&bank, &[0u8; 32]).is_none());
+    }
+
+    #[test]
+    fn priority_is_zero_when_base_and_priority_fees_are_zero() {
+        // Test bank has lamports_per_signature = 0, so base fee is 0.
+        // With compute_unit_price = 0, priority fee is also 0 → reward 0 → priority 0.
+        let (bank, mint) = test_bank();
+        assert_eq!(bank.fee_structure().lamports_per_signature, 0);
+        let bytes = make_tx_bytes(&mint, bank.last_blockhash(), 0);
+        assert_eq!(priority_from(&bank, &bytes), 0);
+    }
+
+    #[test]
+    fn higher_compute_unit_price_yields_higher_priority() {
+        // Need non-zero base fee, otherwise the reward short-circuits to 0
+        // and all priorities collapse regardless of compute_unit_price.
+        let (bank, mint) = test_bank_with_lamports_per_signature(5_000);
+        let low = priority_from(&bank, &make_tx_bytes(&mint, bank.last_blockhash(), 1));
+        let high = priority_from(
+            &bank,
+            &make_tx_bytes(&mint, bank.last_blockhash(), 1_000_000),
+        );
+        assert!(high > low, "expected high {high} > low {low}");
+    }
+
+    #[test]
+    fn floor_priority_from_bytes_matches_typed_path() {
+        // The bytes-path and the typed-path must agree on the same packet,
+        // since the scheduler-side queue priority is computed via the typed
+        // path and the sigverify-side floor check via the bytes path.
+        let (bank, mint) = test_bank();
+        let bytes = make_tx_bytes(&mint, bank.last_blockhash(), 100);
+
+        let from_bytes = priority_from(&bank, &bytes);
+
+        let view = SanitizedTransactionView::try_new_sanitized(
+            &bytes[..],
+            bank.feature_set.snapshot().limit_instruction_accounts,
+        )
+        .unwrap();
+        let runtime_tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
+            view,
+            MessageHash::Compute,
+            None,
+        )
+        .unwrap();
+        let transaction_configuration = runtime_tx
+            .transaction_configuration(&bank.feature_set)
+            .unwrap();
+        let (from_typed, _cost) =
+            calculate_priority_and_cost(&bank, &runtime_tx, &transaction_configuration);
+
+        assert_eq!(from_bytes, from_typed);
+    }
 }


### PR DESCRIPTION
#### Problem

Under high load, the TPU delivers transactions to the banking-stage scheduler faster than the scheduler can process them. The scheduler ends up spending much of its tick budget evicting low-priority entries from a full buffer rather than scheduling high-priority work — and those evicted transactions have already paid full sigverify CPU on the way in.

Low-priority transactions should be dropped upstream, before they reach the scheduler (and ideally before they reach sigverify).

#### Summary of Changes

Adds a saturation-detection + priority-floor mechanism to banking-stage's central scheduler. When the scheduler is saturated, it publishes a priority floor — derived from the lowest-priority transaction in its queue — to a shared atomic. Sigverify reads the floor and drops incoming packets whose proxy priority is at or below it, ahead of signature verification.

Saturation triggers (either):
  - the retained scheduler buffer crosses the saturation watermark
  - on-capacity drops in the just-completed receive_and_buffer call

Desaturation requires both the buffer below the desaturation watermark and no on-capacity drops in this tick. SaturationState clears the shared floor on Drop so a stale value doesn't outlive the controller.

Floor drop in sigverify happens in each non-vote worker thread, post-dedup and pre-signature-verify. Workers parse the transaction priority from raw packet bytes using the same priority formula the scheduler queue uses. Simple votes are exempted from the priority fee floor check.

#### Results

**Test setup**
Single validator cluster. Client is solana-transaction-bench. Incoming transaction rate is ~350K TPS. 2K accounts transferring funds between each other; one transfer/signature per transaction. No duplicate transactions. Fee distribution is random and uniform. Test is run for 15 seconds (more about the duration aspect below).

A screenshot below shows 2 tests: the first one is `master` and the 2nd is this branch, which produces better blocks: higher CU per block (~90M out of 100M max possible) and higher collected priority fees.

<img width="2151" height="481" alt="Screenshot 2026-05-22 at 15 28 50" src="https://github.com/user-attachments/assets/d1c0f4f0-184d-40e2-8b1b-52c26d5bc83e" />

**Zooming in**

master:
<img width="1969" height="1308" alt="Screenshot 2026-05-22 at 15 32 15" src="https://github.com/user-attachments/assets/7f908830-7914-4308-877d-4bc0b24b3aa8" />

this PR:
<img width="2013" height="1299" alt="Screenshot 2026-05-22 at 15 30 49" src="https://github.com/user-attachments/assets/658de79c-ff24-4b5b-961e-692ff5f65ebc" />

As can be seen from these plots, master spends more time on buffering and less on scheduling transactions compared to this branch.

The overhead of the new mechanism is 1.3x of the dedup overhead (transaction parsing):
<img width="811" height="572" alt="Screenshot 2026-05-22 at 15 31 22" src="https://github.com/user-attachments/assets/99105417-ede0-40de-8a65-8db9c28eb803" />

**Note about the test duration aspect**.
In production, we are obviously not so much interested in long-duration tests and throughput. We want good blocks to be produced right from the beginning. If we zoom in on the first few seconds:
<img width="2175" height="864" alt="Screenshot 2026-05-22 at 15 38 28" src="https://github.com/user-attachments/assets/869041d7-0ba8-43e0-b2d7-dcfe6efcf6ae" />

We can see that it takes the scheduler priority floor mechanism about 1s to start producing blocks better than master (CU > 60M), and about 1.5s to start producing 90+M CU blocks (max is 100M). So its (positive) impact is delayed.

However, this mechanism is still useful in real scenarios because validators start accepting transactions a few seconds before a leader slot. Also, it will help to "protect" the scheduler from excessive load when we enable 'New SWQoS'.

Here is another PR https://github.com/anza-xyz/agave/pull/12739 that improves block production in these first 1-1.5 seconds.


