### PR TITLE
Bump scheduler-bindings version to 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Release channels have their own copy of this changelog:
 #### Breaking
 * `--block-production-method central-scheduler` is no longer supported. If passed, a warning is emitted and behavior
   will default to the greedy-scheduler implementation.
+* scheduler-bindings version has been increased to 4. Connecting external schedulers must be updated.
 #### Deprecations
 * Using `minimal` for `--accounts-index-limit` is now deprecated.
 * `--account-shrink-path` is now deprecated.

--- a/scheduling-utils/src/handshake/shared.rs
+++ b/scheduling-utils/src/handshake/shared.rs
@@ -12,7 +12,7 @@ pub(crate) type ShaqError = shaq::error::Error;
 pub const MAX_WORKERS: usize = 64;
 
 /// Protocol version.
-pub(crate) const VERSION: u64 = 3;
+pub(crate) const VERSION: u64 = 4;
 pub(crate) const LOGON_SUCCESS: u8 = 0x01;
 pub(crate) const LOGON_FAILURE: u8 = 0x02;
 pub(crate) const MAX_ALLOCATOR_HANDLES: usize = 128;


### PR DESCRIPTION
#### Problem
- There have been breaking changes to scheduler bindings since agave 4.0
	- Example: #12175

#### Summary of Changes
- Update the VERSION constant for handshake between external schedulers and agave
- Document bump in the change log

Fixes #
