### PR TITLE
XDP: graduate from experimental status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Release channels have their own copy of this changelog:
 * `--account-shrink-path` is now deprecated.
 * `sbf-sdk.tar.bz2` is not included anymore in the Agave release tarball. The file will be made available in the new
   [`cargo-build-sbf`](https://github.com/anza-xyz/cargo-build-sbf) repository.
+* XDP support is no longer experimental. The `--experimental-retransmit-xdp-interface`, `--experimental-retransmit-xdp-cpu-cores`, and
+  `--experimental-retransmit-xdp-zero-copy` flags have been deprecated. Use `--xdp-interface`, `--xdp-cpu-cores`, and `--xdp-zero-copy` instead. Behavior is unchanged: pass `--xdp-cpu-cores` to enable XDP on the specified cores.
 #### Changes
 
 ## 4.0.0

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -18,6 +18,7 @@ use {
         hidden_unless_forced,
         input_validators::{
             is_parsable, is_pubkey, is_pubkey_or_keypair, is_slot, is_url_or_moniker,
+            validate_cpu_ranges,
         },
     },
     solana_clock::Slot,
@@ -144,6 +145,42 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .help("Enables the disk-based accounts index")
             .conflicts_with("accounts_index_limit"),
         replaced_by: "accounts-index-limit",
+    );
+    add_arg!(
+        // deprecated in v4.1.0
+        Arg::with_name("experimental_retransmit_xdp_cpu_cores")
+            .long("experimental-retransmit-xdp-cpu-cores")
+            .takes_value(true)
+            .value_name("CPU_LIST")
+            .conflicts_with("xdp_cpu_cores")
+            .validator(|value| {
+                validate_cpu_ranges(value, "--experimental-retransmit-xdp-cpu-cores")
+            })
+            .help(
+                "Enable XDP retransmit on the specified CPU cores. Use --xdp-cpu-cores instead",
+            ),
+        replaced_by: "xdp-cpu-cores",
+    );
+    add_arg!(
+        // deprecated in v4.1.0
+        Arg::with_name("experimental_retransmit_xdp_interface")
+            .long("experimental-retransmit-xdp-interface")
+            .takes_value(true)
+            .value_name("INTERFACE")
+            .conflicts_with("xdp_interface")
+            .requires("experimental_retransmit_xdp_cpu_cores")
+            .help("Network interface to use for XDP retransmit. Use --xdp-interface instead"),
+        replaced_by: "xdp-interface",
+    );
+    add_arg!(
+        // deprecated in v4.1.0
+        Arg::with_name("experimental_retransmit_xdp_zero_copy")
+            .long("experimental-retransmit-xdp-zero-copy")
+            .takes_value(false)
+            .conflicts_with("xdp_zero_copy")
+            .requires("experimental_retransmit_xdp_cpu_cores")
+            .help("Enable XDP zero copy. Use --xdp-zero-copy instead"),
+        replaced_by: "xdp-zero-copy",
     );
     add_arg!(
         // deprecated in v4.0.0

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1217,32 +1217,27 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help(DefaultSchedulerPool::cli_message()),
     )
     .arg(
-        Arg::with_name("retransmit_xdp_interface")
-            .hidden(hidden_unless_forced())
-            .long("experimental-retransmit-xdp-interface")
+        Arg::with_name("xdp_interface")
+            .long("xdp-interface")
             .takes_value(true)
             .value_name("INTERFACE")
-            .requires("retransmit_xdp_cpu_cores")
-            .help("EXPERIMENTAL: The network interface to use for XDP retransmit"),
+            .requires("xdp_cpu_cores")
+            .help("Network interface to use for XDP"),
     )
     .arg(
-        Arg::with_name("retransmit_xdp_cpu_cores")
-            .hidden(hidden_unless_forced())
-            .long("experimental-retransmit-xdp-cpu-cores")
+        Arg::with_name("xdp_cpu_cores")
+            .long("xdp-cpu-cores")
             .takes_value(true)
             .value_name("CPU_LIST")
-            .validator(|value| {
-                validate_cpu_ranges(value, "--experimental-retransmit-xdp-cpu-cores")
-            })
-            .help("EXPERIMENTAL: Enable XDP retransmit on the specified CPU cores"),
+            .validator(|value| validate_cpu_ranges(value, "--xdp-cpu-cores"))
+            .help("Use the specified CPU cores for XDP"),
     )
     .arg(
-        Arg::with_name("retransmit_xdp_zero_copy")
-            .hidden(hidden_unless_forced())
-            .long("experimental-retransmit-xdp-zero-copy")
+        Arg::with_name("xdp_zero_copy")
+            .long("xdp-zero-copy")
             .takes_value(false)
-            .requires("retransmit_xdp_cpu_cores")
-            .help("EXPERIMENTAL: Enable XDP zero copy. Requires hardware support"),
+            .requires("xdp_cpu_cores")
+            .help("Enable XDP zero copy. Requires hardware support"),
     )
     .args(&pub_sub_config::args(/*test_validator:*/ false))
     .args(&json_rpc_config::args())

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -157,15 +157,21 @@ pub fn execute(
         }
     }
 
-    let xdp_interface = matches.value_of("retransmit_xdp_interface");
-    let xdp_zero_copy = matches.is_present("retransmit_xdp_zero_copy");
-    let retransmit_xdp = matches.value_of("retransmit_xdp_cpu_cores").map(|cpus| {
-        XdpConfig::new(
-            xdp_interface,
-            parse_cpu_ranges(cpus).unwrap(),
-            xdp_zero_copy,
-        )
-    });
+    let xdp_interface = matches
+        .value_of("xdp_interface")
+        .or_else(|| matches.value_of("experimental_retransmit_xdp_interface"));
+    let xdp_zero_copy = matches.is_present("xdp_zero_copy")
+        || matches.is_present("experimental_retransmit_xdp_zero_copy");
+    let retransmit_xdp = matches
+        .value_of("xdp_cpu_cores")
+        .or_else(|| matches.value_of("experimental_retransmit_xdp_cpu_cores"))
+        .map(|cpus| {
+            XdpConfig::new(
+                xdp_interface,
+                parse_cpu_ranges(cpus).unwrap(),
+                xdp_zero_copy,
+            )
+        });
 
     let dynamic_port_range =
         solana_net_utils::parse_port_range(matches.value_of("dynamic_port_range").unwrap())


### PR DESCRIPTION
#### Problem

XDP should not be experimental anymore https://discord.com/channels/428295358100013066/478692221441409024/1496253676891930865
split-off from https://github.com/anza-xyz/agave/pull/12119

#### Summary of Changes

- Remove experimental status from the CLI args for XDP.
