### PR TITLE
BCP: introduces checks on block entries

### DIFF
--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -86,7 +86,21 @@ impl BlockComponentProcessor {
             return Ok(());
         }
 
-        // TODO(ksn): re-introduce on-final logic as we continue upstreaming
+        // If we encounter an UpdateParent when fast leader handover is disabled, error.
+        if !migration_status.should_allow_fast_leader_handover(slot) && self.update_parent.is_some()
+        {
+            return Err(BlockComponentProcessorError::SpuriousUpdateParent);
+        }
+
+        // Post-migration: both header and footer are required
+        if !self.has_footer {
+            return Err(BlockComponentProcessorError::MissingBlockFooter);
+        }
+
+        if !self.has_header && self.update_parent.is_none() {
+            return Err(BlockComponentProcessorError::MissingParentMarker);
+        }
+
         Ok(())
     }
 
@@ -103,7 +117,11 @@ impl BlockComponentProcessor {
             return Ok(());
         }
 
-        // TODO(ksn): re-introduce on_entry_batch logic as we continue upstreaming
+        // We must have either a header or an update parent prior to processing entry batches.
+        if !self.has_header && self.update_parent.is_none() {
+            return Err(BlockComponentProcessorError::MissingParentMarker);
+        }
+
         Ok(())
     }
 
@@ -474,9 +492,7 @@ mod tests {
         )
     }
 
-    // TODO(ksn): re-enable once broadcast stage produces block headers
     #[test]
-    #[ignore]
     fn test_missing_header_error_on_entry_batch() {
         let migration_status = MigrationStatus::post_migration_status();
         let mut processor = BlockComponentProcessor::default();
@@ -489,9 +505,7 @@ mod tests {
         );
     }
 
-    // TODO(ksn): re-enable once broadcast stage produces block footers
     #[test]
-    #[ignore]
     fn test_missing_footer_error_on_slot_full() {
         let migration_status = MigrationStatus::post_migration_status();
         let processor = BlockComponentProcessor {


### PR DESCRIPTION
#### Problem

Now that we are sending and processing block footers, we should be ensuring that we have seen the appropriate entries in the block component processor.


#### Summary of Changes

Introduces the relevant checks.
