### PR TITLE
rpc-client: enable hash atomic feature for tests

### DIFF
--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -60,6 +60,7 @@ futures = { workspace = true }
 jsonrpc-core = { workspace = true }
 jsonrpc-http-server = { workspace = true }
 solana-account-decoder = { path = "../account-decoder", features = ["agave-unstable-api"] }
+solana-hash = { workspace = true, features = ["atomic"] }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }


### PR DESCRIPTION
#### Problem

`cargo check -p solana-rpc-client --lib --tests` fails when the package is built in isolation:

```
error[E0599]: no function or associated item named `new_unique` found for struct `solana_hash::Hash` in the current scope
    --> rpc-client/src/rpc_client.rs:4488:33
     |
4488 |         recent_blockhash: Hash::new_unique(),
     |                                 ^^^^^^^^^^ function or associated item not found in `solana_hash::Hash`

error[E0599]: no function or associated item named `new_unique` found for struct `solana_hash::Hash` in the current scope
    --> rpc-client/src/rpc_client.rs:4502:37
     |
4502 |         recent_blockhash: Hash::new_unique(),
     |                                 ^^^^^^^^^^ function or associated item not found in `solana_hash::Hash`
```

`Hash::new_unique` is gated behind the `atomic` feature on `solana-hash`. Workspace-wide builds (`cargo test --workspace`, the buildkite CI) succeed only because other crates (`bloom`, `cost-model`, `runtime`, `programs/vote`) request the feature and cargo unifies it across the graph. Anyone running `cargo test -p solana-rpc-client --lib` to iterate on rpc-client tests in isolation hits the failure above.

Same exact root cause as #11524, which enabled `solana-hash/atomic` for the bloom benches. Related in spirit to #11598, which fixed a different missing dev-feature (`solana-sha256-hasher/sha2`) on bloom tests under the same broader pattern of package-scoped builds tripping over feature unification.

I bumped into this while working on #10916. When I tried to run just the rpc-client tests to validate that change, I got the E0599 above and initially thought I'd broken something. Filing it separately to keep #10916 focused on the panic fix.

#### Summary of Changes

- Add `solana-hash` to `[dev-dependencies]` with `features = ["atomic"]` so the rpc-client unit tests compile in package-scoped builds. The production `[dependencies]` line is left untouched.