### PR TITLE
runtime-transaction: enable hash atomic and vote-interface bincode features for tests

### DIFF
--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -44,6 +44,7 @@ criterion = { workspace = true }
 rand = { workspace = true }
 solana-compute-budget-instruction = { path = "../compute-budget-instruction", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-compute-budget-interface = { workspace = true }
+solana-hash = { workspace = true, features = ["atomic"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
@@ -52,7 +53,7 @@ solana-signer = { workspace = true }
 solana-system-interface = { workspace = true, features = ["wincode"] }
 solana-system-transaction = { workspace = true }
 solana-transaction = { workspace = true, features = ["blake3"] }
-solana-vote-interface = { workspace = true }
+solana-vote-interface = { workspace = true, features = ["bincode"] }
 
 [[bench]]
 name = "get_signature_details"


### PR DESCRIPTION
#### Problem

`cargo check -p solana-runtime-transaction --lib --tests` fails when the package is built in isolation, with two distinct feature-gating errors:

```
error[E0599]: no function or associated item named `new_unique` found for struct `solana_hash::Hash` in the current scope
   --> runtime-transaction/src/runtime_transaction/sdk_transactions.rs:215:25
    |
215 |         let bank_hash = Hash::new_unique();
    |                               ^^^^^^^^^^ function or associated item not found in `solana_hash::Hash`

(... 5 more occurrences across sdk_transactions.rs and transaction_view.rs ...)

error[E0425]: cannot find function `vote` in module `vote::instruction`
   --> runtime-transaction/src/runtime_transaction/sdk_transactions.rs:222:34
    |
222 |             vote::instruction::vote(&vote_keypair.pubkey(), &auth_keypair.pubkey(), votes);
    |                                ^^^^ the item is gated behind the `bincode` feature
```

Two separate feature gates, both invisible to workspace CI:

- `Hash::new_unique` is gated behind `solana-hash`'s `atomic` feature.
- `vote::instruction::vote` is gated behind `solana-vote-interface`'s `bincode` feature.

Workspace-wide builds (`cargo test --workspace`, the buildkite CI) succeed because other crates in the build graph request both features and cargo unifies them. Anyone running `cargo test -p solana-runtime-transaction --lib` to iterate on this crate's tests in isolation hits both errors at once.

Same root cause for `atomic` as #12277 (rpc-client) and #11524 (bloom benches). The `bincode` gating on `solana-vote-interface` is an additional instance of the same package-scoped feature-unification pattern surfacing on the same crate, so both fixes are bundled here.

I bumped into this while doing a follow-up audit after #12277 to see how widespread the pattern was so @joncinque doesn't get annoyed by it again. `solana-runtime-transaction` was the only other crate in the workspace where the pattern actually fails in isolation rather than being masked by a transitive feature-unifying dep.

#### Summary of Changes

- Add `solana-hash` to `[dev-dependencies]` with `features = ["atomic"]`.
- Enable `bincode` on the existing `solana-vote-interface` dev-dependency entry.
- Production `[dependencies]` surface is left unchanged so consumers of the library are unaffected.