### PR TITLE
core: enable bpf-loader-program svm-internal feature for tests

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -183,7 +183,7 @@ bitvec = { workspace = true }
 criterion = { workspace = true }
 serial_test = { workspace = true }
 solana-account = { workspace = true, features = ["dev-context-only-utils"] }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api"] }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api", "svm-internal"] }
 solana-client = { path = "../client", features = ["dev-context-only-utils"] }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-interface = { workspace = true }


### PR DESCRIPTION
#### Problem

`cargo check -p solana-core --lib --tests` fails when the package is built in isolation:

```
error[E0603]: constant `UPGRADEABLE_LOADER_COMPUTE_UNITS` is private
   --> core/tests/scheduler_cost_adjustment.rs:326:42
    |
326 |             - solana_bpf_loader_program::UPGRADEABLE_LOADER_COMPUTE_UNITS as i64
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private constant
note: the constant `UPGRADEABLE_LOADER_COMPUTE_UNITS` is defined here
   --> programs/bpf_loader/src/lib.rs:37:1

error[E0603]: constant `UPGRADEABLE_LOADER_COMPUTE_UNITS` is private
   --> core/tests/scheduler_cost_adjustment.rs:339:56
    |
339 |     let tx_execution_cost = solana_bpf_loader_program::UPGRADEABLE_LOADER_COMPUTE_UNITS
    |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private constant
```

The constant in `programs/bpf_loader/src/lib.rs:35-37` is conditionally `pub` only when the `svm-internal` feature is enabled:

```rust
#[cfg_attr(feature = "svm-internal", qualifiers(pub))]
const UPGRADEABLE_LOADER_COMPUTE_UNITS: u64 = 2_370;
```

Without the feature, the constant stays private. Workspace builds can hide this because `programs/bpf_loader` requests `svm-internal` for its own tests, and cargo unifies features for the workspace invocation. Package-scoped `solana-core` builds do not include that dev-dependency edge, so `solana-bpf-loader-program/svm-internal` stays off and the test fails to compile.

Same root cause as #12277 (rpc-client, `solana-hash/atomic`, merged) and #11524 (bloom benches, `solana-hash/atomic`, merged). The `svm-internal` gating is yet another instance of the same package-scoped feature-unification pattern surfacing on a different feature.

I bumped into this while doing a follow-up audit after #12277 to see how widespread this pattern is in the workspace. `solana-core` is one of three crates currently failing in isolation; the other two are `solana-runtime-transaction` (#12279) and `agave-bls-cert-verify` (#12281).

#### Summary of Changes

- Enable `svm-internal` on the existing `solana-bpf-loader-program` `[dev-dependencies]` entry in `core/Cargo.toml`. The production `[dependencies]` surface is left unchanged so consumers of solana-core are unaffected.