### PR TITLE
bls-cert-verify: enable agave-votor agave-unstable-api feature for tests

### DIFF
--- a/bls-cert-verify/Cargo.toml
+++ b/bls-cert-verify/Cargo.toml
@@ -27,7 +27,7 @@ wincode = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 agave-bls-cert-verify = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 # See order-crates-for-publishing.py for using this unusual `path`
-agave-votor = { path = "../votor" }
+agave-votor = { path = "../votor", features = ["agave-unstable-api"] }
 criterion = { workspace = true }
 solana-hash = { workspace = true }
 


### PR DESCRIPTION
#### Problem

`cargo check -p agave-bls-cert-verify --lib --tests` fails when the package is built in isolation:

```
error[E0433]: cannot find `consensus_pool` in `agave_votor`
   --> bls-cert-verify/src/cert_verify.rs:250:22
    |
250 |         agave_votor::consensus_pool::certificate_builder::CertificateBuilder,
    |                      ^^^^^^^^^^^^^^ could not find `consensus_pool` in `agave_votor`
error: could not compile `agave-bls-cert-verify` (lib test) due to 1 previous error
```

Unlike the per-symbol gating in earlier instances of this pattern, the entire `agave-votor` lib is gated at the crate root in `votor/src/lib.rs:1`:

```rust
#![cfg(feature = "agave-unstable-api")]
```

Without the feature, `agave-votor`'s lib compiles to effectively empty and every module, including `consensus_pool`, disappears. The references at `bls-cert-verify/src/cert_verify.rs:250` (in a `#[cfg(test)]` block) and `bls-cert-verify/benches/cert_verify.rs:3` both reach into `agave_votor::consensus_pool::certificate_builder::CertificateBuilder` and need the feature enabled to resolve.

Workspace builds can hide this because the workspace-root `Cargo.toml` declares `agave-votor` with `features = ["agave-unstable-api"]`, so any crate using `agave-votor = { workspace = true }` inherits the feature and cargo unifies it. `bls-cert-verify/Cargo.toml` uses a manual path declaration (`agave-votor = { path = "../votor" }`, per the project's publishing-order convention) rather than `workspace = true`, so it does not inherit the workspace-level feature. In package-scoped builds where bls-cert-verify is the lone requester via that path, the feature stays off.

Same root cause as #12277 (rpc-client, `solana-hash/atomic`, merged) and #11524 (bloom benches, `solana-hash/atomic`, merged). The novelty here is that the gate is at crate-root via `#![cfg]` rather than on a single symbol, so the surfaced symptom is "module not found" instead of "function not found", but the underlying cause is identical.

I bumped into this while doing a follow-up audit after #12277 to see how widespread this pattern is in the workspace. `agave-bls-cert-verify` is one of three crates currently failing in isolation; the other two are `solana-runtime-transaction` (#12279) and `solana-core` (#12280).

#### Summary of Changes

- Enable `agave-unstable-api` on the existing `agave-votor` `[dev-dependencies]` entry in `bls-cert-verify/Cargo.toml`. No production dependency changes.