### PR TITLE
bls12-381-syscall: gate bench on agave-unstable-api feature

### DIFF
--- a/bls12-381-syscall/Cargo.toml
+++ b/bls12-381-syscall/Cargo.toml
@@ -33,3 +33,4 @@ workspace = true
 [[bench]]
 name = "bench_main"
 harness = false
+required-features = ["agave-unstable-api"]


### PR DESCRIPTION
#### Problem

`cargo check -p solana-bls12-381-syscall --benches` fails in package-scoped builds:

```
error[E0433]: cannot find type `PodG1Point` in this scope
   --> bls12-381-syscall/benches/bench_main.rs:13:69
    |
13  | fn build_pairing_input<const N: usize>(one_pair_vec: &[u8]) -> ([PodG1Point; N], [PodG2Point; N]) {

error[E0433]: cannot find type `Endianness` in this scope
   --> bls12-381-syscall/benches/bench_main.rs:31:25
    |
31  |     for endianness in [Endianness::BE, Endianness::LE] {
    |                        ^^^^^^^^^^

(... 80 more errors of the same shape ...)
error: could not compile `solana-bls12-381-syscall` (bench "bench_main") due to 82 previous errors
```

The bench at `bls12-381-syscall/benches/bench_main.rs:6` imports `solana_bls12_381_syscall::*`, but the crate's `lib.rs` is gated at the crate root:

```rust
// bls12-381-syscall/src/lib.rs:1
#![cfg(feature = "agave-unstable-api")]
```

Without the feature, the lib compiles to effectively empty. Every type defined in the crate then disappears, including `PodG1Point`, `PodG2Point`, `Endianness`, and `PodGtElement`. The 82 errors are all the same root cause repeated across each missing type.

Workspace builds can hide this because the workspace-root `Cargo.toml` declares `solana-bls12-381-syscall = { ..., features = ["agave-unstable-api"] }`, so any crate using `solana-bls12-381-syscall = { workspace = true }` inherits the feature, and cargo unifies it across the graph. Bench targets, however, are built against the crate's own default features rather than via workspace inheritance. Since this crate defines no default features, the gate stays closed in package-scoped bench builds.

Same root cause as #12281 (bls-cert-verify, `agave-unstable-api` crate-root cfg, open). The difference is that the gating here affects an in-crate bench rather than a downstream crate's tests, so the cargo-idiomatic fix is `required-features` on the `[[bench]]` declaration rather than enabling features on a dev-dependency.

I bumped into this while extending the package-scoped feature-unification audit beyond `--lib --tests` into `--benches`. `solana-bls12-381-syscall` is the only crate in the workspace where this pattern surfaces in bench scope. The other 8 bench failures observed during the audit were all nightly-Rust requirements documented in the README, not feature-gating bugs. Earlier instances of the same broad pattern: #12277 (rpc-client), #12279 (runtime-transaction), #12280 (core), #12281 (bls-cert-verify).

#### Summary of Changes

- Add `required-features = ["agave-unstable-api"]` to the `[[bench]]` declaration in `bls12-381-syscall/Cargo.toml`. Cargo now skips the bench when the feature is off, instead of trying to compile against an empty lib, and builds it normally when the feature is on. No production dependency changes.