### PR TITLE
feat(ci): fetch channel pin overrides from master

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -80,7 +80,7 @@ while keeping the current beta in place), set the pins in
 # current beta, to be held
 PINNED_BETA_CHANNEL=vX.Y
 # current stable, to be held
-PINNED_STABLE_CHANNEL=vX.Y-1 
+PINNED_STABLE_CHANNEL=vX.Y-1
 ```
 
 Only the file that lives on master is used; every branch's CI fetches it from there, so no

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,7 +83,7 @@ PINNED_BETA_CHANNEL=vX.Y
 PINNED_STABLE_CHANNEL=vX.Y-1 
 ```
 
-The file lives only on master; every branch's CI fetches it from there, so no
+Only the file that lives on master is used; every branch's CI fetches it from there, so no
 backport is needed.
 
 When ready to promote, open a PR on master that clears or updates the pins.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -77,7 +77,8 @@ while keeping the current beta in place), set the pins in
 `ci/channel-overrides` on master *before* pushing the new branch:
 
 ```
-PINNED_BETA_CHANNEL=vX.Y      # current beta, to be held
+# current beta, to be held
+PINNED_BETA_CHANNEL=vX.Y
 PINNED_STABLE_CHANNEL=vX.Y-1  # current stable, to be held
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -79,7 +79,8 @@ while keeping the current beta in place), set the pins in
 ```
 # current beta, to be held
 PINNED_BETA_CHANNEL=vX.Y
-PINNED_STABLE_CHANNEL=vX.Y-1  # current stable, to be held
+# current stable, to be held
+PINNED_STABLE_CHANNEL=vX.Y-1 
 ```
 
 The file lives only on master; every branch's CI fetches it from there, so no

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -100,6 +100,20 @@ Alternatively use the Github UI.
     ```
     ci/channel-info.sh
     ```
+   Note: if `ci/channel-overrides` on master has `PINNED_BETA_CHANNEL` / `PINNED_STABLE_CHANNEL` set, those values override auto-detect everywhere.
+
+### Cutting a branch without promoting channels
+
+By default, pushing a new `vX.Y` head auto-promotes it to `BETA_CHANNEL` and demotes the prior beta to stable, because `ci/channel-info.sh` picks the top-2 `vX.Y` heads. To cut a branch without that promotion (e.g. to begin backports while keeping the current beta in place), set the pins in `ci/channel-overrides` on master *before* pushing the new branch:
+
+```
+PINNED_BETA_CHANNEL=vX.Y      # current beta, to be held
+PINNED_STABLE_CHANNEL=vX.Y-1  # current stable, to be held
+```
+
+The file lives only on master; every branch's CI fetches it from there, so no backport is needed.
+
+When ready to promote, open a PR on master that clears or updates the pins. Then proceed with the usual "Miscellaneous Clean up" steps below.
 
 ### Update the Changelog
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -67,6 +67,28 @@ all eligible deprecated symbols have been removed. Our policy is to deprecate
 for at least one full minor version before removal.
 
 ### Create the new branch
+
+#### Cutting a branch without promoting channels
+
+By default, pushing a new `vX.Y` head auto-promotes it to `BETA_CHANNEL` and
+demotes the prior beta to stable, because `ci/channel-info.sh` picks the top-2
+`vX.Y` heads. To cut a branch without that promotion (e.g. to begin backports
+while keeping the current beta in place), set the pins in
+`ci/channel-overrides` on master *before* pushing the new branch:
+
+```
+PINNED_BETA_CHANNEL=vX.Y      # current beta, to be held
+PINNED_STABLE_CHANNEL=vX.Y-1  # current stable, to be held
+```
+
+The file lives only on master; every branch's CI fetches it from there, so no
+backport is needed.
+
+When ready to promote, open a PR on master that clears or updates the pins.
+Then proceed with the usual "Miscellaneous Clean up" steps below.
+
+#### Steps
+
 1. Check out the latest commit on `master` branch:
     ```
     git fetch --all
@@ -100,20 +122,8 @@ Alternatively use the Github UI.
     ```
     ci/channel-info.sh
     ```
-   Note: if `ci/channel-overrides` on master has `PINNED_BETA_CHANNEL` / `PINNED_STABLE_CHANNEL` set, those values override auto-detect everywhere.
-
-### Cutting a branch without promoting channels
-
-By default, pushing a new `vX.Y` head auto-promotes it to `BETA_CHANNEL` and demotes the prior beta to stable, because `ci/channel-info.sh` picks the top-2 `vX.Y` heads. To cut a branch without that promotion (e.g. to begin backports while keeping the current beta in place), set the pins in `ci/channel-overrides` on master *before* pushing the new branch:
-
-```
-PINNED_BETA_CHANNEL=vX.Y      # current beta, to be held
-PINNED_STABLE_CHANNEL=vX.Y-1  # current stable, to be held
-```
-
-The file lives only on master; every branch's CI fetches it from there, so no backport is needed.
-
-When ready to promote, open a PR on master that clears or updates the pins. Then proceed with the usual "Miscellaneous Clean up" steps below.
+   Note: if `ci/channel-overrides` on master has `PINNED_BETA_CHANNEL` /
+   `PINNED_STABLE_CHANNEL` set, those values override auto-detect everywhere.
 
 ### Update the Changelog
 

--- a/ci/channel-info.sh
+++ b/ci/channel-info.sh
@@ -62,6 +62,19 @@ for head in "${heads[@]}"; do
   stable=$head
 done
 
+# Apply channel pin overrides fetched from master. Single source of truth:
+# every branch's CI honors the same file. Hard-fail on transport errors so
+# misconfiguration surfaces immediately.
+overrides_url="https://raw.githubusercontent.com/anza-xyz/agave/master/ci/channel-overrides?ts=$(date +%s)"
+overrides=$(curl -fsSL "$overrides_url") || {
+  echo "error: failed to fetch channel overrides from $overrides_url" >&2
+  exit 1
+}
+# shellcheck disable=SC1090
+source <(echo "$overrides")
+[[ -n $PINNED_BETA_CHANNEL ]]   && beta=${PINNED_BETA_CHANNEL#v}
+[[ -n $PINNED_STABLE_CHANNEL ]] && stable=${PINNED_STABLE_CHANNEL#v}
+
 for tag in "${tags[@]}"; do
   if [[ -n $beta && $tag = $beta* ]]; then
     if [[ -n $beta_tag ]]; then

--- a/ci/channel-info.sh
+++ b/ci/channel-info.sh
@@ -66,7 +66,7 @@ done
 # every branch's CI honors the same file. Hard-fail on transport errors so
 # misconfiguration surfaces immediately.
 overrides_url="https://raw.githubusercontent.com/anza-xyz/agave/master/ci/channel-overrides?ts=$(date +%s)"
-overrides=$(curl -fsSL "$overrides_url") || {
+overrides=$(curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "$overrides_url") || {
   echo "error: failed to fetch channel overrides from $overrides_url" >&2
   exit 1
 }

--- a/ci/channel-info.sh
+++ b/ci/channel-info.sh
@@ -64,16 +64,22 @@ done
 
 # Apply channel pin overrides fetched from master. Single source of truth:
 # every branch's CI honors the same file. Hard-fail on transport errors so
-# misconfiguration surfaces immediately.
+# misconfiguration surfaces immediately. Parse strictly with awk to avoid
+# arbitrary execution.
 overrides_url="https://raw.githubusercontent.com/anza-xyz/agave/master/ci/channel-overrides?ts=$(date +%s)"
 overrides=$(curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused "$overrides_url") || {
   echo "error: failed to fetch channel overrides from $overrides_url" >&2
   exit 1
 }
-# shellcheck disable=SC1090
-source <(echo "$overrides")
-[[ -n $PINNED_BETA_CHANNEL ]]   && beta=${PINNED_BETA_CHANNEL#v}
-[[ -n $PINNED_STABLE_CHANNEL ]] && stable=${PINNED_STABLE_CHANNEL#v}
+extract_pin() {
+  awk -F= -v k="$1" '
+    $1==k && $2 ~ /^(v[0-9a-z.]+)?$/ { print $2; exit }
+  ' <<<"$overrides"
+}
+beta_pin=$(extract_pin PINNED_BETA_CHANNEL)
+stable_pin=$(extract_pin PINNED_STABLE_CHANNEL)
+[[ -n $beta_pin ]]   && beta=${beta_pin#v}
+[[ -n $stable_pin ]] && stable=${stable_pin#v}
 
 for tag in "${tags[@]}"; do
   if [[ -n $beta && $tag = $beta* ]]; then


### PR DESCRIPTION
#### Problem                                                                                                             

`ci/channel-info.sh` derives `BETA_CHANNEL`/`STABLE_CHANNEL` from the top-2 `vX.Y` heads on the canonical remote. Pushing a new release branch therefore auto-promotes it to beta and demotes the current beta to stable, with no opt-out. Teams that want to start backports before the prior beta is ready to ship have no clean way to cut a branch.                                                       
                                                                                                                           
#### Summary of Changes

- Adopts the single-source-of-truth design proposed by @levsha. The pin override file (`ci/channel-overrides`) lives only  
on master; every branch's `ci/channel-info.sh` fetches it from there. No backporting required, no per-branch validator needed.
- Document the workflow and channel-advance procedure in `RELEASE.md`.