### PR TITLE
snapshots: enable solana-hash atomic feature for tests

### DIFF
--- a/snapshots/Cargo.toml
+++ b/snapshots/Cargo.toml
@@ -47,3 +47,4 @@ zstd = { workspace = true }
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
+solana-hash = { workspace = true, features = ["atomic"] }


### PR DESCRIPTION
#### Problem

`cargo check -p agave-snapshots --features agave-unstable-api --lib --tests` fails in package-scoped builds:

```
error[E0599]: no function or associated item named `new_unique` found for struct `solana_hash::Hash` in the current scope
    --> snapshots/src/paths.rs:300:17
     |
300  |                 Hash::new_unique()
     |                       ^^^^^^^^^^ function or associated item not found

(... 8 more identical errors at lines 311, 318, 325, 339, 380, 394, 402, 417 ...)
```

`Hash::new_unique` is gated behind solana-hash's `atomic` feature. The calls live inside `#[cfg(test)] mod tests` at `snapshots/src/paths.rs:260`, which is itself inside the crate-root gate `#![cfg(feature = "agave-unstable-api")]` at `snapshots/src/lib.rs:1`. Default `cargo check -p agave-snapshots --lib --tests` passes only because the crate-root gate keeps the entire lib (and therefore the test module) excluded from compilation.

Workspace builds can hide this because other crates request `solana-hash/atomic` and cargo unifies it across the graph. Package-scoped builds with `agave-unstable-api` enabled do compile the test module but do not unify the atomic feature on, so the test fails with E0599.

Same package-scoped feature-unification gap as #12277 (rpc-client, hash atomic, merged) and #11524 (bloom benches, hash atomic, merged). Same pattern as the currently open #12279 (runtime-transaction, hash atomic + vote-interface bincode), #12280 (core, svm-internal), and #12281 (bls-cert-verify, agave-unstable-api crate-root cfg). The novelty here is that the bug is conditionally hidden behind a crate-root cfg gate: it does not surface in default `cargo check` because the entire crate is gated off, but does surface as soon as `agave-unstable-api` is enabled.

I bumped into this while extending the package-scoped feature-unification audit. `agave-snapshots` and `solana-svm-transaction` (#12287) are the two crates where the bug only surfaces with `agave-unstable-api` enabled, due to crate-root cfg gates that hide the test module entirely from default audits.

#### Summary of Changes

- Add `solana-hash` to `[dev-dependencies]` with `features = ["atomic"]` in `snapshots/Cargo.toml`. The production `[dependencies]` surface is left unchanged so consumers of agave-snapshots are unaffected.