### PR TITLE
svm-transaction: enable solana-pubkey std feature for tests

### DIFF
--- a/svm-transaction/Cargo.toml
+++ b/svm-transaction/Cargo.toml
@@ -23,6 +23,7 @@ solana-transaction = { workspace = true }
 [dev-dependencies]
 solana-message = { workspace = true, features = ["wincode"] }
 solana-nonce = { workspace = true }
+solana-pubkey = { workspace = true, features = ["std"] }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }


### PR DESCRIPTION
#### Problem

`cargo check -p solana-svm-transaction --features agave-unstable-api --lib --tests` fails in package-scoped builds:

```
error[E0599]: no function or associated item named `new_unique` found for struct `Address` in the current scope
   --> svm-transaction/src/tests.rs:52:55
    |
52  |                         account_key: Pubkey::new_unique(),
    |                                              ^^^^^^^^^^ function or associated item not found

(... many more identical errors across tests.rs ...)
```

In solana-pubkey 4.x, `Pubkey` is a re-export of `solana_address::Address`, and `Address::new_unique` is gated behind solana-address's `atomic` feature. Multiple solana-pubkey features propagate to that gate; the minimal direct route is `std`, which solana-pubkey defines as `std = ["solana-address/atomic", "solana-address/std"]`.

The test calls live in `svm-transaction/src/tests.rs` (file-level `#![cfg(test)]`), which is itself inside the crate-root gate `#![cfg(feature = "agave-unstable-api")]` at `svm-transaction/src/lib.rs:1`. Default `cargo check -p solana-svm-transaction --lib --tests` passes only because the crate-root gate keeps the entire lib (and therefore the test module) excluded from compilation.

Workspace builds can hide this because other crates request features that propagate to solana-address via cargo's feature unification. Package-scoped builds with `agave-unstable-api` enabled do compile the test module but do not unify a sufficient feature on, so the test fails with E0599.

The svm-transaction tests use only `Pubkey::new_unique` and never any random-helper from the `rand` crate, so `std` is the minimal feature that unblocks compilation without pulling in unused dependency surface.

Same package-scoped feature-unification gap as #12277 (rpc-client, hash atomic, merged) and #11524 (bloom benches, hash atomic, merged). Same pattern as the currently open #12279 (runtime-transaction, hash atomic + vote-interface bincode), #12280 (core, svm-internal), and #12281 (bls-cert-verify, agave-unstable-api crate-root cfg). Like the snapshots sibling PR (#12286), the bug is conditionally hidden behind a crate-root cfg gate.

I bumped into this while extending the package-scoped feature-unification audit. `solana-svm-transaction` and `agave-snapshots` (#12286) are the two crates where the bug only surfaces with `agave-unstable-api` enabled.

#### Summary of Changes

- Add `solana-pubkey` to `[dev-dependencies]` with `features = ["std"]` in `svm-transaction/Cargo.toml`. The production `[dependencies]` surface is left unchanged so consumers of solana-svm-transaction are unaffected.

Choice of `std` rather than the more common `rand` was suggested by @Nagisa in review.