### PR TITLE
pubsub-client: mark account_subscribe doctest as no_run

### DIFF
--- a/pubsub-client/src/pubsub_client.rs
+++ b/pubsub-client/src/pubsub_client.rs
@@ -44,7 +44,7 @@
 //! This example subscribes to account events and then loops forever receiving
 //! them.
 //!
-//! ```
+//! ```no_run
 //! use anyhow::Result;
 //! use solana_commitment_config::CommitmentConfig;
 //! use solana_pubkey::Pubkey;


### PR DESCRIPTION
#### Problem

`cargo test --doc -p solana-pubsub-client` fails with a runtime panic:

```
thread 'main' panicked at rustls-0.23.40/src/crypto/mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually,
or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
```

The doctest at `pubsub-client/src/pubsub_client.rs:47` is opened with plain ` ``` ` (rather than ` ```no_run `) and contains the rustdoc-convention trailing hidden invocation `# get_account_updates(...)` that actually executes the example at test time. The example calls `PubsubClient::account_subscribe` against `wss://api.devnet.solana.com/`, which initializes a rustls connection. Rustls 0.23+ panics when no CryptoProvider is configured, and the workspace-root `Cargo.toml` declares rustls with `default-features = false` and only the `std` feature, so neither `aws-lc-rs` nor `ring` is enabled.

The package-scoped doctest fails because no other crate enables a rustls CryptoProvider feature in the dependency graph for this single-crate build. Broader workspace doctest runs (`ci/test-docs.sh`, which executes `cargo test --all --doc --exclude solana-local-cluster`) can hide the panic through cargo's feature unification, since other crates in the workspace bring in a CryptoProvider feature transitively. However, even when the panic is hidden, the example still performs real network I/O at test time. Empirically, `cargo test --doc -p solana-pubsub-client -p solana-rpc-client-api` does not panic but blocks for over 60 seconds attempting the actual WebSocket connection to devnet.

The example is intended to demonstrate the API, not to actually connect to devnet. Marking it `no_run` is the right fix regardless of which build mode triggers the symptom: the doctest still compiles (so the API surface is validated) but no longer attempts a real network connection.

I bumped into this while running `cargo test --doc -p solana-pubsub-client` as part of a broader doctest sweep across the workspace. It was the only doctest in agave that fails or hangs in package-scoped mode.

#### Summary of Changes

- Change the doctest fence at `pubsub-client/src/pubsub_client.rs:47` from ` ``` ` to ` ```no_run `. The example continues to compile and validate the API surface; it no longer attempts a real WebSocket connection at test time.