### PR TITLE
refactor(ci): port channel-info.sh to xtask

### DIFF
--- a/ci/test-channel-info-divergence.sh
+++ b/ci/test-channel-info-divergence.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Runs `ci/channel-info.sh` (current authoritative source) and
+# `cargo xtask channel-info` (auto-resolver), diffs their output, and
+# annotates the build on mismatch. Never blocks the pipeline.
+
+set -u
+cd "$(dirname "$0")/.." || exit 1
+
+bash_out=$(ci/channel-info.sh 2>&1) || {
+  echo "ci/channel-info.sh failed (exit $?); skipping divergence check" >&2
+  echo "$bash_out" >&2
+  exit 0
+}
+
+xtask_out=$(cargo run --quiet --manifest-path ci/xtask/Cargo.toml -- channel-info 2>&1) || {
+  echo "cargo xtask channel-info failed (exit $?); skipping divergence check" >&2
+  echo "$xtask_out" >&2
+  exit 0
+}
+
+bash_sorted=$(printf '%s\n' "$bash_out" | LC_ALL=C sort)
+xtask_sorted=$(printf '%s\n' "$xtask_out" | LC_ALL=C sort)
+
+if [[ "$bash_sorted" == "$xtask_sorted" ]]; then
+  echo "channel-info parity OK"
+  exit 0
+fi
+
+echo "channel-info divergence detected" >&2
+echo "--- bash (authoritative)" >&2
+echo "$bash_out" >&2
+echo "--- xtask" >&2
+echo "$xtask_out" >&2
+
+if command -v buildkite-agent >/dev/null 2>&1; then
+  {
+    echo "**channel-info parity divergence**"
+    echo
+    echo '```'
+    echo "bash (authoritative):"
+    echo "$bash_out"
+    echo
+    echo "xtask:"
+    echo "$xtask_out"
+    echo '```'
+  } | buildkite-agent annotate --style warning --context channel-info-divergence || true
+fi
+
+exit 0

--- a/ci/xtask/Cargo.lock
+++ b/ci/xtask/Cargo.lock
@@ -2048,6 +2048,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2559,10 +2574,12 @@ dependencies = [
  "octocrab",
  "pretty_assertions",
  "regex",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
  "tokio",
+ "toml",
  "xtask 0.1.0 (git+https://github.com/anza-xyz/xtask?rev=a9b0cf5facf85eb11458bbefc651132722c18dae)",
 ]
 

--- a/ci/xtask/Cargo.lock
+++ b/ci/xtask/Cargo.lock
@@ -212,6 +212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,7 +340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -478,7 +484,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -519,7 +525,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -657,6 +663,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,7 +696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -786,6 +806,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -807,13 +828,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -974,6 +998,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "iri-string"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,13 +1067,13 @@ checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64",
  "ed25519-dalek",
- "getrandom",
+ "getrandom 0.2.17",
  "hmac",
  "js-sys",
  "p256",
  "p384",
  "pem",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -1095,6 +1125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,7 +1168,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1189,7 +1225,7 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
- "getrandom",
+ "getrandom 0.2.17",
  "http",
  "http-body",
  "http-body-util",
@@ -1426,6 +1462,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,14 +1526,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1452,7 +1559,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1461,7 +1578,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1503,6 +1629,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,7 +1684,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1539,12 +1703,18 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1588,6 +1758,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1815,7 +1986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1923,6 +2094,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1995,6 +2169,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2268,6 +2457,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2476,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2313,6 +2525,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,6 +2543,15 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2557,6 +2788,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2574,6 +2811,7 @@ dependencies = [
  "octocrab",
  "pretty_assertions",
  "regex",
+ "reqwest",
  "semver",
  "serde",
  "serde_json",

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = "0.3.31"
 log = "0.4.28"
 octocrab = { version = "0.51.0", features = ["stream"] }
 regex = "1.12.3"
-semver = "1.0.27"
+semver = { version = "1.0.27", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 serde_yaml = "0.9.34"

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -26,10 +26,12 @@ futures-util = "0.3.31"
 log = "0.4.28"
 octocrab = { version = "0.51.0", features = ["stream"] }
 regex = "1.12.3"
+semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 serde_yaml = "0.9.34"
 tokio = { version = "1.52.3", features = ["full"] }
+toml = "0.9"
 xtask_shared = { package = "xtask", git = "https://github.com/anza-xyz/xtask", rev = "a9b0cf5facf85eb11458bbefc651132722c18dae" }
 
 [dev-dependencies]

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -26,6 +26,7 @@ futures-util = "0.3.31"
 log = "0.4.28"
 octocrab = { version = "0.51.0", features = ["stream"] }
 regex = "1.12.3"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 semver = { version = "1.0.27", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/ci/xtask/src/commands.rs
+++ b/ci/xtask/src/commands.rs
@@ -1,2 +1,3 @@
+pub mod channel_info;
 pub mod generate_pipeline;
 pub mod hello;

--- a/ci/xtask/src/commands/channel_info.rs
+++ b/ci/xtask/src/commands/channel_info.rs
@@ -4,7 +4,7 @@ mod resolve;
 use {
     anyhow::Result,
     futures_util::future::try_join_all,
-    resolve::{EnvInputs, Xy, derive_channels, print_channel_info},
+    resolve::{BranchVersion, EnvInputs, derive_channels, print_channel_info},
     semver::Version,
     std::{collections::BTreeMap, env},
 };
@@ -23,10 +23,10 @@ pub async fn run() -> Result<()> {
         heads
             .iter()
             .copied()
-            .map(|xy| fetch::workspace_version(&client, xy)),
+            .map(|bv| fetch::workspace_version(&client, bv)),
     )
     .await?;
-    let versions: BTreeMap<Xy, Version> = heads.into_iter().zip(fetched).collect();
+    let versions: BTreeMap<BranchVersion, Version> = heads.into_iter().zip(fetched).collect();
 
     let info = derive_channels(&versions, &tags, &read_env())?;
     print_channel_info(&info);

--- a/ci/xtask/src/commands/channel_info.rs
+++ b/ci/xtask/src/commands/channel_info.rs
@@ -1,0 +1,46 @@
+mod fetch;
+mod resolve;
+
+use {
+    anyhow::Result,
+    futures_util::future::try_join_all,
+    resolve::{EnvInputs, Xy, derive_channels, print_channel_info},
+    semver::Version,
+    std::{collections::BTreeMap, env},
+};
+
+pub async fn run() -> Result<()> {
+    let client = fetch::github_client()?;
+
+    let mut heads = fetch::release_heads(&client).await?;
+    let tags = fetch::release_tags(&client).await?;
+
+    heads.sort();
+    heads.reverse();
+    heads.truncate(3);
+
+    let fetched = try_join_all(
+        heads
+            .iter()
+            .copied()
+            .map(|xy| fetch::workspace_version(&client, xy)),
+    )
+    .await?;
+    let versions: BTreeMap<Xy, Version> = heads.into_iter().zip(fetched).collect();
+
+    let info = derive_channels(&versions, &tags, &read_env())?;
+    print_channel_info(&info);
+
+    Ok(())
+}
+
+fn pick_env(key: &str) -> Option<String> {
+    env::var(key).ok().filter(|v| !v.is_empty())
+}
+
+fn read_env() -> EnvInputs {
+    EnvInputs {
+        branch: pick_env("CI_BASE_BRANCH").or_else(|| pick_env("CI_BRANCH")),
+        channel: pick_env("CHANNEL"),
+    }
+}

--- a/ci/xtask/src/commands/channel_info.rs
+++ b/ci/xtask/src/commands/channel_info.rs
@@ -4,7 +4,7 @@ mod resolve;
 use {
     anyhow::Result,
     futures_util::future::try_join_all,
-    resolve::{BranchVersion, EnvInputs, derive_channels, print_channel_info},
+    resolve::{BranchVersion, derive_channels, print_channel_info},
     semver::Version,
     std::{collections::BTreeMap, env},
 };
@@ -28,7 +28,9 @@ pub async fn run() -> Result<()> {
     .await?;
     let versions: BTreeMap<BranchVersion, Version> = heads.into_iter().zip(fetched).collect();
 
-    let info = derive_channels(&versions, &tags, &read_env())?;
+    let branch = pick_env("CI_BASE_BRANCH").or_else(|| pick_env("CI_BRANCH"));
+    let channel = pick_env("CHANNEL");
+    let info = derive_channels(&versions, &tags, branch.as_deref(), channel.as_deref())?;
     print_channel_info(&info);
 
     Ok(())
@@ -36,11 +38,4 @@ pub async fn run() -> Result<()> {
 
 fn pick_env(key: &str) -> Option<String> {
     env::var(key).ok().filter(|v| !v.is_empty())
-}
-
-fn read_env() -> EnvInputs {
-    EnvInputs {
-        branch: pick_env("CI_BASE_BRANCH").or_else(|| pick_env("CI_BRANCH")),
-        channel: pick_env("CHANNEL"),
-    }
 }

--- a/ci/xtask/src/commands/channel_info.rs
+++ b/ci/xtask/src/commands/channel_info.rs
@@ -10,15 +10,14 @@ use {
 };
 
 pub async fn run() -> Result<()> {
-    let client = fetch::github_client()?;
-
-    let mut heads = fetch::release_heads(&client).await?;
-    let tags = fetch::release_tags(&client).await?;
+    let mut heads = fetch::release_heads()?;
+    let tags = fetch::release_tags()?;
 
     heads.sort();
     heads.reverse();
     heads.truncate(3);
 
+    let client = reqwest::Client::new();
     let fetched = try_join_all(
         heads
             .iter()

--- a/ci/xtask/src/commands/channel_info/fetch.rs
+++ b/ci/xtask/src/commands/channel_info/fetch.rs
@@ -1,5 +1,5 @@
 use {
-    super::resolve::{Xy, parse_xy, xy_branch},
+    super::resolve::BranchVersion,
     anyhow::{Result, anyhow},
     futures_util::TryStreamExt,
     semver::Version,
@@ -25,15 +25,15 @@ pub fn github_client() -> Result<octocrab::Octocrab> {
     Ok(builder.build()?)
 }
 
-pub async fn release_heads(client: &octocrab::Octocrab) -> Result<Vec<Xy>> {
+pub async fn release_heads(client: &octocrab::Octocrab) -> Result<Vec<BranchVersion>> {
     let page = client.repos(OWNER, REPO).list_branches().send().await?;
     let stream = page.into_stream(client);
     pin!(stream);
 
     let mut heads = vec![];
     while let Some(branch) = stream.try_next().await? {
-        if let Some(xy) = parse_xy(&branch.name) {
-            heads.push(xy);
+        if let Ok(bv) = branch.name.parse::<BranchVersion>() {
+            heads.push(bv);
         }
     }
 
@@ -76,8 +76,8 @@ struct PackageSection {
     version: Version,
 }
 
-pub async fn workspace_version(client: &octocrab::Octocrab, xy: Xy) -> Result<Version> {
-    let reference = xy_branch(xy);
+pub async fn workspace_version(client: &octocrab::Octocrab, bv: BranchVersion) -> Result<Version> {
+    let reference = bv.to_string();
     let content_items = client
         .repos(OWNER, REPO)
         .get_content()

--- a/ci/xtask/src/commands/channel_info/fetch.rs
+++ b/ci/xtask/src/commands/channel_info/fetch.rs
@@ -73,7 +73,7 @@ struct WorkspaceSection {
 
 #[derive(Deserialize)]
 struct PackageSection {
-    version: String,
+    version: Version,
 }
 
 pub async fn workspace_version(client: &octocrab::Octocrab, xy: Xy) -> Result<Version> {
@@ -97,6 +97,5 @@ pub async fn workspace_version(client: &octocrab::Octocrab, xy: Xy) -> Result<Ve
 
     let parsed: CargoToml = toml::from_str(&raw)
         .map_err(|e| anyhow!("failed to parse Cargo.toml at ref {reference}: {e}"))?;
-    Version::parse(&parsed.workspace.package.version)
-        .map_err(|e| anyhow!("invalid workspace version at ref {reference}: {e}"))
+    Ok(parsed.workspace.package.version)
 }

--- a/ci/xtask/src/commands/channel_info/fetch.rs
+++ b/ci/xtask/src/commands/channel_info/fetch.rs
@@ -1,0 +1,102 @@
+use {
+    super::resolve::{Xy, parse_xy, xy_branch},
+    anyhow::{Result, anyhow},
+    futures_util::TryStreamExt,
+    semver::Version,
+    serde::Deserialize,
+    std::env,
+    tokio::pin,
+};
+
+const OWNER: &str = "anza-xyz";
+const REPO: &str = "agave";
+
+pub fn github_client() -> Result<octocrab::Octocrab> {
+    let builder = match env::var("GH_TOKEN") {
+        Ok(token) if !token.trim().is_empty() => {
+            octocrab::Octocrab::builder().personal_token(token)
+        }
+        _ => {
+            log::warn!("`GH_TOKEN` is not set; using unauthenticated GitHub client");
+            octocrab::Octocrab::builder()
+        }
+    };
+
+    Ok(builder.build()?)
+}
+
+pub async fn release_heads(client: &octocrab::Octocrab) -> Result<Vec<Xy>> {
+    let page = client.repos(OWNER, REPO).list_branches().send().await?;
+    let stream = page.into_stream(client);
+    pin!(stream);
+
+    let mut heads = vec![];
+    while let Some(branch) = stream.try_next().await? {
+        if let Some(xy) = parse_xy(&branch.name) {
+            heads.push(xy);
+        }
+    }
+
+    Ok(heads)
+}
+
+pub async fn release_tags(client: &octocrab::Octocrab) -> Result<Vec<Version>> {
+    let page = client.repos(OWNER, REPO).list_tags().send().await?;
+    let stream = page.into_stream(client);
+    pin!(stream);
+
+    let mut tags = vec![];
+    while let Some(tag) = stream.try_next().await? {
+        let Some(stripped) = tag.name.strip_prefix('v') else {
+            continue;
+        };
+        let Ok(v) = Version::parse(stripped) else {
+            continue;
+        };
+        if v.pre.is_empty() && v.build.is_empty() {
+            tags.push(v);
+        }
+    }
+
+    Ok(tags)
+}
+
+#[derive(Deserialize)]
+struct CargoToml {
+    workspace: WorkspaceSection,
+}
+
+#[derive(Deserialize)]
+struct WorkspaceSection {
+    package: PackageSection,
+}
+
+#[derive(Deserialize)]
+struct PackageSection {
+    version: String,
+}
+
+pub async fn workspace_version(client: &octocrab::Octocrab, xy: Xy) -> Result<Version> {
+    let reference = xy_branch(xy);
+    let content_items = client
+        .repos(OWNER, REPO)
+        .get_content()
+        .path("Cargo.toml")
+        .r#ref(&reference)
+        .send()
+        .await?;
+
+    let item = content_items
+        .items
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("Cargo.toml not found at ref {reference}"))?;
+    let raw = item
+        .decoded_content()
+        .ok_or_else(|| anyhow!("Cargo.toml at ref {reference} has no decodable content"))?;
+
+    let parsed: CargoToml = toml::from_str(&raw)
+        .map_err(|e| anyhow!("failed to parse Cargo.toml at ref {reference}: {e}"))?;
+    Version::parse(&parsed.workspace.package.version)
+        .map_err(|e| anyhow!("invalid workspace version at ref {reference}: {e}"))
+}

--- a/ci/xtask/src/commands/channel_info/fetch.rs
+++ b/ci/xtask/src/commands/channel_info/fetch.rs
@@ -80,7 +80,7 @@ pub async fn workspace_version(client: &reqwest::Client, bv: BranchVersion) -> R
         .text()
         .await
         .map_err(|e| anyhow!("read body for {url}: {e}"))?;
-    let parsed: CargoToml = toml::from_str(&raw)
-        .map_err(|e| anyhow!("failed to parse Cargo.toml at {url}: {e}"))?;
+    let parsed: CargoToml =
+        toml::from_str(&raw).map_err(|e| anyhow!("failed to parse Cargo.toml at {url}: {e}"))?;
     Ok(parsed.workspace.package.version)
 }

--- a/ci/xtask/src/commands/channel_info/fetch.rs
+++ b/ci/xtask/src/commands/channel_info/fetch.rs
@@ -1,64 +1,55 @@
 use {
     super::resolve::BranchVersion,
-    anyhow::{Result, anyhow},
-    futures_util::TryStreamExt,
+    anyhow::{Result, anyhow, bail},
     semver::Version,
     serde::Deserialize,
-    std::env,
-    tokio::pin,
+    std::process::Command,
 };
 
-const OWNER: &str = "anza-xyz";
-const REPO: &str = "agave";
+const REMOTE: &str = "https://github.com/anza-xyz/agave.git";
+const RAW_BASE: &str = "https://raw.githubusercontent.com/anza-xyz/agave";
 
-pub fn github_client() -> Result<octocrab::Octocrab> {
-    let builder = match env::var("GH_TOKEN") {
-        Ok(token) if !token.trim().is_empty() => {
-            octocrab::Octocrab::builder().personal_token(token)
-        }
-        _ => {
-            log::warn!("`GH_TOKEN` is not set; using unauthenticated GitHub client");
-            octocrab::Octocrab::builder()
-        }
-    };
-
-    Ok(builder.build()?)
+fn ls_remote(flag: &str) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["ls-remote", flag, REMOTE])
+        .output()
+        .map_err(|e| anyhow!("failed to invoke `git ls-remote`: {e}"))?;
+    if !output.status.success() {
+        bail!(
+            "`git ls-remote {flag} {REMOTE}` failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim(),
+        );
+    }
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|e| anyhow!("`git ls-remote` stdout is not utf-8: {e}"))?;
+    Ok(stdout.lines().map(str::to_owned).collect())
 }
 
-pub async fn release_heads(client: &octocrab::Octocrab) -> Result<Vec<BranchVersion>> {
-    let page = client.repos(OWNER, REPO).list_branches().send().await?;
-    let stream = page.into_stream(client);
-    pin!(stream);
-
-    let mut heads = vec![];
-    while let Some(branch) = stream.try_next().await? {
-        if let Ok(bv) = branch.name.parse::<BranchVersion>() {
-            heads.push(bv);
-        }
-    }
-
-    Ok(heads)
+fn strip_ref(line: &str, prefix: &str) -> Option<String> {
+    let (_sha, refname) = line.split_once('\t')?;
+    refname.strip_prefix(prefix).map(str::to_owned)
 }
 
-pub async fn release_tags(client: &octocrab::Octocrab) -> Result<Vec<Version>> {
-    let page = client.repos(OWNER, REPO).list_tags().send().await?;
-    let stream = page.into_stream(client);
-    pin!(stream);
+pub fn release_heads() -> Result<Vec<BranchVersion>> {
+    let lines = ls_remote("--heads")?;
+    Ok(lines
+        .iter()
+        .filter_map(|l| strip_ref(l, "refs/heads/"))
+        .filter_map(|name| name.parse::<BranchVersion>().ok())
+        .collect())
+}
 
-    let mut tags = vec![];
-    while let Some(tag) = stream.try_next().await? {
-        let Some(stripped) = tag.name.strip_prefix('v') else {
-            continue;
-        };
-        let Ok(v) = Version::parse(stripped) else {
-            continue;
-        };
-        if v.pre.is_empty() && v.build.is_empty() {
-            tags.push(v);
-        }
-    }
-
-    Ok(tags)
+pub fn release_tags() -> Result<Vec<Version>> {
+    let lines = ls_remote("--tags")?;
+    Ok(lines
+        .iter()
+        .filter_map(|l| strip_ref(l, "refs/tags/"))
+        .filter_map(|name| {
+            let stripped = name.strip_prefix('v')?;
+            let v = Version::parse(stripped).ok()?;
+            (v.pre.is_empty() && v.build.is_empty()).then_some(v)
+        })
+        .collect())
 }
 
 #[derive(Deserialize)]
@@ -76,26 +67,20 @@ struct PackageSection {
     version: Version,
 }
 
-pub async fn workspace_version(client: &octocrab::Octocrab, bv: BranchVersion) -> Result<Version> {
-    let reference = bv.to_string();
-    let content_items = client
-        .repos(OWNER, REPO)
-        .get_content()
-        .path("Cargo.toml")
-        .r#ref(&reference)
+pub async fn workspace_version(client: &reqwest::Client, bv: BranchVersion) -> Result<Version> {
+    let url = format!("{RAW_BASE}/{bv}/Cargo.toml");
+    let resp = client
+        .get(&url)
         .send()
-        .await?;
-
-    let item = content_items
-        .items
-        .into_iter()
-        .next()
-        .ok_or_else(|| anyhow!("Cargo.toml not found at ref {reference}"))?;
-    let raw = item
-        .decoded_content()
-        .ok_or_else(|| anyhow!("Cargo.toml at ref {reference} has no decodable content"))?;
-
+        .await
+        .map_err(|e| anyhow!("GET {url}: {e}"))?
+        .error_for_status()
+        .map_err(|e| anyhow!("GET {url}: {e}"))?;
+    let raw = resp
+        .text()
+        .await
+        .map_err(|e| anyhow!("read body for {url}: {e}"))?;
     let parsed: CargoToml = toml::from_str(&raw)
-        .map_err(|e| anyhow!("failed to parse Cargo.toml at ref {reference}: {e}"))?;
+        .map_err(|e| anyhow!("failed to parse Cargo.toml at {url}: {e}"))?;
     Ok(parsed.workspace.package.version)
 }

--- a/ci/xtask/src/commands/channel_info/resolve.rs
+++ b/ci/xtask/src/commands/channel_info/resolve.rs
@@ -1,20 +1,37 @@
 use {
     anyhow::{Result, anyhow, bail},
     semver::Version,
-    std::collections::BTreeMap,
+    std::{collections::BTreeMap, fmt, str::FromStr},
 };
 
-/// `(major, minor)` pair identifying a `vX.Y` release line.
-pub type Xy = (u64, u64);
-
-pub fn parse_xy(s: &str) -> Option<Xy> {
-    let s = s.strip_prefix('v')?;
-    let (maj, min) = s.split_once('.')?;
-    Some((maj.parse().ok()?, min.parse().ok()?))
+/// `vX.Y` release-line identifier.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct BranchVersion {
+    pub major: u64,
+    pub minor: u64,
 }
 
-pub fn xy_branch(xy: Xy) -> String {
-    format!("v{}.{}", xy.0, xy.1)
+impl FromStr for BranchVersion {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let rest = s
+            .strip_prefix('v')
+            .ok_or_else(|| anyhow!("missing `v` prefix in `{s}`"))?;
+        let (maj, min) = rest
+            .split_once('.')
+            .ok_or_else(|| anyhow!("missing `.` separator in `{s}`"))?;
+        Ok(Self {
+            major: maj.parse()?,
+            minor: min.parse()?,
+        })
+    }
+}
+
+impl fmt::Display for BranchVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "v{}.{}", self.major, self.minor)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -58,26 +75,23 @@ pub struct ChannelInfo {
 }
 
 pub fn derive_channels(
-    versions: &BTreeMap<Xy, Version>,
+    versions: &BTreeMap<BranchVersion, Version>,
     tags: &[Version],
     env_in: &EnvInputs,
 ) -> Result<ChannelInfo> {
-    for (xy, v) in versions {
-        if (v.major, v.minor) != *xy {
-            bail!(
-                "branch {} workspace version {v} does not match branch (major, minor)",
-                xy_branch(*xy),
-            );
+    for (bv, v) in versions {
+        if v.major != bv.major || v.minor != bv.minor {
+            bail!("branch {bv} workspace version {v} does not match branch (major, minor)");
         }
     }
 
-    let sorted: Vec<Xy> = versions.keys().rev().copied().collect();
+    let sorted: Vec<BranchVersion> = versions.keys().rev().copied().collect();
     let h1 = sorted.first().copied();
     let h2 = sorted.get(1).copied();
     let h3 = sorted.get(2).copied();
 
     let h1_stage = h1
-        .map(|xy| stage_of(versions.get(&xy).expect("h1 is in versions")))
+        .map(|bv| stage_of(versions.get(&bv).expect("h1 is in versions")))
         .transpose()?;
 
     let (beta, stable) = match h1_stage {
@@ -91,16 +105,12 @@ pub fn derive_channels(
     if let Some(s) = stable
         && s >= beta
     {
-        bail!(
-            "STABLE {} is not less than BETA {}",
-            xy_branch(s),
-            xy_branch(beta),
-        );
+        bail!("STABLE {s} is not less than BETA {beta}");
     }
 
     let edge_channel = "master".to_string();
-    let beta_channel = xy_branch(beta);
-    let stable_channel = stable.map(xy_branch).unwrap_or_default();
+    let beta_channel = beta.to_string();
+    let stable_channel = stable.map(|s| s.to_string()).unwrap_or_default();
     let beta_channel_latest_tag = latest_tag_for(tags, beta)
         .map(|v| format!("v{v}"))
         .unwrap_or_default();
@@ -136,8 +146,10 @@ pub fn derive_channels(
     })
 }
 
-fn latest_tag_for(tags: &[Version], xy: Xy) -> Option<&Version> {
-    tags.iter().filter(|t| (t.major, t.minor) == xy).max()
+fn latest_tag_for(tags: &[Version], bv: BranchVersion) -> Option<&Version> {
+    tags.iter()
+        .filter(|t| t.major == bv.major && t.minor == bv.minor)
+        .max()
 }
 
 pub fn print_channel_info(info: &ChannelInfo) {
@@ -161,13 +173,17 @@ mod tests {
         Version::parse(s).expect("valid version")
     }
 
-    fn versions(pairs: &[(Xy, &str)]) -> BTreeMap<Xy, Version> {
-        pairs.iter().map(|(xy, s)| (*xy, v(s))).collect()
+    fn bv(major: u64, minor: u64) -> BranchVersion {
+        BranchVersion { major, minor }
+    }
+
+    fn versions(pairs: &[(BranchVersion, &str)]) -> BTreeMap<BranchVersion, Version> {
+        pairs.iter().map(|(b, s)| (*b, v(s))).collect()
     }
 
     #[test]
     fn promotes_top_when_top_is_beta() {
-        let vs = versions(&[((4, 0), "4.0.0"), ((4, 1), "4.1.0-beta.0")]);
+        let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-beta.0")]);
 
         let info = derive_channels(&vs, &[], &EnvInputs::default()).unwrap();
 
@@ -177,7 +193,7 @@ mod tests {
 
     #[test]
     fn promotes_top_when_top_is_ga() {
-        let vs = versions(&[((4, 0), "4.0.5"), ((4, 1), "4.1.0")]);
+        let vs = versions(&[(bv(4, 0), "4.0.5"), (bv(4, 1), "4.1.0")]);
 
         let info = derive_channels(&vs, &[], &EnvInputs::default()).unwrap();
 
@@ -188,9 +204,9 @@ mod tests {
     #[test]
     fn holds_channels_when_top_is_alpha() {
         let vs = versions(&[
-            ((3, 1), "3.1.15"),
-            ((4, 0), "4.0.0"),
-            ((4, 1), "4.1.0-alpha.0"),
+            (bv(3, 1), "3.1.15"),
+            (bv(4, 0), "4.0.0"),
+            (bv(4, 1), "4.1.0-alpha.0"),
         ]);
 
         let info = derive_channels(&vs, &[], &EnvInputs::default()).unwrap();
@@ -201,7 +217,7 @@ mod tests {
 
     #[test]
     fn rc_top_is_promoted() {
-        let vs = versions(&[((4, 0), "4.0.10"), ((4, 1), "4.1.0-rc.2")]);
+        let vs = versions(&[(bv(4, 0), "4.0.10"), (bv(4, 1), "4.1.0-rc.2")]);
 
         let info = derive_channels(&vs, &[], &EnvInputs::default()).unwrap();
 
@@ -211,7 +227,7 @@ mod tests {
 
     #[test]
     fn rejects_mismatched_workspace_version() {
-        let vs = versions(&[((4, 0), "5.0.0")]);
+        let vs = versions(&[(bv(4, 0), "5.0.0")]);
 
         let err = derive_channels(&vs, &[], &EnvInputs::default()).unwrap_err();
 
@@ -220,7 +236,7 @@ mod tests {
 
     #[test]
     fn rejects_unknown_prerelease_label() {
-        let vs = versions(&[((4, 0), "4.0.0"), ((4, 1), "4.1.0-dev.0")]);
+        let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-dev.0")]);
 
         let err = derive_channels(&vs, &[], &EnvInputs::default()).unwrap_err();
 
@@ -229,7 +245,7 @@ mod tests {
 
     #[test]
     fn rejects_when_only_alpha_top_and_nothing_below() {
-        let vs = versions(&[((4, 1), "4.1.0-alpha.0")]);
+        let vs = versions(&[(bv(4, 1), "4.1.0-alpha.0")]);
 
         let err = derive_channels(&vs, &[], &EnvInputs::default()).unwrap_err();
 
@@ -245,7 +261,7 @@ mod tests {
 
     #[test]
     fn picks_latest_tag_per_channel() {
-        let vs = versions(&[((3, 0), "3.0.5"), ((3, 1), "3.1.0-beta.0")]);
+        let vs = versions(&[(bv(3, 0), "3.0.5"), (bv(3, 1), "3.1.0-beta.0")]);
         let tags = vec![v("3.0.1"), v("3.0.5"), v("3.0.2"), v("2.9.9")];
 
         let info = derive_channels(&vs, &tags, &EnvInputs::default()).unwrap();
@@ -256,7 +272,7 @@ mod tests {
 
     #[test]
     fn channel_from_branch_match() {
-        let vs = versions(&[((4, 0), "4.0.0"), ((4, 1), "4.1.0-beta.0")]);
+        let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-beta.0")]);
         let env_in = EnvInputs {
             branch: Some("v4.1".into()),
             channel: None,
@@ -269,7 +285,7 @@ mod tests {
 
     #[test]
     fn channel_env_var_wins() {
-        let vs = versions(&[((4, 0), "4.0.0"), ((4, 1), "4.1.0-beta.0")]);
+        let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-beta.0")]);
         let env_in = EnvInputs {
             branch: Some("master".into()),
             channel: Some("stable".into()),

--- a/ci/xtask/src/commands/channel_info/resolve.rs
+++ b/ci/xtask/src/commands/channel_info/resolve.rs
@@ -1,0 +1,290 @@
+use {
+    anyhow::{Result, anyhow, bail},
+    semver::Version,
+    std::collections::BTreeMap,
+};
+
+/// `(major, minor)` pair identifying a `vX.Y` release line.
+pub type Xy = (u64, u64);
+
+pub fn parse_xy(s: &str) -> Option<Xy> {
+    let s = s.strip_prefix('v')?;
+    let (maj, min) = s.split_once('.')?;
+    Some((maj.parse().ok()?, min.parse().ok()?))
+}
+
+pub fn xy_branch(xy: Xy) -> String {
+    format!("v{}.{}", xy.0, xy.1)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Stage {
+    Alpha,
+    Beta,
+    Rc,
+    Ga,
+}
+
+pub fn stage_of(v: &Version) -> Result<Stage> {
+    if v.pre.is_empty() {
+        return Ok(Stage::Ga);
+    }
+
+    let label = v.pre.as_str().split('.').next().unwrap_or("");
+
+    match label {
+        "alpha" => Ok(Stage::Alpha),
+        "beta" => Ok(Stage::Beta),
+        "rc" => Ok(Stage::Rc),
+        other => bail!("unknown prerelease label `{other}` in version {v}"),
+    }
+}
+
+#[derive(Default)]
+pub struct EnvInputs {
+    pub branch: Option<String>,
+    pub channel: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct ChannelInfo {
+    pub edge_channel: String,
+    pub beta_channel: String,
+    pub beta_channel_latest_tag: String,
+    pub stable_channel: String,
+    pub stable_channel_latest_tag: String,
+    pub channel: String,
+    pub channel_latest_tag: String,
+}
+
+pub fn derive_channels(
+    versions: &BTreeMap<Xy, Version>,
+    tags: &[Version],
+    env_in: &EnvInputs,
+) -> Result<ChannelInfo> {
+    for (xy, v) in versions {
+        if (v.major, v.minor) != *xy {
+            bail!(
+                "branch {} workspace version {v} does not match branch (major, minor)",
+                xy_branch(*xy),
+            );
+        }
+    }
+
+    let sorted: Vec<Xy> = versions.keys().rev().copied().collect();
+    let h1 = sorted.first().copied();
+    let h2 = sorted.get(1).copied();
+    let h3 = sorted.get(2).copied();
+
+    let h1_stage = h1
+        .map(|xy| stage_of(versions.get(&xy).expect("h1 is in versions")))
+        .transpose()?;
+
+    let (beta, stable) = match h1_stage {
+        Some(Stage::Alpha) => (h2, h3),
+        Some(_) => (h1, h2),
+        None => (None, None),
+    };
+
+    let beta = beta.ok_or_else(|| anyhow!("no BETA-eligible vX.Y head"))?;
+
+    if let Some(s) = stable
+        && s >= beta
+    {
+        bail!(
+            "STABLE {} is not less than BETA {}",
+            xy_branch(s),
+            xy_branch(beta),
+        );
+    }
+
+    let edge_channel = "master".to_string();
+    let beta_channel = xy_branch(beta);
+    let stable_channel = stable.map(xy_branch).unwrap_or_default();
+    let beta_channel_latest_tag = latest_tag_for(tags, beta)
+        .map(|v| format!("v{v}"))
+        .unwrap_or_default();
+    let stable_channel_latest_tag = stable
+        .and_then(|xy| latest_tag_for(tags, xy))
+        .map(|v| format!("v{v}"))
+        .unwrap_or_default();
+
+    let channel = env_in
+        .channel
+        .clone()
+        .unwrap_or_else(|| match env_in.branch.as_deref() {
+            Some(b) if b == stable_channel => "stable".into(),
+            Some(b) if b == edge_channel => "edge".into(),
+            Some(b) if b == beta_channel => "beta".into(),
+            _ => String::new(),
+        });
+
+    let channel_latest_tag = match channel.as_str() {
+        "beta" => beta_channel_latest_tag.clone(),
+        "stable" => stable_channel_latest_tag.clone(),
+        _ => String::new(),
+    };
+
+    Ok(ChannelInfo {
+        edge_channel,
+        beta_channel,
+        beta_channel_latest_tag,
+        stable_channel,
+        stable_channel_latest_tag,
+        channel,
+        channel_latest_tag,
+    })
+}
+
+fn latest_tag_for(tags: &[Version], xy: Xy) -> Option<&Version> {
+    tags.iter().filter(|t| (t.major, t.minor) == xy).max()
+}
+
+pub fn print_channel_info(info: &ChannelInfo) {
+    println!("EDGE_CHANNEL={}", info.edge_channel);
+    println!("BETA_CHANNEL={}", info.beta_channel);
+    println!("BETA_CHANNEL_LATEST_TAG={}", info.beta_channel_latest_tag);
+    println!("STABLE_CHANNEL={}", info.stable_channel);
+    println!(
+        "STABLE_CHANNEL_LATEST_TAG={}",
+        info.stable_channel_latest_tag
+    );
+    println!("CHANNEL={}", info.channel);
+    println!("CHANNEL_LATEST_TAG={}", info.channel_latest_tag);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> Version {
+        Version::parse(s).expect("valid version")
+    }
+
+    fn versions(pairs: &[(Xy, &str)]) -> BTreeMap<Xy, Version> {
+        pairs.iter().map(|(xy, s)| (*xy, v(s))).collect()
+    }
+
+    #[test]
+    fn promotes_top_when_top_is_beta() {
+        let vs = versions(&[((4, 0), "4.0.0"), ((4, 1), "4.1.0-beta.0")]);
+
+        let info = derive_channels(&vs, &[], &EnvInputs::default()).unwrap();
+
+        assert_eq!(info.beta_channel, "v4.1");
+        assert_eq!(info.stable_channel, "v4.0");
+    }
+
+    #[test]
+    fn promotes_top_when_top_is_ga() {
+        let vs = versions(&[((4, 0), "4.0.5"), ((4, 1), "4.1.0")]);
+
+        let info = derive_channels(&vs, &[], &EnvInputs::default()).unwrap();
+
+        assert_eq!(info.beta_channel, "v4.1");
+        assert_eq!(info.stable_channel, "v4.0");
+    }
+
+    #[test]
+    fn holds_channels_when_top_is_alpha() {
+        let vs = versions(&[
+            ((3, 1), "3.1.15"),
+            ((4, 0), "4.0.0"),
+            ((4, 1), "4.1.0-alpha.0"),
+        ]);
+
+        let info = derive_channels(&vs, &[], &EnvInputs::default()).unwrap();
+
+        assert_eq!(info.beta_channel, "v4.0");
+        assert_eq!(info.stable_channel, "v3.1");
+    }
+
+    #[test]
+    fn rc_top_is_promoted() {
+        let vs = versions(&[((4, 0), "4.0.10"), ((4, 1), "4.1.0-rc.2")]);
+
+        let info = derive_channels(&vs, &[], &EnvInputs::default()).unwrap();
+
+        assert_eq!(info.beta_channel, "v4.1");
+        assert_eq!(info.stable_channel, "v4.0");
+    }
+
+    #[test]
+    fn rejects_mismatched_workspace_version() {
+        let vs = versions(&[((4, 0), "5.0.0")]);
+
+        let err = derive_channels(&vs, &[], &EnvInputs::default()).unwrap_err();
+
+        assert!(err.to_string().contains("does not match branch"));
+    }
+
+    #[test]
+    fn rejects_unknown_prerelease_label() {
+        let vs = versions(&[((4, 0), "4.0.0"), ((4, 1), "4.1.0-dev.0")]);
+
+        let err = derive_channels(&vs, &[], &EnvInputs::default()).unwrap_err();
+
+        assert!(err.to_string().contains("unknown prerelease label"));
+    }
+
+    #[test]
+    fn rejects_when_only_alpha_top_and_nothing_below() {
+        let vs = versions(&[((4, 1), "4.1.0-alpha.0")]);
+
+        let err = derive_channels(&vs, &[], &EnvInputs::default()).unwrap_err();
+
+        assert!(err.to_string().contains("no BETA-eligible"));
+    }
+
+    #[test]
+    fn rejects_empty() {
+        let err = derive_channels(&BTreeMap::new(), &[], &EnvInputs::default()).unwrap_err();
+
+        assert!(err.to_string().contains("no BETA-eligible"));
+    }
+
+    #[test]
+    fn picks_latest_tag_per_channel() {
+        let vs = versions(&[((3, 0), "3.0.5"), ((3, 1), "3.1.0-beta.0")]);
+        let tags = vec![v("3.0.1"), v("3.0.5"), v("3.0.2"), v("2.9.9")];
+
+        let info = derive_channels(&vs, &tags, &EnvInputs::default()).unwrap();
+
+        assert_eq!(info.beta_channel_latest_tag, "");
+        assert_eq!(info.stable_channel_latest_tag, "v3.0.5");
+    }
+
+    #[test]
+    fn channel_from_branch_match() {
+        let vs = versions(&[((4, 0), "4.0.0"), ((4, 1), "4.1.0-beta.0")]);
+        let env_in = EnvInputs {
+            branch: Some("v4.1".into()),
+            channel: None,
+        };
+
+        let info = derive_channels(&vs, &[], &env_in).unwrap();
+
+        assert_eq!(info.channel, "beta");
+    }
+
+    #[test]
+    fn channel_env_var_wins() {
+        let vs = versions(&[((4, 0), "4.0.0"), ((4, 1), "4.1.0-beta.0")]);
+        let env_in = EnvInputs {
+            branch: Some("master".into()),
+            channel: Some("stable".into()),
+        };
+
+        let info = derive_channels(&vs, &[], &env_in).unwrap();
+
+        assert_eq!(info.channel, "stable");
+    }
+
+    #[test]
+    fn stage_of_classifies_known_labels() {
+        assert_eq!(stage_of(&v("4.0.0")).unwrap(), Stage::Ga);
+        assert_eq!(stage_of(&v("4.0.0-alpha.0")).unwrap(), Stage::Alpha);
+        assert_eq!(stage_of(&v("4.0.0-beta.3")).unwrap(), Stage::Beta);
+        assert_eq!(stage_of(&v("4.0.0-rc.1")).unwrap(), Stage::Rc);
+    }
+}

--- a/ci/xtask/src/commands/channel_info/resolve.rs
+++ b/ci/xtask/src/commands/channel_info/resolve.rs
@@ -57,12 +57,6 @@ pub fn stage_of(v: &Version) -> Result<Stage> {
     }
 }
 
-#[derive(Default)]
-pub struct EnvInputs {
-    pub branch: Option<String>,
-    pub channel: Option<String>,
-}
-
 #[derive(Debug)]
 pub struct ChannelInfo {
     pub edge_channel: String,
@@ -77,7 +71,8 @@ pub struct ChannelInfo {
 pub fn derive_channels(
     versions: &BTreeMap<BranchVersion, Version>,
     tags: &[Version],
-    env_in: &EnvInputs,
+    branch: Option<&str>,
+    channel: Option<&str>,
 ) -> Result<ChannelInfo> {
     for (bv, v) in versions {
         if v.major != bv.major || v.minor != bv.minor {
@@ -119,15 +114,12 @@ pub fn derive_channels(
         .map(|v| format!("v{v}"))
         .unwrap_or_default();
 
-    let channel = env_in
-        .channel
-        .clone()
-        .unwrap_or_else(|| match env_in.branch.as_deref() {
-            Some(b) if b == stable_channel => "stable".into(),
-            Some(b) if b == edge_channel => "edge".into(),
-            Some(b) if b == beta_channel => "beta".into(),
-            _ => String::new(),
-        });
+    let channel = channel.map(str::to_owned).unwrap_or_else(|| match branch {
+        Some(b) if b == stable_channel => "stable".into(),
+        Some(b) if b == edge_channel => "edge".into(),
+        Some(b) if b == beta_channel => "beta".into(),
+        _ => String::new(),
+    });
 
     let channel_latest_tag = match channel.as_str() {
         "beta" => beta_channel_latest_tag.clone(),
@@ -185,7 +177,7 @@ mod tests {
     fn promotes_top_when_top_is_beta() {
         let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-beta.0")]);
 
-        let info = derive_channels(&vs, &[], &EnvInputs::default()).unwrap();
+        let info = derive_channels(&vs, &[], None, None).unwrap();
 
         assert_eq!(info.beta_channel, "v4.1");
         assert_eq!(info.stable_channel, "v4.0");
@@ -195,7 +187,7 @@ mod tests {
     fn promotes_top_when_top_is_ga() {
         let vs = versions(&[(bv(4, 0), "4.0.5"), (bv(4, 1), "4.1.0")]);
 
-        let info = derive_channels(&vs, &[], &EnvInputs::default()).unwrap();
+        let info = derive_channels(&vs, &[], None, None).unwrap();
 
         assert_eq!(info.beta_channel, "v4.1");
         assert_eq!(info.stable_channel, "v4.0");
@@ -209,7 +201,7 @@ mod tests {
             (bv(4, 1), "4.1.0-alpha.0"),
         ]);
 
-        let info = derive_channels(&vs, &[], &EnvInputs::default()).unwrap();
+        let info = derive_channels(&vs, &[], None, None).unwrap();
 
         assert_eq!(info.beta_channel, "v4.0");
         assert_eq!(info.stable_channel, "v3.1");
@@ -219,7 +211,7 @@ mod tests {
     fn rc_top_is_promoted() {
         let vs = versions(&[(bv(4, 0), "4.0.10"), (bv(4, 1), "4.1.0-rc.2")]);
 
-        let info = derive_channels(&vs, &[], &EnvInputs::default()).unwrap();
+        let info = derive_channels(&vs, &[], None, None).unwrap();
 
         assert_eq!(info.beta_channel, "v4.1");
         assert_eq!(info.stable_channel, "v4.0");
@@ -229,7 +221,7 @@ mod tests {
     fn rejects_mismatched_workspace_version() {
         let vs = versions(&[(bv(4, 0), "5.0.0")]);
 
-        let err = derive_channels(&vs, &[], &EnvInputs::default()).unwrap_err();
+        let err = derive_channels(&vs, &[], None, None).unwrap_err();
 
         assert!(err.to_string().contains("does not match branch"));
     }
@@ -238,7 +230,7 @@ mod tests {
     fn rejects_unknown_prerelease_label() {
         let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-dev.0")]);
 
-        let err = derive_channels(&vs, &[], &EnvInputs::default()).unwrap_err();
+        let err = derive_channels(&vs, &[], None, None).unwrap_err();
 
         assert!(err.to_string().contains("unknown prerelease label"));
     }
@@ -247,14 +239,14 @@ mod tests {
     fn rejects_when_only_alpha_top_and_nothing_below() {
         let vs = versions(&[(bv(4, 1), "4.1.0-alpha.0")]);
 
-        let err = derive_channels(&vs, &[], &EnvInputs::default()).unwrap_err();
+        let err = derive_channels(&vs, &[], None, None).unwrap_err();
 
         assert!(err.to_string().contains("no BETA-eligible"));
     }
 
     #[test]
     fn rejects_empty() {
-        let err = derive_channels(&BTreeMap::new(), &[], &EnvInputs::default()).unwrap_err();
+        let err = derive_channels(&BTreeMap::new(), &[], None, None).unwrap_err();
 
         assert!(err.to_string().contains("no BETA-eligible"));
     }
@@ -264,7 +256,7 @@ mod tests {
         let vs = versions(&[(bv(3, 0), "3.0.5"), (bv(3, 1), "3.1.0-beta.0")]);
         let tags = vec![v("3.0.1"), v("3.0.5"), v("3.0.2"), v("2.9.9")];
 
-        let info = derive_channels(&vs, &tags, &EnvInputs::default()).unwrap();
+        let info = derive_channels(&vs, &tags, None, None).unwrap();
 
         assert_eq!(info.beta_channel_latest_tag, "");
         assert_eq!(info.stable_channel_latest_tag, "v3.0.5");
@@ -273,12 +265,8 @@ mod tests {
     #[test]
     fn channel_from_branch_match() {
         let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-beta.0")]);
-        let env_in = EnvInputs {
-            branch: Some("v4.1".into()),
-            channel: None,
-        };
 
-        let info = derive_channels(&vs, &[], &env_in).unwrap();
+        let info = derive_channels(&vs, &[], Some("v4.1"), None).unwrap();
 
         assert_eq!(info.channel, "beta");
     }
@@ -286,12 +274,8 @@ mod tests {
     #[test]
     fn channel_env_var_wins() {
         let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-beta.0")]);
-        let env_in = EnvInputs {
-            branch: Some("master".into()),
-            channel: Some("stable".into()),
-        };
 
-        let info = derive_channels(&vs, &[], &env_in).unwrap();
+        let info = derive_channels(&vs, &[], Some("master"), Some("stable")).unwrap();
 
         assert_eq!(info.channel, "stable");
     }

--- a/ci/xtask/src/commands/generate_pipeline.rs
+++ b/ci/xtask/src/commands/generate_pipeline.rs
@@ -81,6 +81,7 @@ fn generate_private_pipeline() -> Result<buildkite::Pipeline> {
         ..Default::default()
     }));
 
+    pipeline.add_step(default_channel_info_divergence_step());
     pipeline.add_step(default_shellcheck_step());
 
     pipeline.add_step(buildkite::Step::Wait(buildkite::WaitStep {}));
@@ -136,6 +137,7 @@ fn generate_merge_queue_pipeline() -> Result<buildkite::Pipeline> {
     let mut pipeline = buildkite::Pipeline::new();
     pipeline.set_priority(10);
     pipeline.add_step(default_sanity_step());
+    pipeline.add_step(default_channel_info_divergence_step());
     pipeline.add_step(default_checks_step());
     Ok(pipeline)
 }
@@ -298,6 +300,7 @@ pub async fn generate_pull_request_pipeline(pr_number: u64) -> Result<buildkite:
     let mut pipeline = buildkite::Pipeline::new();
 
     pipeline.add_step(default_sanity_step());
+    pipeline.add_step(default_channel_info_divergence_step());
     if flags.shellcheck {
         pipeline.add_step(default_shellcheck_step());
     }
@@ -351,6 +354,7 @@ fn generate_full_pipeline() -> Result<buildkite::Pipeline> {
     let mut pipeline = buildkite::Pipeline::new();
 
     pipeline.add_step(default_sanity_step());
+    pipeline.add_step(default_channel_info_divergence_step());
     pipeline.add_step(default_shellcheck_step());
 
     pipeline.add_step(buildkite::Step::Wait(buildkite::WaitStep {}));
@@ -390,6 +394,20 @@ fn default_sanity_step() -> buildkite::Step {
             String::from("default"),
         )])),
         timeout_in_minutes: Some(5),
+        ..Default::default()
+    })
+}
+
+fn default_channel_info_divergence_step() -> buildkite::Step {
+    buildkite::Step::Command(buildkite::CommandStep {
+        name: String::from("channel-info-divergence"),
+        command: String::from("ci/docker-run-default-image.sh ci/test-channel-info-divergence.sh"),
+        agents: Some(HashMap::from([(
+            String::from("queue"),
+            String::from("default"),
+        )])),
+        timeout_in_minutes: Some(10),
+        soft_fail: Some(true),
         ..Default::default()
     })
 }

--- a/ci/xtask/src/main.rs
+++ b/ci/xtask/src/main.rs
@@ -28,6 +28,8 @@ enum Commands {
     Publish(xtask_shared::commands::publish::CommandArgs),
     #[command(about = "Generate Buildkite pipeline")]
     GeneratePipeline(commands::generate_pipeline::CommandArgs),
+    #[command(about = "Print release channel info")]
+    ChannelInfo,
 }
 
 #[derive(Args, Debug)]
@@ -77,6 +79,9 @@ async fn try_main(xtask: Xtask) -> Result<()> {
         }
         Commands::GeneratePipeline(args) => {
             commands::generate_pipeline::run(args).await?;
+        }
+        Commands::ChannelInfo => {
+            commands::channel_info::run().await?;
         }
     }
 


### PR DESCRIPTION
#### Problem

`ci/channel-info.sh` channel resolution is hand-rolled bash + a manual pin override on master.

#### Summary of Changes

Adds `cargo xtask channel-info`, a Rust auto-resolver derived from each `vX.Y` branch's `workspace.package.version`.

This is step 1 of the plan in #12450: bash stays authoritative; a new soft-failing buildkite step (`channel-info-divergence`) runs the resolver alongside the script on every build, diffs the output, and annotates on mismatch.

Spec, validations, and follow-up steps in #12450.