### PR TITLE
Pass the actual account loader as a callback for invokecontext

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -924,7 +924,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
     /// Execute a transaction using the provided loaded accounts and update
     /// the executors cache if the transaction was successful.
-    fn execute_loaded_transaction<CB: TransactionProcessingCallback>(
+    fn execute_loaded_transaction<CB: InvokeContextCallback>(
         &self,
         callback: &CB,
         tx: &impl SVMTransaction,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -540,7 +540,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     }
 
                     let executed_tx = self.execute_loaded_transaction(
-                        callbacks,
+                        &account_loader,
                         tx,
                         loaded_transaction,
                         &mut execute_timings,


### PR DESCRIPTION
#### Problem

Batched txs modifying the same account see stale accounts state because the bank is incorrectly used for account loads. 