### PR TITLE
Fast Leader Handover

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -6,23 +6,27 @@
 //! Once alpenglow is active, this is the only thread that will touch the [`PohRecorder`].
 use {
     crate::{
-        banking_trace::BankingTracer,
+        banking_trace::{BankingPacketSender, BankingTracer},
         replay_stage::{Finalizer, ReplayStage},
     },
     agave_votor::event::LeaderWindowInfo,
-    agave_votor_messages::reward_certificate::{
-        BuildRewardCertsRequest, BuildRewardCertsRespSucc, BuildRewardCertsResponse,
-        NotarRewardCertificate, SkipRewardCertificate,
+    agave_votor_messages::{
+        consensus_message::Block,
+        reward_certificate::{
+            BuildRewardCertsRequest, BuildRewardCertsRespSucc, BuildRewardCertsResponse,
+            NotarRewardCertificate, SkipRewardCertificate,
+        },
     },
-    crossbeam_channel::{Receiver, Sender},
+    crossbeam_channel::{Receiver, RecvTimeoutError, Sender, select_biased},
     solana_clock::Slot,
     solana_entry::block_component::{
-        BlockFooterV1, BlockMarkerV1, GenesisCertificate, VersionedBlockMarker,
+        BlockFooterV1, GenesisCertificate, UpdateParentV1, VersionedBlockMarker,
     },
     solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
     solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
     solana_measure::measure::Measure,
+    solana_perf::packet::{BytesPacket, Meta, PacketBatch, bytes::Bytes},
     solana_poh::{
         poh_recorder::{GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS, PohRecorder, PohRecorderError},
         record_channels::RecordReceiver,
@@ -37,6 +41,7 @@ use {
         validated_block_finalization::ValidatedBlockFinalizationCert,
         validated_reward_certificate::ValidatedRewardCert,
     },
+    solana_transaction::versioned::VersionedTransaction,
     solana_version::version,
     stats::{LoopMetrics, SlotMetrics},
     std::{
@@ -51,6 +56,14 @@ use {
 };
 
 mod stats;
+
+/// Source of a leader-window notification consumed by BCL.
+enum ParentSource {
+    /// Consensus has finalized the parent for this leader window.
+    ParentReady(LeaderWindowInfo),
+    /// Replay froze the previous leader's last block before consensus finalized it.
+    OptimisticParent(LeaderWindowInfo),
+}
 
 pub struct BlockCreationLoop {
     thread: JoinHandle<()>,
@@ -98,17 +111,25 @@ pub struct BlockCreationLoopConfig {
 
     // Channel to receive RecordReceiver from PohService
     pub record_receiver_receiver: Receiver<RecordReceiver>,
+    pub optimistic_parent_receiver: Receiver<LeaderWindowInfo>,
 
     /// Channel to send the request to build reward certs.
     pub build_reward_certs_sender: Sender<BuildRewardCertsRequest>,
     /// Channel to receive the built reward certs.
     pub reward_certs_receiver: Receiver<BuildRewardCertsResponse>,
+
+    /// Sender for packets to banking stage (used to re-inject transactions after sad leader handover).
+    pub banking_stage_sender: BankingPacketSender,
 }
 
 struct LeaderContext {
     exit: Arc<AtomicBool>,
     my_pubkey: Pubkey,
+    /// Finalized leader-window notifications from Votor.
     leader_window_info_receiver: Receiver<LeaderWindowInfo>,
+    /// ParentReady for a future window observed while producing the current one.
+    pending_parent_ready: Option<LeaderWindowInfo>,
+    /// Highest finalized parent known to Votor, used to abandon stale windows.
     highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
     highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
 
@@ -123,6 +144,8 @@ struct LeaderContext {
     replay_highest_frozen: Arc<ReplayHighestFrozen>,
     build_reward_certs_sender: Sender<BuildRewardCertsRequest>,
     reward_certs_receiver: Receiver<BuildRewardCertsResponse>,
+    /// Banking-stage ingress used to reschedule transactions after sad handover.
+    banking_stage_sender: BankingPacketSender,
 
     // Metrics
     metrics: LoopMetrics,
@@ -134,7 +157,9 @@ struct LeaderContext {
 
 #[derive(Default)]
 pub struct ReplayHighestFrozen {
+    /// Highest slot replay has frozen; used by the leader loop to wait for its parent.
     pub highest_frozen_slot: Mutex<Slot>,
+    /// Notifies the leader loop when replay advances `highest_frozen_slot`.
     pub freeze_notification: Condvar,
 }
 
@@ -154,6 +179,22 @@ enum StartLeaderError {
         /* parent ready slot */ Slot,
         /* leader slot */ Slot,
     ),
+
+    /// The frozen parent bank does not match the expected block id.
+    #[error(
+        "Parent block id mismatch for leader slot {leader_slot}: parent slot {parent_slot}, \
+         expected {expected}, actual {actual:?}"
+    )]
+    ParentBlockIdMismatch {
+        leader_slot: Slot,
+        parent_slot: Slot,
+        expected: Hash,
+        actual: Option<Hash>,
+    },
+
+    /// PoH recorder failed while starting or completing a leader block.
+    #[error("PoH recorder failed: {0}")]
+    PohRecorder(#[from] PohRecorderError),
 }
 
 /// The block creation loop.
@@ -172,13 +213,15 @@ fn start_loop(config: BlockCreationLoopConfig) {
         rpc_subscriptions,
         banking_tracer,
         slot_status_notifier,
-        leader_window_info_receiver,
-        highest_parent_ready,
-        replay_highest_frozen,
         record_receiver_receiver,
-        highest_finalized,
+        leader_window_info_receiver,
+        replay_highest_frozen,
+        highest_parent_ready,
+        optimistic_parent_receiver,
         build_reward_certs_sender,
         reward_certs_receiver,
+        highest_finalized,
+        banking_stage_sender,
     } = config;
 
     // Similar to Votor, if this loop dies kill the validator
@@ -188,6 +231,7 @@ fn start_loop(config: BlockCreationLoopConfig) {
     let mut my_pubkey = cluster_info.id();
 
     info!("{my_pubkey}: Block creation loop initialized");
+
     // Wait for PohService to be shutdown
     let record_receiver = match record_receiver_receiver.recv() {
         Ok(receiver) => receiver,
@@ -211,11 +255,12 @@ fn start_loop(config: BlockCreationLoopConfig) {
     let mut ctx = LeaderContext {
         exit,
         my_pubkey,
-        leader_window_info_receiver,
         highest_parent_ready,
+        leader_window_info_receiver,
+        pending_parent_ready: None,
         blockstore,
+        poh_recorder: poh_recorder.clone(),
         record_receiver,
-        poh_recorder,
         leader_schedule_cache,
         bank_forks,
         rpc_subscriptions,
@@ -224,6 +269,7 @@ fn start_loop(config: BlockCreationLoopConfig) {
         replay_highest_frozen,
         build_reward_certs_sender,
         reward_certs_receiver,
+        banking_stage_sender,
         metrics: LoopMetrics::default(),
         slot_metrics: SlotMetrics::default(),
         highest_finalized,
@@ -255,34 +301,74 @@ fn start_loop(config: BlockCreationLoopConfig) {
             );
         }
 
-        // Wait for the voting loop to notify us, draining all pending messages and keeping the highest slot
+        // Wait for the first window notification, then drain both sources and pick the newest
+        // leader window. This avoids revisiting stale optimistic windows after replay has already
+        // advanced to a later finalized parent.
+        let window_source = if let Some(info) = ctx.pending_parent_ready.take() {
+            Some(ParentSource::ParentReady(info))
+        } else {
+            select_biased! {
+                recv(ctx.leader_window_info_receiver) -> msg => {
+                    msg.ok().map(ParentSource::ParentReady)
+                },
+                recv(optimistic_parent_receiver) -> msg => {
+                    msg.ok().map(ParentSource::OptimisticParent)
+                },
+                default(Duration::from_secs(1)) => continue,
+            }
+        };
+
+        let (mut latest_parent_ready, mut latest_optimistic_parent) = match window_source {
+            Some(ParentSource::ParentReady(first)) => (Some(first), None),
+            Some(ParentSource::OptimisticParent(first)) => (None, Some(first)),
+            None => {
+                info!("{my_pubkey}: channel disconnected");
+                return;
+            }
+        };
+
+        latest_parent_ready = freshest_window_from_iter(
+            latest_parent_ready,
+            ctx.leader_window_info_receiver.try_iter(),
+        );
+        latest_optimistic_parent = freshest_window_from_iter(
+            latest_optimistic_parent,
+            optimistic_parent_receiver.try_iter(),
+        );
+
+        let (info, fast_leader_handover) =
+            select_freshest_window(latest_parent_ready, latest_optimistic_parent);
+        let Some(info) = info else {
+            info!("{my_pubkey}: both leader window channels drained");
+            continue;
+        };
+
         let LeaderWindowInfo {
             start_slot,
             end_slot,
-            parent_block: (parent_slot, _),
+            parent_block: (parent_slot, parent_hash),
             block_timer,
-        } = {
-            // Drain all pending messages and keep the latest one
-            let Some(info) = ctx
-                .leader_window_info_receiver
-                // Timeout so we can check the exit flag
-                .recv_timeout(Duration::from_secs(1))
-                .ok()
-                .and_then(|window| {
-                    ctx.leader_window_info_receiver
-                        .try_iter()
-                        .last()
-                        .or(Some(window))
-                })
-            else {
-                continue;
-            };
+        } = info;
 
-            info
-        };
+        trace!(
+            "{my_pubkey}: window {start_slot}-{end_slot} parent {parent_slot} \
+             flh={fast_leader_handover}"
+        );
 
-        trace!("Received window notification for {start_slot} to {end_slot} parent: {parent_slot}");
-        if let Err(e) = produce_window(start_slot, end_slot, parent_slot, block_timer, &mut ctx) {
+        if (start_slot..=end_slot).any(|slot| ctx.blockstore.has_existing_shreds_for_slot(slot)) {
+            warn!("{my_pubkey}: already have shreds in window {start_slot}-{end_slot}, skipping");
+            continue;
+        }
+
+        if let Err(e) = produce_window(
+            fast_leader_handover,
+            start_slot,
+            end_slot,
+            parent_slot,
+            parent_hash,
+            block_timer,
+            &mut ctx,
+        ) {
             // Give up on this leader window
             error!(
                 "{my_pubkey}: Unable to produce window {start_slot}-{end_slot}, skipping window: \
@@ -322,6 +408,63 @@ fn reset_poh_recorder(bank: &Arc<Bank>, ctx: &LeaderContext) {
 fn block_timeout(bank: &Bank, leader_block_index: usize) -> Duration {
     Duration::from_nanos_u128(bank.ns_per_slot)
         .saturating_mul((leader_block_index as u32).saturating_add(1))
+}
+
+/// Select the freshest leader-window notification within one source.
+///
+/// Equal start slots keep the later notification so coalescing a channel drain
+/// has the same semantics as replacing a single queued item.
+fn freshest_leader_window(
+    current: LeaderWindowInfo,
+    candidate: LeaderWindowInfo,
+) -> LeaderWindowInfo {
+    if current.start_slot > candidate.start_slot {
+        current
+    } else {
+        candidate
+    }
+}
+
+/// Drain a source of leader-window notifications and keep only the highest
+/// start slot, replacing equal start slots with the later notification.
+fn freshest_window_from_iter(
+    current: Option<LeaderWindowInfo>,
+    candidates: impl IntoIterator<Item = LeaderWindowInfo>,
+) -> Option<LeaderWindowInfo> {
+    candidates.into_iter().fold(current, |current, candidate| {
+        Some(match current {
+            Some(current) => freshest_leader_window(current, candidate),
+            None => candidate,
+        })
+    })
+}
+
+/// Preserve the freshest future ParentReady so the next loop iteration starts
+/// from finalized consensus state instead of a stale optimistic notification.
+fn stash_parent_ready(ctx: &mut LeaderContext, info: LeaderWindowInfo) {
+    ctx.pending_parent_ready = Some(match ctx.pending_parent_ready.take() {
+        Some(current) => freshest_leader_window(current, info),
+        None => info,
+    });
+}
+
+/// Choose between finalized and optimistic leader-window notifications.
+///
+/// ParentReady wins ties across sources because finalized parent information
+/// should override an optimistic parent for the same leader window.
+fn select_freshest_window(
+    latest_parent_ready: Option<LeaderWindowInfo>,
+    latest_optimistic_parent: Option<LeaderWindowInfo>,
+) -> (Option<LeaderWindowInfo>, bool) {
+    if latest_parent_ready.as_ref().map(|info| info.start_slot)
+        >= latest_optimistic_parent
+            .as_ref()
+            .map(|info| info.start_slot)
+    {
+        (latest_parent_ready, false)
+    } else {
+        (latest_optimistic_parent, true)
+    }
 }
 
 /// Clamps the block producer timestamp to ensure that the leader produces a timestamp that conforms
@@ -392,32 +535,52 @@ fn produce_block_footer(
 }
 
 /// Produces the leader window from `start_slot` -> `end_slot` using parent
-/// `parent_slot` while abiding to the `skip_timer`
+/// `parent_slot` while abiding to the `block_timer`
 fn produce_window(
+    fast_leader_handover: bool,
     start_slot: Slot,
     end_slot: Slot,
-    mut parent_slot: Slot,
-    block_timer: Instant,
+    parent_slot: Slot,
+    parent_hash: Hash,
+    mut block_timer: Instant,
     ctx: &mut LeaderContext,
 ) -> Result<(), StartLeaderError> {
+    // Insert the first bank
+    let mut working_bank = start_leader_wait_for_parent_replay(
+        start_slot,
+        parent_slot,
+        Some(parent_hash),
+        block_timer,
+        ctx,
+    )?;
+    if fast_leader_handover {
+        ctx.slot_metrics.mark_leader_handover_fast();
+    }
+
     let my_pubkey = ctx.my_pubkey;
     let mut window_production_start = Measure::start("window_production");
     let mut slot = start_slot;
 
     while !ctx.exit.load(Ordering::Relaxed) && slot <= end_slot {
-        // Insert the bank. In case `replay_stage` is slow and `parent_slot` is not
-        // yet frozen, we wait up until the timeout.
-        let working_bank =
-            start_leader_wait_for_parent_replay(slot, parent_slot, block_timer, ctx)?;
         let timeout = block_timeout(&working_bank, leader_slot_index(slot));
         trace!(
-            "{my_pubkey}: waiting for leader bank {slot} to finish, remaining time: {}",
-            timeout.saturating_sub(block_timer.elapsed()).as_millis(),
+            "{my_pubkey}: waiting for leader bank {slot} to finish, remaining time: {}ms",
+            timeout.saturating_sub(block_timer.elapsed()).as_millis()
         );
 
         let mut bank_completion_measure = Measure::start("bank_completion");
-        if let Err(e) = record_and_complete_block(ctx, block_timer, timeout, slot) {
-            panic!("PohRecorder record failed: {e:?}");
+        let optimistic_parent =
+            (fast_leader_handover && slot == start_slot).then_some((parent_slot, parent_hash));
+        if let Err(e) =
+            record_and_complete_block(ctx, slot, optimistic_parent, &mut block_timer, timeout)
+        {
+            if ctx.exit.load(Ordering::Relaxed) {
+                return Ok(());
+            }
+            if !matches!(&e, PohRecorderError::WindowMovedOn(_)) {
+                abort_failed_working_bank(ctx, slot);
+            }
+            return Err(StartLeaderError::PohRecorder(e));
         }
         assert!(!ctx.poh_recorder.read().unwrap().has_bank());
         bank_completion_measure.stop();
@@ -427,19 +590,19 @@ fn produce_window(
         let _ = ctx
             .metrics
             .bank_timeout_completion_elapsed_hist
-            .increment(bank_completion_measure.as_us())
-            .inspect_err(|e| {
-                error!(
-                    "{}: unable to increment bank completion histogram {e:?}",
-                    ctx.my_pubkey
-                );
-            });
+            .increment(bank_completion_measure.as_us());
 
         // Produce our next slot
-        parent_slot = slot;
         slot += 1;
+        if slot > end_slot {
+            trace!("{my_pubkey}: finished leader window {start_slot}-{end_slot}");
+            break;
+        }
+
+        // Although `slot - 1`has been cleared from `poh_recorder`, it might not have finished processing in
+        // `replay_stage`, which is why we use `start_leader_retry_replay`
+        working_bank = start_leader_wait_for_parent_replay(slot, slot - 1, None, block_timer, ctx)?;
     }
-    trace!("{my_pubkey}: finished leader window {start_slot}-{end_slot}");
 
     window_production_start.stop();
     ctx.metrics.window_production_elapsed += window_production_start.as_us();
@@ -450,46 +613,126 @@ fn produce_window(
 /// Afterwards:
 /// - Shutdown the record receiver
 /// - Clear any inflight records
+/// - Insert the block footer
 /// - Insert the alpentick
 /// - Clear the working bank
 fn record_and_complete_block(
     ctx: &mut LeaderContext,
-    block_timer: Instant,
-    block_timeout: Duration,
     bank_slot: Slot,
+    mut optimistic_parent: Option<(Slot, Hash)>,
+    block_timer: &mut Instant,
+    block_timeout: Duration,
 ) -> Result<(), PohRecorderError> {
+    drain_stale_reward_certs(ctx, bank_slot);
     ctx.build_reward_certs_sender
         .send(BuildRewardCertsRequest { bank_slot })
         .map_err(|_| PohRecorderError::ChannelDisconnected)?;
+    let mut accumulated_txs = vec![];
+    let mut records_shutdown = false;
+    let window_has_moved_on = loop {
+        if ctx.exit.load(Ordering::Relaxed) {
+            return Err(PohRecorderError::ChannelDisconnected);
+        }
 
-    // loop until we hit the block timeout
-    while !block_timeout
-        .saturating_sub(block_timer.elapsed())
-        .is_zero()
-    {
-        let Ok(record) = ctx.record_receiver.try_recv() else {
-            continue;
+        // If our window is skipped return
+        if ctx.highest_parent_ready.read().unwrap().0 > bank_slot {
+            break true;
+        }
+
+        // Don't timeout until we've received ParentReady.
+        let block_time_left = time_left(*block_timer, block_timeout);
+        let select_timeout = if block_time_left.is_zero() {
+            if optimistic_parent.is_none() {
+                // Happy path. We've reached the block timeout and have received
+                // ParentReady, so we can proceed to complete the block.
+                break false;
+            }
+
+            // FLH still needs to wait for ParentReady... stop recording so we
+            // don't build a giant block or OOM.
+            if !records_shutdown {
+                shutdown_and_drain_record_receiver(
+                    &ctx.poh_recorder,
+                    &mut ctx.record_receiver,
+                    Some(&mut accumulated_txs),
+                )?;
+                records_shutdown = true;
+            }
+
+            // Poll periodically while waiting for ParentReady so shutdown can
+            // be observed without a zero-duration spin.
+            Duration::from_millis(100)
+        } else {
+            block_time_left
         };
-        ctx.poh_recorder.write().unwrap().record(
-            record.bank_id,
-            record.mixins,
-            record.transaction_batches,
-        )?;
+
+        select_biased! {
+            recv(ctx.leader_window_info_receiver) -> msg => {
+                let info = msg.map_err(|_| PohRecorderError::ChannelDisconnected)?;
+                if process_parent_ready(
+                    ctx,
+                    info,
+                    bank_slot,
+                    &mut optimistic_parent,
+                    &mut accumulated_txs,
+                    block_timer,
+                    &mut records_shutdown,
+                )? {
+                    break true;
+                }
+            },
+            recv(ctx.record_receiver.inner()) -> msg => {
+                let record = msg.map_err(|_| PohRecorderError::ChannelDisconnected)?;
+                ctx.record_receiver
+                    .on_received_record(record.transaction_batches.len() as u64);
+
+                if optimistic_parent.is_some() {
+                    record.transaction_batches.iter().for_each(|batch| {
+                        accumulated_txs.extend(batch.iter().cloned());
+                    });
+                }
+
+                ctx.poh_recorder.write().unwrap().record(
+                    record.bank_id,
+                    record.mixins,
+                    record.transaction_batches,
+                )?;
+            },
+            default(select_timeout) => {},
+        }
+    };
+
+    if window_has_moved_on {
+        // The cluster has selected a later parent, so this bank will never get a
+        // footer. Do not record more transactions into it or wait for reward
+        // certs that are only needed for block completion.
+        if !records_shutdown {
+            ctx.record_receiver.shutdown();
+            for _ in ctx.record_receiver.drain_after_shutdown() {}
+        }
+        abort_working_bank(ctx, bank_slot);
+        return Err(PohRecorderError::WindowMovedOn(bank_slot));
     }
 
     // Shutdown and clear any inflight records
-    ctx.record_receiver.shutdown();
-    for record in ctx.record_receiver.drain() {
-        ctx.poh_recorder.write().unwrap().record(
-            record.bank_id,
-            record.mixins,
-            record.transaction_batches,
-        )?;
+    if !records_shutdown {
+        shutdown_and_drain_record_receiver(&ctx.poh_recorder, &mut ctx.record_receiver, None)?;
     }
 
-    // Alpentick and clear bank
-    let mut w_poh_recorder = ctx.poh_recorder.write().unwrap();
-    let bank = w_poh_recorder
+    // By now, we should have received ParentReady and called handle_parent_ready(), unless
+    // we're behind and the window has moved on.
+    debug_assert!(
+        window_has_moved_on || optimistic_parent.is_none(),
+        "optimistic_parent should be None after receiving ParentReady"
+    );
+
+    // Alpentick and clear bank. Keep the PohRecorder write lock scoped to the
+    // final tick; reward cert production can block and does not need exclusive
+    // access to PohRecorder after record intake has been shut down.
+    let bank = ctx
+        .poh_recorder
+        .read()
+        .unwrap()
         .bank()
         .expect("Bank cannot have been cleared as BlockCreationLoop is the only modifier");
 
@@ -503,17 +746,14 @@ fn record_and_complete_block(
     // Set the tick height for the bank to max_tick_height - 1, so that PohRecorder::flush_cache()
     // will properly increment the tick_height to max_tick_height.
     bank.set_tick_height(max_tick_height - 1);
-    // Write the single tick for this slot
 
     let footer = {
+        let reward_certs = recv_reward_certs(ctx, bank_slot)?;
         let BuildRewardCertsRespSucc {
             skip,
             notar,
             validators: _,
-        } = ctx
-            .reward_certs_receiver
-            .recv()
-            .map_err(|_| PohRecorderError::ChannelDisconnected)??;
+        } = reward_certs;
         let reward_cert = ValidatedRewardCert::try_new(&bank, &skip, &notar)?;
         let guard = ctx.highest_finalized.read().unwrap();
         let footer = produce_block_footer(&bank, skip, notar, guard.as_ref());
@@ -529,9 +769,308 @@ fn record_and_complete_block(
         footer
     };
 
+    let bank_id = bank.bank_id();
+    let produced_slot = bank.slot();
+    let mut w_poh_recorder = ctx.poh_recorder.write().unwrap();
+    let current_bank = w_poh_recorder
+        .bank()
+        .expect("Bank cannot have been cleared as BlockCreationLoop is the only modifier");
+    if current_bank.bank_id() != bank_id {
+        return Err(PohRecorderError::ResetBankError(
+            produced_slot,
+            current_bank.slot(),
+        ));
+    }
+    drop(current_bank);
     drop(bank);
-    w_poh_recorder.tick_alpenglow(max_tick_height, footer);
+    // Write the single tick for this slot
+    w_poh_recorder.tick_alpenglow(max_tick_height, footer)?;
     Ok(())
+}
+
+/// Apply a ParentReady notification while a leader block is being produced.
+///
+/// Returns true when the notification proves this producer is behind and should
+/// abandon the current window. For matching optimistic windows, this may perform
+/// sad leader handover and restart the bank on the finalized parent.
+fn process_parent_ready(
+    ctx: &mut LeaderContext,
+    info: LeaderWindowInfo,
+    bank_slot: Slot,
+    optimistic_parent: &mut Option<(Slot, Hash)>,
+    accumulated_txs: &mut Vec<VersionedTransaction>,
+    block_timer: &mut Instant,
+    records_shutdown: &mut bool,
+) -> Result<bool, PohRecorderError> {
+    if info.start_slot > bank_slot {
+        // Window has moved on; we're behind.
+        stash_parent_ready(ctx, info);
+        return Ok(true);
+    }
+
+    if info.start_slot == bank_slot {
+        if let Some(optimistic_parent_block) = optimistic_parent.take() {
+            if handle_parent_ready(
+                ctx,
+                info,
+                optimistic_parent_block,
+                std::mem::take(accumulated_txs),
+                block_timer,
+            )?
+            .is_some()
+            {
+                *records_shutdown = false;
+            }
+        }
+        return Ok(false);
+    }
+
+    trace!(
+        "{}: ignoring stale ParentReady for window {}-{} while producing slot {bank_slot}",
+        ctx.my_pubkey, info.start_slot, info.end_slot
+    );
+    Ok(false)
+}
+
+/// Drop reward-certificate responses left over from an older bank slot.
+fn drain_stale_reward_certs(ctx: &LeaderContext, bank_slot: Slot) {
+    for reward_cert in ctx.reward_certs_receiver.try_iter() {
+        warn!(
+            "{}: dropping stale reward cert response for bank slot {}, before starting {bank_slot}",
+            ctx.my_pubkey, reward_cert.bank_slot
+        );
+    }
+}
+
+/// Wait for the reward-certificate response for `bank_slot`, ignoring stale
+/// responses generated for banks that have already been abandoned.
+fn recv_reward_certs(
+    ctx: &LeaderContext,
+    bank_slot: Slot,
+) -> Result<BuildRewardCertsRespSucc, PohRecorderError> {
+    loop {
+        if ctx.exit.load(Ordering::Relaxed) {
+            return Err(PohRecorderError::ChannelDisconnected);
+        }
+
+        match ctx
+            .reward_certs_receiver
+            .recv_timeout(Duration::from_millis(100))
+        {
+            Ok(reward_certs) if reward_certs.bank_slot == bank_slot => {
+                break reward_certs.result.map_err(PohRecorderError::from);
+            }
+            Ok(reward_certs) => {
+                warn!(
+                    "{}: ignoring stale reward cert response for bank slot {}, expected \
+                     {bank_slot}",
+                    ctx.my_pubkey, reward_certs.bank_slot
+                );
+            }
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => {
+                return Err(PohRecorderError::ChannelDisconnected);
+            }
+        }
+    }
+}
+
+/// Stop record intake, drain any already-reserved records, and reset PoH after
+/// failing to complete the working bank.
+fn abort_failed_working_bank(ctx: &mut LeaderContext, slot: Slot) {
+    ctx.record_receiver.shutdown();
+    for _ in ctx.record_receiver.drain_after_shutdown() {}
+    abort_working_bank(ctx, slot);
+}
+
+/// Wait for BankingStage commits that already recorded into PoH before removing
+/// the abandoned bank from BankForks and purging its account state.
+///
+/// The caller must first shut down and drain `record_receiver`, so no new
+/// successful records can start for this bank while this barrier is held.
+fn wait_for_abandoned_bank_commits(bank: &Bank) {
+    bank.wait_for_inflight_commits();
+}
+
+/// Remove the leader bank from `BankForks`, finishing scheduler-dropping cleanup
+/// after the write lock is released.
+fn clear_leader_bank_from_forks(ctx: &LeaderContext, slot: Slot) {
+    let clear_bank_cleanup = {
+        let mut bank_forks = ctx.bank_forks.write().unwrap();
+        bank_forks.clear_bank(slot, false)
+    };
+    clear_bank_cleanup.finish();
+}
+
+/// Remove an abandoned leader bank and reset PoH to its parent/root bank.
+fn abort_working_bank(ctx: &mut LeaderContext, slot: Slot) {
+    let Some(bank) = ctx.poh_recorder.read().unwrap().bank() else {
+        return;
+    };
+
+    let reset_bank = bank
+        .parent()
+        .unwrap_or_else(|| ctx.bank_forks.read().unwrap().root_bank());
+    wait_for_abandoned_bank_commits(&bank);
+    clear_leader_bank_from_forks(ctx, slot);
+    reset_poh_recorder(&reset_bank, ctx);
+}
+
+/// Emit an UpdateParent marker into the current leader block.
+///
+/// Broadcast keeps the original shred-header parent, but this marker updates
+/// the replay parent and double-merkle parent leaf for downstream validators.
+fn send_update_parent(
+    poh_recorder: &RwLock<PohRecorder>,
+    new_parent_block: Block,
+) -> Result<(), PohRecorderError> {
+    let (new_parent_slot, new_parent_block_id) = new_parent_block;
+    let update_parent = UpdateParentV1 {
+        new_parent_slot,
+        new_parent_block_id,
+    };
+    let marker = VersionedBlockMarker::new_update_parent(update_parent);
+    poh_recorder.write().unwrap().send_marker(marker)?;
+    Ok(())
+}
+
+/// Handles a parent ready notification when building on an optimistic parent.
+///
+/// Happy path:
+/// - finalized parent matches optimistic parent
+/// - this is a no-op, and a win.
+///
+/// Sad path:
+/// - finalized parent does not match optimistic parent
+/// - we send an UpdateParent to switch to the correct parent (i.e., the finalized parent).
+/// - tell PohRecorder to stop sending us transactions
+/// - we clear the bank for the current slot
+fn handle_parent_ready(
+    ctx: &mut LeaderContext,
+    leader_window_info: LeaderWindowInfo,
+    optimistic_parent_block: (Slot, Hash),
+    mut accumulated_txs: Vec<VersionedTransaction>,
+    block_timer: &mut Instant,
+) -> Result<Option<Arc<Bank>>, PohRecorderError> {
+    if leader_window_info.parent_block == optimistic_parent_block {
+        // Happy path: optimistic parent matches finalized parent
+        return Ok(None);
+    }
+
+    // Sad path: need to switch to the correct parent
+    trace!(
+        "{:?}: Sad leader handover slot optimistic parent = {:?} != {:?} = finalized parent",
+        ctx.my_pubkey, optimistic_parent_block, leader_window_info.parent_block
+    );
+    ctx.slot_metrics.mark_leader_handover_sad();
+
+    // If the optimistic parent doesn't match the finalized parent (specified in ParentReady), then
+    // this resets the block timer to the new parent's timer.
+    *block_timer = leader_window_info.block_timer;
+
+    // Important: We must shutdown and drain the record receiver BEFORE sending the UpdateParent
+    // marker. Otherwise, we could end up sending records for the old bank after the UpdateParent,
+    // which causes a divergence between the leader and replayers.
+    shutdown_and_drain_record_receiver(
+        &ctx.poh_recorder,
+        &mut ctx.record_receiver,
+        Some(&mut accumulated_txs),
+    )?;
+    send_update_parent(&ctx.poh_recorder, leader_window_info.parent_block)?;
+
+    let slot = leader_window_info.start_slot;
+    let (old_parent_slot, _) = optimistic_parent_block;
+    let (new_parent_slot, new_parent_hash) = leader_window_info.parent_block;
+
+    let bank = ctx
+        .poh_recorder
+        .read()
+        .unwrap()
+        .bank()
+        .ok_or(PohRecorderError::ResetBankError(
+            old_parent_slot,
+            new_parent_slot,
+        ))?;
+    wait_for_abandoned_bank_commits(&bank);
+    clear_leader_bank_from_forks(ctx, slot);
+    ctx.poh_recorder.write().unwrap().clear_bank(true);
+
+    // Create the new bank before re-injecting transactions to avoid racing.
+    let new_bank = start_leader_wait_for_parent_replay(
+        slot,
+        new_parent_slot,
+        Some(new_parent_hash),
+        *block_timer,
+        ctx,
+    )
+    .map_err(|_| PohRecorderError::ResetBankError(old_parent_slot, new_parent_slot))?;
+
+    // Re-inject accumulated transactions back to banking stage for rescheduling
+    let packets: Vec<BytesPacket> = accumulated_txs
+        .into_iter()
+        .filter_map(|tx| {
+            let serialized = wincode::serialize(&tx)
+                .inspect_err(|e| {
+                    error!(
+                        "failed to serialize transaction for rescheduling - this should never \
+                         happen: {e:?}"
+                    )
+                })
+                .ok()?;
+            let buffer = Bytes::from(serialized);
+            let mut meta = Meta::default();
+            meta.size = buffer.len();
+            Some(BytesPacket::new(buffer, meta))
+        })
+        .collect();
+
+    if !packets.is_empty() {
+        info!(
+            "{}: rescheduling {} txs after sad leader handover for slot {slot}",
+            ctx.my_pubkey,
+            packets.len(),
+        );
+        let batch: PacketBatch = packets.into();
+        let banking_packet_batch = Arc::new(vec![batch]);
+        ctx.banking_stage_sender
+            .send(banking_packet_batch)
+            .map_err(|_| PohRecorderError::RescheduleTransactionsError(slot))?;
+    }
+
+    Ok(Some(new_bank))
+}
+
+/// Shut down record intake and synchronously record all already-reserved batches.
+///
+/// When `accumulated_txs` is provided, the drained transactions are retained so
+/// sad handover can reschedule them against the recreated bank.
+fn shutdown_and_drain_record_receiver(
+    poh_recorder: &RwLock<PohRecorder>,
+    record_receiver: &mut RecordReceiver,
+    mut accumulated_txs: Option<&mut Vec<VersionedTransaction>>,
+) -> Result<(), PohRecorderError> {
+    record_receiver.shutdown();
+
+    for record in record_receiver.drain_after_shutdown() {
+        if let Some(accumulated_txs) = accumulated_txs.as_deref_mut() {
+            record.transaction_batches.iter().for_each(|batch| {
+                accumulated_txs.extend(batch.iter().cloned());
+            });
+        }
+
+        poh_recorder.write().unwrap().record(
+            record.bank_id,
+            record.mixins,
+            record.transaction_batches,
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Returns the time remaining until timeout.
+fn time_left(block_timer: Instant, timeout: Duration) -> Duration {
+    timeout.saturating_sub(block_timer.elapsed())
 }
 
 /// Similar to `maybe_start_leader`, however if replay of the parent block is lagging we retry
@@ -539,6 +1078,7 @@ fn record_and_complete_block(
 fn start_leader_wait_for_parent_replay(
     slot: Slot,
     parent_slot: Slot,
+    parent_hash: Option<Hash>,
     block_timer: Instant,
     ctx: &mut LeaderContext,
 ) -> Result<Arc<Bank>, StartLeaderError> {
@@ -554,7 +1094,7 @@ fn start_leader_wait_for_parent_replay(
     let end_slot = last_of_consecutive_leader_slots(slot);
 
     let mut slot_delay_start = Measure::start("slot_delay");
-    while !timeout.saturating_sub(block_timer.elapsed()).is_zero() {
+    while !time_left(block_timer, timeout).is_zero() {
         ctx.slot_metrics.attempt_start_leader_count += 1;
 
         // Check if the entire window is skipped.
@@ -571,7 +1111,7 @@ fn start_leader_wait_for_parent_replay(
             ));
         }
 
-        match maybe_start_leader(slot, parent_slot, ctx) {
+        match maybe_start_leader(slot, parent_slot, parent_hash, ctx) {
             Ok(()) => {
                 slot_delay_start.stop();
                 let _ = ctx
@@ -585,6 +1125,7 @@ fn start_leader_wait_for_parent_replay(
                         );
                     });
 
+                ctx.slot_metrics.report();
                 return Ok(ctx
                     .poh_recorder
                     .read()
@@ -594,8 +1135,8 @@ fn start_leader_wait_for_parent_replay(
             }
             Err(StartLeaderError::ReplayIsBehind(_, _)) => {
                 trace!(
-                    "{my_pubkey}: Attempting to produce slot {slot}, however replay of the the \
-                     parent {parent_slot} is not yet finished, waiting. Skip timer {}",
+                    "{my_pubkey}: Attempting to produce slot {slot}, however replay of the parent \
+                     {parent_slot} is not yet finished, waiting. Block timer {}",
                     block_timer.elapsed().as_millis()
                 );
                 let highest_frozen_slot = ctx
@@ -604,17 +1145,15 @@ fn start_leader_wait_for_parent_replay(
                     .lock()
                     .unwrap();
 
-                // We wait until either we finish replay of the parent or the skip timer finishes
+                // We wait until either we finish replay of the parent or the block timer finishes
                 let mut wait_start = Measure::start("replay_is_behind");
-                let _unused = ctx
-                    .replay_highest_frozen
-                    .freeze_notification
-                    .wait_timeout_while(
-                        highest_frozen_slot,
-                        timeout.saturating_sub(block_timer.elapsed()),
-                        |hfs| *hfs < parent_slot,
-                    )
-                    .unwrap();
+                let _unused = {
+                    let timeout = time_left(block_timer, timeout);
+                    ctx.replay_highest_frozen
+                        .freeze_notification
+                        .wait_timeout_while(highest_frozen_slot, timeout, |hfs| *hfs < parent_slot)
+                        .unwrap()
+                };
                 wait_start.stop();
                 ctx.slot_metrics.replay_is_behind_cumulative_wait_elapsed += wait_start.as_us();
                 let _ = ctx
@@ -627,6 +1166,34 @@ fn start_leader_wait_for_parent_replay(
                             ctx.my_pubkey
                         );
                     });
+            }
+            Err(StartLeaderError::ParentBlockIdMismatch {
+                expected, actual, ..
+            }) => {
+                trace!(
+                    "{my_pubkey}: Attempting to produce slot {slot}, however parent {parent_slot} \
+                     has block id {actual:?}, expected {expected}; waiting for bank switch"
+                );
+                let mut wait_start = Measure::start("parent_block_id_mismatch");
+                let wait_timeout = time_left(block_timer, timeout).min(Duration::from_millis(100));
+                if !wait_timeout.is_zero() {
+                    let highest_frozen_slot = ctx
+                        .replay_highest_frozen
+                        .highest_frozen_slot
+                        .lock()
+                        .unwrap();
+                    let _unused = ctx
+                        .replay_highest_frozen
+                        .freeze_notification
+                        .wait_timeout(highest_frozen_slot, wait_timeout)
+                        .unwrap();
+                }
+                wait_start.stop();
+                ctx.slot_metrics.replay_is_behind_cumulative_wait_elapsed += wait_start.as_us();
+                let _ = ctx
+                    .slot_metrics
+                    .replay_is_behind_wait_elapsed_hist
+                    .increment(wait_start.as_us());
             }
             Err(e) => return Err(e),
         }
@@ -650,6 +1217,7 @@ fn start_leader_wait_for_parent_replay(
 fn maybe_start_leader(
     slot: Slot,
     parent_slot: Slot,
+    parent_hash: Option<Hash>,
     ctx: &mut LeaderContext,
 ) -> Result<(), StartLeaderError> {
     if ctx.bank_forks.read().unwrap().get(slot).is_some() {
@@ -667,14 +1235,30 @@ fn maybe_start_leader(
         return Err(StartLeaderError::ReplayIsBehind(parent_slot, slot));
     }
 
+    if let Some(expected) = parent_hash.filter(|hash| *hash != Hash::default()) {
+        let actual = parent_bank.block_id();
+        if actual != Some(expected) {
+            return Err(StartLeaderError::ParentBlockIdMismatch {
+                leader_slot: slot,
+                parent_slot,
+                expected,
+                actual,
+            });
+        }
+    }
+
     // Create and insert the bank
-    create_and_insert_leader_bank(slot, parent_bank, ctx);
+    create_and_insert_leader_bank(slot, parent_bank, ctx)?;
     Ok(())
 }
 
 /// Creates and inserts the leader bank `slot` of this window with
 /// parent `parent_bank`
-fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut LeaderContext) {
+fn create_and_insert_leader_bank(
+    slot: Slot,
+    parent_bank: Arc<Bank>,
+    ctx: &mut LeaderContext,
+) -> Result<(), PohRecorderError> {
     let parent_slot = parent_bank.slot();
     let root_slot = ctx.bank_forks.read().unwrap().root();
     trace!(
@@ -701,6 +1285,14 @@ fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut L
         );
     }
 
+    if ctx.poh_recorder.read().unwrap().start_slot() != parent_slot {
+        // Important to keep Poh somewhat accurate for
+        // parts of the system relying on PohRecorder::would_be_leader()
+        reset_poh_recorder(&parent_bank, ctx);
+    }
+
+    // After potentially resetting, there should be no working bank.
+    // If there still is one, something has gone wrong.
     if let Some(bank) = ctx.poh_recorder.read().unwrap().bank() {
         panic!(
             "{}: Attempting to produce a block for {slot}, however we still are in production of \
@@ -708,12 +1300,6 @@ fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut L
             ctx.my_pubkey,
             bank.slot(),
         );
-    }
-
-    if ctx.poh_recorder.read().unwrap().start_slot() != parent_slot {
-        // Important to keep Poh somewhat accurate for
-        // parts of the system relying on PohRecorder::would_be_leader()
-        reset_poh_recorder(&parent_bank, ctx);
     }
 
     let tpu_bank = ReplayStage::new_bank_from_parent_with_notify(
@@ -738,8 +1324,13 @@ fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut L
     let bank_id = tpu_bank.bank_id();
     ctx.poh_recorder.write().unwrap().set_bank(tpu_bank);
 
-    // If this is the first alpenglow block, emit the genesis certificate marker
-    maybe_include_genesis_certificate(parent_slot, ctx);
+    // If this is the first alpenglow block, emit the genesis certificate marker.
+    // This happens before record intake restarts, so a send failure can be
+    // recovered by clearing the just-created bank and resetting PoH.
+    if let Err(err) = maybe_include_genesis_certificate(parent_slot, ctx) {
+        abort_working_bank(ctx, slot);
+        return Err(err);
+    }
 
     // Wakeup banking stage
     ctx.record_receiver.restart(bank_id);
@@ -749,25 +1340,26 @@ fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut L
         "{}: new fork:{} parent:{} (leader) root:{}",
         ctx.my_pubkey, slot, parent_slot, root_slot
     );
+    Ok(())
 }
 
-///  If this the very first alpenglow block, include the genesis certificate
-///  Note: if the alpenglow genesis is 0, then this is a test cluster with Alpenglow enabled
-///  by default. No need to put in the genesis marker as the genesis account is already populated
-///  during cluster creation.
-fn maybe_include_genesis_certificate(parent_slot: Slot, ctx: &LeaderContext) {
+/// Include the genesis certificate marker in the first Alpenglow block.
+///
+/// If the Alpenglow genesis slot is 0, the cluster started with Alpenglow
+/// enabled and the genesis account was already populated during cluster
+/// creation, so no marker is needed.
+fn maybe_include_genesis_certificate(
+    parent_slot: Slot,
+    ctx: &LeaderContext,
+) -> Result<(), PohRecorderError> {
     if parent_slot != ctx.genesis_cert.slot || parent_slot == 0 {
-        return;
+        return Ok(());
     }
-    let genesis_marker = VersionedBlockMarker::V1(BlockMarkerV1::new_genesis_certificate(
-        ctx.genesis_cert.clone(),
-    ));
 
-    let mut poh_recorder = ctx.poh_recorder.write().unwrap();
     // Send the genesis certificate
-    poh_recorder
-        .send_marker(genesis_marker)
-        .expect("Max tick height cannot have been reached");
+    let genesis_marker = VersionedBlockMarker::new_genesis_certificate(ctx.genesis_cert.clone());
+    let mut poh_recorder = ctx.poh_recorder.write().unwrap();
+    poh_recorder.send_marker(genesis_marker)?;
 
     // Process the genesis certificate
     let bank = poh_recorder.bank().expect("Bank cannot have been cleared");
@@ -779,4 +1371,576 @@ fn maybe_include_genesis_certificate(parent_slot: Slot, ctx: &LeaderContext) {
             &ctx.bank_forks.read().unwrap().migration_status(),
         )
         .expect("Recording genesis certificate should not fail");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::banking_trace::BankingTracer,
+        agave_banking_stage_ingress_types::BankingPacketReceiver,
+        agave_votor_messages::reward_certificate::{BuildRewardCertsRespError, RewardCertError},
+        crossbeam_channel::unbounded,
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
+        solana_entry::{block_component::VersionedUpdateParent, entry_or_marker::EntryOrMarker},
+        solana_keypair::Keypair,
+        solana_leader_schedule::{FixedSchedule, LeaderSchedule, SlotLeader},
+        solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path_auto_delete},
+        solana_poh::{
+            poh_recorder::{PohRecorder, Record, WorkingBankEntryOrMarker},
+            record_channels::record_channels,
+        },
+        solana_poh_config::PohConfig,
+        solana_runtime::{
+            bank::Bank, bank_forks::BankForks, genesis_utils::create_genesis_config_with_leader,
+        },
+        solana_system_transaction as system_transaction,
+        std::num::NonZeroUsize,
+    };
+
+    fn versioned_transfer(lamports: u64) -> VersionedTransaction {
+        let from = Keypair::new();
+        VersionedTransaction::from(system_transaction::transfer(
+            &from,
+            &Pubkey::new_unique(),
+            lamports,
+            Hash::new_unique(),
+        ))
+    }
+
+    fn test_genesis_certificate() -> GenesisCertificate {
+        GenesisCertificate {
+            slot: Slot::MAX,
+            block_id: Hash::default(),
+            bls_signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        }
+    }
+
+    fn fixed_leader_schedule(my_pubkey: Pubkey, root_bank: &Bank) -> Arc<LeaderScheduleCache> {
+        let mut leader_schedule_cache = LeaderScheduleCache::new_from_bank(root_bank);
+        let leader = SlotLeader {
+            id: my_pubkey,
+            vote_address: Pubkey::new_unique(),
+        };
+        let schedule = LeaderSchedule::new_from_schedule(vec![leader; 32], NonZeroUsize::MIN);
+        leader_schedule_cache.set_fixed_leader_schedule(Some(FixedSchedule {
+            leader_schedule: Arc::new(schedule),
+        }));
+        Arc::new(leader_schedule_cache)
+    }
+
+    fn leader_window_info(start_slot: Slot, parent_slot: Slot) -> LeaderWindowInfo {
+        LeaderWindowInfo {
+            start_slot,
+            end_slot: last_of_consecutive_leader_slots(start_slot),
+            parent_block: (parent_slot, Hash::new_unique()),
+            block_timer: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn test_freshest_window_highest() {
+        let selected = freshest_window_from_iter(
+            Some(leader_window_info(8, 7)),
+            [
+                leader_window_info(16, 15),
+                leader_window_info(12, 11),
+                leader_window_info(4, 3),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(selected.start_slot, 16);
+        assert_eq!(selected.parent_block.0, 15);
+    }
+
+    #[test]
+    fn test_freshest_window_tie() {
+        let selected =
+            freshest_window_from_iter(Some(leader_window_info(8, 7)), [leader_window_info(8, 6)])
+                .unwrap();
+
+        assert_eq!(selected.start_slot, 8);
+        assert_eq!(selected.parent_block.0, 6);
+    }
+
+    fn recv_update_parent_marker(
+        entry_receiver: &Receiver<WorkingBankEntryOrMarker>,
+    ) -> UpdateParentV1 {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            assert!(
+                !timeout.is_zero(),
+                "timed out waiting for UpdateParent marker"
+            );
+            let (_bank, (entry_or_marker, _tick_height)) =
+                entry_receiver.recv_timeout(timeout).unwrap();
+            let EntryOrMarker::Marker(VersionedBlockMarker::V1(marker)) = entry_or_marker else {
+                continue;
+            };
+            let Some(VersionedUpdateParent::V1(update_parent)) = marker.as_update_parent() else {
+                continue;
+            };
+            return update_parent.clone();
+        }
+    }
+
+    fn recv_rescheduled_transactions(
+        receiver: &BankingPacketReceiver,
+    ) -> Vec<VersionedTransaction> {
+        let packet_batches = receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        packet_batches
+            .iter()
+            .flat_map(|batch| batch.iter())
+            .map(|packet| {
+                wincode::deserialize::<VersionedTransaction>(
+                    packet.data(..packet.meta().size).unwrap(),
+                )
+                .unwrap()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_abort_failed_working_bank() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let my_pubkey = Pubkey::new_unique();
+        let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
+        let root_bank = Bank::new_for_tests(&genesis.genesis_config);
+        root_bank.freeze();
+        let bank_forks = BankForks::new_rw_arc(root_bank);
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader_schedule_cache = fixed_leader_schedule(my_pubkey, &root_bank);
+
+        let exit = Arc::new(AtomicBool::new(false));
+        let poh_config = PohConfig::default();
+        let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
+            root_bank.tick_height(),
+            root_bank.last_blockhash(),
+            root_bank.clone(),
+            Some((1, 1)),
+            root_bank.ticks_per_slot(),
+            blockstore.clone(),
+            &leader_schedule_cache,
+            &poh_config,
+            exit.clone(),
+        );
+        poh_recorder.enable_alpenglow();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+
+        let (_record_sender, record_receiver) = record_channels(false);
+        let (_leader_window_info_sender, leader_window_info_receiver) = unbounded();
+        let (build_reward_certs_sender, _build_reward_certs_receiver) = unbounded();
+        let (reward_certs_sender, reward_certs_receiver) = unbounded();
+        let (banking_stage_sender, _banking_stage_receiver) = BankingTracer::channel_for_test();
+
+        let mut ctx = LeaderContext {
+            exit,
+            my_pubkey,
+            leader_window_info_receiver,
+            pending_parent_ready: None,
+            highest_parent_ready: Arc::new(RwLock::new((0, (0, Hash::default())))),
+            highest_finalized: Arc::new(RwLock::new(None)),
+            blockstore,
+            record_receiver,
+            poh_recorder,
+            leader_schedule_cache,
+            bank_forks,
+            rpc_subscriptions: None,
+            slot_status_notifier: None,
+            banking_tracer: BankingTracer::new_disabled(),
+            replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
+            build_reward_certs_sender,
+            reward_certs_receiver,
+            banking_stage_sender,
+            metrics: LoopMetrics::default(),
+            slot_metrics: SlotMetrics::default(),
+            genesis_cert: test_genesis_certificate(),
+        };
+
+        create_and_insert_leader_bank(1, root_bank.clone(), &mut ctx).unwrap();
+        assert!(ctx.poh_recorder.read().unwrap().has_bank());
+        assert!(ctx.bank_forks.read().unwrap().get(1).is_some());
+
+        let bank = ctx.poh_recorder.read().unwrap().bank().unwrap();
+        let in_flight_commit = bank.freeze_lock();
+        ctx.record_receiver.shutdown();
+        for _ in ctx.record_receiver.drain_after_shutdown() {}
+        let (abort_started_sender, abort_started_receiver) = unbounded();
+        let (abort_done_sender, abort_done_receiver) = unbounded();
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                abort_started_sender.send(()).unwrap();
+                abort_working_bank(&mut ctx, 1);
+                abort_done_sender.send(()).unwrap();
+            });
+            abort_started_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap();
+            assert!(
+                abort_done_receiver
+                    .recv_timeout(Duration::from_millis(50))
+                    .is_err()
+            );
+            drop(in_flight_commit);
+            abort_done_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap();
+        });
+        create_and_insert_leader_bank(1, root_bank, &mut ctx).unwrap();
+        assert!(ctx.poh_recorder.read().unwrap().has_bank());
+        assert!(ctx.bank_forks.read().unwrap().get(1).is_some());
+
+        abort_failed_working_bank(&mut ctx, 1);
+        assert!(!ctx.poh_recorder.read().unwrap().has_bank());
+        assert!(ctx.bank_forks.read().unwrap().get(1).is_none());
+        assert!(ctx.record_receiver.is_shutdown());
+        assert!(ctx.record_receiver.is_safe_to_restart());
+
+        reward_certs_sender
+            .send(BuildRewardCertsResponse {
+                bank_slot: 1,
+                result: Err(BuildRewardCertsRespError::RewardCertTryNew(
+                    RewardCertError::InvalidBitmap,
+                )),
+            })
+            .unwrap();
+        reward_certs_sender
+            .send(BuildRewardCertsResponse {
+                bank_slot: 2,
+                result: Ok(BuildRewardCertsRespSucc {
+                    validators: vec![my_pubkey],
+                    ..BuildRewardCertsRespSucc::default()
+                }),
+            })
+            .unwrap();
+
+        let reward_certs = recv_reward_certs(&ctx, 2).unwrap();
+        assert_eq!(reward_certs.validators, vec![my_pubkey]);
+    }
+
+    #[test]
+    fn test_marker_send_clears_bank() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let my_pubkey = Pubkey::new_unique();
+        let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
+        let root_bank = Bank::new_for_tests(&genesis.genesis_config);
+        root_bank.freeze();
+        let bank_forks = BankForks::new_rw_arc(root_bank);
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader_schedule_cache = fixed_leader_schedule(my_pubkey, &root_bank);
+        let parent_bank = Bank::new_from_parent(
+            root_bank.clone(),
+            SlotLeader {
+                id: my_pubkey,
+                vote_address: Pubkey::new_unique(),
+            },
+            1,
+        );
+        parent_bank.freeze();
+        bank_forks.write().unwrap().insert(parent_bank);
+        let parent_bank = bank_forks.read().unwrap().get(1).unwrap();
+
+        let exit = Arc::new(AtomicBool::new(false));
+        let poh_config = PohConfig::default();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(
+            root_bank.tick_height(),
+            root_bank.last_blockhash(),
+            root_bank,
+            Some((2, 2)),
+            parent_bank.ticks_per_slot(),
+            blockstore.clone(),
+            &leader_schedule_cache,
+            &poh_config,
+            exit.clone(),
+        );
+        poh_recorder.enable_alpenglow();
+        drop(entry_receiver);
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+
+        let (_record_sender, record_receiver) = record_channels(false);
+        let (_leader_window_info_sender, leader_window_info_receiver) = unbounded();
+        let (build_reward_certs_sender, _build_reward_certs_receiver) = unbounded();
+        let (_reward_certs_sender, reward_certs_receiver) = unbounded();
+        let (banking_stage_sender, _banking_stage_receiver) = BankingTracer::channel_for_test();
+        let mut genesis_cert = test_genesis_certificate();
+        genesis_cert.slot = parent_bank.slot();
+
+        let mut ctx = LeaderContext {
+            exit,
+            my_pubkey,
+            leader_window_info_receiver,
+            pending_parent_ready: None,
+            highest_parent_ready: Arc::new(RwLock::new((0, (0, Hash::default())))),
+            highest_finalized: Arc::new(RwLock::new(None)),
+            blockstore,
+            record_receiver,
+            poh_recorder,
+            leader_schedule_cache,
+            bank_forks,
+            rpc_subscriptions: None,
+            slot_status_notifier: None,
+            banking_tracer: BankingTracer::new_disabled(),
+            replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
+            build_reward_certs_sender,
+            reward_certs_receiver,
+            banking_stage_sender,
+            metrics: LoopMetrics::default(),
+            slot_metrics: SlotMetrics::default(),
+            genesis_cert,
+        };
+
+        let err = create_and_insert_leader_bank(2, parent_bank, &mut ctx).unwrap_err();
+        assert!(matches!(err, PohRecorderError::SendError(_)));
+        assert!(!ctx.poh_recorder.read().unwrap().has_bank());
+        assert!(ctx.bank_forks.read().unwrap().get(2).is_none());
+        assert!(ctx.record_receiver.is_shutdown());
+        assert!(ctx.record_receiver.is_safe_to_restart());
+    }
+
+    #[test]
+    fn test_moved_on_aborts() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let my_pubkey = Pubkey::new_unique();
+        let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
+        let root_bank = Bank::new_for_tests(&genesis.genesis_config);
+        root_bank.freeze();
+        let bank_forks = BankForks::new_rw_arc(root_bank);
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader_schedule_cache = fixed_leader_schedule(my_pubkey, &root_bank);
+
+        let exit = Arc::new(AtomicBool::new(false));
+        let poh_config = PohConfig::default();
+        let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
+            root_bank.tick_height(),
+            root_bank.last_blockhash(),
+            root_bank.clone(),
+            Some((1, 1)),
+            root_bank.ticks_per_slot(),
+            blockstore.clone(),
+            &leader_schedule_cache,
+            &poh_config,
+            exit.clone(),
+        );
+        poh_recorder.enable_alpenglow();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+
+        let (record_sender, record_receiver) = record_channels(false);
+        let (_leader_window_info_sender, leader_window_info_receiver) = unbounded();
+        let (build_reward_certs_sender, build_reward_certs_receiver) = unbounded();
+        let (reward_certs_sender, reward_certs_receiver) = unbounded();
+        let (banking_stage_sender, _banking_stage_receiver) = BankingTracer::channel_for_test();
+
+        let mut ctx = LeaderContext {
+            exit,
+            my_pubkey,
+            leader_window_info_receiver,
+            pending_parent_ready: None,
+            highest_parent_ready: Arc::new(RwLock::new((2, (0, Hash::default())))),
+            highest_finalized: Arc::new(RwLock::new(None)),
+            blockstore,
+            record_receiver,
+            poh_recorder,
+            leader_schedule_cache,
+            bank_forks,
+            rpc_subscriptions: None,
+            slot_status_notifier: None,
+            banking_tracer: BankingTracer::new_disabled(),
+            replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
+            build_reward_certs_sender,
+            reward_certs_receiver,
+            banking_stage_sender,
+            metrics: LoopMetrics::default(),
+            slot_metrics: SlotMetrics::default(),
+            genesis_cert: test_genesis_certificate(),
+        };
+
+        create_and_insert_leader_bank(1, root_bank, &mut ctx).unwrap();
+        let bank_id = ctx.poh_recorder.read().unwrap().bank().unwrap().bank_id();
+        record_sender
+            .try_send(Record::new(
+                vec![Hash::new_unique()],
+                vec![vec![versioned_transfer(1)]],
+                bank_id,
+            ))
+            .unwrap();
+
+        let delayed_reward = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(300));
+            let _ = reward_certs_sender.send(BuildRewardCertsResponse {
+                bank_slot: 1,
+                result: Ok(BuildRewardCertsRespSucc::default()),
+            });
+        });
+
+        let start = Instant::now();
+        let result =
+            record_and_complete_block(&mut ctx, 1, None, &mut Instant::now(), Duration::ZERO);
+        assert!(matches!(result, Err(PohRecorderError::WindowMovedOn(1))));
+        assert!(start.elapsed() < Duration::from_millis(250));
+        assert!(!ctx.poh_recorder.read().unwrap().has_bank());
+        assert!(ctx.bank_forks.read().unwrap().get(1).is_none());
+        assert!(ctx.record_receiver.is_shutdown());
+        assert!(ctx.record_receiver.is_safe_to_restart());
+        assert_eq!(
+            build_reward_certs_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap()
+                .bank_slot,
+            1
+        );
+
+        delayed_reward.join().unwrap();
+    }
+
+    #[test]
+    fn test_sad_leader_handover() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let my_pubkey = Pubkey::new_unique();
+        let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
+        let root_bank = Bank::new_for_tests(&genesis.genesis_config);
+        root_bank.set_block_id(Some(Hash::new_unique()));
+        root_bank.freeze();
+        let bank_forks = BankForks::new_rw_arc(root_bank);
+        let root_bank = bank_forks.read().unwrap().root_bank();
+
+        let leader_schedule_cache = fixed_leader_schedule(my_pubkey, &root_bank);
+
+        let new_parent_slot = 1;
+        let new_parent_hash = Hash::new_unique();
+        let new_parent = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            root_bank.clone(),
+            SlotLeader::new_unique(),
+            new_parent_slot,
+        );
+        new_parent.freeze();
+        new_parent.set_block_id(Some(new_parent_hash));
+
+        let optimistic_parent_slot = 3;
+        let optimistic_parent_hash = Hash::new_unique();
+        let optimistic_parent = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            root_bank.clone(),
+            SlotLeader::new_unique(),
+            optimistic_parent_slot,
+        );
+        optimistic_parent.freeze();
+        optimistic_parent.set_block_id(Some(optimistic_parent_hash));
+
+        let exit = Arc::new(AtomicBool::new(false));
+        let poh_config = PohConfig::default();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(
+            root_bank.tick_height(),
+            root_bank.last_blockhash(),
+            root_bank.clone(),
+            Some((4, 7)),
+            root_bank.ticks_per_slot(),
+            blockstore.clone(),
+            &leader_schedule_cache,
+            &poh_config,
+            exit.clone(),
+        );
+        poh_recorder.enable_alpenglow();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+
+        let (record_sender, record_receiver) = record_channels(false);
+        let (leader_window_info_sender, leader_window_info_receiver) = unbounded();
+        let (build_reward_certs_sender, _build_reward_certs_receiver) = unbounded();
+        let (_reward_certs_sender, reward_certs_receiver) = unbounded();
+        let (banking_stage_sender, banking_stage_receiver) = BankingTracer::channel_for_test();
+
+        let mut ctx = LeaderContext {
+            exit,
+            my_pubkey,
+            leader_window_info_receiver,
+            pending_parent_ready: None,
+            highest_parent_ready: Arc::new(RwLock::new((4, (new_parent_slot, new_parent_hash)))),
+            highest_finalized: Arc::new(RwLock::new(None)),
+            blockstore,
+            record_receiver,
+            poh_recorder,
+            leader_schedule_cache,
+            bank_forks,
+            rpc_subscriptions: None,
+            slot_status_notifier: None,
+            banking_tracer: BankingTracer::new_disabled(),
+            replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
+            build_reward_certs_sender,
+            reward_certs_receiver,
+            banking_stage_sender,
+            metrics: LoopMetrics::default(),
+            slot_metrics: SlotMetrics::default(),
+            genesis_cert: test_genesis_certificate(),
+        };
+
+        let leader_slot = 4;
+        create_and_insert_leader_bank(leader_slot, optimistic_parent, &mut ctx).unwrap();
+        let optimistic_bank_id = ctx.poh_recorder.read().unwrap().bank().unwrap().bank_id();
+
+        let accumulated_tx = versioned_transfer(1);
+        let drained_tx = versioned_transfer(2);
+        record_sender
+            .try_send(Record::new(
+                vec![Hash::new_unique()],
+                vec![vec![drained_tx.clone()]],
+                optimistic_bank_id,
+            ))
+            .unwrap();
+
+        let parent_ready = LeaderWindowInfo {
+            start_slot: leader_slot,
+            end_slot: 7,
+            parent_block: (new_parent_slot, new_parent_hash),
+            block_timer: Instant::now(),
+        };
+        let new_bank = handle_parent_ready(
+            &mut ctx,
+            parent_ready,
+            (optimistic_parent_slot, optimistic_parent_hash),
+            vec![accumulated_tx.clone()],
+            &mut Instant::now(),
+        )
+        .unwrap()
+        .expect("sad handover should recreate the leader bank");
+
+        assert_eq!(new_bank.slot(), leader_slot);
+        assert_eq!(new_bank.parent_slot(), new_parent_slot);
+        assert_eq!(
+            ctx.bank_forks
+                .read()
+                .unwrap()
+                .get(leader_slot)
+                .unwrap()
+                .parent_slot(),
+            new_parent_slot
+        );
+        assert_eq!(
+            ctx.poh_recorder
+                .read()
+                .unwrap()
+                .bank()
+                .unwrap()
+                .parent_slot(),
+            new_parent_slot
+        );
+
+        let update_parent = recv_update_parent_marker(&entry_receiver);
+        assert_eq!(update_parent.new_parent_slot, new_parent_slot);
+        assert_eq!(update_parent.new_parent_block_id, new_parent_hash);
+
+        let rescheduled = recv_rescheduled_transactions(&banking_stage_receiver);
+        assert_eq!(rescheduled.len(), 2);
+        assert!(rescheduled.contains(&accumulated_tx));
+        assert!(rescheduled.contains(&drained_tx));
+
+        drop(leader_window_info_sender);
+    }
 }

--- a/core/src/block_creation_loop/stats.rs
+++ b/core/src/block_creation_loop/stats.rs
@@ -108,6 +108,9 @@ impl LoopMetrics {
 pub(crate) struct SlotMetrics {
     pub(crate) slot: Slot,
     pub(crate) attempt_start_leader_count: u64,
+    pub(crate) leader_handover_fast: bool,
+    // Indicates we had to switch parent.
+    pub(crate) leader_handover_sad: bool,
     pub(crate) replay_is_behind_count: u64,
     pub(crate) already_have_bank_count: u64,
 
@@ -122,6 +125,8 @@ impl SlotMetrics {
             "slot-metrics",
             ("slot", self.slot, i64),
             ("attempt_count", self.attempt_start_leader_count, i64),
+            ("leader_handover_fast", self.leader_handover_fast, i64),
+            ("leader_handover_sad", self.leader_handover_sad, i64),
             ("replay_is_behind_count", self.replay_is_behind_count, i64),
             ("already_have_bank_count", self.already_have_bank_count, i64),
             (
@@ -178,8 +183,42 @@ impl SlotMetrics {
         );
     }
 
+    pub(crate) fn mark_leader_handover_fast(&mut self) {
+        self.leader_handover_fast = true;
+    }
+
+    pub(crate) fn mark_leader_handover_sad(&mut self) {
+        self.leader_handover_sad = true;
+    }
+
     pub(crate) fn reset(&mut self, slot: Slot) {
+        let same_slot = self.slot == slot;
+        let leader_handover_fast = same_slot && self.leader_handover_fast;
+        let leader_handover_sad = same_slot && self.leader_handover_sad;
         *self = Self::default();
+        self.leader_handover_fast = leader_handover_fast;
+        self.leader_handover_sad = leader_handover_sad;
         self.slot = slot;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slot_metrics_handover() {
+        let mut metrics = SlotMetrics::default();
+        metrics.reset(42);
+        metrics.mark_leader_handover_fast();
+        metrics.mark_leader_handover_sad();
+
+        metrics.reset(42);
+        assert!(metrics.leader_handover_fast);
+        assert!(metrics.leader_handover_sad);
+
+        metrics.reset(43);
+        assert!(!metrics.leader_handover_fast);
+        assert!(!metrics.leader_handover_sad);
     }
 }

--- a/core/src/consensus/progress_map.rs
+++ b/core/src/consensus/progress_map.rs
@@ -81,8 +81,18 @@ impl RetransmitInfo {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DeadSlotReason {
+    /// Dead and cannot be brought back to life by an `UpdateParent` marker.
+    Hard,
+    /// Replay execution failed, but an `UpdateParent` marker could still make
+    /// the failed prefix obsolete.
+    ReplayFailureBeforeUpdateParent,
+}
+
 pub struct ForkProgress {
     pub is_dead: bool,
+    pub dead_reason: Option<DeadSlotReason>,
     pub fork_stats: ForkStats,
     pub propagated_stats: PropagatedStats,
     pub replay_stats: Arc<RwLock<ReplaySlotStats>>,
@@ -132,6 +142,7 @@ impl ForkProgress {
 
         Self {
             is_dead: false,
+            dead_reason: None,
             fork_stats: ForkStats::default(),
             replay_stats: Arc::new(RwLock::new(ReplaySlotStats::default())),
             replay_progress: Arc::new(RwLock::new(
@@ -189,6 +200,11 @@ impl ForkProgress {
             new_progress.fork_stats.bank_hash = Some(bank.hash());
         }
         new_progress
+    }
+
+    pub fn mark_dead(&mut self, reason: DeadSlotReason) {
+        self.is_dead = true;
+        self.dead_reason = Some(reason);
     }
 }
 
@@ -339,6 +355,12 @@ impl ProgressMap {
         self.progress_map
             .get(&slot)
             .map(|fork_progress| fork_progress.is_dead)
+    }
+
+    pub fn dead_reason(&self, slot: Slot) -> Option<&DeadSlotReason> {
+        self.progress_map
+            .get(&slot)
+            .and_then(|fork_progress| fork_progress.dead_reason.as_ref())
     }
 
     pub fn get_hash(&self, slot: Slot) -> Option<Hash> {

--- a/core/src/repair/block_id_repair_service.rs
+++ b/core/src/repair/block_id_repair_service.rs
@@ -28,7 +28,7 @@ use {
         event::{RepairEvent, RepairEventReceiver},
     },
     agave_votor_messages::{consensus_message::Block, migration::MigrationStatus},
-    crossbeam_channel::select,
+    crossbeam_channel::{Receiver, Sender, select},
     lazy_lru::LruCache,
     log::{debug, info},
     solana_clock::Slot,
@@ -67,6 +67,21 @@ use {
 };
 
 type OutstandingBlockIdRepairs = OutstandingRequests<BlockIdRepairType>;
+
+/// Replay's transient soft-dead state for slots that may still recover via an
+/// `UpdateParent` marker.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SoftDeadSlotNotification {
+    /// Replay failed before observing a usable `UpdateParent` marker. Block-id
+    /// repair should stop waiting for the Original location and repair by block id.
+    MarkSoftDead(Slot),
+    /// Replay restarted the slot from `UpdateParent`; the transient soft-dead
+    /// signal is stale and should no longer trigger block-id repair.
+    ClearSoftDead(Slot),
+}
+
+pub type SoftDeadSlotSender = Sender<SoftDeadSlotNotification>;
+pub type SoftDeadSlotReceiver = Receiver<SoftDeadSlotNotification>;
 
 const MAX_REPAIR_REQUESTS_PER_ITERATION: usize = 200;
 const MAX_ALTERNATE_BLOCKS_PER_SLOT: usize = 11;
@@ -176,6 +191,12 @@ struct RepairState {
     /// These are re-processed each iteration until Turbine/Eager repair completes or marks the slot dead.
     /// Only the lowest slots are retained if the queue reaches MAX_PENDING_REPAIR_EVENTS.
     pending_repair_events: BTreeSet<RepairEvent>,
+    /// Slots that replay marked soft-dead before a possible `UpdateParent`.
+    ///
+    /// These are not durable dead slots in blockstore, but they are enough signal
+    /// for block-id repair to stop waiting on the Original column and fetch the
+    /// requested certified block by block id.
+    soft_dead_slots: HashSet<Slot>,
 
     /// Requests that have been sent, mapped to the timestamp they were sent.
     /// Used for retry logic - requests that exceed DELTA
@@ -192,6 +213,26 @@ struct RepairState {
 }
 
 impl RepairState {
+    fn apply_soft_dead_slot_notification(&mut self, notification: SoftDeadSlotNotification) {
+        match notification {
+            SoftDeadSlotNotification::MarkSoftDead(slot) => {
+                self.soft_dead_slots.insert(slot);
+            }
+            SoftDeadSlotNotification::ClearSoftDead(slot) => {
+                self.soft_dead_slots.remove(&slot);
+            }
+        }
+    }
+
+    fn apply_soft_dead_slot_notifications(
+        &mut self,
+        notifications: impl IntoIterator<Item = SoftDeadSlotNotification>,
+    ) {
+        for notification in notifications {
+            self.apply_soft_dead_slot_notification(notification);
+        }
+    }
+
     fn push_pending_repair_event(&mut self, event: RepairEvent) {
         self.pending_repair_events.insert(event);
         if self.pending_repair_events.len() > MAX_PENDING_REPAIR_EVENTS {
@@ -228,6 +269,7 @@ impl RepairState {
 pub struct BlockIdRepairChannels {
     pub repair_event_receiver: RepairEventReceiver,
     pub completed_slots_receiver: CompletedSlotsReceiver,
+    pub soft_dead_slot_receiver: SoftDeadSlotReceiver,
 }
 
 struct BlockIdRepairSockets {
@@ -328,6 +370,7 @@ impl BlockIdRepairService {
                     sent_requests: HashMap::default(),
                     requested_blocks: HashSet::default(),
                     pending_repair_events: BTreeSet::default(),
+                    soft_dead_slots: HashSet::default(),
                     response_stats: BlockIdRepairResponsesStats::default(),
                     request_stats: BlockIdRepairRequestsStats::default(),
                 };
@@ -389,6 +432,10 @@ impl BlockIdRepairService {
                     Ok(event) => state.push_pending_repair_event(event),
                     Err(_) => return Ok(false),
                 },
+                recv(&context.channels.soft_dead_slot_receiver) -> result => match result {
+                    Ok(notification) => state.apply_soft_dead_slot_notification(notification),
+                    Err(_) => return Ok(false),
+                },
                 recv(&context.response_receiver) -> result => match result {
                     Ok(response) => pending_response = Some(response),
                     Err(_) => return Ok(false),
@@ -404,6 +451,7 @@ impl BlockIdRepairService {
 
         // Clean up old request tracking
         state.requested_blocks.retain(|(slot, _)| *slot > root);
+        state.soft_dead_slots.retain(|slot| *slot > root);
         state.prune_expected_ping_responses(timestamp());
 
         // Process responses, generate new requests / repair events
@@ -419,9 +467,13 @@ impl BlockIdRepairService {
 
         // Receive new repair events from votor / replay
         state.extend_pending_repair_events(context.channels.repair_event_receiver.try_iter());
+        state.apply_soft_dead_slot_notifications(
+            context.channels.soft_dead_slot_receiver.try_iter(),
+        );
 
         // Filter out actionable repair events from the pending queue
         let requested_blocks = &state.requested_blocks;
+        let soft_dead_slots = &state.soft_dead_slots;
         state.pending_repair_events.retain(|event| {
             if first_error.is_some() {
                 return true;
@@ -433,6 +485,7 @@ impl BlockIdRepairService {
                 root,
                 context.blockstore.as_ref(),
                 requested_blocks,
+                soft_dead_slots,
             ) {
                 Ok(PendingRepairDecision::KeepPending) => true,
                 Ok(PendingRepairDecision::Drop) => false,
@@ -714,6 +767,7 @@ impl BlockIdRepairService {
         root: Slot,
         blockstore: &Blockstore,
         requested_blocks: &HashSet<Block>,
+        soft_dead_slots: &HashSet<Slot>,
     ) -> Result<PendingRepairDecision, BlockstoreError> {
         if event.slot() <= root {
             return Ok(PendingRepairDecision::Drop);
@@ -734,14 +788,15 @@ impl BlockIdRepairService {
                     }));
                 }
 
-                // We don't have the block. Check if turbine failed (dead)
+                // We don't have the block. Check if turbine/replay failed.
                 // Note: we require the invariant that Turbine + Eager repair will either:
                 // - Eventually fill in all shreds for a slot (slot_meta.is_full()) resulting in the DMR calculation
-                // - Mark the slot as dead
-                if blockstore.is_dead(slot) {
+                // - Mark the slot dead, or notify us that replay soft-dead the
+                //   slot before a possible UpdateParent
+                if blockstore.is_dead(slot) || soft_dead_slots.contains(&slot) {
                     info!(
-                        "{my_pubkey}: FetchBlock: slot {slot} is dead, starting repair for \
-                         block_id={block_id:?}"
+                        "{my_pubkey}: FetchBlock: slot {slot} is dead or soft-dead, starting \
+                         repair for block_id={block_id:?}"
                     );
                     return Ok(PendingRepairDecision::Act(RepairAction::StartRepair {
                         slot,
@@ -1145,6 +1200,7 @@ mod tests {
             sent_requests: HashMap::default(),
             requested_blocks: HashSet::default(),
             pending_repair_events: BTreeSet::default(),
+            soft_dead_slots: HashSet::default(),
             response_stats: BlockIdRepairResponsesStats::default(),
             request_stats: BlockIdRepairRequestsStats::default(),
         };
@@ -1165,6 +1221,7 @@ mod tests {
             root,
             blockstore,
             &state.requested_blocks,
+            &state.soft_dead_slots,
         )? {
             PendingRepairDecision::KeepPending => {
                 state.push_pending_repair_event(event);
@@ -1737,6 +1794,37 @@ mod tests {
     }
 
     #[test]
+    fn test_soft_dead_repairs() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let (mut state, _bank_forks) = create_test_repair_state();
+
+        let slot = 100u64;
+        let block_id = Hash::new_unique();
+        state.apply_soft_dead_slot_notification(SoftDeadSlotNotification::MarkSoftDead(slot));
+
+        let event = RepairEvent::FetchBlock { slot, block_id };
+        process_repair_event_for_test(Pubkey::new_unique(), event, 0, &blockstore, &mut state)
+            .unwrap();
+
+        assert_eq!(state.pending_repair_requests.len(), 1);
+        assert!(state.requested_blocks.contains(&(slot, block_id)));
+        assert!(state.pending_repair_events.is_empty());
+    }
+
+    #[test]
+    fn test_clear_soft_dead() {
+        let (mut state, _bank_forks) = create_test_repair_state();
+        let slot = 100u64;
+
+        state.apply_soft_dead_slot_notification(SoftDeadSlotNotification::MarkSoftDead(slot));
+        assert!(state.soft_dead_slots.contains(&slot));
+
+        state.apply_soft_dead_slot_notification(SoftDeadSlotNotification::ClearSoftDead(slot));
+        assert!(!state.soft_dead_slots.contains(&slot));
+    }
+
+    #[test]
     fn test_process_repair_event_deferred_when_turbine_not_complete() {
         // When Turbine hasn't completed (slot not dead, no DMR), event should be deferred
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -1904,6 +1992,7 @@ mod tests {
                     0,
                     &blockstore,
                     &state.requested_blocks,
+                    &state.soft_dead_slots,
                 )
                 .unwrap()
                 {

--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -310,6 +310,8 @@ mod tests {
     ) -> (Arc<Blockstore>, Hash, Vec<Hash>) {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        blockstore.set_block_markers_enabled(true);
+        blockstore.set_update_parent_enabled_from_slot(Some(0));
 
         // First, insert the parent slot so the child slot can be marked full
         let grandparent_slot = parent_slot.saturating_sub(1);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1,5 +1,4 @@
 //! The `replay_stage` replays transactions broadcast by the leader.
-
 use {
     crate::{
         banking_stage::update_bank_forks_and_poh_recorder_for_new_tpu_bank,
@@ -16,13 +15,14 @@ use {
             fork_choice::{ForkChoice, SelectVoteAndResetForkResult, select_vote_and_reset_forks},
             heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
             latest_validator_votes_for_frozen_banks::LatestValidatorVotesForFrozenBanks,
-            progress_map::{ForkProgress, ProgressMap, PropagatedStats},
+            progress_map::{DeadSlotReason, ForkProgress, ProgressMap, PropagatedStats},
             tower_storage::{SavedTower, SavedTowerVersions, TowerStorage},
             tower_vote_state::TowerVoteState,
         },
         cost_update_service::CostUpdate,
         repair::{
             ancestor_hashes_service::AncestorHashesReplayUpdateSender,
+            block_id_repair_service::{SoftDeadSlotNotification, SoftDeadSlotSender},
             cluster_slot_state_verifier::*,
             duplicate_repair_status::AncestorDuplicateSlotToRepair,
             repair_service::{
@@ -34,7 +34,7 @@ use {
         window_service::DuplicateSlotReceiver,
     },
     agave_votor::{
-        event::{CompletedBlock, VotorEvent, VotorEventSender},
+        event::{CompletedBlock, LeaderWindowInfo, VotorEvent, VotorEventSender},
         root_utils,
         vote_history_storage::SavedVoteHistory,
         voting_service::BLSOp,
@@ -45,10 +45,12 @@ use {
         migration::{GENESIS_VOTE_REFRESH, MigrationStatus},
         vote::Vote,
     },
-    crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
+    crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TrySendError},
+    itertools::Itertools,
     rayon::{ThreadPool, prelude::*},
     solana_accounts_db::contains::Contains,
     solana_clock::{BankId, NUM_CONSECUTIVE_LEADER_SLOTS, Slot},
+    solana_entry::block_component::VersionedUpdateParent,
     solana_geyser_plugin_manager::block_metadata_notifier_interface::BlockMetadataNotifierArc,
     solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
@@ -56,7 +58,10 @@ use {
     solana_leader_schedule::SlotLeader,
     solana_ledger::{
         block_error::BlockError,
-        blockstore::Blockstore,
+        blockstore::{
+            Blockstore, UpdateParentReceiver, UpdateParentReplayStatus, UpdateParentSignal,
+        },
+        blockstore_meta::BlockLocation,
         blockstore_processor::{
             self, AsyncVerificationProgress, BlockstoreProcessorError, ChainedBlockIdCheck,
             ConfirmationProgress, ExecuteBatchesInternalMetrics, ReplaySlotStats,
@@ -82,6 +87,7 @@ use {
     solana_runtime::{
         bank::{Bank, NewBankOptions, bank_hash_details},
         bank_forks::BankForks,
+        block_component_processor::BlockComponentProcessorError,
         commitment::BlockCommitmentCache,
         installed_scheduler_pool::BankWithScheduler,
         leader_schedule_utils::first_of_consecutive_leader_slots,
@@ -123,6 +129,7 @@ const MAX_REPAIR_RETRY_LOOP_ATTEMPTS: usize = 10;
 static_assertions::const_assert!(REFRESH_VOTE_BLOCKHEIGHT < solana_clock::MAX_PROCESSING_AGE);
 // Give at least 4 leaders the chance to pack our vote
 const REFRESH_VOTE_BLOCKHEIGHT: usize = 16;
+
 #[derive(PartialEq, Eq, Debug)]
 pub enum HeaviestForkFailures {
     LockedOut(u64),
@@ -184,6 +191,20 @@ impl ReplaySlotFromBlockstore {
     }
 }
 
+/// Select the freshest leader-window notification by start slot, replacing equal
+/// start slots with the later notification. This intentionally mirrors BCL's
+/// `freshest_window_from_iter` selection logic.
+fn freshest_leader_window(
+    current: LeaderWindowInfo,
+    candidate: LeaderWindowInfo,
+) -> LeaderWindowInfo {
+    if current.start_slot > candidate.start_slot {
+        current
+    } else {
+        candidate
+    }
+}
+
 struct BankReplayTracker {
     // The bank being replayed.
     bank: BankWithScheduler,
@@ -213,6 +234,7 @@ struct ProcessActiveBanksContext {
     cluster_slots_update_sender: ClusterSlotsUpdateSender,
     cost_update_sender: Sender<CostUpdate>,
     ancestor_hashes_replay_update_sender: AncestorHashesReplayUpdateSender,
+    soft_dead_slot_sender: SoftDeadSlotSender,
     block_metadata_notifier: Option<BlockMetadataNotifierArc>,
     votor_event_sender: VotorEventSender,
     log_messages_bytes_limit: Option<usize>,
@@ -220,6 +242,178 @@ struct ProcessActiveBanksContext {
     replay_tx_thread_pool: ThreadPool,
     prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
     migration_status: Arc<MigrationStatus>,
+}
+
+impl ProcessActiveBanksContext {
+    /// Borrow the pieces needed to publish a dead-slot transition to blockstore,
+    /// replay-vote, RPC, and the optional slot-status notifier.
+    fn dead_slot_notifications(&self) -> DeadSlotNotifications<'_> {
+        DeadSlotNotifications {
+            blockstore: &self.blockstore,
+            rpc_subscriptions: self.rpc_subscriptions.as_deref(),
+            slot_status_notifier: self.slot_status_notifier.as_ref(),
+            replay_vote_sender: &self.replay_vote_sender,
+            soft_dead_slot_sender: Some(&self.soft_dead_slot_sender),
+        }
+    }
+
+    /// Build the full context needed when a replay error must become a hard or
+    /// soft dead-slot transition.
+    fn dead_slot_context<'a, 'b>(
+        &'a self,
+        root: Slot,
+        duplicate_slots_to_repair: &'a mut DuplicateSlotsToRepair,
+        purge_repair_slot_counter: &'a mut PurgeRepairSlotCounter,
+        tbft_structs: &'a mut Option<&'b mut TowerBFTStructures>,
+    ) -> DeadSlotContext<'a, 'b> {
+        DeadSlotContext {
+            notifications: self.dead_slot_notifications(),
+            duplicate: DeadSlotDuplicateContext {
+                root,
+                duplicate_slots_to_repair,
+                ancestor_hashes_replay_update_sender: &self.ancestor_hashes_replay_update_sender,
+                purge_repair_slot_counter,
+                tbft_structs,
+            },
+            migration_status: self.migration_status.as_ref(),
+        }
+    }
+}
+
+/// Controls the severity used for hard-dead-slot telemetry.
+///
+/// Some terminal replay outcomes are expected protocol behavior, such as a
+/// leader abandoning a block with too few ticks. Those still make the slot dead,
+/// but should not alert operators as validator errors.
+#[derive(Clone, Copy)]
+enum DeadSlotLogLevel {
+    Info,
+    Error,
+}
+
+impl DeadSlotLogLevel {
+    /// Pick the operator-facing severity for a replay failure.
+    fn for_replay_error(err: &BlockstoreProcessorError) -> Self {
+        match err {
+            BlockstoreProcessorError::InvalidBlock(BlockError::TooFewTicks) => Self::Info,
+            _ => Self::Error,
+        }
+    }
+
+    /// Emit the standard dead-slot datapoint with the selected severity.
+    fn datapoint(self, slot: Slot, err: String) {
+        match self {
+            Self::Info => {
+                datapoint_info!(
+                    "replay-stage-mark_dead_slot",
+                    ("error", err, String),
+                    ("slot", slot, i64)
+                );
+            }
+            Self::Error => {
+                datapoint_error!(
+                    "replay-stage-mark_dead_slot",
+                    ("error", err, String),
+                    ("slot", slot, i64)
+                );
+            }
+        }
+    }
+}
+
+/// Sinks that observe replay dead-slot transitions.
+struct DeadSlotNotifications<'a> {
+    /// Persistent ledger state. Hard-dead slots are written here; soft-dead
+    /// slots intentionally are not.
+    blockstore: &'a Blockstore,
+    /// RPC subscription fanout for durable dead-slot notifications.
+    rpc_subscriptions: Option<&'a RpcSubscriptions>,
+    /// Optional test/runtime hook used by slot-status observers.
+    slot_status_notifier: Option<&'a SlotStatusNotifier>,
+    /// Replay-vote channel used to release buffered votes for the failed bank.
+    replay_vote_sender: &'a ReplayVoteSender,
+    /// Block-id repair notification for soft-dead slots. This is intentionally
+    /// separate from the durable Blockstore dead-slot column.
+    soft_dead_slot_sender: Option<&'a SoftDeadSlotSender>,
+}
+
+/// Tower/duplicate bookkeeping that must be updated only for hard-dead slots.
+struct DeadSlotDuplicateContext<'a, 'b> {
+    /// Current root used by the duplicate-slot agreement state machine.
+    root: Slot,
+    /// Slots that should be repaired after duplicate/dead state transitions.
+    duplicate_slots_to_repair: &'a mut DuplicateSlotsToRepair,
+    /// Notifies ancestor-hash repair when a dead slot changes duplicate state.
+    ancestor_hashes_replay_update_sender: &'a AncestorHashesReplayUpdateSender,
+    /// Rate-limits purge repair requests triggered by duplicate/dead handling.
+    purge_repair_slot_counter: &'a mut PurgeRepairSlotCounter,
+    /// Tower data is present only on the Tower replay path; Alpenglow replay
+    /// passes `None` because it does not run this duplicate state machine.
+    tbft_structs: &'a mut Option<&'b mut TowerBFTStructures>,
+}
+
+/// All state needed to decide and publish a replay dead-slot transition.
+struct DeadSlotContext<'a, 'b> {
+    /// Persistent/RPC/replay-vote notification sinks.
+    notifications: DeadSlotNotifications<'a>,
+    /// Duplicate/Tower bookkeeping for hard-dead transitions.
+    duplicate: DeadSlotDuplicateContext<'a, 'b>,
+    /// Migration gates decide whether an UpdateParent marker can still recover
+    /// a failed prefix by restarting replay from a later FEC set.
+    migration_status: &'a MigrationStatus,
+}
+
+/// Borrowed inputs that do not change while discovering new replay banks.
+struct NewBankForksContext<'a> {
+    /// Ledger data and SlotMeta used to discover children of frozen banks.
+    blockstore: &'a Blockstore,
+    /// Fork graph where new banks are inserted after discovery.
+    bank_forks: &'a RwLock<BankForks>,
+    /// Leader schedule used to construct child banks.
+    leader_schedule_cache: &'a LeaderScheduleCache,
+    /// Optional RPC fanout for bank-created notifications.
+    rpc_subscriptions: Option<&'a RpcSubscriptions>,
+    /// Optional slot-status fanout for bank-created notifications.
+    slot_status_notifier: &'a Option<SlotStatusNotifier>,
+    /// Alpenglow migration gates that decide replay offsets and vote-only mode.
+    migration_status: &'a MigrationStatus,
+    /// This validator's identity, used to leave live own-leader banks to BCL.
+    my_pubkey: &'a Pubkey,
+}
+
+/// Borrowed inputs shared by live UpdateParent signal handling and soft-dead
+/// recovery scans.
+struct UpdateParentReplayContext<'a> {
+    /// This validator's identity, used to avoid replaying a live own-leader bank
+    /// that BlockCreationLoop still owns.
+    my_pubkey: Pubkey,
+    /// Ledger metadata and shreds used to validate UpdateParent readiness.
+    blockstore: &'a Blockstore,
+    /// Replay banks that may need to be removed and recreated from the marker.
+    bank_forks: &'a RwLock<BankForks>,
+    /// Optional RPC fanout for hard-dead promotion of unrecoverable soft-dead slots.
+    rpc_subscriptions: Option<&'a RpcSubscriptions>,
+    /// Optional slot-status hook for hard-dead promotion.
+    slot_status_notifier: Option<&'a SlotStatusNotifier>,
+    /// Replay-vote channel used when clearing the old replay bank.
+    replay_vote_sender: &'a ReplayVoteSender,
+    /// Repair notification channel for marking/clearing transient soft-dead slots.
+    soft_dead_slot_sender: &'a SoftDeadSlotSender,
+    /// Migration gates that decide when UpdateParent replay is legal.
+    migration_status: &'a MigrationStatus,
+}
+
+impl<'a> UpdateParentReplayContext<'a> {
+    /// Borrow the notification sinks needed if a soft-dead slot becomes hard-dead.
+    fn dead_slot_notifications(&self) -> DeadSlotNotifications<'a> {
+        DeadSlotNotifications {
+            blockstore: self.blockstore,
+            rpc_subscriptions: self.rpc_subscriptions,
+            slot_status_notifier: self.slot_status_notifier,
+            replay_vote_sender: self.replay_vote_sender,
+            soft_dead_slot_sender: Some(self.soft_dead_slot_sender),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -233,6 +427,7 @@ impl ProcessActiveBanksContext {
         let (cluster_slots_update_sender, _) = unbounded();
         let (cost_update_sender, _) = unbounded();
         let (ancestor_hashes_replay_update_sender, _) = unbounded();
+        let (soft_dead_slot_sender, _) = unbounded();
         let (votor_event_sender, _) = unbounded();
         let migration_status = Arc::new(MigrationStatus::default());
         let replay_tx_thread_pool = rayon::ThreadPoolBuilder::new()
@@ -252,6 +447,7 @@ impl ProcessActiveBanksContext {
             cluster_slots_update_sender,
             cost_update_sender,
             ancestor_hashes_replay_update_sender,
+            soft_dead_slot_sender,
             block_metadata_notifier: None,
             votor_event_sender,
             log_messages_bytes_limit: None,
@@ -375,7 +571,6 @@ pub struct ReplayStageConfig {
     pub banking_tracer: Arc<BankingTracer>,
     pub snapshot_controller: Option<Arc<SnapshotController>>,
     pub replay_highest_frozen: Arc<ReplayHighestFrozen>,
-    pub migration_status: Arc<MigrationStatus>,
 }
 
 pub struct ReplaySenders {
@@ -385,6 +580,7 @@ pub struct ReplaySenders {
     pub entry_notification_sender: Option<EntryNotifierSender>,
     pub bank_notification_sender: Option<BankNotificationSenderConfig>,
     pub ancestor_hashes_replay_update_sender: AncestorHashesReplayUpdateSender,
+    pub soft_dead_slot_sender: SoftDeadSlotSender,
     pub retransmit_slots_sender: Sender<u64>,
     pub replay_vote_sender: ReplayVoteSender,
     pub cluster_slots_update_sender: Sender<Vec<u64>>,
@@ -396,11 +592,14 @@ pub struct ReplaySenders {
     pub dumped_slots_sender: Sender<Vec<(u64, Hash)>>,
     pub votor_event_sender: VotorEventSender,
     pub own_vote_sender: Sender<Vec<ConsensusMessage>>,
+    pub optimistic_parent_sender: Sender<LeaderWindowInfo>,
     pub lockouts_sender: Sender<TowerCommitmentAggregationData>,
 }
 
 pub struct ReplayReceivers {
     pub ledger_signal_receiver: Receiver<bool>,
+    pub update_parent_receiver: UpdateParentReceiver,
+    pub optimistic_parent_latest_receiver: Receiver<LeaderWindowInfo>,
     pub duplicate_slots_receiver: Receiver<u64>,
     pub ancestor_duplicate_slots_receiver: Receiver<AncestorDuplicateSlotToRepair>,
     pub duplicate_confirmed_slots_receiver: Receiver<Vec<(u64, Hash)>>,
@@ -686,7 +885,6 @@ impl ReplayStage {
             banking_tracer,
             snapshot_controller,
             replay_highest_frozen,
-            migration_status,
         } = config;
 
         let ReplaySenders {
@@ -696,6 +894,7 @@ impl ReplayStage {
             entry_notification_sender,
             bank_notification_sender,
             ancestor_hashes_replay_update_sender,
+            soft_dead_slot_sender,
             retransmit_slots_sender,
             replay_vote_sender,
             cluster_slots_update_sender,
@@ -707,11 +906,14 @@ impl ReplayStage {
             dumped_slots_sender,
             votor_event_sender,
             own_vote_sender,
+            optimistic_parent_sender,
             lockouts_sender,
         } = senders;
 
         let ReplayReceivers {
             ledger_signal_receiver,
+            update_parent_receiver,
+            optimistic_parent_latest_receiver,
             duplicate_slots_receiver,
             ancestor_duplicate_slots_receiver,
             duplicate_confirmed_slots_receiver,
@@ -721,19 +923,19 @@ impl ReplayStage {
 
         trace!("replay stage");
 
-        let mut identity_keypair = cluster_info.keypair();
+        // Start the replay stage loop
+        let migration_status = bank_forks.read().unwrap().migration_status();
+        blockstore.configure_block_markers_for_migration(&migration_status);
+        let mut identity_keypair = cluster_info.keypair().clone();
         let mut my_pubkey = identity_keypair.pubkey();
 
         let mut highest_frozen_slot = bank_forks
             .read()
             .unwrap()
-            .frozen_banks()
-            .map(|(slot, _)| slot)
-            .max()
-            .unwrap_or(0);
+            .highest_frozen_bank()
+            .map_or(0, |hfs| hfs.slot());
         *replay_highest_frozen.highest_frozen_slot.lock().unwrap() = highest_frozen_slot;
 
-        // Start the replay stage loop
         let run_replay = move || {
             let _exit = Finalizer::new(exit.clone());
 
@@ -837,6 +1039,7 @@ impl ReplayStage {
                 cluster_slots_update_sender: cluster_slots_update_sender.clone(),
                 cost_update_sender: cost_update_sender.clone(),
                 ancestor_hashes_replay_update_sender: ancestor_hashes_replay_update_sender.clone(),
+                soft_dead_slot_sender: soft_dead_slot_sender.clone(),
                 block_metadata_notifier: block_metadata_notifier.clone(),
                 votor_event_sender: votor_event_sender.clone(),
                 log_messages_bytes_limit,
@@ -866,17 +1069,42 @@ impl ReplayStage {
                     break;
                 }
 
+                let update_parent_context = UpdateParentReplayContext {
+                    my_pubkey,
+                    blockstore: blockstore.as_ref(),
+                    bank_forks: bank_forks.as_ref(),
+                    rpc_subscriptions: rpc_subscriptions.as_deref(),
+                    slot_status_notifier: slot_status_notifier.as_ref(),
+                    replay_vote_sender: &replay_vote_sender,
+                    soft_dead_slot_sender: &soft_dead_slot_sender,
+                    migration_status: migration_status.as_ref(),
+                };
+                Self::interrupt_update_parent_slots(
+                    &update_parent_context,
+                    &mut progress,
+                    &update_parent_receiver,
+                );
+                if migration_status.is_alpenglow_enabled() {
+                    Self::process_soft_dead_update_parent_slots(
+                        &update_parent_context,
+                        &mut progress,
+                    );
+                }
+
                 let mut generate_new_bank_forks_time =
                     Measure::start("generate_new_bank_forks_time");
                 Self::generate_new_bank_forks(
-                    &blockstore,
-                    &bank_forks,
-                    &leader_schedule_cache,
-                    rpc_subscriptions.as_deref(),
-                    &slot_status_notifier,
+                    NewBankForksContext {
+                        blockstore: &blockstore,
+                        bank_forks: &bank_forks,
+                        leader_schedule_cache: &leader_schedule_cache,
+                        rpc_subscriptions: rpc_subscriptions.as_deref(),
+                        slot_status_notifier: &slot_status_notifier,
+                        migration_status: migration_status.as_ref(),
+                        my_pubkey: &my_pubkey,
+                    },
                     &mut progress,
                     &mut replay_timing,
-                    migration_status.as_ref(),
                 );
                 generate_new_bank_forks_time.stop();
 
@@ -904,22 +1132,6 @@ impl ReplayStage {
                     &own_vote_sender,
                 );
                 let did_complete_bank = !new_frozen_slots.is_empty();
-                if migration_status.is_alpenglow_enabled() {
-                    if let Some(highest) = new_frozen_slots.iter().max() {
-                        if *highest > highest_frozen_slot {
-                            highest_frozen_slot = *highest;
-                            let mut l_highest_frozen =
-                                replay_highest_frozen.highest_frozen_slot.lock().unwrap();
-                            // Let the block creation loop know about this new frozen slot
-                            *l_highest_frozen = *highest;
-                            replay_highest_frozen.freeze_notification.notify_one();
-                        }
-                    }
-                    if did_complete_bank {
-                        let bank_forks_r = bank_forks.read().unwrap();
-                        progress.handle_new_root(&bank_forks_r);
-                    }
-                }
                 replay_active_banks_time.stop();
 
                 // Check if we've completed the migration conditions
@@ -940,8 +1152,43 @@ impl ReplayStage {
                     );
                 }
 
-                let forks_root = bank_forks.read().unwrap().root();
-                if !migration_status.is_alpenglow_enabled() {
+                if migration_status.is_alpenglow_enabled() {
+                    let fast_leader_handover_notifies = {
+                        let bank_forks_r = bank_forks.read().unwrap();
+                        new_frozen_slots
+                            .iter()
+                            .filter(|slot| {
+                                migration_status.should_allow_fast_leader_handover(**slot)
+                            })
+                            .filter_map(|slot| bank_forks_r.get(*slot))
+                            .collect_vec()
+                    };
+                    for bank in fast_leader_handover_notifies {
+                        Self::maybe_notify_of_optimistic_parent(
+                            &bank,
+                            &my_pubkey,
+                            &leader_schedule_cache,
+                            &optimistic_parent_sender,
+                            &optimistic_parent_latest_receiver,
+                        );
+                    }
+
+                    if let Some(highest) = new_frozen_slots.iter().max() {
+                        if *highest > highest_frozen_slot {
+                            highest_frozen_slot = *highest;
+                            let mut l_highest_frozen =
+                                replay_highest_frozen.highest_frozen_slot.lock().unwrap();
+                            // Let the block creation loop know about this new frozen slot
+                            *l_highest_frozen = *highest;
+                            replay_highest_frozen.freeze_notification.notify_one();
+                        }
+                    }
+                    if did_complete_bank {
+                        let bank_forks_r = bank_forks.read().unwrap();
+                        progress.handle_new_root(&bank_forks_r);
+                    }
+                } else {
+                    let forks_root = bank_forks.read().unwrap().root();
                     // Process cluster-agreed versions of duplicate slots for which we potentially
                     // have the wrong version. Our version was dead or pruned.
                     // Signalled by ancestor_hashes_service.
@@ -1519,6 +1766,7 @@ impl ReplayStage {
         }
 
         migration_status.enable_alpenglow(exit);
+        blockstore.configure_block_markers_for_migration(migration_status);
 
         assert!(migration_status.is_alpenglow_enabled());
         datapoint_info!(
@@ -2453,7 +2701,6 @@ impl ReplayStage {
             warn!("{my_pubkey} already have bank in forks at {poh_slot}?");
             return None;
         }
-        trace!("{my_pubkey} poh_slot {poh_slot} parent_slot {parent_slot}");
 
         if let Some(next_leader) = leader_schedule_cache.slot_leader_at(poh_slot, Some(&parent)) {
             if !has_new_vote_been_rooted {
@@ -2584,75 +2831,202 @@ impl ReplayStage {
         Ok(tx_count)
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn mark_dead_slot(
+    /// Replay errors that may be caused solely by executing the optimistic-parent prefix.
+    fn is_update_parent_recoverable_replay_error(err: &BlockstoreProcessorError) -> bool {
+        matches!(
+            err,
+            BlockstoreProcessorError::InvalidBlock(_)
+                | BlockstoreProcessorError::InvalidTransaction(_)
+                | BlockstoreProcessorError::UserTransactionsInVoteOnlyBank(_)
+                | BlockstoreProcessorError::BankHashMismatch(..)
+        )
+    }
+
+    /// Returns true when replay failed before the slot's final parent is known.
+    ///
+    /// Fast leader handover may execute a prefix built on an optimistic parent.
+    /// If a later `UpdateParent` marker can still make that prefix obsolete, the
+    /// slot is only soft-dead in `ProgressMap`; blockstore/RPC are updated only
+    /// after the marker proves recovery impossible.
+    fn should_soft_dead_for_update_parent(
         blockstore: &Blockstore,
         bank: &Bank,
-        root: Slot,
         err: &BlockstoreProcessorError,
-        rpc_subscriptions: Option<&RpcSubscriptions>,
-        slot_status_notifier: Option<&SlotStatusNotifier>,
-        progress: &mut ProgressMap,
-        duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
-        ancestor_hashes_replay_update_sender: &AncestorHashesReplayUpdateSender,
-        purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
-        tbft_structs: &mut Option<&mut TowerBFTStructures>,
-        replay_vote_sender: &ReplayVoteSender,
-    ) {
-        // Do not remove from progress map when marking dead! Needed by
-        // `process_duplicate_confirmed_slots()`
-
-        // Block producer can abandon the block if it detects a better one
-        // while producing. Somewhat common and expected in a
-        // network with variable network/machine configuration.
-        let is_serious = !matches!(
-            err,
-            BlockstoreProcessorError::InvalidBlock(BlockError::TooFewTicks)
-        );
+        progress: &ProgressMap,
+        migration_status: &MigrationStatus,
+    ) -> bool {
         let slot = bank.slot();
-        let parent_slot = bank.parent_slot();
-        if is_serious {
-            datapoint_error!(
-                "replay-stage-mark_dead_slot",
-                ("error", format!("error: {err:?}"), String),
-                ("slot", slot, i64)
-            );
-        } else {
-            datapoint_info!(
-                "replay-stage-mark_dead_slot",
-                ("error", format!("error: {err:?}"), String),
-                ("slot", slot, i64)
-            );
+        if !migration_status.should_allow_update_parent(slot)
+            || blockstore.is_dead(slot)
+            || !Self::is_update_parent_recoverable_replay_error(err)
+        {
+            return false;
         }
-        progress.get_mut(&slot).unwrap().is_dead = true;
-        blockstore
-            .set_dead_slot(slot)
-            .expect("Failed to mark slot as dead in blockstore");
+
+        let Some(fork_progress) = progress.get(&slot) else {
+            return false;
+        };
+        let replayed_shreds = fork_progress.replay_progress.read().unwrap().num_shreds;
+        let Some(slot_meta) = blockstore.meta(slot).ok().flatten() else {
+            return false;
+        };
+
+        if slot_meta.has_update_parent() {
+            if replayed_shreds >= u64::from(slot_meta.replay_fec_set_index) {
+                return false;
+            }
+        } else if slot_meta.is_full() {
+            // The slot is complete and no `UpdateParent` marker was observed, so
+            // the replay failure is terminal.
+            return false;
+        }
+
+        true
+    }
+
+    /// Mark a slot soft-dead after replay fails before a possible UpdateParent.
+    ///
+    /// This releases replay-vote state for the current bank, but intentionally
+    /// avoids blockstore/RPC dead-slot writes because a later marker may restart
+    /// replay from the updated parent.
+    fn mark_soft_dead_slot(
+        bank: &Bank,
+        err: &BlockstoreProcessorError,
+        progress: &mut ProgressMap,
+        notifications: &DeadSlotNotifications<'_>,
+    ) {
+        let slot = bank.slot();
+        datapoint_info!(
+            "replay-stage-soft_dead_slot",
+            ("error", format!("error: {err:?}"), String),
+            ("slot", slot, i64),
+        );
+        progress
+            .get_mut(&slot)
+            .unwrap()
+            .mark_dead(DeadSlotReason::ReplayFailureBeforeUpdateParent);
+        Self::send_invalid_bank(bank, notifications.replay_vote_sender);
+        if let Some(soft_dead_slot_sender) = notifications.soft_dead_slot_sender {
+            if let Err(err) =
+                soft_dead_slot_sender.send(SoftDeadSlotNotification::MarkSoftDead(slot))
+            {
+                warn!("Failed to send soft-dead slot {slot} to block-id repair: {err}");
+            }
+        }
+    }
+
+    /// Tell block-id repair to forget a slot's soft-dead state after replay has
+    /// either restarted from UpdateParent or promoted the slot to hard-dead.
+    fn send_clear_soft_dead_slot(soft_dead_slot_sender: &SoftDeadSlotSender, slot: Slot) {
+        let notification = SoftDeadSlotNotification::ClearSoftDead(slot);
+        if let Err(err) = soft_dead_slot_sender.send(notification) {
+            warn!("Failed to clear soft-dead slot {slot} from block-id repair: {err}");
+        }
+    }
+
+    /// Release replay-vote state for a bank that replay will no longer finish.
+    fn send_invalid_bank(bank: &Bank, replay_vote_sender: &ReplayVoteSender) {
         replay_vote_sender
             .send(ReplayVoteMessage::InvalidBank {
                 replay_bank_id: bank.bank_id(),
-                replay_slot: slot,
+                replay_slot: bank.slot(),
             })
             .expect("Failed to send InvalidBank message to replay vote sender");
+    }
 
-        blockstore.slots_stats.mark_dead(slot);
+    /// Fan out observer notifications after the durable hard-dead bit has been
+    /// written to blockstore.
+    fn notify_hard_dead_observers(
+        slot: Slot,
+        parent_slot: Option<Slot>,
+        err: String,
+        notifications: &DeadSlotNotifications<'_>,
+    ) {
+        notifications.blockstore.slots_stats.mark_dead(slot);
 
-        let err = format!("error: {err:?}");
-
-        if let Some(slot_status_notifier) = slot_status_notifier {
+        if let (Some(slot_status_notifier), Some(parent_slot)) =
+            (notifications.slot_status_notifier, parent_slot)
+        {
             slot_status_notifier
                 .read()
                 .unwrap()
                 .notify_slot_dead(slot, parent_slot, err.clone());
         }
 
-        if let Some(rpc_subscriptions) = rpc_subscriptions {
+        if let Some(rpc_subscriptions) = notifications.rpc_subscriptions {
             rpc_subscriptions.notify_slot_update(SlotUpdate::Dead {
                 slot,
                 err,
                 timestamp: timestamp(),
             });
         }
+    }
+
+    /// Persist and publish a hard-dead slot while replay still owns its bank.
+    ///
+    /// Unlike soft-dead slots, hard-dead slots are terminal locally: the slot is
+    /// written dead in blockstore, replay-vote state is released, and observers
+    /// are notified.
+    fn mark_hard_dead_slot_with_bank(
+        bank: &Bank,
+        err: String,
+        log_level: DeadSlotLogLevel,
+        progress: &mut ProgressMap,
+        notifications: &DeadSlotNotifications<'_>,
+    ) {
+        let slot = bank.slot();
+        let parent_slot = bank.parent_slot();
+        log_level.datapoint(slot, err.clone());
+        // Do not remove from progress map when marking dead! Needed by
+        // `process_duplicate_confirmed_slots()`
+        progress
+            .get_mut(&slot)
+            .unwrap()
+            .mark_dead(DeadSlotReason::Hard);
+        notifications
+            .blockstore
+            .set_dead_slot(slot)
+            .expect("Failed to mark slot as dead in blockstore");
+        Self::send_invalid_bank(bank, notifications.replay_vote_sender);
+        Self::notify_hard_dead_observers(slot, Some(parent_slot), err, notifications);
+    }
+
+    /// Persist and publish a hard-dead slot when the replay bank has already
+    /// been cleared. This is used only while promoting soft-dead state.
+    fn mark_hard_dead_slot_without_bank(
+        slot: Slot,
+        parent_slot: Option<Slot>,
+        err: String,
+        log_level: DeadSlotLogLevel,
+        progress: &mut ProgressMap,
+        notifications: &DeadSlotNotifications<'_>,
+    ) {
+        log_level.datapoint(slot, err.clone());
+        if let Some(progress) = progress.get_mut(&slot) {
+            progress.mark_dead(DeadSlotReason::Hard);
+        }
+        notifications
+            .blockstore
+            .set_dead_slot(slot)
+            .expect("Failed to mark completed soft-dead slot as dead");
+        Self::notify_hard_dead_observers(slot, parent_slot, err, notifications);
+    }
+
+    fn mark_hard_dead_slot(
+        bank: &Bank,
+        err: String,
+        log_level: DeadSlotLogLevel,
+        progress: &mut ProgressMap,
+        dead_slot_context: &mut DeadSlotContext<'_, '_>,
+    ) {
+        let slot = bank.slot();
+        Self::mark_hard_dead_slot_with_bank(
+            bank,
+            err,
+            log_level,
+            progress,
+            &dead_slot_context.notifications,
+        );
 
         if let Some(TowerBFTStructures {
             heaviest_subtree_fork_choice,
@@ -2660,7 +3034,7 @@ impl ReplayStage {
             duplicate_confirmed_slots,
             epoch_slots_frozen_slots,
             ..
-        }) = tbft_structs
+        }) = dead_slot_context.duplicate.tbft_structs
         {
             let dead_state = DeadState::new_from_state(
                 slot,
@@ -2671,20 +3045,26 @@ impl ReplayStage {
             );
             check_slot_agrees_with_cluster(
                 slot,
-                root,
-                blockstore,
+                dead_slot_context.duplicate.root,
+                dead_slot_context.notifications.blockstore,
                 duplicate_slots_tracker,
                 epoch_slots_frozen_slots,
                 heaviest_subtree_fork_choice,
-                duplicate_slots_to_repair,
-                ancestor_hashes_replay_update_sender,
-                purge_repair_slot_counter,
+                dead_slot_context.duplicate.duplicate_slots_to_repair,
+                dead_slot_context
+                    .duplicate
+                    .ancestor_hashes_replay_update_sender,
+                dead_slot_context.duplicate.purge_repair_slot_counter,
                 SlotStateUpdate::Dead(dead_state),
             );
 
             // If we previously marked this slot as duplicate in blockstore, let the state machine know
             if !duplicate_slots_tracker.contains(&slot)
-                && blockstore.get_duplicate_slot(slot).is_some()
+                && dead_slot_context
+                    .notifications
+                    .blockstore
+                    .get_duplicate_slot(slot)
+                    .is_some()
             {
                 let duplicate_state = DuplicateState::new_from_state(
                     slot,
@@ -2695,18 +3075,48 @@ impl ReplayStage {
                 );
                 check_slot_agrees_with_cluster(
                     slot,
-                    root,
-                    blockstore,
+                    dead_slot_context.duplicate.root,
+                    dead_slot_context.notifications.blockstore,
                     duplicate_slots_tracker,
                     epoch_slots_frozen_slots,
                     heaviest_subtree_fork_choice,
-                    duplicate_slots_to_repair,
-                    ancestor_hashes_replay_update_sender,
-                    purge_repair_slot_counter,
+                    dead_slot_context.duplicate.duplicate_slots_to_repair,
+                    dead_slot_context
+                        .duplicate
+                        .ancestor_hashes_replay_update_sender,
+                    dead_slot_context.duplicate.purge_repair_slot_counter,
                     SlotStateUpdate::Duplicate(duplicate_state),
                 );
             }
         }
+    }
+
+    /// Classify a replay failure as soft-dead or hard-dead and publish the
+    /// appropriate state transition.
+    fn mark_replay_dead_slot(
+        bank: &Bank,
+        err: &BlockstoreProcessorError,
+        progress: &mut ProgressMap,
+        dead_slot_context: &mut DeadSlotContext<'_, '_>,
+    ) {
+        if Self::should_soft_dead_for_update_parent(
+            dead_slot_context.notifications.blockstore,
+            bank,
+            err,
+            progress,
+            dead_slot_context.migration_status,
+        ) {
+            Self::mark_soft_dead_slot(bank, err, progress, &dead_slot_context.notifications);
+            return;
+        }
+
+        Self::mark_hard_dead_slot(
+            bank,
+            format!("error: {err:?}"),
+            DeadSlotLogLevel::for_replay_error(err),
+            progress,
+            dead_slot_context,
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2780,6 +3190,7 @@ impl ReplayStage {
                     .activated_slot(&agave_feature_set::alpenglow::id())
                 {
                     let migration_slot = migration_status.record_feature_activation(slot);
+                    blockstore.configure_block_markers_for_migration(migration_status);
                     datapoint_info!(
                         "migration-started",
                         ("migration_slot", migration_slot as i64, i64),
@@ -3330,15 +3741,20 @@ impl ReplayStage {
         // It's important that we do this here (after we have a bank) rather than failing
         // in generate_new_bank_forks, as we need a bank to mark as dead in order to kick off
         // ancestor hashes service / duplicate block repair.
-        match check_chained_block_id(&process_active_banks_context.blockstore, &bank) {
+        match check_chained_block_id(
+            &process_active_banks_context.blockstore,
+            &bank,
+            process_active_banks_context.migration_status.as_ref(),
+        ) {
             ChainedBlockIdCheck::Inactive | ChainedBlockIdCheck::Pass => (),
             ChainedBlockIdCheck::Unavailable => {
                 // Missing shred 0, can't replay anyway
                 return (replay_result, None);
             }
             ChainedBlockIdCheck::Mismatch => {
-                // Mismatch, mark dead and don't replay
-                replay_result.is_slot_dead = true;
+                // Mismatch, return a replay error so `process_replay_results`
+                // marks the bank hard-dead and publishes normal dead-slot
+                // notifications.
                 replay_result.replay_result =
                     Some(Err(BlockstoreProcessorError::ChainedBlockIdFailure(
                         bank.slot(),
@@ -3348,7 +3764,12 @@ impl ReplayStage {
             }
         }
 
-        if bank.leader_id() == my_pubkey {
+        if Self::should_skip_own_leader_replay(
+            process_active_banks_context.blockstore.as_ref(),
+            &bank,
+            my_pubkey,
+            process_active_banks_context.migration_status.as_ref(),
+        ) {
             return (replay_result, None);
         }
 
@@ -3364,6 +3785,28 @@ impl ReplayStage {
         replay_result.replay_result = Some(blockstore_result);
 
         (replay_result, Some(replay_blockstore_time.as_us()))
+    }
+
+    /// Live leader banks are executed by BankingStage/PoH and must not be replayed
+    /// from blockstore. Startup replay, however, has always replayed completed
+    /// own-leader slots from the ledger. In Alpenglow, a restarted validator may
+    /// repair one of its own completed leader blocks after startup; those banks are
+    /// created by replay with their tick height staged at the Alpentick boundary,
+    /// so they should follow the startup behavior and replay from blockstore.
+    fn should_skip_own_leader_replay(
+        blockstore: &Blockstore,
+        bank: &Bank,
+        my_pubkey: &Pubkey,
+        migration_status: &MigrationStatus,
+    ) -> bool {
+        if bank.leader_id() != my_pubkey {
+            return false;
+        }
+
+        !migration_status.should_use_alpenglow_leader_path(bank.slot())
+            || bank.is_complete()
+            || bank.tick_height() != bank.max_tick_height().saturating_sub(1)
+            || !blockstore.is_full(bank.slot())
     }
 
     fn replay_active_banks(
@@ -3462,22 +3905,84 @@ impl ReplayStage {
             if let Some(replay_result) = &replay_result.replay_result {
                 match replay_result {
                     Ok(replay_tx_count) => tx_count += replay_tx_count,
-                    Err(err) => {
-                        let root = bank_forks.read().unwrap().root();
-                        Self::mark_dead_slot(
-                            &process_active_banks_context.blockstore,
+                    Err(BlockstoreProcessorError::BlockComponentProcessor(
+                        BlockComponentProcessorError::AbandonedBank(update_parent),
+                    )) => {
+                        // Handle UpdateParent marker during fast leader handover.
+                        // The leader built on an optimistic parent that didn't match the
+                        // finalized parent.
+                        //
+                        // We clear the bank and remove the progress entry. The bank will be
+                        // recreated with the correct parent by generate_new_bank_forks, which
+                        // reads slot meta to determine both the new parent and the correct
+                        // replay offset (replay_fec_set_index).
+                        let new_parent_slot = match &update_parent {
+                            VersionedUpdateParent::V1(x) => x.new_parent_slot,
+                        };
+
+                        datapoint_info!(
+                            "replay-stage-update-parent",
+                            ("slot", bank_slot, i64),
+                            ("old_parent_slot", bank.parent_slot(), i64),
+                            ("new_parent_slot", new_parent_slot, i64),
+                        );
+
+                        info!(
+                            "AbandonedBank at slot {bank_slot}: switching parent from {} to \
+                             {new_parent_slot}",
+                            bank.parent_slot()
+                        );
+
+                        if !matches!(
+                            process_active_banks_context
+                                .blockstore
+                                .update_parent_replay_status(bank_slot, BlockLocation::Original)
+                                .expect("Blockstore operations must succeed"),
+                            UpdateParentReplayStatus::Ready
+                        ) {
+                            let root = bank_forks.read().unwrap().root();
+                            let mut dead_slot_context = process_active_banks_context
+                                .dead_slot_context(
+                                    root,
+                                    duplicate_slots_to_repair,
+                                    purge_repair_slot_counter,
+                                    &mut tbft_structs,
+                                );
+                            Self::mark_hard_dead_slot(
+                                bank,
+                                "error: replay abandoned bank for an unusable UpdateParent"
+                                    .to_string(),
+                                DeadSlotLogLevel::Error,
+                                progress,
+                                &mut dead_slot_context,
+                            );
+                            continue;
+                        }
+
+                        Self::send_invalid_bank(
                             bank,
-                            root,
-                            err,
-                            process_active_banks_context.rpc_subscriptions.as_deref(),
-                            process_active_banks_context.slot_status_notifier.as_ref(),
-                            progress,
-                            duplicate_slots_to_repair,
-                            &process_active_banks_context.ancestor_hashes_replay_update_sender,
-                            purge_repair_slot_counter,
-                            &mut tbft_structs,
                             &process_active_banks_context.replay_vote_sender,
                         );
+
+                        // Clear the bank from bank_forks. It will be recreated with the
+                        // correct parent by generate_new_bank_forks on the next iteration.
+                        Self::clear_bank_if_present(bank_forks.as_ref(), bank_slot);
+
+                        // Remove the progress entry. It will be recreated with the correct
+                        // num_shreds offset when generate_new_bank_forks creates the new bank.
+                        progress.remove(&bank_slot);
+
+                        continue;
+                    }
+                    Err(err) => {
+                        let root = bank_forks.read().unwrap().root();
+                        let mut dead_slot_context = process_active_banks_context.dead_slot_context(
+                            root,
+                            duplicate_slots_to_repair,
+                            purge_repair_slot_counter,
+                            &mut tbft_structs,
+                        );
+                        Self::mark_replay_dead_slot(bank, err, progress, &mut dead_slot_context);
                         // don't try to run the below logic to check if the bank is completed
                         continue;
                     }
@@ -3549,20 +4054,13 @@ impl ReplayStage {
                 );
                 if let Err(err) = replay_res.and(verify_res) {
                     let root = bank_forks.read().unwrap().root();
-                    Self::mark_dead_slot(
-                        &process_active_banks_context.blockstore,
-                        bank,
+                    let mut dead_slot_context = process_active_banks_context.dead_slot_context(
                         root,
-                        &err,
-                        process_active_banks_context.rpc_subscriptions.as_deref(),
-                        process_active_banks_context.slot_status_notifier.as_ref(),
-                        progress,
                         duplicate_slots_to_repair,
-                        &process_active_banks_context.ancestor_hashes_replay_update_sender,
                         purge_repair_slot_counter,
                         &mut tbft_structs,
-                        &process_active_banks_context.replay_vote_sender,
                     );
+                    Self::mark_replay_dead_slot(bank, &err, progress, &mut dead_slot_context);
                     // don't try to run the remaining normal processing for the completed bank
                     continue;
                 }
@@ -3620,23 +4118,21 @@ impl ReplayStage {
                     }
 
                     let root = bank_forks.read().unwrap().root();
-                    Self::mark_dead_slot(
-                        &process_active_banks_context.blockstore,
-                        bank,
+                    let mut dead_slot_context = process_active_banks_context.dead_slot_context(
                         root,
+                        duplicate_slots_to_repair,
+                        purge_repair_slot_counter,
+                        &mut tbft_structs,
+                    );
+                    Self::mark_replay_dead_slot(
+                        bank,
                         &BlockstoreProcessorError::BankHashMismatch(
                             bank_slot,
                             expected_hash,
                             computed_hash,
                         ),
-                        process_active_banks_context.rpc_subscriptions.as_deref(),
-                        process_active_banks_context.slot_status_notifier.as_ref(),
                         progress,
-                        duplicate_slots_to_repair,
-                        &process_active_banks_context.ancestor_hashes_replay_update_sender,
-                        purge_repair_slot_counter,
-                        &mut tbft_structs,
-                        &process_active_banks_context.replay_vote_sender,
+                        &mut dead_slot_context,
                     );
 
                     continue;
@@ -3667,6 +4163,7 @@ impl ReplayStage {
                 {
                     transaction_status_sender.send_transaction_status_freeze_message(bank);
                 }
+
                 // report cost tracker stats
                 process_active_banks_context
                     .cost_update_sender
@@ -3679,6 +4176,7 @@ impl ReplayStage {
                     });
 
                 assert_ne!(bank.hash(), Hash::default());
+
                 bank_progress.fork_stats.bank_hash = Some(bank.hash());
                 if let Some(TowerBFTStructures {
                     heaviest_subtree_fork_choice,
@@ -3892,6 +4390,126 @@ impl ReplayStage {
             &replay_result_vec,
             my_pubkey,
         )
+    }
+
+    /// Fast leader handover: if we're going to be the next leader, and our leader window
+    /// starts on the next slot, then send the bank through the optimistic parent channel.
+    fn maybe_notify_of_optimistic_parent(
+        bank: &Arc<Bank>,
+        my_pubkey: &Pubkey,
+        leader_schedule_cache: &LeaderScheduleCache,
+        optimistic_parent_sender: &Sender<LeaderWindowInfo>,
+        optimistic_parent_latest_receiver: &Receiver<LeaderWindowInfo>,
+    ) {
+        let next_slot = bank.slot().saturating_add(1);
+
+        let is_next_leader = leader_schedule_cache
+            .slot_leader_at(next_slot, Some(bank))
+            .is_some_and(|leader| &leader.id == my_pubkey);
+
+        if !is_next_leader {
+            return;
+        }
+
+        if next_slot != first_of_consecutive_leader_slots(next_slot) {
+            return;
+        }
+
+        // TODO(ksn): if the leader has, e.g., two consecutive leader windows, this line here
+        // prevents fast leader handover from the first leader window to the second. This is because
+        // the block id is only computed after shredding a block, which occurs in broadcast, which
+        // happens after replay. This function, on the other hand, is invoked prior to replay.
+        //
+        // To address this, we should additionally add in an optimistic parent channel that goes
+        // from broadcast to replay.
+        let Some(block_id) = bank.block_id() else {
+            return;
+        };
+
+        let end_slot = next_slot.saturating_add(NUM_CONSECUTIVE_LEADER_SLOTS - 1);
+        let leader_window_info = LeaderWindowInfo {
+            start_slot: next_slot,
+            end_slot,
+            parent_block: (bank.slot(), block_id),
+            block_timer: Instant::now(),
+        };
+
+        Self::try_send_latest_optimistic_parent(
+            optimistic_parent_sender,
+            optimistic_parent_latest_receiver,
+            leader_window_info,
+        );
+    }
+
+    /// Publish an optimistic-parent notification without letting the bounded
+    /// channel preserve stale windows.
+    ///
+    /// If the channel is full, replay drains any queued notifications, keeps the
+    /// freshest window by start slot, and attempts to enqueue only that one.
+    fn try_send_latest_optimistic_parent(
+        optimistic_parent_sender: &Sender<LeaderWindowInfo>,
+        optimistic_parent_latest_receiver: &Receiver<LeaderWindowInfo>,
+        leader_window_info: LeaderWindowInfo,
+    ) {
+        let start_slot = leader_window_info.start_slot;
+        let end_slot = leader_window_info.end_slot;
+
+        match optimistic_parent_sender.try_send(leader_window_info) {
+            Ok(()) => {}
+            Err(TrySendError::Full(leader_window_info)) => {
+                let mut latest = None;
+                let mut queued_count = 0;
+                for queued_info in optimistic_parent_latest_receiver.try_iter() {
+                    queued_count += 1;
+                    latest = Some(match latest {
+                        Some(current) => freshest_leader_window(current, queued_info),
+                        None => queued_info,
+                    });
+                }
+                let latest = match latest {
+                    Some(current) => freshest_leader_window(current, leader_window_info),
+                    None => leader_window_info,
+                };
+                let latest_start_slot = latest.start_slot;
+                let latest_end_slot = latest.end_slot;
+                let result = optimistic_parent_sender.try_send(latest);
+                let dropped_new = usize::from(result.is_err());
+                let dropped = queued_count + dropped_new;
+
+                if dropped > 0 {
+                    datapoint_info!(
+                        "replay_stage-optimistic_parent_notification_dropped",
+                        ("start_slot", start_slot, i64),
+                        ("end_slot", end_slot, i64),
+                        ("latest_start_slot", latest_start_slot, i64),
+                        ("latest_end_slot", latest_end_slot, i64),
+                        ("dropped_count", dropped, i64),
+                    );
+                }
+
+                match result {
+                    Ok(()) => {}
+                    Err(TrySendError::Full(_)) => {
+                        trace!(
+                            "optimistic_parent_sender remained full after draining {queued_count} \
+                             stale notifications for window {start_slot}-{end_slot}"
+                        );
+                    }
+                    Err(TrySendError::Disconnected(_)) => {
+                        trace!(
+                            "optimistic_parent_sender disconnected while sending window \
+                             {start_slot}-{end_slot}"
+                        );
+                    }
+                }
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                trace!(
+                    "optimistic_parent_sender disconnected while sending window \
+                     {start_slot}-{end_slot}"
+                );
+            }
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -4592,16 +5210,274 @@ impl ReplayStage {
         );
     }
 
-    fn generate_new_bank_forks(
+    /// Verify an UpdateParent signal still matches the parent metadata persisted
+    /// in blockstore before clearing any replay state.
+    fn update_parent_signal_matches_slot_meta(
         blockstore: &Blockstore,
-        bank_forks: &RwLock<BankForks>,
-        leader_schedule_cache: &Arc<LeaderScheduleCache>,
-        rpc_subscriptions: Option<&RpcSubscriptions>,
-        slot_status_notifier: &Option<SlotStatusNotifier>,
+        signal: &UpdateParentSignal,
+    ) -> bool {
+        let Some(slot_meta) = blockstore
+            .meta(signal.slot)
+            .expect("Blockstore should not fail")
+        else {
+            return false;
+        };
+
+        slot_meta.parent_slot == Some(signal.parent_slot)
+            && slot_meta.parent_block_id == signal.parent_block_id
+            && slot_meta.replay_fec_set_index == signal.replay_fec_set_index
+            && slot_meta.has_update_parent()
+    }
+
+    /// Only live slots and UpdateParent-recoverable soft-dead slots may be
+    /// restarted from an UpdateParent marker.
+    fn update_parent_can_clear_progress_dead_state(progress: Option<&ForkProgress>) -> bool {
+        let Some(progress) = progress else {
+            return true;
+        };
+        if !progress.is_dead {
+            return true;
+        }
+        matches!(
+            progress.dead_reason,
+            Some(DeadSlotReason::ReplayFailureBeforeUpdateParent)
+        )
+    }
+
+    /// Remove a replay bank if it still exists, finishing deferred cleanup after
+    /// releasing the `BankForks` write lock.
+    fn clear_bank_if_present(bank_forks: &RwLock<BankForks>, slot: Slot) -> bool {
+        let clear_bank_cleanup = {
+            let mut bank_forks = bank_forks.write().unwrap();
+            if bank_forks.get(slot).is_some() {
+                Some(bank_forks.clear_bank(slot, false))
+            } else {
+                None
+            }
+        };
+        if let Some(clear_bank_cleanup) = clear_bank_cleanup {
+            clear_bank_cleanup.finish();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Clear an in-progress bank so the next replay iteration recreates it from
+    /// the UpdateParent parent and FEC-set offset recorded in `SlotMeta`.
+    fn restart_slot_from_update_parent(
+        ctx: &UpdateParentReplayContext<'_>,
+        progress: &mut ProgressMap,
+        signal: &UpdateParentSignal,
+        source: &str,
+    ) -> bool {
+        if !ctx.migration_status.should_allow_update_parent(signal.slot) {
+            return false;
+        }
+        if ctx.blockstore.is_dead(signal.slot) {
+            return false;
+        }
+        if !Self::update_parent_signal_matches_slot_meta(ctx.blockstore, signal) {
+            return false;
+        }
+        match ctx
+            .blockstore
+            .update_parent_replay_status(signal.slot, BlockLocation::Original)
+            .expect("Blockstore operations must succeed")
+        {
+            UpdateParentReplayStatus::Ready => {}
+            UpdateParentReplayStatus::Unavailable | UpdateParentReplayStatus::Invalid => {
+                return false;
+            }
+        }
+
+        // Skip if neither replay bank nor progress exists. If progress exists
+        // without a bank, clear it as stale state so the next replay iteration
+        // can recreate the bank from the updated SlotMeta.
+        let bank = ctx.bank_forks.read().unwrap().get(signal.slot);
+        if bank.is_none() && !progress.contains_key(&signal.slot) {
+            return false;
+        }
+        if bank.as_ref().is_some_and(|bank| {
+            Self::should_skip_own_leader_replay(
+                ctx.blockstore,
+                bank,
+                &ctx.my_pubkey,
+                ctx.migration_status,
+            )
+        }) {
+            return false;
+        }
+
+        let replay_fec_set_index = u64::from(signal.replay_fec_set_index);
+        if !Self::update_parent_can_clear_progress_dead_state(progress.get(&signal.slot)) {
+            return false;
+        }
+
+        // Check if we've already replayed past the UpdateParent marker.
+        let current_num_shreds = progress
+            .get(&signal.slot)
+            .map(|p| p.replay_progress.read().unwrap().num_shreds)
+            .unwrap_or(0);
+
+        if current_num_shreds >= replay_fec_set_index {
+            return false;
+        }
+
+        // Clear and let generate_new_bank_forks restart from replay_fec_set_index.
+        info!(
+            "{}: restarting slot {} from replay_fec_set_index {} via {} (was at {} shreds)",
+            ctx.my_pubkey, signal.slot, replay_fec_set_index, source, current_num_shreds
+        );
+        progress.remove(&signal.slot);
+        if let Some(bank) = bank {
+            Self::send_invalid_bank(&bank, ctx.replay_vote_sender);
+            Self::clear_bank_if_present(ctx.bank_forks, signal.slot);
+        }
+        Self::send_clear_soft_dead_slot(ctx.soft_dead_slot_sender, signal.slot);
+        true
+    }
+
+    /// Revisit soft-dead slots as more shreds arrive.
+    ///
+    /// If an UpdateParent marker is now visible in SlotMeta, replay is restarted
+    /// from the marker's FEC set. If the slot completes without a marker, the
+    /// soft-dead state is promoted to a durable hard-dead slot.
+    fn process_soft_dead_update_parent_slots(
+        ctx: &UpdateParentReplayContext<'_>,
+        progress: &mut ProgressMap,
+    ) {
+        let notifications = ctx.dead_slot_notifications();
+        let soft_dead_slots = progress
+            .iter()
+            .filter_map(|(&slot, progress)| {
+                matches!(
+                    progress.dead_reason,
+                    Some(DeadSlotReason::ReplayFailureBeforeUpdateParent)
+                )
+                .then_some(slot)
+            })
+            .collect_vec();
+
+        for slot in soft_dead_slots {
+            if ctx.blockstore.is_dead(slot) {
+                if let Some(progress) = progress.get_mut(&slot) {
+                    progress.mark_dead(DeadSlotReason::Hard);
+                }
+                Self::send_clear_soft_dead_slot(ctx.soft_dead_slot_sender, slot);
+                continue;
+            }
+
+            let Some(slot_meta) = ctx
+                .blockstore
+                .meta(slot)
+                .expect("Blockstore should not fail")
+            else {
+                continue;
+            };
+            let update_parent_replay_status = if slot_meta.has_update_parent() {
+                ctx.blockstore
+                    .update_parent_replay_status(slot, BlockLocation::Original)
+                    .expect("Blockstore operations must succeed")
+            } else {
+                UpdateParentReplayStatus::Unavailable
+            };
+
+            if matches!(update_parent_replay_status, UpdateParentReplayStatus::Ready) {
+                if let Some(parent_slot) = slot_meta.parent_slot {
+                    let signal = UpdateParentSignal {
+                        slot,
+                        parent_slot,
+                        parent_block_id: slot_meta.parent_block_id,
+                        replay_fec_set_index: slot_meta.replay_fec_set_index,
+                    };
+                    Self::restart_slot_from_update_parent(ctx, progress, &signal, "soft-dead scan");
+                }
+                continue;
+            }
+
+            if matches!(
+                update_parent_replay_status,
+                UpdateParentReplayStatus::Invalid
+            ) || slot_meta.is_full()
+            {
+                if !matches!(
+                    progress.dead_reason(slot),
+                    Some(DeadSlotReason::ReplayFailureBeforeUpdateParent)
+                ) {
+                    continue;
+                }
+                let invalid_update_parent = matches!(
+                    update_parent_replay_status,
+                    UpdateParentReplayStatus::Invalid
+                );
+                let (err, log_level) = if invalid_update_parent {
+                    (
+                        "error: replay failed before UpdateParent, and the UpdateParent/header \
+                         metadata is invalid"
+                            .to_string(),
+                        DeadSlotLogLevel::Error,
+                    )
+                } else {
+                    (
+                        "error: replay failed before a usable UpdateParent marker, and the \
+                         completed slot cannot replay from UpdateParent"
+                            .to_string(),
+                        DeadSlotLogLevel::Info,
+                    )
+                };
+                let bank = ctx.bank_forks.read().unwrap().get(slot);
+                if let Some(bank) = bank {
+                    Self::mark_hard_dead_slot_with_bank(
+                        &bank,
+                        err,
+                        log_level,
+                        progress,
+                        &notifications,
+                    );
+                } else {
+                    Self::mark_hard_dead_slot_without_bank(
+                        slot,
+                        slot_meta.parent_slot,
+                        err,
+                        log_level,
+                        progress,
+                        &notifications,
+                    );
+                }
+                Self::send_clear_soft_dead_slot(ctx.soft_dead_slot_sender, slot);
+            }
+        }
+    }
+
+    /// Handles UpdateParent signals by clearing slot state so replay restarts from
+    /// the new parent. Skips live own-leader banks, slots replay has not started,
+    /// and slots that already replayed past the UpdateParent marker.
+    fn interrupt_update_parent_slots(
+        ctx: &UpdateParentReplayContext<'_>,
+        progress: &mut ProgressMap,
+        update_parent_receiver: &UpdateParentReceiver,
+    ) {
+        while let Ok(signal) = update_parent_receiver.try_recv() {
+            Self::restart_slot_from_update_parent(ctx, progress, &signal, "UpdateParent signal");
+        }
+    }
+
+    fn generate_new_bank_forks(
+        ctx: NewBankForksContext<'_>,
         progress: &mut ProgressMap,
         replay_timing: &mut ReplayLoopTiming,
-        migration_status: &MigrationStatus,
     ) {
+        let NewBankForksContext {
+            blockstore,
+            bank_forks,
+            leader_schedule_cache,
+            rpc_subscriptions,
+            slot_status_notifier,
+            migration_status,
+            my_pubkey,
+        } = ctx;
+
         // Find the next slot that chains to the old slot
         let mut generate_new_bank_forks_read_lock =
             Measure::start("generate_new_bank_forks_read_lock");
@@ -4649,9 +5525,101 @@ impl ReplayStage {
                     trace!("child already active or frozen {child_slot}");
                     continue;
                 }
+
+                debug_assert!(!progress.contains_key(&child_slot));
+
+                let mut child_slot_is_full = false;
+                let mut invalid_update_parent = false;
+                // Determine replay offset from slot meta.
+                let replay_offset = if !migration_status.should_allow_update_parent(child_slot) {
+                    None
+                } else {
+                    let Some(slot_meta) = blockstore
+                        .meta(child_slot)
+                        .expect("Blockstore should not fail")
+                    else {
+                        continue;
+                    };
+                    child_slot_is_full = slot_meta.is_full();
+
+                    // No lock is held between get_slots_since and fetching the slot meta, so
+                    // SlotMeta could have been updated in between. If so, continue and
+                    // the next iteration of generate_new_bank_forks will have consistent values.
+                    if slot_meta.parent_slot != Some(parent_slot) {
+                        continue;
+                    }
+
+                    if Some(slot_meta.parent_block_id) != parent_bank.block_id()
+                        // Genesis doesn't have a block id
+                        && parent_slot != 0
+                    {
+                        // error!(
+                        //     "We have the wrong block in {parent_slot}, expecting {:?} have {:?}. \
+                        //      Deferring replay",
+                        //     slot_meta.parent_block_id,
+                        //     parent_bank.block_id()
+                        // );
+                        // There were duplicate blocks in this slot and we have the wrong one replayed
+                        // Do not continue down this fork
+                        // If this fork ends up being ParentReady, then votor will take care of repairing
+                        // the duplicate parent block and performing the switch for us to continue replay.
+                        continue;
+                    }
+
+                    let num_shreds = u64::from(slot_meta.replay_fec_set_index);
+                    if slot_meta.has_update_parent() {
+                        match blockstore
+                            .update_parent_replay_status(child_slot, BlockLocation::Original)
+                            .expect("Blockstore operations must succeed")
+                        {
+                            UpdateParentReplayStatus::Ready => {
+                                info!(
+                                    "slot {child_slot}: replay offset {} shreds from parent {:?}",
+                                    num_shreds, slot_meta.parent_slot
+                                );
+                                Some(num_shreds)
+                            }
+                            UpdateParentReplayStatus::Unavailable => {
+                                trace!(
+                                    "slot {child_slot}: deferring bank creation until a \
+                                     compatible UpdateParent block header is available"
+                                );
+                                continue;
+                            }
+                            UpdateParentReplayStatus::Invalid => {
+                                invalid_update_parent = true;
+                                warn!(
+                                    "slot {child_slot}: creating replay bank from the start to \
+                                     hard-dead invalid UpdateParent metadata"
+                                );
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    }
+                };
+
                 let leader = leader_schedule_cache
                     .slot_leader_at(child_slot, Some(parent_bank))
                     .unwrap();
+
+                // In Alpenglow, BCL owns live bank creation for our own in-progress leader slots.
+                // After restart or catch-up, however, a fully repaired own leader block may only
+                // exist in blockstore; replay must create that bank so the validator can catch up
+                // to its own completed block.
+                if migration_status.should_use_alpenglow_leader_path(child_slot)
+                    && leader.id == *my_pubkey
+                    && !child_slot_is_full
+                    && !invalid_update_parent
+                {
+                    trace!(
+                        "skipping replay bank creation for in-progress own leader slot \
+                         {child_slot}"
+                    );
+                    continue;
+                }
+
                 info!("new fork:{child_slot} parent:{parent_slot} root:{root}",);
                 // Migration period banks are VoM
                 let options = NewBankOptions {
@@ -4670,6 +5638,25 @@ impl ReplayStage {
                     options,
                 );
                 blockstore_processor::set_alpenglow_ticks(&child_bank, migration_status);
+
+                if let Some(num_shreds) = replay_offset {
+                    let prev_leader_slot = progress.get_bank_prev_leader_slot(&child_bank);
+                    let fork_progress = ForkProgress::new(
+                        parent_bank.last_blockhash(),
+                        prev_leader_slot,
+                        None,
+                        0,
+                        0,
+                        None,
+                    );
+                    {
+                        let mut replay_progress = fork_progress.replay_progress.write().unwrap();
+                        replay_progress.num_shreds = num_shreds;
+                        replay_progress.replay_starts_at_update_parent = true;
+                    }
+                    progress.insert(child_slot, fork_progress);
+                }
+
                 let empty: Vec<Pubkey> = vec![];
                 Self::update_fork_propagated_threshold_from_votes(
                     progress,
@@ -4685,17 +5672,23 @@ impl ReplayStage {
 
         let mut generate_new_bank_forks_write_lock =
             Measure::start("generate_new_bank_forks_write_lock");
+
         if !new_banks.is_empty() {
             let mut forks = bank_forks.write().unwrap();
             let root = forks.root();
             for (slot, bank) in new_banks {
                 if slot < root {
+                    progress.remove(&slot);
                     continue;
                 }
                 if forks.get(slot).is_some() {
+                    // BCL can race us after `known_bank_slots` is captured. If BCL won and
+                    // inserted the bank, discard any replay progress we staged for this slot.
+                    progress.remove(&slot);
                     continue;
                 }
                 if forks.get(bank.parent_slot()).is_none() {
+                    progress.remove(&slot);
                     continue;
                 }
                 forks.insert(bank);
@@ -4813,24 +5806,33 @@ pub(crate) mod tests {
             replay_stage::ReplayStage,
             vote_simulator::{self, VoteSimulator},
         },
+        agave_votor_messages::consensus_message::{Certificate, CertificateType},
         blockstore_processor::{
             ConfirmationProgress, ProcessOptions, confirm_full_slot,
             fill_blockstore_slot_with_ticks, process_bank_0,
         },
-        crossbeam_channel::unbounded,
+        crossbeam_channel::{bounded, unbounded},
         itertools::Itertools,
         solana_account::{ReadableAccount, state_traits::StateMut},
         solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_client::connection_cache::ConnectionCache,
         solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
-        solana_entry::entry::{self, Entry},
+        solana_entry::{
+            block_component::{
+                BlockComponent, BlockFooterV1, BlockHeaderV1, UpdateParentV1, VersionedBlockMarker,
+            },
+            entry::{self, Entry},
+        },
         solana_genesis_config as genesis_config,
         solana_gossip::{crds::Cursor, node::Node},
         solana_hash::Hash,
         solana_instruction::error::InstructionError,
         solana_keypair::Keypair,
         solana_ledger::{
-            blockstore::{BlockstoreError, entries_to_test_shreds, make_slot_entries},
+            blockstore::{
+                BlockstoreError, UpdateParentSignal, entries_to_test_shreds, make_slot_entries,
+            },
             create_new_tmp_ledger,
             genesis_utils::{create_genesis_config, create_genesis_config_with_leader},
             get_tmp_ledger_path, get_tmp_ledger_path_auto_delete,
@@ -4869,6 +5871,154 @@ pub(crate) mod tests {
         test_case::test_case,
         trees::{Tree, tr},
     };
+
+    fn post_migration_status_for_tests() -> MigrationStatus {
+        let migration_status = MigrationStatus::default();
+        migration_status.record_feature_activation(0);
+        let genesis_block = (0, Hash::default());
+        let genesis_certificate = Arc::new(Certificate {
+            cert_type: CertificateType::Genesis(genesis_block.0, genesis_block.1),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        });
+        migration_status.set_genesis_block(genesis_block);
+        migration_status.set_genesis_certificate(genesis_certificate);
+        migration_status.enable_alpenglow_during_startup();
+        migration_status
+    }
+
+    fn enable_block_markers_for_tests(blockstore: &Blockstore) {
+        blockstore.set_block_markers_enabled(true);
+        blockstore.set_update_parent_enabled_from_slot(Some(0));
+    }
+
+    fn update_parent_replay_context<'a>(
+        my_pubkey: Pubkey,
+        blockstore: &'a Blockstore,
+        bank_forks: &'a RwLock<BankForks>,
+        replay_vote_sender: &'a ReplayVoteSender,
+        soft_dead_slot_sender: &'a SoftDeadSlotSender,
+        migration_status: &'a MigrationStatus,
+    ) -> UpdateParentReplayContext<'a> {
+        UpdateParentReplayContext {
+            my_pubkey,
+            blockstore,
+            bank_forks,
+            rpc_subscriptions: None,
+            slot_status_notifier: None,
+            replay_vote_sender,
+            soft_dead_slot_sender,
+            migration_status,
+        }
+    }
+
+    fn block_marker_shreds(
+        slot: Slot,
+        shred_parent_slot: Slot,
+        marker: VersionedBlockMarker,
+        shred_index: u32,
+    ) -> Vec<Shred> {
+        let component = BlockComponent::new_block_marker(marker);
+        Shredder::new(slot, shred_parent_slot, 0, 0)
+            .unwrap()
+            .make_merkle_shreds_from_component(
+                &Keypair::new(),
+                &component,
+                false,
+                Hash::new_unique(),
+                shred_index,
+                shred_index,
+                &ReedSolomonCache::default(),
+                &mut ProcessShredsStats::default(),
+            )
+            .collect()
+    }
+
+    fn insert_update_parent_slot(
+        blockstore: &Blockstore,
+        slot: Slot,
+        block_header_parent_slot: Slot,
+        update_parent_slot: Slot,
+        update_parent_block_id: Hash,
+        replay_fec_set_index: u32,
+    ) {
+        let header = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+            parent_slot: block_header_parent_slot,
+            parent_block_id: Hash::new_unique(),
+        });
+        let update_parent = VersionedBlockMarker::new_update_parent(UpdateParentV1 {
+            new_parent_slot: update_parent_slot,
+            new_parent_block_id: update_parent_block_id,
+        });
+        let mut shreds = block_marker_shreds(slot, block_header_parent_slot, header, 0);
+        shreds.extend(block_marker_shreds(
+            slot,
+            block_header_parent_slot,
+            update_parent,
+            replay_fec_set_index,
+        ));
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+    }
+
+    fn insert_bad_header_update_parent_slot(
+        blockstore: &Blockstore,
+        slot: Slot,
+        shred_parent_slot: Slot,
+        update_parent_slot: Slot,
+        update_parent_block_id: Hash,
+        replay_fec_set_index: u32,
+    ) {
+        let footer = VersionedBlockMarker::new_block_footer(BlockFooterV1 {
+            bank_hash: Hash::new_unique(),
+            block_producer_time_nanos: 0,
+            block_user_agent: vec![],
+            final_cert: None,
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        });
+        let update_parent = VersionedBlockMarker::new_update_parent(UpdateParentV1 {
+            new_parent_slot: update_parent_slot,
+            new_parent_block_id: update_parent_block_id,
+        });
+        let mut shreds = block_marker_shreds(slot, shred_parent_slot, footer, 0);
+        shreds.extend(block_marker_shreds(
+            slot,
+            shred_parent_slot,
+            update_parent,
+            replay_fec_set_index,
+        ));
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+    }
+
+    /// Build the minimal dead-slot context needed by focused replay tests.
+    fn dead_slot_context_for_tests<'a, 'b>(
+        blockstore: &'a Blockstore,
+        replay_vote_sender: &'a ReplayVoteSender,
+        ancestor_hashes_replay_update_sender: &'a AncestorHashesReplayUpdateSender,
+        duplicate_slots_to_repair: &'a mut DuplicateSlotsToRepair,
+        purge_repair_slot_counter: &'a mut PurgeRepairSlotCounter,
+        tbft_structs: &'a mut Option<&'b mut TowerBFTStructures>,
+        migration_status: &'a MigrationStatus,
+        soft_dead_slot_sender: Option<&'a SoftDeadSlotSender>,
+    ) -> DeadSlotContext<'a, 'b> {
+        DeadSlotContext {
+            notifications: DeadSlotNotifications {
+                blockstore,
+                rpc_subscriptions: None,
+                slot_status_notifier: None,
+                replay_vote_sender,
+                soft_dead_slot_sender,
+            },
+            duplicate: DeadSlotDuplicateContext {
+                root: 0,
+                duplicate_slots_to_repair,
+                ancestor_hashes_replay_update_sender,
+                purge_repair_slot_counter,
+                tbft_structs,
+            },
+            migration_status,
+        }
+    }
 
     #[test]
     fn test_is_partition_detected() {
@@ -5045,14 +6195,17 @@ pub(crate) mod tests {
         );
         let mut replay_timing = ReplayLoopTiming::default();
         ReplayStage::generate_new_bank_forks(
-            &blockstore,
-            &bank_forks,
-            &leader_schedule_cache,
-            rpc_subscriptions.as_deref(),
-            &None,
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: rpc_subscriptions.as_deref(),
+                slot_status_notifier: &None,
+                migration_status: &MigrationStatus::default(),
+                my_pubkey: &Pubkey::default(),
+            },
             &mut progress,
             &mut replay_timing,
-            &MigrationStatus::default(),
         );
         assert!(
             bank_forks
@@ -5074,14 +6227,17 @@ pub(crate) mod tests {
                 .is_none()
         );
         ReplayStage::generate_new_bank_forks(
-            &blockstore,
-            &bank_forks,
-            &leader_schedule_cache,
-            rpc_subscriptions.as_deref(),
-            &None,
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: rpc_subscriptions.as_deref(),
+                slot_status_notifier: &None,
+                migration_status: &MigrationStatus::default(),
+                my_pubkey: &Pubkey::default(),
+            },
             &mut progress,
             &mut replay_timing,
-            &MigrationStatus::default(),
         );
         assert!(
             bank_forks
@@ -5690,6 +6846,246 @@ pub(crate) mod tests {
         do_test_dead_slot_on_complete_bank(CompleteBankFailure::VerifyError);
     }
 
+    #[test]
+    fn test_cmr_mismatch_hard_dead() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let bank = bank_forks.read().unwrap().get(slot).unwrap();
+        progress.insert(
+            slot,
+            ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None),
+        );
+
+        let (replay_vote_sender, replay_vote_receiver) = unbounded();
+        let process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
+            bank_forks.clone(),
+            blockstore.clone(),
+            replay_vote_sender,
+        );
+        let replay_result = ReplaySlotFromBlockstore {
+            is_slot_dead: false,
+            bank_slot: slot,
+            replay_result: Some(Err(BlockstoreProcessorError::ChainedBlockIdFailure(
+                slot, 0,
+            ))),
+        };
+
+        ReplayStage::process_replay_results(
+            &process_active_banks_context,
+            &mut progress,
+            &mut Vec::new(),
+            &mut LatestValidatorVotesForFrozenBanks::default(),
+            &mut DuplicateSlotsToRepair::default(),
+            &mut PurgeRepairSlotCounter::default(),
+            None,
+            &[replay_result],
+            &Pubkey::new_unique(),
+        );
+
+        assert!(blockstore.is_dead(slot));
+        assert_eq!(progress.dead_reason(slot), Some(&DeadSlotReason::Hard));
+        assert_eq!(
+            replay_vote_receiver.try_recv(),
+            Ok(ReplayVoteMessage::InvalidBank {
+                replay_bank_id: bank.bank_id(),
+                replay_slot: slot,
+            })
+        );
+    }
+
+    #[test]
+    fn test_abandon_invalidates() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 4;
+        let parent_block_id = Hash::default();
+        enable_block_markers_for_tests(&blockstore);
+        insert_update_parent_slot(&blockstore, slot, 3, 0, parent_block_id, 32);
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+        let bank = Bank::new_from_parent(bank0, SlotLeader::default(), slot);
+        bank_forks.write().unwrap().insert(bank);
+        let bank = bank_forks.read().unwrap().get(slot).unwrap();
+        progress.insert(
+            slot,
+            ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None),
+        );
+
+        let (replay_vote_sender, replay_vote_receiver) = unbounded();
+        let process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
+            bank_forks.clone(),
+            blockstore,
+            replay_vote_sender,
+        );
+        let update_parent =
+            VersionedUpdateParent::V1(solana_entry::block_component::UpdateParentV1 {
+                new_parent_slot: 0,
+                new_parent_block_id: Hash::default(),
+            });
+        let replay_result = ReplaySlotFromBlockstore {
+            is_slot_dead: false,
+            bank_slot: slot,
+            replay_result: Some(Err(BlockstoreProcessorError::BlockComponentProcessor(
+                BlockComponentProcessorError::AbandonedBank(update_parent),
+            ))),
+        };
+
+        ReplayStage::process_replay_results(
+            &process_active_banks_context,
+            &mut progress,
+            &mut Vec::new(),
+            &mut LatestValidatorVotesForFrozenBanks::default(),
+            &mut DuplicateSlotsToRepair::default(),
+            &mut PurgeRepairSlotCounter::default(),
+            None,
+            &[replay_result],
+            &Pubkey::new_unique(),
+        );
+
+        assert!(progress.get(&slot).is_none());
+        assert!(bank_forks.read().unwrap().get(slot).is_none());
+        assert_eq!(
+            replay_vote_receiver.try_recv(),
+            Ok(ReplayVoteMessage::InvalidBank {
+                replay_bank_id: bank.bank_id(),
+                replay_slot: slot,
+            })
+        );
+    }
+
+    #[test]
+    fn test_abandon_invalid_hard_dead() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            leader_schedule_cache,
+            my_pubkey,
+            ..
+        } = replay_blockstore_components(
+            Some(tr(0) / tr(1) / tr(2) / tr(3)),
+            1,
+            None::<GenerateVotes>,
+        );
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 4;
+        let header_parent_slot = 3;
+        let bank3 = bank_forks.read().unwrap().get(header_parent_slot).unwrap();
+        let header_parent_block_id = bank3.block_id().unwrap();
+        enable_block_markers_for_tests(&blockstore);
+        blockstore
+            .insert_shreds(
+                block_marker_shreds(
+                    slot,
+                    header_parent_slot,
+                    VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+                        parent_slot: header_parent_slot,
+                        parent_block_id: header_parent_block_id,
+                    }),
+                    0,
+                ),
+                None,
+                true,
+            )
+            .unwrap();
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.parent_slot = Some(header_parent_slot);
+        meta.parent_block_id = header_parent_block_id;
+        meta.replay_fec_set_index = 32;
+        blockstore.put_meta(slot, &meta).unwrap();
+
+        let mut replay_timing = ReplayLoopTiming::default();
+        ReplayStage::generate_new_bank_forks(
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: None,
+                slot_status_notifier: &None,
+                migration_status: &post_migration_status_for_tests(),
+                my_pubkey: &my_pubkey,
+            },
+            &mut progress,
+            &mut replay_timing,
+        );
+        let bank = bank_forks.read().unwrap().get(slot).unwrap();
+        progress.insert(
+            slot,
+            ForkProgress::new(
+                bank.last_blockhash(),
+                Some(header_parent_slot),
+                None,
+                0,
+                0,
+                None,
+            ),
+        );
+
+        let (replay_vote_sender, replay_vote_receiver) = unbounded();
+        let process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
+            bank_forks.clone(),
+            blockstore.clone(),
+            replay_vote_sender,
+        );
+        let update_parent =
+            VersionedUpdateParent::V1(solana_entry::block_component::UpdateParentV1 {
+                new_parent_slot: header_parent_slot,
+                new_parent_block_id: header_parent_block_id,
+            });
+        let replay_result = ReplaySlotFromBlockstore {
+            is_slot_dead: false,
+            bank_slot: slot,
+            replay_result: Some(Err(BlockstoreProcessorError::BlockComponentProcessor(
+                BlockComponentProcessorError::AbandonedBank(update_parent),
+            ))),
+        };
+
+        ReplayStage::process_replay_results(
+            &process_active_banks_context,
+            &mut progress,
+            &mut Vec::new(),
+            &mut LatestValidatorVotesForFrozenBanks::default(),
+            &mut DuplicateSlotsToRepair::default(),
+            &mut PurgeRepairSlotCounter::default(),
+            None,
+            &[replay_result],
+            &Pubkey::new_unique(),
+        );
+
+        assert!(blockstore.is_dead(slot));
+        assert_eq!(progress.dead_reason(slot), Some(&DeadSlotReason::Hard));
+        assert_eq!(
+            replay_vote_receiver.try_recv(),
+            Ok(ReplayVoteMessage::InvalidBank {
+                replay_bank_id: bank.bank_id(),
+                replay_slot: slot,
+            })
+        );
+        assert!(bank_forks.read().unwrap().get(slot).is_some());
+    }
+
     // Given a shred and a fatal expected error, check that replaying that shred causes causes the fork to be
     // marked as dead. Returns the error for caller to verify.
     fn check_dead_fork<F>(shred_to_insert: F) -> result::Result<(), BlockstoreProcessorError>
@@ -5778,19 +7174,32 @@ pub(crate) mod tests {
             let rpc_subscriptions = Some(rpc_subscriptions);
 
             if let Err(err) = &res {
-                ReplayStage::mark_dead_slot(
-                    &blockstore,
+                let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
+                let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
+                let mut tbft_structs = Some(&mut tbft_structs);
+                let mut dead_slot_context = DeadSlotContext {
+                    notifications: DeadSlotNotifications {
+                        blockstore: &blockstore,
+                        rpc_subscriptions: rpc_subscriptions.as_deref(),
+                        slot_status_notifier: slot_status_notifier.as_ref(),
+                        replay_vote_sender: &replay_vote_sender,
+                        soft_dead_slot_sender: None,
+                    },
+                    duplicate: DeadSlotDuplicateContext {
+                        root: 0,
+                        duplicate_slots_to_repair: &mut duplicate_slots_to_repair,
+                        ancestor_hashes_replay_update_sender: &process_active_banks_context
+                            .ancestor_hashes_replay_update_sender,
+                        purge_repair_slot_counter: &mut purge_repair_slot_counter,
+                        tbft_structs: &mut tbft_structs,
+                    },
+                    migration_status: process_active_banks_context.migration_status.as_ref(),
+                };
+                ReplayStage::mark_replay_dead_slot(
                     &bank1,
-                    0,
                     err,
-                    rpc_subscriptions.as_deref(),
-                    slot_status_notifier.as_ref(),
                     &mut progress,
-                    &mut DuplicateSlotsToRepair::default(),
-                    &process_active_banks_context.ancestor_hashes_replay_update_sender,
-                    &mut PurgeRepairSlotCounter::default(),
-                    &mut Some(&mut tbft_structs),
-                    &replay_vote_sender,
+                    &mut dead_slot_context,
                 );
             }
             assert_eq!(
@@ -7212,14 +8621,17 @@ pub(crate) mod tests {
 
         // 3 should now be an active bank
         ReplayStage::generate_new_bank_forks(
-            &blockstore,
-            &bank_forks,
-            &leader_schedule_cache,
-            rpc_subscriptions.as_deref(),
-            &None,
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: rpc_subscriptions.as_deref(),
+                slot_status_notifier: &None,
+                migration_status: &MigrationStatus::default(),
+                my_pubkey: &Pubkey::default(),
+            },
             &mut progress,
             &mut replay_timing,
-            &MigrationStatus::default(),
         );
         assert_eq!(bank_forks.read().unwrap().active_bank_slots(), vec![3]);
 
@@ -7242,14 +8654,17 @@ pub(crate) mod tests {
         }
         // 5 Should now be an active bank
         ReplayStage::generate_new_bank_forks(
-            &blockstore,
-            &bank_forks,
-            &leader_schedule_cache,
-            rpc_subscriptions.as_deref(),
-            &None,
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: rpc_subscriptions.as_deref(),
+                slot_status_notifier: &None,
+                migration_status: &MigrationStatus::default(),
+                my_pubkey: &Pubkey::default(),
+            },
             &mut progress,
             &mut replay_timing,
-            &MigrationStatus::default(),
         );
         assert_eq!(bank_forks.read().unwrap().active_bank_slots(), vec![5]);
 
@@ -7273,14 +8688,17 @@ pub(crate) mod tests {
         // 6 should now be an active bank even though we haven't repaired it because it
         // wasn't dumped
         ReplayStage::generate_new_bank_forks(
-            &blockstore,
-            &bank_forks,
-            &leader_schedule_cache,
-            rpc_subscriptions.as_deref(),
-            &None,
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: rpc_subscriptions.as_deref(),
+                slot_status_notifier: &None,
+                migration_status: &MigrationStatus::default(),
+                my_pubkey: &Pubkey::default(),
+            },
             &mut progress,
             &mut replay_timing,
-            &MigrationStatus::default(),
         );
         assert_eq!(bank_forks.read().unwrap().active_bank_slots(), vec![6]);
 
@@ -7303,20 +8721,1057 @@ pub(crate) mod tests {
         }
         // 7 should be found as an active bank
         ReplayStage::generate_new_bank_forks(
-            &blockstore,
-            &bank_forks,
-            &leader_schedule_cache,
-            rpc_subscriptions.as_deref(),
-            &None,
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: rpc_subscriptions.as_deref(),
+                slot_status_notifier: &None,
+                migration_status: &MigrationStatus::default(),
+                my_pubkey: &Pubkey::default(),
+            },
             &mut progress,
             &mut replay_timing,
-            &MigrationStatus::default(),
         );
         assert_eq!(bank_forks.read().unwrap().active_bank_slots(), vec![7]);
     }
 
     #[test]
-    fn test_purge_ancestors_descendants() {
+    fn test_update_parent_restart() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(
+            Some(tr(0) / tr(1) / tr(2) / tr(3)),
+            1,
+            None::<GenerateVotes>,
+        );
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        enable_block_markers_for_tests(&blockstore);
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+
+        // Slot 4: 5 shreds, replay_fec_set_index=32; 5 < 32 so cleared.
+        // Slot 5: 40 shreds, replay_fec_set_index=32; 40 >= 32 so skipped.
+        for (slot, shreds) in [(4, 5), (5, 40)] {
+            let bank = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), slot);
+            bank_forks.write().unwrap().insert(bank);
+            let p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+            p.replay_progress.write().unwrap().num_shreds = shreds;
+            progress.insert(slot, p);
+        }
+
+        let (tx, rx) = crossbeam_channel::unbounded();
+        for slot in [4, 5] {
+            let parent_block_id = Hash::default();
+            insert_update_parent_slot(
+                &blockstore,
+                slot,
+                3, // optimistic block-header parent
+                0, // finalized UpdateParent parent
+                parent_block_id,
+                32,
+            );
+            tx.send(UpdateParentSignal {
+                slot,
+                parent_slot: 0,
+                parent_block_id,
+                replay_fec_set_index: 32,
+            })
+            .unwrap();
+        }
+
+        let cleared_bank_id = bank_forks.read().unwrap().get(4).unwrap().bank_id();
+        let (replay_vote_sender, replay_vote_receiver) = unbounded();
+        let (soft_dead_slot_sender, soft_dead_slot_receiver) = unbounded();
+        let migration_status = post_migration_status_for_tests();
+        let update_parent_context = update_parent_replay_context(
+            Pubkey::new_unique(),
+            &blockstore,
+            &bank_forks,
+            &replay_vote_sender,
+            &soft_dead_slot_sender,
+            &migration_status,
+        );
+        ReplayStage::interrupt_update_parent_slots(&update_parent_context, &mut progress, &rx);
+
+        assert!(progress.get(&4).is_none()); // cleared: 5 < 32
+        assert!(progress.get(&5).is_some()); // skipped: 40 >= 32
+        assert_eq!(
+            replay_vote_receiver.try_recv(),
+            Ok(ReplayVoteMessage::InvalidBank {
+                replay_bank_id: cleared_bank_id,
+                replay_slot: 4,
+            })
+        );
+        assert!(replay_vote_receiver.try_recv().is_err());
+        assert_eq!(
+            soft_dead_slot_receiver.try_recv(),
+            Ok(SoftDeadSlotNotification::ClearSoftDead(4))
+        );
+        assert!(soft_dead_slot_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_defer_update_no_header() {
+        let (vote_simulator, blockstore) = setup_forks_from_tree(tr(0), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            validator_keypairs,
+            ..
+        } = vote_simulator;
+        let my_pubkey = *validator_keypairs.keys().next().unwrap();
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&root_bank));
+        let slot = 1;
+        let replay_fec_set_index = 32;
+
+        enable_block_markers_for_tests(&blockstore);
+        let update_parent = VersionedBlockMarker::new_update_parent(UpdateParentV1 {
+            new_parent_slot: 0,
+            new_parent_block_id: Hash::default(),
+        });
+        blockstore
+            .insert_shreds(
+                block_marker_shreds(slot, 0, update_parent, replay_fec_set_index),
+                None,
+                true,
+            )
+            .unwrap();
+        assert!(
+            !blockstore
+                .can_replay_from_update_parent(slot, BlockLocation::Original)
+                .unwrap()
+        );
+        assert!(bank_forks.read().unwrap().get(slot).is_none());
+
+        let mut replay_timing = ReplayLoopTiming::default();
+        ReplayStage::generate_new_bank_forks(
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: None,
+                slot_status_notifier: &None,
+                migration_status: &post_migration_status_for_tests(),
+                my_pubkey: &my_pubkey,
+            },
+            &mut progress,
+            &mut replay_timing,
+        );
+
+        assert!(
+            bank_forks.read().unwrap().get(slot).is_none(),
+            "replay must wait for a compatible header before creating an UpdateParent bank"
+        );
+    }
+
+    #[test]
+    fn test_bad_header_creates_bank() {
+        let (vote_simulator, blockstore) = setup_forks_from_tree(tr(0), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            validator_keypairs,
+            ..
+        } = vote_simulator;
+        let my_pubkey = *validator_keypairs.keys().next().unwrap();
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&root_bank));
+        let slot = 1;
+        let replay_fec_set_index = 32;
+
+        enable_block_markers_for_tests(&blockstore);
+        insert_bad_header_update_parent_slot(
+            &blockstore,
+            slot,
+            0,
+            0,
+            Hash::default(),
+            replay_fec_set_index,
+        );
+        assert_eq!(
+            blockstore
+                .update_parent_replay_status(slot, BlockLocation::Original)
+                .unwrap(),
+            UpdateParentReplayStatus::Invalid
+        );
+
+        let mut replay_timing = ReplayLoopTiming::default();
+        ReplayStage::generate_new_bank_forks(
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: None,
+                slot_status_notifier: &None,
+                migration_status: &post_migration_status_for_tests(),
+                my_pubkey: &my_pubkey,
+            },
+            &mut progress,
+            &mut replay_timing,
+        );
+
+        assert!(
+            bank_forks.read().unwrap().get(slot).is_some(),
+            "invalid UpdateParent metadata should create a bank so replay can hard-dead it"
+        );
+        assert!(progress.get(&slot).is_none());
+    }
+
+    #[test]
+    fn test_update_parent_tower_gated() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let parent_block_id = Hash::default();
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.parent_slot = Some(0);
+        meta.parent_block_id = parent_block_id;
+        meta.replay_fec_set_index = 10;
+        blockstore.put_meta(slot, &meta).unwrap();
+
+        let p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 5;
+        progress.insert(slot, p);
+
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(UpdateParentSignal {
+            slot,
+            parent_slot: 0,
+            parent_block_id,
+            replay_fec_set_index: 10,
+        })
+        .unwrap();
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (soft_dead_slot_sender, soft_dead_slot_receiver) = unbounded();
+        let migration_status = MigrationStatus::default();
+        let update_parent_context = update_parent_replay_context(
+            Pubkey::new_unique(),
+            &blockstore,
+            &bank_forks,
+            &replay_vote_sender,
+            &soft_dead_slot_sender,
+            &migration_status,
+        );
+        ReplayStage::interrupt_update_parent_slots(&update_parent_context, &mut progress, &rx);
+
+        assert!(progress.get(&slot).is_some());
+        assert!(bank_forks.read().unwrap().get(slot).is_some());
+        assert!(soft_dead_slot_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_update_parent_keeps_hard() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let parent_block_id = Hash::default();
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.parent_slot = Some(0);
+        meta.parent_block_id = parent_block_id;
+        meta.replay_fec_set_index = 10;
+        blockstore.put_meta(slot, &meta).unwrap();
+        blockstore.set_dead_slot(slot).unwrap();
+
+        let mut p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 5;
+        p.mark_dead(DeadSlotReason::Hard);
+        progress.insert(slot, p);
+
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(UpdateParentSignal {
+            slot,
+            parent_slot: 0,
+            parent_block_id,
+            replay_fec_set_index: 10,
+        })
+        .unwrap();
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (soft_dead_slot_sender, soft_dead_slot_receiver) = unbounded();
+        let migration_status = post_migration_status_for_tests();
+        let update_parent_context = update_parent_replay_context(
+            Pubkey::new_unique(),
+            &blockstore,
+            &bank_forks,
+            &replay_vote_sender,
+            &soft_dead_slot_sender,
+            &migration_status,
+        );
+        ReplayStage::interrupt_update_parent_slots(&update_parent_context, &mut progress, &rx);
+
+        assert!(blockstore.is_dead(slot));
+        assert!(progress.get(&slot).is_some());
+        assert!(bank_forks.read().unwrap().get(slot).is_some());
+        assert!(soft_dead_slot_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_pre_update_soft_dead() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.replay_fec_set_index = 0;
+        meta.last_index = None;
+        blockstore.put_meta(slot, &meta).unwrap();
+
+        let bank = bank_forks.read().unwrap().get(slot).unwrap();
+        let p = ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 5;
+        progress.insert(slot, p);
+
+        let (replay_vote_sender, replay_vote_receiver) = unbounded();
+        let (soft_dead_slot_sender, soft_dead_slot_receiver) = unbounded();
+        let (ancestor_hashes_replay_update_sender, _) = unbounded();
+        let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
+        let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
+        let mut tbft_structs = None;
+        let migration_status = post_migration_status_for_tests();
+        let mut dead_slot_context = dead_slot_context_for_tests(
+            &blockstore,
+            &replay_vote_sender,
+            &ancestor_hashes_replay_update_sender,
+            &mut duplicate_slots_to_repair,
+            &mut purge_repair_slot_counter,
+            &mut tbft_structs,
+            &migration_status,
+            Some(&soft_dead_slot_sender),
+        );
+        ReplayStage::mark_replay_dead_slot(
+            &bank,
+            &BlockstoreProcessorError::InvalidTransaction(TransactionError::AccountNotFound),
+            &mut progress,
+            &mut dead_slot_context,
+        );
+
+        assert!(!blockstore.is_dead(slot));
+        assert!(matches!(
+            progress.get(&slot).unwrap().dead_reason,
+            Some(DeadSlotReason::ReplayFailureBeforeUpdateParent)
+        ));
+        assert_eq!(
+            replay_vote_receiver.try_recv(),
+            Ok(ReplayVoteMessage::InvalidBank {
+                replay_bank_id: bank.bank_id(),
+                replay_slot: slot,
+            })
+        );
+        assert_eq!(
+            soft_dead_slot_receiver.try_recv(),
+            Ok(SoftDeadSlotNotification::MarkSoftDead(slot))
+        );
+    }
+
+    #[test]
+    fn test_after_update_hard_dead() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.replay_fec_set_index = 5;
+        meta.last_index = None;
+        blockstore.put_meta(slot, &meta).unwrap();
+
+        let bank = bank_forks.read().unwrap().get(slot).unwrap();
+        let p = ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 5;
+        progress.insert(slot, p);
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (ancestor_hashes_replay_update_sender, _) = unbounded();
+        let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
+        let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
+        let mut tbft_structs = None;
+        let migration_status = post_migration_status_for_tests();
+        let mut dead_slot_context = dead_slot_context_for_tests(
+            &blockstore,
+            &replay_vote_sender,
+            &ancestor_hashes_replay_update_sender,
+            &mut duplicate_slots_to_repair,
+            &mut purge_repair_slot_counter,
+            &mut tbft_structs,
+            &migration_status,
+            None,
+        );
+        ReplayStage::mark_replay_dead_slot(
+            &bank,
+            &BlockstoreProcessorError::InvalidTransaction(TransactionError::AccountNotFound),
+            &mut progress,
+            &mut dead_slot_context,
+        );
+
+        assert!(blockstore.is_dead(slot));
+        assert!(matches!(
+            progress.get(&slot).unwrap().dead_reason,
+            Some(DeadSlotReason::Hard)
+        ));
+    }
+
+    #[test]
+    fn test_before_update_soft_dead() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.replay_fec_set_index = 10;
+        meta.last_index = None;
+        blockstore.put_meta(slot, &meta).unwrap();
+
+        let bank = bank_forks.read().unwrap().get(slot).unwrap();
+        let p = ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 5;
+        progress.insert(slot, p);
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (ancestor_hashes_replay_update_sender, _) = unbounded();
+        let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
+        let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
+        let mut tbft_structs = None;
+        let migration_status = post_migration_status_for_tests();
+        let mut dead_slot_context = dead_slot_context_for_tests(
+            &blockstore,
+            &replay_vote_sender,
+            &ancestor_hashes_replay_update_sender,
+            &mut duplicate_slots_to_repair,
+            &mut purge_repair_slot_counter,
+            &mut tbft_structs,
+            &migration_status,
+            None,
+        );
+        ReplayStage::mark_replay_dead_slot(
+            &bank,
+            &BlockstoreProcessorError::InvalidTransaction(TransactionError::AccountNotFound),
+            &mut progress,
+            &mut dead_slot_context,
+        );
+
+        assert!(!blockstore.is_dead(slot));
+        assert!(matches!(
+            progress.get(&slot).unwrap().dead_reason,
+            Some(DeadSlotReason::ReplayFailureBeforeUpdateParent)
+        ));
+    }
+
+    #[test]
+    fn test_soft_dead_restarts() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 4;
+        let parent_block_id = Hash::default();
+        enable_block_markers_for_tests(&blockstore);
+        insert_update_parent_slot(&blockstore, slot, 3, 0, parent_block_id, 32);
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+        let bank = Bank::new_from_parent(bank0, SlotLeader::default(), slot);
+        bank_forks.write().unwrap().insert(bank);
+
+        let mut p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 5;
+        p.mark_dead(DeadSlotReason::ReplayFailureBeforeUpdateParent);
+        progress.insert(slot, p);
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (soft_dead_slot_sender, soft_dead_slot_receiver) = unbounded();
+        let migration_status = post_migration_status_for_tests();
+        let update_parent_context = update_parent_replay_context(
+            Pubkey::new_unique(),
+            &blockstore,
+            &bank_forks,
+            &replay_vote_sender,
+            &soft_dead_slot_sender,
+            &migration_status,
+        );
+        ReplayStage::process_soft_dead_update_parent_slots(&update_parent_context, &mut progress);
+
+        assert!(!blockstore.is_dead(slot));
+        assert!(progress.get(&slot).is_none());
+        assert!(bank_forks.read().unwrap().get(slot).is_none());
+        assert_eq!(
+            soft_dead_slot_receiver.try_recv(),
+            Ok(SoftDeadSlotNotification::ClearSoftDead(slot))
+        );
+    }
+
+    #[test]
+    fn test_own_soft_restart() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            validator_keypairs,
+            ..
+        } = vote_simulator;
+
+        let my_pubkey = *validator_keypairs.keys().next().unwrap();
+        let slot = 4;
+        let parent_block_id = Hash::default();
+        let migration_status = post_migration_status_for_tests();
+        enable_block_markers_for_tests(&blockstore);
+        insert_update_parent_slot(&blockstore, slot, 3, 0, parent_block_id, 32);
+        // The marker helper only inserts the header and UpdateParent marker; mark
+        // this fixture full so the own-leader gate exercises the repaired
+        // completed-slot case.
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.consumed = 33;
+        meta.last_index = Some(32);
+        blockstore.put_meta(slot, &meta).unwrap();
+        assert!(blockstore.is_full(slot));
+
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+        let bank = Bank::new_from_parent(
+            bank0,
+            SlotLeader {
+                id: my_pubkey,
+                ..SlotLeader::default()
+            },
+            slot,
+        );
+        blockstore_processor::set_alpenglow_ticks(&bank, &migration_status);
+        assert!(!ReplayStage::should_skip_own_leader_replay(
+            &blockstore,
+            &bank,
+            &my_pubkey,
+            &migration_status,
+        ));
+        let bank_id = bank.bank_id();
+        bank_forks.write().unwrap().insert(bank);
+
+        let mut p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 0;
+        p.mark_dead(DeadSlotReason::ReplayFailureBeforeUpdateParent);
+        progress.insert(slot, p);
+
+        let (replay_vote_sender, replay_vote_receiver) = unbounded();
+        let (soft_dead_slot_sender, soft_dead_slot_receiver) = unbounded();
+        let update_parent_context = update_parent_replay_context(
+            my_pubkey,
+            &blockstore,
+            &bank_forks,
+            &replay_vote_sender,
+            &soft_dead_slot_sender,
+            &migration_status,
+        );
+        ReplayStage::process_soft_dead_update_parent_slots(&update_parent_context, &mut progress);
+
+        assert!(!blockstore.is_dead(slot));
+        assert!(progress.get(&slot).is_none());
+        assert!(bank_forks.read().unwrap().get(slot).is_none());
+        assert_eq!(
+            replay_vote_receiver.try_recv(),
+            Ok(ReplayVoteMessage::InvalidBank {
+                replay_bank_id: bank_id,
+                replay_slot: slot,
+            })
+        );
+        assert_eq!(
+            soft_dead_slot_receiver.try_recv(),
+            Ok(SoftDeadSlotNotification::ClearSoftDead(slot))
+        );
+    }
+
+    #[test]
+    fn test_soft_dead_no_bank() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 4;
+        let parent_block_id = Hash::default();
+        enable_block_markers_for_tests(&blockstore);
+        insert_update_parent_slot(&blockstore, slot, 3, 0, parent_block_id, 32);
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+        let bank = Bank::new_from_parent(bank0, SlotLeader::default(), slot);
+        bank_forks.write().unwrap().insert(bank);
+
+        let mut p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 5;
+        p.mark_dead(DeadSlotReason::ReplayFailureBeforeUpdateParent);
+        progress.insert(slot, p);
+        let clear_bank_cleanup = {
+            let mut bank_forks = bank_forks.write().unwrap();
+            bank_forks.clear_bank(slot, false)
+        };
+        clear_bank_cleanup.finish();
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (soft_dead_slot_sender, soft_dead_slot_receiver) = unbounded();
+        let migration_status = post_migration_status_for_tests();
+        let update_parent_context = update_parent_replay_context(
+            Pubkey::new_unique(),
+            &blockstore,
+            &bank_forks,
+            &replay_vote_sender,
+            &soft_dead_slot_sender,
+            &migration_status,
+        );
+        ReplayStage::process_soft_dead_update_parent_slots(&update_parent_context, &mut progress);
+
+        assert!(!blockstore.is_dead(slot));
+        assert!(progress.get(&slot).is_none());
+        assert!(bank_forks.read().unwrap().get(slot).is_none());
+        assert_eq!(
+            soft_dead_slot_receiver.try_recv(),
+            Ok(SoftDeadSlotNotification::ClearSoftDead(slot))
+        );
+    }
+
+    #[test]
+    fn test_full_soft_dead_hardens() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.replay_fec_set_index = 0;
+        meta.consumed = 1;
+        meta.last_index = Some(0);
+        blockstore.put_meta(slot, &meta).unwrap();
+
+        let mut p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+        p.mark_dead(DeadSlotReason::ReplayFailureBeforeUpdateParent);
+        progress.insert(slot, p);
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (soft_dead_slot_sender, soft_dead_slot_receiver) = unbounded();
+        let migration_status = post_migration_status_for_tests();
+        let update_parent_context = update_parent_replay_context(
+            Pubkey::new_unique(),
+            &blockstore,
+            &bank_forks,
+            &replay_vote_sender,
+            &soft_dead_slot_sender,
+            &migration_status,
+        );
+        ReplayStage::process_soft_dead_update_parent_slots(&update_parent_context, &mut progress);
+
+        assert!(blockstore.is_dead(slot));
+        assert!(matches!(
+            progress.get(&slot).unwrap().dead_reason,
+            Some(DeadSlotReason::Hard)
+        ));
+        assert_eq!(
+            soft_dead_slot_receiver.try_recv(),
+            Ok(SoftDeadSlotNotification::ClearSoftDead(slot))
+        );
+        assert!(soft_dead_slot_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_soft_dead_bad_header() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 4;
+        enable_block_markers_for_tests(&blockstore);
+        insert_bad_header_update_parent_slot(&blockstore, slot, 0, 0, Hash::default(), 32);
+        assert_eq!(
+            blockstore
+                .update_parent_replay_status(slot, BlockLocation::Original)
+                .unwrap(),
+            UpdateParentReplayStatus::Invalid
+        );
+
+        let mut p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+        p.mark_dead(DeadSlotReason::ReplayFailureBeforeUpdateParent);
+        progress.insert(slot, p);
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (soft_dead_slot_sender, soft_dead_slot_receiver) = unbounded();
+        let migration_status = post_migration_status_for_tests();
+        let update_parent_context = update_parent_replay_context(
+            Pubkey::new_unique(),
+            &blockstore,
+            &bank_forks,
+            &replay_vote_sender,
+            &soft_dead_slot_sender,
+            &migration_status,
+        );
+        ReplayStage::process_soft_dead_update_parent_slots(&update_parent_context, &mut progress);
+
+        assert!(blockstore.is_dead(slot));
+        assert!(matches!(
+            progress.get(&slot).unwrap().dead_reason,
+            Some(DeadSlotReason::Hard)
+        ));
+        assert_eq!(
+            soft_dead_slot_receiver.try_recv(),
+            Ok(SoftDeadSlotNotification::ClearSoftDead(slot))
+        );
+        assert!(soft_dead_slot_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_latest_parent_coalesces() {
+        let (sender, receiver) = bounded(1);
+        sender
+            .try_send(LeaderWindowInfo {
+                start_slot: 8,
+                end_slot: 11,
+                parent_block: (7, Hash::new_unique()),
+                block_timer: Instant::now(),
+            })
+            .unwrap();
+
+        ReplayStage::try_send_latest_optimistic_parent(
+            &sender,
+            &receiver,
+            LeaderWindowInfo {
+                start_slot: 12,
+                end_slot: 15,
+                parent_block: (11, Hash::new_unique()),
+                block_timer: Instant::now(),
+            },
+        );
+
+        let latest = receiver.try_recv().unwrap();
+        assert_eq!(latest.start_slot, 12);
+        assert!(receiver.try_recv().is_err());
+
+        let (sender, receiver) = bounded(1);
+        sender
+            .try_send(LeaderWindowInfo {
+                start_slot: 20,
+                end_slot: 22,
+                parent_block: (19, Hash::new_unique()),
+                block_timer: Instant::now(),
+            })
+            .unwrap();
+
+        ReplayStage::try_send_latest_optimistic_parent(
+            &sender,
+            &receiver,
+            LeaderWindowInfo {
+                start_slot: 20,
+                end_slot: 23,
+                parent_block: (19, Hash::new_unique()),
+                block_timer: Instant::now(),
+            },
+        );
+
+        let latest = receiver.try_recv().unwrap();
+        assert_eq!(latest.end_slot, 23);
+        assert!(receiver.try_recv().is_err());
+
+        let (sender, receiver) = bounded(1);
+        sender
+            .try_send(LeaderWindowInfo {
+                start_slot: 20,
+                end_slot: 23,
+                parent_block: (19, Hash::new_unique()),
+                block_timer: Instant::now(),
+            })
+            .unwrap();
+
+        ReplayStage::try_send_latest_optimistic_parent(
+            &sender,
+            &receiver,
+            LeaderWindowInfo {
+                start_slot: 16,
+                end_slot: 19,
+                parent_block: (15, Hash::new_unique()),
+                block_timer: Instant::now(),
+            },
+        );
+
+        let latest = receiver.try_recv().unwrap();
+        assert_eq!(latest.start_slot, 20);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_replay_own_full_slot() {
+        let (vote_simulator, blockstore) = setup_forks_from_tree(tr(0), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            validator_keypairs,
+            ..
+        } = vote_simulator;
+        let my_pubkey = *validator_keypairs.keys().next().unwrap();
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&root_bank));
+        let slot = 1;
+
+        let (shreds, _) = make_slot_entries(slot, 0, 8);
+        blockstore.insert_shreds(shreds, None, false).unwrap();
+        assert!(blockstore.has_existing_shreds_for_slot(slot));
+        assert!(blockstore.is_full(slot));
+        assert!(bank_forks.read().unwrap().get(slot).is_none());
+
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader = leader_schedule_cache
+            .slot_leader_at(slot, Some(&root_bank))
+            .unwrap();
+        assert_eq!(leader.id, my_pubkey);
+
+        let migration_status = post_migration_status_for_tests();
+        assert!(migration_status.should_allow_block_markers(slot));
+
+        let mut replay_timing = ReplayLoopTiming::default();
+        ReplayStage::generate_new_bank_forks(
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: None,
+                slot_status_notifier: &None,
+                migration_status: &migration_status,
+                my_pubkey: &my_pubkey,
+            },
+            &mut progress,
+            &mut replay_timing,
+        );
+
+        assert!(
+            bank_forks.read().unwrap().get(slot).is_some(),
+            "replay must create a full repaired own leader slot after restart"
+        );
+        let bank = bank_forks.read().unwrap().get(slot).unwrap();
+        assert!(!ReplayStage::should_skip_own_leader_replay(
+            &blockstore,
+            &bank,
+            &my_pubkey,
+            &migration_status,
+        ));
+    }
+
+    #[test]
+    fn test_own_update_full_replay() {
+        let (vote_simulator, blockstore) = setup_forks_from_tree(tr(0), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            validator_keypairs,
+            ..
+        } = vote_simulator;
+        let my_pubkey = *validator_keypairs.keys().next().unwrap();
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&root_bank));
+        let slot = 2;
+        let replay_fec_set_index = 32;
+
+        enable_block_markers_for_tests(&blockstore);
+        insert_update_parent_slot(
+            &blockstore,
+            slot,
+            1,
+            0,
+            Hash::default(),
+            replay_fec_set_index,
+        );
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.consumed = u64::from(replay_fec_set_index) + 1;
+        meta.last_index = Some(u64::from(replay_fec_set_index));
+        blockstore.put_meta(slot, &meta).unwrap();
+        assert!(blockstore.is_full(slot));
+
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader = leader_schedule_cache
+            .slot_leader_at(slot, Some(&root_bank))
+            .unwrap();
+        assert_eq!(leader.id, my_pubkey);
+
+        let migration_status = post_migration_status_for_tests();
+        let mut replay_timing = ReplayLoopTiming::default();
+        ReplayStage::generate_new_bank_forks(
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: None,
+                slot_status_notifier: &None,
+                migration_status: &migration_status,
+                my_pubkey: &my_pubkey,
+            },
+            &mut progress,
+            &mut replay_timing,
+        );
+
+        assert!(
+            bank_forks.read().unwrap().get(slot).is_some(),
+            "replay must create full own leader UpdateParent slots after restart"
+        );
+        let fork_progress = progress.get(&slot).unwrap();
+        let replay_progress = fork_progress.replay_progress.read().unwrap();
+        assert_eq!(replay_progress.num_shreds, u64::from(replay_fec_set_index));
+        assert!(replay_progress.replay_starts_at_update_parent);
+    }
+
+    #[test]
+    fn test_skip_live_own_leader() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            leader_schedule_cache,
+            my_pubkey,
+            ..
+        } = replay_blockstore_components(None, 1, None::<GenerateVotes>);
+        let VoteSimulator { bank_forks, .. } = vote_simulator;
+        let slot = 1;
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader = leader_schedule_cache
+            .slot_leader_at(slot, Some(&root_bank))
+            .unwrap();
+        assert_eq!(leader.id, my_pubkey);
+
+        let bank = Bank::new_from_parent(root_bank, leader, slot);
+        let migration_status = post_migration_status_for_tests();
+        assert!(ReplayStage::should_skip_own_leader_replay(
+            &blockstore,
+            &bank,
+            &my_pubkey,
+            &migration_status,
+        ));
+
+        blockstore_processor::set_alpenglow_ticks(&bank, &migration_status);
+        assert!(ReplayStage::should_skip_own_leader_replay(
+            &blockstore,
+            &bank,
+            &my_pubkey,
+            &migration_status,
+        ));
+    }
+
+    #[test]
+    fn test_skip_own_partial_slot() {
+        let (vote_simulator, blockstore) = setup_forks_from_tree(tr(0), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            validator_keypairs,
+            ..
+        } = vote_simulator;
+        let my_pubkey = *validator_keypairs.keys().next().unwrap();
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&root_bank));
+        let slot = 1;
+
+        let (mut shreds, _) = make_slot_entries(slot, 0, 8);
+        assert!(shreds.len() > 1);
+        shreds.pop();
+        blockstore.insert_shreds(shreds, None, false).unwrap();
+        assert!(blockstore.has_existing_shreds_for_slot(slot));
+        assert!(!blockstore.is_full(slot));
+
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader = leader_schedule_cache
+            .slot_leader_at(slot, Some(&root_bank))
+            .unwrap();
+        assert_eq!(leader.id, my_pubkey);
+
+        let migration_status = post_migration_status_for_tests();
+        let mut replay_timing = ReplayLoopTiming::default();
+        ReplayStage::generate_new_bank_forks(
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: None,
+                slot_status_notifier: &None,
+                migration_status: &migration_status,
+                my_pubkey: &my_pubkey,
+            },
+            &mut progress,
+            &mut replay_timing,
+        );
+
+        assert!(
+            bank_forks.read().unwrap().get(slot).is_none(),
+            "replay must not create our own leader bank from partial blockstore shreds"
+        );
+    }
+
+    #[test]
+    fn test_purge_anc_desc() {
         let (VoteSimulator { bank_forks, .. }, _) = setup_default_forks(1, None::<GenerateVotes>);
 
         // Purge branch rooted at slot 2
@@ -7491,7 +9946,7 @@ pub(crate) mod tests {
 
         // 4 should be the heaviest slot, but should not be votable
         // because of lockout. 5 is the heaviest slot on the same fork as the last vote.
-        let (vote_fork, reset_fork, _) = run_compute_and_select_forks(
+        let (vote_fork, reset_fork, heaviest_fork_failures) = run_compute_and_select_forks(
             &bank_forks,
             &mut progress,
             &mut tower,
@@ -7502,6 +9957,13 @@ pub(crate) mod tests {
         );
         assert!(vote_fork.is_none());
         assert_eq!(reset_fork, Some(5));
+        assert_eq!(
+            heaviest_fork_failures,
+            vec![
+                HeaviestForkFailures::FailedSwitchThreshold(4, 0, 10000),
+                HeaviestForkFailures::LockedOut(4)
+            ]
+        );
 
         // Mark 5 as duplicate
         blockstore.store_duplicate_slot(5, vec![], vec![]).unwrap();
@@ -8545,7 +11007,7 @@ pub(crate) mod tests {
         assert_eq!(tower.last_voted_slot().unwrap(), 1);
 
         // Trying to refresh the vote for bank 1 in bank 2 won't succeed because
-        // the blockheight has not increased enough
+        // the blockheight is not increased enough
         progress
             .get_fork_stats_mut(bank1.slot())
             .unwrap()
@@ -8764,7 +11226,7 @@ pub(crate) mod tests {
         tower_storage: &dyn TowerStorage,
         make_it_landing: bool,
         cursor: &mut Cursor,
-        bank_forks: &RwLock<BankForks>,
+        bank_forks: Arc<RwLock<BankForks>>,
         progress: &mut ProgressMap,
     ) -> Arc<Bank> {
         let my_vote_pubkey = &my_vote_keypair[0].pubkey();
@@ -8818,7 +11280,7 @@ pub(crate) mod tests {
         );
         assert_eq!(tower.last_voted_slot().unwrap(), parent_bank.slot());
         let bank = Bank::new_from_parent_with_bank_forks(
-            bank_forks,
+            &bank_forks,
             parent_bank,
             SlotLeader::default(),
             my_slot,
@@ -8916,7 +11378,7 @@ pub(crate) mod tests {
             &tower_storage,
             true,
             &mut cursor,
-            &bank_forks,
+            bank_forks.clone(),
             &mut progress,
         );
         new_bank = send_vote_in_new_bank(
@@ -8934,7 +11396,7 @@ pub(crate) mod tests {
             &tower_storage,
             false,
             &mut cursor,
-            &bank_forks,
+            bank_forks.clone(),
             &mut progress,
         );
         // Create enough banks on the fork so last vote is outside SlotHash, make sure
@@ -9141,7 +11603,7 @@ pub(crate) mod tests {
         let res = retransmit_slots_receiver.recv_timeout(Duration::from_millis(10));
         assert!(
             res.is_err(),
-            "retry_iteration=1, elapsed < 2^1 * RETRY_BASE_DELAY_MS"
+            "retry_iteration=1, elapsed < 2^1 * RETRANSMIT_BASE_DELAY_MS"
         );
 
         progress.get_retransmit_info_mut(0).unwrap().retry_time = Instant::now()
@@ -10038,6 +12500,7 @@ pub(crate) mod tests {
             rpc_subscriptions,
             ..
         } = replay_blockstore_components(None, 1, None);
+
         let VoteSimulator {
             bank_forks,
             mut progress,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -49,7 +49,7 @@ use {
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::{
-        blockstore::{Blockstore, MAX_COMPLETED_SLOTS_IN_CHANNEL},
+        blockstore::{Blockstore, MAX_COMPLETED_SLOTS_IN_CHANNEL, UpdateParentReceiver},
         blockstore_cleanup_service::BlockstoreCleanupService,
         blockstore_processor::TransactionStatusSender,
         entry_notifier_service::EntryNotifierSender,
@@ -164,6 +164,8 @@ impl Default for TvuConfig {
 pub struct AlpenglowInitializationState {
     // Shared with block creation loop
     pub leader_window_info_sender: Sender<LeaderWindowInfo>,
+    pub optimistic_parent_sender: Sender<LeaderWindowInfo>,
+    pub optimistic_parent_latest_receiver: Receiver<LeaderWindowInfo>,
     pub replay_highest_frozen: Arc<ReplayHighestFrozen>,
     pub highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
     pub highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
@@ -202,6 +204,7 @@ impl Tvu {
         sockets: TvuSockets,
         blockstore: Arc<Blockstore>,
         ledger_signal_receiver: Receiver<bool>,
+        update_parent_receiver: UpdateParentReceiver,
         rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         poh_controller: PohController,
@@ -251,6 +254,8 @@ impl Tvu {
 
         let AlpenglowInitializationState {
             leader_window_info_sender,
+            optimistic_parent_sender,
+            optimistic_parent_latest_receiver,
             replay_highest_frozen,
             highest_parent_ready,
             votor_event_sender,
@@ -409,10 +414,12 @@ impl Tvu {
         let (completed_slots_sender, completed_slots_receiver) =
             bounded(MAX_COMPLETED_SLOTS_IN_CHANNEL);
         blockstore.add_completed_slots_signal(completed_slots_sender);
+        let (soft_dead_slot_sender, soft_dead_slot_receiver) = unbounded();
 
         let block_id_repair_channels = BlockIdRepairChannels {
             repair_event_receiver,
             completed_slots_receiver,
+            soft_dead_slot_receiver,
         };
 
         let window_service = {
@@ -522,6 +529,7 @@ impl Tvu {
             entry_notification_sender,
             bank_notification_sender,
             ancestor_hashes_replay_update_sender,
+            soft_dead_slot_sender,
             retransmit_slots_sender,
             replay_vote_sender,
             cluster_slots_update_sender,
@@ -533,11 +541,14 @@ impl Tvu {
             dumped_slots_sender,
             votor_event_sender,
             own_vote_sender: consensus_message_sender,
+            optimistic_parent_sender,
             lockouts_sender,
         };
 
         let replay_receivers = ReplayReceivers {
             ledger_signal_receiver,
+            update_parent_receiver,
+            optimistic_parent_latest_receiver,
             duplicate_slots_receiver,
             ancestor_duplicate_slots_receiver,
             duplicate_confirmed_slots_receiver,
@@ -569,7 +580,6 @@ impl Tvu {
             banking_tracer,
             snapshot_controller,
             replay_highest_frozen,
-            migration_status,
         };
 
         let voting_service = VotingService::new(
@@ -751,6 +761,7 @@ pub mod tests {
         let BlockstoreSignals {
             blockstore,
             ledger_signal_receiver,
+            update_parent_receiver,
             ..
         } = Blockstore::open_with_signal(&blockstore_path, BlockstoreOptions::default())
             .expect("Expected to successfully open ledger");
@@ -792,6 +803,7 @@ pub mod tests {
         );
         let replay_highest_frozen = Arc::new(ReplayHighestFrozen::default());
         let (leader_window_info_sender, _leader_window_info_receiver) = unbounded();
+        let (optimistic_parent_sender, optimistic_parent_receiver) = unbounded();
         let highest_parent_ready = Arc::new(RwLock::new((0, (0, Hash::default()))));
         let (votor_event_sender, votor_event_receiver): (VotorEventSender, VotorEventReceiver) =
             unbounded();
@@ -827,6 +839,7 @@ pub mod tests {
             },
             blockstore,
             ledger_signal_receiver,
+            update_parent_receiver,
             Some(Arc::new(RpcSubscriptions::new_for_tests(
                 exit.clone(),
                 max_complete_transaction_status_slot,
@@ -869,6 +882,8 @@ pub mod tests {
             Arc::new(connection_cache),
             AlpenglowInitializationState {
                 leader_window_info_sender,
+                optimistic_parent_sender,
+                optimistic_parent_latest_receiver: optimistic_parent_receiver,
                 replay_highest_frozen,
                 highest_parent_ready,
                 votor_event_sender,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -78,7 +78,7 @@ use {
         bank_forks_utils,
         blockstore::{
             Blockstore, BlockstoreError, MAX_COMPLETED_SLOTS_IN_CHANNEL,
-            MAX_REPLAY_WAKE_UP_SIGNALS, PurgeType,
+            MAX_REPLAY_WAKE_UP_SIGNALS, MAX_UPDATE_PARENT_SIGNALS, PurgeType, UpdateParentReceiver,
         },
         blockstore_metric_report_service::BlockstoreMetricReportService,
         blockstore_options::{BLOCKSTORE_DIRECTORY_ROCKS_LEVEL, BlockstoreOptions},
@@ -898,6 +898,7 @@ impl Validator {
             blockstore,
             original_blockstore_root,
             ledger_signal_receiver,
+            update_parent_receiver,
             leader_schedule_cache,
             starting_snapshot_hashes,
             TransactionHistoryServices {
@@ -926,6 +927,7 @@ impl Validator {
         .map_err(ValidatorError::Other)?;
 
         let migration_status = bank_forks.read().unwrap().migration_status();
+        blockstore.configure_block_markers_for_migration(&migration_status);
 
         if !config.no_poh_speed_test {
             check_poh_speed(&bank_forks.read().unwrap().root_bank(), None)?;
@@ -1460,10 +1462,17 @@ impl Validator {
         let highest_parent_ready = Arc::new(RwLock::default());
         // Shared state for highest finalized certificates (updated by Votor, read by block creation loop)
         let highest_finalized = Arc::new(RwLock::new(None));
+        // This channel growing > ~1 indicates problems, so bound channel at a
+        // small (but highly overprovisioned) number for performance and easier
+        // debug if things go off the rails.
+        let (optimistic_parent_sender, optimistic_parent_receiver) = bounded(100);
+        let optimistic_parent_latest_receiver = optimistic_parent_receiver.clone();
         // There will only ever be a single msg in flight so bound channel for [`BuildRewardCertsRequest`] to 1 message.
         let (build_reward_certs_sender, build_reward_certs_receiver) = bounded(1);
         // There will only ever be a single msg in flight so bound channel for [`BuildRewardCertsResponse`] to 1 message.
         let (reward_certs_sender, reward_certs_receiver) = bounded(1);
+
+        let banking_stage_sender_for_bcl = banking_tracer_channels.non_vote_sender.clone();
 
         let block_creation_loop_config = BlockCreationLoopConfig {
             exit: exit.clone(),
@@ -1479,9 +1488,11 @@ impl Validator {
             highest_parent_ready: highest_parent_ready.clone(),
             replay_highest_frozen: replay_highest_frozen.clone(),
             record_receiver_receiver,
+            optimistic_parent_receiver,
             highest_finalized: highest_finalized.clone(),
             build_reward_certs_sender,
             reward_certs_receiver,
+            banking_stage_sender: banking_stage_sender_for_bcl,
         };
         let block_creation_loop = BlockCreationLoop::new(block_creation_loop_config);
 
@@ -1570,6 +1581,7 @@ impl Validator {
             },
             blockstore.clone(),
             ledger_signal_receiver,
+            update_parent_receiver,
             rpc_subscriptions.clone(),
             &poh_recorder,
             poh_controller,
@@ -1617,6 +1629,8 @@ impl Validator {
             vote_connection_cache,
             AlpenglowInitializationState {
                 leader_window_info_sender,
+                optimistic_parent_sender,
+                optimistic_parent_latest_receiver,
                 replay_highest_frozen,
                 highest_parent_ready,
                 votor_event_sender: votor_event_sender.clone(),
@@ -2130,6 +2144,7 @@ fn load_blockstore(
         Arc<Blockstore>,
         Slot,
         Receiver<bool>,
+        UpdateParentReceiver,
         LeaderScheduleCache,
         Option<StartingSnapshotHashes>,
         TransactionHistoryServices,
@@ -2237,12 +2252,15 @@ fn load_blockstore(
     let blockstore_root_scan = BlockstoreRootScan::new(config, blockstore.clone(), exit);
     let (ledger_signal_sender, ledger_signal_receiver) = bounded(MAX_REPLAY_WAKE_UP_SIGNALS);
     blockstore.add_new_shred_signal(ledger_signal_sender);
+    let (update_parent_sender, update_parent_receiver) = bounded(MAX_UPDATE_PARENT_SIGNALS);
+    blockstore.add_update_parent_signal(update_parent_sender);
 
     Ok((
         bank_forks,
         blockstore,
         original_blockstore_root,
         ledger_signal_receiver,
+        update_parent_receiver,
         leader_schedule_cache,
         starting_snapshot_hashes,
         transaction_history_services,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -107,9 +107,30 @@ pub use {
 
 pub const MAX_REPLAY_WAKE_UP_SIGNALS: usize = 1;
 pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;
+/// Maximum queued UpdateParent notifications from blockstore insertion to replay.
+///
+/// Replay also recovers by reading SlotMeta, so dropping this bounded signal is
+/// a latency event rather than the only source of truth. Keep this small enough
+/// that Tower validators do not pay a large idle-memory cost for the channel.
+pub const MAX_UPDATE_PARENT_SIGNALS: usize = 4_096;
 
 pub type CompletedSlotsSender = Sender<Vec<Slot>>;
 pub type CompletedSlotsReceiver = Receiver<Vec<Slot>>;
+
+pub type UpdateParentSender = Sender<UpdateParentSignal>;
+pub type UpdateParentReceiver = Receiver<UpdateParentSignal>;
+
+#[derive(Debug, Clone)]
+pub struct UpdateParentSignal {
+    /// Slot whose parent metadata was updated by an UpdateParent marker.
+    pub slot: Slot,
+    /// New replay parent slot recorded in SlotMeta.
+    pub parent_slot: Slot,
+    /// Block id of `parent_slot`, used to validate the recreated bank.
+    pub parent_block_id: Hash,
+    /// First shred index of the FEC set after the UpdateParent marker.
+    pub replay_fec_set_index: u32,
+}
 
 // Contiguous, sorted and non-empty ranges of shred indices:
 //     completed_ranges[i].start < completed_ranges[i].end
@@ -232,6 +253,7 @@ pub struct BlockstoreSignals {
     pub blockstore: Blockstore,
     pub ledger_signal_receiver: Receiver<bool>,
     pub completed_slots_receiver: CompletedSlotsReceiver,
+    pub update_parent_receiver: UpdateParentReceiver,
 }
 
 // ledger window
@@ -272,9 +294,14 @@ pub struct Blockstore {
     perf_samples_cf: LedgerColumn<cf::PerfSamples>,
 
     max_root: AtomicU64,
+    block_markers_enabled: AtomicBool,
+    // First slot where `UpdateParent` may update parent metadata. Headers can be
+    // parsed earlier during migration, but `UpdateParent` is Alpenglow-only.
+    update_parent_enabled_from_slot: AtomicU64,
     insert_shreds_lock: Mutex<()>,
     new_shreds_signals: Mutex<Vec<Sender<bool>>>,
     completed_slots_senders: Mutex<Vec<CompletedSlotsSender>>,
+    update_parent_signals: Mutex<Vec<UpdateParentSender>>,
     pub lowest_cleanup_slot: RwLock<Slot>,
     // A sender that feeds into the BlockstoreCleanupService request channel
     // to enable manual Blockstore purge requests to be issued
@@ -367,12 +394,17 @@ pub(crate) fn hashes_per_tick_for_ledger(genesis_config: &GenesisConfig) -> u64 
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ParentInfo {
+    /// Parent slot to expose through SlotMeta and replay.
     pub(crate) parent_slot: Slot,
+    /// Parent block id paired with `parent_slot`.
     pub(crate) parent_block_id: Hash,
+    /// Zero for the block header parent; non-zero when populated by UpdateParent.
     pub(crate) replay_fec_set_index: u32,
 }
 
 impl ParentInfo {
+    /// Read the currently persisted parent metadata, if enough information has
+    /// been written to distinguish it from an old/default SlotMeta.
     fn from_slot_meta(slot_meta: &SlotMeta) -> Option<Self> {
         let parent_slot = slot_meta.parent_slot?;
         let parent_info = ParentInfo {
@@ -380,9 +412,8 @@ impl ParentInfo {
             parent_block_id: slot_meta.parent_block_id,
             replay_fec_set_index: slot_meta.replay_fec_set_index,
         };
-        (parent_info.populated_from_update_parent()
-            || parent_info.parent_block_id != Hash::default())
-        .then_some(parent_info)
+        (parent_info.has_update_parent() || parent_info.parent_block_id != Hash::default())
+            .then_some(parent_info)
     }
 
     /// Try to parse a `ParentInfo` from a block header in the first shred
@@ -427,15 +458,11 @@ impl ParentInfo {
             // Validate and allow UpdateParent to replace BlockHeader
             (false, true) => (new, prev, true),
             // Both are UpdateParent - ensure they match
-            (false, false) => match new == prev {
-                true => return Ok(false),
-                false => return Err(BlockstoreError::MultipleUpdateParents(slot)),
-            },
+            (false, false) if new == prev => return Ok(false),
+            (false, false) => return Err(BlockstoreError::MultipleUpdateParents(slot)),
             // Both are block headers - ensure they match
-            (true, true) => match new == prev {
-                true => return Ok(false),
-                false => return Err(BlockstoreError::BlockComponentMismatch(slot)),
-            },
+            (true, true) if new == prev => return Ok(false),
+            (true, true) => return Err(BlockstoreError::BlockComponentMismatch(slot)),
         };
 
         // Validate that the UpdateParent is compatible with the BlockHeader
@@ -452,24 +479,41 @@ impl ParentInfo {
         Ok(should_write)
     }
 
-    fn populated_from_update_parent(&self) -> bool {
+    /// True when this metadata came from an `UpdateParent` marker.
+    fn has_update_parent(&self) -> bool {
         self.replay_fec_set_index > 0
     }
 
+    /// True when this metadata came from the slot's block header.
     fn populated_from_block_header(&self) -> bool {
         self.replay_fec_set_index == 0
     }
 
+    /// Parent slot and block id as a single comparable value.
     fn block(&self) -> (Slot, Hash) {
         (self.parent_slot, self.parent_block_id)
     }
 
+    /// Validate this parent against both ledger ancestry and the shred header.
+    ///
+    /// UpdateParent is allowed to disagree with the shred-header parent; block
+    /// headers are not.
     fn validate_shred_parent(&self, slot: Slot, shred_parent_slot: Slot, root: Slot) -> Result<()> {
         if !verify_shred_slots(slot, self.parent_slot, root) {
             return Err(BlockstoreError::InvalidParentInfo {
                 slot,
                 parent_slot: self.parent_slot,
                 root,
+            });
+        }
+
+        // Genesis does not have a block id. Every path that derives a parent
+        // block id from the genesis bank represents it as the default hash, so
+        // persisted parent metadata must use the same canonical value.
+        if self.parent_slot == 0 && self.parent_block_id != Hash::default() {
+            return Err(BlockstoreError::InvalidGenesisParentBlockId {
+                slot,
+                parent_block_id: self.parent_block_id,
             });
         }
 
@@ -483,6 +527,19 @@ impl ParentInfo {
 
         Ok(())
     }
+}
+
+/// Replay readiness for starting a slot from an `UpdateParent` marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateParentReplayStatus {
+    /// SlotMeta contains UpdateParent metadata and shred 0 contains a compatible header.
+    Ready,
+    /// UpdateParent replay is not available. This can be a normal block with no
+    /// UpdateParent marker, or an out-of-order slot still waiting on shreds.
+    Unavailable,
+    /// UpdateParent metadata and shred 0 are present, but shred 0 is not a
+    /// usable header or the header is incompatible with the UpdateParent.
+    Invalid,
 }
 
 pub fn banking_trace_path(path: &Path) -> PathBuf {
@@ -592,8 +649,11 @@ impl Blockstore {
 
             new_shreds_signals: Mutex::default(),
             completed_slots_senders: Mutex::default(),
+            update_parent_signals: Mutex::default(),
             insert_shreds_lock: Mutex::<()>::default(),
             max_root,
+            block_markers_enabled: AtomicBool::default(),
+            update_parent_enabled_from_slot: AtomicU64::new(Slot::MAX),
             lowest_cleanup_slot: RwLock::<Slot>::default(),
             manual_purge_request_sender: Mutex::default(),
             slots_stats: SlotsStats::default(),
@@ -611,14 +671,17 @@ impl Blockstore {
         let (ledger_signal_sender, ledger_signal_receiver) = bounded(MAX_REPLAY_WAKE_UP_SIGNALS);
         let (completed_slots_sender, completed_slots_receiver) =
             bounded(MAX_COMPLETED_SLOTS_IN_CHANNEL);
+        let (update_parent_sender, update_parent_receiver) = bounded(MAX_UPDATE_PARENT_SIGNALS);
 
         blockstore.add_new_shred_signal(ledger_signal_sender);
         blockstore.add_completed_slots_signal(completed_slots_sender);
+        blockstore.add_update_parent_signal(update_parent_sender);
 
         Ok(BlockstoreSignals {
             blockstore,
             ledger_signal_receiver,
             completed_slots_receiver,
+            update_parent_receiver,
         })
     }
 
@@ -956,8 +1019,10 @@ impl Blockstore {
     }
 
     /// Gets the double merkle root for the block in the given location.
-    /// Returns `None` if the block is not full.
-    /// DoubleMerkleMeta is computed atomically during shred insertion when a slot becomes full.
+    ///
+    /// Returns `None` if the block is not full, or if the slot was completed
+    /// while block markers were disabled. That can happen for legacy Tower
+    /// slots in a process that later enters Alpenglow migration.
     pub fn get_double_merkle_root(
         &self,
         slot: Slot,
@@ -966,11 +1031,6 @@ impl Blockstore {
         let Some(double_merkle_meta_bytes) =
             self.double_merkle_meta_cf.get_slice((slot, location))?
         else {
-            debug_assert!(
-                self.meta_from_location(slot, location)
-                    .unwrap()
-                    .is_none_or(|meta| !meta.is_full())
-            );
             return Ok(None);
         };
 
@@ -1005,6 +1065,10 @@ impl Blockstore {
         location: BlockLocation,
         just_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
     ) -> Option<ParentInfo> {
+        if !self.update_parent_enabled(slot) {
+            return None;
+        }
+
         let current_index = current_shred.index();
         let fec_set_index = current_shred.fec_set_index();
         let data_complete = current_shred.data_complete();
@@ -1012,7 +1076,7 @@ impl Blockstore {
         let (shred_bytes, target_fec_set_index) = if data_complete {
             // Case (a): Current shred has DATA_COMPLETE=true (end of FEC set)
             // Check the 0th shred in the NEXT FEC set for UpdateParent
-            let next_fec_set_index = fec_set_index + DATA_SHREDS_PER_FEC_BLOCK as u32;
+            let next_fec_set_index = fec_set_index.checked_add(DATA_SHREDS_PER_FEC_BLOCK as u32)?;
             let shred_id = ShredId::new(slot, next_fec_set_index, ShredType::Data);
             let shred_bytes =
                 self.get_shred_from_just_inserted_or_db(just_inserted_shreds, shred_id, location);
@@ -1033,7 +1097,7 @@ impl Blockstore {
                 .and_then(|flags| {
                     flags
                         .contains(ShredFlags::DATA_COMPLETE_SHRED)
-                        .then(|| Cow::Borrowed(current_shred.payload()))
+                        .then_some(Cow::Borrowed(current_shred.payload()))
                 });
 
             (shred_bytes, fec_set_index)
@@ -1059,6 +1123,27 @@ impl Blockstore {
         })
     }
 
+    /// Parse shred 0 as a block header if it is already available.
+    ///
+    /// SlotMeta cannot distinguish an old default parent block id from a valid
+    /// genesis-parent header. When an UpdateParent is parsed after such a
+    /// header, inspect the actual header shred so compatibility checks still
+    /// run without treating an unparsed shred-header parent as marker metadata.
+    fn maybe_parse_available_block_header(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+        just_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
+    ) -> Option<(ParentInfo, Slot)> {
+        let shred_id = ShredId::new(slot, 0, ShredType::Data);
+        let shred_bytes =
+            self.get_shred_from_just_inserted_or_db(just_inserted_shreds, shred_id, location)?;
+        let header_shred = Shred::new_from_serialized_shred(shred_bytes.as_ref().to_vec()).ok()?;
+        let parent_info = ParentInfo::maybe_parse_block_header(&header_shred)?;
+        let shred_parent_slot = header_shred.parent().ok()?;
+        Some((parent_info, shred_parent_slot))
+    }
+
     /// Orchestrates parsing and validation of `ParentInfo` during shred
     /// insertion.
     ///
@@ -1074,8 +1159,12 @@ impl Blockstore {
         just_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
         write_batch: &mut WriteBatch,
     ) -> Result<()> {
+        if !self.block_markers_enabled() {
+            return Ok(());
+        }
+
         let slot = shred.slot();
-        let previous_parent_info = ParentInfo::from_slot_meta(slot_meta);
+        let mut previous_parent_info = ParentInfo::from_slot_meta(slot_meta);
 
         let new_parent_info = if shred.index() == 0 {
             ParentInfo::maybe_parse_block_header(shred)
@@ -1094,6 +1183,28 @@ impl Blockstore {
         if let Err(err) = new_parent_info.validate_shred_parent(slot, shred_parent_slot, max_root) {
             self.mark_invalid_parent_info_dead(write_batch, new_parent_info, slot, location, &err)?;
             return Err(err);
+        }
+
+        if previous_parent_info.is_none() && !new_parent_info.populated_from_block_header() {
+            if let Some((block_header_info, block_header_shred_parent)) =
+                self.maybe_parse_available_block_header(slot, location, just_inserted_shreds)
+            {
+                if let Err(err) = block_header_info.validate_shred_parent(
+                    slot,
+                    block_header_shred_parent,
+                    max_root,
+                ) {
+                    self.mark_invalid_parent_info_dead(
+                        write_batch,
+                        block_header_info,
+                        slot,
+                        location,
+                        &err,
+                    )?;
+                    return Err(err);
+                }
+                previous_parent_info = Some(block_header_info);
+            }
         }
 
         // Validate new ParentInfo against previous (if both exist)
@@ -1128,6 +1239,10 @@ impl Blockstore {
         location: BlockLocation,
         err: &BlockstoreError,
     ) -> Result<()> {
+        // Parent markers are consensus-critical. If a marker is malformed or
+        // incompatible with already-persisted metadata, keep the slot from
+        // being replayed rather than letting validators derive different
+        // parents from different shred arrival orders.
         datapoint_error!(
             "blockstore_error",
             (
@@ -1555,9 +1670,7 @@ impl Blockstore {
             .filter_map(|(erasure_set, working_erasure_meta)| {
                 let erasure_meta = working_erasure_meta.as_ref();
                 let slot = erasure_set.slot();
-                let index_meta_entry = index_working_set
-                    .get(&(BlockLocation::Original, slot))
-                    .expect("Index");
+                let index_meta_entry = index_working_set.get(&(BlockLocation::Original, slot))?;
                 let index = &index_meta_entry.index;
                 erasure_meta
                     .should_recover_shreds(index)
@@ -1724,11 +1837,16 @@ impl Blockstore {
         }
     }
 
-    /// Computes and adds DoubleMerkleMeta to the write_batch for any newly completed slots.
+    /// Computes and adds DoubleMerkleMeta to the write_batch for newly completed
+    /// slots after block markers have been enabled.
     fn compute_double_merkle_meta_for_newly_completed_slots(
         &self,
         shred_insertion_tracker: &mut ShredInsertionTracker,
     ) -> Result<()> {
+        if !self.block_markers_enabled() {
+            return Ok(());
+        }
+
         for (&(location, slot), slot_meta_entry) in
             shred_insertion_tracker.slot_meta_working_set.iter()
         {
@@ -1915,12 +2033,14 @@ impl Blockstore {
     ) -> Result<(
         /* signal slot updates */ bool,
         /* slots updated */ Vec<u64>,
+        /* update parent signals */ Vec<UpdateParentSignal>,
     )> {
         let mut start = Measure::start("Commit Working Sets");
-        let (should_signal, newly_completed_slots) = self.commit_slot_meta_working_set(
-            &shred_insertion_tracker.slot_meta_working_set,
-            &mut shred_insertion_tracker.write_batch,
-        )?;
+        let (should_signal, newly_completed_slots, update_parent_signals) = self
+            .commit_slot_meta_working_set(
+                &shred_insertion_tracker.slot_meta_working_set,
+                &mut shred_insertion_tracker.write_batch,
+            )?;
 
         for (erasure_set, working_erasure_meta) in &shred_insertion_tracker.erasure_metas {
             if !working_erasure_meta.should_write() {
@@ -1965,7 +2085,7 @@ impl Blockstore {
         start.stop();
         metrics.commit_working_sets_elapsed_us += start.as_us();
 
-        Ok((should_signal, newly_completed_slots))
+        Ok((should_signal, newly_completed_slots, update_parent_signals))
     }
 
     /// The main helper function that performs the shred insertion logic
@@ -2069,7 +2189,7 @@ impl Blockstore {
         // Compute DoubleMerkleMeta for any newly completed slots so it's committed atomically
         self.compute_double_merkle_meta_for_newly_completed_slots(&mut shred_insertion_tracker)?;
 
-        let (should_signal, newly_completed_slots) =
+        let (should_signal, newly_completed_slots, update_parent_signals) =
             self.commit_updates_to_write_batch(&mut shred_insertion_tracker, metrics)?;
 
         // Write out the accumulated batch.
@@ -2081,8 +2201,10 @@ impl Blockstore {
         send_signals(
             &self.new_shreds_signals.lock().unwrap(),
             &self.completed_slots_senders.lock().unwrap(),
+            &self.update_parent_signals.lock().unwrap(),
             should_signal,
             newly_completed_slots,
+            update_parent_signals,
         );
 
         // Roll up metrics
@@ -2172,6 +2294,10 @@ impl Blockstore {
         self.completed_slots_senders.lock().unwrap().push(s);
     }
 
+    pub fn add_update_parent_signal(&self, s: UpdateParentSender) {
+        self.update_parent_signals.lock().unwrap().push(s);
+    }
+
     pub fn get_new_shred_signals_len(&self) -> usize {
         self.new_shreds_signals.lock().unwrap().len()
     }
@@ -2183,6 +2309,48 @@ impl Blockstore {
     pub fn drop_signal(&self) {
         self.new_shreds_signals.lock().unwrap().clear();
         self.completed_slots_senders.lock().unwrap().clear();
+        self.update_parent_signals.lock().unwrap().clear();
+    }
+
+    /// Enable or disable parsing of Alpenglow block markers on shred insertion.
+    ///
+    /// Marker parsing and double-merkle construction are not needed for
+    /// pre-migration Tower blocks, and keeping them disabled preserves the
+    /// legacy hot path. Replay turns this on once the Alpenglow feature is
+    /// activated or after startup from a migrated ledger.
+    pub fn set_block_markers_enabled(&self, enabled: bool) {
+        self.block_markers_enabled.store(enabled, Ordering::Release);
+    }
+
+    /// Configure marker parsing according to the current migration phase.
+    ///
+    /// Headers are useful during migration discovery, but `UpdateParent` is
+    /// Alpenglow-only. Keeping a separate start slot prevents an illegal
+    /// migration/Tower marker from reparenting `SlotMeta` before replay can
+    /// reject the block.
+    pub fn configure_block_markers_for_migration(&self, migration_status: &MigrationStatus) {
+        self.set_block_markers_enabled(!migration_status.is_pre_feature_activation());
+        self.set_update_parent_enabled_from_slot(
+            migration_status.first_slot_allowing_update_parent(),
+        );
+    }
+
+    /// Enable `UpdateParent` parent-metadata writes starting at `first_slot`.
+    ///
+    /// `None` disables `UpdateParent` parsing while still allowing block headers
+    /// to be parsed when block markers are enabled.
+    pub fn set_update_parent_enabled_from_slot(&self, first_slot: Option<Slot>) {
+        self.update_parent_enabled_from_slot
+            .store(first_slot.unwrap_or(Slot::MAX), Ordering::Release);
+    }
+
+    fn block_markers_enabled(&self) -> bool {
+        self.block_markers_enabled.load(Ordering::Acquire)
+    }
+
+    fn update_parent_enabled(&self, slot: Slot) -> bool {
+        let first_slot = self.update_parent_enabled_from_slot.load(Ordering::Acquire);
+        first_slot != Slot::MAX && slot >= first_slot
     }
 
     /// Clear `slot` from the Blockstore
@@ -2632,8 +2800,7 @@ impl Blockstore {
                 slot_meta,
                 just_inserted_shreds,
                 write_batch,
-            )
-            .map_err(InsertDataShredError::BlockstoreError)?;
+            )?;
         }
 
         let completed_data_sets = self.insert_data_shred(
@@ -2644,6 +2811,7 @@ impl Blockstore {
             write_batch,
             shred_source,
         );
+
         newly_completed_data_sets.extend(completed_data_sets);
         merkle_root_metas
             .entry((location, erasure_set))
@@ -3101,10 +3269,6 @@ impl Blockstore {
             return false;
         }
 
-        let Some(meta_parent_slot) = slot_meta.parent_slot else {
-            return false;
-        };
-
         let Ok(shred_parent) = shred.parent() else {
             warn!(
                 "Invalid data shred could not get parent slot shred_id {:?}",
@@ -3113,30 +3277,40 @@ impl Blockstore {
             return false;
         };
 
-        if meta_parent_slot != shred_parent {
-            let leader_pubkey = leader_schedule
-                .and_then(|leader_schedule| leader_schedule.slot_leader_at(slot, None));
-
-            datapoint_error!(
-                "blockstore_error",
-                (
-                    "error",
-                    format!(
-                        "Leader {:?}, shred_id {:?}: received shred with parent {} but slot_meta \
-                         has parent {}",
-                        leader_pubkey,
-                        shred.id(),
-                        shred_parent,
-                        meta_parent_slot
-                    ),
-                    String
-                )
-            );
-
+        if !verify_shred_slots(slot, shred_parent, max_root) {
             return false;
         }
 
-        verify_shred_slots(slot, meta_parent_slot, max_root)
+        if !slot_meta.has_update_parent() {
+            let Some(meta_parent_slot) = slot_meta.parent_slot else {
+                return false;
+            };
+
+            if meta_parent_slot != shred_parent {
+                let leader_pubkey = leader_schedule
+                    .and_then(|leader_schedule| leader_schedule.slot_leader_at(slot, None));
+
+                datapoint_error!(
+                    "blockstore_error",
+                    (
+                        "error",
+                        format!(
+                            "Leader {:?}, shred_id {:?}: received shred with parent {} but \
+                             slot_meta has parent {} before UpdateParent",
+                            leader_pubkey,
+                            shred.id(),
+                            shred_parent,
+                            meta_parent_slot
+                        ),
+                        String
+                    )
+                );
+
+                return false;
+            }
+        }
+
+        true
     }
 
     fn insert_data_shred<'a>(
@@ -3329,6 +3503,72 @@ impl Blockstore {
             BlockLocation::Alternate { block_id } => {
                 self.alt_data_shred_cf.get_bytes((slot, index, block_id))
             }
+        }
+    }
+
+    /// Returns true if the slot's `UpdateParent` can be used as a replay
+    /// starting point.
+    ///
+    /// Restarting from `replay_fec_set_index` skips the optimistic-parent
+    /// prefix. Before doing that, replay must prove the prefix contained a real
+    /// block header and that the `UpdateParent` is compatible with it. Without
+    /// this guard, a headerless `garbage | UpdateParent | valid suffix` block
+    /// could be accepted by nodes that skip directly to the marker.
+    pub fn can_replay_from_update_parent(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+    ) -> Result<bool> {
+        Ok(matches!(
+            self.update_parent_replay_status(slot, location)?,
+            UpdateParentReplayStatus::Ready
+        ))
+    }
+
+    /// Returns whether replay from an UpdateParent marker is ready,
+    /// unavailable, or invalid for `replay_fec_set_index`.
+    ///
+    /// `Unavailable` is not a block-validity verdict. It is returned for
+    /// ordinary blocks without an observed UpdateParent marker, and for
+    /// out-of-order arrival where replay may need to wait for more shreds.
+    /// `Invalid` is terminal for the local ledger data: shred 0 is present,
+    /// but it cannot form a compatible header for the observed UpdateParent.
+    pub fn update_parent_replay_status(
+        &self,
+        slot: Slot,
+        location: BlockLocation,
+    ) -> Result<UpdateParentReplayStatus> {
+        let Some(slot_meta) = self.meta_from_location(slot, location)? else {
+            return Ok(UpdateParentReplayStatus::Unavailable);
+        };
+        let Some(update_parent_info) =
+            ParentInfo::from_slot_meta(&slot_meta).filter(ParentInfo::has_update_parent)
+        else {
+            return Ok(UpdateParentReplayStatus::Unavailable);
+        };
+
+        let Some(shred_bytes) = self.get_data_shred_from_location(slot, 0, location)? else {
+            return Ok(UpdateParentReplayStatus::Unavailable);
+        };
+        let Ok(header_shred) = Shred::new_from_serialized_shred(shred_bytes) else {
+            return Ok(UpdateParentReplayStatus::Invalid);
+        };
+        let Some(block_header_info) = ParentInfo::maybe_parse_block_header(&header_shred) else {
+            return Ok(UpdateParentReplayStatus::Invalid);
+        };
+        let Ok(shred_parent_slot) = header_shred.parent() else {
+            return Ok(UpdateParentReplayStatus::Invalid);
+        };
+        if block_header_info
+            .validate_shred_parent(slot, shred_parent_slot, self.max_root())
+            .is_err()
+        {
+            return Ok(UpdateParentReplayStatus::Invalid);
+        }
+
+        match ParentInfo::should_write_parent_info(slot, &update_parent_info, &block_header_info) {
+            Ok(true) => Ok(UpdateParentReplayStatus::Ready),
+            Ok(false) | Err(_) => Ok(UpdateParentReplayStatus::Invalid),
         }
     }
 
@@ -4636,6 +4876,16 @@ impl Blockstore {
         // `consumed` is the next missing shred index, but shred `i` existing in
         // completed_data_end_indexes implies it's not missing
         assert!(!completed_data_indexes.contains(&consumed));
+
+        // When using UpdateParent's replay_fec_set_index as start_index, the shreds
+        // before that index might not have been received yet. For now, let's do the dumb
+        // thing of waiting for the previous shreds to arrive prior to replay.
+        //
+        // TODO(ksn): replay can get faster here by not having to wait for the shreds prior
+        // to an UpdateParent.
+        if start_index >= consumed {
+            return vec![];
+        }
         completed_data_indexes
             .range(start_index..consumed)
             .scan(start_index, |start, index| {
@@ -5172,6 +5422,10 @@ impl Blockstore {
     /// checks whether any of its direct and indirect children slots are connected
     /// or not.
     ///
+    /// This function also handles chaining updates when an UpdateParent marker
+    /// overrides a previously set parent from a BlockHeader. The dirty SlotMetas
+    /// identify slots that need reparenting.
+    ///
     /// Note: This chaining only occurs for `SlotMeta`s in the column associated with
     /// `BlockLocation::Original`
     ///
@@ -5322,18 +5576,13 @@ impl Blockstore {
 
         if should_propagate_is_connected {
             meta.borrow_mut().set_connected();
-            self.traverse_children_mut(
-                meta,
-                working_set,
-                new_chained_slots,
-                SlotMeta::set_parent_connected,
-            )?;
+            self.propagate_parent_connected_to_children(meta, working_set, new_chained_slots)?;
         }
 
         Ok(())
     }
 
-    /// Propagate `set_parent_connected` to all children of `slot_meta`.
+    /// Propagate `parent_connected` to children. Requires `slot_meta` to be connected.
     fn propagate_parent_connected_to_children(
         &self,
         slot_meta: &Rc<RefCell<SlotMeta>>,
@@ -5386,8 +5635,6 @@ impl Blockstore {
                     ))
                 })
         {
-            slot_meta.borrow_mut().parent_slot = Some(new_parent_slot);
-
             // Remove slot from old parent's next_slots if parent changed.
             self.find_slot_meta_else_create(working_set, new_chained_slots, old_parent_slot)?
                 .borrow_mut()
@@ -5398,9 +5645,9 @@ impl Blockstore {
             let new_parent_meta =
                 self.find_slot_meta_else_create(working_set, new_chained_slots, new_parent_slot)?;
             {
-                let mut new_parent = new_parent_meta.borrow_mut();
-                if !new_parent.next_slots.contains(&slot) {
-                    new_parent.next_slots.push(slot);
+                let mut new_meta = new_parent_meta.borrow_mut();
+                if !new_meta.next_slots.contains(&slot) {
+                    new_meta.next_slots.push(slot);
                 }
             }
 
@@ -5495,9 +5742,14 @@ impl Blockstore {
         &self,
         slot_meta_working_set: &HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
         write_batch: &mut WriteBatch,
-    ) -> Result<(bool, Vec<u64>)> {
+    ) -> Result<(
+        /* signal slot updates */ bool,
+        /* slots updated */ Vec<u64>,
+        /* update parent signals */ Vec<UpdateParentSignal>,
+    )> {
         let mut should_signal = false;
         let mut newly_completed_slots = vec![];
+        let mut update_parent_signals = Vec::new();
         let completed_slots_senders = self.completed_slots_senders.lock().unwrap();
 
         // Check if any metadata was changed, if so, insert the new version of the
@@ -5515,9 +5767,25 @@ impl Blockstore {
                 should_signal = should_signal || slot_has_updates(meta, meta_backup);
                 self.put_meta_in_batch(write_batch, slot, location, meta)?;
             }
+
+            // Check for new ``UpdateParent`s in the `Original` column
+            // This signal is only used for replay, so we don't need to consider `Alternate` columns
+            if location == BlockLocation::Original
+                && meta.has_update_parent()
+                && meta_backup
+                    .as_ref()
+                    .is_some_and(|m| m.populated_from_block_header())
+            {
+                update_parent_signals.push(UpdateParentSignal {
+                    slot,
+                    parent_slot: meta.parent_slot.expect("Must be present"),
+                    parent_block_id: meta.parent_block_id,
+                    replay_fec_set_index: meta.replay_fec_set_index,
+                });
+            }
         }
 
-        Ok((should_signal, newly_completed_slots))
+        Ok((should_signal, newly_completed_slots, update_parent_signals))
     }
 
     /// Obtain the SlotMeta from the in-memory slot_meta_working_set or load
@@ -5683,7 +5951,7 @@ fn update_completed_data_indexes<'a>(
             .next_back()
             .map(|index| index + 1)
             .or(Some(0u32)),
-        is_last_in_data.then(|| new_shred_index + 1),
+        is_last_in_data.then_some(new_shred_index + 1),
         completed_data_indexes
             .range(new_shred_index + 1..)
             .next()
@@ -5734,8 +6002,10 @@ fn update_slot_meta<'a>(
 fn send_signals(
     new_shreds_signals: &[Sender<bool>],
     completed_slots_senders: &[Sender<Vec<u64>>],
+    update_parent_senders: &[UpdateParentSender],
     should_signal: bool,
     newly_completed_slots: Vec<u64>,
+    update_parent_signals: Vec<UpdateParentSignal>,
 ) {
     if should_signal {
         for signal in new_shreds_signals {
@@ -5768,6 +6038,22 @@ fn send_signals(
                         "Unable to send newly completed slot because channel is full",
                         String
                     ),
+                );
+            }
+        }
+    }
+
+    for signal in update_parent_signals {
+        for sender in update_parent_senders {
+            if let Err(TrySendError::Full(_)) = sender.try_send(signal.clone()) {
+                error!(
+                    "update_parent channel full, dropping signal for slot {}",
+                    signal.slot
+                );
+                datapoint_error!(
+                    "blockstore_error",
+                    ("error", "update_parent channel full", String),
+                    ("slot", signal.slot, i64),
                 );
             }
         }
@@ -6203,6 +6489,7 @@ pub fn test_all_empty_or_min(blockstore: &Blockstore, min_slot: Slot) {
             .next()
             .map(|(slot, _)| slot >= min_slot)
             .unwrap_or(true);
+
     assert!(condition_met);
 }
 
@@ -6301,6 +6588,11 @@ pub mod tests {
         assert_eq!(slot, meta.slot);
         assert!(meta.is_full());
         assert!(meta.next_slots.is_empty());
+    }
+
+    fn enable_block_markers(blockstore: &Blockstore) {
+        blockstore.set_block_markers_enabled(true);
+        blockstore.set_update_parent_enabled_from_slot(Some(0));
     }
 
     fn create_update_parent_shreds(
@@ -6413,6 +6705,15 @@ pub mod tests {
     }
 
     fn create_block_footer_shreds(slot: Slot, parent_slot: Slot, shred_index: u32) -> Vec<Shred> {
+        create_block_footer_shreds_with_last(slot, parent_slot, shred_index, true)
+    }
+
+    fn create_block_footer_shreds_with_last(
+        slot: Slot,
+        parent_slot: Slot,
+        shred_index: u32,
+        is_last_in_slot: bool,
+    ) -> Vec<Shred> {
         use solana_entry::block_component::BlockFooterV1;
         let footer = BlockFooterV1 {
             bank_hash: Hash::new_unique(),
@@ -6430,7 +6731,7 @@ pub mod tests {
             .make_merkle_shreds_from_component(
                 &Keypair::new(),
                 &component,
-                true,
+                is_last_in_slot,
                 Hash::new_unique(),
                 shred_index,
                 shred_index,
@@ -6438,6 +6739,10 @@ pub mod tests {
                 &mut ProcessShredsStats::default(),
             )
             .collect()
+    }
+
+    fn data_shreds(shreds: Vec<Shred>) -> Vec<Shred> {
+        shreds.into_iter().filter(Shred::is_data).collect()
     }
 
     #[test]
@@ -8973,6 +9278,23 @@ pub mod tests {
     }
 
     #[test]
+    fn test_ranges_after_consumed() {
+        let completed_data_end_indexes = [2, 4, 9, 11].iter().copied().collect();
+
+        // start_index > consumed: out-of-order shred delivery during fast leader handover
+        assert_eq!(
+            Blockstore::get_completed_data_ranges(32, &completed_data_end_indexes, 3),
+            vec![]
+        );
+
+        // start_index == consumed
+        assert_eq!(
+            Blockstore::get_completed_data_ranges(5, &completed_data_end_indexes, 5),
+            vec![]
+        );
+    }
+
+    #[test]
     fn test_get_slot_entries_with_shred_count_corruption() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
@@ -10976,6 +11298,79 @@ pub mod tests {
     }
 
     #[test]
+    fn test_skip_alt_recovery() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let slot = 1;
+        let (data_shreds, coding_shreds, leader_schedule_cache) =
+            setup_erasure_shreds(slot, 0, 100);
+        let data_shred = data_shreds[0].clone();
+        let data_shred_index = u64::from(data_shred.index());
+
+        // First populate Original erasure metadata through a coding shred. A
+        // later Alternate-column block-id repair insertion for the same FEC set
+        // will load this erasure meta without touching the Original index in the
+        // current batch.
+        blockstore
+            .do_insert_shreds(
+                std::iter::once((
+                    Cow::Owned(coding_shreds[0].clone()),
+                    /*is_repaired:*/ false,
+                    BlockLocation::Original,
+                )),
+                Some(&leader_schedule_cache),
+                false, // is_trusted
+                None,
+                &mut BlockstoreInsertionMetrics::default(),
+            )
+            .unwrap();
+
+        let genesis_config = create_genesis_config(2).genesis_config;
+        let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
+        let alternate_location = BlockLocation::Alternate {
+            block_id: Hash::new_unique(),
+        };
+        let mut metrics = BlockstoreInsertionMetrics::default();
+
+        blockstore
+            .do_insert_shreds(
+                std::iter::once((
+                    Cow::Owned(data_shred),
+                    /*is_repaired:*/ true,
+                    alternate_location,
+                )),
+                Some(&leader_schedule_cache),
+                false, // is_trusted
+                Some(&mut ShredRecoveryContext::new(
+                    ReedSolomonCache::default(),
+                    dummy_retransmit_sender,
+                    root_bank,
+                    0, // shred_version
+                )),
+                &mut metrics,
+            )
+            .unwrap();
+
+        assert_eq!(metrics.num_recovered, 0);
+        assert!(
+            blockstore
+                .get_index_from_location(slot, alternate_location)
+                .unwrap()
+                .unwrap()
+                .data()
+                .contains(data_shred_index)
+        );
+        assert!(
+            blockstore
+                .get_data_shred(slot, data_shred_index)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
     fn test_recovery_discards_unexpected_data_complete_shreds() {
         const DATA_SHRED_FLAGS_OFFSET: usize = 85;
 
@@ -12913,6 +13308,7 @@ pub mod tests {
     fn test_get_double_merkle_root(use_alternate_location: bool) {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
 
         let parent_slot = 990;
         let parent_block_id = Hash::default();
@@ -13059,6 +13455,26 @@ pub mod tests {
         );
     }
 
+    #[test]
+    fn test_markers_off_skips_dmr() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let slot = 1000;
+        let (data_shreds, _, leader_schedule) = setup_erasure_shreds(slot, 990, 200);
+        blockstore
+            .insert_shreds(data_shreds, Some(&leader_schedule), true)
+            .unwrap();
+
+        assert!(blockstore.meta(slot).unwrap().unwrap().is_full());
+        assert!(
+            blockstore
+                .get_double_merkle_root(slot, BlockLocation::Original)
+                .unwrap()
+                .is_none()
+        );
+    }
+
     #[test_matrix([true, false], [
         (990, 980, false, false), // update parent before block header -> not dead
         (980, 990, false, true),  // update parent after block header -> dead
@@ -13070,6 +13486,7 @@ pub mod tests {
         let slot = 1000;
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
 
         let bh_block_id = Hash::new_unique();
         let up_block_id = if same_block_id {
@@ -13084,11 +13501,13 @@ pub mod tests {
         let block_footer_shreds = create_block_footer_shreds(slot, bh_parent_slot, 64);
 
         let shreds: Vec<Shred> = if block_header_first {
+            // Block header shreds first, then update parent, then footer
             let mut s = block_header_shreds;
             s.extend(update_parent_shreds);
             s.extend(block_footer_shreds);
             s
         } else {
+            // Update parent shreds first, then block header, then footer
             let mut s = update_parent_shreds;
             s.extend(block_header_shreds);
             s.extend(block_footer_shreds);
@@ -13122,6 +13541,7 @@ pub mod tests {
         for block_header_parent_slot in [slot - 2, slot, slot + 1] {
             let ledger_path = get_tmp_ledger_path_auto_delete!();
             let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+            enable_block_markers(&blockstore);
 
             let shreds = create_block_header_shreds_with_shred_parent(
                 slot,
@@ -13154,6 +13574,7 @@ pub mod tests {
         for update_parent_slot in [slot, slot + 1] {
             let ledger_path = get_tmp_ledger_path_auto_delete!();
             let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+            enable_block_markers(&blockstore);
 
             let mut shreds = create_update_parent_shreds_with_shred_parent(
                 slot,
@@ -13183,9 +13604,143 @@ pub mod tests {
     }
 
     #[test]
+    fn test_genesis_parent_id() {
+        let slot = 1000;
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
+
+        blockstore
+            .insert_shreds(
+                create_block_header_shreds_with_shred_parent(slot, 0, 0, Hash::new_unique()),
+                None,
+                false,
+            )
+            .unwrap();
+
+        assert!(blockstore.is_dead(slot));
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_block_id, Hash::default());
+        assert!(!meta.has_update_parent());
+
+        let slot = 1001;
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
+
+        blockstore
+            .insert_shreds(
+                create_block_header_shreds_with_shred_parent(slot, 0, 0, Hash::default()),
+                None,
+                false,
+            )
+            .unwrap();
+        assert!(!blockstore.is_dead(slot));
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(0));
+        assert_eq!(meta.parent_block_id, Hash::default());
+        assert!(!meta.has_update_parent());
+
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds_with_shred_parent(
+                    slot,
+                    0,
+                    0,
+                    Hash::default(),
+                    32,
+                    false,
+                ),
+                None,
+                false,
+            )
+            .unwrap();
+        assert!(blockstore.is_dead(slot));
+        assert!(!blockstore.meta(slot).unwrap().unwrap().has_update_parent());
+
+        let slot = 1002;
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
+
+        blockstore
+            .insert_shreds(
+                create_block_header_shreds(slot, 5, Hash::new_unique()),
+                None,
+                false,
+            )
+            .unwrap();
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds_with_shred_parent(
+                    slot,
+                    5,
+                    0,
+                    Hash::new_unique(),
+                    32,
+                    false,
+                ),
+                None,
+                false,
+            )
+            .unwrap();
+
+        assert!(blockstore.is_dead(slot));
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(5));
+        assert!(!meta.has_update_parent());
+    }
+
+    #[test]
+    fn test_update_parent_disabled_keeps_header_parent() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let migration_status = MigrationStatus::default();
+        migration_status.record_feature_activation(0);
+        blockstore.configure_block_markers_for_migration(&migration_status);
+
+        let slot = 10;
+        let original_parent = 5;
+        let update_parent = 3;
+        let header_parent_block_id = Hash::new_unique();
+        blockstore
+            .insert_shreds(
+                create_block_header_shreds(slot, original_parent, header_parent_block_id),
+                None,
+                true,
+            )
+            .unwrap();
+
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds_with_shred_parent(
+                    slot,
+                    original_parent,
+                    update_parent,
+                    Hash::new_unique(),
+                    32,
+                    true,
+                ),
+                None,
+                true,
+            )
+            .unwrap();
+
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(original_parent));
+        assert_eq!(meta.parent_block_id, header_parent_block_id);
+        assert_eq!(meta.replay_fec_set_index, 0);
+        assert!(!meta.has_update_parent());
+        assert!(!blockstore.is_dead(slot));
+        verify_next_slots(&blockstore, original_parent, &[slot]);
+        verify_next_slots(&blockstore, update_parent, &[]);
+    }
+
+    #[test]
     fn test_block_header_followed_by_update_parent() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
 
         let parent_5_id = Hash::new_unique();
         blockstore
@@ -13212,16 +13767,369 @@ pub mod tests {
             .unwrap();
         assert_eq!(parent_info.parent_slot, 3);
         assert_eq!(parent_info.parent_block_id, parent_3_id);
-        assert!(parent_info.populated_from_update_parent());
+        assert!(parent_info.has_update_parent());
 
         verify_next_slots(&blockstore, 5, &[]);
         verify_next_slots(&blockstore, 3, &[10]);
     }
 
     #[test]
+    fn test_update_parent_needs_header() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
+
+        let slot = 10;
+        let original_parent = 5;
+        let update_parent = 3;
+        let update_parent_block_id = Hash::new_unique();
+
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds_with_shred_parent(
+                    slot,
+                    original_parent,
+                    update_parent,
+                    update_parent_block_id,
+                    32,
+                    false,
+                ),
+                None,
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(
+            blockstore
+                .update_parent_replay_status(slot, BlockLocation::Original)
+                .unwrap(),
+            UpdateParentReplayStatus::Unavailable
+        );
+        assert!(
+            !blockstore
+                .can_replay_from_update_parent(slot, BlockLocation::Original)
+                .unwrap()
+        );
+
+        let invalid_header_slot = 11;
+        blockstore
+            .insert_shreds(
+                create_update_parent_shreds_with_shred_parent(
+                    invalid_header_slot,
+                    original_parent,
+                    update_parent,
+                    update_parent_block_id,
+                    32,
+                    false,
+                ),
+                None,
+                true,
+            )
+            .unwrap();
+        blockstore
+            .insert_shreds(
+                create_block_footer_shreds_with_last(
+                    invalid_header_slot,
+                    original_parent,
+                    0,
+                    false,
+                ),
+                None,
+                true,
+            )
+            .unwrap();
+
+        let meta = blockstore.meta(invalid_header_slot).unwrap().unwrap();
+        assert!(meta.has_update_parent());
+        assert_eq!(
+            blockstore
+                .update_parent_replay_status(invalid_header_slot, BlockLocation::Original)
+                .unwrap(),
+            UpdateParentReplayStatus::Invalid
+        );
+        assert!(
+            !blockstore
+                .can_replay_from_update_parent(invalid_header_slot, BlockLocation::Original)
+                .unwrap()
+        );
+
+        let header_only_slot = 12;
+        blockstore
+            .insert_shreds(
+                create_block_header_shreds(header_only_slot, original_parent, Hash::new_unique()),
+                None,
+                true,
+            )
+            .unwrap();
+        assert_eq!(
+            blockstore
+                .update_parent_replay_status(header_only_slot, BlockLocation::Original)
+                .unwrap(),
+            UpdateParentReplayStatus::Unavailable
+        );
+        assert!(
+            !blockstore
+                .can_replay_from_update_parent(header_only_slot, BlockLocation::Original)
+                .unwrap()
+        );
+        assert!(!blockstore.is_dead(header_only_slot));
+
+        blockstore
+            .insert_shreds(
+                create_block_header_shreds(slot, original_parent, Hash::new_unique()),
+                None,
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(
+            blockstore
+                .update_parent_replay_status(slot, BlockLocation::Original)
+                .unwrap(),
+            UpdateParentReplayStatus::Ready
+        );
+        assert!(
+            blockstore
+                .can_replay_from_update_parent(slot, BlockLocation::Original)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_post_update_orig_after() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
+
+        let slot = 90;
+        let original_parent = 85;
+        let update_parent = 80;
+        blockstore
+            .insert_shreds(
+                data_shreds(create_block_header_shreds(
+                    slot,
+                    original_parent,
+                    Hash::new_unique(),
+                )),
+                None,
+                false,
+            )
+            .unwrap();
+
+        let update_parent_block_id = Hash::new_unique();
+        blockstore
+            .insert_shreds(
+                data_shreds(create_update_parent_shreds_with_shred_parent(
+                    slot,
+                    original_parent,
+                    update_parent,
+                    update_parent_block_id,
+                    32,
+                    false,
+                )),
+                None,
+                false,
+            )
+            .unwrap();
+
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(update_parent));
+        assert_eq!(meta.parent_block_id, update_parent_block_id);
+        assert_eq!(meta.replay_fec_set_index, 32);
+        assert!(!blockstore.is_dead(slot));
+
+        blockstore
+            .insert_shreds(
+                data_shreds(create_block_footer_shreds(slot, original_parent, 64)),
+                None,
+                false,
+            )
+            .unwrap();
+
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(update_parent));
+        assert_eq!(meta.replay_fec_set_index, 32);
+        assert!(blockstore.get_data_shred(slot, 64).unwrap().is_some());
+        assert!(!blockstore.is_dead(slot));
+    }
+
+    #[test]
+    fn test_post_update_orig_before() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
+
+        let slot = 91;
+        let original_parent = 86;
+        let update_parent = 81;
+        blockstore
+            .insert_shreds(
+                data_shreds(create_block_header_shreds(
+                    slot,
+                    original_parent,
+                    Hash::new_unique(),
+                )),
+                None,
+                false,
+            )
+            .unwrap();
+
+        blockstore
+            .insert_shreds(
+                data_shreds(create_block_footer_shreds(slot, original_parent, 64)),
+                None,
+                false,
+            )
+            .unwrap();
+
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(original_parent));
+        assert_eq!(meta.replay_fec_set_index, 0);
+        assert!(blockstore.get_data_shred(slot, 64).unwrap().is_some());
+        assert!(!blockstore.is_dead(slot));
+
+        let update_parent_block_id = Hash::new_unique();
+        blockstore
+            .insert_shreds(
+                data_shreds(create_update_parent_shreds_with_shred_parent(
+                    slot,
+                    original_parent,
+                    update_parent,
+                    update_parent_block_id,
+                    32,
+                    false,
+                )),
+                None,
+                false,
+            )
+            .unwrap();
+
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(update_parent));
+        assert_eq!(meta.parent_block_id, update_parent_block_id);
+        assert_eq!(meta.replay_fec_set_index, 32);
+        assert!(blockstore.get_data_shred(slot, 64).unwrap().is_some());
+        assert!(!blockstore.is_dead(slot));
+    }
+
+    #[test]
+    fn test_marker_boundary_ooo() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
+
+        let slot = 93;
+        let original_parent = 88;
+        let update_parent = 80;
+        blockstore
+            .insert_shreds(
+                data_shreds(create_block_header_shreds(
+                    slot,
+                    original_parent,
+                    Hash::new_unique(),
+                )),
+                None,
+                false,
+            )
+            .unwrap();
+
+        let mut post_update_shreds = vec![];
+        for shred_index in [64, 96, 128] {
+            post_update_shreds.extend(data_shreds(create_block_footer_shreds_with_last(
+                slot,
+                original_parent,
+                shred_index,
+                false,
+            )));
+        }
+        blockstore
+            .insert_shreds(post_update_shreds, None, false)
+            .unwrap();
+
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(original_parent));
+        assert_eq!(meta.replay_fec_set_index, 0);
+
+        let update_parent_block_id = Hash::new_unique();
+        blockstore
+            .insert_shreds(
+                data_shreds(create_update_parent_shreds_with_shred_parent(
+                    slot,
+                    original_parent,
+                    update_parent,
+                    update_parent_block_id,
+                    32,
+                    false,
+                )),
+                None,
+                false,
+            )
+            .unwrap();
+
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(update_parent));
+        assert_eq!(meta.parent_block_id, update_parent_block_id);
+        assert_eq!(meta.replay_fec_set_index, 32);
+        for shred_index in [64, 96, 128] {
+            assert!(
+                blockstore
+                    .get_data_shred(slot, shred_index)
+                    .unwrap()
+                    .is_some()
+            );
+        }
+        assert!(!blockstore.is_dead(slot));
+    }
+
+    #[test]
+    fn test_markers_off_parent_meta() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let slot = 92;
+        let original_parent = 87;
+        let update_parent = 82;
+        blockstore
+            .insert_shreds(
+                data_shreds(create_block_header_shreds(
+                    slot,
+                    original_parent,
+                    Hash::new_unique(),
+                )),
+                None,
+                false,
+            )
+            .unwrap();
+
+        let update_parent_block_id = Hash::new_unique();
+        blockstore
+            .insert_shreds(
+                data_shreds(create_update_parent_shreds_with_shred_parent(
+                    slot,
+                    original_parent,
+                    update_parent,
+                    update_parent_block_id,
+                    32,
+                    false,
+                )),
+                None,
+                false,
+            )
+            .unwrap();
+
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(original_parent));
+        assert_eq!(meta.parent_block_id, Hash::default());
+        assert_eq!(meta.replay_fec_set_index, 0);
+        assert!(!meta.has_update_parent());
+        assert!(!blockstore.is_dead(slot));
+    }
+
+    #[test]
     fn test_update_parent_overrides_block_header() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
 
         blockstore
             .insert_shreds(
@@ -13251,51 +14159,53 @@ pub mod tests {
     fn test_reparenting_via_update_parent() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
 
         blockstore
             .insert_shreds(
-                create_block_header_shreds(30, 25, Hash::new_unique()),
+                create_block_header_shreds(32, 25, Hash::new_unique()),
                 None,
                 true,
             )
             .unwrap();
-        verify_next_slots(&blockstore, 25, &[30]);
+        verify_next_slots(&blockstore, 25, &[32]);
 
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(30, 22, Hash::new_unique(), 32, true),
+                create_update_parent_shreds(32, 22, Hash::new_unique(), 32, true),
                 None,
                 true,
             )
             .unwrap();
 
-        assert_eq!(blockstore.meta(30).unwrap().unwrap().parent_slot, Some(22));
+        assert_eq!(blockstore.meta(32).unwrap().unwrap().parent_slot, Some(22));
         verify_next_slots(&blockstore, 25, &[]);
-        verify_next_slots(&blockstore, 22, &[30]);
+        verify_next_slots(&blockstore, 22, &[32]);
     }
 
     #[test]
     fn test_multiple_children_reparenting() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
 
         let parent_id = Hash::new_unique();
-        for slot in [41, 40, 42] {
+        for slot in [44, 40, 48] {
             blockstore
                 .insert_shreds(create_block_header_shreds(slot, 35, parent_id), None, true)
                 .unwrap();
         }
-        verify_next_slots(&blockstore, 35, &[40, 41, 42]);
+        verify_next_slots(&blockstore, 35, &[40, 44, 48]);
 
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(41, 32, Hash::new_unique(), 32, true),
+                create_update_parent_shreds(44, 32, Hash::new_unique(), 32, true),
                 None,
                 true,
             )
             .unwrap();
-        verify_next_slots(&blockstore, 35, &[40, 42]);
-        verify_next_slots(&blockstore, 32, &[41]);
+        verify_next_slots(&blockstore, 35, &[40, 48]);
+        verify_next_slots(&blockstore, 32, &[44]);
 
         blockstore
             .insert_shreds(
@@ -13304,7 +14214,7 @@ pub mod tests {
                 true,
             )
             .unwrap();
-        verify_next_slots(&blockstore, 35, &[42]);
+        verify_next_slots(&blockstore, 35, &[48]);
         verify_next_slots(&blockstore, 33, &[40]);
     }
 
@@ -13312,34 +14222,38 @@ pub mod tests {
     fn test_interleaved_shred_arrival() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
 
         blockstore
             .insert_shreds(
-                create_block_header_shreds(50, 48, Hash::new_unique()),
+                create_block_header_shreds(52, 48, Hash::new_unique()),
                 None,
                 true,
             )
             .unwrap();
-        assert_eq!(blockstore.meta(50).unwrap().unwrap().parent_slot, Some(48));
+        assert_eq!(blockstore.meta(52).unwrap().unwrap().parent_slot, Some(48));
 
         // Split update parent shreds across two batches
-        let mut update_shreds = create_update_parent_shreds(50, 45, Hash::new_unique(), 32, true);
+        let mut update_shreds = create_update_parent_shreds(52, 45, Hash::new_unique(), 32, true);
         let mid = update_shreds.len() / 2;
         let first_half: Vec<_> = update_shreds.drain(..mid).collect();
 
         blockstore.insert_shreds(first_half, None, true).unwrap();
         blockstore.insert_shreds(update_shreds, None, true).unwrap();
 
-        assert_eq!(blockstore.meta(50).unwrap().unwrap().parent_slot, Some(45));
+        assert_eq!(blockstore.meta(52).unwrap().unwrap().parent_slot, Some(45));
         verify_next_slots(&blockstore, 48, &[]);
-        verify_next_slots(&blockstore, 45, &[50]);
+        verify_next_slots(&blockstore, 45, &[52]);
     }
 
     #[test]
     fn test_same_batch_block_header_then_update_parent() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
 
+        // Insert both BlockHeader and UpdateParent in the same batch,
+        // with BlockHeader shreds first (lower indices)
         let mut shreds = create_block_header_shreds(60, 55, Hash::new_unique());
         shreds.extend(create_update_parent_shreds(
             60,
@@ -13361,28 +14275,26 @@ pub mod tests {
     fn test_same_batch_update_parent_then_block_header() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
 
-        let mut shreds = create_update_parent_shreds(70, 65, Hash::new_unique(), 32, true);
-        shreds.extend(create_block_header_shreds(70, 68, Hash::new_unique()));
+        // Insert both UpdateParent and BlockHeader in the same batch,
+        // with UpdateParent shreds first (but BlockHeader is at index 0)
+        let mut shreds = create_update_parent_shreds(72, 65, Hash::new_unique(), 32, true);
+        shreds.extend(create_block_header_shreds(72, 68, Hash::new_unique()));
 
         blockstore.insert_shreds(shreds, None, true).unwrap();
 
         // UpdateParent should take precedence regardless of insertion order
-        assert_eq!(blockstore.meta(70).unwrap().unwrap().parent_slot, Some(65));
+        assert_eq!(blockstore.meta(72).unwrap().unwrap().parent_slot, Some(65));
         verify_next_slots(&blockstore, 68, &[]);
-        verify_next_slots(&blockstore, 65, &[70]);
+        verify_next_slots(&blockstore, 65, &[72]);
     }
 
     #[test]
     fn test_multiple_update_parents_out_of_order_marks_dead() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-        let data_shreds = |shreds: Vec<Shred>| {
-            shreds
-                .into_iter()
-                .filter(|shred| shred.is_data())
-                .collect_vec()
-        };
+        enable_block_markers(&blockstore);
 
         let slot = 80;
         blockstore
@@ -13443,33 +14355,35 @@ pub mod tests {
     fn test_update_parent_propagates_connectivity() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
 
         // Slot 0 is connected when full
         let (shreds, _) = make_slot_entries(0, 0, 5);
         blockstore.insert_shreds(shreds, None, true).unwrap();
         assert!(blockstore.meta(0).unwrap().unwrap().is_connected());
 
-        // Slot 10 with BlockHeader pointing to disconnected parent
+        // Slot 8 with BlockHeader pointing to disconnected parent
         blockstore
             .insert_shreds(
-                create_block_header_shreds(10, 5, Hash::new_unique()),
+                create_block_header_shreds(8, 5, Hash::new_unique()),
                 None,
                 true,
             )
             .unwrap();
-        assert!(!blockstore.meta(10).unwrap().unwrap().is_connected());
+        assert!(!blockstore.meta(8).unwrap().unwrap().is_connected());
 
         // UpdateParent switches to connected parent, slot becomes connected
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(10, 0, Hash::new_unique(), 32, true),
+                create_update_parent_shreds(8, 0, Hash::default(), 32, true),
                 None,
                 true,
             )
             .unwrap();
 
-        let meta = blockstore.meta(10).unwrap().unwrap();
+        let meta = blockstore.meta(8).unwrap().unwrap();
         assert_eq!(meta.parent_slot, Some(0));
+        // Slot 8 is incomplete (not full), so only parent_connected, not connected
         assert!(meta.is_parent_connected());
     }
 
@@ -13477,6 +14391,7 @@ pub mod tests {
     fn test_update_parent_propagates_connectivity_to_descendants() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
 
         // Slot 0 is connected when full
         let (shreds, _) = make_slot_entries(0, 0, 5);
@@ -13502,7 +14417,7 @@ pub mod tests {
         // Reparent 100 to connected slot 0; connectivity propagates to 200 and 300
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(100, 0, Hash::new_unique(), 32, true),
+                create_update_parent_shreds(100, 0, Hash::default(), 32, true),
                 None,
                 true,
             )
@@ -13520,6 +14435,7 @@ pub mod tests {
     fn test_update_parent_clears_connectivity() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
 
         // Slot 0 and 5 are connected (full slots chained together)
         let (shreds, _) = make_slot_entries(0, 0, 5);
@@ -13528,33 +14444,35 @@ pub mod tests {
         blockstore.insert_shreds(shreds, None, true).unwrap();
         assert!(blockstore.meta(5).unwrap().unwrap().is_connected());
 
-        // Slot 10 with BlockHeader pointing to connected parent 5
+        // Slot 8 with BlockHeader pointing to connected parent 5
         blockstore
             .insert_shreds(
-                create_block_header_shreds(10, 5, Hash::new_unique()),
+                create_block_header_shreds(8, 5, Hash::new_unique()),
                 None,
                 true,
             )
             .unwrap();
-        let meta = blockstore.meta(10).unwrap().unwrap();
+        let meta = blockstore.meta(8).unwrap().unwrap();
         assert!(meta.is_parent_connected());
 
-        // Slot 20 chains to slot 10
-        let (shreds, _) = make_slot_entries(20, 10, 5);
+        // Slot 20 chains to slot 8
+        let (shreds, _) = make_slot_entries(20, 8, 5);
         blockstore.insert_shreds(shreds, None, true).unwrap();
 
-        // UpdateParent switches slot 10 to disconnected parent 3
+        // UpdateParent switches slot 8 to disconnected parent 3 (lower, doesn't exist)
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(10, 3, Hash::new_unique(), 32, true),
+                create_update_parent_shreds(8, 3, Hash::new_unique(), 32, true),
                 None,
                 true,
             )
             .unwrap();
 
-        let meta = blockstore.meta(10).unwrap().unwrap();
+        // Slot 8 should have parent_connected cleared
+        let meta = blockstore.meta(8).unwrap().unwrap();
         assert_eq!(meta.parent_slot, Some(3));
         assert!(!meta.is_parent_connected());
+        // Slot 20 should also have parent_connected cleared
         assert!(!blockstore.meta(20).unwrap().unwrap().is_parent_connected());
     }
 
@@ -13562,46 +14480,47 @@ pub mod tests {
     fn test_connectivity_does_not_propagate_through_incomplete_slot() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        enable_block_markers(&blockstore);
 
         // Slot 0 is the connected root
         let (shreds, _) = make_slot_entries(0, 0, 5);
         blockstore.insert_shreds(shreds, None, true).unwrap();
         assert!(blockstore.meta(0).unwrap().unwrap().is_connected());
 
-        // Slot 50 incomplete, pointing to disconnected parent 40
+        // Slot 48 incomplete, pointing to disconnected parent 40
         blockstore
             .insert_shreds(
-                create_block_header_shreds(50, 40, Hash::new_unique()),
+                create_block_header_shreds(48, 40, Hash::new_unique()),
                 None,
                 true,
             )
             .unwrap();
 
-        // Full children chain from incomplete slot 50
-        let (shreds, _) = make_slot_entries(60, 50, 5);
+        // Full children chain from incomplete slot 48
+        let (shreds, _) = make_slot_entries(60, 48, 5);
         blockstore.insert_shreds(shreds, None, true).unwrap();
         let (shreds, _) = make_slot_entries(70, 60, 5);
         blockstore.insert_shreds(shreds, None, true).unwrap();
 
-        for slot in [50, 60, 70] {
+        for slot in [48, 60, 70] {
             assert!(!blockstore.meta(slot).unwrap().unwrap().is_connected());
         }
 
-        // Reparent slot 50 to connected slot 0, keeping it incomplete
+        // Reparent slot 48 to connected slot 0, keeping it incomplete
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(50, 0, Hash::new_unique(), 32, false),
+                create_update_parent_shreds(48, 0, Hash::default(), 32, false),
                 None,
                 true,
             )
             .unwrap();
 
-        // Slot 50 incomplete: parent_connected but not connected
-        let meta_50 = blockstore.meta(50).unwrap().unwrap();
-        assert!(meta_50.is_parent_connected());
-        assert!(!meta_50.is_connected());
+        // Slot 48 incomplete: parent_connected but not connected
+        let meta_48 = blockstore.meta(48).unwrap().unwrap();
+        assert!(meta_48.is_parent_connected());
+        assert!(!meta_48.is_connected());
 
-        // Children stay disconnected since parent 50 is incomplete
+        // Children stay disconnected since parent 48 is incomplete
         assert!(!blockstore.meta(60).unwrap().unwrap().is_connected());
         assert!(!blockstore.meta(70).unwrap().unwrap().is_connected());
     }

--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -93,6 +93,11 @@ pub enum BlockstoreError {
         parent_slot: Slot,
         root: Slot,
     },
+    #[error("invalid parent block id for genesis parent in slot {slot}: {parent_block_id}")]
+    InvalidGenesisParentBlockId {
+        slot: Slot,
+        parent_block_id: solana_hash::Hash,
+    },
     #[error(
         "block header parent {block_header_parent_slot} does not match shred parent \
          {shred_parent_slot} for slot {slot}"

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -43,6 +43,7 @@ bitflags! {
         // CONNECTED is explicitly the first bit to ensure backwards compatibility
         // with the boolean field that ConnectedFlags replaced in SlotMeta.
         const CONNECTED        = 0b0000_0001;
+        // Parent is connected; the slot becomes CONNECTED once it is also full.
         const PARENT_CONNECTED = 0b1000_0000;
     }
 }
@@ -147,12 +148,12 @@ pub struct SlotMetaBase<T> {
 
 pub type SlotMetaV2 = SlotMetaBase<CompletedDataIndexes>;
 
-/// SlotMetaV3 extends SlotMeta with two additional fields: `parent_block_id`
-/// and `replay_fec_set_index`. The SlotMeta type will continue to be used
-/// (written) for now, but a SlotMetaV3 can be read from the Blockstore and
-/// converted into a SlotMeta. The logic to read and convert SlotMetaV3 to
-/// SlotMeta enables this software to read a Blockstore modified by a future
-/// version where the SlotMetaV3 format is persisted.
+/// Slot metadata persisted by blockstore.
+///
+/// V3 adds `parent_block_id` and `replay_fec_set_index` so replay can validate
+/// and restart slots that switch parent through an UpdateParent marker. The new
+/// fields default on old ledger reads, preserving backward-compatible reads of
+/// V2 data.
 #[derive(Clone, Debug, Default, SchemaRead, SchemaWrite, Eq, PartialEq)]
 pub struct SlotMetaV3 {
     pub slot: Slot,
@@ -167,12 +168,17 @@ pub struct SlotMetaV3 {
     #[wincode(with = "PodConnectedFlags")]
     pub connected_flags: ConnectedFlags,
     pub completed_data_indexes: CompletedDataIndexes,
-    /// The block id of the parent block.
-    /// Populated from the block header / update parent marker.
+    /// Block id paired with `parent_slot`.
+    ///
+    /// Populated by the block header initially, then replaced if an UpdateParent
+    /// marker changes the replay parent for this slot.
     #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Hash>")]
     pub parent_block_id: Hash,
-    /// The FEC set index from which replay should start for this block.
-    /// Populated from the block header / update parent marker.
+    /// Shred/FEC-set index where replay should start for this slot.
+    ///
+    /// A value of zero means replay starts from the block header. A non-zero
+    /// value means an UpdateParent marker was observed and replay must skip the
+    /// optimistic-parent prefix before this FEC set.
     #[wincode(with = "wincode_compat::DefaultOnEmptyRead<u32>")]
     pub replay_fec_set_index: u32,
 }
@@ -582,15 +588,13 @@ impl SlotMeta {
         self.is_connected()
     }
 
-    /// Clear the parent_connected and connected flags.
-    /// Returns true if the slot was previously parent-connected (signaling
-    /// that children need clearing too).
+    /// Clear the meta's parent_connected and connected flags.
+    /// Returns true if the meta was connected, indicating children need clearing.
     pub fn clear_parent_connected(&mut self) -> bool {
-        let was_parent_connected = self.is_parent_connected();
+        let originally_connected = self.is_connected();
         self.connected_flags
-            .set(ConnectedFlags::PARENT_CONNECTED, false);
-        self.connected_flags.set(ConnectedFlags::CONNECTED, false);
-        was_parent_connected
+            .remove(ConnectedFlags::PARENT_CONNECTED | ConnectedFlags::CONNECTED);
+        originally_connected
     }
 
     /// Dangerous.
@@ -632,6 +636,12 @@ impl SlotMeta {
 
     pub(crate) fn populated_from_block_header(&self) -> bool {
         self.replay_fec_set_index == 0
+    }
+
+    /// Returns true once this slot's replay parent has been changed by an
+    /// `UpdateParent` marker.
+    pub fn has_update_parent(&self) -> bool {
+        self.replay_fec_set_index > 0
     }
 }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         block_error::BlockError,
         blockstore::{Blockstore, BlockstoreError},
-        blockstore_meta::SlotMeta,
+        blockstore_meta::{BlockLocation, SlotMeta},
         entry_notifier_service::{EntryNotification, EntryNotifierSender},
         leader_schedule_cache::LeaderScheduleCache,
         transaction_balances::compile_collected_balances,
@@ -1461,6 +1461,9 @@ pub struct ConfirmationProgress {
     pub last_entry: Hash,
     pub tick_hash_count: u64,
     pub num_shreds: u64,
+    /// True when this bank's replay began at an `UpdateParent` FEC-set offset
+    /// rather than at shred zero.
+    pub replay_starts_at_update_parent: bool,
     pub num_entries: usize,
     pub num_txs: usize,
     async_verification: Option<AsyncVerificationProgress>,
@@ -1785,8 +1788,35 @@ fn confirm_slot_with_components(
         load_result
     }?;
 
-    let mut processor = bank.block_component_processor.write().unwrap();
+    // Process block components for Alpenglow slots. Note that we don't need to run migration checks
+    // for BlockMarkers here, despite BlockMarkers only being active post-Alpenglow. Here's why:
+    //
+    // Post-Alpenglow migration - validators that have Alpenglow enabled can parse BlockComponents.
+    // Things just work.
+    //
+    // Pre-Alpenglow migration, suppose a validator receives a BlockMarker:
+    //
+    // (1) validators *incapable* of processing BlockMarkers will mark the slot as dead on shred
+    //     ingest in blockstore.
+    //
+    // (2) validators *capable* of processing BlockMarkers will store the BlockMarkers in shred
+    //     ingest, run through this verifying code here, and then error out when processing a
+    //     BlockMarker, resulting in the slot being marked as dead.
+    let replay_starts_at_update_parent = progress.replay_starts_at_update_parent
+        && migration_status.should_allow_update_parent(slot)
+        && progress.num_shreds > 0
+        && blockstore
+            .meta(slot)
+            .expect("Blockstore operations must succeed")
+            .is_some_and(|meta| {
+                meta.has_update_parent()
+                    && progress.num_shreds == u64::from(meta.replay_fec_set_index)
+            });
 
+    let mut processor = bank.block_component_processor.write().unwrap();
+    processor.set_replay_starts_at_update_parent(replay_starts_at_update_parent);
+
+    // Find the index of the last EntryBatch in slot_components
     let last_entry_batch_index = slot_components
         .iter()
         .rposition(|bc| matches!(bc, BlockComponent::EntryBatch(_)));
@@ -1801,7 +1831,18 @@ fn confirm_slot_with_components(
             BlockComponent::EntryBatch(entries) => {
                 let slot_full = slot_full && ix == last_entry_batch_index.unwrap();
 
-                processor.on_entry_batch(migration_status, slot)?;
+                // Skip block component validation for genesis block. Slot 0 is handled specially,
+                // since it won't have the required block markers.
+                if slot != 0 {
+                    processor
+                        .on_entry_batch(migration_status, slot)
+                        .inspect_err(|err| {
+                            warn!(
+                                "BlockComponentProcessor::on_entry_batch() for slot {slot} failed \
+                                 with {err}"
+                            );
+                        })?;
+                }
 
                 confirm_slot_entries(
                     bank,
@@ -2185,6 +2226,26 @@ fn cleanup_and_populate_pending_from_alpenglow_genesis(
         }
     }
 
+    // Shreds for slots after the genesis block may have arrived while this node
+    // was still in the migration phase. At that point `UpdateParent` is not
+    // allowed to update SlotMeta, so any persisted parent metadata for those
+    // slots can be stale. Match the live transition path and repair these blocks
+    // after Alpenglow is enabled instead of replaying stale metadata.
+    let start_slot = genesis_slot.saturating_add(1);
+    if let Some(end_slot) = blockstore.highest_slot().map_err(|err| {
+        warn!("Failed to load highest slot while enabling Alpenglow during startup: {err:?}");
+        BlockstoreProcessorError::FailedToLoadMeta
+    })? {
+        if end_slot >= start_slot {
+            warn!(
+                "{}: startup Alpenglow migration purging shreds {start_slot} to {end_slot} from \
+                 blockstore",
+                migration_status.my_pubkey()
+            );
+            blockstore.clear_unconfirmed_slots(start_slot, end_slot);
+        }
+    }
+
     let genesis_slot_meta = blockstore
         .meta(genesis_slot)
         .map_err(|err| {
@@ -2252,6 +2313,21 @@ fn process_next_slots(
         // Only process full slots in blockstore_processor, replay_stage
         // handles any partials
         if next_meta.is_full() {
+            let parent_block_id = bank.block_id();
+            if migration_status.should_use_double_merkle_block_id(*next_slot)
+                && bank.slot() != 0
+                && Some(next_meta.parent_block_id) != parent_block_id
+            {
+                warn!(
+                    "startup replay deferring slot {next_slot}: parent {} has block id {:?}, but \
+                     SlotMeta expects {:?}",
+                    bank.slot(),
+                    parent_block_id,
+                    next_meta.parent_block_id,
+                );
+                continue;
+            }
+
             let next_bank = Bank::new_from_parent(
                 bank.clone(),
                 leader_schedule_cache
@@ -2313,6 +2389,7 @@ fn load_frozen_forks(
     snapshot_controller: Option<&SnapshotController>,
 ) -> result::Result<(u64, usize), BlockstoreProcessorError> {
     let migration_status = bank_forks.read().unwrap().migration_status();
+    blockstore.configure_block_markers_for_migration(&migration_status);
     let blockstore_max_root = blockstore.max_root();
     let mut root = bank_forks.read().unwrap().root();
     let max_root = std::cmp::max(root, blockstore_max_root);
@@ -2385,6 +2462,16 @@ fn load_frozen_forks(
                 last_entry_hash,
                 async_verification.take(),
             );
+            // Live replay restarts UpdateParent slots from the marker's FEC set.
+            // Startup replay must use the same offset or a restarted validator can
+            // execute the obsolete optimistic-parent prefix.
+            if migration_status.should_allow_update_parent(slot)
+                && meta.has_update_parent()
+                && blockstore.can_replay_from_update_parent(slot, BlockLocation::Original)?
+            {
+                progress.num_shreds = u64::from(meta.replay_fec_set_index);
+                progress.replay_starts_at_update_parent = true;
+            }
             let mut m = Measure::start("process_single_slot");
             let bank = bank_forks.write().unwrap().insert_from_ledger(bank);
             if let Err(error) = process_single_slot(
@@ -2410,6 +2497,7 @@ fn load_frozen_forks(
                 // We are safe to cleanly transition to alpenglow here
                 if migration_status.is_ready_to_enable() {
                     let genesis_slot = migration_status.enable_alpenglow_during_startup();
+                    blockstore.configure_block_markers_for_migration(&migration_status);
 
                     // We need to clear pending_slots as it might contain Alpenglow blocks initialized as TowerBFT banks.
                     // Clear and populate pending slots from alpenglow genesis
@@ -2531,6 +2619,7 @@ fn load_frozen_forks(
                         .activated_slot(&agave_feature_set::alpenglow::id())
                     {
                         migration_status.record_feature_activation(slot);
+                        blockstore.configure_block_markers_for_migration(&migration_status);
                     }
                 }
             }
@@ -2620,16 +2709,32 @@ fn supermajority_root_from_vote_accounts(
 /// Returns:
 /// - `Inactive`: feature not active, no validation performed
 /// - `Pass`: chained block ID matches parent's block ID (or parent has no
-///   block ID yet), safe to proceed with replay
+///   block ID yet), or the slot replays from an UpdateParent FEC set
 /// - `Mismatch`: definitive mismatch between child's chained merkle root
 ///   and parent's block ID
 /// - `Unavailable`: data shred 0 not received yet, cannot validate
-pub fn check_chained_block_id(blockstore: &Blockstore, bank: &Bank) -> ChainedBlockIdCheck {
+pub fn check_chained_block_id(
+    blockstore: &Blockstore,
+    bank: &Bank,
+    migration_status: &MigrationStatus,
+) -> ChainedBlockIdCheck {
     if !bank.feature_set.snapshot().validate_chained_block_id {
         return ChainedBlockIdCheck::Inactive;
     }
 
     let slot = bank.slot();
+    if migration_status.should_allow_update_parent(slot)
+        && blockstore
+            .meta(slot)
+            .expect("Blockstore operations must succeed")
+            .is_some_and(|meta| meta.has_update_parent())
+    {
+        // This block must contain an `UpdateParent` and Alpenglow is active, so
+        // we rely on Double Merkle verification of parent chained block ID
+        // instead of CMR.
+        return ChainedBlockIdCheck::Pass;
+    }
+
     let parent_slot = bank.parent_slot();
 
     let Ok(expected_parent_block_id) = blockstore.get_parent_chained_block_id(slot) else {
@@ -2678,7 +2783,7 @@ pub fn process_single_slot(
     migration_status: &MigrationStatus,
 ) -> result::Result<(), BlockstoreProcessorError> {
     let slot = bank.slot();
-    match check_chained_block_id(blockstore, bank) {
+    match check_chained_block_id(blockstore, bank, migration_status) {
         ChainedBlockIdCheck::Inactive | ChainedBlockIdCheck::Pass => (),
         ChainedBlockIdCheck::Unavailable => {
             // no shreds to replay
@@ -6251,7 +6356,7 @@ pub mod tests {
         // Case 1: No shreds for child slot — should return Unavailable
         let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 10);
         assert!(matches!(
-            check_chained_block_id(&blockstore, &child_bank),
+            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
             ChainedBlockIdCheck::Unavailable
         ));
 
@@ -6260,7 +6365,7 @@ pub mod tests {
         insert_shreds_with_chained_merkle_root(11, 0, parent_block_id);
         let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 11);
         assert!(matches!(
-            check_chained_block_id(&blockstore, &child_bank),
+            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
             ChainedBlockIdCheck::Pass
         ));
 
@@ -6269,11 +6374,33 @@ pub mod tests {
         insert_shreds_with_chained_merkle_root(12, 0, Hash::new_unique());
         let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 12);
         assert!(matches!(
-            check_chained_block_id(&blockstore, &child_bank),
+            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
             ChainedBlockIdCheck::Mismatch
         ));
 
-        // Case 4: Parent has no shreds (get_block_merkle_root returns Err) —
+        // Case 4: UpdateParent metadata does not bypass Tower validation.
+        insert_shreds_with_chained_merkle_root(13, 0, Hash::new_unique());
+        let mut meta = blockstore.meta(13).unwrap().unwrap();
+        meta.replay_fec_set_index = 32;
+        blockstore.put_meta(13, &meta).unwrap();
+        let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 13);
+        assert!(matches!(
+            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
+            ChainedBlockIdCheck::Mismatch
+        ));
+
+        // Case 5: Alpenglow UpdateParent slots skip shred-0 chained block ID
+        // validation because replay starts at the UpdateParent FEC set.
+        assert!(matches!(
+            check_chained_block_id(
+                &blockstore,
+                &child_bank,
+                &MigrationStatus::post_migration_status()
+            ),
+            ChainedBlockIdCheck::Pass
+        ));
+
+        // Case 6: Parent has no shreds (get_block_merkle_root returns Err) —
         // should return Pass regardless of chained merkle root.
         let no_shreds_parent_bank = Arc::new(Bank::new_from_parent(
             parent_bank,
@@ -6283,8 +6410,50 @@ pub mod tests {
         insert_shreds_with_chained_merkle_root(21, 20, Hash::new_unique());
         let child_bank = Bank::new_from_parent(no_shreds_parent_bank, SlotLeader::default(), 21);
         assert!(matches!(
-            check_chained_block_id(&blockstore, &child_bank),
+            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
             ChainedBlockIdCheck::Pass
         ));
+    }
+
+    #[test]
+    fn test_startup_parent_id_check() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+        let parent_bank = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
+        let parent_block_id = Hash::new_unique();
+        parent_bank.set_block_id(Some(parent_block_id));
+
+        let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&parent_bank);
+        let mut parent_meta = SlotMeta::new(1, Some(0));
+        parent_meta.next_slots = vec![2, 3];
+
+        for (slot, block_id) in [(2, Hash::new_unique()), (3, parent_block_id)] {
+            let mut meta = SlotMeta::new(slot, Some(1));
+            meta.consumed = 1;
+            meta.received = 1;
+            meta.last_index = Some(0);
+            meta.parent_block_id = block_id;
+            meta.replay_fec_set_index = 32;
+            blockstore.put_meta(slot, &meta).unwrap();
+        }
+
+        let mut pending_slots = Vec::new();
+        process_next_slots(
+            &parent_bank,
+            &parent_meta,
+            &blockstore,
+            &leader_schedule_cache,
+            &mut pending_slots,
+            &ProcessOptions::default(),
+            &MigrationStatus::post_migration_status(),
+        )
+        .unwrap();
+
+        assert_eq!(pending_slots.len(), 1);
+        assert_eq!(pending_slots[0].1.slot(), 3);
     }
 }

--- a/ledger/src/shred/merkle_tree.rs
+++ b/ledger/src/shred/merkle_tree.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 use {
     crate::shred::Error, solana_hash::Hash, solana_sha256_hasher::hashv,
     static_assertions::const_assert_eq, std::iter::successors,
@@ -34,6 +36,7 @@ impl MerkleTree {
     ///
     /// [`Error::EmptyIterator`] if the function is called with an empty iterator.
     /// [`Error`] if any of the elements in the iterator contains an [`Error`].
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn try_new(
         shreds: impl ExactSizeIterator<Item = Result<Hash, Error>>,
     ) -> Result<MerkleTree, Error> {

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -81,6 +81,18 @@ pub enum PohRecorderError {
 
     #[error("updating bank footer failed with \"{0}\"")]
     UpdateBankFooter(#[from] BankFooterError),
+
+    #[error("bank {0} did not freeze before block footer timeout")]
+    BankFreezeTimeout(Slot),
+
+    #[error("couldn't reset bank during fast leader handover slot {0} -> slot {1}")]
+    ResetBankError(Slot, Slot),
+
+    #[error("couldn't reschedule pre-UpdateParent transactions")]
+    RescheduleTransactionsError(Slot),
+
+    #[error("leader window moved past slot {0}")]
+    WindowMovedOn(Slot),
 }
 
 pub(crate) type Result<T> = std::result::Result<T, PohRecorderError>;
@@ -321,7 +333,11 @@ impl PohRecorder {
         self.leader_last_tick_height = leader_last_tick_height;
     }
 
-    /// Send the block marker to be broadcast
+    /// Send a block marker into the current working bank's broadcast stream.
+    ///
+    /// This returns an error rather than panicking so leader control code can
+    /// clear the in-progress bank and recover when PoH has already moved on or
+    /// the broadcast receiver has gone away.
     pub fn send_marker(&mut self, marker: VersionedBlockMarker) -> Result<()> {
         let tick_height = self.tick_height();
         let working_bank = self
@@ -334,7 +350,7 @@ impl PohRecorder {
                 working_bank.bank.clone(),
                 (EntryOrMarker::Marker(marker), tick_height),
             ))
-            .unwrap();
+            .map_err(Box::new)?;
 
         Ok(())
     }
@@ -516,7 +532,7 @@ impl PohRecorder {
     /// Updates [`Self::shared_leader_state`] if `set_shared_state` is true.
     /// Otherwise the caller is responsible for setting the state before
     /// releasing the lock.
-    fn clear_bank(&mut self, set_shared_state: bool) {
+    pub fn clear_bank(&mut self, set_shared_state: bool) {
         if let Some(WorkingBank { bank, start, .. }) = self.working_bank.take() {
             let next_leader_slot = self.leader_schedule_cache.next_leader_slot(
                 bank.leader_id(),
@@ -588,15 +604,13 @@ impl PohRecorder {
     }
 
     /// Waits for the bank to freeze and sends the block footer with the bank hash.
-    /// Returns:
-    /// - Ok(()): Footer sent successfully
-    /// - Err(None): Bank freeze timeout (caller should break without updating send_result)
-    /// - Err(Some(e)): Send failed (caller should update send_result and break)
+    /// Returns once the footer has been handed to broadcast, or errors if the
+    /// bank cannot freeze quickly enough to populate the footer's bank hash.
     fn wait_for_freeze_and_send_footer(
         &self,
         mut footer: BlockFooterV1,
         working_bank: &WorkingBank,
-    ) -> std::result::Result<(), Option<Box<SendError<WorkingBankEntryOrMarker>>>> {
+    ) -> Result<()> {
         // Wake replay as soon as the slot reaches max tick height so it can freeze the bank
         // before we block on the footer/bank-hash handoff.
         self.notify_replay_wakeup();
@@ -614,13 +628,15 @@ impl PohRecorder {
         // If the bank still isn't frozen, we've timed out
         if !working_bank.bank.is_frozen() {
             if self.is_exited.load(Ordering::Relaxed) {
-                return Err(None);
+                return Err(PohRecorderError::ChannelDisconnected);
             }
             error!(
                 "slot = {} block production failure. bank freezing timed out.",
                 working_bank.bank.slot()
             );
-            return Err(None);
+            return Err(PohRecorderError::BankFreezeTimeout(
+                working_bank.bank.slot(),
+            ));
         }
 
         // Send out the block footer - we now have the bank hash
@@ -632,19 +648,15 @@ impl PohRecorder {
             working_bank.max_tick_height - 1,
         );
 
-        match self
-            .working_bank_sender
+        self.working_bank_sender
             .send((working_bank.bank.clone(), footer_entry_marker))
-        {
-            Ok(()) => Ok(()),
-            Err(err) => {
+            .map_err(|err| {
                 error!(
                     "slot = {} block production failure. failed to broadcast footer",
                     working_bank.bank.slot()
                 );
-                Err(Some(Box::new(err)))
-            }
-        }
+                PohRecorderError::SendError(Box::new(err))
+            })
     }
 
     // Flush cache will delay flushing the cache for a bank until it past the WorkingBank::min_tick_height
@@ -670,6 +682,7 @@ impl PohRecorder {
             .iter()
             .take_while(|x| x.1 <= working_bank.max_tick_height)
             .count();
+        let has_footer = footer.is_some();
         let mut send_result = Ok(());
 
         if entry_count > 0 {
@@ -685,14 +698,9 @@ impl PohRecorder {
                 working_bank.bank.register_tick(&entry.hash);
 
                 if let Some(footer) = footer.clone() {
-                    match self.wait_for_freeze_and_send_footer(footer, working_bank) {
-                        Ok(()) => {}        // Continue processing
-                        Err(None) => break, // Timeout - break without updating send_result
-                        Err(Some(e)) => {
-                            // Send failed - update send_result and break
-                            send_result = Err(e);
-                            break;
-                        }
+                    if let Err(err) = self.wait_for_freeze_and_send_footer(footer, working_bank) {
+                        send_result = Err(err);
+                        break;
                     }
                 }
 
@@ -701,33 +709,36 @@ impl PohRecorder {
                 send_result = self
                     .working_bank_sender
                     .send((working_bank.bank.clone(), tick))
-                    .map_err(Box::new);
+                    .map_err(|err| PohRecorderError::SendError(Box::new(err)));
                 if send_result.is_err() {
                     break;
                 }
             }
         }
-        if self.tick_height() >= working_bank.max_tick_height {
-            info!(
-                "poh_record: max_tick_height {} reached, clearing working_bank {}",
-                working_bank.max_tick_height,
-                working_bank.bank.slot()
-            );
-            self.start_bank = working_bank.bank.clone();
-            let working_slot = self.start_slot();
-            self.start_tick_height = working_slot * self.ticks_per_slot + 1;
-            self.clear_bank(true);
-        }
-        if send_result.is_err() {
-            info!("WorkingBank::sender disconnected {send_result:?}");
-            // revert the cache, but clear the working bank
-            self.clear_bank(true);
-        } else {
+        if send_result.is_ok() {
+            if self.tick_height() >= working_bank.max_tick_height {
+                info!(
+                    "poh_record: max_tick_height {} reached, clearing working_bank {}",
+                    working_bank.max_tick_height,
+                    working_bank.bank.slot()
+                );
+                self.start_bank = working_bank.bank.clone();
+                let working_slot = self.start_slot();
+                self.start_tick_height = working_slot * self.ticks_per_slot + 1;
+                self.clear_bank(true);
+            }
             // commit the flush
             let _ = self.tick_cache.drain(..entry_count);
+        } else {
+            info!("WorkingBank::sender disconnected or footer failed {send_result:?}");
+            // Alpenglow block completion errors must leave the bank attached so
+            // BlockCreationLoop can clear PoH and BankForks atomically.
+            if !has_footer {
+                self.clear_bank(true);
+            }
         }
 
-        Ok(())
+        send_result
     }
 
     pub fn would_be_leader(&self, within_next_n_ticks: u64) -> bool {
@@ -1033,7 +1044,11 @@ impl PohRecorder {
         self.clear_bank(true);
     }
 
-    pub fn tick_alpenglow(&mut self, slot_max_tick_height: u64, footer: BlockFooterV1) {
+    pub fn tick_alpenglow(
+        &mut self,
+        slot_max_tick_height: u64,
+        footer: BlockFooterV1,
+    ) -> Result<()> {
         let (poh_entry, tick_lock_contention_us) = measure_us!({
             let mut poh_l = self.poh.lock().unwrap();
             poh_l.tick()
@@ -1062,10 +1077,12 @@ impl PohRecorder {
                     .load(Ordering::Acquire),
             ));
 
-            let (_flush_res, flush_cache_and_tick_us) =
+            let (flush_res, flush_cache_and_tick_us) =
                 measure_us!(self.flush_cache(true, Some(footer)));
             self.metrics.flush_cache_tick_us += flush_cache_and_tick_us;
+            flush_res?;
         }
+        Ok(())
     }
 
     pub fn enable_alpenglow(&mut self) {
@@ -1364,6 +1381,126 @@ mod tests {
         assert!(poh_recorder.working_bank.is_some());
         poh_recorder.clear_bank(true);
         assert!(poh_recorder.working_bank.is_none());
+    }
+
+    #[test]
+    fn test_send_marker_error() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path())
+            .expect("Expected to be able to open database ledger");
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let prev_hash = bank.last_blockhash();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(
+            0,
+            prev_hash,
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            Arc::new(blockstore),
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+        poh_recorder.set_bank_for_test(bank);
+        drop(entry_receiver);
+
+        let marker = VersionedBlockMarker::new_block_footer(BlockFooterV1 {
+            bank_hash: Hash::new_unique(),
+            block_producer_time_nanos: 0,
+            block_user_agent: vec![],
+            final_cert: None,
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        });
+        let err = poh_recorder.send_marker(marker).unwrap_err();
+        assert!(matches!(err, PohRecorderError::SendError(_)));
+    }
+
+    fn test_footer() -> BlockFooterV1 {
+        BlockFooterV1 {
+            bank_hash: Hash::default(),
+            block_producer_time_nanos: 0,
+            block_user_agent: vec![],
+            final_cert: None,
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        }
+    }
+
+    fn new_alpenglow_recorder_for_bank(
+        bank: Arc<Bank>,
+        blockstore: Arc<Blockstore>,
+    ) -> (PohRecorder, Receiver<WorkingBankEntryOrMarker>) {
+        let prev_hash = bank.last_blockhash();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            prev_hash,
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            blockstore,
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+        poh_recorder.enable_alpenglow();
+        bank.set_tick_height(bank.max_tick_height() - 1);
+        poh_recorder.set_bank_for_test(bank);
+        (poh_recorder, entry_receiver)
+    }
+
+    #[test]
+    fn test_alpenglow_tick_send_error() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(
+            Blockstore::open(ledger_path.path()).expect("Expected to be able to open ledger"),
+        );
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (mut poh_recorder, entry_receiver) =
+            new_alpenglow_recorder_for_bank(bank.clone(), blockstore);
+        drop(entry_receiver);
+
+        let bank_to_freeze = bank.clone();
+        let freezer = std::thread::spawn(move || {
+            while bank_to_freeze.tick_height() < bank_to_freeze.max_tick_height() {
+                std::hint::spin_loop();
+            }
+            bank_to_freeze.freeze();
+        });
+
+        let err = poh_recorder
+            .tick_alpenglow(bank.max_tick_height(), test_footer())
+            .unwrap_err();
+        freezer.join().unwrap();
+
+        assert!(matches!(err, PohRecorderError::SendError(_)));
+        assert!(poh_recorder.has_bank());
+        assert!(!poh_recorder.tick_cache.is_empty());
+    }
+
+    #[test]
+    fn test_alpenglow_tick_timeout() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(
+            Blockstore::open(ledger_path.path()).expect("Expected to be able to open ledger"),
+        );
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (mut poh_recorder, _entry_receiver) =
+            new_alpenglow_recorder_for_bank(bank.clone(), blockstore);
+
+        let err = poh_recorder
+            .tick_alpenglow(bank.max_tick_height(), test_footer())
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            PohRecorderError::BankFreezeTimeout(slot) if slot == bank.slot()
+        ));
+        assert!(poh_recorder.has_bank());
+        assert!(!poh_recorder.tick_cache.is_empty());
     }
 
     #[test]

--- a/poh/src/record_channels.rs
+++ b/poh/src/record_channels.rs
@@ -79,8 +79,11 @@ pub struct RecordSender {
     /// Used to track active senders for the current bank id. Used so that the receiver
     /// side can determine that no more sends are in-flight while shutting down.
     active_senders: Arc<AtomicU64>,
+    /// Packed active bank id and remaining reserved-capacity budget.
     bank_id_allowed_insertions: BankIdAllowedInsertions,
+    /// Bounded channel carrying records that have reserved capacity.
     sender: Sender<Record>,
+    /// Optional slot-local transaction index assigned in record order.
     transaction_indexes: Option<Arc<Mutex<usize>>>,
 }
 
@@ -174,14 +177,25 @@ impl RecordSender {
 /// The receiver can shutdown the channel, preventing any further sends,
 /// and can restart the channel for a new bank id, re-enabling sends.
 pub struct RecordReceiver {
+    /// Maximum number of record batches that may be reserved for the active bank.
     capacity: u64,
+    /// Number of senders between reservation and channel insertion.
     active_senders: Arc<AtomicU64>,
+    /// Packed active bank id and remaining insertions, or disabled when shut down.
     bank_id_allowed_insertions: BankIdAllowedInsertions,
+    /// Bounded channel carrying reserved records.
     receiver: Receiver<Record>,
+    /// Optional monotonic transaction index shared with senders.
     transaction_indexes: Option<Arc<Mutex<usize>>>,
 }
 
 impl RecordReceiver {
+    /// Returns a reference to the inner receiver for use in `select!` macros.
+    /// After receiving from this, you must call `on_received_record` manually.
+    pub fn inner(&self) -> &Receiver<Record> {
+        &self.receiver
+    }
+
     /// Returns true if the channel should be shutdown.
     pub fn should_shutdown(&self, remaining_hashes_in_slot: u64, ticks_per_slot: u64) -> bool {
         // This channel must guarantee that all sent records are recorded.
@@ -228,9 +242,17 @@ impl RecordReceiver {
         drop(transaction_indexes_lock);
     }
 
-    /// Drain all available records from the channel with `try_recv` loop.
+    /// Drain all records that have been enqueued or reserved by active senders.
     pub fn drain(&self) -> impl Iterator<Item = Record> + '_ {
         core::iter::from_fn(|| self.try_recv().ok())
+    }
+
+    /// Drain all records that were already reserved by senders before shutdown.
+    ///
+    /// This names the shutdown use case explicitly, while sharing `try_recv()`'s
+    /// active-sender guarantee.
+    pub fn drain_after_shutdown(&self) -> impl Iterator<Item = Record> + '_ {
+        self.drain()
     }
 
     /// Channel is empty and there are no active threads attempting to send.
@@ -246,6 +268,10 @@ impl RecordReceiver {
     }
 
     /// Try to receive a record from the channel.
+    ///
+    /// If a sender has already reserved capacity for this bank, do not report
+    /// `Empty` until that sender either enqueues its record or fails. PoH uses
+    /// this to avoid hashing/ticking past a record that was already admitted.
     pub fn try_recv(&self) -> Result<Record, TryRecvError> {
         loop {
             match self.receiver.try_recv() {
@@ -262,7 +288,7 @@ impl RecordReceiver {
                     }
 
                     // No in-flight senders observed, but re-check the channel once more.
-                    // a sender could have enqueued right after the previous Empty observation
+                    // A sender could have enqueued right after the previous Empty observation
                     // and then dropped active_senders back to 0. Re-check once.
                     match self.receiver.try_recv() {
                         Ok(record) => {
@@ -286,7 +312,9 @@ impl RecordReceiver {
         Ok(record)
     }
 
-    fn on_received_record(&self, num_batches: u64) {
+    /// Notify that a record has been received.
+    /// Must be called after receiving a record from `inner()` directly.
+    pub fn on_received_record(&self, num_batches: u64) {
         // The record has been received and processed, so increment the number
         // of allowed insertions, so that new records can be sent.
         self.bank_id_allowed_insertions
@@ -498,7 +526,7 @@ mod shuttle_tests {
     }
 
     #[test]
-    fn test_try_recv_not_sent_on_inner_channel_yet() {
+    fn test_try_recv_waits_active() {
         const NUM_TEST_RUNS: usize = 100_000;
         shuttle::check_random(
             || {
@@ -512,20 +540,42 @@ mod shuttle_tests {
                     });
                 }
 
-                // Snapshot active_senders *before* try_recv
                 let active_at_start = sender.active_senders.load(Ordering::Acquire);
-
-                // Perform try_recv
                 let result = receiver.try_recv();
-
-                // Only fail if it returned None *and* we know there was an active sender at start
                 if result.is_err() && active_at_start > 0 {
                     panic!(
-                        "try_recv returned None while a sender was active at start of call \
-                         (active_senders={})",
-                        active_at_start
+                        "try_recv returned Empty while a sender was active at start of call \
+                         (active_senders={active_at_start})"
                     );
                 }
+            },
+            NUM_TEST_RUNS,
+        )
+    }
+
+    #[test]
+    fn test_drain_shutdown_waits_active() {
+        const NUM_TEST_RUNS: usize = 100_000;
+        shuttle::check_random(
+            || {
+                let (sender, mut receiver) = record_channels(false);
+                receiver.restart(0);
+
+                // Model a sender that reserved capacity before shutdown but
+                // has not yet enqueued its record on the inner channel.
+                sender.active_senders.fetch_add(1, Ordering::AcqRel);
+                let active_senders = sender.active_senders.clone();
+                let inner_sender = sender.sender.clone();
+                shuttle::thread::spawn(move || {
+                    inner_sender.try_send(test_record(0, 1)).unwrap();
+                    active_senders.fetch_sub(1, Ordering::AcqRel);
+                });
+
+                receiver.shutdown();
+                let records: Vec<_> = receiver.drain_after_shutdown().collect();
+                assert_eq!(records.len(), 1);
+                assert_eq!(records[0].bank_id, 0);
+                assert!(receiver.is_safe_to_restart());
             },
             NUM_TEST_RUNS,
         )

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2159,6 +2159,16 @@ impl Bank {
         self.hash.read().unwrap()
     }
 
+    /// Waits for in-flight BankingStage commits to finish without freezing the bank.
+    ///
+    /// BankingStage holds the read side of this lock from before a successful
+    /// PoH record until after the matching account commit. Taking and dropping
+    /// the write side gives callers a quiescence point before abandoning and
+    /// purging an unfrozen leader bank.
+    pub fn wait_for_inflight_commits(&self) {
+        drop(self.hash.write().unwrap());
+    }
+
     pub fn hash(&self) -> Hash {
         *self.hash.read().unwrap()
     }

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -87,6 +87,57 @@ pub struct BankForks {
     migration_status: Arc<MigrationStatus>,
 }
 
+/// Deferred cleanup from [`BankForks::clear_bank`].
+///
+/// Finishing this cleanup can wait for active transaction schedulers and drop
+/// `BankWithScheduler`s. Call [`Self::finish`] only after releasing the
+/// `BankForks` write lock.
+#[must_use = "call finish() after releasing the BankForks write lock"]
+pub struct ClearBankCleanup {
+    /// Root bank that owns per-slot account/program-cache cleanup helpers.
+    root_bank: Arc<Bank>,
+    /// Slots detached from the fork graph and their bank ids.
+    slots_to_purge: Vec<(Slot, BankId)>,
+    /// Banks removed from `BankForks`; their schedulers must quiesce before
+    /// their account/cache state is purged.
+    removed_banks: Vec<BankWithScheduler>,
+}
+
+impl ClearBankCleanup {
+    /// Wait for removed schedulers, finish account/cache cleanup, and drop banks.
+    ///
+    /// This may block while transaction schedulers terminate, so callers must
+    /// not hold a `BankForks` lock while invoking it.
+    pub fn finish(self) {
+        let Self {
+            root_bank,
+            slots_to_purge,
+            removed_banks,
+        } = self;
+
+        // Scheduler workers can still be executing transactions against these
+        // banks after the banks have been detached from `BankForks`. Wait before
+        // purging account/cache state so workers cannot observe a half-removed
+        // slot while loading accounts.
+        for bank in &removed_banks {
+            let _ = bank.wait_for_dropped_scheduler();
+        }
+
+        root_bank.remove_unrooted_slots(&slots_to_purge);
+
+        // `Bank::drop()` uses the scan-tracker state set by
+        // `remove_unrooted_slots()`, so keep the bank wrappers alive until after
+        // the purge. The scheduler wait above makes this drop non-blocking in
+        // the normal case.
+        drop(removed_banks);
+
+        for (slot, _) in slots_to_purge {
+            root_bank.clear_slot_signatures(slot);
+            root_bank.prune_program_cache_by_deployment_slot(slot);
+        }
+    }
+}
+
 impl Index<u64> for BankForks {
     type Output = Arc<Bank>;
     fn index(&self, bank_slot: Slot) -> &Self::Output {
@@ -397,19 +448,20 @@ impl BankForks {
             .unzip()
     }
 
-    /// Clears a bank from bank forks. Panics if the bank is not present in bank forks
-    pub fn clear_bank(&mut self, slot: Slot, write_bank_hash_details: bool) {
+    /// Clears a bank from bank forks. Panics if the bank is not present in bank forks.
+    ///
+    /// The returned cleanup must be finished after releasing the `BankForks`
+    /// write lock because dropping removed banks can wait for active schedulers.
+    pub fn clear_bank(&mut self, slot: Slot, write_bank_hash_details: bool) -> ClearBankCleanup {
         let (slots_to_purge, removed_banks) =
             self.dump_slots(std::iter::once(&slot), write_bank_hash_details);
 
         let root_bank = self.root_bank();
-        root_bank.remove_unrooted_slots(&slots_to_purge);
 
-        drop(removed_banks);
-
-        for (slot, _) in slots_to_purge {
-            root_bank.clear_slot_signatures(slot);
-            root_bank.prune_program_cache_by_deployment_slot(slot);
+        ClearBankCleanup {
+            root_bank,
+            slots_to_purge,
+            removed_banks,
         }
     }
 
@@ -748,6 +800,10 @@ mod tests {
             genesis_utils::{
                 GenesisConfigInfo, create_genesis_config, create_genesis_config_with_leader,
             },
+            installed_scheduler_pool::{
+                InstalledScheduler, ResultWithTimings, ScheduleResult, SchedulerId,
+                UninstalledScheduler, UninstalledSchedulerBox, initialized_result_with_timings,
+            },
         },
         agave_feature_set::FeatureSet,
         agave_votor_messages::{
@@ -755,17 +811,85 @@ mod tests {
             migration::{GENESIS_CERTIFICATE_ACCOUNT, MIGRATION_SLOT_OFFSET},
         },
         assert_matches::assert_matches,
-        solana_account::Account,
+        crossbeam_channel::{Receiver, Sender, bounded},
+        solana_account::{Account, AccountSharedData},
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_clock::UnixTimestamp,
         solana_epoch_schedule::EpochSchedule,
         solana_keypair::Keypair,
         solana_leader_schedule::SlotLeader,
         solana_rent::Rent,
+        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_sdk_ids::system_program,
         solana_signer::Signer,
+        solana_transaction::sanitized::SanitizedTransaction,
+        solana_transaction_error::TransactionError,
+        solana_unified_scheduler_logic::OrderedTaskId,
         solana_vote_program::vote_state::BlockTimestamp,
+        std::{fmt::Debug, thread, time::Duration},
     };
+
+    struct BlockingScheduler {
+        context: SchedulingContext,
+        wait_started_sender: Sender<()>,
+        release_receiver: Receiver<()>,
+    }
+
+    impl Debug for BlockingScheduler {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("BlockingScheduler")
+                .field("slot", &self.context.slot())
+                .finish_non_exhaustive()
+        }
+    }
+
+    impl InstalledScheduler for BlockingScheduler {
+        fn id(&self) -> SchedulerId {
+            1
+        }
+
+        fn context(&self) -> &SchedulingContext {
+            &self.context
+        }
+
+        fn schedule_execution(
+            &self,
+            _transaction: RuntimeTransaction<SanitizedTransaction>,
+            _task_id: OrderedTaskId,
+        ) -> ScheduleResult {
+            Ok(())
+        }
+
+        fn recover_error_after_abort(&mut self) -> TransactionError {
+            unreachable!("blocking test scheduler never aborts")
+        }
+
+        fn wait_for_termination(
+            self: Box<Self>,
+            is_dropped: bool,
+        ) -> (ResultWithTimings, UninstalledSchedulerBox) {
+            assert!(is_dropped);
+            self.wait_started_sender.send(()).unwrap();
+            self.release_receiver
+                .recv_timeout(Duration::from_secs(5))
+                .unwrap();
+            (
+                initialized_result_with_timings(),
+                Box::new(NoopUninstalledScheduler),
+            )
+        }
+
+        fn pause_for_recent_blockhash(&mut self) {}
+
+        fn unpause_after_taken(&self) {}
+    }
+
+    #[derive(Debug)]
+    struct NoopUninstalledScheduler;
+
+    impl UninstalledScheduler for NoopUninstalledScheduler {
+        fn return_to_pool(self: Box<Self>) {}
+    }
 
     // This test verifies that BankForks::new_rw_arc() doesn't create a reference cycle.
     //
@@ -802,6 +926,80 @@ mod tests {
         let bank_forks = bank_forks.read().unwrap();
         assert_eq!(bank_forks[1u64].tick_height(), 1);
         assert_eq!(bank_forks.working_bank().tick_height(), 1);
+    }
+
+    #[test]
+    fn test_clear_bank_drops_after_lock() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let root_bank = bank_forks.read().unwrap()[0].clone();
+        let child_bank = Arc::new(Bank::new_from_parent(root_bank, SlotLeader::default(), 1));
+        let (wait_started_sender, wait_started_receiver) = bounded(1);
+        let (release_sender, release_receiver) = bounded(1);
+
+        let bank_with_scheduler = BankWithScheduler::new(
+            child_bank.clone(),
+            Some(Box::new(BlockingScheduler {
+                context: SchedulingContext::new(child_bank.clone()),
+                wait_started_sender,
+                release_receiver,
+            })),
+        );
+        let account_key = Keypair::new().pubkey();
+        child_bank.store_account(
+            &account_key,
+            &AccountSharedData::new(42, 0, &system_program::ID),
+        );
+        assert!(child_bank.get_account(&account_key).is_some());
+
+        {
+            let mut bank_forks = bank_forks.write().unwrap();
+            assert!(bank_forks.banks.insert(1, bank_with_scheduler).is_none());
+            bank_forks.descendants.entry(1).or_default();
+            for parent in child_bank.proper_ancestors() {
+                bank_forks.descendants.entry(parent).or_default().insert(1);
+            }
+            bank_forks.working_slot = 1;
+            bank_forks
+                .sharable_banks
+                .working_bank
+                .store(child_bank.clone());
+        }
+
+        let clear_bank_cleanup = {
+            let mut bank_forks = bank_forks.write().unwrap();
+            bank_forks.clear_bank(1, false)
+        };
+
+        assert!(wait_started_receiver.try_recv().is_err());
+
+        let (finish_done_sender, finish_done_receiver) = bounded(1);
+        let finish_thread = thread::spawn(move || {
+            clear_bank_cleanup.finish();
+            finish_done_sender.send(()).unwrap();
+        });
+
+        wait_started_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        assert!(
+            finish_done_receiver
+                .recv_timeout(Duration::from_millis(50))
+                .is_err()
+        );
+
+        // The scheduler drain is blocked, but `BankForks` readers must not be.
+        assert!(bank_forks.read().unwrap().get(0).is_some());
+        // The removed bank's account state must also remain available until
+        // the scheduler workers are done using it.
+        assert!(child_bank.get_account(&account_key).is_some());
+
+        release_sender.send(()).unwrap();
+        finish_thread.join().unwrap();
+        finish_done_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        assert!(child_bank.get_account(&account_key).is_none());
     }
 
     fn make_root_bank_for_migration_status_test(

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -70,6 +70,10 @@ pub enum BlockComponentProcessorError {
     NanosecondClockOutOfBounds,
     #[error("Spurious update parent")]
     SpuriousUpdateParent,
+    #[error(
+        "UpdateParent cannot be the initial parent marker unless replay starts at UpdateParent"
+    )]
+    UnexpectedInitialUpdateParent,
     #[error("Abandoned bank")]
     AbandonedBank(VersionedUpdateParent),
     #[error("invalid reward certs {0}")]
@@ -83,9 +87,22 @@ pub struct BlockComponentProcessor {
     has_header: bool,
     has_footer: bool,
     update_parent: Option<VersionedUpdateParent>,
+    /// True when replay intentionally starts at the UpdateParent FEC set.
+    ///
+    /// In normal replay, a block header must be observed before any UpdateParent.
+    /// Restart-from-UpdateParent replay skips the obsolete optimistic-parent
+    /// prefix, so the UpdateParent marker is allowed to act as the first parent
+    /// marker only in that explicit mode.
+    replay_starts_at_update_parent: bool,
 }
 
 impl BlockComponentProcessor {
+    /// Allow `UpdateParent` to be the first parent marker only for banks whose
+    /// replay starts at the persisted UpdateParent FEC-set offset.
+    pub fn set_replay_starts_at_update_parent(&mut self, replay_starts_at_update_parent: bool) {
+        self.replay_starts_at_update_parent = replay_starts_at_update_parent;
+    }
+
     pub fn on_final(
         &self,
         migration_status: &MigrationStatus,
@@ -96,9 +113,8 @@ impl BlockComponentProcessor {
             return Ok(());
         }
 
-        // If we encounter an UpdateParent when fast leader handover is disabled, error.
-        if !migration_status.should_allow_fast_leader_handover(slot) && self.update_parent.is_some()
-        {
+        // If we encounter an UpdateParent before it is legal for this slot, error.
+        if !migration_status.should_allow_update_parent(slot) && self.update_parent.is_some() {
             return Err(BlockComponentProcessorError::SpuriousUpdateParent);
         }
 
@@ -153,6 +169,7 @@ impl BlockComponentProcessor {
         let VersionedBlockMarker::V1(marker) = marker;
 
         let markers_fully_enabled = migration_status.should_allow_block_markers(slot);
+        let update_parent_enabled = migration_status.should_allow_update_parent(slot);
         let in_migration = migration_status.is_in_migration();
 
         match marker {
@@ -176,7 +193,7 @@ impl BlockComponentProcessor {
                 finalization_cert_sender,
             ),
 
-            BlockMarkerV1::UpdateParent(update_parent) if markers_fully_enabled => {
+            BlockMarkerV1::UpdateParent(update_parent) if update_parent_enabled => {
                 self.on_update_parent(update_parent.inner())
             }
 
@@ -377,6 +394,10 @@ impl BlockComponentProcessor {
     ) -> Result<(), BlockComponentProcessorError> {
         if self.update_parent.is_some() {
             return Err(BlockComponentProcessorError::MultipleUpdateParents);
+        }
+
+        if !self.has_header && !self.replay_starts_at_update_parent {
+            return Err(BlockComponentProcessorError::UnexpectedInitialUpdateParent);
         }
 
         self.update_parent = Some(update_parent.clone());
@@ -1174,14 +1195,30 @@ mod tests {
     }
 
     #[test]
-    fn test_update_parent_as_first_marker() {
+    fn test_initial_up_reject() {
         let mut processor = BlockComponentProcessor::default();
         let update_parent = VersionedUpdateParent::V1(UpdateParentV1 {
             new_parent_slot: 0,
             new_parent_block_id: Hash::default(),
         });
 
-        assert!(processor.on_update_parent(&update_parent).is_ok());
+        assert!(matches!(
+            processor.on_update_parent(&update_parent),
+            Err(BlockComponentProcessorError::UnexpectedInitialUpdateParent)
+        ));
+        assert!(processor.update_parent.is_none());
+    }
+
+    #[test]
+    fn test_initial_up_ok() {
+        let mut processor = BlockComponentProcessor::default();
+        processor.set_replay_starts_at_update_parent(true);
+        let update_parent = VersionedUpdateParent::V1(UpdateParentV1 {
+            new_parent_slot: 0,
+            new_parent_block_id: Hash::default(),
+        });
+
+        processor.on_update_parent(&update_parent).unwrap();
         assert!(processor.update_parent.is_some());
     }
 
@@ -1218,6 +1255,7 @@ mod tests {
         });
 
         // First should succeed
+        processor.set_replay_starts_at_update_parent(true);
         processor.on_update_parent(&update_parent).unwrap();
 
         // Second should fail
@@ -1230,6 +1268,7 @@ mod tests {
     #[test]
     fn test_header_after_update_parent_error() {
         let mut processor = BlockComponentProcessor::default();
+        processor.set_replay_starts_at_update_parent(true);
         processor
             .on_update_parent(&VersionedUpdateParent::V1(UpdateParentV1 {
                 new_parent_slot: 0,
@@ -1249,10 +1288,11 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO(ksn): Enable when fast leader handover is enabled in MigrationPhase::should_allow_fast_leader_handover
+    #[ignore] // TODO(ksn): Enable when UpdateParent is enabled in MigrationPhase::should_allow_update_parent
     fn test_workflow_with_update_parent() {
         let migration_status = MigrationStatus::post_migration_status();
         let mut processor = BlockComponentProcessor::default();
+        processor.set_replay_starts_at_update_parent(true);
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
 

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -546,6 +546,20 @@ impl BankWithScheduler {
         )
     }
 
+    /// Waits for scheduler workers before this bank is purged from `BankForks`.
+    ///
+    /// This gives callers an explicit quiescence point without dropping the
+    /// `BankWithScheduler`, so account-cache cleanup can still run before
+    /// `Bank::drop()` removes scan-tracker state.
+    #[must_use]
+    pub(crate) fn wait_for_dropped_scheduler(&self) -> Option<ResultWithTimings> {
+        BankWithSchedulerInner::wait_for_scheduler_termination(
+            &self.inner.bank,
+            &self.inner.scheduler,
+            WaitReason::DroppedFromBankForks,
+        )
+    }
+
     pub const fn no_scheduler_available() -> InstalledSchedulerRwLock {
         RwLock::new(SchedulerStatus::Unavailable)
     }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -8,7 +8,7 @@ use {
     crate::cluster_nodes::ClusterNodesCache,
     agave_votor::event::VotorEventSender,
     agave_votor_messages::migration::MigrationStatus,
-    solana_entry::block_component::BlockComponent,
+    solana_entry::block_component::{BlockComponent, VersionedBlockMarker, VersionedUpdateParent},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::shred::{
@@ -24,8 +24,14 @@ use {
 #[derive(Clone)]
 pub struct StandardBroadcastRun {
     slot: Slot,
+    // Parent encoded in shred headers. This must remain stable for the slot
+    // because it is used to derive PARENT_OFFSET.
     parent: Slot,
     parent_block_id: Hash,
+    // Parent committed into the double-merkle block id. This can change after
+    // an UpdateParent marker.
+    double_merkle_parent: Slot,
+    double_merkle_parent_block_id: Hash,
     chained_merkle_root: Hash,
     carryover_entry: Option<WorkingBankEntryOrMarker>,
     double_merkle_leaves: Vec<Hash>,
@@ -68,6 +74,8 @@ impl StandardBroadcastRun {
             slot: Slot::MAX,
             parent: Slot::MAX,
             parent_block_id: Hash::default(),
+            double_merkle_parent: Slot::MAX,
+            double_merkle_parent_block_id: Hash::default(),
             chained_merkle_root: Hash::default(),
             double_merkle_leaves: vec![],
             carryover_entry: None,
@@ -129,6 +137,8 @@ impl StandardBroadcastRun {
         self.slot = bank.slot();
         self.parent = bank.parent_slot();
         self.parent_block_id = parent_block_id;
+        self.double_merkle_parent = bank.parent_slot();
+        self.double_merkle_parent_block_id = parent_block_id;
         self.chained_merkle_root = chained_merkle_root;
         self.double_merkle_leaves.clear();
         self.next_shred_index = 0u32;
@@ -206,16 +216,23 @@ impl StandardBroadcastRun {
                 })
                 .collect();
 
-        let fec_set_roots = shreds
-            .iter()
-            .unique_by(|shred| shred.fec_set_index())
-            .sorted_unstable_by_key(|shred| shred.fec_set_index())
-            .map(|shred| shred.merkle_root().expect("no more legacy shreds"));
-        // If necessary for perf, these leaves could start being joined in the background
-        self.double_merkle_leaves.extend(fec_set_roots);
+        if self
+            .migration_status
+            .should_use_double_merkle_block_id(self.slot)
+        {
+            let fec_set_roots = shreds
+                .iter()
+                .unique_by(|shred| shred.fec_set_index())
+                .sorted_unstable_by_key(|shred| shred.fec_set_index())
+                .map(|shred| shred.merkle_root().expect("no more legacy shreds"));
+            // If necessary for perf, these leaves could start being joined in the background
+            self.double_merkle_leaves.extend(fec_set_roots);
 
-        if let Some(fec_set_root) = self.double_merkle_leaves.last() {
-            self.chained_merkle_root = *fec_set_root;
+            if let Some(fec_set_root) = self.double_merkle_leaves.last() {
+                self.chained_merkle_root = *fec_set_root;
+            }
+        } else if let Some(shred) = shreds.last() {
+            self.chained_merkle_root = shred.merkle_root().expect("no more legacy shreds");
         }
         if self.next_shred_index > self.max_data_shreds_per_slot {
             return Err(BroadcastError::TooManyShreds);
@@ -224,6 +241,35 @@ impl StandardBroadcastRun {
             return Err(BroadcastError::TooManyShreds);
         }
         Ok(shreds)
+    }
+
+    /// Update only the double-merkle parent commitment after an UpdateParent marker.
+    ///
+    /// The shred-header parent remains `self.parent` for the whole slot so
+    /// PARENT_OFFSET stays stable and receivers do not see parent mismatches.
+    fn maybe_update_parent_from_component(&mut self, component: &BlockComponent) {
+        let Some(VersionedBlockMarker::V1(marker)) = component.as_marker() else {
+            return;
+        };
+        let Some(update_parent) = marker.as_update_parent() else {
+            return;
+        };
+        let (new_parent_slot, new_parent_block_id) = match update_parent {
+            VersionedUpdateParent::V1(update_parent) => (
+                update_parent.new_parent_slot,
+                update_parent.new_parent_block_id,
+            ),
+        };
+        self.double_merkle_parent = new_parent_slot;
+        self.double_merkle_parent_block_id = new_parent_block_id;
+    }
+
+    /// Leaf that binds the current replay parent into the double-merkle block id.
+    fn parent_info_leaf(&self) -> Hash {
+        hashv(&[
+            &self.double_merkle_parent.to_le_bytes(),
+            self.double_merkle_parent_block_id.as_bytes(),
+        ])
     }
 
     #[cfg(test)]
@@ -336,6 +382,7 @@ impl StandardBroadcastRun {
                 process_stats,
             )
             .unwrap();
+        self.maybe_update_parent_from_component(&component);
 
         let shreds = if maybe_send_header {
             header_shreds.extend(shreds);
@@ -404,9 +451,7 @@ impl StandardBroadcastRun {
                 // Block id is the double merkle root
                 let fec_set_count = self.double_merkle_leaves.len();
                 // Add the final leaf (parent info)
-                let parent_info_leaf =
-                    hashv(&[&self.parent.to_le_bytes(), self.parent_block_id.as_bytes()]);
-                self.double_merkle_leaves.push(parent_info_leaf);
+                self.double_merkle_leaves.push(self.parent_info_leaf());
 
                 // Compute the double merkle root
                 // Blockstore population of the DoubleMerkleMeta happens asynchronously when shreds are inserted
@@ -950,5 +995,66 @@ mod test {
         let component = BlockComponent::new_entry_batch(entries).unwrap();
         let r = bs.component_to_shreds(&keypair, &component, 0, false, &mut stats);
         assert_matches!(r, Err(BroadcastError::TooManyShreds));
+    }
+
+    #[test]
+    fn test_update_parent() {
+        let keypair = Keypair::new();
+        let (votor_event_sender, _votor_event_receiver) = unbounded();
+        let mut bs = StandardBroadcastRun::new(
+            0,
+            Arc::new(MigrationStatus::post_migration_status()),
+            votor_event_sender,
+        );
+        bs.slot = 12;
+        bs.parent = 10;
+        let original_parent_block_id = Hash::new_unique();
+        bs.parent_block_id = original_parent_block_id;
+        bs.double_merkle_parent = bs.parent;
+        bs.double_merkle_parent_block_id = bs.parent_block_id;
+
+        let new_parent_slot = 7;
+        let new_parent_block_id = Hash::new_unique();
+        let component = BlockComponent::new_block_marker(VersionedBlockMarker::new_update_parent(
+            solana_entry::block_component::UpdateParentV1 {
+                new_parent_slot,
+                new_parent_block_id,
+            },
+        ));
+        let mut stats = ProcessShredsStats::default();
+        let shreds = bs
+            .component_to_shreds(&keypair, &component, 0, false, &mut stats)
+            .unwrap();
+        assert!(
+            shreds
+                .iter()
+                .filter(|shred| shred.is_data())
+                .all(|shred| shred.parent().unwrap() == 10)
+        );
+
+        bs.maybe_update_parent_from_component(&component);
+        assert_eq!(bs.parent, 10);
+        assert_eq!(bs.parent_block_id, original_parent_block_id);
+        assert_eq!(bs.double_merkle_parent, new_parent_slot);
+        assert_eq!(bs.double_merkle_parent_block_id, new_parent_block_id);
+        assert_eq!(
+            bs.parent_info_leaf(),
+            hashv(&[
+                &new_parent_slot.to_le_bytes(),
+                new_parent_block_id.as_bytes()
+            ])
+        );
+
+        let entries = create_ticks(1, 0, Hash::default());
+        let component = BlockComponent::new_entry_batch(entries).unwrap();
+        let shreds = bs
+            .component_to_shreds(&keypair, &component, 0, false, &mut stats)
+            .unwrap();
+        assert!(
+            shreds
+                .iter()
+                .filter(|shred| shred.is_data())
+                .all(|shred| shred.parent().unwrap() == 10)
+        );
     }
 }

--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -185,6 +185,22 @@ impl MigrationPhase {
         }
     }
 
+    /// First slot where `UpdateParent` may alter parent metadata.
+    ///
+    /// Before this slot, Tower or migration blocks may contain marker-shaped
+    /// bytes, but they must not be allowed to reparent `SlotMeta`.
+    fn first_slot_allowing_update_parent(&self) -> Option<Slot> {
+        match self {
+            MigrationPhase::PreFeatureActivation
+            | MigrationPhase::Migration { .. }
+            | MigrationPhase::ReadyToEnable { .. } => None,
+            MigrationPhase::AlpenglowEnabled { genesis_cert } => {
+                genesis_cert.cert_type.slot().checked_add(1)
+            }
+            MigrationPhase::FullAlpenglowEpoch { .. } => Some(0),
+        }
+    }
+
     /// Check if we are in the process of discovering the genesis block, and `slot` could qualify
     /// to be used for discovery. This entails that `slot` > `migration_slot`. The caller must additionally
     /// check that the parent of `slot` is super-OC.
@@ -274,6 +290,11 @@ impl MigrationPhase {
         self.is_alpenglow_block(slot)
     }
 
+    /// Should live leader-bank creation use the Alpenglow block creation path?
+    fn should_use_alpenglow_leader_path(&self, slot: Slot) -> bool {
+        self.is_alpenglow_block(slot)
+    }
+
     /// Should this block be allowed to have block markers?
     fn should_allow_block_markers(&self, slot: Slot) -> bool {
         // Only allow for alpenglow blocks, TowerBFT blocks should not have markers
@@ -285,9 +306,14 @@ impl MigrationPhase {
         self.is_alpenglow_block(slot)
     }
 
-    /// Should this block allow the UpdateParent marker, i.e., support fast leader handover?
-    fn should_allow_fast_leader_handover(&self, slot: Slot) -> bool {
+    /// Should this block allow an `UpdateParent` marker?
+    fn should_allow_update_parent(&self, slot: Slot) -> bool {
         self.is_alpenglow_block(slot)
+    }
+
+    /// Should replay notify block creation about optimistic parents for this slot?
+    fn should_allow_fast_leader_handover(&self, slot: Slot) -> bool {
+        self.should_allow_update_parent(slot)
     }
 }
 
@@ -434,9 +460,12 @@ impl MigrationStatus {
     dispatch!(pub fn should_send_votor_event(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_respond_to_ancestor_hashes_requests(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_have_alpenglow_ticks(&self, slot: Slot) -> bool);
+    dispatch!(pub fn should_use_alpenglow_leader_path(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_allow_block_markers(&self, slot: Slot) -> bool);
+    dispatch!(pub fn should_allow_update_parent(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_allow_fast_leader_handover(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_use_double_merkle_block_id(&self, slot: Slot) -> bool);
+    dispatch!(pub fn first_slot_allowing_update_parent(&self) -> Option<Slot>);
 
     /// The alpenglow feature flag has been activated in slot `slot`.
     /// This should only be called using the feature account of a *rooted* slot,

--- a/votor-messages/src/reward_certificate.rs
+++ b/votor-messages/src/reward_certificate.rs
@@ -152,5 +152,10 @@ pub enum BuildRewardCertsRespError {
     Encode(EncodeError),
 }
 
-/// A type alias to minimise making changes if the above types change.
-pub type BuildRewardCertsResponse = Result<BuildRewardCertsRespSucc, BuildRewardCertsRespError>;
+/// Response to a [`BuildRewardCertsRequest`].
+pub struct BuildRewardCertsResponse {
+    /// The bank slot from the corresponding request.
+    pub bank_slot: Slot,
+    /// The result of building reward certs for `bank_slot`.
+    pub result: Result<BuildRewardCertsRespSucc, BuildRewardCertsRespError>,
+}

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -21,7 +21,7 @@ use {
     crossbeam_channel::{Receiver, Sender, TrySendError, select},
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
-    solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
+    solana_ledger::leader_schedule_cache::LeaderScheduleCache,
     solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank, bank_forks::SharableBanks,
@@ -47,7 +47,6 @@ pub(crate) struct ConsensusPoolContext {
 
     pub(crate) cluster_info: Arc<ClusterInfo>,
     pub(crate) my_vote_pubkey: Pubkey,
-    pub(crate) blockstore: Arc<Blockstore>,
     pub(crate) sharable_banks: SharableBanks,
     pub(crate) leader_schedule_cache: Arc<LeaderScheduleCache>,
 
@@ -400,15 +399,6 @@ impl ConsensusPoolService {
         let start_slot = *highest_parent_ready;
         let end_slot = last_of_consecutive_leader_slots(start_slot);
 
-        if (start_slot..=end_slot).any(|s| ctx.blockstore.has_existing_shreds_for_slot(s)) {
-            warn!(
-                "{}: We have already produced shreds in the window {start_slot}-{end_slot}, \
-                 skipping production of our leader window",
-                ctx.cluster_info.id()
-            );
-            return;
-        }
-
         match consensus_pool
             .parent_ready_tracker
             .block_production_parent(start_slot)
@@ -459,7 +449,6 @@ mod tests {
         },
         solana_gossip::cluster_info::ClusterInfo,
         solana_hash::Hash,
-        solana_ledger::get_tmp_ledger_path_auto_delete,
         solana_runtime::{
             bank_forks::{BankForks, SharableBanks},
             genesis_utils::{
@@ -481,7 +470,6 @@ mod tests {
         sharable_banks: SharableBanks,
         my_pubkey: Pubkey,
         my_vote_pubkey: Pubkey,
-        blockstore: Arc<Blockstore>,
         exit: Arc<AtomicBool>,
         cluster_info: Arc<ClusterInfo>,
         highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
@@ -511,8 +499,6 @@ mod tests {
             let bank0 = Bank::new_for_tests(&genesis.genesis_config);
             let bank_forks = BankForks::new_rw_arc(bank0);
 
-            let ledger_path = get_tmp_ledger_path_auto_delete!();
-            let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
             let sharable_banks = bank_forks.read().unwrap().sharable_banks();
             let leader_schedule_cache =
                 Arc::new(LeaderScheduleCache::new_from_bank(&sharable_banks.root()));
@@ -537,7 +523,6 @@ mod tests {
                 sharable_banks,
                 my_pubkey,
                 my_vote_pubkey,
-                blockstore,
                 exit: Arc::new(AtomicBool::new(false)),
                 cluster_info,
                 highest_finalized: Arc::new(RwLock::new(None)),
@@ -740,7 +725,6 @@ mod tests {
             generated_cert_types: Arc::new(GeneratedCertTypes::default()),
             cluster_info: ctx.cluster_info.clone(),
             my_vote_pubkey: ctx.my_vote_pubkey,
-            blockstore: ctx.blockstore.clone(),
             sharable_banks: ctx.sharable_banks.clone(),
             leader_schedule_cache: ctx.leader_schedule_cache.clone(),
             consensus_message_receiver: crossbeam_channel::unbounded().1,

--- a/votor/src/consensus_rewards.rs
+++ b/votor/src/consensus_rewards.rs
@@ -108,7 +108,10 @@ impl ConsensusRewards {
                 recv(self.build_reward_certs_receiver) -> msg => {
                     match msg {
                         Ok(msg) => {
-                            let resp = self.build_certs(msg.bank_slot);
+                            let resp = BuildRewardCertsResponse {
+                                bank_slot: msg.bank_slot,
+                                result: self.build_certs(msg.bank_slot),
+                            };
                             if self.reward_certs_sender.send(resp).is_err() {
                                 error!("{my_pubkey}: cert sender channel is disconnected; exiting.");
                                 break;

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -248,7 +248,6 @@ impl Votor {
             generated_cert_types,
             cluster_info: cluster_info.clone(),
             my_vote_pubkey: vote_account,
-            blockstore,
             sharable_banks: sharable_banks.clone(),
             leader_schedule_cache: leader_schedule_cache.clone(),
             consensus_message_receiver,


### PR DESCRIPTION
## Problem

Alpenglow block production currently waits for `ParentReady` / finalization-certificate state before starting the next leader window. That makes leader transitions slower than the Tower path, where a validator can begin producing as soon as the prior leader’s last block is frozen.

This PR allows a validator to optimistically start its leader window on the prior leader’s last frozen block, then switch to the finalized parent later if consensus proves a different parent. The switch is represented by an `UpdateParent` block marker.

## Summary of Changes

- Add optimistic leader-window notifications from replay to `BlockCreationLoop`.
- Teach `BlockCreationLoop` to choose the freshest finalized or optimistic leader window, with finalized `ParentReady` winning ties.
- Add sad leader handover: emit `UpdateParent`, abort the optimistic bank, recreate the bank on the finalized parent, and reschedule drained transactions.
- Add `UpdateParent` marker parsing, persistence, and signaling in blockstore.
- Extend `SlotMeta` with `parent_block_id` and `replay_fec_set_index`.
- Add double-Merkle block id support that commits to FEC roots plus the effective parent.
- Keep shred-header `PARENT_OFFSET` stable across `UpdateParent`; only the double-Merkle parent leaf changes.
- Restart live and startup replay from the `UpdateParent` FEC set after proving header compatibility.
- Add soft-dead vs hard-dead replay failure handling for recoverable pre-`UpdateParent` failures.
- Wire soft-dead notifications into block-id repair.
- Gate marker parsing / DMR work by Alpenglow migration state to preserve Tower hot-path behavior.
- Add tests for UpdateParent ordering, replay restart, soft/hard dead transitions, sad handover, repair, and broadcast behavior.

## Bugs Fixed / Concerns Addressed

- Fixed incorrect block id voting after sad leader handover by using the updated parent/block id in the double-Merkle parent leaf.
- Avoided shred parent mismatch races by keeping `PARENT_OFFSET` based on the original parent for the entire slot.
- Prevented out-of-order post-`UpdateParent` shreds from being rejected before the receiver observes the marker.
- Prevented accepting `garbage | UpdateParent | valid suffix` blocks by requiring a compatible block header before replay can start from `UpdateParent`.
- Prevented recoverable pre-`UpdateParent` replay failures from permanently poisoning blockstore dead state.
- Ensured block-id repair can react to transient soft-dead slots.
- Fixed abandoned leader bank races by waiting for in-flight banking-stage commits before clearing the bank.
- Fixed stale optimistic-parent channel behavior with latest-only coalescing and metrics.
- Avoided aborting a leader window on transient parent block-id mismatch while replay/bank switching may still be in progress.
- Made marker send/footer failures recoverable through `Result` paths instead of panic or partial cleanup.
- Ignored stale reward-cert responses from abandoned banks.
- Preserved replay of fully repaired own leader blocks after restart while still skipping live in-progress own leader replay.

## UpdateParent Design

Fast leader handover has two parent concepts:

- The shred-header parent, used for `PARENT_OFFSET`.
- The effective replay/consensus parent, committed by `SlotMeta` and the double-Merkle parent leaf.

Broadcast always uses the original optimistic parent in shred headers. If sad handover happens, BCL emits an `UpdateParent` marker and broadcast updates only its double-Merkle parent state. This avoids receiver-side parent mismatch races while still making the final block id commit to the correct parent.

Receiver rules:

- Block headers are parsed from shred index 0.
- `UpdateParent` is parsed only at FEC boundaries.
- `SlotMeta.parent_slot`, `parent_block_id`, and `replay_fec_set_index` are updated when a valid marker is observed.
- Shred parent is always checked for well-formedness.
- Shred parent is compared to `SlotMeta.parent_slot` only before `UpdateParent`.
- Conflicting/multiple `UpdateParent`s, header parent mismatch, `UpdateParent` equal to the header parent, or `UpdateParent` greater than the header parent are invalid.

Replay rules:

- Replay does not create/restart a bank from `UpdateParent` until blockstore proves the slot has a compatible block header.
- Replay starts at `replay_fec_set_index`, skipping the obsolete optimistic-parent prefix.
- Startup replay uses the same offset so restarted validators converge with live replay.
- Chained Merkle Root validation is skipped for `UpdateParent` slots; double-Merkle validation carries the parent commitment.

## Soft vs Hard Dead

Hard-dead is terminal:

- Marked in `ProgressMap` as `Hard`.
- Written to blockstore dead slots.
- Sent to replay-vote, slot-status, RPC, slots stats, and Tower duplicate/dead handling.

Soft-dead is transient:

- Used only for recoverable replay failures before a usable `UpdateParent`.
- Marked in `ProgressMap` as `ReplayFailureBeforeUpdateParent`.
- Not written to blockstore dead slots.
- Sends `InvalidBank` to release replay-vote state.
- Sends `MarkSoftDead` to block-id repair so repair can fetch by block id.

A soft-dead slot is restarted when a compatible `UpdateParent` becomes available. Replay clears the old progress/bank, sends `ClearSoftDead`, and recreates the bank from the updated parent at `replay_fec_set_index`.

If the slot becomes full without a usable `UpdateParent`, or if replay fails after the `UpdateParent` replay point, the slot is promoted to hard-dead.
