### PR TITLE
Propagates error from `calc_vote_reward_update_vote_states`

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -525,7 +525,7 @@ fn record_and_complete_block(
             Hash::default(), // Banks we produce do not need the bank hash mismatch check
             reward_cert,
             final_cert_input,
-        );
+        )?;
         footer
     };
 

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -37,7 +37,8 @@ use {
     solana_poh_config::PohConfig,
     solana_pubkey::Pubkey,
     solana_runtime::{
-        bank::Bank, installed_scheduler_pool::BankWithScheduler,
+        bank::Bank, block_component_processor::BankFooterError,
+        installed_scheduler_pool::BankWithScheduler,
         validated_reward_certificate::Error as ValidatedRewardCertError,
     },
     solana_transaction::versioned::VersionedTransaction,
@@ -77,6 +78,9 @@ pub enum PohRecorderError {
 
     #[error("constructing validated reward cert failed with {0}")]
     ValidatedRewardCert(#[from] ValidatedRewardCertError),
+
+    #[error("updating bank footer failed with \"{0}\"")]
+    UpdateBankFooter(#[from] BankFooterError),
 }
 
 pub(crate) type Result<T> = std::result::Result<T, PohRecorderError>;

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -1,7 +1,9 @@
 use {
     crate::{
         bank::Bank,
-        block_component_processor::vote_reward::calc_vote_rewards_update_vote_states,
+        block_component_processor::vote_reward::{
+            CalcVoteRewardUpdateVoteStatesError, calc_vote_rewards_update_vote_states,
+        },
         validated_block_finalization::{
             BlockFinalizationCertError, ValidatedBlockFinalizationCert,
         },
@@ -26,6 +28,12 @@ use {
 };
 
 pub(crate) mod vote_reward;
+
+#[derive(Debug, PartialEq, Eq, Error)]
+pub enum BankFooterError {
+    #[error("calc vote rewards updating vote states failed with \"{0}\"")]
+    CalcVoteRewardUpdateVoteStates(#[from] CalcVoteRewardUpdateVoteStatesError),
+}
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum BlockComponentProcessorError {
@@ -66,6 +74,8 @@ pub enum BlockComponentProcessorError {
     AbandonedBank(VersionedUpdateParent),
     #[error("invalid reward certs {0}")]
     InvalidRewardCerts(#[from] ValidatedRewardCertError),
+    #[error("updating bank footer failed with \"{0}\"")]
+    UpdateBankFooter(#[from] BankFooterError),
 }
 
 #[derive(Default)]
@@ -314,7 +324,7 @@ impl BlockComponentProcessor {
             footer_input
                 .as_ref()
                 .map(|(validators, slot)| (validators, *slot)),
-        );
+        )?;
 
         // Send finalization cert(s) to consensus pool
         if let Some((finalize_cert, notarize_cert)) = pool_input {
@@ -439,13 +449,12 @@ impl BlockComponentProcessor {
         bank_hash: Hash,
         reward_cert: Option<ValidatedRewardCert>,
         final_cert_input: Option<(&HashSet<Pubkey>, Slot)>,
-    ) {
-        // Update clock sysvar
+    ) -> Result<(), BankFooterError> {
         bank.update_clock_from_footer(block_producer_time_nanos);
-
-        calc_vote_rewards_update_vote_states(bank, reward_cert, final_cert_input).unwrap();
+        calc_vote_rewards_update_vote_states(bank, reward_cert, final_cert_input)?;
         // Record expected bank hash from footer for later verification when the bank is frozen.
         bank.set_expected_bank_hash(bank_hash);
+        Ok(())
     }
 }
 

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -16,7 +16,7 @@ pub mod epoch_inflation_account_state;
 
 /// Different types of errors that can happen when calculating and paying voting reward.
 #[derive(Debug, PartialEq, Eq, Error)]
-pub(super) enum Error {
+pub enum CalcVoteRewardUpdateVoteStatesError {
     #[error("missing EpochInflationAccountState for current slot {current_slot}")]
     MissingEpochInflationAccountState { current_slot: Slot },
     #[error("missing epoch stakes for reward_slot {reward_slot} in current_slot {current_slot}")]
@@ -48,7 +48,7 @@ pub(super) fn calc_vote_rewards_update_vote_states(
     bank: &Bank,
     reward_cert: Option<ValidatedRewardCert>,
     final_cert_input: Option<(&HashSet<Pubkey>, Slot)>,
-) -> Result<(), Error> {
+) -> Result<(), CalcVoteRewardUpdateVoteStatesError> {
     let (reward_slot, validators_to_reward) = if let Some(reward_cert) = reward_cert {
         reward_cert.into_parts()
     } else {
@@ -57,12 +57,12 @@ pub(super) fn calc_vote_rewards_update_vote_states(
 
     let current_slot = bank.slot();
     let (reward_slot_accounts, reward_slot_total_stake) = {
-        let epoch_stakes =
-            bank.epoch_stakes_from_slot(reward_slot)
-                .ok_or(Error::MissingEpochStakes {
-                    reward_slot,
-                    current_slot,
-                })?;
+        let epoch_stakes = bank.epoch_stakes_from_slot(reward_slot).ok_or(
+            CalcVoteRewardUpdateVoteStatesError::MissingEpochStakes {
+                reward_slot,
+                current_slot,
+            },
+        )?;
         (
             epoch_stakes.stakes().vote_accounts().as_ref(),
             epoch_stakes.total_stake(),
@@ -78,9 +78,13 @@ pub(super) fn calc_vote_rewards_update_vote_states(
         // that activated Alpenglow should have created the account.
         debug_assert!(epoch_inflation_account_state.is_some());
         epoch_inflation_account_state
-            .ok_or(Error::MissingEpochInflationAccountState { current_slot })?
+            .ok_or(
+                CalcVoteRewardUpdateVoteStatesError::MissingEpochInflationAccountState {
+                    current_slot,
+                },
+            )?
             .get_epoch_state(reward_epoch)
-            .ok_or(Error::NoEpochValidatorStake {
+            .ok_or(CalcVoteRewardUpdateVoteStatesError::NoEpochValidatorStake {
                 reward_epoch,
                 current_slot,
             })?
@@ -94,13 +98,14 @@ pub(super) fn calc_vote_rewards_update_vote_states(
     let mut total_leader_reward = 0u64;
     let current_epoch = bank.epoch();
     for validator_to_reward in validators_to_reward {
-        let (reward_slot_validator_stake, _) = reward_slot_accounts
-            .get(&validator_to_reward)
-            .ok_or(Error::MissingRewardSlotValidator {
-                pubkey: validator_to_reward,
-                reward_slot,
-                current_slot,
-            })?;
+        let (reward_slot_validator_stake, _) =
+            reward_slot_accounts.get(&validator_to_reward).ok_or(
+                CalcVoteRewardUpdateVoteStatesError::MissingRewardSlotValidator {
+                    pubkey: validator_to_reward,
+                    reward_slot,
+                    current_slot,
+                },
+            )?;
         let (validator_reward, add_leader_reward) = calculate_reward(
             &epoch_state,
             reward_slot_total_stake,


### PR DESCRIPTION
#### Problem

`update_bank_with_footer_fields` currently panics if `calc_vote_reward_update_vote_states` fails.  `calc_vote_reward_update_vote_states` can fail for legitimate reasons e.g. if somehow the node is not keeping up with the rest of the network and gets a reward cert for a slot / epoch for which it does not have enough information.

#### Summary of Changes

Propagates error back instead of panicking.
