### PR TITLE
feat(scheduler-bindings): TPU address override at logon

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -470,12 +470,16 @@ impl BankingStage {
                 block_production_method,
                 num_workers,
                 config,
-            } => match block_production_method {
-                BlockProductionMethod::CentralScheduler
-                | BlockProductionMethod::CentralSchedulerGreedy => {
-                    self.spawn_internal_central(num_workers, config)
+            } => {
+                #[cfg(unix)]
+                crate::scheduler_bindings_server::restore_tpu_override();
+                match block_production_method {
+                    BlockProductionMethod::CentralScheduler
+                    | BlockProductionMethod::CentralSchedulerGreedy => {
+                        self.spawn_internal_central(num_workers, config)
+                    }
                 }
-            },
+            }
             #[cfg(unix)]
             BankingControlMsg::External { session } => self.spawn_external(session),
         })?;
@@ -659,6 +663,7 @@ mod external {
                 tpu_to_pack,
                 progress_tracker,
                 workers,
+                tpu_override: _,
             }: AgaveSession,
         ) -> Result<Vec<JoinHandle<()>>, ()> {
             info!("Spawning external scheduler");

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1321,6 +1321,8 @@ pub(crate) mod external {
                 pack_to_worker_capacity: 16,
                 worker_to_pack_capacity: 16,
                 flags: 0,
+                tpu_override_addr: [0; 4],
+                tpu_override_port: 0,
             };
             let (mut agave_session, files) = Server::setup_session(logon).unwrap();
             let mut client_session = client::setup_session(&logon, files).unwrap();

--- a/core/src/scheduler_bindings_server.rs
+++ b/core/src/scheduler_bindings_server.rs
@@ -1,9 +1,41 @@
 use {
-    crate::banking_stage::BankingControlMsg, agave_scheduling_utils::handshake, std::path::Path,
+    crate::banking_stage::BankingControlMsg,
+    agave_scheduling_utils::handshake,
+    solana_gossip::{cluster_info::ClusterInfo, contact_info::Protocol},
+    std::{
+        net::SocketAddr,
+        path::Path,
+        sync::{Arc, Mutex},
+        time::Duration,
+    },
     tokio::sync::mpsc,
 };
 
-pub(crate) fn spawn(path: &Path, session_sender: mpsc::Sender<BankingControlMsg>) {
+const TPU_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Original TPU and TPU forwards addresses captured before the first override.
+static ORIGINAL_TPU: Mutex<Option<(Arc<ClusterInfo>, SocketAddr, SocketAddr)>> = Mutex::new(None);
+
+/// Revert the override applied by [`apply_tpu_override`]. No-op if none is active.
+pub(crate) fn restore_tpu_override() {
+    let Some((cluster_info, tpu, tpu_forwards)) = ORIGINAL_TPU.lock().unwrap().take() else {
+        return;
+    };
+
+    cluster_info
+        .set_tpu_quic(tpu)
+        .expect("captured from gossip; cannot fail");
+    cluster_info
+        .set_tpu_forwards_quic(tpu_forwards)
+        .expect("captured from gossip; cannot fail");
+    info!("Restored original TPU addresses; tpu={tpu}, tpu_forwards={tpu_forwards}");
+}
+
+pub(crate) fn spawn(
+    path: &Path,
+    session_sender: mpsc::Sender<BankingControlMsg>,
+    cluster_info: Arc<ClusterInfo>,
+) {
     // NB: Panic on start if we can't bind.
     let _ = std::fs::remove_file(path);
     let mut listener = handshake::server::Server::new(path).unwrap();
@@ -11,9 +43,22 @@ pub(crate) fn spawn(path: &Path, session_sender: mpsc::Sender<BankingControlMsg>
     std::thread::Builder::new()
         .name("solBindingSrv".to_string())
         .spawn(move || {
+            // Block until gossip has published TPU/TPU forwards.
+            while cluster_info.my_contact_info().tpu(Protocol::QUIC).is_none()
+                || cluster_info
+                    .my_contact_info()
+                    .tpu_forwards(Protocol::QUIC)
+                    .is_none()
+            {
+                std::thread::sleep(TPU_POLL_INTERVAL);
+            }
+
             loop {
                 match listener.accept() {
                     Ok(session) => {
+                        if let Some(tpu_override) = session.tpu_override {
+                            apply_tpu_override(&cluster_info, tpu_override);
+                        }
                         if session_sender
                             .blocking_send(BankingControlMsg::External { session })
                             .is_err()
@@ -28,4 +73,28 @@ pub(crate) fn spawn(path: &Path, session_sender: mpsc::Sender<BankingControlMsg>
             }
         })
         .unwrap();
+}
+
+/// Apply `tpu_override`, capturing originals on the first override.
+fn apply_tpu_override(cluster_info: &Arc<ClusterInfo>, tpu_override: SocketAddr) {
+    let mut original = ORIGINAL_TPU.lock().unwrap();
+    if original.is_none() {
+        let contact = cluster_info.my_contact_info();
+        let tpu = contact
+            .tpu(Protocol::QUIC)
+            .expect("TPU published before accept");
+        let tpu_forwards = contact
+            .tpu_forwards(Protocol::QUIC)
+            .expect("TPU forwards published before accept");
+        *original = Some((cluster_info.clone(), tpu, tpu_forwards));
+    }
+
+    cluster_info
+        .set_tpu_quic(tpu_override)
+        .expect("address validated at handshake");
+    cluster_info
+        .set_tpu_forwards_quic(tpu_override)
+        .expect("address validated at handshake");
+
+    info!("TPU override applied; addr={tpu_override}");
 }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -306,7 +306,11 @@ impl Tpu {
 
         #[cfg(unix)]
         if let Some((path, banking_control_sender)) = scheduler_bindings {
-            super::scheduler_bindings_server::spawn(&path, banking_control_sender);
+            super::scheduler_bindings_server::spawn(
+                &path,
+                banking_control_sender,
+                cluster_info.clone(),
+            );
         }
         #[cfg(not(unix))]
         assert!(scheduler_bindings.is_none());

--- a/core/tests/scheduler_bindings_tpu_override.rs
+++ b/core/tests/scheduler_bindings_tpu_override.rs
@@ -1,0 +1,62 @@
+//! Locks the invariant that the scheduler-bindings handshake rejects exactly the same TPU
+//! override addresses that `solana_gossip::contact_info::sanitize_socket` rejects. If gossip
+//! ever tightens its socket validation, this test will fail until the handshake is updated to
+//! match — otherwise [`crate::scheduler_bindings_server::apply_tpu_override`] would panic.
+
+#![cfg(unix)]
+
+use {
+    agave_scheduling_utils::handshake::{AgaveHandshakeError, ClientLogon, server::Server},
+    solana_gossip::contact_info::{ContactInfo, Protocol},
+    solana_pubkey::Pubkey,
+    std::net::{Ipv4Addr, SocketAddr},
+};
+
+fn handshake_accepts(addr: Ipv4Addr, port: u16) -> bool {
+    let logon = ClientLogon {
+        worker_count: 1,
+        allocator_size: 64 * 1024 * 1024,
+        allocator_handles: 1,
+        tpu_to_pack_capacity: 1024,
+        progress_tracker_capacity: 256,
+        pack_to_worker_capacity: 1024,
+        worker_to_pack_capacity: 1024,
+        flags: 0,
+        tpu_override_addr: addr.octets(),
+        tpu_override_port: port,
+    };
+    !matches!(
+        Server::setup_session(logon),
+        Err(AgaveHandshakeError::InvalidTpuOverride(_))
+    )
+}
+
+fn gossip_accepts(addr: SocketAddr) -> bool {
+    let mut node = ContactInfo::new_localhost(&Pubkey::new_unique(), 0);
+    node.set_tpu(Protocol::QUIC, addr).is_ok()
+}
+
+#[test]
+fn handshake_matches_gossip_sanitize_socket() {
+    // Each case is (addr, port). Port 0 is excluded — the handshake reserves it as the
+    // "no override" sentinel rather than a value submitted to gossip.
+    let cases: &[(Ipv4Addr, u16)] = &[
+        (Ipv4Addr::new(127, 0, 0, 1), 12345),
+        (Ipv4Addr::new(192, 168, 1, 1), 8000),
+        (Ipv4Addr::new(1, 2, 3, 4), 1),
+        (Ipv4Addr::UNSPECIFIED, 12345),
+        (Ipv4Addr::new(224, 0, 0, 1), 12345),
+        (Ipv4Addr::new(239, 255, 255, 255), 12345),
+        (Ipv4Addr::BROADCAST, 12345),
+    ];
+
+    for &(addr, port) in cases {
+        let socket = SocketAddr::from((addr, port));
+        let h = handshake_accepts(addr, port);
+        let g = gossip_accepts(socket);
+        assert_eq!(
+            h, g,
+            "handshake/gossip disagree on {socket}: handshake={h}, gossip={g}"
+        );
+    }
+}

--- a/scheduling-utils/src/bridge/test.rs
+++ b/scheduling-utils/src/bridge/test.rs
@@ -67,6 +67,8 @@ where
             pack_to_worker_capacity: worker_req_cap,
             worker_to_pack_capacity: 1024,
             flags: 0,
+            tpu_override_addr: [0; 4],
+            tpu_override_port: 0,
         };
 
         let (agave, files) = Server::setup_session(logon).unwrap();

--- a/scheduling-utils/src/handshake/server.rs
+++ b/scheduling-utils/src/handshake/server.rs
@@ -13,6 +13,7 @@ use {
         ffi::CStr,
         fs::File,
         io::{IoSlice, Read, Write},
+        net::SocketAddr,
         os::{
             fd::{AsRawFd, FromRawFd},
             unix::net::{UnixListener, UnixStream},
@@ -145,6 +146,17 @@ impl Server {
     pub fn setup_session(
         logon: ClientLogon,
     ) -> Result<(AgaveSession, Vec<File>), AgaveHandshakeError> {
+        // Validate the TPU override before allocating anything so failures are cheap. The
+        // accepted set must remain a subset of what `solana_gossip::contact_info::sanitize_socket`
+        // accepts, otherwise the validator will panic when applying the override.
+        let tpu_override = (logon.tpu_override_port != 0)
+            .then(|| SocketAddr::from((logon.tpu_override_addr, logon.tpu_override_port)));
+        if let Some(addr) = tpu_override {
+            if addr.ip().is_unspecified() || addr.ip().is_multicast() {
+                return Err(AgaveHandshakeError::InvalidTpuOverride(addr));
+            }
+        }
+
         // Setup the allocator in shared memory (`worker_count` & `allocator_handles` have been
         // validated so this won't panic).
         let (allocator_file, tpu_to_pack_allocator) = Self::create_allocator(&logon)?;
@@ -186,6 +198,7 @@ impl Server {
                 },
                 progress_tracker,
                 workers,
+                tpu_override,
             },
             [allocator_file, tpu_to_pack_file, progress_tracker_file]
                 .into_iter()

--- a/scheduling-utils/src/handshake/shared.rs
+++ b/scheduling-utils/src/handshake/shared.rs
@@ -3,6 +3,7 @@ use {
         PackToWorkerMessage, ProgressMessage, TpuToPackMessage, WorkerToPackMessage,
     },
     rts_alloc::Allocator,
+    std::net::SocketAddr,
     thiserror::Error,
 };
 
@@ -38,6 +39,10 @@ pub struct ClientLogon {
     pub worker_to_pack_capacity: usize,
     /// Flags that control the behavior of the new scheduling session.
     pub flags: u16,
+    /// IPv4 octets for the optional TPU address override; ignored when `tpu_override_port` is 0.
+    pub tpu_override_addr: [u8; 4],
+    /// Port for the TPU address override; 0 means no override is requested.
+    pub tpu_override_port: u16,
     // NB: If adding more fields please ensure:
     // - The fields are zeroable.
     // - If possible the fields are backwards compatible:
@@ -98,6 +103,8 @@ pub struct AgaveSession {
     pub tpu_to_pack: AgaveTpuToPackSession,
     pub progress_tracker: shaq::spsc::Producer<ProgressMessage>,
     pub workers: Vec<AgaveWorkerSession>,
+    /// TPU address override requested by the client, if any.
+    pub tpu_override: Option<SocketAddr>,
 }
 
 /// Shared memory objects for the tpu to pack worker.
@@ -136,4 +143,6 @@ pub enum AgaveHandshakeError {
     RtsAlloc(#[from] RtsAllocError),
     #[error("Shaq; err={0:?}")]
     Shaq(#[from] ShaqError),
+    #[error("Invalid TPU override; addr={0}")]
+    InvalidTpuOverride(SocketAddr),
 }

--- a/scheduling-utils/src/handshake/tests.rs
+++ b/scheduling-utils/src/handshake/tests.rs
@@ -8,7 +8,7 @@ use {
         SharableTransactionRegion, TpuToPackMessage, TransactionResponseRegion,
         WorkerToPackMessage,
     },
-    std::time::Duration,
+    std::{net::SocketAddr, time::Duration},
     tempfile::NamedTempFile,
 };
 
@@ -60,6 +60,11 @@ fn message_passing_on_all_queues() {
 
     let server_handle = std::thread::spawn(move || {
         let mut session = server.accept().unwrap();
+
+        assert_eq!(
+            session.tpu_override,
+            Some(SocketAddr::from(([127, 0, 0, 1], 12345))),
+        );
 
         // Send a tpu_to_pack message.
         session.tpu_to_pack.producer.try_write(tpu_to_pack).unwrap();
@@ -116,6 +121,8 @@ fn message_passing_on_all_queues() {
                 pack_to_worker_capacity: 1024,
                 worker_to_pack_capacity: 1024,
                 flags: 0,
+                tpu_override_addr: [127, 0, 0, 1],
+                tpu_override_port: 12345,
             },
             Duration::from_secs(1),
         )
@@ -198,6 +205,8 @@ fn accept_worker_count_max() {
                 pack_to_worker_capacity: 1024,
                 worker_to_pack_capacity: 1024,
                 flags: 0,
+                tpu_override_addr: [0; 4],
+                tpu_override_port: 0,
             },
             Duration::from_secs(1),
         );
@@ -233,6 +242,8 @@ fn reject_worker_count_low() {
                 pack_to_worker_capacity: 1024,
                 worker_to_pack_capacity: 1024,
                 flags: 0,
+                tpu_override_addr: [0; 4],
+                tpu_override_port: 0,
             },
             Duration::from_secs(1),
         );
@@ -271,6 +282,8 @@ fn reject_worker_count_high() {
                 pack_to_worker_capacity: 1024,
                 worker_to_pack_capacity: 1024,
                 flags: 0,
+                tpu_override_addr: [0; 4],
+                tpu_override_port: 0,
             },
             Duration::from_secs(1),
         );
@@ -278,6 +291,46 @@ fn reject_worker_count_high() {
             panic!();
         };
         assert_eq!(reason, "Worker count; count=100");
+    });
+
+    client_handle.join().unwrap();
+    server_handle.join().unwrap();
+}
+
+#[test]
+fn reject_unspecified_tpu_override() {
+    let ipc = NamedTempFile::new().unwrap();
+    std::fs::remove_file(ipc.path()).unwrap();
+    let mut server = Server::new(ipc.path()).unwrap();
+
+    let server_handle = std::thread::spawn(move || {
+        let res = server.accept();
+        let Err(AgaveHandshakeError::InvalidTpuOverride(addr)) = res else {
+            panic!();
+        };
+        assert_eq!(addr, SocketAddr::from(([0, 0, 0, 0], 12345)));
+    });
+    let client_handle = std::thread::spawn(move || {
+        let res = connect(
+            ipc,
+            ClientLogon {
+                worker_count: 1,
+                allocator_size: 1024 * 1024 * 1024,
+                allocator_handles: 1,
+                tpu_to_pack_capacity: 65536,
+                progress_tracker_capacity: 256,
+                pack_to_worker_capacity: 1024,
+                worker_to_pack_capacity: 1024,
+                flags: 0,
+                tpu_override_addr: [0; 4],
+                tpu_override_port: 12345,
+            },
+            Duration::from_secs(1),
+        );
+        let Err(ClientHandshakeError::Rejected(reason)) = res else {
+            panic!();
+        };
+        assert_eq!(reason, "Invalid TPU override; addr=0.0.0.0:12345");
     });
 
     client_handle.join().unwrap();


### PR DESCRIPTION
## Problem

Operators running an external scheduler may want the validator to advertise a different TPU address in gossip. This is a common modification to the existing agave-validator client.

## Summary of Changes

- Adds `tpu_override_addr: [u8; 4]` and `tpu_override_port: u16` to `ClientLogon`. Clients that don't request an override leave the fields zero.
- The bindings-server thread blocks on startup until gossip has published TPU and TPU-forwards.
- On override, the gossip-published TPU and TPU-forwards are captured. When banking transitions back to the internal scheduler, the captured values are restored.