### PR TITLE
fix(geyser): populate entry_count for leader-produced blocks

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3818,7 +3818,7 @@ impl ReplayStage {
                         Some(bank.clock().unix_timestamp),
                         Some(bank.block_height()),
                         bank.executed_transaction_count(),
-                        r_replay_progress.num_entries as u64,
+                        bank.entry_count(),
                         commission_rate_in_basis_points,
                     )
                 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -5579,6 +5579,57 @@ pub mod tests {
     }
 
     #[test]
+    fn test_confirm_slot_entries_updates_bank_entry_count() {
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(100 * LAMPORTS_PER_SOL);
+        let genesis_hash = genesis_config.hash();
+        let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        let bank = BankWithScheduler::new_without_scheduler(bank);
+        let replay_tx_thread_pool = create_thread_pool(1);
+        let mut timing = ConfirmationTiming::default();
+        let mut progress = ConfirmationProgress::new(genesis_hash);
+        let amount = genesis_config.rent.minimum_balance(0);
+
+        let tx = system_transaction::transfer(
+            &mint_keypair,
+            &Pubkey::new_unique(),
+            amount,
+            genesis_hash,
+        );
+        let tx_entry = next_entry(&genesis_hash, 1, vec![tx]);
+        let tick1 = next_entry(&tx_entry.hash, 1, vec![]);
+        let tick2 = next_entry(&tick1.hash, 1, vec![]);
+        let entries = vec![tx_entry, tick1, tick2];
+        let expected = entries.len() as u64;
+
+        confirm_slot_entries(
+            &bank,
+            &replay_tx_thread_pool,
+            (entries, 0, false),
+            &mut timing,
+            &mut progress,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &MigrationStatus::default(),
+        )
+        .unwrap();
+        progress
+            .wait_for_all_verification_results(&mut 0, &mut 0)
+            .unwrap();
+
+        assert_eq!(bank.entry_count(), expected);
+        assert_eq!(progress.num_entries as u64, expected);
+        assert_eq!(bank.entry_count(), progress.num_entries as u64);
+    }
+
+    #[test]
     fn test_confirm_slot_entries_async_sigverify_fail() {
         let GenesisConfigInfo {
             genesis_config,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -556,6 +556,7 @@ impl PartialEq for Bank {
             transaction_error_count: _,
             transaction_entries_count: _,
             transactions_per_entry_max: _,
+            entry_count: _,
             entry_bytes_consumed: _,
             tick_height,
             signature_count,
@@ -787,6 +788,9 @@ pub struct Bank {
 
     /// The number of committed transactions since genesis.
     transaction_count: AtomicU64,
+
+    /// The total number of entries in this slot, including ticks
+    entry_count: AtomicU64,
 
     /// The number of non-vote transactions committed since the most
     /// recent boot from snapshot or genesis. This value is only stored in
@@ -1102,6 +1106,7 @@ impl Bank {
             transaction_error_count: AtomicU64::default(),
             transaction_entries_count: AtomicU64::default(),
             transactions_per_entry_max: AtomicU64::default(),
+            entry_count: AtomicU64::default(),
             entry_bytes_consumed: EntryBytesBudget::new(MAX_ENTRY_BYTES_PER_SLOT),
             tick_height: AtomicU64::default(),
             signature_count: AtomicU64::default(),
@@ -1359,6 +1364,7 @@ impl Bank {
             transaction_error_count: AtomicU64::new(0),
             transaction_entries_count: AtomicU64::new(0),
             transactions_per_entry_max: AtomicU64::new(0),
+            entry_count: AtomicU64::new(0),
             entry_bytes_consumed: EntryBytesBudget::new(parent.entry_bytes_budget().slot_limit()),
             // we will .clone_with_epoch() this soon after stake data update; so just .clone() for now
             stakes_cache,
@@ -1960,6 +1966,7 @@ impl Bank {
             transaction_error_count: AtomicU64::default(),
             transaction_entries_count: AtomicU64::default(),
             transactions_per_entry_max: AtomicU64::default(),
+            entry_count: AtomicU64::default(),
             entry_bytes_consumed: EntryBytesBudget::new(MAX_ENTRY_BYTES_PER_SLOT),
             tick_height: AtomicU64::new(fields.tick_height),
             signature_count: AtomicU64::new(fields.signature_count),
@@ -3190,6 +3197,7 @@ impl Bank {
         // committed before this tick height is incremented (like the blockhash
         // sysvar above)
         self.tick_height.fetch_add(1, Relaxed);
+        self.entry_count.fetch_add(1, Relaxed);
     }
 
     #[cfg(feature = "dev-context-only-utils")]
@@ -3905,6 +3913,7 @@ impl Bank {
             self.transaction_entries_count.fetch_add(1, Relaxed);
             self.transactions_per_entry_max
                 .fetch_max(processed_transactions_count, Relaxed);
+            self.entry_count.fetch_add(1, Relaxed);
         }
 
         let ((), store_accounts_us) = measure_us!({
@@ -4699,6 +4708,10 @@ impl Bank {
 
     pub fn transactions_per_entry_max(&self) -> u64 {
         self.transactions_per_entry_max.load(Relaxed)
+    }
+
+    pub fn entry_count(&self) -> u64 {
+        self.entry_count.load(Relaxed)
     }
 
     pub fn entry_bytes_budget(&self) -> &EntryBytesBudget {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11786,3 +11786,61 @@ fn test_calculate_and_set_block_id_for_dcou() {
         assert_eq!(bank.block_id(), Some(expected_block_id));
     }
 }
+
+#[test]
+fn test_entry_count_starts_at_zero() {
+    let (genesis_config, _) = create_genesis_config(LAMPORTS_PER_SOL);
+    let bank = Bank::new_for_tests(&genesis_config);
+    assert_eq!(bank.entry_count(), 0);
+}
+
+#[test]
+fn test_entry_count_increments_on_register_tick() {
+    let (genesis_config, _) = create_genesis_config(LAMPORTS_PER_SOL);
+    let bank = Bank::new_for_tests(&genesis_config);
+
+    for i in 1..=3 {
+        bank.register_default_tick_for_test();
+        assert_eq!(bank.entry_count(), i);
+    }
+}
+
+#[test]
+fn test_entry_count_includes_tx_entries_and_ticks() {
+    let (genesis_config, keypair) = create_genesis_config(100 * LAMPORTS_PER_SOL);
+    let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+
+    for i in 1..=5 {
+        let recipient = Pubkey::new_unique();
+        let tx = system_transaction::transfer(
+            &keypair,
+            &recipient,
+            LAMPORTS_PER_SOL,
+            genesis_config.hash(),
+        );
+
+        bank.process_transaction(&tx).unwrap();
+
+        assert_eq!(bank.entry_count(), i);
+    }
+
+    for j in 1..=3 {
+        bank.register_default_tick_for_test();
+        assert_eq!(bank.entry_count(), 5 + j);
+    }
+
+    assert_eq!(bank.entry_count(), 8);
+}
+
+#[test]
+fn test_entry_count_resets_for_child_bank() {
+    let (genesis_config, _) = create_genesis_config(LAMPORTS_PER_SOL);
+    let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+
+    bank.register_default_tick_for_test();
+    bank.register_default_tick_for_test();
+    assert_eq!(bank.entry_count(), 2);
+
+    let child_bank = new_from_parent(bank);
+    assert_eq!(child_bank.entry_count(), 0);
+}


### PR DESCRIPTION
## Problem

For blocks the local validator produces as leader, `ReplicaBlockInfoV3.entry_count` and `ReplicaBlockInfoV4.entry_count` come through as `0`. The field is read from `r_replay_progress.num_entries` at [replay_stage.rs:3641](https://github.com/anza-xyz/agave/blob/master/core/src/replay_stage.rs#L3641), which is only incremented inside `confirm_slot_entries`. Leader-produced banks intentionally skip the replay path, so the counter stays at zero and the geyser block metadata notification reports `entry_count = 0` for every locally-produced block.

By contrast, the sibling `bank.executed_transaction_count()` on the same call is read off the bank itself and is correct on both paths.

#12262 has the full call-graph analysis and the design alternatives I considered.

## Proposed Changes

- Add `Bank::entry_count: AtomicU64` next to `transaction_entries_count`. Default-initialize in the three constructors and add to the `BankFieldsToSerialize` destructuring so it stays out of the snapshot wire format.
- Increment in `register_tick` (every tick) and inside `commit_transactions` under the existing `processed_transactions_count > 0` guard (every transaction-bearing entry, the same condition `transaction_entries_count` already uses).
- Add a `bank.entry_count()` getter.
- Switch `notify_block_metadata` to read `bank.entry_count()` in place of `r_replay_progress.num_entries`.

The pattern parallels existing bank-level metadata accessors: `transaction_entries_count` mechanically (per-slot atomic counter), and `executed_transaction_count` in spirit (read off the bank, correct on both paths). The two increment sites cannot fire for the same logical entry: PoH's `record()` rejects empty batches and explicitly cannot produce ticks, the leader path's tick flush calls `register_tick` only while `banking_stage`'s consumer calls `commit_transactions` only, and the replay path matches exhaustively on `EntryType::{Tick, Transactions}`.

## Testing

Tests cover:

- Bank-level unit tests in `runtime/src/bank/tests.rs`: counter starts at zero, `register_tick` bumps by one per call, leader-path slot accumulates correctly through `process_transaction` plus `register_default_tick_for_test` (the regression that fails on master), and child banks reset to zero on `new_from_parent`.
- Replay-path symmetry in `ledger/src/blockstore_processor.rs`: runs `confirm_slot_entries` over a mix of tick and transaction-bearing entries, asserts `bank.entry_count() == progress.num_entries`. This pins the symmetry property the fix relies on: leader and replay paths arrive at the same count for the same slot.

End-to-end smoke test plan: run `solana-test-validator` with `yellowstone-grpc-geyser` and `--blocks-include-entries`. On master, every block has empty entries (the test validator is leader for every slot). With this fix, entries are populated.

## Out of scope

`replay-slot-stats` at [replay_stage.rs:3650](https://github.com/anza-xyz/agave/blob/master/core/src/replay_stage.rs#L3650) reports `total_entries`, `total_transactions`, and `total_shreds` from `r_replay_progress`, so those three fields are also `0` for leader slots. Intentionally not addressed here since fixing only `total_entries` would make the three sibling fields more inconsistent than they are now. I can do it as a follow-up if preferred; rationale in #12262.

Fixes #12262
