### PR TITLE
bpf-loader-program: import AtomicU64 from svm-type-overrides in tests

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1095,8 +1095,8 @@ mod tests {
         solana_rent::Rent,
         solana_sbpf::program::{BuiltinFunctionDefinition, BuiltinProgram},
         solana_sdk_ids::{system_program, sysvar},
-        solana_svm_type_overrides::sync::atomic::Ordering,
-        std::{fs::File, io::Read, ops::Range, sync::atomic::AtomicU64},
+        solana_svm_type_overrides::sync::atomic::{AtomicU64, Ordering},
+        std::{fs::File, io::Read, ops::Range},
     };
 
     fn process_instruction(


### PR DESCRIPTION
#### Problem

`cargo check -p solana-bpf-loader-program --no-default-features --features shuttle-test --all-targets` fails:

```
error[E0308]: mismatched types
    --> programs/bpf_loader/src/lib.rs:3769:33
     |
3769 |             latest_access_slot: AtomicU64::new(0),
     |                                 ^^^^^^^^^^^^^^^^^ expected `AtomicU64`, found `Atomic<u64>`
     |
     = note: expected struct `AtomicU64`
                found struct `Atomic<u64>`

error[E0308]: mismatched types
    --> programs/bpf_loader/src/lib.rs:3812:33
     |
3812 |             latest_access_slot: AtomicU64::new(0),
     |                                 ^^^^^^^^^^^^^^^^^ expected `AtomicU64`, found `Atomic<u64>`
```

`solana-svm-type-overrides` re-exports `std::sync::atomic` by default and switches to `shuttle::sync::atomic` when the `shuttle-test` feature is enabled. The `ProgramCacheEntry` definition (in `solana-program-runtime`) already routes its `AtomicU64` through the override, so the type of `ProgramCacheEntry::latest_access_slot` becomes `Atomic<u64>` under shuttle.

The test module at `programs/bpf_loader/src/lib.rs:1098-1099` imports `Ordering` from `solana_svm_type_overrides::sync::atomic` correctly, but keeps `AtomicU64` from `std::sync::atomic`. The two imports drift apart whenever `shuttle-test` is on, and tests constructing `ProgramCacheEntry` instances fail to compile because they pass stdlib `AtomicU64` into a field that expects the shuttle-aware variant.

Move the `AtomicU64` import alongside `Ordering` so both come from the override module. After the change, `cargo check` and `cargo hack check --each-feature --exclude-all-features --all-targets` pass with `shuttle-test` enabled and with default features.

Scope note: this fix addresses the compile-time gate exposed by #12314's CI matrix only. Running `cargo test --features shuttle-test` on the existing tests still panics with `Shuttle internal error: cannot access ExecutionState` because the test functions themselves are not Shuttle-aware. Making the tests run under Shuttle is a separate change outside the scope of this PR.

Surfaced during the audit work for #12289 while validating the new CI matrix proposed in #12314 (`cargo hack check --each-feature --exclude-all-features --all-targets`). #12314 will require this fix to land before its CI matrix can be merged: in the new CI's `--each-feature` mode, the standalone `shuttle-test` feature build is one of the per-feature checks, and it currently fails on master.

#### Summary of Changes

- Move the `AtomicU64` import in `programs/bpf_loader/src/lib.rs:1098-1099` from `std::sync::atomic` to `solana_svm_type_overrides::sync::atomic`, alongside the existing `Ordering` import. This is a 2-insertion / 2-deletion diff that consolidates two parallel imports onto a single line.