### PR TITLE
bpf-loader-program: make shuttle-test runnable across all targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7272,6 +7272,7 @@ dependencies = [
  "criterion",
  "qualifier_attr",
  "rand 0.9.4",
+ "shuttle",
  "solana-account 4.3.0",
  "solana-bincode",
  "solana-bpf-loader-program",

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -22,6 +22,7 @@ agave-unstable-api = []
 metrics = ["solana-syscalls/metrics", "solana-program-runtime/metrics"]
 sbpf-debugger = ["solana-program-runtime/sbpf-debugger", "solana-sbpf/debugger"]
 shuttle-test = [
+    "dep:shuttle",
     "solana-program-runtime/shuttle-test",
     "solana-sbpf/shuttle-test",
     "solana-svm-type-overrides/shuttle-test",
@@ -31,6 +32,7 @@ svm-internal = []
 [dependencies]
 bincode = { workspace = true }
 qualifier_attr = { workspace = true }
+shuttle = { workspace = true, optional = true }
 solana-account = { workspace = true }
 solana-bincode = { workspace = true }
 solana-clock = { workspace = true }

--- a/programs/bpf_loader/benches/bpf_loader_upgradeable.rs
+++ b/programs/bpf_loader/benches/bpf_loader_upgradeable.rs
@@ -1,219 +1,234 @@
-use {
-    criterion::{Criterion, criterion_group, criterion_main},
-    solana_account::{AccountSharedData, state_traits::StateMut},
-    solana_bpf_loader_program::Entrypoint,
-    solana_instruction::AccountMeta,
-    solana_loader_v3_interface::{
-        instruction::UpgradeableLoaderInstruction, state::UpgradeableLoaderState,
-    },
-    solana_program_runtime::invoke_context::mock_process_instruction,
-    solana_pubkey::Pubkey,
-    solana_sbpf::program::BuiltinFunctionDefinition,
-    solana_sdk_ids::bpf_loader_upgradeable,
-};
+// Criterion measurements are not meaningful when test bodies run inside a
+// Shuttle scheduler (each `bencher.iter` measurement reruns the closure many
+// times under different schedules). Under the `shuttle-test` feature this
+// bench compiles to an empty binary; correctness coverage of the same
+// upgradeable-loader code paths lives in `programs/bpf_loader/src/lib.rs`'s
+// shuttle-wrapped lib tests.
+#[cfg(feature = "shuttle-test")]
+fn main() {}
 
-#[derive(Default)]
-struct TestSetup {
-    loader_address: Pubkey,
-    authority_address: Pubkey,
-    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+#[cfg(not(feature = "shuttle-test"))]
+mod bench {
+    use {
+        criterion::{Criterion, criterion_group},
+        solana_account::{AccountSharedData, state_traits::StateMut},
+        solana_bpf_loader_program::Entrypoint,
+        solana_instruction::AccountMeta,
+        solana_loader_v3_interface::{
+            instruction::UpgradeableLoaderInstruction, state::UpgradeableLoaderState,
+        },
+        solana_program_runtime::invoke_context::mock_process_instruction,
+        solana_pubkey::Pubkey,
+        solana_sbpf::program::BuiltinFunctionDefinition,
+        solana_sdk_ids::bpf_loader_upgradeable,
+    };
 
-    instruction_accounts: Vec<AccountMeta>,
-    instruction_data: Vec<u8>,
-}
+    #[derive(Default)]
+    struct TestSetup {
+        loader_address: Pubkey,
+        authority_address: Pubkey,
+        transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
 
-const ACCOUNT_BALANCE: u64 = u64::MAX / 4;
-const PROGRAM_BUFFER_SIZE: usize = 1024;
+        instruction_accounts: Vec<AccountMeta>,
+        instruction_data: Vec<u8>,
+    }
 
-impl TestSetup {
-    fn new() -> Self {
-        let loader_address = bpf_loader_upgradeable::id();
-        let buffer_address = Pubkey::new_unique();
-        let authority_address = Pubkey::new_unique();
+    const ACCOUNT_BALANCE: u64 = u64::MAX / 4;
+    const PROGRAM_BUFFER_SIZE: usize = 1024;
 
-        let instruction_accounts = vec![AccountMeta {
-            pubkey: buffer_address,
-            is_signer: false,
-            is_writable: true,
-        }];
-        let transaction_accounts = vec![
-            (
-                buffer_address,
-                AccountSharedData::new(
-                    ACCOUNT_BALANCE,
-                    UpgradeableLoaderState::size_of_buffer(PROGRAM_BUFFER_SIZE),
-                    &loader_address,
+    impl TestSetup {
+        fn new() -> Self {
+            let loader_address = bpf_loader_upgradeable::id();
+            let buffer_address = Pubkey::new_unique();
+            let authority_address = Pubkey::new_unique();
+
+            let instruction_accounts = vec![AccountMeta {
+                pubkey: buffer_address,
+                is_signer: false,
+                is_writable: true,
+            }];
+            let transaction_accounts = vec![
+                (
+                    buffer_address,
+                    AccountSharedData::new(
+                        ACCOUNT_BALANCE,
+                        UpgradeableLoaderState::size_of_buffer(PROGRAM_BUFFER_SIZE),
+                        &loader_address,
+                    ),
                 ),
-            ),
-            (
-                authority_address,
-                AccountSharedData::new(ACCOUNT_BALANCE, 0, &loader_address),
-            ),
-        ];
+                (
+                    authority_address,
+                    AccountSharedData::new(ACCOUNT_BALANCE, 0, &loader_address),
+                ),
+            ];
 
-        Self {
-            loader_address,
-            authority_address,
-            transaction_accounts,
-            instruction_accounts,
-            ..TestSetup::default()
+            Self {
+                loader_address,
+                authority_address,
+                transaction_accounts,
+                instruction_accounts,
+                ..TestSetup::default()
+            }
+        }
+
+        fn prep_initialize_buffer(&mut self) {
+            self.instruction_accounts.push(AccountMeta {
+                pubkey: self.authority_address,
+                is_signer: false,
+                is_writable: false,
+            });
+            self.instruction_data =
+                bincode::serialize(&UpgradeableLoaderInstruction::InitializeBuffer).unwrap();
+        }
+
+        fn prep_write(&mut self) {
+            self.instruction_accounts.push(AccountMeta {
+                pubkey: self.authority_address,
+                is_signer: true,
+                is_writable: false,
+            });
+
+            self.transaction_accounts[0]
+                .1
+                .set_state(&UpgradeableLoaderState::Buffer {
+                    authority_address: Some(self.authority_address),
+                })
+                .unwrap();
+
+            self.instruction_data = bincode::serialize(&UpgradeableLoaderInstruction::Write {
+                offset: 0,
+                bytes: vec![64; PROGRAM_BUFFER_SIZE],
+            })
+            .unwrap();
+        }
+
+        fn prep_set_authority(&mut self, checked: bool) {
+            let new_authority_address = Pubkey::new_unique();
+            self.instruction_accounts.push(AccountMeta {
+                pubkey: self.authority_address,
+                is_signer: true,
+                is_writable: false,
+            });
+            self.instruction_accounts.push(AccountMeta {
+                pubkey: new_authority_address,
+                is_signer: checked,
+                is_writable: false,
+            });
+
+            self.transaction_accounts[0]
+                .1
+                .set_state(&UpgradeableLoaderState::ProgramData {
+                    slot: 0,
+                    upgrade_authority_address: Some(self.authority_address),
+                })
+                .unwrap();
+            self.transaction_accounts.push((
+                new_authority_address,
+                AccountSharedData::new(ACCOUNT_BALANCE, 0, &self.loader_address),
+            ));
+            let instruction = if checked {
+                UpgradeableLoaderInstruction::SetAuthorityChecked
+            } else {
+                UpgradeableLoaderInstruction::SetAuthority
+            };
+            self.instruction_data = bincode::serialize(&instruction).unwrap();
+        }
+
+        fn prep_close(&mut self) {
+            self.instruction_accounts.push(AccountMeta {
+                pubkey: self.authority_address,
+                is_signer: false,
+                is_writable: true,
+            });
+            self.instruction_accounts.push(AccountMeta {
+                pubkey: self.authority_address,
+                is_signer: true,
+                is_writable: false,
+            });
+
+            // lets use the same account for recipient and authority
+            self.transaction_accounts
+                .push(self.transaction_accounts[1].clone());
+            self.instruction_data =
+                bincode::serialize(&UpgradeableLoaderInstruction::Close).unwrap();
+        }
+
+        fn run(&self) {
+            mock_process_instruction(
+                &self.loader_address,
+                &self.instruction_data,
+                self.transaction_accounts.clone(),
+                self.instruction_accounts.clone(),
+                Ok(()),
+                Entrypoint::register,
+                |_invoke_context| {},
+                |_invoke_context| {},
+            );
         }
     }
 
-    fn prep_initialize_buffer(&mut self) {
-        self.instruction_accounts.push(AccountMeta {
-            pubkey: self.authority_address,
-            is_signer: false,
-            is_writable: false,
+    fn bench_initialize_buffer(c: &mut Criterion) {
+        let mut test_setup = TestSetup::new();
+        test_setup.prep_initialize_buffer();
+
+        c.bench_function("initialize_buffer", |bencher| {
+            bencher.iter(|| test_setup.run())
         });
-        self.instruction_data =
-            bincode::serialize(&UpgradeableLoaderInstruction::InitializeBuffer).unwrap();
     }
 
-    fn prep_write(&mut self) {
-        self.instruction_accounts.push(AccountMeta {
-            pubkey: self.authority_address,
-            is_signer: true,
-            is_writable: false,
-        });
+    fn bench_write(c: &mut Criterion) {
+        let mut test_setup = TestSetup::new();
+        test_setup.prep_write();
 
-        self.transaction_accounts[0]
-            .1
-            .set_state(&UpgradeableLoaderState::Buffer {
-                authority_address: Some(self.authority_address),
+        c.bench_function("write", |bencher| {
+            bencher.iter(|| {
+                test_setup.run();
             })
-            .unwrap();
-
-        self.instruction_data = bincode::serialize(&UpgradeableLoaderInstruction::Write {
-            offset: 0,
-            bytes: vec![64; PROGRAM_BUFFER_SIZE],
-        })
-        .unwrap();
+        });
     }
 
-    fn prep_set_authority(&mut self, checked: bool) {
-        let new_authority_address = Pubkey::new_unique();
-        self.instruction_accounts.push(AccountMeta {
-            pubkey: self.authority_address,
-            is_signer: true,
-            is_writable: false,
-        });
-        self.instruction_accounts.push(AccountMeta {
-            pubkey: new_authority_address,
-            is_signer: checked,
-            is_writable: false,
-        });
+    fn bench_set_authority(c: &mut Criterion) {
+        let mut test_setup = TestSetup::new();
+        test_setup.prep_set_authority(false);
 
-        self.transaction_accounts[0]
-            .1
-            .set_state(&UpgradeableLoaderState::ProgramData {
-                slot: 0,
-                upgrade_authority_address: Some(self.authority_address),
+        c.bench_function("set_authority", |bencher| {
+            bencher.iter(|| {
+                test_setup.run();
             })
-            .unwrap();
-        self.transaction_accounts.push((
-            new_authority_address,
-            AccountSharedData::new(ACCOUNT_BALANCE, 0, &self.loader_address),
-        ));
-        let instruction = if checked {
-            UpgradeableLoaderInstruction::SetAuthorityChecked
-        } else {
-            UpgradeableLoaderInstruction::SetAuthority
-        };
-        self.instruction_data = bincode::serialize(&instruction).unwrap();
-    }
-
-    fn prep_close(&mut self) {
-        self.instruction_accounts.push(AccountMeta {
-            pubkey: self.authority_address,
-            is_signer: false,
-            is_writable: true,
         });
-        self.instruction_accounts.push(AccountMeta {
-            pubkey: self.authority_address,
-            is_signer: true,
-            is_writable: false,
+    }
+
+    fn bench_close(c: &mut Criterion) {
+        let mut test_setup = TestSetup::new();
+        test_setup.prep_close();
+
+        c.bench_function("close", |bencher| {
+            bencher.iter(|| {
+                test_setup.run();
+            })
         });
-
-        // lets use the same account for recipient and authority
-        self.transaction_accounts
-            .push(self.transaction_accounts[1].clone());
-        self.instruction_data = bincode::serialize(&UpgradeableLoaderInstruction::Close).unwrap();
     }
 
-    fn run(&self) {
-        mock_process_instruction(
-            &self.loader_address,
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-            Entrypoint::register,
-            |_invoke_context| {},
-            |_invoke_context| {},
-        );
+    fn bench_set_authority_checked(c: &mut Criterion) {
+        let mut test_setup = TestSetup::new();
+        test_setup.prep_set_authority(true);
+
+        c.bench_function("set_authority_checked", |bencher| {
+            bencher.iter(|| {
+                test_setup.run();
+            })
+        });
     }
+
+    criterion_group!(
+        benches,
+        bench_initialize_buffer,
+        bench_write,
+        bench_set_authority,
+        bench_close,
+        bench_set_authority_checked
+    );
 }
 
-fn bench_initialize_buffer(c: &mut Criterion) {
-    let mut test_setup = TestSetup::new();
-    test_setup.prep_initialize_buffer();
-
-    c.bench_function("initialize_buffer", |bencher| {
-        bencher.iter(|| test_setup.run())
-    });
-}
-
-fn bench_write(c: &mut Criterion) {
-    let mut test_setup = TestSetup::new();
-    test_setup.prep_write();
-
-    c.bench_function("write", |bencher| {
-        bencher.iter(|| {
-            test_setup.run();
-        })
-    });
-}
-
-fn bench_set_authority(c: &mut Criterion) {
-    let mut test_setup = TestSetup::new();
-    test_setup.prep_set_authority(false);
-
-    c.bench_function("set_authority", |bencher| {
-        bencher.iter(|| {
-            test_setup.run();
-        })
-    });
-}
-
-fn bench_close(c: &mut Criterion) {
-    let mut test_setup = TestSetup::new();
-    test_setup.prep_close();
-
-    c.bench_function("close", |bencher| {
-        bencher.iter(|| {
-            test_setup.run();
-        })
-    });
-}
-
-fn bench_set_authority_checked(c: &mut Criterion) {
-    let mut test_setup = TestSetup::new();
-    test_setup.prep_set_authority(true);
-
-    c.bench_function("set_authority_checked", |bencher| {
-        bencher.iter(|| {
-            test_setup.run();
-        })
-    });
-}
-
-criterion_group!(
-    benches,
-    bench_initialize_buffer,
-    bench_write,
-    bench_set_authority,
-    bench_close,
-    bench_set_authority_checked
-);
-criterion_main!(benches);
+#[cfg(not(feature = "shuttle-test"))]
+criterion::criterion_main!(bench::benches);

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -1,233 +1,249 @@
-use {
-    criterion::{Criterion, criterion_group, criterion_main},
-    solana_account::{Account, AccountSharedData},
-    solana_program_runtime::serialization::serialize_parameters,
-    solana_pubkey::Pubkey,
-    solana_rent::Rent,
-    solana_sdk_ids::{bpf_loader, bpf_loader_deprecated},
-    solana_transaction_context::{
-        instruction_accounts::InstructionAccount, transaction::TransactionContext,
-    },
-};
+// Criterion measurements are not meaningful when test bodies run inside a
+// Shuttle scheduler. Under the `shuttle-test` feature this bench compiles to
+// an empty binary, mirroring `bpf_loader_upgradeable.rs`. The serialization
+// code path is exercised by the lib tests in
+// `programs/bpf_loader/src/lib.rs` and by upstream serialization tests in
+// `solana-program-runtime`.
+#[cfg(feature = "shuttle-test")]
+fn main() {}
 
-fn create_inputs(owner: Pubkey, num_instruction_accounts: usize) -> TransactionContext<'static> {
-    let program_id = solana_pubkey::new_rand();
-    let transaction_accounts = vec![
-        (
-            program_id,
-            AccountSharedData::from(Account {
-                lamports: 0,
-                data: vec![],
-                owner,
-                executable: true,
-                rent_epoch: 0,
-            }),
-        ),
-        (
-            solana_pubkey::new_rand(),
-            AccountSharedData::from(Account {
-                lamports: 1,
-                data: vec![1u8; 100000],
-                owner,
-                executable: false,
-                rent_epoch: 100,
-            }),
-        ),
-        (
-            solana_pubkey::new_rand(),
-            AccountSharedData::from(Account {
-                lamports: 2,
-                data: vec![11u8; 100000],
-                owner,
-                executable: true,
-                rent_epoch: 200,
-            }),
-        ),
-        (
-            solana_pubkey::new_rand(),
-            AccountSharedData::from(Account {
-                lamports: 3,
-                data: vec![],
-                owner,
-                executable: false,
-                rent_epoch: 3100,
-            }),
-        ),
-        (
-            solana_pubkey::new_rand(),
-            AccountSharedData::from(Account {
-                lamports: 4,
-                data: vec![1u8; 100000],
-                owner,
-                executable: false,
-                rent_epoch: 100,
-            }),
-        ),
-        (
-            solana_pubkey::new_rand(),
-            AccountSharedData::from(Account {
-                lamports: 5,
-                data: vec![11u8; 10000],
-                owner,
-                executable: true,
-                rent_epoch: 200,
-            }),
-        ),
-        (
-            solana_pubkey::new_rand(),
-            AccountSharedData::from(Account {
-                lamports: 6,
-                data: vec![],
-                owner,
-                executable: false,
-                rent_epoch: 3100,
-            }),
-        ),
-    ];
-    let mut instruction_accounts: Vec<InstructionAccount> = Vec::new();
-    for (instruction_account_index, index_in_transaction) in [1, 1, 2, 3, 4, 4, 5, 6]
-        .into_iter()
-        .cycle()
-        .take(num_instruction_accounts)
-        .enumerate()
-    {
-        instruction_accounts.push(InstructionAccount::new(
-            index_in_transaction,
-            false,
-            instruction_account_index >= 4,
-        ));
+#[cfg(not(feature = "shuttle-test"))]
+mod bench {
+    use {
+        criterion::{Criterion, criterion_group},
+        solana_account::{Account, AccountSharedData},
+        solana_program_runtime::serialization::serialize_parameters,
+        solana_pubkey::Pubkey,
+        solana_rent::Rent,
+        solana_sdk_ids::{bpf_loader, bpf_loader_deprecated},
+        solana_transaction_context::{
+            instruction_accounts::InstructionAccount, transaction::TransactionContext,
+        },
+    };
+
+    fn create_inputs(
+        owner: Pubkey,
+        num_instruction_accounts: usize,
+    ) -> TransactionContext<'static> {
+        let program_id = solana_pubkey::new_rand();
+        let transaction_accounts = vec![
+            (
+                program_id,
+                AccountSharedData::from(Account {
+                    lamports: 0,
+                    data: vec![],
+                    owner,
+                    executable: true,
+                    rent_epoch: 0,
+                }),
+            ),
+            (
+                solana_pubkey::new_rand(),
+                AccountSharedData::from(Account {
+                    lamports: 1,
+                    data: vec![1u8; 100000],
+                    owner,
+                    executable: false,
+                    rent_epoch: 100,
+                }),
+            ),
+            (
+                solana_pubkey::new_rand(),
+                AccountSharedData::from(Account {
+                    lamports: 2,
+                    data: vec![11u8; 100000],
+                    owner,
+                    executable: true,
+                    rent_epoch: 200,
+                }),
+            ),
+            (
+                solana_pubkey::new_rand(),
+                AccountSharedData::from(Account {
+                    lamports: 3,
+                    data: vec![],
+                    owner,
+                    executable: false,
+                    rent_epoch: 3100,
+                }),
+            ),
+            (
+                solana_pubkey::new_rand(),
+                AccountSharedData::from(Account {
+                    lamports: 4,
+                    data: vec![1u8; 100000],
+                    owner,
+                    executable: false,
+                    rent_epoch: 100,
+                }),
+            ),
+            (
+                solana_pubkey::new_rand(),
+                AccountSharedData::from(Account {
+                    lamports: 5,
+                    data: vec![11u8; 10000],
+                    owner,
+                    executable: true,
+                    rent_epoch: 200,
+                }),
+            ),
+            (
+                solana_pubkey::new_rand(),
+                AccountSharedData::from(Account {
+                    lamports: 6,
+                    data: vec![],
+                    owner,
+                    executable: false,
+                    rent_epoch: 3100,
+                }),
+            ),
+        ];
+        let mut instruction_accounts: Vec<InstructionAccount> = Vec::new();
+        for (instruction_account_index, index_in_transaction) in [1, 1, 2, 3, 4, 4, 5, 6]
+            .into_iter()
+            .cycle()
+            .take(num_instruction_accounts)
+            .enumerate()
+        {
+            instruction_accounts.push(InstructionAccount::new(
+                index_in_transaction,
+                false,
+                instruction_account_index >= 4,
+            ));
+        }
+
+        let mut transaction_context =
+            TransactionContext::new(transaction_accounts, Rent::default(), 1, 1, 1);
+        let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+        transaction_context
+            .configure_top_level_instruction_for_tests(0, instruction_accounts, instruction_data)
+            .unwrap();
+        transaction_context.push().unwrap();
+        transaction_context
     }
 
-    let mut transaction_context =
-        TransactionContext::new(transaction_accounts, Rent::default(), 1, 1, 1);
-    let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-    transaction_context
-        .configure_top_level_instruction_for_tests(0, instruction_accounts, instruction_data)
-        .unwrap();
-    transaction_context.push().unwrap();
-    transaction_context
-}
-
-fn bench_serialize_unaligned(c: &mut Criterion) {
-    let transaction_context = create_inputs(bpf_loader_deprecated::id(), 7);
-    let instruction_context = transaction_context
-        .get_current_instruction_context()
-        .unwrap();
-
-    c.bench_function("serialize_unaligned", |b| {
-        b.iter(|| {
-            let _ = serialize_parameters(
-                &instruction_context,
-                true,  // virtual_address_space_adjustments
-                true,  // account_data_direct_mapping
-                false, // direct_account_pointers_in_program_input
-            )
+    fn bench_serialize_unaligned(c: &mut Criterion) {
+        let transaction_context = create_inputs(bpf_loader_deprecated::id(), 7);
+        let instruction_context = transaction_context
+            .get_current_instruction_context()
             .unwrap();
-        });
-    });
-}
 
-fn bench_serialize_unaligned_copy_account_data(c: &mut Criterion) {
-    let transaction_context = create_inputs(bpf_loader_deprecated::id(), 7);
-    let instruction_context = transaction_context
-        .get_current_instruction_context()
-        .unwrap();
-    c.bench_function("serialize_unaligned_copy_account_data", |b| {
-        b.iter(|| {
-            let _ = serialize_parameters(
-                &instruction_context,
-                false, // virtual_address_space_adjustments
-                false, // account_data_direct_mapping
-                false, // direct_account_pointers_in_program_input
-            )
+        c.bench_function("serialize_unaligned", |b| {
+            b.iter(|| {
+                let _ = serialize_parameters(
+                    &instruction_context,
+                    true,  // virtual_address_space_adjustments
+                    true,  // account_data_direct_mapping
+                    false, // direct_account_pointers_in_program_input
+                )
+                .unwrap();
+            });
+        });
+    }
+
+    fn bench_serialize_unaligned_copy_account_data(c: &mut Criterion) {
+        let transaction_context = create_inputs(bpf_loader_deprecated::id(), 7);
+        let instruction_context = transaction_context
+            .get_current_instruction_context()
             .unwrap();
+        c.bench_function("serialize_unaligned_copy_account_data", |b| {
+            b.iter(|| {
+                let _ = serialize_parameters(
+                    &instruction_context,
+                    false, // virtual_address_space_adjustments
+                    false, // account_data_direct_mapping
+                    false, // direct_account_pointers_in_program_input
+                )
+                .unwrap();
+            });
         });
-    });
-}
+    }
 
-fn bench_serialize_aligned(c: &mut Criterion) {
-    let transaction_context = create_inputs(bpf_loader::id(), 7);
-    let instruction_context = transaction_context
-        .get_current_instruction_context()
-        .unwrap();
-
-    c.bench_function("serialize_aligned", |b| {
-        b.iter(|| {
-            let _ = serialize_parameters(
-                &instruction_context,
-                true, // virtual_address_space_adjustments
-                true, // account_data_direct_mapping
-                true, // direct_account_pointers_in_program_input
-            )
+    fn bench_serialize_aligned(c: &mut Criterion) {
+        let transaction_context = create_inputs(bpf_loader::id(), 7);
+        let instruction_context = transaction_context
+            .get_current_instruction_context()
             .unwrap();
+
+        c.bench_function("serialize_aligned", |b| {
+            b.iter(|| {
+                let _ = serialize_parameters(
+                    &instruction_context,
+                    true, // virtual_address_space_adjustments
+                    true, // account_data_direct_mapping
+                    true, // direct_account_pointers_in_program_input
+                )
+                .unwrap();
+            });
         });
-    });
-}
+    }
 
-fn bench_serialize_aligned_copy_account_data(c: &mut Criterion) {
-    let transaction_context = create_inputs(bpf_loader::id(), 7);
-    let instruction_context = transaction_context
-        .get_current_instruction_context()
-        .unwrap();
-
-    c.bench_function("serialize_aligned_copy_account_data", |b| {
-        b.iter(|| {
-            let _ = serialize_parameters(
-                &instruction_context,
-                false, // virtual_address_space_adjustments
-                false, // account_data_direct_mapping
-                false, // direct_account_pointers_in_program_input
-            )
+    fn bench_serialize_aligned_copy_account_data(c: &mut Criterion) {
+        let transaction_context = create_inputs(bpf_loader::id(), 7);
+        let instruction_context = transaction_context
+            .get_current_instruction_context()
             .unwrap();
+        c.bench_function("serialize_aligned_copy_account_data", |b| {
+            b.iter(|| {
+                let _ = serialize_parameters(
+                    &instruction_context,
+                    false, // virtual_address_space_adjustments
+                    false, // account_data_direct_mapping
+                    false, // direct_account_pointers_in_program_input
+                )
+                .unwrap();
+            });
         });
-    });
-}
+    }
 
-fn bench_serialize_unaligned_max_accounts(c: &mut Criterion) {
-    let transaction_context = create_inputs(bpf_loader_deprecated::id(), 255);
-    let instruction_context = transaction_context
-        .get_current_instruction_context()
-        .unwrap();
-
-    c.bench_function("serialize_unaligned_max_accounts", |b| {
-        b.iter(|| {
-            let _ = serialize_parameters(
-                &instruction_context,
-                true, // virtual_address_space_adjustments
-                true, // account_data_direct_mapping
-                true, // direct_account_pointers_in_program_input
-            )
+    fn bench_serialize_unaligned_max_accounts(c: &mut Criterion) {
+        let transaction_context = create_inputs(bpf_loader_deprecated::id(), 255);
+        let instruction_context = transaction_context
+            .get_current_instruction_context()
             .unwrap();
+
+        c.bench_function("serialize_unaligned_max_accounts", |b| {
+            b.iter(|| {
+                let _ = serialize_parameters(
+                    &instruction_context,
+                    true, // virtual_address_space_adjustments
+                    true, // account_data_direct_mapping
+                    true, // direct_account_pointers_in_program_input
+                )
+                .unwrap();
+            });
         });
-    });
-}
+    }
 
-fn bench_serialize_aligned_max_accounts(c: &mut Criterion) {
-    let transaction_context = create_inputs(bpf_loader::id(), 255);
-    let instruction_context = transaction_context
-        .get_current_instruction_context()
-        .unwrap();
-
-    c.bench_function("serialize_aligned_max_accounts", |b| {
-        b.iter(|| {
-            let _ = serialize_parameters(
-                &instruction_context,
-                true, // virtual_address_space_adjustments
-                true, // account_data_direct_mapping
-                true, // direct_account_pointers_in_program_input
-            )
+    fn bench_serialize_aligned_max_accounts(c: &mut Criterion) {
+        let transaction_context = create_inputs(bpf_loader::id(), 255);
+        let instruction_context = transaction_context
+            .get_current_instruction_context()
             .unwrap();
+
+        c.bench_function("serialize_aligned_max_accounts", |b| {
+            b.iter(|| {
+                let _ = serialize_parameters(
+                    &instruction_context,
+                    true, // virtual_address_space_adjustments
+                    true, // account_data_direct_mapping
+                    true, // direct_account_pointers_in_program_input
+                )
+                .unwrap();
+            });
         });
-    });
+    }
+
+    criterion_group!(
+        benches,
+        bench_serialize_unaligned,
+        bench_serialize_unaligned_copy_account_data,
+        bench_serialize_aligned,
+        bench_serialize_aligned_copy_account_data,
+        bench_serialize_unaligned_max_accounts,
+        bench_serialize_aligned_max_accounts
+    );
 }
 
-criterion_group!(
-    benches,
-    bench_serialize_unaligned,
-    bench_serialize_unaligned_copy_account_data,
-    bench_serialize_aligned,
-    bench_serialize_aligned_copy_account_data,
-    bench_serialize_unaligned_max_accounts,
-    bench_serialize_aligned_max_accounts
-);
-criterion_main!(benches);
+#[cfg(not(feature = "shuttle-test"))]
+criterion::criterion_main!(bench::benches);

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1099,13 +1099,81 @@ mod tests {
         std::{fs::File, io::Read, ops::Range},
     };
 
-    fn process_instruction(
+    // 10 iterations is intentionally low: `mock_process_instruction` runs on a
+    // single thread, so additional `shuttle::check_random` iterations validate
+    // only the harness wiring, not concurrent interleavings. Bump this if a
+    // future refactor introduces `shuttle::thread::spawn` inside
+    // `mock_process_instruction`.
+    #[cfg(feature = "shuttle-test")]
+    const MOCK_PROCESS_RANDOM_ITERATIONS: usize = 10;
+
+    /// Wrapper around `mock_process_instruction` that runs under
+    /// `shuttle::check_random` when the `shuttle-test` feature is enabled,
+    /// providing the Shuttle scheduler context required by
+    /// `solana-svm-type-overrides`'s shuttle-aware atomic types. With default
+    /// features, this is a thin pass-through to `mock_process_instruction`
+    /// with `Entrypoint::register` and an empty post-adjustment closure.
+    ///
+    /// `mock_process_instruction` itself is single-threaded: the only
+    /// Shuttle-backed atomic in the access path is
+    /// `ProgramCacheEntry::latest_access_slot` (routed to
+    /// `shuttle::sync::atomic::AtomicU64` by `solana_svm_type_overrides`), and
+    /// it is touched from one Shuttle thread. Iteration-to-iteration variance
+    /// under `shuttle::check_random` is solely scheduler bookkeeping noise, so
+    /// any iteration's captured result is equivalent. If
+    /// `mock_process_instruction` ever spawns Shuttle threads internally,
+    /// this last-write-wins capture must be re-evaluated.
+    ///
+    /// `setup` is typed as `fn(&mut InvokeContext)` (function pointer, not
+    /// `impl Fn`) so it satisfies Shuttle's `Fn + Send + Sync + 'static` bound
+    /// when captured by value into the inner closure. Callers must pass
+    /// non-capturing closures or `fn` items; capturing closures will produce a
+    /// fn-pointer coercion error at the call site.
+    fn process_instruction_with_setup(
         program_id: &Pubkey,
         instruction_data: &[u8],
         transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
         instruction_accounts: Vec<AccountMeta>,
         expected_result: Result<(), InstructionError>,
+        setup: fn(&mut InvokeContext),
     ) -> Vec<AccountSharedData> {
+        #[cfg(feature = "shuttle-test")]
+        {
+            let program_id = *program_id;
+            let instruction_data = instruction_data.to_vec();
+            let result = shuttle::sync::Arc::new(shuttle::sync::Mutex::new(None));
+            let result_for_test = shuttle::sync::Arc::clone(&result);
+            shuttle::check_random(
+                move || {
+                    let accounts = mock_process_instruction(
+                        &program_id,
+                        &instruction_data,
+                        transaction_accounts.clone(),
+                        instruction_accounts.clone(),
+                        expected_result.clone(),
+                        Entrypoint::register,
+                        setup,
+                        |_invoke_context| {},
+                    );
+                    *result_for_test.lock().unwrap() = Some(accounts);
+                },
+                MOCK_PROCESS_RANDOM_ITERATIONS,
+            );
+
+            // Consume the harness cell after Shuttle exits so extraction does
+            // not call `shuttle::sync::Mutex::lock` outside the scheduler.
+            let mut result = match shuttle::sync::Arc::try_unwrap(result) {
+                Ok(result) => result,
+                Err(_) => panic!("shuttle test result still has outstanding references"),
+            };
+            result
+                .get_mut()
+                .unwrap()
+                .take()
+                .expect("shuttle test did not produce a result")
+        }
+
+        #[cfg(not(feature = "shuttle-test"))]
         mock_process_instruction(
             program_id,
             instruction_data,
@@ -1113,10 +1181,27 @@ mod tests {
             instruction_accounts,
             expected_result,
             Entrypoint::register,
+            setup,
+            |_invoke_context| {},
+        )
+    }
+
+    fn process_instruction(
+        program_id: &Pubkey,
+        instruction_data: &[u8],
+        transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+        instruction_accounts: Vec<AccountMeta>,
+        expected_result: Result<(), InstructionError>,
+    ) -> Vec<AccountSharedData> {
+        process_instruction_with_setup(
+            program_id,
+            instruction_data,
+            transaction_accounts,
+            instruction_accounts,
+            expected_result,
             |invoke_context| {
                 test_utils::load_all_invoked_programs(invoke_context);
             },
-            |_invoke_context| {},
         )
     }
 
@@ -1189,32 +1274,28 @@ mod tests {
         );
 
         // Case: limited budget
-        mock_process_instruction(
+        process_instruction_with_setup(
             &program_id,
             &[],
             vec![(program_id, program_account)],
             Vec::new(),
             Err(InstructionError::ProgramFailedToComplete),
-            Entrypoint::register,
             |invoke_context| {
                 invoke_context.compute_meter.mock_set_remaining(0);
                 test_utils::load_all_invoked_programs(invoke_context);
             },
-            |_invoke_context| {},
         );
 
         // Case: Account not a program
-        mock_process_instruction(
+        process_instruction_with_setup(
             &program_id,
             &[],
             vec![(program_id, parameter_account.clone())],
             Vec::new(),
             Err(InstructionError::UnsupportedProgramId),
-            Entrypoint::register,
             |invoke_context| {
                 test_utils::load_all_invoked_programs(invoke_context);
             },
-            |_invoke_context| {},
         );
         process_instruction(
             &program_id,
@@ -1730,14 +1811,12 @@ mod tests {
         ) -> Vec<AccountSharedData> {
             let instruction_data =
                 bincode::serialize(&UpgradeableLoaderInstruction::Upgrade).unwrap();
-            mock_process_instruction(
+            process_instruction_with_setup(
                 &bpf_loader_upgradeable::id(),
                 &instruction_data,
                 transaction_accounts,
                 instruction_accounts,
                 expected_result,
-                Entrypoint::register,
-                |_invoke_context| {},
                 |_invoke_context| {},
             )
         }
@@ -1883,17 +1962,15 @@ mod tests {
         *instruction_accounts.get_mut(1).unwrap() = instruction_accounts.get(2).unwrap().clone();
         let instruction_data = bincode::serialize(&UpgradeableLoaderInstruction::Upgrade).unwrap();
 
-        mock_process_instruction(
+        process_instruction_with_setup(
             &bpf_loader_upgradeable::id(),
             &instruction_data,
             transaction_accounts.clone(),
             instruction_accounts.clone(),
             Err(InstructionError::InvalidAccountData),
-            Entrypoint::register,
             |invoke_context| {
                 test_utils::load_all_invoked_programs(invoke_context);
             },
-            |_invoke_context| {},
         );
         process_instruction(
             transaction_accounts.clone(),
@@ -2266,13 +2343,12 @@ mod tests {
                     max_data_len,
                 })
                 .unwrap();
-            mock_process_instruction(
+            process_instruction_with_setup(
                 &bpf_loader_upgradeable::id(),
                 &instruction_data,
                 transaction_accounts,
                 instruction_accounts,
                 expected_result,
-                Entrypoint::register,
                 |invoke_context| {
                     // Register the system program for CPI support.
                     invoke_context.program_cache_for_tx_batch.replenish(
@@ -2284,7 +2360,6 @@ mod tests {
                         )),
                     );
                 },
-                |_invoke_context| {},
             )
         }
 
@@ -3746,8 +3821,39 @@ mod tests {
         Ok(())
     }
 
+    // Concurrency rationale: these tests construct `ProgramCacheEntry` instances
+    // directly. The struct's `latest_access_slot: AtomicU64` field is defined in
+    // `solana-program-runtime`; under the `shuttle-test` feature
+    // `solana-svm-type-overrides` swaps `std::sync::atomic::AtomicU64` for
+    // `shuttle::sync::atomic::AtomicU64`, whose Shuttle-backed operations
+    // (load, fetch_max, and similar) must run inside an active Shuttle
+    // scheduler. We therefore extract the test bodies into `do_test_*` helpers
+    // and drive them via `shuttle::check_random` stubs when the feature is on.
+    // We use `check_random` only (no `check_dfs` companion) because the test
+    // bodies spawn no Shuttle threads, so DFS gives no meaningful interleaving
+    // coverage; `check_random` is enough to provide the scheduler context.
+    // This matches the single-scheduler pattern used in
+    // `net-utils/src/token_bucket.rs` and `poh/src/record_channels.rs`.
+    //
+    // 100 iterations is intentionally low: the test bodies are single-threaded
+    // (no `shuttle::thread::spawn`), so additional iterations validate only
+    // the harness wiring, not concurrent interleavings. Bump this if a future
+    // refactor introduces real concurrency in the test bodies.
+    #[cfg(feature = "shuttle-test")]
+    const PROGRAM_USAGE_COUNT_RANDOM_ITERATIONS: usize = 100;
+
     #[test]
     fn test_program_usage_count_on_upgrade() {
+        #[cfg(feature = "shuttle-test")]
+        shuttle::check_random(
+            do_test_program_usage_count_on_upgrade,
+            PROGRAM_USAGE_COUNT_RANDOM_ITERATIONS,
+        );
+        #[cfg(not(feature = "shuttle-test"))]
+        do_test_program_usage_count_on_upgrade();
+    }
+
+    fn do_test_program_usage_count_on_upgrade() {
         let transaction_accounts = vec![(
             sysvar::epoch_schedule::id(),
             create_account_for_test(&EpochSchedule::default()),
@@ -3791,6 +3897,16 @@ mod tests {
 
     #[test]
     fn test_program_usage_count_on_non_upgrade() {
+        #[cfg(feature = "shuttle-test")]
+        shuttle::check_random(
+            do_test_program_usage_count_on_non_upgrade,
+            PROGRAM_USAGE_COUNT_RANDOM_ITERATIONS,
+        );
+        #[cfg(not(feature = "shuttle-test"))]
+        do_test_program_usage_count_on_non_upgrade();
+    }
+
+    fn do_test_program_usage_count_on_non_upgrade() {
         let transaction_accounts = vec![(
             sysvar::epoch_schedule::id(),
             create_account_for_test(&EpochSchedule::default()),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1095,8 +1095,8 @@ mod tests {
         solana_rent::Rent,
         solana_sbpf::program::{BuiltinFunctionDefinition, BuiltinProgram},
         solana_sdk_ids::{system_program, sysvar},
-        solana_svm_type_overrides::sync::atomic::Ordering,
-        std::{fs::File, io::Read, ops::Range, sync::atomic::AtomicU64},
+        solana_svm_type_overrides::sync::atomic::{AtomicU64, Ordering},
+        std::{fs::File, io::Read, ops::Range},
     };
 
     fn process_instruction(


### PR DESCRIPTION
#### Problem

`cargo check -p solana-bpf-loader-program --features shuttle-test --all-targets` (the CI invocation that #12314 will run) succeeds after #12318's compile-time fix, but `cargo test -p solana-bpf-loader-program --features shuttle-test --all-targets` still panics at runtime:

```
Shuttle internal error: cannot access ExecutionState. are you trying to access
a Shuttle primitive from outside a Shuttle test?
```

The two `test_program_usage_count_*` tests construct `ProgramCacheEntry` instances directly. The remaining instruction-processing tests transitively access shuttle-aware atomics through `mock_process_instruction`'s program-cache machinery. `bpf_loader_upgradeable.rs` panics under shuttle-test for the same reason during its smoke pass.

This PR closes the runtime gap so that `cargo test --features shuttle-test --all-targets` passes end-to-end, while preserving normal `cargo bench` behavior under default features.

#### Approach

**Lib tests (correctness coverage)**

Two patterns:

1. A test-mod-local `process_instruction_with_setup` helper wraps `mock_process_instruction` in `shuttle::check_random` when `shuttle-test` is enabled, otherwise passes through. The existing `process_instruction` helper plus five direct `mock_process_instruction` test call sites are converted to use it.
2. The two `test_program_usage_count_*` tests are wrapped in `shuttle::check_random` directly via paired `do_test_*` helpers, matching the `do_test_X` extraction convention in `runtime/src/status_cache.rs` and `runtime/src/read_optimized_dashmap.rs`.

A `check_dfs` companion is not added: the test bodies spawn no Shuttle threads, so DFS gives no meaningful interleaving coverage. `check_random` is enough to provide the scheduler context. This matches the single-scheduler pattern in `net-utils/src/token_bucket.rs` and `poh/src/record_channels.rs`.

Iteration counts are explicit named constants, intentionally low because the wrapped paths are single-threaded under Shuttle (no `shuttle::thread::spawn`). Additional iterations validate harness wiring, not concurrent interleavings:

- `MOCK_PROCESS_RANDOM_ITERATIONS = 10` (helper called many times per test)
- `PROGRAM_USAGE_COUNT_RANDOM_ITERATIONS = 100` (test wrappings called once per test)

**Bench targets (no-op under shuttle-test)**

`bpf_loader_upgradeable.rs` panics under shuttle-test; both benches are gated to no-op under shuttle-test because Criterion targets are performance-only and should not run under shuttle scheduling. Both bench files are restructured so that under `shuttle-test` the bench compiles to an empty `fn main()` while default-features behavior is unchanged. The bench code lives inside `mod bench { ... }` gated `#[cfg(not(feature = "shuttle-test"))]`, with `criterion::criterion_main!(bench::benches)` outside the mod and similarly gated.

Module-level rather than just `criterion_main!`-level gating is required because under `RUSTFLAGS="-D warnings"` (which #12314's CI sets) the otherwise-unused `criterion_group`, bench functions, and helpers would emit `unused-*` warnings that become hard errors.

#### Determinism note

The `Arc<Mutex<Option<_>>>` last-write-wins capture inside `process_instruction_with_setup` is safe because `mock_process_instruction` is single-threaded: the only Shuttle-backed atomic in the access path is `ProgramCacheEntry::latest_access_slot` (routed to `shuttle::sync::atomic::AtomicU64` by `solana_svm_type_overrides`), and it is touched from one Shuttle thread. Iteration-to-iteration variance under `shuttle::check_random` is solely scheduler bookkeeping noise, so any iteration's captured result is equivalent. The wrapper documents this inline and flags the case where the assumption would need to be re-evaluated (Shuttle thread spawn introduced inside `mock_process_instruction`).

#### Verified

```
cargo test -p solana-bpf-loader-program --features shuttle-test --all-targets
    16 lib tests pass; both bench binaries compile to no-op main and exit cleanly

cargo bench -p solana-bpf-loader-program -- --test
    default-features bench smoke: 16 passed, 0 failed

RUSTFLAGS="-D warnings" cargo hack check -p solana-bpf-loader-program --each-feature --exclude-all-features --all-targets
    matches #12314's CI exactly; all 7 feature combinations clean, no unused-* warnings from the gated bench code

cargo +nightly fmt -p solana-bpf-loader-program -- --check
    clean
```

#### Relationship to other PRs

- **#12318 (open)** is the compile-time predecessor. This PR depends on #12318's import fix and stacks on top of that branch.
- **#12314 (open, by yihau)** introduces the `--all-targets` feature-check CI matrix that surfaced this audit. This PR (together with #12318) clears the bpf-loader-program portion of #12314's blocker set.
- **#12289 (closed)** is the audit umbrella issue.

#### Summary of Changes

- Add `shuttle = { workspace = true, optional = true }` to `programs/bpf_loader/Cargo.toml` and wire it into the `shuttle-test` feature with `dep:shuttle`.
- Add `process_instruction_with_setup` test helper in `programs/bpf_loader/src/lib.rs` that wraps `mock_process_instruction` in `shuttle::check_random` under `shuttle-test`, with docstring documenting the single-threaded last-write-wins assumption and the non-capturing closure constraint on the `setup` parameter.
- Convert six `mock_process_instruction` call sites to use `process_instruction_with_setup`.
- Refactor `test_program_usage_count_on_upgrade` and `test_program_usage_count_on_non_upgrade` into `do_test_*` helpers driven by `shuttle::check_random` stubs under `shuttle-test`.
- Add explicit `MOCK_PROCESS_RANDOM_ITERATIONS = 10` and `PROGRAM_USAGE_COUNT_RANDOM_ITERATIONS = 100` constants with rationale comments explaining why low iteration counts are sufficient (single-threaded paths).
- Restructure both bench files (`bpf_loader_upgradeable.rs` and `serialization.rs`) so the bench compiles to an empty `fn main()` under `shuttle-test`, preserving normal Criterion behavior under default features. `bpf_loader_upgradeable.rs` is the bench that panicked; `serialization.rs` is gated for consistency with the same pattern. No bench code is functionally changed.
- Production builds (default features) are unaffected: `shuttle` is declared `optional = true` and activated only by the `shuttle-test` feature.