### PR TITLE
test: move remove-wallet test_parse_status behind the hidapi feature

### DIFF
--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -683,6 +683,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "hidapi")]
     fn test_parse_status() {
         LedgerWallet::parse_status(APDU_SUCCESS_CODE).expect("unexpected result");
         if let RemoteWalletError::LedgerError(err) = LedgerWallet::parse_status(0x6985).unwrap_err()


### PR DESCRIPTION
(help unblock the new ci https://github.com/anza-xyz/agave/pull/12314)

#### Problem

`cargo +nightly-2026-02-28 hack check --each-feature --exclude-all-features --all-targets -p solana-remote-wallet`

```
error[E0433]: cannot find type `LedgerError` in this scope
   --> remote-wallet/src/ledger.rs:690:29
    |
690 |             assert_eq!(err, LedgerError::UserCancel);
    |                             ^^^^^^^^^^^ use of undeclared type `LedgerError`
    |
help: consider importing this enum
    |
659 +     use crate::ledger_error::LedgerError;
    |

error[E0599]: no function or associated item named `parse_status` found for struct `ledger::LedgerWallet` in the current scope
   --> remote-wallet/src/ledger.rs:687:23
    |
107 | pub struct LedgerWallet {
    | ----------------------- function or associated item `parse_status` not found for this struct
...
687 |         LedgerWallet::parse_status(APDU_SUCCESS_CODE).expect("unexpected result");
    |                       ^^^^^^^^^^^^ function or associated item not found in `ledger::LedgerWallet`

error[E0599]: no function or associated item named `parse_status` found for struct `ledger::LedgerWallet` in the current scope
   --> remote-wallet/src/ledger.rs:688:68
    |
107 | pub struct LedgerWallet {
    | ----------------------- function or associated item `parse_status` not found for this struct
...
688 |         if let RemoteWalletError::LedgerError(err) = LedgerWallet::parse_status(0x6985).unwrap_err()
    |                                                                    ^^^^^^^^^^^^ function or associated item not found in `ledger::LedgerWallet`

error[E0599]: no function or associated item named `parse_status` found for struct `ledger::LedgerWallet` in the current scope
   --> remote-wallet/src/ledger.rs:692:65
    |
107 | pub struct LedgerWallet {
    | ----------------------- function or associated item `parse_status` not found for this struct
...
692 |         if let RemoteWalletError::Protocol(err) = LedgerWallet::parse_status(0x6fff).unwrap_err() {
    |                                                                 ^^^^^^^^^^^^ function or associated item not found in `ledger::LedgerWallet`

```

the `impl LedgerWallet` is gated behind the `hidapi` feature

https://github.com/anza-xyz/agave/blob/84383674461465c1c056ce9cd39184d740a98bd8/remote-wallet/src/ledger.rs#L120-L121

I think it makes sense for the tests to use the same feature gate

#### Summary of Changes

move `test_parse_status` behind the `hidapi` feature