### PR TITLE
fix: wrong assertion about number of notar-fallback certs

### DIFF
--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -57,6 +57,7 @@ pub fn vote_to_cert_types(vote: &Vote) -> Vec<CertificateType> {
 
 pub const MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES: usize = 1;
 pub const MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE: usize = 3;
+pub const MAX_NOTAR_FALLBACK_BLOCKS: usize = 7;
 
 pub const SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY: Fraction = Fraction::from_percentage(40);
 pub const SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP: Fraction = Fraction::from_percentage(20);

--- a/votor/src/consensus_pool/parent_ready_tracker.rs
+++ b/votor/src/consensus_pool/parent_ready_tracker.rs
@@ -13,7 +13,7 @@
 //! a block with parent `b` in slot `s` will have their block finalized.
 
 use {
-    crate::{common::MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE, event::VotorEvent},
+    crate::{common::MAX_NOTAR_FALLBACK_BLOCKS, event::VotorEvent},
     agave_votor_messages::consensus_message::Block,
     core::fmt,
     solana_clock::{NUM_CONSECUTIVE_LEADER_SLOTS, Slot},
@@ -108,7 +108,7 @@ impl ParentReadyTracker {
             self.cluster_info.0.id()
         );
         status.notar_fallbacks.push(block);
-        assert!(status.notar_fallbacks.len() <= MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE);
+        assert!(status.notar_fallbacks.len() <= MAX_NOTAR_FALLBACK_BLOCKS);
 
         // Add this block as valid parent to skip connected future blocks
         for s in slot.saturating_add(1).. {


### PR DESCRIPTION
#### Problem
`parent_ready_tracker.rs` had a wrong assertion:
https://github.com/anza-xyz/agave/blob/7edacfb7516bcdaa524a5f3e92c60866b40d19cd/votor/src/consensus_pool/parent_ready_tracker.rs#L111
`MAX_ENTRIES_PER_PUBKEY_FOR_NOTARIZE_LITE` is the limit of how many notar-fallback votes each correct node may cast, which is not the same as the limit of how many notar-fallback certificates can exist.

#### Summary of Changes
- Add new constant `MAX_NOTAR_FALLBACK_BLOCKS` with value 7.
- Fix the assertion by using the new constant.