### PR TITLE
chore: Remove PubSubConfig Default trait impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9761,7 +9761,6 @@ dependencies = [
  "solana-program-pack",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
- "solana-rayon-threadlimit",
  "solana-rent",
  "solana-rpc",
  "solana-rpc-client-api",

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -143,8 +143,11 @@ fn test_account_subscription() {
         Arc::new(RwLock::new(BlockCommitmentCache::default())),
         OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
     ));
-    let (trigger, pubsub_service) =
-        PubSubService::new(PubSubConfig::default(), &subscriptions, pubsub_addr);
+    let (trigger, pubsub_service) = PubSubService::new(
+        PubSubConfig::default_for_tests(),
+        &subscriptions,
+        pubsub_addr,
+    );
 
     check_server_is_ready_or_panic(&pubsub_addr, 10, Duration::from_millis(300));
 
@@ -264,7 +267,7 @@ fn test_block_subscription() {
     let pubsub_addr = pubsub_addr();
     let pub_cfg = PubSubConfig {
         enable_block_subscription: true,
-        ..PubSubConfig::default()
+        ..PubSubConfig::default_for_tests()
     };
     let (trigger, pubsub_service) = PubSubService::new(pub_cfg, &subscriptions, pubsub_addr);
 
@@ -345,8 +348,11 @@ fn test_program_subscription() {
         Arc::new(RwLock::new(BlockCommitmentCache::default())),
         OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
     ));
-    let (trigger, pubsub_service) =
-        PubSubService::new(PubSubConfig::default(), &subscriptions, pubsub_addr);
+    let (trigger, pubsub_service) = PubSubService::new(
+        PubSubConfig::default_for_tests(),
+        &subscriptions,
+        pubsub_addr,
+    );
 
     check_server_is_ready_or_panic(&pubsub_addr, 10, Duration::from_millis(300));
 
@@ -429,8 +435,11 @@ fn test_root_subscription() {
         Arc::new(RwLock::new(BlockCommitmentCache::default())),
         OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
     ));
-    let (trigger, pubsub_service) =
-        PubSubService::new(PubSubConfig::default(), &subscriptions, pubsub_addr);
+    let (trigger, pubsub_service) = PubSubService::new(
+        PubSubConfig::default_for_tests(),
+        &subscriptions,
+        pubsub_addr,
+    );
 
     check_server_is_ready_or_panic(&pubsub_addr, 10, Duration::from_millis(300));
 
@@ -478,8 +487,11 @@ fn test_slot_subscription() {
         Arc::new(RwLock::new(BlockCommitmentCache::default())),
         optimistically_confirmed_bank,
     ));
-    let (trigger, pubsub_service) =
-        PubSubService::new(PubSubConfig::default(), &subscriptions, pubsub_addr);
+    let (trigger, pubsub_service) = PubSubService::new(
+        PubSubConfig::default_for_tests(),
+        &subscriptions,
+        pubsub_addr,
+    );
 
     check_server_is_ready_or_panic(&pubsub_addr, 10, Duration::from_millis(300));
 
@@ -555,8 +567,11 @@ async fn test_slot_subscription_async() {
             Arc::new(RwLock::new(BlockCommitmentCache::default())),
             optimistically_confirmed_bank,
         ));
-        let (trigger, pubsub_service) =
-            PubSubService::new(PubSubConfig::default(), &subscriptions, pubsub_addr);
+        let (trigger, pubsub_service) = PubSubService::new(
+            PubSubConfig::default_for_tests(),
+            &subscriptions,
+            pubsub_addr,
+        );
 
         check_server_is_ready_or_panic(&pubsub_addr, 10, Duration::from_millis(100));
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -409,7 +409,7 @@ impl ValidatorConfig {
             on_start_geyser_plugin_config_files: None,
             geyser_plugin_always_enabled: false,
             rpc_addrs: None,
-            pubsub_config: PubSubConfig::default(),
+            pubsub_config: PubSubConfig::default_for_tests(),
             snapshot_config: SnapshotConfig::new_load_only(),
             broadcast_stage_type: BroadcastStageType::Standard,
             turbine_mode: TurbineMode::default(),

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8417,7 +8417,6 @@ dependencies = [
  "solana-poh-config",
  "solana-program-pack",
  "solana-pubkey 4.2.0",
- "solana-rayon-threadlimit",
  "solana-rpc-client-api",
  "solana-runtime",
  "solana-runtime-transaction",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8049,7 +8049,6 @@ dependencies = [
  "solana-poh-config",
  "solana-program-pack",
  "solana-pubkey 4.2.0",
- "solana-rayon-threadlimit",
  "solana-rpc-client-api",
  "solana-runtime",
  "solana-runtime-transaction",

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -310,7 +310,7 @@ fn test_rpc_subscriptions() {
 
     // Create transaction signatures to subscribe to
     let transfer_amount = Rent::default().minimum_balance(0);
-    let transactions: Vec<Transaction> = (0..1000)
+    let transactions: Vec<Transaction> = (0..100)
         .map(|_| {
             system_transaction::transfer(
                 &alice,

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -65,7 +65,6 @@ solana-poh = { workspace = true }
 solana-poh-config = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-rayon-threadlimit = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-runtime = { workspace = true }
 solana-runtime-transaction = { workspace = true }

--- a/rpc/src/rpc_pubsub_service.rs
+++ b/rpc/src/rpc_pubsub_service.rs
@@ -12,7 +12,6 @@ use {
     jsonrpc_core::IoHandler,
     soketto::handshake::{Server, server},
     solana_metrics::TokenCounter,
-    solana_rayon_threadlimit::get_thread_count,
     solana_time_utils::AtomicInterval,
     std::{
         io,
@@ -31,11 +30,11 @@ use {
     tokio_util::compat::TokioAsyncReadCompatExt,
 };
 
-pub const MAX_ACTIVE_SUBSCRIPTIONS: usize = 1_000_000;
+pub const DEFAULT_MAX_ACTIVE_SUBSCRIPTIONS: usize = 1_000_000;
 pub const DEFAULT_QUEUE_CAPACITY_ITEMS: usize = 10_000_000;
 pub const DEFAULT_TEST_QUEUE_CAPACITY_ITEMS: usize = 100;
 pub const DEFAULT_QUEUE_CAPACITY_BYTES: usize = 256 * 1024 * 1024;
-const DEFAULT_TEST_QUEUE_CAPACITY_BYTES: usize = 16 * 1024 * 1024;
+pub const DEFAULT_TEST_QUEUE_CAPACITY_BYTES: usize = 16 * 1024 * 1024;
 pub const DEFAULT_WORKER_THREADS: usize = 1;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -49,26 +48,12 @@ pub struct PubSubConfig {
     pub notification_threads: Option<NonZeroUsize>,
 }
 
-impl Default for PubSubConfig {
-    fn default() -> Self {
-        Self {
-            enable_block_subscription: false,
-            enable_vote_subscription: false,
-            max_active_subscriptions: MAX_ACTIVE_SUBSCRIPTIONS,
-            queue_capacity_items: DEFAULT_QUEUE_CAPACITY_ITEMS,
-            queue_capacity_bytes: DEFAULT_QUEUE_CAPACITY_BYTES,
-            worker_threads: DEFAULT_WORKER_THREADS,
-            notification_threads: NonZeroUsize::new(get_thread_count()),
-        }
-    }
-}
-
 impl PubSubConfig {
     pub const fn default_for_tests() -> Self {
         Self {
             enable_block_subscription: false,
             enable_vote_subscription: false,
-            max_active_subscriptions: MAX_ACTIVE_SUBSCRIPTIONS,
+            max_active_subscriptions: DEFAULT_MAX_ACTIVE_SUBSCRIPTIONS,
             queue_capacity_items: DEFAULT_TEST_QUEUE_CAPACITY_ITEMS,
             queue_capacity_bytes: DEFAULT_TEST_QUEUE_CAPACITY_BYTES,
             worker_threads: DEFAULT_WORKER_THREADS,
@@ -337,7 +322,7 @@ pub fn test_connection(
             enable_block_subscription: true,
             enable_vote_subscription: true,
             queue_capacity_items: 100,
-            ..PubSubConfig::default()
+            ..PubSubConfig::default_for_tests()
         },
         subscriptions.control().clone(),
         Arc::clone(&current_subscriptions),
@@ -534,8 +519,11 @@ mod tests {
             Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests())),
             optimistically_confirmed_bank,
         ));
-        let (_trigger, pubsub_service) =
-            PubSubService::new(PubSubConfig::default(), &subscriptions, pubsub_addr);
+        let (_trigger, pubsub_service) = PubSubService::new(
+            PubSubConfig::default_for_tests(),
+            &subscriptions,
+            pubsub_addr,
+        );
         let thread = pubsub_service.thread_hdl.thread();
         assert_eq!(thread.name().unwrap(), "solRpcPubSub");
     }
@@ -561,7 +549,7 @@ mod tests {
         let (trigger, _pubsub_service) = PubSubService::new(
             PubSubConfig {
                 enable_block_subscription: true,
-                ..Default::default()
+                ..PubSubConfig::default_for_tests()
             },
             &subscriptions,
             pubsub_addr,

--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -613,7 +613,7 @@ mod tests {
             let (broadcast_sender, _broadcast_receiver) = broadcast::channel(42);
 
             let control = SubscriptionControl::new(
-                PubSubConfig::default().max_active_subscriptions,
+                PubSubConfig::default_for_tests().max_active_subscriptions,
                 sender,
                 broadcast_sender,
             );

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -531,26 +531,6 @@ impl Drop for RpcSubscriptions {
 }
 
 impl RpcSubscriptions {
-    pub fn new(
-        exit: Arc<AtomicBool>,
-        max_complete_transaction_status_slot: Arc<AtomicU64>,
-        blockstore: Arc<Blockstore>,
-        bank_forks: Arc<RwLock<BankForks>>,
-        block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
-        optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
-    ) -> Self {
-        Self::new_with_config(
-            exit,
-            max_complete_transaction_status_slot,
-            blockstore,
-            bank_forks,
-            block_commitment_cache,
-            optimistically_confirmed_bank,
-            &PubSubConfig::default(),
-            None,
-        )
-    }
-
     pub fn new_for_tests(
         exit: Arc<AtomicBool>,
         max_complete_transaction_status_slot: Arc<AtomicU64>,
@@ -684,13 +664,15 @@ impl RpcSubscriptions {
         let blockstore = Arc::new(blockstore);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
-        Self::new(
+        Self::new_with_config(
             Arc::new(AtomicBool::new(false)),
             max_complete_transaction_status_slot,
             blockstore,
             bank_forks,
             Arc::new(RwLock::new(BlockCommitmentCache::default())),
             optimistically_confirmed_bank,
+            &PubSubConfig::default_for_tests(),
+            None,
         )
     }
 

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -160,7 +160,7 @@ impl Default for TestValidatorGenesis {
             tower_storage: Option::<Arc<dyn TowerStorage>>::default(),
             rent: Rent::default(),
             rpc_config: JsonRpcConfig::default_for_test(),
-            pubsub_config: PubSubConfig::default(),
+            pubsub_config: PubSubConfig::default_for_tests(),
             rpc_ports: Option::<(u16, u16)>::default(),
             warp_slot: Option::<Slot>::default(),
             accounts: HashMap::<Pubkey, AccountSharedData>::default(),

--- a/validator/src/commands/run/args/pub_sub_config.rs
+++ b/validator/src/commands/run/args/pub_sub_config.rs
@@ -5,33 +5,26 @@ use {
     clap::{Arg, ArgMatches, value_t},
     solana_clap_utils::input_validators::is_parsable,
     solana_rayon_threadlimit::get_thread_count,
-    solana_rpc::rpc_pubsub_service::PubSubConfig,
+    solana_rpc::rpc_pubsub_service::{
+        DEFAULT_MAX_ACTIVE_SUBSCRIPTIONS, DEFAULT_QUEUE_CAPACITY_BYTES,
+        DEFAULT_QUEUE_CAPACITY_ITEMS, DEFAULT_TEST_QUEUE_CAPACITY_BYTES,
+        DEFAULT_TEST_QUEUE_CAPACITY_ITEMS, PubSubConfig,
+    },
     std::{num::NonZeroUsize, sync::LazyLock},
 };
 
 static DEFAULT_RPC_PUBSUB_MAX_ACTIVE_SUBSCRIPTIONS: LazyLock<String> =
-    LazyLock::new(|| PubSubConfig::default().max_active_subscriptions.to_string());
-static DEFAULT_TEST_RPC_PUBSUB_MAX_ACTIVE_SUBSCRIPTIONS: LazyLock<String> = LazyLock::new(|| {
-    PubSubConfig::default_for_tests()
-        .max_active_subscriptions
-        .to_string()
-});
+    LazyLock::new(|| DEFAULT_MAX_ACTIVE_SUBSCRIPTIONS.to_string());
 
 static DEFAULT_RPC_PUBSUB_QUEUE_CAPACITY_ITEMS: LazyLock<String> =
-    LazyLock::new(|| PubSubConfig::default().queue_capacity_items.to_string());
-static DEFAULT_TEST_RPC_PUBSUB_QUEUE_CAPACITY_ITEMS: LazyLock<String> = LazyLock::new(|| {
-    PubSubConfig::default_for_tests()
-        .queue_capacity_items
-        .to_string()
-});
+    LazyLock::new(|| DEFAULT_QUEUE_CAPACITY_ITEMS.to_string());
+static DEFAULT_TEST_RPC_PUBSUB_QUEUE_CAPACITY_ITEMS: LazyLock<String> =
+    LazyLock::new(|| DEFAULT_TEST_QUEUE_CAPACITY_ITEMS.to_string());
 
 static DEFAULT_RPC_PUBSUB_QUEUE_CAPACITY_BYTES: LazyLock<String> =
-    LazyLock::new(|| PubSubConfig::default().queue_capacity_bytes.to_string());
-static DEFAULT_TEST_RPC_PUBSUB_QUEUE_CAPACITY_BYTES: LazyLock<String> = LazyLock::new(|| {
-    PubSubConfig::default_for_tests()
-        .queue_capacity_bytes
-        .to_string()
-});
+    LazyLock::new(|| DEFAULT_QUEUE_CAPACITY_BYTES.to_string());
+static DEFAULT_TEST_RPC_PUBSUB_QUEUE_CAPACITY_BYTES: LazyLock<String> =
+    LazyLock::new(|| DEFAULT_TEST_QUEUE_CAPACITY_BYTES.to_string());
 
 const DEFAULT_RPC_PUBSUB_WORKER_THREADS: &str = "4";
 static DEFAULT_TEST_RPC_PUBSUB_WORKER_THREADS: LazyLock<String> =
@@ -53,13 +46,11 @@ pub(crate) fn args<'a, 'b>(test_validator: bool) -> Vec<Arg<'a, 'b>> {
         );
     let (
         rpc_pubsub_notification_threads,
-        default_rpc_pubsub_max_active_subscriptions,
         default_rpc_pubsub_queue_capacity_items,
         default_rpc_pubsub_queue_capacity_bytes,
     ) = if test_validator {
         (
             rpc_pubsub_notification_threads.default_value(&DEFAULT_TEST_RPC_PUBSUB_WORKER_THREADS),
-            &DEFAULT_TEST_RPC_PUBSUB_MAX_ACTIVE_SUBSCRIPTIONS,
             &DEFAULT_TEST_RPC_PUBSUB_QUEUE_CAPACITY_ITEMS,
             &DEFAULT_RPC_PUBSUB_QUEUE_CAPACITY_BYTES,
         )
@@ -72,7 +63,6 @@ pub(crate) fn args<'a, 'b>(test_validator: bool) -> Vec<Arg<'a, 'b>> {
                     &DEFAULT_RPC_PUBSUB_NUM_NOTIFICATION_THREADS,
                 )
                 .requires("full_rpc_api"),
-            &DEFAULT_RPC_PUBSUB_MAX_ACTIVE_SUBSCRIPTIONS,
             &DEFAULT_RPC_PUBSUB_QUEUE_CAPACITY_ITEMS,
             &DEFAULT_TEST_RPC_PUBSUB_QUEUE_CAPACITY_BYTES,
         )
@@ -93,7 +83,7 @@ pub(crate) fn args<'a, 'b>(test_validator: bool) -> Vec<Arg<'a, 'b>> {
             .takes_value(true)
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
-            .default_value(default_rpc_pubsub_max_active_subscriptions)
+            .default_value(&DEFAULT_RPC_PUBSUB_MAX_ACTIVE_SUBSCRIPTIONS)
             .help(
                 "The maximum number of active subscriptions that RPC PubSub will accept across \
                  all connections.",


### PR DESCRIPTION
#### Problem
Default trait implementations for production code make it easier to overlook a config change / make a misake.

#### Summary of Changes
- Kill `PubSubConfig`'s `Default` trait impl
- Update tests to use `PubSubConfig::default_for_tests()`

This will use fewer resources in unit tests, and it also inches us closer to being able to kill `solana-rayon-threadlimit`
