### PR TITLE
feat: --disable-block-production

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -86,7 +86,7 @@ pub struct AdminRpcRequestMetadataPostInit {
     pub outstanding_repair_requests: Arc<RwLock<OutstandingShredRepairs>>,
     pub cluster_slots: Arc<ClusterSlots>,
     pub node: Option<Arc<NodeMultihoming>>,
-    pub banking_control_sender: mpsc::Sender<BankingControlMsg>,
+    pub banking_control_sender: Option<mpsc::Sender<BankingControlMsg>>,
     pub snapshot_controller: Arc<SnapshotController>,
     pub blockstore: Arc<Blockstore>,
     pub votor_event_sender: VotorEventSender,

--- a/core/src/block_production_disabled_loop.rs
+++ b/core/src/block_production_disabled_loop.rs
@@ -1,0 +1,182 @@
+//! When block production is disabled, we still perform the Alpenglow / PoH handoff that
+//! [`BlockCreationLoop`](crate::block_creation_loop::BlockCreationLoop) normally runs at
+//! startup, then drain `LeaderWindowInfo` notifications so votor does not block.
+//!
+//! **Warning:** If this validator can become cluster leader, disabling block production will cause
+//! missed leader windows and can halt or fork the cluster. Use only for observers that will not
+//! be scheduled as leader.
+
+use {
+    crate::replay_stage::Finalizer,
+    agave_votor::event::LeaderWindowInfo,
+    crossbeam_channel::Receiver,
+    solana_entry::block_component::GenesisCertificate,
+    solana_gossip::cluster_info::ClusterInfo,
+    solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
+    solana_poh::{
+        poh_recorder::{GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS, PohRecorder},
+        record_channels::RecordReceiver,
+    },
+    solana_pubkey::Pubkey,
+    solana_runtime::{bank::Bank, bank_forks::BankForks},
+    std::{
+        sync::{
+            Arc, RwLock,
+            atomic::{AtomicBool, Ordering},
+        },
+        thread::{self, Builder, JoinHandle},
+        time::Duration,
+    },
+};
+
+pub struct BlockProductionDisabledLoop {
+    thread: JoinHandle<()>,
+}
+
+pub struct BlockProductionDisabledLoopConfig {
+    pub exit: Arc<AtomicBool>,
+    pub bank_forks: Arc<RwLock<BankForks>>,
+    pub blockstore: Arc<Blockstore>,
+    pub cluster_info: Arc<ClusterInfo>,
+    pub poh_recorder: Arc<RwLock<PohRecorder>>,
+    pub leader_schedule_cache: Arc<LeaderScheduleCache>,
+    pub record_receiver_receiver: Receiver<RecordReceiver>,
+    pub leader_window_info_receiver: Receiver<LeaderWindowInfo>,
+}
+
+impl BlockProductionDisabledLoop {
+    pub fn new(config: BlockProductionDisabledLoopConfig) -> Self {
+        let thread = Builder::new()
+            .name("solBlkProdDis".to_string())
+            .spawn(move || {
+                info!("block production disabled: Alpenglow handoff shim started");
+                start_disabled_loop(config);
+                info!("block production disabled: Alpenglow handoff shim stopped");
+            })
+            .unwrap();
+        Self { thread }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.thread.join()
+    }
+}
+
+struct DisabledLeaderContext {
+    exit: Arc<AtomicBool>,
+    my_pubkey: Pubkey,
+    leader_window_info_receiver: Receiver<LeaderWindowInfo>,
+    record_receiver: RecordReceiver,
+    poh_recorder: Arc<RwLock<PohRecorder>>,
+    leader_schedule_cache: Arc<LeaderScheduleCache>,
+    blockstore: Arc<Blockstore>,
+    bank_forks: Arc<RwLock<BankForks>>,
+    cluster_info: Arc<ClusterInfo>,
+}
+
+fn start_disabled_loop(config: BlockProductionDisabledLoopConfig) {
+    let BlockProductionDisabledLoopConfig {
+        exit,
+        bank_forks,
+        blockstore,
+        cluster_info,
+        poh_recorder,
+        leader_schedule_cache,
+        record_receiver_receiver,
+        leader_window_info_receiver,
+    } = config;
+
+    let _exit_guard = Finalizer::new(exit.clone());
+
+    let mut my_pubkey = cluster_info.id();
+    info!("{my_pubkey}: block production disabled handoff initialized");
+
+    let record_receiver = match record_receiver_receiver.recv() {
+        Ok(receiver) => receiver,
+        Err(e) => {
+            info!("{my_pubkey}: record receiver closed before handoff: {e:?}");
+            return;
+        }
+    };
+
+    let genesis_cert = bank_forks
+        .read()
+        .unwrap()
+        .migration_status()
+        .genesis_certificate()
+        .expect("Migration complete, genesis certificate must exist");
+    let _genesis_cert = GenesisCertificate::try_from((*genesis_cert).clone())
+        .expect("Genesis certificate must be valid");
+
+    info!("{my_pubkey}: PoH service has shut down; block production remains disabled");
+
+    let mut ctx = DisabledLeaderContext {
+        exit: exit.clone(),
+        my_pubkey,
+        leader_window_info_receiver,
+        record_receiver,
+        poh_recorder: poh_recorder.clone(),
+        leader_schedule_cache,
+        blockstore,
+        bank_forks,
+        cluster_info,
+    };
+
+    {
+        let mut w_poh_recorder = poh_recorder.write().unwrap();
+        w_poh_recorder.enable_alpenglow();
+    }
+    reset_poh_recorder_disabled(&ctx.bank_forks.read().unwrap().working_bank(), &ctx);
+
+    while !ctx.exit.load(Ordering::Relaxed) {
+        if my_pubkey != ctx.cluster_info.id() {
+            let my_old_pubkey = my_pubkey;
+            my_pubkey = ctx.cluster_info.id();
+            ctx.my_pubkey = my_pubkey;
+            warn!(
+                "Identity changed from {my_old_pubkey} to {my_pubkey} while block production \
+                 disabled"
+            );
+        }
+
+        let Some(latest) = ctx
+            .leader_window_info_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .ok()
+            .and_then(|window| {
+                ctx.leader_window_info_receiver
+                    .try_iter()
+                    .last()
+                    .or(Some(window))
+            })
+        else {
+            continue;
+        };
+
+        warn!(
+            "{my_pubkey}: --disable-block-production: ignoring leader window {}-{} (do not use \
+             this mode if this validator can become leader)",
+            latest.start_slot, latest.end_slot
+        );
+    }
+}
+
+fn reset_poh_recorder_disabled(bank: &Arc<Bank>, ctx: &DisabledLeaderContext) {
+    trace!("{}: resetting poh to {}", ctx.my_pubkey, bank.slot());
+    assert!(
+        ctx.record_receiver.is_shutdown() && ctx.record_receiver.is_safe_to_restart(),
+        "record receiver must be safe for Alpenglow reset after PoH handoff"
+    );
+    let next_leader_slot = ctx.leader_schedule_cache.next_leader_slot(
+        &ctx.my_pubkey,
+        bank.slot(),
+        bank,
+        Some(ctx.blockstore.as_ref()),
+        GRACE_TICKS_FACTOR * MAX_GRACE_SLOTS,
+    );
+
+    ctx.poh_recorder
+        .write()
+        .unwrap()
+        .reset(bank.clone(), next_leader_slot);
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod banking_simulation;
 pub mod banking_stage;
 pub mod banking_trace;
 mod block_creation_loop;
+mod block_production_disabled_loop;
 pub mod bls_sigverify;
 pub mod cluster_info_vote_listener;
 pub mod cluster_slots_service;

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -98,7 +98,6 @@ pub struct Tpu {
     tpu_forwards_quic_t: thread::JoinHandle<()>,
     tpu_entry_notifier: Option<TpuEntryNotifier>,
     staked_nodes_updater_service: StakedNodesUpdaterService,
-    tracer_thread_hdl: TracerThread,
     tpu_vote_quic_t: thread::JoinHandle<()>,
 }
 
@@ -150,7 +149,7 @@ impl Tpu {
         scheduler_bindings: Option<(PathBuf, mpsc::Sender<BankingControlMsg>)>,
         cancel: CancellationToken,
         votor_event_sender: VotorEventSender,
-    ) -> Self {
+    ) -> (Self, TracerThread) {
         let TpuSockets {
             vote: tpu_vote_sockets,
             broadcast: broadcast_sockets,
@@ -355,20 +354,22 @@ impl Tpu {
         key_notifiers.add(KeyUpdaterType::TpuVote, vote_streamer_key_updater);
         key_notifiers.add(KeyUpdaterType::Forward, client_updater);
 
-        Self {
-            fetch_stage,
-            cluster_info_vote_listener,
-            sigverify_stage,
-            banking_stage,
-            forwarding_stage,
-            broadcast_stage,
-            tpu_quic_t,
-            tpu_forwards_quic_t,
-            tpu_entry_notifier,
-            staked_nodes_updater_service,
+        (
+            Self {
+                fetch_stage,
+                cluster_info_vote_listener,
+                sigverify_stage,
+                banking_stage,
+                forwarding_stage,
+                broadcast_stage,
+                tpu_quic_t,
+                tpu_forwards_quic_t,
+                tpu_entry_notifier,
+                staked_nodes_updater_service,
+                tpu_vote_quic_t,
+            },
             tracer_thread_hdl,
-            tpu_vote_quic_t,
-        }
+        )
     }
 
     pub fn join(self) -> thread::Result<()> {
@@ -391,14 +392,6 @@ impl Tpu {
             tpu_entry_notifier.join()?;
         }
         let _ = broadcast_result?;
-        if let Some(tracer_thread_hdl) = self.tracer_thread_hdl {
-            if let Err(tracer_result) = tracer_thread_hdl.join()? {
-                error!(
-                    "banking tracer thread returned error after successful thread join: \
-                     {tracer_result:?}"
-                );
-            }
-        }
         Ok(())
     }
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -7,8 +7,11 @@ use {
         banking_stage::{
             BankingStage, transaction_scheduler::scheduler_controller::SchedulerConfig,
         },
-        banking_trace::{self, BankingTracer, TraceError},
+        banking_trace::{self, BankingTracer, TraceError, TracerThread},
         block_creation_loop::{BlockCreationLoop, BlockCreationLoopConfig, ReplayHighestFrozen},
+        block_production_disabled_loop::{
+            BlockProductionDisabledLoop, BlockProductionDisabledLoopConfig,
+        },
         cluster_info_vote_listener::VoteTracker,
         completed_data_sets_service::CompletedDataSetsService,
         consensus::{
@@ -40,7 +43,7 @@ use {
     },
     agave_xdp::transmitter::{Transmitter, TransmitterBuilder},
     anyhow::{Context, Result, anyhow},
-    crossbeam_channel::{Receiver, bounded, unbounded},
+    crossbeam_channel::{Receiver, RecvTimeoutError, bounded, unbounded},
     serde::{Deserialize, Serialize},
     solana_account::ReadableAccount,
     solana_accounts_db::{
@@ -376,6 +379,11 @@ pub struct ValidatorConfig {
     pub block_production_num_workers: NonZeroUsize,
     pub block_production_scheduler_config: SchedulerConfig,
     pub enable_block_production_forwarding: bool,
+    /// When true, skips the TPU (QUIC ingress, sigverify, banking, forwarding, broadcast) and
+    /// retains an Alpenglow handoff shim that drops leader windows instead of producing blocks.
+    ///
+    /// Do not enable on validators that can become cluster leader.
+    pub disable_block_production: bool,
     pub enable_scheduler_bindings: bool,
     pub generator_config: Option<GeneratorConfig>,
     pub use_snapshot_archives_at_startup: UseSnapshotArchivesAtStartup,
@@ -458,6 +466,7 @@ impl ValidatorConfig {
             block_production_scheduler_config: SchedulerConfig::default(),
             // enable forwarding by default for tests
             enable_block_production_forwarding: true,
+            disable_block_production: false,
             enable_scheduler_bindings: false,
             generator_config: None,
             use_snapshot_archives_at_startup: UseSnapshotArchivesAtStartup::default(),
@@ -646,8 +655,12 @@ pub struct Validator {
     snapshot_packager_service: SnapshotPackagerService,
     poh_recorder: Arc<RwLock<PohRecorder>>,
     poh_service: PohService,
-    block_creation_loop: BlockCreationLoop,
-    tpu: Tpu,
+    block_creation_loop: Option<BlockCreationLoop>,
+    block_production_disabled_loop: Option<BlockProductionDisabledLoop>,
+    tpu: Option<Tpu>,
+    banking_tracer_thread: TracerThread,
+    inactive_tpu_entry_drainer: Option<JoinHandle<()>>,
+    inactive_tpu_retransmit_drainer: Option<JoinHandle<()>>,
     tvu: Tvu,
     ip_echo_server: Option<solana_net_utils::IpEchoServer>,
     pub cluster_info: Arc<ClusterInfo>,
@@ -1465,25 +1478,54 @@ impl Validator {
         // There will only ever be a single msg in flight so bound channel for [`BuildRewardCertsResponse`] to 1 message.
         let (reward_certs_sender, reward_certs_receiver) = bounded(1);
 
-        let block_creation_loop_config = BlockCreationLoopConfig {
-            exit: exit.clone(),
-            bank_forks: bank_forks.clone(),
-            blockstore: blockstore.clone(),
-            cluster_info: cluster_info.clone(),
-            poh_recorder: poh_recorder.clone(),
-            leader_schedule_cache: leader_schedule_cache.clone(),
-            rpc_subscriptions: rpc_subscriptions.clone(),
-            banking_tracer: banking_tracer.clone(),
-            slot_status_notifier: slot_status_notifier.clone(),
-            leader_window_info_receiver,
-            highest_parent_ready: highest_parent_ready.clone(),
-            replay_highest_frozen: replay_highest_frozen.clone(),
-            record_receiver_receiver,
-            highest_finalized: highest_finalized.clone(),
-            build_reward_certs_sender,
-            reward_certs_receiver,
+        let disable_bp = config.disable_block_production;
+        if disable_bp {
+            info!(
+                "Disable block production requested: QUIC TPU ingress, TPU sigverify, banking stage, \
+                 forwarding, broadcast, and cluster vote listener will not run"
+            );
+        }
+
+        let (block_creation_loop, block_production_disabled_loop) = if disable_bp {
+            (
+                None,
+                Some(BlockProductionDisabledLoop::new(
+                    BlockProductionDisabledLoopConfig {
+                        exit: exit.clone(),
+                        bank_forks: bank_forks.clone(),
+                        blockstore: blockstore.clone(),
+                        cluster_info: cluster_info.clone(),
+                        poh_recorder: poh_recorder.clone(),
+                        leader_schedule_cache: leader_schedule_cache.clone(),
+                        record_receiver_receiver,
+                        leader_window_info_receiver,
+                    },
+                )),
+            )
+        } else {
+            let block_creation_loop_config = BlockCreationLoopConfig {
+                exit: exit.clone(),
+                bank_forks: bank_forks.clone(),
+                blockstore: blockstore.clone(),
+                cluster_info: cluster_info.clone(),
+                poh_recorder: poh_recorder.clone(),
+                leader_schedule_cache: leader_schedule_cache.clone(),
+                rpc_subscriptions: rpc_subscriptions.clone(),
+                banking_tracer: banking_tracer.clone(),
+                slot_status_notifier: slot_status_notifier.clone(),
+                leader_window_info_receiver,
+                highest_parent_ready: highest_parent_ready.clone(),
+                replay_highest_frozen: replay_highest_frozen.clone(),
+                record_receiver_receiver,
+                highest_finalized: highest_finalized.clone(),
+                build_reward_certs_sender,
+                reward_certs_receiver,
+            };
+            (
+                Some(BlockCreationLoop::new(block_creation_loop_config)),
+                None,
+            )
         };
-        let block_creation_loop = BlockCreationLoop::new(block_creation_loop_config);
 
         assert_eq!(
             blockstore.get_new_shred_signals_len(),
@@ -1632,79 +1674,120 @@ impl Validator {
         )
         .map_err(ValidatorError::Other)?;
 
-        let tpu_forwarding_client_config = {
-            let runtime_handle = tpu_client_next_runtime
-                .as_ref()
-                .map(TokioRuntime::handle)
-                .unwrap_or_else(|| current_runtime_handle.as_ref().unwrap());
-            ForwardingClientConfig {
-                stake_identity: Arc::as_ref(&identity_keypair),
-                tpu_client_sockets: tpu_transactions_forwards_client_sockets.take().unwrap(),
-                runtime_handle: runtime_handle.clone(),
-                cancel: cancel.clone(),
-                node_multihoming: node_multihoming.clone(),
-            }
-        };
-        let (banking_control_sender, banking_control_receiver) = mpsc::channel(1);
-        let tpu = Tpu::new_with_client(
-            &cluster_info,
-            &poh_recorder,
-            transaction_recorder,
-            entry_receiver,
-            retransmit_slots_receiver,
-            TpuSockets {
-                vote: node.sockets.tpu_vote,
-                broadcast: node.sockets.broadcast,
-                transactions_quic: node.sockets.tpu_quic,
-                transactions_forwards_quic: node.sockets.tpu_forwards_quic,
-                vote_quic: node.sockets.tpu_vote_quic,
-                vote_forwarding_client: node.sockets.tpu_vote_forwarding_client,
-            },
-            rpc_subscriptions,
-            transaction_status_sender,
-            entry_notification_sender,
-            blockstore.clone(),
-            &config.broadcast_stage_type,
-            turbine_xdp_sender,
-            exit.clone(),
-            node.info.shred_version(),
-            vote_tracker,
-            bank_forks.clone(),
-            verified_vote_sender,
-            gossip_verified_vote_hash_sender,
-            replay_vote_receiver,
-            replay_vote_sender,
-            bank_notification_sender,
-            duplicate_confirmed_slot_sender,
-            tpu_forwarding_client_config,
-            &identity_keypair,
-            config.runtime_config.log_messages_bytes_limit,
-            &staked_nodes,
-            config.staked_nodes_overrides.clone(),
-            banking_tracer_channels,
-            tracer_thread,
-            tpu_quic_server_config,
-            tpu_fwd_quic_server_config,
-            vote_quic_server_config,
-            prioritization_fee_cache,
-            tpu_sigverify_threads,
-            config.block_production_method.clone(),
-            config.block_production_num_workers,
-            config.block_production_scheduler_config.clone(),
-            config.filter_keys.clone(),
-            config.enable_block_production_forwarding,
-            config.generator_config.clone(),
-            key_notifiers.clone(),
-            banking_control_receiver,
-            config.enable_scheduler_bindings.then(|| {
+        let banking_control_sender;
+        let (
+            tpu,
+            banking_tracer_thread,
+            inactive_tpu_entry_drainer,
+            inactive_tpu_retransmit_drainer,
+        ) = if disable_bp {
+                banking_control_sender = None;
+                let exit_e = exit.clone();
+                let inactive_tpu_entry_drainer = Some(thread::spawn(move || loop {
+                    if exit_e.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    match entry_receiver.recv_timeout(Duration::from_secs(1)) {
+                        Ok(_) => {}
+                        Err(RecvTimeoutError::Timeout) => {}
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+                }));
+                let exit_r = exit.clone();
+                let inactive_tpu_retransmit_drainer =
+                    Some(thread::spawn(move || loop {
+                        if exit_r.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        match retransmit_slots_receiver.recv_timeout(Duration::from_secs(1)) {
+                            Ok(_) => {}
+                            Err(RecvTimeoutError::Timeout) => {}
+                            Err(RecvTimeoutError::Disconnected) => break,
+                        }
+                    }));
+                (None, tracer_thread, inactive_tpu_entry_drainer, inactive_tpu_retransmit_drainer)
+            } else {
+                let tpu_forwarding_client_config = {
+                    let runtime_handle = tpu_client_next_runtime
+                        .as_ref()
+                        .map(TokioRuntime::handle)
+                        .unwrap_or_else(|| current_runtime_handle.as_ref().unwrap());
+                    ForwardingClientConfig {
+                        stake_identity: Arc::as_ref(&identity_keypair),
+                        tpu_client_sockets: tpu_transactions_forwards_client_sockets.take().unwrap(),
+                        runtime_handle: runtime_handle.clone(),
+                        cancel: cancel.clone(),
+                        node_multihoming: node_multihoming.clone(),
+                    }
+                };
+                let (bc_tx, banking_control_receiver) = mpsc::channel(1);
+                banking_control_sender = Some(bc_tx.clone());
+                let (tpu, tracer_hdl) = Tpu::new_with_client(
+                    &cluster_info,
+                    &poh_recorder,
+                    transaction_recorder,
+                    entry_receiver,
+                    retransmit_slots_receiver,
+                    TpuSockets {
+                        vote: node.sockets.tpu_vote,
+                        broadcast: node.sockets.broadcast,
+                        transactions_quic: node.sockets.tpu_quic,
+                        transactions_forwards_quic: node.sockets.tpu_forwards_quic,
+                        vote_quic: node.sockets.tpu_vote_quic,
+                        vote_forwarding_client: node.sockets.tpu_vote_forwarding_client,
+                    },
+                    rpc_subscriptions,
+                    transaction_status_sender,
+                    entry_notification_sender,
+                    blockstore.clone(),
+                    &config.broadcast_stage_type,
+                    turbine_xdp_sender,
+                    exit.clone(),
+                    node.info.shred_version(),
+                    vote_tracker,
+                    bank_forks.clone(),
+                    verified_vote_sender,
+                    gossip_verified_vote_hash_sender,
+                    replay_vote_receiver,
+                    replay_vote_sender,
+                    bank_notification_sender,
+                    duplicate_confirmed_slot_sender,
+                    tpu_forwarding_client_config,
+                    &identity_keypair,
+                    config.runtime_config.log_messages_bytes_limit,
+                    &staked_nodes,
+                    config.staked_nodes_overrides.clone(),
+                    banking_tracer_channels,
+                    tracer_thread,
+                    tpu_quic_server_config,
+                    tpu_fwd_quic_server_config,
+                    vote_quic_server_config,
+                    prioritization_fee_cache,
+                    tpu_sigverify_threads,
+                    config.block_production_method.clone(),
+                    config.block_production_num_workers,
+                    config.block_production_scheduler_config.clone(),
+                    config.filter_keys.clone(),
+                    config.enable_block_production_forwarding,
+                    config.generator_config.clone(),
+                    key_notifiers.clone(),
+                    banking_control_receiver,
+                    config.enable_scheduler_bindings.then(|| {
+                        (
+                            ledger_path.join("scheduler_bindings.ipc"),
+                            bc_tx.clone(),
+                        )
+                    }),
+                    cancel,
+                    votor_event_sender.clone(),
+                );
                 (
-                    ledger_path.join("scheduler_bindings.ipc"),
-                    banking_control_sender.clone(),
+                    Some(tpu),
+                    tracer_hdl,
+                    None,
+                    None,
                 )
-            }),
-            cancel,
-            votor_event_sender.clone(),
-        );
+            };
 
         datapoint_info!(
             "validator-new",
@@ -1760,6 +1843,7 @@ impl Validator {
             tvu,
             poh_service,
             block_creation_loop,
+            block_production_disabled_loop,
             poh_recorder,
             ip_echo_server,
             validator_exit: config.validator_exit.clone(),
@@ -1770,6 +1854,9 @@ impl Validator {
             blockstore_metric_report_service,
             accounts_background_service,
             xdp_transmitter,
+            banking_tracer_thread,
+            inactive_tpu_entry_drainer,
+            inactive_tpu_retransmit_drainer,
             _tpu_client_next_runtime: tpu_client_next_runtime,
         })
     }
@@ -1862,9 +1949,13 @@ impl Validator {
         drop(self.cluster_info);
 
         self.poh_service.join().expect("poh_service");
-        self.block_creation_loop
-            .join()
-            .expect("block_creation_loop");
+        if let Some(block_creation_loop) = self.block_creation_loop {
+            block_creation_loop
+                .join()
+                .expect("block_creation_loop");
+        } else if let Some(loop_disabled) = self.block_production_disabled_loop {
+            loop_disabled.join().expect("block_production_disabled_loop");
+        }
         drop(self.poh_recorder);
 
         if let Some(json_rpc_service) = self.json_rpc_service {
@@ -1933,8 +2024,33 @@ impl Validator {
         if let Some(xdp_transmitter) = self.xdp_transmitter {
             xdp_transmitter.join().expect("xdp_transmitter");
         }
-        self.tpu.join().expect("tpu");
+        if let Some(tpu) = self.tpu {
+            tpu.join().expect("tpu");
+        } else if let Some(drainer) = self.inactive_tpu_entry_drainer {
+            drainer
+                .join()
+                .expect("inactive_tpu_entry_drainer");
+        }
+        if let Some(tracer_thread_hdl) = self.banking_tracer_thread {
+            match tracer_thread_hdl.join() {
+                Ok(Ok(())) => (),
+                Ok(Err(tracer_result)) => {
+                    error!(
+                        "banking tracer thread returned error after successful thread join: \
+                         {tracer_result:?}"
+                    );
+                }
+                Err(err) => {
+                    panic!("panic while joining banking tracer thread: {err:?}");
+                }
+            }
+        }
         self.tvu.join().expect("tvu");
+        if let Some(drainer) = self.inactive_tpu_retransmit_drainer {
+            drainer
+                .join()
+                .expect("inactive_tpu_retransmit_drainer");
+        }
         if let Some(completed_data_sets_service) = self.completed_data_sets_service {
             completed_data_sets_service
                 .join()

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -70,6 +70,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         block_production_num_workers: config.block_production_num_workers,
         block_production_scheduler_config: config.block_production_scheduler_config.clone(),
         enable_block_production_forwarding: config.enable_block_production_forwarding,
+        disable_block_production: config.disable_block_production,
         enable_scheduler_bindings: config.enable_scheduler_bindings,
         generator_config: config.generator_config.clone(),
         use_snapshot_archives_at_startup: config.use_snapshot_archives_at_startup,

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -814,8 +814,12 @@ impl AdminRpc for AdminRpcImpl {
         }
 
         meta.with_post_init(|post_init| {
-            if post_init
-                .banking_control_sender
+            let Some(sender) = post_init.banking_control_sender.as_ref() else {
+                return Err(jsonrpc_core::error::Error::invalid_params(
+                    "block production is disabled for this validator (--disable-block-production)",
+                ));
+            };
+            if sender
                 .try_send(BankingControlMsg::Internal {
                     block_production_method,
                     num_workers,
@@ -1161,7 +1165,7 @@ mod tests {
                         solana_core::cluster_slots_service::cluster_slots::ClusterSlots::default_for_tests(),
                     ),
                     node: None,
-                    banking_control_sender: mpsc::channel(1).0,
+                    banking_control_sender: Some(mpsc::channel(1).0),
                     snapshot_controller,
                     blockstore,
                     votor_event_sender,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -214,6 +214,18 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Rendezvous with the cluster at this gossip entrypoint"),
     )
     .arg(
+        Arg::with_name("disable_block_production")
+            .long("disable-block-production")
+            .takes_value(false)
+            .help(
+                "Do not run block production ingress or leader pipeline: QUIC TPU and TPU-vote \
+                 servers, UDP fetch/sigverify pipeline, banking stage, forwarding stage, broadcast \
+                 stage, cluster vote listener, and dynamic banking-control RPC wiring are omitted. \
+                 An Alpenglow handoff shim still runs and ignores leader windows. Do not use on a \
+                 validator that can become cluster leader.",
+            ),
+    )
+    .arg(
         Arg::with_name("no_voting")
             .long("no-voting")
             .takes_value(false)

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -796,6 +796,14 @@ pub fn execute(
         UseSnapshotArchivesAtStartup
     );
 
+    if matches.is_present("disable_block_production")
+        && matches.is_present("enable_scheduler_bindings")
+    {
+        Err(String::from(
+            "`--disable-block-production` cannot be used with `--enable-scheduler-bindings`",
+        ))?;
+    }
+
     let mut validator_config = ValidatorConfig {
         log_config,
         require_tower: matches.is_present("require_tower"),
@@ -904,6 +912,7 @@ pub fn execute(
             ),
         },
         enable_block_production_forwarding: staked_nodes_overrides_path.is_some(),
+        disable_block_production: matches.is_present("disable_block_production"),
         enable_scheduler_bindings: matches.is_present("enable_scheduler_bindings"),
         banking_trace_dir_byte_limit: parse_banking_trace_dir_byte_limit(matches),
         validator_exit: Arc::new(RwLock::new(Exit::default())),


### PR DESCRIPTION
# Problem
rpcs spawns quic servers, sigverify stage, banking stage, etc. even though these are totally unused

# Solution
```
--disable-block-production
```
conditionally does not spawn these things.

on a 32c machine, this prevents like 71 threads from spawning