### PR TITLE
Renames AccountStorageEntry "count" fields

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -27,9 +27,9 @@ pub struct AccountStorageEntry {
     pub accounts: AccountsFile,
 
     /// The number of alive accounts in this storage
-    pub(crate) count: AtomicUsize,
+    pub(crate) num_alive_accounts: AtomicUsize,
 
-    pub(crate) alive_bytes: AtomicUsize,
+    pub(crate) num_alive_bytes: AtomicUsize,
 
     /// offsets to accounts that are zero lamport single ref stored in this
     /// storage. These are still alive. But, shrink will be able to remove them.
@@ -37,7 +37,7 @@ pub struct AccountStorageEntry {
     /// NOTE: It's possible that one of these zero lamport single ref accounts
     /// could be written in a new transaction (and later rooted & flushed) and a
     /// later clean runs and marks this account dead before this storage gets a
-    /// chance to be shrunk, thus making the account dead in both "alive_bytes"
+    /// chance to be shrunk, thus making the account dead in both "num_alive_bytes"
     /// and as a zero lamport single ref. If this happens, we will count this
     /// account as "dead" twice. However, this should be fine. It just makes
     /// shrink more likely to visit this storage.
@@ -71,8 +71,8 @@ impl AccountStorageEntry {
             id,
             slot,
             accounts,
-            count: AtomicUsize::new(0),
-            alive_bytes: AtomicUsize::new(0),
+            num_alive_accounts: AtomicUsize::new(0),
+            num_alive_bytes: AtomicUsize::new(0),
             zero_lamport_single_ref_offsets: RwLock::default(),
             obsolete_accounts: RwLock::default(),
         }
@@ -88,8 +88,8 @@ impl AccountStorageEntry {
         self.accounts.reopen_as_readonly().map(|accounts| Self {
             id: self.id,
             slot: self.slot,
-            count: AtomicUsize::new(self.count()),
-            alive_bytes: AtomicUsize::new(self.alive_bytes()),
+            num_alive_accounts: AtomicUsize::new(self.count()),
+            num_alive_bytes: AtomicUsize::new(self.alive_bytes()),
             accounts,
             zero_lamport_single_ref_offsets: RwLock::new(
                 self.zero_lamport_single_ref_offsets.read().unwrap().clone(),
@@ -108,8 +108,8 @@ impl AccountStorageEntry {
             id,
             slot,
             accounts,
-            count: AtomicUsize::new(0),
-            alive_bytes: AtomicUsize::new(0),
+            num_alive_accounts: AtomicUsize::new(0),
+            num_alive_bytes: AtomicUsize::new(0),
             zero_lamport_single_ref_offsets: RwLock::default(),
             obsolete_accounts: RwLock::new(obsolete_accounts),
         }
@@ -117,11 +117,11 @@ impl AccountStorageEntry {
 
     /// Returns the number of alive accounts in this storage
     pub fn count(&self) -> usize {
-        self.count.load(Ordering::Acquire)
+        self.num_alive_accounts.load(Ordering::Acquire)
     }
 
     pub fn alive_bytes(&self) -> usize {
-        self.alive_bytes.load(Ordering::Acquire)
+        self.num_alive_bytes.load(Ordering::Acquire)
     }
 
     /// Returns the accounts that were marked obsolete as of the passed in slot
@@ -218,28 +218,32 @@ impl AccountStorageEntry {
     }
 
     pub(crate) fn add_accounts(&self, num_accounts: usize, num_bytes: usize) {
-        self.count.fetch_add(num_accounts, Ordering::Release);
-        self.alive_bytes.fetch_add(num_bytes, Ordering::Release);
+        self.num_alive_accounts
+            .fetch_add(num_accounts, Ordering::Release);
+        self.num_alive_bytes.fetch_add(num_bytes, Ordering::Release);
     }
 
     /// Removes `num_bytes` and `num_accounts` from the storage,
     /// and returns the remaining number of accounts.
     pub(crate) fn remove_accounts(&self, num_bytes: usize, num_accounts: usize) -> usize {
-        let prev_alive_bytes = self.alive_bytes.fetch_sub(num_bytes, Ordering::Release);
-        let prev_count = self.count.fetch_sub(num_accounts, Ordering::Release);
+        let prev_num_alive_bytes = self.num_alive_bytes.fetch_sub(num_bytes, Ordering::Release);
+        let prev_num_alive_accounts = self
+            .num_alive_accounts
+            .fetch_sub(num_accounts, Ordering::Release);
 
         // enforce invariant that we're not removing too many bytes or accounts
         assert!(
-            num_bytes <= prev_alive_bytes && num_accounts <= prev_count,
-            "Too many bytes or accounts removed from storage! slot: {}, id: {}, initial alive \
-             bytes: {prev_alive_bytes}, initial num accounts: {prev_count}, num bytes removed: \
-             {num_bytes}, num accounts removed: {num_accounts}",
+            num_bytes <= prev_num_alive_bytes && num_accounts <= prev_num_alive_accounts,
+            "Too many bytes or accounts removed from storage! slot: {}, id: {}, initial num alive \
+             bytes: {prev_num_alive_bytes}, initial num alive accounts: \
+             {prev_num_alive_accounts}, num bytes removed: {num_bytes}, num accounts removed: \
+             {num_accounts}",
             self.slot,
             self.id,
         );
 
         // SAFETY: subtraction is safe since we just asserted num_accounts <= prev_num_accounts
-        prev_count - num_accounts
+        prev_num_alive_accounts - num_accounts
     }
 
     /// Returns the path to the underlying accounts storage file

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6491,15 +6491,17 @@ impl AccountsDb {
                     store.count(),
                 );
                 {
-                    let prev_count = store.count.swap(entry.count, Ordering::Release);
+                    let prev_count = store
+                        .num_alive_accounts
+                        .swap(entry.count, Ordering::Release);
                     assert_eq!(prev_count, 0);
                 }
                 store
-                    .alive_bytes
+                    .num_alive_bytes
                     .store(entry.stored_size, Ordering::Release);
             } else {
                 trace!("id: {id} clearing count");
-                store.count.store(0, Ordering::Release);
+                store.num_alive_accounts.store(0, Ordering::Release);
             }
         }
         storage_size_storages_time.stop();

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1154,7 +1154,7 @@ fn test_shrink_zero_lamport_single_ref_account() {
             .storage
             .get_slot_storage_entry(slot)
             .unwrap()
-            .alive_bytes
+            .num_alive_bytes
             .fetch_sub(AppendVec::calculate_stored_size(0), Ordering::Release);
 
         if let Some(latest_full_snapshot_slot) = latest_full_snapshot_slot {
@@ -2242,7 +2242,7 @@ fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: S
         storage_access,
     ));
     db.storage.insert(Arc::clone(&store1));
-    store1.alive_bytes.store(0, Ordering::Release);
+    store1.num_alive_bytes.store(0, Ordering::Release);
     candidates.insert(store1_slot);
 
     let store2_slot = 22;
@@ -2256,7 +2256,7 @@ fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: S
     ));
     db.storage.insert(Arc::clone(&store2));
     store2
-        .alive_bytes
+        .num_alive_bytes
         .store(store_file_size as usize / 2, Ordering::Release);
     candidates.insert(store2_slot);
 
@@ -2271,7 +2271,7 @@ fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: S
     ));
     db.storage.insert(Arc::clone(&store3));
     store3
-        .alive_bytes
+        .num_alive_bytes
         .store(store_file_size as usize, Ordering::Release);
     candidates.insert(store3_slot);
 
@@ -2309,7 +2309,7 @@ fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: S
         storage_access,
     ));
     db.storage.insert(Arc::clone(&store1));
-    store1.alive_bytes.store(0, Ordering::Release);
+    store1.num_alive_bytes.store(0, Ordering::Release);
     candidates.insert(store1_slot);
 
     let store2_slot = 22;
@@ -2323,7 +2323,7 @@ fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: S
     ));
     db.storage.insert(Arc::clone(&store2));
     store2
-        .alive_bytes
+        .num_alive_bytes
         .store(store_file_size as usize / 2, Ordering::Release);
     candidates.insert(store2_slot);
 
@@ -2338,7 +2338,7 @@ fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: S
     ));
     db.storage.insert(Arc::clone(&store3));
     store3
-        .alive_bytes
+        .num_alive_bytes
         .store(store_file_size as usize, Ordering::Release);
     candidates.insert(store3_slot);
 
@@ -2374,7 +2374,7 @@ fn test_select_candidates_by_total_usage_all_clean(storage_access: StorageAccess
     ));
     db.storage.insert(Arc::clone(&store1));
     store1
-        .alive_bytes
+        .num_alive_bytes
         .store(store_file_size as usize / 4, Ordering::Release);
     candidates.insert(store1_slot);
 
@@ -2389,7 +2389,7 @@ fn test_select_candidates_by_total_usage_all_clean(storage_access: StorageAccess
     ));
     db.storage.insert(Arc::clone(&store2));
     store2
-        .alive_bytes
+        .num_alive_bytes
         .store(store_file_size as usize / 2, Ordering::Release);
     candidates.insert(store2_slot);
 
@@ -4336,18 +4336,18 @@ fn test_is_candidate_for_shrink(storage_access: StorageAccess) {
     }
 
     entry
-        .alive_bytes
+        .num_alive_bytes
         .store(store_file_size as usize - 1, Ordering::Release);
     assert!(accounts.is_candidate_for_shrink(&entry));
     entry
-        .alive_bytes
+        .num_alive_bytes
         .store(store_file_size as usize, Ordering::Release);
     assert!(!accounts.is_candidate_for_shrink(&entry));
 
     let shrink_ratio = 0.3;
     let file_size_shrink_limit = (store_file_size as f64 * shrink_ratio) as usize;
     entry
-        .alive_bytes
+        .num_alive_bytes
         .store(file_size_shrink_limit + 1, Ordering::Release);
     accounts.shrink_ratio = AccountShrinkThreshold::TotalSpace { shrink_ratio };
     assert!(accounts.is_candidate_for_shrink(&entry));
@@ -4529,8 +4529,8 @@ define_accounts_db_test!(test_set_storage_count_and_alive_bytes, |accounts| {
 
     // fake out the store count to avoid the assert
     for (_, store) in accounts.storage.iter() {
-        store.alive_bytes.store(0, Ordering::Release);
-        store.count.store(0, Ordering::Release);
+        store.num_alive_bytes.store(0, Ordering::Release);
+        store.num_alive_accounts.store(0, Ordering::Release);
     }
 
     // count needs to be <= approx stored count in store.


### PR DESCRIPTION
#### Problem

This is just a developer quality-of-life thing: the `alive_bytes` and `count` fields in `AccountStorageEntry` have always bothered me. 

The `alive_bytes` field does *not* actually hold bytes, e.g. `&[u8]` or something equivalent. It holds the *number* of alive bytes in the storage. This isn't a huge deal, as it can be inferred from the type and the code, but why not make it clearer?

Second is `count`. Count *of what*? Well, reading the comments on the field, we know it is the count of alive accounts. Note that we have another count of something else, alive bytes! So a single field named "count" is ambiguous to what it is actually counting. Why not make this one explicit?


#### Summary of Changes

Rename `alive_bytes` to `num_alive_bytes`, and `count` to `num_alive_accounts`.

Note this PR purposely doesn't change the AccountStorageEntry *methods* for these fields. That'll be a follow-up PR. This PR aims to minimize all changes outside of `account_storage_entry.rs`.