### PR TITLE
runtime: Add DCOU-only `Bank` parent constructors

### DIFF
--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -132,7 +132,7 @@ fn test_account_subscription() {
     let blockhash = bank.last_blockhash();
     let bank_forks = BankForks::new_rw_arc(bank);
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+    let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
     let bob = Keypair::new();
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -334,7 +334,7 @@ fn test_program_subscription() {
     let blockhash = bank.last_blockhash();
     let bank_forks = BankForks::new_rw_arc(bank);
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+    let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
     let bob = Keypair::new();
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -419,7 +419,7 @@ fn test_root_subscription() {
     let bank = Bank::new_for_tests(&genesis_config);
     let bank_forks = BankForks::new_rw_arc(bank);
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+    let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
     let subscriptions = Arc::new(RpcSubscriptions::new_for_tests(

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1309,7 +1309,8 @@ pub(crate) mod external {
             } = create_slow_genesis_config(10_000);
             let (root_bank, _root_bank_forks) =
                 Bank::new_with_bank_forks_for_tests(&genesis_config);
-            let child_bank = Bank::new_from_parent(root_bank, SlotLeader::new_unique(), 1);
+            let child_bank =
+                Bank::new_from_parent_for_tests(root_bank, SlotLeader::new_unique(), 1);
             let (bank, bank_forks) = child_bank.wrap_with_bank_forks_for_tests();
 
             let logon = ClientLogon {
@@ -2842,7 +2843,7 @@ mod tests {
         } = create_slow_genesis_config(10_000);
         let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         // Warp to next epoch for MaxAge tests.
-        let bank = Bank::new_from_parent(
+        let bank = Bank::new_from_parent_for_tests(
             bank.clone(),
             SlotLeader::new_unique(),
             bank.get_epoch_info().slots_in_epoch,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1344,7 +1344,7 @@ mod tests {
         let address_table_state = generate_new_address_lookup_table(None, 2);
         store_address_lookup_table(&bank, address_table_key, address_table_state);
 
-        let new_bank = Bank::new_from_parent(bank, SlotLeader::new_unique(), 2);
+        let new_bank = Bank::new_from_parent_for_tests(bank, SlotLeader::new_unique(), 2);
         let bank = bank_forks
             .write()
             .unwrap()

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -813,7 +813,7 @@ mod tests {
             Bank::new_for_tests(&genesis.genesis_config).wrap_with_bank_forks_for_tests();
 
         // Create a child descended from the first bank
-        let next_bank = Arc::new(Bank::new_from_parent(
+        let next_bank = Arc::new(Bank::new_from_parent_for_tests(
             first_bank.clone(),
             SlotLeader::new_unique(),
             first_bank.slot() + 1,

--- a/core/src/banking_stage/progress_tracker.rs
+++ b/core/src/banking_stage/progress_tracker.rs
@@ -323,7 +323,7 @@ mod tests {
         assert_eq!(message.latest_blockhash, bank.last_blockhash().to_bytes());
 
         // Child bank past the first epoch boundary - epoch should advance.
-        let child_bank = Arc::new(Bank::new_from_parent(
+        let child_bank = Arc::new(Bank::new_from_parent_for_tests(
             bank,
             SlotLeader::new_unique(),
             MINIMUM_SLOTS_PER_EPOCH,

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -896,7 +896,7 @@ pub(crate) mod tests {
                 .genesis_config;
         let (bank_0, _bank_forks) =
             Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
-        let mut bank = Bank::new_from_parent(
+        let mut bank = Bank::new_from_parent_for_tests(
             bank_0,
             SlotLeader::new_unique(),
             MINIMUM_SLOTS_PER_EPOCH, // This puts us in epoch 1
@@ -980,7 +980,7 @@ pub(crate) mod tests {
             genesis_utils::create_genesis_config_with_vote_accounts(100, &[&keypair_a], vec![200])
                 .genesis_config;
         let (bank_0, _bank_forks) = Bank::new_for_tests(&config).wrap_with_bank_forks_for_tests();
-        let bank = Bank::new_from_parent(
+        let bank = Bank::new_from_parent_for_tests(
             bank_0,
             SlotLeader::new_unique(),
             MINIMUM_SLOTS_PER_EPOCH - 1,
@@ -995,7 +995,11 @@ pub(crate) mod tests {
             genesis_utils::create_genesis_config_with_vote_accounts(100, &[&keypair_b], vec![200])
                 .genesis_config;
         let (bank_0, _bank_forks) = Bank::new_for_tests(&config).wrap_with_bank_forks_for_tests();
-        let bank = Bank::new_from_parent(bank_0, SlotLeader::new_unique(), MINIMUM_SLOTS_PER_EPOCH);
+        let bank = Bank::new_from_parent_for_tests(
+            bank_0,
+            SlotLeader::new_unique(),
+            MINIMUM_SLOTS_PER_EPOCH,
+        );
         assert_eq!(bank.epoch(), 1);
         vote_storage.cache_epoch_boundary_info(&bank);
         vote_storage.insert_batch(VoteSource::Gossip, votes().into_iter());
@@ -1013,7 +1017,7 @@ pub(crate) mod tests {
             genesis_utils::create_genesis_config_with_vote_accounts(100, &[&keypair_c], vec![200])
                 .genesis_config;
         let (bank_0, _bank_forks) = Bank::new_for_tests(&config).wrap_with_bank_forks_for_tests();
-        let bank = Bank::warp_from_parent(
+        let bank = Bank::warp_from_parent_for_tests(
             bank_0,
             SlotLeader::new_unique(),
             3 * MINIMUM_SLOTS_PER_EPOCH,
@@ -1047,8 +1051,11 @@ pub(crate) mod tests {
         // Epoch 1: A and B are both staked, and their current votes are valid
         let (bank_0, _bank_forks) =
             Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
-        let mut bank =
-            Bank::new_from_parent(bank_0, SlotLeader::new_unique(), MINIMUM_SLOTS_PER_EPOCH);
+        let mut bank = Bank::new_from_parent_for_tests(
+            bank_0,
+            SlotLeader::new_unique(),
+            MINIMUM_SLOTS_PER_EPOCH,
+        );
         assert_eq!(bank.epoch(), 1);
 
         bank.set_epoch_stakes_for_test(
@@ -1102,7 +1109,7 @@ pub(crate) mod tests {
         // it populates epoch_stakes(bank.epoch()) with the key cache_epoch_boundary_info expects
         let (bank_0, _bank_forks) =
             Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
-        let mut bank = Bank::warp_from_parent(
+        let mut bank = Bank::warp_from_parent_for_tests(
             bank_0,
             SlotLeader::new_unique(),
             3 * MINIMUM_SLOTS_PER_EPOCH,

--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -1267,7 +1267,7 @@ mod tests {
         );
         let bank0 = Bank::new_for_tests(&genesis.genesis_config);
         let (bank0, _temp_bank_forks) = bank0.wrap_with_bank_forks_for_tests();
-        let bank5 = Bank::new_from_parent(bank0, SlotLeader::default(), 5);
+        let bank5 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 5);
         let bank_forks = BankForks::new_rw_arc(bank5);
 
         bank_forks.write().unwrap().set_root(5, None, None);

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1077,7 +1077,8 @@ mod tests {
                 .unwrap()
                 .contains_key(&bank.slot())
         );
-        let bank1 = Bank::new_from_parent(bank.clone(), SlotLeader::default(), bank.slot() + 1);
+        let bank1 =
+            Bank::new_from_parent_for_tests(bank.clone(), SlotLeader::default(), bank.slot() + 1);
         vote_tracker.progress_with_new_root_bank(&bank1);
         assert!(
             !vote_tracker
@@ -1093,7 +1094,8 @@ mod tests {
         let new_epoch_slot = bank
             .epoch_schedule()
             .get_first_slot_in_epoch(current_epoch + 1);
-        let new_epoch_bank = Bank::new_from_parent(bank, SlotLeader::default(), new_epoch_slot);
+        let new_epoch_bank =
+            Bank::new_from_parent_for_tests(bank, SlotLeader::default(), new_epoch_slot);
         vote_tracker.progress_with_new_root_bank(&new_epoch_bank);
     }
 
@@ -1145,7 +1147,11 @@ mod tests {
         let (bank0, _bank_forks) =
             Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         // Votes for slots less than the provided root bank's slot should not be processed
-        let bank3 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 3));
+        let bank3 = Arc::new(Bank::new_from_parent_for_tests(
+            bank0,
+            SlotLeader::default(),
+            3,
+        ));
         let vote_slots = vec![1, 2];
         send_vote_txs(
             vote_slots,
@@ -1902,8 +1908,11 @@ mod tests {
             })
             .collect();
 
-        let new_root_bank =
-            Bank::new_from_parent(bank, SlotLeader::default(), first_slot_in_new_epoch - 2);
+        let new_root_bank = Bank::new_from_parent_for_tests(
+            bank,
+            SlotLeader::default(),
+            first_slot_in_new_epoch - 2,
+        );
         let notifiers = ConfirmationNotifiers {
             gossip_verified_vote_hash_sender: gossip_verified_vote_hash_sender.clone(),
             verified_voter_slots_sender: verified_voter_slots_sender.clone(),

--- a/core/src/epoch_specs.rs
+++ b/core/src/epoch_specs.rs
@@ -191,7 +191,7 @@ mod tests {
         let mut epoch_specs = EpochSpecs::from(bank_forks.clone());
         for slot in 1..100 {
             let bank = bank_forks.read().unwrap().get(slot - 1).unwrap();
-            let bank = Bank::new_from_parent(bank, SlotLeader::new_unique(), slot);
+            let bank = Bank::new_from_parent_for_tests(bank, SlotLeader::new_unique(), slot);
             bank_forks.write().unwrap().insert(bank);
         }
 

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -139,8 +139,7 @@ impl OptimisticConfirmationVerifier {
 mod test {
     use {
         super::*, crate::vote_simulator::VoteSimulator, solana_leader_schedule::SlotLeader,
-        solana_ledger::get_tmp_ledger_path_auto_delete, solana_runtime::bank::Bank,
-        std::collections::HashMap, trees::tr,
+        solana_ledger::get_tmp_ledger_path_auto_delete, std::collections::HashMap, trees::tr,
     };
 
     #[test]
@@ -278,7 +277,7 @@ mod test {
 
         // Add a new bank 7 that descends from 6
         let bank6 = vote_simulator.bank_forks.read().unwrap().get(6).unwrap();
-        let bank7_new = Bank::new_from_parent(bank6, SlotLeader::default(), 7);
+        let bank7_new = Bank::new_from_parent_for_tests(bank6, SlotLeader::default(), 7);
         vote_simulator.bank_forks.write().unwrap().insert(bank7_new);
         let bank7 = vote_simulator.bank_forks.read().unwrap().get(7).unwrap();
         assert!(!bank7.ancestors.contains_key(&3));

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -1863,7 +1863,8 @@ mod test {
         let bank_forks = &repair_info.bank_forks;
         let root_bank = bank_forks.read().unwrap().root_bank();
         let new_root_slot = dead_duplicate_confirmed_slot_2 + 1;
-        let new_root_bank = Bank::new_from_parent(root_bank, SlotLeader::default(), new_root_slot);
+        let new_root_bank =
+            Bank::new_from_parent_for_tests(root_bank, SlotLeader::default(), new_root_slot);
         new_root_bank.freeze();
         {
             let mut w_bank_forks = bank_forks.write().unwrap();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -5005,7 +5005,7 @@ pub(crate) mod tests {
 
         // Insert a non-root bank so that the propagation logic will update this
         // bank
-        let bank1 = Bank::new_from_parent(
+        let bank1 = Bank::new_from_parent_for_tests(
             bank_forks.read().unwrap().get(0).unwrap(),
             leader_schedule_cache.slot_leader_at(1, None).unwrap(),
             1,
@@ -5126,7 +5126,7 @@ pub(crate) mod tests {
         let bank_forks = BankForks::new_rw_arc(bank0);
 
         let root = 3;
-        let root_bank = Bank::new_from_parent(
+        let root_bank = Bank::new_from_parent_for_tests(
             bank_forks.read().unwrap().get(0).unwrap(),
             SlotLeader::default(),
             root,
@@ -5225,20 +5225,20 @@ pub(crate) mod tests {
         let bank_forks = BankForks::new_rw_arc(bank0);
         let confirmed_root = 1;
         let fork = 2;
-        let bank1 = Bank::new_from_parent(
+        let bank1 = Bank::new_from_parent_for_tests(
             bank_forks.read().unwrap().get(0).unwrap(),
             SlotLeader::default(),
             confirmed_root,
         );
         bank_forks.write().unwrap().insert(bank1);
-        let bank2 = Bank::new_from_parent(
+        let bank2 = Bank::new_from_parent_for_tests(
             bank_forks.read().unwrap().get(confirmed_root).unwrap(),
             SlotLeader::default(),
             fork,
         );
         bank_forks.write().unwrap().insert(bank2);
         let root = 3;
-        let root_bank = Bank::new_from_parent(
+        let root_bank = Bank::new_from_parent_for_tests(
             bank_forks.read().unwrap().get(confirmed_root).unwrap(),
             SlotLeader::default(),
             root,
@@ -5580,7 +5580,7 @@ pub(crate) mod tests {
             DefaultSchedulerPool::new_for_verification(None, None, None, None, None),
         );
 
-        let child_bank = Bank::new_from_parent(bank, SlotLeader::default(), 1);
+        let child_bank = Bank::new_from_parent_for_tests(bank, SlotLeader::default(), 1);
         let bank = bank_forks.write().unwrap().insert(child_bank);
 
         let slot = bank.slot();
@@ -5714,7 +5714,7 @@ pub(crate) mod tests {
             let bank0 = bank_forks.read().unwrap().get(0).unwrap();
             assert!(bank0.is_frozen());
             assert_eq!(bank0.tick_height(), bank0.max_tick_height());
-            let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+            let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
             bank_forks.write().unwrap().insert(bank1);
             let bank1 = bank_forks.read().unwrap().get_with_scheduler(1).unwrap();
             let bank1_progress = progress.entry(bank1.slot()).or_insert_with(|| {
@@ -5982,7 +5982,7 @@ pub(crate) mod tests {
                 )
                 .unwrap();
 
-            let child_bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+            let child_bank = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
             let bank1 = bank_forks
                 .write()
                 .unwrap()
@@ -6635,7 +6635,7 @@ pub(crate) mod tests {
         for i in 1..=10 {
             let parent_bank = bank_forks_arc.read().unwrap().get(i - 1).unwrap().clone();
             let prev_leader_slot = ((i - 1) / 2) * 2;
-            let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), i);
+            let bank = Bank::new_from_parent_for_tests(parent_bank, SlotLeader::default(), i);
             bank_forks_arc.write().unwrap().insert(bank);
             progress_map.insert(
                 i,
@@ -6718,7 +6718,7 @@ pub(crate) mod tests {
         for i in 1..=10 {
             let parent_bank = bank_forks_arc.read().unwrap().get(i - 1).unwrap().clone();
             let prev_leader_slot = i - 1;
-            let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), i);
+            let bank = Bank::new_from_parent_for_tests(parent_bank, SlotLeader::default(), i);
             bank_forks_arc.write().unwrap().insert(bank);
             let mut fork_progress = ForkProgress::new(
                 Hash::default(),
@@ -6872,10 +6872,10 @@ pub(crate) mod tests {
         let genesis_config = genesis_config::create_genesis_config(10000).0;
         let (bank0, bank_forks_arc) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         let parent_slot_bank =
-            Bank::new_from_parent(Arc::clone(&bank0), SlotLeader::default(), parent_slot);
+            Bank::new_from_parent_for_tests(Arc::clone(&bank0), SlotLeader::default(), parent_slot);
         bank_forks_arc.write().unwrap().insert(parent_slot_bank);
         let parent_bank = bank_forks_arc.read().unwrap().get(parent_slot).unwrap();
-        let bank5 = Bank::new_from_parent(parent_bank, SlotLeader::default(), 5);
+        let bank5 = Bank::new_from_parent_for_tests(parent_bank, SlotLeader::default(), 5);
         bank_forks_arc.write().unwrap().insert(bank5);
 
         // Should purge only `previous_leader_slot` from the progress map
@@ -6988,7 +6988,7 @@ pub(crate) mod tests {
 
         // Create bank 7
         let root_bank = bank_forks.read().unwrap().root_bank();
-        let bank7 = Bank::new_from_parent(
+        let bank7 = Bank::new_from_parent_for_tests(
             bank_forks.read().unwrap().get(6).unwrap(),
             SlotLeader::default(),
             7,
@@ -7151,7 +7151,7 @@ pub(crate) mod tests {
 
         // Create bank 7 and insert to blockstore and bank forks
         let root_bank = bank_forks.read().unwrap().root_bank();
-        let bank7 = Bank::new_from_parent(
+        let bank7 = Bank::new_from_parent_for_tests(
             bank_forks.read().unwrap().get(6).unwrap(),
             SlotLeader::default(),
             7,
@@ -9068,7 +9068,7 @@ pub(crate) mod tests {
         let poh_recorder = Arc::new(poh_recorder);
         let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
 
-        let bank1 = Bank::new_from_parent(
+        let bank1 = Bank::new_from_parent_for_tests(
             bank_forks.read().unwrap().get(0).unwrap(),
             leader_schedule_cache.slot_leader_at(1, None).unwrap(),
             1,
@@ -9248,7 +9248,7 @@ pub(crate) mod tests {
 
         let mut prev_index = 0;
         for i in (1..10).chain(11..15) {
-            let bank = Bank::new_from_parent(
+            let bank = Bank::new_from_parent_for_tests(
                 bank_forks.read().unwrap().get(prev_index).unwrap(),
                 leader_schedule_cache.slot_leader_at(i, None).unwrap(),
                 i,
@@ -9339,7 +9339,7 @@ pub(crate) mod tests {
                     != Some(*my_pubkey)
             })
             .unwrap();
-        let bank_to_dump = Bank::new_from_parent(
+        let bank_to_dump = Bank::new_from_parent_for_tests(
             bank_forks.read().unwrap().get(0).unwrap(),
             leader_schedule_cache
                 .slot_leader_at(slot_to_dump, None)
@@ -9963,8 +9963,11 @@ pub(crate) mod tests {
         blockstore.store_duplicate_slot(4, vec![], vec![]).unwrap();
         blockstore.store_duplicate_slot(5, vec![], vec![]).unwrap();
 
-        let bank1_child =
-            Bank::new_from_parent(bank0.clone_without_scheduler(), SlotLeader::default(), 1);
+        let bank1_child = Bank::new_from_parent_for_tests(
+            bank0.clone_without_scheduler(),
+            SlotLeader::default(),
+            1,
+        );
         let bank1 = bank_forks.write().unwrap().insert(bank1_child);
         confirm_full_slot(
             &blockstore,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -3221,7 +3221,7 @@ mod tests {
         ));
 
         // bank=1, wait=0, should pass, bank is past the wait slot
-        let bank_forks = BankForks::new_rw_arc(Bank::new_from_parent(
+        let bank_forks = BankForks::new_rw_arc(Bank::new_from_parent_for_tests(
             bank_forks.read().unwrap().root_bank(),
             SlotLeader::default(),
             1,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -185,7 +185,7 @@ where
     };
     for slot in 1..=last_slot {
         let parent = bank_forks.read().unwrap().get(slot - 1).unwrap().clone();
-        let bank = Bank::new_from_parent(parent.clone(), *parent.leader(), slot);
+        let bank = Bank::new_from_parent_for_tests(parent.clone(), *parent.leader(), slot);
         let bank = bank_forks.write().unwrap().insert(bank);
         f(bank.clone_without_scheduler().as_ref(), mint_keypair);
         // Set root to make sure we don't end up with too many account storage entries
@@ -297,7 +297,7 @@ fn test_slots_to_snapshot() {
             for _ in 0..*add_root_interval {
                 let new_slot = current_bank.slot() + 1;
                 let leader = *current_bank.leader();
-                let new_bank = Bank::new_from_parent(current_bank, leader, new_slot);
+                let new_bank = Bank::new_from_parent_for_tests(current_bank, leader, new_slot);
                 current_bank = bank_forks.write().unwrap().insert(new_bank).clone();
             }
             bank_forks
@@ -422,7 +422,7 @@ fn test_bank_forks_incremental_snapshot() {
         // Make a new bank and perform some transactions
         let bank = {
             let parent = bank_forks.read().unwrap().get(slot - 1).unwrap();
-            let bank = Bank::new_from_parent(parent.clone(), *parent.leader(), slot);
+            let bank = Bank::new_from_parent_for_tests(parent.clone(), *parent.leader(), slot);
             let bank_scheduler = bank_forks.write().unwrap().insert(bank);
             let bank = bank_scheduler.clone_without_scheduler();
 
@@ -652,7 +652,7 @@ fn test_snapshots_with_background_services() {
         // Make a new bank and process some transactions
         {
             let parent = bank_forks.read().unwrap().get(slot - 1).unwrap();
-            let bank = Bank::new_from_parent(parent.clone(), *parent.leader(), slot);
+            let bank = Bank::new_from_parent_for_tests(parent.clone(), *parent.leader(), slot);
             let bank = bank_forks
                 .write()
                 .unwrap()
@@ -807,7 +807,8 @@ fn test_fastboot_snapshots_teardown(exit_backpressure: bool) {
     for slot in 1..=LAST_SLOT {
         // Make a new bank and process some transactions
         let parent_bank = bank_forks.read().unwrap().get(slot - 1).unwrap();
-        let child_bank = Bank::new_from_parent(parent_bank.clone(), *parent_bank.leader(), slot);
+        let child_bank =
+            Bank::new_from_parent_for_tests(parent_bank.clone(), *parent_bank.leader(), slot);
         let bank = bank_forks
             .write()
             .unwrap()

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -81,12 +81,14 @@ fn test_scheduler_waited_by_drop_bank_service() {
 
     // Create bank, which is pruned later
     let pruned = 2;
-    let pruned_bank = Bank::new_from_parent(genesis_bank.clone(), SlotLeader::default(), pruned);
+    let pruned_bank =
+        Bank::new_from_parent_for_tests(genesis_bank.clone(), SlotLeader::default(), pruned);
     let pruned_bank = bank_forks.write().unwrap().insert(pruned_bank);
 
     // Create new root bank
     let root = 3;
-    let root_bank = Bank::new_from_parent(genesis_bank.clone(), SlotLeader::default(), root);
+    let root_bank =
+        Bank::new_from_parent_for_tests(genesis_bank.clone(), SlotLeader::default(), root);
     root_bank.freeze();
     let root_hash = root_bank.hash();
     bank_forks.write().unwrap().insert(root_bank);

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -285,7 +285,7 @@ mod tests {
         let bank_forks_arc = BankForks::new_rw_arc(bank);
         {
             let bank0 = bank_forks_arc.read().unwrap().get(0).unwrap();
-            let bank9 = Bank::new_from_parent(bank0, SlotLeader::default(), 9);
+            let bank9 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 9);
             let mut bank_forks = bank_forks_arc.write().unwrap();
             bank_forks.insert(bank9);
             bank_forks.set_root(9, None, None);
@@ -389,7 +389,7 @@ mod tests {
         let bank_forks_arc = BankForks::new_rw_arc(bank);
         {
             let bank0 = bank_forks_arc.read().unwrap().get(0).unwrap();
-            let bank9 = Bank::new_from_parent(bank0, SlotLeader::default(), 9);
+            let bank9 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 9);
             let mut bank_forks = bank_forks_arc.write().unwrap();
             bank_forks.insert(bank9);
             bank_forks.set_root(9, None, None);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -4801,8 +4801,11 @@ pub mod tests {
         )
         .unwrap();
         let bank0_last_blockhash = bank0.last_blockhash();
-        let bank1_child =
-            Bank::new_from_parent(bank0.clone_without_scheduler(), SlotLeader::default(), 1);
+        let bank1_child = Bank::new_from_parent_for_tests(
+            bank0.clone_without_scheduler(),
+            SlotLeader::default(),
+            1,
+        );
         let bank1 = bank_forks.write().unwrap().insert(bank1_child);
         confirm_full_slot(
             &blockstore,
@@ -4957,7 +4960,11 @@ pub mod tests {
             i += 1;
 
             let slot = bank.slot() + rng().random_range(1..3);
-            bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::default(), slot));
+            bank = Arc::new(Bank::new_from_parent_for_tests(
+                bank,
+                SlotLeader::default(),
+                slot,
+            ));
         }
     }
 
@@ -5050,7 +5057,8 @@ pub mod tests {
         let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         bank0.freeze();
 
-        let bank1_child = Bank::new_from_parent(bank0.clone(), SlotLeader::new_unique(), 1);
+        let bank1_child =
+            Bank::new_from_parent_for_tests(bank0.clone(), SlotLeader::new_unique(), 1);
         let bank1 = bank_forks
             .write()
             .unwrap()
@@ -5896,7 +5904,7 @@ pub mod tests {
         assert_eq!(slot_0_bank.get_hash_age(&genesis_hash), Some(1));
         assert_eq!(slot_0_bank.get_hash_age(&slot_0_hash), Some(0));
 
-        let new_bank = Bank::new_from_parent(slot_0_bank, leader, 2);
+        let new_bank = Bank::new_from_parent_for_tests(slot_0_bank, leader, 2);
         let slot_2_bank = bank_forks
             .write()
             .unwrap()
@@ -6087,7 +6095,7 @@ pub mod tests {
 
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
+        let bank1 = Bank::new_from_parent_for_tests(bank0.clone(), SlotLeader::default(), 1);
         assert!(
             !bank1
                 .feature_set
@@ -6123,7 +6131,7 @@ pub mod tests {
 
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let mut bank1 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
+        let mut bank1 = Bank::new_from_parent_for_tests(bank0.clone(), SlotLeader::default(), 1);
         bank1.activate_feature(&agave_feature_set::alpenglow::id());
         assert!(
             bank1
@@ -6245,7 +6253,8 @@ pub mod tests {
             .expect("parent should have a merkle root");
 
         // Case 1: No shreds for child slot — should return Unavailable
-        let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 10);
+        let child_bank =
+            Bank::new_from_parent_for_tests(parent_bank.clone(), SlotLeader::default(), 10);
         assert!(matches!(
             check_chained_block_id(&blockstore, &child_bank),
             ChainedBlockIdCheck::Unavailable
@@ -6254,7 +6263,8 @@ pub mod tests {
         // Case 2: Chained merkle root matches parent block ID — should return
         // Pass
         insert_shreds_with_chained_merkle_root(11, 0, parent_block_id);
-        let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 11);
+        let child_bank =
+            Bank::new_from_parent_for_tests(parent_bank.clone(), SlotLeader::default(), 11);
         assert!(matches!(
             check_chained_block_id(&blockstore, &child_bank),
             ChainedBlockIdCheck::Pass
@@ -6263,7 +6273,8 @@ pub mod tests {
         // Case 3: Chained merkle root does NOT match parent block ID — should
         // return Mismatch
         insert_shreds_with_chained_merkle_root(12, 0, Hash::new_unique());
-        let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 12);
+        let child_bank =
+            Bank::new_from_parent_for_tests(parent_bank.clone(), SlotLeader::default(), 12);
         assert!(matches!(
             check_chained_block_id(&blockstore, &child_bank),
             ChainedBlockIdCheck::Mismatch
@@ -6271,13 +6282,14 @@ pub mod tests {
 
         // Case 4: Parent has no shreds (get_block_merkle_root returns Err) —
         // should return Pass regardless of chained merkle root.
-        let no_shreds_parent_bank = Arc::new(Bank::new_from_parent(
+        let no_shreds_parent_bank = Arc::new(Bank::new_from_parent_for_tests(
             parent_bank,
             SlotLeader::default(),
             20,
         ));
         insert_shreds_with_chained_merkle_root(21, 20, Hash::new_unique());
-        let child_bank = Bank::new_from_parent(no_shreds_parent_bank, SlotLeader::default(), 21);
+        let child_bank =
+            Bank::new_from_parent_for_tests(no_shreds_parent_bank, SlotLeader::default(), 21);
         assert!(matches!(
             check_chained_block_id(&blockstore, &child_bank),
             ChainedBlockIdCheck::Pass

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -538,7 +538,8 @@ mod tests {
             target_slot += 1;
         }
 
-        let child_bank = Bank::new_from_parent(bank.clone(), SlotLeader::default(), target_slot);
+        let child_bank =
+            Bank::new_from_parent_for_tests(bank.clone(), SlotLeader::default(), target_slot);
         let bank = bank_forks
             .write()
             .unwrap()

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -171,7 +171,7 @@ fn bank_with_feature_activated(
     feature_id: &Pubkey,
 ) -> Arc<Bank> {
     let slot = parent.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(parent, SlotLeader::new_unique(), slot);
+    let mut bank = Bank::new_from_parent_for_tests(parent, SlotLeader::new_unique(), slot);
     bank.activate_feature(feature_id);
     bank_forks
         .write()
@@ -187,7 +187,7 @@ fn bank_with_feature_deactivated(
     feature_id: &Pubkey,
 ) -> Arc<Bank> {
     let slot = parent.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(parent, SlotLeader::new_unique(), slot);
+    let mut bank = Bank::new_from_parent_for_tests(parent, SlotLeader::new_unique(), slot);
     bank.deactivate_feature(feature_id);
     bank_forks
         .write()

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -440,13 +440,13 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+        let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
-        let bank2 = Bank::new_from_parent(bank1, SlotLeader::default(), 2);
+        let bank2 = Bank::new_from_parent_for_tests(bank1, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
         let bank2 = bank_forks.read().unwrap().get(2).unwrap();
-        let bank3 = Bank::new_from_parent(bank2, SlotLeader::default(), 3);
+        let bank3 = Bank::new_from_parent_for_tests(bank2, SlotLeader::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
 
         let optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>> =
@@ -556,7 +556,7 @@ mod tests {
 
         // Test higher root will be cached and clear pending_optimistically_confirmed_banks
         let bank3 = bank_forks.read().unwrap().get(3).unwrap();
-        let bank4 = Bank::new_from_parent(bank3, SlotLeader::default(), 4);
+        let bank4 = Bank::new_from_parent_for_tests(bank3, SlotLeader::default(), 4);
         bank_forks.write().unwrap().insert(bank4);
         OptimisticallyConfirmedBankTracker::process_notification(
             (
@@ -580,7 +580,7 @@ mod tests {
         assert_eq!(highest_confirmed_slot, 4);
 
         let bank4 = bank_forks.read().unwrap().get(4).unwrap();
-        let bank5 = Bank::new_from_parent(bank4, SlotLeader::default(), 5);
+        let bank5 = Bank::new_from_parent_for_tests(bank4, SlotLeader::default(), 5);
         bank_forks.write().unwrap().insert(bank5);
         let bank5 = bank_forks.read().unwrap().get(5).unwrap();
 
@@ -639,10 +639,10 @@ mod tests {
 
         // Banks <= root do not get added to pending list, even if not frozen
         let bank5 = bank_forks.read().unwrap().get(5).unwrap();
-        let bank6 = Bank::new_from_parent(bank5, SlotLeader::default(), 6);
+        let bank6 = Bank::new_from_parent_for_tests(bank5, SlotLeader::default(), 6);
         bank_forks.write().unwrap().insert(bank6);
         let bank5 = bank_forks.read().unwrap().get(5).unwrap();
-        let bank7 = Bank::new_from_parent(bank5, SlotLeader::default(), 7);
+        let bank7 = Bank::new_from_parent_for_tests(bank5, SlotLeader::default(), 7);
         bank_forks.write().unwrap().insert(bank7);
         bank_forks.write().unwrap().set_root(7, None, None);
         OptimisticallyConfirmedBankTracker::process_notification(
@@ -731,7 +731,7 @@ mod tests {
 
             // Test bank will only be cached when frozen
             let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-            let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+            let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
             bank_forks.write().unwrap().insert(bank1);
 
             let mut pending_optimistically_confirmed_banks: HashSet<u64> = HashSet::new();

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8945,13 +8945,13 @@ pub mod tests {
 
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+        let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
-        let bank2 = Bank::new_from_parent(bank1, SlotLeader::default(), 2);
+        let bank2 = Bank::new_from_parent_for_tests(bank1, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
         let bank2 = bank_forks.read().unwrap().get(2).unwrap();
-        let bank3 = Bank::new_from_parent(bank2, SlotLeader::default(), 3);
+        let bank3 = Bank::new_from_parent_for_tests(bank2, SlotLeader::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
 
         let prioritization_fee_cache_inner = None;

--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -180,25 +180,41 @@ pub mod tests {
         assert_eq!(health.check(), RpcHealthStatus::Behind { num_slots: 15 });
 
         // Simulate this node observing slot 4 as optimistically confirmed - status still behind
-        let bank4 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 4));
+        let bank4 = Arc::new(Bank::new_from_parent_for_tests(
+            bank0,
+            SlotLeader::default(),
+            4,
+        ));
         optimistically_confirmed_bank.write().unwrap().bank = bank4.clone();
         assert_eq!(health.check(), RpcHealthStatus::Behind { num_slots: 11 });
 
         // Simulate this node observing slot 5 as optimistically confirmed - status now ok
         // as distance is <= health_check_slot_distance
-        let bank5 = Arc::new(Bank::new_from_parent(bank4, SlotLeader::default(), 5));
+        let bank5 = Arc::new(Bank::new_from_parent_for_tests(
+            bank4,
+            SlotLeader::default(),
+            5,
+        ));
         optimistically_confirmed_bank.write().unwrap().bank = bank5.clone();
         assert_eq!(health.check(), RpcHealthStatus::Ok);
 
         // Node now up with tip of cluster
-        let bank15 = Arc::new(Bank::new_from_parent(bank5, SlotLeader::default(), 15));
+        let bank15 = Arc::new(Bank::new_from_parent_for_tests(
+            bank5,
+            SlotLeader::default(),
+            15,
+        ));
         optimistically_confirmed_bank.write().unwrap().bank = bank15.clone();
         assert_eq!(health.check(), RpcHealthStatus::Ok);
 
         // Node "beyond" tip of cluster - this technically isn't possible but could be
         // observed locally due to a race between updates to Blockstore and
         // OptimisticallyConfirmedBank. Either way, not a problem and status is ok.
-        let bank16 = Arc::new(Bank::new_from_parent(bank15, SlotLeader::default(), 16));
+        let bank16 = Arc::new(Bank::new_from_parent_for_tests(
+            bank15,
+            SlotLeader::default(),
+            16,
+        ));
         optimistically_confirmed_bank.write().unwrap().bank = bank16.clone();
         assert_eq!(health.check(), RpcHealthStatus::Ok);
     }

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -881,7 +881,7 @@ mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+        let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::new_for_tests(
@@ -997,7 +997,7 @@ mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+        let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::new_for_tests(
@@ -1180,7 +1180,7 @@ mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+        let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bob = Keypair::new();
 

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1288,7 +1288,7 @@ pub(crate) mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+        let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let alice = Keypair::new();
 
@@ -1892,7 +1892,7 @@ pub(crate) mod tests {
         let bank_forks = BankForks::new_rw_arc(bank);
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+        let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
 
@@ -1909,7 +1909,7 @@ pub(crate) mod tests {
 
         bank1.process_transaction(&tx).unwrap();
 
-        let bank2 = Bank::new_from_parent(bank1, SlotLeader::default(), 2);
+        let bank2 = Bank::new_from_parent_for_tests(bank1, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
 
         // add account for bob and process the transaction at bank2
@@ -1926,7 +1926,7 @@ pub(crate) mod tests {
 
         bank2.process_transaction(&tx).unwrap();
 
-        let bank3 = Bank::new_from_parent(bank2, SlotLeader::default(), 3);
+        let bank3 = Bank::new_from_parent_for_tests(bank2, SlotLeader::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
 
         // add account for joe and process the transaction at bank3
@@ -2094,7 +2094,7 @@ pub(crate) mod tests {
         let bank_forks = BankForks::new_rw_arc(bank);
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+        let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
 
@@ -2111,7 +2111,7 @@ pub(crate) mod tests {
 
         bank1.process_transaction(&tx).unwrap();
 
-        let bank2 = Bank::new_from_parent(bank1, SlotLeader::default(), 2);
+        let bank2 = Bank::new_from_parent_for_tests(bank1, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
 
         // add account for bob and process the transaction at bank2
@@ -2213,7 +2213,7 @@ pub(crate) mod tests {
         let bank_forks = BankForks::new_rw_arc(bank);
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+        let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank1 = bank_forks.read().unwrap().get(1).unwrap();
 
@@ -2230,7 +2230,7 @@ pub(crate) mod tests {
 
         bank1.process_transaction(&tx).unwrap();
 
-        let bank2 = Bank::new_from_parent(bank1, SlotLeader::default(), 2);
+        let bank2 = Bank::new_from_parent_for_tests(bank1, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
 
         // add account for bob and process the transaction at bank2
@@ -2338,7 +2338,7 @@ pub(crate) mod tests {
             })
         };
 
-        let bank3 = Bank::new_from_parent(bank2, SlotLeader::default(), 3);
+        let bank3 = Bank::new_from_parent_for_tests(bank2, SlotLeader::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
 
         // add account for joe and process the transaction at bank3
@@ -2423,7 +2423,7 @@ pub(crate) mod tests {
             .process_transaction(&past_bank_tx)
             .unwrap();
 
-        let next_bank = Bank::new_from_parent(
+        let next_bank = Bank::new_from_parent_for_tests(
             bank_forks.read().unwrap().get(0).unwrap(),
             SlotLeader::new_unique(),
             1,
@@ -2733,12 +2733,14 @@ pub(crate) mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-        let bank1 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
+        let bank1 = Bank::new_from_parent_for_tests(bank0.clone(), SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
-        let bank2 = Bank::new_from_parent(bank0, SlotLeader::default(), 2);
+        let bank2 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
 
-        let alice = Keypair::from_base58_string("sfLnS4rZ5a8gXke3aGxCgM6usFAVPxLUaBSRdssGY9uS5eoiEWQ41CqDcpXbcekpKsie8Lyy3LNFdhEvjUE1wd9");
+        let alice = Keypair::from_base58_string(
+            "sfLnS4rZ5a8gXke3aGxCgM6usFAVPxLUaBSRdssGY9uS5eoiEWQ41CqDcpXbcekpKsie8Lyy3LNFdhEvjUE1wd9",
+        );
 
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -831,7 +831,7 @@ mod test {
         let mut make_banks = |num_banks| {
             for _ in 0..num_banks {
                 let slot = bank.slot() + 1;
-                bank = Arc::new(Bank::new_from_parent(
+                bank = Arc::new(Bank::new_from_parent_for_tests(
                     bank.clone(),
                     SlotLeader::new_unique(),
                     slot,
@@ -920,37 +920,37 @@ mod test {
         ))));
 
         let (fork0_bank0, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-        let fork0_bank1 = Arc::new(Bank::new_from_parent(
+        let fork0_bank1 = Arc::new(Bank::new_from_parent_for_tests(
             fork0_bank0.clone(),
             SlotLeader::new_unique(),
             fork0_bank0.slot() + 1,
         ));
-        let fork1_bank1 = Arc::new(Bank::new_from_parent(
+        let fork1_bank1 = Arc::new(Bank::new_from_parent_for_tests(
             fork0_bank0.clone(),
             SlotLeader::new_unique(),
             fork0_bank0.slot() + 1,
         ));
-        let fork2_bank1 = Arc::new(Bank::new_from_parent(
+        let fork2_bank1 = Arc::new(Bank::new_from_parent_for_tests(
             fork0_bank0.clone(),
             SlotLeader::new_unique(),
             fork0_bank0.slot() + 1,
         ));
-        let fork0_bank2 = Arc::new(Bank::new_from_parent(
+        let fork0_bank2 = Arc::new(Bank::new_from_parent_for_tests(
             fork0_bank1.clone(),
             SlotLeader::new_unique(),
             fork0_bank1.slot() + 1,
         ));
-        let fork1_bank2 = Arc::new(Bank::new_from_parent(
+        let fork1_bank2 = Arc::new(Bank::new_from_parent_for_tests(
             fork1_bank1.clone(),
             SlotLeader::new_unique(),
             fork1_bank1.slot() + 1,
         ));
-        let fork0_bank3 = Arc::new(Bank::new_from_parent(
+        let fork0_bank3 = Arc::new(Bank::new_from_parent_for_tests(
             fork0_bank2.clone(),
             SlotLeader::new_unique(),
             fork0_bank2.slot() + 1,
         ));
-        let fork3_bank3 = Arc::new(Bank::new_from_parent(
+        let fork3_bank3 = Arc::new(Bank::new_from_parent_for_tests(
             fork0_bank2.clone(),
             SlotLeader::new_unique(),
             fork0_bank2.slot() + 1,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6284,6 +6284,11 @@ impl Bank {
         )
     }
 
+    /// Creates a new bank that points to an immutable checkpoint of another bank.
+    pub fn new_from_parent_for_tests(parent: Arc<Bank>, leader: SlotLeader, slot: Slot) -> Self {
+        Self::new_from_parent(parent, leader, slot)
+    }
+
     pub fn new_from_parent_with_bank_forks(
         bank_forks: &RwLock<BankForks>,
         parent: Arc<Bank>,
@@ -6296,6 +6301,17 @@ impl Bank {
             .unwrap()
             .insert(bank)
             .clone_without_scheduler()
+    }
+
+    /// Creates a new bank that points to an immutable checkpoint of another bank, like
+    /// `new_from_parent_for_tests`, but additionally:
+    ///
+    /// * Doesn't assume that the parent is anywhere near `slot`, parent could be millions of slots
+    ///   in the past.
+    /// * Adjusts the new bank's tick height to avoid having to run PoH for millions of slots.
+    /// * Freezes the new bank, assuming that the user will `Bank::new_from_parent` from this bank.
+    pub fn warp_from_parent_for_tests(parent: Arc<Bank>, leader: SlotLeader, slot: Slot) -> Self {
+        Self::warp_from_parent(parent, leader, slot)
     }
 
     /// Prepare a transaction batch from a list of legacy transactions. Used for tests only.

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1829,7 +1829,11 @@ mod tests {
         for _ in 1..bank.get_epoch_rewards_sysvar().num_partitions {
             assert!(bank.get_epoch_rewards_sysvar().active);
             let new_slot = bank.slot() + 1;
-            bank = Arc::new(Bank::new_from_parent(bank, SlotLeader::default(), new_slot));
+            bank = Arc::new(Bank::new_from_parent_for_tests(
+                bank,
+                SlotLeader::default(),
+                new_slot,
+            ));
         }
 
         assert!(!bank.get_epoch_rewards_sysvar().active);
@@ -1853,7 +1857,7 @@ mod tests {
         // Advance to next epoch boundary to update EpochStakes Kludgy because
         // mutable Bank methods require the bank not be Arc-wrapped.
         let new_slot = bank.slot() + 1;
-        let mut bank = Bank::new_from_parent(bank, SlotLeader::default(), new_slot);
+        let mut bank = Bank::new_from_parent_for_tests(bank, SlotLeader::default(), new_slot);
         let expected_starting_block_height = bank.block_height() + 1;
 
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
@@ -1918,8 +1922,11 @@ mod tests {
         assert_eq!(point_value.rewards, sysvar.total_rewards);
 
         // Advance to first distribution slot (bank_forks kept in scope so parent has fork_graph)
-        let mut bank =
-            Bank::new_from_parent(Arc::new(bank), SlotLeader::default(), SLOTS_PER_EPOCH + 1);
+        let mut bank = Bank::new_from_parent_for_tests(
+            Arc::new(bank),
+            SlotLeader::default(),
+            SLOTS_PER_EPOCH + 1,
+        );
 
         bank.recalculate_partitioned_rewards_if_active(|| &thread_pool);
         let EpochRewardStatus::Active(EpochRewardPhase::Distribution(
@@ -1965,7 +1972,8 @@ mod tests {
         for _ in 1..bank.get_epoch_rewards_sysvar().num_partitions {
             assert!(bank.get_epoch_rewards_sysvar().active);
             let next_slot = bank.slot() + 1;
-            bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::default(), next_slot);
+            bank =
+                Bank::new_from_parent_for_tests(Arc::new(bank), SlotLeader::default(), next_slot);
             bank.recalculate_partitioned_rewards_if_active(|| &thread_pool);
         }
 
@@ -1991,7 +1999,7 @@ mod tests {
 
         // Advance to next epoch boundary (bank_forks kept in scope so parent has fork_graph)
         let new_slot = bank.slot() + 1;
-        let mut bank = Bank::new_from_parent(bank, SlotLeader::default(), new_slot);
+        let mut bank = Bank::new_from_parent_for_tests(bank, SlotLeader::default(), new_slot);
 
         let EpochRewardStatus::Active(EpochRewardPhase::Calculation(calculation_status)) =
             bank.epoch_reward_status.clone()
@@ -2056,7 +2064,7 @@ mod tests {
         // Advance to the epoch boundary, which computes the original in-memory
         // reward list and updates EpochStakes for the new epoch.
         let new_slot = bank.slot() + 1;
-        let mut bank = Bank::new_from_parent(bank, SlotLeader::default(), new_slot);
+        let mut bank = Bank::new_from_parent_for_tests(bank, SlotLeader::default(), new_slot);
 
         let leader_schedule_epoch = bank.epoch_schedule().get_leader_schedule_epoch(bank.slot());
         let filtered_epoch_vote_accounts = bank
@@ -2302,7 +2310,7 @@ mod tests {
         }
 
         // Use new_from_parent (not _with_bank_forks) - we can't insert two banks at same slot
-        let bank_fork2 = Arc::new(Bank::new_from_parent(
+        let bank_fork2 = Arc::new(Bank::new_from_parent_for_tests(
             bank.clone(),
             SlotLeader::default(),
             next_epoch_slot,
@@ -2427,7 +2435,7 @@ mod tests {
         add_voters_and_populate(&bank1, &mut voters, &mut stakers, 5, 5_000_000_000, 10);
         let parent_capitalization = bank1.capitalization();
 
-        let bank2 = Arc::new(Bank::new_from_parent(
+        let bank2 = Arc::new(Bank::new_from_parent_for_tests(
             Arc::clone(&bank1),
             SlotLeader::default(),
             SLOTS_PER_EPOCH * 2,
@@ -2448,7 +2456,7 @@ mod tests {
         add_voters_and_populate(&bank2, &mut voters, &mut stakers, 10, 8_000_000_000, 10);
         let parent_capitalization = bank2.capitalization();
 
-        let bank3 = Arc::new(Bank::new_from_parent(
+        let bank3 = Arc::new(Bank::new_from_parent_for_tests(
             Arc::clone(&bank2),
             SlotLeader::default(),
             SLOTS_PER_EPOCH * 3,

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -1175,7 +1175,7 @@ mod tests {
         let mut total_staking_rewards = 0;
         let mut previous_bank = epoch_boundary_bank;
         for partition_index in 0..expected_num_partitions {
-            let partition_bank = Arc::new(Bank::new_from_parent(
+            let partition_bank = Arc::new(Bank::new_from_parent_for_tests(
                 previous_bank,
                 SlotLeader::default(),
                 SLOTS_PER_EPOCH + partition_index + 1,
@@ -1197,7 +1197,7 @@ mod tests {
 
         // All rewards are recorded
         assert_eq!(total_staking_rewards, num_rewards);
-        let bank = Bank::new_from_parent(
+        let bank = Bank::new_from_parent_for_tests(
             previous_bank,
             SlotLeader::default(),
             SLOTS_PER_EPOCH + expected_num_partitions + 1,

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -209,7 +209,7 @@ mod tests {
         let (bank0, _bank_forks) =
             Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         bank0.squash();
-        let mut bank = Bank::new_from_parent(bank0.clone(), *bank0.leader(), 1);
+        let mut bank = Bank::new_from_parent_for_tests(bank0.clone(), *bank0.leader(), 1);
         bank.set_block_id(Some(Hash::default()));
         bank.freeze();
         add_root_and_flush_write_cache(&bank0);
@@ -293,7 +293,7 @@ mod tests {
         let (bank0, _bank_forks) =
             Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         let bank0_leader = *bank0.leader();
-        let mut bank = Bank::new_from_parent(bank0, bank0_leader, 1);
+        let mut bank = Bank::new_from_parent_for_tests(bank0, bank0_leader, 1);
         while !bank.is_complete() {
             bank.fill_bank_with_ticks_for_tests();
         }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -185,7 +185,7 @@ fn test_race_register_tick_freeze() {
     let leader = SlotLeader::new_unique();
 
     for _ in 0..1000 {
-        let bank = Arc::new(Bank::new_from_parent(bank0.clone(), leader, 1));
+        let bank = Arc::new(Bank::new_from_parent_for_tests(bank0.clone(), leader, 1));
 
         // Check for race between marking bank complete and last blockhash being
         // set.
@@ -432,7 +432,7 @@ fn test_bank_capitalization() {
         42 * 42 + genesis_sysvar_and_builtin_program_lamports() + bank0_sysvar_delta(),
     );
 
-    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+    let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
     assert_eq!(
         bank1.capitalization(),
         42 * 42
@@ -784,7 +784,7 @@ where
     load_vote_and_stake_accounts(&bank0);
 
     // put a child bank in epoch 1
-    let bank1 = Arc::new(Bank::new_from_parent(
+    let bank1 = Arc::new(Bank::new_from_parent_for_tests(
         bank0.clone(),
         SlotLeader::default(),
         bank0.get_slots_in_epoch(bank0.epoch()) + 1,
@@ -809,7 +809,7 @@ where
     bank1.freeze();
 
     // advance past partitioned epoch staking rewards delivery
-    let bank2 = Arc::new(Bank::new_from_parent(
+    let bank2 = Arc::new(Bank::new_from_parent_for_tests(
         bank1.clone(),
         SlotLeader::default(),
         bank1.slot() + 1,
@@ -936,7 +936,7 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
     bank.store_account_and_update_capitalization(&vote_id, &vote_account);
 
     // put a child bank in epoch 1, which calls update_rewards()...
-    let bank1 = Arc::new(Bank::new_from_parent(
+    let bank1 = Arc::new(Bank::new_from_parent_for_tests(
         bank.clone(),
         SlotLeader::default(),
         bank.get_slots_in_epoch(bank.epoch()) + 1,
@@ -961,7 +961,8 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
 
     // put another child bank, since partitioned staking rewards are delivered
     // after the epoch-boundary slot
-    let bank2 = Bank::new_from_parent(bank1.clone(), SlotLeader::default(), bank1.slot() + 1);
+    let bank2 =
+        Bank::new_from_parent_for_tests(bank1.clone(), SlotLeader::default(), bank1.slot() + 1);
     let rewards = bank2.rewards.read().unwrap();
     rewards
         .iter()
@@ -1664,7 +1665,7 @@ fn test_readonly_accounts() {
     let bank = Bank::new_for_tests(&genesis_config);
     let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
     let next_slot = bank.slot() + 1;
-    let bank = Bank::new_from_parent(bank, SlotLeader::default(), next_slot);
+    let bank = Bank::new_from_parent_for_tests(bank, SlotLeader::default(), next_slot);
 
     let node_pubkey0 = solana_pubkey::new_rand();
     let node_pubkey1 = solana_pubkey::new_rand();
@@ -1818,7 +1819,7 @@ fn test_load_and_execute_commit_transactions_fees_only() {
     genesis_config.rent = Rent::default();
     genesis_config.fee_rate_governor = FeeRateGovernor::new(5000, 0);
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let bank = Bank::new_from_parent(
+    let bank = Bank::new_from_parent_for_tests(
         bank,
         SlotLeader::new_unique(),
         genesis_config.epoch_schedule.get_first_slot_in_epoch(1),
@@ -1895,7 +1896,7 @@ fn test_load_and_execute_commit_transactions_failure() {
     genesis_config.rent = Rent::default();
     genesis_config.fee_rate_governor = FeeRateGovernor::new(5000, 0);
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let bank = Bank::new_from_parent(
+    let bank = Bank::new_from_parent_for_tests(
         bank,
         SlotLeader::new_unique(),
         genesis_config.epoch_schedule.get_first_slot_in_epoch(1),
@@ -1969,7 +1970,7 @@ fn test_load_and_execute_commit_transactions_success() {
     genesis_config.rent = Rent::default();
     genesis_config.fee_rate_governor = FeeRateGovernor::new(5000, 0);
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let bank = Bank::new_from_parent(
+    let bank = Bank::new_from_parent_for_tests(
         bank,
         SlotLeader::new_unique(),
         genesis_config.epoch_schedule.get_first_slot_in_epoch(1),
@@ -2134,7 +2135,7 @@ fn test_bank_pay_to_self() {
 
 fn new_from_parent(parent: Arc<Bank>) -> Bank {
     let slot = parent.slot() + 1;
-    Bank::new_from_parent(parent, SlotLeader::default(), slot)
+    Bank::new_from_parent_for_tests(parent, SlotLeader::default(), slot)
 }
 
 fn new_from_parent_with_fork_next_slot(parent: Arc<Bank>, fork: &RwLock<BankForks>) -> Arc<Bank> {
@@ -2458,7 +2459,7 @@ fn test_bank_hash_internal_state_squash() {
     // save hash0 because new_from_parent
     // updates sysvar entries
 
-    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+    let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
 
     // no delta in bank1, hashes should always update
     assert_ne!(hash0, bank1.hash_internal_state());
@@ -2910,7 +2911,7 @@ fn test_bank_epoch_vote_accounts() {
     }
 
     // child crosses epoch boundary and is the first slot in the epoch
-    let child = Bank::new_from_parent(
+    let child = Bank::new_from_parent_for_tests(
         parent.clone(),
         leader,
         SLOTS_PER_EPOCH - (LEADER_SCHEDULE_SLOT_OFFSET % SLOTS_PER_EPOCH),
@@ -2929,7 +2930,7 @@ fn test_bank_epoch_vote_accounts() {
 
     // child crosses epoch boundary but isn't the first slot in the epoch, still
     //  makes an epoch stakes snapshot at 1
-    let child = Bank::new_from_parent(
+    let child = Bank::new_from_parent_for_tests(
         parent,
         leader,
         SLOTS_PER_EPOCH - (LEADER_SCHEDULE_SLOT_OFFSET % SLOTS_PER_EPOCH) + 1,
@@ -3181,7 +3182,7 @@ fn test_bank_cloned_stake_delegations() {
 
     let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     bank.squash();
-    let bank = Bank::new_from_parent(bank, SlotLeader::new_unique(), 1);
+    let bank = Bank::new_from_parent_for_tests(bank, SlotLeader::new_unique(), 1);
 
     let stake_delegations = bank.stakes_cache.stakes().stake_delegations().clone();
     assert_eq!(stake_delegations.len(), 1); // bootstrap validator has
@@ -3557,7 +3558,7 @@ fn test_add_duplicate_static_program() {
     );
 
     let slot = bank.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(bank, SlotLeader::default(), slot);
+    let mut bank = Bank::new_from_parent_for_tests(bank, SlotLeader::default(), slot);
     bank.add_mockup_builtin(solana_vote_program::id(), MockBuiltin::register);
     let bank = bank_forks
         .write()
@@ -3721,7 +3722,7 @@ fn test_hash_internal_state_unchanged() {
         Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
     bank0.freeze();
     let bank0_hash = bank0.hash();
-    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+    let bank1 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
     bank1.freeze();
     let bank1_hash = bank1.hash();
     // Checkpointing should always result in a new state
@@ -4808,7 +4809,7 @@ fn test_account_ids_after_program_ids() {
     tx.message.account_keys.push(solana_pubkey::new_rand());
 
     let slot = bank.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(bank, SlotLeader::default(), slot);
+    let mut bank = Bank::new_from_parent_for_tests(bank, SlotLeader::default(), slot);
     bank.add_mockup_builtin(solana_vote_program::id(), MockBuiltin::register);
     let bank = bank_forks
         .write()
@@ -4976,7 +4977,7 @@ fn test_ref_account_key_after_program_id() {
     ];
 
     let slot = bank.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(bank, SlotLeader::default(), slot);
+    let mut bank = Bank::new_from_parent_for_tests(bank, SlotLeader::default(), slot);
     bank.add_mockup_builtin(solana_vote_program::id(), MockBuiltin::register);
     let bank = bank_forks
         .write()
@@ -5375,7 +5376,7 @@ fn test_add_builtin_no_overwrite() {
     let program_id = solana_pubkey::new_rand();
 
     let (parent_bank, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let mut bank = Arc::new(Bank::new_from_parent(
+    let mut bank = Arc::new(Bank::new_from_parent_for_tests(
         parent_bank,
         SlotLeader::default(),
         slot,
@@ -5400,7 +5401,7 @@ fn test_add_builtin_loader_no_overwrite() {
     let loader_id = solana_pubkey::new_rand();
 
     let (parent_bank, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let mut bank = Arc::new(Bank::new_from_parent(
+    let mut bank = Arc::new(Bank::new_from_parent_for_tests(
         parent_bank,
         SlotLeader::default(),
         slot,
@@ -5591,7 +5592,7 @@ fn test_add_builtin_account_after_frozen() {
     let program_id = Pubkey::from_str("CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre").unwrap();
 
     let (parent_bank, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), slot);
+    let bank = Bank::new_from_parent_for_tests(parent_bank, SlotLeader::default(), slot);
     bank.freeze();
 
     bank.add_builtin_account("mock_program", &program_id);
@@ -5743,7 +5744,7 @@ fn test_add_precompiled_account_after_frozen() {
     let program_id = Pubkey::from_str("CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre").unwrap();
 
     let (parent_bank, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), slot);
+    let bank = Bank::new_from_parent_for_tests(parent_bank, SlotLeader::default(), slot);
     bank.freeze();
 
     bank.add_precompiled_account(&program_id);
@@ -6094,7 +6095,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
 #[test]
 fn test_compute_active_feature_set() {
     let (bank0, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let mut bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+    let mut bank = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
 
     let test_feature = "TestFeature11111111111111111111111111111111"
         .parse::<Pubkey>()
@@ -6145,7 +6146,7 @@ fn test_compute_active_feature_set() {
 #[test]
 fn test_reserved_account_keys() {
     let (bank0, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let mut bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+    let mut bank = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
     let test_feature_id = Pubkey::new_unique();
     bank.feature_set = Arc::new(FeatureSet::new(
         AHashMap::new(),
@@ -6179,7 +6180,7 @@ fn test_reserved_account_keys() {
 fn test_block_limits() {
     const MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_ENABLED: u64 = 40_000_000;
     let (bank0, _bank_forks) = create_simple_test_arc_bank(100_000);
-    let mut bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+    let mut bank = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
 
     // Ensure increased block limits features are inactive.
     assert!(!bank.feature_set.snapshot().raise_block_limits_to_100m);
@@ -6221,7 +6222,7 @@ fn test_block_limits() {
     );
 
     // Make sure the limits propagate to the child-bank.
-    let bank = Bank::new_from_parent(Arc::new(bank), SlotLeader::default(), 2);
+    let bank = Bank::new_from_parent_for_tests(Arc::new(bank), SlotLeader::default(), 2);
     assert_eq!(
         bank.read_cost_tracker().unwrap().get_block_limit(),
         MAX_BLOCK_UNITS_SIMD_0286,
@@ -6880,7 +6881,7 @@ fn test_store_scan_consistency_unrooted() {
                     .chunks(pubkeys_to_modify.len() / num_new_banks)
                 {
                     let slot = current_minor_fork_bank.slot() + 2;
-                    current_minor_fork_bank = Arc::new(Bank::new_from_parent(
+                    current_minor_fork_bank = Arc::new(Bank::new_from_parent_for_tests(
                         current_minor_fork_bank,
                         SlotLeader::new_unique(),
                         slot,
@@ -6905,7 +6906,7 @@ fn test_store_scan_consistency_unrooted() {
                 // `next_major_bank` needs to be sandwiched between the minor fork banks
                 // That way, after the squash(), the minor fork has the potential to see a
                 // *partial* clean of the banks < `next_major_bank`.
-                current_major_fork_bank = Arc::new(Bank::new_from_parent(
+                current_major_fork_bank = Arc::new(Bank::new_from_parent_for_tests(
                     current_major_fork_bank,
                     SlotLeader::new_unique(),
                     current_minor_fork_bank.slot() - 1,
@@ -6991,7 +6992,7 @@ fn test_store_scan_consistency_root() {
                 }
                 prev_bank = current_bank.clone();
                 let slot = current_bank.slot() + 1;
-                current_bank = Arc::new(Bank::new_from_parent(
+                current_bank = Arc::new(Bank::new_from_parent_for_tests(
                     current_bank,
                     SlotLeader::new_unique(),
                     slot,
@@ -7037,7 +7038,7 @@ fn setup_banks_on_fork_to_remove(
         let mut lamports_this_round = 0;
         for i in 0..step_size {
             let slot = bank_at_fork_tip.slot() + 1;
-            bank_at_fork_tip = Arc::new(Bank::new_from_parent(
+            bank_at_fork_tip = Arc::new(Bank::new_from_parent_for_tests(
                 bank_at_fork_tip,
                 SlotLeader::new_unique(),
                 slot,
@@ -8591,7 +8592,7 @@ fn test_check_reserved_keys() {
     let (genesis_config, _mint_keypair) = create_genesis_config(1);
     let (bank0, _bank_forks) =
         Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
-    let mut bank = Bank::new_from_parent(bank0, SlotLeader::new_unique(), 1);
+    let mut bank = Bank::new_from_parent_for_tests(bank0, SlotLeader::new_unique(), 1);
 
     let transaction =
         SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
@@ -10697,14 +10698,14 @@ fn test_register_hard_fork() {
     let (bank0, _bank_forks) =
         Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
-    let bank7 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 7);
+    let bank7 = Bank::new_from_parent_for_tests(bank0.clone(), SlotLeader::default(), 7);
     bank7.register_hard_fork(6);
     bank7.register_hard_fork(7);
     bank7.register_hard_fork(8);
     // Bank7 will reject slot 6 since it is older, but allow the other two hard forks
     assert_eq!(get_hard_forks(&bank7), vec![7, 8]);
 
-    let bank9 = Bank::new_from_parent(bank0, SlotLeader::default(), 9);
+    let bank9 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 9);
     bank9.freeze();
     bank9.register_hard_fork(9);
     bank9.register_hard_fork(10);
@@ -10747,25 +10748,37 @@ fn test_last_restart_slot() {
     assert_eq!(get_last_restart_slot(&bank0), Some(0));
 
     // Not dirty in children where the last restart slot has not changed
-    let bank1 = Arc::new(Bank::new_from_parent(
+    let bank1 = Arc::new(Bank::new_from_parent_for_tests(
         bank0.clone(),
         SlotLeader::default(),
         1,
     ));
     assert!(!last_restart_slot_dirty(&bank1));
     assert_eq!(get_last_restart_slot(&bank1), Some(0));
-    let bank2 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 2));
+    let bank2 = Arc::new(Bank::new_from_parent_for_tests(
+        bank0,
+        SlotLeader::default(),
+        2,
+    ));
     assert!(!last_restart_slot_dirty(&bank2));
     assert_eq!(get_last_restart_slot(&bank2), Some(0));
 
     // Last restart slot has now changed so it will be dirty again
-    let bank3 = Arc::new(Bank::new_from_parent(bank2, SlotLeader::default(), 3));
+    let bank3 = Arc::new(Bank::new_from_parent_for_tests(
+        bank2,
+        SlotLeader::default(),
+        3,
+    ));
     assert!(last_restart_slot_dirty(&bank3));
     assert_eq!(get_last_restart_slot(&bank3), Some(3));
 
     // Last restart will not change for a hard fork that has not occurred yet
     bank3.register_hard_fork(6);
-    let bank4 = Arc::new(Bank::new_from_parent(bank3, SlotLeader::default(), 4));
+    let bank4 = Arc::new(Bank::new_from_parent_for_tests(
+        bank3,
+        SlotLeader::default(),
+        4,
+    ));
     assert!(!last_restart_slot_dirty(&bank4));
     assert_eq!(get_last_restart_slot(&bank4), Some(3));
 }
@@ -11087,7 +11100,7 @@ fn test_bank_epoch_stakes() {
 
     let (bank0, _bank_forks) =
         Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
-    let mut bank1 = Bank::new_from_parent(
+    let mut bank1 = Bank::new_from_parent_for_tests(
         bank0.clone(),
         SlotLeader::default(),
         bank0.get_slots_in_epoch(0) + 1,
@@ -11362,7 +11375,7 @@ fn test_parent_block_id() {
 
     // Create child from parent and ensure parent block ID links back to the
     // expected value.
-    let child_bank = Bank::new_from_parent(parent_bank, SlotLeader::new_unique(), 1);
+    let child_bank = Bank::new_from_parent_for_tests(parent_bank, SlotLeader::new_unique(), 1);
     assert_eq!(parent_block_id, child_bank.parent_block_id());
 }
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -796,7 +796,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap()[0].clone();
-        let child_bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+        let child_bank = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
         child_bank.register_default_tick_for_test();
         bank_forks.write().unwrap().insert(child_bank);
         let bank_forks = bank_forks.read().unwrap();
@@ -838,7 +838,7 @@ mod tests {
             let bank_forks = BankForks::new_rw_arc(bank0);
             let bank0 = bank_forks.read().unwrap()[0].clone();
             bank0.freeze();
-            Bank::new_from_parent(bank0, SlotLeader::default(), root_slot)
+            Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), root_slot)
         };
         root_bank.feature_set = feature_set;
 
@@ -929,7 +929,7 @@ mod tests {
         assert_eq!(migration_status.migration_slot(), None);
 
         // Migration can still succeed
-        let mut bank = Bank::new_from_parent(root_bank, SlotLeader::default(), 10);
+        let mut bank = Bank::new_from_parent_for_tests(root_bank, SlotLeader::default(), 10);
         let genesis_cert = Certificate {
             cert_type: CertificateType::Finalize(1),
             signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
@@ -948,9 +948,9 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap()[0].clone();
-        let bank1 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
+        let bank1 = Bank::new_from_parent_for_tests(bank0.clone(), SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
-        let bank2 = Bank::new_from_parent(bank0, SlotLeader::default(), 2);
+        let bank2 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
         let bank_forks = bank_forks.read().unwrap();
         let descendants = bank_forks.descendants();
@@ -966,9 +966,9 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap()[0].clone();
-        let bank1 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
+        let bank1 = Bank::new_from_parent_for_tests(bank0.clone(), SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
-        let bank2 = Bank::new_from_parent(bank0, SlotLeader::default(), 2);
+        let bank2 = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
         let bank_forks = bank_forks.read().unwrap();
         let ancestors = bank_forks.ancestors();
@@ -985,7 +985,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap()[0].clone();
-        let child_bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+        let child_bank = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(child_bank);
 
         let frozen_slots: HashSet<Slot> = bank_forks
@@ -1004,7 +1004,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap()[0].clone();
-        let child_bank = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+        let child_bank = Bank::new_from_parent_for_tests(bank0, SlotLeader::default(), 1);
         bank_forks.write().unwrap().insert(child_bank);
         assert_eq!(bank_forks.read().unwrap().active_bank_slots(), vec![1]);
     }
@@ -1036,12 +1036,12 @@ mod tests {
             // Clock::unix_timestamp from Bank::unix_timestamp_from_genesis()
             let update_timestamp_case = slot == slots_in_epoch;
 
-            let child1 = Bank::new_from_parent(
+            let child1 = Bank::new_from_parent_for_tests(
                 bank_forks0.read().unwrap()[slot - 1].clone(),
                 SlotLeader::default(),
                 slot,
             );
-            let child2 = Bank::new_from_parent(
+            let child2 = Bank::new_from_parent_for_tests(
                 bank_forks1.read().unwrap()[slot - 1].clone(),
                 SlotLeader::default(),
                 slot,
@@ -1090,7 +1090,7 @@ mod tests {
     fn extend_bank_forks(bank_forks: Arc<RwLock<BankForks>>, parent_child_pairs: &[(Slot, Slot)]) {
         for (parent, child) in parent_child_pairs.iter() {
             let parent: Arc<Bank> = bank_forks.read().unwrap().banks[parent].clone();
-            let child_bank = Bank::new_from_parent(parent, SlotLeader::default(), *child);
+            let child_bank = Bank::new_from_parent_for_tests(parent, SlotLeader::default(), *child);
             bank_forks.write().unwrap().insert(child_bank);
         }
     }

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -432,7 +432,7 @@ mod tests {
             .epoch_schedule
             .get_first_slot_in_epoch(prev_bank.epoch() + 1)
             + NUM_SLOTS_FOR_REWARD;
-        let bank = Bank::new_from_parent(prev_bank.clone(), slot_leader, current_slot);
+        let bank = Bank::new_from_parent_for_tests(prev_bank.clone(), slot_leader, current_slot);
         let reward_slot = current_slot - NUM_SLOTS_FOR_REWARD;
 
         calc_vote_rewards_update_vote_states(
@@ -500,7 +500,7 @@ mod tests {
             .epoch_schedule
             .get_first_slot_in_epoch(prev_bank.epoch() + 1)
             + NUM_SLOTS_FOR_REWARD;
-        let bank = Bank::new_from_parent(prev_bank.clone(), slot_leader, current_slot);
+        let bank = Bank::new_from_parent_for_tests(prev_bank.clone(), slot_leader, current_slot);
         let reward_slot = current_slot - NUM_SLOTS_FOR_REWARD;
 
         let cert_rank = {
@@ -568,7 +568,7 @@ mod tests {
             .epoch_schedule
             .get_first_slot_in_epoch(prev_bank.epoch() + 1)
             + NUM_SLOTS_FOR_REWARD;
-        let bank = Bank::new_from_parent(prev_bank.clone(), slot_leader, current_slot);
+        let bank = Bank::new_from_parent_for_tests(prev_bank.clone(), slot_leader, current_slot);
         let reward_slot = current_slot - NUM_SLOTS_FOR_REWARD;
 
         let cert_rank = {
@@ -642,7 +642,7 @@ mod tests {
             id: node_pubkey,
             vote_address: vote_pubkey,
         };
-        let bank = Bank::new_from_parent(prev_bank.clone(), slot_leader, current_slot);
+        let bank = Bank::new_from_parent_for_tests(prev_bank.clone(), slot_leader, current_slot);
         let reward_slot = current_slot - NUM_SLOTS_FOR_REWARD;
 
         calc_vote_rewards_update_vote_states(

--- a/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
+++ b/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
@@ -203,14 +203,14 @@ mod tests {
             let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis.genesis_config));
             let bank_epoch_0 = bank_forks.read().unwrap().root_bank();
             let first_slot_in_epoch_1 = bank_epoch_0.epoch_schedule().get_first_slot_in_epoch(1);
-            let bank_epoch_1 = Arc::new(Bank::new_from_parent(
+            let bank_epoch_1 = Arc::new(Bank::new_from_parent_for_tests(
                 bank_epoch_0.clone(),
                 SlotLeader::new_unique(),
                 first_slot_in_epoch_1,
             ));
             assert_eq!(bank_epoch_1.epoch(), 1);
             let first_slot_in_epoch_2 = bank_epoch_1.epoch_schedule().get_first_slot_in_epoch(2);
-            let bank_epoch_2 = Arc::new(Bank::new_from_parent(
+            let bank_epoch_2 = Arc::new(Bank::new_from_parent_for_tests(
                 bank_epoch_1.clone(),
                 SlotLeader::new_unique(),
                 first_slot_in_epoch_2,

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -592,7 +592,7 @@ mod tests {
         let bank = bank_forks.read().unwrap().working_bank();
         let leader = SlotLeader::new_unique();
 
-        let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), leader, 1));
+        let bank1 = Arc::new(Bank::new_from_parent_for_tests(bank.clone(), leader, 1));
         sync_update(
             &prioritization_fee_cache,
             bank1.clone(),
@@ -606,7 +606,7 @@ mod tests {
         sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 1, bank1.bank_id());
 
         // add slot 2 entry to cache, but not finalize it
-        let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), leader, 2));
+        let bank2 = Arc::new(Bank::new_from_parent_for_tests(bank.clone(), leader, 2));
         let txs = [build_sanitized_transaction_for_test(
             1,
             &Pubkey::new_unique(),
@@ -614,7 +614,7 @@ mod tests {
         )];
         sync_update(&prioritization_fee_cache, bank2, txs.iter());
 
-        let bank3 = Arc::new(Bank::new_from_parent(bank, leader, 3));
+        let bank3 = Arc::new(Bank::new_from_parent_for_tests(bank, leader, 3));
         sync_update(
             &prioritization_fee_cache,
             bank3.clone(),
@@ -643,9 +643,9 @@ mod tests {
         let bank_forks = BankForks::new_rw_arc(bank0);
         let bank = bank_forks.read().unwrap().working_bank();
         let leader = SlotLeader::new_unique();
-        let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), leader, 1));
-        let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), leader, 2));
-        let bank3 = Arc::new(Bank::new_from_parent(bank, leader, 3));
+        let bank1 = Arc::new(Bank::new_from_parent_for_tests(bank.clone(), leader, 1));
+        let bank2 = Arc::new(Bank::new_from_parent_for_tests(bank.clone(), leader, 2));
+        let bank3 = Arc::new(Bank::new_from_parent_for_tests(bank, leader, 3));
 
         let prioritization_fee_cache = PrioritizationFeeCache::default();
 
@@ -920,8 +920,8 @@ mod tests {
         let bank = bank_forks.read().unwrap().working_bank();
         let leader = SlotLeader::new_unique();
         let slot: Slot = 999;
-        let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), leader, slot));
-        let bank2 = Arc::new(Bank::new_from_parent(bank, leader, slot + 1));
+        let bank1 = Arc::new(Bank::new_from_parent_for_tests(bank.clone(), leader, slot));
+        let bank2 = Arc::new(Bank::new_from_parent_for_tests(bank, leader, slot + 1));
 
         let prioritization_fee_cache = PrioritizationFeeCache::default();
 

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -599,7 +599,7 @@ mod tests {
         // write to multiple accounts and keep track of one, for minimization later
         let pubkey_to_keep = Pubkey::new_unique();
         let slot = bank.slot() + 1;
-        let bank = Bank::new_from_parent(bank.clone(), *bank.leader(), slot);
+        let bank = Bank::new_from_parent_for_tests(bank.clone(), *bank.leader(), slot);
         let bank = bank_forks
             .write()
             .unwrap()

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -219,7 +219,7 @@ mod tests {
         );
         let (bank, _bank_forks) =
             Bank::new_for_tests(&genesis.genesis_config).wrap_with_bank_forks_for_tests();
-        let bank = Bank::new_from_parent(bank, SlotLeader::default(), bank_slot);
+        let bank = Bank::new_from_parent_for_tests(bank, SlotLeader::default(), bank_slot);
 
         let rank_map = bank
             .epoch_stakes_from_slot(reward_slot)

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -632,7 +632,7 @@ mod test {
         let leader_forward_count = 1;
         let config = Config::default();
 
-        let root_bank = Bank::new_from_parent(
+        let root_bank = Bank::new_from_parent_for_tests(
             bank_forks.read().unwrap().working_bank(),
             SlotLeader::default(),
             1,
@@ -655,7 +655,8 @@ mod test {
             (transaction, signature)
         };
 
-        let working_child = Bank::new_from_parent(root_bank.clone(), SlotLeader::default(), 2);
+        let working_child =
+            Bank::new_from_parent_for_tests(root_bank.clone(), SlotLeader::default(), 2);
         let working_bank = bank_forks
             .write()
             .unwrap()
@@ -911,7 +912,7 @@ mod test {
         let leader_forward_count = 1;
         let config = Config::default();
 
-        let root_bank = Bank::new_from_parent(
+        let root_bank = Bank::new_from_parent_for_tests(
             bank_forks.read().unwrap().working_bank(),
             SlotLeader::default(),
             1,
@@ -943,7 +944,8 @@ mod test {
             AccountSharedData::new_data(43, &nonce_state, &system_program::id()).unwrap();
         root_bank.store_account(&nonce_address, &nonce_account);
 
-        let working_child = Bank::new_from_parent(root_bank.clone(), SlotLeader::default(), 2);
+        let working_child =
+            Bank::new_from_parent_for_tests(root_bank.clone(), SlotLeader::default(), 2);
         let working_bank = bank_forks
             .write()
             .unwrap()

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -326,7 +326,7 @@ mod tests {
 
         let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         bank.squash();
-        let bank = Bank::new_from_parent(bank, SlotLeader::new_unique(), 1);
+        let bank = Bank::new_from_parent_for_tests(bank, SlotLeader::new_unique(), 1);
         bank.set_sysvar_for_tests(&EpochRewards::default());
 
         let stake_rent = bank.get_minimum_balance_for_rent_exemption(StakeStateV2::size_of());

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -420,7 +420,11 @@ mod tests {
     #[test]
     fn test_marker_carryover_does_not_advance_last_tick_height() {
         let (genesis_config, bank0, _bank_forks, tx) = setup_test();
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent_for_tests(
+            bank0,
+            SlotLeader::default(),
+            1,
+        ));
         let (s, r) = unbounded();
         let max_tick = bank1.max_tick_height();
 
@@ -458,7 +462,11 @@ mod tests {
     #[test]
     fn test_marker_preserves_entry_ordering() {
         let (genesis_config, bank0, _bank_forks, tx) = setup_test();
-        let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent_for_tests(
+            bank0,
+            SlotLeader::default(),
+            1,
+        ));
         let (s, r) = unbounded();
 
         let mut last_hash = genesis_config.hash();

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -687,7 +687,11 @@ mod test {
         let (blockstore, genesis_config, cluster_info, bank0, leader_keypair, socket, bank_forks) =
             setup(num_shreds_per_slot);
 
-        let bank1 = Arc::new(Bank::new_from_parent(bank0.clone(), *bank0.leader(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent_for_tests(
+            bank0.clone(),
+            *bank0.leader(),
+            1,
+        ));
 
         // Insert 1 less than the number of ticks needed to finish the slot
         let ticks0 = create_ticks(genesis_config.ticks_per_slot - 1, 0, genesis_config.hash());
@@ -761,7 +765,7 @@ mod test {
 
         // Step 2: Make a transmission for another bank that interrupts the transmission for
         // slot 1
-        let bank2 = Arc::new(Bank::new_from_parent(bank1, *bank0.leader(), 2));
+        let bank2 = Arc::new(Bank::new_from_parent_for_tests(bank1, *bank0.leader(), 2));
         let interrupted_slot = standard_broadcast_run.slot;
         // Interrupting the slot should cause the unfinished_slot and stats to reset
         let num_shreds = 1;

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -3087,7 +3087,7 @@ mod tests {
         assert_eq!(bank.transaction_count(), expected_transaction_count.0);
 
         // Create new bank to observe behavior difference around session ending
-        let bank = Arc::new(Bank::new_from_parent(
+        let bank = Arc::new(Bank::new_from_parent_for_tests(
             bank.clone_without_scheduler(),
             SlotLeader::default(),
             bank.slot().checked_add(1).unwrap(),
@@ -3134,7 +3134,7 @@ mod tests {
         // Create two banks for two contexts
         let bank0 = Bank::new_for_tests(&genesis_config);
         let (bank0, _bank_forks) = setup_dummy_fork_graph(bank0);
-        let bank1 = Arc::new(Bank::new_from_parent(
+        let bank1 = Arc::new(Bank::new_from_parent_for_tests(
             bank0.clone(),
             SlotLeader::default(),
             bank0.slot().checked_add(1).unwrap(),
@@ -3352,7 +3352,7 @@ mod tests {
             bank.fill_bank_with_ticks_for_tests();
             bank.freeze();
             let slot = bank.slot();
-            bank = Arc::new(Bank::new_from_parent(
+            bank = Arc::new(Bank::new_from_parent_for_tests(
                 bank,
                 SlotLeader::default(),
                 slot.checked_add(1).unwrap(),

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -693,7 +693,7 @@ mod tests {
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_runtime::{
-            bank::{Bank, NewBankOptions, SlotLeader},
+            bank::{Bank, SlotLeader},
             bank_forks::BankForks,
             genesis_utils::{
                 ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
@@ -784,7 +784,7 @@ mod tests {
     }
 
     fn create_bank(slot: Slot, parent: Arc<Bank>, leader: SlotLeader) -> Bank {
-        Bank::new_from_parent_with_options(parent, leader, slot, NewBankOptions::default())
+        Bank::new_from_parent_for_tests(parent, leader, slot)
     }
 
     fn create_bank_forks(validator_keypairs: &[ValidatorVoteKeypairs]) -> Arc<RwLock<BankForks>> {

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1167,7 +1167,7 @@ mod tests {
         }
 
         fn create_block_only(&mut self, slot: Slot, parent_bank: Arc<Bank>) -> Arc<Bank> {
-            let bank = Bank::new_from_parent(parent_bank, SlotLeader::new_unique(), slot);
+            let bank = Bank::new_from_parent_for_tests(parent_bank, SlotLeader::new_unique(), slot);
             bank.set_block_id(Some(Hash::new_unique()));
             bank.freeze();
             let mut bank_forks_w = self.bank_forks.write().unwrap();

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -605,7 +605,7 @@ mod tests {
                 (authorized_voter, (stake as u64, vote_account))
             })
             .collect();
-        let mut new_bank = Bank::new_from_parent(bank, SlotLeader::default(), 1);
+        let mut new_bank = Bank::new_from_parent_for_tests(bank, SlotLeader::default(), 1);
         assert!(new_bank.epoch_stakes(2).is_none());
         let epoch2_epoch_stakes = VersionedEpochStakes::new_for_tests(vote_accounts_hash_map, 2);
         new_bank.set_epoch_stakes_for_test(2, epoch2_epoch_stakes);


### PR DESCRIPTION
Add `Bank::new_from_parent_for_tests` and `Bank::warp_from_parent_for_tests` that are DCOU-only.

These mirror the existing parent-construction paths but give tests an explicit API surface that can diverge from validator hot paths.

This is a preparatory change for https://github.com/anza-xyz/agave/pull/12284 which will use these helpers to hide test-only thread-pool setup and reduce churn in tests that create only a small number of banks.