### PR TITLE
ci: add channel-overrides file as single source of truth

### DIFF
--- a/ci/channel-overrides
+++ b/ci/channel-overrides
@@ -1,0 +1,5 @@
+# Channel override file consumed by ci/channel-info.sh.
+# Single source of truth: edit on master only, no backports.
+# Empty = auto-detect.
+PINNED_BETA_CHANNEL=
+PINNED_STABLE_CHANNEL=


### PR DESCRIPTION
#### Summary of Changes

Adds an empty `ci/channel-overrides` file. This is the prep step for the redesign of #12285 : a follow-up will rewrite `ci/channel-info.sh` to fetch this file from master via curl, so it lives in one place and never needs to be backported across branches.

Empty values keep current auto-detect behavior; no functional change in this PR.
