### PR TITLE
runtime: expose InvokeContext.pop

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -301,7 +301,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
     }
 
     /// Pop a stack frame from the invocation stack
-    pub(crate) fn pop(&mut self) -> Result<(), InstructionError> {
+    pub fn pop(&mut self) -> Result<(), InstructionError> {
         self.memory_contexts.pop();
         self.transaction_context.pop()
     }


### PR DESCRIPTION
#### Problem
`InvokeContext.pop` is not accessible outside the crate. Our fuzzing harnesses need to call this function, so as part of upstreaming the `solfuzz-agave` fuzzing harnesses this function needs to be public.

#### Summary of Changes
Change `InvokeContext.pop` from `pub(crate)` to `pub`.