### PR TITLE
startup: purge shreds w/ wrong shred version inclusive of WFSM slot

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2473,7 +2473,7 @@ fn should_cleanup_blockstore_incorrect_shred_versions(
     // Perform the check if we are booting as part of a cluster restart at slot root_slot
     let maybe_cluster_restart_slot = maybe_cluster_restart_with_hard_fork(config, root_slot);
     if maybe_cluster_restart_slot.is_some() {
-        return Ok(Some(root_slot + 1));
+        return Ok(Some(root_slot));
     }
 
     // If there are no hard forks, the shred version cannot have changed
@@ -2500,8 +2500,8 @@ fn should_cleanup_blockstore_incorrect_shred_versions(
         // This is the normal case where the last cluster restart & hard fork was a while ago; we
         // can skip the check for this case
         Ok(None)
-    } else if latest_hard_fork < blockstore_max_slot {
-        // blockstore_min_slot < latest_hard_fork < blockstore_max_slot
+    } else if latest_hard_fork <= blockstore_max_slot {
+        // blockstore_min_slot <= latest_hard_fork <= blockstore_max_slot
         //
         // This could be a case where there was a cluster restart, but this node was not part of
         // the supermajority that actually restarted the cluster. Rather, this node likely
@@ -2510,13 +2510,13 @@ fn should_cleanup_blockstore_incorrect_shred_versions(
         //
         // Note that the downloaded snapshot slot (root_slot) could be greater than the latest hard
         // fork slot. Even though this node will only replay slots after root_slot, start the check
-        // at latest_hard_fork + 1 to check (and possibly purge) any invalid state.
-        Ok(Some(latest_hard_fork + 1))
+        // at latest_hard_fork to check (and possibly purge) any invalid state.
+        Ok(Some(latest_hard_fork))
     } else {
-        // blockstore_min_slot <= blockstore_max_slot <= latest_hard_fork
+        // blockstore_min_slot <= blockstore_max_slot < latest_hard_fork
         //
         // All slots in the blockstore are older than the latest hard fork. The blockstore check
-        // would start from latest_hard_fork + 1; skip the check as there are no slots to check
+        // would start from latest_hard_fork; skip the check as there are no slots to check
         //
         // This is kind of an unusual case to hit, maybe a node has been offline for a long time
         // and just restarted with a new downloaded snapshot but the old blockstore
@@ -2961,7 +2961,7 @@ mod tests {
         let mut hard_forks = HardForks::default();
         let mut root_slot;
 
-        // Do check from root_slot + 1 if wait_for_supermajority (10) == root_slot (10)
+        // Do check from root_slot if wait_for_supermajority (10) == root_slot (10)
         root_slot = 10;
         validator_config.wait_for_supermajority = Some(root_slot);
         assert_eq!(
@@ -2972,7 +2972,7 @@ mod tests {
                 &hard_forks
             )
             .unwrap(),
-            Some(root_slot + 1)
+            Some(root_slot)
         );
 
         // No check if wait_for_supermajority (10) < root_slot (15) (no hard forks)
@@ -3003,8 +3003,34 @@ mod tests {
             None,
         );
 
-        // Insert some shreds at newer slots than hard fork
         let entries = entry::create_ticks(1, 0, Hash::default());
+
+        let exact_hard_fork_ledger_path = get_tmp_ledger_path_auto_delete!();
+        let exact_hard_fork_blockstore =
+            Blockstore::open(exact_hard_fork_ledger_path.path()).unwrap();
+        let exact_hard_fork_slot = 10;
+        let shreds = blockstore::entries_to_test_shreds(
+            &entries,
+            exact_hard_fork_slot,
+            exact_hard_fork_slot - 1,
+            true,
+            1,
+        );
+        exact_hard_fork_blockstore
+            .insert_shreds(shreds, None, true)
+            .unwrap();
+        assert_eq!(
+            should_cleanup_blockstore_incorrect_shred_versions(
+                &validator_config,
+                &exact_hard_fork_blockstore,
+                root_slot,
+                &hard_forks
+            )
+            .unwrap(),
+            Some(exact_hard_fork_slot),
+        );
+
+        // Insert some shreds at newer slots than hard fork
         for i in 20..35 {
             let shreds = blockstore::entries_to_test_shreds(
                 &entries,
@@ -3029,7 +3055,7 @@ mod tests {
         );
 
         // Emulate cluster restart at slot 25
-        // Do check from root_slot + 1 regardless of whether wait_for_supermajority set correctly
+        // Do check from root_slot regardless of whether wait_for_supermajority set correctly
         root_slot = 25;
         hard_forks.register(root_slot);
         validator_config.wait_for_supermajority = Some(root_slot);
@@ -3041,7 +3067,7 @@ mod tests {
                 &hard_forks
             )
             .unwrap(),
-            Some(root_slot + 1),
+            Some(root_slot),
         );
         validator_config.wait_for_supermajority = None;
         assert_eq!(
@@ -3052,11 +3078,11 @@ mod tests {
                 &hard_forks
             )
             .unwrap(),
-            Some(root_slot + 1),
+            Some(root_slot),
         );
 
         // Do check with advanced root slot, even without wait_for_supermajority set correctly
-        // Check starts from latest hard fork + 1
+        // Check starts from latest hard fork
         root_slot = 30;
         let latest_hard_fork = hard_forks.iter().last().unwrap().0;
         assert_eq!(
@@ -3067,7 +3093,7 @@ mod tests {
                 &hard_forks
             )
             .unwrap(),
-            Some(latest_hard_fork + 1),
+            Some(latest_hard_fork),
         );
 
         // Purge blockstore up to latest hard fork

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2135,6 +2135,8 @@ fn process_bank_0(
         err @ BlockstoreProcessorError::InvalidTransaction(_) => panic!("{err}"),
         _ => BlockstoreProcessorError::FailedToReplayBank0,
     })?;
+
+    bank0.set_block_id(blockstore.get_block_id(bank0.slot(), migration_status)?);
     bank0.freeze();
     if blockstore.is_primary_access() {
         blockstore.insert_bank_hash(bank0.slot(), bank0.hash(), false);


### PR DESCRIPTION
#### Problem
There is an issue related to how `SIMD-0340 validate chained block id` interacts with a WFSM cluster restart from a snapshot.

When performing this on the alpenglow community cluster we ran into the following issue during replay:
```
WARN  solana_ledger::blockstore_processor] Chained merkle root mismatch for slot 1 (parent 0): child chains to 11111111111111111111111111111111, but parent block ID is CQ7oqugg4WKFENMCLeSAREEQ7K3F1UiJQq7PJHM1ygh1
```

As a recap, SIMD-0340 verifies that the chained merkle root specified at the beginning of block `S` corresponds to the block id of `parent(S)`. This check is currently not enforced for the first block after a snapshot as shreds from the snapshot slot might not be available (or even exist in case of an artificial snapshot), and broadcast will default to using `111..11` in this case

In this setup we have the following:
- Slot 0 *does* have shreds from genesis on some nodes (Tim and I's  bootstrap nodes)
  ```
  Slot 0 (root)
     num_shreds: 32, parent_slot: Some(0), next_slots: [1, 174], num_entries: 64, is_full: true
   ```
- The block id of this slot is `CQ7oqugg4WKFENMCLeSAREEQ7K3F1UiJQq7PJHM1ygh1` the merkle root of the final shred
- Follower nodes *do not* have shreds for genesis
  ```
   Slot 0 (root)
  num_shreds: 0, parent_slot: None, next_slots: [], num_entries: 0, is_full: false
  ```
- Instead everyone has a snapshot on slot 0, which has block id equal to bank hash.
  ```
      block_id: Some(
        2pM9pWtQcWQY4MuRhvCtNpFjBDZMxeNyDsusY2xT8K49,
    )
  ```
- The reason this block id is different is because we erroneously do not set block id on slot 0. SIMD-0333 ensures that all snapshots (even artificial ones generated by ledger-tool) have a `block_id` field set. Thus it defaults to the bank hash.

This combination of things lead to the leader (not bootstrap node) building a block that chains to `111..11`. Normally this would be fine as we are restarting from a snapshot, however for Tim and I's node this genesis snapshot *also* had shreds in blockstore, so we were comparing this to `CQ7oqugg4WKFENMCLeSAREEQ7K3F1UiJQq7PJHM1ygh1` and failing.

(not critical) ensure that bank 0 has the block id set.
(critical) ensure that we do not have shreds for the WFSM slot when restarting from a snapshot

We should backport this fix before enabling SIMD-0340 as any cluster restart where we have outstanding shreds for the artificial snapshot slot is at risk.

Note: in the ag community cluster this would have only forked off Tim and I's node, however there was also a participant that panicked out of the gate and caused a WFSM false start.

#### Summary of Changes
Set the block id for bank 0 correctly
Do the startup purge of shreds inclusive of the hard forks slot, as a ledger-tool created snapshot could have a different block id than the shreds for that slot:
- E.g. suppose we create a ledger tool snapshot for an artificial bank at slot 5
- Startup will only purge from 6 onwards with incorrect shred version
- This means we will have conflicting shreds & snapshot for slot 5