### PR TITLE
Removes stake_minimum_delegation_for_rewards featurization

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -22,7 +22,6 @@ pub struct FeatureSnapshot {
     pub disable_fees_sysvar: bool,
     pub curve25519_syscall_enabled: bool,
     pub stake_raise_minimum_delegation_to_1_sol: bool,
-    pub stake_minimum_delegation_for_rewards: bool,
     pub disable_deploy_of_alloc_free_syscall: bool,
     pub increase_tx_account_lock_limit: bool,
     pub enable_bpf_loader_set_authority_checked_ix: bool,
@@ -98,9 +97,6 @@ impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
             curve25519_syscall_enabled: is_active(&curve25519_syscall_enabled::ID),
             stake_raise_minimum_delegation_to_1_sol: is_active(
                 &stake_raise_minimum_delegation_to_1_sol::ID,
-            ),
-            stake_minimum_delegation_for_rewards: is_active(
-                &stake_minimum_delegation_for_rewards::ID,
             ),
             disable_deploy_of_alloc_free_syscall: is_active(
                 &disable_deploy_of_alloc_free_syscall::ID,
@@ -735,10 +731,6 @@ pub mod require_static_program_ids_in_transaction {
 pub mod stake_raise_minimum_delegation_to_1_sol {
     // This is a feature-proposal *feature id*.  The feature keypair address is `GQXzC7YiSNkje6FFUk6sc2p53XRvKoaZ9VMktYzUMnpL`.
     solana_pubkey::declare_id!("9onWzzvCzNC2jfhxxeqRgs5q7nFAAKpCUvkj6T6GJK9i");
-}
-
-pub mod stake_minimum_delegation_for_rewards {
-    solana_pubkey::declare_id!("G6ANXD6ptCSyNd9znZm7j4dEczAJCfx7Cy43oBx3rKHJ");
 }
 
 pub mod add_set_compute_unit_price_ix {
@@ -1853,10 +1845,6 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             stake_raise_minimum_delegation_to_1_sol::id(),
             "Raise minimum stake delegation to 1.0 SOL #24357",
-        ),
-        (
-            stake_minimum_delegation_for_rewards::id(),
-            "stakes must be at least the minimum delegation to earn rewards",
         ),
         (
             add_set_compute_unit_price_ix::id(),

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -14,7 +14,6 @@ use {
         },
         reward_info::RewardInfo,
         stake_account::StakeAccount,
-        stake_utils,
         stakes::Stakes,
     },
     log::{debug, info},
@@ -25,7 +24,6 @@ use {
     solana_account::{ReadableAccount, WritableAccount},
     solana_clock::{Epoch, Slot},
     solana_measure::{measure::Measure, measure_us},
-    solana_native_token::LAMPORTS_PER_SOL,
     solana_pubkey::Pubkey,
     solana_reward_info::RewardType,
     solana_stake_interface::{stake_history::StakeHistory, state::Delegation},
@@ -394,16 +392,8 @@ impl Bank {
         &self,
         stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
     ) -> FilteredStakeDelegations<'a> {
-        let feature_snapshot = self.feature_set.snapshot();
-        let min_stake_delegation = if feature_snapshot.stake_minimum_delegation_for_rewards {
-            let min_stake_delegation = stake_utils::get_minimum_delegation(
-                feature_snapshot.upgrade_bpf_stake_program_to_v5,
-            )
-            .max(LAMPORTS_PER_SOL);
-            Some(min_stake_delegation)
-        } else {
-            None
-        };
+        // A future feature would set Some(..) here to enforce a minimum delegation for rewards.
+        let min_stake_delegation = None;
         FilteredStakeDelegations {
             stake_delegations,
             min_stake_delegation,


### PR DESCRIPTION
🚧 builds on https://github.com/anza-xyz/agave/pull/12349 🚧 

#### Problem

Given the significant speedup in epoch boundary crossing, combined with the new stake program that'll have a higher minimum delegation, and the fact that firedancer does not implement this feature, I think we should remove `stake_minimum_delegation_for_rewards`.


#### Summary of Changes

Remove `stake_minimum_delegation_for_rewards` featurization.

Note that this is the bare minimum. Further refactoring can be done on the FilteredStakeDelegations type/fns, but I purposely did not include those here.