### PR TITLE
ci(benchmark): drop sbf matrix entry

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,14 +45,6 @@ jobs:
               name: "solana-core",
               commands: ["cargo +$rust_nightly bench -p solana-core"],
             }
-          - {
-              name: "sbf",
-              before_command: "make -C programs/sbf all",
-              commands:
-                [
-                  "cargo +$rust_nightly bench --manifest-path programs/sbf/Cargo.toml --features=sbf_c",
-                ],
-            }
           # spliting solana-accounts-db because it includes criterion bench
           - {
               name: "solana-accounts-db",


### PR DESCRIPTION
#### Problem

`sbf` matrix entry is a no-op since #11267 removed `programs/sbf/benches/bpf_loader.rs` and its `[[bench]]` target. `cargo bench` finishes in 0.37s with zero benches; "Upload Result" pushes empty data to InfluxDB on every master merge.

Example: https://github.com/anza-xyz/agave/actions/runs/25493530372/job/74807325456

#### Summary of Changes

Remove the `sbf` matrix entry from `.github/workflows/benchmark.yml`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->