### PR TITLE
Unkeys stake_minimum_delegation_for_rewards

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -738,7 +738,7 @@ pub mod stake_raise_minimum_delegation_to_1_sol {
 }
 
 pub mod stake_minimum_delegation_for_rewards {
-    solana_pubkey::declare_id!("G6ANXD6ptCSyNd9znZm7j4dEczAJCfx7Cy43oBx3rKHJ");
+    solana_pubkey::declare_id!("MinimumDe1egat1onForRewardsWi11BeDe1eted111");
 }
 
 pub mod add_set_compute_unit_price_ix {


### PR DESCRIPTION
#### Problem

Given the significant speedup in epoch boundary crossing, combined with the new stake program that'll have a higher minimum delegation, and the fact that firedancer does not implement this feature, I think we should remove `stake_minimum_delegation_for_rewards`.


#### Summary of Changes

For this PR, we unkey the feature, and backport. This signals intent-to-remove, and keeps backport code to a minimum.