### PR TITLE
perf(fs): add explicit inlinable read_exact impl for io-uring reader

### DIFF
--- a/fs/src/io_uring/sequential_file_reader.rs
+++ b/fs/src/io_uring/sequential_file_reader.rs
@@ -431,6 +431,24 @@ impl<'a> Read for SequentialFileReader<'a> {
         self.state.consume_in_current_buf(bytes_to_read);
         Ok(bytes_to_read)
     }
+
+    #[inline]
+    fn read_exact(&mut self, mut buf: &mut [u8]) -> io::Result<()> {
+        while !buf.is_empty() {
+            if self.state.current_buf_remaining == 0 && !self.wait_current_buf_full()? {
+                return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "read_exact"));
+            }
+            let current_buf = self.ring.context().get_fast(self.state.current_buf_index);
+            let to_copy_len = buf.len().min(self.state.current_buf_remaining as usize);
+            let slice = current_buf.slice(self.state.current_buf_pos, to_copy_len as IoSize);
+            self.state.consume_in_current_buf(to_copy_len);
+            // Safety: to_copy_len is at most buf.len() checked with `min` above
+            let (to_fill, remaining) = unsafe { buf.split_at_mut_unchecked(to_copy_len) };
+            to_fill.copy_from_slice(slice);
+            buf = remaining;
+        }
+        Ok(())
+    }
 }
 
 impl<'a> BufRead for SequentialFileReader<'a> {
@@ -868,6 +886,12 @@ impl RingOp<BuffersState> for ReadOp {
 mod tests {
     use {super::*, std::io::Seek, tempfile::NamedTempFile};
 
+    fn write_test_pattern(num_bytes: usize, dst: &mut impl io::Write) -> Vec<u8> {
+        let pattern = (0..num_bytes).map(|i| i as u8).collect::<Vec<_>>();
+        io::Write::write_all(dst, &pattern).expect("must write prepared pattern");
+        pattern
+    }
+
     fn read_as_vec(mut reader: impl Read) -> Vec<u8> {
         let mut buf = Vec::new();
         reader.read_to_end(&mut buf).unwrap();
@@ -948,8 +972,7 @@ mod tests {
     fn test_non_registered_buffer_read() {
         let file_size = 64 * 1024;
         let mut temp_file = tempfile::NamedTempFile::new().unwrap();
-        let data = (0..).take(file_size).map(|v| v as u8).collect::<Vec<_>>();
-        io::Write::write_all(temp_file.as_file_mut(), &data).unwrap();
+        let data = write_test_pattern(file_size, &mut temp_file);
 
         let mut reader = SequentialFileReaderBuilder::new()
             .read_capacity(4 * 1024)
@@ -1033,9 +1056,8 @@ mod tests {
 
     #[test]
     fn test_get_offset() {
-        let pattern = (0..600).map(|i| i as u8).collect::<Vec<_>>();
         let mut temp1 = NamedTempFile::new().unwrap();
-        io::Write::write_all(&mut temp1, &pattern).unwrap();
+        write_test_pattern(600, &mut temp1);
 
         let mut reader = SequentialFileReaderBuilder::new()
             .read_capacity(512)
@@ -1068,9 +1090,8 @@ mod tests {
 
     #[test]
     fn test_consume_skip_filled_buf_len() {
-        let pattern = (0..6000).map(|i| i as u8).collect::<Vec<_>>();
         let mut temp1 = NamedTempFile::new().unwrap();
-        io::Write::write_all(&mut temp1, &pattern).unwrap();
+        let pattern = write_test_pattern(6000, &mut temp1);
 
         let mut reader = SequentialFileReaderBuilder::new()
             .read_capacity(512)
@@ -1160,5 +1181,40 @@ mod tests {
         reader.add_file_to_prefetch(temp2.as_file(), 4).unwrap();
         reader.move_to_next_file().unwrap();
         assert_eq!(read_as_vec(&mut reader), vec![0xd, 0xe, 0xf, 0x10]);
+    }
+
+    #[test]
+    fn test_read_exact() {
+        let mut temp1 = NamedTempFile::new().unwrap();
+        let pattern = write_test_pattern(6000, &mut temp1);
+
+        let mut reader = SequentialFileReaderBuilder::new()
+            .read_capacity(512)
+            .build(2048)
+            .unwrap();
+        reader.add_file_to_prefetch(temp1.as_file(), 6000).unwrap();
+
+        // Read within a single read_capacity chunk.
+        let mut buf = [0u8; 100];
+        reader.read_exact(&mut buf).unwrap();
+        assert_eq!(buf, pattern[..100]);
+
+        // Empty read is a no-op.
+        reader.read_exact(&mut []).unwrap();
+        assert_eq!(reader.get_file_offset(), 100);
+
+        // Read crossing multiple read_capacity boundaries.
+        let mut buf = vec![0u8; 2000];
+        reader.read_exact(&mut buf).unwrap();
+        assert_eq!(buf, pattern[100..2100]);
+
+        // Read remaining data exactly to EOF.
+        let mut buf = vec![0u8; 3900];
+        reader.read_exact(&mut buf).unwrap();
+        assert_eq!(buf, pattern[2100..6000]);
+
+        // Reading past EOF returns UnexpectedEof.
+        let err = reader.read_exact(&mut [0u8; 1]).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
     }
 }


### PR DESCRIPTION
#### Problem
io_uring `SequentialFileReader` provides `io::Read` implementation through `read` function, with other functions using library default impl from trait. 
When deserializing data using `wincode::io::std_read::ReadAdapter` lots of data points are read using `take_array` in a loop (e.g. when deserializing Vec of simple non-zero-copy structs) - `take_array` in the adapter calls `io::Read::read_exact`, the loop can currently inline `take_array`, but when `read_exact` is implemented using library default, it cannot inline it, which hurts performance due to extra function calls and because lots of checks are repeated for each call. 

#### Summary of Changes
Provide explicit `read_exact` implementation annotated with `#[inline]` such that when it is called in a loop through inlined `take_array`, the whole body can be inlined and compiler is able to optimize out checks in the hot path. 

This change brings performance of reading vectors of small structs (obsolete account map file) using `SequentialFileReader` quite close (65ms) to standard `BufReader` (50ms) when data is already in kernel buffer cache.  