### PR TITLE
fix(fs): set_file should rewind already read current file

### DIFF
--- a/fs/src/io_uring/sequential_file_reader.rs
+++ b/fs/src/io_uring/sequential_file_reader.rs
@@ -459,7 +459,9 @@ impl<'a> FileBufRead<'a> for SequentialFileReader<'a> {
         // but already partially consumed (so re-prefetching restarts at offset 0,
         // honoring the trait contract).
         while self.state.files.front().is_some_and(|file_state| {
-            !file_state.is_same_file(file) || self.state.current_offset > 0
+            !file_state.is_same_file(file)
+                || file_state.read_limit != read_limit
+                || self.state.current_offset > 0
         }) {
             self.move_to_next_file()?;
         }
@@ -1132,6 +1134,16 @@ mod tests {
         reader.set_file(temp2.as_file(), 4).unwrap();
         assert_eq!(reader.get_file_offset(), 0);
         assert_eq!(read_as_vec(&mut reader), vec![0xd, 0xe, 0xf, 0x10]);
+
+        // Re-setting the same file at offset 0 but with a different `read_limit`
+        // must also re-prefetch the file so the new limit takes effect.
+        reader.set_file(temp2.as_file(), 2).unwrap();
+        assert_eq!(reader.get_file_offset(), 0);
+        // Only `read_limit` differs from the front file (offset is still 0):
+        // this exercises the `read_limit` mismatch branch of `set_file`.
+        reader.set_file(temp2.as_file(), 3).unwrap();
+        assert_eq!(reader.get_file_offset(), 0);
+        assert_eq!(read_as_vec(&mut reader), vec![0xd, 0xe, 0xf]);
     }
 
     #[test]

--- a/fs/src/io_uring/sequential_file_reader.rs
+++ b/fs/src/io_uring/sequential_file_reader.rs
@@ -455,12 +455,12 @@ impl<'a> FileBufRead<'a> for SequentialFileReader<'a> {
     /// `read_limit` must be less than the file size if using direct io.
     /// See `add_owned_file_to_prefetch` for more details.
     fn set_file(&mut self, file: &'a File, read_limit: FileSize) -> io::Result<()> {
-        while self
-            .state
-            .files
-            .front()
-            .is_some_and(|file_state| !file_state.is_same_file(file))
-        {
+        // Pop the front file while it's a different file, or while it's the same file
+        // but already partially consumed (so re-prefetching restarts at offset 0,
+        // honoring the trait contract).
+        while self.state.files.front().is_some_and(|file_state| {
+            !file_state.is_same_file(file) || self.state.current_offset > 0
+        }) {
             self.move_to_next_file()?;
         }
         if self.state.files.is_empty() {
@@ -1126,6 +1126,11 @@ mod tests {
         assert_eq!(read_as_vec(&mut reader), vec![0xa, 0xb, 0xc]);
 
         reader.set_file(temp2.as_file(), 4).unwrap();
+        assert_eq!(read_as_vec(&mut reader), vec![0xd, 0xe, 0xf, 0x10]);
+
+        // Re-setting the same file after consuming it must rewind to offset 0.
+        reader.set_file(temp2.as_file(), 4).unwrap();
+        assert_eq!(reader.get_file_offset(), 0);
         assert_eq!(read_as_vec(&mut reader), vec![0xd, 0xe, 0xf, 0x10]);
     }
 


### PR DESCRIPTION
#### Problem
`FileBufRead::set_file` requires activating specified file and setting its offset / read position to 0. `SequentialFileReader::set_file` skips any other files from the front of prefetch queue, but if it finds the matching file it exists. 

This misses reset of state when `set_file` is called several times using the same file (after reading it) - an edge case scenario triggered in tests for new functionality to be added in other PR.

#### Summary of Changes
Drop current file even if it matches file from `set_file` parameter when current offset is non-zero. This is the simplest way to handle the case, the file is re-fetched. Each `move_to_next_file` resets the offset, so we still preserve prefetched file specified by `set_file` if front of the queue is a different (consumed or not) file.