### PR TITLE
Sets `bls_pubkey` on random vote accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11391,6 +11391,7 @@ dependencies = [
  "serde",
  "solana-account 4.3.0",
  "solana-bincode",
+ "solana-bls-signatures",
  "solana-clock",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9784,6 +9784,7 @@ dependencies = [
  "serde",
  "solana-account 4.3.0",
  "solana-bincode",
+ "solana-bls-signatures",
  "solana-clock",
  "solana-hash 4.3.0",
  "solana-instruction",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10096,6 +10096,7 @@ dependencies = [
  "serde",
  "solana-account 4.3.0",
  "solana-bincode",
+ "solana-bls-signatures",
  "solana-clock",
  "solana-hash 4.3.0",
  "solana-instruction",

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -18,7 +18,7 @@ name = "solana_vote"
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = ["dep:qualifier_attr", "dep:rand", "dep:bincode"]
+dev-context-only-utils = ["dep:qualifier_attr", "dep:rand", "dep:bincode", "dep:solana-bls-signatures"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
@@ -33,6 +33,7 @@ rand = { version = "0.9.4", optional = true }
 serde = { workspace = true, features = ["rc"] }
 solana-account = { workspace = true, features = ["bincode"] }
 solana-bincode = { workspace = true }
+solana-bls-signatures = { workspace = true, optional = true }
 solana-clock = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "dev-context-only-utils")]
-use qualifier_attr::field_qualifiers;
 use {
     crate::vote_state_view::VoteStateView,
     log::*,
@@ -20,6 +18,18 @@ use {
         sync::{Arc, OnceLock},
     },
     thiserror::Error,
+};
+#[cfg(feature = "dev-context-only-utils")]
+use {
+    qualifier_attr::field_qualifiers,
+    rand::Rng,
+    solana_bls_signatures::Keypair as BLSKeypair,
+    solana_clock::Clock,
+    solana_keypair::Keypair,
+    solana_signer::Signer,
+    solana_vote_interface::state::{
+        BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE, VoteInitV2, VoteStateV4, VoteStateVersions,
+    },
 };
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
@@ -100,20 +110,21 @@ impl VoteAccount {
 
     #[cfg(feature = "dev-context-only-utils")]
     pub fn new_random() -> VoteAccount {
-        use {
-            rand::Rng as _,
-            solana_clock::Clock,
-            solana_vote_interface::state::{VoteInit, VoteStateV4, VoteStateVersions},
-        };
+        const BLS_KEYPAIR_DERIVE_SEED: &[u8; 9] = b"alpenglow";
 
         let mut rng = rand::rng();
-        let vote_pubkey = Pubkey::new_unique();
-
-        let vote_init = VoteInit {
+        let authorized_voter_bls_proof_of_possession = [0; BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE];
+        let keypair = Keypair::new();
+        let bls_keypair =
+            BLSKeypair::derive_from_signer(&keypair, BLS_KEYPAIR_DERIVE_SEED).unwrap();
+        let vote_init = VoteInitV2 {
             node_pubkey: Pubkey::new_unique(),
-            authorized_voter: Pubkey::new_unique(),
+            authorized_voter: keypair.pubkey(),
+            authorized_voter_bls_pubkey: bls_keypair.public.to_bytes_compressed(),
+            authorized_voter_bls_proof_of_possession,
             authorized_withdrawer: Pubkey::new_unique(),
-            commission: rng.random(),
+            inflation_rewards_commission_bps: rng.random_range(0..10_000),
+            block_revenue_commission_bps: rng.random_range(0..10_000),
         };
         let clock = Clock {
             slot: rng.random(),
@@ -122,14 +133,18 @@ impl VoteAccount {
             leader_schedule_epoch: rng.random(),
             unix_timestamp: rng.random(),
         };
-        let vote_state = VoteStateV4::new_with_defaults(&vote_pubkey, &vote_init, &clock);
+        let vote_state = VoteStateV4::new(
+            &vote_init,
+            &Pubkey::new_unique(),
+            &Pubkey::new_unique(),
+            &clock,
+        );
         let account = AccountSharedData::new_data(
             rng.random(), // lamports
             &VoteStateVersions::new_v4(vote_state),
             &solana_sdk_ids::vote::id(), // owner
         )
         .unwrap();
-
         VoteAccount::try_from(account).unwrap()
     }
 }


### PR DESCRIPTION
#### Problem

To support developing new tests on https://github.com/anza-xyz/agave/pull/11780, we need the random `VoteAccount` to set a valid bls pubkey.


#### Summary of Changes

Updates `VoteAccount::new_random()` to add a bls pubkey.