### PR TITLE
perf(runtime): Add a new stakes cache implementation for faster epoch boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10262,6 +10262,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "imbl",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "libc",
  "libsecp256k1",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7961,6 +7961,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "imbl",
+ "indexmap",
  "itertools 0.14.0",
  "libc",
  "log",

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -227,6 +227,7 @@ pub fn parse_process_options(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -
     let log_messages_bytes_limit = value_t!(arg_matches, "log_messages_bytes_limit", usize).ok();
     let runtime_config = RuntimeConfig {
         log_messages_bytes_limit,
+        enable_stakes_cache_v2: arg_matches.is_present("enable_stakes_cache_v2"),
         ..RuntimeConfig::default()
     };
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -27,6 +27,7 @@ use {
     serde::Serialize,
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut},
     solana_clap_utils::{
+        hidden_unless_forced,
         input_parsers::{cluster_type_of, pubkey_of, pubkeys_of},
         input_validators::{
             is_parsable, is_pubkey, is_pubkey_or_keypair, is_slot, is_valid_percentage,
@@ -1137,6 +1138,12 @@ fn main() {
                 .arg(&allow_dead_slots_arg)
                 .arg(&debug_key_arg)
                 .arg(&geyser_plugin_args)
+                .arg(
+                    Arg::with_name("enable_stakes_cache_v2")
+                        .long("enable-stakes-cache-v2")
+                        .takes_value(false)
+                        .hidden(hidden_unless_forced()),
+                )
                 .arg(&log_messages_bytes_limit_arg)
                 .arg(
                     Arg::with_name("skip_poh_verify")

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -27,6 +27,7 @@ use {
     serde::Serialize,
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut},
     solana_clap_utils::{
+        hidden_unless_forced,
         input_parsers::{cluster_type_of, pubkey_of, pubkeys_of},
         input_validators::{
             is_parsable, is_pubkey, is_pubkey_or_keypair, is_slot, is_valid_percentage,
@@ -1127,6 +1128,12 @@ fn main() {
                 .arg(&allow_dead_slots_arg)
                 .arg(&debug_key_arg)
                 .arg(&geyser_plugin_args)
+                .arg(
+                    Arg::with_name("enable_stakes_cache_v2")
+                        .long("enable-stakes-cache-v2")
+                        .takes_value(false)
+                        .hidden(hidden_unless_forced()),
+                )
                 .arg(&log_messages_bytes_limit_arg)
                 .arg(
                     Arg::with_name("skip_poh_verify")

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8219,6 +8219,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "imbl",
+ "indexmap",
  "itertools 0.14.0",
  "libc",
  "log",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -80,6 +80,7 @@ crossbeam-channel = { workspace = true }
 crossbeam-utils = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api", "serde"] }
 imbl = { workspace = true, features = ["rayon", "serde"] }
+indexmap = { workspace = true, features = ["rayon"] }
 itertools = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -693,8 +693,8 @@ impl PartialEq for Bank {
                     .stake_delegation_frontier_query()
                     .expect("stakes cache v2 must exist");
                 self_stake_delegation_frontier
-                    .iter()
-                    .eq(other_stake_delegation_frontier.iter())
+                    .iter_unfiltered()
+                    .eq(other_stake_delegation_frontier.iter_unfiltered())
             }
             (None, None) => true,
             _ => false,
@@ -7160,7 +7160,7 @@ impl Bank {
     pub(crate) fn get_stake_accounts(&self, minimized_account_set: &DashSet<Pubkey>) {
         if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
             stake_delegation_frontier
-                .iter_some()
+                .iter_filtered()
                 .for_each(|(pubkey, _)| {
                     minimized_account_set.insert(*pubkey);
                 });

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -70,8 +70,10 @@ use {
             MaxAllowableDrift, calculate_stake_weighted_timestamp,
         },
         stakes::{
-            DelegatedStakes, DeserializableStakes, SerdeStakesToStakeFormat, Stakes, StakesCache,
+            DelegatedStakes, DeserializableStakes, SerdeStakesToStakeFormat, StakeDelegationsView,
+            Stakes, StakesCache,
         },
+        stakes_v2::StakesCacheV2,
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
@@ -632,6 +634,8 @@ impl PartialEq for Bank {
             epoch_schedule,
             inflation,
             stakes_cache,
+            // We check it by comparing stake delegation frontier queries.
+            stakes_cache_v2: _,
             epoch_stakes,
             is_delta,
             #[cfg(feature = "dev-context-only-utils")]
@@ -670,6 +674,21 @@ impl PartialEq for Bank {
             // Adding ".." will remove compile-time checks that if a new field
             // is added to the struct, this PartialEq is accordingly updated.
         } = self;
+        let stakes_cache_v2_eq = match (&self.stakes_cache_v2, &other.stakes_cache_v2) {
+            (Some(_), Some(_)) => {
+                let self_stake_delegation_frontier = self
+                    .stake_delegation_frontier_query()
+                    .expect("stakes cache v2 must exist");
+                let other_stake_delegation_frontier = other
+                    .stake_delegation_frontier_query()
+                    .expect("stakes cache v2 must exist");
+                self_stake_delegation_frontier
+                    .iter()
+                    .eq(other_stake_delegation_frontier.iter())
+            }
+            (None, None) => true,
+            _ => false,
+        };
         *blockhash_queue.read().unwrap() == *other.blockhash_queue.read().unwrap()
             && *max_processing_age == other.max_processing_age
             && *partitioned_rewards_stake_account_stores_per_block
@@ -697,6 +716,7 @@ impl PartialEq for Bank {
             && epoch_schedule == &other.epoch_schedule
             && *inflation.read().unwrap() == *other.inflation.read().unwrap()
             && *stakes_cache.stakes() == *other.stakes_cache.stakes()
+            && stakes_cache_v2_eq
             && epoch_stakes == &other.epoch_stakes
             && is_delta.load(Relaxed) == other.is_delta.load(Relaxed)
             // No deadlock is possible, when Arc::ptr_eq() returns false, because of being
@@ -924,6 +944,7 @@ pub struct Bank {
 
     /// cache of vote_account and stake_account state for this fork
     stakes_cache: StakesCache,
+    stakes_cache_v2: Option<StakesCacheV2>,
 
     /// staked nodes on epoch boundaries, saved off when a bank.slot() is at
     ///   a leader schedule calculation boundary
@@ -1206,6 +1227,7 @@ impl Bank {
             epoch_schedule: EpochSchedule::default(),
             inflation: Arc::<RwLock<Inflation>>::default(),
             stakes_cache: StakesCache::default(),
+            stakes_cache_v2: None,
             epoch_stakes: HashMap::<Epoch, VersionedEpochStakes>::default(),
             is_delta: AtomicBool::default(),
             rewards: RwLock::<Vec<(Pubkey, RewardInfo)>>::default(),
@@ -1296,6 +1318,12 @@ impl Bank {
         bank.process_genesis_config(genesis_config, leader_for_tests, genesis_hash);
 
         bank.compute_and_apply_genesis_features();
+
+        if runtime_config.enable_stakes_cache_v2 {
+            bank.stakes_cache_v2 = Some(StakesCacheV2::new_from_accounts_for_genesis(
+                genesis_config.accounts.iter(),
+            ));
+        }
 
         // genesis needs stakes for all epochs up to the epoch implied by
         //  slot = 0 and genesis configuration
@@ -1397,6 +1425,13 @@ impl Bank {
 
         let (stakes_cache, stakes_cache_time_us) =
             measure_us!(StakesCache::new(parent.stakes_cache.stakes().clone()));
+        let (stakes_cache_v2, stakes_cache_v2_time_us) = measure_us!(
+            parent
+                .stakes_cache_v2
+                .as_ref()
+                .map(StakesCacheV2::new_from_parent)
+        );
+        let stakes_cache_time_us = stakes_cache_time_us.saturating_add(stakes_cache_v2_time_us);
 
         let (epoch_stakes, epoch_stakes_time_us) = measure_us!(parent.epoch_stakes.clone());
 
@@ -1455,6 +1490,7 @@ impl Bank {
             entry_bytes_consumed: EntryBytesBudget::new(parent.entry_bytes_budget().slot_limit()),
             // we will .clone_with_epoch() this soon after stake data update; so just .clone() for now
             stakes_cache,
+            stakes_cache_v2,
             epoch_stakes,
             parent_hash: parent.hash(),
             parent_slot: parent.slot(),
@@ -1723,7 +1759,10 @@ impl Bank {
         // update vote accounts with warmed up stakes before saving a
         // snapshot of stakes in epoch stakes
         let stakes = self.stakes_cache.stakes();
-        let stake_delegations = stakes.stake_delegations_vec();
+        let stake_delegations = match self.stake_delegation_frontier_query() {
+            Some(frontier_query) => StakeDelegationsView::FrontierQuery(frontier_query),
+            None => StakeDelegationsView::Legacy(stakes.stake_delegations_vec()),
+        };
         let (
             (
                 stake_history,
@@ -1818,10 +1857,15 @@ impl Bank {
 
         self.stakes_cache.activate_epoch(
             epoch,
-            stake_history,
+            // Cheap clone of `Arc`. Can be removed once we fully switch to
+            // `StakesCacheV2`.
+            stake_history.clone(),
             unfiltered_distribution_vote_accounts,
             delegated_stakes,
         );
+        if let Some(stakes_cache_v2) = self.stakes_cache_v2.as_ref() {
+            stakes_cache_v2.activate_epoch(epoch, stake_history);
+        }
 
         // Save a snapshot of stakes for use in consensus and stake weighted networking
         let leader_schedule_epoch = self.epoch_schedule.get_leader_schedule_epoch(slot);
@@ -2031,6 +2075,18 @@ impl Bank {
         // Note that we are disabling the read cache while we populate the stakes cache.
         // The stakes accounts will not be expected to be loaded again.
         // If we populate the read cache with these loads, then we'll just soon have to evict these.
+        let stakes_cache_v2 = runtime_config.enable_stakes_cache_v2.then(|| {
+            StakesCacheV2::load_from_deserialized_delegations(fields.stakes.clone(), |pubkey| {
+                let (account, _slot) = bank_rc
+                    .accounts
+                    .load_with_fixed_root_do_not_populate_read_cache(&ancestors, pubkey)?;
+                Some(account)
+            })
+            .expect(
+                "Stakes cache v2 is inconsistent with accounts-db. This can indicate a corrupted \
+                 snapshot or bugs in cached accounts or accounts-db.",
+            )
+        });
         let (stakes, stakes_time) = measure_time!(
             Stakes::load_from_deserialized_delegations(fields.stakes, |pubkey| {
                 let (account, _slot) = bank_rc
@@ -2129,6 +2185,7 @@ impl Bank {
             ),
             epoch_schedule: fields.epoch_schedule,
             inflation: Arc::new(RwLock::new(fields.inflation)),
+            stakes_cache_v2,
             stakes_cache: StakesCache::new(stakes),
             epoch_stakes,
             is_delta: AtomicBool::new(fields.is_delta),
@@ -3097,6 +3154,15 @@ impl Bank {
     pub fn squash(&self) -> SquashTiming {
         self.freeze();
 
+        if let Some(stakes_cache_v2) = &self.stakes_cache_v2 {
+            let parent_banks = self.parents();
+            let rooted_stake_delegation_caches = parent_banks
+                .iter()
+                .rev()
+                .filter_map(|bank| bank.stakes_cache_v2.as_ref());
+            stakes_cache_v2.apply_rooted_stake_delegation_deltas(rooted_stake_delegation_caches);
+        }
+
         //this bank and all its parents are now on the rooted path
         let mut roots = Vec::with_capacity(self.ancestors.len());
         roots.push(self.slot());
@@ -3126,6 +3192,16 @@ impl Bank {
             squash_accounts_cache_ms: total_cache_us / 1000,
             squash_cache_ms: squash_cache_time.as_ms(),
         }
+    }
+
+    fn stake_delegation_frontier_query(&self) -> Option<crate::stakes_v2::FrontierQuery<'_>> {
+        let stakes_cache_v2 = self.stakes_cache_v2.as_ref()?;
+        let parent_banks = self.parents();
+        let caches = parent_banks
+            .iter()
+            .rev()
+            .filter_map(|bank| bank.stakes_cache_v2.as_ref());
+        Some(stakes_cache_v2.frontier_query(caches))
     }
 
     /// Return the more recent checkpoint of this bank instance.
@@ -4717,7 +4793,10 @@ impl Bank {
                     &account,
                     new_warmup_cooldown_rate_epoch,
                     use_fixed_point_stake_math,
-                )
+                );
+                if let Some(stakes_cache_v2) = self.stakes_cache_v2.as_ref() {
+                    stakes_cache_v2.check_and_store(account.pubkey(), &account);
+                }
             })
         });
         self.store_accounts_without_stakes_cache(accounts);
@@ -5726,6 +5805,9 @@ impl Bank {
                     new_warmup_cooldown_rate_epoch,
                     use_fixed_point_stake_math,
                 );
+                if let Some(stakes_cache_v2) = self.stakes_cache_v2.as_ref() {
+                    stakes_cache_v2.check_and_store(pubkey, account);
+                }
             });
     }
 
@@ -7061,13 +7143,19 @@ impl Bank {
 
     /// Get stake and stake node accounts
     pub(crate) fn get_stake_accounts(&self, minimized_account_set: &DashSet<Pubkey>) {
-        self.stakes_cache
-            .stakes()
-            .stake_delegations()
-            .iter()
-            .for_each(|(pubkey, _)| {
+        if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
+            stake_delegation_frontier.iter().for_each(|(pubkey, _)| {
                 minimized_account_set.insert(*pubkey);
             });
+        } else {
+            self.stakes_cache
+                .stakes()
+                .stake_delegations()
+                .iter()
+                .for_each(|(pubkey, _)| {
+                    minimized_account_set.insert(*pubkey);
+                });
+        }
 
         self.stakes_cache
             .stakes()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7144,9 +7144,11 @@ impl Bank {
     /// Get stake and stake node accounts
     pub(crate) fn get_stake_accounts(&self, minimized_account_set: &DashSet<Pubkey>) {
         if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
-            stake_delegation_frontier.iter().for_each(|(pubkey, _)| {
-                minimized_account_set.insert(*pubkey);
-            });
+            stake_delegation_frontier
+                .iter_some()
+                .for_each(|(pubkey, _)| {
+                    minimized_account_set.insert(*pubkey);
+                });
         } else {
             self.stakes_cache
                 .stakes()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -279,26 +279,26 @@ pub type BankSlotDelta = SlotDelta<Result<()>>;
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
 pub struct SquashTiming {
-    pub squash_accounts_ms: u64,
-    pub squash_accounts_cache_ms: u64,
-    pub squash_accounts_cache_v2_ms: Option<u64>,
-    pub squash_cache_ms: u64,
+    pub squash_accounts_us: u64,
+    pub squash_accounts_cache_us: u64,
+    pub squash_accounts_cache_v2_us: Option<u64>,
+    pub squash_cache_us: u64,
 }
 
 impl AddAssign for SquashTiming {
     fn add_assign(&mut self, rhs: Self) {
-        self.squash_accounts_ms += rhs.squash_accounts_ms;
-        self.squash_accounts_cache_ms += rhs.squash_accounts_cache_ms;
-        self.squash_accounts_cache_v2_ms = match (
-            self.squash_accounts_cache_v2_ms,
-            rhs.squash_accounts_cache_v2_ms,
+        self.squash_accounts_us += rhs.squash_accounts_us;
+        self.squash_accounts_cache_us += rhs.squash_accounts_cache_us;
+        self.squash_accounts_cache_v2_us = match (
+            self.squash_accounts_cache_v2_us,
+            rhs.squash_accounts_cache_v2_us,
         ) {
             (Some(lhs), Some(rhs)) => Some(lhs + rhs),
             (Some(lhs), None) => Some(lhs),
             (None, Some(rhs)) => Some(rhs),
             (None, None) => None,
         };
-        self.squash_cache_ms += rhs.squash_cache_ms;
+        self.squash_cache_us += rhs.squash_cache_us;
     }
 }
 
@@ -3193,7 +3193,7 @@ impl Bank {
     pub fn squash(&self) -> SquashTiming {
         self.freeze();
 
-        let squash_accounts_cache_v2_ms = self.stakes_cache_v2.as_ref().map(|stakes_cache_v2| {
+        let squash_accounts_cache_v2_us = self.stakes_cache_v2.as_ref().map(|stakes_cache_v2| {
             let squash_cache_v2_time = Measure::start("squash_cache_v2_time");
             let parent_banks = self.parents();
             let rooted_stake_delegation_caches = parent_banks
@@ -3201,7 +3201,7 @@ impl Bank {
                 .rev()
                 .filter_map(|bank| bank.stakes_cache_v2.as_ref());
             stakes_cache_v2.apply_rooted_stake_delegation_deltas(rooted_stake_delegation_caches);
-            squash_cache_v2_time.end_as_ms()
+            squash_cache_v2_time.end_as_us()
         });
 
         //this bank and all its parents are now on the rooted path
@@ -3229,10 +3229,10 @@ impl Bank {
         squash_cache_time.stop();
 
         SquashTiming {
-            squash_accounts_ms: squash_accounts_time.as_ms(),
-            squash_accounts_cache_ms: total_cache_us / 1000,
-            squash_accounts_cache_v2_ms,
-            squash_cache_ms: squash_cache_time.as_ms(),
+            squash_accounts_us: squash_accounts_time.as_us(),
+            squash_accounts_cache_us: total_cache_us,
+            squash_accounts_cache_v2_us,
+            squash_cache_us: squash_cache_time.as_us(),
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -69,7 +69,11 @@ use {
             MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST, MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2,
             MaxAllowableDrift, calculate_stake_weighted_timestamp,
         },
-        stakes::{DeserializableStakes, SerdeStakesToStakeFormat, Stakes, StakesCache},
+        stakes::{
+            DeserializableStakes, SerdeStakesToStakeFormat, StakeDelegationsView, Stakes,
+            StakesCache,
+        },
+        stakes_v2::StakesCacheV2,
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
@@ -622,6 +626,8 @@ impl PartialEq for Bank {
             epoch_schedule,
             inflation,
             stakes_cache,
+            // We check it by comparing stake delegation frontier queries.
+            stakes_cache_v2: _,
             epoch_stakes,
             is_delta,
             #[cfg(feature = "dev-context-only-utils")]
@@ -660,6 +666,21 @@ impl PartialEq for Bank {
             // Adding ".." will remove compile-time checks that if a new field
             // is added to the struct, this PartialEq is accordingly updated.
         } = self;
+        let stakes_cache_v2_eq = match (&self.stakes_cache_v2, &other.stakes_cache_v2) {
+            (Some(_), Some(_)) => {
+                let self_stake_delegation_frontier = self
+                    .stake_delegation_frontier_query()
+                    .expect("stakes cache v2 must exist");
+                let other_stake_delegation_frontier = other
+                    .stake_delegation_frontier_query()
+                    .expect("stakes cache v2 must exist");
+                self_stake_delegation_frontier
+                    .iter()
+                    .eq(other_stake_delegation_frontier.iter())
+            }
+            (None, None) => true,
+            _ => false,
+        };
         *blockhash_queue.read().unwrap() == *other.blockhash_queue.read().unwrap()
             && *max_processing_age == other.max_processing_age
             && *partitioned_rewards_stake_account_stores_per_block
@@ -687,6 +708,7 @@ impl PartialEq for Bank {
             && epoch_schedule == &other.epoch_schedule
             && *inflation.read().unwrap() == *other.inflation.read().unwrap()
             && *stakes_cache.stakes() == *other.stakes_cache.stakes()
+            && stakes_cache_v2_eq
             && epoch_stakes == &other.epoch_stakes
             && is_delta.load(Relaxed) == other.is_delta.load(Relaxed)
             // No deadlock is possible, when Arc::ptr_eq() returns false, because of being
@@ -913,6 +935,7 @@ pub struct Bank {
 
     /// cache of vote_account and stake_account state for this fork
     stakes_cache: StakesCache,
+    stakes_cache_v2: Option<StakesCacheV2>,
 
     /// staked nodes on epoch boundaries, saved off when a bank.slot() is at
     ///   a leader schedule calculation boundary
@@ -1198,6 +1221,7 @@ impl Bank {
             epoch_schedule: EpochSchedule::default(),
             inflation: Arc::<RwLock<Inflation>>::default(),
             stakes_cache: StakesCache::default(),
+            stakes_cache_v2: None,
             epoch_stakes: HashMap::<Epoch, VersionedEpochStakes>::default(),
             is_delta: AtomicBool::default(),
             rewards: RwLock::<Vec<(Pubkey, RewardInfo)>>::default(),
@@ -1288,6 +1312,12 @@ impl Bank {
         bank.process_genesis_config(genesis_config, leader_for_tests, genesis_hash);
 
         bank.compute_and_apply_genesis_features();
+
+        if runtime_config.enable_stakes_cache_v2 {
+            bank.stakes_cache_v2 = Some(StakesCacheV2::new_from_accounts_for_genesis(
+                genesis_config.accounts.iter(),
+            ));
+        }
 
         // genesis needs stakes for all epochs up to the epoch implied by
         //  slot = 0 and genesis configuration
@@ -1386,6 +1416,13 @@ impl Bank {
 
         let (stakes_cache, stakes_cache_time_us) =
             measure_us!(StakesCache::new(parent.stakes_cache.stakes().clone()));
+        let (stakes_cache_v2, stakes_cache_v2_time_us) = measure_us!(
+            parent
+                .stakes_cache_v2
+                .as_ref()
+                .map(StakesCacheV2::new_from_parent)
+        );
+        let stakes_cache_time_us = stakes_cache_time_us.saturating_add(stakes_cache_v2_time_us);
 
         let (epoch_stakes, epoch_stakes_time_us) = measure_us!(parent.epoch_stakes.clone());
 
@@ -1444,6 +1481,7 @@ impl Bank {
             entry_bytes_consumed: EntryBytesBudget::new(parent.entry_bytes_budget().slot_limit()),
             // we will .clone_with_epoch() this soon after stake data update; so just .clone() for now
             stakes_cache,
+            stakes_cache_v2,
             epoch_stakes,
             parent_hash: parent.hash(),
             parent_slot: parent.slot(),
@@ -1730,7 +1768,10 @@ impl Bank {
         // update vote accounts with warmed up stakes before saving a
         // snapshot of stakes in epoch stakes
         let stakes = self.stakes_cache.stakes();
-        let stake_delegations = stakes.stake_delegations_vec();
+        let stake_delegations = match self.stake_delegation_frontier_query() {
+            Some(frontier_query) => StakeDelegationsView::FrontierQuery(frontier_query),
+            None => StakeDelegationsView::Legacy(stakes.stake_delegations_vec()),
+        };
         let (
             (stake_history, unfiltered_distribution_vote_accounts),
             calculate_activated_stake_time_us,
@@ -1809,9 +1850,14 @@ impl Bank {
 
         self.stakes_cache.activate_epoch(
             epoch,
-            stake_history,
+            // Cheap clone of `Arc`. Can be removed once we fully switch to
+            // `StakesCacheV2`.
+            stake_history.clone(),
             unfiltered_distribution_vote_accounts,
         );
+        if let Some(stakes_cache_v2) = self.stakes_cache_v2.as_ref() {
+            stakes_cache_v2.activate_epoch(epoch, stake_history);
+        }
 
         // Save a snapshot of stakes for use in consensus and stake weighted networking
         let leader_schedule_epoch = self.epoch_schedule.get_leader_schedule_epoch(slot);
@@ -2043,6 +2089,18 @@ impl Bank {
         // Note that we are disabling the read cache while we populate the stakes cache.
         // The stakes accounts will not be expected to be loaded again.
         // If we populate the read cache with these loads, then we'll just soon have to evict these.
+        let stakes_cache_v2 = runtime_config.enable_stakes_cache_v2.then(|| {
+            StakesCacheV2::load_from_deserialized_delegations(fields.stakes.clone(), |pubkey| {
+                let (account, _slot) = bank_rc
+                    .accounts
+                    .load_with_fixed_root_do_not_populate_read_cache(&ancestors, pubkey)?;
+                Some(account)
+            })
+            .expect(
+                "Stakes cache v2 is inconsistent with accounts-db. This can indicate a corrupted \
+                 snapshot or bugs in cached accounts or accounts-db.",
+            )
+        });
         let (stakes, stakes_time) = measure_time!(
             Stakes::load_from_deserialized_delegations(fields.stakes, |pubkey| {
                 let (account, _slot) = bank_rc
@@ -2141,6 +2199,7 @@ impl Bank {
             ),
             epoch_schedule: fields.epoch_schedule,
             inflation: Arc::new(RwLock::new(fields.inflation)),
+            stakes_cache_v2,
             stakes_cache: StakesCache::new(stakes),
             epoch_stakes,
             is_delta: AtomicBool::new(fields.is_delta),
@@ -3071,6 +3130,15 @@ impl Bank {
     pub fn squash(&self) -> SquashTiming {
         self.freeze();
 
+        if let Some(stakes_cache_v2) = &self.stakes_cache_v2 {
+            let parent_banks = self.parents();
+            let rooted_stake_delegation_caches = parent_banks
+                .iter()
+                .rev()
+                .filter_map(|bank| bank.stakes_cache_v2.as_ref());
+            stakes_cache_v2.apply_rooted_stake_delegation_deltas(rooted_stake_delegation_caches);
+        }
+
         //this bank and all its parents are now on the rooted path
         let mut roots = vec![self.slot()];
         roots.append(&mut self.parents().iter().map(|p| p.slot()).collect());
@@ -3101,6 +3169,16 @@ impl Bank {
             squash_accounts_cache_ms: total_cache_us / 1000,
             squash_cache_ms: squash_cache_time.as_ms(),
         }
+    }
+
+    fn stake_delegation_frontier_query(&self) -> Option<crate::stakes_v2::FrontierQuery<'_>> {
+        let stakes_cache_v2 = self.stakes_cache_v2.as_ref()?;
+        let parent_banks = self.parents();
+        let caches = parent_banks
+            .iter()
+            .rev()
+            .filter_map(|bank| bank.stakes_cache_v2.as_ref());
+        Some(stakes_cache_v2.frontier_query(caches))
     }
 
     /// Return the more recent checkpoint of this bank instance.
@@ -4669,7 +4747,10 @@ impl Bank {
                     &account,
                     new_warmup_cooldown_rate_epoch,
                     use_fixed_point_stake_math,
-                )
+                );
+                if let Some(stakes_cache_v2) = self.stakes_cache_v2.as_ref() {
+                    stakes_cache_v2.check_and_store(account.pubkey(), &account);
+                }
             })
         });
         self.store_accounts_without_stakes_cache(accounts);
@@ -5709,6 +5790,9 @@ impl Bank {
                     new_warmup_cooldown_rate_epoch,
                     use_fixed_point_stake_math,
                 );
+                if let Some(stakes_cache_v2) = self.stakes_cache_v2.as_ref() {
+                    stakes_cache_v2.check_and_store(pubkey, account);
+                }
             });
     }
 
@@ -7077,13 +7161,19 @@ impl Bank {
 
     /// Get stake and stake node accounts
     pub(crate) fn get_stake_accounts(&self, minimized_account_set: &DashSet<Pubkey>) {
-        self.stakes_cache
-            .stakes()
-            .stake_delegations()
-            .iter()
-            .for_each(|(pubkey, _)| {
+        if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
+            stake_delegation_frontier.iter().for_each(|(pubkey, _)| {
                 minimized_account_set.insert(*pubkey);
             });
+        } else {
+            self.stakes_cache
+                .stakes()
+                .stake_delegations()
+                .iter()
+                .for_each(|(pubkey, _)| {
+                    minimized_account_set.insert(*pubkey);
+                });
+        }
 
         self.stakes_cache
             .stakes()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7162,9 +7162,11 @@ impl Bank {
     /// Get stake and stake node accounts
     pub(crate) fn get_stake_accounts(&self, minimized_account_set: &DashSet<Pubkey>) {
         if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
-            stake_delegation_frontier.iter().for_each(|(pubkey, _)| {
-                minimized_account_set.insert(*pubkey);
-            });
+            stake_delegation_frontier
+                .iter_some()
+                .for_each(|(pubkey, _)| {
+                    minimized_account_set.insert(*pubkey);
+                });
         } else {
             self.stakes_cache
                 .stakes()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3179,7 +3179,7 @@ impl Bank {
                 .rev()
                 .filter_map(|bank| bank.stakes_cache_v2.as_ref());
             stakes_cache_v2.apply_rooted_stake_delegation_deltas(rooted_stake_delegation_caches);
-            squash_cache_v2_time.end_as_us()
+            squash_cache_v2_time.end_as_ms()
         });
 
         //this bank and all its parents are now on the rooted path

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -92,7 +92,7 @@ use {
     ahash::AHashSet,
     log::*,
     partitioned_epoch_rewards::PartitionedRewardsCalculation,
-    rayon::ThreadPool,
+    rayon::{ThreadPool, iter::ParallelIterator},
     serde::{Deserialize, Serialize},
     solana_account::{
         Account, AccountSharedData, InheritableAccountFields, ReadableAccount, WritableAccount,
@@ -223,7 +223,7 @@ use {
 use {
     dashmap::DashSet,
     qualifier_attr::{field_qualifiers, qualifiers},
-    rayon::iter::{IntoParallelRefIterator, ParallelIterator},
+    rayon::iter::IntoParallelRefIterator,
     solana_accounts_db::accounts_db::{
         ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
     },
@@ -2117,6 +2117,28 @@ impl Bank {
             )
         );
         info!("Loading Stakes took: {stakes_time}");
+        if let Some(stakes_cache_v2) = &stakes_cache_v2 {
+            let stake_delegation_frontier = stakes_cache_v2.frontier_query([]);
+            let stake_delegations = stakes.stake_delegations();
+            assert_eq!(
+                stake_delegation_frontier.len_filtered(),
+                stake_delegations.len(),
+                "stake cache v2 snapshot delegation count differs from stake cache v1",
+            );
+            stake_delegation_frontier
+                .par_iter_filtered()
+                .for_each(|(pubkey, stake_account)| {
+                    let cached_stake_account = stake_delegations.get(pubkey).unwrap_or_else(|| {
+                        panic!(
+                            "stake cache v2 snapshot entry {pubkey} is missing from stake cache v1"
+                        )
+                    });
+                    assert_eq!(
+                        stake_account, cached_stake_account,
+                        "stake cache v2 snapshot entry {pubkey} differs from stake cache v1",
+                    );
+                });
+        }
         assert!(
             fields.versioned_epoch_stakes.is_empty(),
             "should be already converted and passed in epoch_stakes parameter"

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2086,16 +2086,21 @@ impl Bank {
         // The stakes accounts will not be expected to be loaded again.
         // If we populate the read cache with these loads, then we'll just soon have to evict these.
         let stakes_cache_v2 = runtime_config.enable_stakes_cache_v2.then(|| {
-            let (stakes_cache_v2, stakes_time) = measure_time!(StakesCacheV2::load_from_deserialized_delegations(fields.stakes.clone(), |pubkey| {
-                let (account, _slot) = bank_rc
-                    .accounts
-                    .load_with_fixed_root_do_not_populate_read_cache(&ancestors, pubkey)?;
-                Some(account)
-            })
-            .expect(
-                "Stakes cache v2 is inconsistent with accounts-db. This can indicate a corrupted \
-                 snapshot or bugs in cached accounts or accounts-db.",
-            ));
+            let (stakes_cache_v2, stakes_time) = measure_time!(
+                StakesCacheV2::load_from_deserialized_delegations(
+                    fields.stakes.clone(),
+                    |pubkey| {
+                        let (account, _slot) = bank_rc
+                            .accounts
+                            .load_with_fixed_root_do_not_populate_read_cache(&ancestors, pubkey)?;
+                        Some(account)
+                    }
+                )
+                .expect(
+                    "Stakes cache v2 is inconsistent with accounts-db. This can indicate a \
+                     corrupted snapshot or bugs in cached accounts or accounts-db.",
+                )
+            );
             info!("Loading Stakes cache v2 took: {stakes_time}");
             stakes_cache_v2
         });

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -281,6 +281,7 @@ pub type BankSlotDelta = SlotDelta<Result<()>>;
 pub struct SquashTiming {
     pub squash_accounts_ms: u64,
     pub squash_accounts_cache_ms: u64,
+    pub squash_accounts_cache_v2_ms: Option<u64>,
     pub squash_cache_ms: u64,
 }
 
@@ -288,6 +289,15 @@ impl AddAssign for SquashTiming {
     fn add_assign(&mut self, rhs: Self) {
         self.squash_accounts_ms += rhs.squash_accounts_ms;
         self.squash_accounts_cache_ms += rhs.squash_accounts_cache_ms;
+        self.squash_accounts_cache_v2_ms = match (
+            self.squash_accounts_cache_v2_ms,
+            rhs.squash_accounts_cache_v2_ms,
+        ) {
+            (Some(lhs), Some(rhs)) => Some(lhs + rhs),
+            (Some(lhs), None) => Some(lhs),
+            (None, Some(rhs)) => Some(rhs),
+            (None, None) => None,
+        };
         self.squash_cache_ms += rhs.squash_cache_ms;
     }
 }
@@ -2076,7 +2086,7 @@ impl Bank {
         // The stakes accounts will not be expected to be loaded again.
         // If we populate the read cache with these loads, then we'll just soon have to evict these.
         let stakes_cache_v2 = runtime_config.enable_stakes_cache_v2.then(|| {
-            StakesCacheV2::load_from_deserialized_delegations(fields.stakes.clone(), |pubkey| {
+            let (stakes_cache_v2, stakes_time) = measure_time!(StakesCacheV2::load_from_deserialized_delegations(fields.stakes.clone(), |pubkey| {
                 let (account, _slot) = bank_rc
                     .accounts
                     .load_with_fixed_root_do_not_populate_read_cache(&ancestors, pubkey)?;
@@ -2085,7 +2095,9 @@ impl Bank {
             .expect(
                 "Stakes cache v2 is inconsistent with accounts-db. This can indicate a corrupted \
                  snapshot or bugs in cached accounts or accounts-db.",
-            )
+            ));
+            info!("Loading Stakes cache v2 took: {stakes_time}");
+            stakes_cache_v2
         });
         let (stakes, stakes_time) = measure_time!(
             Stakes::load_from_deserialized_delegations(fields.stakes, |pubkey| {
@@ -3154,14 +3166,16 @@ impl Bank {
     pub fn squash(&self) -> SquashTiming {
         self.freeze();
 
-        if let Some(stakes_cache_v2) = &self.stakes_cache_v2 {
+        let squash_accounts_cache_v2_ms = self.stakes_cache_v2.as_ref().map(|stakes_cache_v2| {
+            let squash_cache_v2_time = Measure::start("squash_cache_v2_time");
             let parent_banks = self.parents();
             let rooted_stake_delegation_caches = parent_banks
                 .iter()
                 .rev()
                 .filter_map(|bank| bank.stakes_cache_v2.as_ref());
             stakes_cache_v2.apply_rooted_stake_delegation_deltas(rooted_stake_delegation_caches);
-        }
+            squash_cache_v2_time.end_as_us()
+        });
 
         //this bank and all its parents are now on the rooted path
         let mut roots = Vec::with_capacity(self.ancestors.len());
@@ -3190,6 +3204,7 @@ impl Bank {
         SquashTiming {
             squash_accounts_ms: squash_accounts_time.as_ms(),
             squash_accounts_cache_ms: total_cache_us / 1000,
+            squash_accounts_cache_v2_ms,
             squash_cache_ms: squash_cache_time.as_ms(),
         }
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7164,9 +7164,25 @@ impl Bank {
     /// Get stake and stake node accounts
     pub(crate) fn get_stake_accounts(&self, minimized_account_set: &DashSet<Pubkey>) {
         if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
+            let stakes = self.stakes_cache.stakes();
+            let stake_delegations = stakes.stake_delegations();
+            assert_eq!(
+                stake_delegation_frontier.len_filtered(),
+                stake_delegations.len(),
+                "stake cache v2 frontier delegation count differs from stake cache v1",
+            );
             stake_delegation_frontier
                 .iter_filtered()
-                .for_each(|(pubkey, _)| {
+                .for_each(|(pubkey, stake_account)| {
+                    let cached_stake_account = stake_delegations.get(pubkey).unwrap_or_else(|| {
+                        panic!(
+                            "stake cache v2 frontier entry {pubkey} is missing from stake cache v1"
+                        )
+                    });
+                    assert_eq!(
+                        stake_account, cached_stake_account,
+                        "stake cache v2 frontier entry {pubkey} differs from stake cache v1",
+                    );
                     minimized_account_set.insert(*pubkey);
                 });
         } else {

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -21,7 +21,7 @@ use {
         },
         reward_info::RewardInfo,
         stake_account::StakeAccount,
-        stakes::Stakes,
+        stakes::{StakeDelegationsView, Stakes},
     },
     log::{debug, info},
     rayon::{
@@ -218,10 +218,10 @@ impl Bank {
     }
 
     // Calculate rewards from previous epoch and distribute reward commissions
-    pub(in crate::bank) fn calculate_rewards(
+    pub(in crate::bank) fn calculate_rewards<'a>(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: Vec<(&Pubkey, &StakeAccount<Delegation>)>,
+        stake_delegations: StakeDelegationsView<'a>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         reward_calc_tracer: Option<impl Fn(&RewardCalculationEvent) + Send + Sync>,
@@ -282,6 +282,7 @@ impl Bank {
             stake_rewards,
             capitalization,
             point_value,
+            num_stake_accounts,
             num_filtered_vote_accounts,
             ..
         } = rewards_calculation;
@@ -333,14 +334,20 @@ impl Bank {
             total_stake_rewards_lamports
         );
 
-        let num_stake_accounts = self.stakes_cache.stakes().stake_delegations().len();
         let num_vote_accounts = *num_filtered_vote_accounts;
         self.capitalization.fetch_add(
             distributed_lamports + distributed_to_incinerator_lamports,
             Relaxed,
         );
 
-        let active_stake = if let Some(stake_history_entry) =
+        let active_stake = if let Some(stakes_cache_v2) = self.stakes_cache_v2.as_ref() {
+            stakes_cache_v2
+                .state()
+                .stake_history()
+                .get(prev_epoch)
+                .map(|stake_history_entry| stake_history_entry.effective)
+                .unwrap_or(0)
+        } else if let Some(stake_history_entry) =
             self.stakes_cache.stakes().history().get(prev_epoch)
         {
             stake_history_entry.effective
@@ -362,7 +369,7 @@ impl Bank {
             ("active_stake", active_stake, i64),
             ("pre_capitalization", *capitalization, i64),
             ("post_capitalization", self.capitalization(), i64),
-            ("num_stake_accounts", num_stake_accounts, i64),
+            ("num_stake_accounts", *num_stake_accounts, i64),
             ("num_vote_accounts", num_vote_accounts, i64),
         );
 
@@ -391,7 +398,7 @@ impl Bank {
     pub(super) fn calculate_rewards_for_partitioning<'a>(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+        stake_delegations: StakeDelegationsView<'a>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         reward_calc_tracer: Option<impl Fn(&RewardCalculationEvent) + Send + Sync>,
@@ -401,6 +408,7 @@ impl Bank {
         let capitalization = self.capitalization();
         let epoch_inflation_rewards =
             self.calculate_epoch_inflation_rewards(capitalization, rewarded_epoch);
+        let num_stake_accounts = stake_delegations.len();
         // `distribution_epoch_vote_accounts` is the post-VAT-filter snapshot
         // produced upstream of this call (or unfiltered when VAT is off),
         // so its length is the right value for the `epoch_rewards` metric.
@@ -414,7 +422,7 @@ impl Bank {
         } = self
             .calculate_validator_rewards(
                 stake_history,
-                stake_delegations,
+                &stake_delegations,
                 cached_vote_accounts,
                 rewarded_epoch,
                 epoch_inflation_rewards,
@@ -434,6 +442,7 @@ impl Bank {
             stake_rewards,
             capitalization,
             point_value,
+            num_stake_accounts,
             num_filtered_vote_accounts,
         }
     }
@@ -442,7 +451,7 @@ impl Bank {
     fn calculate_validator_rewards<'a>(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+        stake_delegations: &StakeDelegationsView<'a>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         epoch_inflation_rewards: u64,
@@ -453,7 +462,7 @@ impl Bank {
         let ag_epoch_type = self.get_alpenglow_epoch_type(rewarded_epoch);
         self.calculate_reward_points_partitioned(
             stake_history,
-            &stake_delegations,
+            stake_delegations,
             &cached_vote_accounts,
             epoch_inflation_rewards,
             &ag_epoch_type,
@@ -490,7 +499,13 @@ impl Bank {
     ) -> EpochRewardCalculateParamInfo<'a> {
         // Use `stakes` for stake-related info
         let stake_history = stakes.history().clone();
-        let stake_delegations = stakes.stake_delegations_vec();
+        let stake_delegations =
+            if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
+                StakeDelegationsView::from_frontier_query(stake_delegation_frontier)
+            } else {
+                let stake_delegations = stakes.stake_delegations_vec();
+                StakeDelegationsView::from_stake_delegations(stake_delegations)
+            };
 
         // Use the vote-account snapshot from epoch_stakes, which is VAT-filtered
         // when admission filtering is enabled. Recalculation should match the
@@ -680,7 +695,7 @@ impl Bank {
     fn calculate_stake_rewards_and_commissions<'a>(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+        stake_delegations: &StakeDelegationsView<'a>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         point_value: PointValue,
@@ -802,7 +817,7 @@ impl Bank {
     fn calculate_reward_points_partitioned<'a>(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: &Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+        stake_delegations: &StakeDelegationsView<'a>,
         cached_vote_accounts: &CachedVoteAccounts<'_>,
         epoch_inflation_rewards: u64,
         ag_epoch_type: &AlpenglowEpochType,
@@ -912,13 +927,6 @@ impl Bank {
             points: epoch_rewards_sysvar.total_points,
         };
 
-        let stakes = self.stakes_cache.stakes();
-        let EpochRewardCalculateParamInfo {
-            stake_history,
-            stake_delegations,
-            cached_vote_accounts,
-        } = self.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
-
         // On recalculation, only the `StakeRewardCalculation::stake_rewards`
         // field is relevant. It is assumed that reward commission accounts have
         // already been calculated and delivered, while
@@ -932,19 +940,27 @@ impl Bank {
         // accounts from the start of the epoch. For this reason, the
         // `RewardCommissionAccounts` calculated in this function call should
         // NOT be used ever.
-        let (_, StakeRewardCalculation { stake_rewards, .. }) = self
-            .calculate_stake_rewards_and_commissions(
-                &stake_history,
+        let stake_rewards = {
+            let stakes = self.stakes_cache.stakes();
+            let EpochRewardCalculateParamInfo {
+                stake_history,
                 stake_delegations,
                 cached_vote_accounts,
-                rewarded_epoch,
-                point_value,
-                &ag_epoch_type,
-                thread_pool,
-                null_tracer(),
-                &mut RewardsMetrics::default(), // This is required, but not reporting anything at the moment
-            );
-        drop(stakes);
+            } = self.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+            let (_, StakeRewardCalculation { stake_rewards, .. }) = self
+                .calculate_stake_rewards_and_commissions(
+                    &stake_history,
+                    &stake_delegations,
+                    cached_vote_accounts,
+                    rewarded_epoch,
+                    point_value,
+                    &ag_epoch_type,
+                    thread_pool,
+                    null_tracer(),
+                    &mut RewardsMetrics::default(), // This is required, but not reporting anything at the moment
+                );
+            stake_rewards
+        };
         let partition_indices = hash_rewards_into_partitions(
             &stake_rewards,
             &epoch_rewards_sysvar.parent_blockhash,
@@ -1250,7 +1266,7 @@ mod tests {
         } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
         let calculated_rewards = bank.calculate_validator_rewards(
             &stake_history,
-            stake_delegations,
+            &stake_delegations,
             cached_vote_accounts,
             rewarded_epoch,
             expected_rewards,
@@ -1386,7 +1402,7 @@ mod tests {
 
         let (reward_commissions, ..) = bank.calculate_stake_rewards_and_commissions(
             &stake_history,
-            stake_delegations,
+            &stake_delegations,
             cached_vote_accounts,
             rewarded_epoch,
             point_value,
@@ -2015,16 +2031,17 @@ mod tests {
         let tracer = |_event: &RewardCalculationEvent| {};
         let reward_calc_tracer = Some(tracer);
         let rewarded_epoch = bank.epoch();
-        let stakes: RwLockReadGuard<Stakes<StakeAccount<Delegation>>> = bank.stakes_cache.stakes();
-        let EpochRewardCalculateParamInfo {
-            stake_history,
-            stake_delegations,
-            cached_vote_accounts,
-        } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
-        let (vote_rewards_accounts, stake_reward_calculation) = bank
-            .calculate_stake_rewards_and_commissions(
-                &stake_history,
+        let (vote_rewards_accounts, stake_reward_calculation) = {
+            let stakes: RwLockReadGuard<Stakes<StakeAccount<Delegation>>> =
+                bank.stakes_cache.stakes();
+            let EpochRewardCalculateParamInfo {
+                stake_history,
                 stake_delegations,
+                cached_vote_accounts,
+            } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+            bank.calculate_stake_rewards_and_commissions(
+                &stake_history,
+                &stake_delegations,
                 cached_vote_accounts,
                 rewarded_epoch,
                 point_value,
@@ -2032,8 +2049,8 @@ mod tests {
                 &thread_pool,
                 reward_calc_tracer,
                 &mut rewards_metrics,
-            );
-        drop(stakes);
+            )
+        };
 
         let vote_account = bank
             .load_slow_with_fixed_root(&bank.ancestors, vote_pubkey)
@@ -2096,29 +2113,31 @@ mod tests {
 
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let mut rewards_metrics = RewardsMetrics::default();
-        let stakes = bank.stakes_cache.stakes();
-        let EpochRewardCalculateParamInfo {
-            stake_history,
-            stake_delegations,
-            cached_vote_accounts,
-        } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
-        let PartitionedRewardsCalculation {
-            stake_rewards:
-                StakeRewardCalculation {
-                    stake_rewards: expected_stake_rewards,
-                    ..
-                },
-            ..
-        } = bank.calculate_rewards_for_partitioning(
-            &stake_history,
-            stake_delegations,
-            cached_vote_accounts,
-            rewarded_epoch,
-            null_tracer(),
-            &thread_pool,
-            &mut rewards_metrics,
-        );
-        drop(stakes);
+        let expected_stake_rewards = {
+            let stakes = bank.stakes_cache.stakes();
+            let EpochRewardCalculateParamInfo {
+                stake_history,
+                stake_delegations,
+                cached_vote_accounts,
+            } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+            let PartitionedRewardsCalculation {
+                stake_rewards:
+                    StakeRewardCalculation {
+                        stake_rewards: expected_stake_rewards,
+                        ..
+                    },
+                ..
+            } = bank.calculate_rewards_for_partitioning(
+                &stake_history,
+                stake_delegations,
+                cached_vote_accounts,
+                rewarded_epoch,
+                null_tracer(),
+                &thread_pool,
+                &mut rewards_metrics,
+            );
+            expected_stake_rewards
+        };
 
         let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
         let (recalculated_rewards, recalculated_partition_indices) =
@@ -2216,30 +2235,32 @@ mod tests {
 
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let mut rewards_metrics = RewardsMetrics::default();
-        let stakes = bank.stakes_cache.stakes();
-        let EpochRewardCalculateParamInfo {
-            stake_history,
-            stake_delegations,
-            cached_vote_accounts,
-        } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
-        let PartitionedRewardsCalculation {
-            stake_rewards:
-                StakeRewardCalculation {
-                    stake_rewards: expected_stake_rewards,
-                    ..
-                },
-            point_value,
-            ..
-        } = bank.calculate_rewards_for_partitioning(
-            &stake_history,
-            stake_delegations,
-            cached_vote_accounts,
-            rewarded_epoch,
-            null_tracer(),
-            &thread_pool,
-            &mut rewards_metrics,
-        );
-        drop(stakes);
+        let (expected_stake_rewards, point_value) = {
+            let stakes = bank.stakes_cache.stakes();
+            let EpochRewardCalculateParamInfo {
+                stake_history,
+                stake_delegations,
+                cached_vote_accounts,
+            } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+            let PartitionedRewardsCalculation {
+                stake_rewards:
+                    StakeRewardCalculation {
+                        stake_rewards: expected_stake_rewards,
+                        ..
+                    },
+                point_value,
+                ..
+            } = bank.calculate_rewards_for_partitioning(
+                &stake_history,
+                stake_delegations,
+                cached_vote_accounts,
+                rewarded_epoch,
+                null_tracer(),
+                &thread_pool,
+                &mut rewards_metrics,
+            );
+            (expected_stake_rewards, point_value)
+        };
 
         bank.recalculate_partitioned_rewards_if_active(|| &thread_pool);
         let EpochRewardStatus::Active(EpochRewardPhase::Distribution(

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -739,39 +739,48 @@ impl Bank {
                 .par_iter()
                 .zip_eq(stake_rewards.spare_capacity_mut())
                 .with_min_len(500)
-                .filter_map(|((stake_pubkey, stake_account), stake_reward_ref)| {
-                    let maybe_reward_record = self.redeem_delegation_rewards(
-                        rewarded_epoch,
-                        stake_pubkey,
-                        stake_account,
-                        &point_value,
-                        stake_history,
-                        &cached_vote_accounts,
-                        reward_calc_tracer.as_ref(),
-                        new_warmup_cooldown_rate_epoch,
-                        delay_commission_updates,
-                        commission_rate_in_basis_points,
-                        adjust_delegations_for_rent,
-                        ag_epoch_type,
-                        custom_commission_collector,
-                        use_fixed_point_stake_math,
-                    );
+                .filter_map(|(maybe_stake, stake_reward_ref)| {
+                    let (stake_reward, maybe_reward_record) = match maybe_stake {
+                        Some((stake_pubkey, stake_account)) => {
+                            let maybe_reward_record = self.redeem_delegation_rewards(
+                                rewarded_epoch,
+                                stake_pubkey,
+                                stake_account,
+                                &point_value,
+                                stake_history,
+                                &cached_vote_accounts,
+                                reward_calc_tracer.as_ref(),
+                                new_warmup_cooldown_rate_epoch,
+                                delay_commission_updates,
+                                commission_rate_in_basis_points,
+                                adjust_delegations_for_rent,
+                                ag_epoch_type,
+                                custom_commission_collector,
+                                use_fixed_point_stake_math,
+                            );
 
-                    let (stake_reward, maybe_reward_record) = match maybe_reward_record {
-                        Some(res) => {
-                            let InflationRewardWithCommission {
-                                inflation,
-                                commission_pubkey,
-                                reward_commission,
-                            } = res;
-                            let stakers_reward = inflation.stake_reward;
-                            (
-                                Some(PartitionedStakeReward {
-                                    stake_pubkey: *stake_pubkey,
-                                    inflation,
-                                }),
-                                Some((stakers_reward, commission_pubkey, reward_commission)),
-                            )
+                            match maybe_reward_record {
+                                Some(res) => {
+                                    let InflationRewardWithCommission {
+                                        inflation,
+                                        commission_pubkey,
+                                        reward_commission,
+                                    } = res;
+                                    let stakers_reward = inflation.stake_reward;
+                                    (
+                                        Some(PartitionedStakeReward {
+                                            stake_pubkey: *stake_pubkey,
+                                            inflation,
+                                        }),
+                                        Some((
+                                            stakers_reward,
+                                            commission_pubkey,
+                                            reward_commission,
+                                        )),
+                                    )
+                                }
+                                None => (None, None),
+                            }
                         }
                         None => (None, None),
                     };
@@ -864,7 +873,7 @@ impl Bank {
         let use_fixed_point_stake_math = self.use_fixed_point_stake_math();
         let (points, measure_us) = measure_us!(thread_pool.install(|| {
             stake_delegations
-                .par_iter()
+                .par_iter_some()
                 .map(|(_stake_pubkey, stake_account)| {
                     let vote_pubkey = stake_account.delegation().voter_pubkey;
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -22,7 +22,7 @@ use {
         },
         reward_info::RewardInfo,
         stake_account::StakeAccount,
-        stakes::Stakes,
+        stakes::{StakeDelegationsView, Stakes},
     },
     log::{debug, info},
     rayon::{
@@ -224,10 +224,10 @@ impl Bank {
     }
 
     // Calculate rewards from previous epoch and distribute reward commissions
-    pub(in crate::bank) fn calculate_rewards(
+    pub(in crate::bank) fn calculate_rewards<'a>(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: Vec<(&Pubkey, &StakeAccount<Delegation>)>,
+        stake_delegations: StakeDelegationsView<'a>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
@@ -290,6 +290,7 @@ impl Bank {
             stake_rewards,
             capitalization,
             point_value,
+            num_stake_accounts,
             num_filtered_vote_accounts,
             ..
         } = rewards_calculation;
@@ -341,14 +342,20 @@ impl Bank {
             total_stake_rewards_lamports
         );
 
-        let num_stake_accounts = self.stakes_cache.stakes().stake_delegations().len();
         let num_vote_accounts = *num_filtered_vote_accounts;
         self.capitalization.fetch_add(
             distributed_lamports + distributed_to_incinerator_lamports,
             Relaxed,
         );
 
-        let active_stake = if let Some(stake_history_entry) =
+        let active_stake = if let Some(stakes_cache_v2) = self.stakes_cache_v2.as_ref() {
+            stakes_cache_v2
+                .state()
+                .stake_history()
+                .get(prev_epoch)
+                .map(|stake_history_entry| stake_history_entry.effective)
+                .unwrap_or(0)
+        } else if let Some(stake_history_entry) =
             self.stakes_cache.stakes().history().get(prev_epoch)
         {
             stake_history_entry.effective
@@ -370,7 +377,7 @@ impl Bank {
             ("active_stake", active_stake, i64),
             ("pre_capitalization", *capitalization, i64),
             ("post_capitalization", self.capitalization(), i64),
-            ("num_stake_accounts", num_stake_accounts, i64),
+            ("num_stake_accounts", *num_stake_accounts, i64),
             ("num_vote_accounts", num_vote_accounts, i64),
         );
 
@@ -399,7 +406,7 @@ impl Bank {
     pub(super) fn calculate_rewards_for_partitioning<'a>(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+        stake_delegations: StakeDelegationsView<'a>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
@@ -410,6 +417,7 @@ impl Bank {
         let capitalization = self.capitalization();
         let epoch_inflation_rewards =
             self.calculate_epoch_inflation_rewards(capitalization, rewarded_epoch);
+        let num_stake_accounts = stake_delegations.len();
         // `distribution_epoch_vote_accounts` is the post-VAT-filter snapshot
         // produced upstream of this call (or unfiltered when VAT is off),
         // so its length is the right value for the `epoch_rewards` metric.
@@ -423,7 +431,7 @@ impl Bank {
         } = self
             .calculate_validator_rewards(
                 stake_history,
-                stake_delegations,
+                &stake_delegations,
                 cached_vote_accounts,
                 rewarded_epoch,
                 epoch_inflation_rewards,
@@ -444,6 +452,7 @@ impl Bank {
             stake_rewards,
             capitalization,
             point_value,
+            num_stake_accounts,
             num_filtered_vote_accounts,
         }
     }
@@ -453,7 +462,7 @@ impl Bank {
     fn calculate_validator_rewards<'a>(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+        stake_delegations: &StakeDelegationsView<'a>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         epoch_inflation_rewards: u64,
@@ -466,7 +475,7 @@ impl Bank {
             AlpenglowEpochType::get(self, rewarded_epoch, || Some(reward_epoch_delegated_stakes));
         self.calculate_reward_points_partitioned(
             stake_history,
-            &stake_delegations,
+            stake_delegations,
             &cached_vote_accounts,
             epoch_inflation_rewards,
             &ag_epoch_type,
@@ -503,7 +512,13 @@ impl Bank {
     ) -> EpochRewardCalculateParamInfo<'a> {
         // Use `stakes` for stake-related info
         let stake_history = stakes.history().clone();
-        let stake_delegations = stakes.stake_delegations_vec();
+        let stake_delegations =
+            if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
+                StakeDelegationsView::from_frontier_query(stake_delegation_frontier)
+            } else {
+                let stake_delegations = stakes.stake_delegations_vec();
+                StakeDelegationsView::from_stake_delegations(stake_delegations)
+            };
 
         // Use the vote-account snapshot from epoch_stakes, which is VAT-filtered
         // when admission filtering is enabled. Recalculation should match the
@@ -689,7 +704,7 @@ impl Bank {
     fn calculate_stake_rewards_and_commissions<'a>(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+        stake_delegations: &StakeDelegationsView<'a>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         point_value: PointValue,
@@ -752,7 +767,7 @@ impl Bank {
                             let stakers_reward = inflation.stake_reward;
                             (
                                 Some(PartitionedStakeReward {
-                                    stake_pubkey: **stake_pubkey,
+                                    stake_pubkey: *stake_pubkey,
                                     inflation,
                                 }),
                                 Some((stakers_reward, commission_pubkey, reward_commission)),
@@ -814,7 +829,7 @@ impl Bank {
     fn calculate_reward_points_partitioned<'a>(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: &Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+        stake_delegations: &StakeDelegationsView<'a>,
         cached_vote_accounts: &CachedVoteAccounts<'_>,
         epoch_inflation_rewards: u64,
         ag_epoch_type: &AlpenglowEpochType,
@@ -922,16 +937,6 @@ impl Bank {
             points: epoch_rewards_sysvar.total_points,
         };
 
-        let stakes = self.stakes_cache.stakes();
-        let EpochRewardCalculateParamInfo {
-            stake_history,
-            stake_delegations,
-            cached_vote_accounts,
-        } = self.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
-        let ag_epoch_type = AlpenglowEpochType::get(self, rewarded_epoch, || {
-            RewardEpochDelegatedStakes::get(self)
-        });
-
         // On recalculation, only the `StakeRewardCalculation::stake_rewards`
         // field is relevant. It is assumed that reward commission accounts have
         // already been calculated and delivered, while
@@ -945,19 +950,30 @@ impl Bank {
         // accounts from the start of the epoch. For this reason, the
         // `RewardCommissionAccounts` calculated in this function call should
         // NOT be used ever.
-        let (_, StakeRewardCalculation { stake_rewards, .. }) = self
-            .calculate_stake_rewards_and_commissions(
-                &stake_history,
+        let stake_rewards = {
+            let stakes = self.stakes_cache.stakes();
+            let EpochRewardCalculateParamInfo {
+                stake_history,
                 stake_delegations,
                 cached_vote_accounts,
-                rewarded_epoch,
-                point_value,
-                &ag_epoch_type,
-                thread_pool,
-                null_tracer(),
-                &mut RewardsMetrics::default(), // This is required, but not reporting anything at the moment
-            );
-        drop(stakes);
+            } = self.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+            let ag_epoch_type = AlpenglowEpochType::get(self, rewarded_epoch, || {
+                RewardEpochDelegatedStakes::get(self)
+            });
+            let (_, StakeRewardCalculation { stake_rewards, .. }) = self
+                .calculate_stake_rewards_and_commissions(
+                    &stake_history,
+                    &stake_delegations,
+                    cached_vote_accounts,
+                    rewarded_epoch,
+                    point_value,
+                    &ag_epoch_type,
+                    thread_pool,
+                    null_tracer(),
+                    &mut RewardsMetrics::default(), // This is required, but not reporting anything at the moment
+                );
+            stake_rewards
+        };
         let partition_indices = hash_rewards_into_partitions(
             &stake_rewards,
             &epoch_rewards_sysvar.parent_blockhash,
@@ -1274,7 +1290,7 @@ mod tests {
         } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
         let calculated_rewards = bank.calculate_validator_rewards(
             &stake_history,
-            stake_delegations,
+            &stake_delegations,
             cached_vote_accounts,
             rewarded_epoch,
             expected_rewards,
@@ -1422,6 +1438,7 @@ mod tests {
                 points: 1,
             },
             num_filtered_vote_accounts: 1,
+            num_stake_accounts: 1,
         };
         let mut rewards_metrics = RewardsMetrics::default();
 
@@ -1479,7 +1496,7 @@ mod tests {
 
         let (reward_commissions, ..) = bank.calculate_stake_rewards_and_commissions(
             &stake_history,
-            stake_delegations,
+            &stake_delegations,
             cached_vote_accounts,
             rewarded_epoch,
             point_value,
@@ -2108,16 +2125,17 @@ mod tests {
         let tracer = |_event: &RewardCalculationEvent| {};
         let reward_calc_tracer = Some(tracer);
         let rewarded_epoch = bank.epoch();
-        let stakes: RwLockReadGuard<Stakes<StakeAccount<Delegation>>> = bank.stakes_cache.stakes();
-        let EpochRewardCalculateParamInfo {
-            stake_history,
-            stake_delegations,
-            cached_vote_accounts,
-        } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
-        let (vote_rewards_accounts, stake_reward_calculation) = bank
-            .calculate_stake_rewards_and_commissions(
-                &stake_history,
+        let (vote_rewards_accounts, stake_reward_calculation) = {
+            let stakes: RwLockReadGuard<Stakes<StakeAccount<Delegation>>> =
+                bank.stakes_cache.stakes();
+            let EpochRewardCalculateParamInfo {
+                stake_history,
                 stake_delegations,
+                cached_vote_accounts,
+            } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+            bank.calculate_stake_rewards_and_commissions(
+                &stake_history,
+                &stake_delegations,
                 cached_vote_accounts,
                 rewarded_epoch,
                 point_value,
@@ -2125,8 +2143,8 @@ mod tests {
                 &thread_pool,
                 reward_calc_tracer,
                 &mut rewards_metrics,
-            );
-        drop(stakes);
+            )
+        };
 
         let vote_account = bank
             .load_slow_with_fixed_root(&bank.ancestors, vote_pubkey)
@@ -2191,30 +2209,32 @@ mod tests {
 
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let mut rewards_metrics = RewardsMetrics::default();
-        let stakes = bank.stakes_cache.stakes();
-        let EpochRewardCalculateParamInfo {
-            stake_history,
-            stake_delegations,
-            cached_vote_accounts,
-        } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
-        let PartitionedRewardsCalculation {
-            stake_rewards:
-                StakeRewardCalculation {
-                    stake_rewards: expected_stake_rewards,
-                    ..
-                },
-            ..
-        } = bank.calculate_rewards_for_partitioning(
-            &stake_history,
-            stake_delegations,
-            cached_vote_accounts,
-            rewarded_epoch,
-            reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
-            null_tracer(),
-            &thread_pool,
-            &mut rewards_metrics,
-        );
-        drop(stakes);
+        let expected_stake_rewards = {
+            let stakes = bank.stakes_cache.stakes();
+            let EpochRewardCalculateParamInfo {
+                stake_history,
+                stake_delegations,
+                cached_vote_accounts,
+            } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+            let PartitionedRewardsCalculation {
+                stake_rewards:
+                    StakeRewardCalculation {
+                        stake_rewards: expected_stake_rewards,
+                        ..
+                    },
+                ..
+            } = bank.calculate_rewards_for_partitioning(
+                &stake_history,
+                stake_delegations,
+                cached_vote_accounts,
+                rewarded_epoch,
+                reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
+                null_tracer(),
+                &thread_pool,
+                &mut rewards_metrics,
+            );
+            expected_stake_rewards
+        };
 
         let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
         let (recalculated_rewards, recalculated_partition_indices) =
@@ -2312,31 +2332,33 @@ mod tests {
 
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let mut rewards_metrics = RewardsMetrics::default();
-        let stakes = bank.stakes_cache.stakes();
-        let EpochRewardCalculateParamInfo {
-            stake_history,
-            stake_delegations,
-            cached_vote_accounts,
-        } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
-        let PartitionedRewardsCalculation {
-            stake_rewards:
-                StakeRewardCalculation {
-                    stake_rewards: expected_stake_rewards,
-                    ..
-                },
-            point_value,
-            ..
-        } = bank.calculate_rewards_for_partitioning(
-            &stake_history,
-            stake_delegations,
-            cached_vote_accounts,
-            rewarded_epoch,
-            reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
-            null_tracer(),
-            &thread_pool,
-            &mut rewards_metrics,
-        );
-        drop(stakes);
+        let (expected_stake_rewards, point_value) = {
+            let stakes = bank.stakes_cache.stakes();
+            let EpochRewardCalculateParamInfo {
+                stake_history,
+                stake_delegations,
+                cached_vote_accounts,
+            } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+            let PartitionedRewardsCalculation {
+                stake_rewards:
+                    StakeRewardCalculation {
+                        stake_rewards: expected_stake_rewards,
+                        ..
+                    },
+                point_value,
+                ..
+            } = bank.calculate_rewards_for_partitioning(
+                &stake_history,
+                stake_delegations,
+                cached_vote_accounts,
+                rewarded_epoch,
+                reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
+                null_tracer(),
+                &thread_pool,
+                &mut rewards_metrics,
+            );
+            (expected_stake_rewards, point_value)
+        };
 
         bank.recalculate_partitioned_rewards_if_active(|| &thread_pool);
         let EpochRewardStatus::Active(EpochRewardPhase::Distribution(

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1140,7 +1140,9 @@ mod tests {
                     tests::{
                         RewardBank, SLOTS_PER_EPOCH, build_partitioned_stake_rewards,
                         create_default_reward_bank, create_reward_bank,
-                        create_reward_bank_with_specific_stakes, populate_vote_accounts_with_votes,
+                        create_reward_bank_with_specific_stakes,
+                        create_reward_bank_with_specific_stakes_and_runtime_config,
+                        populate_vote_accounts_with_votes,
                     },
                 },
                 tests::create_genesis_config,
@@ -2192,6 +2194,74 @@ mod tests {
                 .as_ref()
                 .unwrap(),
             &expected_reward
+        );
+    }
+
+    #[test]
+    fn test_calculate_stake_rewards_and_commissions_skips_removed_v2_overlay_stake() {
+        agave_logger::setup();
+
+        let (RewardBank { bank, stakers, .. }, bank_forks) =
+            create_reward_bank_with_specific_stakes_and_runtime_config(
+                vec![2_000_000_000],
+                PartitionedEpochRewardsConfig::default().stake_account_stores_per_block,
+                SLOTS_PER_EPOCH,
+                RuntimeConfig {
+                    enable_stakes_cache_v2: true,
+                    ..RuntimeConfig::default()
+                },
+            );
+        let stake_pubkey = *stakers.first().unwrap();
+        assert!(bank.stakes_cache_v2.is_some());
+
+        let slot = bank.slot() + 1;
+        let bank =
+            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), slot);
+        bank.stakes_cache_v2
+            .as_ref()
+            .unwrap()
+            .remove_stake_delegation(&stake_pubkey);
+
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+        let mut rewards_metrics = RewardsMetrics::default();
+        let point_value = PointValue {
+            rewards: 100000,
+            points: 1000,
+        };
+        let rewarded_epoch = bank.epoch();
+        let stakes = bank.stakes_cache.stakes();
+        let EpochRewardCalculateParamInfo {
+            stake_history,
+            stake_delegations,
+            cached_vote_accounts,
+        } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+
+        assert_eq!(stake_delegations.len_unfiltered(), 1);
+        assert_eq!(stake_delegations.len_filtered(), 0);
+
+        let (reward_commissions, stake_reward_calculation) = bank
+            .calculate_stake_rewards_and_commissions(
+                &stake_history,
+                &stake_delegations,
+                cached_vote_accounts,
+                rewarded_epoch,
+                point_value,
+                &AlpenglowEpochType::Tower,
+                &thread_pool,
+                null_tracer(),
+                &mut rewards_metrics,
+            );
+
+        assert!(reward_commissions.is_empty());
+        assert_eq!(stake_reward_calculation.total_stake_rewards_lamports, 0);
+        assert_eq!(stake_reward_calculation.stake_rewards.total_len(), 1);
+        assert_eq!(stake_reward_calculation.stake_rewards.num_rewards(), 0);
+        assert!(
+            stake_reward_calculation
+                .stake_rewards
+                .get(0)
+                .unwrap()
+                .is_none()
         );
     }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -417,7 +417,7 @@ impl Bank {
         let capitalization = self.capitalization();
         let epoch_inflation_rewards =
             self.calculate_epoch_inflation_rewards(capitalization, rewarded_epoch);
-        let num_stake_accounts = stake_delegations.len();
+        let num_stake_accounts = stake_delegations.len_filtered();
         // `distribution_epoch_vote_accounts` is the post-VAT-filter snapshot
         // produced upstream of this call (or unfiltered when VAT is off),
         // so its length is the right value for the `epoch_rewards` metric.
@@ -733,10 +733,11 @@ impl Bank {
         // Producing the stake reward with rayon triggers a lot of
         // (re)allocations. To avoid that, we allocate it at the start and
         // pass `stake_rewards.spare_capacity_mut()` as one of iterators.
-        let mut stake_rewards = PartitionedStakeRewards::with_capacity(stake_delegations.len());
+        let mut stake_rewards =
+            PartitionedStakeRewards::with_capacity(stake_delegations.len_unfiltered());
         let rewards_accumulator: RewardsAccumulator = thread_pool.install(|| {
             stake_delegations
-                .par_iter()
+                .par_iter_unfiltered()
                 .zip_eq(stake_rewards.spare_capacity_mut())
                 .with_min_len(500)
                 .filter_map(|(maybe_stake, stake_reward_ref)| {
@@ -873,7 +874,7 @@ impl Bank {
         let use_fixed_point_stake_math = self.use_fixed_point_stake_math();
         let (points, measure_us) = measure_us!(thread_pool.install(|| {
             stake_delegations
-                .par_iter_some()
+                .par_iter_filtered()
                 .map(|(_stake_pubkey, stake_account)| {
                     let vote_pubkey = stake_account.delegation().voter_pubkey;
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -730,36 +730,45 @@ impl Bank {
                 .par_iter()
                 .zip_eq(stake_rewards.spare_capacity_mut())
                 .with_min_len(500)
-                .filter_map(|((stake_pubkey, stake_account), stake_reward_ref)| {
-                    let maybe_reward_record = self.redeem_delegation_rewards(
-                        rewarded_epoch,
-                        stake_pubkey,
-                        stake_account,
-                        &point_value,
-                        stake_history,
-                        &cached_vote_accounts,
-                        reward_calc_tracer.as_ref(),
-                        new_warmup_cooldown_rate_epoch,
-                        delay_commission_updates,
-                        commission_rate_in_basis_points,
-                        adjust_delegations_for_rent,
-                        ag_epoch_type,
-                        custom_commission_collector,
-                        use_fixed_point_stake_math,
-                    );
+                .filter_map(|(maybe_stake, stake_reward_ref)| {
+                    let (stake_reward, maybe_reward_record) = match maybe_stake {
+                        Some((stake_pubkey, stake_account)) => {
+                            let maybe_reward_record = self.redeem_delegation_rewards(
+                                rewarded_epoch,
+                                stake_pubkey,
+                                stake_account,
+                                &point_value,
+                                stake_history,
+                                &cached_vote_accounts,
+                                reward_calc_tracer.as_ref(),
+                                new_warmup_cooldown_rate_epoch,
+                                delay_commission_updates,
+                                commission_rate_in_basis_points,
+                                adjust_delegations_for_rent,
+                                ag_epoch_type,
+                                custom_commission_collector,
+                                use_fixed_point_stake_math,
+                            );
 
-                    let (stake_reward, maybe_reward_record) = match maybe_reward_record {
-                        Some(res) => {
-                            let DelegationRewards {
-                                stake_reward,
-                                commission_pubkey,
-                                reward_commission,
-                            } = res;
-                            let stakers_reward = stake_reward.stake_reward;
-                            (
-                                Some(stake_reward),
-                                Some((stakers_reward, commission_pubkey, reward_commission)),
-                            )
+                            match maybe_reward_record {
+                                Some(res) => {
+                                    let DelegationRewards {
+                                        stake_reward,
+                                        commission_pubkey,
+                                        reward_commission,
+                                    } = res;
+                                    let stakers_reward = stake_reward.stake_reward;
+                                    (
+                                        Some(stake_reward),
+                                        Some((
+                                            stakers_reward,
+                                            commission_pubkey,
+                                            reward_commission,
+                                        )),
+                                    )
+                                }
+                                None => (None, None),
+                            }
                         }
                         None => (None, None),
                     };
@@ -852,7 +861,7 @@ impl Bank {
         let use_fixed_point_stake_math = self.use_fixed_point_stake_math();
         let (points, measure_us) = measure_us!(thread_pool.install(|| {
             stake_delegations
-                .par_iter()
+                .par_iter_some()
                 .map(|(_stake_pubkey, stake_account)| {
                     let vote_pubkey = stake_account.delegation().voter_pubkey;
 

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -586,6 +586,20 @@ mod tests {
         stake_account_stores_per_block: u64,
         advance_num_slots: u64,
     ) -> (RewardBank, Arc<RwLock<BankForks>>) {
+        create_reward_bank_with_specific_stakes_and_runtime_config(
+            stakes,
+            stake_account_stores_per_block,
+            advance_num_slots,
+            RuntimeConfig::default(),
+        )
+    }
+
+    pub(super) fn create_reward_bank_with_specific_stakes_and_runtime_config(
+        stakes: Vec<u64>,
+        stake_account_stores_per_block: u64,
+        advance_num_slots: u64,
+        runtime_config: RuntimeConfig,
+    ) -> (RewardBank, Arc<RwLock<BankForks>>) {
         // Disable slot time reduction features as they will override the custom
         // stores per block provided in this test helper.
         let features_to_deactivate = crate::slot_params::slot_time_feature_ids().to_vec();
@@ -605,7 +619,7 @@ mod tests {
 
         let bank = Bank::new_from_genesis(
             &genesis_config,
-            Arc::new(RuntimeConfig::default()),
+            Arc::new(runtime_config),
             Vec::new(),
             None,
             accounts_db_config,

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -7,7 +7,7 @@ use {
     super::Bank,
     crate::{
         inflation_rewards::points::PointValue, reward_info::RewardInfo,
-        stake_account::StakeAccount, stake_history::StakeHistory,
+        stake_history::StakeHistory, stakes::StakeDelegationsView,
     },
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::{
@@ -16,7 +16,7 @@ use {
     },
     solana_clock::Slot,
     solana_pubkey::{Pubkey, PubkeyHasherBuilder},
-    solana_stake_interface::state::{Delegation, Stake},
+    solana_stake_interface::state::Stake,
     solana_vote::vote_account::VoteAccounts,
     std::{collections::HashMap, mem::MaybeUninit, sync::Arc},
 };
@@ -296,7 +296,7 @@ pub(super) struct CachedVoteAccounts<'a> {
 /// hold reward calc info to avoid recalculation across functions
 pub(super) struct EpochRewardCalculateParamInfo<'a> {
     pub(super) stake_history: StakeHistory,
-    pub(super) stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+    pub(super) stake_delegations: StakeDelegationsView<'a>,
     pub(super) cached_vote_accounts: CachedVoteAccounts<'a>,
 }
 
@@ -309,6 +309,7 @@ pub(super) struct PartitionedRewardsCalculation {
     stake_rewards: StakeRewardCalculation,
     capitalization: u64,
     point_value: PointValue,
+    num_stake_accounts: usize,
     /// Number of vote accounts in the distribution-epoch snapshot after
     /// SIMD-0357 VAT filtering (or the unfiltered count when VAT is off).
     /// Surfaced for the `epoch_rewards` datapoint without re-running the

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -7,7 +7,7 @@ use {
     super::Bank,
     crate::{
         inflation_rewards::points::PointValue, reward_info::RewardInfo,
-        stake_account::StakeAccount, stake_history::StakeHistory,
+        stake_history::StakeHistory, stakes::StakeDelegationsView,
     },
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::{
@@ -16,7 +16,7 @@ use {
     },
     solana_clock::Slot,
     solana_pubkey::{Pubkey, PubkeyHasherBuilder},
-    solana_stake_interface::state::{Delegation, Stake},
+    solana_stake_interface::state::Stake,
     solana_vote::vote_account::VoteAccounts,
     std::{collections::HashMap, mem::MaybeUninit, sync::Arc},
 };
@@ -304,7 +304,7 @@ pub(super) struct CachedVoteAccounts<'a> {
 /// hold reward calc info to avoid recalculation across functions
 pub(super) struct EpochRewardCalculateParamInfo<'a> {
     pub(super) stake_history: StakeHistory,
-    pub(super) stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+    pub(super) stake_delegations: StakeDelegationsView<'a>,
     pub(super) cached_vote_accounts: CachedVoteAccounts<'a>,
 }
 
@@ -317,6 +317,7 @@ pub(super) struct PartitionedRewardsCalculation {
     stake_rewards: StakeRewardCalculation,
     capitalization: u64,
     point_value: PointValue,
+    num_stake_accounts: usize,
     /// Number of vote accounts in the distribution-epoch snapshot after
     /// SIMD-0357 VAT filtering (or the unfiltered count when VAT is off).
     /// Surfaced for the `epoch_rewards` datapoint without re-running the

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11024,17 +11024,17 @@ fn test_squash_timing_add_assign() {
     let mut t0 = SquashTiming::default();
 
     let t1 = SquashTiming {
-        squash_accounts_ms: 1,
-        squash_accounts_cache_ms: 2,
-        squash_cache_ms: 5,
-        squash_accounts_cache_v2_ms: Some(5),
+        squash_accounts_us: 1,
+        squash_accounts_cache_us: 2,
+        squash_cache_us: 5,
+        squash_accounts_cache_v2_us: Some(5),
     };
 
     let expected = SquashTiming {
-        squash_accounts_ms: 2,
-        squash_accounts_cache_ms: 2 * 2,
-        squash_cache_ms: 5 * 2,
-        squash_accounts_cache_v2_ms: Some(5 * 2),
+        squash_accounts_us: 2,
+        squash_accounts_cache_us: 2 * 2,
+        squash_cache_us: 5 * 2,
+        squash_accounts_cache_v2_us: Some(5 * 2),
     };
 
     t0 += t1;
@@ -11045,17 +11045,17 @@ fn test_squash_timing_add_assign() {
     let mut t0 = SquashTiming::default();
 
     let t1 = SquashTiming {
-        squash_accounts_ms: 1,
-        squash_accounts_cache_ms: 2,
-        squash_cache_ms: 5,
-        squash_accounts_cache_v2_ms: None,
+        squash_accounts_us: 1,
+        squash_accounts_cache_us: 2,
+        squash_cache_us: 5,
+        squash_accounts_cache_v2_us: None,
     };
 
     let expected = SquashTiming {
-        squash_accounts_ms: 2,
-        squash_accounts_cache_ms: 2 * 2,
-        squash_cache_ms: 5 * 2,
-        squash_accounts_cache_v2_ms: None,
+        squash_accounts_us: 2,
+        squash_accounts_cache_us: 2 * 2,
+        squash_cache_us: 5 * 2,
+        squash_accounts_cache_v2_us: None,
     };
 
     t0 += t1;

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -644,8 +644,6 @@ impl Bank {
         thread_pool: &ThreadPool,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
     ) -> StakeDelegationsMap {
-        let stakes = self.stakes_cache.stakes();
-        let stake_delegations = stakes.stake_delegations_vec();
         // Obtain all unique voter pubkeys from stake delegations.
         fn merge(mut acc: HashSet<Pubkey>, other: HashSet<Pubkey>) -> HashSet<Pubkey> {
             if acc.len() < other.len() {
@@ -654,19 +652,34 @@ impl Bank {
             acc.extend(other);
             acc
         }
-        let voter_pubkeys = thread_pool.install(|| {
-            stake_delegations
-                .par_iter()
-                .fold(
-                    HashSet::default,
-                    |mut voter_pubkeys, (_stake_pubkey, stake_account)| {
-                        voter_pubkeys.insert(stake_account.delegation().voter_pubkey);
-                        voter_pubkeys
-                    },
-                )
-                .reduce(HashSet::default, merge)
-        });
+        let voter_pubkeys =
+            if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
+                thread_pool.install(|| {
+                    stake_delegation_frontier
+                        .par_iter()
+                        .fold(
+                            HashSet::default,
+                            |mut voter_pubkeys, (_stake_pubkey, stake_account)| {
+                                voter_pubkeys.insert(stake_account.delegation().voter_pubkey);
+                                voter_pubkeys
+                            },
+                        )
+                        .reduce(HashSet::default, merge)
+                })
+            } else {
+                let stakes = self.stakes_cache.stakes();
+                thread_pool.install(|| {
+                    stakes.stake_delegations().iter().fold(
+                        HashSet::default(),
+                        |mut voter_pubkeys, (_stake_pubkey, stake_account)| {
+                            voter_pubkeys.insert(stake_account.delegation().voter_pubkey);
+                            voter_pubkeys
+                        },
+                    )
+                })
+            };
         // Obtain vote-accounts for unique voter pubkeys.
+        let stakes = self.stakes_cache.stakes();
         let cached_vote_accounts = stakes.vote_accounts();
         let solana_vote_program: Pubkey = solana_vote_program::id();
         let vote_accounts_cache_miss_count = AtomicUsize::default();
@@ -706,12 +719,12 @@ impl Bank {
                 .collect()
         });
         // Join stake accounts with vote-accounts.
-        for (stake_pubkey, stake_account) in stake_delegations.into_iter() {
+        let push_stake_delegation = |(stake_pubkey, stake_account): (&Pubkey, &StakeAccount<_>)| {
             let delegation = stake_account.delegation();
             let Some(mut vote_delegations) =
                 stake_delegations_map.get_mut(&delegation.voter_pubkey)
             else {
-                continue;
+                return;
             };
             if let Some(reward_calc_tracer) = reward_calc_tracer.as_ref() {
                 let delegation =
@@ -721,8 +734,20 @@ impl Bank {
             }
             let stake_delegation = (*stake_pubkey, stake_account.clone());
             vote_delegations.push(stake_delegation);
+        };
+        if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
+            thread_pool.install(|| {
+                stake_delegation_frontier
+                    .par_iter()
+                    .for_each(push_stake_delegation);
+            });
+        } else {
+            let stakes = self.stakes_cache.stakes();
+            stakes
+                .stake_delegations()
+                .iter()
+                .for_each(push_stake_delegation);
         }
-
         stake_delegations_map
     }
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -654,7 +654,7 @@ impl Bank {
             if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
                 thread_pool.install(|| {
                     stake_delegation_frontier
-                        .par_iter()
+                        .par_iter_some()
                         .fold(
                             HashSet::default,
                             |mut voter_pubkeys, (_stake_pubkey, stake_account)| {
@@ -736,7 +736,7 @@ impl Bank {
         if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
             thread_pool.install(|| {
                 stake_delegation_frontier
-                    .par_iter()
+                    .par_iter_some()
                     .for_each(push_stake_delegation);
             });
         } else {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11027,18 +11027,41 @@ fn test_squash_timing_add_assign() {
         squash_accounts_ms: 1,
         squash_accounts_cache_ms: 2,
         squash_cache_ms: 5,
+        squash_accounts_cache_v2_ms: Some(5),
     };
 
     let expected = SquashTiming {
         squash_accounts_ms: 2,
         squash_accounts_cache_ms: 2 * 2,
         squash_cache_ms: 5 * 2,
+        squash_accounts_cache_v2_ms: Some(5 * 2),
     };
 
     t0 += t1;
     t0 += t1;
 
-    assert!(t0 == expected);
+    assert_eq!(t0, expected);
+
+    let mut t0 = SquashTiming::default();
+
+    let t1 = SquashTiming {
+        squash_accounts_ms: 1,
+        squash_accounts_cache_ms: 2,
+        squash_cache_ms: 5,
+        squash_accounts_cache_v2_ms: None,
+    };
+
+    let expected = SquashTiming {
+        squash_accounts_ms: 2,
+        squash_accounts_cache_ms: 2 * 2,
+        squash_cache_ms: 5 * 2,
+        squash_accounts_cache_v2_ms: None,
+    };
+
+    t0 += t1;
+    t0 += t1;
+
+    assert_eq!(t0, expected)
 }
 
 #[test]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -656,7 +656,7 @@ impl Bank {
             if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
                 thread_pool.install(|| {
                     stake_delegation_frontier
-                        .par_iter_some()
+                        .par_iter_filtered()
                         .fold(
                             HashSet::default,
                             |mut voter_pubkeys, (_stake_pubkey, stake_account)| {
@@ -738,7 +738,7 @@ impl Bank {
         if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
             thread_pool.install(|| {
                 stake_delegation_frontier
-                    .par_iter_some()
+                    .par_iter_filtered()
                     .for_each(push_stake_delegation);
             });
         } else {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -642,8 +642,6 @@ impl Bank {
         thread_pool: &ThreadPool,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
     ) -> StakeDelegationsMap {
-        let stakes = self.stakes_cache.stakes();
-        let stake_delegations = stakes.stake_delegations_vec();
         // Obtain all unique voter pubkeys from stake delegations.
         fn merge(mut acc: HashSet<Pubkey>, other: HashSet<Pubkey>) -> HashSet<Pubkey> {
             if acc.len() < other.len() {
@@ -652,19 +650,34 @@ impl Bank {
             acc.extend(other);
             acc
         }
-        let voter_pubkeys = thread_pool.install(|| {
-            stake_delegations
-                .par_iter()
-                .fold(
-                    HashSet::default,
-                    |mut voter_pubkeys, (_stake_pubkey, stake_account)| {
-                        voter_pubkeys.insert(stake_account.delegation().voter_pubkey);
-                        voter_pubkeys
-                    },
-                )
-                .reduce(HashSet::default, merge)
-        });
+        let voter_pubkeys =
+            if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
+                thread_pool.install(|| {
+                    stake_delegation_frontier
+                        .par_iter()
+                        .fold(
+                            HashSet::default,
+                            |mut voter_pubkeys, (_stake_pubkey, stake_account)| {
+                                voter_pubkeys.insert(stake_account.delegation().voter_pubkey);
+                                voter_pubkeys
+                            },
+                        )
+                        .reduce(HashSet::default, merge)
+                })
+            } else {
+                let stakes = self.stakes_cache.stakes();
+                thread_pool.install(|| {
+                    stakes.stake_delegations().iter().fold(
+                        HashSet::default(),
+                        |mut voter_pubkeys, (_stake_pubkey, stake_account)| {
+                            voter_pubkeys.insert(stake_account.delegation().voter_pubkey);
+                            voter_pubkeys
+                        },
+                    )
+                })
+            };
         // Obtain vote-accounts for unique voter pubkeys.
+        let stakes = self.stakes_cache.stakes();
         let cached_vote_accounts = stakes.vote_accounts();
         let solana_vote_program: Pubkey = solana_vote_program::id();
         let vote_accounts_cache_miss_count = AtomicUsize::default();
@@ -704,12 +717,12 @@ impl Bank {
                 .collect()
         });
         // Join stake accounts with vote-accounts.
-        for (stake_pubkey, stake_account) in stake_delegations.into_iter() {
+        let push_stake_delegation = |(stake_pubkey, stake_account): (&Pubkey, &StakeAccount<_>)| {
             let delegation = stake_account.delegation();
             let Some(mut vote_delegations) =
                 stake_delegations_map.get_mut(&delegation.voter_pubkey)
             else {
-                continue;
+                return;
             };
             if let Some(reward_calc_tracer) = reward_calc_tracer.as_ref() {
                 let delegation =
@@ -719,8 +732,20 @@ impl Bank {
             }
             let stake_delegation = (*stake_pubkey, stake_account.clone());
             vote_delegations.push(stake_delegation);
+        };
+        if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
+            thread_pool.install(|| {
+                stake_delegation_frontier
+                    .par_iter()
+                    .for_each(push_stake_delegation);
+            });
+        } else {
+            let stakes = self.stakes_cache.stakes();
+            stakes
+                .stake_delegations()
+                .iter()
+                .for_each(push_stake_delegation);
         }
-
         stake_delegations_map
     }
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -656,7 +656,7 @@ impl Bank {
             if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
                 thread_pool.install(|| {
                     stake_delegation_frontier
-                        .par_iter()
+                        .par_iter_some()
                         .fold(
                             HashSet::default,
                             |mut voter_pubkeys, (_stake_pubkey, stake_account)| {
@@ -738,7 +738,7 @@ impl Bank {
         if let Some(stake_delegation_frontier) = self.stake_delegation_frontier_query() {
             thread_pool.install(|| {
                 stake_delegation_frontier
-                    .par_iter()
+                    .par_iter_some()
                     .for_each(push_stake_delegation);
             });
         } else {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -568,24 +568,24 @@ impl BankForks {
             ),
             ("total_banks", self.banks.len(), i64),
             (
-                "total_squash_cache_ms",
-                set_root_metrics.timings.total_squash_time.squash_cache_ms,
+                "total_squash_cache_us",
+                set_root_metrics.timings.total_squash_time.squash_cache_us,
                 i64
             ),
             (
-                "total_squash_accounts_ms",
+                "total_squash_accounts_us",
                 set_root_metrics
                     .timings
                     .total_squash_time
-                    .squash_accounts_ms,
+                    .squash_accounts_us,
                 i64
             ),
             (
-                "total_squash_accounts_cache_ms",
+                "total_squash_accounts_cache_us",
                 set_root_metrics
                     .timings
                     .total_squash_time
-                    .squash_accounts_cache_ms,
+                    .squash_accounts_cache_us,
                 i64
             ),
             (

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -45,6 +45,7 @@ pub mod stake_history;
 pub mod stake_utils;
 pub mod stake_weighted_timestamp;
 pub mod stakes;
+mod stakes_v2;
 pub mod static_ids;
 pub mod status_cache;
 pub mod test_utils;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -47,6 +47,7 @@ pub mod stake_history;
 pub mod stake_utils;
 pub mod stake_weighted_timestamp;
 pub mod stakes;
+mod stakes_v2;
 pub mod static_ids;
 pub mod status_cache;
 pub mod test_utils;

--- a/runtime/src/runtime_config.rs
+++ b/runtime/src/runtime_config.rs
@@ -6,4 +6,5 @@ pub struct RuntimeConfig {
     pub compute_budget: Option<ComputeBudget>,
     pub log_messages_bytes_limit: Option<usize>,
     pub transaction_account_lock_limit: Option<usize>,
+    pub enable_stakes_cache_v2: bool,
 }

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -116,9 +116,11 @@ impl<'a> StakeDelegationsView<'a> {
         match self {
             Self::FrontierQuery(stake_delegations) => Either::Left(stake_delegations.par_iter()),
             Self::Legacy(stake_delegations) => {
-                Either::Right(stake_delegations.par_iter().map(|(pubkey, stake_account)|
-                        // Dereference `&&` to `&`.
-                        Some((*pubkey, *stake_account))))
+                Either::Right(
+                    stake_delegations
+                        .par_iter()
+                        .map(|&(pubkey, stake_account)| Some((pubkey, stake_account))),
+                )
             }
         }
     }
@@ -141,8 +143,7 @@ impl<'a> StakeDelegationsView<'a> {
             Self::Legacy(stake_delegations) => Either::Right(
                 stake_delegations
                     .par_iter()
-                    // Replace `&(&&K, &&V)` with `(&K, &V)`.
-                    .map(|(pubkey, stake_account)| (*pubkey, *stake_account)),
+                    .map(|&(pubkey, stake_account)| (pubkey, stake_account)),
             ),
         }
     }

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -98,12 +98,28 @@ impl<'a> StakeDelegationsView<'a> {
 
     pub(crate) fn par_iter(
         &'a self,
-    ) -> impl IndexedParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {
+    ) -> impl IndexedParallelIterator<Item = Option<(&'a Pubkey, &'a StakeAccount)>> {
         match self {
             Self::FrontierQuery(stake_delegations) => Either::Left(stake_delegations.par_iter()),
+            Self::Legacy(stake_delegations) => {
+                Either::Right(stake_delegations.par_iter().map(|(pubkey, stake_account)|
+                        // Dereference `&&` to `&`.
+                        Some((*pubkey, *stake_account))))
+            }
+        }
+    }
+
+    pub(crate) fn par_iter_some(
+        &'a self,
+    ) -> impl ParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {
+        match self {
+            Self::FrontierQuery(stake_delegations) => {
+                Either::Left(stake_delegations.par_iter_some())
+            }
             Self::Legacy(stake_delegations) => Either::Right(
                 stake_delegations
                     .par_iter()
+                    // Replace `&(&&K, &&V)` with `(&K, &V)`.
                     .map(|(pubkey, stake_account)| (*pubkey, *stake_account)),
             ),
         }
@@ -459,7 +475,7 @@ impl Stakes<StakeAccount> {
         // prev epoch.
         let stake_history_entry = thread_pool.install(|| {
             stake_delegations
-                .par_iter()
+                .par_iter_some()
                 .fold(
                     StakeActivationStatus::default,
                     |acc, (_stake_pubkey, stake_account)| {
@@ -732,7 +748,7 @@ fn refresh_vote_accounts(
     }
     let delegated_stakes = thread_pool.install(|| {
         stake_delegations
-            .par_iter()
+            .par_iter_some()
             .fold(
                 HashMap::default,
                 |mut delegated_stakes, (_stake_pubkey, stake_account)| {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -5,11 +5,16 @@ use {
         stake_account,
         stake_delegation::{delegation_activation_status, delegation_effective_stake},
         stake_history::StakeHistory,
+        stakes_v2::FrontierQuery,
     },
     imbl::HashMap as ImblHashMap,
     log::error,
     num_derive::ToPrimitive,
-    rayon::{ThreadPool, prelude::*},
+    rayon::{
+        ThreadPool,
+        iter::{Either, IndexedParallelIterator},
+        prelude::*,
+    },
     serde::Serialize,
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::utils::create_account_shared_data,
@@ -66,6 +71,44 @@ pub enum InvalidCacheEntryReason {
 }
 
 type StakeAccount = stake_account::StakeAccount<Delegation>;
+
+/// Shared view on stake delegations used by epoch-boundary stake logic.
+pub(crate) enum StakeDelegationsView<'a> {
+    Legacy(Vec<(&'a Pubkey, &'a StakeAccount)>),
+    FrontierQuery(FrontierQuery<'a>),
+}
+
+impl<'a> StakeDelegationsView<'a> {
+    pub(crate) fn from_frontier_query(stake_delegations: FrontierQuery<'a>) -> Self {
+        Self::FrontierQuery(stake_delegations)
+    }
+
+    pub(crate) fn from_stake_delegations(
+        stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount)>,
+    ) -> Self {
+        Self::Legacy(stake_delegations)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::FrontierQuery(stake_delegations) => stake_delegations.len(),
+            Self::Legacy(stake_delegations) => stake_delegations.len(),
+        }
+    }
+
+    pub(crate) fn par_iter(
+        &'a self,
+    ) -> impl IndexedParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {
+        match self {
+            Self::FrontierQuery(stake_delegations) => Either::Left(stake_delegations.par_iter()),
+            Self::Legacy(stake_delegations) => Either::Right(
+                stake_delegations
+                    .par_iter()
+                    .map(|(pubkey, stake_account)| (*pubkey, *stake_account)),
+            ),
+        }
+    }
+}
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Default, Debug)]
@@ -409,7 +452,7 @@ impl Stakes<StakeAccount> {
         next_epoch: Epoch,
         thread_pool: &ThreadPool,
         new_rate_activation_epoch: Option<Epoch>,
-        stake_delegations: &[(&Pubkey, &StakeAccount)],
+        stake_delegations: &StakeDelegationsView<'_>,
         use_fixed_point_stake_math: bool,
     ) -> (StakeHistory, VoteAccounts) {
         // Wrap up the prev epoch by adding new stake history entry for the
@@ -672,7 +715,7 @@ fn refresh_vote_accounts(
     thread_pool: &ThreadPool,
     epoch: Epoch,
     vote_accounts: &VoteAccounts,
-    stake_delegations: &[(&Pubkey, &StakeAccount)],
+    stake_delegations: &StakeDelegationsView<'_>,
     stake_history: &StakeHistory,
     new_rate_activation_epoch: Option<Epoch>,
     use_fixed_point_stake_math: bool,
@@ -724,7 +767,7 @@ fn refresh_vote_accounts(
 pub(crate) mod tests {
     use {
         super::*,
-        crate::{stake_delegation::effective_stake, stake_utils},
+        crate::{stake_delegation::effective_stake, stake_utils, stakes_v2::StakesCacheV2},
         rayon::ThreadPoolBuilder,
         solana_account::WritableAccount,
         solana_pubkey::Pubkey,
@@ -803,20 +846,58 @@ pub(crate) mod tests {
         )
     }
 
+    fn empty_stakes_caches(epoch: Epoch) -> (StakesCache, StakesCacheV2) {
+        let stakes = Stakes {
+            epoch,
+            ..Default::default()
+        };
+        let stakes_cache = StakesCache::new(stakes);
+        let stakes_cache_v2 = StakesCacheV2::empty(epoch);
+        (stakes_cache, stakes_cache_v2)
+    }
+
+    fn stake_caches_check_and_store(
+        stakes_cache: &StakesCache,
+        stakes_cache_v2: &StakesCacheV2,
+        pubkey: &Pubkey,
+        account: &impl ReadableAccount,
+        new_rate_activation_epoch: Option<Epoch>,
+        use_fixed_point_stake_math: bool,
+    ) {
+        stakes_cache.check_and_store(
+            pubkey,
+            account,
+            new_rate_activation_epoch,
+            use_fixed_point_stake_math,
+        );
+        stakes_cache_v2.check_and_store(pubkey, account);
+    }
+
     #[test]
     fn test_stakes_basic() {
         for i in 0..4 {
-            let stakes_cache = StakesCache::new(Stakes {
-                epoch: i,
-                ..Stakes::default()
-            });
+            let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(i);
             let rent = Rent::default();
 
             let ((vote_pubkey, vote_account), (stake_pubkey, mut stake_account)) =
                 create_staked_node_accounts(10, &rent);
 
-            stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+            stake_caches_check_and_store(
+                &stakes_cache,
+                &stakes_cache_v2,
+                &vote_pubkey,
+                &vote_account,
+                None,
+                true,
+            );
+            stake_caches_check_and_store(
+                &stakes_cache,
+                &stakes_cache_v2,
+                &stake_pubkey,
+                &stake_account,
+                None,
+                true,
+            );
             let stake = stake_account
                 .deserialize_data::<StakeStateV2>()
                 .unwrap()
@@ -835,7 +916,14 @@ pub(crate) mod tests {
             }
 
             stake_account.set_lamports(42);
-            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+            stake_caches_check_and_store(
+                &stakes_cache,
+                &stakes_cache_v2,
+                &stake_pubkey,
+                &stake_account,
+                None,
+                true,
+            );
             {
                 let stakes = stakes_cache.stakes();
                 let vote_accounts = stakes.vote_accounts();
@@ -851,7 +939,14 @@ pub(crate) mod tests {
             // activate more
             let mut stake_account =
                 create_stake_account(42, &vote_pubkey, &solana_pubkey::new_rand(), &rent);
-            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+            stake_caches_check_and_store(
+                &stakes_cache,
+                &stakes_cache_v2,
+                &stake_pubkey,
+                &stake_account,
+                None,
+                true,
+            );
             let stake = stake_account
                 .deserialize_data::<StakeStateV2>()
                 .unwrap()
@@ -870,7 +965,14 @@ pub(crate) mod tests {
             }
 
             stake_account.set_lamports(0);
-            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+            stake_caches_check_and_store(
+                &stakes_cache,
+                &stakes_cache_v2,
+                &stake_pubkey,
+                &stake_account,
+                None,
+                true,
+            );
             {
                 let stakes = stakes_cache.stakes();
                 let vote_accounts = stakes.vote_accounts();
@@ -882,7 +984,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_stakes_highest() {
-        let stakes_cache = StakesCache::default();
+        let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(0);
         let rent = Rent::default();
 
         assert_eq!(stakes_cache.stakes().highest_staked_node(), None);
@@ -890,14 +992,42 @@ pub(crate) mod tests {
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account,
+            None,
+            true,
+        );
 
         let ((vote11_pubkey, vote11_account), (stake11_pubkey, stake11_account)) =
             create_staked_node_accounts(20, &rent);
 
-        stakes_cache.check_and_store(&vote11_pubkey, &vote11_account, None, true);
-        stakes_cache.check_and_store(&stake11_pubkey, &stake11_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote11_pubkey,
+            &vote11_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake11_pubkey,
+            &stake11_account,
+            None,
+            true,
+        );
 
         let vote11_node_pubkey = VoteStateV4::deserialize(vote11_account.data(), &vote11_pubkey)
             .unwrap()
@@ -915,17 +1045,28 @@ pub(crate) mod tests {
 
     #[test]
     fn test_stakes_vote_account_disappear_reappear() {
-        let stakes_cache = StakesCache::new(Stakes {
-            epoch: 4,
-            ..Stakes::default()
-        });
+        let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(4);
         let rent = Rent::default();
 
         let ((vote_pubkey, mut vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -935,7 +1076,14 @@ pub(crate) mod tests {
         }
 
         vote_account.set_lamports(0);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -945,7 +1093,14 @@ pub(crate) mod tests {
         }
 
         vote_account.set_lamports(1);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -959,7 +1114,14 @@ pub(crate) mod tests {
         let mut pushed = vote_account.data().to_vec();
         pushed.push(0);
         vote_account.set_data(pushed);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -970,7 +1132,14 @@ pub(crate) mod tests {
 
         // Vote account uninitialized
         vote_account.set_data(vec![0; VoteStateV4::size_of()]);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -980,7 +1149,14 @@ pub(crate) mod tests {
         }
 
         vote_account.set_data(cache_data);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -992,10 +1168,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_stakes_change_delegate() {
-        let stakes_cache = StakesCache::new(Stakes {
-            epoch: 4,
-            ..Stakes::default()
-        });
+        let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(4);
         let rent = Rent::default();
 
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
@@ -1004,11 +1177,32 @@ pub(crate) mod tests {
         let ((vote_pubkey2, vote_account2), (_stake_pubkey2, stake_account2)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&vote_pubkey2, &vote_account2, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey2,
+            &vote_account2,
+            None,
+            true,
+        );
 
         // delegates to vote_pubkey
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account,
+            None,
+            true,
+        );
 
         let stake = stake_account
             .deserialize_data::<StakeStateV2>()
@@ -1031,7 +1225,14 @@ pub(crate) mod tests {
         }
 
         // delegates to vote_pubkey2
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account2, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account2,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -1049,10 +1250,7 @@ pub(crate) mod tests {
     }
     #[test]
     fn test_stakes_multiple_stakers() {
-        let stakes_cache = StakesCache::new(Stakes {
-            epoch: 4,
-            ..Stakes::default()
-        });
+        let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(4);
         let rent = Rent::default();
 
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
@@ -1061,11 +1259,32 @@ pub(crate) mod tests {
         let stake_pubkey2 = solana_pubkey::new_rand();
         let stake_account2 = create_stake_account(10, &vote_pubkey, &stake_pubkey2, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
 
         // delegates to vote_pubkey
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey2, &stake_account2, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey2,
+            &stake_account2,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -1077,14 +1296,28 @@ pub(crate) mod tests {
 
     #[test]
     fn test_activate_epoch() {
-        let stakes_cache = StakesCache::default();
+        let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(0);
         let rent = Rent::default();
 
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account,
+            None,
+            true,
+        );
         let stake = stake_account
             .deserialize_data::<StakeStateV2>()
             .unwrap()
@@ -1103,14 +1336,14 @@ pub(crate) mod tests {
         }
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let next_epoch = 3;
+        let stake_delegations = stakes_cache_v2.frontier_query([]);
         let (stake_history, vote_accounts) = {
             let stakes = stakes_cache.stakes();
-            let stake_delegations = stakes.stake_delegations_vec();
             stakes.calculate_activated_stake(
                 next_epoch,
                 &thread_pool,
                 None,
-                &stake_delegations,
+                &StakeDelegationsView::FrontierQuery(stake_delegations),
                 true,
             )
         };
@@ -1129,17 +1362,28 @@ pub(crate) mod tests {
 
     #[test]
     fn test_stakes_not_delegate() {
-        let stakes_cache = StakesCache::new(Stakes {
-            epoch: 4,
-            ..Stakes::default()
-        });
+        let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(4);
         let rent = Rent::default();
 
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -1149,7 +1393,9 @@ pub(crate) mod tests {
         }
 
         // not a stake account, and whacks above entry
-        stakes_cache.check_and_store(
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
             &stake_pubkey,
             &AccountSharedData::new(1, 0, &stake::program::id()),
             None,

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -100,6 +100,16 @@ impl<'a> StakeDelegationsView<'a> {
         }
     }
 
+    /// Returns an indexed parallel iterator (with a known size) over all stake
+    /// delegations.
+    ///
+    /// Each item is `Option<(&Pubkey, &StakeAccount)>` — `None` for tombstones
+    /// that should be skipped.
+    ///
+    /// # Performance
+    ///
+    /// Known size of the iterator makes it a good choice for usage that
+    /// involves allocating collections.
     pub(crate) fn par_iter(
         &'a self,
     ) -> impl IndexedParallelIterator<Item = Option<(&'a Pubkey, &'a StakeAccount)>> {
@@ -113,6 +123,14 @@ impl<'a> StakeDelegationsView<'a> {
         }
     }
 
+    /// Returns a parallel iterator (with an unknown size) over all valid stake
+    /// delegations, filtering out any tombstones.
+    ///
+    /// # Performance
+    ///
+    /// Unknown size of the iterator makes it a bad choice for usage that
+    /// involves allocating collections, where [`StakeDelegationsView::par_iter`]
+    /// should be used instead.
     pub(crate) fn par_iter_some(
         &'a self,
     ) -> impl ParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -93,9 +93,26 @@ impl<'a> StakeDelegationsView<'a> {
         Self::Legacy(stake_delegations)
     }
 
-    pub(crate) fn len(&self) -> usize {
+    /// Returns the total number of stake delegation entries, including rooted
+    /// entries, frontier-only inserts, without excluding overlay-removed
+    /// roots. The reurned number is equivalent to the number of elements
+    /// yielded by [`StakeDelegationsView::par_iter_unfiltered`], including the
+    /// `None` elements.
+    pub(crate) fn len_unfiltered(&self) -> usize {
         match self {
-            Self::FrontierQuery(stake_delegations) => stake_delegations.len(),
+            Self::FrontierQuery(stake_delegations) => stake_delegations.len_unfiltered(),
+            Self::Legacy(stake_delegations) => stake_delegations.len(),
+        }
+    }
+
+    /// Returns the total number of stake delegation entries, including rooted
+    /// entries, frontier-only inserts, and excluding overlay-removed roots.
+    /// The reurned number is equivalent to the number of elements yielded by
+    /// [`StakeDelegationsView::par_iter_filtered`], and does not include the
+    /// `None` elements.
+    pub(crate) fn len_filtered(&self) -> usize {
+        match self {
+            Self::FrontierQuery(stake_delegations) => stake_delegations.len_filtered(),
             Self::Legacy(stake_delegations) => stake_delegations.len(),
         }
     }
@@ -104,24 +121,25 @@ impl<'a> StakeDelegationsView<'a> {
     /// delegations.
     ///
     /// Each item is `Option<(&Pubkey, &StakeAccount)>` — `None` for tombstones
-    /// that should be skipped.
+    /// that should be skipped, or rooted entries that were removed by the
+    /// overlay.
     ///
     /// # Performance
     ///
     /// Known size of the iterator makes it a good choice for usage that
     /// involves allocating collections.
-    pub(crate) fn par_iter(
+    pub(crate) fn par_iter_unfiltered(
         &'a self,
     ) -> impl IndexedParallelIterator<Item = Option<(&'a Pubkey, &'a StakeAccount)>> {
         match self {
-            Self::FrontierQuery(stake_delegations) => Either::Left(stake_delegations.par_iter()),
-            Self::Legacy(stake_delegations) => {
-                Either::Right(
-                    stake_delegations
-                        .par_iter()
-                        .map(|&(pubkey, stake_account)| Some((pubkey, stake_account))),
-                )
+            Self::FrontierQuery(stake_delegations) => {
+                Either::Left(stake_delegations.par_iter_unfiltered())
             }
+            Self::Legacy(stake_delegations) => Either::Right(
+                stake_delegations
+                    .par_iter()
+                    .map(|&(pubkey, stake_account)| Some((pubkey, stake_account))),
+            ),
         }
     }
 
@@ -131,14 +149,14 @@ impl<'a> StakeDelegationsView<'a> {
     /// # Performance
     ///
     /// Unknown size of the iterator makes it a bad choice for usage that
-    /// involves allocating collections, where [`StakeDelegationsView::par_iter`]
-    /// should be used instead.
-    pub(crate) fn par_iter_some(
+    /// involves allocating collections, where
+    /// [`StakeDelegationsView::par_iter_unfiltered`] should be used instead.
+    pub(crate) fn par_iter_filtered(
         &'a self,
     ) -> impl ParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {
         match self {
             Self::FrontierQuery(stake_delegations) => {
-                Either::Left(stake_delegations.par_iter_some())
+                Either::Left(stake_delegations.par_iter_filtered())
             }
             Self::Legacy(stake_delegations) => Either::Right(
                 stake_delegations
@@ -526,7 +544,7 @@ impl Stakes<StakeAccount> {
         // prev epoch.
         let (stake_history_entry, effective_delegated_stakes) = thread_pool.install(|| {
             stake_delegations
-                .par_iter_some()
+                .par_iter_filtered()
                 .fold(
                     || (StakeActivationStatus::default(), HashMap::default()),
                     |(acc, mut delegated_stakes), (_stake_pubkey, stake_account)| {
@@ -873,7 +891,7 @@ fn refresh_vote_accounts(
     }
     let delegated_stakes = thread_pool.install(|| {
         stake_delegations
-            .par_iter_some()
+            .par_iter_filtered()
             .fold(
                 DelegatedStakes::default,
                 |mut delegated_stakes, (_stake_pubkey, stake_account)| {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -102,12 +102,28 @@ impl<'a> StakeDelegationsView<'a> {
 
     pub(crate) fn par_iter(
         &'a self,
-    ) -> impl IndexedParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {
+    ) -> impl IndexedParallelIterator<Item = Option<(&'a Pubkey, &'a StakeAccount)>> {
         match self {
             Self::FrontierQuery(stake_delegations) => Either::Left(stake_delegations.par_iter()),
+            Self::Legacy(stake_delegations) => {
+                Either::Right(stake_delegations.par_iter().map(|(pubkey, stake_account)|
+                        // Dereference `&&` to `&`.
+                        Some((*pubkey, *stake_account))))
+            }
+        }
+    }
+
+    pub(crate) fn par_iter_some(
+        &'a self,
+    ) -> impl ParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {
+        match self {
+            Self::FrontierQuery(stake_delegations) => {
+                Either::Left(stake_delegations.par_iter_some())
+            }
             Self::Legacy(stake_delegations) => Either::Right(
                 stake_delegations
                     .par_iter()
+                    // Replace `&(&&K, &&V)` with `(&K, &V)`.
                     .map(|(pubkey, stake_account)| (*pubkey, *stake_account)),
             ),
         }
@@ -491,7 +507,7 @@ impl Stakes<StakeAccount> {
         // prev epoch.
         let (stake_history_entry, effective_delegated_stakes) = thread_pool.install(|| {
             stake_delegations
-                .par_iter()
+                .par_iter_some()
                 .fold(
                     || (StakeActivationStatus::default(), HashMap::default()),
                     |(acc, mut delegated_stakes), (_stake_pubkey, stake_account)| {
@@ -838,7 +854,7 @@ fn refresh_vote_accounts(
     }
     let delegated_stakes = thread_pool.install(|| {
         stake_delegations
-            .par_iter()
+            .par_iter_some()
             .fold(
                 DelegatedStakes::default,
                 |mut delegated_stakes, (_stake_pubkey, stake_account)| {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -8,11 +8,16 @@ use {
         stake_account,
         stake_delegation::{delegation_activation_status, delegation_effective_stake},
         stake_history::StakeHistory,
+        stakes_v2::FrontierQuery,
     },
     imbl::HashMap as ImblHashMap,
     log::error,
     num_derive::ToPrimitive,
-    rayon::{ThreadPool, prelude::*},
+    rayon::{
+        ThreadPool,
+        iter::{Either, IndexedParallelIterator},
+        prelude::*,
+    },
     serde::Serialize,
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::utils::create_account_shared_data,
@@ -70,6 +75,44 @@ pub enum InvalidCacheEntryReason {
 
 type StakeAccount = stake_account::StakeAccount<Delegation>;
 pub(crate) type DelegatedStakes = ImblHashMap<Pubkey, u64>;
+
+/// Shared view on stake delegations used by epoch-boundary stake logic.
+pub(crate) enum StakeDelegationsView<'a> {
+    Legacy(Vec<(&'a Pubkey, &'a StakeAccount)>),
+    FrontierQuery(FrontierQuery<'a>),
+}
+
+impl<'a> StakeDelegationsView<'a> {
+    pub(crate) fn from_frontier_query(stake_delegations: FrontierQuery<'a>) -> Self {
+        Self::FrontierQuery(stake_delegations)
+    }
+
+    pub(crate) fn from_stake_delegations(
+        stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount)>,
+    ) -> Self {
+        Self::Legacy(stake_delegations)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::FrontierQuery(stake_delegations) => stake_delegations.len(),
+            Self::Legacy(stake_delegations) => stake_delegations.len(),
+        }
+    }
+
+    pub(crate) fn par_iter(
+        &'a self,
+    ) -> impl IndexedParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {
+        match self {
+            Self::FrontierQuery(stake_delegations) => Either::Left(stake_delegations.par_iter()),
+            Self::Legacy(stake_delegations) => Either::Right(
+                stake_delegations
+                    .par_iter()
+                    .map(|(pubkey, stake_account)| (*pubkey, *stake_account)),
+            ),
+        }
+    }
+}
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Default, Debug)]
@@ -436,7 +479,7 @@ impl Stakes<StakeAccount> {
         next_epoch: Epoch,
         thread_pool: &ThreadPool,
         new_rate_activation_epoch: Option<Epoch>,
-        stake_delegations: &[(&Pubkey, &StakeAccount)],
+        stake_delegations: &StakeDelegationsView<'_>,
         use_fixed_point_stake_math: bool,
     ) -> (
         StakeHistory,
@@ -779,7 +822,7 @@ fn refresh_vote_accounts(
     thread_pool: &ThreadPool,
     epoch: Epoch,
     vote_accounts: &VoteAccounts,
-    stake_delegations: &[(&Pubkey, &StakeAccount)],
+    stake_delegations: &StakeDelegationsView<'_>,
     stake_history: &StakeHistory,
     new_rate_activation_epoch: Option<Epoch>,
     use_fixed_point_stake_math: bool,
@@ -832,7 +875,7 @@ fn refresh_vote_accounts(
 pub(crate) mod tests {
     use {
         super::*,
-        crate::{stake_delegation::effective_stake, stake_utils},
+        crate::{stake_delegation::effective_stake, stake_utils, stakes_v2::StakesCacheV2},
         rayon::ThreadPoolBuilder,
         solana_account::WritableAccount,
         solana_pubkey::Pubkey,
@@ -912,20 +955,58 @@ pub(crate) mod tests {
         )
     }
 
+    fn empty_stakes_caches(epoch: Epoch) -> (StakesCache, StakesCacheV2) {
+        let stakes = Stakes {
+            epoch,
+            ..Default::default()
+        };
+        let stakes_cache = StakesCache::new(stakes);
+        let stakes_cache_v2 = StakesCacheV2::empty(epoch);
+        (stakes_cache, stakes_cache_v2)
+    }
+
+    fn stake_caches_check_and_store(
+        stakes_cache: &StakesCache,
+        stakes_cache_v2: &StakesCacheV2,
+        pubkey: &Pubkey,
+        account: &impl ReadableAccount,
+        new_rate_activation_epoch: Option<Epoch>,
+        use_fixed_point_stake_math: bool,
+    ) {
+        stakes_cache.check_and_store(
+            pubkey,
+            account,
+            new_rate_activation_epoch,
+            use_fixed_point_stake_math,
+        );
+        stakes_cache_v2.check_and_store(pubkey, account);
+    }
+
     #[test]
     fn test_stakes_basic() {
         for i in 0..4 {
-            let stakes_cache = StakesCache::new(Stakes {
-                epoch: i,
-                ..Stakes::default()
-            });
+            let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(i);
             let rent = Rent::default();
 
             let ((vote_pubkey, vote_account), (stake_pubkey, mut stake_account)) =
                 create_staked_node_accounts(10, &rent);
 
-            stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+            stake_caches_check_and_store(
+                &stakes_cache,
+                &stakes_cache_v2,
+                &vote_pubkey,
+                &vote_account,
+                None,
+                true,
+            );
+            stake_caches_check_and_store(
+                &stakes_cache,
+                &stakes_cache_v2,
+                &stake_pubkey,
+                &stake_account,
+                None,
+                true,
+            );
             let stake = stake_account
                 .deserialize_data::<StakeStateV2>()
                 .unwrap()
@@ -944,7 +1025,14 @@ pub(crate) mod tests {
             }
 
             stake_account.set_lamports(42);
-            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+            stake_caches_check_and_store(
+                &stakes_cache,
+                &stakes_cache_v2,
+                &stake_pubkey,
+                &stake_account,
+                None,
+                true,
+            );
             {
                 let stakes = stakes_cache.stakes();
                 let vote_accounts = stakes.vote_accounts();
@@ -960,7 +1048,14 @@ pub(crate) mod tests {
             // activate more
             let mut stake_account =
                 create_stake_account(42, &vote_pubkey, &solana_pubkey::new_rand(), &rent);
-            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+            stake_caches_check_and_store(
+                &stakes_cache,
+                &stakes_cache_v2,
+                &stake_pubkey,
+                &stake_account,
+                None,
+                true,
+            );
             let stake = stake_account
                 .deserialize_data::<StakeStateV2>()
                 .unwrap()
@@ -979,7 +1074,14 @@ pub(crate) mod tests {
             }
 
             stake_account.set_lamports(0);
-            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+            stake_caches_check_and_store(
+                &stakes_cache,
+                &stakes_cache_v2,
+                &stake_pubkey,
+                &stake_account,
+                None,
+                true,
+            );
             {
                 let stakes = stakes_cache.stakes();
                 let vote_accounts = stakes.vote_accounts();
@@ -991,7 +1093,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_stakes_highest() {
-        let stakes_cache = StakesCache::default();
+        let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(0);
         let rent = Rent::default();
 
         assert_eq!(stakes_cache.stakes().highest_staked_node(), None);
@@ -999,14 +1101,42 @@ pub(crate) mod tests {
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account,
+            None,
+            true,
+        );
 
         let ((vote11_pubkey, vote11_account), (stake11_pubkey, stake11_account)) =
             create_staked_node_accounts(20, &rent);
 
-        stakes_cache.check_and_store(&vote11_pubkey, &vote11_account, None, true);
-        stakes_cache.check_and_store(&stake11_pubkey, &stake11_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote11_pubkey,
+            &vote11_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake11_pubkey,
+            &stake11_account,
+            None,
+            true,
+        );
 
         let vote11_node_pubkey = VoteStateV4::deserialize(vote11_account.data(), &vote11_pubkey)
             .unwrap()
@@ -1024,17 +1154,28 @@ pub(crate) mod tests {
 
     #[test]
     fn test_stakes_vote_account_disappear_reappear() {
-        let stakes_cache = StakesCache::new(Stakes {
-            epoch: 4,
-            ..Stakes::default()
-        });
+        let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(4);
         let rent = Rent::default();
 
         let ((vote_pubkey, mut vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -1044,7 +1185,14 @@ pub(crate) mod tests {
         }
 
         vote_account.set_lamports(0);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -1054,7 +1202,14 @@ pub(crate) mod tests {
         }
 
         vote_account.set_lamports(1);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -1068,7 +1223,14 @@ pub(crate) mod tests {
         let mut pushed = vote_account.data().to_vec();
         pushed.push(0);
         vote_account.set_data(pushed);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -1079,7 +1241,14 @@ pub(crate) mod tests {
 
         // Vote account uninitialized
         vote_account.set_data(vec![0; VoteStateV4::size_of()]);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -1089,7 +1258,14 @@ pub(crate) mod tests {
         }
 
         vote_account.set_data(cache_data);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -1101,10 +1277,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_stakes_change_delegate() {
-        let stakes_cache = StakesCache::new(Stakes {
-            epoch: 4,
-            ..Stakes::default()
-        });
+        let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(4);
         let rent = Rent::default();
 
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
@@ -1113,11 +1286,32 @@ pub(crate) mod tests {
         let ((vote_pubkey2, vote_account2), (_stake_pubkey2, stake_account2)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&vote_pubkey2, &vote_account2, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey2,
+            &vote_account2,
+            None,
+            true,
+        );
 
         // delegates to vote_pubkey
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account,
+            None,
+            true,
+        );
 
         let stake = stake_account
             .deserialize_data::<StakeStateV2>()
@@ -1140,7 +1334,14 @@ pub(crate) mod tests {
         }
 
         // delegates to vote_pubkey2
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account2, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account2,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -1158,10 +1359,7 @@ pub(crate) mod tests {
     }
     #[test]
     fn test_stakes_multiple_stakers() {
-        let stakes_cache = StakesCache::new(Stakes {
-            epoch: 4,
-            ..Stakes::default()
-        });
+        let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(4);
         let rent = Rent::default();
 
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
@@ -1170,11 +1368,32 @@ pub(crate) mod tests {
         let stake_pubkey2 = solana_pubkey::new_rand();
         let stake_account2 = create_stake_account(10, &vote_pubkey, &stake_pubkey2, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
 
         // delegates to vote_pubkey
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey2, &stake_account2, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey2,
+            &stake_account2,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -1186,14 +1405,28 @@ pub(crate) mod tests {
 
     #[test]
     fn test_activate_epoch() {
-        let stakes_cache = StakesCache::default();
+        let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(0);
         let rent = Rent::default();
 
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account,
+            None,
+            true,
+        );
         let stake = stake_account
             .deserialize_data::<StakeStateV2>()
             .unwrap()
@@ -1214,14 +1447,14 @@ pub(crate) mod tests {
         }
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let next_epoch = 3;
+        let stake_delegations = stakes_cache_v2.frontier_query([]);
         let (stake_history, vote_accounts, delegated_stakes, effective_delegated_stakes) = {
             let stakes = stakes_cache.stakes();
-            let stake_delegations = stakes.stake_delegations_vec();
             stakes.calculate_activated_stake(
                 next_epoch,
                 &thread_pool,
                 None,
-                &stake_delegations,
+                &StakeDelegationsView::FrontierQuery(stake_delegations),
                 true,
             )
         };
@@ -1247,17 +1480,28 @@ pub(crate) mod tests {
 
     #[test]
     fn test_stakes_not_delegate() {
-        let stakes_cache = StakesCache::new(Stakes {
-            epoch: 4,
-            ..Stakes::default()
-        });
+        let (stakes_cache, stakes_cache_v2) = empty_stakes_caches(4);
         let rent = Rent::default();
 
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &vote_pubkey,
+            &vote_account,
+            None,
+            true,
+        );
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
+            &stake_pubkey,
+            &stake_account,
+            None,
+            true,
+        );
 
         {
             let stakes = stakes_cache.stakes();
@@ -1267,7 +1511,9 @@ pub(crate) mod tests {
         }
 
         // not a stake account, and whacks above entry
-        stakes_cache.check_and_store(
+        stake_caches_check_and_store(
+            &stakes_cache,
+            &stakes_cache_v2,
             &stake_pubkey,
             &AccountSharedData::new(1, 0, &stake::program::id()),
             None,

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -96,6 +96,16 @@ impl<'a> StakeDelegationsView<'a> {
         }
     }
 
+    /// Returns an indexed parallel iterator (with a known size) over all stake
+    /// delegations.
+    ///
+    /// Each item is `Option<(&Pubkey, &StakeAccount)>` — `None` for tombstones
+    /// that should be skipped.
+    ///
+    /// # Performance
+    ///
+    /// Known size of the iterator makes it a good choice for usage that
+    /// involves allocating collections.
     pub(crate) fn par_iter(
         &'a self,
     ) -> impl IndexedParallelIterator<Item = Option<(&'a Pubkey, &'a StakeAccount)>> {
@@ -109,6 +119,14 @@ impl<'a> StakeDelegationsView<'a> {
         }
     }
 
+    /// Returns a parallel iterator (with an unknown size) over all valid stake
+    /// delegations, filtering out any tombstones.
+    ///
+    /// # Performance
+    ///
+    /// Unknown size of the iterator makes it a bad choice for usage that
+    /// involves allocating collections, where [`StakeDelegationsView::par_iter`]
+    /// should be used instead.
     pub(crate) fn par_iter_some(
         &'a self,
     ) -> impl ParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -95,7 +95,7 @@ impl<'a> StakeDelegationsView<'a> {
 
     /// Returns the total number of stake delegation entries, including rooted
     /// entries, frontier-only inserts, without excluding overlay-removed
-    /// roots. The reurned number is equivalent to the number of elements
+    /// roots. The returned number is equivalent to the number of elements
     /// yielded by [`StakeDelegationsView::par_iter_unfiltered`], including the
     /// `None` elements.
     pub(crate) fn len_unfiltered(&self) -> usize {
@@ -107,7 +107,7 @@ impl<'a> StakeDelegationsView<'a> {
 
     /// Returns the total number of stake delegation entries, including rooted
     /// entries, frontier-only inserts, and excluding overlay-removed roots.
-    /// The reurned number is equivalent to the number of elements yielded by
+    /// The returned number is equivalent to the number of elements yielded by
     /// [`StakeDelegationsView::par_iter_filtered`], and does not include the
     /// `None` elements.
     pub(crate) fn len_filtered(&self) -> usize {
@@ -120,9 +120,8 @@ impl<'a> StakeDelegationsView<'a> {
     /// Returns an indexed parallel iterator (with a known size) over all stake
     /// delegations.
     ///
-    /// Each item is `Option<(&Pubkey, &StakeAccount)>` — `None` for tombstones
-    /// that should be skipped, or rooted entries that were removed by the
-    /// overlay.
+    /// Each item is `Option<(&Pubkey, &StakeAccount)>` — `None` for rooted
+    /// entries that were removed by the overlay.
     ///
     /// # Performance
     ///
@@ -144,7 +143,7 @@ impl<'a> StakeDelegationsView<'a> {
     }
 
     /// Returns a parallel iterator (with an unknown size) over all valid stake
-    /// delegations, filtering out any tombstones.
+    /// delegations, filtering out roots removed by the overlay.
     ///
     /// # Performance
     ///

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -332,5 +332,18 @@ mod tests {
         // DeserializableStakes doesn't preserve same order of elements as Stakes, compare converted
         let other_stakes = Stakes::from_deserialized(other.stakes);
         assert_eq!(other_stakes, dummy.stakes.into());
+
+        let stake_delegation_frontier = stakes_cache_v2.frontier_query([]);
+        let stakes = stakes_cache.stakes();
+        let stake_delegations = stakes.stake_delegations();
+        assert_eq!(
+            stake_delegation_frontier.len_filtered(),
+            stake_delegations.len()
+        );
+        stake_delegation_frontier
+            .iter_filtered()
+            .for_each(|(pubkey, stake_account)| {
+                assert_eq!(stake_delegations.get(pubkey), Some(stake_account));
+            });
     }
 }

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -198,7 +198,7 @@ pub(crate) struct DeserializableStakes<T> {
 mod tests {
     use {
         super::*,
-        crate::{stake_utils, stakes::StakesCache},
+        crate::{stake_utils, stakes::StakesCache, stakes_v2::StakesCacheV2},
         rand::Rng,
         serde::Deserialize,
         solana_rent::Rent,
@@ -275,6 +275,7 @@ mod tests {
             epoch: rng.random(),
             ..Stakes::default()
         });
+        let stakes_cache_v2 = StakesCacheV2::empty(0);
         for _ in 0..rng.random_range(5usize..10) {
             let vote_pubkey = solana_pubkey::new_rand();
             let node_pubkey = solana_pubkey::new_rand();
@@ -292,6 +293,7 @@ mod tests {
                 rng.random_range(0..1_000_000), // lamports
             );
             stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+            stakes_cache_v2.check_and_store(&vote_pubkey, &vote_account);
             for _ in 0..rng.random_range(10usize..20) {
                 let stake_pubkey = solana_pubkey::new_rand();
                 let rent = Rent::free();
@@ -303,6 +305,7 @@ mod tests {
                     rng.random_range(0..1_000_000), // lamports
                 );
                 stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+                stakes_cache_v2.check_and_store(&stake_pubkey, &stake_account);
             }
         }
         let stakes: Stakes<StakeAccount> = stakes_cache.stakes().clone();

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -196,7 +196,7 @@ pub(crate) struct DeserializableStakes<T> {
 mod tests {
     use {
         super::*,
-        crate::{stake_utils, stakes::StakesCache},
+        crate::{stake_utils, stakes::StakesCache, stakes_v2::StakesCacheV2},
         rand::Rng,
         serde::Deserialize,
         solana_rent::Rent,
@@ -272,6 +272,7 @@ mod tests {
             epoch: rng.random(),
             ..Stakes::default()
         });
+        let stakes_cache_v2 = StakesCacheV2::empty(0);
         for _ in 0..rng.random_range(5usize..10) {
             let vote_pubkey = solana_pubkey::new_rand();
             let node_pubkey = solana_pubkey::new_rand();
@@ -289,6 +290,7 @@ mod tests {
                 rng.random_range(0..1_000_000), // lamports
             );
             stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+            stakes_cache_v2.check_and_store(&vote_pubkey, &vote_account);
             for _ in 0..rng.random_range(10usize..20) {
                 let stake_pubkey = solana_pubkey::new_rand();
                 let rent = Rent::free();
@@ -300,6 +302,7 @@ mod tests {
                     rng.random_range(0..1_000_000), // lamports
                 );
                 stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+                stakes_cache_v2.check_and_store(&stake_pubkey, &stake_account);
             }
         }
         let stakes: Stakes<StakeAccount> = stakes_cache.stakes().clone();

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -127,7 +127,7 @@ struct FrontierEntry {
 pub(crate) struct FrontierQuery<'a> {
     /// Lock guard holding the index of rooted stake delegations.
     inner: RwLockReadGuard<'a, StakeDelegationIndexInner>,
-    overlay: AHashMap<Pubkey, Option<Arc<StakeAccount>>>,
+    overlay: Overlay,
     overlay_only_inserts: Vec<FrontierEntry>,
     /// Number of rooted entries that are removed by the overlay.
     num_removed: usize,

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -38,8 +38,8 @@ impl StakesCacheV2State {
     }
 }
 
-/// A hash map that contains per-fork changes to the stake accounts.
-type Overlay = AHashMap<Pubkey, Option<Arc<StakeAccount>>>;
+/// Stake delegation changes recorded by one unrooted bank/fork.
+type ForkDelta = AHashMap<Pubkey, Option<Arc<StakeAccount>>>;
 
 type RootEntriesInner = IndexMap<Pubkey, Arc<StakeAccount>, AHashRandomState>;
 
@@ -88,25 +88,59 @@ impl RootEntries {
     }
 }
 
-/// Returns the stake pubkey and account, applying any overlay updates.
+type FrontierOverridesInner = AHashMap<usize, Option<Arc<StakeAccount>>>;
+
+/// Aggregated frontier changes to stake delegations already present in
+/// [`RootEntries`].
 ///
-/// If the overlay contains an update for this entry's stake pubkey, the
-/// overlayed value is returned. If the overlay marks the stake as removed
-/// (`None`), `None` is returned. Otherwise the rooted value is returned.
-fn apply_overlay<'a>(
-    stake_pubkey: &'a Pubkey,
-    stake_account: &'a Arc<StakeAccount>,
-    overlay: &'a Overlay,
-) -> Option<(&'a Pubkey, &'a StakeAccount)> {
-    match overlay.get(stake_pubkey) {
-        // Overlay updates the stake.
-        Some(Some(stake_account)) => Some((stake_pubkey, stake_account.as_ref())),
-        // Overlay removes the stake.
-        Some(None) => None,
-        // Overlay doesn't modify the stake.
-        None => Some((stake_pubkey, stake_account.as_ref())),
+/// A [`FrontierOverrides`] value is built for one frontier query by walking
+/// fork deltas from unrooted ancestors and the current bank in ancestor order.
+/// Entries are keyed by rooted entry index so query iteration does not need to
+/// hash each rooted stake pubkey again.
+#[derive(Debug, Default)]
+struct FrontierOverrides(FrontierOverridesInner);
+
+impl FrontierOverrides {
+    /// Returns the stake pubkey and account, applying any override.
+    ///
+    /// If the override contains an update for this entry's stake pubkey, the
+    /// updated value is returned. If the override marks the stake as removed,
+    /// `None` is returned. Otherwise the rooted value is returned.
+    fn apply_override<'a>(
+        &'a self,
+        root_index: usize,
+        stake_pubkey: &'a Pubkey,
+        stake_account: &'a Arc<StakeAccount>,
+    ) -> Option<(&'a Pubkey, &'a StakeAccount)> {
+        match self.0.get(&root_index) {
+            Some(Some(stake_account)) => Some((stake_pubkey, stake_account.as_ref())),
+            Some(None) => None,
+            None => Some((stake_pubkey, stake_account.as_ref())),
+        }
     }
 }
+
+impl Deref for FrontierOverrides {
+    type Target = FrontierOverridesInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for FrontierOverrides {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// Aggregated frontier inserts for stake delegations not present in
+/// [`RootEntries`].
+///
+/// A [`FrontierInserts`] value is built for one frontier query from fork deltas
+/// across unrooted ancestors and the current bank. These entries have no rooted
+/// index, so they remain keyed by stake pubkey.
+type FrontierInserts = IndexMap<Pubkey, Arc<StakeAccount>, AHashRandomState>;
 
 #[derive(Debug)]
 struct StakeDelegationIndexInner {
@@ -118,21 +152,19 @@ struct StakeDelegationIndexInner {
 #[derive(Debug)]
 struct StakeDelegationIndex(RwLock<StakeDelegationIndexInner>);
 
-/// Frontier-only entry that does not exist in the rooted base.
-#[derive(Clone, Debug)]
-struct FrontierEntry {
-    stake_pubkey: Pubkey,
-    stake_account: Arc<StakeAccount>,
-}
-
 /// Merged stake-delegation view for one bank frontier.
+///
+/// The view combines rooted stake delegations with fork deltas from unrooted
+/// ancestors and the current bank.
 #[derive(Debug)]
 pub(crate) struct FrontierQuery<'a> {
     /// Lock guard holding the index of rooted stake delegations.
     inner: RwLockReadGuard<'a, StakeDelegationIndexInner>,
-    overlay: Overlay,
-    overlay_only_inserts: Vec<FrontierEntry>,
-    /// Number of rooted entries that are removed by the overlay.
+    /// Aggregated frontier changes for rooted stake delegations.
+    overrides: FrontierOverrides,
+    /// Aggregated frontier inserts absent from rooted stake delegations.
+    inserts: FrontierInserts,
+    /// Number of rooted entries that are removed by frontier overrides.
     num_removed: usize,
 }
 
@@ -146,7 +178,7 @@ impl<'a> FrontierQuery<'a> {
         self.inner
             .root_entries
             .len()
-            .wrapping_add(self.overlay_only_inserts.len())
+            .wrapping_add(self.inserts.len())
     }
 
     /// Returns the total number of stake delegation entries, including rooted
@@ -159,7 +191,7 @@ impl<'a> FrontierQuery<'a> {
             .root_entries
             .len()
             .wrapping_sub(self.num_removed)
-            .wrapping_add(self.overlay_only_inserts.len())
+            .wrapping_add(self.inserts.len())
     }
 
     /// Returns an indexed parallel iterator (with a known size) over all stake
@@ -178,13 +210,17 @@ impl<'a> FrontierQuery<'a> {
         self.inner
             .root_entries
             .par_iter()
-            .map(|(stake_pubkey, stake_account)| {
-                apply_overlay(stake_pubkey, stake_account, &self.overlay)
+            .enumerate()
+            .map(|(root_index, (stake_pubkey, stake_account))| {
+                self.overrides
+                    .apply_override(root_index, stake_pubkey, stake_account)
             })
             .chain(
-                self.overlay_only_inserts
+                self.inserts
                     .par_iter()
-                    .map(|entry| Some((&entry.stake_pubkey, entry.stake_account.as_ref()))),
+                    .map(|(stake_pubkey, stake_account)| {
+                        Some((stake_pubkey, stake_account.as_ref()))
+                    }),
             )
     }
 
@@ -221,13 +257,15 @@ impl<'a> FrontierQuery<'a> {
         self.inner
             .root_entries
             .iter()
-            .map(|(stake_pubkey, stake_account)| {
-                apply_overlay(stake_pubkey, stake_account, &self.overlay)
+            .enumerate()
+            .map(|(root_index, (stake_pubkey, stake_account))| {
+                self.overrides
+                    .apply_override(root_index, stake_pubkey, stake_account)
             })
             .chain(
-                self.overlay_only_inserts
-                    .iter()
-                    .map(|entry| Some((&entry.stake_pubkey, entry.stake_account.as_ref()))),
+                self.inserts.iter().map(|(stake_pubkey, stake_account)| {
+                    Some((stake_pubkey, stake_account.as_ref()))
+                }),
             )
     }
 
@@ -247,10 +285,11 @@ impl<'a> FrontierQuery<'a> {
 impl StakeDelegationIndex {
     /// Applies rooted stake delegation deltas (in ancestor order) to the index,
     /// updating or removing entries.
-    fn apply_rooted_deltas(
-        &self,
-        deltas_in_ancestor_order: impl IntoIterator<Item = AHashMap<Pubkey, Option<Arc<StakeAccount>>>>,
-    ) {
+    fn apply_rooted_deltas<D, I>(&self, deltas_in_ancestor_order: D)
+    where
+        D: IntoIterator<Item = I>,
+        I: IntoIterator<Item = (Pubkey, Option<Arc<StakeAccount>>)>,
+    {
         let mut inner = self.0.write().unwrap();
         for delta in deltas_in_ancestor_order {
             for (stake_pubkey, maybe_stake_account) in delta {
@@ -276,7 +315,7 @@ impl StakeDelegationIndex {
 #[derive(Debug)]
 pub(crate) struct StakesCacheV2 {
     stake_delegation_index: Arc<StakeDelegationIndex>,
-    fork_delta: RwLock<AHashMap<Pubkey, Option<Arc<StakeAccount>>>>,
+    fork_delta: RwLock<ForkDelta>,
     state: RwLock<StakesCacheV2State>,
 }
 
@@ -325,7 +364,7 @@ impl StakesCacheV2 {
             stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
                 StakeDelegationIndexInner { root_entries },
             ))),
-            fork_delta: RwLock::new(AHashMap::default()),
+            fork_delta: RwLock::new(ForkDelta::default()),
             state: RwLock::new(StakesCacheV2State {
                 epoch,
                 stake_history,
@@ -379,7 +418,7 @@ impl StakesCacheV2 {
             stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
                 StakeDelegationIndexInner { root_entries },
             ))),
-            fork_delta: RwLock::new(AHashMap::default()),
+            fork_delta: RwLock::new(ForkDelta::default()),
             state: RwLock::new(StakesCacheV2State {
                 epoch,
                 stake_history,
@@ -394,58 +433,57 @@ impl StakesCacheV2 {
         let state = parent.state.read().unwrap().clone();
         Self {
             stake_delegation_index,
-            fork_delta: RwLock::new(AHashMap::default()),
+            fork_delta: RwLock::new(ForkDelta::default()),
             state: RwLock::new(state),
         }
     }
 
     /// Builds a `FrontierQuery` by merging rooted entries with all fork deltas
-    /// in ancestor order, applying overlay updates and collecting frontier-only
-    /// inserts.
+    /// in ancestor order, applying fork delta updates and collecting
+    /// frontier-only inserts.
     pub(crate) fn frontier_query<'a>(
         &self,
         caches_in_ancestor_order: impl IntoIterator<Item = &'a Self>,
     ) -> FrontierQuery<'_> {
-        let mut overlay = AHashMap::new();
-        let mut insert_to_overlay =
+        let inner = self.stake_delegation_index.0.read().unwrap();
+        let mut overrides = FrontierOverrides::default();
+        let mut inserts = FrontierInserts::default();
+        let mut insert_to_frontier =
             |stake_pubkey: &Pubkey, stake_account: &Option<Arc<StakeAccount>>| {
-                overlay.insert(*stake_pubkey, stake_account.clone());
+                if let Some((root_index, _, _)) = inner.root_entries.get_full(stake_pubkey) {
+                    overrides.insert(root_index, stake_account.clone());
+                } else {
+                    match stake_account {
+                        Some(stake_account) => {
+                            inserts.insert(*stake_pubkey, Arc::clone(stake_account));
+                        }
+                        None => {
+                            inserts.swap_remove(stake_pubkey);
+                        }
+                    }
+                }
             };
         for cache in caches_in_ancestor_order {
             let fork_delta = cache.fork_delta.read().unwrap();
             for (stake_pubkey, stake_account) in fork_delta.iter() {
-                insert_to_overlay(stake_pubkey, stake_account);
+                insert_to_frontier(stake_pubkey, stake_account);
             }
         }
         {
             let fork_delta = self.fork_delta.read().unwrap();
             for (stake_pubkey, stake_account) in fork_delta.iter() {
-                insert_to_overlay(stake_pubkey, stake_account);
+                insert_to_frontier(stake_pubkey, stake_account);
             }
         }
 
-        let inner = self.stake_delegation_index.0.read().unwrap();
-
-        let mut overlay_only_inserts = Vec::new();
-        let mut num_removed: usize = 0;
-        for (stake_pubkey, maybe_stake_account) in overlay.iter() {
-            if inner.root_entries.contains_key(stake_pubkey) {
-                if maybe_stake_account.is_none() {
-                    num_removed = num_removed.wrapping_add(1);
-                }
-            } else if let Some(stake_account) = maybe_stake_account {
-                overlay_only_inserts.push(FrontierEntry {
-                    stake_pubkey: *stake_pubkey,
-                    stake_account: Arc::clone(stake_account),
-                });
-            }
-        }
-        overlay_only_inserts.sort_unstable_by_key(|entry| entry.stake_pubkey);
-
+        let num_removed = overrides
+            .values()
+            .filter(|override_entry| override_entry.is_none())
+            .count();
         FrontierQuery {
             inner,
-            overlay,
-            overlay_only_inserts,
+            overrides,
+            inserts,
             num_removed,
         }
     }
@@ -530,7 +568,7 @@ impl StakesCacheV2 {
             stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
                 StakeDelegationIndexInner { root_entries },
             ))),
-            fork_delta: RwLock::new(AHashMap::default()),
+            fork_delta: RwLock::new(ForkDelta::default()),
             state: RwLock::new(StakesCacheV2State {
                 epoch,
                 stake_history: StakeHistory::default(),
@@ -545,7 +583,7 @@ impl StakesCacheV2 {
                     root_entries: RootEntries::default(),
                 },
             ))),
-            fork_delta: RwLock::new(AHashMap::default()),
+            fork_delta: RwLock::new(ForkDelta::default()),
             state: RwLock::new(StakesCacheV2State {
                 epoch,
                 stake_history: StakeHistory::default(),
@@ -628,7 +666,7 @@ mod tests {
     }
 
     #[test]
-    fn test_frontier_query_preserves_root_and_insert_order() {
+    fn test_frontier_query_yields_roots_before_frontier_inserts() {
         let rent = Rent::default();
         let vote_pubkey_a = new_rand();
         let vote_pubkey_b = new_rand();

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -4,6 +4,7 @@ use {
         stake_history::StakeHistory,
         stakes::{DeserializableStakes, Error},
     },
+    ahash::AHashMap,
     rayon::iter::{
         IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
         IntoParallelRefMutIterator, ParallelIterator,
@@ -16,7 +17,6 @@ use {
     solana_vote::vote_account::{VoteAccount, VoteAccounts, VoteAccountsHashMap},
     solana_vote_interface::state::VoteStateVersions,
     std::{
-        collections::HashMap,
         ops::Deref,
         sync::{Arc, RwLock, RwLockReadGuard},
     },
@@ -39,7 +39,7 @@ impl StakesCacheV2State {
 }
 
 /// A hash map that contains per-fork changes to the stake accounts.
-type Overlay = HashMap<Pubkey, Option<Arc<StakeAccount>>>;
+type Overlay = AHashMap<Pubkey, Option<Arc<StakeAccount>>>;
 
 /// Rooted stake delegation entry.
 #[derive(Clone, Debug)]
@@ -104,7 +104,7 @@ struct StakeDelegationIndexInner {
     /// Indices of all tombstones are stored in `free_root_indices`.
     root_entries: Vec<MaybeRootEntry>,
     /// Positions of the given pubkeys inside `root_entries`.
-    root_positions: HashMap<Pubkey, usize>,
+    root_positions: AHashMap<Pubkey, usize>,
     /// Indices of all tombstones in `root_entries`.
     free_root_indices: Vec<usize>,
     /// Manually tracked length of the cache that excludes tombstones.
@@ -127,7 +127,7 @@ struct FrontierEntry {
 pub(crate) struct FrontierQuery<'a> {
     /// Lock guard holding the index of rooted stake delegations.
     inner: RwLockReadGuard<'a, StakeDelegationIndexInner>,
-    overlay: HashMap<Pubkey, Option<Arc<StakeAccount>>>,
+    overlay: AHashMap<Pubkey, Option<Arc<StakeAccount>>>,
     overlay_only_inserts: Vec<FrontierEntry>,
     /// Number of rooted entries that are removed by the overlay.
     num_removed: usize,
@@ -243,7 +243,7 @@ impl StakeDelegationIndex {
     /// updating or removing entries and reusing freed slots via the freelist.
     fn apply_rooted_deltas(
         &self,
-        deltas_in_ancestor_order: impl IntoIterator<Item = HashMap<Pubkey, Option<Arc<StakeAccount>>>>,
+        deltas_in_ancestor_order: impl IntoIterator<Item = AHashMap<Pubkey, Option<Arc<StakeAccount>>>>,
     ) {
         let mut inner = self.0.write().unwrap();
         for delta in deltas_in_ancestor_order {
@@ -290,7 +290,7 @@ impl StakeDelegationIndex {
 #[derive(Debug)]
 pub(crate) struct StakesCacheV2 {
     stake_delegation_index: Arc<StakeDelegationIndex>,
-    fork_delta: RwLock<HashMap<Pubkey, Option<Arc<StakeAccount>>>>,
+    fork_delta: RwLock<AHashMap<Pubkey, Option<Arc<StakeAccount>>>>,
     state: RwLock<StakesCacheV2State>,
 }
 
@@ -303,9 +303,9 @@ impl StakesCacheV2 {
         let epoch = 0;
         let stake_history = StakeHistory::default();
         let mut vote_accounts = VoteAccountsHashMap::default();
-        let mut delegated_stakes: HashMap<Pubkey, u64> = HashMap::default();
+        let mut delegated_stakes: AHashMap<Pubkey, u64> = AHashMap::default();
         let mut root_entries = Vec::new();
-        let mut root_positions = HashMap::new();
+        let mut root_positions = AHashMap::new();
 
         for (pubkey, account) in accounts {
             if account.lamports() == 0 {
@@ -348,7 +348,7 @@ impl StakesCacheV2 {
                     filtered_len,
                 },
             ))),
-            fork_delta: RwLock::new(HashMap::default()),
+            fork_delta: RwLock::new(AHashMap::default()),
             state: RwLock::new(StakesCacheV2State {
                 epoch,
                 stake_history,
@@ -391,7 +391,7 @@ impl StakesCacheV2 {
             root_entries.set_len(filtered_len);
         }
 
-        let mut root_positions = HashMap::with_capacity(root_entries.len());
+        let mut root_positions = AHashMap::with_capacity(root_entries.len());
         for (index, root_entry) in root_entries.iter().enumerate() {
             let stake_pubkey = root_entry
                 .as_ref()
@@ -415,7 +415,7 @@ impl StakesCacheV2 {
                     filtered_len,
                 },
             ))),
-            fork_delta: RwLock::new(HashMap::default()),
+            fork_delta: RwLock::new(AHashMap::default()),
             state: RwLock::new(StakesCacheV2State {
                 epoch,
                 stake_history,
@@ -430,7 +430,7 @@ impl StakesCacheV2 {
         let state = parent.state.read().unwrap().clone();
         Self {
             stake_delegation_index,
-            fork_delta: RwLock::new(HashMap::default()),
+            fork_delta: RwLock::new(AHashMap::default()),
             state: RwLock::new(state),
         }
     }
@@ -442,7 +442,7 @@ impl StakesCacheV2 {
         &self,
         caches_in_ancestor_order: impl IntoIterator<Item = &'a Self>,
     ) -> FrontierQuery<'_> {
-        let mut overlay = HashMap::new();
+        let mut overlay = AHashMap::new();
         let mut num_removed: usize = 0;
         let mut insert_to_overlay =
             |stake_pubkey: &Pubkey, stake_account: &Option<Arc<StakeAccount>>| {
@@ -561,7 +561,7 @@ impl StakesCacheV2 {
         epoch: Epoch,
     ) -> Self {
         let mut root_entries = Vec::with_capacity(accounts.len());
-        let mut root_positions = HashMap::with_capacity(accounts.len());
+        let mut root_positions = AHashMap::with_capacity(accounts.len());
 
         for (pubkey, account) in accounts {
             root_entries.push(MaybeRootEntry::new(pubkey, Arc::new(account)));
@@ -579,7 +579,7 @@ impl StakesCacheV2 {
                     filtered_len,
                 },
             ))),
-            fork_delta: RwLock::new(HashMap::default()),
+            fork_delta: RwLock::new(AHashMap::default()),
             state: RwLock::new(StakesCacheV2State {
                 epoch,
                 stake_history: StakeHistory::default(),
@@ -592,12 +592,12 @@ impl StakesCacheV2 {
             stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
                 StakeDelegationIndexInner {
                     root_entries: Vec::new(),
-                    root_positions: HashMap::new(),
+                    root_positions: AHashMap::new(),
                     free_root_indices: Vec::new(),
                     filtered_len: 0,
                 },
             ))),
-            fork_delta: RwLock::new(HashMap::default()),
+            fork_delta: RwLock::new(AHashMap::default()),
             state: RwLock::new(StakesCacheV2State {
                 epoch,
                 stake_history: StakeHistory::default(),
@@ -762,7 +762,7 @@ mod tests {
         };
 
         // Remove the stake A.
-        index.apply_rooted_deltas([HashMap::from_iter([(stake_pubkey_a, None)])]);
+        index.apply_rooted_deltas([AHashMap::from_iter([(stake_pubkey_a, None)])]);
         {
             let inner = index.0.read().unwrap();
             assert_eq!(inner.root_entries.len(), 2);
@@ -771,7 +771,7 @@ mod tests {
 
         // Add a stake C, make sure it uses the free slot.
         let root_account_c = create_stake_account(30, &vote_pubkey_a, &stake_pubkey_c, &rent);
-        index.apply_rooted_deltas([HashMap::from_iter([(
+        index.apply_rooted_deltas([AHashMap::from_iter([(
             stake_pubkey_c,
             Some(Arc::new(StakeAccount::try_from(root_account_c).unwrap())),
         )])]);
@@ -828,7 +828,7 @@ mod tests {
         let new_account = create_stake_account(30, &vote_pubkey_c, &stake_pubkey_c, &rent);
         cache
             .stake_delegation_index
-            .apply_rooted_deltas([HashMap::from_iter([(
+            .apply_rooted_deltas([AHashMap::from_iter([(
                 stake_pubkey_c,
                 Some(Arc::new(StakeAccount::try_from(new_account).unwrap())),
             )])]);

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -92,9 +92,16 @@ impl MaybeRootEntry {
 
 #[derive(Debug)]
 struct StakeDelegationIndexInner {
+    /// Rooted stake entries, that might be either defined stakes or
+    /// tombstones.
+    ///
+    /// Indices of all tombstones are stored in `free_root_indices`.
     root_entries: Vec<MaybeRootEntry>,
+    /// Positions of the given pubkeys inside `root_entries`.
     root_positions: HashMap<Pubkey, usize>,
+    /// Indices of all tombstones in `root_entries`.
     free_root_indices: Vec<usize>,
+    /// Manually tracked length of the cache.
     len: usize,
 }
 

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -249,7 +249,6 @@ impl StakeDelegationIndex {
 ///   banks.
 /// - A local [`ForkDelta`].
 /// - A local [`StakesCacheV2State`].
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug)]
 pub(crate) struct StakesCacheV2 {
     stake_delegation_index: Arc<StakeDelegationIndex>,

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -4,10 +4,10 @@ use {
         stake_history::StakeHistory,
         stakes::{DeserializableStakes, Error},
     },
-    ahash::AHashMap,
+    ahash::{AHashMap, RandomState as AHashRandomState},
+    indexmap::IndexMap,
     rayon::iter::{
-        IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
-        IntoParallelRefMutIterator, ParallelIterator,
+        IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
     },
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::utils::create_account_shared_data,
@@ -17,7 +17,7 @@ use {
     solana_vote::vote_account::{VoteAccount, VoteAccounts, VoteAccountsHashMap},
     solana_vote_interface::state::VoteStateVersions,
     std::{
-        ops::Deref,
+        ops::{Deref, DerefMut},
         sync::{Arc, RwLock, RwLockReadGuard},
     },
 };
@@ -41,74 +41,77 @@ impl StakesCacheV2State {
 /// A hash map that contains per-fork changes to the stake accounts.
 type Overlay = AHashMap<Pubkey, Option<Arc<StakeAccount>>>;
 
-/// Rooted stake delegation entry.
-#[derive(Clone, Debug)]
-struct RootEntry {
-    stake_pubkey: Pubkey,
-    stake_account: Arc<StakeAccount>,
+type RootEntriesInner = IndexMap<Pubkey, Arc<StakeAccount>, AHashRandomState>;
+
+/// A dense index map of all rooted stake delegations.
+#[derive(Debug)]
+struct RootEntries(RootEntriesInner);
+
+impl Default for RootEntries {
+    fn default() -> Self {
+        Self(IndexMap::with_hasher(AHashRandomState::new()))
+    }
 }
 
-/// Rooted stake delegation entry that might be a tombstone.
-#[derive(Clone, Debug)]
-struct MaybeRootEntry(Option<RootEntry>);
-
-impl Deref for MaybeRootEntry {
-    type Target = Option<RootEntry>;
+impl Deref for RootEntries {
+    type Target = RootEntriesInner;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl MaybeRootEntry {
-    /// Creates a new entry wrapping the given stake account.
-    fn new(stake_pubkey: Pubkey, stake_account: Arc<StakeAccount>) -> Self {
-        Self(Some(RootEntry {
-            stake_pubkey,
-            stake_account,
-        }))
+impl DerefMut for RootEntries {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
+}
 
-    /// Creates a tombstone entry representing a removed stake.
-    fn tombstone() -> Self {
-        Self(None)
+impl IntoIterator for RootEntries {
+    type Item = (Pubkey, Arc<StakeAccount>);
+    type IntoIter = indexmap::map::IntoIter<Pubkey, Arc<StakeAccount>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
+}
 
-    /// Returns the stake pubkey and account, applying any overlay updates.
-    ///
-    /// If the overlay contains an update for this entry's stake pubkey,
-    /// the overlayed value is returned. If the overlay marks the stake as
-    /// removed (`None`), `None` is returned. Otherwise the root entry's
-    /// value is returned.
-    fn apply_overlay<'a>(&'a self, overlay: &'a Overlay) -> Option<(&'a Pubkey, &'a StakeAccount)> {
-        self.0.as_ref().and_then(|root_entry| {
-            match overlay.get(&root_entry.stake_pubkey) {
-                // Overlay updates the stake.
-                Some(Some(stake_account)) => {
-                    Some((&root_entry.stake_pubkey, stake_account.as_ref()))
-                }
-                // Overlay removes the stake.
-                Some(None) => None,
-                // Overlay doesn't modify the stake.
-                None => Some((&root_entry.stake_pubkey, root_entry.stake_account.as_ref())),
-            }
-        })
+#[cfg(test)]
+impl RootEntries {
+    /// Creates an empty [`RootEntries`] map with at least the specified
+    /// capacity.
+    fn with_capacity(capacity: usize) -> Self {
+        Self(IndexMap::with_capacity_and_hasher(
+            capacity,
+            AHashRandomState::new(),
+        ))
+    }
+}
+
+/// Returns the stake pubkey and account, applying any overlay updates.
+///
+/// If the overlay contains an update for this entry's stake pubkey, the
+/// overlayed value is returned. If the overlay marks the stake as removed
+/// (`None`), `None` is returned. Otherwise the rooted value is returned.
+fn apply_overlay<'a>(
+    stake_pubkey: &'a Pubkey,
+    stake_account: &'a Arc<StakeAccount>,
+    overlay: &'a Overlay,
+) -> Option<(&'a Pubkey, &'a StakeAccount)> {
+    match overlay.get(stake_pubkey) {
+        // Overlay updates the stake.
+        Some(Some(stake_account)) => Some((stake_pubkey, stake_account.as_ref())),
+        // Overlay removes the stake.
+        Some(None) => None,
+        // Overlay doesn't modify the stake.
+        None => Some((stake_pubkey, stake_account.as_ref())),
     }
 }
 
 #[derive(Debug)]
 struct StakeDelegationIndexInner {
-    /// Rooted stake entries, that might be either defined stakes or
-    /// tombstones.
-    ///
-    /// Indices of all tombstones are stored in `free_root_indices`.
-    root_entries: Vec<MaybeRootEntry>,
-    /// Positions of the given pubkeys inside `root_entries`.
-    root_positions: AHashMap<Pubkey, usize>,
-    /// Indices of all tombstones in `root_entries`.
-    free_root_indices: Vec<usize>,
-    /// Manually tracked length of the cache that excludes tombstones.
-    filtered_len: usize,
+    /// Rooted stake entries.
+    root_entries: RootEntries,
 }
 
 /// Index of rooted stake delegations, shared across banks.
@@ -136,9 +139,9 @@ pub(crate) struct FrontierQuery<'a> {
 impl<'a> FrontierQuery<'a> {
     /// Returns the total number of stake delegation entries, including rooted
     /// entries, frontier-only inserts, without excluding overlay-removed
-    /// roots and tombstones. The reurned number is equivalent to the number of
-    /// elements yielded by [`FrontierQuery::par_iter_unfiltered`], including
-    /// the `None` elements.
+    /// roots. The returned number is equivalent to the number of elements
+    /// yielded by [`FrontierQuery::par_iter_unfiltered`], including the `None`
+    /// elements.
     pub(crate) fn len_unfiltered(&self) -> usize {
         self.inner
             .root_entries
@@ -148,12 +151,13 @@ impl<'a> FrontierQuery<'a> {
 
     /// Returns the total number of stake delegation entries, including rooted
     /// entries, frontier-only inserts, and excluding overlay-removed roots.
-    /// The reurned number is equivalent to the number of elements yielded by
+    /// The returned number is equivalent to the number of elements yielded by
     /// [`FrontierQuery::par_iter_filtered`], and does not include the `None`
     /// elements.
     pub(crate) fn len_filtered(&self) -> usize {
         self.inner
-            .filtered_len
+            .root_entries
+            .len()
             .wrapping_sub(self.num_removed)
             .wrapping_add(self.overlay_only_inserts.len())
     }
@@ -161,9 +165,8 @@ impl<'a> FrontierQuery<'a> {
     /// Returns an indexed parallel iterator (with a known size) over all stake
     /// delegations.
     ///
-    /// Each item is `Option<(&Pubkey, &StakeAccount)>` — `None` for tombstones
-    /// that should be skipped, or rooted entries that were removed by the
-    /// overlay.
+    /// Each item is `Option<(&Pubkey, &StakeAccount)>` — `None` for rooted
+    /// entries that were removed by the overlay.
     ///
     /// # Performance
     ///
@@ -175,7 +178,9 @@ impl<'a> FrontierQuery<'a> {
         self.inner
             .root_entries
             .par_iter()
-            .map(|root_entry| root_entry.apply_overlay(&self.overlay))
+            .map(|(stake_pubkey, stake_account)| {
+                apply_overlay(stake_pubkey, stake_account, &self.overlay)
+            })
             .chain(
                 self.overlay_only_inserts
                     .par_iter()
@@ -184,7 +189,7 @@ impl<'a> FrontierQuery<'a> {
     }
 
     /// Returns a parallel iterator (with an unknown size) over all valid stake
-    /// delegations, filtering out any tombstones.
+    /// delegations, filtering out roots removed by the overlay.
     ///
     /// # Performance
     ///
@@ -203,9 +208,8 @@ impl<'a> FrontierQuery<'a> {
 impl<'a> FrontierQuery<'a> {
     /// Returns an iterator (with a known size) over all stake delegations.
     ///
-    /// Each item is `Option<(&Pubkey, &StakeAccount)>` — `None` for tombstones
-    /// that should be skipped, or rooted entries that were removed by the
-    /// overlay.
+    /// Each item is `Option<(&Pubkey, &StakeAccount)>` — `None` for rooted
+    /// entries that were removed by the overlay.
     ///
     /// # Performance
     ///
@@ -217,7 +221,9 @@ impl<'a> FrontierQuery<'a> {
         self.inner
             .root_entries
             .iter()
-            .map(|root_entry| root_entry.apply_overlay(&self.overlay))
+            .map(|(stake_pubkey, stake_account)| {
+                apply_overlay(stake_pubkey, stake_account, &self.overlay)
+            })
             .chain(
                 self.overlay_only_inserts
                     .iter()
@@ -226,7 +232,7 @@ impl<'a> FrontierQuery<'a> {
     }
 
     /// Returns an iterator (with an unknown size) over all valid stake
-    /// delegations, filtering out any tombstones.
+    /// delegations, filtering out roots removed by the overlay.
     ///
     /// # Performance
     ///
@@ -240,7 +246,7 @@ impl<'a> FrontierQuery<'a> {
 
 impl StakeDelegationIndex {
     /// Applies rooted stake delegation deltas (in ancestor order) to the index,
-    /// updating or removing entries and reusing freed slots via the freelist.
+    /// updating or removing entries.
     fn apply_rooted_deltas(
         &self,
         deltas_in_ancestor_order: impl IntoIterator<Item = AHashMap<Pubkey, Option<Arc<StakeAccount>>>>,
@@ -250,30 +256,10 @@ impl StakeDelegationIndex {
             for (stake_pubkey, maybe_stake_account) in delta {
                 match maybe_stake_account {
                     Some(stake_account) => {
-                        if let Some(index) = inner.root_positions.get(&stake_pubkey).copied() {
-                            inner.root_entries[index] =
-                                MaybeRootEntry::new(stake_pubkey, stake_account);
-                        } else {
-                            let index = inner
-                                .free_root_indices
-                                .pop()
-                                .unwrap_or_else(|| inner.root_entries.len());
-                            inner.root_positions.insert(stake_pubkey, index);
-                            let root_entry = MaybeRootEntry::new(stake_pubkey, stake_account);
-                            if index == inner.root_entries.len() {
-                                inner.root_entries.push(root_entry);
-                            } else {
-                                inner.root_entries[index] = root_entry;
-                            }
-                            inner.filtered_len = inner.filtered_len.wrapping_add(1);
-                        }
+                        inner.root_entries.insert(stake_pubkey, stake_account);
                     }
                     None => {
-                        if let Some(index) = inner.root_positions.remove(&stake_pubkey) {
-                            inner.root_entries[index] = MaybeRootEntry::tombstone();
-                            inner.free_root_indices.push(index);
-                            inner.filtered_len = inner.filtered_len.wrapping_sub(1);
-                        }
+                        inner.root_entries.swap_remove(&stake_pubkey);
                     }
                 }
             }
@@ -304,8 +290,7 @@ impl StakesCacheV2 {
         let stake_history = StakeHistory::default();
         let mut vote_accounts = VoteAccountsHashMap::default();
         let mut delegated_stakes: AHashMap<Pubkey, u64> = AHashMap::default();
-        let mut root_entries = Vec::new();
-        let mut root_positions = AHashMap::new();
+        let mut root_entries = RootEntries::default();
 
         for (pubkey, account) in accounts {
             if account.lamports() == 0 {
@@ -327,12 +312,9 @@ impl StakesCacheV2 {
                 #[expect(deprecated, reason = "we still use the legacy stake calculation")]
                 let stake = delegation.stake(epoch, &stake_history, None);
                 *delegated_stakes.entry(delegation.voter_pubkey).or_default() += stake;
-                root_entries.push(MaybeRootEntry::new(*pubkey, Arc::new(stake_account)));
-                root_positions.insert(*pubkey, root_entries.len() - 1);
+                root_entries.insert(*pubkey, Arc::new(stake_account));
             }
         }
-
-        let filtered_len = root_entries.len();
 
         let mut vote_accounts = VoteAccounts::from(Arc::new(vote_accounts));
         for (vote_pubkey, stake) in delegated_stakes {
@@ -341,12 +323,7 @@ impl StakesCacheV2 {
 
         Self {
             stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
-                StakeDelegationIndexInner {
-                    root_entries,
-                    root_positions,
-                    free_root_indices: Vec::new(),
-                    filtered_len,
-                },
+                StakeDelegationIndexInner { root_entries },
             ))),
             fork_delta: RwLock::new(AHashMap::default()),
             state: RwLock::new(StakesCacheV2State {
@@ -365,40 +342,32 @@ impl StakesCacheV2 {
     where
         F: Fn(&Pubkey) -> Option<AccountSharedData> + Sync,
     {
-        let filtered_len = stakes.stake_delegations.len();
-        let mut root_entries = Vec::with_capacity(filtered_len);
-        root_entries
-            .spare_capacity_mut()
-            .par_iter_mut()
-            .take(filtered_len)
-            .zip_eq(stakes.stake_delegations.into_par_iter())
-            .try_for_each(|(root_entry, (pubkey, delegation))| {
-                let Some(stake_account) = get_account(&pubkey) else {
-                    return Err(Error::StakeAccountNotFound(pubkey));
-                };
+        let root_entries = stakes
+            .stake_delegations
+            .into_par_iter()
+            .try_fold(
+                RootEntries::default,
+                |mut root_entries, (pubkey, delegation)| {
+                    let Some(stake_account) = get_account(&pubkey) else {
+                        return Err(Error::StakeAccountNotFound(pubkey));
+                    };
 
-                let stake_account = StakeAccount::try_from(stake_account)?;
-                if stake_account.delegation() == &delegation {
-                    root_entry.write(MaybeRootEntry::new(pubkey, Arc::new(stake_account)));
-                    Ok(())
-                } else {
-                    Err(Error::InvalidDelegation(pubkey))
-                }
-            })?;
-        // SAFETY: We initialized all the `root_entries` elements up to
-        // `root_entries_len`.
-        unsafe {
-            root_entries.set_len(filtered_len);
-        }
-
-        let mut root_positions = AHashMap::with_capacity(root_entries.len());
-        for (index, root_entry) in root_entries.iter().enumerate() {
-            let stake_pubkey = root_entry
-                .as_ref()
-                .expect("stake delegation root entry must be populated")
-                .stake_pubkey;
-            root_positions.insert(stake_pubkey, index);
-        }
+                    let stake_account = StakeAccount::try_from(stake_account)?;
+                    if stake_account.delegation() == &delegation {
+                        root_entries.insert(pubkey, Arc::new(stake_account));
+                        Ok(root_entries)
+                    } else {
+                        Err(Error::InvalidDelegation(pubkey))
+                    }
+                },
+            )
+            .try_reduce(
+                RootEntries::default,
+                |mut root_entries, other_root_entries| {
+                    root_entries.extend(other_root_entries);
+                    Ok(root_entries)
+                },
+            )?;
 
         let DeserializableStakes {
             epoch,
@@ -408,12 +377,7 @@ impl StakesCacheV2 {
 
         Ok(Self {
             stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
-                StakeDelegationIndexInner {
-                    root_entries,
-                    root_positions,
-                    free_root_indices: Vec::new(),
-                    filtered_len,
-                },
+                StakeDelegationIndexInner { root_entries },
             ))),
             fork_delta: RwLock::new(AHashMap::default()),
             state: RwLock::new(StakesCacheV2State {
@@ -443,12 +407,8 @@ impl StakesCacheV2 {
         caches_in_ancestor_order: impl IntoIterator<Item = &'a Self>,
     ) -> FrontierQuery<'_> {
         let mut overlay = AHashMap::new();
-        let mut num_removed: usize = 0;
         let mut insert_to_overlay =
             |stake_pubkey: &Pubkey, stake_account: &Option<Arc<StakeAccount>>| {
-                if stake_account.is_none() {
-                    num_removed = num_removed.wrapping_add(1);
-                }
                 overlay.insert(*stake_pubkey, stake_account.clone());
             };
         for cache in caches_in_ancestor_order {
@@ -466,20 +426,20 @@ impl StakesCacheV2 {
 
         let inner = self.stake_delegation_index.0.read().unwrap();
 
-        let mut overlay_only_inserts = overlay
-            .iter()
-            .filter_map(|(stake_pubkey, maybe_stake_account)| {
-                if inner.root_positions.contains_key(stake_pubkey) {
-                    return None;
+        let mut overlay_only_inserts = Vec::new();
+        let mut num_removed: usize = 0;
+        for (stake_pubkey, maybe_stake_account) in overlay.iter() {
+            if inner.root_entries.contains_key(stake_pubkey) {
+                if maybe_stake_account.is_none() {
+                    num_removed = num_removed.wrapping_add(1);
                 }
-                maybe_stake_account
-                    .as_ref()
-                    .map(|stake_account| FrontierEntry {
-                        stake_pubkey: *stake_pubkey,
-                        stake_account: Arc::clone(stake_account),
-                    })
-            })
-            .collect::<Vec<_>>();
+            } else if let Some(stake_account) = maybe_stake_account {
+                overlay_only_inserts.push(FrontierEntry {
+                    stake_pubkey: *stake_pubkey,
+                    stake_account: Arc::clone(stake_account),
+                });
+            }
+        }
         overlay_only_inserts.sort_unstable_by_key(|entry| entry.stake_pubkey);
 
         FrontierQuery {
@@ -560,24 +520,15 @@ impl StakesCacheV2 {
         accounts: impl ExactSizeIterator<Item = (Pubkey, StakeAccount)>,
         epoch: Epoch,
     ) -> Self {
-        let mut root_entries = Vec::with_capacity(accounts.len());
-        let mut root_positions = AHashMap::with_capacity(accounts.len());
+        let mut root_entries = RootEntries::with_capacity(accounts.len());
 
         for (pubkey, account) in accounts {
-            root_entries.push(MaybeRootEntry::new(pubkey, Arc::new(account)));
-            root_positions.insert(pubkey, root_entries.len() - 1);
+            root_entries.insert(pubkey, Arc::new(account));
         }
-
-        let filtered_len = root_entries.len();
 
         Self {
             stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
-                StakeDelegationIndexInner {
-                    root_entries,
-                    root_positions,
-                    free_root_indices: Vec::new(),
-                    filtered_len,
-                },
+                StakeDelegationIndexInner { root_entries },
             ))),
             fork_delta: RwLock::new(AHashMap::default()),
             state: RwLock::new(StakesCacheV2State {
@@ -591,10 +542,7 @@ impl StakesCacheV2 {
         Self {
             stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
                 StakeDelegationIndexInner {
-                    root_entries: Vec::new(),
-                    root_positions: AHashMap::new(),
-                    free_root_indices: Vec::new(),
-                    filtered_len: 0,
+                    root_entries: RootEntries::default(),
                 },
             ))),
             fork_delta: RwLock::new(AHashMap::default()),
@@ -730,7 +678,7 @@ mod tests {
     }
 
     #[test]
-    fn test_root_slot_reuse_after_delete() {
+    fn test_root_delete_removes_entry() {
         let rent = Rent::default();
         let vote_pubkey_a = new_rand();
         let vote_pubkey_b = new_rand();
@@ -756,20 +704,17 @@ mod tests {
             0,
         );
         let index = &root_cache.stake_delegation_index;
-        let removed_index = {
-            let inner = index.0.read().unwrap();
-            *inner.root_positions.get(&stake_pubkey_a).unwrap()
-        };
 
         // Remove the stake A.
         index.apply_rooted_deltas([AHashMap::from_iter([(stake_pubkey_a, None)])]);
         {
             let inner = index.0.read().unwrap();
-            assert_eq!(inner.root_entries.len(), 2);
-            assert_eq!(&inner.free_root_indices, &[removed_index]);
+            assert_eq!(inner.root_entries.len(), 1);
+            assert!(!inner.root_entries.contains_key(&stake_pubkey_a));
+            assert!(inner.root_entries.contains_key(&stake_pubkey_b));
         }
 
-        // Add a stake C, make sure it uses the free slot.
+        // Add a stake C.
         let root_account_c = create_stake_account(30, &vote_pubkey_a, &stake_pubkey_c, &rent);
         index.apply_rooted_deltas([AHashMap::from_iter([(
             stake_pubkey_c,
@@ -778,18 +723,21 @@ mod tests {
 
         let inner = index.0.read().unwrap();
         assert_eq!(inner.root_entries.len(), 2);
-        assert!(inner.free_root_indices.is_empty());
+        assert!(!inner.root_entries.contains_key(&stake_pubkey_a));
+        assert!(inner.root_entries.contains_key(&stake_pubkey_b));
         assert_eq!(
-            inner.root_positions.get(&stake_pubkey_c),
-            Some(&removed_index)
+            inner
+                .root_entries
+                .get(&stake_pubkey_c)
+                .unwrap()
+                .delegation()
+                .stake,
+            30
         );
-        let reused_entry = inner.root_entries[removed_index].as_ref().unwrap();
-        assert_eq!(reused_entry.stake_pubkey, stake_pubkey_c);
-        assert_eq!(reused_entry.stake_account.delegation().stake, 30);
     }
 
     #[test]
-    fn test_apply_rooted_deltas_adds_new_key_beyond_freelist() {
+    fn test_apply_rooted_deltas_adds_new_key() {
         let rent = Rent::default();
         let vote_pubkey_a = new_rand();
         let vote_pubkey_b = new_rand();
@@ -798,7 +746,7 @@ mod tests {
         let stake_pubkey_b = new_rand();
         let stake_pubkey_c = new_rand();
 
-        // Create a cache with 2 entries and an empty freelist
+        // Create a cache with 2 entries.
         let root_account_a = create_stake_account(10, &vote_pubkey_a, &stake_pubkey_a, &rent);
         let root_account_b = create_stake_account(20, &vote_pubkey_b, &stake_pubkey_b, &rent);
         let cache = StakesCacheV2::new_from_accounts(
@@ -818,13 +766,10 @@ mod tests {
 
         // Verify initial state
         let inner = cache.stake_delegation_index.0.read().unwrap();
-        assert_eq!(inner.filtered_len, 2);
         assert_eq!(inner.root_entries.len(), 2);
-        assert!(inner.free_root_indices.is_empty());
         drop(inner);
 
-        // Apply a delta that adds a new key beyond the current root_entries capacity
-        // This should push a new entry into a new index slot
+        // Apply a delta that adds a new key.
         let new_account = create_stake_account(30, &vote_pubkey_c, &stake_pubkey_c, &rent);
         cache
             .stake_delegation_index
@@ -835,19 +780,17 @@ mod tests {
 
         let inner = cache.stake_delegation_index.0.read().unwrap();
         // All three keys should be present
-        assert_eq!(inner.filtered_len, 3);
-        assert!(inner.root_positions.contains_key(&stake_pubkey_a));
-        assert!(inner.root_positions.contains_key(&stake_pubkey_b));
-        assert!(inner.root_positions.contains_key(&stake_pubkey_c));
-        // root_entries should have grown to 3
         assert_eq!(inner.root_entries.len(), 3);
-        // freelist should still be empty (no slots were freed)
-        assert!(inner.free_root_indices.is_empty());
-        // Verify the new entry is at position 2
-        assert_eq!(inner.root_positions.get(&stake_pubkey_c), Some(&2));
+        assert!(inner.root_entries.contains_key(&stake_pubkey_a));
+        assert!(inner.root_entries.contains_key(&stake_pubkey_b));
         assert_eq!(
-            inner.root_entries[2].as_ref().map(|e| e.stake_pubkey),
-            Some(stake_pubkey_c)
+            inner
+                .root_entries
+                .get(&stake_pubkey_c)
+                .unwrap()
+                .delegation()
+                .stake,
+            30
         );
     }
 
@@ -867,10 +810,10 @@ mod tests {
             let inner = root_cache.stake_delegation_index.0.read().unwrap();
             assert_eq!(inner.root_entries.len(), 1);
             assert_eq!(
-                inner.root_entries[0]
-                    .as_ref()
+                inner
+                    .root_entries
+                    .get(&stake_pubkey)
                     .unwrap()
-                    .stake_account
                     .delegation()
                     .stake,
                 10
@@ -889,10 +832,10 @@ mod tests {
         let inner = root_cache.stake_delegation_index.0.read().unwrap();
         assert_eq!(inner.root_entries.len(), 1);
         assert_eq!(
-            inner.root_entries[0]
-                .as_ref()
+            inner
+                .root_entries
+                .get(&stake_pubkey)
                 .unwrap()
-                .stake_account
                 .delegation()
                 .stake,
             50
@@ -931,12 +874,15 @@ mod tests {
         root_cache.apply_rooted_stake_delegation_deltas([&ancestor, &grandchild]);
 
         let inner = root_cache.stake_delegation_index.0.read().unwrap();
-        let entry = inner
-            .root_entries
-            .iter()
-            .find(|e| e.as_ref().map(|e| e.stake_pubkey) == Some(stake_pubkey))
-            .unwrap();
-        assert_eq!(entry.as_ref().unwrap().stake_account.delegation().stake, 30);
+        assert_eq!(
+            inner
+                .root_entries
+                .get(&stake_pubkey)
+                .unwrap()
+                .delegation()
+                .stake,
+            30
+        );
     }
 
     #[test]
@@ -962,8 +908,7 @@ mod tests {
         root_cache.apply_rooted_stake_delegation_deltas([&fork_cache]);
 
         let inner = root_cache.stake_delegation_index.0.read().unwrap();
-        assert_eq!(inner.filtered_len, 0);
-        assert!(inner.root_entries.iter().all(|e| e.is_none()));
+        assert!(inner.root_entries.is_empty());
     }
 
     #[test]
@@ -985,13 +930,16 @@ mod tests {
 
         // The rooted entry should be unchanged
         let inner = root_cache.stake_delegation_index.0.read().unwrap();
-        assert_eq!(inner.filtered_len, 1);
-        let entry = inner
-            .root_entries
-            .iter()
-            .find(|e| e.as_ref().map(|e| e.stake_pubkey) == Some(stake_pubkey))
-            .unwrap();
-        assert_eq!(entry.as_ref().unwrap().stake_account.delegation().stake, 10);
+        assert_eq!(inner.root_entries.len(), 1);
+        assert_eq!(
+            inner
+                .root_entries
+                .get(&stake_pubkey)
+                .unwrap()
+                .delegation()
+                .stake,
+            10
+        );
     }
 
     #[test]
@@ -1022,9 +970,9 @@ mod tests {
         root_cache.apply_rooted_stake_delegation_deltas([&fork_cache]);
 
         let inner = root_cache.stake_delegation_index.0.read().unwrap();
-        assert_eq!(inner.filtered_len, 2);
-        assert!(inner.root_positions.contains_key(&existing_stake_pubkey));
-        assert!(inner.root_positions.contains_key(&new_stake_pubkey));
+        assert_eq!(inner.root_entries.len(), 2);
+        assert!(inner.root_entries.contains_key(&existing_stake_pubkey));
+        assert!(inner.root_entries.contains_key(&new_stake_pubkey));
     }
 
     #[test]
@@ -1057,11 +1005,14 @@ mod tests {
         root_cache.apply_rooted_stake_delegation_deltas([&fork_cache]);
 
         let inner = root_cache.stake_delegation_index.0.read().unwrap();
-        let entry = inner
-            .root_entries
-            .iter()
-            .find(|e| e.as_ref().map(|e| e.stake_pubkey) == Some(stake_pubkey))
-            .unwrap();
-        assert_eq!(entry.as_ref().unwrap().stake_account.delegation().stake, 30);
+        assert_eq!(
+            inner
+                .root_entries
+                .get(&stake_pubkey)
+                .unwrap()
+                .delegation()
+                .stake,
+            30
+        );
     }
 }

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -17,6 +17,7 @@ use {
     solana_vote_interface::state::VoteStateVersions,
     std::{
         collections::HashMap,
+        ops::Deref,
         sync::{Arc, RwLock, RwLockReadGuard},
     },
 };
@@ -36,6 +37,9 @@ impl StakesCacheV2State {
     }
 }
 
+/// A hash map that contains per-fork changes to the stake accounts.
+type Overlay = HashMap<Pubkey, Option<Arc<StakeAccount>>>;
+
 /// Rooted stake delegation entry.
 #[derive(Clone, Debug)]
 struct RootEntry {
@@ -43,11 +47,55 @@ struct RootEntry {
     stake_account: Arc<StakeAccount>,
 }
 
+/// Rooted stake delegation entry that might be a tombstone.
+#[derive(Clone, Debug)]
+struct MaybeRootEntry(Option<RootEntry>);
+
+impl Deref for MaybeRootEntry {
+    type Target = Option<RootEntry>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl MaybeRootEntry {
+    /// Returns a new entry for a stake account.
+    fn new(stake_pubkey: Pubkey, stake_account: Arc<StakeAccount>) -> Self {
+        Self(Some(RootEntry {
+            stake_pubkey,
+            stake_account,
+        }))
+    }
+
+    /// Returns a new tombstone.
+    fn tombstone() -> Self {
+        Self(None)
+    }
+
+    /// Returns a stake account with a potential change from the overlay applied.
+    fn apply_overlay<'a>(&'a self, overlay: &'a Overlay) -> Option<(&'a Pubkey, &'a StakeAccount)> {
+        self.0.as_ref().and_then(|root_entry| {
+            match overlay.get(&root_entry.stake_pubkey) {
+                // Overlay updates the stake.
+                Some(Some(stake_account)) => {
+                    Some((&root_entry.stake_pubkey, stake_account.as_ref()))
+                }
+                // Overlay removes the stake.
+                Some(None) => None,
+                // Overlay doesn't modify the stake.
+                None => Some((&root_entry.stake_pubkey, root_entry.stake_account.as_ref())),
+            }
+        })
+    }
+}
+
 #[derive(Debug)]
 struct StakeDelegationIndexInner {
-    root_entries: Vec<Option<RootEntry>>,
+    root_entries: Vec<MaybeRootEntry>,
     root_positions: HashMap<Pubkey, usize>,
     free_root_indices: Vec<usize>,
+    len: usize,
 }
 
 /// Index of rooted stake delegations, shared across banks.
@@ -64,65 +112,54 @@ struct FrontierEntry {
 /// Merged stake-delegation view for one bank frontier.
 #[derive(Debug)]
 pub(crate) struct FrontierQuery<'a> {
+    /// Lock guard holding the index of rooted stake delegations.
     inner: RwLockReadGuard<'a, StakeDelegationIndexInner>,
-    /// Rooted slots that remain visible after applying unrooted deltas. We
-    /// materialize the visible set once so repeated frontier iterations do
-    /// not have to rescan all rooted entries and skip the hidden ones.
-    visible_root_indices: Vec<usize>,
     overlay: HashMap<Pubkey, Option<Arc<StakeAccount>>>,
     overlay_only_inserts: Vec<FrontierEntry>,
 }
 
 impl<'a> FrontierQuery<'a> {
     pub(crate) fn len(&self) -> usize {
-        self.visible_root_indices.len() + self.overlay_only_inserts.len()
+        self.inner.len + self.overlay_only_inserts.len()
     }
 
     pub(crate) fn par_iter(
         &'a self,
-    ) -> impl IndexedParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {
-        self.visible_root_indices
+    ) -> impl IndexedParallelIterator<Item = Option<(&'a Pubkey, &'a StakeAccount)>> {
+        self.inner
+            .root_entries
             .par_iter()
-            .map(move |root_index| {
-                let root_entry = self.inner.root_entries[*root_index]
-                    .as_ref()
-                    .expect("visible rooted frontier entry must exist");
-                let stake_account = self
-                    .overlay
-                    .get(&root_entry.stake_pubkey)
-                    .and_then(|stake_account| stake_account.as_ref())
-                    .map_or(root_entry.stake_account.as_ref(), Arc::as_ref);
-                (&root_entry.stake_pubkey, stake_account)
-            })
+            .map(|root_entry| root_entry.apply_overlay(&self.overlay))
             .chain(
                 self.overlay_only_inserts
                     .par_iter()
-                    .map(|entry| (&entry.stake_pubkey, entry.stake_account.as_ref())),
+                    .map(|entry| Some((&entry.stake_pubkey, entry.stake_account.as_ref()))),
             )
+    }
+
+    pub(crate) fn par_iter_some(
+        &'a self,
+    ) -> impl ParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {
+        self.par_iter().filter_map(|maybe_stake| maybe_stake)
     }
 }
 
 #[cfg(feature = "dev-context-only-utils")]
 impl<'a> FrontierQuery<'a> {
-    pub(crate) fn iter(&'a self) -> impl Iterator<Item = (&'a Pubkey, &'a StakeAccount)> {
-        self.visible_root_indices
+    pub(crate) fn iter(&'a self) -> impl Iterator<Item = Option<(&'a Pubkey, &'a StakeAccount)>> {
+        self.inner
+            .root_entries
             .iter()
-            .map(move |root_index| {
-                let root_entry = self.inner.root_entries[*root_index]
-                    .as_ref()
-                    .expect("visible rooted frontier entry must exist");
-                let stake_account = self
-                    .overlay
-                    .get(&root_entry.stake_pubkey)
-                    .and_then(|stake_account| stake_account.as_ref())
-                    .map_or(root_entry.stake_account.as_ref(), Arc::as_ref);
-                (&root_entry.stake_pubkey, stake_account)
-            })
+            .map(|root_entry| root_entry.apply_overlay(&self.overlay))
             .chain(
                 self.overlay_only_inserts
                     .iter()
-                    .map(|entry| (&entry.stake_pubkey, entry.stake_account.as_ref())),
+                    .map(|entry| Some((&entry.stake_pubkey, entry.stake_account.as_ref()))),
             )
+    }
+
+    pub(crate) fn iter_some(&'a self) -> impl Iterator<Item = (&'a Pubkey, &'a StakeAccount)> {
+        self.iter().filter_map(|maybe_stake| maybe_stake)
     }
 }
 
@@ -137,31 +174,28 @@ impl StakeDelegationIndex {
                 match maybe_stake_account {
                     Some(stake_account) => {
                         if let Some(index) = inner.root_positions.get(&stake_pubkey).copied() {
-                            inner.root_entries[index] = Some(RootEntry {
-                                stake_pubkey,
-                                stake_account,
-                            });
+                            inner.root_entries[index] =
+                                MaybeRootEntry::new(stake_pubkey, stake_account);
                         } else {
                             let index = inner
                                 .free_root_indices
                                 .pop()
                                 .unwrap_or_else(|| inner.root_entries.len());
                             inner.root_positions.insert(stake_pubkey, index);
-                            let root_entry = Some(RootEntry {
-                                stake_pubkey,
-                                stake_account,
-                            });
+                            let root_entry = MaybeRootEntry::new(stake_pubkey, stake_account);
                             if index == inner.root_entries.len() {
                                 inner.root_entries.push(root_entry);
                             } else {
                                 inner.root_entries[index] = root_entry;
                             }
+                            inner.len = inner.len.wrapping_add(1);
                         }
                     }
                     None => {
                         if let Some(index) = inner.root_positions.remove(&stake_pubkey) {
-                            inner.root_entries[index] = None;
+                            inner.root_entries[index] = MaybeRootEntry::tombstone();
                             inner.free_root_indices.push(index);
+                            inner.len = inner.len.wrapping_sub(1);
                         }
                     }
                 }
@@ -185,35 +219,6 @@ pub(crate) struct StakesCacheV2 {
 }
 
 impl StakesCacheV2 {
-    fn from_root_entries_and_state(
-        root_entries: Vec<Option<RootEntry>>,
-        epoch: Epoch,
-        stake_history: StakeHistory,
-    ) -> Self {
-        let mut root_positions = HashMap::with_capacity(root_entries.len());
-        for (index, root_entry) in root_entries.iter().enumerate() {
-            let stake_pubkey = root_entry
-                .as_ref()
-                .expect("stake delegation root entry must be populated")
-                .stake_pubkey;
-            root_positions.insert(stake_pubkey, index);
-        }
-        Self {
-            stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
-                StakeDelegationIndexInner {
-                    root_entries,
-                    root_positions,
-                    free_root_indices: Vec::new(),
-                },
-            ))),
-            fork_delta: RwLock::new(HashMap::default()),
-            state: RwLock::new(StakesCacheV2State {
-                epoch,
-                stake_history,
-            }),
-        }
-    }
-
     pub(crate) fn new_from_accounts_for_genesis<'a, T: ReadableAccount + 'a>(
         accounts: impl IntoIterator<Item = (&'a Pubkey, &'a T)>,
     ) -> Self {
@@ -222,6 +227,7 @@ impl StakesCacheV2 {
         let mut vote_accounts = VoteAccountsHashMap::default();
         let mut delegated_stakes: HashMap<Pubkey, u64> = HashMap::default();
         let mut root_entries = Vec::new();
+        let mut root_positions = HashMap::new();
 
         for (pubkey, account) in accounts {
             if account.lamports() == 0 {
@@ -244,20 +250,34 @@ impl StakesCacheV2 {
                     #[expect(deprecated, reason = "we still use the legacy stake calculation")]
                     let stake = delegation.stake(epoch, &stake_history, None);
                     *delegated_stakes.entry(delegation.voter_pubkey).or_default() += stake;
-                    root_entries.push(Some(RootEntry {
-                        stake_pubkey: *pubkey,
-                        stake_account: Arc::new(stake_account),
-                    }));
+                    root_entries.push(MaybeRootEntry::new(*pubkey, Arc::new(stake_account)));
+                    root_positions.insert(*pubkey, root_entries.len() - 1);
                 }
             }
         }
+
+        let len = root_entries.len();
 
         let mut vote_accounts = VoteAccounts::from(Arc::new(vote_accounts));
         for (vote_pubkey, stake) in delegated_stakes {
             vote_accounts.add_stake(&vote_pubkey, stake);
         }
 
-        Self::from_root_entries_and_state(root_entries, epoch, stake_history)
+        Self {
+            stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
+                StakeDelegationIndexInner {
+                    root_entries,
+                    root_positions,
+                    free_root_indices: Vec::new(),
+                    len,
+                },
+            ))),
+            fork_delta: RwLock::new(HashMap::default()),
+            state: RwLock::new(StakesCacheV2State {
+                epoch,
+                stake_history,
+            }),
+        }
     }
 
     pub(crate) fn load_from_deserialized_delegations<F>(
@@ -267,12 +287,12 @@ impl StakesCacheV2 {
     where
         F: Fn(&Pubkey) -> Option<AccountSharedData> + Sync,
     {
-        let root_entries_len = stakes.stake_delegations.len();
-        let mut root_entries = Vec::with_capacity(root_entries_len);
+        let len = stakes.stake_delegations.len();
+        let mut root_entries = Vec::with_capacity(len);
         root_entries
             .spare_capacity_mut()
             .par_iter_mut()
-            .take(root_entries_len)
+            .take(len)
             .zip_eq(stakes.stake_delegations.into_par_iter())
             .try_for_each(|(root_entry, (pubkey, delegation))| {
                 let Some(stake_account) = get_account(&pubkey) else {
@@ -281,10 +301,7 @@ impl StakesCacheV2 {
 
                 let stake_account = StakeAccount::try_from(stake_account)?;
                 if stake_account.delegation() == &delegation {
-                    root_entry.write(Some(RootEntry {
-                        stake_pubkey: pubkey,
-                        stake_account: Arc::new(stake_account),
-                    }));
+                    root_entry.write(MaybeRootEntry::new(pubkey, Arc::new(stake_account)));
                     Ok(())
                 } else {
                     Err(Error::InvalidDelegation(pubkey))
@@ -293,13 +310,39 @@ impl StakesCacheV2 {
         // SAFETY: We initialized all the `root_entries` elements up to
         // `root_entries_len`.
         unsafe {
-            root_entries.set_len(root_entries_len);
+            root_entries.set_len(len);
         }
-        Ok(Self::from_root_entries_and_state(
-            root_entries,
-            stakes.epoch,
-            stakes.stake_history,
-        ))
+
+        let mut root_positions = HashMap::with_capacity(root_entries.len());
+        for (index, root_entry) in root_entries.iter().enumerate() {
+            let stake_pubkey = root_entry
+                .as_ref()
+                .expect("stake delegation root entry must be populated")
+                .stake_pubkey;
+            root_positions.insert(stake_pubkey, index);
+        }
+
+        let DeserializableStakes {
+            epoch,
+            stake_history,
+            ..
+        } = stakes;
+
+        Ok(Self {
+            stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
+                StakeDelegationIndexInner {
+                    root_entries,
+                    root_positions,
+                    free_root_indices: Vec::new(),
+                    len,
+                },
+            ))),
+            fork_delta: RwLock::new(HashMap::default()),
+            state: RwLock::new(StakesCacheV2State {
+                epoch,
+                stake_history,
+            }),
+        })
     }
 
     pub(crate) fn new_from_parent(parent: &Self) -> Self {
@@ -310,11 +353,6 @@ impl StakesCacheV2 {
             fork_delta: RwLock::new(HashMap::default()),
             state: RwLock::new(state),
         }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn empty(epoch: Epoch) -> Self {
-        Self::from_root_entries_and_state(Vec::new(), epoch, StakeHistory::default())
     }
 
     pub(crate) fn frontier_query<'a>(
@@ -336,16 +374,6 @@ impl StakesCacheV2 {
         }
 
         let inner = self.stake_delegation_index.0.read().unwrap();
-        let mut visible_root_indices = Vec::with_capacity(inner.root_positions.len());
-        for (root_index, root_entry) in inner.root_entries.iter().enumerate() {
-            let Some(root_entry) = root_entry.as_ref() else {
-                continue;
-            };
-            if matches!(overlay.get(&root_entry.stake_pubkey), Some(None)) {
-                continue;
-            }
-            visible_root_indices.push(root_index);
-        }
 
         let mut overlay_only_inserts = overlay
             .iter()
@@ -365,7 +393,6 @@ impl StakesCacheV2 {
 
         FrontierQuery {
             inner,
-            visible_root_indices,
             overlay,
             overlay_only_inserts,
         }
@@ -428,25 +455,63 @@ impl StakesCacheV2 {
 }
 
 #[cfg(test)]
+impl StakesCacheV2 {
+    pub(crate) fn new_from_accounts(
+        accounts: impl ExactSizeIterator<Item = (Pubkey, StakeAccount)>,
+        epoch: Epoch,
+    ) -> Self {
+        let mut root_entries = Vec::with_capacity(accounts.len());
+        let mut root_positions = HashMap::with_capacity(accounts.len());
+
+        for (pubkey, account) in accounts {
+            root_entries.push(MaybeRootEntry::new(pubkey, Arc::new(account)));
+            root_positions.insert(pubkey, root_entries.len() - 1);
+        }
+
+        let len = root_entries.len();
+
+        Self {
+            stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
+                StakeDelegationIndexInner {
+                    root_entries,
+                    root_positions,
+                    free_root_indices: Vec::new(),
+                    len,
+                },
+            ))),
+            fork_delta: RwLock::new(HashMap::default()),
+            state: RwLock::new(StakesCacheV2State {
+                epoch,
+                stake_history: StakeHistory::default(),
+            }),
+        }
+    }
+
+    pub(crate) fn empty(epoch: Epoch) -> Self {
+        Self {
+            stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
+                StakeDelegationIndexInner {
+                    root_entries: Vec::new(),
+                    root_positions: HashMap::new(),
+                    free_root_indices: Vec::new(),
+                    len: 0,
+                },
+            ))),
+            fork_delta: RwLock::new(HashMap::default()),
+            state: RwLock::new(StakesCacheV2State {
+                epoch,
+                stake_history: StakeHistory::default(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use {
-        super::*, crate::stakes::tests::create_stake_account, rayon::ThreadPoolBuilder,
-        solana_pubkey::new_rand, solana_rent::Rent,
+        super::*, crate::stakes::tests::create_stake_account, solana_pubkey::new_rand,
+        solana_rent::Rent,
     };
-
-    fn root_entries_from_stake_accounts(
-        stake_delegations: impl IntoIterator<Item = (Pubkey, StakeAccount)>,
-    ) -> Vec<Option<RootEntry>> {
-        stake_delegations
-            .into_iter()
-            .map(|(stake_pubkey, stake_account)| {
-                Some(RootEntry {
-                    stake_pubkey,
-                    stake_account: Arc::new(stake_account),
-                })
-            })
-            .collect()
-    }
 
     #[test]
     fn test_frontier_query_overlays_root_and_deltas() {
@@ -460,18 +525,20 @@ mod tests {
         let root_account_a = create_stake_account(10, &vote_pubkey_a, &stake_pubkey_a, &rent);
         let root_account_b = create_stake_account(20, &vote_pubkey_b, &stake_pubkey_b, &rent);
 
-        let root_entries = root_entries_from_stake_accounts([
-            (
-                stake_pubkey_a,
-                StakeAccount::try_from(root_account_a).unwrap(),
-            ),
-            (
-                stake_pubkey_b,
-                StakeAccount::try_from(root_account_b).unwrap(),
-            ),
-        ]);
-        let root_cache =
-            StakesCacheV2::from_root_entries_and_state(root_entries, 0, StakeHistory::default());
+        let root_cache = StakesCacheV2::new_from_accounts(
+            [
+                (
+                    stake_pubkey_a,
+                    StakeAccount::try_from(root_account_a).unwrap(),
+                ),
+                (
+                    stake_pubkey_b,
+                    StakeAccount::try_from(root_account_b).unwrap(),
+                ),
+            ]
+            .into_iter(),
+            0,
+        );
         let fork_cache = StakesCacheV2::new_from_parent(&root_cache);
         let updated_account_a = create_stake_account(30, &vote_pubkey_b, &stake_pubkey_a, &rent);
         let inserted_account_c = create_stake_account(40, &vote_pubkey_a, &stake_pubkey_c, &rent);
@@ -485,10 +552,8 @@ mod tests {
             StakeAccount::try_from(inserted_account_c).unwrap(),
         );
 
-        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let frontier_query = root_cache.frontier_query([&fork_cache]);
-        let stake_delegations =
-            thread_pool.install(|| frontier_query.par_iter().collect::<Vec<_>>());
+        let stake_delegations = frontier_query.iter_some().collect::<Vec<_>>();
         assert_eq!(stake_delegations.len(), 2);
         assert!(stake_delegations.iter().any(|(pubkey, account)| {
             **pubkey == stake_pubkey_a && account.delegation().stake == 30
@@ -526,18 +591,20 @@ mod tests {
         let root_account_a = create_stake_account(10, &vote_pubkey_a, &stake_pubkey_a, &rent);
         let root_account_b = create_stake_account(20, &vote_pubkey_b, &stake_pubkey_b, &rent);
 
-        let root_entries = root_entries_from_stake_accounts([
-            (
-                stake_pubkey_a,
-                StakeAccount::try_from(root_account_a).unwrap(),
-            ),
-            (
-                stake_pubkey_b,
-                StakeAccount::try_from(root_account_b).unwrap(),
-            ),
-        ]);
-        let root_cache =
-            StakesCacheV2::from_root_entries_and_state(root_entries, 0, StakeHistory::default());
+        let root_cache = StakesCacheV2::new_from_accounts(
+            [
+                (
+                    stake_pubkey_a,
+                    StakeAccount::try_from(root_account_a).unwrap(),
+                ),
+                (
+                    stake_pubkey_b,
+                    StakeAccount::try_from(root_account_b).unwrap(),
+                ),
+            ]
+            .into_iter(),
+            0,
+        );
         let fork_cache = StakesCacheV2::new_from_parent(&root_cache);
         let updated_account_a = create_stake_account(30, &vote_pubkey_b, &stake_pubkey_a, &rent);
         let inserted_account_c = create_stake_account(40, &vote_pubkey_a, &stake_pubkey_c, &rent);
@@ -551,14 +618,11 @@ mod tests {
             StakeAccount::try_from(inserted_account_c).unwrap(),
         );
 
-        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let frontier_query = root_cache.frontier_query([&fork_cache]);
-        let query_entries = thread_pool.install(|| {
-            frontier_query
-                .par_iter()
-                .map(|(pubkey, stake_account)| (*pubkey, stake_account.delegation().stake))
-                .collect::<Vec<_>>()
-        });
+        let query_entries = frontier_query
+            .iter_some()
+            .map(|(pubkey, stake_account)| (*pubkey, stake_account.delegation().stake))
+            .collect::<Vec<_>>();
         assert_eq!(
             &query_entries,
             &[(stake_pubkey_a, 30), (stake_pubkey_c, 40)]
@@ -577,18 +641,20 @@ mod tests {
         let root_account_a = create_stake_account(10, &vote_pubkey_a, &stake_pubkey_a, &rent);
         let root_account_b = create_stake_account(20, &vote_pubkey_b, &stake_pubkey_b, &rent);
 
-        let root_entries = root_entries_from_stake_accounts([
-            (
-                stake_pubkey_a,
-                StakeAccount::try_from(root_account_a).unwrap(),
-            ),
-            (
-                stake_pubkey_b,
-                StakeAccount::try_from(root_account_b).unwrap(),
-            ),
-        ]);
-        let root_cache =
-            StakesCacheV2::from_root_entries_and_state(root_entries, 0, StakeHistory::default());
+        let root_cache = StakesCacheV2::new_from_accounts(
+            [
+                (
+                    stake_pubkey_a,
+                    StakeAccount::try_from(root_account_a).unwrap(),
+                ),
+                (
+                    stake_pubkey_b,
+                    StakeAccount::try_from(root_account_b).unwrap(),
+                ),
+            ]
+            .into_iter(),
+            0,
+        );
         let index = &root_cache.stake_delegation_index;
         let removed_index = {
             let inner = index.0.read().unwrap();

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -406,20 +406,15 @@ impl StakesCacheV2 {
     }
 
     pub(crate) fn apply_rooted_stake_delegation_deltas<'a>(
-        &self,
+        &'a self,
         caches_in_ancestor_order: impl IntoIterator<Item = &'a Self>,
     ) {
         let deltas_in_ancestor_order = caches_in_ancestor_order
             .into_iter()
+            .chain([self])
             .filter_map(|cache| {
                 let mut fork_delta = cache.fork_delta.write().unwrap();
                 (!fork_delta.is_empty()).then(|| std::mem::take(&mut *fork_delta))
-            })
-            .chain({
-                let mut fork_delta = self.fork_delta.write().unwrap();
-                (!fork_delta.is_empty())
-                    .then(|| std::mem::take(&mut *fork_delta))
-                    .into_iter()
             });
         self.stake_delegation_index
             .apply_rooted_deltas(deltas_in_ancestor_order);

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -107,8 +107,8 @@ struct StakeDelegationIndexInner {
     root_positions: HashMap<Pubkey, usize>,
     /// Indices of all tombstones in `root_entries`.
     free_root_indices: Vec<usize>,
-    /// Manually tracked length of the cache.
-    len: usize,
+    /// Manually tracked length of the cache that excludes tombstones.
+    filtered_len: usize,
 }
 
 /// Index of rooted stake delegations, shared across banks.
@@ -129,26 +129,47 @@ pub(crate) struct FrontierQuery<'a> {
     inner: RwLockReadGuard<'a, StakeDelegationIndexInner>,
     overlay: HashMap<Pubkey, Option<Arc<StakeAccount>>>,
     overlay_only_inserts: Vec<FrontierEntry>,
+    /// Number of rooted entries that are removed by the overlay.
+    num_removed: usize,
 }
 
 impl<'a> FrontierQuery<'a> {
-    /// Returns the total number of stake delegations, including both rooted
-    /// entries and frontier-only inserts.
-    pub(crate) fn len(&self) -> usize {
-        self.inner.len + self.overlay_only_inserts.len()
+    /// Returns the total number of stake delegation entries, including rooted
+    /// entries, frontier-only inserts, without excluding overlay-removed
+    /// roots and tombstones. The reurned number is equivalent to the number of
+    /// elements yielded by [`FrontierQuery::par_iter_unfiltered`], including
+    /// the `None` elements.
+    pub(crate) fn len_unfiltered(&self) -> usize {
+        self.inner
+            .root_entries
+            .len()
+            .wrapping_add(self.overlay_only_inserts.len())
+    }
+
+    /// Returns the total number of stake delegation entries, including rooted
+    /// entries, frontier-only inserts, and excluding overlay-removed roots.
+    /// The reurned number is equivalent to the number of elements yielded by
+    /// [`FrontierQuery::par_iter_filtered`], and does not include the `None`
+    /// elements.
+    pub(crate) fn len_filtered(&self) -> usize {
+        self.inner
+            .filtered_len
+            .wrapping_sub(self.num_removed)
+            .wrapping_add(self.overlay_only_inserts.len())
     }
 
     /// Returns an indexed parallel iterator (with a known size) over all stake
     /// delegations.
     ///
     /// Each item is `Option<(&Pubkey, &StakeAccount)>` — `None` for tombstones
-    /// that should be skipped.
+    /// that should be skipped, or rooted entries that were removed by the
+    /// overlay.
     ///
     /// # Performance
     ///
     /// Known size of the iterator makes it a good choice for usage that
     /// involves allocating collections.
-    pub(crate) fn par_iter(
+    pub(crate) fn par_iter_unfiltered(
         &'a self,
     ) -> impl IndexedParallelIterator<Item = Option<(&'a Pubkey, &'a StakeAccount)>> {
         self.inner
@@ -168,20 +189,31 @@ impl<'a> FrontierQuery<'a> {
     /// # Performance
     ///
     /// Unknown size of the iterator makes it a bad choice for usage that
-    /// involves allocating collections, where [`FrontierQuery::par_iter`]
-    /// should be used instead.
-    pub(crate) fn par_iter_some(
+    /// involves allocating collections, where
+    /// [`FrontierQuery::par_iter_unfiltered`] should be used instead.
+    pub(crate) fn par_iter_filtered(
         &'a self,
     ) -> impl ParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {
-        self.par_iter().filter_map(|maybe_stake| maybe_stake)
+        self.par_iter_unfiltered()
+            .filter_map(|maybe_stake| maybe_stake)
     }
 }
 
 #[cfg(feature = "dev-context-only-utils")]
 impl<'a> FrontierQuery<'a> {
-    /// Returns a sequential iterator over all stake delegations, including rooted
-    /// entries with overlay applied and frontier-only inserts.
-    pub(crate) fn iter(&'a self) -> impl Iterator<Item = Option<(&'a Pubkey, &'a StakeAccount)>> {
+    /// Returns an iterator (with a known size) over all stake delegations.
+    ///
+    /// Each item is `Option<(&Pubkey, &StakeAccount)>` — `None` for tombstones
+    /// that should be skipped, or rooted entries that were removed by the
+    /// overlay.
+    ///
+    /// # Performance
+    ///
+    /// Known size of the iterator makes it a good choice for usage that
+    /// involves allocating collections.
+    pub(crate) fn iter_unfiltered(
+        &'a self,
+    ) -> impl Iterator<Item = Option<(&'a Pubkey, &'a StakeAccount)>> {
         self.inner
             .root_entries
             .iter()
@@ -193,10 +225,16 @@ impl<'a> FrontierQuery<'a> {
             )
     }
 
-    /// Returns a sequential iterator over all valid stake delegations, filtering
-    /// out any tombstones.
-    pub(crate) fn iter_some(&'a self) -> impl Iterator<Item = (&'a Pubkey, &'a StakeAccount)> {
-        self.iter().flatten()
+    /// Returns an iterator (with an unknown size) over all valid stake
+    /// delegations, filtering out any tombstones.
+    ///
+    /// # Performance
+    ///
+    /// Unknown size of the iterator makes it a bad choice for usage that
+    /// involves allocating collections, where
+    /// [`FrontierQuery::iter_unfiltered`] should be used instead.
+    pub(crate) fn iter_filtered(&'a self) -> impl Iterator<Item = (&'a Pubkey, &'a StakeAccount)> {
+        self.iter_unfiltered().flatten()
     }
 }
 
@@ -227,14 +265,14 @@ impl StakeDelegationIndex {
                             } else {
                                 inner.root_entries[index] = root_entry;
                             }
-                            inner.len = inner.len.wrapping_add(1);
+                            inner.filtered_len = inner.filtered_len.wrapping_add(1);
                         }
                     }
                     None => {
                         if let Some(index) = inner.root_positions.remove(&stake_pubkey) {
                             inner.root_entries[index] = MaybeRootEntry::tombstone();
                             inner.free_root_indices.push(index);
-                            inner.len = inner.len.wrapping_sub(1);
+                            inner.filtered_len = inner.filtered_len.wrapping_sub(1);
                         }
                     }
                 }
@@ -296,7 +334,7 @@ impl StakesCacheV2 {
             }
         }
 
-        let len = root_entries.len();
+        let filtered_len = root_entries.len();
 
         let mut vote_accounts = VoteAccounts::from(Arc::new(vote_accounts));
         for (vote_pubkey, stake) in delegated_stakes {
@@ -309,7 +347,7 @@ impl StakesCacheV2 {
                     root_entries,
                     root_positions,
                     free_root_indices: Vec::new(),
-                    len,
+                    filtered_len,
                 },
             ))),
             fork_delta: RwLock::new(HashMap::default()),
@@ -329,12 +367,12 @@ impl StakesCacheV2 {
     where
         F: Fn(&Pubkey) -> Option<AccountSharedData> + Sync,
     {
-        let len = stakes.stake_delegations.len();
-        let mut root_entries = Vec::with_capacity(len);
+        let filtered_len = stakes.stake_delegations.len();
+        let mut root_entries = Vec::with_capacity(filtered_len);
         root_entries
             .spare_capacity_mut()
             .par_iter_mut()
-            .take(len)
+            .take(filtered_len)
             .zip_eq(stakes.stake_delegations.into_par_iter())
             .try_for_each(|(root_entry, (pubkey, delegation))| {
                 let Some(stake_account) = get_account(&pubkey) else {
@@ -352,7 +390,7 @@ impl StakesCacheV2 {
         // SAFETY: We initialized all the `root_entries` elements up to
         // `root_entries_len`.
         unsafe {
-            root_entries.set_len(len);
+            root_entries.set_len(filtered_len);
         }
 
         let mut root_positions = HashMap::with_capacity(root_entries.len());
@@ -376,7 +414,7 @@ impl StakesCacheV2 {
                     root_entries,
                     root_positions,
                     free_root_indices: Vec::new(),
-                    len,
+                    filtered_len,
                 },
             ))),
             fork_delta: RwLock::new(HashMap::default()),
@@ -407,16 +445,24 @@ impl StakesCacheV2 {
         caches_in_ancestor_order: impl IntoIterator<Item = &'a Self>,
     ) -> FrontierQuery<'_> {
         let mut overlay = HashMap::new();
+        let mut num_removed: usize = 0;
+        let mut insert_to_overlay =
+            |stake_pubkey: &Pubkey, stake_account: &Option<Arc<StakeAccount>>| {
+                if stake_account.is_none() {
+                    num_removed = num_removed.wrapping_add(1);
+                }
+                overlay.insert(*stake_pubkey, stake_account.clone());
+            };
         for cache in caches_in_ancestor_order {
             let fork_delta = cache.fork_delta.read().unwrap();
             for (stake_pubkey, stake_account) in fork_delta.iter() {
-                overlay.insert(*stake_pubkey, stake_account.clone());
+                insert_to_overlay(stake_pubkey, stake_account);
             }
         }
         {
             let fork_delta = self.fork_delta.read().unwrap();
             for (stake_pubkey, stake_account) in fork_delta.iter() {
-                overlay.insert(*stake_pubkey, stake_account.clone());
+                insert_to_overlay(stake_pubkey, stake_account);
             }
         }
 
@@ -442,6 +488,7 @@ impl StakesCacheV2 {
             inner,
             overlay,
             overlay_only_inserts,
+            num_removed,
         }
     }
 
@@ -523,7 +570,7 @@ impl StakesCacheV2 {
             root_positions.insert(pubkey, root_entries.len() - 1);
         }
 
-        let len = root_entries.len();
+        let filtered_len = root_entries.len();
 
         Self {
             stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
@@ -531,7 +578,7 @@ impl StakesCacheV2 {
                     root_entries,
                     root_positions,
                     free_root_indices: Vec::new(),
-                    len,
+                    filtered_len,
                 },
             ))),
             fork_delta: RwLock::new(HashMap::default()),
@@ -549,7 +596,7 @@ impl StakesCacheV2 {
                     root_entries: Vec::new(),
                     root_positions: HashMap::new(),
                     free_root_indices: Vec::new(),
-                    len: 0,
+                    filtered_len: 0,
                 },
             ))),
             fork_delta: RwLock::new(HashMap::default()),
@@ -608,7 +655,7 @@ mod tests {
         );
 
         let frontier_query = root_cache.frontier_query([&fork_cache]);
-        let stake_delegations = frontier_query.iter_some().collect::<Vec<_>>();
+        let stake_delegations = frontier_query.iter_filtered().collect::<Vec<_>>();
         assert_eq!(stake_delegations.len(), 2);
         assert!(stake_delegations.iter().any(|(pubkey, account)| {
             **pubkey == stake_pubkey_a && account.delegation().stake == 30
@@ -675,7 +722,7 @@ mod tests {
 
         let frontier_query = root_cache.frontier_query([&fork_cache]);
         let query_entries = frontier_query
-            .iter_some()
+            .iter_filtered()
             .map(|(pubkey, stake_account)| (*pubkey, stake_account.delegation().stake))
             .collect::<Vec<_>>();
         assert_eq!(
@@ -773,7 +820,7 @@ mod tests {
 
         // Verify initial state
         let inner = cache.stake_delegation_index.0.read().unwrap();
-        assert_eq!(inner.len, 2);
+        assert_eq!(inner.filtered_len, 2);
         assert_eq!(inner.root_entries.len(), 2);
         assert!(inner.free_root_indices.is_empty());
         drop(inner);
@@ -790,7 +837,7 @@ mod tests {
 
         let inner = cache.stake_delegation_index.0.read().unwrap();
         // All three keys should be present
-        assert_eq!(inner.len, 3);
+        assert_eq!(inner.filtered_len, 3);
         assert!(inner.root_positions.contains_key(&stake_pubkey_a));
         assert!(inner.root_positions.contains_key(&stake_pubkey_b));
         assert!(inner.root_positions.contains_key(&stake_pubkey_c));
@@ -917,7 +964,7 @@ mod tests {
         root_cache.apply_rooted_stake_delegation_deltas([&fork_cache]);
 
         let inner = root_cache.stake_delegation_index.0.read().unwrap();
-        assert_eq!(inner.len, 0);
+        assert_eq!(inner.filtered_len, 0);
         assert!(inner.root_entries.iter().all(|e| e.is_none()));
     }
 
@@ -940,7 +987,7 @@ mod tests {
 
         // The rooted entry should be unchanged
         let inner = root_cache.stake_delegation_index.0.read().unwrap();
-        assert_eq!(inner.len, 1);
+        assert_eq!(inner.filtered_len, 1);
         let entry = inner
             .root_entries
             .iter()
@@ -977,7 +1024,7 @@ mod tests {
         root_cache.apply_rooted_stake_delegation_deltas([&fork_cache]);
 
         let inner = root_cache.stake_delegation_index.0.read().unwrap();
-        assert_eq!(inner.len, 2);
+        assert_eq!(inner.filtered_len, 2);
         assert!(inner.root_positions.contains_key(&existing_stake_pubkey));
         assert!(inner.root_positions.contains_key(&new_stake_pubkey));
     }

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -313,24 +313,22 @@ impl StakesCacheV2 {
             }
 
             if solana_vote_program::check_id(account.owner()) {
-                if VoteStateVersions::is_correct_size_and_initialized(account.data()) {
-                    if let Ok(vote_account) =
+                if VoteStateVersions::is_correct_size_and_initialized(account.data())
+                    && let Ok(vote_account) =
                         VoteAccount::try_from(create_account_shared_data(account))
-                    {
-                        vote_accounts.insert(*pubkey, (0, vote_account));
-                    }
-                }
-            } else if stake_program::check_id(account.owner()) {
-                if let Ok(stake_account) =
-                    StakeAccount::try_from(create_account_shared_data(account))
                 {
-                    let delegation = stake_account.delegation();
-                    #[expect(deprecated, reason = "we still use the legacy stake calculation")]
-                    let stake = delegation.stake(epoch, &stake_history, None);
-                    *delegated_stakes.entry(delegation.voter_pubkey).or_default() += stake;
-                    root_entries.push(MaybeRootEntry::new(*pubkey, Arc::new(stake_account)));
-                    root_positions.insert(*pubkey, root_entries.len() - 1);
+                    vote_accounts.insert(*pubkey, (0, vote_account));
                 }
+            } else if stake_program::check_id(account.owner())
+                && let Ok(stake_account) =
+                    StakeAccount::try_from(create_account_shared_data(account))
+            {
+                let delegation = stake_account.delegation();
+                #[expect(deprecated, reason = "we still use the legacy stake calculation")]
+                let stake = delegation.stake(epoch, &stake_history, None);
+                *delegated_stakes.entry(delegation.voter_pubkey).or_default() += stake;
+                root_entries.push(MaybeRootEntry::new(*pubkey, Arc::new(stake_account)));
+                root_positions.insert(*pubkey, root_entries.len() - 1);
             }
         }
 

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -663,6 +663,7 @@ mod tests {
             *inner.root_positions.get(&stake_pubkey_a).unwrap()
         };
 
+        // Remove the stake A.
         index.apply_rooted_deltas([HashMap::from_iter([(stake_pubkey_a, None)])]);
         {
             let inner = index.0.read().unwrap();
@@ -670,6 +671,7 @@ mod tests {
             assert_eq!(&inner.free_root_indices, &[removed_index]);
         }
 
+        // Add a stake C, make sure it uses the free slot.
         let root_account_c = create_stake_account(30, &vote_pubkey_a, &stake_pubkey_c, &rent);
         index.apply_rooted_deltas([HashMap::from_iter([(
             stake_pubkey_c,
@@ -683,67 +685,9 @@ mod tests {
             inner.root_positions.get(&stake_pubkey_c),
             Some(&removed_index)
         );
-        assert_eq!(
-            inner.root_entries[removed_index]
-                .as_ref()
-                .map(|entry| entry.stake_pubkey),
-            Some(stake_pubkey_c)
-        );
-    }
-
-    #[test]
-    fn test_apply_rooted_deltas_replaces_existing_key_with_new_key() {
-        let rent = Rent::default();
-        let vote_pubkey_a = new_rand();
-        let vote_pubkey_b = new_rand();
-        let existing_stake_pubkey = new_rand();
-        let new_stake_pubkey = new_rand();
-
-        let root_account = create_stake_account(10, &vote_pubkey_a, &existing_stake_pubkey, &rent);
-        let mut cache = StakesCacheV2::new_from_accounts(
-            [(
-                existing_stake_pubkey,
-                StakeAccount::try_from(root_account).unwrap(),
-            )]
-            .into_iter(),
-            0,
-        );
-
-        // Verify initial state
-        let inner = cache.stake_delegation_index.0.read().unwrap();
-        assert_eq!(inner.len, 1);
-        assert_eq!(inner.root_entries.len(), 1);
-        assert!(inner.free_root_indices.is_empty());
-        drop(inner);
-
-        // Apply a delta that replaces the existing key with a new key at the same position
-        let new_account = create_stake_account(20, &vote_pubkey_b, &new_stake_pubkey, &rent);
-        cache
-            .stake_delegation_index
-            .0
-            .write()
-            .unwrap()
-            .apply_rooted_deltas([HashMap::from_iter([(
-                new_stake_pubkey,
-                Some(Arc::new(StakeAccount::try_from(new_account).unwrap())),
-            )])]);
-
-        let inner = cache.stake_delegation_index.0.read().unwrap();
-        // The existing key should be gone
-        assert!(!inner.root_positions.contains_key(&existing_stake_pubkey));
-        // The new key should be present at the same position
-        assert_eq!(inner.root_positions.get(&new_stake_pubkey), Some(&0));
-        // The old slot should be in the freelist
-        assert_eq!(inner.free_root_indices, vec![0]);
-        // len should still be 1 (one active entry)
-        assert_eq!(inner.len, 1);
-        // root_entries should still be length 1 (reused, not extended)
-        assert_eq!(inner.root_entries.len(), 1);
-        // The entry at position 0 should be the new key
-        assert_eq!(
-            inner.root_entries[0].as_ref().map(|e| e.stake_pubkey),
-            Some(new_stake_pubkey)
-        );
+        let reused_entry = inner.root_entries[removed_index].as_ref().unwrap();
+        assert_eq!(reused_entry.stake_pubkey, stake_pubkey_c);
+        assert_eq!(reused_entry.stake_account.delegation().stake, 30);
     }
 
     #[test]
@@ -759,7 +703,7 @@ mod tests {
         // Create a cache with 2 entries and an empty freelist
         let root_account_a = create_stake_account(10, &vote_pubkey_a, &stake_pubkey_a, &rent);
         let root_account_b = create_stake_account(20, &vote_pubkey_b, &stake_pubkey_b, &rent);
-        let mut cache = StakesCacheV2::new_from_accounts(
+        let cache = StakesCacheV2::new_from_accounts(
             [
                 (
                     stake_pubkey_a,
@@ -786,9 +730,6 @@ mod tests {
         let new_account = create_stake_account(30, &vote_pubkey_c, &stake_pubkey_c, &rent);
         cache
             .stake_delegation_index
-            .0
-            .write()
-            .unwrap()
             .apply_rooted_deltas([HashMap::from_iter([(
                 stake_pubkey_c,
                 Some(Arc::new(StakeAccount::try_from(new_account).unwrap())),
@@ -824,6 +765,20 @@ mod tests {
             0,
         );
 
+        {
+            let inner = root_cache.stake_delegation_index.0.read().unwrap();
+            assert_eq!(inner.root_entries.len(), 1);
+            assert_eq!(
+                inner.root_entries[0]
+                    .as_ref()
+                    .unwrap()
+                    .stake_account
+                    .delegation()
+                    .stake,
+                10
+            );
+        }
+
         let fork_cache = StakesCacheV2::new_from_parent(&root_cache);
         let updated_account = create_stake_account(50, &vote_pubkey, &stake_pubkey, &rent);
         fork_cache.upsert_stake_delegation(
@@ -834,12 +789,16 @@ mod tests {
         root_cache.apply_rooted_stake_delegation_deltas([&fork_cache]);
 
         let inner = root_cache.stake_delegation_index.0.read().unwrap();
-        let entry = inner
-            .root_entries
-            .iter()
-            .find(|e| e.as_ref().map(|e| e.stake_pubkey) == Some(stake_pubkey))
-            .unwrap();
-        assert_eq!(entry.as_ref().unwrap().stake_account.delegation().stake, 50);
+        assert_eq!(inner.root_entries.len(), 1);
+        assert_eq!(
+            inner.root_entries[0]
+                .as_ref()
+                .unwrap()
+                .stake_account
+                .delegation()
+                .stake,
+            50
+        );
     }
 
     #[test]
@@ -983,14 +942,14 @@ mod tests {
         );
 
         let fork_cache = StakesCacheV2::new_from_parent(&root_cache);
-        // Ancestor sets stake to 20
+        // Ancestor sets stake to 20.
         let ancestor_account = create_stake_account(20, &vote_pubkey, &stake_pubkey, &rent);
         fork_cache.upsert_stake_delegation(
             stake_pubkey,
             StakeAccount::try_from(ancestor_account).unwrap(),
         );
 
-        // Root cache itself sets stake to 30 (should override ancestor)
+        // Root cache itself sets stake to 30 (should override ancestor).
         let root_update_account = create_stake_account(30, &vote_pubkey, &stake_pubkey, &rent);
         root_cache.upsert_stake_delegation(
             stake_pubkey,

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -166,7 +166,7 @@ impl<'a> FrontierQuery<'a> {
     }
 
     pub(crate) fn iter_some(&'a self) -> impl Iterator<Item = (&'a Pubkey, &'a StakeAccount)> {
-        self.iter().filter_map(|maybe_stake| maybe_stake)
+        self.iter().flatten()
     }
 }
 

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -732,10 +732,7 @@ mod tests {
         // The existing key should be gone
         assert!(!inner.root_positions.contains_key(&existing_stake_pubkey));
         // The new key should be present at the same position
-        assert_eq!(
-            inner.root_positions.get(&new_stake_pubkey),
-            Some(&0)
-        );
+        assert_eq!(inner.root_positions.get(&new_stake_pubkey), Some(&0));
         // The old slot should be in the freelist
         assert_eq!(inner.free_root_indices, vec![0]);
         // len should still be 1 (one active entry)
@@ -744,9 +741,7 @@ mod tests {
         assert_eq!(inner.root_entries.len(), 1);
         // The entry at position 0 should be the new key
         assert_eq!(
-            inner.root_entries[0]
-                .as_ref()
-                .map(|e| e.stake_pubkey),
+            inner.root_entries[0].as_ref().map(|e| e.stake_pubkey),
             Some(new_stake_pubkey)
         );
     }
@@ -810,14 +805,9 @@ mod tests {
         // freelist should still be empty (no slots were freed)
         assert!(inner.free_root_indices.is_empty());
         // Verify the new entry is at position 2
+        assert_eq!(inner.root_positions.get(&stake_pubkey_c), Some(&2));
         assert_eq!(
-            inner.root_positions.get(&stake_pubkey_c),
-            Some(&2)
-        );
-        assert_eq!(
-            inner.root_entries[2]
-                .as_ref()
-                .map(|e| e.stake_pubkey),
+            inner.root_entries[2].as_ref().map(|e| e.stake_pubkey),
             Some(stake_pubkey_c)
         );
     }

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -448,10 +448,19 @@ impl StakesCacheV2 {
         let inner = self.stake_delegation_index.0.read().unwrap();
         let mut overrides = FrontierOverrides::default();
         let mut inserts = FrontierInserts::default();
+        let mut num_removed: usize = 0;
         let mut insert_to_frontier =
             |stake_pubkey: &Pubkey, stake_account: &Option<Arc<StakeAccount>>| {
                 if let Some((root_index, _, _)) = inner.root_entries.get_full(stake_pubkey) {
-                    overrides.insert(root_index, stake_account.clone());
+                    let previous_stake_account =
+                        overrides.insert(root_index, stake_account.clone());
+                    if stake_account.is_none() {
+                        if !matches!(previous_stake_account, Some(None)) {
+                            num_removed = num_removed.wrapping_add(1);
+                        }
+                    } else if matches!(previous_stake_account, Some(None)) {
+                        num_removed = num_removed.wrapping_sub(1);
+                    }
                 } else {
                     match stake_account {
                         Some(stake_account) => {
@@ -476,10 +485,6 @@ impl StakesCacheV2 {
             }
         }
 
-        let num_removed = overrides
-            .values()
-            .filter(|override_entry| override_entry.is_none())
-            .count();
         FrontierQuery {
             inner,
             overrides,
@@ -647,6 +652,33 @@ mod tests {
         assert!(stake_delegations.iter().any(|(pubkey, account)| {
             **pubkey == stake_pubkey_c && account.delegation().stake == 40
         }));
+    }
+
+    #[test]
+    fn test_frontier_query_counts_only_final_removed_root_overrides() {
+        let rent = Rent::default();
+        let vote_pubkey = new_rand();
+        let stake_pubkey = new_rand();
+
+        let root_account = create_stake_account(10, &vote_pubkey, &stake_pubkey, &rent);
+        let root_cache = StakesCacheV2::new_from_accounts(
+            [(stake_pubkey, StakeAccount::try_from(root_account).unwrap())].into_iter(),
+            0,
+        );
+
+        let ancestor = StakesCacheV2::new_from_parent(&root_cache);
+        let child = StakesCacheV2::new_from_parent(&ancestor);
+
+        ancestor.remove_stake_delegation(&stake_pubkey);
+        let updated_account = create_stake_account(20, &vote_pubkey, &stake_pubkey, &rent);
+        child.upsert_stake_delegation(
+            stake_pubkey,
+            StakeAccount::try_from(updated_account).unwrap(),
+        );
+
+        let frontier_query = child.frontier_query([&ancestor]);
+        assert_eq!(frontier_query.len_unfiltered(), 1);
+        assert_eq!(frontier_query.len_filtered(), 1);
     }
 
     #[test]

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -690,4 +690,200 @@ mod tests {
             Some(stake_pubkey_c)
         );
     }
+
+    #[test]
+    fn test_apply_rooted_stake_delegation_deltas_applies_updates() {
+        let rent = Rent::default();
+        let vote_pubkey = new_rand();
+        let stake_pubkey = new_rand();
+
+        let root_account = create_stake_account(10, &vote_pubkey, &stake_pubkey, &rent);
+        let root_cache = StakesCacheV2::new_from_accounts(
+            [(stake_pubkey, StakeAccount::try_from(root_account).unwrap())].into_iter(),
+            0,
+        );
+
+        let fork_cache = StakesCacheV2::new_from_parent(&root_cache);
+        let updated_account = create_stake_account(50, &vote_pubkey, &stake_pubkey, &rent);
+        fork_cache.upsert_stake_delegation(
+            stake_pubkey,
+            StakeAccount::try_from(updated_account).unwrap(),
+        );
+
+        root_cache.apply_rooted_stake_delegation_deltas([&fork_cache]);
+
+        let inner = root_cache.stake_delegation_index.0.read().unwrap();
+        let entry = inner
+            .root_entries
+            .iter()
+            .find(|e| e.as_ref().map(|e| e.stake_pubkey) == Some(stake_pubkey))
+            .unwrap();
+        assert_eq!(entry.as_ref().unwrap().stake_account.delegation().stake, 50);
+    }
+
+    #[test]
+    fn test_apply_rooted_stake_delegation_deltas_overrides_ancestor_deltas() {
+        let rent = Rent::default();
+        let vote_pubkey = new_rand();
+        let stake_pubkey = new_rand();
+
+        let root_account = create_stake_account(10, &vote_pubkey, &stake_pubkey, &rent);
+        let root_cache = StakesCacheV2::new_from_accounts(
+            [(stake_pubkey, StakeAccount::try_from(root_account).unwrap())].into_iter(),
+            0,
+        );
+
+        let ancestor = StakesCacheV2::new_from_parent(&root_cache);
+        let grandchild = StakesCacheV2::new_from_parent(&ancestor);
+
+        // Ancestor updates stake to 20
+        let ancestor_account = create_stake_account(20, &vote_pubkey, &stake_pubkey, &rent);
+        ancestor.upsert_stake_delegation(
+            stake_pubkey,
+            StakeAccount::try_from(ancestor_account).unwrap(),
+        );
+
+        // Grandchild updates stake to 30 (should override ancestor's 20)
+        let grandchild_account = create_stake_account(30, &vote_pubkey, &stake_pubkey, &rent);
+        grandchild.upsert_stake_delegation(
+            stake_pubkey,
+            StakeAccount::try_from(grandchild_account).unwrap(),
+        );
+
+        root_cache.apply_rooted_stake_delegation_deltas([&ancestor, &grandchild]);
+
+        let inner = root_cache.stake_delegation_index.0.read().unwrap();
+        let entry = inner
+            .root_entries
+            .iter()
+            .find(|e| e.as_ref().map(|e| e.stake_pubkey) == Some(stake_pubkey))
+            .unwrap();
+        assert_eq!(entry.as_ref().unwrap().stake_account.delegation().stake, 30);
+    }
+
+    #[test]
+    fn test_apply_rooted_stake_delegation_deltas_deletes_via_none() {
+        let rent = Rent::default();
+        let vote_pubkey = new_rand();
+        let stake_pubkey = new_rand();
+
+        let root_account = create_stake_account(10, &vote_pubkey, &stake_pubkey, &rent);
+        let root_cache = StakesCacheV2::new_from_accounts(
+            [(stake_pubkey, StakeAccount::try_from(root_account).unwrap())].into_iter(),
+            0,
+        );
+
+        let fork_cache = StakesCacheV2::new_from_parent(&root_cache);
+        // Remove the stake via None delta
+        fork_cache
+            .fork_delta
+            .write()
+            .unwrap()
+            .insert(stake_pubkey, None);
+
+        root_cache.apply_rooted_stake_delegation_deltas([&fork_cache]);
+
+        let inner = root_cache.stake_delegation_index.0.read().unwrap();
+        assert_eq!(inner.len, 0);
+        assert!(inner.root_entries.iter().all(|e| e.is_none()));
+    }
+
+    #[test]
+    fn test_apply_rooted_stake_delegation_deltas_skips_empty_deltas() {
+        let rent = Rent::default();
+        let vote_pubkey = new_rand();
+        let stake_pubkey = new_rand();
+
+        let root_account = create_stake_account(10, &vote_pubkey, &stake_pubkey, &rent);
+        let root_cache = StakesCacheV2::new_from_accounts(
+            [(stake_pubkey, StakeAccount::try_from(root_account).unwrap())].into_iter(),
+            0,
+        );
+
+        let fork_cache = StakesCacheV2::new_from_parent(&root_cache);
+        // fork_cache has an empty fork_delta by default
+
+        root_cache.apply_rooted_stake_delegation_deltas([&fork_cache]);
+
+        // The rooted entry should be unchanged
+        let inner = root_cache.stake_delegation_index.0.read().unwrap();
+        assert_eq!(inner.len, 1);
+        let entry = inner
+            .root_entries
+            .iter()
+            .find(|e| e.as_ref().map(|e| e.stake_pubkey) == Some(stake_pubkey))
+            .unwrap();
+        assert_eq!(entry.as_ref().unwrap().stake_account.delegation().stake, 10);
+    }
+
+    #[test]
+    fn test_apply_rooted_stake_delegation_deltas_inserts_new_entries() {
+        let rent = Rent::default();
+        let vote_pubkey_a = new_rand();
+        let vote_pubkey_b = new_rand();
+        let existing_stake_pubkey = new_rand();
+        let new_stake_pubkey = new_rand();
+
+        let root_account = create_stake_account(10, &vote_pubkey_a, &existing_stake_pubkey, &rent);
+        let root_cache = StakesCacheV2::new_from_accounts(
+            [(
+                existing_stake_pubkey,
+                StakeAccount::try_from(root_account).unwrap(),
+            )]
+            .into_iter(),
+            0,
+        );
+
+        let fork_cache = StakesCacheV2::new_from_parent(&root_cache);
+        let new_account = create_stake_account(20, &vote_pubkey_b, &new_stake_pubkey, &rent);
+        fork_cache.upsert_stake_delegation(
+            new_stake_pubkey,
+            StakeAccount::try_from(new_account).unwrap(),
+        );
+
+        root_cache.apply_rooted_stake_delegation_deltas([&fork_cache]);
+
+        let inner = root_cache.stake_delegation_index.0.read().unwrap();
+        assert_eq!(inner.len, 2);
+        assert!(inner.root_positions.contains_key(&existing_stake_pubkey));
+        assert!(inner.root_positions.contains_key(&new_stake_pubkey));
+    }
+
+    #[test]
+    fn test_apply_rooted_stake_delegation_deltas_applies_own_delta_last() {
+        let rent = Rent::default();
+        let vote_pubkey = new_rand();
+        let stake_pubkey = new_rand();
+
+        let root_account = create_stake_account(10, &vote_pubkey, &stake_pubkey, &rent);
+        let root_cache = StakesCacheV2::new_from_accounts(
+            [(stake_pubkey, StakeAccount::try_from(root_account).unwrap())].into_iter(),
+            0,
+        );
+
+        let fork_cache = StakesCacheV2::new_from_parent(&root_cache);
+        // Ancestor sets stake to 20
+        let ancestor_account = create_stake_account(20, &vote_pubkey, &stake_pubkey, &rent);
+        fork_cache.upsert_stake_delegation(
+            stake_pubkey,
+            StakeAccount::try_from(ancestor_account).unwrap(),
+        );
+
+        // Root cache itself sets stake to 30 (should override ancestor)
+        let root_update_account = create_stake_account(30, &vote_pubkey, &stake_pubkey, &rent);
+        root_cache.upsert_stake_delegation(
+            stake_pubkey,
+            StakeAccount::try_from(root_update_account).unwrap(),
+        );
+
+        root_cache.apply_rooted_stake_delegation_deltas([&fork_cache]);
+
+        let inner = root_cache.stake_delegation_index.0.read().unwrap();
+        let entry = inner
+            .root_entries
+            .iter()
+            .find(|e| e.as_ref().map(|e| e.stake_pubkey) == Some(stake_pubkey))
+            .unwrap();
+        assert_eq!(entry.as_ref().unwrap().stake_account.delegation().stake, 30);
+    }
 }

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -32,6 +32,7 @@ pub(crate) struct StakesCacheV2State {
 }
 
 impl StakesCacheV2State {
+    /// Returns the stake history associated with this state.
     pub(crate) fn stake_history(&self) -> &StakeHistory {
         &self.stake_history
     }
@@ -60,7 +61,7 @@ impl Deref for MaybeRootEntry {
 }
 
 impl MaybeRootEntry {
-    /// Returns a new entry for a stake account.
+    /// Creates a new entry wrapping the given stake account.
     fn new(stake_pubkey: Pubkey, stake_account: Arc<StakeAccount>) -> Self {
         Self(Some(RootEntry {
             stake_pubkey,
@@ -68,12 +69,17 @@ impl MaybeRootEntry {
         }))
     }
 
-    /// Returns a new tombstone.
+    /// Creates a tombstone entry representing a removed stake.
     fn tombstone() -> Self {
         Self(None)
     }
 
-    /// Returns a stake account with a potential change from the overlay applied.
+    /// Returns the stake pubkey and account, applying any overlay updates.
+    ///
+    /// If the overlay contains an update for this entry's stake pubkey,
+    /// the overlayed value is returned. If the overlay marks the stake as
+    /// removed (`None`), `None` is returned. Otherwise the root entry's
+    /// value is returned.
     fn apply_overlay<'a>(&'a self, overlay: &'a Overlay) -> Option<(&'a Pubkey, &'a StakeAccount)> {
         self.0.as_ref().and_then(|root_entry| {
             match overlay.get(&root_entry.stake_pubkey) {
@@ -126,10 +132,22 @@ pub(crate) struct FrontierQuery<'a> {
 }
 
 impl<'a> FrontierQuery<'a> {
+    /// Returns the total number of stake delegations, including both rooted
+    /// entries and frontier-only inserts.
     pub(crate) fn len(&self) -> usize {
         self.inner.len + self.overlay_only_inserts.len()
     }
 
+    /// Returns an indexed parallel iterator (with a known size) over all stake
+    /// delegations.
+    ///
+    /// Each item is `Option<(&Pubkey, &StakeAccount)>` — `None` for tombstones
+    /// that should be skipped.
+    ///
+    /// # Performance
+    ///
+    /// Known size of the iterator makes it a good choice for usage that
+    /// involves allocating collections.
     pub(crate) fn par_iter(
         &'a self,
     ) -> impl IndexedParallelIterator<Item = Option<(&'a Pubkey, &'a StakeAccount)>> {
@@ -144,6 +162,14 @@ impl<'a> FrontierQuery<'a> {
             )
     }
 
+    /// Returns a parallel iterator (with an unknown size) over all valid stake
+    /// delegations, filtering out any tombstones.
+    ///
+    /// # Performance
+    ///
+    /// Unknown size of the iterator makes it a bad choice for usage that
+    /// involves allocating collections, where [`FrontierQuery::par_iter`]
+    /// should be used instead.
     pub(crate) fn par_iter_some(
         &'a self,
     ) -> impl ParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {
@@ -153,6 +179,8 @@ impl<'a> FrontierQuery<'a> {
 
 #[cfg(feature = "dev-context-only-utils")]
 impl<'a> FrontierQuery<'a> {
+    /// Returns a sequential iterator over all stake delegations, including rooted
+    /// entries with overlay applied and frontier-only inserts.
     pub(crate) fn iter(&'a self) -> impl Iterator<Item = Option<(&'a Pubkey, &'a StakeAccount)>> {
         self.inner
             .root_entries
@@ -165,12 +193,16 @@ impl<'a> FrontierQuery<'a> {
             )
     }
 
+    /// Returns a sequential iterator over all valid stake delegations, filtering
+    /// out any tombstones.
     pub(crate) fn iter_some(&'a self) -> impl Iterator<Item = (&'a Pubkey, &'a StakeAccount)> {
         self.iter().flatten()
     }
 }
 
 impl StakeDelegationIndex {
+    /// Applies rooted stake delegation deltas (in ancestor order) to the index,
+    /// updating or removing entries and reusing freed slots via the freelist.
     fn apply_rooted_deltas(
         &self,
         deltas_in_ancestor_order: impl IntoIterator<Item = HashMap<Pubkey, Option<Arc<StakeAccount>>>>,
@@ -226,6 +258,8 @@ pub(crate) struct StakesCacheV2 {
 }
 
 impl StakesCacheV2 {
+    /// Creates a new `StakesCacheV2` from genesis accounts, extracting vote
+    /// accounts and stake delegations to build the initial rooted index.
     pub(crate) fn new_from_accounts_for_genesis<'a, T: ReadableAccount + 'a>(
         accounts: impl IntoIterator<Item = (&'a Pubkey, &'a T)>,
     ) -> Self {
@@ -287,6 +321,8 @@ impl StakesCacheV2 {
         }
     }
 
+    /// Loads `StakesCacheV2` from deserialized stake delegations, fetching each
+    /// full stake account via `get_account` and verifying delegation consistency.
     pub(crate) fn load_from_deserialized_delegations<F>(
         stakes: DeserializableStakes<Delegation>,
         get_account: F,
@@ -352,6 +388,8 @@ impl StakesCacheV2 {
         })
     }
 
+    /// Creates a new `StakesCacheV2` from a parent bank, sharing the rooted
+    /// index but starting with an empty fork delta.
     pub(crate) fn new_from_parent(parent: &Self) -> Self {
         let stake_delegation_index = Arc::clone(&parent.stake_delegation_index);
         let state = parent.state.read().unwrap().clone();
@@ -362,6 +400,9 @@ impl StakesCacheV2 {
         }
     }
 
+    /// Builds a `FrontierQuery` by merging rooted entries with all fork deltas
+    /// in ancestor order, applying overlay updates and collecting frontier-only
+    /// inserts.
     pub(crate) fn frontier_query<'a>(
         &self,
         caches_in_ancestor_order: impl IntoIterator<Item = &'a Self>,
@@ -405,6 +446,8 @@ impl StakesCacheV2 {
         }
     }
 
+    /// Applies rooted stake delegation deltas from ancestor caches and this
+    /// bank's own fork delta, updating the shared rooted index.
     pub(crate) fn apply_rooted_stake_delegation_deltas<'a>(
         &'a self,
         caches_in_ancestor_order: impl IntoIterator<Item = &'a Self>,
@@ -420,6 +463,8 @@ impl StakesCacheV2 {
             .apply_rooted_deltas(deltas_in_ancestor_order);
     }
 
+    /// Checks if an account is a stake program account and either stores a new
+    /// delegation or removes an existing one if the account is empty or invalid.
     pub(crate) fn check_and_store(&self, pubkey: &Pubkey, account: &impl ReadableAccount) {
         if !stake_program::check_id(account.owner()) {
             return;
@@ -434,6 +479,8 @@ impl StakesCacheV2 {
         }
     }
 
+    /// Inserts or updates a stake delegation in the fork delta, making it visible
+    /// to subsequent frontier queries.
     pub(crate) fn upsert_stake_delegation(&self, pubkey: Pubkey, stake_account: StakeAccount) {
         self.fork_delta
             .write()
@@ -441,14 +488,21 @@ impl StakesCacheV2 {
             .insert(pubkey, Some(Arc::new(stake_account)));
     }
 
+    /// Removes a stake delegation from the fork delta. Subsequent frontier queries
+    /// will not include this stake.
     pub(crate) fn remove_stake_delegation(&self, pubkey: &Pubkey) {
         self.fork_delta.write().unwrap().insert(*pubkey, None);
     }
 
-    pub(crate) fn state(&self) -> RwLockReadGuard<'_, StakesCacheV2State> {
+    /// Returns the current epoch and stake history associated with this cache.
+    pub(crate) fn state(&self) -> std::sync::RwLockReadGuard<'_, StakesCacheV2State> {
         self.state.read().unwrap()
     }
 
+    /// Advances the epoch to `next_epoch` and updates the stake history.
+    ///
+    /// This method is called at epoch boundary to finalize rooted deltas and
+    /// update the stake history for stake-weighted calculations.
     pub(crate) fn activate_epoch(&self, next_epoch: Epoch, stake_history: StakeHistory) {
         let mut state = self.state.write().unwrap();
         state.epoch = next_epoch;

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -692,6 +692,137 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_rooted_deltas_replaces_existing_key_with_new_key() {
+        let rent = Rent::default();
+        let vote_pubkey_a = new_rand();
+        let vote_pubkey_b = new_rand();
+        let existing_stake_pubkey = new_rand();
+        let new_stake_pubkey = new_rand();
+
+        let root_account = create_stake_account(10, &vote_pubkey_a, &existing_stake_pubkey, &rent);
+        let mut cache = StakesCacheV2::new_from_accounts(
+            [(
+                existing_stake_pubkey,
+                StakeAccount::try_from(root_account).unwrap(),
+            )]
+            .into_iter(),
+            0,
+        );
+
+        // Verify initial state
+        let inner = cache.stake_delegation_index.0.read().unwrap();
+        assert_eq!(inner.len, 1);
+        assert_eq!(inner.root_entries.len(), 1);
+        assert!(inner.free_root_indices.is_empty());
+        drop(inner);
+
+        // Apply a delta that replaces the existing key with a new key at the same position
+        let new_account = create_stake_account(20, &vote_pubkey_b, &new_stake_pubkey, &rent);
+        cache
+            .stake_delegation_index
+            .0
+            .write()
+            .unwrap()
+            .apply_rooted_deltas([HashMap::from_iter([(
+                new_stake_pubkey,
+                Some(Arc::new(StakeAccount::try_from(new_account).unwrap())),
+            )])]);
+
+        let inner = cache.stake_delegation_index.0.read().unwrap();
+        // The existing key should be gone
+        assert!(!inner.root_positions.contains_key(&existing_stake_pubkey));
+        // The new key should be present at the same position
+        assert_eq!(
+            inner.root_positions.get(&new_stake_pubkey),
+            Some(&0)
+        );
+        // The old slot should be in the freelist
+        assert_eq!(inner.free_root_indices, vec![0]);
+        // len should still be 1 (one active entry)
+        assert_eq!(inner.len, 1);
+        // root_entries should still be length 1 (reused, not extended)
+        assert_eq!(inner.root_entries.len(), 1);
+        // The entry at position 0 should be the new key
+        assert_eq!(
+            inner.root_entries[0]
+                .as_ref()
+                .map(|e| e.stake_pubkey),
+            Some(new_stake_pubkey)
+        );
+    }
+
+    #[test]
+    fn test_apply_rooted_deltas_adds_new_key_beyond_freelist() {
+        let rent = Rent::default();
+        let vote_pubkey_a = new_rand();
+        let vote_pubkey_b = new_rand();
+        let vote_pubkey_c = new_rand();
+        let stake_pubkey_a = new_rand();
+        let stake_pubkey_b = new_rand();
+        let stake_pubkey_c = new_rand();
+
+        // Create a cache with 2 entries and an empty freelist
+        let root_account_a = create_stake_account(10, &vote_pubkey_a, &stake_pubkey_a, &rent);
+        let root_account_b = create_stake_account(20, &vote_pubkey_b, &stake_pubkey_b, &rent);
+        let mut cache = StakesCacheV2::new_from_accounts(
+            [
+                (
+                    stake_pubkey_a,
+                    StakeAccount::try_from(root_account_a).unwrap(),
+                ),
+                (
+                    stake_pubkey_b,
+                    StakeAccount::try_from(root_account_b).unwrap(),
+                ),
+            ]
+            .into_iter(),
+            0,
+        );
+
+        // Verify initial state
+        let inner = cache.stake_delegation_index.0.read().unwrap();
+        assert_eq!(inner.len, 2);
+        assert_eq!(inner.root_entries.len(), 2);
+        assert!(inner.free_root_indices.is_empty());
+        drop(inner);
+
+        // Apply a delta that adds a new key beyond the current root_entries capacity
+        // This should push a new entry into a new index slot
+        let new_account = create_stake_account(30, &vote_pubkey_c, &stake_pubkey_c, &rent);
+        cache
+            .stake_delegation_index
+            .0
+            .write()
+            .unwrap()
+            .apply_rooted_deltas([HashMap::from_iter([(
+                stake_pubkey_c,
+                Some(Arc::new(StakeAccount::try_from(new_account).unwrap())),
+            )])]);
+
+        let inner = cache.stake_delegation_index.0.read().unwrap();
+        // All three keys should be present
+        assert_eq!(inner.len, 3);
+        assert!(inner.root_positions.contains_key(&stake_pubkey_a));
+        assert!(inner.root_positions.contains_key(&stake_pubkey_b));
+        assert!(inner.root_positions.contains_key(&stake_pubkey_c));
+        // root_entries should have grown to 3
+        assert_eq!(inner.root_entries.len(), 3);
+        // freelist should still be empty (no slots were freed)
+        assert!(inner.free_root_indices.is_empty());
+        // Verify the new entry is at position 2
+        assert_eq!(
+            inner.root_positions.get(&stake_pubkey_c),
+            Some(&2)
+        );
+        assert_eq!(
+            inner.root_entries[2]
+                .as_ref()
+                .map(|e| e.stake_pubkey),
+            Some(stake_pubkey_c)
+        );
+    }
+
+    #[test]
     fn test_apply_rooted_stake_delegation_deltas_applies_updates() {
         let rent = Rent::default();
         let vote_pubkey = new_rand();

--- a/runtime/src/stakes_v2.rs
+++ b/runtime/src/stakes_v2.rs
@@ -1,0 +1,625 @@
+use {
+    crate::{
+        stake_account,
+        stake_history::StakeHistory,
+        stakes::{DeserializableStakes, Error},
+    },
+    rayon::iter::{
+        IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
+        IntoParallelRefMutIterator, ParallelIterator,
+    },
+    solana_account::{AccountSharedData, ReadableAccount},
+    solana_accounts_db::utils::create_account_shared_data,
+    solana_clock::Epoch,
+    solana_pubkey::Pubkey,
+    solana_stake_interface::{program as stake_program, state::Delegation},
+    solana_vote::vote_account::{VoteAccount, VoteAccounts, VoteAccountsHashMap},
+    solana_vote_interface::state::VoteStateVersions,
+    std::{
+        collections::HashMap,
+        sync::{Arc, RwLock, RwLockReadGuard},
+    },
+};
+
+type StakeAccount = stake_account::StakeAccount<Delegation>;
+
+/// Per-bank state consisting of currently processed epoch and stake history.
+#[derive(Debug, Clone)]
+pub(crate) struct StakesCacheV2State {
+    epoch: Epoch,
+    stake_history: StakeHistory,
+}
+
+impl StakesCacheV2State {
+    pub(crate) fn stake_history(&self) -> &StakeHistory {
+        &self.stake_history
+    }
+}
+
+/// Rooted stake delegation entry.
+#[derive(Clone, Debug)]
+struct RootEntry {
+    stake_pubkey: Pubkey,
+    stake_account: Arc<StakeAccount>,
+}
+
+#[derive(Debug)]
+struct StakeDelegationIndexInner {
+    root_entries: Vec<Option<RootEntry>>,
+    root_positions: HashMap<Pubkey, usize>,
+    free_root_indices: Vec<usize>,
+}
+
+/// Index of rooted stake delegations, shared across banks.
+#[derive(Debug)]
+struct StakeDelegationIndex(RwLock<StakeDelegationIndexInner>);
+
+/// Frontier-only entry that does not exist in the rooted base.
+#[derive(Clone, Debug)]
+struct FrontierEntry {
+    stake_pubkey: Pubkey,
+    stake_account: Arc<StakeAccount>,
+}
+
+/// Merged stake-delegation view for one bank frontier.
+#[derive(Debug)]
+pub(crate) struct FrontierQuery<'a> {
+    inner: RwLockReadGuard<'a, StakeDelegationIndexInner>,
+    /// Rooted slots that remain visible after applying unrooted deltas. We
+    /// materialize the visible set once so repeated frontier iterations do
+    /// not have to rescan all rooted entries and skip the hidden ones.
+    visible_root_indices: Vec<usize>,
+    overlay: HashMap<Pubkey, Option<Arc<StakeAccount>>>,
+    overlay_only_inserts: Vec<FrontierEntry>,
+}
+
+impl<'a> FrontierQuery<'a> {
+    pub(crate) fn len(&self) -> usize {
+        self.visible_root_indices.len() + self.overlay_only_inserts.len()
+    }
+
+    pub(crate) fn par_iter(
+        &'a self,
+    ) -> impl IndexedParallelIterator<Item = (&'a Pubkey, &'a StakeAccount)> {
+        self.visible_root_indices
+            .par_iter()
+            .map(move |root_index| {
+                let root_entry = self.inner.root_entries[*root_index]
+                    .as_ref()
+                    .expect("visible rooted frontier entry must exist");
+                let stake_account = self
+                    .overlay
+                    .get(&root_entry.stake_pubkey)
+                    .and_then(|stake_account| stake_account.as_ref())
+                    .map_or(root_entry.stake_account.as_ref(), Arc::as_ref);
+                (&root_entry.stake_pubkey, stake_account)
+            })
+            .chain(
+                self.overlay_only_inserts
+                    .par_iter()
+                    .map(|entry| (&entry.stake_pubkey, entry.stake_account.as_ref())),
+            )
+    }
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl<'a> FrontierQuery<'a> {
+    pub(crate) fn iter(&'a self) -> impl Iterator<Item = (&'a Pubkey, &'a StakeAccount)> {
+        self.visible_root_indices
+            .iter()
+            .map(move |root_index| {
+                let root_entry = self.inner.root_entries[*root_index]
+                    .as_ref()
+                    .expect("visible rooted frontier entry must exist");
+                let stake_account = self
+                    .overlay
+                    .get(&root_entry.stake_pubkey)
+                    .and_then(|stake_account| stake_account.as_ref())
+                    .map_or(root_entry.stake_account.as_ref(), Arc::as_ref);
+                (&root_entry.stake_pubkey, stake_account)
+            })
+            .chain(
+                self.overlay_only_inserts
+                    .iter()
+                    .map(|entry| (&entry.stake_pubkey, entry.stake_account.as_ref())),
+            )
+    }
+}
+
+impl StakeDelegationIndex {
+    fn apply_rooted_deltas(
+        &self,
+        deltas_in_ancestor_order: impl IntoIterator<Item = HashMap<Pubkey, Option<Arc<StakeAccount>>>>,
+    ) {
+        let mut inner = self.0.write().unwrap();
+        for delta in deltas_in_ancestor_order {
+            for (stake_pubkey, maybe_stake_account) in delta {
+                match maybe_stake_account {
+                    Some(stake_account) => {
+                        if let Some(index) = inner.root_positions.get(&stake_pubkey).copied() {
+                            inner.root_entries[index] = Some(RootEntry {
+                                stake_pubkey,
+                                stake_account,
+                            });
+                        } else {
+                            let index = inner
+                                .free_root_indices
+                                .pop()
+                                .unwrap_or_else(|| inner.root_entries.len());
+                            inner.root_positions.insert(stake_pubkey, index);
+                            let root_entry = Some(RootEntry {
+                                stake_pubkey,
+                                stake_account,
+                            });
+                            if index == inner.root_entries.len() {
+                                inner.root_entries.push(root_entry);
+                            } else {
+                                inner.root_entries[index] = root_entry;
+                            }
+                        }
+                    }
+                    None => {
+                        if let Some(index) = inner.root_positions.remove(&stake_pubkey) {
+                            inner.root_entries[index] = None;
+                            inner.free_root_indices.push(index);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Stakes cache stored by a bank. It consists of:
+///
+/// - A reference to [`StakeDelegationIndex`], that is shared between all
+///   banks.
+/// - A local [`ForkDelta`].
+/// - A local [`StakesCacheV2State`].
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug)]
+pub(crate) struct StakesCacheV2 {
+    stake_delegation_index: Arc<StakeDelegationIndex>,
+    fork_delta: RwLock<HashMap<Pubkey, Option<Arc<StakeAccount>>>>,
+    state: RwLock<StakesCacheV2State>,
+}
+
+impl StakesCacheV2 {
+    fn from_root_entries_and_state(
+        root_entries: Vec<Option<RootEntry>>,
+        epoch: Epoch,
+        stake_history: StakeHistory,
+    ) -> Self {
+        let mut root_positions = HashMap::with_capacity(root_entries.len());
+        for (index, root_entry) in root_entries.iter().enumerate() {
+            let stake_pubkey = root_entry
+                .as_ref()
+                .expect("stake delegation root entry must be populated")
+                .stake_pubkey;
+            root_positions.insert(stake_pubkey, index);
+        }
+        Self {
+            stake_delegation_index: Arc::new(StakeDelegationIndex(RwLock::new(
+                StakeDelegationIndexInner {
+                    root_entries,
+                    root_positions,
+                    free_root_indices: Vec::new(),
+                },
+            ))),
+            fork_delta: RwLock::new(HashMap::default()),
+            state: RwLock::new(StakesCacheV2State {
+                epoch,
+                stake_history,
+            }),
+        }
+    }
+
+    pub(crate) fn new_from_accounts_for_genesis<'a, T: ReadableAccount + 'a>(
+        accounts: impl IntoIterator<Item = (&'a Pubkey, &'a T)>,
+    ) -> Self {
+        let epoch = 0;
+        let stake_history = StakeHistory::default();
+        let mut vote_accounts = VoteAccountsHashMap::default();
+        let mut delegated_stakes: HashMap<Pubkey, u64> = HashMap::default();
+        let mut root_entries = Vec::new();
+
+        for (pubkey, account) in accounts {
+            if account.lamports() == 0 {
+                continue;
+            }
+
+            if solana_vote_program::check_id(account.owner()) {
+                if VoteStateVersions::is_correct_size_and_initialized(account.data()) {
+                    if let Ok(vote_account) =
+                        VoteAccount::try_from(create_account_shared_data(account))
+                    {
+                        vote_accounts.insert(*pubkey, (0, vote_account));
+                    }
+                }
+            } else if stake_program::check_id(account.owner()) {
+                if let Ok(stake_account) =
+                    StakeAccount::try_from(create_account_shared_data(account))
+                {
+                    let delegation = stake_account.delegation();
+                    #[expect(deprecated, reason = "we still use the legacy stake calculation")]
+                    let stake = delegation.stake(epoch, &stake_history, None);
+                    *delegated_stakes.entry(delegation.voter_pubkey).or_default() += stake;
+                    root_entries.push(Some(RootEntry {
+                        stake_pubkey: *pubkey,
+                        stake_account: Arc::new(stake_account),
+                    }));
+                }
+            }
+        }
+
+        let mut vote_accounts = VoteAccounts::from(Arc::new(vote_accounts));
+        for (vote_pubkey, stake) in delegated_stakes {
+            vote_accounts.add_stake(&vote_pubkey, stake);
+        }
+
+        Self::from_root_entries_and_state(root_entries, epoch, stake_history)
+    }
+
+    pub(crate) fn load_from_deserialized_delegations<F>(
+        stakes: DeserializableStakes<Delegation>,
+        get_account: F,
+    ) -> Result<Self, Error>
+    where
+        F: Fn(&Pubkey) -> Option<AccountSharedData> + Sync,
+    {
+        let root_entries_len = stakes.stake_delegations.len();
+        let mut root_entries = Vec::with_capacity(root_entries_len);
+        root_entries
+            .spare_capacity_mut()
+            .par_iter_mut()
+            .take(root_entries_len)
+            .zip_eq(stakes.stake_delegations.into_par_iter())
+            .try_for_each(|(root_entry, (pubkey, delegation))| {
+                let Some(stake_account) = get_account(&pubkey) else {
+                    return Err(Error::StakeAccountNotFound(pubkey));
+                };
+
+                let stake_account = StakeAccount::try_from(stake_account)?;
+                if stake_account.delegation() == &delegation {
+                    root_entry.write(Some(RootEntry {
+                        stake_pubkey: pubkey,
+                        stake_account: Arc::new(stake_account),
+                    }));
+                    Ok(())
+                } else {
+                    Err(Error::InvalidDelegation(pubkey))
+                }
+            })?;
+        // SAFETY: We initialized all the `root_entries` elements up to
+        // `root_entries_len`.
+        unsafe {
+            root_entries.set_len(root_entries_len);
+        }
+        Ok(Self::from_root_entries_and_state(
+            root_entries,
+            stakes.epoch,
+            stakes.stake_history,
+        ))
+    }
+
+    pub(crate) fn new_from_parent(parent: &Self) -> Self {
+        let stake_delegation_index = Arc::clone(&parent.stake_delegation_index);
+        let state = parent.state.read().unwrap().clone();
+        Self {
+            stake_delegation_index,
+            fork_delta: RwLock::new(HashMap::default()),
+            state: RwLock::new(state),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn empty(epoch: Epoch) -> Self {
+        Self::from_root_entries_and_state(Vec::new(), epoch, StakeHistory::default())
+    }
+
+    pub(crate) fn frontier_query<'a>(
+        &self,
+        caches_in_ancestor_order: impl IntoIterator<Item = &'a Self>,
+    ) -> FrontierQuery<'_> {
+        let mut overlay = HashMap::new();
+        for cache in caches_in_ancestor_order {
+            let fork_delta = cache.fork_delta.read().unwrap();
+            for (stake_pubkey, stake_account) in fork_delta.iter() {
+                overlay.insert(*stake_pubkey, stake_account.clone());
+            }
+        }
+        {
+            let fork_delta = self.fork_delta.read().unwrap();
+            for (stake_pubkey, stake_account) in fork_delta.iter() {
+                overlay.insert(*stake_pubkey, stake_account.clone());
+            }
+        }
+
+        let inner = self.stake_delegation_index.0.read().unwrap();
+        let mut visible_root_indices = Vec::with_capacity(inner.root_positions.len());
+        for (root_index, root_entry) in inner.root_entries.iter().enumerate() {
+            let Some(root_entry) = root_entry.as_ref() else {
+                continue;
+            };
+            if matches!(overlay.get(&root_entry.stake_pubkey), Some(None)) {
+                continue;
+            }
+            visible_root_indices.push(root_index);
+        }
+
+        let mut overlay_only_inserts = overlay
+            .iter()
+            .filter_map(|(stake_pubkey, maybe_stake_account)| {
+                if inner.root_positions.contains_key(stake_pubkey) {
+                    return None;
+                }
+                maybe_stake_account
+                    .as_ref()
+                    .map(|stake_account| FrontierEntry {
+                        stake_pubkey: *stake_pubkey,
+                        stake_account: Arc::clone(stake_account),
+                    })
+            })
+            .collect::<Vec<_>>();
+        overlay_only_inserts.sort_unstable_by_key(|entry| entry.stake_pubkey);
+
+        FrontierQuery {
+            inner,
+            visible_root_indices,
+            overlay,
+            overlay_only_inserts,
+        }
+    }
+
+    pub(crate) fn apply_rooted_stake_delegation_deltas<'a>(
+        &self,
+        caches_in_ancestor_order: impl IntoIterator<Item = &'a Self>,
+    ) {
+        let deltas_in_ancestor_order = caches_in_ancestor_order
+            .into_iter()
+            .filter_map(|cache| {
+                let mut fork_delta = cache.fork_delta.write().unwrap();
+                (!fork_delta.is_empty()).then(|| std::mem::take(&mut *fork_delta))
+            })
+            .chain({
+                let mut fork_delta = self.fork_delta.write().unwrap();
+                (!fork_delta.is_empty())
+                    .then(|| std::mem::take(&mut *fork_delta))
+                    .into_iter()
+            });
+        self.stake_delegation_index
+            .apply_rooted_deltas(deltas_in_ancestor_order);
+    }
+
+    pub(crate) fn check_and_store(&self, pubkey: &Pubkey, account: &impl ReadableAccount) {
+        if !stake_program::check_id(account.owner()) {
+            return;
+        }
+        if account.lamports() == 0 {
+            self.remove_stake_delegation(pubkey);
+            return;
+        }
+        match StakeAccount::try_from(create_account_shared_data(account)) {
+            Ok(stake_account) => self.upsert_stake_delegation(*pubkey, stake_account),
+            Err(_) => self.remove_stake_delegation(pubkey),
+        }
+    }
+
+    pub(crate) fn upsert_stake_delegation(&self, pubkey: Pubkey, stake_account: StakeAccount) {
+        self.fork_delta
+            .write()
+            .unwrap()
+            .insert(pubkey, Some(Arc::new(stake_account)));
+    }
+
+    pub(crate) fn remove_stake_delegation(&self, pubkey: &Pubkey) {
+        self.fork_delta.write().unwrap().insert(*pubkey, None);
+    }
+
+    pub(crate) fn state(&self) -> RwLockReadGuard<'_, StakesCacheV2State> {
+        self.state.read().unwrap()
+    }
+
+    pub(crate) fn activate_epoch(&self, next_epoch: Epoch, stake_history: StakeHistory) {
+        let mut state = self.state.write().unwrap();
+        state.epoch = next_epoch;
+        state.stake_history = stake_history;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, crate::stakes::tests::create_stake_account, rayon::ThreadPoolBuilder,
+        solana_pubkey::new_rand, solana_rent::Rent,
+    };
+
+    fn root_entries_from_stake_accounts(
+        stake_delegations: impl IntoIterator<Item = (Pubkey, StakeAccount)>,
+    ) -> Vec<Option<RootEntry>> {
+        stake_delegations
+            .into_iter()
+            .map(|(stake_pubkey, stake_account)| {
+                Some(RootEntry {
+                    stake_pubkey,
+                    stake_account: Arc::new(stake_account),
+                })
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_frontier_query_overlays_root_and_deltas() {
+        let rent = Rent::default();
+        let vote_pubkey_a = new_rand();
+        let vote_pubkey_b = new_rand();
+        let stake_pubkey_a = new_rand();
+        let stake_pubkey_b = new_rand();
+        let stake_pubkey_c = new_rand();
+
+        let root_account_a = create_stake_account(10, &vote_pubkey_a, &stake_pubkey_a, &rent);
+        let root_account_b = create_stake_account(20, &vote_pubkey_b, &stake_pubkey_b, &rent);
+
+        let root_entries = root_entries_from_stake_accounts([
+            (
+                stake_pubkey_a,
+                StakeAccount::try_from(root_account_a).unwrap(),
+            ),
+            (
+                stake_pubkey_b,
+                StakeAccount::try_from(root_account_b).unwrap(),
+            ),
+        ]);
+        let root_cache =
+            StakesCacheV2::from_root_entries_and_state(root_entries, 0, StakeHistory::default());
+        let fork_cache = StakesCacheV2::new_from_parent(&root_cache);
+        let updated_account_a = create_stake_account(30, &vote_pubkey_b, &stake_pubkey_a, &rent);
+        let inserted_account_c = create_stake_account(40, &vote_pubkey_a, &stake_pubkey_c, &rent);
+        fork_cache.upsert_stake_delegation(
+            stake_pubkey_a,
+            StakeAccount::try_from(updated_account_a).unwrap(),
+        );
+        fork_cache.remove_stake_delegation(&stake_pubkey_b);
+        fork_cache.upsert_stake_delegation(
+            stake_pubkey_c,
+            StakeAccount::try_from(inserted_account_c).unwrap(),
+        );
+
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+        let frontier_query = root_cache.frontier_query([&fork_cache]);
+        let stake_delegations =
+            thread_pool.install(|| frontier_query.par_iter().collect::<Vec<_>>());
+        assert_eq!(stake_delegations.len(), 2);
+        assert!(stake_delegations.iter().any(|(pubkey, account)| {
+            **pubkey == stake_pubkey_a && account.delegation().stake == 30
+        }));
+        assert!(stake_delegations.iter().any(|(pubkey, account)| {
+            **pubkey == stake_pubkey_c && account.delegation().stake == 40
+        }));
+    }
+
+    #[test]
+    fn test_new_from_parent_starts_with_empty_delta() {
+        let root_cache = StakesCacheV2::empty(0);
+        let fork_cache = StakesCacheV2::new_from_parent(&root_cache);
+        assert!(fork_cache.fork_delta.read().unwrap().is_empty());
+
+        let rent = Rent::default();
+        let vote_pubkey = new_rand();
+        let stake_pubkey = new_rand();
+        let stake_account = create_stake_account(10, &vote_pubkey, &stake_pubkey, &rent);
+        fork_cache
+            .upsert_stake_delegation(stake_pubkey, StakeAccount::try_from(stake_account).unwrap());
+
+        assert!(!fork_cache.fork_delta.read().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_frontier_query_preserves_root_and_insert_order() {
+        let rent = Rent::default();
+        let vote_pubkey_a = new_rand();
+        let vote_pubkey_b = new_rand();
+        let stake_pubkey_a = new_rand();
+        let stake_pubkey_b = new_rand();
+        let stake_pubkey_c = new_rand();
+
+        let root_account_a = create_stake_account(10, &vote_pubkey_a, &stake_pubkey_a, &rent);
+        let root_account_b = create_stake_account(20, &vote_pubkey_b, &stake_pubkey_b, &rent);
+
+        let root_entries = root_entries_from_stake_accounts([
+            (
+                stake_pubkey_a,
+                StakeAccount::try_from(root_account_a).unwrap(),
+            ),
+            (
+                stake_pubkey_b,
+                StakeAccount::try_from(root_account_b).unwrap(),
+            ),
+        ]);
+        let root_cache =
+            StakesCacheV2::from_root_entries_and_state(root_entries, 0, StakeHistory::default());
+        let fork_cache = StakesCacheV2::new_from_parent(&root_cache);
+        let updated_account_a = create_stake_account(30, &vote_pubkey_b, &stake_pubkey_a, &rent);
+        let inserted_account_c = create_stake_account(40, &vote_pubkey_a, &stake_pubkey_c, &rent);
+        fork_cache.upsert_stake_delegation(
+            stake_pubkey_a,
+            StakeAccount::try_from(updated_account_a).unwrap(),
+        );
+        fork_cache.remove_stake_delegation(&stake_pubkey_b);
+        fork_cache.upsert_stake_delegation(
+            stake_pubkey_c,
+            StakeAccount::try_from(inserted_account_c).unwrap(),
+        );
+
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+        let frontier_query = root_cache.frontier_query([&fork_cache]);
+        let query_entries = thread_pool.install(|| {
+            frontier_query
+                .par_iter()
+                .map(|(pubkey, stake_account)| (*pubkey, stake_account.delegation().stake))
+                .collect::<Vec<_>>()
+        });
+        assert_eq!(
+            &query_entries,
+            &[(stake_pubkey_a, 30), (stake_pubkey_c, 40)]
+        );
+    }
+
+    #[test]
+    fn test_root_slot_reuse_after_delete() {
+        let rent = Rent::default();
+        let vote_pubkey_a = new_rand();
+        let vote_pubkey_b = new_rand();
+        let stake_pubkey_a = new_rand();
+        let stake_pubkey_b = new_rand();
+        let stake_pubkey_c = new_rand();
+
+        let root_account_a = create_stake_account(10, &vote_pubkey_a, &stake_pubkey_a, &rent);
+        let root_account_b = create_stake_account(20, &vote_pubkey_b, &stake_pubkey_b, &rent);
+
+        let root_entries = root_entries_from_stake_accounts([
+            (
+                stake_pubkey_a,
+                StakeAccount::try_from(root_account_a).unwrap(),
+            ),
+            (
+                stake_pubkey_b,
+                StakeAccount::try_from(root_account_b).unwrap(),
+            ),
+        ]);
+        let root_cache =
+            StakesCacheV2::from_root_entries_and_state(root_entries, 0, StakeHistory::default());
+        let index = &root_cache.stake_delegation_index;
+        let removed_index = {
+            let inner = index.0.read().unwrap();
+            *inner.root_positions.get(&stake_pubkey_a).unwrap()
+        };
+
+        index.apply_rooted_deltas([HashMap::from_iter([(stake_pubkey_a, None)])]);
+        {
+            let inner = index.0.read().unwrap();
+            assert_eq!(inner.root_entries.len(), 2);
+            assert_eq!(&inner.free_root_indices, &[removed_index]);
+        }
+
+        let root_account_c = create_stake_account(30, &vote_pubkey_a, &stake_pubkey_c, &rent);
+        index.apply_rooted_deltas([HashMap::from_iter([(
+            stake_pubkey_c,
+            Some(Arc::new(StakeAccount::try_from(root_account_c).unwrap())),
+        )])]);
+
+        let inner = index.0.read().unwrap();
+        assert_eq!(inner.root_entries.len(), 2);
+        assert!(inner.free_root_indices.is_empty());
+        assert_eq!(
+            inner.root_positions.get(&stake_pubkey_c),
+            Some(&removed_index)
+        );
+        assert_eq!(
+            inner.root_entries[removed_index]
+                .as_ref()
+                .map(|entry| entry.stake_pubkey),
+            Some(stake_pubkey_c)
+        );
+    }
+}

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1130,6 +1130,7 @@ impl TestValidator {
                 }),
             log_messages_bytes_limit: config.log_messages_bytes_limit,
             transaction_account_lock_limit: config.transaction_account_lock_limit,
+            enable_stakes_cache_v2: false,
         };
 
         let mut validator_config = ValidatorConfig {

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1170,6 +1170,7 @@ impl TestValidator {
                 }),
             log_messages_bytes_limit: config.log_messages_bytes_limit,
             transaction_account_lock_limit: config.transaction_account_lock_limit,
+            enable_stakes_cache_v2: false,
         };
 
         let mut validator_config = ValidatorConfig {

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -900,6 +900,12 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .help("Override the runtime's account lock limit per transaction"),
         )
         .arg(
+            Arg::with_name("enable_stakes_cache_v2")
+                .long("enable-stakes-cache-v2")
+                .takes_value(false)
+                .hidden(hidden_unless_forced()),
+        )
+        .arg(
             Arg::with_name("clone_feature_set")
                 .long("clone-feature-set")
                 .takes_value(false)

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -867,6 +867,12 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .help("Override the runtime's account lock limit per transaction"),
         )
         .arg(
+            Arg::with_name("enable_stakes_cache_v2")
+                .long("enable-stakes-cache-v2")
+                .takes_value(false)
+                .hidden(hidden_unless_forced()),
+        )
+        .arg(
             Arg::with_name("clone_feature_set")
                 .long("clone-feature-set")
                 .takes_value(false)

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -819,6 +819,7 @@ pub fn execute(
         wait_to_vote_slot: None,
         runtime_config: RuntimeConfig {
             log_messages_bytes_limit: value_of(matches, "log_messages_bytes_limit"),
+            enable_stakes_cache_v2: matches.is_present("enable_stakes_cache_v2"),
             ..RuntimeConfig::default()
         },
         staked_nodes_overrides: staked_nodes_overrides.clone(),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -829,6 +829,7 @@ pub fn execute(
         wait_to_vote_slot: None,
         runtime_config: RuntimeConfig {
             log_messages_bytes_limit: value_of(matches, "log_messages_bytes_limit"),
+            enable_stakes_cache_v2: matches.is_present("enable_stakes_cache_v2"),
             ..RuntimeConfig::default()
         },
         staked_nodes_overrides: staked_nodes_overrides.clone(),


### PR DESCRIPTION
#### Problem

The current implementation of stakes cache is based on `imbl::HashMap`, where each bank has its own clone of it. That works from the memory footprint point of view. But `imbl::HashMap` is quite slow to iterate on. Crossing epoch boundary takes 189ms and the vast majority of that time is spent on collecting stake delegations from that structure:

<img width="2528" height="956" alt="stakes_cache_before_0" src="https://github.com/user-attachments/assets/9920ab61-e815-447b-bebf-b29299070f7c" />
<img width="2528" height="956" alt="stakes_cache_before_1" src="https://github.com/user-attachments/assets/7ebb61e0-f4dd-45c2-967d-386e392d56cd" />

#### Summary of Changes

Alongside the current stakes cache implementation, add a new one called `StakesCacheV2`. It's opt-in and can be enabled with (currently hidden) `--enable-stakes-cache-v2` argument (see the last paragraph for the rationale).

It consists of two parts:

1) A dense index of rooted stake delegations, that is shared by all banks and consists of an `IndexMap` of stake delegations (that are rooted).
2) A separate cache (hash map) for unrooted stake delegations in forks.

When a fork is rooted, all its deltas are applied to the rooted cache. For each ForkDelta entry, it uses rooted_positions to find a slot in rooted_entries and updates it.

The new cache provides a frontier query - a materialized overlay of all unrooted stake delegation deltas for the given bank. When the stakes cache v2 is enabled, that query replaces the use of `StakesCache::stake_delegations_vec`.

With that design, crossing epoch boundary takes 115ms:

<img width="2528" height="956" alt="stakes_cache_after_latest_1" src="https://github.com/user-attachments/assets/f16a17ab-6d35-48df-b329-1dfc46674b73" />

The new stakes cache is currently used only for epoch boundary. Its usage in all other places, that the old `StakesCache` is being used, is going to be introduced in separate, self-contained changes, to make the review easier. This is the reason why the new cache is opt-in with a hidden argument. The argument can be removed, and the new stakes cache can be made the default one, once the entire migration is done.