### PR TITLE
Sigverify: worker threads dedup

### DIFF
--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -8,6 +8,7 @@ use {
     crossbeam_channel::{Receiver, Sender, TrySendError, bounded},
     solana_measure::measure_us,
     solana_perf::{
+        deduper::{self, Deduper},
         packet::PacketBatch,
         sigverify::{self},
     },
@@ -24,14 +25,6 @@ use {
     },
 };
 
-pub(crate) struct TransactionSigVerifier {
-    worker_sender: Sender<TransactionVerifyTask>,
-}
-
-struct TransactionVerifyTask {
-    batch: PacketBatch,
-}
-
 pub(crate) struct GossipVerifyTask {
     batch: PacketBatch,
     transaction: Transaction,
@@ -44,33 +37,32 @@ pub(crate) struct GossipVerifiedVoteBatch {
 
 #[derive(Clone)]
 pub(crate) struct SigVerifyWorkerStats {
+    pub(crate) total_batches: Arc<AtomicUsize>,
+    pub(crate) total_packets: Arc<AtomicUsize>,
+    pub(crate) total_dedup: Arc<AtomicUsize>,
+    pub(crate) total_dedup_time_us: Arc<AtomicUsize>,
     pub(crate) total_valid_packets: Arc<AtomicUsize>,
     pub(crate) total_verify_time_us: Arc<AtomicUsize>,
 }
 
-impl TransactionSigVerifier {
-    fn new(worker_sender: Sender<TransactionVerifyTask>) -> Self {
-        Self { worker_sender }
-    }
+#[derive(Clone)]
+pub(crate) struct SigVerifyWorkerState {
+    banking_stage_sender: BankingPacketSender,
+    deduper: Arc<Deduper<2, [u8]>>,
+    stats: SigVerifyWorkerStats,
+}
 
-    pub(crate) fn send_packets_to_worker_pool(
-        &mut self,
-        batches: Vec<PacketBatch>,
-    ) -> Result<usize, SigVerifyServiceError> {
-        let mut dropped_packets = 0;
-        for batch in batches {
-            match self.worker_sender.try_send(TransactionVerifyTask { batch }) {
-                Ok(()) => {}
-                Err(TrySendError::Full(task)) => {
-                    dropped_packets += task.batch.len();
-                }
-                Err(TrySendError::Disconnected(_)) => {
-                    return Err(SigVerifyServiceError::WorkerQueueClosed);
-                }
-            }
+impl SigVerifyWorkerState {
+    pub(crate) fn new(
+        banking_stage_sender: BankingPacketSender,
+        deduper: Arc<Deduper<2, [u8]>>,
+        stats: SigVerifyWorkerStats,
+    ) -> Self {
+        Self {
+            banking_stage_sender,
+            deduper,
+            stats,
         }
-
-        Ok(dropped_packets)
     }
 }
 
@@ -118,30 +110,28 @@ impl GossipSigVerifier {
     }
 }
 
-// Work queues are kept separate so that a spam on TPU
-// will not lead to us dropping votes.
-const SIGVERIFY_NON_VOTE_WORK_CHANNEL_SIZE: usize = 50_000;
-const SIGVERIFY_TPU_VOTE_WORK_CHANNEL_SIZE: usize = 5_000; // channel is batches not individual packets
+/// Gossip votes use a bounded queue into the worker pool.
 const SIGVERIFY_GOSSIP_VOTE_WORK_CHANNEL_SIZE: usize = 50_000;
+
+pub(crate) struct SigVerifyWorkerSenders {
+    pub(crate) gossip_verified_vote_sender: Sender<GossipVerifiedVoteBatch>,
+    pub(crate) forward_stage_sender: Sender<(BankingPacketBatch, bool)>,
+}
 
 #[derive(Clone)]
 struct WorkerPoolChannels {
-    non_vote_receiver: Receiver<TransactionVerifyTask>,
-    tpu_vote_receiver: Receiver<TransactionVerifyTask>,
+    non_vote_receiver: Receiver<PacketBatch>,
+    tpu_vote_receiver: Receiver<PacketBatch>,
     gossip_receiver: Receiver<GossipVerifyTask>,
-    non_vote_banking_sender: BankingPacketSender,
-    tpu_vote_banking_sender: BankingPacketSender,
     gossip_verified_vote_sender: Sender<GossipVerifiedVoteBatch>,
     forward_stage_sender: Sender<(BankingPacketBatch, bool)>,
     sharable_banks: SharableBanks,
-    non_vote_stats: SigVerifyWorkerStats,
-    tpu_vote_stats: SigVerifyWorkerStats,
+    non_vote_state: SigVerifyWorkerState,
+    tpu_vote_state: SigVerifyWorkerState,
 }
 
 pub(crate) struct SigVerifyWorkerPool {
     exit: Arc<AtomicBool>,
-    non_vote_sender: Sender<TransactionVerifyTask>,
-    tpu_vote_sender: Sender<TransactionVerifyTask>,
     gossip_sender: Sender<GossipVerifyTask>,
     worker_hdls: Vec<JoinHandle<()>>,
 }
@@ -160,29 +150,24 @@ impl Drop for SigVerifyWorkerPool {
 impl SigVerifyWorkerPool {
     pub(crate) fn new(
         num_workers: NonZeroUsize,
-        non_vote_banking_sender: BankingPacketSender,
-        tpu_vote_banking_sender: BankingPacketSender,
-        gossip_verified_vote_sender: Sender<GossipVerifiedVoteBatch>,
-        forward_stage_sender: Sender<(BankingPacketBatch, bool)>,
+        non_vote_receiver: Receiver<PacketBatch>,
+        tpu_vote_receiver: Receiver<PacketBatch>,
+        senders: SigVerifyWorkerSenders,
         forward_non_votes: bool,
         sharable_banks: SharableBanks,
-        non_vote_stats: SigVerifyWorkerStats,
-        tpu_vote_stats: SigVerifyWorkerStats,
+        non_vote_state: SigVerifyWorkerState,
+        tpu_vote_state: SigVerifyWorkerState,
     ) -> Self {
-        let (non_vote_sender, non_vote_receiver) = bounded(SIGVERIFY_NON_VOTE_WORK_CHANNEL_SIZE);
-        let (tpu_vote_sender, tpu_vote_receiver) = bounded(SIGVERIFY_TPU_VOTE_WORK_CHANNEL_SIZE);
         let (gossip_sender, gossip_receiver) = bounded(SIGVERIFY_GOSSIP_VOTE_WORK_CHANNEL_SIZE);
         let channels = WorkerPoolChannels {
             non_vote_receiver,
             tpu_vote_receiver,
             gossip_receiver,
-            non_vote_banking_sender,
-            tpu_vote_banking_sender,
-            gossip_verified_vote_sender,
-            forward_stage_sender,
+            gossip_verified_vote_sender: senders.gossip_verified_vote_sender,
+            forward_stage_sender: senders.forward_stage_sender,
             sharable_banks,
-            non_vote_stats,
-            tpu_vote_stats,
+            non_vote_state,
+            tpu_vote_state,
         };
         let exit = Arc::new(AtomicBool::new(false));
         let worker_hdls = (0..num_workers.get())
@@ -198,19 +183,9 @@ impl SigVerifyWorkerPool {
             .collect();
         Self {
             exit,
-            non_vote_sender,
-            tpu_vote_sender,
             gossip_sender,
             worker_hdls,
         }
-    }
-
-    pub(crate) fn non_vote_verifier(&self) -> TransactionSigVerifier {
-        TransactionSigVerifier::new(self.non_vote_sender.clone())
-    }
-
-    pub(crate) fn tpu_vote_verifier(&self) -> TransactionSigVerifier {
-        TransactionSigVerifier::new(self.tpu_vote_sender.clone())
     }
 
     pub(crate) fn gossip_verifier(&self) -> GossipSigVerifier {
@@ -232,30 +207,28 @@ impl SigVerifyWorkerPool {
         crossbeam_channel::select! {
             recv(&channels.non_vote_receiver) -> maybe_work => {
                 match maybe_work {
-                    Ok(work) => Self::run_transaction_task(
-                        work,
+                    Ok(batch) => Self::run_transaction_task(
+                        batch,
                         false,
-                        &channels.non_vote_banking_sender,
                         &channels.forward_stage_sender,
                         forward_non_votes,
                         false,
                         &channels.sharable_banks,
-                        &channels.non_vote_stats,
+                        &channels.non_vote_state,
                     ),
                     Err(_) => false,
                 }
             }
             recv(&channels.tpu_vote_receiver) -> maybe_work => {
                 match maybe_work {
-                    Ok(work) => Self::run_transaction_task(
-                        work,
+                    Ok(batch) => Self::run_transaction_task(
+                        batch,
                         true,
-                        &channels.tpu_vote_banking_sender,
                         &channels.forward_stage_sender,
                         true,
                         true,
                         &channels.sharable_banks,
-                        &channels.tpu_vote_stats,
+                        &channels.tpu_vote_state,
                     ),
                     Err(_) => false,
                 }
@@ -274,31 +247,55 @@ impl SigVerifyWorkerPool {
     }
 
     fn run_transaction_task(
-        mut work: TransactionVerifyTask,
+        mut batch: PacketBatch,
         reject_non_vote: bool,
-        banking_stage_sender: &BankingPacketSender,
         forward_stage_sender: &Sender<(BankingPacketBatch, bool)>,
         should_forward: bool,
         is_tpu_vote: bool,
         sharable_banks: &SharableBanks,
-        stats: &SigVerifyWorkerStats,
+        state: &SigVerifyWorkerState,
     ) -> bool {
+        state.stats.total_batches.fetch_add(1, Ordering::Relaxed);
+        state
+            .stats
+            .total_packets
+            .fetch_add(batch.len(), Ordering::Relaxed);
+
+        let (discard_or_dedup_fail, dedup_time_us) =
+            measure_us!(deduper::dedup_packets_and_count_discards(
+                &state.deduper,
+                std::slice::from_mut(&mut batch)
+            ));
+        state
+            .stats
+            .total_dedup
+            .fetch_add(discard_or_dedup_fail as usize, Ordering::Relaxed);
+        state
+            .stats
+            .total_dedup_time_us
+            .fetch_add(dedup_time_us as usize, Ordering::Relaxed);
+
         let enable_tx_v1 = sharable_banks.working().feature_set.snapshot().enable_tx_v1;
         let (_, verify_time_us) = measure_us!(sigverify::ed25519_verify_serial(
-            &mut work.batch,
+            &mut batch,
             reject_non_vote,
             enable_tx_v1,
         ));
-        let num_valid_packets = sigverify::count_valid_packets(std::iter::once(&work.batch));
-        stats
+        let num_valid_packets = sigverify::count_valid_packets(std::iter::once(&batch));
+        state
+            .stats
             .total_valid_packets
             .fetch_add(num_valid_packets, Ordering::Relaxed);
-        stats
+        state
+            .stats
             .total_verify_time_us
             .fetch_add(verify_time_us as usize, Ordering::Relaxed);
 
-        let banking_packet_batch = BankingPacketBatch::new(vec![work.batch]);
-        if let Err(err) = banking_stage_sender.send(banking_packet_batch.clone()) {
+        let banking_packet_batch = BankingPacketBatch::new(vec![batch]);
+        if let Err(err) = state
+            .banking_stage_sender
+            .send(banking_packet_batch.clone())
+        {
             error!("sigverify send failed: {err:?}");
             return false;
         }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -8,26 +8,21 @@ use {
     crate::{
         banking_trace::BankingPacketSender,
         sigverify::{
-            GossipSigVerifier, GossipVerifiedVoteBatch, SigVerifyWorkerPool, SigVerifyWorkerStats,
-            TransactionSigVerifier,
+            GossipSigVerifier, GossipVerifiedVoteBatch, SigVerifyWorkerPool,
+            SigVerifyWorkerSenders, SigVerifyWorkerState, SigVerifyWorkerStats,
         },
     },
     agave_banking_stage_ingress_types::BankingPacketBatch,
     core::time::Duration,
-    crossbeam_channel::{Receiver, RecvTimeoutError, Sender, unbounded},
-    solana_measure::measure::Measure,
-    solana_perf::{
-        deduper::{self, Deduper},
-        packet::PacketBatch,
-    },
+    crossbeam_channel::{Receiver, Sender, unbounded},
+    solana_perf::{deduper::Deduper, packet::PacketBatch},
     solana_runtime::bank_forks::SharableBanks,
-    solana_streamer::streamer::{self, StreamerError},
     solana_transaction::Transaction,
     std::{
         num::NonZeroUsize,
         sync::{
             Arc,
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
         },
         thread::{self, Builder, JoinHandle},
         time::Instant,
@@ -37,17 +32,17 @@ use {
 
 #[derive(Error, Debug)]
 pub enum SigVerifyServiceError {
-    #[error("streamer error")]
-    Streamer(#[from] StreamerError),
     #[error("sigverify worker queue closed")]
     WorkerQueueClosed,
 }
 
-type Result<T> = std::result::Result<T, SigVerifyServiceError>;
+const DEDUPER_NUM_BITS: u64 = 63_999_979;
+const MAX_DEDUPER_AGE: Duration = Duration::from_secs(2);
+const DEDUPER_FALSE_POSITIVE_RATE: f64 = 0.001;
 
 pub struct SigVerifyStage {
-    non_vote_thread_hdl: JoinHandle<()>,
-    tpu_vote_thread_hdl: JoinHandle<()>,
+    exit: Arc<AtomicBool>,
+    servicer_thread_hdl: Option<JoinHandle<()>>,
     // pool held so workers stay alive. If dropped, workers in pool shut down.
     _worker_pool: SigVerifyWorkerPool,
 }
@@ -59,18 +54,19 @@ pub struct GossipSigVerifyHandle {
 
 #[derive(Default)]
 struct SigVerifierStats {
-    recv_batches_us_hist: histogram::Histogram, // time to call recv_batch
-    dedup_packets_pp_us_hist: histogram::Histogram, // per-packet time to call verify_batch
-    batches_hist: histogram::Histogram,         // number of packet batches per verify call
-    packets_hist: histogram::Histogram,         // number of packets per verify call
     num_deduper_saturations: usize,
-    total_batches: usize,
-    total_packets: usize,
-    total_dedup: usize,
+    total_batches: Arc<AtomicUsize>,
+    total_packets: Arc<AtomicUsize>,
+    total_dedup: Arc<AtomicUsize>,
     total_valid_packets: Arc<AtomicUsize>,
-    total_dedup_time_us: usize,
+    total_dedup_time_us: Arc<AtomicUsize>,
     total_verify_time_us: Arc<AtomicUsize>,
-    total_dropped_on_capacity: usize,
+}
+
+struct ServicerState {
+    deduper: Arc<Deduper<2, [u8]>>,
+    metrics_name: &'static str,
+    stats: SigVerifierStats,
 }
 
 impl SigVerifierStats {
@@ -78,68 +74,12 @@ impl SigVerifierStats {
 
     fn maybe_report_and_reset(&mut self, name: &'static str) {
         // No need to report a datapoint if no batches/packets received
-        if self.total_batches == 0 {
+        if self.total_batches.load(Ordering::Relaxed) == 0 {
             return;
         }
 
         datapoint_info!(
             name,
-            (
-                "recv_batches_us_90pct",
-                self.recv_batches_us_hist.percentile(90.0).unwrap_or(0),
-                i64
-            ),
-            (
-                "recv_batches_us_min",
-                self.recv_batches_us_hist.minimum().unwrap_or(0),
-                i64
-            ),
-            (
-                "recv_batches_us_max",
-                self.recv_batches_us_hist.maximum().unwrap_or(0),
-                i64
-            ),
-            (
-                "recv_batches_us_mean",
-                self.recv_batches_us_hist.mean().unwrap_or(0),
-                i64
-            ),
-            (
-                "dedup_packets_pp_us_90pct",
-                self.dedup_packets_pp_us_hist.percentile(90.0).unwrap_or(0),
-                i64
-            ),
-            (
-                "dedup_packets_pp_us_min",
-                self.dedup_packets_pp_us_hist.minimum().unwrap_or(0),
-                i64
-            ),
-            (
-                "dedup_packets_pp_us_max",
-                self.dedup_packets_pp_us_hist.maximum().unwrap_or(0),
-                i64
-            ),
-            (
-                "dedup_packets_pp_us_mean",
-                self.dedup_packets_pp_us_hist.mean().unwrap_or(0),
-                i64
-            ),
-            (
-                "batches_90pct",
-                self.batches_hist.percentile(90.0).unwrap_or(0),
-                i64
-            ),
-            ("batches_min", self.batches_hist.minimum().unwrap_or(0), i64),
-            ("batches_max", self.batches_hist.maximum().unwrap_or(0), i64),
-            ("batches_mean", self.batches_hist.mean().unwrap_or(0), i64),
-            (
-                "packets_90pct",
-                self.packets_hist.percentile(90.0).unwrap_or(0),
-                i64
-            ),
-            ("packets_min", self.packets_hist.minimum().unwrap_or(0), i64),
-            ("packets_max", self.packets_hist.maximum().unwrap_or(0), i64),
-            ("packets_mean", self.packets_hist.mean().unwrap_or(0), i64),
             (
                 "num_deduper_saturations",
                 core::mem::take(&mut self.num_deduper_saturations),
@@ -147,23 +87,22 @@ impl SigVerifierStats {
             ),
             (
                 "total_batches",
-                core::mem::take(&mut self.total_batches),
+                self.total_batches.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
                 "total_packets",
-                core::mem::take(&mut self.total_packets),
+                self.total_packets.swap(0, Ordering::Relaxed),
                 i64
             ),
-            ("total_dedup", core::mem::take(&mut self.total_dedup), i64),
+            (
+                "total_dedup",
+                self.total_dedup.swap(0, Ordering::Relaxed),
+                i64
+            ),
             (
                 "total_dedup_time_us",
-                core::mem::take(&mut self.total_dedup_time_us),
-                i64
-            ),
-            (
-                "total_dropped_on_capacity",
-                core::mem::take(&mut self.total_dropped_on_capacity),
+                self.total_dedup_time_us.swap(0, Ordering::Relaxed),
                 i64
             ),
             (
@@ -177,11 +116,6 @@ impl SigVerifierStats {
                 i64
             ),
         );
-
-        self.recv_batches_us_hist = histogram::Histogram::new();
-        self.dedup_packets_pp_us_hist = histogram::Histogram::new();
-        self.batches_hist = histogram::Histogram::new();
-        self.packets_hist = histogram::Histogram::new();
     }
 }
 
@@ -199,36 +133,57 @@ impl SigVerifyStage {
         let (gossip_verified_vote_sender, verified_vote_receiver) = unbounded();
         let non_vote_stats = SigVerifierStats::default();
         let tpu_vote_stats = SigVerifierStats::default();
+        let exit = Arc::new(AtomicBool::new(false));
+        let mut rng = rand::rng();
+        let non_vote_deduper = Arc::new(Deduper::<2, [u8]>::new(&mut rng, DEDUPER_NUM_BITS));
+        let tpu_vote_deduper = Arc::new(Deduper::<2, [u8]>::new(&mut rng, DEDUPER_NUM_BITS));
         let worker_pool = SigVerifyWorkerPool::new(
             num_workers,
-            non_vote_sender,
-            tpu_vote_sender,
-            gossip_verified_vote_sender,
-            forward_stage_sender,
+            packet_receiver,
+            vote_packet_receiver,
+            SigVerifyWorkerSenders {
+                gossip_verified_vote_sender,
+                forward_stage_sender,
+            },
             forward_non_votes,
             sharable_banks,
-            SigVerifyWorkerStats {
-                total_valid_packets: non_vote_stats.total_valid_packets.clone(),
-                total_verify_time_us: non_vote_stats.total_verify_time_us.clone(),
-            },
-            SigVerifyWorkerStats {
-                total_valid_packets: tpu_vote_stats.total_valid_packets.clone(),
-                total_verify_time_us: tpu_vote_stats.total_verify_time_us.clone(),
-            },
+            SigVerifyWorkerState::new(
+                non_vote_sender,
+                non_vote_deduper.clone(),
+                SigVerifyWorkerStats {
+                    total_batches: non_vote_stats.total_batches.clone(),
+                    total_packets: non_vote_stats.total_packets.clone(),
+                    total_dedup: non_vote_stats.total_dedup.clone(),
+                    total_dedup_time_us: non_vote_stats.total_dedup_time_us.clone(),
+                    total_valid_packets: non_vote_stats.total_valid_packets.clone(),
+                    total_verify_time_us: non_vote_stats.total_verify_time_us.clone(),
+                },
+            ),
+            SigVerifyWorkerState::new(
+                tpu_vote_sender,
+                tpu_vote_deduper.clone(),
+                SigVerifyWorkerStats {
+                    total_batches: tpu_vote_stats.total_batches.clone(),
+                    total_packets: tpu_vote_stats.total_packets.clone(),
+                    total_dedup: tpu_vote_stats.total_dedup.clone(),
+                    total_dedup_time_us: tpu_vote_stats.total_dedup_time_us.clone(),
+                    total_valid_packets: tpu_vote_stats.total_valid_packets.clone(),
+                    total_verify_time_us: tpu_vote_stats.total_verify_time_us.clone(),
+                },
+            ),
         );
-        let non_vote_thread_hdl = Self::verifier_service(
-            packet_receiver,
-            worker_pool.non_vote_verifier(),
-            "solSigVerTpu",
-            "tpu-verifier",
-            non_vote_stats,
-        );
-        let tpu_vote_thread_hdl = Self::verifier_service(
-            vote_packet_receiver,
-            worker_pool.tpu_vote_verifier(),
-            "solSigVerTpuVot",
-            "tpu-vote-verifier",
-            tpu_vote_stats,
+        let servicer_thread_hdl = Self::servicer(
+            exit.clone(),
+            ServicerState {
+                deduper: non_vote_deduper,
+                metrics_name: "tpu-verifier",
+                stats: non_vote_stats,
+            },
+            ServicerState {
+                deduper: tpu_vote_deduper,
+                metrics_name: "tpu-vote-verifier",
+                stats: tpu_vote_stats,
+            },
         );
         let gossip_sigverify_handle = GossipSigVerifyHandle {
             verifier: worker_pool.gossip_verifier(),
@@ -237,97 +192,68 @@ impl SigVerifyStage {
 
         (
             Self {
-                non_vote_thread_hdl,
-                tpu_vote_thread_hdl,
+                exit,
+                servicer_thread_hdl: Some(servicer_thread_hdl),
                 _worker_pool: worker_pool,
             },
             gossip_sigverify_handle,
         )
     }
 
-    pub fn join(self) -> thread::Result<()> {
-        let non_vote_result = self.non_vote_thread_hdl.join();
-        let tpu_vote_result = self.tpu_vote_thread_hdl.join();
-        non_vote_result?;
-        tpu_vote_result?;
-        Ok(())
+    pub fn join(mut self) -> thread::Result<()> {
+        self.join_servicer_thread()
     }
 
-    fn verifier<const K: usize>(
-        deduper: &Deduper<K, [u8]>,
-        recvr: &Receiver<PacketBatch>,
-        verifier: &mut TransactionSigVerifier,
-        stats: &mut SigVerifierStats,
-    ) -> Result<()> {
-        const SOFT_RECEIVE_CAP: usize = 5_000;
-        let (mut batches, num_packets, recv_duration) =
-            streamer::recv_packet_batches(recvr, SOFT_RECEIVE_CAP)?;
-
-        let batches_len = batches.len();
-        stats
-            .recv_batches_us_hist
-            .increment(recv_duration.as_micros() as u64)
-            .unwrap();
-        stats.batches_hist.increment(batches_len as u64).unwrap();
-        stats.packets_hist.increment(num_packets as u64).unwrap();
-        stats.total_batches += batches_len;
-        stats.total_packets += num_packets;
-
-        let mut dedup_time = Measure::start("sigverify_dedup_time");
-        let discard_or_dedup_fail =
-            deduper::dedup_packets_and_count_discards(deduper, &mut batches) as usize;
-        dedup_time.stop();
-        stats.total_dropped_on_capacity += verifier.send_packets_to_worker_pool(batches)?;
-        stats
-            .dedup_packets_pp_us_hist
-            .increment(dedup_time.as_us() / (num_packets as u64))
-            .unwrap();
-        stats.total_dedup += discard_or_dedup_fail;
-        stats.total_dedup_time_us += dedup_time.as_us() as usize;
-
-        Ok(())
+    fn join_servicer_thread(&mut self) -> thread::Result<()> {
+        self.exit.store(true, Ordering::Relaxed);
+        self.servicer_thread_hdl
+            .take()
+            .map(JoinHandle::join)
+            .unwrap_or(Ok(()))
     }
 
-    fn verifier_service(
-        packet_receiver: Receiver<PacketBatch>,
-        mut verifier: TransactionSigVerifier,
-        thread_name: &'static str,
-        metrics_name: &'static str,
-        mut stats: SigVerifierStats,
+    /// Drives deduper reset and metrics reporting for sigverify packet streams.
+    fn servicer(
+        exit: Arc<AtomicBool>,
+        mut non_vote_state: ServicerState,
+        mut tpu_vote_state: ServicerState,
     ) -> JoinHandle<()> {
         let mut last_print = Instant::now();
-        const MAX_DEDUPER_AGE: Duration = Duration::from_secs(2);
-        const DEDUPER_FALSE_POSITIVE_RATE: f64 = 0.001;
-        const DEDUPER_NUM_BITS: u64 = 63_999_979;
         Builder::new()
-            .name(thread_name.to_string())
+            .name("solSigVerSvc".to_string())
             .spawn(move || {
                 let mut rng = rand::rng();
-                let deduper = Deduper::<2, [u8]>::new(&mut rng, DEDUPER_NUM_BITS);
-                loop {
-                    if deduper.maybe_reset(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, MAX_DEDUPER_AGE) {
-                        stats.num_deduper_saturations += 1;
-                    }
-                    if let Err(e) =
-                        Self::verifier(&deduper, &packet_receiver, &mut verifier, &mut stats)
-                    {
-                        match e {
-                            SigVerifyServiceError::Streamer(StreamerError::RecvTimeout(
-                                RecvTimeoutError::Disconnected,
-                            )) => break,
-                            SigVerifyServiceError::Streamer(StreamerError::RecvTimeout(
-                                RecvTimeoutError::Timeout,
-                            )) => (),
-                            _ => error!("{e:?}"),
+                while !exit.load(Ordering::Relaxed) {
+                    for state in [&mut non_vote_state, &mut tpu_vote_state] {
+                        if state.deduper.maybe_reset(
+                            &mut rng,
+                            DEDUPER_FALSE_POSITIVE_RATE,
+                            MAX_DEDUPER_AGE,
+                        ) {
+                            state.stats.num_deduper_saturations += 1;
                         }
                     }
                     if last_print.elapsed() > SigVerifierStats::REPORT_INTERVAL {
-                        stats.maybe_report_and_reset(metrics_name);
+                        non_vote_state
+                            .stats
+                            .maybe_report_and_reset(non_vote_state.metrics_name);
+                        tpu_vote_state
+                            .stats
+                            .maybe_report_and_reset(tpu_vote_state.metrics_name);
                         last_print = Instant::now();
                     }
+                    thread::sleep(Duration::from_millis(10));
                 }
             })
             .unwrap()
+    }
+}
+
+impl Drop for SigVerifyStage {
+    fn drop(&mut self) {
+        if let Err(err) = self.join_servicer_thread() {
+            error!("sigverify servicer encountered unexpected error: {err:?}");
+        }
     }
 }
 
@@ -534,8 +460,6 @@ mod tests {
             wincode::serialize(&test_tx_v1()).unwrap(),
         ));
         packet_s.send(PacketBatch::from(bytes_batch)).unwrap();
-        drop(packet_s);
-        drop(vote_packet_s);
 
         let verified_batch = verified_r.recv_timeout(Duration::from_secs(30)).unwrap();
         assert_eq!(verified_batch.len(), 1);
@@ -545,6 +469,8 @@ mod tests {
             expected_valid
         );
 
+        drop(packet_s);
+        drop(vote_packet_s);
         drop(gossip_sigverify_handle);
         stage.join().unwrap();
     }


### PR DESCRIPTION
#### Problem
- We have a main thread that does dedup, then sends to worker threads
- We can and should dedup in parallel

#### Summary of Changes
- Modify dedup to use an arc-swapped generation
- Move dedup into worker threads
- Remove histogram metrics

Fixes #
