### PR TITLE
perf(snapshots): use FileBufRead in AccountsStorageReader during archive

### DIFF
--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -1,26 +1,54 @@
 use {
     crate::{account_info::Offset, account_storage_entry::AccountStorageEntry},
+    agave_fs::{
+        buffered_reader::{self, FileBufRead},
+        io_setup::IoSetupState,
+    },
     solana_clock::Slot,
     std::{
         fs::File,
-        io::{self, Read, Seek, SeekFrom},
+        io::{self, Read},
+        marker::PhantomData,
     },
 };
 
-/// A wrapper type around `AccountStorageEntry` that implements the `Read` trait.
-/// This type skips over the data in accounts contained in the obsolete accounts structure
-pub struct AccountStorageReader {
-    sorted_obsolete_accounts: Vec<(Offset, usize)>,
-    current_offset: usize,
-    file: File,
-    num_alive_bytes: usize,
-    num_total_bytes: usize,
+pub fn storage_file_buf_reader<'a>(
+    max_buf_size: usize,
+    io_setup: &IoSetupState,
+) -> io::Result<impl FileBufRead<'a> + use<'a>> {
+    #[cfg(target_os = "linux")]
+    let reader = buffered_reader::new_io_uring_file_buf_reader(max_buf_size, io_setup)?;
+    #[cfg(not(target_os = "linux"))]
+    let reader = {
+        let _ = (max_buf_size, io_setup);
+        const READER_STACK_BUFFER_SIZE: usize = 64 * 1024;
+        buffered_reader::BufferedReader::<READER_STACK_BUFFER_SIZE>::new()
+    };
+    Ok(reader)
 }
 
-impl AccountStorageReader {
+/// A wrapper type around `AccountStorageEntry` that implements the `Read` trait.
+/// This type skips over the data in accounts contained in the obsolete accounts structure
+pub struct AccountStorageReader<'a, 'r, R: FileBufRead<'a>> {
+    sorted_obsolete_accounts: Vec<(Offset, usize)>,
+    current_offset: usize,
+    reader: &'r mut R,
+    num_alive_bytes: usize,
+    num_total_bytes: usize,
+    _file: PhantomData<&'a File>,
+}
+
+impl<'a, 'r, R: FileBufRead<'a>> AccountStorageReader<'a, 'r, R> {
     /// Creates a new `AccountStorageReader` from an `AccountStorageEntry`.
     /// The obsolete accounts structure is sorted during initialization.
-    pub fn new(storage: &AccountStorageEntry, snapshot_slot: Option<Slot>) -> io::Result<Self> {
+    ///
+    /// `file_reader` is a buffered reader supplied by the caller. It is reset and
+    /// associated with the storage's file.
+    pub fn new(
+        storage: &'a AccountStorageEntry,
+        snapshot_slot: Option<Slot>,
+        file_reader: &'r mut R,
+    ) -> io::Result<Self> {
         let internals = storage.accounts.internals_for_archive();
         let num_total_bytes = storage.accounts.len();
         let num_alive_bytes = num_total_bytes - storage.get_obsolete_bytes(snapshot_slot);
@@ -40,14 +68,15 @@ impl AccountStorageReader {
         sorted_obsolete_accounts
             .sort_unstable_by(|(a_offset, _), (b_offset, _)| b_offset.cmp(a_offset));
 
-        let file = File::open(internals.path)?;
+        file_reader.set_file(internals.file, num_total_bytes as u64)?;
 
         Ok(Self {
             sorted_obsolete_accounts,
             current_offset: 0,
-            file,
+            reader: file_reader,
             num_alive_bytes,
             num_total_bytes,
+            _file: PhantomData,
         })
     }
 
@@ -60,7 +89,7 @@ impl AccountStorageReader {
     }
 }
 
-impl Read for AccountStorageReader {
+impl<'a, R: FileBufRead<'a>> Read for AccountStorageReader<'a, '_, R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut total_read = 0;
         let buf_len = buf.len();
@@ -69,7 +98,9 @@ impl Read for AccountStorageReader {
             let next_obsolete_account = self.sorted_obsolete_accounts.last();
             if let Some(&(obsolete_start, obsolete_size)) = next_obsolete_account {
                 if self.current_offset == obsolete_start {
-                    self.current_offset += obsolete_size.min(self.num_total_bytes - obsolete_start);
+                    let skip_len = obsolete_size.min(self.num_total_bytes - obsolete_start);
+                    self.reader.consume_or_skip(skip_len);
+                    self.current_offset += skip_len;
                     self.sorted_obsolete_accounts.pop();
                     continue;
                 }
@@ -87,9 +118,7 @@ impl Read for AccountStorageReader {
 
             let bytes_to_read = bytes_left_in_buffer.min(bytes_to_read_from_file);
 
-            self.file
-                .seek(SeekFrom::Start(self.current_offset as u64))?;
-            let read_size = self.file.read(&mut buf[total_read..][..bytes_to_read])?;
+            let read_size = self.reader.read(&mut buf[total_read..][..bytes_to_read])?;
 
             if read_size == 0 {
                 break; // EOF
@@ -113,6 +142,7 @@ mod tests {
             accounts_db::get_temp_accounts_paths,
             accounts_file::{AccountsFile, AccountsFileProvider},
         },
+        agave_fs::io_setup::IoSetupState,
         log::*,
         rand::{
             SeedableRng,
@@ -121,9 +151,11 @@ mod tests {
         },
         solana_account::AccountSharedData,
         solana_pubkey::Pubkey,
-        std::iter,
+        std::{fs::File, iter},
         test_case::test_case,
     };
+
+    const MAX_BUFFER_SIZE: usize = 2 * 1024 * 1024;
 
     fn create_storage_for_storage_reader(
         slot: Slot,
@@ -153,7 +185,9 @@ mod tests {
 
         storage.accounts.write_accounts(&(slot, &accounts[..]), 0);
 
-        let reader = AccountStorageReader::new(&storage, None).unwrap();
+        let mut buf_reader =
+            storage_file_buf_reader(MAX_BUFFER_SIZE, &IoSetupState::default()).unwrap();
+        let reader = AccountStorageReader::new(&storage, None, &mut buf_reader).unwrap();
         assert_eq!(reader.len(), storage.accounts.len());
     }
 
@@ -220,7 +254,9 @@ mod tests {
         let storage = storage.reopen_as_readonly().unwrap_or(storage);
 
         // Create the reader and check the length
-        let mut reader = AccountStorageReader::new(&storage, None).unwrap();
+        let mut file_reader =
+            storage_file_buf_reader(MAX_BUFFER_SIZE, &IoSetupState::default()).unwrap();
+        let mut reader = AccountStorageReader::new(&storage, None, &mut file_reader).unwrap();
         let current_len = storage.accounts.len() - storage.get_obsolete_bytes(None);
         assert_eq!(reader.len(), current_len);
 
@@ -332,8 +368,11 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
 
         // Now iterate through all the possible snapshot slots and verify correctness
+        let mut file_reader =
+            storage_file_buf_reader(MAX_BUFFER_SIZE, &IoSetupState::default()).unwrap();
         for snapshot_slot in 0..slot_marked_dead {
-            let mut reader = AccountStorageReader::new(&storage, Some(snapshot_slot)).unwrap();
+            let mut reader =
+                AccountStorageReader::new(&storage, Some(snapshot_slot), &mut file_reader).unwrap();
             let current_len =
                 storage.accounts.len() - storage.get_obsolete_bytes(Some(snapshot_slot));
             assert_eq!(reader.len(), current_len);

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -1,15 +1,14 @@
 use {
-    crate::{account_info::Offset, account_storage_entry::AccountStorageEntry},
+    crate::{
+        account_info::Offset, account_storage_entry::AccountStorageEntry,
+        accounts_file::OpenFileForArchive,
+    },
     agave_fs::{
         buffered_reader::{self, FileBufRead},
         io_setup::IoSetupState,
     },
     solana_clock::Slot,
-    std::{
-        fs::File,
-        io::{self, Read},
-        marker::PhantomData,
-    },
+    std::io::{self, Read},
 };
 
 // Read-ahead buffer capacity, sized as a multiple of the default io-uring
@@ -40,28 +39,46 @@ pub fn storage_file_buf_reader<'a>(
     Ok(reader)
 }
 
+/// Returns a file handle for each storage suitable for archive-style reads
+/// matching `use_direct_io` (see [`OpenFileForArchive`]).
+///
+/// Returned as a `Vec` so the handles outlive the buffered reader they'll be
+/// fed into.
+pub fn open_storage_files<'s>(
+    storages: impl IntoIterator<Item = &'s AccountStorageEntry>,
+    use_direct_io: bool,
+) -> io::Result<Vec<OpenFileForArchive<'s>>> {
+    storages
+        .into_iter()
+        .map(|storage| storage.accounts.open_file_for_archive(use_direct_io))
+        .collect()
+}
+
 /// A wrapper type around `AccountStorageEntry` that implements the `Read` trait.
-/// This type skips over the data in accounts contained in the obsolete accounts structure
-pub struct AccountStorageReader<'a, 'r, R: FileBufRead<'a>> {
+/// This type skips over the data in accounts contained in the obsolete accounts
+/// structure.
+///
+/// The caller is responsible for activating the storage's file on `file_reader`
+/// via `set_file` (typically using a file opened with [`open_storage_files`])
+/// before constructing the reader.
+pub struct AccountStorageReader<'r, R> {
     sorted_obsolete_accounts: Vec<(Offset, usize)>,
     reader: &'r mut R,
     num_alive_bytes: usize,
     num_total_bytes: usize,
-    _file: PhantomData<&'a File>,
 }
 
-impl<'a, 'r, R: FileBufRead<'a>> AccountStorageReader<'a, 'r, R> {
+impl<'a, 'r, R: FileBufRead<'a>> AccountStorageReader<'r, R> {
     /// Creates a new `AccountStorageReader` from an `AccountStorageEntry`.
     /// The obsolete accounts structure is sorted during initialization.
     ///
-    /// `file_reader` is a buffered reader supplied by the caller. It is reset and
-    /// associated with the storage's file.
+    /// Expects that the caller has already attached the storage's file to
+    /// `file_reader` via `set_file`.
     pub fn new(
-        storage: &'a AccountStorageEntry,
+        storage: &AccountStorageEntry,
         snapshot_slot: Option<Slot>,
         file_reader: &'r mut R,
     ) -> io::Result<Self> {
-        let internals = storage.accounts.internals_for_archive();
         let num_total_bytes = storage.accounts.len();
         let num_alive_bytes = num_total_bytes - storage.get_obsolete_bytes(snapshot_slot);
 
@@ -80,14 +97,11 @@ impl<'a, 'r, R: FileBufRead<'a>> AccountStorageReader<'a, 'r, R> {
         sorted_obsolete_accounts
             .sort_unstable_by(|(a_offset, _), (b_offset, _)| b_offset.cmp(a_offset));
 
-        file_reader.set_file(internals.file, num_total_bytes as u64)?;
-
         Ok(Self {
             sorted_obsolete_accounts,
             reader: file_reader,
             num_alive_bytes,
             num_total_bytes,
-            _file: PhantomData,
         })
     }
 
@@ -100,7 +114,7 @@ impl<'a, 'r, R: FileBufRead<'a>> AccountStorageReader<'a, 'r, R> {
     }
 }
 
-impl<'a, R: FileBufRead<'a>> Read for AccountStorageReader<'a, '_, R> {
+impl<'a, R: FileBufRead<'a>> Read for AccountStorageReader<'_, R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut total_read = 0;
         let buf_len = buf.len();
@@ -193,12 +207,16 @@ mod tests {
 
         storage.accounts.write_accounts(&(slot, &accounts[..]), 0);
 
+        let files = open_storage_files(iter::once(&storage), false).unwrap();
         let mut buf_reader = storage_file_buf_reader(
             ACCOUNT_STORAGE_MAX_BUFFER_SIZE,
             false,
             &IoSetupState::default(),
         )
         .unwrap();
+        buf_reader
+            .set_file(files[0].as_ref(), storage.accounts.len() as u64)
+            .unwrap();
         let reader = AccountStorageReader::new(&storage, None, &mut buf_reader).unwrap();
         assert_eq!(reader.len(), storage.accounts.len());
     }
@@ -266,12 +284,16 @@ mod tests {
         let storage = storage.reopen_as_readonly().unwrap_or(storage);
 
         // Create the reader and check the length
+        let files = open_storage_files(iter::once(&storage), false).unwrap();
         let mut file_reader = storage_file_buf_reader(
             ACCOUNT_STORAGE_MAX_BUFFER_SIZE,
             false,
             &IoSetupState::default(),
         )
         .unwrap();
+        file_reader
+            .set_file(files[0].as_ref(), storage.accounts.len() as u64)
+            .unwrap();
         let mut reader = AccountStorageReader::new(&storage, None, &mut file_reader).unwrap();
         let current_len = storage.accounts.len() - storage.get_obsolete_bytes(None);
         assert_eq!(reader.len(), current_len);
@@ -384,6 +406,7 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
 
         // Now iterate through all the possible snapshot slots and verify correctness
+        let files = open_storage_files(iter::once(&storage), false).unwrap();
         let mut file_reader = storage_file_buf_reader(
             ACCOUNT_STORAGE_MAX_BUFFER_SIZE,
             false,
@@ -391,6 +414,9 @@ mod tests {
         )
         .unwrap();
         for snapshot_slot in 0..slot_marked_dead {
+            file_reader
+                .set_file(files[0].as_ref(), storage.accounts.len() as u64)
+                .unwrap();
             let mut reader =
                 AccountStorageReader::new(&storage, Some(snapshot_slot), &mut file_reader).unwrap();
             let current_len =

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -36,7 +36,6 @@ pub fn storage_file_buf_reader<'a>(
 /// This type skips over the data in accounts contained in the obsolete accounts structure
 pub struct AccountStorageReader<'a, 'r, R: FileBufRead<'a>> {
     sorted_obsolete_accounts: Vec<(Offset, usize)>,
-    current_offset: usize,
     reader: &'r mut R,
     num_alive_bytes: usize,
     num_total_bytes: usize,
@@ -77,7 +76,6 @@ impl<'a, 'r, R: FileBufRead<'a>> AccountStorageReader<'a, 'r, R> {
 
         Ok(Self {
             sorted_obsolete_accounts,
-            current_offset: 0,
             reader: file_reader,
             num_alive_bytes,
             num_total_bytes,
@@ -101,11 +99,11 @@ impl<'a, R: FileBufRead<'a>> Read for AccountStorageReader<'a, '_, R> {
 
         while total_read < buf_len {
             let next_obsolete_account = self.sorted_obsolete_accounts.last();
+            let file_offset = self.reader.get_file_offset() as usize;
             if let Some(&(obsolete_start, obsolete_size)) = next_obsolete_account {
-                if self.current_offset == obsolete_start {
+                if file_offset == obsolete_start {
                     let skip_len = obsolete_size.min(self.num_total_bytes - obsolete_start);
                     self.reader.consume_or_skip(skip_len);
-                    self.current_offset += skip_len;
                     self.sorted_obsolete_accounts.pop();
                     continue;
                 }
@@ -116,9 +114,9 @@ impl<'a, R: FileBufRead<'a>> Read for AccountStorageReader<'a, '_, R> {
 
             // Cannot read beyond the next obsolete account or the end of the file
             let bytes_to_read_from_file = if let Some((obsolete_start, _)) = next_obsolete_account {
-                obsolete_start.saturating_sub(self.current_offset)
+                obsolete_start.saturating_sub(file_offset)
             } else {
-                self.num_total_bytes.saturating_sub(self.current_offset)
+                self.num_total_bytes.saturating_sub(file_offset)
             };
 
             let bytes_to_read = bytes_left_in_buffer.min(bytes_to_read_from_file);
@@ -129,7 +127,6 @@ impl<'a, R: FileBufRead<'a>> Read for AccountStorageReader<'a, '_, R> {
                 break; // EOF
             }
 
-            self.current_offset += read_size;
             total_read += read_size;
         }
 

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -17,15 +17,23 @@ use {
 // file fits entirely within the buffer.
 pub const ACCOUNT_STORAGE_MAX_BUFFER_SIZE: usize = 10 * 1024 * 1024;
 
+/// When `use_page_cache` is `true`, direct I/O is forced off regardless of
+/// `io_setup.use_direct_io` so that reads can hit the kernel's page cache.
+/// Otherwise, the `io_setup.use_direct_io` setting is honored.
 pub fn storage_file_buf_reader<'a>(
     max_buf_size: usize,
+    use_page_cache: bool,
     io_setup: &IoSetupState,
 ) -> io::Result<impl FileBufRead<'a> + use<'a>> {
     #[cfg(target_os = "linux")]
-    let reader = buffered_reader::new_io_uring_file_buf_reader(max_buf_size, io_setup)?;
+    let reader = buffered_reader::SequentialFileReaderBuilder::new()
+        .shared_sqpoll(io_setup.shared_sqpoll_fd())
+        .use_direct_io(io_setup.use_direct_io && !use_page_cache)
+        .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
+        .build(max_buf_size)?;
     #[cfg(not(target_os = "linux"))]
     let reader = {
-        let _ = (max_buf_size, io_setup);
+        let _ = (max_buf_size, use_page_cache, io_setup);
         const READER_STACK_BUFFER_SIZE: usize = 64 * 1024;
         buffered_reader::BufferedReader::<READER_STACK_BUFFER_SIZE>::new()
     };
@@ -185,9 +193,12 @@ mod tests {
 
         storage.accounts.write_accounts(&(slot, &accounts[..]), 0);
 
-        let mut buf_reader =
-            storage_file_buf_reader(ACCOUNT_STORAGE_MAX_BUFFER_SIZE, &IoSetupState::default())
-                .unwrap();
+        let mut buf_reader = storage_file_buf_reader(
+            ACCOUNT_STORAGE_MAX_BUFFER_SIZE,
+            false,
+            &IoSetupState::default(),
+        )
+        .unwrap();
         let reader = AccountStorageReader::new(&storage, None, &mut buf_reader).unwrap();
         assert_eq!(reader.len(), storage.accounts.len());
     }
@@ -255,9 +266,12 @@ mod tests {
         let storage = storage.reopen_as_readonly().unwrap_or(storage);
 
         // Create the reader and check the length
-        let mut file_reader =
-            storage_file_buf_reader(ACCOUNT_STORAGE_MAX_BUFFER_SIZE, &IoSetupState::default())
-                .unwrap();
+        let mut file_reader = storage_file_buf_reader(
+            ACCOUNT_STORAGE_MAX_BUFFER_SIZE,
+            false,
+            &IoSetupState::default(),
+        )
+        .unwrap();
         let mut reader = AccountStorageReader::new(&storage, None, &mut file_reader).unwrap();
         let current_len = storage.accounts.len() - storage.get_obsolete_bytes(None);
         assert_eq!(reader.len(), current_len);
@@ -370,9 +384,12 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
 
         // Now iterate through all the possible snapshot slots and verify correctness
-        let mut file_reader =
-            storage_file_buf_reader(ACCOUNT_STORAGE_MAX_BUFFER_SIZE, &IoSetupState::default())
-                .unwrap();
+        let mut file_reader = storage_file_buf_reader(
+            ACCOUNT_STORAGE_MAX_BUFFER_SIZE,
+            false,
+            &IoSetupState::default(),
+        )
+        .unwrap();
         for snapshot_slot in 0..slot_marked_dead {
             let mut reader =
                 AccountStorageReader::new(&storage, Some(snapshot_slot), &mut file_reader).unwrap();

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -12,6 +12,11 @@ use {
     },
 };
 
+// Read-ahead buffer capacity, sized as a multiple of the default io-uring
+// reader's read size (1 MiB) and large enough that almost any account storage
+// file fits entirely within the buffer.
+pub const ACCOUNT_STORAGE_MAX_BUFFER_SIZE: usize = 10 * 1024 * 1024;
+
 pub fn storage_file_buf_reader<'a>(
     max_buf_size: usize,
     io_setup: &IoSetupState,
@@ -155,8 +160,6 @@ mod tests {
         test_case::test_case,
     };
 
-    const MAX_BUFFER_SIZE: usize = 2 * 1024 * 1024;
-
     fn create_storage_for_storage_reader(
         slot: Slot,
         provider: AccountsFileProvider,
@@ -186,7 +189,8 @@ mod tests {
         storage.accounts.write_accounts(&(slot, &accounts[..]), 0);
 
         let mut buf_reader =
-            storage_file_buf_reader(MAX_BUFFER_SIZE, &IoSetupState::default()).unwrap();
+            storage_file_buf_reader(ACCOUNT_STORAGE_MAX_BUFFER_SIZE, &IoSetupState::default())
+                .unwrap();
         let reader = AccountStorageReader::new(&storage, None, &mut buf_reader).unwrap();
         assert_eq!(reader.len(), storage.accounts.len());
     }
@@ -255,7 +259,8 @@ mod tests {
 
         // Create the reader and check the length
         let mut file_reader =
-            storage_file_buf_reader(MAX_BUFFER_SIZE, &IoSetupState::default()).unwrap();
+            storage_file_buf_reader(ACCOUNT_STORAGE_MAX_BUFFER_SIZE, &IoSetupState::default())
+                .unwrap();
         let mut reader = AccountStorageReader::new(&storage, None, &mut file_reader).unwrap();
         let current_len = storage.accounts.len() - storage.get_obsolete_bytes(None);
         assert_eq!(reader.len(), current_len);
@@ -369,7 +374,8 @@ mod tests {
 
         // Now iterate through all the possible snapshot slots and verify correctness
         let mut file_reader =
-            storage_file_buf_reader(MAX_BUFFER_SIZE, &IoSetupState::default()).unwrap();
+            storage_file_buf_reader(ACCOUNT_STORAGE_MAX_BUFFER_SIZE, &IoSetupState::default())
+                .unwrap();
         for snapshot_slot in 0..slot_marked_dead {
             let mut reader =
                 AccountStorageReader::new(&storage, Some(snapshot_slot), &mut file_reader).unwrap();

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -248,7 +248,7 @@ impl AccountsFile {
 
     /// Returns a file handle suitable for archive-style reads. With
     /// `use_direct_io = true` a fresh fd is opened with `O_DIRECT`; otherwise
-    /// the `AppendVec`'s existing fd is borrowed, saving one fd per storage.
+    /// the `AccountsFile`'s existing fd is borrowed, saving one fd per storage.
     pub fn open_file_for_archive(&self, use_direct_io: bool) -> io::Result<OpenFileForArchive<'_>> {
         if use_direct_io {
             open_for_reading(self.path(), true).map(OpenFileForArchive::Owned)
@@ -280,7 +280,7 @@ impl AccountsFileProvider {
 /// The access method to use when archiving an AccountsFile
 #[derive(Debug)]
 pub enum OpenFileForArchive<'a> {
-    /// Borrowed `AppendVec` fd; lacks `O_DIRECT`, so reads go through the
+    /// Borrowed `AccountsFile` fd; lacks `O_DIRECT`, so reads go through the
     /// kernel page cache (incompatible with direct-I/O reads).
     Borrowed(&'a File),
     /// Freshly opened fd, typically with `O_DIRECT` on Linux.

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -11,6 +11,7 @@ use {
     solana_clock::Slot,
     solana_pubkey::Pubkey,
     std::{
+        fs::File,
         mem,
         path::{Path, PathBuf},
     },
@@ -273,8 +274,8 @@ impl AccountsFileProvider {
 /// The access method to use when archiving an AccountsFile
 #[derive(Debug)]
 pub struct InternalsForArchive<'a> {
-    /// Path to the backing file used to archive the contents
-    pub path: &'a Path,
+    /// File handle of the backing file used to archive the contents
+    pub file: &'a File,
 }
 
 /// Information after storing accounts

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -6,13 +6,13 @@ use {
         append_vec::{AppendVec, AppendVecError},
         storable_accounts::StorableAccounts,
     },
-    agave_fs::{FileInfo, buffered_reader::RequiredLenBufFileRead},
+    agave_fs::{FileInfo, buffered_reader::RequiredLenBufFileRead, file_io::open_for_reading},
     solana_account::AccountSharedData,
     solana_clock::Slot,
     solana_pubkey::Pubkey,
     std::{
         fs::File,
-        mem,
+        io, mem,
         path::{Path, PathBuf},
     },
     thiserror::Error,
@@ -246,10 +246,16 @@ impl AccountsFile {
         }
     }
 
-    /// Returns the way to access this accounts file when archiving
-    pub fn internals_for_archive(&self) -> InternalsForArchive<'_> {
-        match self {
-            Self::AppendVec(av) => av.internals_for_archive(),
+    /// Returns a file handle suitable for archive-style reads. With
+    /// `use_direct_io = true` a fresh fd is opened with `O_DIRECT`; otherwise
+    /// the `AppendVec`'s existing fd is borrowed, saving one fd per storage.
+    pub fn open_file_for_archive(&self, use_direct_io: bool) -> io::Result<OpenFileForArchive<'_>> {
+        if use_direct_io {
+            open_for_reading(self.path(), true).map(OpenFileForArchive::Owned)
+        } else {
+            Ok(match self {
+                Self::AppendVec(av) => av.open_file_for_archive(),
+            })
         }
     }
 }
@@ -273,9 +279,21 @@ impl AccountsFileProvider {
 
 /// The access method to use when archiving an AccountsFile
 #[derive(Debug)]
-pub struct InternalsForArchive<'a> {
-    /// File handle of the backing file used to archive the contents
-    pub file: &'a File,
+pub enum OpenFileForArchive<'a> {
+    /// Borrowed `AppendVec` fd; lacks `O_DIRECT`, so reads go through the
+    /// kernel page cache (incompatible with direct-I/O reads).
+    Borrowed(&'a File),
+    /// Freshly opened fd, typically with `O_DIRECT` on Linux.
+    Owned(File),
+}
+
+impl AsRef<File> for OpenFileForArchive<'_> {
+    fn as_ref(&self) -> &File {
+        match self {
+            Self::Borrowed(f) => f,
+            Self::Owned(f) => f,
+        }
+    }
 }
 
 /// Information after storing accounts

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1075,7 +1075,7 @@ impl AppendVec {
 
     /// Returns the way to access this accounts file when archiving
     pub(crate) fn internals_for_archive(&self) -> InternalsForArchive<'_> {
-        InternalsForArchive { path: self.path() }
+        InternalsForArchive { file: &self.file }
     }
 }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -15,7 +15,7 @@ use {
     crate::{
         account_info::Offset,
         account_storage::stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
-        accounts_file::{InternalsForArchive, StoredAccountsInfo},
+        accounts_file::{OpenFileForArchive, StoredAccountsInfo},
         storable_accounts::StorableAccounts,
         u64_align,
         utils::create_account_shared_data,
@@ -1074,8 +1074,8 @@ impl AppendVec {
     }
 
     /// Returns the way to access this accounts file when archiving
-    pub(crate) fn internals_for_archive(&self) -> InternalsForArchive<'_> {
-        InternalsForArchive { file: &self.file }
+    pub(crate) fn open_file_for_archive(&self) -> OpenFileForArchive<'_> {
+        OpenFileForArchive::Borrowed(&self.file)
     }
 }
 

--- a/fs/src/buffered_reader.rs
+++ b/fs/src/buffered_reader.rs
@@ -13,6 +13,8 @@
 //!
 //! When reading full accounts data whose sizes exceed the small stack buffer, the `BufReaderWithOverflow`
 //! should be used, which supports dynamically allocated buffer for preparing contiguous data slices.
+#[cfg(target_os = "linux")]
+use crate::io_uring::sequential_file_reader::{SequentialFileReader, SequentialFileReaderBuilder};
 use {
     crate::{
         FileSize,
@@ -425,14 +427,7 @@ pub fn large_file_buf_reader(
 ) -> io::Result<impl BufRead + use<>> {
     #[cfg(target_os = "linux")]
     {
-        assert!(agave_io_uring::io_uring_supported());
-        use crate::io_uring::sequential_file_reader::SequentialFileReaderBuilder;
-
-        let mut reader = SequentialFileReaderBuilder::new()
-            .shared_sqpoll(io_setup.shared_sqpoll_fd())
-            .use_direct_io(io_setup.use_direct_io)
-            .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
-            .build(buf_size)?;
+        let mut reader = new_io_uring_file_buf_reader(buf_size, io_setup)?;
         reader.set_path(path)?;
         Ok(reader)
     }
@@ -443,6 +438,20 @@ pub fn large_file_buf_reader(
         let _ = io_setup;
         Ok(BufReader::with_capacity(buf_size, file))
     }
+}
+
+#[cfg(target_os = "linux")]
+pub fn new_io_uring_file_buf_reader<'a>(
+    buf_size: usize,
+    io_setup: &IoSetupState,
+) -> io::Result<SequentialFileReader<'a>> {
+    assert!(agave_io_uring::io_uring_supported());
+
+    SequentialFileReaderBuilder::new()
+        .shared_sqpoll(io_setup.shared_sqpoll_fd())
+        .use_direct_io(io_setup.use_direct_io)
+        .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
+        .build(buf_size)
 }
 
 #[cfg(test)]

--- a/fs/src/buffered_reader.rs
+++ b/fs/src/buffered_reader.rs
@@ -14,7 +14,7 @@
 //! When reading full accounts data whose sizes exceed the small stack buffer, the `BufReaderWithOverflow`
 //! should be used, which supports dynamically allocated buffer for preparing contiguous data slices.
 #[cfg(target_os = "linux")]
-use crate::io_uring::sequential_file_reader::{SequentialFileReader, SequentialFileReaderBuilder};
+pub use crate::io_uring::sequential_file_reader::SequentialFileReaderBuilder;
 use {
     crate::{
         FileSize,
@@ -427,7 +427,13 @@ pub fn large_file_buf_reader(
 ) -> io::Result<impl BufRead + use<>> {
     #[cfg(target_os = "linux")]
     {
-        let mut reader = new_io_uring_file_buf_reader(buf_size, io_setup)?;
+        assert!(agave_io_uring::io_uring_supported());
+
+        let mut reader = SequentialFileReaderBuilder::new()
+            .shared_sqpoll(io_setup.shared_sqpoll_fd())
+            .use_direct_io(io_setup.use_direct_io)
+            .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
+            .build(buf_size)?;
         reader.set_path(path)?;
         Ok(reader)
     }
@@ -438,20 +444,6 @@ pub fn large_file_buf_reader(
         let _ = io_setup;
         Ok(BufReader::with_capacity(buf_size, file))
     }
-}
-
-#[cfg(target_os = "linux")]
-pub fn new_io_uring_file_buf_reader<'a>(
-    buf_size: usize,
-    io_setup: &IoSetupState,
-) -> io::Result<SequentialFileReader<'a>> {
-    assert!(agave_io_uring::io_uring_supported());
-
-    SequentialFileReaderBuilder::new()
-        .shared_sqpoll(io_setup.shared_sqpoll_fd())
-        .use_direct_io(io_setup.use_direct_io)
-        .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
-        .build(buf_size)
 }
 
 #[cfg(test)]

--- a/fs/src/file_io.rs
+++ b/fs/src/file_io.rs
@@ -12,6 +12,33 @@ use {
     },
 };
 
+/// Open `path` for reading, applying `O_DIRECT` on Linux when `use_direct_io`
+/// is true.
+///
+/// Use this when handing the resulting `File` to a `FileBufRead` reader that
+/// was built with a matching `use_direct_io` setting: opening with `O_DIRECT`
+/// here is what actually engages direct I/O at the kernel level. Reusing an
+/// `&File` opened without `O_DIRECT` will result in cached reads regardless of
+/// the reader's configuration.
+pub fn open_for_reading(path: &Path, use_direct_io: bool) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut flags = libc::O_NOATIME;
+        if use_direct_io {
+            flags |= libc::O_DIRECT;
+        }
+        options.custom_flags(flags);
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = use_direct_io;
+    }
+    options.open(path)
+}
+
 /// `buffer` contains `valid_bytes` of data at its end.
 /// Move those valid bytes to the beginning of `buffer`, then read from `offset` to fill the rest of `buffer`.
 /// Update `offset` for the next read and update `valid_bytes` to specify valid portion of `buffer`.

--- a/fs/src/io_setup.rs
+++ b/fs/src/io_setup.rs
@@ -59,7 +59,7 @@ impl IoSetupState {
     }
 
     #[cfg(target_os = "linux")]
-    pub(crate) fn shared_sqpoll_fd(&self) -> Option<BorrowedFd<'_>> {
+    pub fn shared_sqpoll_fd(&self) -> Option<BorrowedFd<'_>> {
         self.shared_sqpoll.as_ref().map(|s| s.as_fd())
     }
 }

--- a/fs/src/io_uring/sequential_file_reader.rs
+++ b/fs/src/io_uring/sequential_file_reader.rs
@@ -48,6 +48,7 @@ pub struct SequentialFileReaderBuilder<'sp> {
 }
 
 impl<'sp> SequentialFileReaderBuilder<'sp> {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
             read_capacity: DEFAULT_READ_SIZE,

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -124,7 +124,8 @@ mod serde_snapshot_tests {
         let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
         let mut next_append_vec_id = 0;
         const MAX_BUFFER_SIZE: usize = 2 * 1024 * 1024;
-        let mut buf_reader = storage_file_buf_reader(MAX_BUFFER_SIZE, &IoSetupState::default())?;
+        let mut buf_reader =
+            storage_file_buf_reader(MAX_BUFFER_SIZE, false, &IoSetupState::default())?;
         for storage_entry in storage_entries.iter() {
             // Copy file to new directory
             let file_name = AccountsFile::file_name(storage_entry.slot(), storage_entry.id());

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -9,7 +9,7 @@ mod serde_snapshot_tests {
             },
             snapshot_utils::StorageAndNextAccountsFileId,
         },
-        agave_fs::FileInfo,
+        agave_fs::{FileInfo, io_setup::IoSetupState},
         bincode::{Error, serialize_into},
         log::info,
         rand::{Rng, rng},
@@ -18,7 +18,7 @@ mod serde_snapshot_tests {
             ObsoleteAccounts,
             account_storage::AccountStorageMap,
             account_storage_entry::AccountStorageEntry,
-            account_storage_reader::AccountStorageReader,
+            account_storage_reader::{AccountStorageReader, storage_file_buf_reader},
             accounts::Accounts,
             accounts_db::{
                 ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDb, AccountsDbConfig, AtomicAccountsFileId,
@@ -123,11 +123,14 @@ mod serde_snapshot_tests {
         let storage_entries = accounts_db.get_storages(RangeFull).0;
         let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
         let mut next_append_vec_id = 0;
-        for storage_entry in storage_entries.into_iter() {
+        const MAX_BUFFER_SIZE: usize = 2 * 1024 * 1024;
+        let mut buf_reader = storage_file_buf_reader(MAX_BUFFER_SIZE, &IoSetupState::default())?;
+        for storage_entry in storage_entries.iter() {
             // Copy file to new directory
             let file_name = AccountsFile::file_name(storage_entry.slot(), storage_entry.id());
             let output_path = output_dir.as_ref().join(file_name);
-            let mut reader = AccountStorageReader::new(&storage_entry, None).unwrap();
+            let mut reader =
+                AccountStorageReader::new(storage_entry, None, &mut buf_reader).unwrap();
             let mut writer = File::create(&output_path)?;
             io::copy(&mut reader, &mut writer)?;
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -9,7 +9,7 @@ mod serde_snapshot_tests {
             },
             snapshot_utils::StorageAndNextAccountsFileId,
         },
-        agave_fs::{FileInfo, io_setup::IoSetupState},
+        agave_fs::{FileInfo, buffered_reader::FileBufRead as _, io_setup::IoSetupState},
         bincode::{Error, serialize_into},
         log::info,
         rand::{Rng, rng},
@@ -18,7 +18,9 @@ mod serde_snapshot_tests {
             ObsoleteAccounts,
             account_storage::AccountStorageMap,
             account_storage_entry::AccountStorageEntry,
-            account_storage_reader::{AccountStorageReader, storage_file_buf_reader},
+            account_storage_reader::{
+                AccountStorageReader, open_storage_files, storage_file_buf_reader,
+            },
             accounts::Accounts,
             accounts_db::{
                 ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDb, AccountsDbConfig, AtomicAccountsFileId,
@@ -124,12 +126,14 @@ mod serde_snapshot_tests {
         let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
         let mut next_append_vec_id = 0;
         const MAX_BUFFER_SIZE: usize = 2 * 1024 * 1024;
+        let storage_files = open_storage_files(storage_entries.iter().map(|s| s.as_ref()), false)?;
         let mut buf_reader =
             storage_file_buf_reader(MAX_BUFFER_SIZE, false, &IoSetupState::default())?;
-        for storage_entry in storage_entries.iter() {
+        for (storage_entry, file) in storage_entries.iter().zip(storage_files.iter()) {
             // Copy file to new directory
             let file_name = AccountsFile::file_name(storage_entry.slot(), storage_entry.id());
             let output_path = output_dir.as_ref().join(file_name);
+            buf_reader.set_file(file.as_ref(), storage_entry.accounts.len() as u64)?;
             let mut reader =
                 AccountStorageReader::new(storage_entry, None, &mut buf_reader).unwrap();
             let mut writer = File::create(&output_path)?;

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -3,13 +3,17 @@ use {
         ArchiveFormat, Result, SnapshotArchiveKind, error::ArchiveSnapshotPackageError, paths,
         snapshot_archive_info::SnapshotArchiveInfo, snapshot_hash::SnapshotHash,
     },
-    agave_fs::{buffered_writer::large_file_buf_writer, io_setup::IoSetupState},
+    agave_fs::{
+        buffered_reader::FileBufRead as _, buffered_writer::large_file_buf_writer,
+        io_setup::IoSetupState,
+    },
     log::info,
     solana_accounts_db::{
         account_storage::AccountStoragesOrderer,
         account_storage_entry::AccountStorageEntry,
         account_storage_reader::{
-            ACCOUNT_STORAGE_MAX_BUFFER_SIZE, AccountStorageReader, storage_file_buf_reader,
+            ACCOUNT_STORAGE_MAX_BUFFER_SIZE, AccountStorageReader, open_storage_files,
+            storage_file_buf_reader,
         },
         accounts_file::AccountsFile,
     },
@@ -125,13 +129,24 @@ pub fn archive_snapshot(
             // page-cached reads over direct I/O.
             let use_page_cache =
                 matches!(snapshot_archive_kind, SnapshotArchiveKind::Incremental(_));
+            let use_direct_io = io_setup.use_direct_io && !use_page_cache;
+            // Pre-open every storage file (with the buffered reader's
+            // direct-IO setting) so they outlive `buf_reader` — the reader's
+            // `'a` lifetime needs to borrow into them across loop iterations.
+            let storage_files = open_storage_files(storages_orderer.iter(), use_direct_io)
+                .map_err(E::StorageFileBufReaderError)?;
             let mut buf_reader =
                 storage_file_buf_reader(ACCOUNT_STORAGE_MAX_BUFFER_SIZE, use_page_cache, io_setup)
                     .map_err(E::StorageFileBufReaderError)?;
-            for storage in storages_orderer.iter() {
+            for (storage, file) in storages_orderer.iter().zip(storage_files.iter()) {
                 let path_in_archive = Path::new(ACCOUNTS_DIR)
                     .join(AccountsFile::file_name(storage.slot(), storage.id()));
 
+                buf_reader
+                    .set_file(file.as_ref(), storage.accounts.len() as u64)
+                    .map_err(|err| {
+                        E::AccountStorageReaderError(err, storage.path().to_path_buf())
+                    })?;
                 let reader =
                     AccountStorageReader::new(storage, Some(snapshot_slot), &mut buf_reader)
                         .map_err(|err| {

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -8,7 +8,9 @@ use {
     solana_accounts_db::{
         account_storage::AccountStoragesOrderer,
         account_storage_entry::AccountStorageEntry,
-        account_storage_reader::{AccountStorageReader, storage_file_buf_reader},
+        account_storage_reader::{
+            ACCOUNT_STORAGE_MAX_BUFFER_SIZE, AccountStorageReader, storage_file_buf_reader,
+        },
         accounts_file::AccountsFile,
     },
     solana_clock::Slot,
@@ -21,9 +23,6 @@ use {
 // such that during unpacking large writes are mixed with file metadata operations
 // and towards the end of archive (sizes equalize) writes are >256KiB / file.
 const INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO: (usize, usize) = (4, 1);
-
-// Buffer size capacity for read-ahead using default io-uring reader.
-const ACCOUNT_STORAGE_MAX_BUFFER_SIZE: usize = 4 * 1024 * 1024;
 
 /// Archives a snapshot into `archive_path`
 pub fn archive_snapshot(

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -120,8 +120,14 @@ pub fn archive_snapshot(
                 snapshot_storages,
                 INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO,
             );
-            let mut buf_reader = storage_file_buf_reader(ACCOUNT_STORAGE_MAX_BUFFER_SIZE, io_setup)
-                .map_err(E::StorageFileBufReaderError)?;
+            // For incremental snapshots, the storage files have just been
+            // written and are likely still hot in the page cache, so prefer
+            // page-cached reads over direct I/O.
+            let use_page_cache =
+                matches!(snapshot_archive_kind, SnapshotArchiveKind::Incremental(_));
+            let mut buf_reader =
+                storage_file_buf_reader(ACCOUNT_STORAGE_MAX_BUFFER_SIZE, use_page_cache, io_setup)
+                    .map_err(E::StorageFileBufReaderError)?;
             for storage in storages_orderer.iter() {
                 let path_in_archive = Path::new(ACCOUNTS_DIR)
                     .join(AccountsFile::file_name(storage.slot(), storage.id()));

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -6,8 +6,10 @@ use {
     agave_fs::{buffered_writer::large_file_buf_writer, io_setup::IoSetupState},
     log::info,
     solana_accounts_db::{
-        account_storage::AccountStoragesOrderer, account_storage_entry::AccountStorageEntry,
-        account_storage_reader::AccountStorageReader, accounts_file::AccountsFile,
+        account_storage::AccountStoragesOrderer,
+        account_storage_entry::AccountStorageEntry,
+        account_storage_reader::{AccountStorageReader, storage_file_buf_reader},
+        accounts_file::AccountsFile,
     },
     solana_clock::Slot,
     solana_measure::measure::Measure,
@@ -19,6 +21,9 @@ use {
 // such that during unpacking large writes are mixed with file metadata operations
 // and towards the end of archive (sizes equalize) writes are >256KiB / file.
 const INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO: (usize, usize) = (4, 1);
+
+// Buffer size capacity for read-ahead using default io-uring reader.
+const ACCOUNT_STORAGE_MAX_BUFFER_SIZE: usize = 4 * 1024 * 1024;
 
 /// Archives a snapshot into `archive_path`
 pub fn archive_snapshot(
@@ -116,14 +121,17 @@ pub fn archive_snapshot(
                 snapshot_storages,
                 INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO,
             );
+            let mut buf_reader = storage_file_buf_reader(ACCOUNT_STORAGE_MAX_BUFFER_SIZE, io_setup)
+                .map_err(E::StorageFileBufReaderError)?;
             for storage in storages_orderer.iter() {
                 let path_in_archive = Path::new(ACCOUNTS_DIR)
                     .join(AccountsFile::file_name(storage.slot(), storage.id()));
 
                 let reader =
-                    AccountStorageReader::new(storage, Some(snapshot_slot)).map_err(|err| {
-                        E::AccountStorageReaderError(err, storage.path().to_path_buf())
-                    })?;
+                    AccountStorageReader::new(storage, Some(snapshot_slot), &mut buf_reader)
+                        .map_err(|err| {
+                            E::AccountStorageReaderError(err, storage.path().to_path_buf())
+                        })?;
                 let mut header = tar::Header::new_gnu();
                 header.set_path(path_in_archive).map_err(|err| {
                     E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())

--- a/snapshots/src/error.rs
+++ b/snapshots/src/error.rs
@@ -271,6 +271,9 @@ pub enum ArchiveSnapshotPackageError {
 
     #[error("failed to create account storage reader '{1}': {0}")]
     AccountStorageReaderError(#[source] io::Error, PathBuf),
+
+    #[error("failed to initialize file buffered reader: {0}")]
+    StorageFileBufReaderError(#[source] io::Error),
 }
 
 /// Errors that can happen in `hard_link_storages_to_snapshot()`


### PR DESCRIPTION
#### Problem
Archiving snapshot uses `AccountsStorageReader` that goes over accounts storage files, reads them using sync io and seeks past the obsolete accounts. The overhead of doing syscalls is high
<img width="1994" height="1270" alt="master-create-snapshot" src="https://github.com/user-attachments/assets/e6798980-26d0-4a4c-9c74-558b77e977b4" />

#### Summary of Changes
Use buffered reader with io-uring read-ahead for reading the accounts data

Profile after change
<img width="1994" height="1270" alt="pr-create-snapshot" src="https://github.com/user-attachments/assets/6db23c0a-6bee-4fa1-b709-e01bfa1307c4" />

Create snapshot timing change:
```
master
datapoint: archive-snapshot-package slot=418416911i archive_format="TarZstd" 
  duration_ms=941174i full-snapshot-archive-size=108583477415i

PR
datapoint: archive-snapshot-package slot=418416911i archive_format="TarZstd" 
  duration_ms=808265i full-snapshot-archive-size=108583682177i
```

Note: some helper code was extracted from https://github.com/anza-xyz/agave/pull/10188, which I still want to work on and merge once I tune parameters to get perf improvement, so we can keep an eye on other contexts for using the helper functions.