### PR TITLE
fix(stats): reset `ConsensusPoolServiceStats::standstill` upon finalize

### DIFF
--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -162,6 +162,7 @@ impl ConsensusPoolService {
                 consensus_pool,
                 events,
                 &ctx.commitment_sender,
+                stats,
             )?;
         Self::maybe_update_root_and_send_new_certificates(
             consensus_pool,
@@ -340,6 +341,7 @@ impl ConsensusPoolService {
         consensus_pool: &mut ConsensusPool,
         votor_events: &mut Vec<VotorEvent>,
         commitment_sender: &Sender<CommitmentAggregationData>,
+        stats: &mut ConsensusPoolServiceStats,
     ) -> Result<(Option<Slot>, Vec<Arc<Certificate>>), AddVoteError> {
         let (new_finalized_slot, new_certificates_to_send) =
             consensus_pool.add_message(root_bank, my_vote_pubkey, message, votor_events)?;
@@ -352,6 +354,7 @@ impl ConsensusPoolService {
             new_finalized_slot,
             commitment_sender,
         )?;
+        stats.standstill = false;
         Ok((Some(new_finalized_slot), new_certificates_to_send))
     }
 
@@ -578,6 +581,7 @@ mod tests {
                 rank: my_rank as u16,
             });
 
+            let mut stats = ConsensusPoolServiceStats::new();
             let result = ConsensusPoolService::add_message_and_maybe_update_commitment(
                 &root_bank,
                 &ctx.my_pubkey,
@@ -586,11 +590,11 @@ mod tests {
                 &mut ctx.consensus_pool,
                 &mut events,
                 &ctx.commitment_sender,
+                &mut stats,
             );
             assert!(result.is_ok());
 
             let (new_finalized_slot, new_certificates_to_send) = result.unwrap();
-            let mut stats = ConsensusPoolServiceStats::new();
             let mut standstill_timer = Instant::now();
 
             // Send certificates if any were produced
@@ -660,6 +664,7 @@ mod tests {
         };
         events.clear();
 
+        let mut stats = ConsensusPoolServiceStats::new();
         let result = ConsensusPoolService::add_message_and_maybe_update_commitment(
             &root_bank,
             &ctx.my_pubkey,
@@ -668,11 +673,11 @@ mod tests {
             &mut ctx.consensus_pool,
             &mut events,
             &ctx.commitment_sender,
+            &mut stats,
         );
         assert!(result.is_ok());
 
         let (new_finalized_slot, new_certificates_to_send) = result.unwrap();
-        let mut stats = ConsensusPoolServiceStats::new();
         let mut standstill_timer = Instant::now();
 
         ConsensusPoolService::maybe_update_root_and_send_new_certificates(
@@ -714,6 +719,7 @@ mod tests {
         let mut events = vec![];
 
         // Send skip certificates for all slots up to the next leader slot
+        let mut stats = ConsensusPoolServiceStats::new();
         for slot in 1..next_leader_slot.0 {
             let skip_certificate = Certificate {
                 cert_type: CertificateType::Skip(slot),
@@ -729,6 +735,7 @@ mod tests {
                 &mut ctx.consensus_pool,
                 &mut events,
                 &ctx.commitment_sender,
+                &mut stats,
             );
             assert!(result.is_ok());
         }
@@ -750,7 +757,6 @@ mod tests {
             commitment_sender: ctx.commitment_sender.clone(),
             highest_finalized: ctx.highest_finalized.clone(),
         };
-        let mut stats = ConsensusPoolServiceStats::new();
 
         // Add a ParentReady event for the slot before our leader slot
         events.push(VotorEvent::ParentReady {


### PR DESCRIPTION
#### Problem
`ConsensusPoolServiceStats::standstill` is set to `true` when `standstill_timer` fires in `ConsensusPoolService::consensus_pool_ingest_loop()` and we enter standstill mode, but it is never reset to `false`.

#### Summary of Changes
- Now setting `ConsensusPoolServiceStats::standstill` to `false` any time a new finalization is seen.
- Changed `ConsensusPoolService::add_message_and_maybe_update_commitment()` to take `stats`.
- Adapted tests accordingly.

Fixes #12373
