### PR TITLE
Re-allocate memory maps after evictions from in memory cache

### DIFF
--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -108,13 +108,26 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         self.disk.is_some()
     }
 
-    /// Returns true when `entries_in_bin` exceeds the per-bin high-water mark, indicating
-    /// the bin is over the threshold and flush/eviction should occur.
-    pub fn is_bin_at_threshold(&self, entries_in_bin: usize) -> bool {
+    /// Returns true when a bin's entry count is high enough that eviction should begin.
+    /// The threshold is the configured `high_water_mark`.
+    pub fn should_evict_based_on_count(&self, count: usize) -> bool {
+        match &self.threshold_entries_per_bin {
+            None => self.is_disk_index_enabled(),
+            Some(threshold_entries_per_bin) => count > threshold_entries_per_bin.high_water_mark,
+        }
+    }
+
+    /// Returns true when a bin's HashMap free entries (`capacity - len`) are low
+    /// enough that eviction should begin to prevent an imminent capacity doubling.
+    /// The threshold is the overhead gap between `target_entries` and `high_water_mark`.
+    pub fn should_evict_based_on_free_entries(&self, free_entries: usize) -> bool {
         match &self.threshold_entries_per_bin {
             None => self.is_disk_index_enabled(),
             Some(threshold_entries_per_bin) => {
-                entries_in_bin > threshold_entries_per_bin.high_water_mark
+                let overhead = threshold_entries_per_bin
+                    .target_entries
+                    .saturating_sub(threshold_entries_per_bin.high_water_mark);
+                free_entries < overhead
             }
         }
     }
@@ -295,7 +308,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
                      low_water_mark_entries_per_bin: {low_water_mark}",
                 );
                 Some(ThresholdEntriesPerBin {
-                    _target_entries: target_entries_per_bin,
+                    target_entries: target_entries_per_bin,
                     high_water_mark,
                     low_water_mark,
                 })
@@ -506,7 +519,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
 #[derive(Clone, Copy, Debug)]
 pub struct ThresholdEntriesPerBin {
     /// Rounded target entries per bin used as the baseline for thresholds.
-    pub _target_entries: usize,
+    pub target_entries: usize,
     /// Entry count above which a bin triggers flushing to disk and eviction
     /// from in-memory index.
     pub high_water_mark: usize,
@@ -625,9 +638,9 @@ mod tests {
         assert!(test.is_disk_index_enabled());
     }
 
-    /// Ensure that is_bin_at_threshold() is correct when using IndexLimit::Threshold
+    /// Ensure that should_evict_based_on_count() is correct when using IndexLimit::Threshold
     #[test]
-    fn test_is_bin_at_threshold_with_threshold_limit() {
+    fn test_should_evict_based_on_count_with_threshold_limit() {
         let bins = 1;
         let num_entries_overhead = DEFAULT_NUM_ENTRIES_OVERHEAD;
         let num_entries_to_evict = DEFAULT_NUM_ENTRIES_TO_EVICT;
@@ -651,15 +664,15 @@ mod tests {
         // the low water mark must be non-zero and less than the high water mark
         assert!((1..thresholds.high_water_mark).contains(&thresholds.low_water_mark));
 
-        // Test: Below, at, and above the is_bin_at_threshold() boundary
-        assert!(!test.is_bin_at_threshold(thresholds.high_water_mark - 1));
-        assert!(!test.is_bin_at_threshold(thresholds.high_water_mark));
-        assert!(test.is_bin_at_threshold(thresholds.high_water_mark + 1));
+        // Test: Below, at, and above the should_evict_based_on_count() boundary
+        assert!(!test.should_evict_based_on_count(thresholds.high_water_mark - 1));
+        assert!(!test.should_evict_based_on_count(thresholds.high_water_mark));
+        assert!(test.should_evict_based_on_count(thresholds.high_water_mark + 1));
     }
 
-    /// Ensure that is_bin_at_threshold() is always true when using IndexLimit::Minimal
+    /// Ensure that should_evict_based_on_count() is always true when using IndexLimit::Minimal
     #[test]
-    fn test_is_bin_at_threshold_minimal() {
+    fn test_should_evict_based_on_count_minimal() {
         let bins = 1;
         let config = AccountsIndexConfig {
             index_limit: IndexLimit::Minimal,
@@ -667,14 +680,14 @@ mod tests {
         };
         let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
 
-        assert!(test.is_bin_at_threshold(0));
-        assert!(test.is_bin_at_threshold(1000));
-        assert!(test.is_bin_at_threshold(usize::MAX));
+        assert!(test.should_evict_based_on_count(0));
+        assert!(test.should_evict_based_on_count(1000));
+        assert!(test.should_evict_based_on_count(usize::MAX));
     }
 
-    /// Ensure that is_bin_at_threshold() is always false when using IndexLimit::InMemOnly
+    /// Ensure that should_evict_based_on_count() is always false when using IndexLimit::InMemOnly
     #[test]
-    fn test_is_bin_at_threshold_in_mem_only() {
+    fn test_should_evict_based_on_count_in_mem_only() {
         let bins = 1;
         let config = AccountsIndexConfig {
             index_limit: IndexLimit::InMemOnly,
@@ -682,9 +695,71 @@ mod tests {
         };
         let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
 
-        assert!(!test.is_bin_at_threshold(0));
-        assert!(!test.is_bin_at_threshold(1000));
-        assert!(!test.is_bin_at_threshold(usize::MAX));
+        assert!(!test.should_evict_based_on_count(0));
+        assert!(!test.should_evict_based_on_count(1000));
+        assert!(!test.should_evict_based_on_count(usize::MAX));
+    }
+
+    /// Ensure that should_evict_based_on_free_entries() is correct when using IndexLimit::Threshold
+    #[test]
+    fn test_should_evict_based_on_free_entries_with_threshold_limit() {
+        let bins = 1;
+        let num_entries_overhead = DEFAULT_NUM_ENTRIES_OVERHEAD;
+        let num_entries_to_evict = DEFAULT_NUM_ENTRIES_TO_EVICT;
+        let num_entries = (num_entries_overhead + num_entries_to_evict) * 3;
+        let bytes_per_entry = InMemAccountsIndex::<u64, u64>::size_of_uninitialized()
+            + InMemAccountsIndex::<u64, u64>::size_of_single_entry();
+        let config = AccountsIndexConfig {
+            index_limit: IndexLimit::Threshold(IndexLimitThreshold {
+                num_bytes: (num_entries * bytes_per_entry) as u64,
+                num_entries_overhead,
+                num_entries_to_evict,
+            }),
+            ..Default::default()
+        };
+        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
+
+        let thresholds = test.threshold_entries_per_bin.unwrap();
+        let overhead = thresholds
+            .target_entries
+            .saturating_sub(thresholds.high_water_mark);
+        // overhead must be non-zero, otherwise the boundary checks below are meaningless
+        assert!(overhead > 0);
+
+        // Test: Below, at, and above the should_evict_based_on_free_entries() boundary
+        assert!(test.should_evict_based_on_free_entries(overhead - 1));
+        assert!(!test.should_evict_based_on_free_entries(overhead));
+        assert!(!test.should_evict_based_on_free_entries(overhead + 1));
+    }
+
+    /// Ensure that should_evict_based_on_free_entries() is always true when using IndexLimit::Minimal
+    #[test]
+    fn test_should_evict_based_on_free_entries_minimal() {
+        let bins = 1;
+        let config = AccountsIndexConfig {
+            index_limit: IndexLimit::Minimal,
+            ..Default::default()
+        };
+        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
+
+        assert!(test.should_evict_based_on_free_entries(0));
+        assert!(test.should_evict_based_on_free_entries(1000));
+        assert!(test.should_evict_based_on_free_entries(usize::MAX));
+    }
+
+    /// Ensure that should_evict_based_on_free_entries() is always false when using IndexLimit::InMemOnly
+    #[test]
+    fn test_should_evict_based_on_free_entries_in_mem_only() {
+        let bins = 1;
+        let config = AccountsIndexConfig {
+            index_limit: IndexLimit::InMemOnly,
+            ..Default::default()
+        };
+        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
+
+        assert!(!test.should_evict_based_on_free_entries(0));
+        assert!(!test.should_evict_based_on_free_entries(1000));
+        assert!(!test.should_evict_based_on_free_entries(usize::MAX));
     }
 
     #[test]

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1362,6 +1362,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         debug_assert!(iterate_for_age);
 
         if !self.check_flush_trigger() {
+            // Still mark as aged to avoid infinite scanning
             assert_eq!(current_age, self.storage.current_age());
             self.set_has_aged(current_age, can_advance_age);
             return;
@@ -1453,17 +1454,28 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// behind by evictions. hashbrown counts tombstones against `capacity`, so
     /// without this the bin's effective capacity drifts down over time and triggers
     /// the hashmap to double in capacity.
+    ///
+    /// Only called in Threshold mode, where `capacity >= target_entries` is guaranteed
+    /// by the time eviction runs (`check_flush_trigger` gates on `high_water_mark`).
     fn reallocate_to_clear_tombstones(&self) {
         let stats = self.stats();
         let m = Measure::start("reallocate_hashmap");
 
+        let target_entries = self
+            .storage
+            .threshold_entries_per_bin
+            .as_ref()
+            .expect("reallocate_to_clear_tombstones only runs in Threshold mode")
+            .target_entries;
+
         let mut map = self.map_internal.write().unwrap();
         let capacity_pre = map.capacity();
 
-        // Drain the old map into a fresh allocation sized for the current `len()`.
-        // Building a brand-new map (rather than `shrink_to_fit`) guarantees a full
-        // rehash, which is what actually clears the tombstones.
-        let mut new_map = HashMap::with_capacity_and_hasher(map.len(), map.hasher().clone());
+        // Drain the old map into a fresh allocation sized to `target_entries` so the
+        // backing storage stays stable across eviction cycles. Building a brand-new
+        // map (rather than `shrink_to_fit`) guarantees a full rehash, which is what
+        // actually clears the tombstones.
+        let mut new_map = HashMap::with_capacity_and_hasher(target_entries, map.hasher().clone());
         new_map.extend(map.drain());
         *map = new_map;
         let capacity_post = map.capacity();
@@ -1510,7 +1522,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             stats.update_in_mem_capacity(capacity_pre, capacity_post);
         }
 
-        if evicted > 0 {
+        // Only Threshold mode cares about tombstone-driven capacity doublings; Minimal
+        // evicts everything each pass, so rebuilding every flush is wasted work.
+        if evicted > 0 && self.storage.threshold_entries_per_bin.is_some() {
             self.reallocate_to_clear_tombstones();
         }
 
@@ -3114,7 +3128,9 @@ mod tests {
     fn test_check_flush_trigger_below_hwm_gate() {
         // 56 entries fill hashbrown's raw=64 table exactly: capacity=56 (below HWM=100)
         // and free_entries=0 (below overhead=1, so low_free_entries would fire).
-        let index = new_should_write_through_for_test(Some((100, 50)));
+        let hwm = 100;
+        let lwm = 50;
+        let index = new_should_write_through_for_test(Some((hwm, lwm)));
         for _ in 0..56 {
             let pubkey = solana_pubkey::new_rand();
             let entry = Box::new(AccountMapEntry::new(
@@ -3149,7 +3165,9 @@ mod tests {
     fn test_check_flush_trigger_below_thresholds() {
         // 60 entries push capacity to 112 (above LWM=50), len stays below HWM=100,
         // and free_entries (52) far exceeds overhead (1) — both conditions report false.
-        let index = new_should_write_through_for_test(Some((100, 50)));
+        let hwm = 100;
+        let lwm = 50;
+        let index = new_should_write_through_for_test(Some((hwm, lwm)));
         for _ in 0..60 {
             let pubkey = solana_pubkey::new_rand();
             let entry = Box::new(AccountMapEntry::new(
@@ -3159,7 +3177,7 @@ mod tests {
             ));
             index.map_internal.write().unwrap().insert(pubkey, entry);
         }
-        assert!(index.map_internal.read().unwrap().capacity() > 50);
+        assert!(index.map_internal.read().unwrap().capacity() > lwm);
 
         assert!(!index.check_flush_trigger());
     }
@@ -3168,8 +3186,10 @@ mod tests {
     /// and the count-based trigger stat is incremented.
     #[test]
     fn test_check_flush_trigger_high_count() {
+        let hwm = 2;
+        let lwm = 1;
         // high_water_mark=2: inserting 4 entries puts the bin past the count threshold.
-        let index = new_should_write_through_for_test(Some((2, 1)));
+        let index = new_should_write_through_for_test(Some((hwm, lwm)));
         for _ in 0..4 {
             let pubkey = solana_pubkey::new_rand();
             let entry = Box::new(AccountMapEntry::new(
@@ -3188,7 +3208,11 @@ mod tests {
     /// tombstones consuming `growth_left`.
     #[test]
     fn test_reallocate_to_clear_tombstones_preserves_entries() {
-        let index = new_for_test::<u64>();
+        // Reallocate only runs in Threshold mode. Pick high_water_mark=99 so
+        // target_entries=100, matching the natural backing size for 100 inserts.
+        let hwm = 99;
+        let lwm = 70;
+        let index = new_should_write_through_for_test(Some((hwm, lwm)));
 
         // Insert enough entries to settle the bin's hashmap at a stable capacity.
         let num_inserts = 100;
@@ -3244,6 +3268,42 @@ mod tests {
                 .num_hashmap_reallocates
                 .load(Ordering::Relaxed),
             1
+        );
+    }
+
+    /// Minimal mode evicts everything on every flush, so the per-pass HashMap
+    /// rebuild would be pure waste. Verify `evict_from_cache` skips it.
+    #[test]
+    fn test_reallocate_skipped_in_minimal_mode() {
+        let index = new_disk_buckets_for_test::<u64>();
+        assert!(index.storage.threshold_entries_per_bin.is_none());
+
+        let current_age = index.storage.current_age();
+        let pubkeys: Vec<_> = (0..100).map(|_| solana_pubkey::new_rand()).collect();
+        {
+            let mut map = index.map_internal.write().unwrap();
+            for pubkey in &pubkeys {
+                let entry = AccountMapEntry::new(
+                    SlotList::from([(/*slot*/ 0, /*info*/ 0)]),
+                    /*ref_count*/ 1,
+                    AccountMapEntryMeta::new_clean(&index.storage),
+                );
+                entry.set_age(current_age);
+                map.insert(*pubkey, Box::new(entry));
+            }
+        }
+
+        index.evict_from_cache(&pubkeys, current_age, /*ages_flushing_now*/ 0);
+
+        // All entries were evicted...
+        assert_eq!(index.map_internal.read().unwrap().len(), 0);
+        // ...but reallocate must not have run in Minimal mode.
+        assert_eq!(
+            index
+                .stats()
+                .num_hashmap_reallocates
+                .load(Ordering::Relaxed),
+            0
         );
     }
 }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -597,7 +597,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 // is expensive when the dirty entries are not being written through
                 // This is a rare case; background eviction clears the excess over time.
                 if self.should_write_through
-                    && self.storage.is_bin_at_threshold(map.len())
+                    && self.storage.should_evict_based_on_count(map.len())
                     && !map.contains_key(pubkey)
                 {
                     let evict_key = map.iter().find(|(_, v)| !v.dirty()).map(|(k, _)| *k);
@@ -1285,6 +1285,50 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         std::mem::take(&mut duplicates.duplicates_from_in_memory_only)
     }
 
+    /// Decide whether this bin needs flushing/eviction. Returns true if the caller should proceed.
+    ///
+    /// Fires on either of two conditions:
+    /// - Free-entry headroom is below the configured overhead. Tombstones left by prior evictions
+    ///   reduce capacity without being included in len, so a rehash can be imminent before the
+    ///   count crosses the high-water mark. This is the primary trigger in steady state.
+    /// - Entry count exceeds the high-water mark. This is a backstop for the case where the
+    ///   hashmap has already doubled in size, leaving plenty of headroom so the first condition
+    ///   would not fire on its own.
+    ///
+    /// Returns false for bins still in initial growth (capacity below `high_water_mark`).
+    fn check_flush_trigger(&self) -> bool {
+        let (entries_in_bin, capacity) = {
+            let map = self.map_internal.read().unwrap();
+            (map.len(), map.capacity())
+        };
+
+        // Skip during initial growth: below HWM, low free entries reflect a not-yet-grown
+        // table, not tombstones. If tombstones do force a doubling before len crosses HWM,
+        // the count check catches it later once len grows past HWM.
+        if let Some(thresholds) = &self.storage.threshold_entries_per_bin {
+            if capacity < thresholds.high_water_mark {
+                return false;
+            }
+        }
+
+        let high_count_triggered = self.storage.should_evict_based_on_count(entries_in_bin);
+        let low_free_entries_triggered = self
+            .storage
+            .should_evict_based_on_free_entries(capacity.saturating_sub(entries_in_bin));
+        if !high_count_triggered && !low_free_entries_triggered {
+            return false;
+        }
+        if low_free_entries_triggered {
+            // Primary case: low free-entry headroom (typically from tombstones).
+            Self::update_stat(&self.stats().evict_triggered_by_low_free_entries, 1);
+        } else {
+            // Backstop: bin is past the high-water mark while free-entry headroom
+            // still has slack — typically because the hashmap doubled in size.
+            Self::update_stat(&self.stats().evict_triggered_by_high_count, 1);
+        }
+        true
+    }
+
     /// synchronize the in-mem index with the disk index
     fn flush_internal(&self, flush_guard: &FlushGuard, can_advance_age: bool) {
         let current_age = self.storage.current_age();
@@ -1317,10 +1361,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         // from this point forward, we know iterate_for_age == true
         debug_assert!(iterate_for_age);
 
-        let entries_in_bin = self.map_internal.read().unwrap().len();
-        if !self.storage.is_bin_at_threshold(entries_in_bin) {
-            // Entry count is below threshold, no need to flush or evict
-            // Still mark as aged to avoid infinite scanning
+        if !self.check_flush_trigger() {
             assert_eq!(current_age, self.storage.current_age());
             self.set_has_aged(current_age, can_advance_age);
             return;
@@ -1408,6 +1449,31 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         }
     }
 
+    /// Rebuild the bin's HashMap into a fresh allocation to clear tombstones left
+    /// behind by evictions. hashbrown counts tombstones against `capacity`, so
+    /// without this the bin's effective capacity drifts down over time and triggers
+    /// the hashmap to double in capacity.
+    fn reallocate_to_clear_tombstones(&self) {
+        let stats = self.stats();
+        let m = Measure::start("reallocate_hashmap");
+
+        let mut map = self.map_internal.write().unwrap();
+        let capacity_pre = map.capacity();
+
+        // Drain the old map into a fresh allocation sized for the current `len()`.
+        // Building a brand-new map (rather than `shrink_to_fit`) guarantees a full
+        // rehash, which is what actually clears the tombstones.
+        let mut new_map = HashMap::with_capacity_and_hasher(map.len(), map.hasher().clone());
+        new_map.extend(map.drain());
+        *map = new_map;
+        let capacity_post = map.capacity();
+        drop(map);
+
+        stats.update_in_mem_capacity(capacity_pre, capacity_post);
+        Self::update_stat(&stats.num_hashmap_reallocates, 1);
+        Self::update_time_stat(&stats.hashmap_reallocate_us, m);
+    }
+
     // evict keys in 'evictions' from in-mem cache, likely due to age
     fn evict_from_cache(&self, evictions: &[Pubkey], current_age: Age, ages_flushing_now: Age) {
         if evictions.is_empty() {
@@ -1443,6 +1509,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             drop(map);
             stats.update_in_mem_capacity(capacity_pre, capacity_post);
         }
+
+        if evicted > 0 {
+            self.reallocate_to_clear_tombstones();
+        }
+
         stats.sub_mem_count(evicted);
         Self::update_stat(
             &stats.flush_entries_evicted_from_mem_background,
@@ -1688,7 +1759,7 @@ mod tests {
         let mut holder = BucketMapHolder::new(BINS_FOR_TESTING, &config, 1);
         if let Some((high_water_mark, low_water_mark)) = threshold {
             holder.threshold_entries_per_bin = Some(ThresholdEntriesPerBin {
-                _target_entries: high_water_mark + 1,
+                target_entries: high_water_mark + 1,
                 high_water_mark,
                 low_water_mark,
             });
@@ -2836,7 +2907,7 @@ mod tests {
         let low_water_mark = 100;
         let high_water_mark = low_water_mark + num_entries_to_evict;
         holder.threshold_entries_per_bin = Some(ThresholdEntriesPerBin {
-            _target_entries: high_water_mark + num_entries_overhead,
+            target_entries: high_water_mark + num_entries_overhead,
             high_water_mark,
             low_water_mark,
         });
@@ -3033,6 +3104,146 @@ mod tests {
         assert!(
             index.load_from_disk(evicted_pubkey).is_some(),
             "evicted entry should still be on disk"
+        );
+    }
+
+    /// While the bin's hashmap is still in initial growth (capacity below `high_water_mark`),
+    /// the growth gate short-circuits check_flush_trigger to false even when the
+    /// low-free-entries check would otherwise fire.
+    #[test]
+    fn test_check_flush_trigger_below_hwm_gate() {
+        // 56 entries fill hashbrown's raw=64 table exactly: capacity=56 (below HWM=100)
+        // and free_entries=0 (below overhead=1, so low_free_entries would fire).
+        let index = new_should_write_through_for_test(Some((100, 50)));
+        for _ in 0..56 {
+            let pubkey = solana_pubkey::new_rand();
+            let entry = Box::new(AccountMapEntry::new(
+                SlotList::from([(0, 0)]),
+                1,
+                AccountMapEntryMeta::new_dirty(&index.storage, true),
+            ));
+            index.map_internal.write().unwrap().insert(pubkey, entry);
+        }
+
+        let map = index.map_internal.read().unwrap();
+        let len = map.len();
+        let capacity = map.capacity();
+        let free_entries = capacity.saturating_sub(len);
+        drop(map);
+
+        // Confirm that without the gate that low free entries would fire
+        assert!(
+            index
+                .storage
+                .should_evict_based_on_free_entries(free_entries)
+        );
+
+        // But with the gate, check_flush_trigger returns false
+        assert!(!index.check_flush_trigger());
+    }
+
+    /// Once capacity has cleared the low-water mark, check_flush_trigger must still return
+    /// false when the entry count is below the high-water mark and free-entry headroom exceeds
+    /// the configured overhead.
+    #[test]
+    fn test_check_flush_trigger_below_thresholds() {
+        // 60 entries push capacity to 112 (above LWM=50), len stays below HWM=100,
+        // and free_entries (52) far exceeds overhead (1) — both conditions report false.
+        let index = new_should_write_through_for_test(Some((100, 50)));
+        for _ in 0..60 {
+            let pubkey = solana_pubkey::new_rand();
+            let entry = Box::new(AccountMapEntry::new(
+                SlotList::from([(0, 0)]),
+                1,
+                AccountMapEntryMeta::new_dirty(&index.storage, true),
+            ));
+            index.map_internal.write().unwrap().insert(pubkey, entry);
+        }
+        assert!(index.map_internal.read().unwrap().capacity() > 50);
+
+        assert!(!index.check_flush_trigger());
+    }
+
+    /// When the entry count crosses the high-water mark, check_flush_trigger returns true
+    /// and the count-based trigger stat is incremented.
+    #[test]
+    fn test_check_flush_trigger_high_count() {
+        // high_water_mark=2: inserting 4 entries puts the bin past the count threshold.
+        let index = new_should_write_through_for_test(Some((2, 1)));
+        for _ in 0..4 {
+            let pubkey = solana_pubkey::new_rand();
+            let entry = Box::new(AccountMapEntry::new(
+                SlotList::from([(0, 0)]),
+                1,
+                AccountMapEntryMeta::new_dirty(&index.storage, true),
+            ));
+            index.map_internal.write().unwrap().insert(pubkey, entry);
+        }
+
+        assert!(index.check_flush_trigger());
+    }
+
+    /// reallocate_to_clear_tombstones must rebuild the bin's hashmap so that all
+    /// remaining entries survive and `capacity()` recovers from the drop caused by
+    /// tombstones consuming `growth_left`.
+    #[test]
+    fn test_reallocate_to_clear_tombstones_preserves_entries() {
+        let index = new_for_test::<u64>();
+
+        // Insert enough entries to settle the bin's hashmap at a stable capacity.
+        let num_inserts = 100;
+        let num_removes = 30;
+        let pubkeys: Vec<_> = (0..num_inserts)
+            .map(|_| solana_pubkey::new_rand())
+            .collect();
+        {
+            let mut map = index.map_internal.write().unwrap();
+            for pubkey in &pubkeys {
+                let entry = Box::new(AccountMapEntry::new(
+                    SlotList::from([(0, 42)]),
+                    1,
+                    AccountMapEntryMeta::new_dirty(&index.storage, true),
+                ));
+                map.insert(*pubkey, entry);
+            }
+        }
+        let capacity_after_inserts = index.map_internal.read().unwrap().capacity();
+
+        // Remove a portion of the entries to create tombstones. Hashbrown reduces capacity
+        // for each tombstone created, so we should see a capacity drop here.
+        let mut map = index.map_internal.write().unwrap();
+        for pubkey in &pubkeys[..num_removes] {
+            map.remove(pubkey);
+        }
+        drop(map);
+
+        let capacity_after_removes = index.map_internal.read().unwrap().capacity();
+
+        // Verify that capacity dropped due to added tombstones
+        assert!(capacity_after_removes < capacity_after_inserts);
+
+        index.reallocate_to_clear_tombstones();
+
+        let map = index.map_internal.read().unwrap();
+
+        // All remaining entries should survive the realloc.
+        assert_eq!(map.len(), num_inserts - num_removes);
+        for pubkey in &pubkeys[num_removes..] {
+            assert!(map.contains_key(pubkey));
+        }
+
+        // Tombstones cleared: the new map sized for `len()` lands on the same raw
+        // bucket count as before the removes, so capacity is back to its post-insert
+        // value.
+        assert_eq!(map.capacity(), capacity_after_inserts);
+        drop(map);
+
+        assert_eq!(
+            index
+                .stats()
+                .num_hashmap_reallocates
+                .load(Ordering::Relaxed),
+            1
         );
     }
 }

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -68,6 +68,10 @@ pub struct Stats {
     bins: u64,
     pub flush_should_evict_us: AtomicU64,
     pub flush_read_lock_us: AtomicU64,
+    pub num_hashmap_reallocates: AtomicU64,
+    pub hashmap_reallocate_us: AtomicU64,
+    pub evict_triggered_by_low_free_entries: AtomicU64,
+    pub evict_triggered_by_high_count: AtomicU64,
 }
 
 impl Stats {
@@ -436,6 +440,28 @@ impl Stats {
                 (
                     "flush_read_lock_us",
                     self.flush_read_lock_us.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "num_hashmap_reallocates",
+                    self.num_hashmap_reallocates.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "hashmap_reallocate_us",
+                    self.hashmap_reallocate_us.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "evict_triggered_by_low_free_entries",
+                    self.evict_triggered_by_low_free_entries
+                        .swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "evict_triggered_by_high_count",
+                    self.evict_triggered_by_high_count
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (


### PR DESCRIPTION
#### Problem
After https://github.com/anza-xyz/agave/pull/12030 was merged, capacity doublings are still being seen on validators running with the threshold accounts index. 

The capacity doublings are due to tombstones: When an item is evicted from the hashmap, a tombstone may be left in the hashmap to avoid moving surrounding entries. When this occurs, the number of items in the hashmap is reduced, but the growth_left parameter is not increased leading to a reduction in capacity.
```
    pub fn capacity(&self) -> usize {
        self.table.items + self.table.growth_left
    }
```
Capacity is then used to determine when the hashmap doubles in size, leading to a doubling in size despite self.table.items being lower than the doubling point. 

Tombstones are only freed when the hashmap is grown, shrunk or re-allocated. In our scenario
1. Hashmap growing (doubling) is to be avoided, so it is not an option
2. For some configurations the LWM is > 50% of total hashmap size, so the hashmap will never shrink
3. This leaves re-allocation as the only option to recover Tombstones. Or vendoring our own version of hashbrown. 

#### Summary of Changes
- Trigger evictions based on len being above threshold, or capacity()-len() being less than our threshold
- After evictions have been triggered, re-allocate the hashmap
- Add tests


Note that the 100GB data was gathered with old names etc... 
#### Performance:

This was run on a 100GB index size( worse case scenario). Re-allocating the map takes ~1.6ms.
<img width="1841" height="408" alt="image" src="https://github.com/user-attachments/assets/a1f5aa03-c6dd-4d84-887d-3a7206fd06ce" />

This does not cause a significant delta in replay times:
<img width="1841" height="502" alt="image" src="https://github.com/user-attachments/assets/b2410534-091d-45f3-8761-6e690290e710" />

If this does become a problem, it would be possible to replace the hashmap without holding a write lock the whole time, but it would be signficantly more complex, so I don't see a need. 

#### Bins: 
Capacity looks good over two days:
Note: I set the grouping to 6 hours here to just show the total amount. the re-allocations are spread out over an hour or so.
<img width="1841" height="502" alt="image" src="https://github.com/user-attachments/assets/7e76a924-2704-4d80-8269-0e89d8772618" />

#### Memory:
No jumps in memory usage other than the epoch transition
<img width="1841" height="367" alt="image" src="https://github.com/user-attachments/assets/44f1f061-9d41-4916-80de-b0bac2f644cc" />

#### 25GB Testing over 2 days

Every 24 hours or so most bins gets re-allocated
<img width="921" height="166" alt="image" src="https://github.com/user-attachments/assets/3ffa54f9-858f-48a4-901d-04bc9ad89025" />

This leads to a dip and increase in memory usage as some of the bins actually shrunk to half size:
<img width="921" height="286" alt="image" src="https://github.com/user-attachments/assets/b2a19a63-5d2b-423d-801e-9a1220331435" />

Corresponding dip in capacity:
<img width="921" height="166" alt="image" src="https://github.com/user-attachments/assets/ad65107a-0b17-440b-8b00-2b6b43c636f5" />


No notable outliers in max/load store though compared with edge canaries running with in memory index. 
<img width="921" height="286" alt="image" src="https://github.com/user-attachments/assets/f5adbf63-f96a-43fa-a9ca-d5adb54b9c67" />




Fixes #
