### PR TITLE
chore: Fix swapped validator/test-validator config

### DIFF
--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1312,6 +1312,8 @@ mod tests {
                     notification_threads: None,
                     queue_capacity_items:
                         solana_rpc::rpc_pubsub_service::DEFAULT_QUEUE_CAPACITY_ITEMS,
+                    queue_capacity_bytes:
+                        solana_rpc::rpc_pubsub_service::DEFAULT_QUEUE_CAPACITY_BYTES,
                     ..PubSubConfig::default_for_tests()
                 },
                 send_transaction_service_config: SendTransactionServiceConfig::default(),

--- a/validator/src/commands/run/args/pub_sub_config.rs
+++ b/validator/src/commands/run/args/pub_sub_config.rs
@@ -61,7 +61,7 @@ pub(crate) fn args<'a, 'b>(test_validator: bool) -> Vec<Arg<'a, 'b>> {
             rpc_pubsub_notification_threads.default_value(&DEFAULT_TEST_RPC_PUBSUB_WORKER_THREADS),
             &DEFAULT_TEST_RPC_PUBSUB_MAX_ACTIVE_SUBSCRIPTIONS,
             &DEFAULT_TEST_RPC_PUBSUB_QUEUE_CAPACITY_ITEMS,
-            &DEFAULT_RPC_PUBSUB_QUEUE_CAPACITY_BYTES,
+            &DEFAULT_TEST_RPC_PUBSUB_QUEUE_CAPACITY_BYTES,
         )
     } else {
         (
@@ -74,7 +74,7 @@ pub(crate) fn args<'a, 'b>(test_validator: bool) -> Vec<Arg<'a, 'b>> {
                 .requires("full_rpc_api"),
             &DEFAULT_RPC_PUBSUB_MAX_ACTIVE_SUBSCRIPTIONS,
             &DEFAULT_RPC_PUBSUB_QUEUE_CAPACITY_ITEMS,
-            &DEFAULT_TEST_RPC_PUBSUB_QUEUE_CAPACITY_BYTES,
+            &DEFAULT_RPC_PUBSUB_QUEUE_CAPACITY_BYTES,
         )
     };
 


### PR DESCRIPTION
#### Problem
The --rpc-pubsub-queue-capacity-bytes default value was inadvertently swapped

#### Summary of Changes
Fix the swap

This was introduced in https://github.com/anza-xyz/agave/pull/7269 which is in both v4.0 and v3.1; I missed it during review 😢 but our good friend claude caught it over in https://github.com/anza-xyz/agave/pull/12333#discussion_r3209995161
