### PR TITLE
local_cluster: add alpenglow equivocation test

### DIFF
--- a/core/src/repair/malicious_repair_handler.rs
+++ b/core/src/repair/malicious_repair_handler.rs
@@ -1,29 +1,139 @@
 use {
-    super::{repair_handler::RepairHandler, repair_response::repair_response_packet_from_bytes},
+    super::{
+        repair_handler::RepairHandler, repair_response::repair_response_packet_from_bytes,
+        standard_repair_handler::StandardRepairHandler,
+    },
+    log::info,
     solana_clock::Slot,
+    solana_entry::entry::Entry,
+    solana_hash::Hash,
+    solana_keypair::Keypair,
     solana_ledger::{
         blockstore::Blockstore,
-        shred::{Nonce, SIZE_OF_DATA_SHRED_HEADERS},
+        leader_schedule_cache::LeaderScheduleCache,
+        shred::{Nonce, ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
     },
     solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler},
+    solana_signer::Signer,
     std::{net::SocketAddr, sync::Arc},
 };
 
 #[derive(Copy, Clone, Debug, Default)]
 pub struct MaliciousRepairConfig {
-    bad_shred_slot_frequency: Option<Slot>,
+    /// If set, respond maliciously for slots where `slot % frequency == 0`
+    pub bad_shred_slot_frequency: Option<Slot>,
+    /// If set, respond maliciously for shred indices where `index % frequency == 0`
+    pub bad_shred_index_frequency: Option<u64>,
+    /// If set, only respond maliciously for slots within this range (inclusive)
+    pub slot_range: Option<(Slot, Slot)>,
 }
 
 pub struct MaliciousRepairHandler {
     blockstore: Arc<Blockstore>,
+    keypair: Arc<Keypair>,
+    leader_schedule_cache: Arc<LeaderScheduleCache>,
     config: MaliciousRepairConfig,
+    reed_solomon_cache: ReedSolomonCache,
+    standard_repair_handler: StandardRepairHandler,
 }
 
 impl MaliciousRepairHandler {
-    const BAD_DATA_INDEX: usize = SIZE_OF_DATA_SHRED_HEADERS + 5;
+    pub fn new(
+        blockstore: Arc<Blockstore>,
+        keypair: Arc<Keypair>,
+        leader_schedule_cache: Arc<LeaderScheduleCache>,
+        config: MaliciousRepairConfig,
+    ) -> Self {
+        Self {
+            standard_repair_handler: StandardRepairHandler::new(blockstore.clone()),
+            blockstore,
+            keypair,
+            leader_schedule_cache,
+            config,
+            reed_solomon_cache: ReedSolomonCache::default(),
+        }
+    }
 
-    pub fn new(blockstore: Arc<Blockstore>, config: MaliciousRepairConfig) -> Self {
-        Self { blockstore, config }
+    /// Check if we should respond maliciously for this slot and shred index
+    fn should_respond_maliciously(&self, slot: Slot, shred_index: u64) -> bool {
+        if let Some((start, end)) = self.config.slot_range {
+            if slot < start || slot > end {
+                return false;
+            }
+        }
+
+        let slot_matches = self
+            .config
+            .bad_shred_slot_frequency
+            .is_some_and(|freq| slot.is_multiple_of(freq));
+        let index_matches = self
+            .config
+            .bad_shred_index_frequency
+            .is_some_and(|freq| shred_index.is_multiple_of(freq));
+
+        // If both frequencies are set, both must match
+        // If only one is set, that one must match
+        match (
+            self.config.bad_shred_slot_frequency,
+            self.config.bad_shred_index_frequency,
+        ) {
+            (Some(_), Some(_)) => slot_matches && index_matches,
+            (Some(_), None) => slot_matches,
+            (None, Some(_)) => index_matches,
+            (None, None) => false,
+        }
+    }
+
+    /// Check if we were the leader for this slot
+    fn is_leader_for_slot(&self, slot: Slot) -> bool {
+        self.leader_schedule_cache
+            .slot_leader_at(slot, None)
+            .is_some_and(|leader| leader.id == self.keypair.pubkey())
+    }
+
+    /// Generate an equivocating shred - a legitimately signed shred with different data
+    fn generate_equivocating_shred(
+        &self,
+        original_shred: &Shred,
+        shred_index: u64,
+    ) -> Option<Vec<u8>> {
+        let slot = original_shred.slot();
+        let parent_slot = original_shred.parent().ok()?;
+        let version = original_shred.version();
+        // Use 0 for reference_tick since we can't access the private method
+        // This is fine for equivocation testing purposes
+        let reference_tick = 0u8;
+
+        // Create a shredder with the same slot parameters
+        let shredder = Shredder::new(slot, parent_slot, reference_tick, version).ok()?;
+
+        // Create fake entries with different data than the original
+        // We use a unique hash based on the shred index to ensure different content
+        let fake_hash = Hash::new_unique();
+        let fake_entries = vec![Entry::new(&fake_hash, 1, vec![])];
+
+        // Generate new shreds signed by our keypair
+        let chained_merkle_root = original_shred.chained_merkle_root().ok()?;
+        let is_last_in_slot = original_shred.last_in_slot();
+
+        let shreds: Vec<Shred> = shredder
+            .make_merkle_shreds_from_entries(
+                &self.keypair,
+                &fake_entries,
+                is_last_in_slot,
+                chained_merkle_root,
+                shred_index as u32, // next_shred_index
+                0,                  // next_code_index
+                &self.reed_solomon_cache,
+                &mut ProcessShredsStats::default(),
+            )
+            .collect();
+
+        // Return the first data shred's payload
+        shreds
+            .into_iter()
+            .find(|s| s.is_data())
+            .map(|s| s.into_payload().to_vec())
     }
 }
 
@@ -39,30 +149,45 @@ impl RepairHandler for MaliciousRepairHandler {
         dest: &SocketAddr,
         nonce: Nonce,
     ) -> Option<Packet> {
-        let mut shred = self
+        // Get the original shred from blockstore
+        let original_shred_bytes = self
             .blockstore
             .get_data_shred(slot, shred_index)
             .expect("Blockstore could not get data shred")?;
-        if self
-            .config
-            .bad_shred_slot_frequency
-            .is_some_and(|freq| slot.is_multiple_of(freq))
-        {
-            // Change some random piece of data
-            shred[Self::BAD_DATA_INDEX] = shred[Self::BAD_DATA_INDEX].wrapping_add(1);
+
+        // Only respond maliciously if:
+        // 1. We were the leader for this slot (we have the keypair to sign)
+        // 2. The slot/index matches our frequency configuration
+        if self.is_leader_for_slot(slot) && self.should_respond_maliciously(slot, shred_index) {
+            // Parse the original shred to get its metadata
+            if let Ok(original_shred) =
+                Shred::new_from_serialized_shred(original_shred_bytes.clone())
+            {
+                if let Some(equivocating_shred) =
+                    self.generate_equivocating_shred(&original_shred, shred_index)
+                {
+                    info!(
+                        "Responding with equivocating shred in slot {slot} index {shred_index} to \
+                         {dest}"
+                    );
+                    return repair_response_packet_from_bytes(equivocating_shred, dest, nonce);
+                }
+            }
         }
-        repair_response_packet_from_bytes(shred, dest, nonce)
+
+        // Fall back to normal response
+        repair_response_packet_from_bytes(original_shred_bytes, dest, nonce)
     }
 
     fn run_orphan(
         &self,
-        _recycler: &PacketBatchRecycler,
-        _from_addr: &SocketAddr,
-        _slot: Slot,
-        _max_responses: usize,
-        _nonce: Nonce,
+        recycler: &PacketBatchRecycler,
+        from_addr: &SocketAddr,
+        slot: Slot,
+        max_responses: usize,
+        nonce: Nonce,
     ) -> Option<PacketBatch> {
-        // Don't respond to orphan repair
-        None
+        self.standard_repair_handler
+            .run_orphan(recycler, from_addr, slot, max_responses, nonce)
     }
 }

--- a/core/src/repair/mod.rs
+++ b/core/src/repair/mod.rs
@@ -2,7 +2,7 @@ pub mod ancestor_hashes_service;
 pub mod block_id_repair_service;
 pub mod cluster_slot_state_verifier;
 pub mod duplicate_repair_status;
-pub(crate) mod malicious_repair_handler;
+pub mod malicious_repair_handler;
 pub mod outstanding_requests;
 pub mod packet_threshold;
 pub mod repair_generic_traversal;

--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -14,9 +14,11 @@ use {
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
+    solana_keypair::Keypair,
     solana_ledger::{
         ancestor_iterator::{AncestorIterator, AncestorIteratorWithHash},
         blockstore::Blockstore,
+        leader_schedule_cache::LeaderScheduleCache,
         shred::{DATA_SHREDS_PER_FEC_BLOCK, ErasureSetId, Nonce},
     },
     solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, RecycledPacketBatch},
@@ -231,12 +233,20 @@ pub enum RepairHandlerType {
 }
 
 impl RepairHandlerType {
-    pub fn to_handler(&self, blockstore: Arc<Blockstore>) -> Box<dyn RepairHandler + Send + Sync> {
+    pub fn to_handler(
+        &self,
+        blockstore: Arc<Blockstore>,
+        identity: Arc<Keypair>,
+        leader_schedule_cache: Arc<LeaderScheduleCache>,
+    ) -> Box<dyn RepairHandler + Send + Sync> {
         match self {
             RepairHandlerType::Standard => Box::new(StandardRepairHandler::new(blockstore)),
-            RepairHandlerType::Malicious(config) => {
-                Box::new(MaliciousRepairHandler::new(blockstore, *config))
-            }
+            RepairHandlerType::Malicious(config) => Box::new(MaliciousRepairHandler::new(
+                blockstore,
+                identity,
+                leader_schedule_cache,
+                *config,
+            )),
         }
     }
 
@@ -247,13 +257,15 @@ impl RepairHandlerType {
         sharable_banks: SharableBanks,
         serve_repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
         leader_state: SharedLeaderState,
+        leader_schedule_cache: Arc<LeaderScheduleCache>,
         migration_status: Arc<MigrationStatus>,
     ) -> ServeRepair {
+        let identity_keypair = cluster_info.keypair();
         ServeRepair::new_with_leader_state(
             cluster_info,
             sharable_banks,
             serve_repair_whitelist,
-            self.to_handler(blockstore),
+            self.to_handler(blockstore, identity_keypair, leader_schedule_cache),
             leader_state,
             migration_status,
         )

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1440,6 +1440,7 @@ impl Validator {
                 bank_forks_r.sharable_banks(),
                 config.repair_whitelist.clone(),
                 leader_state,
+                leader_schedule_cache.clone(),
                 bank_forks_r.migration_status(),
             )
         };

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1030,11 +1030,6 @@ impl Blockstore {
         let Some(double_merkle_meta_bytes) =
             self.double_merkle_meta_cf.get_slice((slot, location))?
         else {
-            debug_assert!(
-                self.meta_from_location(slot, location)
-                    .unwrap()
-                    .is_none_or(|meta| !meta.is_full())
-            );
             return Ok(None);
         };
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -26,6 +26,9 @@ use {
             SWITCH_FORK_THRESHOLD, Tower, VOTE_THRESHOLD_DEPTH, tower_storage::FileTowerStorage,
         },
         optimistic_confirmation_verifier::OptimisticConfirmationVerifier,
+        repair::{
+            malicious_repair_handler::MaliciousRepairConfig, repair_handler::RepairHandlerType,
+        },
         replay_stage::DUPLICATE_THRESHOLD,
         validator::{BlockProductionMethod, BlockVerificationMethod, ValidatorConfig},
     },
@@ -42,10 +45,11 @@ use {
         ancestor_iterator::AncestorIterator,
         bank_forks_utils,
         blockstore::{Blockstore, PurgeType, entries_to_test_shreds},
+        blockstore_options::{AccessType, BlockstoreOptions},
         blockstore_processor::{self, ProcessOptions},
         leader_schedule_cache::LeaderScheduleCache,
         shred::{
-            ProcessShredsStats, ReedSolomonCache, Shred, Shredder,
+            DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats, ReedSolomonCache, Shred, Shredder,
             filter::{TurbineMode, TurbineModeKind},
         },
         use_snapshot_archives_at_startup::UseSnapshotArchivesAtStartup,
@@ -6059,6 +6063,109 @@ fn test_alpenglow_imbalanced_stakes_catchup() {
         vote_listener_addr,
         &validator_node_keypairs,
         &node_stakes,
+    );
+}
+
+/// We start 2 nodes, where the first node A holds 90% of the stake.
+/// B has turbine disabled, and receives duplicate blocks through eager repair.
+/// However, through informed repair it is able to repair the correct blocks and keep up with A.
+#[test]
+#[serial]
+fn test_alpenglow_basic_equivocation() {
+    agave_logger::setup_with_default(AG_DEBUG_LOG_FILTER);
+    // Create node stakes
+    let slots_per_epoch = 512;
+
+    let total_stake = 2 * DEFAULT_NODE_STAKE;
+    let tenth_stake = total_stake / 10;
+    let node_a_stake = 9 * tenth_stake;
+    let node_b_stake = total_stake - node_a_stake;
+
+    let node_stakes = vec![node_a_stake, node_b_stake];
+
+    // Create leader schedule with A as the leader
+    let (leader_schedule, validator_keys) = create_custom_leader_schedule_with_random_keys(&[4, 0]);
+
+    let leader_schedule = FixedSchedule {
+        leader_schedule: Arc::new(leader_schedule),
+    };
+
+    let mut a_validator_config = ValidatorConfig::default_for_test();
+    a_validator_config.wait_for_supermajority = Some(0);
+    a_validator_config.fixed_leader_schedule = Some(leader_schedule);
+
+    let node_b_turbine_mode = TurbineMode::new(TurbineModeKind::TurbineDisabled);
+    let mut b_validator_config = safe_clone_config(&a_validator_config);
+    b_validator_config.turbine_mode = node_b_turbine_mode.clone();
+
+    // Equivocate every other slot, one shred per FEC set
+    let last_duplicate = 20;
+    let duplicate_frequency = 2;
+    let expected_duplicate_blocks = (last_duplicate / duplicate_frequency) as usize - 1;
+    a_validator_config.repair_handler_type = RepairHandlerType::Malicious(MaliciousRepairConfig {
+        bad_shred_slot_frequency: Some(duplicate_frequency),
+        bad_shred_index_frequency: Some(DATA_SHREDS_PER_FEC_BLOCK as u64),
+        slot_range: Some((0, last_duplicate)),
+    });
+
+    // Cluster config
+    let mut cluster_config = ClusterConfig {
+        mint_lamports: DEFAULT_MINT_LAMPORTS + total_stake,
+        node_stakes: node_stakes.clone(),
+        validator_configs: vec![a_validator_config, b_validator_config],
+        validator_keys: Some(
+            validator_keys
+                .iter()
+                .cloned()
+                .zip(iter::repeat_with(|| true))
+                .collect(),
+        ),
+        slots_per_epoch,
+        stakers_slot_offset: slots_per_epoch,
+        skip_warmup_slots: true,
+        ..ClusterConfig::default()
+    };
+
+    // Create local cluster
+    let cluster = LocalCluster::new_alpenglow(&mut cluster_config, SocketAddrSpace::Unspecified);
+    let node_b_pubkey = validator_keys[1].node_keypair.pubkey();
+
+    // Check to make sure the low staked node observes duplicate blocks
+    let start = Instant::now();
+    loop {
+        let blockstore = Blockstore::open_with_options(
+            &cluster.ledger_path(&node_b_pubkey),
+            BlockstoreOptions {
+                access_type: AccessType::ReadOnly,
+                ..BlockstoreOptions::default()
+            },
+        )
+        .unwrap();
+        let total_duplicate_blocks_observed = (1..=last_duplicate)
+            .filter(|slot| blockstore.has_duplicate_shreds_in_slot(*slot))
+            .count();
+        if total_duplicate_blocks_observed == expected_duplicate_blocks {
+            break;
+        }
+        if start.elapsed() > Duration::from_secs(60) {
+            panic!(
+                "Expected to see {expected_duplicate_blocks} in 60 seconds but only saw \
+                 {total_duplicate_blocks_observed}"
+            );
+        }
+        sleep(Duration::from_secs(1));
+    }
+
+    // Turn turbine back on, now the low staked node will be able to catchup
+    node_b_turbine_mode.set(TurbineModeKind::Enabled);
+
+    // Ensure all nodes are rooting
+    // Although the low staked node might be behind while the leader is equivocating,
+    // once the leader stops equivocating it will be able to catch up
+    cluster.check_for_new_roots(
+        32,
+        "test_alpenglow_basic_equivocation",
+        SocketAddrSpace::Unspecified,
     );
 }
 


### PR DESCRIPTION
Upstream of test in https://github.com/anza-xyz/alpenglow/pull/710

#### Problem
We need a local-cluster test to exercise the block id repair service and duplicate block handling in Alpenglow

#### Summary of Changes
Upstream the test and the malicious repair handler
