### PR TITLE
Add Jemalloc Stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7949,6 +7949,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 2.0.18",
+ "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
  "tokio-util 0.7.18",
@@ -12172,10 +12173,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,8 +275,12 @@ indexmap = "2.14.0"
 indicatif = "0.18.4"
 io-uring = { version = "0.7.12", features = ["io_safety"] }
 itertools = "0.14.0"
+jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.6.0", features = [
+    "stats",
+] }
 jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
     "unprefixed_malloc_on_supported_platforms",
+    "stats",
 ] }
 json5 = "1.3.1"
 jsonrpc-core = "18.0.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -173,6 +173,9 @@ tokio-util = { workspace = true }
 trees = { workspace = true }
 wincode = { workspace = true }
 
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
+jemalloc-ctl = { workspace = true }
+
 [target."cfg(unix)".dependencies]
 sysctl = { workspace = true }
 

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -703,6 +703,28 @@ impl SystemMonitorService {
         }
     }
 
+    #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+    fn report_jemalloc_stats() {
+        use jemalloc_ctl::{epoch, stats};
+        // Advance the epoch so jemalloc refreshes its cached stat values.
+        if let Ok(e) = epoch::mib() {
+            let _ = e.advance();
+            let allocated = stats::allocated::mib().and_then(|m| m.read()).unwrap_or(0);
+            let active = stats::active::mib().and_then(|m| m.read()).unwrap_or(0);
+            let resident = stats::resident::mib().and_then(|m| m.read()).unwrap_or(0);
+            let retained = stats::retained::mib().and_then(|m| m.read()).unwrap_or(0);
+            datapoint_info!(
+                "jemalloc_stats",
+                ("allocated_bytes", allocated as i64, i64),
+                ("active_bytes", active as i64, i64),
+                ("resident_bytes", resident as i64, i64),
+                ("retained_bytes", retained as i64, i64),
+                // Freed memory jemalloc is holding but hasn't returned to the OS yet.
+                ("dirty_bytes", resident.saturating_sub(active) as i64, i64),
+            );
+        }
+    }
+
     fn cpu_info() -> Result<CpuInfo, Error> {
         let cpu_num = sys_info::cpu_num()?;
         let cpu_freq_mhz = sys_info::cpu_speed()?;
@@ -981,7 +1003,10 @@ impl SystemMonitorService {
             }
             if config.report_os_memory_stats && mem_timer.should_update(SAMPLE_INTERVAL_MEM_MS) {
                 Self::report_mem_stats();
+                #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+                Self::report_jemalloc_stats();
             }
+
             if config.report_os_cpu_stats {
                 if cpu_timer.should_update(SAMPLE_INTERVAL_CPU_MS) {
                     Self::report_cpu_stats();

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -707,22 +707,28 @@ impl SystemMonitorService {
     fn report_jemalloc_stats() {
         use jemalloc_ctl::{epoch, stats};
         // Advance the epoch so jemalloc refreshes its cached stat values.
-        if let Ok(e) = epoch::mib() {
-            let _ = e.advance();
-            let allocated = stats::allocated::mib().and_then(|m| m.read()).unwrap_or(0);
-            let active = stats::active::mib().and_then(|m| m.read()).unwrap_or(0);
-            let resident = stats::resident::mib().and_then(|m| m.read()).unwrap_or(0);
-            let retained = stats::retained::mib().and_then(|m| m.read()).unwrap_or(0);
-            datapoint_info!(
-                "jemalloc_stats",
-                ("allocated_bytes", allocated as i64, i64),
-                ("active_bytes", active as i64, i64),
-                ("resident_bytes", resident as i64, i64),
-                ("retained_bytes", retained as i64, i64),
-                // Freed memory jemalloc is holding but hasn't returned to the OS yet.
-                ("dirty_bytes", resident.saturating_sub(active) as i64, i64),
-            );
-        }
+        epoch::mib().unwrap().advance().unwrap();
+        let allocated = stats::allocated::mib()
+            .and_then(|m| m.read())
+            .expect("Jemalloc stats is compiled in");
+        let active = stats::active::mib()
+            .and_then(|m| m.read())
+            .expect("Jemalloc stats is compiled in");
+        let resident = stats::resident::mib()
+            .and_then(|m| m.read())
+            .expect("Jemalloc stats is compiled in");
+        let retained = stats::retained::mib()
+            .and_then(|m| m.read())
+            .expect("Jemalloc stats is compiled in");
+        datapoint_info!(
+            "jemalloc_stats",
+            ("allocated_bytes", allocated, i64),
+            ("active_bytes", active, i64),
+            ("resident_bytes", resident, i64),
+            ("retained_bytes", retained, i64),
+            // Freed memory jemalloc is holding but hasn't returned to the OS yet.
+            ("dirty_bytes", resident.saturating_sub(active), i64),
+        );
     }
 
     fn cpu_info() -> Result<CpuInfo, Error> {
@@ -1006,7 +1012,6 @@ impl SystemMonitorService {
                 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
                 Self::report_jemalloc_stats();
             }
-
             if config.report_os_cpu_stats {
                 if cpu_timer.should_update(SAMPLE_INTERVAL_CPU_MS) {
                     Self::report_cpu_stats();

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6985,6 +6985,7 @@ dependencies = [
  "sysctl",
  "tempfile",
  "thiserror 2.0.18",
+ "tikv-jemalloc-ctl",
  "tokio",
  "tokio-util 0.7.18",
  "trees",
@@ -10473,6 +10474,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6657,6 +6657,7 @@ dependencies = [
  "sysctl",
  "tempfile",
  "thiserror 2.0.18",
+ "tikv-jemalloc-ctl",
  "tokio",
  "tokio-util 0.7.18",
  "trees",
@@ -10810,10 +10811,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
#### Problem
Current memory analysis stats look at the whole system rather than the process, and provides limited visibility. Jemalloc has stats hooks that provide more in depth data that is process specific

#### Summary of Changes
- Add them

<img width="921" height="204" alt="image" src="https://github.com/user-attachments/assets/17f3339d-151e-4e00-9132-b9ab13c2132b" />

## Jemalloc Memory Statistics Overview

| Statistic | Description | What it Tells You |
|-----------|-------------|-------------------|
| **Allocated** | The total number of bytes currently allocated by the application (active data). | The actual memory requested by your code. If this grows indefinitely, you have a memory leak. |
| **Active** | The total number of bytes in pages currently backing live allocations. | Includes application data + internal fragmentation. If Active $\gg$ Allocated, you have high fragmentation. |
| **Resident** | Physical RAM used by the allocator, including metadata and unused dirty pages. | Close to the RSS (Resident Set Size) reported by `top` or `ps`. It's the physical memory pressure. |
| **Retained** | Virtual memory retained by jemalloc (via mmap/madvise), not returned to the OS, but not currently used. | Memory kept for future reuse to avoid mmap overhead. It doesn't count against physical RAM usage. |
| **Dirty** | Resident - Active | Memory that is unused and could be freed using madvise. |

</div></div>

The ctl library also supports configuration of jemalloc, which could be worth investigating. 
Fixes #
