### PR TITLE
blockstore: rekey some of the alt shred columns by (slot, block_id, ..)

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -886,7 +886,7 @@ impl Blockstore {
             BlockLocation::Alternate { block_id } => {
                 let (slot, fec_set_index) = erasure_set.store_key();
                 self.alt_merkle_root_meta_cf
-                    .get((slot, fec_set_index, block_id))
+                    .get((slot, block_id, fec_set_index))
             }
         }
     }
@@ -908,7 +908,7 @@ impl Blockstore {
             ),
             BlockLocation::Alternate { block_id } => self.alt_merkle_root_meta_cf.put_in_batch(
                 write_batch,
-                (slot, fec_set_index, block_id),
+                (slot, block_id, fec_set_index),
                 merkle_root_meta,
             ),
         }
@@ -3327,7 +3327,7 @@ impl Blockstore {
         match location {
             BlockLocation::Original => self.get_data_shred(slot, index),
             BlockLocation::Alternate { block_id } => {
-                self.alt_data_shred_cf.get_bytes((slot, index, block_id))
+                self.alt_data_shred_cf.get_bytes((slot, block_id, index))
             }
         }
     }
@@ -3363,10 +3363,10 @@ impl Blockstore {
                 let iter = self
                     .alt_data_shred_cf
                     .iter(IteratorMode::From(
-                        (slot, start_index, block_id),
+                        (slot, block_id, start_index),
                         IteratorDirection::Forward,
                     ))?
-                    .take_while(move |((shred_slot, _, shred_block_id), _)| {
+                    .take_while(move |((shred_slot, shred_block_id, _), _)| {
                         *shred_slot == slot && *shred_block_id == block_id
                     })
                     .map(|(_, bytes)| bytes);
@@ -3403,7 +3403,7 @@ impl Blockstore {
             BlockLocation::Alternate { block_id } => {
                 self.alt_data_shred_cf.put_bytes_in_batch(
                     write_batch,
-                    (slot, index, block_id),
+                    (slot, block_id, index),
                     shred,
                 );
             }
@@ -13057,6 +13057,67 @@ pub mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[test]
+    fn test_get_data_shreds_for_slot() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let parent_slot = 990;
+        let slot = 1000;
+        let num_entries = 200;
+        let locations = [
+            BlockLocation::Original,
+            BlockLocation::Alternate {
+                block_id: Hash::new_from_array([1u8; HASH_BYTES]),
+            },
+            BlockLocation::Alternate {
+                block_id: Hash::new_from_array([2u8; HASH_BYTES]),
+            },
+            BlockLocation::Alternate {
+                block_id: Hash::new_from_array([3u8; HASH_BYTES]),
+            },
+        ];
+
+        // Setup and insert shreds from 4 blocks into the columns for `slot`
+        let data_shreds: [Vec<Shred>; 4] = std::array::from_fn(|i| {
+            let (data_shreds, _coding_shreds, leader_schedule_cache) =
+                setup_erasure_shreds(slot, parent_slot, num_entries);
+            let location = locations[i];
+            let is_repaired = location != BlockLocation::Original;
+            let shreds = data_shreds
+                .iter()
+                .map(|shred| (Cow::Borrowed(shred), is_repaired, location));
+            let insert_results = blockstore
+                .do_insert_shreds(
+                    shreds,
+                    Some(&leader_schedule_cache),
+                    false,
+                    None,
+                    &mut BlockstoreInsertionMetrics::default(),
+                )
+                .unwrap();
+            assert!(insert_results.duplicate_shreds.is_empty());
+            data_shreds
+        });
+
+        // Verify that each block is able to be fetched
+        for (i, location) in locations.iter().enumerate() {
+            let shreds = &data_shreds[i];
+            let len = shreds.len();
+            let start_indices = [0, len / 2, len - 1];
+            for start_index in start_indices {
+                let expected_shreds = &shreds[start_index..];
+                let fetched_shreds = blockstore
+                    .get_data_shreds_for_slot_from_location(slot, start_index as u64, *location)
+                    .unwrap();
+                assert_eq!(fetched_shreds.len(), expected_shreds.len());
+                for (fetched, expected) in fetched_shreds.iter().zip(expected_shreds.iter()) {
+                    assert_eq!(fetched.index(), expected.index());
+                    assert_eq!(fetched.payload(), expected.payload());
+                }
+            }
+        }
     }
 
     #[test_matrix([true, false], [

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -162,7 +162,7 @@ pub mod columns {
     /// Similar to [`ShredData`], however this column is only populated for alternate
     /// versions fetched via block_id based repair.
     ///
-    /// * index type: `(slot: u64, shred_index: u64, block_id: Hash)`
+    /// * index type: `(slot: u64, block_id: Hash, shred_index: u64)`
     /// * value type: [`Vec<u8>`]
     pub struct AlternateShredData;
 
@@ -241,7 +241,7 @@ pub mod columns {
     /// Similar to [`MerkleRootMeta`], however this column is only populated for alternate
     /// versions fetched via block_id based repair.
     ///
-    /// * index type: `(slot: u64, fec_set_index: u32, block_id: Hash)`
+    /// * index type: `(slot: u64, block_id: Hash, fec_set_index: u32)`
     /// * value type: [`blockstore_meta::MerkleRootMeta`]
     pub struct AlternateMerkleRootMeta;
 
@@ -569,23 +569,23 @@ impl ColumnName for columns::ShredData {
 }
 
 impl Column for columns::AlternateShredData {
-    type Index = (Slot, /*shred index:*/ u64, /* block id*/ Hash);
+    type Index = (Slot, /* block_id */ Hash, /* shred index: */ u64);
     type Key = [u8; std::mem::size_of::<Slot>() + std::mem::size_of::<u64>() + HASH_BYTES];
 
     #[inline]
-    fn key((slot, index, hash): &Self::Index) -> Self::Key {
+    fn key((slot, block_id, index): &Self::Index) -> Self::Key {
         convert_column_index_to_key_bytes!(Key,
             ..8 => &slot.to_be_bytes(),
-            8..16 => &index.to_be_bytes(),
-            16.. => &hash.to_bytes(),
+            8..40 => &block_id.to_bytes(),
+            40.. => &index.to_be_bytes(),
         )
     }
 
     fn index(key: &[u8]) -> Self::Index {
         convert_column_key_bytes_to_index!(key,
             0..8  => Slot::from_be_bytes,
-            8..16 => u64::from_be_bytes,  // shred index
-            16..48 => Hash::new_from_array,
+            8..40 => Hash::new_from_array, // block_id
+            40..48 => u64::from_be_bytes,  // shred index
         )
     }
 
@@ -594,7 +594,7 @@ impl Column for columns::AlternateShredData {
     }
 
     fn as_index(slot: Slot) -> Self::Index {
-        (slot, 0, Hash::default())
+        (slot, Hash::default(), 0)
     }
 }
 impl ColumnName for columns::AlternateShredData {
@@ -807,32 +807,32 @@ impl TypedColumn for columns::MerkleRootMeta {
 }
 
 impl Column for columns::AlternateMerkleRootMeta {
-    type Index = (Slot, /*fec_set_index:*/ u32, /* block_id */ Hash);
+    type Index = (Slot, /* block_id */ Hash, /*fec_set_index:*/ u32);
     type Key = [u8; std::mem::size_of::<Slot>() + std::mem::size_of::<u32>() + HASH_BYTES];
 
     #[inline]
-    fn key((slot, fec_set_index, block_id): &Self::Index) -> Self::Key {
+    fn key((slot, block_id, fec_set_index): &Self::Index) -> Self::Key {
         convert_column_index_to_key_bytes!(Key,
             ..8 => &slot.to_be_bytes(),
-            8..12 => &fec_set_index.to_be_bytes(),
-            12.. => &block_id.to_bytes(),
+            8..40 => &block_id.to_bytes(),
+            40.. => &fec_set_index.to_be_bytes(),
         )
     }
 
     fn index(key: &[u8]) -> Self::Index {
         convert_column_key_bytes_to_index!(key,
             0..8  => Slot::from_be_bytes,
-            8..12 => u32::from_be_bytes,  // fec_set_index
-            12..44 => Hash::new_from_array, // block_id
+            8..40 => Hash::new_from_array, // block_id
+            40..44 => u32::from_be_bytes,  // fec_set_index
         )
     }
 
-    fn slot((slot, _fec_set_index, _block_id): Self::Index) -> Slot {
+    fn slot((slot, _block_id, _fec_set_index): Self::Index) -> Slot {
         slot
     }
 
     fn as_index(slot: Slot) -> Self::Index {
-        (slot, 0, Hash::default())
+        (slot, Hash::default(), 0)
     }
 }
 


### PR DESCRIPTION
Found while doing some extended testing of https://github.com/anza-xyz/agave/pull/11753

#### Problem
`get_data_shreds_for_slot_from_location` does not work correctly for shreds from the `Alternate` column when there are multiple blocks within a slot.

Since the key for the column is `(slot, shred_idx, block_id)`, when there are multiple blocks the shreds are interleaved. This causes the scan here to return prematurely.
```rust
                let iter = self
                    .alt_data_shred_cf
                    .iter(IteratorMode::From(
                        (slot, start_index, block_id),
                        IteratorDirection::Forward,
                    ))?
                    .take_while(move |((shred_slot, _, shred_block_id), _)| {
                        *shred_slot == slot && *shred_block_id == block_id
                    })
```

#### Summary of Changes
Instead change the column to be keyed by `(slot, block_id, shred_idx)` and do the same for `AlternateMerkleRootMeta` to be keyed by `(slot, block_id, fec_set_index)`