### PR TITLE
ledger-tool: Remove slot-list arg from list-roots

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -32,7 +32,7 @@ use {
         borrow::Cow,
         collections::{BTreeMap, BTreeSet, HashMap},
         fs::File,
-        io::{BufRead, BufReader, Write, stdout},
+        io::{BufRead, BufReader},
         path::{Path, PathBuf},
         sync::atomic::AtomicBool,
         time::{Duration, UNIX_EPOCH},
@@ -382,17 +382,6 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                     .help("First root to start searching from"),
             )
             .arg(
-                Arg::with_name("slot_list")
-                    .long("slot-list")
-                    .value_name("FILENAME")
-                    .required(false)
-                    .takes_value(true)
-                    .help(
-                        "The location of the output YAML file. A list of rollback slot heights \
-                         and hashes will be written to the file",
-                    ),
-            )
-            .arg(
                 Arg::with_name("num_roots")
                     .long("num-roots")
                     .value_name("NUM")
@@ -721,15 +710,6 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
 
             let iter = blockstore.rooted_slot_iterator(start_root)?;
 
-            let mut output: Box<dyn Write> = if let Some(path) = arg_matches.value_of("slot_list") {
-                match File::create(path) {
-                    Ok(file) => Box::new(file),
-                    _ => Box::new(stdout()),
-                }
-            } else {
-                Box::new(stdout())
-            };
-
             for slot in iter
                 .take(num_roots)
                 .take_while(|slot| *slot <= max_height as u64)
@@ -738,7 +718,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 .rev()
             {
                 let blockhash = blockstore.get_slot_entries(slot, 0)?.last().unwrap().hash;
-                writeln!(output, "{slot}: {blockhash:?}").expect("failed to write");
+                println!("{slot}: {blockhash:?}");
             }
         }
         ("parse_full_frozen", Some(arg_matches)) => {


### PR DESCRIPTION
#### Problem
Someone wishing to print to file can simply use the bash redirection like they would for every other ledger-tool command
