### PR TITLE
chore: Add bank slot to unified scheduler panic message

### DIFF
--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -604,7 +604,9 @@ impl BankWithSchedulerInner {
                 pool.register_timeout_listener(self.do_create_timeout_listener());
                 f(scheduler.active_scheduler())
             }
-            SchedulerStatus::Unavailable => unreachable!("no installed scheduler"),
+            SchedulerStatus::Unavailable => {
+                unreachable!("no installed scheduler for slot {}", self.bank.slot())
+            }
         }
     }
 


### PR DESCRIPTION

#### Problem
We observed a panic on this unreachable statement [on the AG test cluster](https://discord.com/channels/428295358100013066/1499484763361247392/1502886163164430386).

#### Summary of Changes
Print the slot number for an unreachable branch error message within BankWithSchedulerInner::with_active_scheduler(). The slot can potentially be gleamed from context but this log makes things easier