### PR TITLE
validator: fix off-by-one in --dynamic-port-range validation

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -342,11 +342,14 @@ pub fn port_validator(port: String) -> Result<(), String> {
 
 pub fn port_range_validator(port_range: String) -> Result<(), String> {
     if let Some((start, end)) = solana_net_utils::parse_port_range(&port_range) {
-        if end - start < MINIMUM_VALIDATOR_PORT_RANGE_WIDTH {
+        // `MINIMUM_VALIDATOR_PORT_RANGE_WIDTH` counts ports inclusively, while
+        // `end - start` measures the half-open width of the range, so the
+        // valid threshold is `MINIMUM_VALIDATOR_PORT_RANGE_WIDTH - 1`.
+        if end - start < MINIMUM_VALIDATOR_PORT_RANGE_WIDTH - 1 {
             Err(format!(
                 "Port range is too small.  Try --dynamic-port-range {}-{}",
                 start,
-                start + MINIMUM_VALIDATOR_PORT_RANGE_WIDTH
+                start + (MINIMUM_VALIDATOR_PORT_RANGE_WIDTH - 1)
             ))
         } else {
             Ok(())
@@ -927,5 +930,38 @@ mod test {
                 next_name,
             );
         }
+    }
+
+    #[test]
+    fn port_range_validator_accepts_minimum_width() {
+        // `MINIMUM_VALIDATOR_PORT_RANGE_WIDTH` is interpreted as an inclusive
+        // count of ports (e.g. 26 means ports `start..=start + 25`).
+        let min = MINIMUM_VALIDATOR_PORT_RANGE_WIDTH;
+        let exact = format!("8000-{}", 8000 + (min - 1));
+        assert_eq!(port_range_validator(exact), Ok(()));
+
+        let larger = format!("8000-{}", 8000 + min);
+        assert_eq!(port_range_validator(larger), Ok(()));
+    }
+
+    #[test]
+    fn port_range_validator_rejects_too_small_range() {
+        let min = MINIMUM_VALIDATOR_PORT_RANGE_WIDTH;
+        let too_small_end = 8000 + (min - 2);
+        let too_small = format!("8000-{}", too_small_end);
+        let suggested_end = 8000 + (min - 1);
+        let expected = format!(
+            "Port range is too small.  Try --dynamic-port-range 8000-{}",
+            suggested_end
+        );
+        assert_eq!(port_range_validator(too_small), Err(expected));
+    }
+
+    #[test]
+    fn port_range_validator_rejects_invalid_input() {
+        assert_eq!(
+            port_range_validator("not-a-range".to_string()),
+            Err("Invalid port range".to_string())
+        );
     }
 }


### PR DESCRIPTION
#### Problem

`port_range_validator` in `validator/src/cli.rs` rejects `--dynamic-port-range`
values that should be accepted, and the error message it prints suggests a
range that is itself one port larger than necessary.

`solana_net_utils::parse_port_range` returns a half-open range `[start, end)`
(sockets are bound via `for port in range.0..range.1` in
`net-utils/src/sockets.rs`), while `MINIMUM_VALIDATOR_PORT_RANGE_WIDTH = 26`
is documented and intended as the **inclusive** count of ports the validator
needs.

The previous check:

```rust
if end - start < MINIMUM_VALIDATOR_PORT_RANGE_WIDTH {
    Err(format!(
        "Port range is too small.  Try --dynamic-port-range {}-{}",
        start,
        start + MINIMUM_VALIDATOR_PORT_RANGE_WIDTH
    ))
}
```

requires `end - start >= 26`, i.e. **27** inclusive ports, and the suggested
fallback `start + 26` is also one too high. As reported in #7759, running:

```
--dynamic-port-range 8000-8025
```

(26 ports, matching the documented minimum) fails with:

> error: Invalid value for '--dynamic-port-range <MIN_PORT-MAX_PORT>':
> Port range is too small.  Try --dynamic-port-range 8000-8026

#### Summary of Changes

* Use `MINIMUM_VALIDATOR_PORT_RANGE_WIDTH - 1` in both the comparison and the
  suggested range in the error message, so the validator accepts exactly
  `MINIMUM_VALIDATOR_PORT_RANGE_WIDTH` inclusive ports as documented.
* Add a short comment explaining the inclusive vs. half-open semantics so the
  off-by-one is not reintroduced.
* Add unit tests in `cli::test` covering:
  * the exact-minimum and larger-than-minimum accepted cases,
  * the too-small case (also asserting the exact suggested-range string), and
  * invalid input.

No public API or constant values are changed; only the validation arithmetic
and the user-facing error message.

#### Test Plan

```
./cargo test -p agave-validator --lib cli::test::
```

Output:

```
running 4 tests
test cli::test::make_sure_deprecated_arguments_are_sorted_alphabetically ... ok
test cli::test::port_range_validator_rejects_invalid_input ... ok
test cli::test::port_range_validator_rejects_too_small_range ... ok
test cli::test::port_range_validator_accepts_minimum_width ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 155 filtered out
```

Manual check:

```
agave-validator --dynamic-port-range 8000-8025 ...
```

is now accepted, matching the documented minimum of 26 ports. Ranges below
the minimum produce a corrected suggestion, e.g.:

```
Port range is too small.  Try --dynamic-port-range 8000-8025
```

Fixes #7759

