### PR TITLE
repair: bound ancestor_hashes_service network response channel

### DIFF
--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -11,11 +11,12 @@ use {
             serve_repair::{
                 AncestorHashesRepairType, AncestorHashesResponse, RepairProtocol, ServeRepair,
             },
+            serve_repair_service::RESPONSE_CHANNEL_SIZE,
             standard_repair_handler::StandardRepairHandler,
         },
         replay_stage::DUPLICATE_THRESHOLD,
     },
-    crossbeam_channel::{Receiver, RecvTimeoutError, Sender, unbounded},
+    crossbeam_channel::{Receiver, RecvTimeoutError, Sender, bounded, unbounded},
     dashmap::{DashMap, mapref::entry::Entry::Occupied},
     solana_clock::Slot,
     solana_gossip::{contact_info::Protocol, ping_pong::Pong},
@@ -167,7 +168,7 @@ impl AncestorHashesService {
             return None;
         }
         let outstanding_requests = Arc::<RwLock<OutstandingAncestorHashesRepairs>>::default();
-        let (response_sender, response_receiver) = unbounded();
+        let (response_sender, response_receiver) = bounded(RESPONSE_CHANNEL_SIZE);
         let t_receiver = streamer::receiver(
             "solRcvrAncHash".to_string(),
             ancestor_hashes_request_socket.clone(),


### PR DESCRIPTION
#### Problem

Unbounded channels must go. 

#### Summary of Changes

Replace unbounded() with bounded(RESPONSE_CHANNEL_SIZE = 4096) for the network-driven response channel of AncestorHashesService. streamer::receiver already uses try_send and counts drops on a full channel, so the swap caps memory growth without changing liveness.

Internal control-plane channels (retryable_slots, ancestor_duplicate_slots, ancestor_hashes_replay_update) are intentionally left unbounded -- they are not driven by network traffic, and the alpenglow migration removes this service entirely.

