### PR TITLE
alpenglow: upstream flh

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -6,23 +6,27 @@
 //! Once alpenglow is active, this is the only thread that will touch the [`PohRecorder`].
 use {
     crate::{
-        banking_trace::BankingTracer,
+        banking_trace::{BankingPacketSender, BankingTracer},
         replay_stage::{Finalizer, ReplayStage},
     },
     agave_votor::event::LeaderWindowInfo,
-    agave_votor_messages::reward_certificate::{
-        BuildRewardCertsRequest, BuildRewardCertsRespSucc, BuildRewardCertsResponse,
-        NotarRewardCertificate, SkipRewardCertificate,
+    agave_votor_messages::{
+        consensus_message::Block,
+        reward_certificate::{
+            BuildRewardCertsRequest, BuildRewardCertsRespSucc, BuildRewardCertsResponse,
+            NotarRewardCertificate, SkipRewardCertificate,
+        },
     },
-    crossbeam_channel::{Receiver, Sender},
+    crossbeam_channel::{Receiver, RecvTimeoutError, Sender, select_biased},
     solana_clock::Slot,
     solana_entry::block_component::{
-        BlockFooterV1, BlockMarkerV1, GenesisCertificate, VersionedBlockMarker,
+        BlockFooterV1, GenesisCertificate, UpdateParentV1, VersionedBlockMarker,
     },
     solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
     solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
     solana_measure::measure::Measure,
+    solana_perf::packet::{BytesPacket, Meta, PacketBatch, bytes::Bytes},
     solana_poh::{
         poh_recorder::{GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS, PohRecorder, PohRecorderError},
         record_channels::RecordReceiver,
@@ -38,6 +42,7 @@ use {
         validated_block_finalization::ValidatedBlockFinalizationCert,
         validated_reward_certificate::ValidatedRewardCert,
     },
+    solana_transaction::versioned::VersionedTransaction,
     solana_version::version,
     stats::{LoopMetrics, SlotMetrics},
     std::{
@@ -52,6 +57,14 @@ use {
 };
 
 mod stats;
+
+/// Source of a leader-window notification consumed by BCL.
+enum ParentSource {
+    /// Consensus has finalized the parent for this leader window.
+    ParentReady(LeaderWindowInfo),
+    /// Replay froze the previous leader's last block before consensus finalized it.
+    OptimisticParent(LeaderWindowInfo),
+}
 
 pub struct BlockCreationLoop {
     thread: JoinHandle<()>,
@@ -100,17 +113,25 @@ pub struct BlockCreationLoopConfig {
 
     // Channel to receive RecordReceiver from PohService
     pub record_receiver_receiver: Receiver<RecordReceiver>,
+    pub optimistic_parent_receiver: Receiver<LeaderWindowInfo>,
 
     /// Channel to send the request to build reward certs.
     pub build_reward_certs_sender: Sender<BuildRewardCertsRequest>,
     /// Channel to receive the built reward certs.
     pub reward_certs_receiver: Receiver<BuildRewardCertsResponse>,
+
+    /// Sender for packets to banking stage (used to re-inject transactions after sad leader handover).
+    pub banking_stage_sender: BankingPacketSender,
 }
 
 struct LeaderContext {
     exit: Arc<AtomicBool>,
     my_pubkey: Pubkey,
+    /// Finalized leader-window notifications from Votor.
     leader_window_info_receiver: Receiver<LeaderWindowInfo>,
+    /// ParentReady for a future window observed while producing the current one.
+    pending_parent_ready: Option<LeaderWindowInfo>,
+    /// Highest finalized parent known to Votor, used to abandon stale windows.
     highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
     highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
 
@@ -126,6 +147,8 @@ struct LeaderContext {
     replay_highest_frozen: Arc<ReplayHighestFrozen>,
     build_reward_certs_sender: Sender<BuildRewardCertsRequest>,
     reward_certs_receiver: Receiver<BuildRewardCertsResponse>,
+    /// Banking-stage ingress used to reschedule transactions after sad handover.
+    banking_stage_sender: BankingPacketSender,
 
     // Metrics
     metrics: LoopMetrics,
@@ -137,7 +160,9 @@ struct LeaderContext {
 
 #[derive(Default)]
 pub struct ReplayHighestFrozen {
+    /// Highest slot replay has frozen; used by the leader loop to wait for its parent.
     pub highest_frozen_slot: Mutex<Slot>,
+    /// Notifies the leader loop when replay advances `highest_frozen_slot`.
     pub freeze_notification: Condvar,
 }
 
@@ -158,9 +183,25 @@ enum StartLeaderError {
         /* leader slot */ Slot,
     ),
 
-    /// Failed to insert our leader bank
-    #[error("Failed to insert leader bank: {0}")]
-    InsertBankError(#[from] BankForksControllerError),
+    /// Failed to apply a serialized `BankForks` update through ReplayStage.
+    #[error("Failed to update bank forks: {0}")]
+    BankForksController(#[from] BankForksControllerError),
+
+    /// The frozen parent bank does not match the expected block id.
+    #[error(
+        "Parent block id mismatch for leader slot {leader_slot}: parent slot {parent_slot}, \
+         expected {expected}, actual {actual:?}"
+    )]
+    ParentBlockIdMismatch {
+        leader_slot: Slot,
+        parent_slot: Slot,
+        expected: Hash,
+        actual: Option<Hash>,
+    },
+
+    /// PoH recorder failed while starting or completing a leader block.
+    #[error("PoH recorder failed: {0}")]
+    PohRecorder(#[from] PohRecorderError),
 }
 
 /// The block creation loop.
@@ -180,13 +221,15 @@ fn start_loop(config: BlockCreationLoopConfig) {
         rpc_subscriptions,
         banking_tracer,
         slot_status_notifier,
-        leader_window_info_receiver,
-        highest_parent_ready,
-        replay_highest_frozen,
         record_receiver_receiver,
-        highest_finalized,
+        leader_window_info_receiver,
+        replay_highest_frozen,
+        highest_parent_ready,
+        optimistic_parent_receiver,
         build_reward_certs_sender,
         reward_certs_receiver,
+        highest_finalized,
+        banking_stage_sender,
     } = config;
 
     // Similar to Votor, if this loop dies kill the validator
@@ -196,6 +239,7 @@ fn start_loop(config: BlockCreationLoopConfig) {
     let mut my_pubkey = cluster_info.id();
 
     info!("{my_pubkey}: Block creation loop initialized");
+
     // Wait for PohService to be shutdown
     let record_receiver = match record_receiver_receiver.recv() {
         Ok(receiver) => receiver,
@@ -219,11 +263,12 @@ fn start_loop(config: BlockCreationLoopConfig) {
     let mut ctx = LeaderContext {
         exit,
         my_pubkey,
-        leader_window_info_receiver,
         highest_parent_ready,
+        leader_window_info_receiver,
+        pending_parent_ready: None,
         blockstore,
+        poh_recorder: poh_recorder.clone(),
         record_receiver,
-        poh_recorder,
         leader_schedule_cache,
         bank_forks,
         bank_forks_controller,
@@ -233,6 +278,7 @@ fn start_loop(config: BlockCreationLoopConfig) {
         replay_highest_frozen,
         build_reward_certs_sender,
         reward_certs_receiver,
+        banking_stage_sender,
         metrics: LoopMetrics::default(),
         slot_metrics: SlotMetrics::default(),
         highest_finalized,
@@ -264,34 +310,74 @@ fn start_loop(config: BlockCreationLoopConfig) {
             );
         }
 
-        // Wait for the voting loop to notify us, draining all pending messages and keeping the highest slot
+        // Wait for the first window notification, then drain both sources and pick the newest
+        // leader window. This avoids revisiting stale optimistic windows after replay has already
+        // advanced to a later finalized parent.
+        let window_source = if let Some(info) = ctx.pending_parent_ready.take() {
+            Some(ParentSource::ParentReady(info))
+        } else {
+            select_biased! {
+                recv(ctx.leader_window_info_receiver) -> msg => {
+                    msg.ok().map(ParentSource::ParentReady)
+                },
+                recv(optimistic_parent_receiver) -> msg => {
+                    msg.ok().map(ParentSource::OptimisticParent)
+                },
+                default(Duration::from_secs(1)) => continue,
+            }
+        };
+
+        let (mut latest_parent_ready, mut latest_optimistic_parent) = match window_source {
+            Some(ParentSource::ParentReady(first)) => (Some(first), None),
+            Some(ParentSource::OptimisticParent(first)) => (None, Some(first)),
+            None => {
+                info!("{my_pubkey}: channel disconnected");
+                return;
+            }
+        };
+
+        latest_parent_ready = freshest_window_from_iter(
+            latest_parent_ready,
+            ctx.leader_window_info_receiver.try_iter(),
+        );
+        latest_optimistic_parent = freshest_window_from_iter(
+            latest_optimistic_parent,
+            optimistic_parent_receiver.try_iter(),
+        );
+
+        let (info, fast_leader_handover) =
+            select_freshest_window(latest_parent_ready, latest_optimistic_parent);
+        let Some(info) = info else {
+            info!("{my_pubkey}: both leader window channels drained");
+            continue;
+        };
+
         let LeaderWindowInfo {
             start_slot,
             end_slot,
-            parent_block: (parent_slot, _),
+            parent_block: (parent_slot, parent_hash),
             block_timer,
-        } = {
-            // Drain all pending messages and keep the latest one
-            let Some(info) = ctx
-                .leader_window_info_receiver
-                // Timeout so we can check the exit flag
-                .recv_timeout(Duration::from_secs(1))
-                .ok()
-                .and_then(|window| {
-                    ctx.leader_window_info_receiver
-                        .try_iter()
-                        .last()
-                        .or(Some(window))
-                })
-            else {
-                continue;
-            };
+        } = info;
 
-            info
-        };
+        trace!(
+            "{my_pubkey}: window {start_slot}-{end_slot} parent {parent_slot} \
+             flh={fast_leader_handover}"
+        );
 
-        trace!("Received window notification for {start_slot} to {end_slot} parent: {parent_slot}");
-        if let Err(e) = produce_window(start_slot, end_slot, parent_slot, block_timer, &mut ctx) {
+        if (start_slot..=end_slot).any(|slot| ctx.blockstore.has_existing_shreds_for_slot(slot)) {
+            warn!("{my_pubkey}: already have shreds in window {start_slot}-{end_slot}, skipping");
+            continue;
+        }
+
+        if let Err(e) = produce_window(
+            fast_leader_handover,
+            start_slot,
+            end_slot,
+            parent_slot,
+            parent_hash,
+            block_timer,
+            &mut ctx,
+        ) {
             // Give up on this leader window
             error!(
                 "{my_pubkey}: Unable to produce window {start_slot}-{end_slot}, skipping window: \
@@ -331,6 +417,63 @@ fn reset_poh_recorder(bank: &Arc<Bank>, ctx: &LeaderContext) {
 fn block_timeout(bank: &Bank, leader_block_index: usize) -> Duration {
     Duration::from_nanos_u128(bank.ns_per_slot)
         .saturating_mul((leader_block_index as u32).saturating_add(1))
+}
+
+/// Select the freshest leader-window notification within one source.
+///
+/// Equal start slots keep the later notification so coalescing a channel drain
+/// has the same semantics as replacing a single queued item.
+fn freshest_leader_window(
+    current: LeaderWindowInfo,
+    candidate: LeaderWindowInfo,
+) -> LeaderWindowInfo {
+    if current.start_slot > candidate.start_slot {
+        current
+    } else {
+        candidate
+    }
+}
+
+/// Drain a source of leader-window notifications and keep only the highest
+/// start slot, replacing equal start slots with the later notification.
+fn freshest_window_from_iter(
+    current: Option<LeaderWindowInfo>,
+    candidates: impl IntoIterator<Item = LeaderWindowInfo>,
+) -> Option<LeaderWindowInfo> {
+    candidates.into_iter().fold(current, |current, candidate| {
+        Some(match current {
+            Some(current) => freshest_leader_window(current, candidate),
+            None => candidate,
+        })
+    })
+}
+
+/// Preserve the freshest future ParentReady so the next loop iteration starts
+/// from finalized consensus state instead of a stale optimistic notification.
+fn stash_parent_ready(ctx: &mut LeaderContext, info: LeaderWindowInfo) {
+    ctx.pending_parent_ready = Some(match ctx.pending_parent_ready.take() {
+        Some(current) => freshest_leader_window(current, info),
+        None => info,
+    });
+}
+
+/// Choose between finalized and optimistic leader-window notifications.
+///
+/// ParentReady wins ties across sources because finalized parent information
+/// should override an optimistic parent for the same leader window.
+fn select_freshest_window(
+    latest_parent_ready: Option<LeaderWindowInfo>,
+    latest_optimistic_parent: Option<LeaderWindowInfo>,
+) -> (Option<LeaderWindowInfo>, bool) {
+    if latest_parent_ready.as_ref().map(|info| info.start_slot)
+        >= latest_optimistic_parent
+            .as_ref()
+            .map(|info| info.start_slot)
+    {
+        (latest_parent_ready, false)
+    } else {
+        (latest_optimistic_parent, true)
+    }
 }
 
 /// Clamps the block producer timestamp to ensure that the leader produces a timestamp that conforms
@@ -401,32 +544,52 @@ fn produce_block_footer(
 }
 
 /// Produces the leader window from `start_slot` -> `end_slot` using parent
-/// `parent_slot` while abiding to the `skip_timer`
+/// `parent_slot` while abiding to the `block_timer`
 fn produce_window(
+    fast_leader_handover: bool,
     start_slot: Slot,
     end_slot: Slot,
-    mut parent_slot: Slot,
-    block_timer: Instant,
+    parent_slot: Slot,
+    parent_hash: Hash,
+    mut block_timer: Instant,
     ctx: &mut LeaderContext,
 ) -> Result<(), StartLeaderError> {
+    // Insert the first bank
+    let mut working_bank = start_leader_wait_for_parent_replay(
+        start_slot,
+        parent_slot,
+        Some(parent_hash),
+        block_timer,
+        ctx,
+    )?;
+    if fast_leader_handover {
+        ctx.slot_metrics.mark_leader_handover_fast();
+    }
+
     let my_pubkey = ctx.my_pubkey;
     let mut window_production_start = Measure::start("window_production");
     let mut slot = start_slot;
 
     while !ctx.exit.load(Ordering::Relaxed) && slot <= end_slot {
-        // Insert the bank. In case `replay_stage` is slow and `parent_slot` is not
-        // yet frozen, we wait up until the timeout.
-        let working_bank =
-            start_leader_wait_for_parent_replay(slot, parent_slot, block_timer, ctx)?;
         let timeout = block_timeout(&working_bank, leader_slot_index(slot));
         trace!(
-            "{my_pubkey}: waiting for leader bank {slot} to finish, remaining time: {}",
-            timeout.saturating_sub(block_timer.elapsed()).as_millis(),
+            "{my_pubkey}: waiting for leader bank {slot} to finish, remaining time: {}ms",
+            timeout.saturating_sub(block_timer.elapsed()).as_millis()
         );
 
         let mut bank_completion_measure = Measure::start("bank_completion");
-        if let Err(e) = record_and_complete_block(ctx, block_timer, timeout, slot) {
-            panic!("PohRecorder record failed: {e:?}");
+        let optimistic_parent =
+            (fast_leader_handover && slot == start_slot).then_some((parent_slot, parent_hash));
+        if let Err(e) =
+            record_and_complete_block(ctx, slot, optimistic_parent, &mut block_timer, timeout)
+        {
+            if ctx.exit.load(Ordering::Relaxed) {
+                return Ok(());
+            }
+            if !matches!(&e, PohRecorderError::WindowMovedOn(_)) {
+                abort_failed_working_bank(ctx, slot)?;
+            }
+            return Err(StartLeaderError::PohRecorder(e));
         }
         assert!(!ctx.poh_recorder.read().unwrap().has_bank());
         bank_completion_measure.stop();
@@ -436,19 +599,19 @@ fn produce_window(
         let _ = ctx
             .metrics
             .bank_timeout_completion_elapsed_hist
-            .increment(bank_completion_measure.as_us())
-            .inspect_err(|e| {
-                error!(
-                    "{}: unable to increment bank completion histogram {e:?}",
-                    ctx.my_pubkey
-                );
-            });
+            .increment(bank_completion_measure.as_us());
 
         // Produce our next slot
-        parent_slot = slot;
         slot += 1;
+        if slot > end_slot {
+            trace!("{my_pubkey}: finished leader window {start_slot}-{end_slot}");
+            break;
+        }
+
+        // Although `slot - 1`has been cleared from `poh_recorder`, it might not have finished processing in
+        // `replay_stage`, which is why we use `start_leader_retry_replay`
+        working_bank = start_leader_wait_for_parent_replay(slot, slot - 1, None, block_timer, ctx)?;
     }
-    trace!("{my_pubkey}: finished leader window {start_slot}-{end_slot}");
 
     window_production_start.stop();
     ctx.metrics.window_production_elapsed += window_production_start.as_us();
@@ -459,42 +622,119 @@ fn produce_window(
 /// Afterwards:
 /// - Shutdown the record receiver
 /// - Clear any inflight records
+/// - Insert the block footer
 /// - Insert the alpentick
 /// - Clear the working bank
 fn record_and_complete_block(
     ctx: &mut LeaderContext,
-    block_timer: Instant,
-    block_timeout: Duration,
     bank_slot: Slot,
+    mut optimistic_parent: Option<(Slot, Hash)>,
+    block_timer: &mut Instant,
+    block_timeout: Duration,
 ) -> Result<(), PohRecorderError> {
+    drain_stale_reward_certs(ctx, bank_slot);
     ctx.build_reward_certs_sender
         .send(BuildRewardCertsRequest { bank_slot })
         .map_err(|_| PohRecorderError::ChannelDisconnected)?;
+    let mut accumulated_txs = vec![];
+    let mut records_shutdown = false;
+    let window_has_moved_on = loop {
+        if ctx.exit.load(Ordering::Relaxed) {
+            return Err(PohRecorderError::ChannelDisconnected);
+        }
 
-    // loop until we hit the block timeout
-    while !block_timeout
-        .saturating_sub(block_timer.elapsed())
-        .is_zero()
-    {
-        let Ok(record) = ctx.record_receiver.try_recv() else {
-            continue;
+        // If our window is skipped return
+        if ctx.highest_parent_ready.read().unwrap().0 > bank_slot {
+            break true;
+        }
+
+        // Don't timeout until we've received ParentReady.
+        let block_time_left = time_left(*block_timer, block_timeout);
+        let select_timeout = if block_time_left.is_zero() {
+            if optimistic_parent.is_none() {
+                // Happy path. We've reached the block timeout and have received
+                // ParentReady, so we can proceed to complete the block.
+                break false;
+            }
+
+            // FLH still needs to wait for ParentReady... stop recording so we
+            // don't build a giant block or OOM.
+            if !records_shutdown {
+                shutdown_and_drain_record_receiver(
+                    &ctx.poh_recorder,
+                    &mut ctx.record_receiver,
+                    Some(&mut accumulated_txs),
+                )?;
+                records_shutdown = true;
+            }
+
+            // Poll periodically while waiting for ParentReady so shutdown can
+            // be observed without a zero-duration spin.
+            Duration::from_millis(100)
+        } else {
+            block_time_left
         };
-        ctx.poh_recorder.write().unwrap().record(
-            record.bank_id,
-            record.mixins,
-            record.transaction_batches,
-        )?;
+
+        select_biased! {
+            recv(ctx.leader_window_info_receiver) -> msg => {
+                let info = msg.map_err(|_| PohRecorderError::ChannelDisconnected)?;
+                if process_parent_ready(
+                    ctx,
+                    info,
+                    bank_slot,
+                    &mut optimistic_parent,
+                    &mut accumulated_txs,
+                    block_timer,
+                    &mut records_shutdown,
+                )? {
+                    break true;
+                }
+            },
+            recv(ctx.record_receiver.inner()) -> msg => {
+                let record = msg.map_err(|_| PohRecorderError::ChannelDisconnected)?;
+                ctx.record_receiver
+                    .on_received_record(record.transaction_batches.len() as u64);
+
+                if optimistic_parent.is_some() {
+                    record.transaction_batches.iter().for_each(|batch| {
+                        accumulated_txs.extend(batch.iter().cloned());
+                    });
+                }
+
+                ctx.poh_recorder.write().unwrap().record(
+                    record.bank_id,
+                    record.mixins,
+                    record.transaction_batches,
+                )?;
+            },
+            default(select_timeout) => {},
+        }
+    };
+
+    if window_has_moved_on {
+        // The cluster has selected a later parent, so this bank will never get a
+        // footer. Do not record more transactions into it or wait for reward
+        // certs that are only needed for block completion.
+        if !records_shutdown {
+            ctx.record_receiver.shutdown();
+            for _ in ctx.record_receiver.drain_after_shutdown() {}
+        }
+        abort_working_bank(ctx, bank_slot)
+            .map_err(|_| PohRecorderError::ResetBankError(bank_slot, bank_slot))?;
+        return Err(PohRecorderError::WindowMovedOn(bank_slot));
     }
 
     // Shutdown and clear any inflight records
-    ctx.record_receiver.shutdown();
-    for record in ctx.record_receiver.drain() {
-        ctx.poh_recorder.write().unwrap().record(
-            record.bank_id,
-            record.mixins,
-            record.transaction_batches,
-        )?;
+    if !records_shutdown {
+        shutdown_and_drain_record_receiver(&ctx.poh_recorder, &mut ctx.record_receiver, None)?;
     }
+
+    // By now, we should have received ParentReady and called handle_parent_ready(), unless
+    // we're behind and the window has moved on.
+    debug_assert!(
+        window_has_moved_on || optimistic_parent.is_none(),
+        "optimistic_parent should be None after receiving ParentReady"
+    );
 
     // Alpentick and clear bank
     let mut w_poh_recorder = ctx.poh_recorder.write().unwrap();
@@ -512,17 +752,14 @@ fn record_and_complete_block(
     // Set the tick height for the bank to max_tick_height - 1, so that PohRecorder::flush_cache()
     // will properly increment the tick_height to max_tick_height.
     bank.set_tick_height(max_tick_height - 1);
-    // Write the single tick for this slot
 
     let footer = {
+        let reward_certs = recv_reward_certs(ctx, bank_slot)?;
         let BuildRewardCertsRespSucc {
             skip,
             notar,
             validators: _,
-        } = ctx
-            .reward_certs_receiver
-            .recv()
-            .map_err(|_| PohRecorderError::ChannelDisconnected)??;
+        } = reward_certs;
         let reward_cert = ValidatedRewardCert::try_new(&bank, &skip, &notar)?;
         let guard = ctx.highest_finalized.read().unwrap();
         let footer = produce_block_footer(&bank, skip, notar, guard.as_ref());
@@ -539,8 +776,281 @@ fn record_and_complete_block(
     };
 
     drop(bank);
-    w_poh_recorder.tick_alpenglow(max_tick_height, footer);
+    // Write the single tick for this slot
+    w_poh_recorder.tick_alpenglow(max_tick_height, footer)?;
     Ok(())
+}
+
+/// Apply a ParentReady notification while a leader block is being produced.
+///
+/// Returns true when the notification proves this producer is behind and should
+/// abandon the current window. For matching optimistic windows, this may perform
+/// sad leader handover and restart the bank on the finalized parent.
+fn process_parent_ready(
+    ctx: &mut LeaderContext,
+    info: LeaderWindowInfo,
+    bank_slot: Slot,
+    optimistic_parent: &mut Option<(Slot, Hash)>,
+    accumulated_txs: &mut Vec<VersionedTransaction>,
+    block_timer: &mut Instant,
+    records_shutdown: &mut bool,
+) -> Result<bool, PohRecorderError> {
+    if info.start_slot > bank_slot {
+        // Window has moved on; we're behind.
+        stash_parent_ready(ctx, info);
+        return Ok(true);
+    }
+
+    if info.start_slot == bank_slot {
+        if let Some(optimistic_parent_block) = optimistic_parent.take() {
+            if handle_parent_ready(
+                ctx,
+                info,
+                optimistic_parent_block,
+                std::mem::take(accumulated_txs),
+                block_timer,
+            )?
+            .is_some()
+            {
+                *records_shutdown = false;
+            }
+        }
+        return Ok(false);
+    }
+
+    trace!(
+        "{}: ignoring stale ParentReady for window {}-{} while producing slot {bank_slot}",
+        ctx.my_pubkey, info.start_slot, info.end_slot
+    );
+    Ok(false)
+}
+
+/// Drop reward-certificate responses left over from an older bank slot.
+fn drain_stale_reward_certs(ctx: &LeaderContext, bank_slot: Slot) {
+    for reward_cert in ctx.reward_certs_receiver.try_iter() {
+        warn!(
+            "{}: dropping stale reward cert response for bank slot {}, before starting {bank_slot}",
+            ctx.my_pubkey, reward_cert.bank_slot
+        );
+    }
+}
+
+/// Wait for the reward-certificate response for `bank_slot`, ignoring stale
+/// responses generated for banks that have already been abandoned.
+fn recv_reward_certs(
+    ctx: &LeaderContext,
+    bank_slot: Slot,
+) -> Result<BuildRewardCertsRespSucc, PohRecorderError> {
+    loop {
+        if ctx.exit.load(Ordering::Relaxed) {
+            return Err(PohRecorderError::ChannelDisconnected);
+        }
+
+        match ctx
+            .reward_certs_receiver
+            .recv_timeout(Duration::from_millis(100))
+        {
+            Ok(reward_certs) if reward_certs.bank_slot == bank_slot => {
+                break reward_certs.result.map_err(PohRecorderError::from);
+            }
+            Ok(reward_certs) => {
+                warn!(
+                    "{}: ignoring stale reward cert response for bank slot {}, expected \
+                     {bank_slot}",
+                    ctx.my_pubkey, reward_certs.bank_slot
+                );
+            }
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => {
+                return Err(PohRecorderError::ChannelDisconnected);
+            }
+        }
+    }
+}
+
+/// Stop record intake, drain any already-reserved records, and reset PoH after
+/// failing to complete the working bank.
+fn abort_failed_working_bank(
+    ctx: &mut LeaderContext,
+    slot: Slot,
+) -> Result<(), BankForksControllerError> {
+    ctx.record_receiver.shutdown();
+    for _ in ctx.record_receiver.drain_after_shutdown() {}
+    abort_working_bank(ctx, slot)
+}
+
+/// Remove an abandoned leader bank and reset PoH to its parent/root bank.
+fn abort_working_bank(ctx: &mut LeaderContext, slot: Slot) -> Result<(), BankForksControllerError> {
+    let Some(bank) = ctx.poh_recorder.read().unwrap().bank() else {
+        return Ok(());
+    };
+
+    let reset_bank = bank
+        .parent()
+        .unwrap_or_else(|| ctx.bank_forks.read().unwrap().root_bank());
+    bank.wait_for_inflight_commits();
+    ctx.bank_forks_controller.clear_bank(slot)?;
+    reset_poh_recorder(&reset_bank, ctx);
+    Ok(())
+}
+
+/// Emit an UpdateParent marker into the current leader block.
+///
+/// Broadcast keeps the original shred-header parent, but this marker updates
+/// the replay parent and double-merkle parent leaf for downstream validators.
+fn send_update_parent(
+    poh_recorder: &RwLock<PohRecorder>,
+    new_parent_block: Block,
+) -> Result<(), PohRecorderError> {
+    let (new_parent_slot, new_parent_block_id) = new_parent_block;
+    let update_parent = UpdateParentV1 {
+        new_parent_slot,
+        new_parent_block_id,
+    };
+    let marker = VersionedBlockMarker::new_update_parent(update_parent);
+    poh_recorder.write().unwrap().send_marker(marker)?;
+    Ok(())
+}
+
+/// Handles a parent ready notification when building on an optimistic parent.
+///
+/// Happy path:
+/// - finalized parent matches optimistic parent
+/// - this is a no-op, and a win.
+///
+/// Sad path:
+/// - finalized parent does not match optimistic parent
+/// - we send an UpdateParent to switch to the correct parent (i.e., the finalized parent).
+/// - tell PohRecorder to stop sending us transactions
+/// - we clear the bank for the current slot
+fn handle_parent_ready(
+    ctx: &mut LeaderContext,
+    leader_window_info: LeaderWindowInfo,
+    optimistic_parent_block: (Slot, Hash),
+    mut accumulated_txs: Vec<VersionedTransaction>,
+    block_timer: &mut Instant,
+) -> Result<Option<Arc<Bank>>, PohRecorderError> {
+    if leader_window_info.parent_block == optimistic_parent_block {
+        // Happy path: optimistic parent matches finalized parent
+        return Ok(None);
+    }
+
+    // Sad path: need to switch to the correct parent
+    trace!(
+        "{:?}: Sad leader handover slot optimistic parent = {:?} != {:?} = finalized parent",
+        ctx.my_pubkey, optimistic_parent_block, leader_window_info.parent_block
+    );
+    ctx.slot_metrics.mark_leader_handover_sad();
+
+    // If the optimistic parent doesn't match the finalized parent (specified in ParentReady), then
+    // this resets the block timer to the new parent's timer.
+    *block_timer = leader_window_info.block_timer;
+
+    // Important: We must shutdown and drain the record receiver BEFORE sending the UpdateParent
+    // marker. Otherwise, we could end up sending records for the old bank after the UpdateParent,
+    // which causes a divergence between the leader and replayers.
+    shutdown_and_drain_record_receiver(
+        &ctx.poh_recorder,
+        &mut ctx.record_receiver,
+        Some(&mut accumulated_txs),
+    )?;
+    send_update_parent(&ctx.poh_recorder, leader_window_info.parent_block)?;
+
+    let slot = leader_window_info.start_slot;
+    let (old_parent_slot, _) = optimistic_parent_block;
+    let (new_parent_slot, new_parent_hash) = leader_window_info.parent_block;
+
+    let bank = ctx
+        .poh_recorder
+        .read()
+        .unwrap()
+        .bank()
+        .ok_or(PohRecorderError::ResetBankError(
+            old_parent_slot,
+            new_parent_slot,
+        ))?;
+    bank.wait_for_inflight_commits();
+    ctx.bank_forks_controller
+        .clear_bank(slot)
+        .map_err(|_| PohRecorderError::ResetBankError(old_parent_slot, new_parent_slot))?;
+    ctx.poh_recorder.write().unwrap().clear_bank(true);
+
+    // Create the new bank before re-injecting transactions to avoid racing.
+    let new_bank = start_leader_wait_for_parent_replay(
+        slot,
+        new_parent_slot,
+        Some(new_parent_hash),
+        *block_timer,
+        ctx,
+    )
+    .map_err(|_| PohRecorderError::ResetBankError(old_parent_slot, new_parent_slot))?;
+
+    // Re-inject accumulated transactions back to banking stage for rescheduling
+    let packets: Vec<BytesPacket> = accumulated_txs
+        .into_iter()
+        .filter_map(|tx| {
+            let serialized = wincode::serialize(&tx)
+                .inspect_err(|e| {
+                    error!(
+                        "failed to serialize transaction for rescheduling - this should never \
+                         happen: {e:?}"
+                    )
+                })
+                .ok()?;
+            let buffer = Bytes::from(serialized);
+            let mut meta = Meta::default();
+            meta.size = buffer.len();
+            Some(BytesPacket::new(buffer, meta))
+        })
+        .collect();
+
+    if !packets.is_empty() {
+        info!(
+            "{}: rescheduling {} txs after sad leader handover for slot {slot}",
+            ctx.my_pubkey,
+            packets.len(),
+        );
+        let batch: PacketBatch = packets.into();
+        let banking_packet_batch = Arc::new(vec![batch]);
+        ctx.banking_stage_sender
+            .send(banking_packet_batch)
+            .map_err(|_| PohRecorderError::RescheduleTransactionsError(slot))?;
+    }
+
+    Ok(Some(new_bank))
+}
+
+/// Shut down record intake and synchronously record all already-reserved batches.
+///
+/// When `accumulated_txs` is provided, the drained transactions are retained so
+/// sad handover can reschedule them against the recreated bank.
+fn shutdown_and_drain_record_receiver(
+    poh_recorder: &RwLock<PohRecorder>,
+    record_receiver: &mut RecordReceiver,
+    mut accumulated_txs: Option<&mut Vec<VersionedTransaction>>,
+) -> Result<(), PohRecorderError> {
+    record_receiver.shutdown();
+
+    for record in record_receiver.drain_after_shutdown() {
+        if let Some(accumulated_txs) = accumulated_txs.as_deref_mut() {
+            record.transaction_batches.iter().for_each(|batch| {
+                accumulated_txs.extend(batch.iter().cloned());
+            });
+        }
+
+        poh_recorder.write().unwrap().record(
+            record.bank_id,
+            record.mixins,
+            record.transaction_batches,
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Returns the time remaining until timeout.
+fn time_left(block_timer: Instant, timeout: Duration) -> Duration {
+    timeout.saturating_sub(block_timer.elapsed())
 }
 
 /// Similar to `maybe_start_leader`, however if replay of the parent block is lagging we retry
@@ -548,6 +1058,7 @@ fn record_and_complete_block(
 fn start_leader_wait_for_parent_replay(
     slot: Slot,
     parent_slot: Slot,
+    parent_hash: Option<Hash>,
     block_timer: Instant,
     ctx: &mut LeaderContext,
 ) -> Result<Arc<Bank>, StartLeaderError> {
@@ -563,7 +1074,7 @@ fn start_leader_wait_for_parent_replay(
     let end_slot = last_of_consecutive_leader_slots(slot);
 
     let mut slot_delay_start = Measure::start("slot_delay");
-    while !timeout.saturating_sub(block_timer.elapsed()).is_zero() {
+    while !time_left(block_timer, timeout).is_zero() {
         ctx.slot_metrics.attempt_start_leader_count += 1;
 
         // Check if the entire window is skipped.
@@ -580,7 +1091,7 @@ fn start_leader_wait_for_parent_replay(
             ));
         }
 
-        match maybe_start_leader(slot, parent_slot, ctx) {
+        match maybe_start_leader(slot, parent_slot, parent_hash, ctx) {
             Ok(()) => {
                 slot_delay_start.stop();
                 let _ = ctx
@@ -594,6 +1105,7 @@ fn start_leader_wait_for_parent_replay(
                         );
                     });
 
+                ctx.slot_metrics.report();
                 return Ok(ctx
                     .poh_recorder
                     .read()
@@ -603,8 +1115,8 @@ fn start_leader_wait_for_parent_replay(
             }
             Err(StartLeaderError::ReplayIsBehind(_, _)) => {
                 trace!(
-                    "{my_pubkey}: Attempting to produce slot {slot}, however replay of the the \
-                     parent {parent_slot} is not yet finished, waiting. Skip timer {}",
+                    "{my_pubkey}: Attempting to produce slot {slot}, however replay of the parent \
+                     {parent_slot} is not yet finished, waiting. Block timer {}",
                     block_timer.elapsed().as_millis()
                 );
                 let highest_frozen_slot = ctx
@@ -613,17 +1125,15 @@ fn start_leader_wait_for_parent_replay(
                     .lock()
                     .unwrap();
 
-                // We wait until either we finish replay of the parent or the skip timer finishes
+                // We wait until either we finish replay of the parent or the block timer finishes
                 let mut wait_start = Measure::start("replay_is_behind");
-                let _unused = ctx
-                    .replay_highest_frozen
-                    .freeze_notification
-                    .wait_timeout_while(
-                        highest_frozen_slot,
-                        timeout.saturating_sub(block_timer.elapsed()),
-                        |hfs| *hfs < parent_slot,
-                    )
-                    .unwrap();
+                let _unused = {
+                    let timeout = time_left(block_timer, timeout);
+                    ctx.replay_highest_frozen
+                        .freeze_notification
+                        .wait_timeout_while(highest_frozen_slot, timeout, |hfs| *hfs < parent_slot)
+                        .unwrap()
+                };
                 wait_start.stop();
                 ctx.slot_metrics.replay_is_behind_cumulative_wait_elapsed += wait_start.as_us();
                 let _ = ctx
@@ -636,6 +1146,34 @@ fn start_leader_wait_for_parent_replay(
                             ctx.my_pubkey
                         );
                     });
+            }
+            Err(StartLeaderError::ParentBlockIdMismatch {
+                expected, actual, ..
+            }) => {
+                trace!(
+                    "{my_pubkey}: Attempting to produce slot {slot}, however parent {parent_slot} \
+                     has block id {actual:?}, expected {expected}; waiting for bank switch"
+                );
+                let mut wait_start = Measure::start("parent_block_id_mismatch");
+                let wait_timeout = time_left(block_timer, timeout).min(Duration::from_millis(100));
+                if !wait_timeout.is_zero() {
+                    let highest_frozen_slot = ctx
+                        .replay_highest_frozen
+                        .highest_frozen_slot
+                        .lock()
+                        .unwrap();
+                    let _unused = ctx
+                        .replay_highest_frozen
+                        .freeze_notification
+                        .wait_timeout(highest_frozen_slot, wait_timeout)
+                        .unwrap();
+                }
+                wait_start.stop();
+                ctx.slot_metrics.replay_is_behind_cumulative_wait_elapsed += wait_start.as_us();
+                let _ = ctx
+                    .slot_metrics
+                    .replay_is_behind_wait_elapsed_hist
+                    .increment(wait_start.as_us());
             }
             Err(e) => return Err(e),
         }
@@ -659,6 +1197,7 @@ fn start_leader_wait_for_parent_replay(
 fn maybe_start_leader(
     slot: Slot,
     parent_slot: Slot,
+    parent_hash: Option<Hash>,
     ctx: &mut LeaderContext,
 ) -> Result<(), StartLeaderError> {
     if ctx.bank_forks.read().unwrap().get(slot).is_some() {
@@ -674,6 +1213,18 @@ fn maybe_start_leader(
     if !parent_bank.is_frozen() {
         ctx.slot_metrics.replay_is_behind_count += 1;
         return Err(StartLeaderError::ReplayIsBehind(parent_slot, slot));
+    }
+
+    if let Some(expected) = parent_hash.filter(|hash| *hash != Hash::default()) {
+        let actual = parent_bank.block_id();
+        if actual != Some(expected) {
+            return Err(StartLeaderError::ParentBlockIdMismatch {
+                leader_slot: slot,
+                parent_slot,
+                expected,
+                actual,
+            });
+        }
     }
 
     // Create and insert the bank
@@ -713,6 +1264,14 @@ fn create_and_insert_leader_bank(
         );
     }
 
+    if ctx.poh_recorder.read().unwrap().start_slot() != parent_slot {
+        // Important to keep Poh somewhat accurate for
+        // parts of the system relying on PohRecorder::would_be_leader()
+        reset_poh_recorder(&parent_bank, ctx);
+    }
+
+    // After potentially resetting, there should be no working bank.
+    // If there still is one, something has gone wrong.
     if let Some(bank) = ctx.poh_recorder.read().unwrap().bank() {
         panic!(
             "{}: Attempting to produce a block for {slot}, however we still are in production of \
@@ -720,12 +1279,6 @@ fn create_and_insert_leader_bank(
             ctx.my_pubkey,
             bank.slot(),
         );
-    }
-
-    if ctx.poh_recorder.read().unwrap().start_slot() != parent_slot {
-        // Important to keep Poh somewhat accurate for
-        // parts of the system relying on PohRecorder::would_be_leader()
-        reset_poh_recorder(&parent_bank, ctx);
     }
 
     let tpu_bank = ReplayStage::new_bank_from_parent_with_notify(
@@ -751,8 +1304,13 @@ fn create_and_insert_leader_bank(
     let bank_id = tpu_bank.bank_id();
     ctx.poh_recorder.write().unwrap().set_bank(tpu_bank);
 
-    // If this is the first alpenglow block, emit the genesis certificate marker
-    maybe_include_genesis_certificate(parent_slot, ctx);
+    // If this is the first alpenglow block, emit the genesis certificate marker.
+    // This happens before record intake restarts, so a send failure can be
+    // recovered by clearing the just-created bank and resetting PoH.
+    if let Err(err) = maybe_include_genesis_certificate(parent_slot, ctx) {
+        abort_working_bank(ctx, slot)?;
+        return Err(StartLeaderError::PohRecorder(err));
+    }
 
     // Wakeup banking stage
     ctx.record_receiver.restart(bank_id);
@@ -769,19 +1327,18 @@ fn create_and_insert_leader_bank(
 ///  Note: if the alpenglow genesis is 0, then this is a test cluster with Alpenglow enabled
 ///  by default. No need to put in the genesis marker as the genesis account is already populated
 ///  during cluster creation.
-fn maybe_include_genesis_certificate(parent_slot: Slot, ctx: &LeaderContext) {
+fn maybe_include_genesis_certificate(
+    parent_slot: Slot,
+    ctx: &LeaderContext,
+) -> Result<(), PohRecorderError> {
     if parent_slot != ctx.genesis_cert.slot || parent_slot == 0 {
-        return;
+        return Ok(());
     }
-    let genesis_marker = VersionedBlockMarker::V1(BlockMarkerV1::new_genesis_certificate(
-        ctx.genesis_cert.clone(),
-    ));
 
-    let mut poh_recorder = ctx.poh_recorder.write().unwrap();
     // Send the genesis certificate
-    poh_recorder
-        .send_marker(genesis_marker)
-        .expect("Max tick height cannot have been reached");
+    let genesis_marker = VersionedBlockMarker::new_genesis_certificate(ctx.genesis_cert.clone());
+    let mut poh_recorder = ctx.poh_recorder.write().unwrap();
+    poh_recorder.send_marker(genesis_marker)?;
 
     // Process the genesis certificate
     let bank = poh_recorder.bank().expect("Bank cannot have been cleared");
@@ -793,4 +1350,628 @@ fn maybe_include_genesis_certificate(parent_slot: Slot, ctx: &LeaderContext) {
             &ctx.bank_forks.read().unwrap().migration_status(),
         )
         .expect("Recording genesis certificate should not fail");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::banking_trace::BankingTracer,
+        agave_banking_stage_ingress_types::BankingPacketReceiver,
+        agave_votor_messages::reward_certificate::{BuildRewardCertsRespError, RewardCertError},
+        crossbeam_channel::unbounded,
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
+        solana_entry::{block_component::VersionedUpdateParent, entry_or_marker::EntryOrMarker},
+        solana_keypair::Keypair,
+        solana_leader_schedule::{FixedSchedule, LeaderSchedule, SlotLeader},
+        solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path_auto_delete},
+        solana_poh::{
+            poh_recorder::{PohRecorder, Record, WorkingBankEntryOrMarker},
+            record_channels::record_channels,
+        },
+        solana_poh_config::PohConfig,
+        solana_runtime::{
+            bank::Bank, bank_forks::BankForks, genesis_utils::create_genesis_config_with_leader,
+            installed_scheduler_pool::BankWithScheduler,
+        },
+        solana_system_transaction as system_transaction,
+        std::num::NonZeroUsize,
+    };
+
+    fn versioned_transfer(lamports: u64) -> VersionedTransaction {
+        let from = Keypair::new();
+        VersionedTransaction::from(system_transaction::transfer(
+            &from,
+            &Pubkey::new_unique(),
+            lamports,
+            Hash::new_unique(),
+        ))
+    }
+
+    fn test_genesis_certificate() -> GenesisCertificate {
+        GenesisCertificate {
+            slot: Slot::MAX,
+            block_id: Hash::default(),
+            bls_signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        }
+    }
+
+    fn fixed_leader_schedule(my_pubkey: Pubkey, root_bank: &Bank) -> Arc<LeaderScheduleCache> {
+        let mut leader_schedule_cache = LeaderScheduleCache::new_from_bank(root_bank);
+        let leader = SlotLeader {
+            id: my_pubkey,
+            vote_address: Pubkey::new_unique(),
+        };
+        let schedule = LeaderSchedule::new_from_schedule(vec![leader; 32], NonZeroUsize::MIN);
+        leader_schedule_cache.set_fixed_leader_schedule(Some(FixedSchedule {
+            leader_schedule: Arc::new(schedule),
+        }));
+        Arc::new(leader_schedule_cache)
+    }
+
+    struct TestBankForksController {
+        bank_forks: Arc<RwLock<BankForks>>,
+    }
+
+    impl BankForksController for TestBankForksController {
+        fn insert_bank(&self, bank: Bank) -> Result<BankWithScheduler, BankForksControllerError> {
+            Ok(self.bank_forks.write().unwrap().insert(bank))
+        }
+
+        fn set_root(
+            &self,
+            _my_pubkey: Pubkey,
+            _parent_slot: Slot,
+            new_root: Slot,
+            highest_super_majority_root: Option<Slot>,
+        ) -> Result<(), BankForksControllerError> {
+            // Test code only so we allow writing bank forks directly.
+            self.bank_forks
+                .write()
+                .unwrap()
+                .set_root(new_root, None, highest_super_majority_root);
+            Ok(())
+        }
+
+        fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError> {
+            let bank_to_clear = self.bank_forks.read().unwrap().get_with_scheduler(slot);
+            if let Some(bank) = bank_to_clear {
+                let _ = bank.wait_for_completed_scheduler();
+            }
+            self.bank_forks.write().unwrap().clear_bank(slot, false);
+            Ok(())
+        }
+    }
+
+    fn test_bank_forks_controller(
+        bank_forks: Arc<RwLock<BankForks>>,
+    ) -> Arc<dyn BankForksController> {
+        Arc::new(TestBankForksController { bank_forks })
+    }
+
+    fn leader_window_info(start_slot: Slot, parent_slot: Slot) -> LeaderWindowInfo {
+        LeaderWindowInfo {
+            start_slot,
+            end_slot: last_of_consecutive_leader_slots(start_slot),
+            parent_block: (parent_slot, Hash::new_unique()),
+            block_timer: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn test_freshest_window_highest() {
+        let selected = freshest_window_from_iter(
+            Some(leader_window_info(8, 7)),
+            [
+                leader_window_info(16, 15),
+                leader_window_info(12, 11),
+                leader_window_info(4, 3),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(selected.start_slot, 16);
+        assert_eq!(selected.parent_block.0, 15);
+    }
+
+    #[test]
+    fn test_freshest_window_tie() {
+        let selected =
+            freshest_window_from_iter(Some(leader_window_info(8, 7)), [leader_window_info(8, 6)])
+                .unwrap();
+
+        assert_eq!(selected.start_slot, 8);
+        assert_eq!(selected.parent_block.0, 6);
+    }
+
+    fn recv_update_parent_marker(
+        entry_receiver: &Receiver<WorkingBankEntryOrMarker>,
+    ) -> UpdateParentV1 {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            assert!(
+                !timeout.is_zero(),
+                "timed out waiting for UpdateParent marker"
+            );
+            let (_bank, (entry_or_marker, _tick_height)) =
+                entry_receiver.recv_timeout(timeout).unwrap();
+            let EntryOrMarker::Marker(VersionedBlockMarker::V1(marker)) = entry_or_marker else {
+                continue;
+            };
+            let Some(VersionedUpdateParent::V1(update_parent)) = marker.as_update_parent() else {
+                continue;
+            };
+            return update_parent.clone();
+        }
+    }
+
+    fn recv_rescheduled_transactions(
+        receiver: &BankingPacketReceiver,
+    ) -> Vec<VersionedTransaction> {
+        let packet_batches = receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        packet_batches
+            .iter()
+            .flat_map(|batch| batch.iter())
+            .map(|packet| {
+                wincode::deserialize::<VersionedTransaction>(
+                    packet.data(..packet.meta().size).unwrap(),
+                )
+                .unwrap()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_abort_failed_working_bank() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let my_pubkey = Pubkey::new_unique();
+        let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
+        let root_bank = Bank::new_for_tests(&genesis.genesis_config);
+        root_bank.freeze();
+        let bank_forks = BankForks::new_rw_arc(root_bank);
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader_schedule_cache = fixed_leader_schedule(my_pubkey, &root_bank);
+
+        let exit = Arc::new(AtomicBool::new(false));
+        let poh_config = PohConfig::default();
+        let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
+            root_bank.tick_height(),
+            root_bank.last_blockhash(),
+            root_bank.clone(),
+            Some((1, 1)),
+            root_bank.ticks_per_slot(),
+            blockstore.clone(),
+            &leader_schedule_cache,
+            &poh_config,
+            exit.clone(),
+        );
+        poh_recorder.enable_alpenglow();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+
+        let (_record_sender, record_receiver) = record_channels(false);
+        let (_leader_window_info_sender, leader_window_info_receiver) = unbounded();
+        let (build_reward_certs_sender, _build_reward_certs_receiver) = unbounded();
+        let (reward_certs_sender, reward_certs_receiver) = unbounded();
+        let (banking_stage_sender, _banking_stage_receiver) = BankingTracer::channel_for_test();
+        let bank_forks_controller = test_bank_forks_controller(bank_forks.clone());
+
+        let mut ctx = LeaderContext {
+            exit,
+            my_pubkey,
+            leader_window_info_receiver,
+            pending_parent_ready: None,
+            highest_parent_ready: Arc::new(RwLock::new((0, (0, Hash::default())))),
+            highest_finalized: Arc::new(RwLock::new(None)),
+            blockstore,
+            record_receiver,
+            poh_recorder,
+            leader_schedule_cache,
+            bank_forks,
+            bank_forks_controller,
+            rpc_subscriptions: None,
+            slot_status_notifier: None,
+            banking_tracer: BankingTracer::new_disabled(),
+            replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
+            build_reward_certs_sender,
+            reward_certs_receiver,
+            banking_stage_sender,
+            metrics: LoopMetrics::default(),
+            slot_metrics: SlotMetrics::default(),
+            genesis_cert: test_genesis_certificate(),
+        };
+
+        create_and_insert_leader_bank(1, root_bank.clone(), &mut ctx).unwrap();
+        assert!(ctx.poh_recorder.read().unwrap().has_bank());
+        assert!(ctx.bank_forks.read().unwrap().get(1).is_some());
+
+        let bank = ctx.poh_recorder.read().unwrap().bank().unwrap();
+        let in_flight_commit = bank.freeze_lock();
+        ctx.record_receiver.shutdown();
+        for _ in ctx.record_receiver.drain_after_shutdown() {}
+        let (abort_started_sender, abort_started_receiver) = unbounded();
+        let (abort_done_sender, abort_done_receiver) = unbounded();
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                abort_started_sender.send(()).unwrap();
+                abort_working_bank(&mut ctx, 1).unwrap();
+                abort_done_sender.send(()).unwrap();
+            });
+            abort_started_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap();
+            assert!(
+                abort_done_receiver
+                    .recv_timeout(Duration::from_millis(50))
+                    .is_err()
+            );
+            drop(in_flight_commit);
+            abort_done_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap();
+        });
+        create_and_insert_leader_bank(1, root_bank, &mut ctx).unwrap();
+        assert!(ctx.poh_recorder.read().unwrap().has_bank());
+        assert!(ctx.bank_forks.read().unwrap().get(1).is_some());
+
+        abort_failed_working_bank(&mut ctx, 1).unwrap();
+        assert!(!ctx.poh_recorder.read().unwrap().has_bank());
+        assert!(ctx.bank_forks.read().unwrap().get(1).is_none());
+        assert!(ctx.record_receiver.is_shutdown());
+        assert!(ctx.record_receiver.is_safe_to_restart());
+
+        reward_certs_sender
+            .send(BuildRewardCertsResponse {
+                bank_slot: 1,
+                result: Err(BuildRewardCertsRespError::RewardCertTryNew(
+                    RewardCertError::InvalidBitmap,
+                )),
+            })
+            .unwrap();
+        reward_certs_sender
+            .send(BuildRewardCertsResponse {
+                bank_slot: 2,
+                result: Ok(BuildRewardCertsRespSucc {
+                    validators: vec![my_pubkey],
+                    ..BuildRewardCertsRespSucc::default()
+                }),
+            })
+            .unwrap();
+
+        let reward_certs = recv_reward_certs(&ctx, 2).unwrap();
+        assert_eq!(reward_certs.validators, vec![my_pubkey]);
+    }
+
+    #[test]
+    fn test_marker_send_clears_bank() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let my_pubkey = Pubkey::new_unique();
+        let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
+        let root_bank = Bank::new_for_tests(&genesis.genesis_config);
+        root_bank.freeze();
+        let bank_forks = BankForks::new_rw_arc(root_bank);
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader_schedule_cache = fixed_leader_schedule(my_pubkey, &root_bank);
+        let parent_bank = Bank::new_from_parent(
+            root_bank.clone(),
+            SlotLeader {
+                id: my_pubkey,
+                vote_address: Pubkey::new_unique(),
+            },
+            1,
+        );
+        parent_bank.freeze();
+        bank_forks.write().unwrap().insert(parent_bank);
+        let parent_bank = bank_forks.read().unwrap().get(1).unwrap();
+
+        let exit = Arc::new(AtomicBool::new(false));
+        let poh_config = PohConfig::default();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(
+            root_bank.tick_height(),
+            root_bank.last_blockhash(),
+            root_bank,
+            Some((2, 2)),
+            parent_bank.ticks_per_slot(),
+            blockstore.clone(),
+            &leader_schedule_cache,
+            &poh_config,
+            exit.clone(),
+        );
+        poh_recorder.enable_alpenglow();
+        drop(entry_receiver);
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+
+        let (_record_sender, record_receiver) = record_channels(false);
+        let (_leader_window_info_sender, leader_window_info_receiver) = unbounded();
+        let (build_reward_certs_sender, _build_reward_certs_receiver) = unbounded();
+        let (_reward_certs_sender, reward_certs_receiver) = unbounded();
+        let (banking_stage_sender, _banking_stage_receiver) = BankingTracer::channel_for_test();
+        let mut genesis_cert = test_genesis_certificate();
+        genesis_cert.slot = parent_bank.slot();
+        let bank_forks_controller = test_bank_forks_controller(bank_forks.clone());
+
+        let mut ctx = LeaderContext {
+            exit,
+            my_pubkey,
+            leader_window_info_receiver,
+            pending_parent_ready: None,
+            highest_parent_ready: Arc::new(RwLock::new((0, (0, Hash::default())))),
+            highest_finalized: Arc::new(RwLock::new(None)),
+            blockstore,
+            record_receiver,
+            poh_recorder,
+            leader_schedule_cache,
+            bank_forks,
+            bank_forks_controller,
+            rpc_subscriptions: None,
+            slot_status_notifier: None,
+            banking_tracer: BankingTracer::new_disabled(),
+            replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
+            build_reward_certs_sender,
+            reward_certs_receiver,
+            banking_stage_sender,
+            metrics: LoopMetrics::default(),
+            slot_metrics: SlotMetrics::default(),
+            genesis_cert,
+        };
+
+        let err = create_and_insert_leader_bank(2, parent_bank, &mut ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            StartLeaderError::PohRecorder(PohRecorderError::SendError(_))
+        ));
+        assert!(!ctx.poh_recorder.read().unwrap().has_bank());
+        assert!(ctx.bank_forks.read().unwrap().get(2).is_none());
+        assert!(ctx.record_receiver.is_shutdown());
+        assert!(ctx.record_receiver.is_safe_to_restart());
+    }
+
+    #[test]
+    fn test_moved_on_aborts() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let my_pubkey = Pubkey::new_unique();
+        let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
+        let root_bank = Bank::new_for_tests(&genesis.genesis_config);
+        root_bank.freeze();
+        let bank_forks = BankForks::new_rw_arc(root_bank);
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader_schedule_cache = fixed_leader_schedule(my_pubkey, &root_bank);
+
+        let exit = Arc::new(AtomicBool::new(false));
+        let poh_config = PohConfig::default();
+        let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
+            root_bank.tick_height(),
+            root_bank.last_blockhash(),
+            root_bank.clone(),
+            Some((1, 1)),
+            root_bank.ticks_per_slot(),
+            blockstore.clone(),
+            &leader_schedule_cache,
+            &poh_config,
+            exit.clone(),
+        );
+        poh_recorder.enable_alpenglow();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+
+        let (record_sender, record_receiver) = record_channels(false);
+        let (_leader_window_info_sender, leader_window_info_receiver) = unbounded();
+        let (build_reward_certs_sender, build_reward_certs_receiver) = unbounded();
+        let (reward_certs_sender, reward_certs_receiver) = unbounded();
+        let (banking_stage_sender, _banking_stage_receiver) = BankingTracer::channel_for_test();
+        let bank_forks_controller = test_bank_forks_controller(bank_forks.clone());
+
+        let mut ctx = LeaderContext {
+            exit,
+            my_pubkey,
+            leader_window_info_receiver,
+            pending_parent_ready: None,
+            highest_parent_ready: Arc::new(RwLock::new((2, (0, Hash::default())))),
+            highest_finalized: Arc::new(RwLock::new(None)),
+            blockstore,
+            record_receiver,
+            poh_recorder,
+            leader_schedule_cache,
+            bank_forks,
+            bank_forks_controller,
+            rpc_subscriptions: None,
+            slot_status_notifier: None,
+            banking_tracer: BankingTracer::new_disabled(),
+            replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
+            build_reward_certs_sender,
+            reward_certs_receiver,
+            banking_stage_sender,
+            metrics: LoopMetrics::default(),
+            slot_metrics: SlotMetrics::default(),
+            genesis_cert: test_genesis_certificate(),
+        };
+
+        create_and_insert_leader_bank(1, root_bank, &mut ctx).unwrap();
+        let bank_id = ctx.poh_recorder.read().unwrap().bank().unwrap().bank_id();
+        record_sender
+            .try_send(Record::new(
+                vec![Hash::new_unique()],
+                vec![vec![versioned_transfer(1)]],
+                bank_id,
+            ))
+            .unwrap();
+
+        let delayed_reward = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(300));
+            let _ = reward_certs_sender.send(BuildRewardCertsResponse {
+                bank_slot: 1,
+                result: Ok(BuildRewardCertsRespSucc::default()),
+            });
+        });
+
+        let start = Instant::now();
+        let result =
+            record_and_complete_block(&mut ctx, 1, None, &mut Instant::now(), Duration::ZERO);
+        assert!(matches!(result, Err(PohRecorderError::WindowMovedOn(1))));
+        assert!(start.elapsed() < Duration::from_millis(250));
+        assert!(!ctx.poh_recorder.read().unwrap().has_bank());
+        assert!(ctx.bank_forks.read().unwrap().get(1).is_none());
+        assert!(ctx.record_receiver.is_shutdown());
+        assert!(ctx.record_receiver.is_safe_to_restart());
+        assert_eq!(
+            build_reward_certs_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap()
+                .bank_slot,
+            1
+        );
+
+        delayed_reward.join().unwrap();
+    }
+
+    #[test]
+    fn test_sad_leader_handover() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let my_pubkey = Pubkey::new_unique();
+        let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
+        let root_bank = Bank::new_for_tests(&genesis.genesis_config);
+        root_bank.set_block_id(Some(Hash::new_unique()));
+        root_bank.freeze();
+        let bank_forks = BankForks::new_rw_arc(root_bank);
+        let root_bank = bank_forks.read().unwrap().root_bank();
+
+        let leader_schedule_cache = fixed_leader_schedule(my_pubkey, &root_bank);
+
+        let new_parent_slot = 1;
+        let new_parent_hash = Hash::new_unique();
+        let new_parent = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            root_bank.clone(),
+            SlotLeader::new_unique(),
+            new_parent_slot,
+        );
+        new_parent.freeze();
+        new_parent.set_block_id(Some(new_parent_hash));
+
+        let optimistic_parent_slot = 3;
+        let optimistic_parent_hash = Hash::new_unique();
+        let optimistic_parent = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            root_bank.clone(),
+            SlotLeader::new_unique(),
+            optimistic_parent_slot,
+        );
+        optimistic_parent.freeze();
+        optimistic_parent.set_block_id(Some(optimistic_parent_hash));
+
+        let exit = Arc::new(AtomicBool::new(false));
+        let poh_config = PohConfig::default();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(
+            root_bank.tick_height(),
+            root_bank.last_blockhash(),
+            root_bank.clone(),
+            Some((4, 7)),
+            root_bank.ticks_per_slot(),
+            blockstore.clone(),
+            &leader_schedule_cache,
+            &poh_config,
+            exit.clone(),
+        );
+        poh_recorder.enable_alpenglow();
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
+
+        let (record_sender, record_receiver) = record_channels(false);
+        let (leader_window_info_sender, leader_window_info_receiver) = unbounded();
+        let (build_reward_certs_sender, _build_reward_certs_receiver) = unbounded();
+        let (_reward_certs_sender, reward_certs_receiver) = unbounded();
+        let (banking_stage_sender, banking_stage_receiver) = BankingTracer::channel_for_test();
+        let bank_forks_controller = test_bank_forks_controller(bank_forks.clone());
+
+        let mut ctx = LeaderContext {
+            exit,
+            my_pubkey,
+            leader_window_info_receiver,
+            pending_parent_ready: None,
+            highest_parent_ready: Arc::new(RwLock::new((4, (new_parent_slot, new_parent_hash)))),
+            highest_finalized: Arc::new(RwLock::new(None)),
+            blockstore,
+            record_receiver,
+            poh_recorder,
+            leader_schedule_cache,
+            bank_forks,
+            bank_forks_controller,
+            rpc_subscriptions: None,
+            slot_status_notifier: None,
+            banking_tracer: BankingTracer::new_disabled(),
+            replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
+            build_reward_certs_sender,
+            reward_certs_receiver,
+            banking_stage_sender,
+            metrics: LoopMetrics::default(),
+            slot_metrics: SlotMetrics::default(),
+            genesis_cert: test_genesis_certificate(),
+        };
+
+        let leader_slot = 4;
+        create_and_insert_leader_bank(leader_slot, optimistic_parent, &mut ctx).unwrap();
+        let optimistic_bank_id = ctx.poh_recorder.read().unwrap().bank().unwrap().bank_id();
+
+        let accumulated_tx = versioned_transfer(1);
+        let drained_tx = versioned_transfer(2);
+        record_sender
+            .try_send(Record::new(
+                vec![Hash::new_unique()],
+                vec![vec![drained_tx.clone()]],
+                optimistic_bank_id,
+            ))
+            .unwrap();
+
+        let parent_ready = LeaderWindowInfo {
+            start_slot: leader_slot,
+            end_slot: 7,
+            parent_block: (new_parent_slot, new_parent_hash),
+            block_timer: Instant::now(),
+        };
+        let new_bank = handle_parent_ready(
+            &mut ctx,
+            parent_ready,
+            (optimistic_parent_slot, optimistic_parent_hash),
+            vec![accumulated_tx.clone()],
+            &mut Instant::now(),
+        )
+        .unwrap()
+        .expect("sad handover should recreate the leader bank");
+
+        assert_eq!(new_bank.slot(), leader_slot);
+        assert_eq!(new_bank.parent_slot(), new_parent_slot);
+        assert_eq!(
+            ctx.bank_forks
+                .read()
+                .unwrap()
+                .get(leader_slot)
+                .unwrap()
+                .parent_slot(),
+            new_parent_slot
+        );
+        assert_eq!(
+            ctx.poh_recorder
+                .read()
+                .unwrap()
+                .bank()
+                .unwrap()
+                .parent_slot(),
+            new_parent_slot
+        );
+
+        let update_parent = recv_update_parent_marker(&entry_receiver);
+        assert_eq!(update_parent.new_parent_slot, new_parent_slot);
+        assert_eq!(update_parent.new_parent_block_id, new_parent_hash);
+
+        let rescheduled = recv_rescheduled_transactions(&banking_stage_receiver);
+        assert_eq!(rescheduled.len(), 2);
+        assert!(rescheduled.contains(&accumulated_tx));
+        assert!(rescheduled.contains(&drained_tx));
+
+        drop(leader_window_info_sender);
+    }
 }

--- a/core/src/block_creation_loop/stats.rs
+++ b/core/src/block_creation_loop/stats.rs
@@ -108,6 +108,10 @@ impl LoopMetrics {
 pub(crate) struct SlotMetrics {
     pub(crate) slot: Slot,
     pub(crate) attempt_start_leader_count: u64,
+    /// Indicates we have attempted fast leader handover
+    pub(crate) leader_handover_fast: bool,
+    /// Indicates we had to switch parent.
+    pub(crate) leader_handover_sad: bool,
     pub(crate) replay_is_behind_count: u64,
     pub(crate) already_have_bank_count: u64,
 
@@ -122,6 +126,8 @@ impl SlotMetrics {
             "slot-metrics",
             ("slot", self.slot, i64),
             ("attempt_count", self.attempt_start_leader_count, i64),
+            ("leader_handover_fast", self.leader_handover_fast, i64),
+            ("leader_handover_sad", self.leader_handover_sad, i64),
             ("replay_is_behind_count", self.replay_is_behind_count, i64),
             ("already_have_bank_count", self.already_have_bank_count, i64),
             (
@@ -178,8 +184,42 @@ impl SlotMetrics {
         );
     }
 
+    pub(crate) fn mark_leader_handover_fast(&mut self) {
+        self.leader_handover_fast = true;
+    }
+
+    pub(crate) fn mark_leader_handover_sad(&mut self) {
+        self.leader_handover_sad = true;
+    }
+
     pub(crate) fn reset(&mut self, slot: Slot) {
+        let same_slot = self.slot == slot;
+        let leader_handover_fast = same_slot && self.leader_handover_fast;
+        let leader_handover_sad = same_slot && self.leader_handover_sad;
         *self = Self::default();
+        self.leader_handover_fast = leader_handover_fast;
+        self.leader_handover_sad = leader_handover_sad;
         self.slot = slot;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slot_metrics_handover() {
+        let mut metrics = SlotMetrics::default();
+        metrics.reset(42);
+        metrics.mark_leader_handover_fast();
+        metrics.mark_leader_handover_sad();
+
+        metrics.reset(42);
+        assert!(metrics.leader_handover_fast);
+        assert!(metrics.leader_handover_sad);
+
+        metrics.reset(43);
+        assert!(!metrics.leader_handover_fast);
+        assert!(!metrics.leader_handover_sad);
     }
 }

--- a/core/src/consensus/progress_map.rs
+++ b/core/src/consensus/progress_map.rs
@@ -81,8 +81,17 @@ impl RetransmitInfo {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DeadSlotReason {
+    /// Dead and cannot be brought back to life by an `UpdateParent` marker.
+    Hard,
+    /// Replay execution failed, but an `UpdateParent` marker could still make
+    /// the failed prefix obsolete.
+    ReplayFailureBeforeUpdateParent,
+}
+
 pub struct ForkProgress {
-    pub is_dead: bool,
+    pub dead_reason: Option<DeadSlotReason>,
     pub fork_stats: ForkStats,
     pub propagated_stats: PropagatedStats,
     pub replay_stats: Arc<RwLock<ReplaySlotStats>>,
@@ -131,7 +140,7 @@ impl ForkProgress {
             .unwrap_or((false, 0, HashSet::new(), false, 0));
 
         Self {
-            is_dead: false,
+            dead_reason: None,
             fork_stats: ForkStats::default(),
             replay_stats: Arc::new(RwLock::new(ReplaySlotStats::default())),
             replay_progress: Arc::new(RwLock::new(
@@ -189,6 +198,10 @@ impl ForkProgress {
             new_progress.fork_stats.bank_hash = Some(bank.hash());
         }
         new_progress
+    }
+
+    pub fn mark_dead(&mut self, reason: DeadSlotReason) {
+        self.dead_reason = Some(reason);
     }
 }
 
@@ -338,7 +351,13 @@ impl ProgressMap {
     pub fn is_dead(&self, slot: Slot) -> Option<bool> {
         self.progress_map
             .get(&slot)
-            .map(|fork_progress| fork_progress.is_dead)
+            .map(|fork_progress| fork_progress.dead_reason.is_some())
+    }
+
+    pub fn dead_reason(&self, slot: Slot) -> Option<&DeadSlotReason> {
+        self.progress_map
+            .get(&slot)
+            .and_then(|fork_progress| fork_progress.dead_reason.as_ref())
     }
 
     pub fn get_hash(&self, slot: Slot) -> Option<Hash> {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1,5 +1,4 @@
 //! The `replay_stage` replays transactions broadcast by the leader.
-
 use {
     crate::{
         banking_stage::update_bank_forks_and_poh_recorder_for_new_tpu_bank,
@@ -34,7 +33,7 @@ use {
         window_service::DuplicateSlotReceiver,
     },
     agave_votor::{
-        event::{CompletedBlock, VotorEvent, VotorEventSender},
+        event::{CompletedBlock, LeaderWindowInfo, VotorEvent, VotorEventSender},
         root_utils,
         vote_history_storage::SavedVoteHistory,
         voting_service::BLSOp,
@@ -45,7 +44,8 @@ use {
         migration::{GENESIS_VOTE_REFRESH, MigrationStatus},
         vote::Vote,
     },
-    crossbeam_channel::{Receiver, Sender, TryRecvError, select},
+    crossbeam_channel::{Receiver, Sender, TryRecvError, TrySendError, select},
+    itertools::Itertools,
     rayon::{ThreadPool, prelude::*},
     solana_accounts_db::contains::Contains,
     solana_clock::{BankId, NUM_CONSECUTIVE_LEADER_SLOTS, Slot},
@@ -55,8 +55,7 @@ use {
     solana_keypair::Keypair,
     solana_leader_schedule::SlotLeader,
     solana_ledger::{
-        block_error::BlockError,
-        blockstore::Blockstore,
+        blockstore::{Blockstore, UpdateParentReceiver},
         blockstore_processor::{
             self, AsyncVerificationProgress, BlockstoreProcessorError, ChainedBlockIdCheck,
             ConfirmationProgress, ExecuteBatchesInternalMetrics, ReplaySlotStats,
@@ -78,11 +77,11 @@ use {
         rpc_subscriptions::RpcSubscriptions,
         slot_status_notifier::SlotStatusNotifier,
     },
-    solana_rpc_client_api::response::SlotUpdate,
     solana_runtime::{
         bank::{Bank, NewBankOptions, bank_hash_details},
         bank_forks::BankForks,
         bank_forks_controller::{BankForksCommand, BankForksCommandReceiver},
+        block_component_processor::BlockComponentProcessorError,
         commitment::BlockCommitmentCache,
         installed_scheduler_pool::BankWithScheduler,
         leader_schedule_utils::first_of_consecutive_leader_slots,
@@ -109,6 +108,19 @@ use {
     },
 };
 
+mod dead_slots;
+mod update_parent;
+
+use {
+    dead_slots::{
+        DeadSlotContext, DeadSlotDuplicateContext, DeadSlotNotifications, mark_replay_dead_slot,
+    },
+    update_parent::{
+        ChildBankReplayStart, child_bank_replay_start, handle_abandoned_bank,
+        handle_update_parent_interrupts, process_soft_dead_slots,
+    },
+};
+
 pub const MAX_ENTRY_RECV_PER_ITER: usize = 512;
 pub const SUPERMINORITY_THRESHOLD: f64 = 1f64 / 3f64;
 pub const MAX_UNCONFIRMED_SLOTS: usize = 5;
@@ -124,6 +136,7 @@ const MAX_REPAIR_RETRY_LOOP_ATTEMPTS: usize = 10;
 static_assertions::const_assert!(REFRESH_VOTE_BLOCKHEIGHT < solana_clock::MAX_PROCESSING_AGE);
 // Give at least 4 leaders the chance to pack our vote
 const REFRESH_VOTE_BLOCKHEIGHT: usize = 16;
+
 #[derive(PartialEq, Eq, Debug)]
 pub enum HeaviestForkFailures {
     LockedOut(u64),
@@ -185,6 +198,20 @@ impl ReplaySlotFromBlockstore {
     }
 }
 
+/// Select the freshest leader-window notification by start slot, replacing equal
+/// start slots with the later notification. This intentionally mirrors BCL's
+/// `freshest_window_from_iter` selection logic.
+fn freshest_leader_window(
+    current: LeaderWindowInfo,
+    candidate: LeaderWindowInfo,
+) -> LeaderWindowInfo {
+    if current.start_slot > candidate.start_slot {
+        current
+    } else {
+        candidate
+    }
+}
+
 struct BankReplayTracker {
     // The bank being replayed.
     bank: BankWithScheduler,
@@ -231,6 +258,59 @@ struct ProcessBankForksContext {
     rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
     drop_bank_sender: Sender<Vec<BankWithScheduler>>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
+}
+
+impl ProcessActiveBanksContext {
+    /// Clone the handles needed to publish a dead-slot transition to blockstore,
+    /// replay-vote, RPC, and the optional slot-status notifier.
+    fn dead_slot_notifications(&self) -> DeadSlotNotifications {
+        DeadSlotNotifications {
+            blockstore: self.blockstore.clone(),
+            rpc_subscriptions: self.rpc_subscriptions.clone(),
+            slot_status_notifier: self.slot_status_notifier.clone(),
+            replay_vote_sender: self.replay_vote_sender.clone(),
+        }
+    }
+
+    /// Build the full context needed when a replay error must become a hard or
+    /// soft dead-slot transition.
+    fn dead_slot_context<'a>(
+        &'a self,
+        root: Slot,
+        duplicate_slots_to_repair: &'a mut DuplicateSlotsToRepair,
+        purge_repair_slot_counter: &'a mut PurgeRepairSlotCounter,
+        tbft_structs: Option<&'a mut TowerBFTStructures>,
+    ) -> DeadSlotContext<'a> {
+        DeadSlotContext {
+            notifications: self.dead_slot_notifications(),
+            duplicate: DeadSlotDuplicateContext {
+                root,
+                duplicate_slots_to_repair,
+                ancestor_hashes_replay_update_sender: &self.ancestor_hashes_replay_update_sender,
+                purge_repair_slot_counter,
+                tbft_structs,
+            },
+            migration_status: self.migration_status.as_ref(),
+        }
+    }
+}
+
+/// Borrowed inputs that do not change while discovering new replay banks.
+struct NewBankForksContext<'a> {
+    /// Ledger data and SlotMeta used to discover children of frozen banks.
+    blockstore: &'a Blockstore,
+    /// Fork graph where new banks are inserted after discovery.
+    bank_forks: &'a RwLock<BankForks>,
+    /// Leader schedule used to construct child banks.
+    leader_schedule_cache: &'a LeaderScheduleCache,
+    /// Optional RPC fanout for bank-created notifications.
+    rpc_subscriptions: Option<&'a RpcSubscriptions>,
+    /// Optional slot-status fanout for bank-created notifications.
+    slot_status_notifier: &'a Option<SlotStatusNotifier>,
+    /// Alpenglow migration gates that decide replay offsets and vote-only mode.
+    migration_status: &'a MigrationStatus,
+    /// This validator's identity, used to leave live own-leader banks to BCL.
+    my_pubkey: &'a Pubkey,
 }
 
 #[cfg(test)]
@@ -386,7 +466,6 @@ pub struct ReplayStageConfig {
     pub banking_tracer: Arc<BankingTracer>,
     pub snapshot_controller: Option<Arc<SnapshotController>>,
     pub replay_highest_frozen: Arc<ReplayHighestFrozen>,
-    pub migration_status: Arc<MigrationStatus>,
 }
 
 pub struct ReplaySenders {
@@ -407,11 +486,14 @@ pub struct ReplaySenders {
     pub dumped_slots_sender: Sender<Vec<(u64, Hash)>>,
     pub votor_event_sender: VotorEventSender,
     pub own_vote_sender: Sender<Vec<ConsensusMessage>>,
+    pub optimistic_parent_sender: Sender<LeaderWindowInfo>,
     pub lockouts_sender: Sender<TowerCommitmentAggregationData>,
 }
 
 pub struct ReplayReceivers {
     pub ledger_signal_receiver: Receiver<bool>,
+    pub update_parent_receiver: UpdateParentReceiver,
+    pub optimistic_parent_receiver: Receiver<LeaderWindowInfo>,
     pub duplicate_slots_receiver: Receiver<u64>,
     pub ancestor_duplicate_slots_receiver: Receiver<AncestorDuplicateSlotToRepair>,
     pub duplicate_confirmed_slots_receiver: Receiver<Vec<(u64, Hash)>>,
@@ -698,7 +780,6 @@ impl ReplayStage {
             banking_tracer,
             snapshot_controller,
             replay_highest_frozen,
-            migration_status,
         } = config;
 
         let ReplaySenders {
@@ -719,11 +800,14 @@ impl ReplayStage {
             dumped_slots_sender,
             votor_event_sender,
             own_vote_sender,
+            optimistic_parent_sender,
             lockouts_sender,
         } = senders;
 
         let ReplayReceivers {
             ledger_signal_receiver,
+            update_parent_receiver,
+            optimistic_parent_receiver,
             duplicate_slots_receiver,
             ancestor_duplicate_slots_receiver,
             duplicate_confirmed_slots_receiver,
@@ -734,19 +818,18 @@ impl ReplayStage {
 
         trace!("replay stage");
 
-        let mut identity_keypair = cluster_info.keypair();
+        // Start the replay stage loop
+        let migration_status = bank_forks.read().unwrap().migration_status();
+        let mut identity_keypair = cluster_info.keypair().clone();
         let mut my_pubkey = identity_keypair.pubkey();
 
         let mut highest_frozen_slot = bank_forks
             .read()
             .unwrap()
-            .frozen_banks()
-            .map(|(slot, _)| slot)
-            .max()
-            .unwrap_or(0);
+            .highest_frozen_bank()
+            .map_or(0, |hfs| hfs.slot());
         *replay_highest_frozen.highest_frozen_slot.lock().unwrap() = highest_frozen_slot;
 
-        // Start the replay stage loop
         let run_replay = move || {
             let _exit = Finalizer::new(exit.clone());
 
@@ -900,17 +983,31 @@ impl ReplayStage {
                     break;
                 }
 
+                handle_update_parent_interrupts(
+                    &my_pubkey,
+                    &blockstore,
+                    &bank_forks,
+                    &mut progress,
+                    &mut async_verification_freelist,
+                    &update_parent_receiver,
+                    &replay_vote_sender,
+                    migration_status.as_ref(),
+                );
+
                 let mut generate_new_bank_forks_time =
                     Measure::start("generate_new_bank_forks_time");
                 Self::generate_new_bank_forks(
-                    &blockstore,
-                    &bank_forks,
-                    &leader_schedule_cache,
-                    rpc_subscriptions.as_deref(),
-                    &slot_status_notifier,
+                    NewBankForksContext {
+                        blockstore: &blockstore,
+                        bank_forks: &bank_forks,
+                        leader_schedule_cache: &leader_schedule_cache,
+                        rpc_subscriptions: rpc_subscriptions.as_deref(),
+                        slot_status_notifier: &slot_status_notifier,
+                        migration_status: migration_status.as_ref(),
+                        my_pubkey: &my_pubkey,
+                    },
                     &mut progress,
                     &mut replay_timing,
-                    migration_status.as_ref(),
                 );
                 generate_new_bank_forks_time.stop();
 
@@ -938,22 +1035,6 @@ impl ReplayStage {
                     &own_vote_sender,
                 );
                 let did_complete_bank = !new_frozen_slots.is_empty();
-                if migration_status.is_alpenglow_enabled() {
-                    if let Some(highest) = new_frozen_slots.iter().max() {
-                        if *highest > highest_frozen_slot {
-                            highest_frozen_slot = *highest;
-                            let mut l_highest_frozen =
-                                replay_highest_frozen.highest_frozen_slot.lock().unwrap();
-                            // Let the block creation loop know about this new frozen slot
-                            *l_highest_frozen = *highest;
-                            replay_highest_frozen.freeze_notification.notify_one();
-                        }
-                    }
-                    if did_complete_bank {
-                        let bank_forks_r = bank_forks.read().unwrap();
-                        progress.handle_new_root(&bank_forks_r);
-                    }
-                }
                 replay_active_banks_time.stop();
 
                 // Check if we've completed the migration conditions
@@ -974,8 +1055,33 @@ impl ReplayStage {
                     );
                 }
 
-                let forks_root = bank_forks.read().unwrap().root();
-                if !migration_status.is_alpenglow_enabled() {
+                if migration_status.is_alpenglow_enabled() {
+                    process_soft_dead_slots(
+                        &my_pubkey,
+                        &blockstore,
+                        &bank_forks,
+                        &rpc_subscriptions,
+                        &slot_status_notifier,
+                        &mut progress,
+                        &mut async_verification_freelist,
+                        &replay_vote_sender,
+                        migration_status.as_ref(),
+                    );
+                    Self::alpenglow_handle_newly_frozen_banks(
+                        &new_frozen_slots,
+                        &migration_status,
+                        &bank_forks,
+                        &my_pubkey,
+                        &leader_schedule_cache,
+                        &optimistic_parent_sender,
+                        &optimistic_parent_receiver,
+                        &replay_highest_frozen,
+                        &mut highest_frozen_slot,
+                        &mut progress,
+                        did_complete_bank,
+                    );
+                } else {
+                    let forks_root = bank_forks.read().unwrap().root();
                     // Process cluster-agreed versions of duplicate slots for which we potentially
                     // have the wrong version. Our version was dead or pruned.
                     // Signalled by ancestor_hashes_service.
@@ -1467,6 +1573,54 @@ impl ReplayStage {
             .unwrap();
 
         Ok(Self { t_replay })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn alpenglow_handle_newly_frozen_banks(
+        new_frozen_slots: &[Slot],
+        migration_status: &MigrationStatus,
+        bank_forks: &RwLock<BankForks>,
+        my_pubkey: &Pubkey,
+        leader_schedule_cache: &LeaderScheduleCache,
+        optimistic_parent_sender: &Sender<LeaderWindowInfo>,
+        optimistic_parent_receiver: &Receiver<LeaderWindowInfo>,
+        replay_highest_frozen: &ReplayHighestFrozen,
+        highest_frozen_slot: &mut Slot,
+        progress: &mut ProgressMap,
+        did_complete_bank: bool,
+    ) {
+        let flh_candidate_banks = {
+            let bank_forks_r = bank_forks.read().unwrap();
+            new_frozen_slots
+                .iter()
+                .filter(|slot| migration_status.should_allow_fast_leader_handover(**slot))
+                .filter_map(|slot| bank_forks_r.get(*slot))
+                .collect_vec()
+        };
+        for bank in flh_candidate_banks {
+            Self::maybe_notify_of_optimistic_parent(
+                &bank,
+                my_pubkey,
+                leader_schedule_cache,
+                optimistic_parent_sender,
+                optimistic_parent_receiver,
+            );
+        }
+
+        if let Some(highest) = new_frozen_slots.iter().max() {
+            if *highest > *highest_frozen_slot {
+                *highest_frozen_slot = *highest;
+                let mut l_highest_frozen =
+                    replay_highest_frozen.highest_frozen_slot.lock().unwrap();
+                // Let the block creation loop know about this new frozen slot
+                *l_highest_frozen = *highest;
+                replay_highest_frozen.freeze_notification.notify_one();
+            }
+        }
+        if did_complete_bank {
+            let bank_forks_r = bank_forks.read().unwrap();
+            progress.handle_new_root(&bank_forks_r);
+        }
     }
 
     /// Enables alpenglow
@@ -2457,9 +2611,9 @@ impl ReplayStage {
     ) {
         if let Some(current_leader) = current_leader.as_ref() {
             if current_leader != new_leader {
-                let msg = if current_leader == my_pubkey {
+                let msg = if Self::leader_is_me(current_leader, my_pubkey) {
                     ". I am no longer the leader"
-                } else if new_leader == my_pubkey {
+                } else if Self::leader_is_me(new_leader, my_pubkey) {
                     ". I am now the leader"
                 } else {
                     ""
@@ -2593,7 +2747,7 @@ impl ReplayStage {
             trace!("{my_pubkey} leader {next_leader_id} at poh slot: {poh_slot}");
 
             // I guess I missed my slot
-            if next_leader_id != my_pubkey {
+            if !Self::leader_is_me(next_leader_id, my_pubkey) {
                 return None;
             }
 
@@ -2710,131 +2864,6 @@ impl ReplayStage {
         let tx_count_after = w_replay_progress.num_txs;
         let tx_count = tx_count_after - tx_count_before;
         Ok(tx_count)
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn mark_dead_slot(
-        blockstore: &Blockstore,
-        bank: &Bank,
-        root: Slot,
-        err: &BlockstoreProcessorError,
-        rpc_subscriptions: Option<&RpcSubscriptions>,
-        slot_status_notifier: Option<&SlotStatusNotifier>,
-        progress: &mut ProgressMap,
-        duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
-        ancestor_hashes_replay_update_sender: &AncestorHashesReplayUpdateSender,
-        purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
-        tbft_structs: &mut Option<&mut TowerBFTStructures>,
-        replay_vote_sender: &ReplayVoteSender,
-    ) {
-        // Do not remove from progress map when marking dead! Needed by
-        // `process_duplicate_confirmed_slots()`
-
-        // Block producer can abandon the block if it detects a better one
-        // while producing. Somewhat common and expected in a
-        // network with variable network/machine configuration.
-        let is_serious = !matches!(
-            err,
-            BlockstoreProcessorError::InvalidBlock(BlockError::TooFewTicks)
-        );
-        let slot = bank.slot();
-        let parent_slot = bank.parent_slot();
-        if is_serious {
-            datapoint_error!(
-                "replay-stage-mark_dead_slot",
-                ("error", format!("error: {err:?}"), String),
-                ("slot", slot, i64)
-            );
-        } else {
-            datapoint_info!(
-                "replay-stage-mark_dead_slot",
-                ("error", format!("error: {err:?}"), String),
-                ("slot", slot, i64)
-            );
-        }
-        progress.get_mut(&slot).unwrap().is_dead = true;
-        blockstore
-            .set_dead_slot(slot)
-            .expect("Failed to mark slot as dead in blockstore");
-        replay_vote_sender
-            .send(ReplayVoteMessage::InvalidBank {
-                replay_bank_id: bank.bank_id(),
-                replay_slot: slot,
-            })
-            .expect("Failed to send InvalidBank message to replay vote sender");
-
-        blockstore.slots_stats.mark_dead(slot);
-
-        let err = format!("error: {err:?}");
-
-        if let Some(slot_status_notifier) = slot_status_notifier {
-            slot_status_notifier
-                .read()
-                .unwrap()
-                .notify_slot_dead(slot, parent_slot, err.clone());
-        }
-
-        if let Some(rpc_subscriptions) = rpc_subscriptions {
-            rpc_subscriptions.notify_slot_update(SlotUpdate::Dead {
-                slot,
-                err,
-                timestamp: timestamp(),
-            });
-        }
-
-        if let Some(TowerBFTStructures {
-            heaviest_subtree_fork_choice,
-            duplicate_slots_tracker,
-            duplicate_confirmed_slots,
-            epoch_slots_frozen_slots,
-            ..
-        }) = tbft_structs
-        {
-            let dead_state = DeadState::new_from_state(
-                slot,
-                duplicate_slots_tracker,
-                duplicate_confirmed_slots,
-                heaviest_subtree_fork_choice,
-                epoch_slots_frozen_slots,
-            );
-            check_slot_agrees_with_cluster(
-                slot,
-                root,
-                blockstore,
-                duplicate_slots_tracker,
-                epoch_slots_frozen_slots,
-                heaviest_subtree_fork_choice,
-                duplicate_slots_to_repair,
-                ancestor_hashes_replay_update_sender,
-                purge_repair_slot_counter,
-                SlotStateUpdate::Dead(dead_state),
-            );
-
-            // If we previously marked this slot as duplicate in blockstore, let the state machine know
-            if !duplicate_slots_tracker.contains(&slot)
-                && blockstore.get_duplicate_slot(slot).is_some()
-            {
-                let duplicate_state = DuplicateState::new_from_state(
-                    slot,
-                    duplicate_confirmed_slots,
-                    heaviest_subtree_fork_choice,
-                    || true,
-                    || None,
-                );
-                check_slot_agrees_with_cluster(
-                    slot,
-                    root,
-                    blockstore,
-                    duplicate_slots_tracker,
-                    epoch_slots_frozen_slots,
-                    heaviest_subtree_fork_choice,
-                    duplicate_slots_to_repair,
-                    ancestor_hashes_replay_update_sender,
-                    purge_repair_slot_counter,
-                    SlotStateUpdate::Duplicate(duplicate_state),
-                );
-            }
-        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -3348,7 +3377,10 @@ impl ReplayStage {
         replay_result: &mut ReplaySlotFromBlockstore,
     ) -> Option<BankReplayTracker> {
         let bank_slot = replay_result.bank_slot;
-        if progress.get(&bank_slot).map(|p| p.is_dead).unwrap_or(false) {
+        if progress
+            .get(&bank_slot)
+            .is_some_and(|p| p.dead_reason.is_some())
+        {
             // If the fork was marked as dead, don't replay it
             debug!("bank_slot {bank_slot:?} is marked dead");
             replay_result.is_slot_dead = true;
@@ -3454,19 +3486,28 @@ impl ReplayStage {
             replay_progress,
         } = bank_replay_tracker;
 
+        if Self::leader_is_me(bank.leader_id(), my_pubkey) {
+            return (replay_result, None);
+        }
+
         // Check if the child block's chained merkle root chains to the parent's block id.
         // It's important that we do this here (after we have a bank) rather than failing
         // in generate_new_bank_forks, as we need a bank to mark as dead in order to kick off
         // ancestor hashes service / duplicate block repair.
-        match check_chained_block_id(&process_active_banks_context.blockstore, &bank) {
+        match check_chained_block_id(
+            &process_active_banks_context.blockstore,
+            &bank,
+            process_active_banks_context.migration_status.as_ref(),
+        ) {
             ChainedBlockIdCheck::Inactive | ChainedBlockIdCheck::Pass => (),
             ChainedBlockIdCheck::Unavailable => {
                 // Missing shred 0, can't replay anyway
                 return (replay_result, None);
             }
             ChainedBlockIdCheck::Mismatch => {
-                // Mismatch, mark dead and don't replay
-                replay_result.is_slot_dead = true;
+                // Mismatch, return a replay error so `process_replay_results`
+                // marks the bank hard-dead and publishes normal dead-slot
+                // notifications.
                 replay_result.replay_result =
                     Some(Err(BlockstoreProcessorError::ChainedBlockIdFailure(
                         bank.slot(),
@@ -3474,10 +3515,6 @@ impl ReplayStage {
                     )));
                 return (replay_result, None);
             }
-        }
-
-        if bank.leader_id() == my_pubkey {
-            return (replay_result, None);
         }
 
         let mut replay_blockstore_time = Measure::start("replay_blockstore_into_bank");
@@ -3492,6 +3529,14 @@ impl ReplayStage {
         replay_result.replay_result = Some(blockstore_result);
 
         (replay_result, Some(replay_blockstore_time.as_us()))
+    }
+
+    /// Live replay must not execute this validator's own leader banks from
+    /// blockstore. Those banks are driven by BankingStage/PoH while the node is
+    /// live; already-recorded own slots are replayed by startup ledger replay
+    /// before ReplayStage starts.
+    fn leader_is_me(slot_leader: &Pubkey, my_pubkey: &Pubkey) -> bool {
+        slot_leader == my_pubkey
     }
 
     fn replay_active_banks(
@@ -3590,22 +3635,32 @@ impl ReplayStage {
             if let Some(replay_result) = &replay_result.replay_result {
                 match replay_result {
                     Ok(replay_tx_count) => tx_count += replay_tx_count,
+                    Err(BlockstoreProcessorError::BlockComponentProcessor(
+                        BlockComponentProcessorError::AbandonedBank(update_parent),
+                    )) => {
+                        handle_abandoned_bank(
+                            process_active_banks_context,
+                            bank,
+                            bank_slot,
+                            update_parent,
+                            bank_forks,
+                            progress,
+                            async_verification_freelist,
+                            duplicate_slots_to_repair,
+                            purge_repair_slot_counter,
+                            tbft_structs.as_deref_mut(),
+                        );
+                        continue;
+                    }
                     Err(err) => {
                         let root = bank_forks.read().unwrap().root();
-                        Self::mark_dead_slot(
-                            &process_active_banks_context.blockstore,
-                            bank,
+                        let mut dead_slot_context = process_active_banks_context.dead_slot_context(
                             root,
-                            err,
-                            process_active_banks_context.rpc_subscriptions.as_deref(),
-                            process_active_banks_context.slot_status_notifier.as_ref(),
-                            progress,
                             duplicate_slots_to_repair,
-                            &process_active_banks_context.ancestor_hashes_replay_update_sender,
                             purge_repair_slot_counter,
-                            &mut tbft_structs,
-                            &process_active_banks_context.replay_vote_sender,
+                            tbft_structs.as_deref_mut(),
                         );
+                        mark_replay_dead_slot(bank, err, progress, &mut dead_slot_context);
                         // don't try to run the below logic to check if the bank is completed
                         continue;
                     }
@@ -3675,24 +3730,17 @@ impl ReplayStage {
                 );
                 if let Err(err) = replay_res.and(verify_res) {
                     let root = bank_forks.read().unwrap().root();
-                    Self::mark_dead_slot(
-                        &process_active_banks_context.blockstore,
-                        bank,
+                    let mut dead_slot_context = process_active_banks_context.dead_slot_context(
                         root,
-                        &err,
-                        process_active_banks_context.rpc_subscriptions.as_deref(),
-                        process_active_banks_context.slot_status_notifier.as_ref(),
-                        progress,
                         duplicate_slots_to_repair,
-                        &process_active_banks_context.ancestor_hashes_replay_update_sender,
                         purge_repair_slot_counter,
-                        &mut tbft_structs,
-                        &process_active_banks_context.replay_vote_sender,
+                        tbft_structs.as_deref_mut(),
                     );
+                    mark_replay_dead_slot(bank, &err, progress, &mut dead_slot_context);
                     // don't try to run the remaining normal processing for the completed bank
                     continue;
                 }
-                let is_leader_block = bank.leader_id() == my_pubkey;
+                let is_leader_block = Self::leader_is_me(bank.leader_id(), my_pubkey);
 
                 // The block id is the merkle root of the last data shred
                 // For leader blocks, we might not have finished shredding (as it happens asynchronously)
@@ -3714,7 +3762,7 @@ impl ReplayStage {
                 let verify_result = if process_active_banks_context
                     .migration_status
                     .should_allow_block_markers(bank.slot())
-                    && bank.leader_id() != my_pubkey
+                    && !Self::leader_is_me(bank.leader_id(), my_pubkey)
                 {
                     bank.freeze_and_verify_bank_hash()
                 } else {
@@ -3746,23 +3794,21 @@ impl ReplayStage {
                     }
 
                     let root = bank_forks.read().unwrap().root();
-                    Self::mark_dead_slot(
-                        &process_active_banks_context.blockstore,
-                        bank,
+                    let mut dead_slot_context = process_active_banks_context.dead_slot_context(
                         root,
+                        duplicate_slots_to_repair,
+                        purge_repair_slot_counter,
+                        tbft_structs.as_deref_mut(),
+                    );
+                    mark_replay_dead_slot(
+                        bank,
                         &BlockstoreProcessorError::BankHashMismatch(
                             bank_slot,
                             expected_hash,
                             computed_hash,
                         ),
-                        process_active_banks_context.rpc_subscriptions.as_deref(),
-                        process_active_banks_context.slot_status_notifier.as_ref(),
                         progress,
-                        duplicate_slots_to_repair,
-                        &process_active_banks_context.ancestor_hashes_replay_update_sender,
-                        purge_repair_slot_counter,
-                        &mut tbft_structs,
-                        &process_active_banks_context.replay_vote_sender,
+                        &mut dead_slot_context,
                     );
 
                     continue;
@@ -4018,6 +4064,126 @@ impl ReplayStage {
             &replay_result_vec,
             my_pubkey,
         )
+    }
+
+    /// Fast leader handover: if we're going to be the next leader, and our leader window
+    /// starts on the next slot, then send the bank through the optimistic parent channel.
+    fn maybe_notify_of_optimistic_parent(
+        bank: &Arc<Bank>,
+        my_pubkey: &Pubkey,
+        leader_schedule_cache: &LeaderScheduleCache,
+        optimistic_parent_sender: &Sender<LeaderWindowInfo>,
+        optimistic_parent_receiver: &Receiver<LeaderWindowInfo>,
+    ) {
+        let next_slot = bank.slot().saturating_add(1);
+
+        let is_next_leader = leader_schedule_cache
+            .slot_leader_at(next_slot, Some(bank))
+            .is_some_and(|leader| Self::leader_is_me(&leader.id, my_pubkey));
+
+        if !is_next_leader {
+            return;
+        }
+
+        if next_slot != first_of_consecutive_leader_slots(next_slot) {
+            return;
+        }
+
+        // TODO: if the leader has, e.g., two consecutive leader windows, this line here
+        // prevents fast leader handover from the first leader window to the second. This is because
+        // the block id is only computed after shredding a block, which occurs in broadcast, which
+        // happens after replay. This function, on the other hand, is invoked prior to replay.
+        //
+        // To address this, we should additionally add in an optimistic parent channel that goes
+        // from broadcast to replay.
+        let Some(block_id) = bank.block_id() else {
+            return;
+        };
+
+        let end_slot = next_slot.saturating_add(NUM_CONSECUTIVE_LEADER_SLOTS - 1);
+        let leader_window_info = LeaderWindowInfo {
+            start_slot: next_slot,
+            end_slot,
+            parent_block: (bank.slot(), block_id),
+            block_timer: Instant::now(),
+        };
+
+        Self::try_send_latest_optimistic_parent(
+            optimistic_parent_sender,
+            optimistic_parent_receiver,
+            leader_window_info,
+        );
+    }
+
+    /// Publish an optimistic-parent notification without letting the bounded
+    /// channel preserve stale windows.
+    ///
+    /// If the channel is full, replay drains any queued notifications, keeps the
+    /// freshest window by start slot, and attempts to enqueue only that one.
+    fn try_send_latest_optimistic_parent(
+        optimistic_parent_sender: &Sender<LeaderWindowInfo>,
+        optimistic_parent_receiver: &Receiver<LeaderWindowInfo>,
+        leader_window_info: LeaderWindowInfo,
+    ) {
+        let start_slot = leader_window_info.start_slot;
+        let end_slot = leader_window_info.end_slot;
+
+        match optimistic_parent_sender.try_send(leader_window_info) {
+            Ok(()) => {}
+            Err(TrySendError::Full(leader_window_info)) => {
+                let mut latest = None;
+                let mut queued_count = 0;
+                for queued_info in optimistic_parent_receiver.try_iter() {
+                    queued_count += 1;
+                    latest = Some(match latest {
+                        Some(current) => freshest_leader_window(current, queued_info),
+                        None => queued_info,
+                    });
+                }
+                let latest = match latest {
+                    Some(current) => freshest_leader_window(current, leader_window_info),
+                    None => leader_window_info,
+                };
+                let latest_start_slot = latest.start_slot;
+                let latest_end_slot = latest.end_slot;
+                let result = optimistic_parent_sender.try_send(latest);
+                let dropped_new = usize::from(result.is_err());
+                let dropped = queued_count + dropped_new;
+
+                if dropped > 0 {
+                    datapoint_info!(
+                        "replay_stage-optimistic_parent_notification_dropped",
+                        ("start_slot", start_slot, i64),
+                        ("end_slot", end_slot, i64),
+                        ("latest_start_slot", latest_start_slot, i64),
+                        ("latest_end_slot", latest_end_slot, i64),
+                        ("dropped_count", dropped, i64),
+                    );
+                }
+
+                match result {
+                    Ok(()) => {}
+                    Err(TrySendError::Full(_)) => {
+                        trace!(
+                            "optimistic_parent_sender remained full after draining {queued_count} \
+                             stale notifications for window {start_slot}-{end_slot}"
+                        );
+                    }
+                    Err(TrySendError::Disconnected(_)) => {
+                        trace!(
+                            "optimistic_parent_sender disconnected while sending window \
+                             {start_slot}-{end_slot}"
+                        );
+                    }
+                }
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                trace!(
+                    "optimistic_parent_sender disconnected while sending window \
+                     {start_slot}-{end_slot}"
+                );
+            }
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -4815,15 +4981,20 @@ impl ReplayStage {
     }
 
     fn generate_new_bank_forks(
-        blockstore: &Blockstore,
-        bank_forks: &RwLock<BankForks>,
-        leader_schedule_cache: &Arc<LeaderScheduleCache>,
-        rpc_subscriptions: Option<&RpcSubscriptions>,
-        slot_status_notifier: &Option<SlotStatusNotifier>,
+        ctx: NewBankForksContext<'_>,
         progress: &mut ProgressMap,
         replay_timing: &mut ReplayLoopTiming,
-        migration_status: &MigrationStatus,
     ) {
+        let NewBankForksContext {
+            blockstore,
+            bank_forks,
+            leader_schedule_cache,
+            rpc_subscriptions,
+            slot_status_notifier,
+            migration_status,
+            my_pubkey,
+        } = ctx;
+
         // Find the next slot that chains to the old slot
         let mut generate_new_bank_forks_read_lock =
             Measure::start("generate_new_bank_forks_read_lock");
@@ -4835,7 +5006,9 @@ impl ReplayStage {
             let frozen_bank_slots: Vec<_> = frozen_banks
                 .keys()
                 .cloned()
-                .filter(|slot| *slot >= forks.root() && !progress.get(slot).unwrap().is_dead)
+                .filter(|slot| {
+                    *slot >= forks.root() && progress.get(slot).unwrap().dead_reason.is_none()
+                })
                 .collect();
             let known_bank_slots = forks.banks().keys().copied().collect::<HashSet<_>>();
 
@@ -4871,9 +5044,33 @@ impl ReplayStage {
                     trace!("child already active or frozen {child_slot}");
                     continue;
                 }
+
+                debug_assert!(!progress.contains_key(&child_slot));
+
                 let leader = leader_schedule_cache
                     .slot_leader_at(child_slot, Some(parent_bank))
                     .unwrap();
+
+                // Live ReplayStage should never create banks for our own
+                // leader slots. BCL/PoH own live block production, and startup
+                // replay handles any already-recorded own blocks after restart.
+                if Self::leader_is_me(&leader.id, my_pubkey) {
+                    trace!("skipping replay bank creation for own leader slot {child_slot}");
+                    continue;
+                }
+
+                let replay_offset = match child_bank_replay_start(
+                    blockstore,
+                    parent_bank,
+                    parent_slot,
+                    child_slot,
+                    migration_status,
+                ) {
+                    ChildBankReplayStart::FromStart => None,
+                    ChildBankReplayStart::FromUpdateParent(num_shreds) => Some(num_shreds),
+                    ChildBankReplayStart::Defer => continue,
+                };
+
                 info!("new fork:{child_slot} parent:{parent_slot} root:{root}",);
                 // Migration period banks are VoM
                 let options = NewBankOptions {
@@ -4892,6 +5089,7 @@ impl ReplayStage {
                     options,
                 );
                 blockstore_processor::set_alpenglow_ticks(&child_bank, migration_status);
+
                 let empty: Vec<Pubkey> = vec![];
                 Self::update_fork_propagated_threshold_from_votes(
                     progress,
@@ -4900,7 +5098,7 @@ impl ReplayStage {
                     parent_bank.slot(),
                     &bank_forks.read().unwrap(),
                 );
-                new_banks.insert(child_slot, child_bank);
+                new_banks.insert(child_slot, (child_bank, replay_offset));
             }
         }
         generate_new_bank_forks_loop.stop();
@@ -4910,15 +5108,31 @@ impl ReplayStage {
         if !new_banks.is_empty() {
             let mut forks = bank_forks.write().unwrap();
             let root = forks.root();
-            for (slot, bank) in new_banks {
+            for (slot, (bank, replay_offset)) in new_banks {
                 if slot < root {
                     continue;
                 }
                 if forks.get(slot).is_some() {
                     continue;
                 }
-                if forks.get(bank.parent_slot()).is_none() {
+                let Some(parent_bank) = forks.get(bank.parent_slot()) else {
                     continue;
+                };
+                if let Some(num_shreds) = replay_offset {
+                    let prev_leader_slot = progress.get_bank_prev_leader_slot(&bank);
+                    let fork_progress = ForkProgress::new(
+                        parent_bank.last_blockhash(),
+                        prev_leader_slot,
+                        None,
+                        0,
+                        0,
+                        None,
+                    );
+                    {
+                        let mut replay_progress = fork_progress.replay_progress.write().unwrap();
+                        replay_progress.num_shreds = num_shreds;
+                    }
+                    progress.insert(slot, fork_progress);
                 }
                 forks.insert(bank);
             }
@@ -5028,31 +5242,42 @@ pub(crate) mod tests {
             commitment_service::AggregateCommitmentService,
             consensus::{
                 ThresholdDecision, Tower, VOTE_THRESHOLD_DEPTH,
-                progress_map::{RETRANSMIT_BASE_DELAY_MS, ValidatorStakeInfo},
+                progress_map::{DeadSlotReason, RETRANSMIT_BASE_DELAY_MS, ValidatorStakeInfo},
                 tower_storage::{FileTowerStorage, NullTowerStorage},
                 tree_diff::TreeDiff,
             },
             replay_stage::ReplayStage,
             vote_simulator::{self, VoteSimulator},
         },
+        agave_votor_messages::consensus_message::{Certificate, CertificateType},
         blockstore_processor::{
             ConfirmationProgress, ProcessOptions, confirm_full_slot,
             fill_blockstore_slot_with_ticks, process_bank_0,
         },
-        crossbeam_channel::unbounded,
+        crossbeam_channel::{bounded, unbounded},
         itertools::Itertools,
         solana_account::{ReadableAccount, state_traits::StateMut},
         solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_client::connection_cache::ConnectionCache,
         solana_clock::NUM_CONSECUTIVE_LEADER_SLOTS,
-        solana_entry::entry::{self, Entry},
+        solana_entry::{
+            block_component::{
+                BlockComponent, BlockFooterV1, BlockHeaderV1, UpdateParentV1, VersionedBlockMarker,
+                VersionedUpdateParent,
+            },
+            entry::{self, Entry},
+        },
         solana_genesis_config as genesis_config,
         solana_gossip::{crds::Cursor, node::Node},
         solana_hash::Hash,
         solana_instruction::error::InstructionError,
         solana_keypair::Keypair,
         solana_ledger::{
-            blockstore::{BlockstoreError, entries_to_test_shreds, make_slot_entries},
+            block_error::BlockError,
+            blockstore::{
+                BlockstoreError, UpdateParentSignal, entries_to_test_shreds, make_slot_entries,
+            },
             create_new_tmp_ledger,
             genesis_utils::{create_genesis_config, create_genesis_config_with_leader},
             get_tmp_ledger_path, get_tmp_ledger_path_auto_delete,
@@ -5068,6 +5293,7 @@ pub(crate) mod tests {
         },
         solana_runtime::{
             bank::BankTestConfig,
+            block_component_processor::BlockComponentProcessorError,
             commitment::{BlockCommitment, VOTE_THRESHOLD_SIZE},
             genesis_utils::{GenesisConfigInfo, ValidatorVoteKeypairs},
         },
@@ -5091,6 +5317,113 @@ pub(crate) mod tests {
         test_case::test_case,
         trees::{Tree, tr},
     };
+
+    fn post_migration_status_for_tests() -> MigrationStatus {
+        let migration_status = MigrationStatus::default();
+        migration_status.record_feature_activation(0);
+        let genesis_block = (0, Hash::default());
+        let genesis_certificate = Arc::new(Certificate {
+            cert_type: CertificateType::Genesis(genesis_block.0, genesis_block.1),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        });
+        migration_status.set_genesis_block(genesis_block);
+        migration_status.set_genesis_certificate(genesis_certificate);
+        migration_status.enable_alpenglow_during_startup();
+        migration_status
+    }
+
+    fn block_marker_shreds(
+        slot: Slot,
+        shred_parent_slot: Slot,
+        marker: VersionedBlockMarker,
+        shred_index: u32,
+    ) -> Vec<Shred> {
+        block_marker_shreds_with_last(
+            slot,
+            shred_parent_slot,
+            marker,
+            shred_index,
+            false, // is_last_in_slot
+        )
+    }
+
+    fn block_marker_shreds_with_last(
+        slot: Slot,
+        shred_parent_slot: Slot,
+        marker: VersionedBlockMarker,
+        shred_index: u32,
+        is_last_in_slot: bool,
+    ) -> Vec<Shred> {
+        let component = BlockComponent::new_block_marker(marker);
+        Shredder::new(slot, shred_parent_slot, 0, 0)
+            .unwrap()
+            .make_merkle_shreds_from_component(
+                &Keypair::new(),
+                &component,
+                is_last_in_slot,
+                Hash::new_unique(),
+                shred_index,
+                shred_index,
+                &ReedSolomonCache::default(),
+                &mut ProcessShredsStats::default(),
+            )
+            .collect()
+    }
+
+    fn insert_update_parent_slot(
+        blockstore: &Blockstore,
+        slot: Slot,
+        block_header_parent_slot: Slot,
+        update_parent_slot: Slot,
+        update_parent_block_id: Hash,
+        replay_fec_set_index: u32,
+    ) {
+        let header = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+            parent_slot: block_header_parent_slot,
+            parent_block_id: Hash::new_unique(),
+        });
+        let update_parent = VersionedBlockMarker::new_update_parent(UpdateParentV1 {
+            new_parent_slot: update_parent_slot,
+            new_parent_block_id: update_parent_block_id,
+        });
+        let mut shreds = block_marker_shreds(slot, block_header_parent_slot, header, 0);
+        shreds.extend(block_marker_shreds(
+            slot,
+            block_header_parent_slot,
+            update_parent,
+            replay_fec_set_index,
+        ));
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+    }
+
+    /// Build the minimal dead-slot context needed by focused replay tests.
+    fn dead_slot_context_for_tests<'a>(
+        blockstore: Arc<Blockstore>,
+        replay_vote_sender: ReplayVoteSender,
+        ancestor_hashes_replay_update_sender: &'a AncestorHashesReplayUpdateSender,
+        duplicate_slots_to_repair: &'a mut DuplicateSlotsToRepair,
+        purge_repair_slot_counter: &'a mut PurgeRepairSlotCounter,
+        tbft_structs: Option<&'a mut TowerBFTStructures>,
+        migration_status: &'a MigrationStatus,
+    ) -> DeadSlotContext<'a> {
+        DeadSlotContext {
+            notifications: DeadSlotNotifications {
+                blockstore,
+                rpc_subscriptions: None,
+                slot_status_notifier: None,
+                replay_vote_sender,
+            },
+            duplicate: DeadSlotDuplicateContext {
+                root: 0,
+                duplicate_slots_to_repair,
+                ancestor_hashes_replay_update_sender,
+                purge_repair_slot_counter,
+                tbft_structs,
+            },
+            migration_status,
+        }
+    }
 
     #[test]
     fn test_is_partition_detected() {
@@ -5267,14 +5600,17 @@ pub(crate) mod tests {
         );
         let mut replay_timing = ReplayLoopTiming::default();
         ReplayStage::generate_new_bank_forks(
-            &blockstore,
-            &bank_forks,
-            &leader_schedule_cache,
-            rpc_subscriptions.as_deref(),
-            &None,
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: rpc_subscriptions.as_deref(),
+                slot_status_notifier: &None,
+                migration_status: &MigrationStatus::default(),
+                my_pubkey: &Pubkey::default(),
+            },
             &mut progress,
             &mut replay_timing,
-            &MigrationStatus::default(),
         );
         assert!(
             bank_forks
@@ -5296,14 +5632,17 @@ pub(crate) mod tests {
                 .is_none()
         );
         ReplayStage::generate_new_bank_forks(
-            &blockstore,
-            &bank_forks,
-            &leader_schedule_cache,
-            rpc_subscriptions.as_deref(),
-            &None,
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: rpc_subscriptions.as_deref(),
+                slot_status_notifier: &None,
+                migration_status: &MigrationStatus::default(),
+                my_pubkey: &Pubkey::default(),
+            },
             &mut progress,
             &mut replay_timing,
-            &MigrationStatus::default(),
         );
         assert!(
             bank_forks
@@ -5881,7 +6220,7 @@ pub(crate) mod tests {
         let my_pubkey = Pubkey::default();
 
         assert!(!process_active_banks_context.blockstore.is_dead(slot));
-        assert!(!progress.get(&slot).unwrap().is_dead);
+        assert!(progress.get(&slot).unwrap().dead_reason.is_none());
         assert!(!blockstore.is_dead(slot));
 
         let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
@@ -5898,7 +6237,7 @@ pub(crate) mod tests {
             &my_pubkey,
         );
 
-        assert!(progress.get(&slot).unwrap().is_dead);
+        assert!(progress.get(&slot).unwrap().dead_reason.is_some());
         assert!(blockstore.is_dead(slot));
     }
 
@@ -5910,6 +6249,130 @@ pub(crate) mod tests {
     #[test]
     fn test_dead_slot_on_complete_bank_verify_err() {
         do_test_dead_slot_on_complete_bank(CompleteBankFailure::VerifyError);
+    }
+
+    #[test]
+    fn test_cmr_mismatch_hard_dead() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let bank = bank_forks.read().unwrap().get(slot).unwrap();
+        progress.insert(
+            slot,
+            ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None),
+        );
+
+        let (replay_vote_sender, replay_vote_receiver) = unbounded();
+        let process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
+            bank_forks.clone(),
+            blockstore.clone(),
+            replay_vote_sender,
+        );
+        let replay_result = ReplaySlotFromBlockstore {
+            is_slot_dead: false,
+            bank_slot: slot,
+            replay_result: Some(Err(BlockstoreProcessorError::ChainedBlockIdFailure(
+                slot, 0,
+            ))),
+        };
+
+        ReplayStage::process_replay_results(
+            &process_active_banks_context,
+            &mut progress,
+            &mut Vec::new(),
+            &mut LatestValidatorVotesForFrozenBanks::default(),
+            &mut DuplicateSlotsToRepair::default(),
+            &mut PurgeRepairSlotCounter::default(),
+            None,
+            &[replay_result],
+            &Pubkey::new_unique(),
+        );
+
+        assert!(blockstore.is_dead(slot));
+        assert_eq!(progress.dead_reason(slot), Some(&DeadSlotReason::Hard));
+        assert_eq!(
+            replay_vote_receiver.try_recv(),
+            Ok(ReplayVoteMessage::InvalidBank {
+                replay_bank_id: bank.bank_id(),
+                replay_slot: slot,
+            })
+        );
+    }
+
+    #[test]
+    fn test_abandon_invalidates() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 4;
+        let parent_block_id = Hash::new_unique();
+        insert_update_parent_slot(&blockstore, slot, 3, 0, parent_block_id, 32);
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+        let bank = Bank::new_from_parent(bank0, SlotLeader::default(), slot);
+        bank_forks.write().unwrap().insert(bank);
+        let bank = bank_forks.read().unwrap().get(slot).unwrap();
+        progress.insert(
+            slot,
+            ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None),
+        );
+
+        let (replay_vote_sender, replay_vote_receiver) = unbounded();
+        let process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
+            bank_forks.clone(),
+            blockstore,
+            replay_vote_sender,
+        );
+        let update_parent =
+            VersionedUpdateParent::V1(solana_entry::block_component::UpdateParentV1 {
+                new_parent_slot: 0,
+                new_parent_block_id: Hash::default(),
+            });
+        let replay_result = ReplaySlotFromBlockstore {
+            is_slot_dead: false,
+            bank_slot: slot,
+            replay_result: Some(Err(BlockstoreProcessorError::BlockComponentProcessor(
+                BlockComponentProcessorError::AbandonedBank(update_parent),
+            ))),
+        };
+
+        ReplayStage::process_replay_results(
+            &process_active_banks_context,
+            &mut progress,
+            &mut Vec::new(),
+            &mut LatestValidatorVotesForFrozenBanks::default(),
+            &mut DuplicateSlotsToRepair::default(),
+            &mut PurgeRepairSlotCounter::default(),
+            None,
+            &[replay_result],
+            &Pubkey::new_unique(),
+        );
+
+        assert!(progress.get(&slot).is_none());
+        assert!(bank_forks.read().unwrap().get(slot).is_none());
+        assert_eq!(
+            replay_vote_receiver.try_recv(),
+            Ok(ReplayVoteMessage::InvalidBank {
+                replay_bank_id: bank.bank_id(),
+                replay_slot: slot,
+            })
+        );
     }
 
     // Given a shred and a fatal expected error, check that replaying that shred causes causes the fork to be
@@ -6000,20 +6463,26 @@ pub(crate) mod tests {
             let rpc_subscriptions = Some(rpc_subscriptions);
 
             if let Err(err) = &res {
-                ReplayStage::mark_dead_slot(
-                    &blockstore,
-                    &bank1,
-                    0,
-                    err,
-                    rpc_subscriptions.as_deref(),
-                    slot_status_notifier.as_ref(),
-                    &mut progress,
-                    &mut DuplicateSlotsToRepair::default(),
-                    &process_active_banks_context.ancestor_hashes_replay_update_sender,
-                    &mut PurgeRepairSlotCounter::default(),
-                    &mut Some(&mut tbft_structs),
-                    &replay_vote_sender,
-                );
+                let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
+                let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
+                let mut dead_slot_context = DeadSlotContext {
+                    notifications: DeadSlotNotifications {
+                        blockstore: blockstore.clone(),
+                        rpc_subscriptions: rpc_subscriptions.clone(),
+                        slot_status_notifier: slot_status_notifier.clone(),
+                        replay_vote_sender: replay_vote_sender.clone(),
+                    },
+                    duplicate: DeadSlotDuplicateContext {
+                        root: 0,
+                        duplicate_slots_to_repair: &mut duplicate_slots_to_repair,
+                        ancestor_hashes_replay_update_sender: &process_active_banks_context
+                            .ancestor_hashes_replay_update_sender,
+                        purge_repair_slot_counter: &mut purge_repair_slot_counter,
+                        tbft_structs: Some(&mut tbft_structs),
+                    },
+                    migration_status: process_active_banks_context.migration_status.as_ref(),
+                };
+                mark_replay_dead_slot(&bank1, err, &mut progress, &mut dead_slot_context);
             }
             assert_eq!(
                 replay_vote_receiver.try_recv(),
@@ -6027,7 +6496,7 @@ pub(crate) mod tests {
             assert!(
                 progress
                     .get(&bank1.slot())
-                    .map(|b| b.is_dead)
+                    .map(|b| b.dead_reason.is_some())
                     .unwrap_or(false)
             );
 
@@ -7434,14 +7903,17 @@ pub(crate) mod tests {
 
         // 3 should now be an active bank
         ReplayStage::generate_new_bank_forks(
-            &blockstore,
-            &bank_forks,
-            &leader_schedule_cache,
-            rpc_subscriptions.as_deref(),
-            &None,
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: rpc_subscriptions.as_deref(),
+                slot_status_notifier: &None,
+                migration_status: &MigrationStatus::default(),
+                my_pubkey: &Pubkey::default(),
+            },
             &mut progress,
             &mut replay_timing,
-            &MigrationStatus::default(),
         );
         assert_eq!(bank_forks.read().unwrap().active_bank_slots(), vec![3]);
 
@@ -7464,14 +7936,17 @@ pub(crate) mod tests {
         }
         // 5 Should now be an active bank
         ReplayStage::generate_new_bank_forks(
-            &blockstore,
-            &bank_forks,
-            &leader_schedule_cache,
-            rpc_subscriptions.as_deref(),
-            &None,
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: rpc_subscriptions.as_deref(),
+                slot_status_notifier: &None,
+                migration_status: &MigrationStatus::default(),
+                my_pubkey: &Pubkey::default(),
+            },
             &mut progress,
             &mut replay_timing,
-            &MigrationStatus::default(),
         );
         assert_eq!(bank_forks.read().unwrap().active_bank_slots(), vec![5]);
 
@@ -7495,14 +7970,17 @@ pub(crate) mod tests {
         // 6 should now be an active bank even though we haven't repaired it because it
         // wasn't dumped
         ReplayStage::generate_new_bank_forks(
-            &blockstore,
-            &bank_forks,
-            &leader_schedule_cache,
-            rpc_subscriptions.as_deref(),
-            &None,
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: rpc_subscriptions.as_deref(),
+                slot_status_notifier: &None,
+                migration_status: &MigrationStatus::default(),
+                my_pubkey: &Pubkey::default(),
+            },
             &mut progress,
             &mut replay_timing,
-            &MigrationStatus::default(),
         );
         assert_eq!(bank_forks.read().unwrap().active_bank_slots(), vec![6]);
 
@@ -7525,20 +8003,664 @@ pub(crate) mod tests {
         }
         // 7 should be found as an active bank
         ReplayStage::generate_new_bank_forks(
-            &blockstore,
-            &bank_forks,
-            &leader_schedule_cache,
-            rpc_subscriptions.as_deref(),
-            &None,
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: rpc_subscriptions.as_deref(),
+                slot_status_notifier: &None,
+                migration_status: &MigrationStatus::default(),
+                my_pubkey: &Pubkey::default(),
+            },
             &mut progress,
             &mut replay_timing,
-            &MigrationStatus::default(),
         );
         assert_eq!(bank_forks.read().unwrap().active_bank_slots(), vec![7]);
     }
 
     #[test]
-    fn test_purge_ancestors_descendants() {
+    fn test_update_parent_restart() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(
+            Some(tr(0) / tr(1) / tr(2) / tr(3)),
+            1,
+            None::<GenerateVotes>,
+        );
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+
+        // Slot 4: 5 shreds, replay_fec_set_index=32; 5 < 32 so cleared.
+        // Slot 5: 40 shreds, replay_fec_set_index=32; 40 >= 32 so skipped.
+        for (slot, shreds) in [(4, 5), (5, 40)] {
+            let bank = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), slot);
+            bank_forks.write().unwrap().insert(bank);
+            let p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+            p.replay_progress.write().unwrap().num_shreds = shreds;
+            progress.insert(slot, p);
+        }
+
+        let (tx, rx) = crossbeam_channel::unbounded();
+        for slot in [4, 5] {
+            let parent_block_id = Hash::new_unique();
+            insert_update_parent_slot(
+                &blockstore,
+                slot,
+                3, // optimistic block-header parent
+                0, // finalized UpdateParent parent
+                parent_block_id,
+                32,
+            );
+            tx.send(UpdateParentSignal { slot }).unwrap();
+        }
+
+        let cleared_bank_id = bank_forks.read().unwrap().get(4).unwrap().bank_id();
+        let (replay_vote_sender, replay_vote_receiver) = unbounded();
+        let mut async_verification_freelist = Vec::new();
+        handle_update_parent_interrupts(
+            &Pubkey::new_unique(),
+            &blockstore,
+            &bank_forks,
+            &mut progress,
+            &mut async_verification_freelist,
+            &rx,
+            &replay_vote_sender,
+            &post_migration_status_for_tests(),
+        );
+
+        assert!(progress.get(&4).is_none()); // cleared: 5 < 32
+        assert!(progress.get(&5).is_some()); // skipped: 40 >= 32
+        assert_eq!(
+            replay_vote_receiver.try_recv(),
+            Ok(ReplayVoteMessage::InvalidBank {
+                replay_bank_id: cleared_bank_id,
+                replay_slot: 4,
+            })
+        );
+        assert!(replay_vote_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_headerless_update_parent() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            leader_schedule_cache,
+            ..
+        } = replay_blockstore_components(Some(tr(0)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+        let my_pubkey = Pubkey::new_unique();
+        let slot = 1;
+        let migration_status = post_migration_status_for_tests();
+
+        let footer_marker = || {
+            VersionedBlockMarker::new_block_footer(BlockFooterV1 {
+                bank_hash: Hash::new_unique(),
+                block_producer_time_nanos: 0,
+                block_user_agent: vec![],
+                final_cert: None,
+                skip_reward_cert: None,
+                notar_reward_cert: None,
+            })
+        };
+        let update_parent = VersionedBlockMarker::new_update_parent(UpdateParentV1 {
+            new_parent_slot: 0,
+            new_parent_block_id: Hash::default(),
+        });
+
+        let mut shreds = block_marker_shreds(slot, 0, footer_marker(), 0);
+        shreds.extend(block_marker_shreds(slot, 0, update_parent, 32));
+        shreds.extend(block_marker_shreds_with_last(
+            slot,
+            0,
+            footer_marker(),
+            64,
+            true,
+        ));
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+        let slot_meta = blockstore.meta(slot).unwrap().unwrap();
+        assert!(blockstore.is_full(slot), "{slot_meta:?}");
+        assert!(slot_meta.has_update_parent());
+        assert!(bank_forks.read().unwrap().get(slot).is_none());
+
+        let mut replay_timing = ReplayLoopTiming::default();
+        ReplayStage::generate_new_bank_forks(
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: None,
+                slot_status_notifier: &None,
+                migration_status: &migration_status,
+                my_pubkey: &my_pubkey,
+            },
+            &mut progress,
+            &mut replay_timing,
+        );
+
+        assert!(
+            bank_forks.read().unwrap().get(slot).is_some(),
+            "headerless UpdateParent should create a replay bank from the marker"
+        );
+        assert_eq!(
+            progress
+                .get(&slot)
+                .unwrap()
+                .replay_progress
+                .read()
+                .unwrap()
+                .num_shreds,
+            32
+        );
+    }
+
+    #[test]
+    fn test_update_parent_tower_gated() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let parent_block_id = Hash::new_unique();
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.parent_slot = Some(0);
+        meta.parent_block_id = parent_block_id;
+        meta.replay_fec_set_index = 10;
+        blockstore.put_meta(slot, &meta).unwrap();
+
+        let p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 5;
+        progress.insert(slot, p);
+
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(UpdateParentSignal { slot }).unwrap();
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let mut async_verification_freelist = Vec::new();
+        handle_update_parent_interrupts(
+            &Pubkey::new_unique(),
+            &blockstore,
+            &bank_forks,
+            &mut progress,
+            &mut async_verification_freelist,
+            &rx,
+            &replay_vote_sender,
+            &MigrationStatus::default(),
+        );
+
+        assert!(progress.get(&slot).is_some());
+        assert!(bank_forks.read().unwrap().get(slot).is_some());
+    }
+
+    #[test]
+    fn test_update_parent_keeps_hard() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let parent_block_id = Hash::new_unique();
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.parent_slot = Some(0);
+        meta.parent_block_id = parent_block_id;
+        meta.replay_fec_set_index = 10;
+        blockstore.put_meta(slot, &meta).unwrap();
+        blockstore.set_dead_slot(slot).unwrap();
+
+        let mut p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 5;
+        p.mark_dead(DeadSlotReason::Hard);
+        progress.insert(slot, p);
+
+        let (tx, rx) = crossbeam_channel::unbounded();
+        tx.send(UpdateParentSignal { slot }).unwrap();
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let mut async_verification_freelist = Vec::new();
+        handle_update_parent_interrupts(
+            &Pubkey::new_unique(),
+            &blockstore,
+            &bank_forks,
+            &mut progress,
+            &mut async_verification_freelist,
+            &rx,
+            &replay_vote_sender,
+            &post_migration_status_for_tests(),
+        );
+
+        assert!(blockstore.is_dead(slot));
+        assert!(progress.get(&slot).is_some());
+        assert!(bank_forks.read().unwrap().get(slot).is_some());
+    }
+
+    #[test]
+    fn test_pre_update_soft_dead() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.replay_fec_set_index = 0;
+        meta.last_index = None;
+        blockstore.put_meta(slot, &meta).unwrap();
+
+        let bank = bank_forks.read().unwrap().get(slot).unwrap();
+        let p = ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 5;
+        progress.insert(slot, p);
+
+        let (replay_vote_sender, replay_vote_receiver) = unbounded();
+        let (ancestor_hashes_replay_update_sender, _) = unbounded();
+        let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
+        let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
+        let migration_status = post_migration_status_for_tests();
+        let mut dead_slot_context = dead_slot_context_for_tests(
+            blockstore.clone(),
+            replay_vote_sender.clone(),
+            &ancestor_hashes_replay_update_sender,
+            &mut duplicate_slots_to_repair,
+            &mut purge_repair_slot_counter,
+            None,
+            &migration_status,
+        );
+        mark_replay_dead_slot(
+            &bank,
+            &BlockstoreProcessorError::InvalidTransaction(TransactionError::AccountNotFound),
+            &mut progress,
+            &mut dead_slot_context,
+        );
+
+        assert!(!blockstore.is_dead(slot));
+        assert!(matches!(
+            progress.get(&slot).unwrap().dead_reason,
+            Some(DeadSlotReason::ReplayFailureBeforeUpdateParent)
+        ));
+        assert_eq!(
+            replay_vote_receiver.try_recv(),
+            Ok(ReplayVoteMessage::InvalidBank {
+                replay_bank_id: bank.bank_id(),
+                replay_slot: slot,
+            })
+        );
+    }
+
+    #[test]
+    fn test_after_update_hard_dead() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.replay_fec_set_index = 5;
+        meta.last_index = None;
+        blockstore.put_meta(slot, &meta).unwrap();
+
+        let bank = bank_forks.read().unwrap().get(slot).unwrap();
+        let p = ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 5;
+        progress.insert(slot, p);
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (ancestor_hashes_replay_update_sender, _) = unbounded();
+        let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
+        let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
+        let migration_status = post_migration_status_for_tests();
+        let mut dead_slot_context = dead_slot_context_for_tests(
+            blockstore.clone(),
+            replay_vote_sender.clone(),
+            &ancestor_hashes_replay_update_sender,
+            &mut duplicate_slots_to_repair,
+            &mut purge_repair_slot_counter,
+            None,
+            &migration_status,
+        );
+        mark_replay_dead_slot(
+            &bank,
+            &BlockstoreProcessorError::InvalidTransaction(TransactionError::AccountNotFound),
+            &mut progress,
+            &mut dead_slot_context,
+        );
+
+        assert!(blockstore.is_dead(slot));
+        assert!(matches!(
+            progress.get(&slot).unwrap().dead_reason,
+            Some(DeadSlotReason::Hard)
+        ));
+    }
+
+    #[test]
+    fn test_before_update_soft_dead() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+        let bank = Bank::new_from_parent(bank0, SlotLeader::default(), slot);
+        let bank = bank_forks.write().unwrap().insert(bank);
+        let header = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+            parent_slot: 0,
+            parent_block_id: Hash::default(),
+        });
+        let update_parent = VersionedBlockMarker::new_update_parent(UpdateParentV1 {
+            new_parent_slot: 0,
+            new_parent_block_id: Hash::default(),
+        });
+        let mut shreds = block_marker_shreds(slot, 0, header, 0);
+        shreds.retain(|shred| !shred.is_data() || shred.index() != 0);
+        shreds.extend(block_marker_shreds(slot, 0, update_parent, 32));
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+        assert!(blockstore.meta(slot).unwrap().unwrap().has_update_parent());
+
+        let p = ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 5;
+        progress.insert(slot, p);
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (ancestor_hashes_replay_update_sender, _) = unbounded();
+        let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
+        let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
+        let migration_status = post_migration_status_for_tests();
+        let mut dead_slot_context = dead_slot_context_for_tests(
+            blockstore.clone(),
+            replay_vote_sender.clone(),
+            &ancestor_hashes_replay_update_sender,
+            &mut duplicate_slots_to_repair,
+            &mut purge_repair_slot_counter,
+            None,
+            &migration_status,
+        );
+        mark_replay_dead_slot(
+            &bank,
+            &BlockstoreProcessorError::BlockComponentProcessor(
+                BlockComponentProcessorError::MissingParentMarker,
+            ),
+            &mut progress,
+            &mut dead_slot_context,
+        );
+
+        assert!(!blockstore.is_dead(slot));
+        assert!(matches!(
+            progress.get(&slot).unwrap().dead_reason,
+            Some(DeadSlotReason::ReplayFailureBeforeUpdateParent)
+        ));
+    }
+
+    #[test]
+    fn test_soft_dead_restarts() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 4;
+        let parent_block_id = Hash::new_unique();
+        insert_update_parent_slot(&blockstore, slot, 3, 0, parent_block_id, 32);
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+        let bank = Bank::new_from_parent(bank0, SlotLeader::default(), slot);
+        bank_forks.write().unwrap().insert(bank);
+
+        let mut p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+        p.replay_progress.write().unwrap().num_shreds = 5;
+        p.mark_dead(DeadSlotReason::ReplayFailureBeforeUpdateParent);
+        progress.insert(slot, p);
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let mut async_verification_freelist = Vec::new();
+        process_soft_dead_slots(
+            &Pubkey::new_unique(),
+            &blockstore,
+            &bank_forks,
+            &None,
+            &None,
+            &mut progress,
+            &mut async_verification_freelist,
+            &replay_vote_sender,
+            &post_migration_status_for_tests(),
+        );
+
+        assert!(!blockstore.is_dead(slot));
+        assert!(progress.get(&slot).is_none());
+        assert!(bank_forks.read().unwrap().get(slot).is_none());
+    }
+
+    #[test]
+    fn test_full_soft_dead_hardens() {
+        let ReplayBlockstoreComponents {
+            blockstore,
+            vote_simulator,
+            ..
+        } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            ..
+        } = vote_simulator;
+
+        let slot = 1;
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.replay_fec_set_index = 0;
+        meta.consumed = 1;
+        meta.last_index = Some(0);
+        blockstore.put_meta(slot, &meta).unwrap();
+
+        let mut p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+        p.mark_dead(DeadSlotReason::ReplayFailureBeforeUpdateParent);
+        progress.insert(slot, p);
+
+        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let mut async_verification_freelist = Vec::new();
+        process_soft_dead_slots(
+            &Pubkey::new_unique(),
+            &blockstore,
+            &bank_forks,
+            &None,
+            &None,
+            &mut progress,
+            &mut async_verification_freelist,
+            &replay_vote_sender,
+            &post_migration_status_for_tests(),
+        );
+
+        assert!(blockstore.is_dead(slot));
+        assert!(matches!(
+            progress.get(&slot).unwrap().dead_reason,
+            Some(DeadSlotReason::Hard)
+        ));
+    }
+
+    #[test]
+    fn test_latest_parent_coalesces() {
+        let (sender, receiver) = bounded(1);
+        sender
+            .try_send(LeaderWindowInfo {
+                start_slot: 8,
+                end_slot: 11,
+                parent_block: (7, Hash::new_unique()),
+                block_timer: Instant::now(),
+            })
+            .unwrap();
+
+        ReplayStage::try_send_latest_optimistic_parent(
+            &sender,
+            &receiver,
+            LeaderWindowInfo {
+                start_slot: 12,
+                end_slot: 15,
+                parent_block: (11, Hash::new_unique()),
+                block_timer: Instant::now(),
+            },
+        );
+
+        let latest = receiver.try_recv().unwrap();
+        assert_eq!(latest.start_slot, 12);
+        assert!(receiver.try_recv().is_err());
+
+        let (sender, receiver) = bounded(1);
+        sender
+            .try_send(LeaderWindowInfo {
+                start_slot: 20,
+                end_slot: 22,
+                parent_block: (19, Hash::new_unique()),
+                block_timer: Instant::now(),
+            })
+            .unwrap();
+
+        ReplayStage::try_send_latest_optimistic_parent(
+            &sender,
+            &receiver,
+            LeaderWindowInfo {
+                start_slot: 20,
+                end_slot: 23,
+                parent_block: (19, Hash::new_unique()),
+                block_timer: Instant::now(),
+            },
+        );
+
+        let latest = receiver.try_recv().unwrap();
+        assert_eq!(latest.end_slot, 23);
+        assert!(receiver.try_recv().is_err());
+
+        let (sender, receiver) = bounded(1);
+        sender
+            .try_send(LeaderWindowInfo {
+                start_slot: 20,
+                end_slot: 23,
+                parent_block: (19, Hash::new_unique()),
+                block_timer: Instant::now(),
+            })
+            .unwrap();
+
+        ReplayStage::try_send_latest_optimistic_parent(
+            &sender,
+            &receiver,
+            LeaderWindowInfo {
+                start_slot: 16,
+                end_slot: 19,
+                parent_block: (15, Hash::new_unique()),
+                block_timer: Instant::now(),
+            },
+        );
+
+        let latest = receiver.try_recv().unwrap();
+        assert_eq!(latest.start_slot, 20);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_skip_own_update_full() {
+        let (vote_simulator, blockstore) = setup_forks_from_tree(tr(0), 1, None::<GenerateVotes>);
+        let VoteSimulator {
+            bank_forks,
+            mut progress,
+            validator_keypairs,
+            ..
+        } = vote_simulator;
+        let my_pubkey = *validator_keypairs.keys().next().unwrap();
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&root_bank));
+        let slot = 2;
+        let replay_fec_set_index = 32;
+
+        insert_update_parent_slot(
+            &blockstore,
+            slot,
+            1,
+            0,
+            Hash::new_unique(),
+            replay_fec_set_index,
+        );
+        let mut meta = blockstore.meta(slot).unwrap().unwrap();
+        meta.consumed = u64::from(replay_fec_set_index) + 1;
+        meta.last_index = Some(u64::from(replay_fec_set_index));
+        blockstore.put_meta(slot, &meta).unwrap();
+        assert!(blockstore.is_full(slot));
+
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let leader = leader_schedule_cache
+            .slot_leader_at(slot, Some(&root_bank))
+            .unwrap();
+        assert_eq!(leader.id, my_pubkey);
+
+        let mut replay_timing = ReplayLoopTiming::default();
+        let migration_status = post_migration_status_for_tests();
+        ReplayStage::generate_new_bank_forks(
+            NewBankForksContext {
+                blockstore: &blockstore,
+                bank_forks: &bank_forks,
+                leader_schedule_cache: &leader_schedule_cache,
+                rpc_subscriptions: None,
+                slot_status_notifier: &None,
+                migration_status: &migration_status,
+                my_pubkey: &my_pubkey,
+            },
+            &mut progress,
+            &mut replay_timing,
+        );
+
+        assert!(
+            bank_forks.read().unwrap().get(slot).is_none(),
+            "live replay must not create own leader banks from blockstore"
+        );
+        assert!(progress.get(&slot).is_none());
+    }
+
+    #[test]
+    fn test_purge_anc_desc() {
         let (VoteSimulator { bank_forks, .. }, _) = setup_default_forks(1, None::<GenerateVotes>);
 
         // Purge branch rooted at slot 2
@@ -7713,7 +8835,7 @@ pub(crate) mod tests {
 
         // 4 should be the heaviest slot, but should not be votable
         // because of lockout. 5 is the heaviest slot on the same fork as the last vote.
-        let (vote_fork, reset_fork, _) = run_compute_and_select_forks(
+        let (vote_fork, reset_fork, heaviest_fork_failures) = run_compute_and_select_forks(
             &bank_forks,
             &mut progress,
             &mut tower,
@@ -7724,6 +8846,13 @@ pub(crate) mod tests {
         );
         assert!(vote_fork.is_none());
         assert_eq!(reset_fork, Some(5));
+        assert_eq!(
+            heaviest_fork_failures,
+            vec![
+                HeaviestForkFailures::FailedSwitchThreshold(4, 0, 10000),
+                HeaviestForkFailures::LockedOut(4)
+            ]
+        );
 
         // Mark 5 as duplicate
         blockstore.store_duplicate_slot(5, vec![], vec![]).unwrap();
@@ -8767,7 +9896,7 @@ pub(crate) mod tests {
         assert_eq!(tower.last_voted_slot().unwrap(), 1);
 
         // Trying to refresh the vote for bank 1 in bank 2 won't succeed because
-        // the blockheight has not increased enough
+        // the blockheight is not increased enough
         progress
             .get_fork_stats_mut(bank1.slot())
             .unwrap()
@@ -8986,7 +10115,7 @@ pub(crate) mod tests {
         tower_storage: &dyn TowerStorage,
         make_it_landing: bool,
         cursor: &mut Cursor,
-        bank_forks: &RwLock<BankForks>,
+        bank_forks: Arc<RwLock<BankForks>>,
         progress: &mut ProgressMap,
     ) -> Arc<Bank> {
         let my_vote_pubkey = &my_vote_keypair[0].pubkey();
@@ -9040,7 +10169,7 @@ pub(crate) mod tests {
         );
         assert_eq!(tower.last_voted_slot().unwrap(), parent_bank.slot());
         let bank = Bank::new_from_parent_with_bank_forks(
-            bank_forks,
+            &bank_forks,
             parent_bank,
             SlotLeader::default(),
             my_slot,
@@ -9138,7 +10267,7 @@ pub(crate) mod tests {
             &tower_storage,
             true,
             &mut cursor,
-            &bank_forks,
+            bank_forks.clone(),
             &mut progress,
         );
         new_bank = send_vote_in_new_bank(
@@ -9156,7 +10285,7 @@ pub(crate) mod tests {
             &tower_storage,
             false,
             &mut cursor,
-            &bank_forks,
+            bank_forks.clone(),
             &mut progress,
         );
         // Create enough banks on the fork so last vote is outside SlotHash, make sure
@@ -9363,7 +10492,7 @@ pub(crate) mod tests {
         let res = retransmit_slots_receiver.recv_timeout(Duration::from_millis(10));
         assert!(
             res.is_err(),
-            "retry_iteration=1, elapsed < 2^1 * RETRY_BASE_DELAY_MS"
+            "retry_iteration=1, elapsed < 2^1 * RETRANSMIT_BASE_DELAY_MS"
         );
 
         progress.get_retransmit_info_mut(0).unwrap().retry_time = Instant::now()
@@ -10260,6 +11389,7 @@ pub(crate) mod tests {
             rpc_subscriptions,
             ..
         } = replay_blockstore_components(None, 1, None);
+
         let VoteSimulator {
             bank_forks,
             mut progress,

--- a/core/src/replay_stage/dead_slots.rs
+++ b/core/src/replay_stage/dead_slots.rs
@@ -1,0 +1,358 @@
+//! Dead-slot classification and notification helpers for replay.
+
+use {
+    super::TowerBFTStructures,
+    crate::{
+        consensus::progress_map::{DeadSlotReason, ProgressMap},
+        repair::{
+            ancestor_hashes_service::AncestorHashesReplayUpdateSender,
+            cluster_slot_state_verifier::{
+                DeadState, DuplicateSlotsToRepair, DuplicateState, PurgeRepairSlotCounter,
+                SlotStateUpdate, check_slot_agrees_with_cluster,
+            },
+        },
+    },
+    agave_votor_messages::migration::MigrationStatus,
+    solana_clock::Slot,
+    solana_ledger::{
+        block_error::BlockError, blockstore::Blockstore,
+        blockstore_processor::BlockstoreProcessorError,
+    },
+    solana_rpc::{rpc_subscriptions::RpcSubscriptions, slot_status_notifier::SlotStatusNotifier},
+    solana_rpc_client_api::response::SlotUpdate,
+    solana_runtime::{
+        bank::Bank,
+        vote_sender_types::{ReplayVoteMessage, ReplayVoteSender},
+    },
+    solana_time_utils::timestamp,
+    std::sync::Arc,
+};
+
+/// Controls the severity used for hard-dead-slot telemetry.
+///
+/// Some terminal replay outcomes are expected protocol behavior, such as a
+/// leader abandoning a block with too few ticks. Those still make the slot dead,
+/// but should not alert operators as validator errors.
+#[derive(Clone, Copy)]
+pub(super) enum DeadSlotLogLevel {
+    Info,
+    Error,
+}
+
+impl DeadSlotLogLevel {
+    /// Pick the operator-facing severity for a replay failure.
+    pub(super) fn for_replay_error(err: &BlockstoreProcessorError) -> Self {
+        match err {
+            BlockstoreProcessorError::InvalidBlock(BlockError::TooFewTicks) => Self::Info,
+            _ => Self::Error,
+        }
+    }
+
+    /// Emit the standard dead-slot datapoint with the selected severity.
+    pub(super) fn datapoint(self, slot: Slot, err: String) {
+        match self {
+            Self::Info => {
+                datapoint_info!(
+                    "replay-stage-mark_dead_slot",
+                    ("error", err, String),
+                    ("slot", slot, i64)
+                );
+            }
+            Self::Error => {
+                datapoint_error!(
+                    "replay-stage-mark_dead_slot",
+                    ("error", err, String),
+                    ("slot", slot, i64)
+                );
+            }
+        }
+    }
+}
+
+/// Sinks that observe replay dead-slot transitions.
+pub(super) struct DeadSlotNotifications {
+    /// Persistent ledger state. Hard-dead slots are written here; soft-dead
+    /// slots intentionally are not.
+    pub(super) blockstore: Arc<Blockstore>,
+    /// RPC subscription fanout for durable dead-slot notifications.
+    pub(super) rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
+    /// Optional test/runtime hook used by slot-status observers.
+    pub(super) slot_status_notifier: Option<SlotStatusNotifier>,
+    /// Replay-vote channel used to release buffered votes for the failed bank.
+    pub(super) replay_vote_sender: ReplayVoteSender,
+}
+
+/// Tower/duplicate bookkeeping that must be updated only for hard-dead slots.
+pub(super) struct DeadSlotDuplicateContext<'a> {
+    /// Current root used by the duplicate-slot agreement state machine.
+    pub(super) root: Slot,
+    /// Slots that should be repaired after duplicate/dead state transitions.
+    pub(super) duplicate_slots_to_repair: &'a mut DuplicateSlotsToRepair,
+    /// Notifies ancestor-hash repair when a dead slot changes duplicate state.
+    pub(super) ancestor_hashes_replay_update_sender: &'a AncestorHashesReplayUpdateSender,
+    /// Rate-limits purge repair requests triggered by duplicate/dead handling.
+    pub(super) purge_repair_slot_counter: &'a mut PurgeRepairSlotCounter,
+    /// Tower data is present only on the Tower replay path; Alpenglow replay
+    /// passes `None` because it does not run this duplicate state machine.
+    pub(super) tbft_structs: Option<&'a mut TowerBFTStructures>,
+}
+
+/// All state needed to decide and publish a replay dead-slot transition.
+pub(super) struct DeadSlotContext<'a> {
+    /// Persistent/RPC/replay-vote notification sinks.
+    pub(super) notifications: DeadSlotNotifications,
+    /// Duplicate/Tower bookkeeping for hard-dead transitions.
+    pub(super) duplicate: DeadSlotDuplicateContext<'a>,
+    /// Migration gates decide whether an UpdateParent marker can still recover
+    /// a failed prefix by restarting replay from a later FEC set.
+    pub(super) migration_status: &'a MigrationStatus,
+}
+
+/// Replay errors that may be caused solely by executing the optimistic-parent prefix.
+fn is_update_parent_recoverable_replay_error(err: &BlockstoreProcessorError) -> bool {
+    match err {
+        BlockstoreProcessorError::InvalidBlock(_)
+        | BlockstoreProcessorError::InvalidTransaction(_)
+        | BlockstoreProcessorError::UserTransactionsInVoteOnlyBank(_)
+        | BlockstoreProcessorError::ChainedBlockIdFailure(_, _) => true,
+        BlockstoreProcessorError::BlockComponentProcessor(err) => {
+            err.is_update_parent_recoverable_replay_error()
+        }
+        BlockstoreProcessorError::FailedToLoadEntries(_)
+        | BlockstoreProcessorError::FailedToLoadMeta
+        | BlockstoreProcessorError::FailedToReplayBank0
+        | BlockstoreProcessorError::NoValidForksFound
+        | BlockstoreProcessorError::InvalidHardFork(_)
+        | BlockstoreProcessorError::BankHashMismatch(..)
+        | BlockstoreProcessorError::RootBankWithMismatchedCapitalization(_) => false,
+    }
+}
+
+/// Returns true when replay failed before the slot's final parent is known.
+///
+/// Fast leader handover may execute a prefix built on an optimistic parent. If
+/// a later `UpdateParent` marker can still make that prefix obsolete, the slot
+/// is only soft-dead in `ProgressMap`; blockstore/RPC are updated only after the
+/// marker proves recovery impossible.
+fn should_mark_soft_dead(
+    blockstore: &Blockstore,
+    bank: &Bank,
+    err: &BlockstoreProcessorError,
+    progress: &ProgressMap,
+    migration_status: &MigrationStatus,
+) -> bool {
+    let slot = bank.slot();
+    if !migration_status.should_allow_fast_leader_handover(slot)
+        || blockstore.is_dead(slot)
+        || !is_update_parent_recoverable_replay_error(err)
+    {
+        return false;
+    }
+
+    let Some(fork_progress) = progress.get(&slot) else {
+        return false;
+    };
+    let replayed_shreds = fork_progress.replay_progress.read().unwrap().num_shreds;
+    let Some(slot_meta) = blockstore.meta(slot).ok().flatten() else {
+        return false;
+    };
+
+    if slot_meta.has_update_parent() {
+        if replayed_shreds >= u64::from(slot_meta.replay_fec_set_index) {
+            // Execution error past update parent is hard-dead, because the
+            // marker can no longer make the replayed prefix obsolete.
+            return false;
+        }
+    } else if slot_meta.is_full() {
+        // The slot is complete and no `UpdateParent` marker was observed, so
+        // the replay failure is terminal.
+        return false;
+    }
+
+    true
+}
+
+/// Mark a slot soft-dead after replay fails before a possible UpdateParent.
+///
+/// This releases replay-vote state for the current bank, but intentionally
+/// avoids blockstore/RPC dead-slot writes because a later marker may restart
+/// replay from the updated parent.
+fn mark_soft_dead_slot(
+    bank: &Bank,
+    err: &BlockstoreProcessorError,
+    progress: &mut ProgressMap,
+    notifications: &DeadSlotNotifications,
+) {
+    let slot = bank.slot();
+    datapoint_info!(
+        "replay-stage-soft_dead_slot",
+        ("error", format!("error: {err:?}"), String),
+        ("slot", slot, i64),
+    );
+    progress
+        .get_mut(&slot)
+        .unwrap()
+        .mark_dead(DeadSlotReason::ReplayFailureBeforeUpdateParent);
+    send_invalid_bank(bank, &notifications.replay_vote_sender);
+}
+
+/// Release replay-vote state for a bank that replay will no longer finish.
+pub(super) fn send_invalid_bank(bank: &Bank, replay_vote_sender: &ReplayVoteSender) {
+    replay_vote_sender
+        .send(ReplayVoteMessage::InvalidBank {
+            replay_bank_id: bank.bank_id(),
+            replay_slot: bank.slot(),
+        })
+        .expect("Failed to send InvalidBank message to replay vote sender");
+}
+
+/// Persist and publish a hard-dead slot.
+///
+/// Unlike soft-dead slots, hard-dead slots are terminal locally: the slot is
+/// written dead in blockstore and observers are notified.
+pub(super) fn mark_hard_dead_slot_notifications(
+    bank: &Bank,
+    err: String,
+    log_level: DeadSlotLogLevel,
+    progress: &mut ProgressMap,
+    notifications: &DeadSlotNotifications,
+) {
+    let slot = bank.slot();
+    let parent_slot = bank.parent_slot();
+    log_level.datapoint(slot, err.clone());
+    // Do not remove from progress map when marking dead! Needed by
+    // `process_duplicate_confirmed_slots()`
+    progress
+        .get_mut(&slot)
+        .unwrap()
+        .mark_dead(DeadSlotReason::Hard);
+    notifications
+        .blockstore
+        .set_dead_slot(slot)
+        .expect("Failed to mark slot as dead in blockstore");
+    send_invalid_bank(bank, &notifications.replay_vote_sender);
+
+    notifications.blockstore.slots_stats.mark_dead(slot);
+
+    if let Some(slot_status_notifier) = notifications.slot_status_notifier.as_ref() {
+        slot_status_notifier
+            .read()
+            .unwrap()
+            .notify_slot_dead(slot, parent_slot, err.clone());
+    }
+
+    if let Some(rpc_subscriptions) = notifications.rpc_subscriptions.as_ref() {
+        rpc_subscriptions.notify_slot_update(SlotUpdate::Dead {
+            slot,
+            err,
+            timestamp: timestamp(),
+        });
+    }
+}
+
+pub(super) fn mark_hard_dead_slot(
+    bank: &Bank,
+    err: String,
+    log_level: DeadSlotLogLevel,
+    progress: &mut ProgressMap,
+    dead_slot_context: &mut DeadSlotContext<'_>,
+) {
+    let slot = bank.slot();
+    mark_hard_dead_slot_notifications(
+        bank,
+        err,
+        log_level,
+        progress,
+        &dead_slot_context.notifications,
+    );
+
+    if let Some(TowerBFTStructures {
+        heaviest_subtree_fork_choice,
+        duplicate_slots_tracker,
+        duplicate_confirmed_slots,
+        epoch_slots_frozen_slots,
+        ..
+    }) = dead_slot_context.duplicate.tbft_structs.as_deref_mut()
+    {
+        let dead_state = DeadState::new_from_state(
+            slot,
+            duplicate_slots_tracker,
+            duplicate_confirmed_slots,
+            heaviest_subtree_fork_choice,
+            epoch_slots_frozen_slots,
+        );
+        check_slot_agrees_with_cluster(
+            slot,
+            dead_slot_context.duplicate.root,
+            dead_slot_context.notifications.blockstore.as_ref(),
+            duplicate_slots_tracker,
+            epoch_slots_frozen_slots,
+            heaviest_subtree_fork_choice,
+            dead_slot_context.duplicate.duplicate_slots_to_repair,
+            dead_slot_context
+                .duplicate
+                .ancestor_hashes_replay_update_sender,
+            dead_slot_context.duplicate.purge_repair_slot_counter,
+            SlotStateUpdate::Dead(dead_state),
+        );
+
+        // If we previously marked this slot as duplicate in blockstore, let the state machine know.
+        if !duplicate_slots_tracker.contains(&slot)
+            && dead_slot_context
+                .notifications
+                .blockstore
+                .get_duplicate_slot(slot)
+                .is_some()
+        {
+            let duplicate_state = DuplicateState::new_from_state(
+                slot,
+                duplicate_confirmed_slots,
+                heaviest_subtree_fork_choice,
+                || true,
+                || None,
+            );
+            check_slot_agrees_with_cluster(
+                slot,
+                dead_slot_context.duplicate.root,
+                dead_slot_context.notifications.blockstore.as_ref(),
+                duplicate_slots_tracker,
+                epoch_slots_frozen_slots,
+                heaviest_subtree_fork_choice,
+                dead_slot_context.duplicate.duplicate_slots_to_repair,
+                dead_slot_context
+                    .duplicate
+                    .ancestor_hashes_replay_update_sender,
+                dead_slot_context.duplicate.purge_repair_slot_counter,
+                SlotStateUpdate::Duplicate(duplicate_state),
+            );
+        }
+    }
+}
+
+/// Classify a replay failure as soft-dead or hard-dead and publish the
+/// appropriate state transition.
+pub(super) fn mark_replay_dead_slot(
+    bank: &Bank,
+    err: &BlockstoreProcessorError,
+    progress: &mut ProgressMap,
+    dead_slot_context: &mut DeadSlotContext<'_>,
+) {
+    if should_mark_soft_dead(
+        dead_slot_context.notifications.blockstore.as_ref(),
+        bank,
+        err,
+        progress,
+        dead_slot_context.migration_status,
+    ) {
+        mark_soft_dead_slot(bank, err, progress, &dead_slot_context.notifications);
+        return;
+    }
+
+    mark_hard_dead_slot(
+        bank,
+        format!("error: {err:?}"),
+        DeadSlotLogLevel::for_replay_error(err),
+        progress,
+        dead_slot_context,
+    );
+}

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -1,0 +1,371 @@
+//! Fast-leader-handover replay helpers.
+
+use {
+    super::{
+        ProcessActiveBanksContext, ReplayStage, TowerBFTStructures,
+        dead_slots::{
+            DeadSlotLogLevel, DeadSlotNotifications, mark_hard_dead_slot,
+            mark_hard_dead_slot_notifications, send_invalid_bank,
+        },
+    },
+    crate::{
+        consensus::progress_map::{DeadSlotReason, ProgressMap},
+        repair::cluster_slot_state_verifier::{DuplicateSlotsToRepair, PurgeRepairSlotCounter},
+    },
+    agave_votor_messages::migration::MigrationStatus,
+    solana_clock::Slot,
+    solana_entry::block_component::VersionedUpdateParent,
+    solana_ledger::{
+        blockstore::{Blockstore, UpdateParentReceiver},
+        blockstore_meta::SlotMeta,
+        blockstore_processor::AsyncVerificationProgress,
+    },
+    solana_pubkey::Pubkey,
+    solana_runtime::{bank::Bank, bank_forks::BankForks, vote_sender_types::ReplayVoteSender},
+    std::{
+        collections::BTreeSet,
+        sync::{Arc, RwLock},
+    },
+};
+
+/// Replay-start decision for a child bank discovered from blockstore metadata.
+pub(super) enum ChildBankReplayStart {
+    /// Create the bank and replay from shred zero.
+    FromStart,
+    /// Create the bank and begin replay at the `UpdateParent` FEC-set boundary.
+    FromUpdateParent(u64),
+    /// Do not create the bank yet. The local parent information is not
+    /// coherent enough to safely choose a replay start.
+    Defer,
+}
+
+/// Return the UpdateParent replay offset recorded in SlotMeta, if it is
+/// usable from the currently rooted fork.
+fn update_parent_replay_offset(slot: Slot, slot_meta: &SlotMeta, root: Slot) -> Option<u64> {
+    if !slot_meta.has_update_parent() {
+        return None;
+    }
+    let parent_slot = slot_meta.parent_slot?;
+    (root <= parent_slot && parent_slot < slot).then_some(u64::from(slot_meta.replay_fec_set_index))
+}
+
+/// Decide whether a newly discovered child bank should replay from the
+/// beginning, from an `UpdateParent` FEC set, or wait for coherent metadata.
+pub(super) fn child_bank_replay_start(
+    blockstore: &Blockstore,
+    parent_bank: &Bank,
+    parent_slot: Slot,
+    child_slot: Slot,
+    migration_status: &MigrationStatus,
+) -> ChildBankReplayStart {
+    if !migration_status.should_allow_block_markers(child_slot) {
+        return ChildBankReplayStart::FromStart;
+    }
+
+    let Some(slot_meta) = blockstore
+        .meta(child_slot)
+        .expect("Blockstore should not fail")
+    else {
+        return ChildBankReplayStart::Defer;
+    };
+
+    // No lock is held between get_slots_since and fetching the slot meta, so
+    // SlotMeta could have been updated in between. If so, continue and the
+    // next iteration of generate_new_bank_forks will have consistent values.
+    if slot_meta.parent_slot != Some(parent_slot) {
+        return ChildBankReplayStart::Defer;
+    }
+
+    // Genesis doesn't have a block id.
+    if parent_slot != 0 && Some(slot_meta.parent_block_id) != parent_bank.block_id() {
+        // There were duplicate blocks in this slot and we have the wrong one
+        // replayed. Do not continue down this fork. If this fork ends up
+        // being ParentReady, votor will repair the duplicate parent block and
+        // perform the switch so replay can continue.
+        return ChildBankReplayStart::Defer;
+    }
+
+    let num_shreds = u64::from(slot_meta.replay_fec_set_index);
+    if !slot_meta.has_update_parent() {
+        return ChildBankReplayStart::FromStart;
+    }
+
+    info!(
+        "slot {child_slot}: replay offset {} shreds from parent {:?}",
+        num_shreds, slot_meta.parent_slot
+    );
+    ChildBankReplayStart::FromUpdateParent(num_shreds)
+}
+
+/// Clear an in-progress bank so the next replay iteration recreates it from
+/// the current UpdateParent parent and FEC-set offset recorded in `SlotMeta`.
+fn try_restart_slot_from_update_parent(
+    my_pubkey: &Pubkey,
+    blockstore: &Blockstore,
+    bank_forks: &RwLock<BankForks>,
+    progress: &mut ProgressMap,
+    async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+    slot: Slot,
+    replay_vote_sender: &ReplayVoteSender,
+    migration_status: &MigrationStatus,
+    source: &str,
+) -> bool {
+    if !migration_status.should_allow_fast_leader_handover(slot) {
+        return false;
+    }
+    if blockstore.is_dead(slot) {
+        return false;
+    }
+    let Some(slot_meta) = blockstore.meta(slot).expect("Blockstore should not fail") else {
+        return false;
+    };
+    let Some(replay_fec_set_index) =
+        update_parent_replay_offset(slot, &slot_meta, bank_forks.read().unwrap().root())
+    else {
+        return false;
+    };
+
+    // Skip if neither replay bank nor progress exists. If progress exists
+    // without a bank, clear it as stale state so the next replay iteration
+    // can recreate the bank from the updated SlotMeta.
+    let bank = bank_forks.read().unwrap().get(slot);
+    if bank.is_none() && !progress.contains_key(&slot) {
+        return false;
+    }
+    if bank
+        .as_ref()
+        .is_some_and(|bank| ReplayStage::leader_is_me(bank.leader_id(), my_pubkey))
+    {
+        return false;
+    }
+    if progress.get(&slot).is_some_and(|progress| {
+        progress.dead_reason.is_some()
+            && !matches!(
+                progress.dead_reason,
+                Some(DeadSlotReason::ReplayFailureBeforeUpdateParent)
+            )
+    }) {
+        return false;
+    }
+
+    // Check if we've already replayed past the UpdateParent marker.
+    let current_num_shreds = progress
+        .get(&slot)
+        .map(|p| p.replay_progress.read().unwrap().num_shreds)
+        .unwrap_or(0);
+
+    if current_num_shreds >= replay_fec_set_index {
+        return false;
+    }
+
+    // Clear and let generate_new_bank_forks restart from replay_fec_set_index.
+    info!(
+        "{my_pubkey}: restarting slot {slot} from replay_fec_set_index {replay_fec_set_index} via \
+         {source} (was at {current_num_shreds} shreds)",
+    );
+    if let Some(bank) = bank {
+        send_invalid_bank(&bank, replay_vote_sender);
+    }
+    ReplayStage::clear_banks(
+        &BTreeSet::from([slot]),
+        bank_forks,
+        progress,
+        async_verification_freelist,
+    );
+    true
+}
+
+/// Revisit soft-dead slots as more shreds arrive.
+///
+/// If an UpdateParent marker is now visible in SlotMeta, replay is restarted
+/// from the marker's FEC set. If the slot completes without a marker, the
+/// soft-dead state is promoted to a durable hard-dead slot.
+pub(super) fn process_soft_dead_slots(
+    my_pubkey: &Pubkey,
+    blockstore: &Arc<Blockstore>,
+    bank_forks: &RwLock<BankForks>,
+    rpc_subscriptions: &Option<Arc<solana_rpc::rpc_subscriptions::RpcSubscriptions>>,
+    slot_status_notifier: &Option<solana_rpc::slot_status_notifier::SlotStatusNotifier>,
+    progress: &mut ProgressMap,
+    async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+    replay_vote_sender: &ReplayVoteSender,
+    migration_status: &MigrationStatus,
+) {
+    let soft_dead_slots = progress
+        .iter()
+        .filter_map(|(&slot, progress)| {
+            matches!(
+                progress.dead_reason,
+                Some(DeadSlotReason::ReplayFailureBeforeUpdateParent)
+            )
+            .then_some(slot)
+        })
+        .collect::<Vec<_>>();
+
+    for slot in soft_dead_slots {
+        if blockstore.is_dead(slot) {
+            if let Some(progress) = progress.get_mut(&slot) {
+                progress.mark_dead(DeadSlotReason::Hard);
+            }
+            continue;
+        }
+
+        let Some(slot_meta) = blockstore.meta(slot).expect("Blockstore should not fail") else {
+            continue;
+        };
+        let replay_offset =
+            update_parent_replay_offset(slot, &slot_meta, bank_forks.read().unwrap().root());
+
+        if replay_offset.is_some() {
+            try_restart_slot_from_update_parent(
+                my_pubkey,
+                blockstore.as_ref(),
+                bank_forks,
+                progress,
+                async_verification_freelist,
+                slot,
+                replay_vote_sender,
+                migration_status,
+                "soft-dead scan",
+            );
+            continue;
+        }
+
+        if slot_meta.has_update_parent() || slot_meta.is_full() {
+            let (err, log_level) = if slot_meta.has_update_parent() {
+                (
+                    "error: replay failed before UpdateParent, and the UpdateParent metadata is \
+                     invalid"
+                        .to_string(),
+                    DeadSlotLogLevel::Error,
+                )
+            } else {
+                (
+                    "error: replay failed before a usable UpdateParent marker, and the completed \
+                     slot cannot replay from UpdateParent"
+                        .to_string(),
+                    DeadSlotLogLevel::Info,
+                )
+            };
+            let bank = bank_forks.read().unwrap().get(slot);
+            if let Some(bank) = bank {
+                let notifications = DeadSlotNotifications {
+                    blockstore: blockstore.clone(),
+                    rpc_subscriptions: rpc_subscriptions.clone(),
+                    slot_status_notifier: slot_status_notifier.clone(),
+                    replay_vote_sender: replay_vote_sender.clone(),
+                };
+                mark_hard_dead_slot_notifications(&bank, err, log_level, progress, &notifications);
+            }
+        }
+    }
+}
+
+/// Handles UpdateParent signals by clearing slot state so replay restarts from
+/// the new parent. Skips live own-leader banks, slots replay has not started,
+/// and slots that already replayed past the UpdateParent marker.
+pub(super) fn handle_update_parent_interrupts(
+    my_pubkey: &Pubkey,
+    blockstore: &Blockstore,
+    bank_forks: &RwLock<BankForks>,
+    progress: &mut ProgressMap,
+    async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+    update_parent_receiver: &UpdateParentReceiver,
+    replay_vote_sender: &ReplayVoteSender,
+    migration_status: &MigrationStatus,
+) {
+    while let Ok(signal) = update_parent_receiver.try_recv() {
+        try_restart_slot_from_update_parent(
+            my_pubkey,
+            blockstore,
+            bank_forks,
+            progress,
+            async_verification_freelist,
+            signal.slot,
+            replay_vote_sender,
+            migration_status,
+            "UpdateParent signal",
+        );
+    }
+}
+
+/// Restart an obsolete optimistic-parent bank after replay reaches the
+/// `UpdateParent` marker itself.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn handle_abandoned_bank(
+    process_active_banks_context: &ProcessActiveBanksContext,
+    bank: &Arc<Bank>,
+    bank_slot: Slot,
+    update_parent: &VersionedUpdateParent,
+    bank_forks: &Arc<RwLock<BankForks>>,
+    progress: &mut ProgressMap,
+    async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+    duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
+    purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
+    tbft_structs: Option<&mut TowerBFTStructures>,
+) {
+    // Handle UpdateParent marker during fast leader handover. The leader
+    // built on an optimistic parent that didn't match the finalized parent.
+    //
+    // We clear the bank and remove the progress entry. The bank will be
+    // recreated with the correct parent by generate_new_bank_forks, which
+    // reads slot meta to determine both the new parent and the correct
+    // replay offset (replay_fec_set_index).
+    let new_parent_slot = match &update_parent {
+        VersionedUpdateParent::V1(x) => x.new_parent_slot,
+    };
+
+    datapoint_info!(
+        "replay-stage-update-parent",
+        ("slot", bank_slot, i64),
+        ("old_parent_slot", bank.parent_slot(), i64),
+        ("new_parent_slot", new_parent_slot, i64),
+    );
+
+    info!(
+        "AbandonedBank at slot {bank_slot}: switching parent from {} to {new_parent_slot}",
+        bank.parent_slot()
+    );
+
+    let update_parent_ready = !process_active_banks_context.blockstore.is_dead(bank_slot)
+        && process_active_banks_context
+            .blockstore
+            .meta(bank_slot)
+            .expect("Blockstore operations must succeed")
+            .is_some_and(|slot_meta| {
+                update_parent_replay_offset(
+                    bank_slot,
+                    &slot_meta,
+                    bank_forks.read().unwrap().root(),
+                )
+                .is_some()
+            });
+    if !update_parent_ready {
+        let root = bank_forks.read().unwrap().root();
+        let mut dead_slot_context = process_active_banks_context.dead_slot_context(
+            root,
+            duplicate_slots_to_repair,
+            purge_repair_slot_counter,
+            tbft_structs,
+        );
+        mark_hard_dead_slot(
+            bank,
+            "error: replay abandoned bank for an unusable UpdateParent".to_string(),
+            DeadSlotLogLevel::Error,
+            progress,
+            &mut dead_slot_context,
+        );
+        return;
+    }
+
+    send_invalid_bank(bank, &process_active_banks_context.replay_vote_sender);
+
+    // Clear the bank from bank_forks. It will be recreated with the correct
+    // parent by generate_new_bank_forks on the next iteration.
+    ReplayStage::clear_banks(
+        &BTreeSet::from([bank_slot]),
+        bank_forks.as_ref(),
+        progress,
+        async_verification_freelist,
+    );
+}

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -49,7 +49,7 @@ use {
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::{
-        blockstore::{Blockstore, MAX_COMPLETED_SLOTS_IN_CHANNEL},
+        blockstore::{Blockstore, MAX_COMPLETED_SLOTS_IN_CHANNEL, UpdateParentReceiver},
         blockstore_cleanup_service::BlockstoreCleanupService,
         blockstore_processor::TransactionStatusSender,
         entry_notifier_service::EntryNotifierSender,
@@ -168,6 +168,8 @@ impl Default for TvuConfig {
 pub struct AlpenglowInitializationState {
     // Shared with block creation loop
     pub leader_window_info_sender: Sender<LeaderWindowInfo>,
+    pub optimistic_parent_sender: Sender<LeaderWindowInfo>,
+    pub optimistic_parent_receiver: Receiver<LeaderWindowInfo>,
     pub replay_highest_frozen: Arc<ReplayHighestFrozen>,
     pub highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
     pub highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
@@ -208,6 +210,7 @@ impl Tvu {
         sockets: TvuSockets,
         blockstore: Arc<Blockstore>,
         ledger_signal_receiver: Receiver<bool>,
+        update_parent_receiver: UpdateParentReceiver,
         rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         poh_controller: PohController,
@@ -257,6 +260,8 @@ impl Tvu {
 
         let AlpenglowInitializationState {
             leader_window_info_sender,
+            optimistic_parent_sender,
+            optimistic_parent_receiver,
             replay_highest_frozen,
             highest_parent_ready,
             bank_forks_controller,
@@ -539,11 +544,14 @@ impl Tvu {
             dumped_slots_sender,
             votor_event_sender,
             own_vote_sender: consensus_message_sender,
+            optimistic_parent_sender,
             lockouts_sender,
         };
 
         let replay_receivers = ReplayReceivers {
             ledger_signal_receiver,
+            update_parent_receiver,
+            optimistic_parent_receiver,
             duplicate_slots_receiver,
             ancestor_duplicate_slots_receiver,
             duplicate_confirmed_slots_receiver,
@@ -576,7 +584,6 @@ impl Tvu {
             banking_tracer,
             snapshot_controller,
             replay_highest_frozen,
-            migration_status,
         };
 
         let voting_service = VotingService::new(
@@ -758,6 +765,7 @@ pub mod tests {
         let BlockstoreSignals {
             blockstore,
             ledger_signal_receiver,
+            update_parent_receiver,
             ..
         } = Blockstore::open_with_signal(&blockstore_path, BlockstoreOptions::default())
             .expect("Expected to successfully open ledger");
@@ -799,6 +807,7 @@ pub mod tests {
         );
         let replay_highest_frozen = Arc::new(ReplayHighestFrozen::default());
         let (leader_window_info_sender, _leader_window_info_receiver) = unbounded();
+        let (optimistic_parent_sender, optimistic_parent_receiver) = unbounded();
         let highest_parent_ready = Arc::new(RwLock::new((0, (0, Hash::default()))));
         let (votor_event_sender, votor_event_receiver): (VotorEventSender, VotorEventReceiver) =
             unbounded();
@@ -837,6 +846,7 @@ pub mod tests {
             },
             blockstore,
             ledger_signal_receiver,
+            update_parent_receiver,
             Some(Arc::new(RpcSubscriptions::new_for_tests(
                 exit.clone(),
                 max_complete_transaction_status_slot,
@@ -879,6 +889,8 @@ pub mod tests {
             Arc::new(connection_cache),
             AlpenglowInitializationState {
                 leader_window_info_sender,
+                optimistic_parent_sender,
+                optimistic_parent_receiver,
                 replay_highest_frozen,
                 highest_parent_ready,
                 votor_event_sender,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -78,7 +78,7 @@ use {
         bank_forks_utils,
         blockstore::{
             Blockstore, BlockstoreError, MAX_COMPLETED_SLOTS_IN_CHANNEL,
-            MAX_REPLAY_WAKE_UP_SIGNALS, PurgeType,
+            MAX_REPLAY_WAKE_UP_SIGNALS, MAX_UPDATE_PARENT_SIGNALS, PurgeType, UpdateParentReceiver,
         },
         blockstore_metric_report_service::BlockstoreMetricReportService,
         blockstore_options::{BLOCKSTORE_DIRECTORY_ROCKS_LEVEL, BlockstoreOptions},
@@ -899,6 +899,7 @@ impl Validator {
             blockstore,
             original_blockstore_root,
             ledger_signal_receiver,
+            update_parent_receiver,
             leader_schedule_cache,
             starting_snapshot_hashes,
             TransactionHistoryServices {
@@ -1464,10 +1465,16 @@ impl Validator {
         let highest_parent_ready = Arc::new(RwLock::default());
         // Shared state for highest finalized certificates (updated by Votor, read by block creation loop)
         let highest_finalized = Arc::new(RwLock::new(None));
+        // This channel growing > ~1 indicates problems, so bound channel at a
+        // small (but highly overprovisioned) number for performance and easier
+        // debug if things go off the rails.
+        let (optimistic_parent_sender, optimistic_parent_receiver) = bounded(100);
         // There will only ever be a single msg in flight so bound channel for [`BuildRewardCertsRequest`] to 1 message.
         let (build_reward_certs_sender, build_reward_certs_receiver) = bounded(1);
         // There will only ever be a single msg in flight so bound channel for [`BuildRewardCertsResponse`] to 1 message.
         let (reward_certs_sender, reward_certs_receiver) = bounded(1);
+
+        let banking_stage_sender_for_bcl = banking_tracer_channels.non_vote_sender.clone();
 
         let block_creation_loop_config = BlockCreationLoopConfig {
             exit: exit.clone(),
@@ -1484,9 +1491,11 @@ impl Validator {
             highest_parent_ready: highest_parent_ready.clone(),
             replay_highest_frozen: replay_highest_frozen.clone(),
             record_receiver_receiver,
+            optimistic_parent_receiver: optimistic_parent_receiver.clone(),
             highest_finalized: highest_finalized.clone(),
             build_reward_certs_sender,
             reward_certs_receiver,
+            banking_stage_sender: banking_stage_sender_for_bcl,
         };
         let block_creation_loop = BlockCreationLoop::new(block_creation_loop_config);
 
@@ -1575,6 +1584,7 @@ impl Validator {
             },
             blockstore.clone(),
             ledger_signal_receiver,
+            update_parent_receiver,
             rpc_subscriptions.clone(),
             &poh_recorder,
             poh_controller,
@@ -1622,6 +1632,8 @@ impl Validator {
             vote_connection_cache,
             AlpenglowInitializationState {
                 leader_window_info_sender,
+                optimistic_parent_sender,
+                optimistic_parent_receiver,
                 replay_highest_frozen,
                 highest_parent_ready,
                 bank_forks_controller,
@@ -2137,6 +2149,7 @@ fn load_blockstore(
         Arc<Blockstore>,
         Slot,
         Receiver<bool>,
+        UpdateParentReceiver,
         LeaderScheduleCache,
         Option<StartingSnapshotHashes>,
         TransactionHistoryServices,
@@ -2244,12 +2257,15 @@ fn load_blockstore(
     let blockstore_root_scan = BlockstoreRootScan::new(config, blockstore.clone(), exit);
     let (ledger_signal_sender, ledger_signal_receiver) = bounded(MAX_REPLAY_WAKE_UP_SIGNALS);
     blockstore.add_new_shred_signal(ledger_signal_sender);
+    let (update_parent_sender, update_parent_receiver) = bounded(MAX_UPDATE_PARENT_SIGNALS);
+    blockstore.add_update_parent_signal(update_parent_sender);
 
     Ok((
         bank_forks,
         blockstore,
         original_blockstore_root,
         ledger_signal_receiver,
+        update_parent_receiver,
         leader_schedule_cache,
         starting_snapshot_hashes,
         transaction_history_services,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -107,9 +107,28 @@ pub use {
 
 pub const MAX_REPLAY_WAKE_UP_SIGNALS: usize = 1;
 pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;
+/// Maximum queued UpdateParent notifications from blockstore insertion to replay.
+///
+/// Replay also recovers by reading SlotMeta, so dropping this bounded signal is
+/// a latency event rather than the only source of truth. Keep this small enough
+/// that Tower validators do not pay a large idle-memory cost for the channel.
+pub const MAX_UPDATE_PARENT_SIGNALS: usize = 4_096;
 
 pub type CompletedSlotsSender = Sender<Vec<Slot>>;
 pub type CompletedSlotsReceiver = Receiver<Vec<Slot>>;
+
+pub type UpdateParentSender = Sender<UpdateParentSignal>;
+pub type UpdateParentReceiver = Receiver<UpdateParentSignal>;
+
+#[derive(Debug, Clone)]
+pub struct UpdateParentSignal {
+    /// Slot whose parent metadata was updated by an UpdateParent marker.
+    ///
+    /// This is only a wakeup for replay. Consumers must re-read SlotMeta/dead
+    /// state from blockstore so stale queued signals cannot override newer
+    /// parent metadata or a durable dead-slot decision.
+    pub slot: Slot,
+}
 
 // Contiguous, sorted and non-empty ranges of shred indices:
 //     completed_ranges[i].start < completed_ranges[i].end
@@ -232,6 +251,7 @@ pub struct BlockstoreSignals {
     pub blockstore: Blockstore,
     pub ledger_signal_receiver: Receiver<bool>,
     pub completed_slots_receiver: CompletedSlotsReceiver,
+    pub update_parent_receiver: UpdateParentReceiver,
 }
 
 // ledger window
@@ -275,6 +295,7 @@ pub struct Blockstore {
     insert_shreds_lock: Mutex<()>,
     new_shreds_signals: Mutex<Vec<Sender<bool>>>,
     completed_slots_senders: Mutex<Vec<CompletedSlotsSender>>,
+    update_parent_signals: Mutex<Vec<UpdateParentSender>>,
     pub lowest_cleanup_slot: RwLock<Slot>,
     // A sender that feeds into the BlockstoreCleanupService request channel
     // to enable manual Blockstore purge requests to be issued
@@ -367,12 +388,17 @@ pub(crate) fn hashes_per_tick_for_ledger(genesis_config: &GenesisConfig) -> u64 
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ParentInfo {
+    /// Parent slot to expose through SlotMeta and replay.
     pub(crate) parent_slot: Slot,
+    /// Parent block id paired with `parent_slot`.
     pub(crate) parent_block_id: Hash,
+    /// Zero for the block header parent; non-zero when populated by UpdateParent.
     pub(crate) replay_fec_set_index: u32,
 }
 
 impl ParentInfo {
+    /// Read the currently persisted parent metadata, if enough information has
+    /// been written to distinguish it from an old/default SlotMeta.
     fn from_slot_meta(slot_meta: &SlotMeta) -> Option<Self> {
         let parent_slot = slot_meta.parent_slot?;
         let parent_info = ParentInfo {
@@ -380,9 +406,8 @@ impl ParentInfo {
             parent_block_id: slot_meta.parent_block_id,
             replay_fec_set_index: slot_meta.replay_fec_set_index,
         };
-        (parent_info.populated_from_update_parent()
-            || parent_info.parent_block_id != Hash::default())
-        .then_some(parent_info)
+        (parent_info.has_update_parent() || parent_info.parent_block_id != Hash::default())
+            .then_some(parent_info)
     }
 
     /// Try to parse a `ParentInfo` from a block header in the first shred
@@ -427,15 +452,11 @@ impl ParentInfo {
             // Validate and allow UpdateParent to replace BlockHeader
             (false, true) => (new, prev, true),
             // Both are UpdateParent - ensure they match
-            (false, false) => match new == prev {
-                true => return Ok(false),
-                false => return Err(BlockstoreError::MultipleUpdateParents(slot)),
-            },
+            (false, false) if new == prev => return Ok(false),
+            (false, false) => return Err(BlockstoreError::MultipleUpdateParents(slot)),
             // Both are block headers - ensure they match
-            (true, true) => match new == prev {
-                true => return Ok(false),
-                false => return Err(BlockstoreError::BlockComponentMismatch(slot)),
-            },
+            (true, true) if new == prev => return Ok(false),
+            (true, true) => return Err(BlockstoreError::BlockComponentMismatch(slot)),
         };
 
         // Validate that the UpdateParent is compatible with the BlockHeader
@@ -452,18 +473,27 @@ impl ParentInfo {
         Ok(should_write)
     }
 
-    fn populated_from_update_parent(&self) -> bool {
+    /// True when this metadata came from an `UpdateParent` marker.
+    fn has_update_parent(&self) -> bool {
         self.replay_fec_set_index > 0
     }
 
+    /// True when this metadata came from the slot's block header.
     fn populated_from_block_header(&self) -> bool {
         self.replay_fec_set_index == 0
     }
 
+    /// Parent slot and block id as a single comparable value.
     fn block(&self) -> (Slot, Hash) {
         (self.parent_slot, self.parent_block_id)
     }
 
+    /// Validate this parent against both ledger ancestry and the shred header.
+    ///
+    /// UpdateParent is allowed to choose the shred-header parent slot or an
+    /// older parent slot; block headers must exactly match the shred header.
+    /// The shred header has no parent block id, so same-slot UpdateParent
+    /// switches remain legal for duplicate parent blocks.
     fn validate_shred_parent(&self, slot: Slot, shred_parent_slot: Slot, root: Slot) -> Result<()> {
         if !verify_shred_slots(slot, self.parent_slot, root) {
             return Err(BlockstoreError::InvalidParentInfo {
@@ -477,6 +507,14 @@ impl ParentInfo {
             return Err(BlockstoreError::BlockHeaderParentMismatch {
                 slot,
                 block_header_parent_slot: self.parent_slot,
+                shred_parent_slot,
+            });
+        }
+
+        if self.has_update_parent() && self.parent_slot > shred_parent_slot {
+            return Err(BlockstoreError::UpdateParentSlotGreaterThanShredParent {
+                slot,
+                update_parent_slot: self.parent_slot,
                 shred_parent_slot,
             });
         }
@@ -592,6 +630,7 @@ impl Blockstore {
 
             new_shreds_signals: Mutex::default(),
             completed_slots_senders: Mutex::default(),
+            update_parent_signals: Mutex::default(),
             insert_shreds_lock: Mutex::<()>::default(),
             max_root,
             lowest_cleanup_slot: RwLock::<Slot>::default(),
@@ -611,14 +650,17 @@ impl Blockstore {
         let (ledger_signal_sender, ledger_signal_receiver) = bounded(MAX_REPLAY_WAKE_UP_SIGNALS);
         let (completed_slots_sender, completed_slots_receiver) =
             bounded(MAX_COMPLETED_SLOTS_IN_CHANNEL);
+        let (update_parent_sender, update_parent_receiver) = bounded(MAX_UPDATE_PARENT_SIGNALS);
 
         blockstore.add_new_shred_signal(ledger_signal_sender);
         blockstore.add_completed_slots_signal(completed_slots_sender);
+        blockstore.add_update_parent_signal(update_parent_sender);
 
         Ok(BlockstoreSignals {
             blockstore,
             ledger_signal_receiver,
             completed_slots_receiver,
+            update_parent_receiver,
         })
     }
 
@@ -956,8 +998,10 @@ impl Blockstore {
     }
 
     /// Gets the double merkle root for the block in the given location.
-    /// Returns `None` if the block is not full.
-    /// DoubleMerkleMeta is computed atomically during shred insertion when a slot becomes full.
+    ///
+    /// Returns `None` if the block is not full, or if the slot was completed
+    /// while block markers were disabled. That can happen for legacy Tower
+    /// slots in a process that later enters Alpenglow migration.
     pub fn get_double_merkle_root(
         &self,
         slot: Slot,
@@ -1033,7 +1077,7 @@ impl Blockstore {
                 .and_then(|flags| {
                     flags
                         .contains(ShredFlags::DATA_COMPLETE_SHRED)
-                        .then(|| Cow::Borrowed(current_shred.payload()))
+                        .then_some(Cow::Borrowed(current_shred.payload()))
                 });
 
             (shred_bytes, fec_set_index)
@@ -1128,6 +1172,10 @@ impl Blockstore {
         location: BlockLocation,
         err: &BlockstoreError,
     ) -> Result<()> {
+        // Parent markers are consensus-critical. If a marker is malformed or
+        // incompatible with already-persisted metadata, keep the slot from
+        // being replayed rather than letting validators derive different
+        // parents from different shred arrival orders.
         datapoint_error!(
             "blockstore_error",
             (
@@ -1555,9 +1603,7 @@ impl Blockstore {
             .filter_map(|(erasure_set, working_erasure_meta)| {
                 let erasure_meta = working_erasure_meta.as_ref();
                 let slot = erasure_set.slot();
-                let index_meta_entry = index_working_set
-                    .get(&(BlockLocation::Original, slot))
-                    .expect("Index");
+                let index_meta_entry = index_working_set.get(&(BlockLocation::Original, slot))?;
                 let index = &index_meta_entry.index;
                 erasure_meta
                     .should_recover_shreds(index)
@@ -1724,7 +1770,8 @@ impl Blockstore {
         }
     }
 
-    /// Computes and adds DoubleMerkleMeta to the write_batch for any newly completed slots.
+    /// Computes and adds DoubleMerkleMeta to the write_batch for newly completed
+    /// slots after block markers have been enabled.
     fn compute_double_merkle_meta_for_newly_completed_slots(
         &self,
         shred_insertion_tracker: &mut ShredInsertionTracker,
@@ -1915,12 +1962,14 @@ impl Blockstore {
     ) -> Result<(
         /* signal slot updates */ bool,
         /* slots updated */ Vec<u64>,
+        /* update parent signals */ Vec<UpdateParentSignal>,
     )> {
         let mut start = Measure::start("Commit Working Sets");
-        let (should_signal, newly_completed_slots) = self.commit_slot_meta_working_set(
-            &shred_insertion_tracker.slot_meta_working_set,
-            &mut shred_insertion_tracker.write_batch,
-        )?;
+        let (should_signal, newly_completed_slots, update_parent_signals) = self
+            .commit_slot_meta_working_set(
+                &shred_insertion_tracker.slot_meta_working_set,
+                &mut shred_insertion_tracker.write_batch,
+            )?;
 
         for (erasure_set, working_erasure_meta) in &shred_insertion_tracker.erasure_metas {
             if !working_erasure_meta.should_write() {
@@ -1965,7 +2014,7 @@ impl Blockstore {
         start.stop();
         metrics.commit_working_sets_elapsed_us += start.as_us();
 
-        Ok((should_signal, newly_completed_slots))
+        Ok((should_signal, newly_completed_slots, update_parent_signals))
     }
 
     /// The main helper function that performs the shred insertion logic
@@ -2069,7 +2118,7 @@ impl Blockstore {
         // Compute DoubleMerkleMeta for any newly completed slots so it's committed atomically
         self.compute_double_merkle_meta_for_newly_completed_slots(&mut shred_insertion_tracker)?;
 
-        let (should_signal, newly_completed_slots) =
+        let (should_signal, newly_completed_slots, update_parent_signals) =
             self.commit_updates_to_write_batch(&mut shred_insertion_tracker, metrics)?;
 
         // Write out the accumulated batch.
@@ -2081,8 +2130,10 @@ impl Blockstore {
         send_signals(
             &self.new_shreds_signals.lock().unwrap(),
             &self.completed_slots_senders.lock().unwrap(),
+            &self.update_parent_signals.lock().unwrap(),
             should_signal,
             newly_completed_slots,
+            update_parent_signals,
         );
 
         // Roll up metrics
@@ -2172,6 +2223,10 @@ impl Blockstore {
         self.completed_slots_senders.lock().unwrap().push(s);
     }
 
+    pub fn add_update_parent_signal(&self, s: UpdateParentSender) {
+        self.update_parent_signals.lock().unwrap().push(s);
+    }
+
     pub fn get_new_shred_signals_len(&self) -> usize {
         self.new_shreds_signals.lock().unwrap().len()
     }
@@ -2183,6 +2238,7 @@ impl Blockstore {
     pub fn drop_signal(&self) {
         self.new_shreds_signals.lock().unwrap().clear();
         self.completed_slots_senders.lock().unwrap().clear();
+        self.update_parent_signals.lock().unwrap().clear();
     }
 
     /// Clear `slot` from the Blockstore
@@ -2632,8 +2688,7 @@ impl Blockstore {
                 slot_meta,
                 just_inserted_shreds,
                 write_batch,
-            )
-            .map_err(InsertDataShredError::BlockstoreError)?;
+            )?;
         }
 
         let completed_data_sets = self.insert_data_shred(
@@ -3101,10 +3156,6 @@ impl Blockstore {
             return false;
         }
 
-        let Some(meta_parent_slot) = slot_meta.parent_slot else {
-            return false;
-        };
-
         let Ok(shred_parent) = shred.parent() else {
             warn!(
                 "Invalid data shred could not get parent slot shred_id {:?}",
@@ -3113,30 +3164,40 @@ impl Blockstore {
             return false;
         };
 
-        if meta_parent_slot != shred_parent {
-            let leader_pubkey = leader_schedule
-                .and_then(|leader_schedule| leader_schedule.slot_leader_at(slot, None));
-
-            datapoint_error!(
-                "blockstore_error",
-                (
-                    "error",
-                    format!(
-                        "Leader {:?}, shred_id {:?}: received shred with parent {} but slot_meta \
-                         has parent {}",
-                        leader_pubkey,
-                        shred.id(),
-                        shred_parent,
-                        meta_parent_slot
-                    ),
-                    String
-                )
-            );
-
+        if !verify_shred_slots(slot, shred_parent, max_root) {
             return false;
         }
 
-        verify_shred_slots(slot, meta_parent_slot, max_root)
+        if !slot_meta.has_update_parent() {
+            let Some(meta_parent_slot) = slot_meta.parent_slot else {
+                return false;
+            };
+
+            if meta_parent_slot != shred_parent {
+                let leader_pubkey = leader_schedule
+                    .and_then(|leader_schedule| leader_schedule.slot_leader_at(slot, None));
+
+                datapoint_error!(
+                    "blockstore_error",
+                    (
+                        "error",
+                        format!(
+                            "Leader {:?}, shred_id {:?}: received shred with parent {} but \
+                             slot_meta has parent {} before UpdateParent",
+                            leader_pubkey,
+                            shred.id(),
+                            shred_parent,
+                            meta_parent_slot
+                        ),
+                        String
+                    )
+                );
+
+                return false;
+            }
+        }
+
+        true
     }
 
     fn insert_data_shred<'a>(
@@ -4636,6 +4697,15 @@ impl Blockstore {
         // `consumed` is the next missing shred index, but shred `i` existing in
         // completed_data_end_indexes implies it's not missing
         assert!(!completed_data_indexes.contains(&consumed));
+
+        // When using UpdateParent's replay_fec_set_index as start_index, the
+        // shreds before that index might not have been received yet. For now,
+        // let's do the dumb thing of waiting for the previous shreds to arrive
+        // prior to replay so earlier conflicting UpdateParent markers are
+        // observed before the suffix can execute.
+        if start_index >= consumed {
+            return vec![];
+        }
         completed_data_indexes
             .range(start_index..consumed)
             .scan(start_index, |start, index| {
@@ -5172,6 +5242,10 @@ impl Blockstore {
     /// checks whether any of its direct and indirect children slots are connected
     /// or not.
     ///
+    /// This function also handles chaining updates when an UpdateParent marker
+    /// overrides a previously set parent from a BlockHeader. The dirty SlotMetas
+    /// identify slots that need reparenting.
+    ///
     /// Note: This chaining only occurs for `SlotMeta`s in the column associated with
     /// `BlockLocation::Original`
     ///
@@ -5322,18 +5396,13 @@ impl Blockstore {
 
         if should_propagate_is_connected {
             meta.borrow_mut().set_connected();
-            self.traverse_children_mut(
-                meta,
-                working_set,
-                new_chained_slots,
-                SlotMeta::set_parent_connected,
-            )?;
+            self.propagate_parent_connected_to_children(meta, working_set, new_chained_slots)?;
         }
 
         Ok(())
     }
 
-    /// Propagate `set_parent_connected` to all children of `slot_meta`.
+    /// Propagate `parent_connected` to children. Requires `slot_meta` to be connected.
     fn propagate_parent_connected_to_children(
         &self,
         slot_meta: &Rc<RefCell<SlotMeta>>,
@@ -5386,8 +5455,6 @@ impl Blockstore {
                     ))
                 })
         {
-            slot_meta.borrow_mut().parent_slot = Some(new_parent_slot);
-
             // Remove slot from old parent's next_slots if parent changed.
             self.find_slot_meta_else_create(working_set, new_chained_slots, old_parent_slot)?
                 .borrow_mut()
@@ -5398,9 +5465,9 @@ impl Blockstore {
             let new_parent_meta =
                 self.find_slot_meta_else_create(working_set, new_chained_slots, new_parent_slot)?;
             {
-                let mut new_parent = new_parent_meta.borrow_mut();
-                if !new_parent.next_slots.contains(&slot) {
-                    new_parent.next_slots.push(slot);
+                let mut new_meta = new_parent_meta.borrow_mut();
+                if !new_meta.next_slots.contains(&slot) {
+                    new_meta.next_slots.push(slot);
                 }
             }
 
@@ -5495,9 +5562,14 @@ impl Blockstore {
         &self,
         slot_meta_working_set: &HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
         write_batch: &mut WriteBatch,
-    ) -> Result<(bool, Vec<u64>)> {
+    ) -> Result<(
+        /* signal slot updates */ bool,
+        /* slots updated */ Vec<u64>,
+        /* update parent signals */ Vec<UpdateParentSignal>,
+    )> {
         let mut should_signal = false;
         let mut newly_completed_slots = vec![];
+        let mut update_parent_signals = Vec::new();
         let completed_slots_senders = self.completed_slots_senders.lock().unwrap();
 
         // Check if any metadata was changed, if so, insert the new version of the
@@ -5515,9 +5587,20 @@ impl Blockstore {
                 should_signal = should_signal || slot_has_updates(meta, meta_backup);
                 self.put_meta_in_batch(write_batch, slot, location, meta)?;
             }
+
+            // Check for new ``UpdateParent`s in the `Original` column
+            // This signal is only used for replay, so we don't need to consider `Alternate` columns
+            if location == BlockLocation::Original
+                && meta.has_update_parent()
+                && meta_backup
+                    .as_ref()
+                    .is_some_and(|m| m.populated_from_block_header())
+            {
+                update_parent_signals.push(UpdateParentSignal { slot });
+            }
         }
 
-        Ok((should_signal, newly_completed_slots))
+        Ok((should_signal, newly_completed_slots, update_parent_signals))
     }
 
     /// Obtain the SlotMeta from the in-memory slot_meta_working_set or load
@@ -5683,7 +5766,7 @@ fn update_completed_data_indexes<'a>(
             .next_back()
             .map(|index| index + 1)
             .or(Some(0u32)),
-        is_last_in_data.then(|| new_shred_index + 1),
+        is_last_in_data.then_some(new_shred_index + 1),
         completed_data_indexes
             .range(new_shred_index + 1..)
             .next()
@@ -5734,8 +5817,10 @@ fn update_slot_meta<'a>(
 fn send_signals(
     new_shreds_signals: &[Sender<bool>],
     completed_slots_senders: &[Sender<Vec<u64>>],
+    update_parent_senders: &[UpdateParentSender],
     should_signal: bool,
     newly_completed_slots: Vec<u64>,
+    update_parent_signals: Vec<UpdateParentSignal>,
 ) {
     if should_signal {
         for signal in new_shreds_signals {
@@ -5768,6 +5853,22 @@ fn send_signals(
                         "Unable to send newly completed slot because channel is full",
                         String
                     ),
+                );
+            }
+        }
+    }
+
+    for signal in update_parent_signals {
+        for sender in update_parent_senders {
+            if let Err(TrySendError::Full(_)) = sender.try_send(signal.clone()) {
+                error!(
+                    "update_parent channel full, dropping signal for slot {}",
+                    signal.slot
+                );
+                datapoint_error!(
+                    "blockstore_error",
+                    ("error", "update_parent channel full", String),
+                    ("slot", signal.slot, i64),
                 );
             }
         }
@@ -6303,23 +6404,6 @@ pub mod tests {
         assert!(meta.next_slots.is_empty());
     }
 
-    fn create_update_parent_shreds(
-        slot: Slot,
-        parent_slot: Slot,
-        parent_block_id: Hash,
-        shred_index: u32,
-        is_last_in_slot: bool,
-    ) -> Vec<Shred> {
-        create_update_parent_shreds_with_shred_parent(
-            slot,
-            0,
-            parent_slot,
-            parent_block_id,
-            shred_index,
-            is_last_in_slot,
-        )
-    }
-
     fn create_update_parent_shreds_with_shred_parent(
         slot: Slot,
         shred_parent_slot: Slot,
@@ -6413,6 +6497,15 @@ pub mod tests {
     }
 
     fn create_block_footer_shreds(slot: Slot, parent_slot: Slot, shred_index: u32) -> Vec<Shred> {
+        create_block_footer_shreds_with_last(slot, parent_slot, shred_index, true)
+    }
+
+    fn create_block_footer_shreds_with_last(
+        slot: Slot,
+        parent_slot: Slot,
+        shred_index: u32,
+        is_last_in_slot: bool,
+    ) -> Vec<Shred> {
         use solana_entry::block_component::BlockFooterV1;
         let footer = BlockFooterV1 {
             bank_hash: Hash::new_unique(),
@@ -6430,7 +6523,7 @@ pub mod tests {
             .make_merkle_shreds_from_component(
                 &Keypair::new(),
                 &component,
-                true,
+                is_last_in_slot,
                 Hash::new_unique(),
                 shred_index,
                 shred_index,
@@ -6438,6 +6531,10 @@ pub mod tests {
                 &mut ProcessShredsStats::default(),
             )
             .collect()
+    }
+
+    fn data_shreds(shreds: Vec<Shred>) -> Vec<Shred> {
+        shreds.into_iter().filter(Shred::is_data).collect()
     }
 
     #[test]
@@ -8973,6 +9070,23 @@ pub mod tests {
     }
 
     #[test]
+    fn test_ranges_after_consumed() {
+        let completed_data_end_indexes = [2, 4, 9, 11].iter().copied().collect();
+
+        // start_index > consumed: out-of-order shred delivery during fast leader handover
+        assert_eq!(
+            Blockstore::get_completed_data_ranges(32, &completed_data_end_indexes, 3),
+            vec![]
+        );
+
+        // start_index == consumed
+        assert_eq!(
+            Blockstore::get_completed_data_ranges(5, &completed_data_end_indexes, 5),
+            vec![]
+        );
+    }
+
+    #[test]
     fn test_get_slot_entries_with_shred_count_corruption() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
@@ -10973,6 +11087,79 @@ pub mod tests {
         }
 
         verify_index_integrity(&blockstore, slot);
+    }
+
+    #[test]
+    fn test_skip_alt_recovery() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let slot = 1;
+        let (data_shreds, coding_shreds, leader_schedule_cache) =
+            setup_erasure_shreds(slot, 0, 100);
+        let data_shred = data_shreds[0].clone();
+        let data_shred_index = u64::from(data_shred.index());
+
+        // First populate Original erasure metadata through a coding shred. A
+        // later Alternate-column block-id repair insertion for the same FEC set
+        // will load this erasure meta without touching the Original index in the
+        // current batch.
+        blockstore
+            .do_insert_shreds(
+                std::iter::once((
+                    Cow::Owned(coding_shreds[0].clone()),
+                    /*is_repaired:*/ false,
+                    BlockLocation::Original,
+                )),
+                Some(&leader_schedule_cache),
+                false, // is_trusted
+                None,
+                &mut BlockstoreInsertionMetrics::default(),
+            )
+            .unwrap();
+
+        let genesis_config = create_genesis_config(2).genesis_config;
+        let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
+        let alternate_location = BlockLocation::Alternate {
+            block_id: Hash::new_unique(),
+        };
+        let mut metrics = BlockstoreInsertionMetrics::default();
+
+        blockstore
+            .do_insert_shreds(
+                std::iter::once((
+                    Cow::Owned(data_shred),
+                    /*is_repaired:*/ true,
+                    alternate_location,
+                )),
+                Some(&leader_schedule_cache),
+                false, // is_trusted
+                Some(&mut ShredRecoveryContext::new(
+                    ReedSolomonCache::default(),
+                    dummy_retransmit_sender,
+                    root_bank,
+                    0, // shred_version
+                )),
+                &mut metrics,
+            )
+            .unwrap();
+
+        assert_eq!(metrics.num_recovered, 0);
+        assert!(
+            blockstore
+                .get_index_from_location(slot, alternate_location)
+                .unwrap()
+                .unwrap()
+                .data()
+                .contains(data_shred_index)
+        );
+        assert!(
+            blockstore
+                .get_data_shred(slot, data_shred_index)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -13140,16 +13327,24 @@ pub mod tests {
         };
 
         let block_header_shreds = create_block_header_shreds(slot, bh_parent_slot, bh_block_id);
-        let update_parent_shreds =
-            create_update_parent_shreds(slot, up_parent_slot, up_block_id, 32, false);
+        let update_parent_shreds = create_update_parent_shreds_with_shred_parent(
+            slot,
+            bh_parent_slot,
+            up_parent_slot,
+            up_block_id,
+            32,
+            false,
+        );
         let block_footer_shreds = create_block_footer_shreds(slot, bh_parent_slot, 64);
 
         let shreds: Vec<Shred> = if block_header_first {
+            // Block header shreds first, then update parent, then footer
             let mut s = block_header_shreds;
             s.extend(update_parent_shreds);
             s.extend(block_footer_shreds);
             s
         } else {
+            // Update parent shreds first, then block header, then footer
             let mut s = update_parent_shreds;
             s.extend(block_header_shreds);
             s.extend(block_footer_shreds);
@@ -13210,9 +13405,9 @@ pub mod tests {
     #[test]
     fn test_invalid_update_parent_parent_info_marks_dead() {
         let slot = 1000;
-        let shred_parent_slot = slot - 1;
+        let shred_parent_slot = slot - 5;
 
-        for update_parent_slot in [slot, slot + 1] {
+        for update_parent_slot in [shred_parent_slot + 1, slot, slot + 1] {
             let ledger_path = get_tmp_ledger_path_auto_delete!();
             let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -13259,7 +13454,7 @@ pub mod tests {
         let parent_3_id = Hash::new_unique();
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(10, 3, parent_3_id, 32, true),
+                create_update_parent_shreds_with_shred_parent(10, 5, 3, parent_3_id, 32, true),
                 None,
                 true,
             )
@@ -13273,66 +13468,135 @@ pub mod tests {
             .unwrap();
         assert_eq!(parent_info.parent_slot, 3);
         assert_eq!(parent_info.parent_block_id, parent_3_id);
-        assert!(parent_info.populated_from_update_parent());
+        assert!(parent_info.has_update_parent());
 
         verify_next_slots(&blockstore, 5, &[]);
         verify_next_slots(&blockstore, 3, &[10]);
     }
 
     #[test]
-    fn test_update_parent_overrides_block_header() {
+    fn test_post_update_orig_after() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
+        let slot = 90;
+        let original_parent = 85;
+        let update_parent = 80;
         blockstore
             .insert_shreds(
-                create_block_header_shreds(20, 18, Hash::new_unique()),
+                data_shreds(create_block_header_shreds(
+                    slot,
+                    original_parent,
+                    Hash::new_unique(),
+                )),
                 None,
-                true,
+                false,
             )
             .unwrap();
 
-        assert_eq!(blockstore.meta(20).unwrap().unwrap().parent_slot, Some(18));
-        verify_next_slots(&blockstore, 18, &[20]);
-
+        let update_parent_block_id = Hash::new_unique();
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(20, 15, Hash::new_unique(), 32, true),
+                data_shreds(create_update_parent_shreds_with_shred_parent(
+                    slot,
+                    original_parent,
+                    update_parent,
+                    update_parent_block_id,
+                    32,
+                    false,
+                )),
                 None,
-                true,
+                false,
             )
             .unwrap();
 
-        assert_eq!(blockstore.meta(20).unwrap().unwrap().parent_slot, Some(15));
-        verify_next_slots(&blockstore, 18, &[]);
-        verify_next_slots(&blockstore, 15, &[20]);
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(update_parent));
+        assert_eq!(meta.parent_block_id, update_parent_block_id);
+        assert_eq!(meta.replay_fec_set_index, 32);
+        assert!(!blockstore.is_dead(slot));
+
+        blockstore
+            .insert_shreds(
+                data_shreds(create_block_footer_shreds(slot, original_parent, 64)),
+                None,
+                false,
+            )
+            .unwrap();
+
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(update_parent));
+        assert_eq!(meta.replay_fec_set_index, 32);
+        assert!(blockstore.get_data_shred(slot, 64).unwrap().is_some());
+        assert!(!blockstore.is_dead(slot));
     }
 
     #[test]
-    fn test_reparenting_via_update_parent() {
+    fn test_marker_boundary_ooo() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
+        let slot = 93;
+        let original_parent = 88;
+        let update_parent = 80;
         blockstore
             .insert_shreds(
-                create_block_header_shreds(30, 25, Hash::new_unique()),
+                data_shreds(create_block_header_shreds(
+                    slot,
+                    original_parent,
+                    Hash::new_unique(),
+                )),
                 None,
-                true,
-            )
-            .unwrap();
-        verify_next_slots(&blockstore, 25, &[30]);
-
-        blockstore
-            .insert_shreds(
-                create_update_parent_shreds(30, 22, Hash::new_unique(), 32, true),
-                None,
-                true,
+                false,
             )
             .unwrap();
 
-        assert_eq!(blockstore.meta(30).unwrap().unwrap().parent_slot, Some(22));
-        verify_next_slots(&blockstore, 25, &[]);
-        verify_next_slots(&blockstore, 22, &[30]);
+        let mut post_update_shreds = vec![];
+        for shred_index in [64, 96, 128] {
+            post_update_shreds.extend(data_shreds(create_block_footer_shreds_with_last(
+                slot,
+                original_parent,
+                shred_index,
+                false,
+            )));
+        }
+        blockstore
+            .insert_shreds(post_update_shreds, None, false)
+            .unwrap();
+
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(original_parent));
+        assert_eq!(meta.replay_fec_set_index, 0);
+
+        let update_parent_block_id = Hash::new_unique();
+        blockstore
+            .insert_shreds(
+                data_shreds(create_update_parent_shreds_with_shred_parent(
+                    slot,
+                    original_parent,
+                    update_parent,
+                    update_parent_block_id,
+                    32,
+                    false,
+                )),
+                None,
+                false,
+            )
+            .unwrap();
+
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        assert_eq!(meta.parent_slot, Some(update_parent));
+        assert_eq!(meta.parent_block_id, update_parent_block_id);
+        assert_eq!(meta.replay_fec_set_index, 32);
+        for shred_index in [64, 96, 128] {
+            assert!(
+                blockstore
+                    .get_data_shred(slot, shred_index)
+                    .unwrap()
+                    .is_some()
+            );
+        }
+        assert!(!blockstore.is_dead(slot));
     }
 
     #[test]
@@ -13341,31 +13605,45 @@ pub mod tests {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         let parent_id = Hash::new_unique();
-        for slot in [41, 40, 42] {
+        for slot in [44, 40, 48] {
             blockstore
                 .insert_shreds(create_block_header_shreds(slot, 35, parent_id), None, true)
                 .unwrap();
         }
-        verify_next_slots(&blockstore, 35, &[40, 41, 42]);
+        verify_next_slots(&blockstore, 35, &[40, 44, 48]);
 
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(41, 32, Hash::new_unique(), 32, true),
+                create_update_parent_shreds_with_shred_parent(
+                    44,
+                    35,
+                    32,
+                    Hash::new_unique(),
+                    32,
+                    true,
+                ),
                 None,
                 true,
             )
             .unwrap();
-        verify_next_slots(&blockstore, 35, &[40, 42]);
-        verify_next_slots(&blockstore, 32, &[41]);
+        verify_next_slots(&blockstore, 35, &[40, 48]);
+        verify_next_slots(&blockstore, 32, &[44]);
 
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(40, 33, Hash::new_unique(), 32, true),
+                create_update_parent_shreds_with_shred_parent(
+                    40,
+                    35,
+                    33,
+                    Hash::new_unique(),
+                    32,
+                    true,
+                ),
                 None,
                 true,
             )
             .unwrap();
-        verify_next_slots(&blockstore, 35, &[42]);
+        verify_next_slots(&blockstore, 35, &[48]);
         verify_next_slots(&blockstore, 33, &[40]);
     }
 
@@ -13376,24 +13654,25 @@ pub mod tests {
 
         blockstore
             .insert_shreds(
-                create_block_header_shreds(50, 48, Hash::new_unique()),
+                create_block_header_shreds(52, 48, Hash::new_unique()),
                 None,
                 true,
             )
             .unwrap();
-        assert_eq!(blockstore.meta(50).unwrap().unwrap().parent_slot, Some(48));
+        assert_eq!(blockstore.meta(52).unwrap().unwrap().parent_slot, Some(48));
 
         // Split update parent shreds across two batches
-        let mut update_shreds = create_update_parent_shreds(50, 45, Hash::new_unique(), 32, true);
+        let mut update_shreds =
+            create_update_parent_shreds_with_shred_parent(52, 48, 45, Hash::new_unique(), 32, true);
         let mid = update_shreds.len() / 2;
         let first_half: Vec<_> = update_shreds.drain(..mid).collect();
 
         blockstore.insert_shreds(first_half, None, true).unwrap();
         blockstore.insert_shreds(update_shreds, None, true).unwrap();
 
-        assert_eq!(blockstore.meta(50).unwrap().unwrap().parent_slot, Some(45));
+        assert_eq!(blockstore.meta(52).unwrap().unwrap().parent_slot, Some(45));
         verify_next_slots(&blockstore, 48, &[]);
-        verify_next_slots(&blockstore, 45, &[50]);
+        verify_next_slots(&blockstore, 45, &[52]);
     }
 
     #[test]
@@ -13401,9 +13680,12 @@ pub mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
+        // Insert both BlockHeader and UpdateParent in the same batch,
+        // with BlockHeader shreds first (lower indices)
         let mut shreds = create_block_header_shreds(60, 55, Hash::new_unique());
-        shreds.extend(create_update_parent_shreds(
+        shreds.extend(create_update_parent_shreds_with_shred_parent(
             60,
+            55,
             52,
             Hash::new_unique(),
             32,
@@ -13423,27 +13705,24 @@ pub mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
-        let mut shreds = create_update_parent_shreds(70, 65, Hash::new_unique(), 32, true);
-        shreds.extend(create_block_header_shreds(70, 68, Hash::new_unique()));
+        // Insert both UpdateParent and BlockHeader in the same batch,
+        // with UpdateParent shreds first (but BlockHeader is at index 0)
+        let mut shreds =
+            create_update_parent_shreds_with_shred_parent(72, 68, 65, Hash::new_unique(), 32, true);
+        shreds.extend(create_block_header_shreds(72, 68, Hash::new_unique()));
 
         blockstore.insert_shreds(shreds, None, true).unwrap();
 
         // UpdateParent should take precedence regardless of insertion order
-        assert_eq!(blockstore.meta(70).unwrap().unwrap().parent_slot, Some(65));
+        assert_eq!(blockstore.meta(72).unwrap().unwrap().parent_slot, Some(65));
         verify_next_slots(&blockstore, 68, &[]);
-        verify_next_slots(&blockstore, 65, &[70]);
+        verify_next_slots(&blockstore, 65, &[72]);
     }
 
     #[test]
     fn test_multiple_update_parents_out_of_order_marks_dead() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-        let data_shreds = |shreds: Vec<Shred>| {
-            shreds
-                .into_iter()
-                .filter(|shred| shred.is_data())
-                .collect_vec()
-        };
 
         let slot = 80;
         blockstore
@@ -13455,13 +13734,15 @@ pub mod tests {
             .unwrap();
 
         let first_update_parent_slot = 70;
-        let mut first_update_parent_shreds = data_shreds(create_update_parent_shreds(
-            slot,
-            first_update_parent_slot,
-            Hash::new_unique(),
-            32,
-            false,
-        ));
+        let mut first_update_parent_shreds =
+            data_shreds(create_update_parent_shreds_with_shred_parent(
+                slot,
+                75,
+                first_update_parent_slot,
+                Hash::new_unique(),
+                32,
+                false,
+            ));
         let first_update_parent_marker = first_update_parent_shreds.remove(0);
         assert_eq!(first_update_parent_marker.index(), 32);
 
@@ -13474,8 +13755,9 @@ pub mod tests {
         let second_update_parent_slot = 65;
         blockstore
             .insert_shreds(
-                data_shreds(create_update_parent_shreds(
+                data_shreds(create_update_parent_shreds_with_shred_parent(
                     slot,
+                    75,
                     second_update_parent_slot,
                     Hash::new_unique(),
                     64,
@@ -13510,27 +13792,35 @@ pub mod tests {
         blockstore.insert_shreds(shreds, None, true).unwrap();
         assert!(blockstore.meta(0).unwrap().unwrap().is_connected());
 
-        // Slot 10 with BlockHeader pointing to disconnected parent
+        // Slot 8 with BlockHeader pointing to disconnected parent
         blockstore
             .insert_shreds(
-                create_block_header_shreds(10, 5, Hash::new_unique()),
+                create_block_header_shreds(8, 5, Hash::new_unique()),
                 None,
                 true,
             )
             .unwrap();
-        assert!(!blockstore.meta(10).unwrap().unwrap().is_connected());
+        assert!(!blockstore.meta(8).unwrap().unwrap().is_connected());
 
         // UpdateParent switches to connected parent, slot becomes connected
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(10, 0, Hash::new_unique(), 32, true),
+                create_update_parent_shreds_with_shred_parent(
+                    8,
+                    5,
+                    0,
+                    Hash::new_unique(),
+                    32,
+                    true,
+                ),
                 None,
                 true,
             )
             .unwrap();
 
-        let meta = blockstore.meta(10).unwrap().unwrap();
+        let meta = blockstore.meta(8).unwrap().unwrap();
         assert_eq!(meta.parent_slot, Some(0));
+        // Slot 8 is incomplete (not full), so only parent_connected, not connected
         assert!(meta.is_parent_connected());
     }
 
@@ -13563,7 +13853,14 @@ pub mod tests {
         // Reparent 100 to connected slot 0; connectivity propagates to 200 and 300
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(100, 0, Hash::new_unique(), 32, true),
+                create_update_parent_shreds_with_shred_parent(
+                    100,
+                    50,
+                    0,
+                    Hash::new_unique(),
+                    32,
+                    true,
+                ),
                 None,
                 true,
             )
@@ -13589,33 +13886,42 @@ pub mod tests {
         blockstore.insert_shreds(shreds, None, true).unwrap();
         assert!(blockstore.meta(5).unwrap().unwrap().is_connected());
 
-        // Slot 10 with BlockHeader pointing to connected parent 5
+        // Slot 8 with BlockHeader pointing to connected parent 5
         blockstore
             .insert_shreds(
-                create_block_header_shreds(10, 5, Hash::new_unique()),
+                create_block_header_shreds(8, 5, Hash::new_unique()),
                 None,
                 true,
             )
             .unwrap();
-        let meta = blockstore.meta(10).unwrap().unwrap();
+        let meta = blockstore.meta(8).unwrap().unwrap();
         assert!(meta.is_parent_connected());
 
-        // Slot 20 chains to slot 10
-        let (shreds, _) = make_slot_entries(20, 10, 5);
+        // Slot 20 chains to slot 8
+        let (shreds, _) = make_slot_entries(20, 8, 5);
         blockstore.insert_shreds(shreds, None, true).unwrap();
 
-        // UpdateParent switches slot 10 to disconnected parent 3
+        // UpdateParent switches slot 8 to disconnected parent 3 (lower, doesn't exist)
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(10, 3, Hash::new_unique(), 32, true),
+                create_update_parent_shreds_with_shred_parent(
+                    8,
+                    5,
+                    3,
+                    Hash::new_unique(),
+                    32,
+                    true,
+                ),
                 None,
                 true,
             )
             .unwrap();
 
-        let meta = blockstore.meta(10).unwrap().unwrap();
+        // Slot 8 should have parent_connected cleared
+        let meta = blockstore.meta(8).unwrap().unwrap();
         assert_eq!(meta.parent_slot, Some(3));
         assert!(!meta.is_parent_connected());
+        // Slot 20 should also have parent_connected cleared
         assert!(!blockstore.meta(20).unwrap().unwrap().is_parent_connected());
     }
 
@@ -13629,40 +13935,47 @@ pub mod tests {
         blockstore.insert_shreds(shreds, None, true).unwrap();
         assert!(blockstore.meta(0).unwrap().unwrap().is_connected());
 
-        // Slot 50 incomplete, pointing to disconnected parent 40
+        // Slot 48 incomplete, pointing to disconnected parent 40
         blockstore
             .insert_shreds(
-                create_block_header_shreds(50, 40, Hash::new_unique()),
+                create_block_header_shreds(48, 40, Hash::new_unique()),
                 None,
                 true,
             )
             .unwrap();
 
-        // Full children chain from incomplete slot 50
-        let (shreds, _) = make_slot_entries(60, 50, 5);
+        // Full children chain from incomplete slot 48
+        let (shreds, _) = make_slot_entries(60, 48, 5);
         blockstore.insert_shreds(shreds, None, true).unwrap();
         let (shreds, _) = make_slot_entries(70, 60, 5);
         blockstore.insert_shreds(shreds, None, true).unwrap();
 
-        for slot in [50, 60, 70] {
+        for slot in [48, 60, 70] {
             assert!(!blockstore.meta(slot).unwrap().unwrap().is_connected());
         }
 
-        // Reparent slot 50 to connected slot 0, keeping it incomplete
+        // Reparent slot 48 to connected slot 0, keeping it incomplete
         blockstore
             .insert_shreds(
-                create_update_parent_shreds(50, 0, Hash::new_unique(), 32, false),
+                create_update_parent_shreds_with_shred_parent(
+                    48,
+                    40,
+                    0,
+                    Hash::new_unique(),
+                    32,
+                    false,
+                ),
                 None,
                 true,
             )
             .unwrap();
 
-        // Slot 50 incomplete: parent_connected but not connected
-        let meta_50 = blockstore.meta(50).unwrap().unwrap();
-        assert!(meta_50.is_parent_connected());
-        assert!(!meta_50.is_connected());
+        // Slot 48 incomplete: parent_connected but not connected
+        let meta_48 = blockstore.meta(48).unwrap().unwrap();
+        assert!(meta_48.is_parent_connected());
+        assert!(!meta_48.is_connected());
 
-        // Children stay disconnected since parent 50 is incomplete
+        // Children stay disconnected since parent 48 is incomplete
         assert!(!blockstore.meta(60).unwrap().unwrap().is_connected());
         assert!(!blockstore.meta(70).unwrap().unwrap().is_connected());
     }

--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -81,6 +81,15 @@ pub enum BlockstoreError {
     UpdateParentMatchesBlockHeader(Slot),
     #[error("update parent slot greater than block header for slot {0}")]
     UpdateParentSlotGreaterThanBlockHeader(Slot),
+    #[error(
+        "update parent {update_parent_slot} is greater than shred parent {shred_parent_slot} for \
+         slot {slot}"
+    )]
+    UpdateParentSlotGreaterThanShredParent {
+        slot: Slot,
+        update_parent_slot: Slot,
+        shred_parent_slot: Slot,
+    },
     #[error("unexpected block component")]
     UnexpectedBlockComponent,
     #[error("multiple update parents for slot {0}")]

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -43,6 +43,7 @@ bitflags! {
         // CONNECTED is explicitly the first bit to ensure backwards compatibility
         // with the boolean field that ConnectedFlags replaced in SlotMeta.
         const CONNECTED        = 0b0000_0001;
+        // Parent is connected; the slot becomes CONNECTED once it is also full.
         const PARENT_CONNECTED = 0b1000_0000;
     }
 }
@@ -147,12 +148,12 @@ pub struct SlotMetaBase<T> {
 
 pub type SlotMetaV2 = SlotMetaBase<CompletedDataIndexes>;
 
-/// SlotMetaV3 extends SlotMeta with two additional fields: `parent_block_id`
-/// and `replay_fec_set_index`. The SlotMeta type will continue to be used
-/// (written) for now, but a SlotMetaV3 can be read from the Blockstore and
-/// converted into a SlotMeta. The logic to read and convert SlotMetaV3 to
-/// SlotMeta enables this software to read a Blockstore modified by a future
-/// version where the SlotMetaV3 format is persisted.
+/// Slot metadata persisted by blockstore.
+///
+/// V3 adds `parent_block_id` and `replay_fec_set_index` so replay can validate
+/// and restart slots that switch parent through an UpdateParent marker. The new
+/// fields default on old ledger reads, preserving backward-compatible reads of
+/// V2 data.
 #[derive(Clone, Debug, Default, SchemaRead, SchemaWrite, Eq, PartialEq)]
 pub struct SlotMetaV3 {
     pub slot: Slot,
@@ -167,12 +168,17 @@ pub struct SlotMetaV3 {
     #[wincode(with = "PodConnectedFlags")]
     pub connected_flags: ConnectedFlags,
     pub completed_data_indexes: CompletedDataIndexes,
-    /// The block id of the parent block.
-    /// Populated from the block header / update parent marker.
+    /// Block id paired with `parent_slot`.
+    ///
+    /// Populated by the block header initially, then replaced if an UpdateParent
+    /// marker changes the replay parent for this slot.
     #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Hash>")]
     pub parent_block_id: Hash,
-    /// The FEC set index from which replay should start for this block.
-    /// Populated from the block header / update parent marker.
+    /// Shred/FEC-set index where replay should start for this slot.
+    ///
+    /// A value of zero means replay starts from the block header. A non-zero
+    /// value means an UpdateParent marker was observed and replay must skip the
+    /// optimistic-parent prefix before this FEC set.
     #[wincode(with = "wincode_compat::DefaultOnEmptyRead<u32>")]
     pub replay_fec_set_index: u32,
 }
@@ -582,15 +588,13 @@ impl SlotMeta {
         self.is_connected()
     }
 
-    /// Clear the parent_connected and connected flags.
-    /// Returns true if the slot was previously parent-connected (signaling
-    /// that children need clearing too).
+    /// Clear the meta's parent_connected and connected flags.
+    /// Returns true if the meta was connected, indicating children need clearing.
     pub fn clear_parent_connected(&mut self) -> bool {
-        let was_parent_connected = self.is_parent_connected();
+        let originally_connected = self.is_connected();
         self.connected_flags
-            .set(ConnectedFlags::PARENT_CONNECTED, false);
-        self.connected_flags.set(ConnectedFlags::CONNECTED, false);
-        was_parent_connected
+            .remove(ConnectedFlags::PARENT_CONNECTED | ConnectedFlags::CONNECTED);
+        originally_connected
     }
 
     /// Dangerous.
@@ -632,6 +636,12 @@ impl SlotMeta {
 
     pub(crate) fn populated_from_block_header(&self) -> bool {
         self.replay_fec_set_index == 0
+    }
+
+    /// Returns true once this slot's replay parent has been changed by an
+    /// `UpdateParent` marker.
+    pub fn has_update_parent(&self) -> bool {
+        self.replay_fec_set_index > 0
     }
 }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -22,7 +22,7 @@ use {
     solana_clock::Slot,
     solana_cost_model::{cost_model::CostModel, transaction_cost::TransactionCost},
     solana_entry::{
-        block_component::BlockComponent,
+        block_component::{BlockComponent, VersionedBlockMarker},
         entry::{self, Entry, EntrySlice, EntryType, create_ticks},
     },
     solana_genesis_config::GenesisConfig,
@@ -1785,8 +1785,34 @@ fn confirm_slot_with_components(
         load_result
     }?;
 
+    // Process block components for Alpenglow slots. Note that we don't need to run migration checks
+    // for BlockMarkers here, despite BlockMarkers only being active post-Alpenglow. Here's why:
+    //
+    // Post-Alpenglow migration - validators that have Alpenglow enabled can parse BlockComponents.
+    // Things just work.
+    //
+    // Pre-Alpenglow migration, suppose a validator receives a BlockMarker:
+    //
+    // (1) validators *incapable* of processing BlockMarkers will mark the slot as dead on shred
+    //     ingest in blockstore.
+    //
+    // (2) validators *capable* of processing BlockMarkers will store the BlockMarkers in shred
+    //     ingest, run through this verifying code here, and then error out when processing a
+    //     BlockMarker, resulting in the slot being marked as dead.
+    // Only replay that starts at the persisted UpdateParent FEC set may accept
+    // UpdateParent as its first parent marker. From-shred-zero replay still
+    // requires a block header before UpdateParent.
+    let replay_starts_at_update_parent = migration_status.should_allow_fast_leader_handover(slot)
+        && blockstore
+            .meta(slot)
+            .expect("Blockstore operations must succeed")
+            .is_some_and(|meta| {
+                meta.has_update_parent()
+                    && progress.num_shreds == u64::from(meta.replay_fec_set_index)
+            });
     let mut processor = bank.block_component_processor.write().unwrap();
 
+    // Find the index of the last EntryBatch in slot_components
     let last_entry_batch_index = slot_components
         .iter()
         .rposition(|bc| matches!(bc, BlockComponent::EntryBatch(_)));
@@ -1801,7 +1827,18 @@ fn confirm_slot_with_components(
             BlockComponent::EntryBatch(entries) => {
                 let slot_full = slot_full && ix == last_entry_batch_index.unwrap();
 
-                processor.on_entry_batch(migration_status, slot)?;
+                // Skip block component validation for genesis block. Slot 0 is handled specially,
+                // since it won't have the required block markers.
+                if slot != 0 {
+                    processor
+                        .on_entry_batch(migration_status, slot)
+                        .inspect_err(|err| {
+                            warn!(
+                                "BlockComponentProcessor::on_entry_batch() for slot {slot} failed \
+                                 with {err}"
+                            );
+                        })?;
+                }
 
                 confirm_slot_entries(
                     bank,
@@ -1820,11 +1857,18 @@ fn confirm_slot_with_components(
             }
             BlockComponent::BlockMarker(marker) => {
                 if let Some(parent_bank) = bank.parent() {
+                    let allow_initial_update_parent = replay_starts_at_update_parent
+                        && matches!(
+                            &marker,
+                            VersionedBlockMarker::V1(marker)
+                                if marker.as_update_parent().is_some()
+                        );
                     processor
                         .on_marker(
                             bank.clone_without_scheduler(),
                             parent_bank,
                             marker,
+                            allow_initial_update_parent,
                             finalization_cert_sender,
                             migration_status,
                         )
@@ -2252,6 +2296,21 @@ fn process_next_slots(
         // Only process full slots in blockstore_processor, replay_stage
         // handles any partials
         if next_meta.is_full() {
+            let parent_block_id = bank.block_id();
+            if migration_status.should_allow_block_markers(*next_slot)
+                && bank.slot() != 0
+                && Some(next_meta.parent_block_id) != parent_block_id
+            {
+                warn!(
+                    "startup replay deferring slot {next_slot}: parent {} has block id {:?}, but \
+                     SlotMeta expects {:?}",
+                    bank.slot(),
+                    parent_block_id,
+                    next_meta.parent_block_id,
+                );
+                continue;
+            }
+
             let next_bank = Bank::new_from_parent(
                 bank.clone(),
                 leader_schedule_cache
@@ -2385,6 +2444,13 @@ fn load_frozen_forks(
                 last_entry_hash,
                 async_verification.take(),
             );
+            // Live replay restarts UpdateParent slots from the marker's FEC set.
+            // Startup replay must use the same offset or a restarted validator can
+            // execute the obsolete optimistic-parent prefix.
+            if migration_status.should_allow_fast_leader_handover(slot) && meta.has_update_parent()
+            {
+                progress.num_shreds = u64::from(meta.replay_fec_set_index);
+            }
             let mut m = Measure::start("process_single_slot");
             let bank = bank_forks.write().unwrap().insert_from_ledger(bank);
             if let Err(error) = process_single_slot(
@@ -2620,16 +2686,32 @@ fn supermajority_root_from_vote_accounts(
 /// Returns:
 /// - `Inactive`: feature not active, no validation performed
 /// - `Pass`: chained block ID matches parent's block ID (or parent has no
-///   block ID yet), safe to proceed with replay
+///   block ID yet), or the slot replays from an UpdateParent FEC set
 /// - `Mismatch`: definitive mismatch between child's chained merkle root
 ///   and parent's block ID
 /// - `Unavailable`: data shred 0 not received yet, cannot validate
-pub fn check_chained_block_id(blockstore: &Blockstore, bank: &Bank) -> ChainedBlockIdCheck {
+pub fn check_chained_block_id(
+    blockstore: &Blockstore,
+    bank: &Bank,
+    migration_status: &MigrationStatus,
+) -> ChainedBlockIdCheck {
     if !bank.feature_set.snapshot().validate_chained_block_id {
         return ChainedBlockIdCheck::Inactive;
     }
 
     let slot = bank.slot();
+    if migration_status.should_allow_fast_leader_handover(slot)
+        && blockstore
+            .meta(slot)
+            .expect("Blockstore operations must succeed")
+            .is_some_and(|meta| meta.has_update_parent())
+    {
+        // This block contains an `UpdateParent` and Alpenglow is active, so we
+        // rely on Double Merkle verification of parent chained block ID instead
+        // of CMR.
+        return ChainedBlockIdCheck::Pass;
+    }
+
     let parent_slot = bank.parent_slot();
 
     let Ok(expected_parent_block_id) = blockstore.get_parent_chained_block_id(slot) else {
@@ -2678,7 +2760,7 @@ pub fn process_single_slot(
     migration_status: &MigrationStatus,
 ) -> result::Result<(), BlockstoreProcessorError> {
     let slot = bank.slot();
-    match check_chained_block_id(blockstore, bank) {
+    match check_chained_block_id(blockstore, bank, migration_status) {
         ChainedBlockIdCheck::Inactive | ChainedBlockIdCheck::Pass => (),
         ChainedBlockIdCheck::Unavailable => {
             // no shreds to replay
@@ -6251,7 +6333,7 @@ pub mod tests {
         // Case 1: No shreds for child slot — should return Unavailable
         let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 10);
         assert!(matches!(
-            check_chained_block_id(&blockstore, &child_bank),
+            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
             ChainedBlockIdCheck::Unavailable
         ));
 
@@ -6260,7 +6342,7 @@ pub mod tests {
         insert_shreds_with_chained_merkle_root(11, 0, parent_block_id);
         let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 11);
         assert!(matches!(
-            check_chained_block_id(&blockstore, &child_bank),
+            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
             ChainedBlockIdCheck::Pass
         ));
 
@@ -6269,11 +6351,33 @@ pub mod tests {
         insert_shreds_with_chained_merkle_root(12, 0, Hash::new_unique());
         let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 12);
         assert!(matches!(
-            check_chained_block_id(&blockstore, &child_bank),
+            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
             ChainedBlockIdCheck::Mismatch
         ));
 
-        // Case 4: Parent has no shreds (get_block_merkle_root returns Err) —
+        // Case 4: UpdateParent metadata does not bypass Tower validation.
+        insert_shreds_with_chained_merkle_root(13, 0, Hash::new_unique());
+        let mut meta = blockstore.meta(13).unwrap().unwrap();
+        meta.replay_fec_set_index = 32;
+        blockstore.put_meta(13, &meta).unwrap();
+        let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 13);
+        assert!(matches!(
+            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
+            ChainedBlockIdCheck::Mismatch
+        ));
+
+        // Case 5: Alpenglow UpdateParent slots skip shred-0 chained block ID
+        // validation because replay starts at the UpdateParent FEC set.
+        assert!(matches!(
+            check_chained_block_id(
+                &blockstore,
+                &child_bank,
+                &MigrationStatus::post_migration_status()
+            ),
+            ChainedBlockIdCheck::Pass
+        ));
+
+        // Case 6: Parent has no shreds (get_block_merkle_root returns Err) —
         // should return Pass regardless of chained merkle root.
         let no_shreds_parent_bank = Arc::new(Bank::new_from_parent(
             parent_bank,
@@ -6283,8 +6387,50 @@ pub mod tests {
         insert_shreds_with_chained_merkle_root(21, 20, Hash::new_unique());
         let child_bank = Bank::new_from_parent(no_shreds_parent_bank, SlotLeader::default(), 21);
         assert!(matches!(
-            check_chained_block_id(&blockstore, &child_bank),
+            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
             ChainedBlockIdCheck::Pass
         ));
+    }
+
+    #[test]
+    fn test_startup_parent_id_check() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+        let parent_bank = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
+        let parent_block_id = Hash::new_unique();
+        parent_bank.set_block_id(Some(parent_block_id));
+
+        let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&parent_bank);
+        let mut parent_meta = SlotMeta::new(1, Some(0));
+        parent_meta.next_slots = vec![2, 3];
+
+        for (slot, block_id) in [(2, Hash::new_unique()), (3, parent_block_id)] {
+            let mut meta = SlotMeta::new(slot, Some(1));
+            meta.consumed = 1;
+            meta.received = 1;
+            meta.last_index = Some(0);
+            meta.parent_block_id = block_id;
+            meta.replay_fec_set_index = 32;
+            blockstore.put_meta(slot, &meta).unwrap();
+        }
+
+        let mut pending_slots = Vec::new();
+        process_next_slots(
+            &parent_bank,
+            &parent_meta,
+            &blockstore,
+            &leader_schedule_cache,
+            &mut pending_slots,
+            &ProcessOptions::default(),
+            &MigrationStatus::post_migration_status(),
+        )
+        .unwrap();
+
+        assert_eq!(pending_slots.len(), 1);
+        assert_eq!(pending_slots[0].1.slot(), 3);
     }
 }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -354,14 +354,14 @@ fn test_restart_node() {
     cluster_tests::sleep_n_epochs(
         1.0,
         &cluster.genesis_config.poh_config,
-        clock::DEFAULT_TICKS_PER_SLOT,
+        ticks_per_slot,
         slots_per_epoch,
     );
     cluster.exit_restart_node(&nodes[0], validator_config, SocketAddrSpace::Unspecified);
     cluster_tests::sleep_n_epochs(
         0.5,
         &cluster.genesis_config.poh_config,
-        clock::DEFAULT_TICKS_PER_SLOT,
+        ticks_per_slot,
         slots_per_epoch,
     );
     cluster_tests::send_many_transactions(
@@ -5939,7 +5939,7 @@ fn test_restart_node_alpenglow() {
     cluster_tests::sleep_n_epochs(
         1.0,
         &cluster.genesis_config.poh_config,
-        clock::DEFAULT_TICKS_PER_SLOT,
+        ticks_per_slot,
         slots_per_epoch,
     );
     info!("Restarting node");
@@ -5947,7 +5947,7 @@ fn test_restart_node_alpenglow() {
     cluster_tests::sleep_n_epochs(
         0.5,
         &cluster.genesis_config.poh_config,
-        clock::DEFAULT_TICKS_PER_SLOT,
+        ticks_per_slot,
         slots_per_epoch,
     );
     cluster_tests::send_many_transactions(

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -81,6 +81,18 @@ pub enum PohRecorderError {
 
     #[error("updating bank footer failed with \"{0}\"")]
     UpdateBankFooter(#[from] BankFooterError),
+
+    #[error("bank {0} did not freeze before block footer timeout")]
+    BankFreezeTimeout(Slot),
+
+    #[error("couldn't reset bank during fast leader handover slot {0} -> slot {1}")]
+    ResetBankError(Slot, Slot),
+
+    #[error("couldn't reschedule pre-UpdateParent transactions for slot {0}")]
+    RescheduleTransactionsError(Slot),
+
+    #[error("leader window moved past slot {0}")]
+    WindowMovedOn(Slot),
 }
 
 pub(crate) type Result<T> = std::result::Result<T, PohRecorderError>;
@@ -334,7 +346,7 @@ impl PohRecorder {
                 working_bank.bank.clone(),
                 (EntryOrMarker::Marker(marker), tick_height),
             ))
-            .unwrap();
+            .map_err(Box::new)?;
 
         Ok(())
     }
@@ -516,7 +528,7 @@ impl PohRecorder {
     /// Updates [`Self::shared_leader_state`] if `set_shared_state` is true.
     /// Otherwise the caller is responsible for setting the state before
     /// releasing the lock.
-    fn clear_bank(&mut self, set_shared_state: bool) {
+    pub fn clear_bank(&mut self, set_shared_state: bool) {
         if let Some(WorkingBank { bank, start, .. }) = self.working_bank.take() {
             let next_leader_slot = self.leader_schedule_cache.next_leader_slot(
                 bank.leader_id(),
@@ -588,15 +600,13 @@ impl PohRecorder {
     }
 
     /// Waits for the bank to freeze and sends the block footer with the bank hash.
-    /// Returns:
-    /// - Ok(()): Footer sent successfully
-    /// - Err(None): Bank freeze timeout (caller should break without updating send_result)
-    /// - Err(Some(e)): Send failed (caller should update send_result and break)
+    /// Returns once the footer has been handed to broadcast, or errors if the
+    /// bank cannot freeze quickly enough to populate the footer's bank hash.
     fn wait_for_freeze_and_send_footer(
         &self,
         mut footer: BlockFooterV1,
         working_bank: &WorkingBank,
-    ) -> std::result::Result<(), Option<Box<SendError<WorkingBankEntryOrMarker>>>> {
+    ) -> Result<()> {
         // Wake replay as soon as the slot reaches max tick height so it can freeze the bank
         // before we block on the footer/bank-hash handoff.
         self.notify_replay_wakeup();
@@ -614,13 +624,15 @@ impl PohRecorder {
         // If the bank still isn't frozen, we've timed out
         if !working_bank.bank.is_frozen() {
             if self.is_exited.load(Ordering::Relaxed) {
-                return Err(None);
+                return Err(PohRecorderError::ChannelDisconnected);
             }
             error!(
                 "slot = {} block production failure. bank freezing timed out.",
                 working_bank.bank.slot()
             );
-            return Err(None);
+            return Err(PohRecorderError::BankFreezeTimeout(
+                working_bank.bank.slot(),
+            ));
         }
 
         // Send out the block footer - we now have the bank hash
@@ -632,19 +644,15 @@ impl PohRecorder {
             working_bank.max_tick_height - 1,
         );
 
-        match self
-            .working_bank_sender
+        self.working_bank_sender
             .send((working_bank.bank.clone(), footer_entry_marker))
-        {
-            Ok(()) => Ok(()),
-            Err(err) => {
+            .map_err(|err| {
                 error!(
                     "slot = {} block production failure. failed to broadcast footer",
                     working_bank.bank.slot()
                 );
-                Err(Some(Box::new(err)))
-            }
-        }
+                PohRecorderError::SendError(Box::new(err))
+            })
     }
 
     // Flush cache will delay flushing the cache for a bank until it past the WorkingBank::min_tick_height
@@ -670,6 +678,7 @@ impl PohRecorder {
             .iter()
             .take_while(|x| x.1 <= working_bank.max_tick_height)
             .count();
+        let has_footer = footer.is_some();
         let mut send_result = Ok(());
 
         if entry_count > 0 {
@@ -685,14 +694,9 @@ impl PohRecorder {
                 working_bank.bank.register_tick(&entry.hash);
 
                 if let Some(footer) = footer.clone() {
-                    match self.wait_for_freeze_and_send_footer(footer, working_bank) {
-                        Ok(()) => {}        // Continue processing
-                        Err(None) => break, // Timeout - break without updating send_result
-                        Err(Some(e)) => {
-                            // Send failed - update send_result and break
-                            send_result = Err(e);
-                            break;
-                        }
+                    if let Err(err) = self.wait_for_freeze_and_send_footer(footer, working_bank) {
+                        send_result = Err(err);
+                        break;
                     }
                 }
 
@@ -701,33 +705,36 @@ impl PohRecorder {
                 send_result = self
                     .working_bank_sender
                     .send((working_bank.bank.clone(), tick))
-                    .map_err(Box::new);
+                    .map_err(|err| PohRecorderError::SendError(Box::new(err)));
                 if send_result.is_err() {
                     break;
                 }
             }
         }
-        if self.tick_height() >= working_bank.max_tick_height {
-            info!(
-                "poh_record: max_tick_height {} reached, clearing working_bank {}",
-                working_bank.max_tick_height,
-                working_bank.bank.slot()
-            );
-            self.start_bank = working_bank.bank.clone();
-            let working_slot = self.start_slot();
-            self.start_tick_height = working_slot * self.ticks_per_slot + 1;
-            self.clear_bank(true);
-        }
-        if send_result.is_err() {
-            info!("WorkingBank::sender disconnected {send_result:?}");
-            // revert the cache, but clear the working bank
-            self.clear_bank(true);
-        } else {
+        if send_result.is_ok() {
+            if self.tick_height() >= working_bank.max_tick_height {
+                info!(
+                    "poh_record: max_tick_height {} reached, clearing working_bank {}",
+                    working_bank.max_tick_height,
+                    working_bank.bank.slot()
+                );
+                self.start_bank = working_bank.bank.clone();
+                let working_slot = self.start_slot();
+                self.start_tick_height = working_slot * self.ticks_per_slot + 1;
+                self.clear_bank(true);
+            }
             // commit the flush
             let _ = self.tick_cache.drain(..entry_count);
+        } else {
+            info!("WorkingBank::sender disconnected or footer failed {send_result:?}");
+            // Alpenglow block completion errors must leave the bank attached so
+            // BlockCreationLoop can clear PoH and BankForks atomically.
+            if !has_footer {
+                self.clear_bank(true);
+            }
         }
 
-        Ok(())
+        send_result
     }
 
     pub fn would_be_leader(&self, within_next_n_ticks: u64) -> bool {
@@ -1033,7 +1040,11 @@ impl PohRecorder {
         self.clear_bank(true);
     }
 
-    pub fn tick_alpenglow(&mut self, slot_max_tick_height: u64, footer: BlockFooterV1) {
+    pub fn tick_alpenglow(
+        &mut self,
+        slot_max_tick_height: u64,
+        footer: BlockFooterV1,
+    ) -> Result<()> {
         let (poh_entry, tick_lock_contention_us) = measure_us!({
             let mut poh_l = self.poh.lock().unwrap();
             poh_l.tick()
@@ -1062,10 +1073,12 @@ impl PohRecorder {
                     .load(Ordering::Acquire),
             ));
 
-            let (_flush_res, flush_cache_and_tick_us) =
+            let (flush_res, flush_cache_and_tick_us) =
                 measure_us!(self.flush_cache(true, Some(footer)));
             self.metrics.flush_cache_tick_us += flush_cache_and_tick_us;
+            flush_res?;
         }
+        Ok(())
     }
 
     pub fn enable_alpenglow(&mut self) {
@@ -1364,6 +1377,126 @@ mod tests {
         assert!(poh_recorder.working_bank.is_some());
         poh_recorder.clear_bank(true);
         assert!(poh_recorder.working_bank.is_none());
+    }
+
+    #[test]
+    fn test_send_marker_error() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path())
+            .expect("Expected to be able to open database ledger");
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let prev_hash = bank.last_blockhash();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(
+            0,
+            prev_hash,
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            Arc::new(blockstore),
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+        poh_recorder.set_bank_for_test(bank);
+        drop(entry_receiver);
+
+        let marker = VersionedBlockMarker::new_block_footer(BlockFooterV1 {
+            bank_hash: Hash::new_unique(),
+            block_producer_time_nanos: 0,
+            block_user_agent: vec![],
+            final_cert: None,
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        });
+        let err = poh_recorder.send_marker(marker).unwrap_err();
+        assert!(matches!(err, PohRecorderError::SendError(_)));
+    }
+
+    fn test_footer() -> BlockFooterV1 {
+        BlockFooterV1 {
+            bank_hash: Hash::default(),
+            block_producer_time_nanos: 0,
+            block_user_agent: vec![],
+            final_cert: None,
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        }
+    }
+
+    fn new_alpenglow_recorder_for_bank(
+        bank: Arc<Bank>,
+        blockstore: Arc<Blockstore>,
+    ) -> (PohRecorder, Receiver<WorkingBankEntryOrMarker>) {
+        let prev_hash = bank.last_blockhash();
+        let (mut poh_recorder, entry_receiver) = PohRecorder::new(
+            bank.tick_height(),
+            prev_hash,
+            bank.clone(),
+            Some((4, 4)),
+            bank.ticks_per_slot(),
+            blockstore,
+            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+        poh_recorder.enable_alpenglow();
+        bank.set_tick_height(bank.max_tick_height() - 1);
+        poh_recorder.set_bank_for_test(bank);
+        (poh_recorder, entry_receiver)
+    }
+
+    #[test]
+    fn test_alpenglow_tick_send_error() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(
+            Blockstore::open(ledger_path.path()).expect("Expected to be able to open ledger"),
+        );
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (mut poh_recorder, entry_receiver) =
+            new_alpenglow_recorder_for_bank(bank.clone(), blockstore);
+        drop(entry_receiver);
+
+        let bank_to_freeze = bank.clone();
+        let freezer = std::thread::spawn(move || {
+            while bank_to_freeze.tick_height() < bank_to_freeze.max_tick_height() {
+                std::hint::spin_loop();
+            }
+            bank_to_freeze.freeze();
+        });
+
+        let err = poh_recorder
+            .tick_alpenglow(bank.max_tick_height(), test_footer())
+            .unwrap_err();
+        freezer.join().unwrap();
+
+        assert!(matches!(err, PohRecorderError::SendError(_)));
+        assert!(poh_recorder.has_bank());
+        assert!(!poh_recorder.tick_cache.is_empty());
+    }
+
+    #[test]
+    fn test_alpenglow_tick_timeout() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(
+            Blockstore::open(ledger_path.path()).expect("Expected to be able to open ledger"),
+        );
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let (mut poh_recorder, _entry_receiver) =
+            new_alpenglow_recorder_for_bank(bank.clone(), blockstore);
+
+        let err = poh_recorder
+            .tick_alpenglow(bank.max_tick_height(), test_footer())
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            PohRecorderError::BankFreezeTimeout(slot) if slot == bank.slot()
+        ));
+        assert!(poh_recorder.has_bank());
+        assert!(!poh_recorder.tick_cache.is_empty());
     }
 
     #[test]

--- a/poh/src/record_channels.rs
+++ b/poh/src/record_channels.rs
@@ -174,14 +174,25 @@ impl RecordSender {
 /// The receiver can shutdown the channel, preventing any further sends,
 /// and can restart the channel for a new bank id, re-enabling sends.
 pub struct RecordReceiver {
+    /// Maximum number of record batches that may be reserved for the active bank.
     capacity: u64,
+    /// Number of senders between reservation and channel insertion.
     active_senders: Arc<AtomicU64>,
+    /// Packed active bank id and remaining insertions, or disabled when shut down.
     bank_id_allowed_insertions: BankIdAllowedInsertions,
+    /// Bounded channel carrying reserved records.
     receiver: Receiver<Record>,
+    /// Optional monotonic transaction index shared with senders.
     transaction_indexes: Option<Arc<Mutex<usize>>>,
 }
 
 impl RecordReceiver {
+    /// Returns a reference to the inner receiver for use in `select!` macros.
+    /// After receiving from this, you must call `on_received_record` manually.
+    pub fn inner(&self) -> &Receiver<Record> {
+        &self.receiver
+    }
+
     /// Returns true if the channel should be shutdown.
     pub fn should_shutdown(&self, remaining_hashes_in_slot: u64, ticks_per_slot: u64) -> bool {
         // This channel must guarantee that all sent records are recorded.
@@ -228,9 +239,17 @@ impl RecordReceiver {
         drop(transaction_indexes_lock);
     }
 
-    /// Drain all available records from the channel with `try_recv` loop.
+    /// Drain all records that have been enqueued or reserved by active senders.
     pub fn drain(&self) -> impl Iterator<Item = Record> + '_ {
         core::iter::from_fn(|| self.try_recv().ok())
+    }
+
+    /// Drain all records that were already reserved by senders before shutdown.
+    ///
+    /// This names the shutdown use case explicitly, while sharing `try_recv()`'s
+    /// active-sender guarantee.
+    pub fn drain_after_shutdown(&self) -> impl Iterator<Item = Record> + '_ {
+        self.drain()
     }
 
     /// Channel is empty and there are no active threads attempting to send.
@@ -246,6 +265,10 @@ impl RecordReceiver {
     }
 
     /// Try to receive a record from the channel.
+    ///
+    /// If a sender has already reserved capacity for this bank, do not report
+    /// `Empty` until that sender either enqueues its record or fails. PoH uses
+    /// this to avoid hashing/ticking past a record that was already admitted.
     pub fn try_recv(&self) -> Result<Record, TryRecvError> {
         loop {
             match self.receiver.try_recv() {
@@ -286,7 +309,9 @@ impl RecordReceiver {
         Ok(record)
     }
 
-    fn on_received_record(&self, num_batches: u64) {
+    /// Notify that a record has been received.
+    /// Must be called after receiving a record from `inner()` directly.
+    pub fn on_received_record(&self, num_batches: u64) {
         // The record has been received and processed, so increment the number
         // of allowed insertions, so that new records can be sent.
         self.bank_id_allowed_insertions
@@ -498,7 +523,7 @@ mod shuttle_tests {
     }
 
     #[test]
-    fn test_try_recv_not_sent_on_inner_channel_yet() {
+    fn test_try_recv_waits_active() {
         const NUM_TEST_RUNS: usize = 100_000;
         shuttle::check_random(
             || {
@@ -512,20 +537,42 @@ mod shuttle_tests {
                     });
                 }
 
-                // Snapshot active_senders *before* try_recv
                 let active_at_start = sender.active_senders.load(Ordering::Acquire);
-
-                // Perform try_recv
                 let result = receiver.try_recv();
-
-                // Only fail if it returned None *and* we know there was an active sender at start
                 if result.is_err() && active_at_start > 0 {
                     panic!(
-                        "try_recv returned None while a sender was active at start of call \
-                         (active_senders={})",
-                        active_at_start
+                        "try_recv returned Empty while a sender was active at start of call \
+                         (active_senders={active_at_start})"
                     );
                 }
+            },
+            NUM_TEST_RUNS,
+        )
+    }
+
+    #[test]
+    fn test_drain_shutdown_waits_active() {
+        const NUM_TEST_RUNS: usize = 100_000;
+        shuttle::check_random(
+            || {
+                let (sender, mut receiver) = record_channels(false);
+                receiver.restart(0);
+
+                // Model a sender that reserved capacity before shutdown but
+                // has not yet enqueued its record on the inner channel.
+                sender.active_senders.fetch_add(1, Ordering::AcqRel);
+                let active_senders = sender.active_senders.clone();
+                let inner_sender = sender.sender.clone();
+                shuttle::thread::spawn(move || {
+                    inner_sender.try_send(test_record(0, 1)).unwrap();
+                    active_senders.fetch_sub(1, Ordering::AcqRel);
+                });
+
+                receiver.shutdown();
+                let records: Vec<_> = receiver.drain_after_shutdown().collect();
+                assert_eq!(records.len(), 1);
+                assert_eq!(records[0].bank_id, 0);
+                assert!(receiver.is_safe_to_restart());
             },
             NUM_TEST_RUNS,
         )

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2233,6 +2233,16 @@ impl Bank {
         self.hash.read().unwrap()
     }
 
+    /// Waits for in-flight BankingStage commits to finish without freezing the bank.
+    ///
+    /// BankingStage holds the read side of this lock from before a successful
+    /// PoH record until after the matching account commit. Taking and dropping
+    /// the write side gives callers a quiescence point before abandoning and
+    /// purging an unfrozen leader bank.
+    pub fn wait_for_inflight_commits(&self) {
+        drop(self.hash.write().unwrap());
+    }
+
     pub fn hash(&self) -> Hash {
         *self.hash.read().unwrap()
     }

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -397,14 +397,18 @@ impl BankForks {
             .unzip()
     }
 
-    /// Clears a bank from bank forks. Panics if the bank is not present in bank forks
+    /// Clears a bank from bank forks. Panics if the bank is not present in bank forks.
+    ///
+    /// Callers must quiesce any scheduler for this bank before calling this
+    /// method. ReplayStage does that outside the `BankForks` write lock before
+    /// servicing clear-bank controller commands.
     pub fn clear_bank(&mut self, slot: Slot, write_bank_hash_details: bool) {
         let (slots_to_purge, removed_banks) =
             self.dump_slots(std::iter::once(&slot), write_bank_hash_details);
 
         let root_bank = self.root_bank();
-        root_bank.remove_unrooted_slots(&slots_to_purge);
 
+        root_bank.remove_unrooted_slots(&slots_to_purge);
         drop(removed_banks);
 
         for (slot, _) in slots_to_purge {
@@ -748,6 +752,10 @@ mod tests {
             genesis_utils::{
                 GenesisConfigInfo, create_genesis_config, create_genesis_config_with_leader,
             },
+            installed_scheduler_pool::{
+                InstalledScheduler, ResultWithTimings, ScheduleResult, SchedulerId,
+                UninstalledScheduler, UninstalledSchedulerBox, initialized_result_with_timings,
+            },
         },
         agave_feature_set::FeatureSet,
         agave_votor_messages::{
@@ -755,17 +763,85 @@ mod tests {
             migration::{GENESIS_CERTIFICATE_ACCOUNT, MIGRATION_SLOT_OFFSET},
         },
         assert_matches::assert_matches,
-        solana_account::Account,
+        crossbeam_channel::{Receiver, Sender, bounded},
+        solana_account::{Account, AccountSharedData},
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_clock::UnixTimestamp,
         solana_epoch_schedule::EpochSchedule,
         solana_keypair::Keypair,
         solana_leader_schedule::SlotLeader,
         solana_rent::Rent,
+        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_sdk_ids::system_program,
         solana_signer::Signer,
+        solana_transaction::sanitized::SanitizedTransaction,
+        solana_transaction_error::TransactionError,
+        solana_unified_scheduler_logic::OrderedTaskId,
         solana_vote_program::vote_state::BlockTimestamp,
+        std::{fmt::Debug, thread, time::Duration},
     };
+
+    struct BlockingScheduler {
+        context: SchedulingContext,
+        wait_started_sender: Sender<()>,
+        release_receiver: Receiver<()>,
+    }
+
+    impl Debug for BlockingScheduler {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("BlockingScheduler")
+                .field("slot", &self.context.slot())
+                .finish_non_exhaustive()
+        }
+    }
+
+    impl InstalledScheduler for BlockingScheduler {
+        fn id(&self) -> SchedulerId {
+            1
+        }
+
+        fn context(&self) -> &SchedulingContext {
+            &self.context
+        }
+
+        fn schedule_execution(
+            &self,
+            _transaction: RuntimeTransaction<SanitizedTransaction>,
+            _task_id: OrderedTaskId,
+        ) -> ScheduleResult {
+            Ok(())
+        }
+
+        fn recover_error_after_abort(&mut self) -> TransactionError {
+            unreachable!("blocking test scheduler never aborts")
+        }
+
+        fn wait_for_termination(
+            self: Box<Self>,
+            is_dropped: bool,
+        ) -> (ResultWithTimings, UninstalledSchedulerBox) {
+            assert!(!is_dropped);
+            self.wait_started_sender.send(()).unwrap();
+            self.release_receiver
+                .recv_timeout(Duration::from_secs(5))
+                .unwrap();
+            (
+                initialized_result_with_timings(),
+                Box::new(NoopUninstalledScheduler),
+            )
+        }
+
+        fn pause_for_recent_blockhash(&mut self) {}
+
+        fn unpause_after_taken(&self) {}
+    }
+
+    #[derive(Debug)]
+    struct NoopUninstalledScheduler;
+
+    impl UninstalledScheduler for NoopUninstalledScheduler {
+        fn return_to_pool(self: Box<Self>) {}
+    }
 
     // This test verifies that BankForks::new_rw_arc() doesn't create a reference cycle.
     //
@@ -802,6 +878,80 @@ mod tests {
         let bank_forks = bank_forks.read().unwrap();
         assert_eq!(bank_forks[1u64].tick_height(), 1);
         assert_eq!(bank_forks.working_bank().tick_height(), 1);
+    }
+
+    #[test]
+    fn test_clear_bank_after_scheduler_wait() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let root_bank = bank_forks.read().unwrap()[0].clone();
+        let child_bank = Arc::new(Bank::new_from_parent(root_bank, SlotLeader::default(), 1));
+        let (wait_started_sender, wait_started_receiver) = bounded(1);
+        let (release_sender, release_receiver) = bounded(1);
+
+        let bank_with_scheduler = BankWithScheduler::new(
+            child_bank.clone(),
+            Some(Box::new(BlockingScheduler {
+                context: SchedulingContext::new(child_bank.clone()),
+                wait_started_sender,
+                release_receiver,
+            })),
+        );
+        let account_key = Keypair::new().pubkey();
+        child_bank.store_account(
+            &account_key,
+            &AccountSharedData::new(42, 0, &system_program::ID),
+        );
+        assert!(child_bank.get_account(&account_key).is_some());
+
+        {
+            let mut bank_forks = bank_forks.write().unwrap();
+            assert!(bank_forks.banks.insert(1, bank_with_scheduler).is_none());
+            bank_forks.descendants.entry(1).or_default();
+            for parent in child_bank.proper_ancestors() {
+                bank_forks.descendants.entry(parent).or_default().insert(1);
+            }
+            bank_forks.working_slot = 1;
+            bank_forks
+                .sharable_banks
+                .working_bank
+                .store(child_bank.clone());
+        }
+
+        let clear_bank_forks = bank_forks.clone();
+        let (finish_done_sender, finish_done_receiver) = bounded(1);
+        let finish_thread = thread::spawn(move || {
+            let bank_to_clear = clear_bank_forks
+                .read()
+                .unwrap()
+                .get_with_scheduler(1)
+                .unwrap();
+            let _ = bank_to_clear.wait_for_completed_scheduler();
+            clear_bank_forks.write().unwrap().clear_bank(1, false);
+            finish_done_sender.send(()).unwrap();
+        });
+
+        wait_started_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        assert!(
+            finish_done_receiver
+                .recv_timeout(Duration::from_millis(50))
+                .is_err()
+        );
+
+        // The scheduler drain is blocked, but `BankForks` readers must not be.
+        assert!(bank_forks.read().unwrap().get(0).is_some());
+        // The removed bank's account state must also remain available until
+        // the scheduler workers are done using it.
+        assert!(child_bank.get_account(&account_key).is_some());
+
+        release_sender.send(()).unwrap();
+        finish_thread.join().unwrap();
+        finish_done_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        assert!(child_bank.get_account(&account_key).is_none());
     }
 
     fn make_root_bank_for_migration_status_test(

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -70,12 +70,41 @@ pub enum BlockComponentProcessorError {
     NanosecondClockOutOfBounds,
     #[error("Spurious update parent")]
     SpuriousUpdateParent,
+    #[error(
+        "UpdateParent cannot be the initial parent marker unless replay starts at UpdateParent"
+    )]
+    UnexpectedInitialUpdateParent,
     #[error("Abandoned bank")]
     AbandonedBank(VersionedUpdateParent),
     #[error("invalid reward certs {0}")]
     InvalidRewardCerts(#[from] ValidatedRewardCertError),
     #[error("updating bank footer failed with \"{0}\"")]
     UpdateBankFooter(#[from] BankFooterError),
+}
+
+impl BlockComponentProcessorError {
+    pub fn is_update_parent_recoverable_replay_error(&self) -> bool {
+        match self {
+            BlockComponentProcessorError::MissingParentMarker
+            | BlockComponentProcessorError::MultipleBlockFooters
+            | BlockComponentProcessorError::MultipleBlockHeaders
+            | BlockComponentProcessorError::HeaderParentSlotMismatch { .. }
+            | BlockComponentProcessorError::NanosecondClockOutOfBounds
+            | BlockComponentProcessorError::UnexpectedInitialUpdateParent
+            | BlockComponentProcessorError::AbandonedBank(_)
+            | BlockComponentProcessorError::InvalidRewardCerts(_)
+            | BlockComponentProcessorError::UpdateBankFooter(_)
+            | BlockComponentProcessorError::InvalidFinalizationCertificate(_) => true,
+            BlockComponentProcessorError::BlockComponentPreMigration
+            | BlockComponentProcessorError::GenesisCertificateAlreadyPopulated
+            | BlockComponentProcessorError::GenesisCertificateInAlpenglowCluster
+            | BlockComponentProcessorError::GenesisCertificateOnNonChild
+            | BlockComponentProcessorError::GenesisCertificateFailedVerification
+            | BlockComponentProcessorError::MissingBlockFooter
+            | BlockComponentProcessorError::MultipleUpdateParents
+            | BlockComponentProcessorError::SpuriousUpdateParent => false,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -146,6 +175,7 @@ impl BlockComponentProcessor {
         bank: Arc<Bank>,
         parent_bank: Arc<Bank>,
         marker: VersionedBlockMarker,
+        allow_initial_update_parent: bool,
         finalization_cert_sender: Option<&Sender<Vec<ConsensusMessage>>>,
         migration_status: &MigrationStatus,
     ) -> Result<(), BlockComponentProcessorError> {
@@ -177,7 +207,7 @@ impl BlockComponentProcessor {
             ),
 
             BlockMarkerV1::UpdateParent(update_parent) if markers_fully_enabled => {
-                self.on_update_parent(update_parent.inner())
+                self.on_update_parent(update_parent.inner(), allow_initial_update_parent)
             }
 
             // Any other combination means we saw a marker too early
@@ -374,14 +404,22 @@ impl BlockComponentProcessor {
     fn on_update_parent(
         &mut self,
         update_parent: &VersionedUpdateParent,
+        allow_initial_update_parent: bool,
     ) -> Result<(), BlockComponentProcessorError> {
         if self.update_parent.is_some() {
             return Err(BlockComponentProcessorError::MultipleUpdateParents);
         }
 
+        if !self.has_header && !allow_initial_update_parent {
+            return Err(BlockComponentProcessorError::UnexpectedInitialUpdateParent);
+        }
+
         self.update_parent = Some(update_parent.clone());
 
         if self.has_header {
+            // Only an error in the sense that replay execution of this block
+            // prefix is now over. Replay execution can continue after resetting
+            // bank.
             Err(BlockComponentProcessorError::AbandonedBank(
                 update_parent.clone(),
             ))
@@ -663,7 +701,7 @@ mod tests {
         let bank = create_child_bank(&bank_forks, &parent, 1);
 
         processor
-            .on_marker(bank, parent, marker, None, &migration_status)
+            .on_marker(bank, parent, marker, false, None, &migration_status)
             .unwrap();
         assert!(processor.has_header);
     }
@@ -681,7 +719,7 @@ mod tests {
         let bank = create_child_bank(&bank_forks, &parent, 1);
 
         assert!(matches!(
-            processor.on_marker(bank, parent, marker, None, &migration_status),
+            processor.on_marker(bank, parent, marker, false, None, &migration_status),
             Err(BlockComponentProcessorError::HeaderParentSlotMismatch {
                 header_parent_slot: 7,
                 bank_parent_slot: 0,
@@ -715,7 +753,7 @@ mod tests {
         });
 
         processor
-            .on_marker(bank.clone(), parent, marker, None, &migration_status)
+            .on_marker(bank.clone(), parent, marker, false, None, &migration_status)
             .unwrap();
         assert!(processor.has_footer);
 
@@ -779,7 +817,7 @@ mod tests {
             parent_block_id: Hash::default(),
         });
 
-        let result = processor.on_marker(bank, parent, marker, None, &migration_status);
+        let result = processor.on_marker(bank, parent, marker, false, None, &migration_status);
         assert!(matches!(
             result,
             Err(BlockComponentProcessorError::BlockComponentPreMigration)
@@ -808,6 +846,7 @@ mod tests {
                 bank.clone(),
                 parent.clone(),
                 footer_marker,
+                false,
                 None,
                 &migration_status
             ),
@@ -821,7 +860,14 @@ mod tests {
 
         let mut processor = BlockComponentProcessor::default();
         assert!(matches!(
-            processor.on_marker(bank, parent, update_parent_marker, None, &migration_status),
+            processor.on_marker(
+                bank,
+                parent,
+                update_parent_marker,
+                false,
+                None,
+                &migration_status
+            ),
             Err(BlockComponentProcessorError::BlockComponentPreMigration)
         ));
     }
@@ -857,6 +903,7 @@ mod tests {
                 bank.clone(),
                 parent.clone(),
                 header_marker,
+                false,
                 None,
                 &migration_status,
             )
@@ -880,7 +927,14 @@ mod tests {
             notar_reward_cert: None,
         });
         processor
-            .on_marker(bank.clone(), parent, footer_marker, None, &migration_status)
+            .on_marker(
+                bank.clone(),
+                parent,
+                footer_marker,
+                false,
+                None,
+                &migration_status,
+            )
             .unwrap();
 
         // Verify clock sysvar was updated
@@ -940,8 +994,14 @@ mod tests {
         });
 
         // Should succeed - footer is processed
-        let result =
-            processor.on_marker(bank.clone(), parent, footer_marker, None, &migration_status);
+        let result = processor.on_marker(
+            bank.clone(),
+            parent,
+            footer_marker,
+            false,
+            None,
+            &migration_status,
+        );
         assert!(result.is_ok());
         assert!(processor.has_footer);
 
@@ -1174,14 +1234,29 @@ mod tests {
     }
 
     #[test]
-    fn test_update_parent_as_first_marker() {
+    fn test_initial_up_reject() {
         let mut processor = BlockComponentProcessor::default();
         let update_parent = VersionedUpdateParent::V1(UpdateParentV1 {
             new_parent_slot: 0,
             new_parent_block_id: Hash::default(),
         });
 
-        assert!(processor.on_update_parent(&update_parent).is_ok());
+        assert!(matches!(
+            processor.on_update_parent(&update_parent, false),
+            Err(BlockComponentProcessorError::UnexpectedInitialUpdateParent)
+        ));
+        assert!(processor.update_parent.is_none());
+    }
+
+    #[test]
+    fn test_initial_up_ok() {
+        let mut processor = BlockComponentProcessor::default();
+        let update_parent = VersionedUpdateParent::V1(UpdateParentV1 {
+            new_parent_slot: 0,
+            new_parent_block_id: Hash::default(),
+        });
+
+        processor.on_update_parent(&update_parent, true).unwrap();
         assert!(processor.update_parent.is_some());
     }
 
@@ -1204,7 +1279,7 @@ mod tests {
         });
 
         assert!(matches!(
-            processor.on_update_parent(&update_parent),
+            processor.on_update_parent(&update_parent, false),
             Err(BlockComponentProcessorError::AbandonedBank(_))
         ));
     }
@@ -1218,11 +1293,11 @@ mod tests {
         });
 
         // First should succeed
-        processor.on_update_parent(&update_parent).unwrap();
+        processor.on_update_parent(&update_parent, true).unwrap();
 
         // Second should fail
         assert!(matches!(
-            processor.on_update_parent(&update_parent),
+            processor.on_update_parent(&update_parent, true),
             Err(BlockComponentProcessorError::MultipleUpdateParents)
         ));
     }
@@ -1231,10 +1306,13 @@ mod tests {
     fn test_header_after_update_parent_error() {
         let mut processor = BlockComponentProcessor::default();
         processor
-            .on_update_parent(&VersionedUpdateParent::V1(UpdateParentV1 {
-                new_parent_slot: 0,
-                new_parent_block_id: Hash::default(),
-            }))
+            .on_update_parent(
+                &VersionedUpdateParent::V1(UpdateParentV1 {
+                    new_parent_slot: 0,
+                    new_parent_block_id: Hash::default(),
+                }),
+                true,
+            )
             .unwrap();
 
         let header = VersionedBlockHeader::V1(BlockHeaderV1 {
@@ -1257,10 +1335,13 @@ mod tests {
         let bank = create_child_bank(&bank_forks, &parent, 1);
 
         processor
-            .on_update_parent(&VersionedUpdateParent::V1(UpdateParentV1 {
-                new_parent_slot: 0,
-                new_parent_block_id: Hash::default(),
-            }))
+            .on_update_parent(
+                &VersionedUpdateParent::V1(UpdateParentV1 {
+                    new_parent_slot: 0,
+                    new_parent_block_id: Hash::default(),
+                }),
+                true,
+            )
             .unwrap();
 
         assert!(processor.on_entry_batch(&migration_status, 1).is_ok());

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -7,8 +7,8 @@ use {
     },
     crate::cluster_nodes::ClusterNodesCache,
     agave_votor::event::VotorEventSender,
-    agave_votor_messages::migration::MigrationStatus,
-    solana_entry::block_component::BlockComponent,
+    agave_votor_messages::{consensus_message::Block, migration::MigrationStatus},
+    solana_entry::block_component::{BlockComponent, VersionedBlockMarker, VersionedUpdateParent},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::shred::{
@@ -24,8 +24,13 @@ use {
 #[derive(Clone)]
 pub struct StandardBroadcastRun {
     slot: Slot,
+    // Parent encoded in shred headers. This must remain stable for the slot
+    // because it is used to derive PARENT_OFFSET.
     parent: Slot,
     parent_block_id: Hash,
+    // Parent slot and block id committed into the double-merkle block id. This
+    // can change after an UpdateParent marker.
+    parent_for_double_merkle: Block,
     chained_merkle_root: Hash,
     carryover_entry: Option<WorkingBankEntryOrMarker>,
     double_merkle_leaves: Vec<Hash>,
@@ -68,6 +73,7 @@ impl StandardBroadcastRun {
             slot: Slot::MAX,
             parent: Slot::MAX,
             parent_block_id: Hash::default(),
+            parent_for_double_merkle: (Slot::MAX, Hash::default()),
             chained_merkle_root: Hash::default(),
             double_merkle_leaves: vec![],
             carryover_entry: None,
@@ -129,6 +135,7 @@ impl StandardBroadcastRun {
         self.slot = bank.slot();
         self.parent = bank.parent_slot();
         self.parent_block_id = parent_block_id;
+        self.parent_for_double_merkle = (bank.parent_slot(), parent_block_id);
         self.chained_merkle_root = chained_merkle_root;
         self.double_merkle_leaves.clear();
         self.next_shred_index = 0u32;
@@ -206,16 +213,23 @@ impl StandardBroadcastRun {
                 })
                 .collect();
 
-        let fec_set_roots = shreds
-            .iter()
-            .unique_by(|shred| shred.fec_set_index())
-            .sorted_unstable_by_key(|shred| shred.fec_set_index())
-            .map(|shred| shred.merkle_root().expect("no more legacy shreds"));
-        // If necessary for perf, these leaves could start being joined in the background
-        self.double_merkle_leaves.extend(fec_set_roots);
+        if self
+            .migration_status
+            .should_use_double_merkle_block_id(self.slot)
+        {
+            let fec_set_roots = shreds
+                .iter()
+                .unique_by(|shred| shred.fec_set_index())
+                .sorted_unstable_by_key(|shred| shred.fec_set_index())
+                .map(|shred| shred.merkle_root().expect("no more legacy shreds"));
+            // If necessary for perf, these leaves could start being joined in the background
+            self.double_merkle_leaves.extend(fec_set_roots);
 
-        if let Some(fec_set_root) = self.double_merkle_leaves.last() {
-            self.chained_merkle_root = *fec_set_root;
+            if let Some(fec_set_root) = self.double_merkle_leaves.last() {
+                self.chained_merkle_root = *fec_set_root;
+            }
+        } else if let Some(shred) = shreds.last() {
+            self.chained_merkle_root = shred.merkle_root().expect("no more legacy shreds");
         }
         if self.next_shred_index > self.max_data_shreds_per_slot {
             return Err(BroadcastError::TooManyShreds);
@@ -224,6 +238,34 @@ impl StandardBroadcastRun {
             return Err(BroadcastError::TooManyShreds);
         }
         Ok(shreds)
+    }
+
+    /// Update only the double-merkle parent commitment after an UpdateParent marker.
+    ///
+    /// The shred-header parent remains `self.parent` for the whole slot so
+    /// PARENT_OFFSET stays stable and receivers do not see parent mismatches.
+    fn maybe_update_parent_from_component(&mut self, component: &BlockComponent) {
+        let Some(VersionedBlockMarker::V1(marker)) = component.as_marker() else {
+            return;
+        };
+        let Some(update_parent) = marker.as_update_parent() else {
+            return;
+        };
+        let parent_for_double_merkle = match update_parent {
+            VersionedUpdateParent::V1(update_parent) => (
+                update_parent.new_parent_slot,
+                update_parent.new_parent_block_id,
+            ),
+        };
+        self.parent_for_double_merkle = parent_for_double_merkle;
+    }
+
+    /// Leaf that binds the current replay parent into the double-merkle block id.
+    fn parent_info_leaf(&self) -> Hash {
+        hashv(&[
+            &self.parent_for_double_merkle.0.to_le_bytes(),
+            self.parent_for_double_merkle.1.as_bytes(),
+        ])
     }
 
     #[cfg(test)]
@@ -336,6 +378,7 @@ impl StandardBroadcastRun {
                 process_stats,
             )
             .unwrap();
+        self.maybe_update_parent_from_component(&component);
 
         let shreds = if maybe_send_header {
             header_shreds.extend(shreds);
@@ -404,9 +447,7 @@ impl StandardBroadcastRun {
                 // Block id is the double merkle root
                 let fec_set_count = self.double_merkle_leaves.len();
                 // Add the final leaf (parent info)
-                let parent_info_leaf =
-                    hashv(&[&self.parent.to_le_bytes(), self.parent_block_id.as_bytes()]);
-                self.double_merkle_leaves.push(parent_info_leaf);
+                self.double_merkle_leaves.push(self.parent_info_leaf());
 
                 // Compute the double merkle root
                 // Blockstore population of the DoubleMerkleMeta happens asynchronously when shreds are inserted
@@ -950,5 +991,67 @@ mod test {
         let component = BlockComponent::new_entry_batch(entries).unwrap();
         let r = bs.component_to_shreds(&keypair, &component, 0, false, &mut stats);
         assert_matches!(r, Err(BroadcastError::TooManyShreds));
+    }
+
+    #[test]
+    fn test_update_parent() {
+        let keypair = Keypair::new();
+        let (votor_event_sender, _votor_event_receiver) = unbounded();
+        let mut bs = StandardBroadcastRun::new(
+            0,
+            Arc::new(MigrationStatus::post_migration_status()),
+            votor_event_sender,
+        );
+        bs.slot = 12;
+        bs.parent = 10;
+        let original_parent_block_id = Hash::new_unique();
+        bs.parent_block_id = original_parent_block_id;
+        bs.parent_for_double_merkle = (bs.parent, bs.parent_block_id);
+
+        let new_parent_slot = 7;
+        let new_parent_block_id = Hash::new_unique();
+        let component = BlockComponent::new_block_marker(VersionedBlockMarker::new_update_parent(
+            solana_entry::block_component::UpdateParentV1 {
+                new_parent_slot,
+                new_parent_block_id,
+            },
+        ));
+        let mut stats = ProcessShredsStats::default();
+        let shreds = bs
+            .component_to_shreds(&keypair, &component, 0, false, &mut stats)
+            .unwrap();
+        assert!(
+            shreds
+                .iter()
+                .filter(|shred| shred.is_data())
+                .all(|shred| shred.parent().unwrap() == 10)
+        );
+
+        bs.maybe_update_parent_from_component(&component);
+        assert_eq!(bs.parent, 10);
+        assert_eq!(bs.parent_block_id, original_parent_block_id);
+        assert_eq!(
+            bs.parent_for_double_merkle,
+            (new_parent_slot, new_parent_block_id)
+        );
+        assert_eq!(
+            bs.parent_info_leaf(),
+            hashv(&[
+                &new_parent_slot.to_le_bytes(),
+                new_parent_block_id.as_bytes()
+            ])
+        );
+
+        let entries = create_ticks(1, 0, Hash::default());
+        let component = BlockComponent::new_entry_batch(entries).unwrap();
+        let shreds = bs
+            .component_to_shreds(&keypair, &component, 0, false, &mut stats)
+            .unwrap();
+        assert!(
+            shreds
+                .iter()
+                .filter(|shred| shred.is_data())
+                .all(|shred| shred.parent().unwrap() == 10)
+        );
     }
 }

--- a/votor-messages/src/reward_certificate.rs
+++ b/votor-messages/src/reward_certificate.rs
@@ -152,5 +152,10 @@ pub enum BuildRewardCertsRespError {
     Encode(EncodeError),
 }
 
-/// A type alias to minimise making changes if the above types change.
-pub type BuildRewardCertsResponse = Result<BuildRewardCertsRespSucc, BuildRewardCertsRespError>;
+/// Response to a [`BuildRewardCertsRequest`].
+pub struct BuildRewardCertsResponse {
+    /// The bank slot from the corresponding request.
+    pub bank_slot: Slot,
+    /// The result of building reward certs for `bank_slot`.
+    pub result: Result<BuildRewardCertsRespSucc, BuildRewardCertsRespError>,
+}

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -421,15 +421,6 @@ impl ConsensusPoolService {
         let start_slot = *highest_parent_ready;
         let end_slot = last_of_consecutive_leader_slots(start_slot);
 
-        if (start_slot..=end_slot).any(|s| ctx.blockstore.has_existing_shreds_for_slot(s)) {
-            warn!(
-                "{}: We have already produced shreds in the window {start_slot}-{end_slot}, \
-                 skipping production of our leader window",
-                ctx.cluster_info.id()
-            );
-            return;
-        }
-
         match consensus_pool
             .parent_ready_tracker
             .block_production_parent(start_slot)

--- a/votor/src/consensus_rewards.rs
+++ b/votor/src/consensus_rewards.rs
@@ -108,7 +108,10 @@ impl ConsensusRewards {
                 recv(self.build_reward_certs_receiver) -> msg => {
                     match msg {
                         Ok(msg) => {
-                            let resp = self.build_certs(msg.bank_slot);
+                            let resp = BuildRewardCertsResponse {
+                                bank_slot: msg.bank_slot,
+                                result: self.build_certs(msg.bank_slot),
+                            };
                             if self.reward_certs_sender.send(resp).is_err() {
                                 error!("{my_pubkey}: cert sender channel is disconnected; exiting.");
                                 break;


### PR DESCRIPTION
## Problem

Alpenglow leader production currently waits for Votor to produce a certified `ParentReady` signal before starting the next leader window. That is slower than the Tower path, where a validator can begin producing as soon as the prior leader’s last block is frozen.

This PR allows a validator to optimistically start its leader window on the prior leader’s last frozen block. If the later certified parent agrees, production continues normally. If consensus proves a different parent, the leader performs sad leader handover by emitting an `UpdateParent` marker, abandoning the optimistic bank, recreating the bank on the certified parent, and rescheduling transactions already accepted for that slot.

## Summary of Changes

- Add optimistic leader-window notifications from replay to `BlockCreationLoop` when our next leader window starts immediately after a frozen block with a known block id.
- Teach `BlockCreationLoop` to drain both `ParentReady` and optimistic-parent channels, select the freshest window by `start_slot`, and let `ParentReady` win ties.
- Add latest-only coalescing for optimistic-parent notifications so stale windows do not clog the bounded channel.
- Add fast leader handover for optimistic starts and sad leader handover when the later `ParentReady` parent differs.
- Add `UpdateParent` marker emission, blockstore parsing/persistence, and replay signaling.
- Add `SlotMeta.parent_block_id` and `SlotMeta.replay_fec_set_index` so replay can identify the effective parent and marker replay point.
- Add double-Merkle block ids for Alpenglow blocks, with a final parent-info leaf.
- Keep shred-header `PARENT_OFFSET` stable for the whole slot; only the effective replay parent and double-Merkle parent leaf change after `UpdateParent`.
- Restart live and startup replay from `replay_fec_set_index` when valid `UpdateParent` metadata is present.
- Add soft-dead replay state for recoverable pre-`UpdateParent` failures, plus hard-dead promotion when recovery is impossible.
- Route live BCL bank creation/clearing through `BankForksController` so production `BankForks` writes are handled by replay-stage ownership.
- Preserve Tower safety by enforcing marker legality through migration-state checks in replay/block-component processing.

## Leader Parent Decision Flow

There are two leader-window sources:

- `ParentReady`: certified-safe parent from Votor, derived from notar-fallback-or-stronger certificates and skip connectivity.
- `OptimisticParent`: replay observed the prior leader’s last block freeze, the next slot is our first leader slot, and the frozen bank has a block id.

`BlockCreationLoop` waits for either source, drains both channels, and chooses the highest `start_slot`. If both sources report the same `start_slot`, `ParentReady` wins because certified parent state overrides optimistic state.

If `ParentReady` wins, production starts normally on the certified parent.

If `OptimisticParent` wins, BCL starts the first slot of the leader window on that optimistic parent. While producing that first slot:

- If `ParentReady` arrives for the same window and the parent matches, this is the FLH happy path.
- If `ParentReady` arrives for the same window and the parent differs, this is sad leader handover.
- If `ParentReady` arrives for a later window, BCL aborts the current bank and stashes the newer `ParentReady`.
- If a stale `ParentReady` arrives for an older window, it is ignored.
- If the block timeout fires before `ParentReady`, BCL stops accepting new records, drains already-reserved records, and waits for `ParentReady` or shutdown.

Sad leader handover order:

1. Shut down record intake and drain already-reserved records, accumulating their transactions.
2. Emit `UpdateParent` with the certified parent from `ParentReady`.
3. Wait for in-flight BankingStage commits that already recorded into PoH.
4. Clear the abandoned bank through `BankForksController`.
5. Clear PoH’s working bank.
6. Recreate the leader bank on the certified parent.
7. Reschedule accumulated transactions into BankingStage for the recreated bank.

## UpdateParent Design

Fast leader handover has two parent concepts:

- Shred-header parent, used for `PARENT_OFFSET` and wire compatibility.
- Effective replay/consensus parent, stored in `SlotMeta` and committed into the double-Merkle parent leaf.

Broadcast always uses the original optimistic parent in shred headers for the whole slot. After sad handover, broadcast updates only the double-Merkle parent state. This keeps receiver-side shred parent checks stable while making the final Alpenglow block id commit to the certified parent.

Blockstore rules:

- Block headers are parsed from shred index 0.
- `UpdateParent` is parsed only at FEC boundaries, as the first shred of the FEC set after a completed data segment.
- `SlotMeta.parent_slot`, `parent_block_id`, and `replay_fec_set_index` are updated only after marker validation.
- Shred parent is always checked for basic well-formedness.
- Shred parent is compared to `SlotMeta.parent_slot` only before `UpdateParent`.
- Header parent must match the shred-header parent.
- `UpdateParent` may disagree with the shred-header parent, but its parent slot must not be greater than the shred-header parent.
- If both header and `UpdateParent` are observed, `UpdateParent` must be compatible with the header.
- `UpdateParent` to the exact same `(slot, block_id)` as the header parent is invalid.
- Conflicting multiple `UpdateParent`s are invalid; exact duplicate markers are idempotent.
- Blockstore marker parsing is intentionally feature-agnostic. Migration legality is enforced when replay/block-component processing attempts to execute the slot.

Replay rules:

- A slot with `UpdateParent` does not need a valid block header prefix before replay can start at the marker.
- The optimistic prefix may be malformed or headerless; replay intentionally skips it once `SlotMeta.has_update_parent()` is present and the parent metadata is coherent.
- Live replay clears/recreates an in-progress bank when an `UpdateParent` signal arrives and replay has not already reached the marker.
- Startup replay uses the same `replay_fec_set_index` offset so restarted validators do not execute the obsolete optimistic-parent prefix.
- If normal from-zero replay encounters `UpdateParent` after a header, the bank is abandoned and recreated from the marker offset.
- If replay intentionally starts at `UpdateParent`, the block-component processor allows `UpdateParent` to be the first parent marker only when `progress.num_shreds == SlotMeta.replay_fec_set_index`.
- From-zero replay still requires a parent marker before entries.
- Live replay does not create banks for our own leader slots; BCL owns live production. Startup replay can still replay completed repaired own-leader blocks after restart.

## Soft vs Hard Dead

Hard-dead is terminal local state:

- Marked in `ProgressMap` as `DeadSlotReason::Hard`.
- Written to blockstore dead slots.
- Sends `InvalidBank` to replay-vote.
- Publishes slot-status, RPC `SlotUpdate::Dead`, slots-stats, and Tower duplicate/dead handling where applicable.
- Cannot be revived by a later `UpdateParent`.

Soft-dead is transient local state:

- Used only for replay failures that may have occurred in the obsolete optimistic-parent prefix.
- Marked in `ProgressMap` as `DeadSlotReason::ReplayFailureBeforeUpdateParent`.
- Not written to blockstore dead slots.
- Not externally reported through RPC or slot-status notifications.
- Sends `InvalidBank` to release replay-vote state.

A soft-dead slot is restarted when usable `UpdateParent` metadata becomes available. Replay clears the old bank/progress and recreates the bank from the updated parent at `replay_fec_set_index`.

A soft-dead slot is promoted to hard-dead if the slot becomes full without a usable `UpdateParent`, if `UpdateParent` metadata is present but unusable from the current root, or if replay fails after it has already reached the `UpdateParent` replay point.

## Merkle and Verification Rules

Tower and pre-Alpenglow blocks keep the legacy block id:

- The block id is the Merkle root of the last shred/FEC set.
- Chained Merkle Root validation checks that the child’s shred-0 chained root matches the parent’s last-shred Merkle root.
- Block markers observed before they are legal for the migration phase are rejected during block-component processing.

During migration:

- Blocks before Alpenglow genesis remain Tower-style.
- Vote-only migration banks do not use FLH.
- Header/genesis-certificate marker handling is allowed where needed to discover or verify Alpenglow genesis.
- Full block-marker handling, double-Merkle block ids, and `UpdateParent` are only legal for Alpenglow blocks after genesis.

Alpenglow blocks use double-Merkle block ids:

- The double-Merkle tree contains one leaf per FEC-set Merkle root plus one final parent-info leaf.
- The parent-info leaf is `hash(parent_slot || parent_block_id)`.
- Without `UpdateParent`, the parent-info leaf is the block-header parent.
- With `UpdateParent`, the parent-info leaf is the updated certified parent.
- For Alpenglow slots with `UpdateParent`, chained-block-id validation is skipped because the shred header intentionally remains on the original parent; the double-Merkle parent leaf carries the consensus parent commitment.

## Bugs Fixed / Concerns Addressed

- Fixed wrong block id voting after sad leader handover by updating the double-Merkle parent leaf.
- Avoided shred parent mismatch races by keeping shred-header parent stable across `UpdateParent`.
- Prevented out-of-order post-`UpdateParent` shreds from being rejected before the marker is observed.
- Ensured conflicting/multiple `UpdateParent`s make the slot hard-dead in blockstore.
- Prevented recoverable pre-`UpdateParent` replay failures from permanently poisoning blockstore dead state.
- Waited for in-flight BankingStage commits before clearing abandoned banks.
- Avoided dropping bank scheduler state while holding the `BankForks` write lock.
- Treated transient parent block-id mismatch as retryable while replay/bank switching catches up.
- Made marker send failures flow through `Result` cleanup paths.
- Ignored stale reward-cert responses from abandoned banks.
- Preserved replay of fully repaired own leader blocks after restart while still skipping live in-progress own-leader replay.
- Added latest-only optimistic-parent notification coalescing and metrics for dropped notifications.

## Important Assumptions

- FLH is only legal for Alpenglow blocks.
- `UpdateParent` changes the effective replay parent, not the shred-header parent.
- Consumers that need the canonical parent for a slot must use `SlotMeta.parent_slot` and `parent_block_id`, not raw shred `PARENT_OFFSET`.
- Replay may temporarily mark a slot soft-dead, but only blockstore hard-dead state is durable or externally reported.
- BCL owns live own-leader bank creation; replay may still create an own-leader bank for a completed repaired slot after restart.
- The optimistic prefix before `UpdateParent` is intentionally not part of the final replayed block once the marker is used.
- This PR does not address tx-status/RPC/Geyser side effects from a later-aborted pre-`UpdateParent` prefix; that remains follow-up work.

## Testing

Added focused unit coverage for:

- Optimistic-parent notification coalescing.
- FLH happy path and sad leader handover.
- `UpdateParent` marker insertion, ordering, duplicate/conflict handling, and out-of-order shred arrival.
- Headerless / garbage-prefix `UpdateParent` replay from marker.
- Live replay restart and startup replay offset behavior.
- Soft-dead to restart and soft-dead to hard-dead transitions.
- Double-Merkle parent-info leaf and repair proofs.
- Tower/pre-migration marker rejection behavior.
- BankingStage commit quiescing and bank clearing behavior.

Cluster validation:

- 44-node Alpenglow cluster with induced sad leader handover via test hooks withholding notarize votes and delaying skip votes/certs ran for multiple days.
- 10-node Tower cluster ran overnight to check for non-Alpenglow regressions.
