### PR TITLE
ledger-tool: Add flag to copy block metadata

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -329,6 +329,12 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                     .value_name("DIR")
                     .takes_value(true)
                     .help("Target ledger directory to write inner \"rocksdb\" within."),
+            )
+            .arg(
+                Arg::with_name("copy_block_metadata")
+                    .long("copy-block-metadata")
+                    .takes_value(false)
+                    .help("Copy block and transaction metadata (if available)"),
             ),
         SubCommand::with_name("dead-slots")
             .about("Print all the dead slots in the ledger")
@@ -627,6 +633,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             let ending_slot = value_t_or_exit!(arg_matches, "ending_slot", Slot);
             let target_ledger =
                 PathBuf::from(value_t_or_exit!(arg_matches, "target_ledger", String));
+            let copy_block_metadata = arg_matches.is_present("copy_block_metadata");
 
             let source = crate::open_blockstore(&ledger_path, arg_matches, AccessType::ReadOnly);
             let target = crate::open_blockstore(
@@ -639,7 +646,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 .slot_meta_iterator(starting_slot)?
                 .take_while(|(slot, _meta)| *slot <= ending_slot)
             {
-                match source.copy_slot(&target, slot) {
+                match source.copy_slot(&target, slot, copy_block_metadata) {
                     Ok(()) => {}
                     Err(err) => {
                         warn!("Error copying slot {slot}: {err}");

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -29,7 +29,6 @@ use {
         shred::Shred,
     },
     std::{
-        borrow::Cow,
         collections::{BTreeMap, BTreeSet, HashMap},
         fs::File,
         io::{BufRead, BufReader},
@@ -636,14 +635,15 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 AccessType::PrimaryForMaintenance,
             );
 
-            for (slot, _meta) in source.slot_meta_iterator(starting_slot)? {
-                if slot > ending_slot {
-                    break;
-                }
-                let shreds = source.get_data_shreds_for_slot(slot, 0)?;
-                let shreds = shreds.into_iter().map(Cow::Owned);
-                if target.insert_cow_shreds(shreds, None, true).is_err() {
-                    warn!("error inserting shreds for slot {slot}");
+            for (slot, _meta) in source
+                .slot_meta_iterator(starting_slot)?
+                .take_while(|(slot, _meta)| *slot <= ending_slot)
+            {
+                match source.copy_slot(&target, slot) {
+                    Ok(()) => {}
+                    Err(err) => {
+                        warn!("Error copying slot {slot}: {err}");
+                    }
                 }
             }
         }

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -332,6 +332,12 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                     .value_name("DIR")
                     .takes_value(true)
                     .help("Target ledger directory to write inner \"rocksdb\" within."),
+            )
+            .arg(
+                Arg::with_name("copy_block_metadata")
+                    .long("copy-block-metadata")
+                    .takes_value(false)
+                    .help("Copy block and transaction metadata (if available)"),
             ),
         SubCommand::with_name("dead-slots")
             .about("Print all the dead slots in the ledger")
@@ -622,6 +628,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             let ending_slot = value_t_or_exit!(arg_matches, "ending_slot", Slot);
             let target_ledger =
                 PathBuf::from(value_t_or_exit!(arg_matches, "target_ledger", String));
+            let copy_block_metadata = arg_matches.is_present("copy_block_metadata");
 
             let source = crate::open_blockstore(&ledger_path, arg_matches, AccessType::ReadOnly);
             let target = crate::open_blockstore(
@@ -634,7 +641,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 .slot_meta_iterator(starting_slot)?
                 .take_while(|(slot, _meta)| *slot <= ending_slot)
             {
-                match source.copy_slot(&target, slot) {
+                match source.copy_slot(&target, slot, copy_block_metadata) {
                     Ok(()) => {}
                     Err(err) => {
                         warn!("Error copying slot {slot}: {err}");

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -28,7 +28,6 @@ use {
         shred::Shred,
     },
     std::{
-        borrow::Cow,
         collections::{BTreeMap, BTreeSet, HashMap},
         fs::File,
         io::{BufRead, BufReader},
@@ -630,20 +629,16 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 arg_matches,
                 AccessType::PrimaryForMaintenance,
             );
-            let mut pinnable_slice = target.new_pinnable_slice();
-            let mut write_batch = target.get_write_batch();
 
-            for (slot, _meta) in source.slot_meta_iterator(starting_slot)? {
-                if slot > ending_slot {
-                    break;
-                }
-                let shreds = source.get_data_shreds_for_slot(slot, 0)?;
-                let shreds = shreds.into_iter().map(Cow::Owned);
-                if target
-                    .insert_cow_shreds(shreds, true, &mut pinnable_slice, &mut write_batch)
-                    .is_err()
-                {
-                    warn!("error inserting shreds for slot {slot}");
+            for (slot, _meta) in source
+                .slot_meta_iterator(starting_slot)?
+                .take_while(|(slot, _meta)| *slot <= ending_slot)
+            {
+                match source.copy_slot(&target, slot) {
+                    Ok(()) => {}
+                    Err(err) => {
+                        warn!("Error copying slot {slot}: {err}");
+                    }
                 }
             }
         }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -91,6 +91,8 @@ use {
     wincode::{Deserialize as _, containers::Vec as WincodeVec},
 };
 
+#[cfg(feature = "dev-context-only-utils")]
+pub mod admin;
 pub mod blockstore_purge;
 pub mod column;
 pub mod error;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -98,6 +98,8 @@ use {
     wincode::config::DefaultConfig,
 };
 
+#[cfg(feature = "dev-context-only-utils")]
+pub mod admin;
 pub mod blockstore_purge;
 pub mod cleanup_service;
 pub mod column;

--- a/ledger/src/blockstore/admin.rs
+++ b/ledger/src/blockstore/admin.rs
@@ -1,0 +1,19 @@
+//! Administrative functions to manipulate the Blockstore that are not necessary
+//! for normal operation
+use {
+    crate::blockstore::{Blockstore, Result},
+    solana_clock::Slot,
+    std::borrow::Cow,
+};
+
+impl Blockstore {
+    /// Copy a slot from this Blockstore to `target_blockstore`
+    pub fn copy_slot(&self, target_blockstore: &Blockstore, slot: Slot) -> Result<()> {
+        let shreds = self.get_data_shreds_for_slot(slot, 0)?;
+        let shreds = shreds.into_iter().map(Cow::Owned);
+
+        target_blockstore.insert_cow_shreds(shreds, None, true)?;
+
+        Ok(())
+    }
+}

--- a/ledger/src/blockstore/admin.rs
+++ b/ledger/src/blockstore/admin.rs
@@ -8,12 +8,259 @@ use {
 
 impl Blockstore {
     /// Copy a slot from this Blockstore to `target_blockstore`
-    pub fn copy_slot(&self, target_blockstore: &Blockstore, slot: Slot) -> Result<()> {
+    pub fn copy_slot(
+        &self,
+        target_blockstore: &Self,
+        slot: Slot,
+        copy_block_metadata: bool,
+    ) -> Result<()> {
         let shreds = self.get_data_shreds_for_slot(slot, 0)?;
         let shreds = shreds.into_iter().map(Cow::Owned);
-
         target_blockstore.insert_cow_shreds(shreds, None, true)?;
 
-        Ok(())
+        if !copy_block_metadata {
+            return Ok(());
+        }
+
+        let mut batch = target_blockstore.get_write_batch()?;
+
+        if let Some(bank_hash) = self.bank_hash_cf.get(slot)? {
+            target_blockstore
+                .bank_hash_cf
+                .put_in_batch(&mut batch, slot, &bank_hash)?;
+        }
+        if let Some(optimistic_slot) = self.optimistic_slots_cf.get(slot)? {
+            target_blockstore.optimistic_slots_cf.put_in_batch(
+                &mut batch,
+                slot,
+                &optimistic_slot,
+            )?;
+        }
+        if let Some(root) = self.roots_cf.get(slot)? {
+            target_blockstore
+                .roots_cf
+                .put_in_batch(&mut batch, slot, &root)?;
+        }
+        if let Some(dead) = self.dead_slots_cf.get(slot)? {
+            target_blockstore
+                .dead_slots_cf
+                .put_in_batch(&mut batch, slot, &dead)?;
+        }
+
+        if let Some(block_height) = self.block_height_cf.get(slot)? {
+            target_blockstore
+                .block_height_cf
+                .put_in_batch(&mut batch, slot, &block_height)?;
+        }
+        if let Some(block_time) = self.blocktime_cf.get(slot)? {
+            target_blockstore
+                .blocktime_cf
+                .put_in_batch(&mut batch, slot, &block_time)?;
+        }
+
+        if let Some(rewards) = self.rewards_cf.get_slice(slot)? {
+            target_blockstore
+                .rewards_cf
+                .put_bytes_in_batch(&mut batch, slot, &rewards);
+        }
+
+        let (entries, _, _) =
+            self.get_slot_entries_with_shred_info(slot, 0, /*allow_dead_slots:*/ true)?;
+        for transaction in entries.iter().flat_map(|entry| entry.transactions.iter()) {
+            let signature = transaction.signatures[0];
+            let index = (signature, slot);
+
+            if let Some(transaction_meta) = self.transaction_status_cf.get_slice(index)? {
+                target_blockstore.transaction_status_cf.put_bytes_in_batch(
+                    &mut batch,
+                    index,
+                    &transaction_meta,
+                );
+            }
+            if let Some(transaction_memo) = self.transaction_memos_cf.get_slice(index)? {
+                target_blockstore.transaction_memos_cf.put_bytes_in_batch(
+                    &mut batch,
+                    index,
+                    &transaction_memo,
+                );
+            }
+        }
+        // Intentionally skip copying address_signatures_cf; this column can
+        // be recreated from transactions if really desired
+
+        target_blockstore.write_batch(batch)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use {
+        super::*,
+        crate::{blockstore::entries_to_test_shreds, get_tmp_ledger_path_auto_delete},
+        solana_clock::UnixTimestamp,
+        solana_entry::entry::Entry,
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_message::v0::LoadedAddresses,
+        solana_runtime::bank::RewardType,
+        solana_signer::Signer,
+        solana_system_transaction as system_transaction,
+        solana_transaction_context::transaction::TransactionReturnData,
+        solana_transaction_status::{Reward, RewardsAndNumPartitions, TransactionStatusMeta},
+    };
+
+    fn create_entries_with_transactions() -> Vec<Entry> {
+        let keypair = Keypair::new();
+        let hash = Hash::default();
+
+        let entry0 = Entry::new(&hash, 0, vec![]);
+
+        let tx0 = system_transaction::transfer(&keypair, &keypair.pubkey(), 0, hash);
+        let entry1 = Entry::new(&hash, 0, vec![tx0]);
+
+        let tx1 = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, hash);
+        let tx2 = system_transaction::transfer(&keypair, &keypair.pubkey(), 2, hash);
+        let entry2 = Entry::new(&hash, 0, vec![tx1, tx2]);
+
+        vec![entry0, entry1, entry2]
+    }
+
+    fn populate_slot_with_metadata(blockstore: &Blockstore, slot: Slot, entries: &[Entry]) {
+        let shreds = entries_to_test_shreds(entries, slot, slot.saturating_sub(1), true, 0);
+        blockstore.insert_shreds(shreds, None, true).unwrap();
+
+        let hash = Hash::from([(slot % 256) as u8; 32]);
+
+        blockstore
+            .insert_optimistic_slot(slot, &hash, (slot * 100) as UnixTimestamp)
+            .unwrap();
+        blockstore.insert_bank_hash(slot, hash, true);
+        blockstore.set_block_height(slot, slot).unwrap();
+        blockstore
+            .set_block_time(slot, (slot * 100) as UnixTimestamp)
+            .unwrap();
+
+        let rewards = (0..2)
+            .map(|i| Reward {
+                pubkey: solana_pubkey::new_rand().to_string(),
+                lamports: (slot + i) as i64,
+                post_balance: slot + i,
+                reward_type: Some(RewardType::Fee),
+                commission: None,
+                commission_bps: None,
+            })
+            .collect();
+        let rewards = RewardsAndNumPartitions {
+            rewards,
+            num_partitions: Some(slot),
+        };
+        blockstore.write_rewards(slot, rewards).unwrap();
+
+        for (index, transaction) in entries
+            .iter()
+            .flat_map(|entry| entry.transactions.iter())
+            .enumerate()
+        {
+            let signature = transaction.signatures[0];
+
+            let status_meta = TransactionStatusMeta {
+                status: Ok(()),
+                fee: slot,
+                pre_balances: vec![slot + 1],
+                post_balances: vec![slot + 2],
+                inner_instructions: Some(vec![]),
+                log_messages: Some(vec![]),
+                pre_token_balances: Some(vec![]),
+                post_token_balances: Some(vec![]),
+                rewards: Some(vec![]),
+                loaded_addresses: LoadedAddresses::default(),
+                return_data: Some(TransactionReturnData::default()),
+                compute_units_consumed: Some(slot + 3),
+                cost_units: Some(slot + 4),
+            };
+            blockstore
+                .write_transaction_status(slot, signature, std::iter::empty(), status_meta, index)
+                .unwrap();
+            blockstore
+                .write_transaction_memos(&signature, slot, format!("{signature}"))
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn test_blockstore_copy() {
+        let source_ledger_path = get_tmp_ledger_path_auto_delete!();
+        let source_blockstore = Blockstore::open(source_ledger_path.path()).unwrap();
+
+        let target_ledger_path = get_tmp_ledger_path_auto_delete!();
+        let target_blockstore = Blockstore::open(target_ledger_path.path()).unwrap();
+
+        let entries = create_entries_with_transactions();
+
+        // Basic copy without block metadata
+        let slot = 10;
+        let allow_dead_slots = false;
+        let copy_block_metadata = false;
+        populate_slot_with_metadata(&source_blockstore, slot, &entries);
+        source_blockstore
+            .copy_slot(&target_blockstore, slot, copy_block_metadata)
+            .unwrap();
+
+        assert_eq!(
+            source_blockstore
+                .get_slot_entries_with_shred_info(slot, 0, allow_dead_slots)
+                .unwrap(),
+            target_blockstore
+                .get_slot_entries_with_shred_info(slot, 0, allow_dead_slots)
+                .unwrap()
+        );
+
+        // Copy dead slot without block metadata
+        let slot = 20;
+        let allow_dead_slots = true;
+        let copy_block_metadata = false;
+        populate_slot_with_metadata(&source_blockstore, slot, &entries);
+        source_blockstore.set_dead_slot(slot).unwrap();
+        source_blockstore
+            .copy_slot(&target_blockstore, slot, copy_block_metadata)
+            .unwrap();
+
+        assert!(!target_blockstore.is_dead(slot));
+        assert_eq!(
+            source_blockstore
+                .get_slot_entries_with_shred_info(slot, 0, allow_dead_slots)
+                .unwrap(),
+            target_blockstore
+                .get_slot_entries_with_shred_info(slot, 0, allow_dead_slots)
+                .unwrap()
+        );
+
+        // Copy slot with block metadata
+        let slot = 30;
+        let copy_block_metadata = true;
+        populate_slot_with_metadata(&source_blockstore, slot, &entries);
+        source_blockstore.set_roots([slot].iter()).unwrap();
+        source_blockstore
+            .copy_slot(&target_blockstore, slot, copy_block_metadata)
+            .unwrap();
+
+        assert_eq!(
+            source_blockstore.get_bank_hash(slot).unwrap(),
+            target_blockstore.get_bank_hash(slot).unwrap()
+        );
+        assert_eq!(
+            source_blockstore.get_optimistic_slot(slot).unwrap(),
+            target_blockstore.get_optimistic_slot(slot).unwrap()
+        );
+        assert!(target_blockstore.is_root(slot));
+        let require_previous_blockhash = false;
+        assert_eq!(
+            source_blockstore
+                .get_rooted_block(slot, require_previous_blockhash)
+                .unwrap(),
+            target_blockstore
+                .get_rooted_block(slot, require_previous_blockhash)
+                .unwrap()
+        );
     }
 }

--- a/ledger/src/blockstore/admin.rs
+++ b/ledger/src/blockstore/admin.rs
@@ -7,10 +7,258 @@ use {
 
 impl Blockstore {
     /// Copy a slot from this Blockstore to `target_blockstore`
-    pub fn copy_slot(&self, target_blockstore: &Blockstore, slot: Slot) -> Result<()> {
+    pub fn copy_slot(
+        &self,
+        target_blockstore: &Self,
+        slot: Slot,
+        copy_block_metadata: bool,
+    ) -> Result<()> {
         let shreds = self.get_data_shreds_for_slot(slot, 0)?;
         target_blockstore.insert_shreds(shreds, true)?;
 
-        Ok(())
+        if !copy_block_metadata {
+            return Ok(());
+        }
+
+        let mut batch = target_blockstore.get_write_batch();
+
+        if let Some(bank_hash) = self.bank_hash_cf.get(slot)? {
+            target_blockstore
+                .bank_hash_cf
+                .put_in_batch(&mut batch, slot, &bank_hash)?;
+        }
+        if let Some(optimistic_slot) = self.optimistic_slots_cf.get(slot)? {
+            target_blockstore.optimistic_slots_cf.put_in_batch(
+                &mut batch,
+                slot,
+                &optimistic_slot,
+            )?;
+        }
+        if let Some(root) = self.roots_cf.get(slot)? {
+            target_blockstore
+                .roots_cf
+                .put_in_batch(&mut batch, slot, &root)?;
+        }
+        if let Some(dead) = self.dead_slots_cf.get(slot)? {
+            target_blockstore
+                .dead_slots_cf
+                .put_in_batch(&mut batch, slot, &dead)?;
+        }
+
+        if let Some(block_height) = self.block_height_cf.get(slot)? {
+            target_blockstore
+                .block_height_cf
+                .put_in_batch(&mut batch, slot, &block_height)?;
+        }
+        if let Some(block_time) = self.blocktime_cf.get(slot)? {
+            target_blockstore
+                .blocktime_cf
+                .put_in_batch(&mut batch, slot, &block_time)?;
+        }
+
+        if let Some(rewards) = self.rewards_cf.get_slice(slot)? {
+            target_blockstore
+                .rewards_cf
+                .put_bytes_in_batch(&mut batch, slot, &rewards);
+        }
+
+        let (entries, _, _) =
+            self.get_slot_entries_with_shred_info(slot, 0, /*allow_dead_slots:*/ true)?;
+        for transaction in entries.iter().flat_map(|entry| entry.transactions.iter()) {
+            let signature = transaction.signatures[0];
+            let index = (signature, slot);
+
+            if let Some(transaction_meta) = self.transaction_status_cf.get_slice(index)? {
+                target_blockstore.transaction_status_cf.put_bytes_in_batch(
+                    &mut batch,
+                    index,
+                    &transaction_meta,
+                );
+            }
+            if let Some(transaction_memo) = self.transaction_memos_cf.get_slice(index)? {
+                target_blockstore.transaction_memos_cf.put_bytes_in_batch(
+                    &mut batch,
+                    index,
+                    &transaction_memo,
+                );
+            }
+        }
+        // Intentionally skip copying address_signatures_cf; this column can
+        // be recreated from transactions if really desired
+
+        target_blockstore.write_batch(batch)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use {
+        super::*,
+        crate::{blockstore::entries_to_test_shreds, get_tmp_ledger_path_auto_delete},
+        solana_clock::UnixTimestamp,
+        solana_entry::entry::Entry,
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_message::v0::LoadedAddresses,
+        solana_runtime::bank::RewardType,
+        solana_signer::Signer,
+        solana_system_transaction as system_transaction,
+        solana_transaction_context::transaction::TransactionReturnData,
+        solana_transaction_status::{Reward, RewardsAndNumPartitions, TransactionStatusMeta},
+    };
+
+    fn create_entries_with_transactions() -> Vec<Entry> {
+        let keypair = Keypair::new();
+        let hash = Hash::default();
+
+        let entry0 = Entry::new(&hash, 0, vec![]);
+
+        let tx0 = system_transaction::transfer(&keypair, &keypair.pubkey(), 0, hash);
+        let entry1 = Entry::new(&hash, 0, vec![tx0]);
+
+        let tx1 = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, hash);
+        let tx2 = system_transaction::transfer(&keypair, &keypair.pubkey(), 2, hash);
+        let entry2 = Entry::new(&hash, 0, vec![tx1, tx2]);
+
+        vec![entry0, entry1, entry2]
+    }
+
+    fn populate_slot_with_metadata(blockstore: &Blockstore, slot: Slot, entries: &[Entry]) {
+        let shreds = entries_to_test_shreds(entries, slot, slot.saturating_sub(1), true, 0);
+        blockstore.insert_shreds(shreds, true).unwrap();
+
+        let hash = Hash::from([(slot % 256) as u8; 32]);
+
+        blockstore
+            .insert_optimistic_slot(slot, &hash, (slot * 100) as UnixTimestamp)
+            .unwrap();
+        blockstore.insert_bank_hash(slot, hash, true);
+        blockstore.set_block_height(slot, slot).unwrap();
+        blockstore
+            .set_block_time(slot, (slot * 100) as UnixTimestamp)
+            .unwrap();
+
+        let rewards = (0..2)
+            .map(|i| Reward {
+                pubkey: solana_pubkey::new_rand().to_string(),
+                lamports: (slot + i) as i64,
+                post_balance: slot + i,
+                reward_type: Some(RewardType::Fee),
+                commission: None,
+                commission_bps: None,
+            })
+            .collect();
+        let rewards = RewardsAndNumPartitions {
+            rewards,
+            num_partitions: Some(slot),
+        };
+        blockstore.write_rewards(slot, rewards).unwrap();
+
+        for (index, transaction) in entries
+            .iter()
+            .flat_map(|entry| entry.transactions.iter())
+            .enumerate()
+        {
+            let signature = transaction.signatures[0];
+
+            let status_meta = TransactionStatusMeta {
+                status: Ok(()),
+                fee: slot,
+                pre_balances: vec![slot + 1],
+                post_balances: vec![slot + 2],
+                inner_instructions: Some(vec![]),
+                log_messages: Some(vec![]),
+                pre_token_balances: Some(vec![]),
+                post_token_balances: Some(vec![]),
+                rewards: Some(vec![]),
+                loaded_addresses: LoadedAddresses::default(),
+                return_data: Some(TransactionReturnData::default()),
+                compute_units_consumed: Some(slot + 3),
+                cost_units: Some(slot + 4),
+            };
+            blockstore
+                .write_transaction_status(slot, signature, std::iter::empty(), status_meta, index)
+                .unwrap();
+            blockstore
+                .write_transaction_memos(&signature, slot, format!("{signature}"))
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn test_blockstore_copy() {
+        let source_ledger_path = get_tmp_ledger_path_auto_delete!();
+        let source_blockstore = Blockstore::open(source_ledger_path.path()).unwrap();
+
+        let target_ledger_path = get_tmp_ledger_path_auto_delete!();
+        let target_blockstore = Blockstore::open(target_ledger_path.path()).unwrap();
+
+        let entries = create_entries_with_transactions();
+
+        // Basic copy without block metadata
+        let slot = 10;
+        let allow_dead_slots = false;
+        let copy_block_metadata = false;
+        populate_slot_with_metadata(&source_blockstore, slot, &entries);
+        source_blockstore
+            .copy_slot(&target_blockstore, slot, copy_block_metadata)
+            .unwrap();
+
+        assert_eq!(
+            source_blockstore
+                .get_slot_entries_with_shred_info(slot, 0, allow_dead_slots)
+                .unwrap(),
+            target_blockstore
+                .get_slot_entries_with_shred_info(slot, 0, allow_dead_slots)
+                .unwrap()
+        );
+
+        // Copy dead slot without block metadata
+        let slot = 20;
+        let allow_dead_slots = true;
+        let copy_block_metadata = false;
+        populate_slot_with_metadata(&source_blockstore, slot, &entries);
+        source_blockstore.set_dead_slot(slot).unwrap();
+        source_blockstore
+            .copy_slot(&target_blockstore, slot, copy_block_metadata)
+            .unwrap();
+
+        assert!(!target_blockstore.is_dead(slot));
+        assert_eq!(
+            source_blockstore
+                .get_slot_entries_with_shred_info(slot, 0, allow_dead_slots)
+                .unwrap(),
+            target_blockstore
+                .get_slot_entries_with_shred_info(slot, 0, allow_dead_slots)
+                .unwrap()
+        );
+
+        // Copy slot with block metadata
+        let slot = 30;
+        let copy_block_metadata = true;
+        populate_slot_with_metadata(&source_blockstore, slot, &entries);
+        source_blockstore.set_roots([slot].iter()).unwrap();
+        source_blockstore
+            .copy_slot(&target_blockstore, slot, copy_block_metadata)
+            .unwrap();
+
+        assert_eq!(
+            source_blockstore.get_bank_hash(slot).unwrap(),
+            target_blockstore.get_bank_hash(slot).unwrap()
+        );
+        assert_eq!(
+            source_blockstore.get_optimistic_slot(slot).unwrap(),
+            target_blockstore.get_optimistic_slot(slot).unwrap()
+        );
+        assert!(target_blockstore.is_root(slot));
+        let require_previous_blockhash = false;
+        assert_eq!(
+            source_blockstore
+                .get_rooted_block(slot, require_previous_blockhash)
+                .unwrap(),
+            target_blockstore
+                .get_rooted_block(slot, require_previous_blockhash)
+                .unwrap()
+        );
     }
 }

--- a/ledger/src/blockstore/admin.rs
+++ b/ledger/src/blockstore/admin.rs
@@ -1,0 +1,16 @@
+//! Administrative functions to manipulate the Blockstore that are not necessary
+//! for normal operation
+use {
+    crate::blockstore::{Blockstore, Result},
+    solana_clock::Slot,
+};
+
+impl Blockstore {
+    /// Copy a slot from this Blockstore to `target_blockstore`
+    pub fn copy_slot(&self, target_blockstore: &Blockstore, slot: Slot) -> Result<()> {
+        let shreds = self.get_data_shreds_for_slot(slot, 0)?;
+        target_blockstore.insert_shreds(shreds, true)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
#### Problem
Currently, `agave-ledger-tool copy` only copies the shreds over to the target `Blockstore`. This means fields like whether the slot is dead/OC'd/rooted is not transferred as well as block/transaction metadata that is populated if the validator is running with those flags. There are situations where it is desirable to copy this information over

#### Summary of Changes
Add a new flag, `--copy-block-metadata`, to optionally copy all of this information over to the target Blockstore as well