### PR TITLE
fix: TTL for repair ping request from `DELTA` to `2 * DELTA`

### DIFF
--- a/core/src/repair/block_id_repair_service.rs
+++ b/core/src/repair/block_id_repair_service.rs
@@ -213,7 +213,7 @@ impl RepairState {
     }
 
     fn prune_expected_ping_responses(&mut self, now: u64) {
-        let ttl_ms = u64::try_from(DELTA.as_millis()).unwrap();
+        let ttl_ms = u64::try_from(2 * DELTA.as_millis()).unwrap();
         self.expected_ping_responses
             .retain(|_, sent_at| now.saturating_sub(*sent_at) <= ttl_ms);
     }


### PR DESCRIPTION
#### Problem
In the method `prune_expected_ping_responses()` of `block_id_repair_service.rs` we delete all pending responses, for which the request was sent longer than `DELTA` ago. However, `DELTA` represents the maximum one-way delay from one node to another so if the node we sent the request to is `DELTA` far away, we can only expect the response `2 * DELTA` after we sent the request.

#### Summary of Changes
Instead prune only responses for which the request was sent `> 2 * DELTA` ago.