### PR TITLE
[SIMD-0392 - runtime]: Rent increase adaptations

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -491,12 +491,14 @@ impl Consumer {
             .ok_or(TransactionError::AccountNotFound)?;
 
         validate_fee_payer(
-            fee_payer,
             &mut fee_payer_account,
             0,
             error_counters,
             &bank.rent_collector().rent,
             fee,
+            bank.feature_set
+                .snapshot()
+                .relax_post_exec_min_balance_check,
         )
     }
 }

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -215,7 +215,7 @@ impl Bank {
                 account.lamports(),
                 account.data().len(),
                 &self.rent_collector().rent,
-                false,
+                feature_snapshot.relax_post_exec_min_balance_check,
             ) {
                 return Err(DepositFeeError::InvalidRentPayingAccount);
             }
@@ -259,7 +259,7 @@ pub mod tests {
     use {
         super::*,
         crate::genesis_utils::{create_genesis_config, create_genesis_config_with_leader},
-        agave_feature_set::FeatureSet,
+        agave_feature_set::{self as feature_set, FeatureSet},
         solana_account::state_traits::StateMut,
         solana_pubkey as pubkey,
         solana_rent::Rent,
@@ -554,6 +554,55 @@ pub mod tests {
             bank.get_account(&nonexistent_pubkey).is_none(),
             "Account should still not exist after failed deposit"
         );
+    }
+
+    #[test]
+    fn test_deposit_or_burn_fee_respects_relaxed_post_exec_min_balance_check() {
+        for relax_post_exec_min_balance_check in [false, true] {
+            let mut genesis = create_genesis_config(0);
+            let rent = Rent::default();
+            genesis.genesis_config.rent = rent.clone();
+            let mut bank = Bank::new_for_tests(&genesis.genesis_config);
+
+            let data_len = 64;
+            let rent_exempt_minimum = rent.minimum_balance(data_len);
+            assert!(rent_exempt_minimum > 1);
+
+            let pre_balance = rent_exempt_minimum - 2;
+            let deposit = 1;
+            let post_balance = pre_balance + deposit;
+            let leader_id = *bank.leader_id();
+
+            let account = AccountSharedData::new(pre_balance, data_len, &system_program::id());
+            bank.store_account(&leader_id, &account);
+
+            let mut feature_set = FeatureSet::all_enabled();
+            if !relax_post_exec_min_balance_check {
+                feature_set.deactivate(&feature_set::relax_post_exec_min_balance_check::id());
+            }
+            bank.feature_set = Arc::new(feature_set);
+
+            let burned = bank.deposit_or_burn_fee(deposit);
+            let rewards = bank.rewards.read().unwrap();
+
+            // post simd-392, deposits to existing accounts are always valid because
+            // they are rent-exempt before and after the deposit takes place.
+            // pre simd-392, if a deposit to a rent-paying account isn't sufficient to
+            // make it rent-exempt then it fails and the deposit is burned.
+            if relax_post_exec_min_balance_check {
+                assert_eq!(burned, 0);
+                assert_eq!(bank.get_balance(&leader_id), post_balance);
+                assert_eq!(rewards.len(), 1, "fee should be distributed to the leader");
+                assert_eq!(rewards[0].1.post_balance, post_balance);
+            } else {
+                assert_eq!(burned, deposit);
+                assert_eq!(bank.get_balance(&leader_id), pre_balance);
+                assert!(
+                    rewards.is_empty(),
+                    "fee should be burned when the rent transition is invalid"
+                );
+            }
+        }
     }
 
     #[test]

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -564,71 +564,95 @@ pub mod tests {
     fn test_deposit_or_burn_fee_respects_relaxed_post_exec_min_balance_check(
         custom_commission_collector: bool,
     ) {
-        for relax_post_exec_min_balance_check in [false, true] {
-            let mut genesis = create_genesis_config_with_leader(0, &pubkey::new_rand(), 1000);
-            let rent = Rent::default();
-            genesis.genesis_config.rent = rent.clone();
+        enum CollectorState {
+            InitializedToSubRentExemptMinimum,
+            UninitializedToSubRentExemptMinimum,
+            UninitializedToRentExempt,
+        }
 
-            let data_len = 64;
-            let rent_exempt_minimum = rent.minimum_balance(data_len);
-            assert!(rent_exempt_minimum > 1);
+        for collector_state in [
+            CollectorState::InitializedToSubRentExemptMinimum,
+            CollectorState::UninitializedToSubRentExemptMinimum,
+            CollectorState::UninitializedToRentExempt,
+        ] {
+            for relax_post_exec_min_balance_check in [false, true] {
+                let mut genesis = create_genesis_config_with_leader(0, &pubkey::new_rand(), 1000);
+                let rent = Rent::default();
+                genesis.genesis_config.rent = rent.clone();
 
-            let pre_balance = rent_exempt_minimum - 2;
-            let deposit = 1;
-            let post_balance = pre_balance + deposit;
-            let maybe_collector_id = if custom_commission_collector {
-                let mut maybe_collector_id = None;
-                for account in genesis.genesis_config.accounts.values_mut() {
-                    if account.owner == solana_sdk_ids::vote::id() {
-                        let mut vote_state =
-                            VoteStateV4::deserialize(account.data(), &Pubkey::default()).unwrap();
-                        let collector_id = Pubkey::new_unique();
-                        vote_state.block_revenue_collector = collector_id;
-                        maybe_collector_id = Some(collector_id);
-                        let versioned = VoteStateVersions::V4(Box::new(vote_state));
-                        account.set_state(&versioned).unwrap();
+                let initialized_data_len = 64;
+                let rent_exempt_minimum = rent.minimum_balance(initialized_data_len);
+                assert!(rent_exempt_minimum > 1);
+
+                let (pre_balance, deposit, should_succeed) = match collector_state {
+                    CollectorState::InitializedToSubRentExemptMinimum => (
+                        rent_exempt_minimum - 2,
+                        1,
+                        relax_post_exec_min_balance_check,
+                    ),
+                    CollectorState::UninitializedToSubRentExemptMinimum => (0, 1, false),
+                    CollectorState::UninitializedToRentExempt => (0, rent_exempt_minimum, true),
+                };
+                let post_balance = pre_balance + deposit;
+                let maybe_collector_id = if custom_commission_collector {
+                    let mut maybe_collector_id = None;
+                    for account in genesis.genesis_config.accounts.values_mut() {
+                        if account.owner == solana_sdk_ids::vote::id() {
+                            let mut vote_state =
+                                VoteStateV4::deserialize(account.data(), &Pubkey::default())
+                                    .unwrap();
+                            let collector_id = Pubkey::new_unique();
+                            vote_state.block_revenue_collector = collector_id;
+                            maybe_collector_id = Some(collector_id);
+                            let versioned = VoteStateVersions::V4(Box::new(vote_state));
+                            account.set_state(&versioned).unwrap();
+                        }
                     }
+                    maybe_collector_id
+                } else {
+                    None
+                };
+
+                let mut bank = Bank::new_for_tests(&genesis.genesis_config);
+
+                let mut feature_set = FeatureSet::all_enabled();
+                if !custom_commission_collector {
+                    feature_set.deactivate(&agave_feature_set::custom_commission_collector::id());
                 }
-                maybe_collector_id
-            } else {
-                None
-            };
+                if !relax_post_exec_min_balance_check {
+                    feature_set.deactivate(&feature_set::relax_post_exec_min_balance_check::id());
+                }
+                bank.feature_set = Arc::new(feature_set);
 
-            let mut bank = Bank::new_for_tests(&genesis.genesis_config);
-
-            let account = AccountSharedData::new(pre_balance, data_len, &system_program::id());
-
-            let mut feature_set = FeatureSet::all_enabled();
-            if !custom_commission_collector {
-                feature_set.deactivate(&agave_feature_set::custom_commission_collector::id());
-            }
-            if !relax_post_exec_min_balance_check {
-                feature_set.deactivate(&feature_set::relax_post_exec_min_balance_check::id());
-            }
-            bank.feature_set = Arc::new(feature_set);
-
-            let collector_id = maybe_collector_id.unwrap_or(*bank.leader_id());
-            bank.store_account(&collector_id, &account);
-
-            let burned = bank.deposit_or_burn_fee(deposit);
-            let rewards = bank.rewards.read().unwrap();
-
-            // post simd-392, deposits to existing accounts are always valid because
-            // they are rent-exempt before and after the deposit takes place.
-            // pre simd-392, if a deposit to a rent-paying account isn't sufficient to
-            // make it rent-exempt then it fails and the deposit is burned.
-            if relax_post_exec_min_balance_check {
-                assert_eq!(burned, 0);
-                assert_eq!(bank.get_balance(&collector_id), post_balance);
-                assert_eq!(rewards.len(), 1, "fee should be distributed to the leader");
-                assert_eq!(rewards[0].1.post_balance, post_balance);
-            } else {
-                assert_eq!(burned, deposit);
-                assert_eq!(bank.get_balance(&collector_id), pre_balance);
-                assert!(
-                    rewards.is_empty(),
-                    "fee should be burned when the rent transition is invalid"
+                let collector_id = maybe_collector_id.unwrap_or(*bank.leader_id());
+                let account = AccountSharedData::new(
+                    pre_balance,
+                    initialized_data_len,
+                    &system_program::id(),
                 );
+                bank.store_account(&collector_id, &account);
+
+                let burned = bank.deposit_or_burn_fee(deposit);
+                let rewards = bank.rewards.read().unwrap();
+
+                // post simd-392, deposits to existing accounts are always valid because
+                // they are rent-exempt before and after the deposit takes place.
+                // Deposits to uninitialized accounts still must make the account rent-exempt.
+                // pre simd-392, if a deposit to a rent-paying account isn't sufficient to
+                // make it rent-exempt then it fails and the deposit is burned.
+                if should_succeed {
+                    assert_eq!(burned, 0);
+                    assert_eq!(bank.get_balance(&collector_id), post_balance);
+                    assert_eq!(rewards.len(), 1, "fee should be distributed to the leader");
+                    assert_eq!(rewards[0].1.post_balance, post_balance);
+                } else {
+                    assert_eq!(burned, deposit);
+                    assert_eq!(bank.get_balance(&collector_id), pre_balance);
+                    assert!(
+                        rewards.is_empty(),
+                        "fee should be burned when the rent transition is invalid"
+                    );
+                }
             }
         }
     }

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -210,13 +210,16 @@ impl Bank {
 
             // rent state transition must be checked in case the account receiving the distribution
             // doesn't exist yet.
-            if !check_static_account_rent_state_transition(
+            if check_static_account_rent_state_transition(
                 pre_balance,
                 account.lamports(),
                 account.data().len(),
                 &self.rent_collector().rent,
+                0, // account index isn't relevant and only used for error message
                 feature_snapshot.relax_post_exec_min_balance_check,
-            ) {
+            )
+            .is_err()
+            {
                 return Err(DepositFeeError::InvalidRentPayingAccount);
             }
         }

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -559,13 +559,15 @@ pub mod tests {
         );
     }
 
-    #[test]
-    fn test_deposit_or_burn_fee_respects_relaxed_post_exec_min_balance_check() {
+    #[test_case(true; "custom_commission_collector")]
+    #[test_case(false; "no_custom_commission_collector")]
+    fn test_deposit_or_burn_fee_respects_relaxed_post_exec_min_balance_check(
+        custom_commission_collector: bool,
+    ) {
         for relax_post_exec_min_balance_check in [false, true] {
-            let mut genesis = create_genesis_config(0);
+            let mut genesis = create_genesis_config_with_leader(0, &pubkey::new_rand(), 1000);
             let rent = Rent::default();
             genesis.genesis_config.rent = rent.clone();
-            let mut bank = Bank::new_for_tests(&genesis.genesis_config);
 
             let data_len = 64;
             let rent_exempt_minimum = rent.minimum_balance(data_len);
@@ -574,16 +576,39 @@ pub mod tests {
             let pre_balance = rent_exempt_minimum - 2;
             let deposit = 1;
             let post_balance = pre_balance + deposit;
-            let leader_id = *bank.leader_id();
+            let maybe_collector_id = if custom_commission_collector {
+                let mut maybe_collector_id = None;
+                for account in genesis.genesis_config.accounts.values_mut() {
+                    if account.owner == solana_sdk_ids::vote::id() {
+                        let mut vote_state =
+                            VoteStateV4::deserialize(account.data(), &Pubkey::default()).unwrap();
+                        let collector_id = Pubkey::new_unique();
+                        vote_state.block_revenue_collector = collector_id;
+                        maybe_collector_id = Some(collector_id);
+                        let versioned = VoteStateVersions::V4(Box::new(vote_state));
+                        account.set_state(&versioned).unwrap();
+                    }
+                }
+                maybe_collector_id
+            } else {
+                None
+            };
+
+            let mut bank = Bank::new_for_tests(&genesis.genesis_config);
 
             let account = AccountSharedData::new(pre_balance, data_len, &system_program::id());
-            bank.store_account(&leader_id, &account);
 
             let mut feature_set = FeatureSet::all_enabled();
+            if !custom_commission_collector {
+                feature_set.deactivate(&agave_feature_set::custom_commission_collector::id());
+            }
             if !relax_post_exec_min_balance_check {
                 feature_set.deactivate(&feature_set::relax_post_exec_min_balance_check::id());
             }
             bank.feature_set = Arc::new(feature_set);
+
+            let collector_id = maybe_collector_id.unwrap_or(*bank.leader_id());
+            bank.store_account(&collector_id, &account);
 
             let burned = bank.deposit_or_burn_fee(deposit);
             let rewards = bank.rewards.read().unwrap();
@@ -594,12 +619,12 @@ pub mod tests {
             // make it rent-exempt then it fails and the deposit is burned.
             if relax_post_exec_min_balance_check {
                 assert_eq!(burned, 0);
-                assert_eq!(bank.get_balance(&leader_id), post_balance);
+                assert_eq!(bank.get_balance(&collector_id), post_balance);
                 assert_eq!(rewards.len(), 1, "fee should be distributed to the leader");
                 assert_eq!(rewards[0].1.post_balance, post_balance);
             } else {
                 assert_eq!(burned, deposit);
-                assert_eq!(bank.get_balance(&leader_id), pre_balance);
+                assert_eq!(bank.get_balance(&collector_id), pre_balance);
                 assert!(
                     rewards.is_empty(),
                     "fee should be burned when the rent transition is invalid"

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -12,7 +12,7 @@ use {
         transaction_meta::TransactionConfiguration, transaction_with_meta::TransactionWithMeta,
     },
     solana_sdk_ids::incinerator,
-    solana_svm::rent_calculator::{get_account_rent_state, transition_allowed},
+    solana_svm::rent_calculator::check_static_account_rent_state_transition,
     solana_system_interface::program as system_program,
     std::{result::Result, sync::atomic::Ordering::Relaxed},
     thiserror::Error,
@@ -202,24 +202,21 @@ impl Bank {
                 return Err(DepositFeeError::InvalidAccountOwner);
             }
 
-            let recipient_pre_rent_state = get_account_rent_state(
-                &self.rent_collector().rent,
-                account.lamports(),
-                account.data().len(),
-            );
+            let pre_balance = account.lamports();
             let distribution = account.checked_add_lamports(fees);
             if distribution.is_err() {
                 return Err(DepositFeeError::LamportOverflow);
             }
 
-            let recipient_post_rent_state = get_account_rent_state(
-                &self.rent_collector().rent,
+            // rent state transition must be checked in case the account receiving the distribution
+            // doesn't exist yet.
+            if !check_static_account_rent_state_transition(
+                pre_balance,
                 account.lamports(),
                 account.data().len(),
-            );
-            let rent_state_transition_allowed =
-                transition_allowed(&recipient_pre_rent_state, &recipient_post_rent_state);
-            if !rent_state_transition_allowed {
+                &self.rent_collector().rent,
+                false,
+            ) {
                 return Err(DepositFeeError::InvalidRentPayingAccount);
             }
         }
@@ -502,6 +499,61 @@ pub mod tests {
                 Err(DepositFeeError::ReservedCollector) | Err(DepositFeeError::InvalidAccountOwner),
             ));
         }
+    }
+
+    #[test]
+    fn test_deposit_fees_to_nonexistent_account_rent_exempt() {
+        let mut genesis = create_genesis_config(0);
+        let rent = Rent::default();
+        genesis.genesis_config.rent = rent.clone();
+        let bank = Bank::new_for_tests(&genesis.genesis_config);
+        let nonexistent_pubkey = Pubkey::new_unique();
+
+        // Fee is sufficient to make the new account rent-exempt
+        let deposit_amount = rent.minimum_balance(0);
+
+        assert!(
+            bank.get_account(&nonexistent_pubkey).is_none(),
+            "Account should not exist before deposit"
+        );
+
+        assert_eq!(
+            bank.deposit_fees(&nonexistent_pubkey, deposit_amount),
+            Ok(deposit_amount),
+            "Deposit should succeed when fee is sufficient for rent-exemption"
+        );
+
+        let account = bank.get_account(&nonexistent_pubkey).unwrap();
+        assert_eq!(account.lamports(), deposit_amount);
+        assert_eq!(account.owner(), &system_program::id());
+    }
+
+    #[test]
+    fn test_deposit_fees_to_nonexistent_account_not_rent_exempt() {
+        let mut genesis = create_genesis_config(0);
+        let rent = Rent::default();
+        genesis.genesis_config.rent = rent.clone();
+        let bank = Bank::new_for_tests(&genesis.genesis_config);
+        let nonexistent_pubkey = Pubkey::new_unique();
+
+        // Fee is insufficient to make the new account rent-exempt
+        let deposit_amount = rent.minimum_balance(0) - 1;
+
+        assert!(
+            bank.get_account(&nonexistent_pubkey).is_none(),
+            "Account should not exist before deposit"
+        );
+
+        assert_eq!(
+            bank.deposit_fees(&nonexistent_pubkey, deposit_amount),
+            Err(DepositFeeError::InvalidRentPayingAccount),
+            "Deposit should fail when fee is insufficient for rent-exemption"
+        );
+
+        assert!(
+            bank.get_account(&nonexistent_pubkey).is_none(),
+            "Account should still not exist after failed deposit"
+        );
     }
 
     #[test]

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -262,7 +262,7 @@ pub mod tests {
     use {
         super::*,
         crate::genesis_utils::{create_genesis_config, create_genesis_config_with_leader},
-        agave_feature_set::{self as feature_set, FeatureSet},
+        agave_feature_set::FeatureSet,
         solana_account::state_traits::StateMut,
         solana_pubkey as pubkey,
         solana_rent::Rent,
@@ -620,7 +620,8 @@ pub mod tests {
                     feature_set.deactivate(&agave_feature_set::custom_commission_collector::id());
                 }
                 if !relax_post_exec_min_balance_check {
-                    feature_set.deactivate(&feature_set::relax_post_exec_min_balance_check::id());
+                    feature_set
+                        .deactivate(&agave_feature_set::relax_post_exec_min_balance_check::id());
                 }
                 bank.feature_set = Arc::new(feature_set);
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -389,14 +389,20 @@ pub fn validate_fee_payer(
             TransactionError::InsufficientFundsForFee
         })?;
 
-    let payer_pre_rent_state =
-        get_account_rent_state(rent, payer_account.lamports(), payer_account.data().len());
+    let payer_pre_rent_state = get_account_rent_state(
+        payer_account.lamports(),
+        payer_account.data().len(),
+        rent.minimum_balance(payer_account.data().len()),
+    );
     payer_account
         .checked_sub_lamports(fee)
         .map_err(|_| TransactionError::InsufficientFundsForFee)?;
 
-    let payer_post_rent_state =
-        get_account_rent_state(rent, payer_account.lamports(), payer_account.data().len());
+    let payer_post_rent_state = get_account_rent_state(
+        payer_account.lamports(),
+        payer_account.data().len(),
+        rent.minimum_balance(payer_account.data().len()),
+    );
     check_rent_state_with_account(
         &payer_pre_rent_state,
         &payer_post_rent_state,
@@ -1915,9 +1921,23 @@ mod tests {
             1,
         );
 
+        let pre_account_state_info = TransactionAccountStateInfo::new_pre_exec(
+            &transaction_context,
+            sanitized_tx.message(),
+            &rent,
+            true,
+        );
+        assert_eq!(pre_account_state_info.len(), num_accounts);
+
         assert_eq!(
-            TransactionAccountStateInfo::new(&transaction_context, sanitized_tx.message(), &rent,)
-                .len(),
+            TransactionAccountStateInfo::new_post_exec(
+                &transaction_context,
+                sanitized_tx.message(),
+                &pre_account_state_info,
+                &rent,
+                true,
+            )
+            .len(),
             num_accounts,
         );
     }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1276,20 +1276,21 @@ mod tests {
             ..Rent::default()
         };
 
-        // nonce payer account has balance of u64::MAX, so does fee; due to nonce account
-        // requires additional min_balance, expect InsufficientFundsForFee error if feature gate is
-        // enabled
-        validate_fee_payer_account(
-            ValidateFeePayerTestParameter {
-                is_nonce: true,
-                payer_init_balance: u64::MAX,
-                fee: u64::MAX,
-                relax_post_exec_min_balance_check: true,
-                expected_result: Err(TransactionError::InsufficientFundsForFee),
-                payer_post_balance: u64::MAX,
-            },
-            &rent,
-        );
+        // nonce payer account has balance of u64::MAX, so does fee; the additional nonce
+        // min_balance requirement makes the checked arithmetic fail regardless of feature gate.
+        for relax_post_exec_min_balance_check in [false, true] {
+            validate_fee_payer_account(
+                ValidateFeePayerTestParameter {
+                    is_nonce: true,
+                    payer_init_balance: u64::MAX,
+                    fee: u64::MAX,
+                    relax_post_exec_min_balance_check,
+                    expected_result: Err(TransactionError::InsufficientFundsForFee),
+                    payer_post_balance: u64::MAX,
+                },
+                &rent,
+            );
+        }
     }
 
     #[test]

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1183,18 +1183,20 @@ mod tests {
 
     #[test]
     fn test_validate_fee_payer() {
-        let rent = Rent {
-            lamports_per_byte: 1,
-            ..Rent::default()
-        };
-        let min_balance = rent.minimum_balance(NonceState::size());
+        let rent = Rent::default();
+        let nonce_min_balance = rent.minimum_balance(NonceState::size());
+        let system_min_balance = rent.minimum_balance(0);
         let fee = 5_000;
 
         // If payer account has sufficient balance, expect successful fee deduction,
-        // regardless feature gate status, or if payer is nonce account.
+        // regardless of feature gate status.
         {
             for relax_post_exec_min_balance_check in [false, true] {
-                for (is_nonce, min_balance) in [(true, min_balance), (false, 0)] {
+                for (is_nonce, min_balance) in [
+                    (true, nonce_min_balance),
+                    (false, system_min_balance), // rent-exempt case
+                    (false, 0),                  // sub-exempt case, spend to zero
+                ] {
                     validate_fee_payer_account(
                         ValidateFeePayerTestParameter {
                             is_nonce,
@@ -1230,23 +1232,93 @@ mod tests {
             }
         }
 
-        // If payer account has insufficient balance, expect InsufficientFundsForFee error
-        // regardless feature gate status, or if payer is nonce account.
+        // Check InsufficientFunds error cases. Note: balance checks that occur
+        // before rent state transition checks return InsufficientFundsForFee,
+        //while those that occur after return InsufficientFundsForRent.
         {
             for relax_post_exec_min_balance_check in [false, true] {
-                for (is_nonce, min_balance) in [(true, min_balance), (false, 0)] {
+                for (is_nonce, payer_init_balance, expected_result) in [
+                    // rent-exempt nonce: arithmetic check fails before rent-state validation
+                    (
+                        true,
+                        nonce_min_balance + fee - 1,
+                        Err(TransactionError::InsufficientFundsForFee),
+                    ),
+                    // sub-exempt nonce: arithmetic check fails before rent-state validation
+                    (
+                        true,
+                        nonce_min_balance - 1,
+                        Err(TransactionError::InsufficientFundsForFee),
+                    ),
+                    // sub-exempt system: insufficient lamports to pay the fee at all
+                    (
+                        false,
+                        fee - 1,
+                        Err(TransactionError::InsufficientFundsForFee),
+                    ),
+                    // sub-exempt system: fee debit succeeds but an invalid state
+                    // transition of RentExempt -> RentPaying is produced if
+                    // relax_post_exec_min_balance_check is true. Otherwise, the
+                    // valid RentPaying -> RentPaying transition is produced.
+                    (
+                        false,
+                        system_min_balance - 1,
+                        if relax_post_exec_min_balance_check {
+                            Err(TransactionError::InsufficientFundsForRent { account_index: 0 })
+                        } else {
+                            Ok(())
+                        },
+                    ),
+                    // rent-exempt system: fee debit succeeds but drops below the rent-exempt minimum
+                    (
+                        false,
+                        system_min_balance + fee - 1,
+                        Err(TransactionError::InsufficientFundsForRent { account_index: 0 }),
+                    ),
+                ] {
+                    // Fee payer validation debits lamports before rent-state
+                    // validation, so only InsufficientFundsForFee leaves the
+                    // original balance unchanged.
+                    let expected_post_balance = if matches!(
+                        expected_result,
+                        Err(TransactionError::InsufficientFundsForFee)
+                    ) {
+                        payer_init_balance
+                    } else {
+                        payer_init_balance - fee
+                    };
                     validate_fee_payer_account(
                         ValidateFeePayerTestParameter {
                             is_nonce,
-                            payer_init_balance: min_balance + fee - 1,
+                            payer_init_balance,
                             fee,
                             relax_post_exec_min_balance_check,
-                            expected_result: Err(TransactionError::InsufficientFundsForFee),
-                            payer_post_balance: min_balance + fee - 1,
+                            expected_result,
+                            payer_post_balance: expected_post_balance,
                         },
                         &rent,
                     );
                 }
+            }
+        }
+
+        // Regular system fee payer may be spent all the way down to zero but
+        // a nonce fee payer cannot.
+        {
+            // try to spend rent-exempt nonce account down to zero
+            let fee = nonce_min_balance;
+            for relax_post_exec_min_balance_check in [false, true] {
+                validate_fee_payer_account(
+                    ValidateFeePayerTestParameter {
+                        is_nonce: true,
+                        payer_init_balance: nonce_min_balance,
+                        fee,
+                        relax_post_exec_min_balance_check,
+                        expected_result: Err(TransactionError::InsufficientFundsForFee),
+                        payer_post_balance: nonce_min_balance,
+                    },
+                    &rent,
+                );
             }
         }
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -3,9 +3,7 @@ use qualifier_attr::{field_qualifiers, qualifiers};
 use {
     crate::{
         account_overrides::AccountOverrides,
-        rent_calculator::{
-            RENT_EXEMPT_RENT_EPOCH, check_rent_state_with_account, get_account_rent_state,
-        },
+        rent_calculator::{RENT_EXEMPT_RENT_EPOCH, check_static_account_rent_state_transition},
         rollback_accounts::RollbackAccounts,
         transaction_error_metrics::TransactionErrorMetrics,
     },
@@ -356,12 +354,12 @@ pub fn update_rent_exempt_status_for_account(rent: &Rent, account: &mut AccountS
 /// fee, the error_metrics is incremented, and a specific error is
 /// returned.
 pub fn validate_fee_payer(
-    payer_address: &Pubkey,
     payer_account: &mut AccountSharedData,
     payer_index: IndexOfAccount,
     error_metrics: &mut TransactionErrorMetrics,
     rent: &Rent,
     fee: u64,
+    relax_post_exec_min_balance_check: bool,
 ) -> Result<()> {
     if payer_account.lamports() == 0 {
         error_metrics.account_not_found += 1;
@@ -389,25 +387,19 @@ pub fn validate_fee_payer(
             TransactionError::InsufficientFundsForFee
         })?;
 
-    let payer_pre_rent_state = get_account_rent_state(
-        payer_account.lamports(),
-        payer_account.data().len(),
-        rent.minimum_balance(payer_account.data().len()),
-    );
+    let pre_balance = payer_account.lamports();
     payer_account
         .checked_sub_lamports(fee)
         .map_err(|_| TransactionError::InsufficientFundsForFee)?;
+    let post_balance = payer_account.lamports();
 
-    let payer_post_rent_state = get_account_rent_state(
-        payer_account.lamports(),
+    check_static_account_rent_state_transition(
+        pre_balance,
+        post_balance,
         payer_account.data().len(),
-        rent.minimum_balance(payer_account.data().len()),
-    );
-    check_rent_state_with_account(
-        &payer_pre_rent_state,
-        &payer_post_rent_state,
-        payer_address,
+        rent,
         payer_index,
+        relax_post_exec_min_balance_check,
     )
 }
 
@@ -1161,11 +1153,11 @@ mod tests {
         is_nonce: bool,
         payer_init_balance: u64,
         fee: u64,
+        relax_post_exec_min_balance_check: bool,
         expected_result: Result<()>,
         payer_post_balance: u64,
     }
     fn validate_fee_payer_account(test_parameter: ValidateFeePayerTestParameter, rent: &Rent) {
-        let payer_account_keys = Keypair::new();
         let mut account = if test_parameter.is_nonce {
             AccountSharedData::new_data(
                 test_parameter.payer_init_balance,
@@ -1177,12 +1169,12 @@ mod tests {
             AccountSharedData::new(test_parameter.payer_init_balance, 0, &system_program::id())
         };
         let result = validate_fee_payer(
-            &payer_account_keys.pubkey(),
             &mut account,
             0,
             &mut TransactionErrorMetrics::default(),
             rent,
             test_parameter.fee,
+            test_parameter.relax_post_exec_min_balance_check,
         );
 
         assert_eq!(result, test_parameter.expected_result);
@@ -1201,67 +1193,79 @@ mod tests {
         // If payer account has sufficient balance, expect successful fee deduction,
         // regardless feature gate status, or if payer is nonce account.
         {
-            for (is_nonce, min_balance) in [(true, min_balance), (false, 0)] {
-                validate_fee_payer_account(
-                    ValidateFeePayerTestParameter {
-                        is_nonce,
-                        payer_init_balance: min_balance + fee,
-                        fee,
-                        expected_result: Ok(()),
-                        payer_post_balance: min_balance,
-                    },
-                    &rent,
-                );
+            for relax_post_exec_min_balance_check in [false, true] {
+                for (is_nonce, min_balance) in [(true, min_balance), (false, 0)] {
+                    validate_fee_payer_account(
+                        ValidateFeePayerTestParameter {
+                            is_nonce,
+                            payer_init_balance: min_balance + fee,
+                            fee,
+                            relax_post_exec_min_balance_check,
+                            expected_result: Ok(()),
+                            payer_post_balance: min_balance,
+                        },
+                        &rent,
+                    );
+                }
             }
         }
 
-        // If payer account has no balance, expected AccountNotFound Error
+        // If payer account has no balance, expected AccountNotFound error
         // regardless feature gate status, or if payer is nonce account.
         {
-            for is_nonce in [true, false] {
-                validate_fee_payer_account(
-                    ValidateFeePayerTestParameter {
-                        is_nonce,
-                        payer_init_balance: 0,
-                        fee,
-                        expected_result: Err(TransactionError::AccountNotFound),
-                        payer_post_balance: 0,
-                    },
-                    &rent,
-                );
+            for relax_post_exec_min_balance_check in [false, true] {
+                for is_nonce in [true, false] {
+                    validate_fee_payer_account(
+                        ValidateFeePayerTestParameter {
+                            is_nonce,
+                            payer_init_balance: 0,
+                            fee,
+                            relax_post_exec_min_balance_check,
+                            expected_result: Err(TransactionError::AccountNotFound),
+                            payer_post_balance: 0,
+                        },
+                        &rent,
+                    );
+                }
             }
         }
 
         // If payer account has insufficient balance, expect InsufficientFundsForFee error
         // regardless feature gate status, or if payer is nonce account.
         {
-            for (is_nonce, min_balance) in [(true, min_balance), (false, 0)] {
+            for relax_post_exec_min_balance_check in [false, true] {
+                for (is_nonce, min_balance) in [(true, min_balance), (false, 0)] {
+                    validate_fee_payer_account(
+                        ValidateFeePayerTestParameter {
+                            is_nonce,
+                            payer_init_balance: min_balance + fee - 1,
+                            fee,
+                            relax_post_exec_min_balance_check,
+                            expected_result: Err(TransactionError::InsufficientFundsForFee),
+                            payer_post_balance: min_balance + fee - 1,
+                        },
+                        &rent,
+                    );
+                }
+            }
+        }
+
+        // normal payer account has balance of u64::MAX, so does fee; since it does not require
+        // min_balance, expect successful fee deduction, regardless of feature gate status
+        {
+            for relax_post_exec_min_balance_check in [false, true] {
                 validate_fee_payer_account(
                     ValidateFeePayerTestParameter {
-                        is_nonce,
-                        payer_init_balance: min_balance + fee - 1,
-                        fee,
-                        expected_result: Err(TransactionError::InsufficientFundsForFee),
-                        payer_post_balance: min_balance + fee - 1,
+                        is_nonce: false,
+                        payer_init_balance: u64::MAX,
+                        fee: u64::MAX,
+                        relax_post_exec_min_balance_check,
+                        expected_result: Ok(()),
+                        payer_post_balance: 0,
                     },
                     &rent,
                 );
             }
-        }
-
-        // normal payer account has balance of u64::MAX, so does fee; since it does not  require
-        // min_balance, expect successful fee deduction, regardless of feature gate status
-        {
-            validate_fee_payer_account(
-                ValidateFeePayerTestParameter {
-                    is_nonce: false,
-                    payer_init_balance: u64::MAX,
-                    fee: u64::MAX,
-                    expected_result: Ok(()),
-                    payer_post_balance: 0,
-                },
-                &rent,
-            );
         }
     }
 
@@ -1280,6 +1284,7 @@ mod tests {
                 is_nonce: true,
                 payer_init_balance: u64::MAX,
                 fee: u64::MAX,
+                relax_post_exec_min_balance_check: true,
                 expected_result: Err(TransactionError::InsufficientFundsForFee),
                 payer_post_balance: u64::MAX,
             },

--- a/svm/src/rent_calculator.rs
+++ b/svm/src/rent_calculator.rs
@@ -16,10 +16,9 @@ use {
 pub const RENT_EXEMPT_RENT_EPOCH: Epoch = Epoch::MAX;
 
 /// Rent state of a Solana account.
-#[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum RentState {
     /// account.lamports == 0
-    #[default]
     Uninitialized,
     /// 0 < account.lamports < rent-exempt-minimum
     RentPaying {
@@ -98,16 +97,16 @@ pub fn get_account_rent_state(
 /// Determine the pre-execution rent state of an account.
 ///
 /// Equivalent to get_account_rent_state, with the additional option of
-/// disallowing the RentPaying state. If allow_rent_paying is false, accounts
+/// disallowing the RentPaying state. If disallow_rent_paying is true, accounts
 /// that would previously be designated RentPaying will instead be RentExempt.
 pub fn get_pre_exec_account_rent_state(
     account_lamports: u64,
     account_size: usize,
     min_balance: u64,
-    allow_rent_paying: bool,
+    disallow_rent_paying: bool,
 ) -> RentState {
     match get_account_rent_state(account_lamports, account_size, min_balance) {
-        RentState::RentPaying { .. } if !allow_rent_paying => RentState::RentExempt,
+        RentState::RentPaying { .. } if disallow_rent_paying => RentState::RentExempt,
         rent_state => rent_state,
     }
 }
@@ -159,7 +158,7 @@ pub fn check_static_account_rent_state_transition(
         data_size,
         rent_min_balance,
         // post SIMD-392 activation, RentPaying accounts are no longer possible
-        !relax_post_exec_min_balance_check,
+        relax_post_exec_min_balance_check,
     );
     let post_state = get_post_exec_account_rent_state(
         post_exec_balance,

--- a/svm/src/rent_calculator.rs
+++ b/svm/src/rent_calculator.rs
@@ -75,7 +75,7 @@ pub fn check_rent_state_with_account(
 /// Determine the rent state of an account.
 ///
 /// This method has a default implementation that treats accounts with zero
-/// lamports as uninitialized and uses the implemented `get_rent` to
+/// lamports as uninitialized and uses the provided `min_balance` to
 /// determine whether an account is rent-exempt.
 pub fn get_account_rent_state(
     account_lamports: u64,
@@ -94,6 +94,43 @@ pub fn get_account_rent_state(
     }
 }
 
+fn get_pre_account_rent_state(
+    account_lamports: u64,
+    account_size: usize,
+    min_balance: u64,
+    allow_rent_paying: bool,
+) -> RentState {
+    match get_account_rent_state(account_lamports, account_size, min_balance) {
+        RentState::RentPaying { .. } if !allow_rent_paying => RentState::RentExempt,
+        rent_state => rent_state,
+    }
+}
+
+fn get_post_account_rent_state(
+    account_lamports: u64,
+    account_size: usize,
+    min_balance: u64,
+    pre_rent_state: &RentState,
+    pre_exec_balance: u64,
+    relax_post_exec_min_balance_check: bool,
+) -> RentState {
+    if !relax_post_exec_min_balance_check {
+        return get_account_rent_state(account_lamports, account_size, min_balance);
+    };
+
+    match (account_lamports, &pre_rent_state) {
+        (0, _) => RentState::Uninitialized,
+        (post_balance, _) if post_balance >= min_balance => RentState::RentExempt,
+        (post_balance, RentState::RentExempt) if post_balance >= pre_exec_balance => {
+            RentState::RentExempt
+        }
+        (post_balance, _) => RentState::RentPaying {
+            data_size: account_size,
+            lamports: post_balance,
+        },
+    }
+}
+
 /// Returns whether a transition from the pre_exec_balance to the
 /// post_exec_balance is valid for an account that hasn't changed owner
 /// or data size.
@@ -106,30 +143,21 @@ pub fn check_static_account_rent_state_transition(
     relax_post_exec_min_balance_check: bool,
 ) -> TransactionResult<()> {
     let rent_min_balance = rent.minimum_balance(data_size);
-    let (pre_state, post_state) = if relax_post_exec_min_balance_check {
-        let pre_state = if pre_exec_balance == 0 {
-            RentState::Uninitialized
-        } else {
-            RentState::RentExempt
-        };
-        let post_state = match (post_exec_balance, &pre_state) {
-            (0, _) => RentState::Uninitialized,
-            (post_balance, _) if post_balance >= rent_min_balance => RentState::RentExempt,
-            (post_balance, RentState::RentExempt) if post_balance >= pre_exec_balance => {
-                RentState::RentExempt
-            }
-            (post_balance, _) => RentState::RentPaying {
-                data_size,
-                lamports: post_balance,
-            },
-        };
-        (pre_state, post_state)
-    } else {
-        (
-            get_account_rent_state(pre_exec_balance, data_size, rent_min_balance),
-            get_account_rent_state(post_exec_balance, data_size, rent_min_balance),
-        )
-    };
+    let pre_state = get_pre_account_rent_state(
+        pre_exec_balance,
+        data_size,
+        rent_min_balance,
+        // post SIMD-392 activation, RentPaying accounts are no longer possible
+        !relax_post_exec_min_balance_check,
+    );
+    let post_state = get_post_account_rent_state(
+        post_exec_balance,
+        data_size,
+        rent_min_balance,
+        &pre_state,
+        pre_exec_balance,
+        relax_post_exec_min_balance_check,
+    );
 
     if !transition_allowed(&pre_state, &post_state) {
         let account_index = account_index as u8;

--- a/svm/src/rent_calculator.rs
+++ b/svm/src/rent_calculator.rs
@@ -102,8 +102,9 @@ pub fn check_static_account_rent_state_transition(
     post_exec_balance: u64,
     data_size: usize,
     rent: &Rent,
+    account_index: IndexOfAccount,
     relax_post_exec_min_balance_check: bool,
-) -> bool {
+) -> TransactionResult<()> {
     let rent_min_balance = rent.minimum_balance(data_size);
     let (pre_state, post_state) = if relax_post_exec_min_balance_check {
         let pre_state = if pre_exec_balance == 0 {
@@ -129,7 +130,13 @@ pub fn check_static_account_rent_state_transition(
             get_account_rent_state(post_exec_balance, data_size, rent_min_balance),
         )
     };
-    transition_allowed(&pre_state, &post_state)
+
+    if !transition_allowed(&pre_state, &post_state) {
+        let account_index = account_index as u8;
+        Err(TransactionError::InsufficientFundsForRent { account_index })
+    } else {
+        Ok(())
+    }
 }
 
 /// Check whether a transition from the pre_rent_state to the

--- a/svm/src/rent_calculator.rs
+++ b/svm/src/rent_calculator.rs
@@ -78,13 +78,13 @@ pub fn check_rent_state_with_account(
 /// lamports as uninitialized and uses the implemented `get_rent` to
 /// determine whether an account is rent-exempt.
 pub fn get_account_rent_state(
-    rent: &Rent,
     account_lamports: u64,
     account_size: usize,
+    min_balance: u64,
 ) -> RentState {
     if account_lamports == 0 {
         RentState::Uninitialized
-    } else if rent.is_exempt(account_lamports, account_size) {
+    } else if account_lamports >= min_balance {
         RentState::RentExempt
     } else {
         RentState::RentPaying {
@@ -92,6 +92,44 @@ pub fn get_account_rent_state(
             lamports: account_lamports,
         }
     }
+}
+
+/// Check whether a transition from the pre_exec_balance to the
+/// post_exec_balance is valid for an account that hasn't changed owner
+/// or data size.
+pub fn check_static_account_rent_state_transition(
+    pre_exec_balance: u64,
+    post_exec_balance: u64,
+    data_size: usize,
+    rent: &Rent,
+    relax_post_exec_min_balance_check: bool,
+) -> bool {
+    let rent_min_balance = rent.minimum_balance(data_size);
+    let (pre_state, post_state) = if relax_post_exec_min_balance_check {
+        let pre_state = if pre_exec_balance == 0 {
+            RentState::Uninitialized
+        } else {
+            RentState::RentExempt
+        };
+        let post_state = match (post_exec_balance, &pre_state) {
+            (0, _) => RentState::Uninitialized,
+            (post_balance, _) if post_balance >= rent_min_balance => RentState::RentExempt,
+            (post_balance, RentState::RentExempt) if post_balance >= pre_exec_balance => {
+                RentState::RentExempt
+            }
+            (post_balance, _) => RentState::RentPaying {
+                data_size,
+                lamports: post_balance,
+            },
+        };
+        (pre_state, post_state)
+    } else {
+        (
+            get_account_rent_state(pre_exec_balance, data_size, rent_min_balance),
+            get_account_rent_state(post_exec_balance, data_size, rent_min_balance),
+        )
+    };
+    transition_allowed(&pre_state, &post_state)
 }
 
 /// Check whether a transition from the pre_rent_state to the

--- a/svm/src/rent_calculator.rs
+++ b/svm/src/rent_calculator.rs
@@ -16,7 +16,7 @@ use {
 pub const RENT_EXEMPT_RENT_EPOCH: Epoch = Epoch::MAX;
 
 /// Rent state of a Solana account.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RentState {
     /// account.lamports == 0
     Uninitialized,
@@ -94,7 +94,7 @@ pub fn get_account_rent_state(
     }
 }
 
-/// Check whether a transition from the pre_exec_balance to the
+/// Returns whether a transition from the pre_exec_balance to the
 /// post_exec_balance is valid for an account that hasn't changed owner
 /// or data size.
 pub fn check_static_account_rent_state_transition(

--- a/svm/src/rent_calculator.rs
+++ b/svm/src/rent_calculator.rs
@@ -16,9 +16,10 @@ use {
 pub const RENT_EXEMPT_RENT_EPOCH: Epoch = Epoch::MAX;
 
 /// Rent state of a Solana account.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub enum RentState {
     /// account.lamports == 0
+    #[default]
     Uninitialized,
     /// 0 < account.lamports < rent-exempt-minimum
     RentPaying {
@@ -94,7 +95,12 @@ pub fn get_account_rent_state(
     }
 }
 
-fn get_pre_account_rent_state(
+/// Determine the pre-execution rent state of an account.
+///
+/// Equivalent to get_account_rent_state, with the additional option of
+/// disallowing the RentPaying state. If allow_rent_paying is false, accounts
+/// that would previously be designated RentPaying will instead be RentExempt.
+pub fn get_pre_exec_account_rent_state(
     account_lamports: u64,
     account_size: usize,
     min_balance: u64,
@@ -106,15 +112,20 @@ fn get_pre_account_rent_state(
     }
 }
 
-fn get_post_account_rent_state(
+/// Determine the post-execution rent state of an account.
+///
+/// Equivalent to get_account_rent_state, with the additional option of
+/// relaxing the criteria to designate an account as RentExempt. The relaxed
+/// designation follows the rules specified by SIMD-392.
+pub fn get_post_exec_account_rent_state(
     account_lamports: u64,
     account_size: usize,
     min_balance: u64,
     pre_rent_state: &RentState,
     pre_exec_balance: u64,
-    relax_post_exec_min_balance_check: bool,
+    relax_rent_exempt_criteria: bool,
 ) -> RentState {
-    if !relax_post_exec_min_balance_check {
+    if !relax_rent_exempt_criteria {
         return get_account_rent_state(account_lamports, account_size, min_balance);
     };
 
@@ -143,14 +154,14 @@ pub fn check_static_account_rent_state_transition(
     relax_post_exec_min_balance_check: bool,
 ) -> TransactionResult<()> {
     let rent_min_balance = rent.minimum_balance(data_size);
-    let pre_state = get_pre_account_rent_state(
+    let pre_state = get_pre_exec_account_rent_state(
         pre_exec_balance,
         data_size,
         rent_min_balance,
         // post SIMD-392 activation, RentPaying accounts are no longer possible
         !relax_post_exec_min_balance_check,
     );
-    let post_state = get_post_account_rent_state(
+    let post_state = get_post_exec_account_rent_state(
         post_exec_balance,
         data_size,
         rent_min_balance,

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -361,6 +361,10 @@ mod test {
         );
 
         assert_eq!(
+            pre[0].info.as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentExempt)
+        );
+        assert_eq!(
             post[0].info.as_ref().map(|info| &info.rent_state),
             Some(&RentState::RentExempt)
         );
@@ -400,6 +404,13 @@ mod test {
         );
 
         assert_eq!(
+            pre[0].info.as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentPaying {
+                data_size: data_len,
+                lamports: pre_balance
+            })
+        );
+        assert_eq!(
             post[0].info.as_ref().map(|info| &info.rent_state),
             Some(&RentState::RentPaying {
                 data_size: data_len,
@@ -410,7 +421,7 @@ mod test {
     }
 
     #[test]
-    fn test_post_exec_unchanged_size_violation() {
+    fn test_basic_rent_transition_violation() {
         let rent = Rent::default();
         let account = Pubkey::new_unique();
         let program = Pubkey::new_unique();
@@ -454,6 +465,10 @@ mod test {
         );
 
         assert_eq!(
+            pre[0].info.as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentExempt)
+        );
+        assert_eq!(
             post[0].info.as_ref().map(|info| &info.rent_state),
             Some(&RentState::RentPaying {
                 data_size: data_len,
@@ -467,6 +482,7 @@ mod test {
             res.err(),
             Some(TransactionError::InsufficientFundsForRent { account_index: 0 })
         );
+
     }
 
     #[test]
@@ -523,6 +539,10 @@ mod test {
         );
 
         assert_eq!(
+            pre[0].info.as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentExempt)
+        );
+        assert_eq!(
             post[0].info.as_ref().map(|info| &info.rent_state),
             Some(&RentState::RentPaying {
                 data_size: post_len,
@@ -534,6 +554,32 @@ mod test {
             res.err(),
             Some(TransactionError::InsufficientFundsForRent { account_index: 0 })
         );
+
+        // If the account is topped up to the new rent-exempt minimum after the
+        // resize, the same transition becomes valid.
+        let post_min = rent.minimum_balance(post_len);
+        let tx_accounts_post = vec![
+            (
+                account,
+                AccountSharedData::new(post_min, post_len, &Pubkey::default()),
+            ),
+            (program, AccountSharedData::default()),
+            (other_account, AccountSharedData::default()),
+        ];
+        let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 2);
+        let post = TransactionAccountStateInfo::new_post_exec(
+            &context_post,
+            &sanitized_message,
+            &pre,
+            &rent,
+            true,
+        );
+
+        assert_eq!(
+            post[0].info.as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentExempt)
+        );
+        assert!(verify_changes(&pre, &post, &context_post).is_ok());
     }
 
     #[test]
@@ -590,6 +636,10 @@ mod test {
             true,
         );
 
+        assert_eq!(
+            pre[0].info.as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentExempt)
+        );
         assert_eq!(
             post[0].info.as_ref().unwrap().rent_state,
             RentState::RentExempt
@@ -649,6 +699,10 @@ mod test {
             true,
         );
 
+        assert_eq!(
+            pre[0].info.as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentExempt)
+        );
         assert_eq!(
             post[0].info.as_ref().map(|info| &info.rent_state),
             Some(&RentState::RentPaying {

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -11,16 +11,12 @@ use {
     solana_transaction_error::TransactionResult as Result,
 };
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug)]
 pub(crate) struct TransactionAccountStateInfo {
     info: Option<WritableTransactionAccountStateInfo>, // None: readonly account
 }
 
 impl TransactionAccountStateInfo {
-    pub(crate) fn as_ref(&self) -> Option<&WritableTransactionAccountStateInfo> {
-        self.info.as_ref()
-    }
-
     pub(crate) fn new_pre_exec(
         transaction_context: &TransactionContext,
         message: &impl SVMMessage,
@@ -37,7 +33,7 @@ impl TransactionAccountStateInfo {
                         balance,
                         data_size,
                         rent.minimum_balance(data_size),
-                        !relax_post_exec_min_balance_check, // SIMD-0392 enabled. Assume `RentPaying` is impossible
+                        relax_post_exec_min_balance_check, // SIMD-0392 enabled. Assume `RentPaying` is impossible
                     );
 
                     WritableTransactionAccountStateInfo {
@@ -64,18 +60,14 @@ impl TransactionAccountStateInfo {
         iter_writable_accounts(transaction_context, message)
             .zip(pre_exec_state_infos)
             .map(|(acct_ref, pre_exec_state_info)| {
-                let info = acct_ref.map(|account| {
+                let info = acct_ref.and_then(|account| {
                     // the same account MUST be present and marked writable in both pre and post exec
                     debug_assert!(
                         pre_exec_state_info.info.is_some(),
                         "message and pre-exec state out of sync, fatal"
                     );
-                    if pre_exec_state_info.info.is_none() {
-                        // to avoid panicking in release, treat missing pre-exec info as uninitialized
-                        return WritableTransactionAccountStateInfo::default();
-                    }
 
-                    let pre_exec_state_info = pre_exec_state_info.info.as_ref().unwrap();
+                    let pre_exec_state_info = pre_exec_state_info.info.as_ref()?;
                     let balance = account.lamports();
                     let data_size = account.data().len();
                     let min_balance = rent.minimum_balance(data_size);
@@ -85,12 +77,12 @@ impl TransactionAccountStateInfo {
 
                     // Criteria for rent-exempt relaxation as specified by SIMD-392
                     let relax_rent_exempt_criteria = relax_post_exec_min_balance_check
-                        && *pre_state == RentState::RentExempt
                         && data_size <= pre_exec_state_info.data_size
+                        && *pre_state == RentState::RentExempt
                         && pre_exec_state_info.owner == owner;
 
                     // Post-exec owner is currently not consumed by any caller.
-                    WritableTransactionAccountStateInfo {
+                    Some(WritableTransactionAccountStateInfo {
                         rent_state: get_post_exec_account_rent_state(
                             balance,
                             data_size,
@@ -102,7 +94,7 @@ impl TransactionAccountStateInfo {
                         balance,
                         data_size,
                         owner,
-                    }
+                    })
                 });
                 Self { info }
             })
@@ -119,7 +111,7 @@ pub(crate) fn verify_changes(
         pre_state_infos.iter().zip(post_state_infos).enumerate()
     {
         if let (Some(pre_state_info), Some(post_state_info)) =
-            (pre_state_info.as_ref(), post_state_info.as_ref())
+            (pre_state_info.info.as_ref(), post_state_info.info.as_ref())
         {
             check_rent_state(
                 &pre_state_info.rent_state,
@@ -135,14 +127,14 @@ pub(crate) fn verify_changes(
 // Returns the cumulative size of all post-exec uninitialized accounts
 pub(crate) fn get_uninitialized_accounts_size(post: &[TransactionAccountStateInfo]) -> u64 {
     post.iter()
-        .filter_map(TransactionAccountStateInfo::as_ref)
+        .filter_map(|state| state.info.as_ref())
         .filter_map(|post| {
             matches!(&post.rent_state, RentState::Uninitialized).then_some(post.data_size as u64)
         })
         .sum()
 }
 
-#[derive(PartialEq, Debug, Clone, Default)]
+#[derive(PartialEq, Debug)]
 pub(crate) struct WritableTransactionAccountStateInfo {
     rent_state: RentState,
     balance: u64,
@@ -185,7 +177,7 @@ mod test {
         solana_rent::Rent,
         solana_transaction_context::transaction::TransactionContext,
         solana_transaction_error::TransactionError,
-        std::collections::HashSet,
+        std::{collections::HashSet, iter::repeat_with},
     };
 
     // Helpers to reduce duplication in tests
@@ -266,7 +258,7 @@ mod test {
         let program = Pubkey::new_unique();
         let other_account = Pubkey::new_unique();
 
-        let data_len: usize = 64;
+        let data_len = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(1);
 
@@ -340,7 +332,7 @@ mod test {
         let program = Pubkey::new_unique();
         let other_account = Pubkey::new_unique();
 
-        let data_len: usize = 64;
+        let data_len = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5); // less than full rent-exempt, but > 0
 
@@ -365,7 +357,7 @@ mod test {
         );
 
         assert_eq!(
-            post[0].as_ref().map(|info| &info.rent_state),
+            post[0].info.as_ref().map(|info| &info.rent_state),
             Some(&RentState::RentExempt)
         );
     }
@@ -377,7 +369,7 @@ mod test {
         let program = Pubkey::new_unique();
         let other_account = Pubkey::new_unique();
 
-        let data_len: usize = 64;
+        let data_len = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5);
 
@@ -402,13 +394,13 @@ mod test {
         );
 
         assert_eq!(
-            post[0].as_ref().map(|info| &info.rent_state),
+            post[0].info.as_ref().map(|info| &info.rent_state),
             Some(&RentState::RentPaying {
                 data_size: data_len,
                 lamports: pre_balance
             })
         );
-        assert!(post[1].as_ref().is_none());
+        assert!(post[1].info.as_ref().is_none());
     }
 
     #[test]
@@ -418,7 +410,7 @@ mod test {
         let program = Pubkey::new_unique();
         let other_account = Pubkey::new_unique();
 
-        let data_len: usize = 64;
+        let data_len = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5);
 
@@ -453,7 +445,7 @@ mod test {
         );
 
         assert_eq!(
-            post[0].as_ref().map(|info| &info.rent_state),
+            post[0].info.as_ref().map(|info| &info.rent_state),
             Some(&RentState::RentPaying {
                 data_size: data_len,
                 lamports: post_balance
@@ -475,8 +467,8 @@ mod test {
         let program = Pubkey::new_unique();
         let other_account = Pubkey::new_unique();
 
-        let pre_len: usize = 32;
-        let post_len: usize = 256; // larger size => larger full min
+        let pre_len = 32;
+        let post_len = 256; // larger size => larger full min
         let pre_min = rent.minimum_balance(pre_len);
         let pre_balance = pre_min.saturating_sub(1);
 
@@ -517,7 +509,7 @@ mod test {
         );
 
         assert_eq!(
-            post[0].as_ref().map(|info| &info.rent_state),
+            post[0].info.as_ref().map(|info| &info.rent_state),
             Some(&RentState::RentPaying {
                 data_size: post_len,
                 lamports: pre_balance
@@ -542,8 +534,8 @@ mod test {
         let program = Pubkey::new_unique();
         let other_account = Pubkey::new_unique();
 
-        let pre_len: usize = 256;
-        let post_len: usize = pre_len / 8; // smaller size, but rent increased after creation
+        let pre_len = 256;
+        let post_len = pre_len / 8; // smaller size, but rent increased after creation
         let pre_balance = pre_rent.minimum_balance(pre_len);
         let post_min = post_rent.minimum_balance(post_len);
         assert!(post_min > pre_balance);
@@ -584,7 +576,10 @@ mod test {
             true,
         );
 
-        assert_eq!(post[0].as_ref().unwrap().rent_state, RentState::RentExempt);
+        assert_eq!(
+            post[0].info.as_ref().unwrap().rent_state,
+            RentState::RentExempt
+        );
         let res = verify_changes(&pre, &post, &context_post);
         assert!(res.is_ok());
     }
@@ -598,7 +593,7 @@ mod test {
         let owner_pre = Pubkey::new_unique();
         let owner_post = Pubkey::new_unique();
 
-        let data_len: usize = 64;
+        let data_len = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5);
 
@@ -639,7 +634,7 @@ mod test {
         );
 
         assert_eq!(
-            post[0].as_ref().map(|info| &info.rent_state),
+            post[0].info.as_ref().map(|info| &info.rent_state),
             Some(&RentState::RentPaying {
                 data_size: data_len,
                 lamports: pre_balance
@@ -721,18 +716,17 @@ mod test {
 
     #[test]
     fn test_get_uninitialized_accounts_size_with_deleted_accounts() {
-        let mut post_state_infos = vec![
-            TransactionAccountStateInfo {
+        let mut post_state_infos: Vec<TransactionAccountStateInfo> =
+            repeat_with(|| TransactionAccountStateInfo {
                 info: Some(WritableTransactionAccountStateInfo {
                     rent_state: RentState::Uninitialized,
                     balance: 0,
                     data_size: 50,
                     owner: Pubkey::new_unique(),
                 }),
-            }
-            .clone();
-            3
-        ];
+            })
+            .take(3)
+            .collect();
 
         // add non-deleted account to ensure only uninitialized accounts are counted
         post_state_infos.push(TransactionAccountStateInfo {

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -175,14 +175,12 @@ mod test {
         super::*,
         solana_account::{AccountSharedData, WritableAccount},
         solana_hash::Hash,
-        solana_keypair::Keypair,
         solana_message::{
             LegacyMessage, Message, MessageHeader, SanitizedMessage,
             compiled_instruction::CompiledInstruction,
         },
         solana_pubkey::Pubkey,
         solana_rent::Rent,
-        solana_signer::Signer,
         solana_transaction_context::transaction::TransactionContext,
         solana_transaction_error::TransactionError,
         std::collections::HashSet,
@@ -217,17 +215,16 @@ mod test {
     #[test]
     fn test_pre_exec_basics() {
         let rent = Rent::default();
-        let account = Keypair::new();
-        let program = Keypair::new();
-        let other_account = Keypair::new();
+        let account = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let other_account = Pubkey::new_unique();
 
-        let sanitized_message =
-            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let sanitized_message = sanitized_msg_for(program, account, other_account);
 
         let transaction_accounts = vec![
-            (account.pubkey(), AccountSharedData::default()),
-            (program.pubkey(), AccountSharedData::default()),
-            (other_account.pubkey(), AccountSharedData::default()),
+            (account, AccountSharedData::default()),
+            (program, AccountSharedData::default()),
+            (other_account, AccountSharedData::default()),
         ];
         let default_owner = Pubkey::default();
 
@@ -263,23 +260,22 @@ mod test {
     #[test]
     fn test_pre_exec_legacy_rent_paying() {
         let rent = Rent::default();
-        let account = Keypair::new();
-        let program = Keypair::new();
-        let other_account = Keypair::new();
+        let account = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let other_account = Pubkey::new_unique();
 
         let data_len: usize = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(1);
 
-        let sanitized_message =
-            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let sanitized_message = sanitized_msg_for(program, account, other_account);
         let tx_accounts = vec![
             (
-                account.pubkey(),
+                account,
                 AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
             ),
-            (program.pubkey(), AccountSharedData::default()),
-            (other_account.pubkey(), AccountSharedData::default()),
+            (program, AccountSharedData::default()),
+            (other_account, AccountSharedData::default()),
         ];
         let context = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 2);
         let pre =
@@ -298,18 +294,13 @@ mod test {
     #[should_panic(expected = "message and transaction context out of sync, fatal")]
     fn test_new_panic() {
         let rent = Rent::default();
-        let account = Keypair::new();
-        let program = Keypair::new();
-        let other_account = Keypair::new();
-        let extra_account = Keypair::new();
+        let account = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let other_account = Pubkey::new_unique();
+        let extra_account = Pubkey::new_unique();
 
         let message = Message {
-            account_keys: vec![
-                account.pubkey(),
-                program.pubkey(),
-                other_account.pubkey(),
-                extra_account.pubkey(),
-            ],
+            account_keys: vec![account, program, other_account, extra_account],
             header: MessageHeader::default(),
             instructions: vec![
                 CompiledInstruction {
@@ -330,9 +321,9 @@ mod test {
             SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()));
 
         let transaction_accounts = vec![
-            (account.pubkey(), AccountSharedData::default()),
-            (program.pubkey(), AccountSharedData::default()),
-            (other_account.pubkey(), AccountSharedData::default()),
+            (account, AccountSharedData::default()),
+            (program, AccountSharedData::default()),
+            (other_account, AccountSharedData::default()),
         ];
 
         let context = TransactionContext::new(transaction_accounts, rent.clone(), 20, 20, 2);
@@ -343,23 +334,22 @@ mod test {
     #[test]
     fn test_post_exec_unchanged_size_allows_pre_balance() {
         let rent = Rent::default();
-        let account = Keypair::new();
-        let program = Keypair::new();
-        let other_account = Keypair::new();
+        let account = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let other_account = Pubkey::new_unique();
 
         let data_len: usize = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5); // less than full rent-exempt, but > 0
 
-        let sanitized_message =
-            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let sanitized_message = sanitized_msg_for(program, account, other_account);
         let tx_accounts = vec![
             (
-                account.pubkey(),
+                account,
                 AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
             ),
-            (program.pubkey(), AccountSharedData::default()),
-            (other_account.pubkey(), AccountSharedData::default()),
+            (program, AccountSharedData::default()),
+            (other_account, AccountSharedData::default()),
         ];
         let context = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 2);
         let pre =
@@ -381,23 +371,22 @@ mod test {
     #[test]
     fn test_post_exec_legacy_ignores_pre_balance() {
         let rent = Rent::default();
-        let account = Keypair::new();
-        let program = Keypair::new();
-        let other_account = Keypair::new();
+        let account = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let other_account = Pubkey::new_unique();
 
         let data_len: usize = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5);
 
-        let sanitized_message =
-            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let sanitized_message = sanitized_msg_for(program, account, other_account);
         let tx_accounts = vec![
             (
-                account.pubkey(),
+                account,
                 AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
             ),
-            (program.pubkey(), AccountSharedData::default()),
-            (other_account.pubkey(), AccountSharedData::default()),
+            (program, AccountSharedData::default()),
+            (other_account, AccountSharedData::default()),
         ];
         let context = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 2);
         let pre =
@@ -423,23 +412,22 @@ mod test {
     #[test]
     fn test_post_exec_unchanged_size_violation() {
         let rent = Rent::default();
-        let account = Keypair::new();
-        let program = Keypair::new();
-        let other_account = Keypair::new();
+        let account = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let other_account = Pubkey::new_unique();
 
         let data_len: usize = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5);
 
-        let sanitized_message =
-            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let sanitized_message = sanitized_msg_for(program, account, other_account);
         let mut tx_accounts = vec![
             (
-                account.pubkey(),
+                account,
                 AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
             ),
-            (program.pubkey(), AccountSharedData::default()),
-            (other_account.pubkey(), AccountSharedData::default()),
+            (program, AccountSharedData::default()),
+            (other_account, AccountSharedData::default()),
         ];
         let context_pre = TransactionContext::new(tx_accounts.clone(), rent.clone(), 20, 20, 2);
         let pre = TransactionAccountStateInfo::new_pre_exec(
@@ -481,25 +469,24 @@ mod test {
     #[test]
     fn test_post_exec_size_changed_requires_full_min() {
         let rent = Rent::default();
-        let account = Keypair::new();
-        let program = Keypair::new();
-        let other_account = Keypair::new();
+        let account = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let other_account = Pubkey::new_unique();
 
         let pre_len: usize = 32;
         let post_len: usize = 256; // larger size => larger full min
         let pre_min = rent.minimum_balance(pre_len);
         let pre_balance = pre_min.saturating_sub(1);
 
-        let sanitized_message =
-            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let sanitized_message = sanitized_msg_for(program, account, other_account);
 
         let tx_accounts_pre = vec![
             (
-                account.pubkey(),
+                account,
                 AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
             ),
-            (program.pubkey(), AccountSharedData::default()),
-            (other_account.pubkey(), AccountSharedData::default()),
+            (program, AccountSharedData::default()),
+            (other_account, AccountSharedData::default()),
         ];
         let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 2);
         let pre = TransactionAccountStateInfo::new_pre_exec(
@@ -512,11 +499,11 @@ mod test {
         // post: size increased; balance unchanged => should require full min for new size
         let tx_accounts_post = vec![
             (
-                account.pubkey(),
+                account,
                 AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
             ),
-            (program.pubkey(), AccountSharedData::default()),
-            (other_account.pubkey(), AccountSharedData::default()),
+            (program, AccountSharedData::default()),
+            (other_account, AccountSharedData::default()),
         ];
         let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 2);
         let post = TransactionAccountStateInfo::new_post_exec(
@@ -549,9 +536,9 @@ mod test {
             ..Rent::default()
         };
 
-        let account = Keypair::new();
-        let program = Keypair::new();
-        let other_account = Keypair::new();
+        let account = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let other_account = Pubkey::new_unique();
 
         let pre_len: usize = 256;
         let post_len: usize = pre_len / 8; // smaller size, but rent increased after creation
@@ -559,16 +546,15 @@ mod test {
         let post_min = post_rent.minimum_balance(post_len);
         assert!(post_min > pre_balance);
 
-        let sanitized_message =
-            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let sanitized_message = sanitized_msg_for(program, account, other_account);
 
         let tx_accounts_pre = vec![
             (
-                account.pubkey(),
+                account,
                 AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
             ),
-            (program.pubkey(), AccountSharedData::default()),
-            (other_account.pubkey(), AccountSharedData::default()),
+            (program, AccountSharedData::default()),
+            (other_account, AccountSharedData::default()),
         ];
         let context_pre = TransactionContext::new(tx_accounts_pre, pre_rent.clone(), 20, 20, 2);
         let pre = TransactionAccountStateInfo::new_pre_exec(
@@ -581,11 +567,11 @@ mod test {
         // post: size decreased; rent increased => should still not require top-up
         let tx_accounts_post = vec![
             (
-                account.pubkey(),
+                account,
                 AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
             ),
-            (program.pubkey(), AccountSharedData::default()),
-            (other_account.pubkey(), AccountSharedData::default()),
+            (program, AccountSharedData::default()),
+            (other_account, AccountSharedData::default()),
         ];
         let context_post = TransactionContext::new(tx_accounts_post, post_rent.clone(), 20, 20, 2);
         let post = TransactionAccountStateInfo::new_post_exec(
@@ -604,26 +590,25 @@ mod test {
     #[test]
     fn test_post_exec_owner_changed_requires_full_min() {
         let rent = Rent::default();
-        let account = Keypair::new();
-        let program = Keypair::new();
-        let other_account = Keypair::new();
-        let owner_pre = Keypair::new();
-        let owner_post = Keypair::new();
+        let account = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let other_account = Pubkey::new_unique();
+        let owner_pre = Pubkey::new_unique();
+        let owner_post = Pubkey::new_unique();
 
         let data_len: usize = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5);
 
-        let sanitized_message =
-            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let sanitized_message = sanitized_msg_for(program, account, other_account);
 
         let tx_accounts_pre = vec![
             (
-                account.pubkey(),
-                AccountSharedData::new(pre_balance, data_len, &owner_pre.pubkey()),
+                account,
+                AccountSharedData::new(pre_balance, data_len, &owner_pre),
             ),
-            (program.pubkey(), AccountSharedData::default()),
-            (other_account.pubkey(), AccountSharedData::default()),
+            (program, AccountSharedData::default()),
+            (other_account, AccountSharedData::default()),
         ];
         let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 2);
         let pre = TransactionAccountStateInfo::new_pre_exec(
@@ -636,11 +621,11 @@ mod test {
         // post: owner changed; balance/size unchanged => should require full min
         let tx_accounts_post = vec![
             (
-                account.pubkey(),
-                AccountSharedData::new(pre_balance, data_len, &owner_post.pubkey()),
+                account,
+                AccountSharedData::new(pre_balance, data_len, &owner_post),
             ),
-            (program.pubkey(), AccountSharedData::default()),
-            (other_account.pubkey(), AccountSharedData::default()),
+            (program, AccountSharedData::default()),
+            (other_account, AccountSharedData::default()),
         ];
         let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 2);
         let post = TransactionAccountStateInfo::new_post_exec(
@@ -669,8 +654,8 @@ mod test {
     fn test_verify_changes() {
         // mostly a sanity check for the plumbing since transitions_allowed enforces
         // the specific transition rules.
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
+        let key1 = Pubkey::new_unique();
+        let key2 = Pubkey::new_unique();
         let owner = Pubkey::default();
         let pre_state_infos = vec![TransactionAccountStateInfo {
             info: Some(WritableTransactionAccountStateInfo {
@@ -690,8 +675,8 @@ mod test {
         }];
 
         let transaction_accounts = vec![
-            (key1.pubkey(), AccountSharedData::default()),
-            (key2.pubkey(), AccountSharedData::default()),
+            (key1, AccountSharedData::default()),
+            (key2, AccountSharedData::default()),
         ];
 
         let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 2);
@@ -720,8 +705,8 @@ mod test {
         }];
 
         let transaction_accounts = vec![
-            (key1.pubkey(), AccountSharedData::default()),
-            (key2.pubkey(), AccountSharedData::default()),
+            (key1, AccountSharedData::default()),
+            (key2, AccountSharedData::default()),
         ];
 
         let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 2);
@@ -734,7 +719,7 @@ mod test {
 
     #[test]
     fn test_get_uninitialized_accounts_size_with_deleted_accounts() {
-        let post_state_infos = vec![
+        let mut post_state_infos = vec![
             TransactionAccountStateInfo {
                 info: Some(WritableTransactionAccountStateInfo {
                     rent_state: RentState::Uninitialized,
@@ -746,6 +731,16 @@ mod test {
             .clone();
             3
         ];
+
+        // add non-deleted account to ensure only uninitialized accounts are counted
+        post_state_infos.push(TransactionAccountStateInfo {
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state: RentState::RentExempt,
+                balance: 100,
+                data_size: 50,
+                owner: Pubkey::new_unique(),
+            }),
+        });
 
         // 3 deleted accounts should contribute 3 * (50) = 150 to the count
         assert_eq!(get_uninitialized_accounts_size(&post_state_infos), 150);

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -25,7 +25,7 @@ impl TransactionAccountStateInfo {
         rent: &Rent,
         relax_post_exec_min_balance_check: bool,
     ) -> Vec<Self> {
-        write_iter_accounts(transaction_context, message)
+        iter_writable_accounts(transaction_context, message)
             .map(|acct_ref| {
                 let info = acct_ref.map(|account| {
                     let balance = account.lamports();
@@ -64,7 +64,7 @@ impl TransactionAccountStateInfo {
     ) -> Vec<Self> {
         debug_assert_eq!(pre_exec_state_infos.len(), message.account_keys().len());
 
-        write_iter_accounts(transaction_context, message)
+        iter_writable_accounts(transaction_context, message)
             .zip(pre_exec_state_infos)
             .map(|(acct_ref, pre_exec_state_info)| {
                 let info = acct_ref.map(|account| {
@@ -148,7 +148,7 @@ pub(crate) struct WritableTransactionAccountStateInfo {
     owner: Pubkey,
 }
 
-fn write_iter_accounts<'a>(
+fn iter_writable_accounts<'a>(
     transaction_context: &'a TransactionContext,
     message: &impl SVMMessage,
 ) -> impl Iterator<Item = Option<solana_transaction_context::transaction_accounts::AccountRef<'a>>>

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -1,10 +1,12 @@
 use {
     crate::rent_calculator::{RentState, check_rent_state, get_account_rent_state},
     solana_account::ReadableAccount,
+    solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction_context::{IndexOfAccount, transaction::TransactionContext},
     solana_transaction_error::TransactionResult as Result,
+    std::cmp::min,
 };
 
 #[derive(PartialEq, Debug)]
@@ -13,91 +15,172 @@ pub(crate) struct TransactionAccountStateInfo {
 }
 
 impl TransactionAccountStateInfo {
-    pub(crate) fn new(
+    pub(crate) fn as_ref(&self) -> Option<&WritableTransactionAccountStateInfo> {
+        self.info.as_ref()
+    }
+
+    pub(crate) fn new_pre_exec(
         transaction_context: &TransactionContext,
         message: &impl SVMMessage,
         rent: &Rent,
+        relax_post_exec_min_balance_check: bool,
     ) -> Vec<Self> {
-        (0..message.account_keys().len())
-            .map(|i| {
-                let info = if message.is_writable(i) {
-                    let state = if let Ok(account) = transaction_context
-                        .accounts()
-                        .try_borrow(i as IndexOfAccount)
-                    {
-                        let balance = account.lamports();
-                        let data_size = account.data().len();
-                        let rent_state = get_account_rent_state(rent, balance, data_size);
-                        Some(WritableTransactionAccountStateInfo {
-                            rent_state,
-                            data_size,
-                        })
+        iter_accounts(transaction_context, message)
+            .map(|acct_ref| {
+                let info = acct_ref.map(|account| {
+                    let balance = account.lamports();
+                    let data_size = account.data().len();
+                    let owner = *account.owner();
+
+                    let rent_state = if relax_post_exec_min_balance_check {
+                        // SIMD-0392 enabled. Assume `RentExempt` is impossible.
+                        if account.lamports() == 0 {
+                            RentState::Uninitialized
+                        } else {
+                            RentState::RentExempt
+                        }
                     } else {
-                        None
+                        get_account_rent_state(balance, data_size, rent.minimum_balance(data_size))
                     };
-                    debug_assert!(
-                        state.is_some(),
-                        "message and transaction context out of sync, fatal"
-                    );
-                    state
-                } else {
-                    None
-                };
+
+                    WritableTransactionAccountStateInfo {
+                        rent_state,
+                        balance,
+                        data_size,
+                        owner,
+                    }
+                });
                 Self { info }
             })
             .collect()
     }
 
-    pub(crate) fn verify_changes(
-        pre_state_infos: &[Self],
-        post_state_infos: &[Self],
+    pub(crate) fn new_post_exec(
         transaction_context: &TransactionContext,
-    ) -> Result<()> {
-        for (i, (pre_state_info, post_state_info)) in
-            pre_state_infos.iter().zip(post_state_infos).enumerate()
-        {
-            if let (Some(pre_state_info), Some(post_state_info)) =
-                (pre_state_info.info.as_ref(), post_state_info.info.as_ref())
-            {
-                check_rent_state(
-                    &pre_state_info.rent_state,
-                    &post_state_info.rent_state,
-                    transaction_context,
-                    i as IndexOfAccount,
-                )?;
-            }
-        }
-        Ok(())
+        message: &impl SVMMessage,
+        pre_exec_state_infos: &[TransactionAccountStateInfo],
+        rent: &Rent,
+        relax_post_exec_min_balance_check: bool,
+    ) -> Vec<Self> {
+        debug_assert_eq!(pre_exec_state_infos.len(), message.account_keys().len());
+
+        iter_accounts(transaction_context, message)
+            .zip(pre_exec_state_infos)
+            .map(|(acct_ref, pre_exec_state_info)| {
+                let info = acct_ref.map(|account| {
+                    // the same account MUST be present and marked writable in both pre and post exec
+                    debug_assert!(
+                        pre_exec_state_info.info.is_some(),
+                        "message and pre-exec state out of sync, fatal"
+                    );
+
+                    let balance = account.lamports();
+                    let data_size = account.data().len();
+                    let mut min_balance = rent.minimum_balance(data_size);
+
+                    if relax_post_exec_min_balance_check {
+                        // SIMD-0392 enabled.
+                        // Adjust min_balance according to SIMD-0392.
+                        if let Some(pre_exec_info) = pre_exec_state_info.as_ref() {
+                            // if the account size increased, account was created in this transaction,
+                            // or the owner of the account changed, do standard rent exempt check
+                            // otherwise, pre-exec balance can also be used as the minimum balance
+                            if pre_exec_info.rent_state != RentState::Uninitialized
+                                && data_size <= pre_exec_info.data_size
+                                && account.owner() == &pre_exec_info.owner
+                            {
+                                min_balance = min(pre_exec_info.balance, min_balance);
+                            }
+                        }
+                    }
+
+                    // Post-exec owner is currently not consumed by any caller.
+                    WritableTransactionAccountStateInfo {
+                        rent_state: get_account_rent_state(balance, data_size, min_balance),
+                        balance,
+                        data_size,
+                        owner: Pubkey::default(), // pubkey isn't needed for post-exec
+                    }
+                });
+                Self { info }
+            })
+            .collect()
     }
 }
 
-#[derive(PartialEq, Debug)]
-struct WritableTransactionAccountStateInfo {
-    rent_state: RentState,
-    data_size: usize,
+pub(crate) fn verify_changes(
+    pre_state_infos: &[TransactionAccountStateInfo],
+    post_state_infos: &[TransactionAccountStateInfo],
+    transaction_context: &TransactionContext,
+) -> Result<()> {
+    for (i, (pre_state_info, post_state_info)) in
+        pre_state_infos.iter().zip(post_state_infos).enumerate()
+    {
+        if let (Some(pre_state_info), Some(post_state_info)) =
+            (pre_state_info.as_ref(), post_state_info.as_ref())
+        {
+            check_rent_state(
+                &pre_state_info.rent_state,
+                &post_state_info.rent_state,
+                transaction_context,
+                i as IndexOfAccount,
+            )?;
+        }
+    }
+    Ok(())
 }
 
 // Returns the cumulative size of all post-exec uninitialized accounts
 pub(crate) fn get_uninitialized_accounts_size(post: &[TransactionAccountStateInfo]) -> u64 {
     post.iter()
-        .filter_map(|post_info| post_info.info.as_ref())
+        .filter_map(TransactionAccountStateInfo::as_ref)
         .filter_map(|post| {
             matches!(&post.rent_state, RentState::Uninitialized).then_some(post.data_size as u64)
         })
         .sum()
 }
 
+#[derive(PartialEq, Debug)]
+pub(crate) struct WritableTransactionAccountStateInfo {
+    rent_state: RentState,
+    balance: u64,
+    data_size: usize,
+    owner: Pubkey,
+}
+
+fn iter_accounts<'a>(
+    transaction_context: &'a TransactionContext,
+    message: &impl SVMMessage,
+) -> impl Iterator<Item = Option<solana_transaction_context::transaction_accounts::AccountRef<'a>>>
+{
+    (0..message.account_keys().len()).map(|i| {
+        if message.is_writable(i) {
+            let account = transaction_context
+                .accounts()
+                .try_borrow(i as IndexOfAccount);
+            debug_assert!(
+                account.is_ok(),
+                "message and transaction context out of sync, fatal"
+            );
+            account.ok()
+        } else {
+            None
+        }
+    })
+}
+
 #[cfg(test)]
 mod test {
     use {
         super::*,
-        solana_account::AccountSharedData,
+        solana_account::{AccountSharedData, WritableAccount},
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_message::{
             LegacyMessage, Message, MessageHeader, SanitizedMessage,
             compiled_instruction::CompiledInstruction,
         },
+        solana_pubkey::Pubkey,
         solana_rent::Rent,
         solana_signer::Signer,
         solana_transaction_context::transaction::TransactionContext,
@@ -105,16 +188,10 @@ mod test {
         std::collections::HashSet,
     };
 
-    #[test]
-    fn test_new() {
-        let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
-
+    // Helpers to reduce duplication in tests
+    fn sanitized_msg_for(key1: Pubkey, key2: Pubkey, key4: Pubkey) -> SanitizedMessage {
         let message = Message {
-            account_keys: vec![key2.pubkey(), key1.pubkey(), key4.pubkey()],
+            account_keys: vec![key2, key1, key4],
             header: MessageHeader::default(),
             instructions: vec![
                 CompiledInstruction {
@@ -130,35 +207,103 @@ mod test {
             ],
             recent_blockhash: Hash::default(),
         };
+        SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()))
+    }
 
-        let sanitized_message =
-            SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()));
+    fn accounts_key2_first(
+        key1: Pubkey,
+        key2: Pubkey,
+        key3: Pubkey,
+        acc2: AccountSharedData,
+    ) -> Vec<(Pubkey, AccountSharedData)> {
+        vec![
+            (key2, acc2),
+            (key1, AccountSharedData::default()),
+            (key3, AccountSharedData::default()),
+        ]
+    }
+
+    fn ctx_from(accounts: Vec<(Pubkey, AccountSharedData)>, rent: &Rent) -> TransactionContext<'_> {
+        TransactionContext::new(accounts, rent.clone(), 20, 20, 1)
+    }
+
+    fn state_info(
+        rent_state: RentState,
+        balance: u64,
+        data_size: usize,
+        owner: Pubkey,
+    ) -> TransactionAccountStateInfo {
+        TransactionAccountStateInfo {
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state,
+                balance,
+                data_size,
+                owner,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_pre_exec_basics() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
 
         let transaction_accounts = vec![
             (key1.pubkey(), AccountSharedData::default()),
             (key2.pubkey(), AccountSharedData::default()),
             (key3.pubkey(), AccountSharedData::default()),
         ];
+        let default_owner = Pubkey::default();
 
         let context = TransactionContext::new(transaction_accounts, rent.clone(), 20, 20, 1);
-        let result = TransactionAccountStateInfo::new(&context, &sanitized_message, &rent);
+        let result =
+            TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, true);
         assert_eq!(
             result,
             vec![
-                TransactionAccountStateInfo {
-                    info: Some(WritableTransactionAccountStateInfo {
-                        rent_state: RentState::Uninitialized,
-                        data_size: 0,
-                    })
-                },
+                state_info(RentState::Uninitialized, 0, 0, default_owner),
                 TransactionAccountStateInfo { info: None },
-                TransactionAccountStateInfo {
-                    info: Some(WritableTransactionAccountStateInfo {
-                        rent_state: RentState::Uninitialized,
-                        data_size: 0,
-                    })
-                }
+                state_info(RentState::Uninitialized, 0, 0, default_owner),
             ]
+        );
+
+        // no post-exec in this test
+    }
+
+    #[test]
+    fn test_pre_exec_legacy_rent_paying() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let data_len: usize = 64;
+        let min_full = rent.minimum_balance(data_len);
+        let pre_balance = min_full.saturating_sub(1);
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let tx_accounts = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+        );
+        let context = ctx_from(tx_accounts, &rent);
+        let pre =
+            TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, false);
+
+        assert_eq!(
+            pre[0].info.as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentPaying {
+                data_size: data_len,
+                lamports: pre_balance
+            })
         );
     }
 
@@ -199,33 +344,325 @@ mod test {
         ];
 
         let context = TransactionContext::new(transaction_accounts, rent.clone(), 20, 20, 1);
-        let _result = TransactionAccountStateInfo::new(&context, &sanitized_message, &rent);
+        let _result =
+            TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, true);
+    }
+
+    #[test]
+    fn test_post_exec_unchanged_size_allows_pre_balance() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let data_len: usize = 64;
+        let min_full = rent.minimum_balance(data_len);
+        let pre_balance = min_full.saturating_sub(5); // less than full rent-exempt, but > 0
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let tx_accounts = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+        );
+        let context = ctx_from(tx_accounts, &rent);
+        let pre =
+            TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, true);
+        let post = TransactionAccountStateInfo::new_post_exec(
+            &context,
+            &sanitized_message,
+            &pre,
+            &rent,
+            true,
+        );
+
+        // account index 0 in message is key2; expect RentExempt due to grace
+        assert_eq!(
+            post[0].as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentExempt)
+        );
+    }
+
+    #[test]
+    fn test_post_exec_legacy_ignores_pre_balance() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let data_len: usize = 64;
+        let min_full = rent.minimum_balance(data_len);
+        let pre_balance = min_full.saturating_sub(5);
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let tx_accounts = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+        );
+        let context = ctx_from(tx_accounts, &rent);
+        let pre =
+            TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, false);
+        let post = TransactionAccountStateInfo::new_post_exec(
+            &context,
+            &sanitized_message,
+            &pre,
+            &rent,
+            false,
+        );
+
+        assert_eq!(
+            post[0].as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentPaying {
+                data_size: data_len,
+                lamports: pre_balance
+            })
+        );
+        assert!(post[1].as_ref().is_none());
+    }
+
+    #[test]
+    fn test_post_exec_unchanged_size_violation() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let data_len: usize = 64;
+        let min_full = rent.minimum_balance(data_len);
+        let pre_balance = min_full.saturating_sub(5);
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let mut tx_accounts = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+        );
+        let context_pre = TransactionContext::new(tx_accounts.clone(), rent.clone(), 20, 20, 1);
+        let pre = TransactionAccountStateInfo::new_pre_exec(
+            &context_pre,
+            &sanitized_message,
+            &rent,
+            true,
+        );
+
+        // post: drop balance by 1 (below minimum balance)
+        let post_balance = pre_balance.saturating_sub(1);
+        tx_accounts[0].1.set_lamports(post_balance);
+
+        let context_post = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 1);
+        let post = TransactionAccountStateInfo::new_post_exec(
+            &context_post,
+            &sanitized_message,
+            &pre,
+            &rent,
+            true,
+        );
+
+        assert_eq!(
+            post[0].as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentPaying {
+                data_size: data_len,
+                lamports: post_balance
+            })
+        );
+
+        // verify_changes should flag InsufficientFundsForRent
+        let res = verify_changes(&pre, &post, &context_post);
+        assert_eq!(
+            res.err(),
+            Some(TransactionError::InsufficientFundsForRent { account_index: 0 })
+        );
+    }
+
+    #[test]
+    fn test_post_exec_size_changed_requires_full_min() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let pre_len: usize = 32;
+        let post_len: usize = 256; // larger size => larger full min
+        let pre_min = rent.minimum_balance(pre_len);
+        let pre_balance = pre_min.saturating_sub(1);
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+
+        let tx_accounts_pre = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
+        );
+        let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 1);
+        let pre = TransactionAccountStateInfo::new_pre_exec(
+            &context_pre,
+            &sanitized_message,
+            &rent,
+            true,
+        );
+
+        // post: size increased; balance unchanged => should require full min for new size
+        let tx_accounts_post = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
+        );
+        let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 1);
+        let post = TransactionAccountStateInfo::new_post_exec(
+            &context_post,
+            &sanitized_message,
+            &pre,
+            &rent,
+            true,
+        );
+
+        assert_eq!(
+            post[0].as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentPaying {
+                data_size: post_len,
+                lamports: pre_balance
+            })
+        );
+        let res = verify_changes(&pre, &post, &context_post);
+        assert_eq!(
+            res.err(),
+            Some(TransactionError::InsufficientFundsForRent { account_index: 0 })
+        );
+    }
+
+    #[test]
+    fn test_post_exec_size_shrunk_does_not_require_balance_adjustment() {
+        let pre_rent = Rent::default();
+        let post_rent = Rent {
+            lamports_per_byte: pre_rent.lamports_per_byte * 9,
+            ..Rent::default()
+        };
+
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+
+        let pre_len: usize = 256;
+        let post_len: usize = pre_len / 8; // smaller size, but rent increased after creation
+        let pre_balance = pre_rent.minimum_balance(pre_len);
+        let post_min = post_rent.minimum_balance(post_len);
+        assert!(post_min > pre_balance);
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+
+        let tx_accounts_pre = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
+        );
+        let context_pre = TransactionContext::new(tx_accounts_pre, pre_rent.clone(), 20, 20, 1);
+        let pre = TransactionAccountStateInfo::new_pre_exec(
+            &context_pre,
+            &sanitized_message,
+            &pre_rent,
+            true,
+        );
+
+        // post: size decreased; rent increased => should still not require top-up
+        let tx_accounts_post = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
+        );
+        let context_post = TransactionContext::new(tx_accounts_post, post_rent.clone(), 20, 20, 1);
+        let post = TransactionAccountStateInfo::new_post_exec(
+            &context_post,
+            &sanitized_message,
+            &pre,
+            &post_rent,
+            true,
+        );
+
+        assert_eq!(post[0].as_ref().unwrap().rent_state, RentState::RentExempt);
+        let res = verify_changes(&pre, &post, &context_post);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_post_exec_owner_changed_requires_full_min() {
+        let rent = Rent::default();
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+        let key3 = Keypair::new();
+        let key4 = Keypair::new();
+        let owner_pre = Keypair::new();
+        let owner_post = Keypair::new();
+
+        let data_len: usize = 64;
+        let min_full = rent.minimum_balance(data_len);
+        let pre_balance = min_full.saturating_sub(5);
+
+        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+
+        let tx_accounts_pre = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, data_len, &owner_pre.pubkey()),
+        );
+        let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 1);
+        let pre = TransactionAccountStateInfo::new_pre_exec(
+            &context_pre,
+            &sanitized_message,
+            &rent,
+            true,
+        );
+
+        // post: owner changed; balance/size unchanged => should require full min
+        let tx_accounts_post = accounts_key2_first(
+            key1.pubkey(),
+            key2.pubkey(),
+            key3.pubkey(),
+            AccountSharedData::new(pre_balance, data_len, &owner_post.pubkey()),
+        );
+        let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 1);
+        let post = TransactionAccountStateInfo::new_post_exec(
+            &context_post,
+            &sanitized_message,
+            &pre,
+            &rent,
+            true,
+        );
+
+        assert_eq!(
+            post[0].as_ref().map(|info| &info.rent_state),
+            Some(&RentState::RentPaying {
+                data_size: data_len,
+                lamports: pre_balance
+            })
+        );
+        let res = verify_changes(&pre, &post, &context_post);
+        assert_eq!(
+            res.err(),
+            Some(TransactionError::InsufficientFundsForRent { account_index: 0 })
+        );
     }
 
     #[test]
     fn test_verify_changes() {
         let key1 = Keypair::new();
         let key2 = Keypair::new();
-        let pre_rent_state = vec![
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::Uninitialized,
-                    data_size: 0,
-                }),
-            },
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::Uninitialized,
-                    data_size: 0,
-                }),
-            },
-        ];
-        let post_rent_state = vec![TransactionAccountStateInfo {
-            info: Some(WritableTransactionAccountStateInfo {
-                rent_state: RentState::Uninitialized,
-                data_size: 0,
-            }),
-        }];
+        let owner = Pubkey::default();
+        let pre_state_infos = vec![state_info(RentState::Uninitialized, 0, 0, owner)];
+        let post_rent_states = vec![state_info(RentState::Uninitialized, 0, 0, owner)];
 
         let transaction_accounts = vec![
             (key1.pubkey(), AccountSharedData::default()),
@@ -234,28 +671,19 @@ mod test {
 
         let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 1);
 
-        let result = TransactionAccountStateInfo::verify_changes(
-            &pre_rent_state,
-            &post_rent_state,
-            &context,
-        );
+        let result = verify_changes(&pre_state_infos, &post_rent_states, &context);
         assert!(result.is_ok());
 
-        let pre_rent_state = vec![TransactionAccountStateInfo {
-            info: Some(WritableTransactionAccountStateInfo {
-                rent_state: RentState::Uninitialized,
-                data_size: 0,
-            }),
-        }];
-        let post_rent_state = vec![TransactionAccountStateInfo {
-            info: Some(WritableTransactionAccountStateInfo {
-                rent_state: RentState::RentPaying {
-                    data_size: 2,
-                    lamports: 5,
-                },
+        let pre_state_infos = vec![state_info(RentState::Uninitialized, 0, 0, owner)];
+        let post_rent_states = vec![state_info(
+            RentState::RentPaying {
                 data_size: 2,
-            }),
-        }];
+                lamports: 5,
+            },
+            0,
+            0,
+            owner,
+        )];
 
         let transaction_accounts = vec![
             (key1.pubkey(), AccountSharedData::default()),
@@ -263,11 +691,7 @@ mod test {
         ];
 
         let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 1);
-        let result = TransactionAccountStateInfo::verify_changes(
-            &pre_rent_state,
-            &post_rent_state,
-            &context,
-        );
+        let result = verify_changes(&pre_state_infos, &post_rent_states, &context);
         assert_eq!(
             result.err(),
             Some(TransactionError::InsufficientFundsForRent { account_index: 0 })
@@ -276,31 +700,13 @@ mod test {
 
     #[test]
     fn test_get_uninitialized_accounts_size_with_deleted_accounts() {
+        let owner1 = Pubkey::new_unique();
+        let owner2 = Pubkey::new_unique();
+        let owner3 = Pubkey::new_unique();
         let post_state_infos = vec![
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::Uninitialized,
-                    data_size: 50,
-                }),
-            },
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::Uninitialized,
-                    data_size: 50,
-                }),
-            },
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::Uninitialized,
-                    data_size: 50,
-                }),
-            },
-            TransactionAccountStateInfo {
-                info: Some(WritableTransactionAccountStateInfo {
-                    rent_state: RentState::RentExempt,
-                    data_size: 50,
-                }),
-            },
+            state_info(RentState::Uninitialized, 0, 50, owner1),
+            state_info(RentState::Uninitialized, 0, 50, owner2),
+            state_info(RentState::Uninitialized, 0, 50, owner3),
         ];
 
         // 3 deleted accounts should contribute 3 * (50) = 150 to the count

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -1,12 +1,14 @@
 use {
-    crate::rent_calculator::{RentState, check_rent_state, get_account_rent_state},
+    crate::rent_calculator::{
+        RentState, check_rent_state, get_post_exec_account_rent_state,
+        get_pre_exec_account_rent_state,
+    },
     solana_account::ReadableAccount,
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction_context::{IndexOfAccount, transaction::TransactionContext},
     solana_transaction_error::TransactionResult as Result,
-    std::cmp::min,
 };
 
 #[derive(PartialEq, Debug, Clone)]
@@ -31,17 +33,12 @@ impl TransactionAccountStateInfo {
                     let balance = account.lamports();
                     let data_size = account.data().len();
                     let owner = *account.owner();
-
-                    let rent_state = if relax_post_exec_min_balance_check {
-                        // SIMD-0392 enabled. Assume `RentPaying` is impossible.
-                        if account.lamports() == 0 {
-                            RentState::Uninitialized
-                        } else {
-                            RentState::RentExempt
-                        }
-                    } else {
-                        get_account_rent_state(balance, data_size, rent.minimum_balance(data_size))
-                    };
+                    let rent_state = get_pre_exec_account_rent_state(
+                        balance,
+                        data_size,
+                        rent.minimum_balance(data_size),
+                        !relax_post_exec_min_balance_check, // SIMD-0392 enabled. Assume `RentPaying` is impossible
+                    );
 
                     WritableTransactionAccountStateInfo {
                         rent_state,
@@ -73,33 +70,38 @@ impl TransactionAccountStateInfo {
                         pre_exec_state_info.info.is_some(),
                         "message and pre-exec state out of sync, fatal"
                     );
+                    if pre_exec_state_info.info.is_none() {
+                        // to avoid panicking in release, treat missing pre-exec info as uninitialized
+                        return WritableTransactionAccountStateInfo::default();
+                    }
 
+                    let pre_exec_state_info = pre_exec_state_info.info.as_ref().unwrap();
                     let balance = account.lamports();
                     let data_size = account.data().len();
-                    let mut min_balance = rent.minimum_balance(data_size);
+                    let min_balance = rent.minimum_balance(data_size);
+                    let owner = *account.owner();
+                    let pre_state = &pre_exec_state_info.rent_state;
+                    let pre_balance = pre_exec_state_info.balance;
 
-                    if relax_post_exec_min_balance_check {
-                        // SIMD-0392 enabled.
-                        // Adjust min_balance according to SIMD-0392.
-                        if let Some(pre_exec_info) = pre_exec_state_info.as_ref() {
-                            // if the account size increased, account was created in this transaction,
-                            // or the owner of the account changed, do standard rent exempt check
-                            // otherwise, pre-exec balance can also be used as the minimum balance
-                            if pre_exec_info.rent_state != RentState::Uninitialized
-                                && data_size <= pre_exec_info.data_size
-                                && account.owner() == &pre_exec_info.owner
-                            {
-                                min_balance = min(pre_exec_info.balance, min_balance);
-                            }
-                        }
-                    }
+                    // Criteria for rent-exempt relaxation as specified by SIMD-392
+                    let relax_rent_exempt_criteria = relax_post_exec_min_balance_check
+                        && *pre_state == RentState::RentExempt
+                        && data_size <= pre_exec_state_info.data_size
+                        && pre_exec_state_info.owner == owner;
 
                     // Post-exec owner is currently not consumed by any caller.
                     WritableTransactionAccountStateInfo {
-                        rent_state: get_account_rent_state(balance, data_size, min_balance),
+                        rent_state: get_post_exec_account_rent_state(
+                            balance,
+                            data_size,
+                            min_balance,
+                            pre_state,
+                            pre_balance,
+                            relax_rent_exempt_criteria,
+                        ),
                         balance,
                         data_size,
-                        owner: *account.owner(),
+                        owner,
                     }
                 });
                 Self { info }
@@ -140,7 +142,7 @@ pub(crate) fn get_uninitialized_accounts_size(post: &[TransactionAccountStateInf
         .sum()
 }
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, Default)]
 pub(crate) struct WritableTransactionAccountStateInfo {
     rent_state: RentState,
     balance: u64,

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -77,7 +77,7 @@ impl TransactionAccountStateInfo {
 
                     // Criteria for rent-exempt relaxation as specified by SIMD-392
                     let relax_rent_exempt_criteria = relax_post_exec_min_balance_check
-                        && data_size <= pre_exec_state_info.data_size
+                        && pre_exec_state_info.data_size >= data_size
                         && *pre_state == RentState::RentExempt
                         && pre_exec_state_info.owner == owner;
 
@@ -260,7 +260,9 @@ mod test {
 
         let data_len = 64;
         let min_full = rent.minimum_balance(data_len);
-        let pre_balance = min_full.saturating_sub(1);
+        let pre_balance = min_full - 1;
+        // account must be both initialized and have a sub-exempt balance
+        assert!(pre_balance > 0);
 
         let sanitized_message = sanitized_msg_for(program, account, other_account);
         let tx_accounts = vec![
@@ -334,7 +336,9 @@ mod test {
 
         let data_len = 64;
         let min_full = rent.minimum_balance(data_len);
-        let pre_balance = min_full.saturating_sub(5); // less than full rent-exempt, but > 0
+        let pre_balance = min_full - 5;
+        // account must be both initialized and have a sub-exempt balance
+        assert!(pre_balance > 0);
 
         let sanitized_message = sanitized_msg_for(program, account, other_account);
         let tx_accounts = vec![
@@ -371,7 +375,9 @@ mod test {
 
         let data_len = 64;
         let min_full = rent.minimum_balance(data_len);
-        let pre_balance = min_full.saturating_sub(5);
+        let pre_balance = min_full - 5;
+        // account must be both initialized and have a sub-exempt balance
+        assert!(pre_balance > 0);
 
         let sanitized_message = sanitized_msg_for(program, account, other_account);
         let tx_accounts = vec![
@@ -412,7 +418,9 @@ mod test {
 
         let data_len = 64;
         let min_full = rent.minimum_balance(data_len);
-        let pre_balance = min_full.saturating_sub(5);
+        let pre_balance = min_full - 5;
+        // account must be both initialized and have a sub-exempt balance
+        assert!(pre_balance > 0);
 
         let sanitized_message = sanitized_msg_for(program, account, other_account);
         let mut tx_accounts = vec![
@@ -432,7 +440,8 @@ mod test {
         );
 
         // post: drop balance by 1 (below minimum balance)
-        let post_balance = pre_balance.saturating_sub(1);
+        let post_balance = pre_balance - 1;
+        assert!(pre_balance > 0);
         tx_accounts[0].1.set_lamports(post_balance);
 
         let context_post = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 2);
@@ -461,16 +470,21 @@ mod test {
     }
 
     #[test]
-    fn test_post_exec_size_changed_requires_full_min() {
+    fn test_post_exec_size_changed_requires_current_rent_min() {
         let rent = Rent::default();
         let account = Pubkey::new_unique();
         let program = Pubkey::new_unique();
         let other_account = Pubkey::new_unique();
 
         let pre_len = 32;
-        let post_len = 256; // larger size => larger full min
+        // size increase prevents the post-exec rent-exempt relaxation from applying,
+        // so the account will be subject to the full rent-exempt minimum during balance
+        // checks.
+        let post_len = 256;
         let pre_min = rent.minimum_balance(pre_len);
-        let pre_balance = pre_min.saturating_sub(1);
+        let pre_balance = pre_min - 1;
+        // account must be both initialized and have a sub-exempt balance
+        assert!(pre_balance > 0);
 
         let sanitized_message = sanitized_msg_for(program, account, other_account);
 
@@ -595,7 +609,9 @@ mod test {
 
         let data_len = 64;
         let min_full = rent.minimum_balance(data_len);
-        let pre_balance = min_full.saturating_sub(5);
+        let pre_balance = min_full - 5;
+        // account must be both initialized and have a sub-exempt balance
+        assert!(pre_balance > 0);
 
         let sanitized_message = sanitized_msg_for(program, account, other_account);
 

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -9,7 +9,7 @@ use {
     std::cmp::min,
 };
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub(crate) struct TransactionAccountStateInfo {
     info: Option<WritableTransactionAccountStateInfo>, // None: readonly account
 }
@@ -25,7 +25,7 @@ impl TransactionAccountStateInfo {
         rent: &Rent,
         relax_post_exec_min_balance_check: bool,
     ) -> Vec<Self> {
-        iter_accounts(transaction_context, message)
+        write_iter_accounts(transaction_context, message)
             .map(|acct_ref| {
                 let info = acct_ref.map(|account| {
                     let balance = account.lamports();
@@ -33,7 +33,7 @@ impl TransactionAccountStateInfo {
                     let owner = *account.owner();
 
                     let rent_state = if relax_post_exec_min_balance_check {
-                        // SIMD-0392 enabled. Assume `RentExempt` is impossible.
+                        // SIMD-0392 enabled. Assume `RentPaying` is impossible.
                         if account.lamports() == 0 {
                             RentState::Uninitialized
                         } else {
@@ -64,7 +64,7 @@ impl TransactionAccountStateInfo {
     ) -> Vec<Self> {
         debug_assert_eq!(pre_exec_state_infos.len(), message.account_keys().len());
 
-        iter_accounts(transaction_context, message)
+        write_iter_accounts(transaction_context, message)
             .zip(pre_exec_state_infos)
             .map(|(acct_ref, pre_exec_state_info)| {
                 let info = acct_ref.map(|account| {
@@ -99,7 +99,7 @@ impl TransactionAccountStateInfo {
                         rent_state: get_account_rent_state(balance, data_size, min_balance),
                         balance,
                         data_size,
-                        owner: Pubkey::default(), // pubkey isn't needed for post-exec
+                        owner: *account.owner(),
                     }
                 });
                 Self { info }
@@ -140,7 +140,7 @@ pub(crate) fn get_uninitialized_accounts_size(post: &[TransactionAccountStateInf
         .sum()
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub(crate) struct WritableTransactionAccountStateInfo {
     rent_state: RentState,
     balance: u64,
@@ -148,7 +148,7 @@ pub(crate) struct WritableTransactionAccountStateInfo {
     owner: Pubkey,
 }
 
-fn iter_accounts<'a>(
+fn write_iter_accounts<'a>(
     transaction_context: &'a TransactionContext,
     message: &impl SVMMessage,
 ) -> impl Iterator<Item = Option<solana_transaction_context::transaction_accounts::AccountRef<'a>>>
@@ -189,9 +189,13 @@ mod test {
     };
 
     // Helpers to reduce duplication in tests
-    fn sanitized_msg_for(key1: Pubkey, key2: Pubkey, key4: Pubkey) -> SanitizedMessage {
+    fn sanitized_msg_for(
+        program_key: Pubkey,
+        writable_key: Pubkey,
+        other_writable_key: Pubkey,
+    ) -> SanitizedMessage {
         let message = Message {
-            account_keys: vec![key2, key1, key4],
+            account_keys: vec![writable_key, program_key, other_writable_key],
             header: MessageHeader::default(),
             instructions: vec![
                 CompiledInstruction {
@@ -210,65 +214,46 @@ mod test {
         SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()))
     }
 
-    fn accounts_key2_first(
-        key1: Pubkey,
-        key2: Pubkey,
-        key3: Pubkey,
-        acc2: AccountSharedData,
-    ) -> Vec<(Pubkey, AccountSharedData)> {
-        vec![
-            (key2, acc2),
-            (key1, AccountSharedData::default()),
-            (key3, AccountSharedData::default()),
-        ]
-    }
-
-    fn ctx_from(accounts: Vec<(Pubkey, AccountSharedData)>, rent: &Rent) -> TransactionContext<'_> {
-        TransactionContext::new(accounts, rent.clone(), 20, 20, 1)
-    }
-
-    fn state_info(
-        rent_state: RentState,
-        balance: u64,
-        data_size: usize,
-        owner: Pubkey,
-    ) -> TransactionAccountStateInfo {
-        TransactionAccountStateInfo {
-            info: Some(WritableTransactionAccountStateInfo {
-                rent_state,
-                balance,
-                data_size,
-                owner,
-            }),
-        }
-    }
-
     #[test]
     fn test_pre_exec_basics() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
 
         let transaction_accounts = vec![
-            (key1.pubkey(), AccountSharedData::default()),
-            (key2.pubkey(), AccountSharedData::default()),
-            (key3.pubkey(), AccountSharedData::default()),
+            (account.pubkey(), AccountSharedData::default()),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
         ];
         let default_owner = Pubkey::default();
 
-        let context = TransactionContext::new(transaction_accounts, rent.clone(), 20, 20, 1);
+        let context = TransactionContext::new(transaction_accounts, rent.clone(), 20, 20, 2);
         let result =
             TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, true);
         assert_eq!(
             result,
             vec![
-                state_info(RentState::Uninitialized, 0, 0, default_owner),
+                TransactionAccountStateInfo {
+                    info: Some(WritableTransactionAccountStateInfo {
+                        rent_state: RentState::Uninitialized,
+                        balance: 0,
+                        data_size: 0,
+                        owner: default_owner,
+                    }),
+                },
                 TransactionAccountStateInfo { info: None },
-                state_info(RentState::Uninitialized, 0, 0, default_owner),
+                TransactionAccountStateInfo {
+                    info: Some(WritableTransactionAccountStateInfo {
+                        rent_state: RentState::Uninitialized,
+                        balance: 0,
+                        data_size: 0,
+                        owner: default_owner,
+                    }),
+                },
             ]
         );
 
@@ -278,23 +263,25 @@ mod test {
     #[test]
     fn test_pre_exec_legacy_rent_paying() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
         let data_len: usize = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(1);
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
-        let tx_accounts = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
-        );
-        let context = ctx_from(tx_accounts, &rent);
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let tx_accounts = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 2);
         let pre =
             TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, false);
 
@@ -311,13 +298,18 @@ mod test {
     #[should_panic(expected = "message and transaction context out of sync, fatal")]
     fn test_new_panic() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
+        let extra_account = Keypair::new();
 
         let message = Message {
-            account_keys: vec![key2.pubkey(), key1.pubkey(), key4.pubkey(), key3.pubkey()],
+            account_keys: vec![
+                account.pubkey(),
+                program.pubkey(),
+                other_account.pubkey(),
+                extra_account.pubkey(),
+            ],
             header: MessageHeader::default(),
             instructions: vec![
                 CompiledInstruction {
@@ -338,12 +330,12 @@ mod test {
             SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()));
 
         let transaction_accounts = vec![
-            (key1.pubkey(), AccountSharedData::default()),
-            (key2.pubkey(), AccountSharedData::default()),
-            (key3.pubkey(), AccountSharedData::default()),
+            (account.pubkey(), AccountSharedData::default()),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
         ];
 
-        let context = TransactionContext::new(transaction_accounts, rent.clone(), 20, 20, 1);
+        let context = TransactionContext::new(transaction_accounts, rent.clone(), 20, 20, 2);
         let _result =
             TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, true);
     }
@@ -351,23 +343,25 @@ mod test {
     #[test]
     fn test_post_exec_unchanged_size_allows_pre_balance() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
         let data_len: usize = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5); // less than full rent-exempt, but > 0
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
-        let tx_accounts = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
-        );
-        let context = ctx_from(tx_accounts, &rent);
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let tx_accounts = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 2);
         let pre =
             TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, true);
         let post = TransactionAccountStateInfo::new_post_exec(
@@ -378,7 +372,6 @@ mod test {
             true,
         );
 
-        // account index 0 in message is key2; expect RentExempt due to grace
         assert_eq!(
             post[0].as_ref().map(|info| &info.rent_state),
             Some(&RentState::RentExempt)
@@ -388,23 +381,25 @@ mod test {
     #[test]
     fn test_post_exec_legacy_ignores_pre_balance() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
         let data_len: usize = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5);
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
-        let tx_accounts = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
-        );
-        let context = ctx_from(tx_accounts, &rent);
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let tx_accounts = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 2);
         let pre =
             TransactionAccountStateInfo::new_pre_exec(&context, &sanitized_message, &rent, false);
         let post = TransactionAccountStateInfo::new_post_exec(
@@ -428,23 +423,25 @@ mod test {
     #[test]
     fn test_post_exec_unchanged_size_violation() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
         let data_len: usize = 64;
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5);
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
-        let mut tx_accounts = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
-        );
-        let context_pre = TransactionContext::new(tx_accounts.clone(), rent.clone(), 20, 20, 1);
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
+        let mut tx_accounts = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, data_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_pre = TransactionContext::new(tx_accounts.clone(), rent.clone(), 20, 20, 2);
         let pre = TransactionAccountStateInfo::new_pre_exec(
             &context_pre,
             &sanitized_message,
@@ -456,7 +453,7 @@ mod test {
         let post_balance = pre_balance.saturating_sub(1);
         tx_accounts[0].1.set_lamports(post_balance);
 
-        let context_post = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 1);
+        let context_post = TransactionContext::new(tx_accounts, rent.clone(), 20, 20, 2);
         let post = TransactionAccountStateInfo::new_post_exec(
             &context_post,
             &sanitized_message,
@@ -484,25 +481,27 @@ mod test {
     #[test]
     fn test_post_exec_size_changed_requires_full_min() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
         let pre_len: usize = 32;
         let post_len: usize = 256; // larger size => larger full min
         let pre_min = rent.minimum_balance(pre_len);
         let pre_balance = pre_min.saturating_sub(1);
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
 
-        let tx_accounts_pre = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
-        );
-        let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 1);
+        let tx_accounts_pre = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 2);
         let pre = TransactionAccountStateInfo::new_pre_exec(
             &context_pre,
             &sanitized_message,
@@ -511,13 +510,15 @@ mod test {
         );
 
         // post: size increased; balance unchanged => should require full min for new size
-        let tx_accounts_post = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
-        );
-        let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 1);
+        let tx_accounts_post = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 2);
         let post = TransactionAccountStateInfo::new_post_exec(
             &context_post,
             &sanitized_message,
@@ -548,10 +549,9 @@ mod test {
             ..Rent::default()
         };
 
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
 
         let pre_len: usize = 256;
         let post_len: usize = pre_len / 8; // smaller size, but rent increased after creation
@@ -559,15 +559,18 @@ mod test {
         let post_min = post_rent.minimum_balance(post_len);
         assert!(post_min > pre_balance);
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
 
-        let tx_accounts_pre = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
-        );
-        let context_pre = TransactionContext::new(tx_accounts_pre, pre_rent.clone(), 20, 20, 1);
+        let tx_accounts_pre = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, pre_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_pre = TransactionContext::new(tx_accounts_pre, pre_rent.clone(), 20, 20, 2);
         let pre = TransactionAccountStateInfo::new_pre_exec(
             &context_pre,
             &sanitized_message,
@@ -576,13 +579,15 @@ mod test {
         );
 
         // post: size decreased; rent increased => should still not require top-up
-        let tx_accounts_post = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
-        );
-        let context_post = TransactionContext::new(tx_accounts_post, post_rent.clone(), 20, 20, 1);
+        let tx_accounts_post = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, post_len, &Pubkey::default()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_post = TransactionContext::new(tx_accounts_post, post_rent.clone(), 20, 20, 2);
         let post = TransactionAccountStateInfo::new_post_exec(
             &context_post,
             &sanitized_message,
@@ -599,10 +604,9 @@ mod test {
     #[test]
     fn test_post_exec_owner_changed_requires_full_min() {
         let rent = Rent::default();
-        let key1 = Keypair::new();
-        let key2 = Keypair::new();
-        let key3 = Keypair::new();
-        let key4 = Keypair::new();
+        let account = Keypair::new();
+        let program = Keypair::new();
+        let other_account = Keypair::new();
         let owner_pre = Keypair::new();
         let owner_post = Keypair::new();
 
@@ -610,15 +614,18 @@ mod test {
         let min_full = rent.minimum_balance(data_len);
         let pre_balance = min_full.saturating_sub(5);
 
-        let sanitized_message = sanitized_msg_for(key1.pubkey(), key2.pubkey(), key4.pubkey());
+        let sanitized_message =
+            sanitized_msg_for(program.pubkey(), account.pubkey(), other_account.pubkey());
 
-        let tx_accounts_pre = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, data_len, &owner_pre.pubkey()),
-        );
-        let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 1);
+        let tx_accounts_pre = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, data_len, &owner_pre.pubkey()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_pre = TransactionContext::new(tx_accounts_pre, rent.clone(), 20, 20, 2);
         let pre = TransactionAccountStateInfo::new_pre_exec(
             &context_pre,
             &sanitized_message,
@@ -627,13 +634,15 @@ mod test {
         );
 
         // post: owner changed; balance/size unchanged => should require full min
-        let tx_accounts_post = accounts_key2_first(
-            key1.pubkey(),
-            key2.pubkey(),
-            key3.pubkey(),
-            AccountSharedData::new(pre_balance, data_len, &owner_post.pubkey()),
-        );
-        let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 1);
+        let tx_accounts_post = vec![
+            (
+                account.pubkey(),
+                AccountSharedData::new(pre_balance, data_len, &owner_post.pubkey()),
+            ),
+            (program.pubkey(), AccountSharedData::default()),
+            (other_account.pubkey(), AccountSharedData::default()),
+        ];
+        let context_post = TransactionContext::new(tx_accounts_post, rent.clone(), 20, 20, 2);
         let post = TransactionAccountStateInfo::new_post_exec(
             &context_post,
             &sanitized_message,
@@ -658,39 +667,64 @@ mod test {
 
     #[test]
     fn test_verify_changes() {
+        // mostly a sanity check for the plumbing since transitions_allowed enforces
+        // the specific transition rules.
         let key1 = Keypair::new();
         let key2 = Keypair::new();
         let owner = Pubkey::default();
-        let pre_state_infos = vec![state_info(RentState::Uninitialized, 0, 0, owner)];
-        let post_rent_states = vec![state_info(RentState::Uninitialized, 0, 0, owner)];
+        let pre_state_infos = vec![TransactionAccountStateInfo {
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state: RentState::Uninitialized,
+                balance: 0,
+                data_size: 0,
+                owner,
+            }),
+        }];
+        let post_rent_states = vec![TransactionAccountStateInfo {
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state: RentState::Uninitialized,
+                balance: 0,
+                data_size: 0,
+                owner,
+            }),
+        }];
 
         let transaction_accounts = vec![
             (key1.pubkey(), AccountSharedData::default()),
             (key2.pubkey(), AccountSharedData::default()),
         ];
 
-        let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 1);
+        let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 2);
 
         let result = verify_changes(&pre_state_infos, &post_rent_states, &context);
         assert!(result.is_ok());
 
-        let pre_state_infos = vec![state_info(RentState::Uninitialized, 0, 0, owner)];
-        let post_rent_states = vec![state_info(
-            RentState::RentPaying {
-                data_size: 2,
-                lamports: 5,
-            },
-            0,
-            0,
-            owner,
-        )];
+        let pre_state_infos = vec![TransactionAccountStateInfo {
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state: RentState::Uninitialized,
+                balance: 0,
+                data_size: 0,
+                owner,
+            }),
+        }];
+        let post_rent_states = vec![TransactionAccountStateInfo {
+            info: Some(WritableTransactionAccountStateInfo {
+                rent_state: RentState::RentPaying {
+                    data_size: 2,
+                    lamports: 5,
+                },
+                balance: 0,
+                data_size: 0,
+                owner,
+            }),
+        }];
 
         let transaction_accounts = vec![
             (key1.pubkey(), AccountSharedData::default()),
             (key2.pubkey(), AccountSharedData::default()),
         ];
 
-        let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 1);
+        let context = TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 2);
         let result = verify_changes(&pre_state_infos, &post_rent_states, &context);
         assert_eq!(
             result.err(),
@@ -700,13 +734,17 @@ mod test {
 
     #[test]
     fn test_get_uninitialized_accounts_size_with_deleted_accounts() {
-        let owner1 = Pubkey::new_unique();
-        let owner2 = Pubkey::new_unique();
-        let owner3 = Pubkey::new_unique();
         let post_state_infos = vec![
-            state_info(RentState::Uninitialized, 0, 50, owner1),
-            state_info(RentState::Uninitialized, 0, 50, owner2),
-            state_info(RentState::Uninitialized, 0, 50, owner3),
+            TransactionAccountStateInfo {
+                info: Some(WritableTransactionAccountStateInfo {
+                    rent_state: RentState::Uninitialized,
+                    balance: 0,
+                    data_size: 50,
+                    owner: Pubkey::new_unique(),
+                }),
+            }
+            .clone();
+            3
         ];
 
         // 3 deleted accounts should contribute 3 * (50) = 150 to the count

--- a/svm/src/transaction_account_state_info.rs
+++ b/svm/src/transaction_account_state_info.rs
@@ -482,7 +482,6 @@ mod test {
             res.err(),
             Some(TransactionError::InsufficientFundsForRent { account_index: 0 })
         );
-
     }
 
     #[test]

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -11,7 +11,7 @@ use {
         program_loader::{get_program_deployment_slot, load_program_with_pubkey},
         rollback_accounts::RollbackAccounts,
         transaction_account_state_info::{
-            TransactionAccountStateInfo, get_uninitialized_accounts_size,
+            TransactionAccountStateInfo, get_uninitialized_accounts_size, verify_changes,
         },
         transaction_balances::{BalanceCollectionRoutines, BalanceCollector},
         transaction_error_metrics::TransactionErrorMetrics,
@@ -963,8 +963,14 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             tx.num_instructions(),
         );
 
-        let pre_account_state_info =
-            TransactionAccountStateInfo::new(&transaction_context, tx, &environment.rent);
+        let relax_post_exec_min_balance_check =
+            environment.feature_set.relax_post_exec_min_balance_check;
+        let pre_account_state_info = TransactionAccountStateInfo::new_pre_exec(
+            &transaction_context,
+            tx,
+            &environment.rent,
+            relax_post_exec_min_balance_check,
+        );
 
         let log_collector = if config.recording_config.enable_log_recording {
             match config.log_messages_bytes_limit {
@@ -1011,10 +1017,15 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         execute_timings.execute_accessories.process_message_us += process_message_time.as_us();
 
         let mut post_account_state_info_result = process_result
-            .and_then(|_| {
-                let post_account_state_info =
-                    TransactionAccountStateInfo::new(&transaction_context, tx, &environment.rent);
-                TransactionAccountStateInfo::verify_changes(
+            .and_then(|_info| {
+                let post_account_state_info = TransactionAccountStateInfo::new_post_exec(
+                    &transaction_context,
+                    tx,
+                    &pre_account_state_info,
+                    &environment.rent,
+                    relax_post_exec_min_balance_check,
+                );
+                verify_changes(
                     &pre_account_state_info,
                     &post_account_state_info,
                     &transaction_context,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -461,6 +461,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         &environment.blockhash,
                         environment.blockhash_lamports_per_signature,
                         &environment.rent,
+                        environment.feature_set.relax_post_exec_min_balance_check,
                         &mut error_metrics,
                     )
                 }));
@@ -664,6 +665,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         environment_blockhash: &Hash,
         next_lamports_per_signature: u64,
         rent: &Rent,
+        relax_post_exec_min_balance_check: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> TransactionResult<ValidatedTransactionDetails> {
         let CheckedTransactionDetails {
@@ -695,6 +697,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             nonce_info,
             compute_budget_and_limits,
             rent,
+            relax_post_exec_min_balance_check,
             error_counters,
         )
     }
@@ -708,6 +711,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         nonce_info: Option<NonceInfo>,
         compute_budget_and_limits: SVMTransactionExecutionAndFeeBudgetLimits,
         rent: &Rent,
+        relax_post_exec_min_balance_check: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> TransactionResult<ValidatedTransactionDetails> {
         let fee_payer_address = message.fee_payer();
@@ -727,12 +731,12 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         let fee_payer_index = 0;
         validate_fee_payer(
-            fee_payer_address,
             &mut loaded_fee_payer.account,
             fee_payer_index,
             error_counters,
             rent,
             compute_budget_and_limits.fee_details.total_fee(),
+            relax_post_exec_min_balance_check,
         )?;
 
         // Capture fee-subtracted fee payer account and next nonce account state
@@ -2219,6 +2223,7 @@ mod tests {
                 &Hash::default(),
                 lamports_per_signature,
                 &rent,
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2270,6 +2275,7 @@ mod tests {
                 &Hash::default(),
                 lamports_per_signature,
                 &Rent::default(),
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2310,6 +2316,7 @@ mod tests {
                 &Hash::default(),
                 lamports_per_signature,
                 &Rent::default(),
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2354,6 +2361,7 @@ mod tests {
                 &Hash::default(),
                 lamports_per_signature,
                 &rent,
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2396,6 +2404,7 @@ mod tests {
                 &Hash::default(),
                 lamports_per_signature,
                 &Rent::default(),
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2582,6 +2591,7 @@ mod tests {
                 &environment_blockhash,
                 lamports_per_signature,
                 &rent,
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2642,6 +2652,7 @@ mod tests {
                 &environment_blockhash,
                 lamports_per_signature,
                 &rent,
+                mock_bank.feature_set.relax_post_exec_min_balance_check,
                 &mut error_counters,
             );
 
@@ -2690,6 +2701,7 @@ mod tests {
             &Hash::default(),
             lamports_per_signature,
             &Rent::default(),
+            mock_bank.feature_set.relax_post_exec_min_balance_check,
             &mut TransactionErrorMetrics::default(),
         )
         .unwrap();

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -2537,7 +2537,7 @@ fn simd0392_balance_checks() -> Vec<SvmTestEntry> {
         let fee_payer_keypair = Keypair::new();
         let fee_payer = fee_payer_keypair.pubkey();
         let fee_payer_data =
-            mk_system_account(old_min_balance + LAMPORTS_PER_SIGNATURE, target_size);
+            mk_system_account(new_min_balance + LAMPORTS_PER_SIGNATURE - 1, target_size);
         test_entry.add_initial_account(fee_payer, &fee_payer_data);
 
         let target = Pubkey::new_unique();

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -2368,6 +2368,196 @@ fn simd83_account_reallocate() -> Vec<SvmTestEntry> {
     test_entries
 }
 
+fn simd0392_balance_checks() -> Vec<SvmTestEntry> {
+    let mut test_entries = vec![];
+
+    let program_name = "write-to-account";
+    let program_id = program_address(program_name);
+
+    let base_rent = Rent::default();
+    let bumped_rent = Rent {
+        lamports_per_byte: base_rent.lamports_per_byte.saturating_mul(4),
+        ..base_rent
+    };
+
+    let target_size = 8usize;
+    let old_min_balance = base_rent.minimum_balance(target_size);
+    let new_min_balance = bumped_rent.minimum_balance(target_size);
+    assert!(new_min_balance > old_min_balance + LAMPORTS_PER_SIGNATURE);
+
+    let mk_program_account = |lamports, size| {
+        AccountSharedData::create_from_existing_shared_data(
+            lamports,
+            Arc::new(vec![0; size]),
+            program_id,
+            false,
+            u64::MAX,
+        )
+    };
+
+    let mk_system_account = |lamports, size| {
+        AccountSharedData::create_from_existing_shared_data(
+            lamports,
+            Arc::new(vec![0; size]),
+            system_program::id(),
+            false,
+            u64::MAX,
+        )
+    };
+
+    // write-only should succeed below updated rent minimum
+    {
+        let mut test_entry = SvmTestEntry::default();
+        test_entry.set_rent_params(bumped_rent.clone());
+        test_entry.add_initial_program(program_name);
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        fee_payer_data.set_rent_epoch(u64::MAX);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let target = Pubkey::new_unique();
+        let target_data = mk_program_account(old_min_balance, target_size);
+        test_entry.add_initial_account(target, &target_data);
+
+        let set_data_transaction = WriteProgramInstruction::Set.create_transaction(
+            program_id,
+            &fee_payer_keypair,
+            target,
+            None,
+        );
+        test_entry.push_transaction(set_data_transaction);
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+
+        let mut expected_target = target_data;
+        expected_target.data_as_mut_slice()[0] = 100;
+        test_entry.update_expected_account_data(target, &expected_target);
+
+        test_entries.push(test_entry);
+    }
+
+    // realloc to a smaller size should succeed below updated rent minimum
+    {
+        let mut test_entry = SvmTestEntry::default();
+        test_entry.set_rent_params(bumped_rent.clone());
+        test_entry.add_initial_program(program_name);
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        fee_payer_data.set_rent_epoch(u64::MAX);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let target = Pubkey::new_unique();
+        let target_data = mk_program_account(old_min_balance, target_size);
+        test_entry.add_initial_account(target, &target_data);
+
+        let new_target_size = target_size - 1;
+        let realloc_transaction = WriteProgramInstruction::Realloc(new_target_size)
+            .create_transaction(program_id, &fee_payer_keypair, target, None);
+        test_entry.push_transaction(realloc_transaction);
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+
+        let expected_target = mk_program_account(old_min_balance, new_target_size);
+        test_entry.update_expected_account_data(target, &expected_target);
+
+        test_entries.push(test_entry);
+    }
+
+    // realloc to a larger size should fail below updated rent minimum
+    {
+        let mut test_entry = SvmTestEntry::default();
+        test_entry.set_rent_params(bumped_rent.clone());
+        test_entry.add_initial_program(program_name);
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        fee_payer_data.set_rent_epoch(u64::MAX);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let target = Pubkey::new_unique();
+        let target_data = mk_program_account(old_min_balance, target_size);
+        test_entry.add_initial_account(target, &target_data);
+
+        let new_target_size = target_size + 1;
+        let realloc_transaction = WriteProgramInstruction::Realloc(new_target_size)
+            .create_transaction(program_id, &fee_payer_keypair, target, None);
+        test_entry
+            .push_transaction_with_status(realloc_transaction, ExecutionStatus::ExecutedFailed);
+
+        test_entry.decrease_expected_lamports(&fee_payer, LAMPORTS_PER_SIGNATURE);
+
+        test_entries.push(test_entry);
+    }
+
+    // owner change should fail below updated rent minimum
+    {
+        let mut test_entry = SvmTestEntry::default();
+        test_entry.set_rent_params(bumped_rent.clone());
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+        let mut fee_payer_data = AccountSharedData::default();
+        fee_payer_data.set_lamports(LAMPORTS_PER_SOL);
+        fee_payer_data.set_rent_epoch(u64::MAX);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let target_keypair = Keypair::new();
+        let target = target_keypair.pubkey();
+        let target_data = mk_system_account(old_min_balance, target_size);
+        test_entry.add_initial_account(target, &target_data);
+
+        let new_owner = Pubkey::new_unique();
+        let transaction = Transaction::new_signed_with_payer(
+            &[system_instruction::assign(&target, &new_owner)],
+            Some(&fee_payer),
+            &[&fee_payer_keypair, &target_keypair],
+            Hash::default(),
+        );
+        test_entry.push_transaction_with_status(transaction, ExecutionStatus::ExecutedFailed);
+
+        test_entry.decrease_expected_lamports(&fee_payer, 2 * LAMPORTS_PER_SIGNATURE);
+
+        test_entries.push(test_entry);
+    }
+
+    // fee payer drops below updated rent minimum, should fail
+    {
+        let mut test_entry = SvmTestEntry::default();
+        test_entry.set_rent_params(bumped_rent.clone());
+        test_entry.add_initial_program(program_name);
+
+        let fee_payer_keypair = Keypair::new();
+        let fee_payer = fee_payer_keypair.pubkey();
+        let fee_payer_data =
+            mk_system_account(old_min_balance + LAMPORTS_PER_SIGNATURE, target_size);
+        test_entry.add_initial_account(fee_payer, &fee_payer_data);
+
+        let target = Pubkey::new_unique();
+        let target_data = mk_program_account(old_min_balance, target_size);
+        test_entry.add_initial_account(target, &target_data);
+
+        let set_data_transaction = WriteProgramInstruction::Set.create_transaction(
+            program_id,
+            &fee_payer_keypair,
+            target,
+            None,
+        );
+        test_entry.push_transaction_with_status(set_data_transaction, ExecutionStatus::Discarded);
+
+        test_entries.push(test_entry);
+    }
+
+    test_entries
+}
+
 enum AbortReason {
     None,
     Unprocessable,
@@ -2549,6 +2739,7 @@ fn drop_on_failure_batch(statuses: &[bool]) -> Vec<SvmTestEntry> {
 #[test_case(simd83_account_deallocate())]
 #[test_case(simd83_fee_payer_deallocate())]
 #[test_case(simd83_account_reallocate())]
+#[test_case(simd0392_balance_checks())]
 #[test_case(all_or_nothing(AbortReason::None))]
 #[test_case(all_or_nothing(AbortReason::Unprocessable))]
 #[test_case(all_or_nothing(AbortReason::DropOnFailure))]

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -2527,34 +2527,6 @@ fn simd0392_balance_checks() -> Vec<SvmTestEntry> {
 
         test_entries.push(test_entry);
     }
-
-    // fee payer drops below updated rent minimum, should fail
-    {
-        let mut test_entry = SvmTestEntry::default();
-        test_entry.set_rent_params(bumped_rent.clone());
-        test_entry.add_initial_program(program_name);
-
-        let fee_payer_keypair = Keypair::new();
-        let fee_payer = fee_payer_keypair.pubkey();
-        let fee_payer_data =
-            mk_system_account(new_min_balance + LAMPORTS_PER_SIGNATURE - 1, target_size);
-        test_entry.add_initial_account(fee_payer, &fee_payer_data);
-
-        let target = Pubkey::new_unique();
-        let target_data = mk_program_account(old_min_balance, target_size);
-        test_entry.add_initial_account(target, &target_data);
-
-        let set_data_transaction = WriteProgramInstruction::Set.create_transaction(
-            program_id,
-            &fee_payer_keypair,
-            target,
-            None,
-        );
-        test_entry.push_transaction_with_status(set_data_transaction, ExecutionStatus::Discarded);
-
-        test_entries.push(test_entry);
-    }
-
     test_entries
 }
 

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -2380,7 +2380,7 @@ fn simd0392_balance_checks() -> Vec<SvmTestEntry> {
         ..base_rent
     };
 
-    let target_size = 8usize;
+    let target_size = 8;
     let old_min_balance = base_rent.minimum_balance(target_size);
     let new_min_balance = bumped_rent.minimum_balance(target_size);
     assert!(new_min_balance > old_min_balance + LAMPORTS_PER_SIGNATURE);


### PR DESCRIPTION
#### Description

Runtime related changes for [SIMD-0392](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0392-rent-increase-adaptations.md). Separated from the stake rewards related [changes](https://github.com/anza-xyz/agave/pull/12408) to make reviewing easier.

#### Summary of Changes
- For any RentState transition checks on accounts, the definition of RentExempt is expanded as defined in SIMD-0392:
   - if account size and ownership haven't changed, the account exists pre-transition, and the new balance is no less than the pre-transition balance then the account is considered RentExempt post-transition.
- These relaxed rules apply to all RentState transitions, including regularly transaction execution, fee paying, and fee distribution.
- Transaction execution rent transition validation logic is primarily implemented in `transaction_account_state_info.rs`. This is the bulk of the overall implementation.
  - Every other transition is enforced by `check_static_account_rent_state_transition()`.