### PR TITLE
[SIMD-0392 - stake rewards]: Rent increase adaptations

### DIFF
--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -139,6 +139,58 @@ impl StakeReward {
         }
     }
 
+    pub fn new_with_pre_stake_account(
+        reward_lamports: i64,
+        stake_lamports: u64,
+        rent: &Rent,
+    ) -> (AccountSharedData, Self) {
+        let vote_pubkey = Pubkey::new_unique();
+        let node_pubkey = Pubkey::new_unique();
+        let vote_account = vote_state::create_v4_account_with_authorized(
+            &node_pubkey,
+            &vote_pubkey,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
+            &vote_pubkey,
+            1000,
+            &vote_pubkey,
+            0,
+            &node_pubkey,
+            stake_lamports,
+        );
+
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let stake_pubkey = Pubkey::new_unique();
+        let pre_stake_account = create_stake_account(
+            &stake_pubkey,
+            &vote_pubkey,
+            &vote_account,
+            rent,
+            rent_exempt_reserve + stake_lamports,
+        );
+        let post_stake_account = create_stake_account(
+            &stake_pubkey,
+            &vote_pubkey,
+            &vote_account,
+            rent,
+            rent_exempt_reserve + stake_lamports + reward_lamports as u64,
+        );
+
+        (
+            pre_stake_account,
+            Self {
+                stake_pubkey,
+                stake_reward_info: StakeRewardInfo {
+                    reward_type: solana_reward_info::RewardType::Staking,
+                    lamports: reward_lamports,
+                    post_balance: 0,         /* unused atm */
+                    commission_bps: Some(0), /* unused but tests require some value */
+                },
+
+                stake_account: post_stake_account,
+            },
+        )
+    }
+
     pub fn credit(&mut self, amount: u64) {
         self.stake_reward_info.lamports = amount as i64;
         self.stake_reward_info.post_balance += amount;
@@ -160,6 +212,7 @@ fn create_stake_account(
     let vote_state =
         vote_state::VoteStateV4::deserialize(vote_account.data(), voter_pubkey).unwrap();
     let credits_observed = vote_state.credits();
+    let last_epoch = vote_state.epoch_credits.last().map(|c| c.0).unwrap_or(0);
 
     let rent_exempt_reserve = rent.minimum_balance(stake_account.data().len());
     let stake_amount = lamports
@@ -173,10 +226,14 @@ fn create_stake_account(
         ..Meta::default()
     };
 
-    let stake = Stake {
+    let mut stake = Stake {
         delegation: Delegation::new(voter_pubkey, stake_amount, Epoch::MAX),
         credits_observed,
     };
+
+    if stake_amount == 0 {
+        stake.delegation.deactivation_epoch = last_epoch;
+    }
 
     stake_account
         .set_state(&StakeStateV2::Stake(meta, stake, StakeFlags::empty()))

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -780,8 +780,10 @@ impl JsonRpcRequestProcessor {
                 first_confirmed_block_in_epoch,
                 &addresses,
                 &|reward_type| -> bool {
+                    let is_staking_reward = reward_type == RewardType::Staking
+                        || reward_type == RewardType::DeactivatedStake;
                     reward_type == RewardType::Voting
-                        || (!epoch_has_partitioned_rewards && reward_type == RewardType::Staking)
+                        || (!epoch_has_partitioned_rewards && is_staking_reward)
                 },
             )
             .collect()
@@ -861,7 +863,10 @@ impl JsonRpcRequestProcessor {
                     block.rewards,
                     slot,
                     addresses,
-                    &|reward_type| -> bool { reward_type == RewardType::Staking },
+                    &|reward_type| -> bool {
+                        reward_type == RewardType::Staking
+                            || reward_type == RewardType::DeactivatedStake
+                    },
                 );
                 reward_map.extend(index_reward_map);
             }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -9,6 +9,7 @@ use {
     crate::{
         bank::{RewardCalcTracer, RewardCalculationEvent, RewardsMetrics, null_tracer},
         inflation_rewards::{
+            adjust_delegation_for_rent,
             points::{CalculationEnvironment, DelegatedVoteState, PointValue, calculate_points},
             redeem_rewards,
         },
@@ -131,7 +132,6 @@ impl Bank {
         let stake_rewards = Arc::clone(&stake_rewards.stake_rewards);
 
         let num_partitions = self.get_reward_distribution_num_blocks(&stake_rewards);
-
         self.set_epoch_reward_status_calculation(distribution_starting_block_height, stake_rewards);
 
         self.create_epoch_rewards_sysvar(
@@ -430,6 +430,7 @@ impl Bank {
         new_rate_activation_epoch: Option<Epoch>,
         delay_commission_updates: bool,
         commission_rate_in_basis_points: bool,
+        adjust_delegations_for_rent: bool,
     ) -> Option<DelegationRewards> {
         // curry closure to add the contextual stake_pubkey
         let reward_calc_tracer = reward_calc_tracer.as_ref().map(|outer| {
@@ -447,12 +448,53 @@ impl Bank {
 
         let stake_pubkey = *stake_pubkey;
         let vote_pubkey = stake_account.delegation().voter_pubkey;
+
+        let current_lamports = stake_account.lamports();
+        let minimum_lamports = self
+            .rent_collector
+            .rent
+            .minimum_balance(stake_account.data_len());
+        let mut stake = *stake_account.stake();
+
         let Some(vote_account) = distribution_epoch_vote_accounts.get(&vote_pubkey) else {
             debug!("could not find vote account {vote_pubkey} in cache");
-            return None;
+            // Even if the vote account doesn't exist, there might still be a
+            // need to adjust the stake delegation
+            if adjust_delegations_for_rent {
+                let delegation = stake.delegation.stake;
+                let stake_was_adjusted = adjust_delegation_for_rent(
+                    &mut stake.delegation,
+                    rewarded_epoch,
+                    delegation,
+                    current_lamports,
+                    minimum_lamports,
+                );
+                if stake_was_adjusted {
+                    debug!("delegation for stake {stake_pubkey} was adjusted");
+                    let stake_reward = PartitionedStakeReward {
+                        stake_pubkey,
+                        stake,
+                        stake_reward: 0,
+                        commission_bps: 0,
+                    };
+                    let reward_commission = RewardCommission {
+                        commission_bps: 0,
+                        commission_lamports: 0,
+                    };
+                    return Some(DelegationRewards {
+                        stake_reward,
+                        commission_pubkey: vote_pubkey,
+                        reward_commission,
+                    });
+                } else {
+                    debug!("delegation for stake {stake_pubkey} was not adjusted");
+                    return None;
+                }
+            } else {
+                return None;
+            }
         };
         let vote_state = vote_account.vote_state_view();
-        let stake_state = stake_account.stake_state();
 
         // Fetch the voter commission from past epochs to attempt to
         // delay the effect of commission updates by at least one
@@ -478,7 +520,7 @@ impl Bank {
         };
 
         match redeem_rewards(
-            stake_state,
+            stake,
             commission_bps,
             DelegatedVoteState::from(vote_state),
             CalculationEnvironment {
@@ -487,9 +529,11 @@ impl Bank {
                 stake_history,
                 new_rate_activation_epoch,
                 commission_rate_in_basis_points,
+                adjust_delegations_for_rent,
             },
             reward_calc_tracer,
-            stake_account.lamports(),
+            current_lamports,
+            minimum_lamports,
         ) {
             Ok((stake_reward, commission_lamports, stake)) => {
                 let stake_reward = PartitionedStakeReward {
@@ -532,6 +576,9 @@ impl Bank {
         let feature_snapshot = self.feature_set.snapshot();
         let delay_commission_updates = feature_snapshot.delay_commission_updates;
         let commission_rate_in_basis_points = feature_snapshot.commission_rate_in_basis_points;
+        // Name intentionally doesn't match -- "adjust delegations for rent" is
+        // part of relaxing post-exec min balance checks.
+        let adjust_delegations_for_rent = feature_snapshot.relax_post_exec_min_balance_check;
 
         let mut measure_redeem_rewards = Measure::start("redeem-rewards");
         // For N stake delegations, where N is >1,000,000, we produce:
@@ -561,6 +608,7 @@ impl Bank {
                         new_warmup_cooldown_rate_epoch,
                         delay_commission_updates,
                         commission_rate_in_basis_points,
+                        adjust_delegations_for_rent,
                     );
 
                     let (stake_reward, maybe_reward_record) = match maybe_reward_record {
@@ -866,6 +914,7 @@ mod tests {
         solana_epoch_schedule::EpochSchedule,
         solana_keypair::Keypair,
         solana_native_token::LAMPORTS_PER_SOL,
+        solana_rent::Rent,
         solana_signer::Signer,
         solana_stake_interface::{
             stake_flags::StakeFlags,
@@ -1147,6 +1196,37 @@ mod tests {
         })
     }
 
+    fn create_stake_account(
+        lamports: u64,
+        delegation: u64,
+        vote_address: &Pubkey,
+        activation_epoch: Epoch,
+    ) -> AccountSharedData {
+        let mut stake_account = AccountSharedData::new(
+            lamports,
+            StakeStateV2::size_of(),
+            &solana_sdk_ids::stake::id(),
+        );
+        let rent_exempt_reserve = lamports.saturating_sub(delegation);
+
+        let meta = Meta {
+            authorized: Authorized::auto(&Pubkey::new_unique()),
+            #[expect(deprecated)]
+            rent_exempt_reserve,
+            ..Meta::default()
+        };
+
+        let stake = Stake {
+            delegation: Delegation::new(vote_address, delegation, activation_epoch),
+            credits_observed: 0,
+        };
+
+        stake_account
+            .set_state(&StakeStateV2::Stake(meta, stake, StakeFlags::empty()))
+            .expect("set_state");
+        stake_account
+    }
+
     fn apply_epoch_operations(
         bank: Arc<Bank>,
         bank_forks: &RwLock<BankForks>,
@@ -1189,25 +1269,8 @@ mod tests {
                 let size = StakeStateV2::size_of();
                 let rent_exempt_reserve = bank.rent_collector().rent.minimum_balance(size);
                 let lamports = rent_exempt_reserve + stake_amount;
-                let mut stake_account =
-                    AccountSharedData::new(lamports, size, &solana_sdk_ids::stake::id());
-
-                let meta = Meta {
-                    authorized: Authorized::auto(&Pubkey::new_unique()),
-                    #[expect(deprecated)]
-                    rent_exempt_reserve,
-                    ..Meta::default()
-                };
-
-                let stake = Stake {
-                    delegation: Delegation::new(vote_address, *stake_amount, bank.epoch()),
-                    credits_observed: 0,
-                };
-
-                stake_account
-                    .set_state(&StakeStateV2::Stake(meta, stake, StakeFlags::empty()))
-                    .expect("set_state");
-
+                let stake_account =
+                    create_stake_account(lamports, *stake_amount, vote_address, bank.epoch());
                 bank.store_account(&Pubkey::new_unique(), &stake_account);
             }
 
@@ -1486,6 +1549,85 @@ mod tests {
                 )],
             },
         );
+    }
+
+    #[test]
+    fn test_adjust_delegation_for_prestaked_vote_account() {
+        let GenesisConfigInfo {
+            mut genesis_config,
+            voting_keypair,
+            ..
+        } = genesis_utils::create_genesis_config_with_leader(
+            1_000_000 * LAMPORTS_PER_SOL,
+            &Pubkey::new_unique(),
+            42 * LAMPORTS_PER_SOL,
+        );
+        let genesis_vote_address = voting_keypair.pubkey();
+
+        genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
+        genesis_config.rent = Rent::default();
+
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+
+        let old_delegation = LAMPORTS_PER_SOL;
+        let rent_exempt_amount = genesis_config.rent.minimum_balance(StakeStateV2::size_of());
+
+        let vote_address = Pubkey::new_unique();
+
+        // No rent exemption at all
+        let stake_address_to_adjust = Pubkey::new_unique();
+        let stake_account =
+            create_stake_account(old_delegation, old_delegation, &vote_address, bank.epoch());
+        bank.store_account(&stake_address_to_adjust, &stake_account);
+
+        // Will be deactivated, below rent exemption
+        let stake_address_to_deactivate = Pubkey::new_unique();
+        let stake_account = create_stake_account(
+            rent_exempt_amount - 1,
+            rent_exempt_amount - 1,
+            &vote_address,
+            bank.epoch(),
+        );
+        bank.store_account(&stake_address_to_deactivate, &stake_account);
+
+        // Make a vote account earn points, otherwise stakes don't get updated
+        // at all
+        let bank = apply_epoch_operations(
+            bank,
+            bank_forks.as_ref(),
+            EpochOperations {
+                epoch: 0,
+                vote_operations: vec![(
+                    genesis_vote_address,
+                    VoteOperations {
+                        earned_credits: Some(1000),
+                        ..VoteOperations::default()
+                    },
+                )],
+            },
+        );
+
+        // Advance bank to next slot for distribution, see adjustment
+        let slot = bank.slot();
+        let bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank,
+            SlotLeader::new_unique(),
+            slot + 1,
+        );
+
+        let stake_account = bank.get_account(&stake_address_to_adjust).unwrap();
+        let stake_state: StakeStateV2 = stake_account.state().unwrap();
+        let new_delegation = stake_state.stake().unwrap().delegation.stake;
+        assert_ne!(old_delegation, new_delegation);
+        assert_eq!(old_delegation, new_delegation + rent_exempt_amount);
+
+        let stake_account = bank.get_account(&stake_address_to_deactivate).unwrap();
+        let stake_state: StakeStateV2 = stake_account.state().unwrap();
+        let new_delegation = stake_state.stake().unwrap().delegation;
+        assert_eq!(new_delegation.stake, 0);
+        assert_eq!(new_delegation.deactivation_epoch, 0);
     }
 
     #[test]

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -14,10 +14,15 @@ use {
     serde::{Deserialize, Serialize},
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut},
     solana_accounts_db::stake_rewards::{StakeReward, StakeRewardInfo},
+    solana_clock::Epoch,
     solana_measure::measure_us,
     solana_pubkey::Pubkey,
+    solana_rent::Rent,
     solana_reward_info::RewardType,
-    solana_stake_interface::state::{Delegation, StakeStateV2},
+    solana_stake_interface::{
+        stake_history::StakeHistory,
+        state::{Delegation, StakeStateV2},
+    },
     std::sync::{Arc, atomic::Ordering::Relaxed},
     thiserror::Error,
 };
@@ -190,8 +195,13 @@ impl Bank {
     }
 
     fn build_updated_stake_reward(
+        distribution_epoch: u64,
+        stake_history: &StakeHistory,
+        new_warmup_cooldown_rate_epoch: Option<Epoch>,
         stakes_cache_accounts: &imbl::HashMap<Pubkey, StakeAccount<Delegation>>,
         partitioned_stake_reward: &PartitionedStakeReward,
+        rent: &Rent,
+        adjust_delegations_for_rent: bool,
     ) -> Result<StakeReward, DistributionError> {
         let stake_account = stakes_cache_accounts
             .get(&partitioned_stake_reward.stake_pubkey)
@@ -209,13 +219,25 @@ impl Bank {
         account
             .checked_add_lamports(partitioned_stake_reward.stake_reward)
             .map_err(|_| DistributionError::ArithmeticOverflow)?;
-        assert_eq!(
-            stake
+        if adjust_delegations_for_rent {
+            let minimum_balance = rent.minimum_balance(account.data().len());
+            assert!(
+                partitioned_stake_reward.stake.delegation.stake
+                    <= account.lamports().saturating_sub(minimum_balance),
+                "stake reward delegation must be consistent with the updated stake account \
+                 lamport balance"
+            );
+        } else {
+            let expected_delegation = stake
                 .delegation
                 .stake
-                .saturating_add(partitioned_stake_reward.stake_reward),
-            partitioned_stake_reward.stake.delegation.stake
-        );
+                .saturating_add(partitioned_stake_reward.stake_reward);
+            assert_eq!(
+                expected_delegation, partitioned_stake_reward.stake.delegation.stake,
+                "stake reward delegation must be consistent with the updated stake account \
+                 lamport balance"
+            );
+        }
         account
             .set_state(&StakeStateV2::Stake(
                 meta,
@@ -223,10 +245,21 @@ impl Bank {
                 flags,
             ))
             .map_err(|_| DistributionError::UnableToSetState)?;
+
+        let reward_type = if partitioned_stake_reward.stake.delegation.stake(
+            distribution_epoch,
+            stake_history,
+            new_warmup_cooldown_rate_epoch,
+        ) == 0
+        {
+            RewardType::DeactivatedStake
+        } else {
+            RewardType::Staking
+        };
         Ok(StakeReward {
             stake_pubkey: partitioned_stake_reward.stake_pubkey,
             stake_reward_info: StakeRewardInfo {
-                reward_type: RewardType::Staking,
+                reward_type,
                 lamports: i64::try_from(partitioned_stake_reward.stake_reward).unwrap(),
                 post_balance: account.lamports(),
                 commission_bps: Some(partitioned_stake_reward.commission_bps),
@@ -249,6 +282,11 @@ impl Bank {
         partition_rewards: &StartBlockHeightAndPartitionedRewards,
         partition_index: u64,
     ) -> DistributionResults {
+        let feature_snapshot = self.feature_set.snapshot();
+        // Name intentionally doesn't match -- "adjust delegations for rent" is
+        // part of relaxing post-exec min balance checks.
+        let adjust_delegations_for_rent = feature_snapshot.relax_post_exec_min_balance_check;
+
         let mut lamports_distributed = 0;
         let mut lamports_burned = 0;
         let indices = partition_rewards
@@ -263,6 +301,9 @@ impl Bank {
         let mut updated_stake_rewards = Vec::with_capacity(indices.len());
         let stakes_cache = self.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
+        let stake_history = stakes_cache.history();
+        let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
+        let rent = &self.rent_collector.rent;
         for index in indices {
             let partitioned_stake_reward = partition_rewards
                 .all_stake_rewards
@@ -279,8 +320,15 @@ impl Bank {
                 });
             let stake_pubkey = partitioned_stake_reward.stake_pubkey;
             let reward_amount = partitioned_stake_reward.stake_reward;
-            match Self::build_updated_stake_reward(stakes_cache_accounts, partitioned_stake_reward)
-            {
+            match Self::build_updated_stake_reward(
+                self.epoch,
+                stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                partitioned_stake_reward,
+                rent,
+                adjust_delegations_for_rent,
+            ) {
                 Ok(stake_reward) => {
                     lamports_distributed += reward_amount;
                     updated_stake_rewards.push(stake_reward);
@@ -329,12 +377,14 @@ mod tests {
         solana_reward_info::RewardType,
         solana_stake_interface::{
             stake_flags::StakeFlags,
+            stake_history::StakeHistoryEntry,
             state::{Meta, Stake},
         },
         solana_sysvar as sysvar,
         solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
         solana_vote_program::vote_state,
         std::sync::Arc,
+        test_case::test_case,
     };
 
     #[test]
@@ -618,10 +668,31 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_build_updated_stake_reward() {
+    #[test_case(true; "adjust_delegations_for_rent")]
+    #[test_case(false; "no_adjust_delegations_for_rent")]
+    fn test_build_updated_stake_reward(adjust_delegations_for_rent: bool) {
         let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
         let bank = Bank::new_for_tests(&genesis_config);
+        // add an entry so we can get full deactivation one epoch later
+        let mut stake_history = StakeHistory::default();
+        stake_history.add(
+            0,
+            StakeHistoryEntry {
+                effective: 1_000_000 * LAMPORTS_PER_SOL,
+                activating: LAMPORTS_PER_SOL,
+                deactivating: LAMPORTS_PER_SOL,
+            },
+        );
+
+        let distribution_epoch = bank.epoch + 1;
+        let new_warmup_cooldown_rate_epoch = bank.new_warmup_cooldown_rate_epoch();
+        let mut rent = bank.rent_collector.rent.clone();
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+
+        // Adjust rent down, no impact at all
+        if adjust_delegations_for_rent {
+            rent.lamports_per_byte /= 2;
+        }
 
         let voter_pubkey = Pubkey::new_unique();
         let new_stake = Stake {
@@ -645,13 +716,19 @@ mod tests {
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
         assert_eq!(
-            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward,)
-                .unwrap_err(),
+            Bank::build_updated_stake_reward(
+                distribution_epoch,
+                &stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                &partitioned_stake_reward,
+                &rent,
+                adjust_delegations_for_rent,
+            )
+            .unwrap_err(),
             DistributionError::AccountNotFound
         );
         drop(stakes_cache);
-
-        let rent_exempt_reserve = 2_282_880;
 
         let overflowing_account = Pubkey::new_unique();
         let mut stake_account = AccountSharedData::new(
@@ -676,8 +753,16 @@ mod tests {
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
         assert_eq!(
-            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward,)
-                .unwrap_err(),
+            Bank::build_updated_stake_reward(
+                distribution_epoch,
+                &stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                &partitioned_stake_reward,
+                &rent,
+                adjust_delegations_for_rent,
+            )
+            .unwrap_err(),
             DistributionError::ArithmeticOverflow
         );
         drop(stakes_cache);
@@ -739,8 +824,97 @@ mod tests {
             },
         };
         assert_eq!(
-            Bank::build_updated_stake_reward(stakes_cache_accounts, &partitioned_stake_reward,)
-                .unwrap(),
+            Bank::build_updated_stake_reward(
+                distribution_epoch,
+                &stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                &partitioned_stake_reward,
+                &rent,
+                adjust_delegations_for_rent,
+            )
+            .unwrap(),
+            expected_stake_reward
+        );
+        drop(stakes_cache);
+
+        let deactivating_account = Pubkey::new_unique();
+        let deactivating_stake = Stake {
+            delegation: Delegation {
+                voter_pubkey,
+                stake: 55_555,
+                deactivation_epoch: bank.epoch,
+                ..Delegation::default()
+            },
+            credits_observed: 42,
+        };
+        let starting_stake = deactivating_stake.delegation.stake - stake_reward;
+        let starting_lamports = rent_exempt_reserve + starting_stake;
+        let mut stake_account = AccountSharedData::new(
+            starting_lamports,
+            StakeStateV2::size_of(),
+            &solana_stake_interface::program::id(),
+        );
+        let other_stake = Stake {
+            delegation: Delegation {
+                voter_pubkey,
+                stake: starting_stake,
+                deactivation_epoch: bank.epoch,
+                ..Delegation::default()
+            },
+            credits_observed: 11,
+        };
+        stake_account
+            .set_state(&StakeStateV2::Stake(
+                Meta::default(),
+                other_stake,
+                StakeFlags::default(),
+            ))
+            .unwrap();
+        bank.store_account(&deactivating_account, &stake_account);
+        let partitioned_stake_reward = PartitionedStakeReward {
+            stake_pubkey: deactivating_account,
+            stake: deactivating_stake,
+            stake_reward,
+            commission_bps,
+        };
+        let stakes_cache = bank.stakes_cache.stakes();
+        let stakes_cache_accounts = stakes_cache.stake_delegations();
+        let expected_lamports = starting_lamports + stake_reward;
+        let mut expected_stake_account = AccountSharedData::new(
+            expected_lamports,
+            StakeStateV2::size_of(),
+            &solana_stake_interface::program::id(),
+        );
+        expected_stake_account
+            .set_state(&StakeStateV2::Stake(
+                Meta::default(),
+                deactivating_stake,
+                StakeFlags::default(),
+            ))
+            .unwrap();
+
+        let expected_stake_reward = StakeReward {
+            stake_pubkey: deactivating_account,
+            stake_account: expected_stake_account,
+            stake_reward_info: StakeRewardInfo {
+                reward_type: RewardType::DeactivatedStake,
+                lamports: stake_reward as i64,
+                post_balance: expected_lamports,
+                commission_bps: Some(commission_bps),
+            },
+        };
+        assert_eq!(
+            Bank::build_updated_stake_reward(
+                distribution_epoch,
+                &stake_history,
+                new_warmup_cooldown_rate_epoch,
+                stakes_cache_accounts,
+                &partitioned_stake_reward,
+                &rent,
+                adjust_delegations_for_rent,
+            )
+            .unwrap(),
             expected_stake_reward
         );
         drop(stakes_cache);
@@ -807,5 +981,100 @@ mod tests {
             ..
         } = bank.store_stake_accounts_in_partition(&partitioned_rewards, 0);
         assert_eq!(expected_total, lamports_distributed);
+    }
+
+    #[test]
+    fn test_distribute_with_increased_rent() {
+        let (mut genesis_config, _mint_keypair) =
+            create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        genesis_config.epoch_schedule = EpochSchedule::custom(432000, 432000, false);
+        let bank = Bank::new_for_tests(&genesis_config);
+
+        // Set up epoch_rewards sysvar with rewards with 10e9 lamports to distribute.
+        let total_rewards = 10 * LAMPORTS_PER_SOL;
+        let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
+        let total_points = (total_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
+        bank.create_epoch_rewards_sysvar(
+            0,
+            42,
+            num_partitions,
+            &PointValue {
+                rewards: total_rewards,
+                points: total_points,
+            },
+        );
+        let pre_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
+        let expected_balance =
+            bank.get_minimum_balance_for_rent_exemption(pre_epoch_rewards_account.data().len());
+        // Expected balance is the sysvar rent-exempt balance
+        assert_eq!(pre_epoch_rewards_account.lamports(), expected_balance);
+
+        // Use lower lamports per byte for creating, bank has higher amount
+        let mut lower_rent = bank.rent_collector.rent.clone();
+        lower_rent.lamports_per_byte /= 10;
+        let higher_rent = &bank.rent_collector.rent;
+
+        // Set up a partition of rewards to distribute
+        let stake_rewards = [
+            // Zero stake -> destaked
+            StakeReward::new_with_pre_stake_account(0, 0, &lower_rent),
+            // Below new minimum, small reward -> destaked
+            StakeReward::new_with_pre_stake_account(1, 1, &lower_rent),
+            // Below new minimum, no reward -> delegation modified
+            StakeReward::new_with_pre_stake_account(0, LAMPORTS_PER_SOL, &lower_rent),
+            // Below new minimum, small reward -> delegation modified
+            StakeReward::new_with_pre_stake_account(1, LAMPORTS_PER_SOL, &lower_rent),
+            // Below new minimum, big reward -> delegation modified
+            StakeReward::new_with_pre_stake_account(
+                LAMPORTS_PER_SOL as i64,
+                LAMPORTS_PER_SOL,
+                &lower_rent,
+            ),
+            // Above new minimum, small reward -> delegation capped
+            StakeReward::new_with_pre_stake_account(1, LAMPORTS_PER_SOL, higher_rent),
+            // Above new minimum, big reward -> delegation capped
+            StakeReward::new_with_pre_stake_account(
+                LAMPORTS_PER_SOL as i64,
+                LAMPORTS_PER_SOL,
+                higher_rent,
+            ),
+        ]
+        .into_iter()
+        .map(|r| {
+            bank.store_account(&r.1.stake_pubkey, &r.0);
+            r.1
+        })
+        .collect::<Vec<_>>();
+
+        let expected_num = stake_rewards.len();
+        let rewards_to_distribute = stake_rewards
+            .iter()
+            .map(|stake_reward| stake_reward.stake_reward_info.lamports)
+            .sum::<i64>() as u64;
+        let all_rewards = convert_rewards(stake_rewards);
+
+        let partitioned_rewards = StartBlockHeightAndPartitionedRewards {
+            distribution_starting_block_height: bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
+            all_stake_rewards: Arc::new(all_rewards),
+            partition_indices: vec![(0..expected_num).collect::<Vec<_>>()],
+        };
+
+        // Distribute rewards
+        let pre_cap = bank.capitalization();
+        bank.distribute_epoch_rewards_in_partition(&partitioned_rewards, 0);
+        let post_cap = bank.capitalization();
+        let post_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
+
+        // Assert that epoch rewards sysvar lamports balance does not change
+        assert_eq!(post_epoch_rewards_account.lamports(), expected_balance);
+
+        let epoch_rewards: sysvar::epoch_rewards::EpochRewards =
+            from_account(&post_epoch_rewards_account).unwrap();
+        assert_eq!(epoch_rewards.total_rewards, total_rewards);
+        assert_eq!(epoch_rewards.distributed_rewards, rewards_to_distribute,);
+
+        // Assert that the bank total capital changed by the amount of rewards
+        // distributed
+        assert_eq!(pre_cap + rewards_to_distribute, post_cap);
     }
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -965,7 +965,10 @@ fn do_test_bank_update_rewards_determinism() -> u64 {
     let rewards = bank2.rewards.read().unwrap();
     rewards
         .iter()
-        .find(|(_address, reward)| reward.reward_type == RewardType::Staking)
+        .find(|(_address, reward)| {
+            reward.reward_type == RewardType::Staking
+                || reward.reward_type == RewardType::DeactivatedStake
+        })
         .unwrap();
 
     bank1.capitalization()

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -5,10 +5,11 @@ use {
         CalculatedStakePoints, CalculationEnvironment, DelegatedVoteState,
         InflationPointCalculationEvent, SkippedReason, calculate_stake_points_and_credits,
     },
+    solana_clock::Epoch,
     solana_instruction::error::InstructionError,
     solana_stake_interface::{
         error::StakeError,
-        state::{Stake, StakeStateV2},
+        state::{Delegation, Stake},
     },
 };
 
@@ -28,58 +29,56 @@ struct CalculatedStakeRewards {
 /// * Updated stake information
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn redeem_rewards<'a>(
-    stake_state: &StakeStateV2,
+    mut stake: Stake,
     voter_commission_bps: u16,
     vote_state: DelegatedVoteState,
     calculation_environment: CalculationEnvironment<'a>,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
-    stake_account_lamports_for_trace: u64,
+    current_lamports: u64,
+    minimum_lamports: u64,
 ) -> Result<(u64, u64, Stake), InstructionError> {
-    if let StakeStateV2::Stake(_meta, stake, _stake_flags) = stake_state {
-        if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-            let CalculationEnvironment {
+    if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
+        let CalculationEnvironment {
+            rewarded_epoch,
+            stake_history,
+            new_rate_activation_epoch,
+            commission_rate_in_basis_points,
+            ..
+        } = calculation_environment;
+        inflation_point_calc_tracer(
+            &InflationPointCalculationEvent::EffectiveStakeAtRewardedEpoch(stake.stake(
                 rewarded_epoch,
                 stake_history,
                 new_rate_activation_epoch,
-                commission_rate_in_basis_points,
-                ..
-            } = calculation_environment;
-            inflation_point_calc_tracer(
-                &InflationPointCalculationEvent::EffectiveStakeAtRewardedEpoch(stake.stake(
-                    rewarded_epoch,
-                    stake_history,
-                    new_rate_activation_epoch,
-                )),
-            );
-            inflation_point_calc_tracer(&InflationPointCalculationEvent::PriorTotalLamports(
-                stake_account_lamports_for_trace,
+            )),
+        );
+        inflation_point_calc_tracer(&InflationPointCalculationEvent::PriorTotalLamports(
+            current_lamports,
+        ));
+        // Choose which trace to emit based on the `commission_rate_in_basis_points` feature.
+        if commission_rate_in_basis_points {
+            inflation_point_calc_tracer(&InflationPointCalculationEvent::CommissionBps(
+                voter_commission_bps,
             ));
-            // Choose which trace to emit based on the `commission_rate_in_basis_points` feature.
-            if commission_rate_in_basis_points {
-                inflation_point_calc_tracer(&InflationPointCalculationEvent::CommissionBps(
-                    voter_commission_bps,
-                ));
-            } else {
-                inflation_point_calc_tracer(&InflationPointCalculationEvent::Commission(
-                    (voter_commission_bps / 100) as u8,
-                ));
-            }
-        }
-
-        let mut stake = *stake;
-        if let Some((stakers_reward, voters_reward)) = redeem_stake_rewards(
-            &mut stake,
-            voter_commission_bps,
-            vote_state,
-            calculation_environment,
-            inflation_point_calc_tracer,
-        ) {
-            Ok((stakers_reward, voters_reward, stake))
         } else {
-            Err(StakeError::NoCreditsToRedeem.into())
+            inflation_point_calc_tracer(&InflationPointCalculationEvent::Commission(
+                (voter_commission_bps / 100) as u8,
+            ));
         }
+    }
+
+    if let Some((stakers_reward, voters_reward)) = redeem_stake_rewards(
+        &mut stake,
+        voter_commission_bps,
+        vote_state,
+        calculation_environment,
+        inflation_point_calc_tracer,
+        current_lamports,
+        minimum_lamports,
+    ) {
+        Ok((stakers_reward, voters_reward, stake))
     } else {
-        Err(InstructionError::InvalidAccountData)
+        Err(StakeError::NoCreditsToRedeem.into())
     }
 }
 
@@ -89,6 +88,8 @@ fn redeem_stake_rewards<'a>(
     vote_state: DelegatedVoteState,
     calculation_environment: CalculationEnvironment<'a>,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
+    current_lamports: u64,
+    minimum_lamports: u64,
 ) -> Option<(u64, u64)> {
     if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
         inflation_point_calc_tracer(&InflationPointCalculationEvent::CreditsObserved(
@@ -96,7 +97,10 @@ fn redeem_stake_rewards<'a>(
             None,
         ));
     }
-    calculate_stake_rewards(
+
+    let rewarded_epoch = calculation_environment.rewarded_epoch;
+    let adjust_delegations_for_rent = calculation_environment.adjust_delegations_for_rent;
+    let maybe_rewards = calculate_stake_rewards(
         stake,
         voter_commission_bps,
         vote_state,
@@ -111,12 +115,65 @@ fn redeem_stake_rewards<'a>(
             ));
         }
         stake.credits_observed = calculated_stake_rewards.new_credits_observed;
-        stake.delegation.stake += calculated_stake_rewards.staker_rewards;
         (
             calculated_stake_rewards.staker_rewards,
             calculated_stake_rewards.voter_rewards,
         )
-    })
+    });
+
+    let staker_rewards = maybe_rewards.map(|x| x.0).unwrap_or(0);
+    if adjust_delegations_for_rent {
+        let new_delegation_with_rewards = stake.delegation.stake.saturating_add(staker_rewards);
+        let stake_was_adjusted = adjust_delegation_for_rent(
+            &mut stake.delegation,
+            rewarded_epoch,
+            new_delegation_with_rewards,
+            current_lamports.saturating_add(staker_rewards),
+            minimum_lamports,
+        );
+        // If `maybe_rewards.is_some()`, need to drive forward credits, even
+        // if rewards are zero
+        if stake_was_adjusted || maybe_rewards.is_some() {
+            let voter_rewards = maybe_rewards.map(|x| x.1).unwrap_or(0);
+            Some((staker_rewards, voter_rewards))
+        } else {
+            None
+        }
+    } else {
+        stake.delegation.stake += staker_rewards;
+        maybe_rewards
+    }
+}
+
+/// Adjusts stake delegation based on Rent sysvar parameters at epoch boundary
+///
+/// As part of SIMD-0392, if Rent is ever increased, we need to make sure that
+/// lamports are not double-counted for the rent-exempt minimum and the stake
+/// delegation. This function adjusts the delegation in a Stake if needed.
+pub(crate) fn adjust_delegation_for_rent(
+    delegation: &mut Delegation,
+    rewarded_epoch: Epoch,
+    new_delegation_with_rewards: u64,
+    lamports_with_rewards: u64,
+    minimum_lamports: u64,
+) -> bool {
+    let new_delegation = std::cmp::min(
+        new_delegation_with_rewards,
+        lamports_with_rewards.saturating_sub(minimum_lamports),
+    );
+
+    if new_delegation != delegation.stake {
+        delegation.stake = new_delegation;
+        // Deactivate stake if needed. This deactivation is immediate,
+        // unlike a requested deactivation which happens at the next epoch
+        // boundary
+        if new_delegation == 0 {
+            delegation.deactivation_epoch = rewarded_epoch;
+        }
+        true
+    } else {
+        false
+    }
 }
 
 /// for a given stake and vote_state, calculate what distributions and what updates should be made
@@ -278,7 +335,11 @@ mod tests {
         solana_clock::Epoch,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_pubkey::Pubkey,
-        solana_stake_interface::{stake_history::StakeHistory, state::Delegation},
+        solana_rent::Rent,
+        solana_stake_interface::{
+            stake_history::StakeHistory,
+            state::{Delegation, StakeStateV2},
+        },
         solana_vote_program::vote_state::{VoteStateV4, handler::VoteStateHandler},
         test_case::test_case,
     };
@@ -295,8 +356,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_stake_state_redeem_rewards() {
+    #[test_case(true; "adjust_delegations_for_rent")]
+    #[test_case(false; "no_adjust_delegations_for_rent")]
+    fn test_stake_state_redeem_rewards(adjust_delegations_for_rent: bool) {
         let mut vote_state = VoteStateHandler::new_v4(VoteStateV4::default());
         // assume stake.stake() is right
         // bootstrap means fully-vested stake at epoch 0
@@ -310,6 +372,15 @@ mod tests {
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
+
+        let mut rent = Rent::default();
+        let minimum_balance = rent.minimum_balance(StakeStateV2::size_of());
+
+        // Adjust rent down, no impact
+        if adjust_delegations_for_rent {
+            rent.lamports_per_byte /= 2;
+        }
+        let new_minimum_balance = rent.minimum_balance(StakeStateV2::size_of());
 
         // this one can't collect now, credits_observed == vote_state.credits()
         assert_eq!(
@@ -327,8 +398,11 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
+                stake_lamports + minimum_balance,
+                new_minimum_balance,
             )
         );
 
@@ -352,8 +426,11 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
+                stake_lamports + minimum_balance,
+                new_minimum_balance,
             )
         );
 
@@ -374,6 +451,7 @@ mod tests {
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
+        let adjust_delegations_for_rent = true;
 
         // this one can't collect now, credits_observed == vote_state.credits()
         assert_eq!(
@@ -391,6 +469,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -420,6 +499,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -446,6 +526,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -475,6 +556,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -502,6 +584,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -531,6 +614,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -554,6 +638,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -574,6 +659,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -601,6 +687,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -628,6 +715,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -706,6 +794,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
@@ -734,9 +823,274 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )
+        );
+    }
+
+    fn check_rent_adjusted_stake_delegation(
+        rewarded_epoch: u64,
+        mut pre_stake: Stake,
+        pre_lamports: u64,
+        new_minimum_balance: u64,
+        total_rewards: u64,
+        post_stake: Stake,
+        staker_rewards: Option<u64>,
+    ) {
+        let mut vote_state = VoteStateHandler::new_v4(VoteStateV4::default());
+        // put 1 credit to create rewards
+        vote_state.increment_credits(rewarded_epoch, 1);
+        let stake_history: &StakeHistory = &StakeHistory::default();
+        let new_rate_activation_epoch = None;
+        let commission_rate_in_basis_points = true;
+        let adjust_delegations_for_rent = true;
+
+        let maybe_rewards = redeem_stake_rewards(
+            &mut pre_stake,
+            vote_state.as_ref_v4().inflation_rewards_commission_bps,
+            DelegatedVoteState::from(vote_state.as_ref_v4()),
+            CalculationEnvironment {
+                rewarded_epoch,
+                point_value: &PointValue {
+                    rewards: total_rewards,
+                    points: 1,
+                },
+                stake_history,
+                new_rate_activation_epoch,
+                commission_rate_in_basis_points,
+                adjust_delegations_for_rent,
+            },
+            null_tracer(),
+            pre_lamports,
+            new_minimum_balance,
+        );
+        assert_eq!(pre_stake, post_stake);
+        assert_eq!(maybe_rewards.map(|x| x.0), staker_rewards)
+    }
+
+    #[test]
+    fn rent_adjusted_stake_delegation_calculations() {
+        let old_minimum_balance = 8;
+        let new_minimum_balance = 9;
+        let rewarded_epoch = 1;
+
+        // No rewards at all -> updated (all stakes get driven forward if
+        // inflation is disabled)
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            new_minimum_balance + 1,
+            new_minimum_balance,
+            0,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(0),
+        );
+
+        // Stake receives no rewards or delegation adjustment -> no update
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            new_minimum_balance + 1,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            None,
+        );
+
+        // Already destaked -> no update
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 0,
+                    deactivation_epoch: 0,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            old_minimum_balance - 1,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 0,
+                    deactivation_epoch: 0,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            None,
+        );
+
+        // Staked, already below minimum, go further below minimum
+        // -> destaked, still one lamport of rewards though
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            old_minimum_balance - 1,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 0,
+                    deactivation_epoch: rewarded_epoch,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(1),
+        );
+
+        // Delegation hits exactly 0 -> destaked, no rewards
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance,
+            new_minimum_balance,
+            0,
+            Stake {
+                delegation: Delegation {
+                    stake: 0,
+                    deactivation_epoch: rewarded_epoch,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(0),
+        );
+
+        // Delegation decreases to 1 -> still staked
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 2,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance + 1,
+            new_minimum_balance,
+            0,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(0),
+        );
+
+        // Rewards partially cover minimum balance change
+        // -> decrease stake
+        // This case is confusing because it pays out 2 lamports in rewards,
+        // so we adjust minimum up so that even with 2 lamports in rewards, the
+        // delegation goes down.
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 2,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance,
+            new_minimum_balance + 1,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(2),
+        );
+
+        // Rewards cover minimum balance change -> no change in stake
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(1),
+        );
+
+        // Well above new minimum balance -> delegation change capped to rewards
+        check_rent_adjusted_stake_delegation(
+            rewarded_epoch,
+            Stake {
+                delegation: Delegation {
+                    stake: 1,
+                    ..Default::default()
+                },
+                credits_observed: 0,
+            },
+            new_minimum_balance + 2,
+            new_minimum_balance,
+            1,
+            Stake {
+                delegation: Delegation {
+                    stake: 2,
+                    ..Default::default()
+                },
+                credits_observed: 1,
+            },
+            Some(1),
         );
     }
 
@@ -752,6 +1106,7 @@ mod tests {
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
+        let adjust_delegations_for_rent = true;
 
         calculate_stake_rewards(
             &stake,
@@ -763,6 +1118,7 @@ mod tests {
                 stake_history,
                 new_rate_activation_epoch,
                 commission_rate_in_basis_points,
+                adjust_delegations_for_rent,
             },
             null_tracer(),
         );
@@ -783,6 +1139,7 @@ mod tests {
         let stake_history = &StakeHistory::default();
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
+        let adjust_delegations_for_rent = true;
 
         // this one can't collect now, credits_observed == vote_state.credits()
         assert_eq!(
@@ -800,6 +1157,7 @@ mod tests {
                     stake_history,
                     new_rate_activation_epoch,
                     commission_rate_in_basis_points,
+                    adjust_delegations_for_rent,
                 },
                 null_tracer(),
             )

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -36,6 +36,7 @@ pub(crate) struct CalculationEnvironment<'a> {
     pub(crate) stake_history: &'a StakeHistory,
     pub(crate) new_rate_activation_epoch: Option<Epoch>,
     pub(crate) commission_rate_in_basis_points: bool,
+    pub(crate) adjust_delegations_for_rent: bool,
 }
 
 #[derive(Debug)]

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -45,6 +45,11 @@ impl<T> StakeAccount<T> {
     pub(crate) fn stake_state(&self) -> &StakeStateV2 {
         &self.stake_state
     }
+
+    #[inline]
+    pub(crate) fn data_len(&self) -> usize {
+        self.account.data().len()
+    }
 }
 
 impl StakeAccount<Delegation> {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -1372,6 +1372,10 @@ mod test {
         reward.reward_type = Some(RewardType::Staking);
         let gen_reward: generated::Reward = reward.clone().into();
         assert_eq!(reward, gen_reward.into());
+
+        reward.reward_type = Some(RewardType::DeactivatedStake);
+        let gen_reward: generated::Reward = reward.clone().into();
+        assert_eq!(reward, gen_reward.into());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Stake rewards calculation and distribution related changes for [SIMD-0392](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0392-rent-increase-adaptations.md). Separated from the [runtime changes](https://github.com/anza-xyz/agave/pull/12406) to make reviewing easier.

-- Copied from @joncinque's original implementation [PR](https://github.com/igor56D/agave/pull/1) -- 

For SIMD-0392 to be complete, rewards calculation needs to ensure that stake lamports can't be double-counted as rent and delegation.

#### Summary of Changes

- Add feature gate and assert during distribution
- Add lamport balances, adjust calculation
- Add tests, adjust existing tests
- Add distribution test
- Add new reward-info type
- Add new reward type everywhere, pedantically
- Add new field to CalculationEnvironment