### PR TITLE
Fix - #10880

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1237,7 +1237,7 @@ pub mod enable_sbpf_v3_deployment_and_execution {
 }
 
 pub mod disable_sbpf_v0_v1_v2_deployment {
-    solana_pubkey::declare_id!("5789pRHRXvzpj5ZmGAjHL2QRCDwFx5CuoUqEB55hunbo");
+    solana_pubkey::declare_id!("B8JJXCy5amZyWG9r7EnUYLwzXSXTxG7GZ1qZ1qggo83g");
 }
 
 pub mod remove_accounts_executable_flag_checks {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -2145,6 +2145,24 @@ mod tests {
             instruction_accounts,
             Err(InstructionError::IncorrectAuthority),
         );
+
+        // Case: Upgrade to SBPFv0
+        let mut file =
+            File::open("test_elfs/out/sbpfv0_verifier_err.so").expect("file open failed");
+        let mut elf_new = Vec::new();
+        file.read_to_end(&mut elf_new).unwrap();
+        let (transaction_accounts, instruction_accounts) = get_accounts(
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf_orig,
+            &elf_new,
+        );
+        process_instruction(
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::InvalidAccountData),
+        );
     }
 
     #[test]
@@ -2638,6 +2656,25 @@ mod tests {
             instruction_accounts,
             Err(InstructionError::IncorrectAuthority),
         );
+
+        // Case: Deploy SBPFv0
+        let mut file =
+            File::open("test_elfs/out/sbpfv0_verifier_err.so").expect("file open failed");
+        let mut elf = Vec::new();
+        file.read_to_end(&mut elf).unwrap();
+        let (transaction_accounts, instruction_accounts) = get_accounts(
+            &payer_address,
+            &buffer_address,
+            &upgrade_authority_address,
+            &upgrade_authority_address,
+            &elf,
+        );
+        process_instruction(
+            elf.len(),
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::InvalidAccountData),
+        );
     }
 
     #[test]
@@ -2709,7 +2746,7 @@ mod tests {
             }
         );
 
-        // Case: Not upgradeable
+        // Case: Finalize
         let accounts = process_instruction(
             &loader_id,
             &instruction,
@@ -2727,6 +2764,28 @@ mod tests {
                 slot,
                 upgrade_authority_address: None,
             }
+        );
+
+        // Case: Finalize a SBPFv0 program
+        let mut file =
+            File::open("test_elfs/out/sbpfv0_verifier_err.so").expect("file open failed");
+        let mut elf = Vec::new();
+        file.read_to_end(&mut elf).unwrap();
+        programdata_account.resize(UpgradeableLoaderState::size_of_programdata(elf.len()), 0);
+        programdata_account
+            .data_as_mut_slice()
+            .get_mut(UpgradeableLoaderState::size_of_programdata_metadata()..)
+            .unwrap()
+            .copy_from_slice(&elf);
+        process_instruction(
+            &loader_id,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (upgrade_authority_address, upgrade_authority_account.clone()),
+            ],
+            vec![programdata_meta.clone(), upgrade_authority_meta.clone()],
+            Err(InstructionError::InvalidAccountData),
         );
 
         // Case: Authority did not sign

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -577,7 +577,10 @@ fn process_loader_upgradeable_instruction(
                         ic_logger_msg!(log_collector, "Upgrade authority did not sign");
                         return Err(InstructionError::MissingRequiredSignature);
                     }
-                    if new_authority.is_none()
+                    if invoke_context
+                        .get_feature_set()
+                        .disable_sbpf_v0_v1_v2_deployment
+                        && new_authority.is_none()
                         && let Some(program) = account
                             .get_data()
                             .get(UpgradeableLoaderState::size_of_programdata_metadata()..)

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -19,7 +19,7 @@ use {
         vm::execute,
     },
     solana_pubkey::Pubkey,
-    solana_sbpf::declare_builtin_function,
+    solana_sbpf::{declare_builtin_function, elf::get_sbpf_version, program::SBPFVersion},
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, native_loader},
     solana_svm_log_collector::{LogCollector, ic_logger_msg, ic_msg},
     solana_svm_measure::measure::Measure,
@@ -576,6 +576,15 @@ fn process_loader_upgradeable_instruction(
                     if !instruction_context.is_instruction_account_signer(1)? {
                         ic_logger_msg!(log_collector, "Upgrade authority did not sign");
                         return Err(InstructionError::MissingRequiredSignature);
+                    }
+                    if new_authority.is_none()
+                        && let Some(program) = account
+                            .get_data()
+                            .get(UpgradeableLoaderState::size_of_programdata_metadata()..)
+                        && let Ok(sbpf_version) = get_sbpf_version(program)
+                        && sbpf_version < SBPFVersion::V3
+                    {
+                        return Err(InstructionError::InvalidAccountData);
                     }
                     account.set_state(&UpgradeableLoaderState::ProgramData {
                         slot,


### PR DESCRIPTION
#### Problem

@0x0ece found that our implementation of [SIMD-0500](https://github.com/solana-foundation/solana-improvement-documents/pull/500) was lacking one check described in the SIMD.

#### Summary of Changes

- Adds missing `sbpf_version` check in loader-v3 `set_authority(None)` aka. finalize.
- Rekeys the feature `disable_sbpf_v0_v1_v2_deployment`.
- Adds test cases.