### PR TITLE
perf(snapshots): optimize obsolete account items deserialization

### DIFF
--- a/runtime/src/serde_snapshot/obsolete_accounts.rs
+++ b/runtime/src/serde_snapshot/obsolete_accounts.rs
@@ -91,7 +91,7 @@ impl SerdeObsoleteAccounts {
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
-    frozen_abi(digest = "7Hb4XtqaUBY27yyz7V1kVXZ9aTnary8GDroB12JRvGjz")
+    frozen_abi(digest = "FbAP5pg2FLgSkMWiv3eMwEh433qMoNRbaJij9aLtG2NH")
 )]
 #[derive(Serialize, Debug, SchemaRead, SchemaWrite)]
 pub(crate) struct SerdeObsoleteAccountsMap {

--- a/runtime/src/serde_snapshot/obsolete_accounts.rs
+++ b/runtime/src/serde_snapshot/obsolete_accounts.rs
@@ -12,6 +12,18 @@ use {
     wincode::{SchemaRead, SchemaWrite},
 };
 
+#[repr(C)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Debug, SchemaRead, SchemaWrite, Serialize)]
+pub struct SerdeObsoleteAccountItem {
+    /// Offset of the account in the account storage entry
+    pub offset: Offset,
+    /// Length of the account data
+    pub data_len: usize,
+    /// Slot when the account was marked obsolete
+    pub slot: Slot,
+}
+
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Default, Serialize, SchemaRead, SchemaWrite)]
 pub(crate) struct SerdeObsoleteAccounts {
@@ -23,18 +35,15 @@ pub(crate) struct SerdeObsoleteAccounts {
     /// is used to validate the size when creating the accounts file.
     pub bytes: u64,
     /// A list of accounts that are obsolete in the storage being restored.
-    pub accounts: Vec<(Offset, usize, Slot)>,
+    pub accounts: Vec<SerdeObsoleteAccountItem>,
 }
 
 impl SerdeObsoleteAccounts {
     /// Creates a new `SerdeObsoleteAccounts` instance from a given storage entry and snapshot slot.
     fn new_from_storage_entry_at_slot(storage: &AccountStorageEntry, snapshot_slot: Slot) -> Self {
-        let accounts = storage
-            .obsolete_accounts_for_snapshots(snapshot_slot)
-            .accounts
-            .into_iter()
-            .map(|item| (item.offset, item.data_len, item.slot))
-            .collect();
+        let accounts = Self::items_from_obsolete_accounts(
+            storage.obsolete_accounts_for_snapshots(snapshot_slot),
+        );
 
         SerdeObsoleteAccounts {
             id: storage.id() as SerializedAccountsFileId,
@@ -47,10 +56,10 @@ impl SerdeObsoleteAccounts {
         let accounts = self
             .accounts
             .into_iter()
-            .map(|(offset, data_len, slot)| ObsoleteAccountItem {
-                offset,
-                data_len,
-                slot,
+            .map(|item| ObsoleteAccountItem {
+                offset: item.offset,
+                data_len: item.data_len,
+                slot: item.slot,
             })
             .collect();
 
@@ -59,6 +68,20 @@ impl SerdeObsoleteAccounts {
             self.id as AccountsFileId,
             self.bytes as usize,
         )
+    }
+
+    fn items_from_obsolete_accounts(
+        obsolete_accounts: ObsoleteAccounts,
+    ) -> Vec<SerdeObsoleteAccountItem> {
+        obsolete_accounts
+            .accounts
+            .into_iter()
+            .map(|item| SerdeObsoleteAccountItem {
+                offset: item.offset,
+                data_len: item.data_len,
+                slot: item.slot,
+            })
+            .collect()
     }
 }
 
@@ -135,16 +158,12 @@ mod test {
         let map = obsolete_accounts
             .iter()
             .map(|entry| {
-                let accounts = entry
-                    .value()
-                    .accounts
-                    .iter()
-                    .map(|item| (item.offset, item.data_len, item.slot))
-                    .collect();
                 let serde_obsolete_accounts = SerdeObsoleteAccounts {
                     id: *entry.key() as SerializedAccountsFileId,
                     bytes: num_obsolete_accounts_per_storage as u64 * 1000,
-                    accounts,
+                    accounts: SerdeObsoleteAccounts::items_from_obsolete_accounts(
+                        entry.value().clone(),
+                    ),
                 };
                 (*entry.key(), serde_obsolete_accounts)
             })


### PR DESCRIPTION
#### Problem
`SerdeObsoleteAccounts` stored its account items as `Vec<(Offset, usize, Slot)>`. Wincode's deserializer can't take its zero-copy fast path for tuples, so each element was decoded field-by-field — wasteful given how many obsolete-account items a snapshot can contain.

#### Summary of Changes
- Introduce a `#[repr(C)]` `SerdeObsoleteAccountItem` struct with explicit `offset`, `data_len`, and `slot` fields, in an order matching the bincode wire format.
- Replace `Vec<(Offset, usize, Slot)>` in `SerdeObsoleteAccounts` with `Vec<SerdeObsoleteAccountItem>`. Because the struct's memory layout matches the wire format, wincode can deserialize the whole `Vec` with a single bulk memcpy instead of per-element decoding.
- Factor out `items_from_obsolete_accounts` to convert from `ObsoleteAccounts` into the new vec, and update the existing tests to use it.
- Bump the `SerdeObsoleteAccountsMap` `frozen_abi` digest to reflect the new schema.

##### Performance impact
Runtime of deserializing obsolete accounts goes from 42ms to 25ms, which consists of mostly Vec allocations now

<img width="1808" height="746" alt="obraz" src="https://github.com/user-attachments/assets/051ddc40-06f3-459b-b6da-d6c437862439" />
