### PR TITLE
Reject duplicate V1 transaction keys

### DIFF
--- a/transaction-view/benches/transaction_view.rs
+++ b/transaction-view/benches/transaction_view.rs
@@ -9,7 +9,9 @@ use {
     solana_keypair::Keypair,
     solana_message::{
         Message, MessageHeader, VersionedMessage,
+        compiled_instruction::CompiledInstruction,
         v0::{self, MessageAddressTableLookup},
+        v1,
     },
     solana_pubkey::Pubkey,
     solana_signer::Signer,
@@ -188,6 +190,32 @@ fn packed_atls() -> Vec<VersionedTransaction> {
         .collect()
 }
 
+fn max_v1_static_accounts() -> Vec<VersionedTransaction> {
+    (0..NUM_TRANSACTIONS)
+        .map(|_| {
+            let account_keys = (0..64).map(|_| Pubkey::new_unique()).collect();
+            VersionedTransaction {
+                signatures: vec![Default::default()],
+                message: VersionedMessage::V1(v1::Message {
+                    header: MessageHeader {
+                        num_required_signatures: 1,
+                        num_readonly_signed_accounts: 0,
+                        num_readonly_unsigned_accounts: 63,
+                    },
+                    account_keys,
+                    lifetime_specifier: Hash::default(),
+                    instructions: vec![CompiledInstruction {
+                        program_id_index: 1,
+                        accounts: (0..64).collect(),
+                        data: vec![],
+                    }],
+                    config: v1::TransactionConfig::empty(),
+                }),
+            }
+        })
+        .collect()
+}
+
 fn bench_parse_min_sized_transactions(c: &mut Criterion) {
     let serialized_transactions = serialize_transactions(minimum_sized_transactions());
     let mut group = c.benchmark_group("min sized transactions");
@@ -223,12 +251,20 @@ fn bench_parse_packed_atls(c: &mut Criterion) {
     bench_transactions_parsing(&mut group, serialized_transactions);
 }
 
+fn bench_parse_max_v1_static_accounts(c: &mut Criterion) {
+    let serialized_transactions = serialize_transactions(max_v1_static_accounts());
+    let mut group = c.benchmark_group("max v1 static accounts");
+    group.throughput(Throughput::Elements(serialized_transactions.len() as u64));
+    bench_transactions_parsing(&mut group, serialized_transactions);
+}
+
 criterion_group!(
     benches,
     bench_parse_min_sized_transactions,
     bench_parse_simple_transfers,
     bench_parse_packed_transfers,
     bench_parse_packed_noops,
-    bench_parse_packed_atls
+    bench_parse_packed_atls,
+    bench_parse_max_v1_static_accounts
 );
 criterion_main!(benches);

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -119,11 +119,24 @@ fn sanitize_account_access(view: &UnsanitizedTransactionView<impl TransactionDat
         return Err(TransactionViewError::SanitizeError);
     }
 
-    // No duplicated accounts
-    // Note: This check is performed downstream in `validate_account_locks()`.
-    // It is skipped here to avoid redundant work on the hot path.
+    if matches!(view.version(), TransactionVersion::V1) && has_duplicate_static_account_keys(view) {
+        return Err(TransactionViewError::SanitizeError);
+    }
 
     Ok(())
+}
+
+fn has_duplicate_static_account_keys(
+    view: &UnsanitizedTransactionView<impl TransactionData>,
+) -> bool {
+    let mut static_account_keys = view.static_account_keys();
+    while let Some((account_key, remaining_account_keys)) = static_account_keys.split_first() {
+        if remaining_account_keys.contains(account_key) {
+            return true;
+        }
+        static_account_keys = remaining_account_keys;
+    }
+    false
 }
 
 /// Instructions Constraints
@@ -211,7 +224,9 @@ mod tests {
         solana_pubkey::Pubkey,
         solana_signature::Signature,
         solana_system_interface::instruction as system_instruction,
-        solana_transaction::versioned::VersionedTransaction,
+        solana_transaction::versioned::{
+            VersionedTransaction, sanitized::SanitizedVersionedTransaction,
+        },
     };
 
     fn create_legacy_transaction(
@@ -594,6 +609,32 @@ mod tests {
                 sanitize_account_access(&view),
                 Err(TransactionViewError::SanitizeError)
             );
+        }
+
+        {
+            let account_key = Pubkey::new_unique();
+            let transaction = create_v1_transaction(
+                1,
+                MessageHeader {
+                    num_required_signatures: 1,
+                    num_readonly_signed_accounts: 0,
+                    num_readonly_unsigned_accounts: 1,
+                },
+                vec![account_key, account_key],
+                vec![],
+                TransactionConfig::empty(),
+            );
+            assert!(SanitizedVersionedTransaction::try_new(transaction.clone()).is_err());
+            let data = wincode::serialize(&transaction).unwrap();
+            let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
+            assert_eq!(
+                sanitize_account_access(&view),
+                Err(TransactionViewError::SanitizeError)
+            );
+            assert!(matches!(
+                TransactionView::try_new_sanitized(data.as_ref(), true),
+                Err(TransactionViewError::SanitizeError)
+            ));
         }
     }
 


### PR DESCRIPTION
#### Problem

`TransactionView::try_new_sanitized()` accepts duplicate static account keys in V1 transactions. The normal sanitized transaction path rejects them.

#### Summary of Changes

Reject duplicate V1 static account keys in `TransactionView` sanitization.

Fixes #12420