### PR TITLE
Add target entry size in block-production

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -33,10 +33,9 @@ use {
 /// Consumer will create chunks of transactions from buffer with up to this size.
 pub const TARGET_NUM_TRANSACTIONS_PER_BATCH: usize = 64;
 
-const SERIALIZED_ENTRIES_OVERHEAD: u64 = {
-    48  // Entry Header
-    + 8 // Vec<Entry> length
-};
+pub(crate) const ENTRY_OVERHEAD_BYTES: u64 = 48;
+
+const SERIALIZED_ENTRIES_OVERHEAD: u64 = ENTRY_OVERHEAD_BYTES + 8; // Vec<Entry> length
 
 #[derive(Debug)]
 pub struct ExecutionFlags {

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -10,7 +10,7 @@ use {
         transaction_state_container::StateContainer,
     },
     crate::banking_stage::{
-        consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH,
+        consumer::{ENTRY_OVERHEAD_BYTES, TARGET_NUM_TRANSACTIONS_PER_BATCH},
         scheduler_messages::{ConsumeWork, FinishedConsumeWork},
     },
     agave_scheduling_utils::thread_aware_account_locks::{
@@ -18,14 +18,19 @@ use {
     },
     crossbeam_channel::{Receiver, Sender},
     solana_cost_model::block_cost_limits::MAX_BLOCK_UNITS,
+    solana_ledger::shred::get_data_shred_bytes_per_batch_typical,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     std::num::Saturating,
 };
+
+const DEFAULT_TARGET_ENTRY_BYTES_PER_BATCH: u64 =
+    get_data_shred_bytes_per_batch_typical() * 15 / 100;
 
 pub(crate) struct GreedySchedulerConfig {
     pub target_scheduled_cus: u64,
     pub max_scanned_transactions_per_scheduling_pass: usize,
     pub target_transactions_per_batch: usize,
+    pub target_entry_bytes_per_batch: u64,
 }
 
 impl Default for GreedySchedulerConfig {
@@ -34,6 +39,7 @@ impl Default for GreedySchedulerConfig {
             target_scheduled_cus: MAX_BLOCK_UNITS / 4,
             max_scanned_transactions_per_scheduling_pass: 100_000,
             target_transactions_per_batch: TARGET_NUM_TRANSACTIONS_PER_BATCH,
+            target_entry_bytes_per_batch: DEFAULT_TARGET_ENTRY_BYTES_PER_BATCH,
         }
     }
 }
@@ -53,6 +59,10 @@ impl<Tx: TransactionWithMeta> GreedyScheduler<Tx> {
         finished_consume_work_receiver: Receiver<FinishedConsumeWork<Tx>>,
         config: GreedySchedulerConfig,
     ) -> Self {
+        assert!(
+            config.target_entry_bytes_per_batch > ENTRY_OVERHEAD_BYTES,
+            "target entry bytes per batch must exceed entry overhead"
+        );
         Self {
             unschedulables: Vec::with_capacity(config.max_scanned_transactions_per_scheduling_pass),
             common: SchedulingCommon::new(
@@ -161,6 +171,13 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                     max_age,
                     cost,
                 }) => {
+                    let transaction_bytes = transaction.serialized_size() as u64;
+                    if self.common.batches.entry_bytes()[thread_id] + transaction_bytes
+                        > self.config.target_entry_bytes_per_batch
+                    {
+                        num_sent += self.common.send_batches()?;
+                    }
+
                     num_scheduled += 1;
                     self.common.batches.add_transaction_to_batch(
                         thread_id,
@@ -168,12 +185,15 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                         transaction,
                         max_age,
                         cost,
+                        transaction_bytes,
                     );
                     budget = budget.saturating_sub(cost);
 
-                    // If target batch size is reached, send all the batches
+                    // If a hard batch target is reached, send all the batches.
                     if self.common.batches.transactions()[thread_id].len()
                         >= self.config.target_transactions_per_batch
+                        || self.common.batches.entry_bytes()[thread_id]
+                            >= self.config.target_entry_bytes_per_batch
                     {
                         num_sent += self.common.send_batches()?;
                     }
@@ -274,7 +294,7 @@ mod test {
         solana_compute_budget_interface::ComputeBudgetInstruction,
         solana_hash::Hash,
         solana_keypair::Keypair,
-        solana_message::Message,
+        solana_message::{Message, v1::MAX_TRANSACTION_SIZE},
         solana_pubkey::Pubkey,
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_signer::Signer,
@@ -352,6 +372,10 @@ mod test {
         }
 
         container
+    }
+
+    fn single_transfer_transaction_size() -> u64 {
+        prioritized_tranfers(&Keypair::new(), [Pubkey::new_unique()], 1, 1).serialized_size() as u64
     }
 
     fn collect_work(
@@ -497,6 +521,41 @@ mod test {
         assert_eq!(scheduling_summary.num_scheduled, 2);
         assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
         assert_eq!(collect_work(&work_receivers[0]).1, vec![vec![1], vec![0]]);
+    }
+
+    #[test]
+    fn test_schedule_single_threaded_scheduling_entry_bytes_target() {
+        let (mut scheduler, work_receivers, _finished_work_sender) = create_test_frame(
+            1,
+            GreedySchedulerConfig {
+                target_transactions_per_batch: 10,
+                target_entry_bytes_per_batch: ENTRY_OVERHEAD_BYTES
+                    + single_transfer_transaction_size()
+                    + 1,
+                ..GreedySchedulerConfig::default()
+            },
+        );
+        let mut container = create_container([
+            (&Keypair::new(), &[Pubkey::new_unique()], 1, 1),
+            (&Keypair::new(), &[Pubkey::new_unique()], 2, 2),
+            (&Keypair::new(), &[Pubkey::new_unique()], 3, 3),
+        ]);
+
+        let scheduling_summary = scheduler.schedule(&mut container, u64::MAX).unwrap();
+        assert_eq!(scheduling_summary.num_scheduled, 3);
+        assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
+        assert_eq!(
+            collect_work(&work_receivers[0]).1,
+            vec![vec![2], vec![1], vec![0]]
+        );
+    }
+
+    #[test]
+    fn test_default_entry_bytes_target_exceeds_max_transaction_size() {
+        assert!(
+            ENTRY_OVERHEAD_BYTES + (MAX_TRANSACTION_SIZE as u64)
+                < GreedySchedulerConfig::default().target_entry_bytes_per_batch
+        );
     }
 
     #[test]

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -23,6 +23,9 @@ use {
     std::num::Saturating,
 };
 
+// 15% of a batch is chosen as a target. If all entries are within this bound, the
+// maximum padding in a batch is 15%. 15% is also chosen because it is close to the
+// maximum transaction size (4096 / ~13% batch size).
 const DEFAULT_TARGET_ENTRY_BYTES_PER_BATCH: u64 =
     get_data_shred_bytes_per_batch_typical() * 15 / 100;
 

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -3,8 +3,11 @@ use {
         in_flight_tracker::InFlightTracker, scheduler_error::SchedulerError,
         transaction_state_container::StateContainer,
     },
-    crate::banking_stage::scheduler_messages::{
-        ConsumeWork, FinishedConsumeWork, MaxAge, TransactionBatchId, TransactionId,
+    crate::banking_stage::{
+        consumer::ENTRY_OVERHEAD_BYTES,
+        scheduler_messages::{
+            ConsumeWork, FinishedConsumeWork, MaxAge, TransactionBatchId, TransactionId,
+        },
     },
     agave_scheduling_utils::thread_aware_account_locks::{
         MAX_THREADS, ThreadAwareAccountLocks, ThreadId, ThreadSet,
@@ -19,6 +22,7 @@ pub struct Batches<Tx> {
     transactions: Vec<Vec<Tx>>,
     max_ages: Vec<Vec<MaxAge>>,
     total_cus: Vec<u64>,
+    entry_bytes: Vec<u64>,
     target_num_transactions_per_batch: usize,
 }
 
@@ -38,6 +42,7 @@ impl<Tx> Batches<Tx> {
             transactions: make_vecs(num_threads, target_num_transactions_per_batch),
             max_ages: make_vecs(num_threads, target_num_transactions_per_batch),
             total_cus: vec![0; num_threads],
+            entry_bytes: vec![ENTRY_OVERHEAD_BYTES; num_threads],
             target_num_transactions_per_batch,
         }
     }
@@ -48,6 +53,10 @@ impl<Tx> Batches<Tx> {
             && self.transactions.iter().all(|txs| txs.is_empty())
             && self.max_ages.iter().all(|max_ages| max_ages.is_empty())
             && self.total_cus.iter().all(|&cus| cus == 0)
+            && self
+                .entry_bytes
+                .iter()
+                .all(|&bytes| bytes == ENTRY_OVERHEAD_BYTES)
     }
 
     pub fn total_cus(&self) -> &[u64] {
@@ -58,6 +67,10 @@ impl<Tx> Batches<Tx> {
         &self.transactions
     }
 
+    pub fn entry_bytes(&self) -> &[u64] {
+        &self.entry_bytes
+    }
+
     pub fn add_transaction_to_batch(
         &mut self,
         thread_id: ThreadId,
@@ -65,17 +78,20 @@ impl<Tx> Batches<Tx> {
         transaction: Tx,
         max_age: MaxAge,
         cus: u64,
+        transaction_bytes: u64,
     ) {
         self.ids[thread_id].push(transaction_id);
         self.transactions[thread_id].push(transaction);
         self.max_ages[thread_id].push(max_age);
         self.total_cus[thread_id] += cus;
+        self.entry_bytes[thread_id] += transaction_bytes;
     }
 
     pub fn take_batch(
         &mut self,
         thread_id: ThreadId,
     ) -> (Vec<TransactionId>, Vec<Tx>, Vec<MaxAge>, u64) {
+        self.entry_bytes[thread_id] = ENTRY_OVERHEAD_BYTES;
         (
             core::mem::replace(
                 &mut self.ids[thread_id],
@@ -363,12 +379,14 @@ mod tests {
                 |_thread_set| thread_id,
             )
             .unwrap();
+        let transaction_bytes = transaction.serialized_size() as u64;
         common.batches.add_transaction_to_batch(
             thread_id,
             tx_id.id,
             transaction,
             max_age,
             DUMMY_COST,
+            transaction_bytes,
         );
     }
 
@@ -455,10 +473,16 @@ mod tests {
             (0..NUM_WORKERS).map(|_| unbounded()).unzip();
         let (_finished_work_sender, finished_work_receiver) = unbounded();
         let mut common = SchedulingCommon::new(work_senders, finished_work_receiver, 10);
+        assert_eq!(
+            common.batches.entry_bytes(),
+            vec![ENTRY_OVERHEAD_BYTES; NUM_WORKERS]
+        );
 
         pop_and_add_transaction(&mut container, &mut common, 0);
+        assert!(common.batches.entry_bytes()[0] > ENTRY_OVERHEAD_BYTES);
         let num_scheduled = common.send_batch(0).unwrap();
         assert_eq!(num_scheduled, 1);
+        assert_eq!(common.batches.entry_bytes()[0], ENTRY_OVERHEAD_BYTES);
         assert_eq!(work_receivers[0].len(), 1);
         assert_eq!(
             common.in_flight_tracker.num_in_flight_per_thread(),

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -831,15 +831,17 @@ mod tests {
             .send(to_banking_packet_batch(&txs2))
             .unwrap();
 
-        // We expect 4 batches to be scheduled
         test_receive_then_schedule(&mut scheduler_controller);
-        let consume_works = (0..4)
-            .map(|_| consume_work_receivers[0].try_recv().unwrap())
-            .collect_vec();
+        let consume_works = consume_work_receivers[0].try_iter().collect_vec();
 
         assert_eq!(
-            consume_works.iter().map(|cw| cw.ids.len()).collect_vec(),
-            vec![TARGET_NUM_TRANSACTIONS_PER_BATCH; 4]
+            consume_works.iter().map(|cw| cw.ids.len()).sum::<usize>(),
+            4 * TARGET_NUM_TRANSACTIONS_PER_BATCH
+        );
+        assert!(
+            consume_works
+                .iter()
+                .all(|cw| cw.ids.len() < TARGET_NUM_TRANSACTIONS_PER_BATCH)
         );
     }
 


### PR DESCRIPTION
#### Problem
- This helps us make some broadcast performance improvements
	- See discussion on #10574 

#### Summary of Changes
- Add a target entry size in bytes in the scheduler

Fixes #
