### PR TITLE
clippy(snapshots): fix lifetime for RPIT of iterators in edition 2024

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -5007,7 +5007,7 @@ fn test_boot_from_local_state() {
             std::thread::yield_now();
         }
         let other_full_snapshot_archives = snapshot_paths::full_snapshot_archives_iter(
-            &other_validator_config.full_snapshot_archives_dir,
+            other_validator_config.full_snapshot_archives_dir.path(),
         )
         .collect::<Vec<_>>();
         debug!("validator{i} full snapshot archives: {other_full_snapshot_archives:?}");
@@ -5034,7 +5034,9 @@ fn test_boot_from_local_state() {
 
         let other_incremental_snapshot_archives =
             snapshot_paths::incremental_snapshot_archives_iter(
-                &other_validator_config.incremental_snapshot_archives_dir,
+                other_validator_config
+                    .incremental_snapshot_archives_dir
+                    .path(),
             )
             .collect::<Vec<_>>();
         debug!(

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1605,7 +1605,7 @@ pub fn purge_old_snapshot_archives(
     );
 
     let mut full_snapshot_archives =
-        snapshot_paths::full_snapshot_archives_iter(&full_snapshot_archives_dir)
+        snapshot_paths::full_snapshot_archives_iter(full_snapshot_archives_dir.as_ref())
             .collect::<Vec<_>>();
     full_snapshot_archives.sort_unstable();
     full_snapshot_archives.reverse();
@@ -1653,7 +1653,7 @@ pub fn purge_old_snapshot_archives(
     );
     let mut incremental_snapshot_archives_by_base_slot = HashMap::<Slot, Vec<_>>::new();
     for incremental_snapshot_archive in
-        incremental_snapshot_archives_iter(&incremental_snapshot_archives_dir)
+        incremental_snapshot_archives_iter(incremental_snapshot_archives_dir.as_ref())
     {
         incremental_snapshot_archives_by_base_slot
             .entry(incremental_snapshot_archive.base_slot())
@@ -2449,7 +2449,7 @@ mod tests {
                 NonZeroUsize::new(usize::MAX).unwrap(),
             );
             let mut full_snapshot_archives =
-                full_snapshot_archives_iter(&full_snapshot_archives_dir).collect::<Vec<_>>();
+                full_snapshot_archives_iter(full_snapshot_archives_dir.path()).collect::<Vec<_>>();
             full_snapshot_archives.sort_unstable();
             assert_eq!(
                 full_snapshot_archives.len(),

--- a/snapshots/src/paths.rs
+++ b/snapshots/src/paths.rs
@@ -164,7 +164,7 @@ pub fn get_bank_snapshot_dir(bank_snapshots_dir: impl AsRef<Path>, slot: Slot) -
 fn snapshot_archives_iter<T>(
     snapshot_archives_dir: &Path,
     cb: fn(PathBuf) -> Result<T>,
-) -> impl Iterator<Item = T> {
+) -> impl Iterator<Item = T> + use<T> {
     let remote_dir = build_snapshot_archives_remote_dir(snapshot_archives_dir);
 
     [
@@ -192,20 +192,20 @@ fn snapshot_archives_iter<T>(
 
 /// Get an iterator of the full snapshot archives from a directory
 pub fn full_snapshot_archives_iter(
-    full_snapshot_archives_dir: impl AsRef<Path>,
-) -> impl Iterator<Item = FullSnapshotArchiveInfo> {
+    full_snapshot_archives_dir: &Path,
+) -> impl Iterator<Item = FullSnapshotArchiveInfo> + use<> {
     snapshot_archives_iter(
-        full_snapshot_archives_dir.as_ref(),
+        full_snapshot_archives_dir,
         FullSnapshotArchiveInfo::new_from_path,
     )
 }
 
 /// Get the incremental snapshot archives from a directory
 pub fn incremental_snapshot_archives_iter(
-    incremental_snapshot_archives_dir: impl AsRef<Path>,
-) -> impl Iterator<Item = IncrementalSnapshotArchiveInfo> {
+    incremental_snapshot_archives_dir: &Path,
+) -> impl Iterator<Item = IncrementalSnapshotArchiveInfo> + use<> {
     snapshot_archives_iter(
-        incremental_snapshot_archives_dir.as_ref(),
+        incremental_snapshot_archives_dir,
         IncrementalSnapshotArchiveInfo::new_from_path,
     )
 }
@@ -235,7 +235,7 @@ pub fn get_highest_incremental_snapshot_archive_slot(
 pub fn get_highest_full_snapshot_archive_info(
     full_snapshot_archives_dir: impl AsRef<Path>,
 ) -> Option<FullSnapshotArchiveInfo> {
-    full_snapshot_archives_iter(full_snapshot_archives_dir).max()
+    full_snapshot_archives_iter(full_snapshot_archives_dir.as_ref()).max()
 }
 
 /// Get the path for the incremental snapshot archive with the highest slot, for a given full
@@ -248,7 +248,7 @@ pub fn get_highest_incremental_snapshot_archive_info(
     // full snapshot slot as the value passed in, perform the filtering before sorting to avoid
     // doing unnecessary work.
     let mut incremental_snapshot_archives =
-        incremental_snapshot_archives_iter(incremental_snapshot_archives_dir)
+        incremental_snapshot_archives_iter(incremental_snapshot_archives_dir.as_ref())
             .filter(|incremental_snapshot_archive_info| {
                 incremental_snapshot_archive_info.base_slot() == full_snapshot_slot
             })


### PR DESCRIPTION
#### Problem
After switching to Rust 2024 edition, `full_snapshot_archives_iter` and `incremental_snapshot_archives_iter` in `snapshots/src/paths.rs` fail to compile when called from `get_highest_full_snapshot_archive_info` / `get_highest_incremental_snapshot_archive_info`:

```
error[E0310]: the parameter type `impl AsRef<Path>` may not live long enough
   --> snapshots/src/paths.rs:238:5
    |
238 |     full_snapshot_archives_iter(full_snapshot_archives_dir).max()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     the parameter type `impl AsRef<Path>` must be valid for the static lifetime...
```

In Rust 2024, return-position `impl Trait` captures all in-scope generic type parameters by default. The returned `impl Iterator` therefore captures the anonymous generic from `impl AsRef<Path>`, and since the opaque type has no other lifetime in scope, the compiler requires that generic to be `'static` — which then propagates to callers.

The implementation doesn't actually borrow from the path argument (it calls `to_path_buf()` immediately), so the captured generic is spurious. The compiler's suggested `+ 'static` bound over-constrains all callers.

The natural fix — `+ use<>` (Rust 2024 precise-capturing syntax) — is rejected by the compiler because `use<>` must mention every in-scope type parameter, and an `impl Trait` parameter has no name to list.

#### Summary of Changes
- Changed `full_snapshot_archives_iter` and `incremental_snapshot_archives_iter` to take `&Path` instead of `impl AsRef<Path>`. With no generic type parameter in scope, `+ use<>` becomes legal and tells the compiler the returned iterator captures nothing from the signature.
- Added `+ use<T>` to the private `snapshot_archives_iter<T>` helper so it captures `T` only (not the input `&Path` lifetime).
- Updated callers that previously relied on `AsRef<Path>` polymorphism:
  - `snapshots/src/paths.rs`: `get_highest_*_info` now calls `.as_ref()` on its `impl AsRef<Path>` parameter when forwarding.
  - `runtime/src/snapshot_utils.rs`: two `&impl AsRef<Path>` callsites switched to `.as_ref()`; one test passing `&TempDir` switched to `.path()`.
  - `local-cluster/tests/local_cluster.rs`: two callsites passing `&TempDir` switched to `.path()`.
- Other callers already passed `.path()` or `&PathBuf` (deref-coerces to `&Path`) and need no change.
