### PR TITLE
nit: remove not applicable TODO comment

### DIFF
--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -51,10 +51,6 @@ pub(crate) struct ConsensusPoolContext {
     pub(crate) sharable_banks: SharableBanks,
     pub(crate) leader_schedule_cache: Arc<LeaderScheduleCache>,
 
-    // TODO: for now we ingest our own votes into the certificate pool
-    // just like regular votes. However do we need to convert
-    // Vote -> BLSMessage -> Vote?
-    // consider adding a separate pathway in consensus_pool.add_message() for ingesting own votes
     pub(crate) consensus_message_receiver: Receiver<Vec<ConsensusMessage>>,
 
     pub(crate) bls_sender: Sender<BLSOp>,


### PR DESCRIPTION
#### Problem
The TODO comment states that there is an opportunity for a better path for ingesting our own votes. We don't just use the `Vote` part of the `VoteMessage`, the signature and rank are actually used when ingesting the vote and would thus have to be looked up on the other ingestion path as well.

#### Summary of Changes
Remove the TODO comment.