### PR TITLE
nit: fix invalid expect format placeholders

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -227,10 +227,12 @@ impl ConsensusPool {
                     Some(match self.vote_pools.get(&(slot, *vote_type))? {
                         VotePool::SimpleVotePool(pool) => pool.total_stake(),
                         VotePool::DuplicateBlockVotePool(pool) => {
-                            pool.total_stake_by_block_id(block_id.as_ref().expect(
-                                "Duplicate block pool for {vote_type:?} expects a block id for \
-                                 certificate {cert_type:?}",
-                            ))
+                            pool.total_stake_by_block_id(block_id.as_ref().unwrap_or_else(|| {
+                                panic!(
+                                    "Duplicate block pool for {vote_type:?} expects a block id \
+                                     for certificate {cert_type:?}"
+                                )
+                            }))
                         }
                     })
                 })


### PR DESCRIPTION
#### Problem
`expect()` is not a macro that does string formatting, it just treats its argument as a regular string literal, e.g. "{vote_type:?}" would print literally

#### Summary of Changes
replace `expect(...)` with `unwrap_or_else(|| {panic!(...))`