### PR TITLE
test(solana-vote): enable solana-bls-signatures/solana-signer-derive in dcou

### DIFF
--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -18,7 +18,13 @@ name = "solana_vote"
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = ["dep:qualifier_attr", "dep:rand", "dep:bincode", "dep:solana-bls-signatures"]
+dev-context-only-utils = [
+    "dep:qualifier_attr",
+    "dep:rand",
+    "dep:bincode",
+    "dep:solana-bls-signatures",
+    "solana-bls-signatures/solana-signer-derive",
+]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",


### PR DESCRIPTION
#### Problem

(related to https://github.com/anza-xyz/agave/pull/12314)

`cargo +nightly-2026-02-28 hack check --each-feature --exclude-all-features --all-targets -p solana-vote` failed

```
error[E0599]: no function or associated item named `derive_from_signer` found for struct `solana_bls_signatures::Keypair` in the current scope
   --> vote/src/vote_account.rs:119:25
    |
119 |             BLSKeypair::derive_from_signer(&keypair, BLS_KEYPAIR_DERIVE_SEED).unwrap();
    |                         ^^^^^^^^^^^^^^^^^^ function or associated item not found in `solana_bls_signatures::Keypair`
    |
```

#### Summary of Changes

that function is behind the `solana-signer-derive` feature and that user is behind dcou. let's enable it when dcou is enabled