### PR TITLE
test(solana-runtime): do not compile some bench when shuttle-test enabled

### DIFF
--- a/runtime/benches/status_cache.rs
+++ b/runtime/benches/status_cache.rs
@@ -1,17 +1,18 @@
 #![feature(test)]
 extern crate test;
 
+#[cfg(not(feature = "shuttle-test"))]
+use {bincode::serialize, solana_hash::HASH_BYTES, solana_sha256_hasher::hash};
 use {
-    bincode::serialize,
     rand::{Rng, SeedableRng, rngs::SmallRng},
     solana_accounts_db::ancestors::Ancestors,
-    solana_hash::{HASH_BYTES, Hash},
+    solana_hash::Hash,
     solana_runtime::bank::BankStatusCache,
-    solana_sha256_hasher::hash,
     solana_signature::{SIGNATURE_BYTES, Signature},
     test::Bencher,
 };
 
+#[cfg(not(feature = "shuttle-test"))]
 #[bench]
 fn bench_status_cache_serialize(bencher: &mut Bencher) {
     let mut status_cache = BankStatusCache::default();
@@ -35,6 +36,7 @@ fn bench_status_cache_serialize(bencher: &mut Bencher) {
     });
 }
 
+#[cfg(not(feature = "shuttle-test"))]
 #[bench]
 fn bench_status_cache_serialize_max(bencher: &mut Bencher) {
     // Fill up the status cache to better match what intense runtime usage would


### PR DESCRIPTION
#### Problem

(related to https://github.com/anza-xyz/agave/pull/12314)

`cargo +nightly-2026-02-28 hack check --each-feature --exclude-all-features --all-targets -p solana-runtime` failed:

```
error[E0277]: the trait bound `Mutex<HashMap<Hash, (usize, Vec<([u8; 20], Result<(), TransactionError>)>), RandomState>>: serde::Serialize` is not satisfied
   --> runtime/benches/status_cache.rs:34:27
    |
 34 |         let _ = serialize(&status_cache.root_slot_deltas()).unwrap();
    |                 --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde_core::ser::Serialize` is not implemented for `Mutex<HashMap<Hash, (usize, Vec<([u8; 20], Result<(), TransactionError>)>), RandomState>>`
    |                 |
    |                 required by a bound introduced by this call
```

correct me if I'm wrong but it looks like `shuttle::sync::Mutex` doesn’t support serialization 🤔 

#### Summary of Changes

don't comptile some bench tests when `shuttle-test` enabled