### PR TITLE
cleanup(accounts-db): rip out StorageAccess::Mmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ Release channels have their own copy of this changelog:
 #### Changes
 ### Validator
 #### Breaking
+#### Deprecations
+* `--accounts-db-access-storages-method` is now deprecated and a no-op (the `mmap` value was
+  deprecated in v4.0.0; mmap mode has now been removed entirely). The flag is still accepted for
+  backward compatibility, but account storages are always accessed via file I/O.
 #### Changes
-* `--accounts-db-access-storages-method` (deprecated in v4.0.0) is now a no-op. The flag is still
-  accepted for backward compatibility, but account storages are always accessed via file I/O.
 
 ## 4.1.0
 ### RPC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Release channels have their own copy of this changelog:
 ### Validator
 #### Breaking
 #### Changes
+* `--accounts-db-access-storages-method` (deprecated in v4.0.0) is now a no-op. The flag is still
+  accepted for backward compatibility, but account storages are always accessed via file I/O.
 
 ## 4.1.0
 ### RPC

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6938,7 +6938,6 @@ dependencies = [
  "dashmap",
  "itertools 0.14.0",
  "log",
- "memmap2 0.9.10",
  "memoffset 0.9.1",
  "modular-bitfield",
  "num_cpus",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -44,7 +44,6 @@ bv = { workspace = true, features = ["serde"] }
 dashmap = { workspace = true, features = ["rayon", "raw-api"] }
 itertools = { workspace = true }
 log = { workspace = true }
-memmap2 = { workspace = true }
 modular-bitfield = { workspace = true }
 num_cpus = { workspace = true }
 qualifier_attr = { workspace = true, optional = true }

--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -3,7 +3,6 @@ use {
     criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::{
-        accounts_file::StorageAccess,
         append_vec::{self, AppendVec},
         utils::create_account_shared_data,
     },
@@ -26,8 +25,8 @@ const ACCOUNTS_COUNTS: [usize; 4] = [
     10_000, // reasonable largest number of accounts written per slot
 ];
 
-fn bench_write_accounts_file(c: &mut Criterion, storage_access: StorageAccess) {
-    let mut group = c.benchmark_group(format!("write_accounts_file_{storage_access:?}"));
+fn bench_write_accounts_file(c: &mut Criterion) {
+    let mut group = c.benchmark_group("write_accounts_file");
 
     // most accounts on mnb are 165-200 bytes, so use that here too
     let space = 200;
@@ -56,7 +55,7 @@ fn bench_write_accounts_file(c: &mut Criterion, storage_access: StorageAccess) {
                 || {
                     let path = temp_dir.path().join(format!("append_vec_{accounts_count}"));
                     let file_size = accounts.len() * (space + append_vec::STORE_META_OVERHEAD);
-                    AppendVec::new(path, true, file_size, storage_access)
+                    AppendVec::new(path, true, file_size)
                 },
                 |append_vec| {
                     let res = append_vec.append_accounts(&storable_accounts, 0).unwrap();
@@ -67,18 +66,6 @@ fn bench_write_accounts_file(c: &mut Criterion, storage_access: StorageAccess) {
             );
         });
     }
-}
-
-fn bench_write_accounts_file_file_io(c: &mut Criterion) {
-    bench_write_accounts_file(c, StorageAccess::File);
-}
-
-fn bench_write_accounts_file_mmap(c: &mut Criterion) {
-    bench_write_accounts_file(
-        c,
-        #[allow(deprecated)]
-        StorageAccess::Mmap,
-    );
 }
 
 fn bench_scan_pubkeys(c: &mut Criterion) {
@@ -108,39 +95,22 @@ fn bench_scan_pubkeys(c: &mut Criterion) {
             .iter()
             .map(|(_, account)| AppendVec::calculate_stored_size(account.data().len()))
             .sum();
-        let append_vec = AppendVec::new(append_vec_path, true, file_size, StorageAccess::File);
+        let append_vec = AppendVec::new(append_vec_path, true, file_size);
         let stored_accounts_info = append_vec
             .append_accounts(&(Slot::MAX, storable_accounts.as_slice()), 0)
             .unwrap();
         assert_eq!(stored_accounts_info.offsets.len(), accounts_count);
         append_vec.flush().unwrap();
-        // Open append vecs for reading here, outside of the bench function, so we don't open lots
-        // of file handles and run out/crash.  We also need to *not* remove the backing file in
-        // these new append vecs because that would cause double-free (or triple-free here).
-        // Wrap the append vecs in ManuallyDrop to *not* remove the backing file on drop.
-        let append_vec_mmap = ManuallyDrop::new(
-            AppendVec::new_from_file(
-                append_vec.path(),
-                append_vec.len(),
-                #[allow(deprecated)]
-                StorageAccess::Mmap,
-            )
-            .unwrap()
-            .0,
-        );
+        // Open the append vec for reading here, outside of the bench function, so we don't open
+        // lots of file handles and run out/crash.  We also need to *not* remove the backing file in
+        // this new append vec because that would cause a double-free.  Wrap the append vec in
+        // ManuallyDrop to *not* remove the backing file on drop.
         let append_vec_file = ManuallyDrop::new(
-            AppendVec::new_from_file(append_vec.path(), append_vec.len(), StorageAccess::File)
+            AppendVec::new_from_file(append_vec.path(), append_vec.len())
                 .unwrap()
                 .0,
         );
 
-        group.bench_function(BenchmarkId::new("append_vec_mmap", accounts_count), |b| {
-            b.iter(|| {
-                let mut count = 0;
-                append_vec_mmap.scan_pubkeys(|_| count += 1).unwrap();
-                assert_eq!(count, accounts_count);
-            });
-        });
         group.bench_function(BenchmarkId::new("append_vec_file", accounts_count), |b| {
             b.iter(|| {
                 let mut count = 0;
@@ -176,28 +146,18 @@ fn bench_get_account_shared_data(c: &mut Criterion) {
             .iter()
             .map(|(_, account)| AppendVec::calculate_stored_size(account.data().len()))
             .sum();
-        let append_vec = AppendVec::new(append_vec_path, true, file_size, StorageAccess::File);
+        let append_vec = AppendVec::new(append_vec_path, true, file_size);
         let stored_accounts_info = append_vec
             .append_accounts(&(Slot::MAX, storable_accounts.as_slice()), 0)
             .unwrap();
         assert_eq!(stored_accounts_info.offsets.len(), 1);
         append_vec.flush().unwrap();
-        // Open append vecs for reading here, outside of the bench function, so we don't open lots
-        // of file handles and run out/crash.  We also need to *not* remove the backing file in
-        // these new append vecs because that would cause double-free (or triple-free here).
-        // Wrap the append vecs in ManuallyDrop to *not* remove the backing file on drop.
-        let append_vec_mmap = ManuallyDrop::new(
-            AppendVec::new_from_file(
-                append_vec.path(),
-                append_vec.len(),
-                #[allow(deprecated)]
-                StorageAccess::Mmap,
-            )
-            .unwrap()
-            .0,
-        );
+        // Open the append vec for reading here, outside of the bench function, so we don't open
+        // lots of file handles and run out/crash.  We also need to *not* remove the backing file in
+        // this new append vec because that would cause a double-free.  Wrap the append vec in
+        // ManuallyDrop to *not* remove the backing file on drop.
         let append_vec_file = ManuallyDrop::new(
-            AppendVec::new_from_file(append_vec.path(), append_vec.len(), StorageAccess::File)
+            AppendVec::new_from_file(append_vec.path(), append_vec.len())
                 .unwrap()
                 .0,
         );
@@ -205,29 +165,6 @@ fn bench_get_account_shared_data(c: &mut Criterion) {
         // Run the benchmarks!
         // Note, use `iter_with_large_drop()` to avoid timing how long it takes to drop the Vec of
         // account data.
-        group.bench_function(
-            // The baseline.
-            BenchmarkId::new("append_vec_mmap_get_account_shared_data", data_size),
-            |b| {
-                b.iter_with_large_drop(|| {
-                    _ = append_vec_mmap.get_account_shared_data(0).unwrap();
-                });
-            },
-        );
-        group.bench_function(
-            // The mmap "baseline" impl (above) does exactly the same as this one (below),
-            // so we expect perf to be identical.
-            BenchmarkId::new("append_vec_mmap_get_stored_account_callback", data_size),
-            |b| {
-                b.iter_with_large_drop(|| {
-                    _ = append_vec_mmap
-                        .get_stored_account_callback(0, |account| {
-                            create_account_shared_data(&account)
-                        })
-                        .unwrap();
-                });
-            },
-        );
         group.bench_function(
             // The custom file io impl, which avoids the extra allocation.
             BenchmarkId::new("append_vec_file_get_account_shared_data", data_size),
@@ -257,8 +194,7 @@ fn bench_get_account_shared_data(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    bench_write_accounts_file_file_io,
-    bench_write_accounts_file_mmap,
+    bench_write_accounts_file,
     bench_scan_pubkeys,
     bench_get_account_shared_data,
 );

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -502,20 +502,18 @@ fn select_from_range_with_start_end_rates(
 mod tests {
     use {
         super::*,
-        crate::accounts_file::{AccountsFileProvider, StorageAccess},
+        crate::accounts_file::AccountsFileProvider,
         std::{iter, path::Path},
         tempfile::TempDir,
-        test_case::test_case,
     };
 
-    fn new_test_storage(storage_access: StorageAccess) -> (TempDir, Arc<AccountStorageEntry>) {
-        new_test_storage_with(0, 0, storage_access)
+    fn new_test_storage() -> (TempDir, Arc<AccountStorageEntry>) {
+        new_test_storage_with(0, 0)
     }
 
     fn new_test_storage_with(
         slot: Slot,
         id: AccountsFileId,
-        storage_access: StorageAccess,
     ) -> (TempDir, Arc<AccountStorageEntry>) {
         let temp_dir = TempDir::new().unwrap();
         let store_file_size = 4000;
@@ -525,14 +523,12 @@ mod tests {
             id,
             store_file_size,
             AccountsFileProvider::AppendVec,
-            storage_access,
         ));
         (temp_dir, storage)
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_shrink_in_progress(storage_access: StorageAccess) {
+    #[test]
+    fn test_shrink_in_progress() {
         // test that we check in order map then shrink_in_progress_map
         let storage = AccountStorage::default();
         let slot = 0;
@@ -551,7 +547,6 @@ mod tests {
             id,
             store_file_size,
             AccountsFileProvider::AppendVec,
-            storage_access,
         ));
         let entry2 = Arc::new(AccountStorageEntry::new(
             common_store_path,
@@ -559,7 +554,6 @@ mod tests {
             id,
             store_file_size2,
             AccountsFileProvider::AppendVec,
-            storage_access,
         ));
         storage.map.insert(slot, entry);
 
@@ -601,11 +595,10 @@ mod tests {
         );
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
+    #[test]
     #[should_panic(expected = "shrink is in progress!")]
-    fn test_get_slot_storage_entry_fail(storage_access: StorageAccess) {
-        let (_temp_dir, sample) = new_test_storage(storage_access);
+    fn test_get_slot_storage_entry_fail() {
+        let (_temp_dir, sample) = new_test_storage();
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
@@ -615,11 +608,10 @@ mod tests {
         storage.get_slot_storage_entry(0);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
+    #[test]
     #[should_panic(expected = "shrink is in progress!")]
-    fn test_all_slots_fail(storage_access: StorageAccess) {
-        let (_temp_dir, sample) = new_test_storage(storage_access);
+    fn test_all_slots_fail() {
+        let (_temp_dir, sample) = new_test_storage();
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
@@ -629,11 +621,10 @@ mod tests {
         storage.all_slots();
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
+    #[test]
     #[should_panic(expected = "shrink is in progress!")]
-    fn test_initialize_fail(storage_access: StorageAccess) {
-        let (_temp_dir, sample) = new_test_storage(storage_access);
+    fn test_initialize_fail() {
+        let (_temp_dir, sample) = new_test_storage();
         let mut storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
@@ -643,13 +634,12 @@ mod tests {
         storage.initialize(AccountStorageMap::default());
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
+    #[test]
     #[should_panic(
         expected = "shrink_can_be_active || self.shrink_in_progress_map.read().unwrap().is_empty()"
     )]
-    fn test_remove_fail(storage_access: StorageAccess) {
-        let (_temp_dir, sample) = new_test_storage(storage_access);
+    fn test_remove_fail() {
+        let (_temp_dir, sample) = new_test_storage();
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
@@ -659,11 +649,10 @@ mod tests {
         storage.remove(&0, false);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
+    #[test]
     #[should_panic(expected = "shrink is in progress!")]
-    fn test_iter_fail(storage_access: StorageAccess) {
-        let (_temp_dir, sample) = new_test_storage(storage_access);
+    fn test_iter_fail() {
+        let (_temp_dir, sample) = new_test_storage();
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
@@ -673,11 +662,10 @@ mod tests {
         storage.iter();
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
+    #[test]
     #[should_panic(expected = "shrink is in progress!")]
-    fn test_insert_fail(storage_access: StorageAccess) {
-        let (_temp_dir, sample) = new_test_storage(storage_access);
+    fn test_insert_fail() {
+        let (_temp_dir, sample) = new_test_storage();
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map
@@ -687,18 +675,16 @@ mod tests {
         storage.insert(sample);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_shrinking_in_progress_second_call(storage_access: StorageAccess) {
+    #[test]
+    fn test_shrinking_in_progress_second_call() {
         // already called 'shrink_in_progress' on this slot, but it finished, so we succeed
         // verify data structures during and after shrink and then with subsequent shrink call
         let storage = AccountStorage::default();
         let slot = 0;
         let id_to_shrink = 1;
         let id_shrunk = 0;
-        let (_temp_dir1, sample_to_shrink) =
-            new_test_storage_with(slot, id_to_shrink, storage_access);
-        let (_temp_dir2, sample) = new_test_storage_with(slot, id_shrunk, storage_access);
+        let (_temp_dir1, sample_to_shrink) = new_test_storage_with(slot, id_to_shrink);
+        let (_temp_dir2, sample) = new_test_storage_with(slot, id_shrunk);
         storage.map.insert(slot, sample_to_shrink.clone());
         let shrinking_in_progress =
             storage.shrinking_in_progress(slot, sample_to_shrink.clone(), sample.clone());
@@ -722,22 +708,20 @@ mod tests {
         storage.shrinking_in_progress(slot, sample.clone(), sample);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
+    #[test]
     #[should_panic(expected = "pre-existing storage for shrinking slot")]
-    fn test_shrinking_in_progress_fail1(storage_access: StorageAccess) {
+    fn test_shrinking_in_progress_fail1() {
         // nothing in slot currently
-        let (_temp_dir, sample) = new_test_storage(storage_access);
+        let (_temp_dir, sample) = new_test_storage();
         let storage = AccountStorage::default();
         storage.shrinking_in_progress(0, sample.clone(), sample);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
+    #[test]
     #[should_panic(expected = "duplicate call")]
-    fn test_shrinking_in_progress_fail2(storage_access: StorageAccess) {
+    fn test_shrinking_in_progress_fail2() {
         // already entry in shrink_in_progress_map
-        let (_temp_dir, sample) = new_test_storage(storage_access);
+        let (_temp_dir, sample) = new_test_storage();
         let storage = AccountStorage::default();
         storage.map.insert(0, sample.clone());
         storage
@@ -748,13 +732,12 @@ mod tests {
         storage.shrinking_in_progress(0, sample.clone(), sample);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
+    #[test]
     #[should_panic(expected = "duplicate call")]
-    fn test_shrinking_in_progress_fail3(storage_access: StorageAccess) {
+    fn test_shrinking_in_progress_fail3() {
         // already called 'shrink_in_progress' on this slot and it is still active
-        let (_temp_dir1, sample_to_shrink) = new_test_storage(storage_access);
-        let (_temp_dir2, sample) = new_test_storage(storage_access);
+        let (_temp_dir1, sample_to_shrink) = new_test_storage();
+        let (_temp_dir2, sample) = new_test_storage();
         let storage = AccountStorage::default();
         storage.map.insert(0, sample_to_shrink.clone());
         let _shrinking_in_progress =
@@ -762,12 +745,11 @@ mod tests {
         storage.shrinking_in_progress(0, sample_to_shrink, sample);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_missing(storage_access: StorageAccess) {
+    #[test]
+    fn test_missing() {
         // already called 'shrink_in_progress' on this slot, but it finished, so we succeed
         // verify data structures during and after shrink and then with subsequent shrink call
-        let (_temp_dir, sample) = new_test_storage(storage_access);
+        let (_temp_dir, sample) = new_test_storage();
         let storage = AccountStorage::default();
         let id = sample.id();
         let missing_id = 9999;
@@ -810,9 +792,8 @@ mod tests {
         assert!(storage.get_account_storage_entry(slot, id).is_some());
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_get_if(storage_access: StorageAccess) {
+    #[test]
+    fn test_get_if() {
         let storage = AccountStorage::default();
         assert!(storage.get_if(|_, _| true).is_empty());
 
@@ -826,7 +807,6 @@ mod tests {
                 id,
                 5000,
                 AccountsFileProvider::AppendVec,
-                storage_access,
             );
             storage.map.insert(slot, entry.into());
         }
@@ -846,11 +826,10 @@ mod tests {
         assert_eq!(storage.get_if(|_, _| true).len(), ids.len());
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
+    #[test]
     #[should_panic(expected = "shrink is in progress!")]
-    fn test_get_if_fail(storage_access: StorageAccess) {
-        let (_temp_dir, sample) = new_test_storage(storage_access);
+    fn test_get_if_fail() {
+        let (_temp_dir, sample) = new_test_storage();
         let storage = AccountStorage::default();
         storage
             .shrink_in_progress_map

--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         account_info::Offset,
         accounts_db::AccountsFileId,
-        accounts_file::{AccountsFile, AccountsFileError, AccountsFileProvider, StorageAccess},
+        accounts_file::{AccountsFile, AccountsFileError, AccountsFileProvider},
         obsolete_accounts::ObsoleteAccounts,
     },
     solana_clock::Slot,
@@ -61,11 +61,10 @@ impl AccountStorageEntry {
         id: AccountsFileId,
         file_size: u64,
         provider: AccountsFileProvider,
-        storage_access: StorageAccess,
     ) -> Self {
         let tail = AccountsFile::file_name(slot, id);
         let path = Path::new(path).join(tail);
-        let accounts = provider.new_writable(path, file_size, storage_access);
+        let accounts = provider.new_writable(path, file_size);
 
         Self {
             id,
@@ -79,12 +78,7 @@ impl AccountStorageEntry {
     }
 
     /// open a new instance of the storage that is readonly
-    pub(crate) fn reopen_as_readonly(&self, storage_access: StorageAccess) -> Option<Self> {
-        if storage_access != StorageAccess::File {
-            // if we are only using mmap, then no reason to re-open
-            return None;
-        }
-
+    pub(crate) fn reopen_as_readonly(&self) -> Option<Self> {
         self.accounts.reopen_as_readonly().map(|accounts| Self {
             id: self.id,
             slot: self.slot,

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        account_info::Offset, account_storage_entry::AccountStorageEntry,
-        accounts_file::InternalsForArchive,
-    },
+    crate::{account_info::Offset, account_storage_entry::AccountStorageEntry},
     solana_clock::Slot,
     std::{
         fs::File,
@@ -12,19 +9,18 @@ use {
 
 /// A wrapper type around `AccountStorageEntry` that implements the `Read` trait.
 /// This type skips over the data in accounts contained in the obsolete accounts structure
-pub struct AccountStorageReader<'a> {
+pub struct AccountStorageReader {
     sorted_obsolete_accounts: Vec<(Offset, usize)>,
     current_offset: usize,
-    file: Option<File>,
-    internals: InternalsForArchive<'a>,
+    file: File,
     num_alive_bytes: usize,
     num_total_bytes: usize,
 }
 
-impl<'a> AccountStorageReader<'a> {
+impl AccountStorageReader {
     /// Creates a new `AccountStorageReader` from an `AccountStorageEntry`.
     /// The obsolete accounts structure is sorted during initialization.
-    pub fn new(storage: &'a AccountStorageEntry, snapshot_slot: Option<Slot>) -> io::Result<Self> {
+    pub fn new(storage: &AccountStorageEntry, snapshot_slot: Option<Slot>) -> io::Result<Self> {
         let internals = storage.accounts.internals_for_archive();
         let num_total_bytes = storage.accounts.len();
         let num_alive_bytes = num_total_bytes - storage.get_obsolete_bytes(snapshot_slot);
@@ -44,16 +40,12 @@ impl<'a> AccountStorageReader<'a> {
         sorted_obsolete_accounts
             .sort_unstable_by(|(a_offset, _), (b_offset, _)| b_offset.cmp(a_offset));
 
-        let file = match internals {
-            InternalsForArchive::Mmap(_internals) => None,
-            InternalsForArchive::FileIo(path) => Some(File::open(path)?),
-        };
+        let file = File::open(internals.path)?;
 
         Ok(Self {
             sorted_obsolete_accounts,
             current_offset: 0,
             file,
-            internals,
             num_alive_bytes,
             num_total_bytes,
         })
@@ -68,7 +60,7 @@ impl<'a> AccountStorageReader<'a> {
     }
 }
 
-impl Read for AccountStorageReader<'_> {
+impl Read for AccountStorageReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut total_read = 0;
         let buf_len = buf.len();
@@ -95,20 +87,9 @@ impl Read for AccountStorageReader<'_> {
 
             let bytes_to_read = bytes_left_in_buffer.min(bytes_to_read_from_file);
 
-            let read_size = match self.internals {
-                InternalsForArchive::Mmap(data) => (&data
-                    [self.current_offset..self.current_offset + bytes_to_read])
-                    .read(&mut buf[total_read..][..bytes_to_read])?,
-
-                InternalsForArchive::FileIo(_) => {
-                    let file = &mut self
-                        .file
-                        .as_mut()
-                        .expect("File is opened during initialization");
-                    file.seek(SeekFrom::Start(self.current_offset as u64))?;
-                    file.read(&mut buf[total_read..][..bytes_to_read])?
-                }
-            };
+            self.file
+                .seek(SeekFrom::Start(self.current_offset as u64))?;
+            let read_size = self.file.read(&mut buf[total_read..][..bytes_to_read])?;
 
             if read_size == 0 {
                 break; // EOF
@@ -130,7 +111,7 @@ mod tests {
             ObsoleteAccounts,
             account_storage_entry::AccountStorageEntry,
             accounts_db::get_temp_accounts_paths,
-            accounts_file::{AccountsFile, AccountsFileProvider, StorageAccess},
+            accounts_file::{AccountsFile, AccountsFileProvider},
         },
         log::*,
         rand::{
@@ -147,24 +128,19 @@ mod tests {
     fn create_storage_for_storage_reader(
         slot: Slot,
         provider: AccountsFileProvider,
-        storage_access: StorageAccess,
     ) -> (AccountStorageEntry, Vec<tempfile::TempDir>) {
         let id = 0;
         let (temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
         let file_size = 1024 * 1024;
         (
-            AccountStorageEntry::new(&paths[0], slot, id, file_size, provider, storage_access),
+            AccountStorageEntry::new(&paths[0], slot, id, file_size, provider),
             temp_dirs,
         )
     }
 
-    #[test_case(AccountsFileProvider::AppendVec, #[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(AccountsFileProvider::AppendVec, StorageAccess::File)]
-    fn test_account_storage_reader_no_obsolete_accounts(
-        provider: AccountsFileProvider,
-        storage_access: StorageAccess,
-    ) {
-        let (storage, _temp_dirs) = create_storage_for_storage_reader(0, provider, storage_access);
+    #[test_case(AccountsFileProvider::AppendVec)]
+    fn test_account_storage_reader_no_obsolete_accounts(provider: AccountsFileProvider) {
+        let (storage, _temp_dirs) = create_storage_for_storage_reader(0, provider);
 
         let account = AccountSharedData::new(1, 10, &Pubkey::default());
         let account2 = AccountSharedData::new(1, 10, &Pubkey::default());
@@ -181,26 +157,19 @@ mod tests {
         assert_eq!(reader.len(), storage.accounts.len());
     }
 
-    #[test_case(0, 0, StorageAccess::File)]
-    #[test_case(1, 0, StorageAccess::File)]
-    #[test_case(1, 1, StorageAccess::File)]
-    #[test_case(100, 0, StorageAccess::File)]
-    #[test_case(100, 10, StorageAccess::File)]
-    #[test_case(100, 100, StorageAccess::File)]
-    #[test_case(0, 0, #[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(1, 0, #[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(1, 1, #[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(100, 0, #[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(100, 10, #[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(100, 100, #[allow(deprecated)] StorageAccess::Mmap)]
+    #[test_case(0, 0)]
+    #[test_case(1, 0)]
+    #[test_case(1, 1)]
+    #[test_case(100, 0)]
+    #[test_case(100, 10)]
+    #[test_case(100, 100)]
     fn test_account_storage_reader_with_obsolete_accounts(
         total_accounts: usize,
         number_of_accounts_to_remove: usize,
-        storage_access: StorageAccess,
     ) {
         agave_logger::setup();
         let (storage, _temp_dirs) =
-            create_storage_for_storage_reader(0, AccountsFileProvider::AppendVec, storage_access);
+            create_storage_for_storage_reader(0, AccountsFileProvider::AppendVec);
 
         let slot = 0;
 
@@ -248,22 +217,7 @@ mod tests {
             .unwrap()
             .mark_accounts_obsolete(obsolete_account_offset.into_iter().zip(data_lens), 0);
 
-        let storage = storage
-            .reopen_as_readonly(storage_access)
-            .unwrap_or(storage);
-
-        // Assert that storage.accounts was reopened with the specified access type
-        match storage_access {
-            StorageAccess::File => assert!(matches!(
-                storage.accounts.internals_for_archive(),
-                InternalsForArchive::FileIo(_)
-            )),
-            #[allow(deprecated)]
-            StorageAccess::Mmap => assert!(matches!(
-                storage.accounts.internals_for_archive(),
-                InternalsForArchive::Mmap(_)
-            )),
-        }
+        let storage = storage.reopen_as_readonly().unwrap_or(storage);
 
         // Create the reader and check the length
         let mut reader = AccountStorageReader::new(&storage, None).unwrap();
@@ -285,8 +239,7 @@ mod tests {
         // and verify that the number of accounts in the new file is correct
         if (total_accounts - number_of_accounts_to_remove) != 0 {
             let (accounts_file, num_accounts) =
-                AccountsFile::new_from_file(temp_file_path, current_len, StorageAccess::File)
-                    .unwrap();
+                AccountsFile::new_from_file(temp_file_path, current_len).unwrap();
 
             // Verify that the correct number of accounts were found in the file
             assert_eq!(
@@ -307,11 +260,10 @@ mod tests {
         }
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_account_storage_reader_filter_by_slot(storage_access: StorageAccess) {
+    #[test]
+    fn test_account_storage_reader_filter_by_slot() {
         let (storage, _temp_dirs) =
-            create_storage_for_storage_reader(10, AccountsFileProvider::AppendVec, storage_access);
+            create_storage_for_storage_reader(10, AccountsFileProvider::AppendVec);
         let total_accounts = 30;
 
         let slot = 0;
@@ -398,8 +350,7 @@ mod tests {
             drop(output_file);
 
             let (accounts_file, _num_accounts) =
-                AccountsFile::new_from_file(temp_file_path, current_len, StorageAccess::File)
-                    .unwrap();
+                AccountsFile::new_from_file(temp_file_path, current_len).unwrap();
 
             // Create a new AccountStorageEntry from the output file
             let new_storage = AccountStorageEntry::new_existing(

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -43,7 +43,7 @@ use {
             StoreAccountsFrozenStats, StoreAccountsTiming, StoreAccountsUnfrozenStats,
             WriteAccountsToCacheStats,
         },
-        accounts_file::{AccountsFile, AccountsFileProvider, StorageAccess},
+        accounts_file::{AccountsFile, AccountsFileProvider},
         accounts_hash::{AccountLtHash, AccountsLtHash, ZERO_LAMPORT_ACCOUNT_LT_HASH},
         accounts_index::{
             AccountSecondaryIndexes, AccountsIndex, AccountsIndexRootsStats,
@@ -973,9 +973,6 @@ pub struct AccountsDb {
     /// storage format to use for new storages
     accounts_file_provider: AccountsFileProvider,
 
-    /// method to use for accessing storages
-    storage_access: StorageAccess,
-
     /// index scan filtering for shrinking
     scan_filter_for_shrinking: ScanFilter,
 
@@ -1129,7 +1126,6 @@ impl AccountsDb {
             write_cache_limit_bytes: accounts_db_config.write_cache_limit_bytes,
             partitioned_epoch_rewards_config: accounts_db_config.partitioned_epoch_rewards_config,
             exhaustively_verify_refcounts: accounts_db_config.exhaustively_verify_refcounts,
-            storage_access: accounts_db_config.storage_access,
             scan_filter_for_shrinking: accounts_db_config.scan_filter_for_shrinking,
             thread_pool_foreground,
             thread_pool_background,
@@ -1193,7 +1189,6 @@ impl AccountsDb {
             self.next_id(),
             size,
             self.accounts_file_provider,
-            self.storage_access,
         )
     }
 
@@ -2513,11 +2508,6 @@ impl AccountsDb {
         }
     }
 
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn set_storage_access(&mut self, storage_access: StorageAccess) {
-        self.storage_access = storage_access;
-    }
-
     pub(crate) fn get_unique_accounts_from_storage_for_shrink(
         &self,
         store: &AccountStorageEntry,
@@ -3004,7 +2994,7 @@ impl AccountsDb {
             .storage
             .get_slot_storage_entry_shrinking_in_progress_ok(slot)
         {
-            if let Some(new_storage) = storage.reopen_as_readonly(self.storage_access) {
+            if let Some(new_storage) = storage.reopen_as_readonly() {
                 // consider here the race condition of tx processing having looked up something in the index,
                 // which could return (slot, append vec id). We want the lookup for the storage to get a storage
                 // that works whether the lookup occurs before or after the replace call here.
@@ -6635,11 +6625,6 @@ impl AccountsDb {
     /// This is useful for testing clean algorithms.
     pub fn get_len_of_slots_with_uncleaned_pubkeys(&self) -> usize {
         self.uncleaned_pubkeys.len()
-    }
-
-    #[cfg(test)]
-    pub fn storage_access(&self) -> StorageAccess {
-        self.storage_access
     }
 
     /// Call clean_accounts() with the common parameters that tests/benches use.

--- a/accounts-db/src/accounts_db/accounts_db_config.rs
+++ b/accounts-db/src/accounts_db/accounts_db_config.rs
@@ -1,7 +1,6 @@
 use {
     super::{AccountShrinkThreshold, DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION},
     crate::{
-        accounts_file::StorageAccess,
         accounts_index::{
             ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
             AccountSecondaryIndexes, AccountsIndexConfig, ScanFilter,
@@ -38,7 +37,6 @@ pub struct AccountsDbConfig {
     pub skip_initial_hash_calc: bool,
     pub exhaustively_verify_refcounts: bool,
     pub partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig,
-    pub storage_access: StorageAccess,
     pub scan_filter_for_shrinking: ScanFilter,
     /// Number of threads for background operations (`thread_pool_background')
     pub num_background_threads: Option<NonZeroUsize>,
@@ -62,7 +60,6 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     skip_initial_hash_calc: false,
     exhaustively_verify_refcounts: false,
     partitioned_epoch_rewards_config: DEFAULT_PARTITIONED_EPOCH_REWARDS_CONFIG,
-    storage_access: StorageAccess::File,
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormalTest,
     num_background_threads: None,
     num_foreground_threads: None,
@@ -84,7 +81,6 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     skip_initial_hash_calc: false,
     exhaustively_verify_refcounts: false,
     partitioned_epoch_rewards_config: DEFAULT_PARTITIONED_EPOCH_REWARDS_CONFIG,
-    storage_access: StorageAccess::File,
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormal,
     num_background_threads: None,
     num_foreground_threads: None,

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -397,11 +397,6 @@ impl LatestAccountsIndexRootsStats {
                 "append_vecs_dirty",
                 APPEND_VEC_STATS.files_dirty.load(Ordering::Relaxed),
                 i64
-            ),
-            (
-                "append_vecs_open_as_file_io",
-                APPEND_VEC_STATS.open_as_file_io.load(Ordering::Relaxed),
-                i64
             )
         );
 

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -399,11 +399,6 @@ impl LatestAccountsIndexRootsStats {
                 i64
             ),
             (
-                "append_vecs_open_as_mmap",
-                APPEND_VEC_STATS.open_as_mmap.load(Ordering::Relaxed),
-                i64
-            ),
-            (
                 "append_vecs_open_as_file_io",
                 APPEND_VEC_STATS.open_as_file_io.load(Ordering::Relaxed),
                 i64

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -289,7 +289,6 @@ fn sample_storage_with_entries_id_fill_percentage(
     mark_alive: bool,
     account_data_size: Option<u64>,
     fill_percentage: u64,
-    storage_access: StorageAccess,
 ) -> Arc<AccountStorageEntry> {
     let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
     let file_size = account_data_size.unwrap_or(123) * 100 / fill_percentage;
@@ -300,13 +299,11 @@ fn sample_storage_with_entries_id_fill_percentage(
         id,
         size_aligned as u64,
         AccountsFileProvider::AppendVec,
-        storage_access,
     );
     let av = AccountsFile::AppendVec(AppendVec::new(
         &tf.path,
         true,
         (1024 * 1024).max(size_aligned),
-        storage_access,
     ));
     data.accounts = av;
 
@@ -322,7 +319,6 @@ fn sample_storage_with_entries_id(
     id: AccountsFileId,
     mark_alive: bool,
     account_data_size: Option<u64>,
-    storage_access: StorageAccess,
 ) -> Arc<AccountStorageEntry> {
     sample_storage_with_entries_id_fill_percentage(
         tf,
@@ -332,7 +328,6 @@ fn sample_storage_with_entries_id(
         mark_alive,
         account_data_size,
         100,
-        storage_access,
     )
 }
 
@@ -2221,9 +2216,8 @@ fn test_select_candidates_by_total_usage_no_candidates() {
     assert_eq!(0, next_candidates.len());
 }
 
-#[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-#[test_case(StorageAccess::File)]
-fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: StorageAccess) {
+#[test]
+fn test_select_candidates_by_total_usage_3_way_split_condition() {
     // three candidates, one selected for shrink, one is put back to the candidate list and one is ignored
     agave_logger::setup();
     let mut candidates = ShrinkCandidates::default();
@@ -2239,7 +2233,6 @@ fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: S
         store1_slot as AccountsFileId,
         store_file_size,
         AccountsFileProvider::AppendVec,
-        storage_access,
     ));
     db.storage.insert(Arc::clone(&store1));
     store1.num_alive_bytes.store(0, Ordering::Release);
@@ -2252,7 +2245,6 @@ fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: S
         store2_slot as AccountsFileId,
         store_file_size,
         AccountsFileProvider::AppendVec,
-        storage_access,
     ));
     db.storage.insert(Arc::clone(&store2));
     store2
@@ -2267,7 +2259,6 @@ fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: S
         store3_slot as AccountsFileId,
         store_file_size,
         AccountsFileProvider::AppendVec,
-        storage_access,
     ));
     db.storage.insert(Arc::clone(&store3));
     store3
@@ -2288,9 +2279,8 @@ fn test_select_candidates_by_total_usage_3_way_split_condition(storage_access: S
     assert!(next_candidates.contains(&store2_slot));
 }
 
-#[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-#[test_case(StorageAccess::File)]
-fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: StorageAccess) {
+#[test]
+fn test_select_candidates_by_total_usage_2_way_split_condition() {
     // three candidates, 2 are selected for shrink, one is ignored
     agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
@@ -2306,7 +2296,6 @@ fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: S
         store1_slot as AccountsFileId,
         store_file_size,
         AccountsFileProvider::AppendVec,
-        storage_access,
     ));
     db.storage.insert(Arc::clone(&store1));
     store1.num_alive_bytes.store(0, Ordering::Release);
@@ -2319,7 +2308,6 @@ fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: S
         store2_slot as AccountsFileId,
         store_file_size,
         AccountsFileProvider::AppendVec,
-        storage_access,
     ));
     db.storage.insert(Arc::clone(&store2));
     store2
@@ -2334,7 +2322,6 @@ fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: S
         store3_slot as AccountsFileId,
         store_file_size,
         AccountsFileProvider::AppendVec,
-        storage_access,
     ));
     db.storage.insert(Arc::clone(&store3));
     store3
@@ -2352,9 +2339,8 @@ fn test_select_candidates_by_total_usage_2_way_split_condition(storage_access: S
     assert_eq!(0, next_candidates.len());
 }
 
-#[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-#[test_case(StorageAccess::File)]
-fn test_select_candidates_by_total_usage_all_clean(storage_access: StorageAccess) {
+#[test]
+fn test_select_candidates_by_total_usage_all_clean() {
     // 2 candidates, they must be selected to achieve the target alive ratio
     agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
@@ -2370,7 +2356,6 @@ fn test_select_candidates_by_total_usage_all_clean(storage_access: StorageAccess
         store1_slot as AccountsFileId,
         store_file_size,
         AccountsFileProvider::AppendVec,
-        storage_access,
     ));
     db.storage.insert(Arc::clone(&store1));
     store1
@@ -2385,7 +2370,6 @@ fn test_select_candidates_by_total_usage_all_clean(storage_access: StorageAccess
         store2_slot as AccountsFileId,
         store_file_size,
         AccountsFileProvider::AppendVec,
-        storage_access,
     ));
     db.storage.insert(Arc::clone(&store2));
     store2
@@ -4271,9 +4255,8 @@ fn test_remove_uncleaned_slots_and_collect_pubkeys_up_to_slot() {
     assert!(candidates_contain(&pubkey3));
 }
 
-#[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-#[test_case(StorageAccess::File)]
-fn test_shrink_productive(storage_access: StorageAccess) {
+#[test]
+fn test_shrink_productive() {
     agave_logger::setup();
     let path = Path::new("");
     let file_size = 100;
@@ -4285,7 +4268,6 @@ fn test_shrink_productive(storage_access: StorageAccess) {
         slot as AccountsFileId,
         file_size,
         AccountsFileProvider::AppendVec,
-        storage_access,
     ));
     store.add_account(file_size as usize);
     assert!(!AccountsDb::is_shrinking_productive(&store));
@@ -4296,7 +4278,6 @@ fn test_shrink_productive(storage_access: StorageAccess) {
         slot as AccountsFileId,
         file_size,
         AccountsFileProvider::AppendVec,
-        storage_access,
     ));
     store.add_account(file_size as usize / 2);
     store.add_account(file_size as usize / 4);
@@ -4307,9 +4288,8 @@ fn test_shrink_productive(storage_access: StorageAccess) {
     assert!(!AccountsDb::is_shrinking_productive(&store));
 }
 
-#[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-#[test_case(StorageAccess::File)]
-fn test_is_candidate_for_shrink(storage_access: StorageAccess) {
+#[test]
+fn test_is_candidate_for_shrink() {
     agave_logger::setup();
 
     let mut accounts = AccountsDb::new_single_for_tests();
@@ -4321,7 +4301,6 @@ fn test_is_candidate_for_shrink(storage_access: StorageAccess) {
         1,
         store_file_size,
         AccountsFileProvider::AppendVec,
-        storage_access,
     ));
     match accounts.shrink_ratio {
         AccountShrinkThreshold::TotalSpace { shrink_ratio } => {
@@ -5720,7 +5699,6 @@ pub(crate) fn create_storages_and_update_index(
             id,
             alive,
             account_data_size,
-            db.storage_access(),
         );
         insert_store(db, Arc::clone(&storage));
     }
@@ -5807,10 +5785,9 @@ fn insert_store(db: &AccountsDb, append_vec: Arc<AccountStorageEntry>) {
     db.storage.insert(append_vec);
 }
 
-#[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-#[test_case(StorageAccess::File)]
+#[test]
 #[should_panic(expected = "self.storage.remove")]
-fn test_handle_dropped_roots_for_ancient_assert(storage_access: StorageAccess) {
+fn test_handle_dropped_roots_for_ancient_assert() {
     agave_logger::setup();
     let common_store_path = Path::new("");
     let store_file_size = 10_000;
@@ -5820,7 +5797,6 @@ fn test_handle_dropped_roots_for_ancient_assert(storage_access: StorageAccess) {
         1,
         store_file_size,
         AccountsFileProvider::AppendVec,
-        storage_access,
     ));
     let db = AccountsDb::new_single_for_tests();
     let slot0 = 0;

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -40,17 +40,6 @@ pub enum AccountsFileError {
     AppendVecError(#[from] AppendVecError),
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub enum StorageAccess {
-    /// storages should be accessed by Mmap
-    #[deprecated(since = "4.0.0")]
-    Mmap,
-    /// storages should be accessed by File I/O
-    /// ancient storages are created by 1-shot write to pack multiple accounts together more efficiently with new formats
-    #[default]
-    File,
-}
-
 #[derive(Debug)]
 /// An enum for accessing an accounts file which can be implemented
 /// under different formats.
@@ -64,12 +53,8 @@ impl AccountsFile {
     /// The second element of the returned tuple is the number of accounts in the
     /// accounts file.
     #[cfg(feature = "dev-context-only-utils")]
-    pub fn new_from_file(
-        path: impl Into<PathBuf>,
-        current_len: usize,
-        storage_access: StorageAccess,
-    ) -> Result<(Self, usize)> {
-        let (av, num_accounts) = AppendVec::new_from_file(path, current_len, storage_access)?;
+    pub fn new_from_file(path: impl Into<PathBuf>, current_len: usize) -> Result<(Self, usize)> {
+        let (av, num_accounts) = AppendVec::new_from_file(path, current_len)?;
         Ok((Self::AppendVec(av), num_accounts))
     }
 
@@ -78,12 +63,8 @@ impl AccountsFile {
     /// This version of `new()` may only be called when reconstructing storages as part of startup.
     /// It trusts the snapshot's value for `current_len`, and relies on later index generation or
     /// accounts verification to ensure it is valid.
-    pub fn new_for_startup(
-        file_info: FileInfo,
-        current_len: usize,
-        storage_access: StorageAccess,
-    ) -> Result<Self> {
-        let av = AppendVec::new_for_startup(file_info, current_len, storage_access)?;
+    pub fn new_for_startup(file_info: FileInfo, current_len: usize) -> Result<Self> {
+        let av = AppendVec::new_for_startup(file_info, current_len)?;
         Ok(Self::AppendVec(av))
     }
 
@@ -280,30 +261,20 @@ pub enum AccountsFileProvider {
 }
 
 impl AccountsFileProvider {
-    pub fn new_writable(
-        &self,
-        path: impl Into<PathBuf>,
-        file_size: u64,
-        storage_access: StorageAccess,
-    ) -> AccountsFile {
+    pub fn new_writable(&self, path: impl Into<PathBuf>, file_size: u64) -> AccountsFile {
         match self {
-            Self::AppendVec => AccountsFile::AppendVec(AppendVec::new(
-                path,
-                true,
-                file_size as usize,
-                storage_access,
-            )),
+            Self::AppendVec => {
+                AccountsFile::AppendVec(AppendVec::new(path, true, file_size as usize))
+            }
         }
     }
 }
 
 /// The access method to use when archiving an AccountsFile
 #[derive(Debug)]
-pub enum InternalsForArchive<'a> {
-    /// Accessing the internals is done via Mmap
-    Mmap(&'a [u8]),
-    /// Accessing the internals is done via File I/O
-    FileIo(&'a Path),
+pub struct InternalsForArchive<'a> {
+    /// Path to the backing file used to archive the contents
+    pub path: &'a Path,
 }
 
 /// Information after storing accounts

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1126,7 +1126,6 @@ mod tests {
                     get_all_accounts, remove_account_for_tests,
                 },
             },
-            accounts_file::StorageAccess,
             accounts_index::{
                 AccountsIndexScanResult, ReclaimsSlotList, RefCount, ScanFilter, UpsertReclaim,
             },
@@ -1542,99 +1541,92 @@ mod tests {
         // or all slots shrunk so no roots or storages should be removed
         for in_shrink_candidate_slots in [false, true] {
             for all_slots_shrunk in [false, true] {
-                for storage_access in [
-                    #[allow(deprecated)]
-                    StorageAccess::Mmap,
-                    StorageAccess::File,
-                ] {
-                    for num_slots in 0..3 {
-                        let (mut db, storages, slots, infos) = get_sample_storages(num_slots, None);
-                        db.set_storage_access(storage_access);
-                        let mut accounts_per_storage = infos
-                            .iter()
-                            .zip(
-                                storages
-                                    .iter()
-                                    .map(|store| db.get_unique_accounts_from_storage(store)),
-                            )
-                            .collect::<Vec<_>>();
+                for num_slots in 0..3 {
+                    let (db, storages, slots, infos) = get_sample_storages(num_slots, None);
+                    let mut accounts_per_storage = infos
+                        .iter()
+                        .zip(
+                            storages
+                                .iter()
+                                .map(|store| db.get_unique_accounts_from_storage(store)),
+                        )
+                        .collect::<Vec<_>>();
 
-                        let accounts_to_combine = db.calc_accounts_to_combine(
-                            &mut accounts_per_storage,
-                            &default_tuning(),
-                            IncludeManyRefSlots::Include,
-                        );
-                        let mut stats = ShrinkStatsSub::default();
-                        let mut write_ancient_accounts = WriteAncientAccounts::default();
+                    let accounts_to_combine = db.calc_accounts_to_combine(
+                        &mut accounts_per_storage,
+                        &default_tuning(),
+                        IncludeManyRefSlots::Include,
+                    );
+                    let mut stats = ShrinkStatsSub::default();
+                    let mut write_ancient_accounts = WriteAncientAccounts::default();
 
-                        slots.clone().for_each(|slot| {
-                            db.add_root(slot);
-                            let storage = db.storage.get_slot_storage_entry(slot);
-                            assert!(storage.is_some());
-                            if in_shrink_candidate_slots {
-                                db.shrink_candidate_slots.lock().unwrap().insert(slot);
-                            }
-                        });
-
-                        let roots = db
-                            .accounts_index
-                            .roots_tracker
-                            .read()
-                            .unwrap()
-                            .alive_roots
-                            .get_all();
-                        assert_eq!(roots, slots.clone().collect::<Vec<_>>());
-
-                        if all_slots_shrunk {
-                            // make it look like each of the slots was shrunk
-                            slots.clone().for_each(|slot| {
-                                let old_store = db
-                                    .storage
-                                    .get_slot_storage_entry_shrinking_in_progress_ok(slot)
-                                    .unwrap();
-                                write_ancient_accounts
-                                    .shrinks_in_progress
-                                    .insert(slot, db.get_store_for_shrink(slot, old_store, 1));
-                            });
+                    slots.clone().for_each(|slot| {
+                        db.add_root(slot);
+                        let storage = db.storage.get_slot_storage_entry(slot);
+                        assert!(storage.is_some());
+                        if in_shrink_candidate_slots {
+                            db.shrink_candidate_slots.lock().unwrap().insert(slot);
                         }
+                    });
 
-                        db.finish_combine_ancient_slots_packed_internal(
-                            accounts_to_combine,
-                            write_ancient_accounts,
-                            &mut stats,
-                        );
+                    let roots = db
+                        .accounts_index
+                        .roots_tracker
+                        .read()
+                        .unwrap()
+                        .alive_roots
+                        .get_all();
+                    assert_eq!(roots, slots.clone().collect::<Vec<_>>());
 
+                    if all_slots_shrunk {
+                        // make it look like each of the slots was shrunk
                         slots.clone().for_each(|slot| {
-                            assert!(!db.shrink_candidate_slots.lock().unwrap().contains(&slot));
-                        });
-
-                        let roots_after = db
-                            .accounts_index
-                            .roots_tracker
-                            .read()
-                            .unwrap()
-                            .alive_roots
-                            .get_all();
-
-                        assert_eq!(
-                            roots_after,
-                            if all_slots_shrunk {
-                                slots.clone().collect::<Vec<_>>()
-                            } else {
-                                vec![]
-                            },
-                            "all_slots_shrunk: {all_slots_shrunk}"
-                        );
-                        slots.for_each(|slot| {
-                            let storage = db.storage.get_slot_storage_entry(slot);
-                            if all_slots_shrunk {
-                                assert!(storage.is_some());
-                                assert!(!storage.unwrap().has_accounts());
-                            } else {
-                                assert!(storage.is_none());
-                            }
+                            let old_store = db
+                                .storage
+                                .get_slot_storage_entry_shrinking_in_progress_ok(slot)
+                                .unwrap();
+                            write_ancient_accounts
+                                .shrinks_in_progress
+                                .insert(slot, db.get_store_for_shrink(slot, old_store, 1));
                         });
                     }
+
+                    db.finish_combine_ancient_slots_packed_internal(
+                        accounts_to_combine,
+                        write_ancient_accounts,
+                        &mut stats,
+                    );
+
+                    slots.clone().for_each(|slot| {
+                        assert!(!db.shrink_candidate_slots.lock().unwrap().contains(&slot));
+                    });
+
+                    let roots_after = db
+                        .accounts_index
+                        .roots_tracker
+                        .read()
+                        .unwrap()
+                        .alive_roots
+                        .get_all();
+
+                    assert_eq!(
+                        roots_after,
+                        if all_slots_shrunk {
+                            slots.clone().collect::<Vec<_>>()
+                        } else {
+                            vec![]
+                        },
+                        "all_slots_shrunk: {all_slots_shrunk}"
+                    );
+                    slots.for_each(|slot| {
+                        let storage = db.storage.get_slot_storage_entry(slot);
+                        if all_slots_shrunk {
+                            assert!(storage.is_some());
+                            assert!(!storage.unwrap().has_accounts());
+                        } else {
+                            assert!(storage.is_none());
+                        }
+                    });
                 }
             }
         }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -174,13 +174,11 @@ pub struct AppendVec {
 const PAGE_SIZE: usize = 4 * 1024;
 
 pub struct AppendVecStat {
-    pub open_as_file_io: AtomicU64,
     pub files_open: AtomicU64,
     pub files_dirty: AtomicU64,
 }
 
 pub static APPEND_VEC_STATS: AppendVecStat = AppendVecStat {
-    open_as_file_io: AtomicU64::new(0),
     files_open: AtomicU64::new(0),
     files_dirty: AtomicU64::new(0),
 };
@@ -193,9 +191,6 @@ impl Drop for AppendVec {
             APPEND_VEC_STATS.files_dirty.fetch_sub(1, Ordering::Relaxed);
         }
 
-        APPEND_VEC_STATS
-            .open_as_file_io
-            .fetch_sub(1, Ordering::Relaxed);
         if self.remove_file_on_drop.load(Ordering::Acquire) {
             // If we're reopening in readonly mode, we don't delete the file. See
             // AppendVec::reopen_as_readonly.
@@ -243,9 +238,6 @@ impl AppendVec {
         data.rewind().unwrap();
         data.flush().unwrap();
 
-        APPEND_VEC_STATS
-            .open_as_file_io
-            .fetch_add(1, Ordering::Relaxed);
         APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
 
         AppendVec {
@@ -382,9 +374,6 @@ impl AppendVec {
         Self::sanitize_len_and_size(current_len, file_info.size as usize)?;
 
         APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
-        APPEND_VEC_STATS
-            .open_as_file_io
-            .fetch_add(1, Ordering::Relaxed);
 
         Ok(AppendVec {
             path: file_info.path,

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -15,8 +15,7 @@ use {
     crate::{
         account_info::Offset,
         account_storage::stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
-        accounts_file::{InternalsForArchive, StorageAccess, StoredAccountsInfo},
-        is_zero_lamport::IsZeroLamport,
+        accounts_file::{InternalsForArchive, StoredAccountsInfo},
         storable_accounts::StorableAccounts,
         u64_align,
         utils::create_account_shared_data,
@@ -30,7 +29,6 @@ use {
         file_io::{read_into_buffer, write_buffer_to_file},
     },
     log::*,
-    memmap2::MmapMut,
     meta::{AccountMeta, StoredAccountNoData, StoredMeta},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_pubkey::Pubkey,
@@ -110,15 +108,6 @@ struct AccountOffsets {
     offset_to_end_of_data: usize,
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Debug)]
-enum AppendVecFileBacking {
-    /// A file-backed block of memory that is used to store the data for each appended item.
-    Mmap(MmapMut),
-    /// This was opened as a read only file
-    File(File),
-}
-
 /// Validates and serializes appends (when `append_guard` is called) such that only
 /// writable AppendVec is updated and only from a single thread at a time.
 #[derive(Debug)]
@@ -159,8 +148,8 @@ pub struct AppendVec {
     /// The file path where the data is stored.
     path: PathBuf,
 
-    /// access the file data
-    backing: AppendVecFileBacking,
+    /// the underlying file that backs this storage
+    file: File,
 
     /// Guards and serializes writes if allowed
     read_write_state: ReadWriteState,
@@ -185,14 +174,12 @@ pub struct AppendVec {
 const PAGE_SIZE: usize = 4 * 1024;
 
 pub struct AppendVecStat {
-    pub open_as_mmap: AtomicU64,
     pub open_as_file_io: AtomicU64,
     pub files_open: AtomicU64,
     pub files_dirty: AtomicU64,
 }
 
 pub static APPEND_VEC_STATS: AppendVecStat = AppendVecStat {
-    open_as_mmap: AtomicU64::new(0),
     open_as_file_io: AtomicU64::new(0),
     files_open: AtomicU64::new(0),
     files_dirty: AtomicU64::new(0),
@@ -206,18 +193,9 @@ impl Drop for AppendVec {
             APPEND_VEC_STATS.files_dirty.fetch_sub(1, Ordering::Relaxed);
         }
 
-        match &self.backing {
-            AppendVecFileBacking::Mmap(_) => {
-                APPEND_VEC_STATS
-                    .open_as_mmap
-                    .fetch_sub(1, Ordering::Relaxed);
-            }
-            AppendVecFileBacking::File(_) => {
-                APPEND_VEC_STATS
-                    .open_as_file_io
-                    .fetch_sub(1, Ordering::Relaxed);
-            }
-        }
+        APPEND_VEC_STATS
+            .open_as_file_io
+            .fetch_sub(1, Ordering::Relaxed);
         if self.remove_file_on_drop.load(Ordering::Acquire) {
             // If we're reopening in readonly mode, we don't delete the file. See
             // AppendVec::reopen_as_readonly.
@@ -232,12 +210,7 @@ impl Drop for AppendVec {
 }
 
 impl AppendVec {
-    pub fn new(
-        file: impl Into<PathBuf>,
-        create: bool,
-        size: usize,
-        storage_access: StorageAccess,
-    ) -> Self {
+    pub fn new(file: impl Into<PathBuf>, create: bool, size: usize) -> Self {
         let file = file.into();
         let initial_len = 0;
         AppendVec::sanitize_len_and_size(initial_len, size).unwrap();
@@ -270,34 +243,14 @@ impl AppendVec {
         data.rewind().unwrap();
         data.flush().unwrap();
 
-        let backing = match storage_access {
-            #[allow(deprecated)]
-            StorageAccess::Mmap => {
-                //UNSAFE: Required to create a Mmap
-                let mmap = unsafe { MmapMut::map_mut(&data) };
-                let mmap = mmap.unwrap_or_else(|err| {
-                    panic!(
-                        "Failed to map the data file (size: {size}): {err}. Please increase \
-                         sysctl vm.max_map_count or equivalent for your platform.",
-                    );
-                });
-                APPEND_VEC_STATS
-                    .open_as_mmap
-                    .fetch_add(1, Ordering::Relaxed);
-                AppendVecFileBacking::Mmap(mmap)
-            }
-            StorageAccess::File => {
-                APPEND_VEC_STATS
-                    .open_as_file_io
-                    .fetch_add(1, Ordering::Relaxed);
-                AppendVecFileBacking::File(data)
-            }
-        };
+        APPEND_VEC_STATS
+            .open_as_file_io
+            .fetch_add(1, Ordering::Relaxed);
         APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
 
         AppendVec {
             path: file,
-            backing,
+            file: data,
             // writable state's mutex forces append to be single threaded, but concurrent with
             // reads. See UNSAFE usage in `append_ptr`
             read_write_state: ReadWriteState::new(true),
@@ -332,14 +285,7 @@ impl AppendVec {
         // Check to see if we're actually dirty before flushing.
         let should_flush = self.is_dirty.swap(false, Ordering::AcqRel);
         if should_flush {
-            match &self.backing {
-                AppendVecFileBacking::Mmap(mmap) => {
-                    mmap.flush()?;
-                }
-                AppendVecFileBacking::File(file) => {
-                    file.sync_all()?;
-                }
-            }
+            self.file.sync_all()?;
             APPEND_VEC_STATS.files_dirty.fetch_sub(1, Ordering::Relaxed);
         }
         Ok(())
@@ -347,25 +293,17 @@ impl AppendVec {
 
     /// Return AppendVec opened in read-only file-io mode or `None` if it already is such
     pub(crate) fn reopen_as_readonly_file_io(&self) -> Option<Self> {
-        if matches!(self.read_write_state, ReadWriteState::ReadOnly)
-            && matches!(self.backing, AppendVecFileBacking::File(_))
-        {
-            // Early return if already in read-only mode *and* already a file-io
+        if matches!(self.read_write_state, ReadWriteState::ReadOnly) {
+            // Already in read-only mode; nothing to do.
             return None;
         }
 
         // we are re-opening the file, so don't remove the file on disk when the old one is dropped
         self.remove_file_on_drop.store(false, Ordering::Release);
 
-        // add a memory barrier to ensure the the last mmap writes
-        // happen before the first file-io reads
-        std::sync::atomic::fence(Ordering::AcqRel);
-
         // The file should have already been sanitized. Don't need to check when we open the file again.
         let file_info = FileInfo::new_from_path(&self.path).ok()?;
-        let mut new =
-            AppendVec::new_from_file_info_unchecked(file_info, self.len(), StorageAccess::File)
-                .ok()?;
+        let mut new = AppendVec::new_from_file_info_unchecked(file_info, self.len()).ok()?;
         if self.is_dirty.swap(false, Ordering::AcqRel) {
             // *move* the dirty-ness to the new append vec
             *new.is_dirty.get_mut() = true;
@@ -394,16 +332,9 @@ impl AppendVec {
     }
 
     #[cfg(feature = "dev-context-only-utils")]
-    pub fn new_from_file(
-        path: impl Into<PathBuf>,
-        current_len: usize,
-        storage_access: StorageAccess,
-    ) -> Result<(Self, usize)> {
-        // AppendVec is in read-only mode, but mmap access requires file to be writable
-        #[allow(deprecated)]
-        let is_writable = storage_access == StorageAccess::Mmap;
-        let file_info = FileInfo::new_from_path_writable(path, is_writable)?;
-        let new = Self::new_from_file_info_unchecked(file_info, current_len, storage_access)?;
+    pub fn new_from_file(path: impl Into<PathBuf>, current_len: usize) -> Result<(Self, usize)> {
+        let file_info = FileInfo::new_from_path_writable(path, false)?;
+        let new = Self::new_from_file_info_unchecked(file_info, current_len)?;
 
         let num_accounts = new.sanitize_layout_and_length()?;
         Ok((new, num_accounts))
@@ -414,12 +345,8 @@ impl AppendVec {
     /// This version of `new()` may only be called when reconstructing storages as part of startup.
     /// It trusts the snapshot's value for `current_len`, and relies on later index generation or
     /// accounts verification to ensure it is valid.
-    pub fn new_for_startup(
-        file_info: FileInfo,
-        current_len: usize,
-        storage_access: StorageAccess,
-    ) -> Result<Self> {
-        let new = Self::new_from_file_info_unchecked(file_info, current_len, storage_access)?;
+    pub fn new_for_startup(file_info: FileInfo, current_len: usize) -> Result<Self> {
+        let new = Self::new_from_file_info_unchecked(file_info, current_len)?;
 
         // The current_len is allowed to be either exactly the same as file_size, or
         // u64-aligned-equivalent to file_size.  This is because `flush` and `shink` compute the
@@ -451,50 +378,17 @@ impl AppendVec {
     /// Creates an appendvec in read-only mode from existing `FileInfo` and without full data checks
     ///
     /// Validation of account data and counting the number of accounts is skipped.
-    pub fn new_from_file_info_unchecked(
-        file_info: FileInfo,
-        current_len: usize,
-        storage_access: StorageAccess,
-    ) -> Result<Self> {
+    pub fn new_from_file_info_unchecked(file_info: FileInfo, current_len: usize) -> Result<Self> {
         Self::sanitize_len_and_size(current_len, file_info.size as usize)?;
 
         APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
-
-        if storage_access == StorageAccess::File {
-            APPEND_VEC_STATS
-                .open_as_file_io
-                .fetch_add(1, Ordering::Relaxed);
-
-            return Ok(AppendVec {
-                path: file_info.path,
-                backing: AppendVecFileBacking::File(file_info.file),
-                read_write_state: ReadWriteState::ReadOnly,
-                current_len: AtomicUsize::new(current_len),
-                file_size: file_info.size,
-                remove_file_on_drop: AtomicBool::new(true),
-                is_dirty: AtomicBool::new(false),
-            });
-        }
-
-        let mmap = unsafe {
-            let result = MmapMut::map_mut(&file_info.file);
-            if result.is_err() {
-                // for vm.max_map_count, error is: {code: 12, kind: Other, message: "Cannot allocate memory"}
-                info!(
-                    "memory map error: {result:?}. This may be because vm.max_map_count is not \
-                     set correctly."
-                );
-            }
-            result?
-        };
-
         APPEND_VEC_STATS
-            .open_as_mmap
+            .open_as_file_io
             .fetch_add(1, Ordering::Relaxed);
 
         Ok(AppendVec {
             path: file_info.path,
-            backing: AppendVecFileBacking::Mmap(mmap),
+            file: file_info.file,
             read_write_state: ReadWriteState::ReadOnly,
             current_len: AtomicUsize::new(current_len),
             file_size: file_info.size,
@@ -508,7 +402,7 @@ impl AppendVec {
     pub fn new_for_store_tool(path: impl Into<PathBuf>) -> Result<Self> {
         let file_info = FileInfo::new_from_path(path)?;
         let file_size = file_info.size;
-        Self::new_from_file_info_unchecked(file_info, file_size as usize, StorageAccess::default())
+        Self::new_from_file_info_unchecked(file_info, file_size as usize)
     }
 
     /// Checks that all accounts layout is correct and returns the number of accounts.
@@ -556,23 +450,9 @@ impl AppendVec {
     /// the internal buffer. Then update `offset` to the first byte after the copied data.
     fn append_ptr(&self, offset: &mut usize, src: *const u8, len: usize) -> io::Result<()> {
         let pos = u64_align!(*offset);
-        match &self.backing {
-            AppendVecFileBacking::Mmap(mmap) => {
-                let data = &mmap[pos..(pos + len)];
-                //UNSAFE: This mut append is safe because only 1 thread can append at a time
-                //Mutex<()> guarantees exclusive write access to the memory occupied in
-                //the range.
-                unsafe {
-                    let dst = data.as_ptr() as *mut _;
-                    ptr::copy(src, dst, len);
-                };
-            }
-            AppendVecFileBacking::File(file) => {
-                // Safety: caller should ensure the passed pointer and length are valid.
-                let data = unsafe { slice::from_raw_parts(src, len) };
-                write_buffer_to_file(file, data, pos as u64)?;
-            }
-        }
+        // Safety: caller should ensure the passed pointer and length are valid.
+        let data = unsafe { slice::from_raw_parts(src, len) };
+        write_buffer_to_file(&self.file, data, pos as u64)?;
         *offset = pos + len;
         Ok(())
     }
@@ -613,13 +493,6 @@ impl AppendVec {
         //UNSAFE: The cast is safe because the slice is aligned and fits into the memory
         //and the lifetime of the &T is tied to self, which holds the underlying memory map
         Some((unsafe { &*ptr }, next))
-    }
-
-    /// MmapMut could have more capacity than `len()` knows is valid.
-    /// Return the subset of `mmap` that is known to be valid.
-    /// This allows comparisons against the slice len.
-    fn get_valid_slice_from_mmap<'a>(&self, mmap: &'a MmapMut) -> ValidSlice<'a> {
-        ValidSlice(&mmap[..self.len()])
     }
 
     /// Calls `callback` with the stored account at `offset`.
@@ -682,89 +555,68 @@ impl AppendVec {
         offset: usize,
         mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>) -> Ret,
     ) -> Option<Ret> {
-        match &self.backing {
-            AppendVecFileBacking::Mmap(mmap) => {
-                let slice = self.get_valid_slice_from_mmap(mmap);
-                let (meta, next) = Self::get_type::<StoredMeta>(slice, offset)?;
-                let (account_meta, next) = Self::get_type::<AccountMeta>(slice, next)?;
-                let (_hash, next) = Self::get_type::<ObsoleteAccountHash>(slice, next)?;
-                let (data, next) = Self::get_slice(slice, next, meta.data_len as usize)?;
-                let stored_size = next - offset;
-                Some(callback(StoredAccountMeta {
-                    meta,
-                    account_meta,
-                    data,
-                    offset,
-                    stored_size,
-                }))
+        // 4096 was just picked to be a single page size
+        let mut buf = [MaybeUninit::<u8>::uninit(); PAGE_SIZE];
+        // SAFETY: `read_into_buffer` will only write to uninitialized memory.
+        let bytes_read = read_into_buffer(
+            &self.file,
+            self.len() as FileSize,
+            offset as FileSize,
+            unsafe { slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, buf.len()) },
+        )
+        .ok()?;
+        // SAFETY: we only read the initialized portion.
+        let valid_bytes =
+            ValidSlice(unsafe { slice::from_raw_parts(buf.as_ptr() as *const u8, bytes_read) });
+        let (meta, next) = Self::get_type::<StoredMeta>(valid_bytes, 0)?;
+        let (account_meta, next) = Self::get_type::<AccountMeta>(valid_bytes, next)?;
+        let (_hash, next) = Self::get_type::<ObsoleteAccountHash>(valid_bytes, next)?;
+        let data_len = meta.data_len;
+        let remaining_bytes_for_data = bytes_read - next;
+        Some(if remaining_bytes_for_data >= data_len as usize {
+            // we already read enough data to load this account
+            let (data, next) = Self::get_slice(valid_bytes, next, meta.data_len as usize)?;
+            let stored_size = next;
+            let account = StoredAccountMeta {
+                meta,
+                account_meta,
+                data,
+                offset,
+                stored_size,
+            };
+            callback(account)
+        } else {
+            // not enough was read from file to get `data`
+            assert!(data_len <= MAX_PERMITTED_DATA_LENGTH, "{data_len}");
+            let mut data: Box<[MaybeUninit<u8>]> = Box::new_uninit_slice(data_len as usize);
+            // instead, we could piece together what we already read here. Maybe we just needed 1 more byte.
+            // Note here `next` is a 0-based offset from the beginning of this account.
+            // SAFETY: `read_into_buffer` will only write to uninitialized memory.
+            let bytes_read = read_into_buffer(
+                &self.file,
+                self.len() as FileSize,
+                (offset + next) as FileSize,
+                unsafe {
+                    slice::from_raw_parts_mut(data.as_mut_ptr() as *mut u8, data_len as usize)
+                },
+            )
+            .ok()?;
+            if bytes_read < data_len as usize {
+                // eof or otherwise couldn't read all the data
+                return None;
             }
-            AppendVecFileBacking::File(file) => {
-                // 4096 was just picked to be a single page size
-                let mut buf = [MaybeUninit::<u8>::uninit(); PAGE_SIZE];
-                // SAFETY: `read_into_buffer` will only write to uninitialized memory.
-                let bytes_read =
-                    read_into_buffer(file, self.len() as FileSize, offset as FileSize, unsafe {
-                        slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, buf.len())
-                    })
-                    .ok()?;
-                // SAFETY: we only read the initialized portion.
-                let valid_bytes = ValidSlice(unsafe {
-                    slice::from_raw_parts(buf.as_ptr() as *const u8, bytes_read)
-                });
-                let (meta, next) = Self::get_type::<StoredMeta>(valid_bytes, 0)?;
-                let (account_meta, next) = Self::get_type::<AccountMeta>(valid_bytes, next)?;
-                let (_hash, next) = Self::get_type::<ObsoleteAccountHash>(valid_bytes, next)?;
-                let data_len = meta.data_len;
-                let remaining_bytes_for_data = bytes_read - next;
-                Some(if remaining_bytes_for_data >= data_len as usize {
-                    // we already read enough data to load this account
-                    let (data, next) = Self::get_slice(valid_bytes, next, meta.data_len as usize)?;
-                    let stored_size = next;
-                    let account = StoredAccountMeta {
-                        meta,
-                        account_meta,
-                        data,
-                        offset,
-                        stored_size,
-                    };
-                    callback(account)
-                } else {
-                    // not enough was read from file to get `data`
-                    assert!(data_len <= MAX_PERMITTED_DATA_LENGTH, "{data_len}");
-                    let mut data: Box<[MaybeUninit<u8>]> = Box::new_uninit_slice(data_len as usize);
-                    // instead, we could piece together what we already read here. Maybe we just needed 1 more byte.
-                    // Note here `next` is a 0-based offset from the beginning of this account.
-                    // SAFETY: `read_into_buffer` will only write to uninitialized memory.
-                    let bytes_read = read_into_buffer(
-                        file,
-                        self.len() as FileSize,
-                        (offset + next) as FileSize,
-                        unsafe {
-                            slice::from_raw_parts_mut(
-                                data.as_mut_ptr() as *mut u8,
-                                data_len as usize,
-                            )
-                        },
-                    )
-                    .ok()?;
-                    if bytes_read < data_len as usize {
-                        // eof or otherwise couldn't read all the data
-                        return None;
-                    }
-                    // SAFETY: we've just checked that `bytes_read` is at least `data_len`.
-                    let data = unsafe { data.assume_init() };
-                    let stored_size = Self::calculate_stored_size(data_len as usize);
-                    let account = StoredAccountMeta {
-                        meta,
-                        account_meta,
-                        data: &data[..],
-                        offset,
-                        stored_size,
-                    };
-                    callback(account)
-                })
-            }
-        }
+            // SAFETY: we've just checked that `bytes_read` is at least `data_len`.
+            let data = unsafe { data.assume_init() };
+            let stored_size = Self::calculate_stored_size(data_len as usize);
+            let account = StoredAccountMeta {
+                meta,
+                account_meta,
+                data: &data[..],
+                offset,
+                stored_size,
+            };
+            callback(account)
+        })
     }
 
     /// calls `callback` with the stored account fixed portion for the account at `offset` if its data doesn't overrun
@@ -774,119 +626,93 @@ impl AppendVec {
         offset: usize,
         mut callback: impl for<'local> FnMut(StoredAccountNoData<'local>) -> Ret,
     ) -> Option<Ret> {
-        match &self.backing {
-            AppendVecFileBacking::Mmap(mmap) => {
-                let slice = self.get_valid_slice_from_mmap(mmap);
-                let (meta, next) = Self::get_type::<StoredMeta>(slice, offset)?;
-                let (account_meta, _) = Self::get_type::<AccountMeta>(slice, next)?;
-                let stored_size = Self::calculate_stored_size_checked(meta.data_len as usize)?;
+        let mut buf = [MaybeUninit::<u8>::uninit(); STORE_META_OVERHEAD];
+        // SAFETY: `read_into_buffer` will only write to uninitialized memory.
+        let bytes_read = read_into_buffer(
+            &self.file,
+            self.len() as FileSize,
+            offset as FileSize,
+            unsafe { slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, buf.len()) },
+        )
+        .ok()?;
+        // SAFETY: we only read the initialized portion.
+        let valid_bytes =
+            ValidSlice(unsafe { slice::from_raw_parts(buf.as_ptr() as *const u8, bytes_read) });
+        let (meta, next) = Self::get_type::<StoredMeta>(valid_bytes, 0)?;
+        let (account_meta, _) = Self::get_type::<AccountMeta>(valid_bytes, next)?;
+        let stored_size = Self::calculate_stored_size_checked(meta.data_len as usize)?;
 
-                Some(callback(StoredAccountNoData {
-                    meta,
-                    account_meta,
-                    offset,
-                    stored_size,
-                }))
-            }
-            AppendVecFileBacking::File(file) => {
-                let mut buf = [MaybeUninit::<u8>::uninit(); STORE_META_OVERHEAD];
-                // SAFETY: `read_into_buffer` will only write to uninitialized memory.
-                let bytes_read =
-                    read_into_buffer(file, self.len() as FileSize, offset as FileSize, unsafe {
-                        slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, buf.len())
-                    })
-                    .ok()?;
-                // SAFETY: we only read the initialized portion.
-                let valid_bytes = ValidSlice(unsafe {
-                    slice::from_raw_parts(buf.as_ptr() as *const u8, bytes_read)
-                });
-                let (meta, next) = Self::get_type::<StoredMeta>(valid_bytes, 0)?;
-                let (account_meta, _) = Self::get_type::<AccountMeta>(valid_bytes, next)?;
-                let stored_size = Self::calculate_stored_size_checked(meta.data_len as usize)?;
-
-                Some(callback(StoredAccountNoData {
-                    meta,
-                    account_meta,
-                    offset,
-                    stored_size,
-                }))
-            }
-        }
+        Some(callback(StoredAccountNoData {
+            meta,
+            account_meta,
+            offset,
+            stored_size,
+        }))
     }
 
     /// return an `AccountSharedData` for an account at `offset`.
     /// This fn can efficiently return exactly what is needed by a caller.
     /// This is on the critical path of tx processing for accounts not in the read or write caches.
     pub fn get_account_shared_data(&self, offset: usize) -> Option<AccountSharedData> {
-        match &self.backing {
-            AppendVecFileBacking::Mmap(_) => self
-                .get_stored_account_meta_callback(offset, |account| {
-                    create_account_shared_data(&account)
-                }),
-            AppendVecFileBacking::File(file) => {
-                let mut buf = MaybeUninit::<[u8; PAGE_SIZE]>::uninit();
-                let bytes_read =
-                    read_into_buffer(file, self.len() as FileSize, offset as FileSize, unsafe {
-                        &mut *buf.as_mut_ptr()
-                    })
-                    .ok()?;
-                // SAFETY: we only read the initialized portion.
-                let valid_bytes = ValidSlice(unsafe {
-                    slice::from_raw_parts(buf.as_ptr() as *const u8, bytes_read)
-                });
-                let (meta, next) = Self::get_type::<StoredMeta>(valid_bytes, 0)?;
-                let (account_meta, next) = Self::get_type::<AccountMeta>(valid_bytes, next)?;
-                let (_hash, next) = Self::get_type::<ObsoleteAccountHash>(valid_bytes, next)?;
-                let data_len = meta.data_len;
-                let remaining_bytes_for_data = bytes_read - next;
-                Some(if remaining_bytes_for_data >= data_len as usize {
-                    // we already read enough data to load this account
-                    let (data, next) = Self::get_slice(valid_bytes, next, meta.data_len as usize)?;
-                    let stored_size = next;
-                    let account = StoredAccountMeta {
-                        meta,
-                        account_meta,
-                        data,
-                        offset,
-                        stored_size,
-                    };
-                    // data is within `buf`, so just allocate a new vec for data
-                    create_account_shared_data(&account)
-                } else {
-                    // not enough was read from file to get `data`
-                    assert!(data_len <= MAX_PERMITTED_DATA_LENGTH, "{data_len}");
-                    let mut data = Vec::with_capacity(data_len as usize);
-                    let slice = data.spare_capacity_mut();
-                    // Note here `next` is a 0-based offset from the beginning of this account.
-                    // SAFETY: `read_into_buffer` will only write to uninitialized memory.
-                    let bytes_read = read_into_buffer(
-                        file,
-                        self.len() as FileSize,
-                        (offset + next) as FileSize,
-                        unsafe {
-                            slice::from_raw_parts_mut(
-                                slice.as_mut_ptr() as *mut u8,
-                                data_len as usize,
-                            )
-                        },
-                    )
-                    .ok()?;
-                    if bytes_read < data_len as usize {
-                        // eof or otherwise couldn't read all the data
-                        return None;
-                    }
-                    // SAFETY: we've just checked that `bytes_read` is at least `data_len`.
-                    unsafe { data.set_len(data_len as usize) };
-                    AccountSharedData::create_from_existing_shared_data(
-                        account_meta.lamports,
-                        Arc::new(data),
-                        account_meta.owner,
-                        account_meta.executable,
-                        account_meta.rent_epoch,
-                    )
-                })
+        let mut buf = MaybeUninit::<[u8; PAGE_SIZE]>::uninit();
+        let bytes_read = read_into_buffer(
+            &self.file,
+            self.len() as FileSize,
+            offset as FileSize,
+            unsafe { &mut *buf.as_mut_ptr() },
+        )
+        .ok()?;
+        // SAFETY: we only read the initialized portion.
+        let valid_bytes =
+            ValidSlice(unsafe { slice::from_raw_parts(buf.as_ptr() as *const u8, bytes_read) });
+        let (meta, next) = Self::get_type::<StoredMeta>(valid_bytes, 0)?;
+        let (account_meta, next) = Self::get_type::<AccountMeta>(valid_bytes, next)?;
+        let (_hash, next) = Self::get_type::<ObsoleteAccountHash>(valid_bytes, next)?;
+        let data_len = meta.data_len;
+        let remaining_bytes_for_data = bytes_read - next;
+        Some(if remaining_bytes_for_data >= data_len as usize {
+            // we already read enough data to load this account
+            let (data, next) = Self::get_slice(valid_bytes, next, meta.data_len as usize)?;
+            let stored_size = next;
+            let account = StoredAccountMeta {
+                meta,
+                account_meta,
+                data,
+                offset,
+                stored_size,
+            };
+            // data is within `buf`, so just allocate a new vec for data
+            create_account_shared_data(&account)
+        } else {
+            // not enough was read from file to get `data`
+            assert!(data_len <= MAX_PERMITTED_DATA_LENGTH, "{data_len}");
+            let mut data = Vec::with_capacity(data_len as usize);
+            let slice = data.spare_capacity_mut();
+            // Note here `next` is a 0-based offset from the beginning of this account.
+            // SAFETY: `read_into_buffer` will only write to uninitialized memory.
+            let bytes_read = read_into_buffer(
+                &self.file,
+                self.len() as FileSize,
+                (offset + next) as FileSize,
+                unsafe {
+                    slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut u8, data_len as usize)
+                },
+            )
+            .ok()?;
+            if bytes_read < data_len as usize {
+                // eof or otherwise couldn't read all the data
+                return None;
             }
-        }
+            // SAFETY: we've just checked that `bytes_read` is at least `data_len`.
+            unsafe { data.set_len(data_len as usize) };
+            AccountSharedData::create_from_existing_shared_data(
+                account_meta.lamports,
+                Arc::new(data),
+                account_meta.owner,
+                account_meta.executable,
+                account_meta.rent_epoch,
+            )
+        })
     }
 
     #[cfg(test)]
@@ -1004,65 +830,45 @@ impl AppendVec {
         reader: &mut impl RequiredLenBufFileRead<'a>,
         mut callback: impl for<'local> FnMut(StoredAccountMeta<'local>),
     ) -> Result<()> {
-        match &self.backing {
-            AppendVecFileBacking::Mmap(_mmap) => {
-                let mut offset = 0;
-                while self
-                    .get_stored_account_meta_callback(offset, |account| {
-                        offset += account.stored_size();
-                        if account.is_zero_lamport() && account.pubkey() == &Pubkey::default() {
-                            // we passed the last useful account
-                            return false;
-                        }
+        reader.set_file(&self.file, self.len() as FileSize)?;
 
-                        callback(account);
-                        true
-                    })
-                    .unwrap_or_default()
-                {}
+        let mut min_buf_len = STORE_META_OVERHEAD;
+        loop {
+            let offset = reader.get_file_offset() as usize;
+            let bytes = match reader.fill_buf_required(min_buf_len) {
+                Ok([]) => break,
+                Ok(bytes) => ValidSlice::new(bytes),
+                Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(err) => return Err(AppendVecError::Io(err)),
+            };
+
+            let (meta, next) = Self::get_type::<StoredMeta>(bytes, 0).unwrap();
+            let (account_meta, next) = Self::get_type::<AccountMeta>(bytes, next).unwrap();
+            if account_meta.lamports == 0 && meta.pubkey == Pubkey::default() {
+                // we passed the last useful account
+                break;
             }
-            AppendVecFileBacking::File(file) => {
-                reader.set_file(file, self.len() as FileSize)?;
-
-                let mut min_buf_len = STORE_META_OVERHEAD;
-                loop {
-                    let offset = reader.get_file_offset() as usize;
-                    let bytes = match reader.fill_buf_required(min_buf_len) {
-                        Ok([]) => break,
-                        Ok(bytes) => ValidSlice::new(bytes),
-                        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
-                        Err(err) => return Err(AppendVecError::Io(err)),
-                    };
-
-                    let (meta, next) = Self::get_type::<StoredMeta>(bytes, 0).unwrap();
-                    let (account_meta, next) = Self::get_type::<AccountMeta>(bytes, next).unwrap();
-                    if account_meta.lamports == 0 && meta.pubkey == Pubkey::default() {
-                        // we passed the last useful account
-                        break;
-                    }
-                    let (_hash, next) = Self::get_type::<ObsoleteAccountHash>(bytes, next).unwrap();
-                    let data_len = meta.data_len as usize;
-                    let leftover = bytes.len() - next;
-                    if leftover >= data_len {
-                        // we already read enough data to load this account
-                        let data = &bytes.0[next..(next + data_len)];
-                        let stored_size = Self::calculate_stored_size(data_len);
-                        let account = StoredAccountMeta {
-                            meta,
-                            account_meta,
-                            data,
-                            offset,
-                            stored_size,
-                        };
-                        callback(account);
-                        reader.consume_or_skip(stored_size);
-                        // restore default required buffer size
-                        min_buf_len = STORE_META_OVERHEAD;
-                    } else {
-                        // repeat loop with required buffer size holding whole account data
-                        min_buf_len = STORE_META_OVERHEAD + data_len;
-                    }
-                }
+            let (_hash, next) = Self::get_type::<ObsoleteAccountHash>(bytes, next).unwrap();
+            let data_len = meta.data_len as usize;
+            let leftover = bytes.len() - next;
+            if leftover >= data_len {
+                // we already read enough data to load this account
+                let data = &bytes.0[next..(next + data_len)];
+                let stored_size = Self::calculate_stored_size(data_len);
+                let account = StoredAccountMeta {
+                    meta,
+                    account_meta,
+                    data,
+                    offset,
+                    stored_size,
+                };
+                callback(account);
+                reader.consume_or_skip(stored_size);
+                // restore default required buffer size
+                min_buf_len = STORE_META_OVERHEAD;
+            } else {
+                // repeat loop with required buffer size holding whole account data
+                min_buf_len = STORE_META_OVERHEAD + data_len;
             }
         }
         Ok(())
@@ -1108,51 +914,36 @@ impl AppendVec {
         // self.len() is an atomic load, so only do it once
         let self_len = self.len();
         let mut account_sizes = Vec::with_capacity(sorted_offsets.len());
-        match &self.backing {
-            AppendVecFileBacking::Mmap(mmap) => {
-                let slice = self.get_valid_slice_from_mmap(mmap);
-                for &offset in sorted_offsets {
-                    let Some((stored_meta, _)) = Self::get_type::<StoredMeta>(slice, offset) else {
-                        break;
-                    };
-                    let next = Self::next_account_offset(offset, stored_meta);
-                    if next.offset_to_end_of_data > self_len {
-                        // data doesn't fit, so don't include
-                        break;
-                    }
-                    account_sizes.push(stored_meta.data_len as usize);
-                }
+        let mut buffer = [MaybeUninit::<u8>::uninit(); mem::size_of::<StoredMeta>()];
+        for &offset in sorted_offsets {
+            // SAFETY: `read_into_buffer` will only write to uninitialized memory.
+            let Some(bytes_read) = read_into_buffer(
+                &self.file,
+                self_len as FileSize,
+                offset as FileSize,
+                unsafe {
+                    slice::from_raw_parts_mut(
+                        buffer.as_mut_ptr() as *mut u8,
+                        mem::size_of::<StoredMeta>(),
+                    )
+                },
+            )
+            .ok() else {
+                break;
+            };
+            // SAFETY: we only read the initialized portion.
+            let bytes = ValidSlice(unsafe {
+                slice::from_raw_parts(buffer.as_ptr() as *const u8, bytes_read)
+            });
+            let Some((stored_meta, _)) = Self::get_type::<StoredMeta>(bytes, 0) else {
+                break;
+            };
+            let next = Self::next_account_offset(offset, stored_meta);
+            if next.offset_to_end_of_data > self_len {
+                // data doesn't fit, so don't include
+                break;
             }
-            AppendVecFileBacking::File(file) => {
-                let mut buffer = [MaybeUninit::<u8>::uninit(); mem::size_of::<StoredMeta>()];
-                for &offset in sorted_offsets {
-                    // SAFETY: `read_into_buffer` will only write to uninitialized memory.
-                    let Some(bytes_read) =
-                        read_into_buffer(file, self_len as FileSize, offset as FileSize, unsafe {
-                            slice::from_raw_parts_mut(
-                                buffer.as_mut_ptr() as *mut u8,
-                                mem::size_of::<StoredMeta>(),
-                            )
-                        })
-                        .ok()
-                    else {
-                        break;
-                    };
-                    // SAFETY: we only read the initialized portion.
-                    let bytes = ValidSlice(unsafe {
-                        slice::from_raw_parts(buffer.as_ptr() as *const u8, bytes_read)
-                    });
-                    let Some((stored_meta, _)) = Self::get_type::<StoredMeta>(bytes, 0) else {
-                        break;
-                    };
-                    let next = Self::next_account_offset(offset, stored_meta);
-                    if next.offset_to_end_of_data > self_len {
-                        // data doesn't fit, so don't include
-                        break;
-                    }
-                    account_sizes.push(stored_meta.data_len as usize);
-                }
-            }
+            account_sizes.push(stored_meta.data_len as usize);
         }
         account_sizes
     }
@@ -1172,75 +963,42 @@ impl AppendVec {
         mut callback: impl FnMut(StoredAccountNoData),
     ) -> Result<()> {
         let self_len = self.len();
-        match &self.backing {
-            AppendVecFileBacking::Mmap(mmap) => {
-                let mut offset = 0;
-                let slice = self.get_valid_slice_from_mmap(mmap);
-                while let Some((stored_meta, next)) = Self::get_type::<StoredMeta>(slice, offset) {
-                    let Some((account_meta, _)) = Self::get_type::<AccountMeta>(slice, next) else {
-                        break;
-                    };
-                    if account_meta.lamports == 0 && stored_meta.pubkey == Pubkey::default() {
-                        // we passed the last useful account
-                        break;
-                    }
-                    let Some(unaligned_stored_size) = Self::calculate_unaligned_stored_size_checked(
-                        stored_meta.data_len as usize,
-                    ) else {
-                        break;
-                    };
-                    if offset + unaligned_stored_size > self_len {
-                        break;
-                    }
-                    let stored_size = u64_align!(unaligned_stored_size);
-                    callback(StoredAccountNoData {
-                        meta: stored_meta,
-                        account_meta,
-                        offset,
-                        stored_size,
-                    });
-                    offset += stored_size;
-                }
+        // Heuristic observed in benchmarking that maintains a reasonable balance between syscalls and data waste
+        const BUFFER_SIZE: usize = PAGE_SIZE * 4;
+        let mut reader =
+            BufferedReader::<BUFFER_SIZE>::new().with_file(&self.file, self_len as FileSize);
+        const REQUIRED_READ_LEN: usize =
+            mem::size_of::<StoredMeta>() + mem::size_of::<AccountMeta>();
+        loop {
+            let offset = reader.get_file_offset() as usize;
+            let bytes = match reader.fill_buf_required(REQUIRED_READ_LEN) {
+                Ok([]) => break,
+                Ok(bytes) => ValidSlice::new(bytes),
+                Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(err) => return Err(AppendVecError::Io(err)),
+            };
+            let (stored_meta, next) = Self::get_type::<StoredMeta>(bytes, 0).unwrap();
+            let (account_meta, _) = Self::get_type::<AccountMeta>(bytes, next).unwrap();
+            if account_meta.lamports == 0 && stored_meta.pubkey == Pubkey::default() {
+                // we passed the last useful account
+                break;
             }
-            AppendVecFileBacking::File(file) => {
-                // Heuristic observed in benchmarking that maintains a reasonable balance between syscalls and data waste
-                const BUFFER_SIZE: usize = PAGE_SIZE * 4;
-                let mut reader =
-                    BufferedReader::<BUFFER_SIZE>::new().with_file(file, self_len as FileSize);
-                const REQUIRED_READ_LEN: usize =
-                    mem::size_of::<StoredMeta>() + mem::size_of::<AccountMeta>();
-                loop {
-                    let offset = reader.get_file_offset() as usize;
-                    let bytes = match reader.fill_buf_required(REQUIRED_READ_LEN) {
-                        Ok([]) => break,
-                        Ok(bytes) => ValidSlice::new(bytes),
-                        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
-                        Err(err) => return Err(AppendVecError::Io(err)),
-                    };
-                    let (stored_meta, next) = Self::get_type::<StoredMeta>(bytes, 0).unwrap();
-                    let (account_meta, _) = Self::get_type::<AccountMeta>(bytes, next).unwrap();
-                    if account_meta.lamports == 0 && stored_meta.pubkey == Pubkey::default() {
-                        // we passed the last useful account
-                        break;
-                    }
-                    let Some(unaligned_stored_size) = Self::calculate_unaligned_stored_size_checked(
-                        stored_meta.data_len as usize,
-                    ) else {
-                        break;
-                    };
-                    if offset + unaligned_stored_size > self_len {
-                        break;
-                    }
-                    let stored_size = u64_align!(unaligned_stored_size);
-                    callback(StoredAccountNoData {
-                        meta: stored_meta,
-                        account_meta,
-                        offset,
-                        stored_size,
-                    });
-                    reader.consume_or_skip(stored_size);
-                }
+            let Some(unaligned_stored_size) =
+                Self::calculate_unaligned_stored_size_checked(stored_meta.data_len as usize)
+            else {
+                break;
+            };
+            if offset + unaligned_stored_size > self_len {
+                break;
             }
+            let stored_size = u64_align!(unaligned_stored_size);
+            callback(StoredAccountNoData {
+                meta: stored_meta,
+                account_meta,
+                offset,
+                stored_size,
+            });
+            reader.consume_or_skip(stored_size);
         }
         Ok(())
     }
@@ -1328,11 +1086,7 @@ impl AppendVec {
 
     /// Returns the way to access this accounts file when archiving
     pub(crate) fn internals_for_archive(&self) -> InternalsForArchive<'_> {
-        match &self.backing {
-            AppendVecFileBacking::File(_file) => InternalsForArchive::FileIo(self.path()),
-            // note this returns the entire mmap slice, even bytes that we consider invalid
-            AppendVecFileBacking::Mmap(mmap) => InternalsForArchive::Mmap(mmap),
-        }
+        InternalsForArchive { path: self.path() }
     }
 }
 
@@ -1372,7 +1126,7 @@ mod tests {
         solana_account::{AccountSharedData, WritableAccount, accounts_equal},
         solana_clock::Slot,
         std::{mem::ManuallyDrop, time::Instant},
-        test_case::{test_case, test_matrix},
+        test_case::test_case,
     };
 
     impl AppendVec {
@@ -1393,17 +1147,15 @@ mod tests {
     // Offset of the first account's `data_len` field.
     const ACCOUNT_0_DATA_LEN_OFFSET: u64 = core::mem::offset_of!(StoredMeta, data_len) as u64;
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
+    #[test]
     #[should_panic(expected = "FileSizeTooSmall(0)")]
-    fn test_append_vec_new_bad_size(storage_access: StorageAccess) {
+    fn test_append_vec_new_bad_size() {
         let path = get_append_vec_path("test_append_vec_new_bad_size");
-        let _av = AppendVec::new(&path.path, true, 0, storage_access);
+        let _av = AppendVec::new(&path.path, true, 0);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_append_vec_new_from_file_bad_size(storage_access: StorageAccess) {
+    #[test]
+    fn test_append_vec_new_from_file_bad_size() {
         let file = get_append_vec_path("test_append_vec_new_from_file_bad_size");
         let path = &file.path;
 
@@ -1412,9 +1164,9 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(path)
-            .expect("create a test file for mmap");
+            .expect("create a test file");
 
-        let result = AppendVec::new_from_file(path, 0, storage_access);
+        let result = AppendVec::new_from_file(path, 0);
         assert_matches!(result, Err(ref message) if message.to_string().contains("too small file size 0 for AppendVec"));
     }
 
@@ -1458,11 +1210,10 @@ mod tests {
         assert_matches!(result, Err(ref message) if message.to_string().contains("is larger than file size (1048576)"));
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_append_vec_one(storage_access: StorageAccess) {
+    #[test]
+    fn test_append_vec_one() {
         let path = get_append_vec_path("test_append");
-        let av = AppendVec::new(&path.path, true, 1024 * 1024, storage_access);
+        let av = AppendVec::new(&path.path, true, 1024 * 1024);
         let account = create_test_account(0);
         let index = av.append_account_test(&account).unwrap();
         assert_eq!(av.get_account_test(index).unwrap(), account);
@@ -1483,11 +1234,10 @@ mod tests {
         assert_eq!(av.get_account_test(index), None);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_append_vec_one_with_data(storage_access: StorageAccess) {
+    #[test]
+    fn test_append_vec_one_with_data() {
         let path = get_append_vec_path("test_append");
-        let av = AppendVec::new(&path.path, true, 1024 * 1024, storage_access);
+        let av = AppendVec::new(&path.path, true, 1024 * 1024);
         let data_len = 1;
         let account = create_test_account(data_len);
         let index = av.append_account_test(&account).unwrap();
@@ -1500,13 +1250,12 @@ mod tests {
         truncate_and_test(av, index);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_remaining_bytes(storage_access: StorageAccess) {
+    #[test]
+    fn test_remaining_bytes() {
         let path = get_append_vec_path("test_append");
         let sz = 1024 * 1024;
         let sz64 = sz as u64;
-        let av = AppendVec::new(&path.path, true, sz, storage_access);
+        let av = AppendVec::new(&path.path, true, sz);
         assert_eq!(av.capacity(), sz64);
         assert_eq!(av.remaining_bytes(), sz64);
 
@@ -1541,11 +1290,10 @@ mod tests {
         assert_eq!(av.remaining_bytes(), sz64 - u64_align!(av_len) as u64);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_append_vec_data(storage_access: StorageAccess) {
+    #[test]
+    fn test_append_vec_data() {
         let path = get_append_vec_path("test_append_data");
-        let av = AppendVec::new(&path.path, true, 1024 * 1024, storage_access);
+        let av = AppendVec::new(&path.path, true, 1024 * 1024);
         let account = create_test_account(5);
         let index = av.append_account_test(&account).unwrap();
         assert_eq!(av.get_account_test(index).unwrap(), account);
@@ -1621,13 +1369,7 @@ mod tests {
         }
 
         let path = get_append_vec_path("test_scan_accounts_stored_meta_correctness");
-        let av = ManuallyDrop::new(AppendVec::new(
-            &path.path,
-            true,
-            file_size,
-            #[allow(deprecated)]
-            StorageAccess::Mmap,
-        ));
+        let av = ManuallyDrop::new(AppendVec::new(&path.path, true, file_size));
         let slot = 42;
         let stored_accounts_info = av
             .append_accounts(&(slot, test_accounts.as_slice()), 0)
@@ -1640,12 +1382,12 @@ mod tests {
     #[test]
     fn test_scan_accounts_correctness() {
         let num_accounts = 100;
-        let (av_mmap, _, test_accounts, path) = rand_exhaustive_append_vec(num_accounts);
-        let av_file = AppendVec::new_from_file(&path.path, av_mmap.len(), StorageAccess::File)
+        let (av_writer, _, test_accounts, path) = rand_exhaustive_append_vec(num_accounts);
+        let av_reader = AppendVec::new_from_file(&path.path, av_writer.len())
             .unwrap()
             .0;
         let mut reader = new_scan_accounts_reader();
-        for av in [&av_mmap, &av_file] {
+        for av in [&av_writer, &av_reader] {
             let mut index = 0;
             av.scan_accounts_stored_meta(&mut reader, |v| {
                 let (pubkey, account) = &test_accounts[index];
@@ -1657,7 +1399,7 @@ mod tests {
             .expect("must scan accounts storage");
             assert_eq!(index, num_accounts);
         }
-        for av in [&av_mmap, &av_file] {
+        for av in [&av_writer, &av_reader] {
             let mut index = 0;
             av.scan_stored_accounts_no_data(|stored_account| {
                 let (pubkey, account) = &test_accounts[index];
@@ -1679,56 +1421,55 @@ mod tests {
     fn test_scan_useless_accounts() {
         let num_accounts = 33;
         let num_new_accounts = num_accounts - 2;
-        let (av_mmap, stored_accounts_info, test_accounts, path) =
+        let (av_writer, stored_accounts_info, test_accounts, path) =
             rand_exhaustive_append_vec(num_accounts);
-        let av_current_len = av_mmap.len();
+        let av_current_len = av_writer.len();
+        av_writer.flush().unwrap();
 
-        // Rewrite the append vec to mark account at num_new_accounts as useless.
-        // This will also "hide" any accounts later in the file.
-        if let AppendVecFileBacking::Mmap(mmap) = &av_mmap.backing {
-            let slice = av_mmap.get_valid_slice_from_mmap(mmap);
-            let mut stored_meta_offset = stored_accounts_info.offsets[num_new_accounts];
-            let (stored_meta, mut account_meta_offset) =
-                AppendVec::get_type::<StoredMeta>(slice, stored_meta_offset).unwrap();
-            let (account_meta, _next) =
-                AppendVec::get_type::<AccountMeta>(slice, account_meta_offset).unwrap();
-            assert_eq!(stored_meta.pubkey, test_accounts[num_new_accounts].0);
-
-            let new_stored_meta = StoredMeta {
-                pubkey: Pubkey::default(),
-                ..stored_meta.clone()
-            };
-            let new_account_meta = AccountMeta {
-                lamports: 0,
-                ..account_meta.clone()
-            };
-            av_mmap
-                .append_ptr(
-                    &mut stored_meta_offset,
+        // Rewrite the append vec on disk to mark account at num_new_accounts as
+        // useless. This will also "hide" any accounts later in the file.
+        let stored_meta_offset = stored_accounts_info.offsets[num_new_accounts];
+        let account_meta_offset = stored_meta_offset + mem::size_of::<StoredMeta>();
+        let new_stored_meta = StoredMeta {
+            write_version_obsolete: 0,
+            data_len: 0,
+            pubkey: Pubkey::default(),
+        };
+        let new_account_meta = AccountMeta {
+            lamports: 0,
+            rent_epoch: 0,
+            owner: Pubkey::default(),
+            executable: false,
+        };
+        {
+            let mut file = OpenOptions::new().write(true).open(&path.path).unwrap();
+            file.seek(SeekFrom::Start(stored_meta_offset as u64))
+                .unwrap();
+            let stored_meta_bytes: &[u8] = unsafe {
+                slice::from_raw_parts(
                     ptr::from_ref(&new_stored_meta).cast(),
-                    size_of::<StoredMeta>(),
+                    mem::size_of::<StoredMeta>(),
                 )
+            };
+            file.write_all(stored_meta_bytes).unwrap();
+            file.seek(SeekFrom::Start(account_meta_offset as u64))
                 .unwrap();
-            av_mmap
-                .append_ptr(
-                    &mut account_meta_offset,
+            let account_meta_bytes: &[u8] = unsafe {
+                slice::from_raw_parts(
                     ptr::from_ref(&new_account_meta).cast(),
-                    size_of::<AccountMeta>(),
+                    mem::size_of::<AccountMeta>(),
                 )
-                .unwrap();
-            av_mmap.flush().unwrap();
-        } else {
-            panic!("append vec must be mmap");
+            };
+            file.write_all(account_meta_bytes).unwrap();
+            file.flush().unwrap();
         }
 
         let file_info = FileInfo::new_from_path(&path.path).unwrap();
-        let av_file =
-            AppendVec::new_from_file_info_unchecked(file_info, av_current_len, StorageAccess::File)
-                .unwrap();
+        let av_reader = AppendVec::new_from_file_info_unchecked(file_info, av_current_len).unwrap();
         let mut reader = new_scan_accounts_reader();
-        for av in [&av_mmap, &av_file] {
-            let mut index = 0;
-            av.scan_accounts_stored_meta(&mut reader, |stored_account| {
+        let mut index = 0;
+        av_reader
+            .scan_accounts_stored_meta(&mut reader, |stored_account| {
                 let (pubkey, account) = &test_accounts[index];
                 let recovered = create_account_shared_data(&stored_account);
                 assert_eq!(stored_account.pubkey(), pubkey);
@@ -1736,11 +1477,10 @@ mod tests {
                 index += 1;
             })
             .expect("must scan accounts storage");
-            assert_eq!(index, num_new_accounts);
-        }
-        for av in [&av_mmap, &av_file] {
-            let mut index = 0;
-            av.scan_stored_accounts_no_data(|stored_account| {
+        assert_eq!(index, num_new_accounts);
+        let mut index = 0;
+        av_reader
+            .scan_stored_accounts_no_data(|stored_account| {
                 let (pubkey, account) = &test_accounts[index];
                 assert_eq!(stored_account.pubkey(), pubkey);
                 assert_eq!(stored_account.lamports(), account.lamports());
@@ -1751,15 +1491,13 @@ mod tests {
                 index += 1;
             })
             .expect("must scan accounts storage");
-            assert_eq!(index, num_new_accounts);
-        }
+        assert_eq!(index, num_new_accounts);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_append_vec_append_many(storage_access: StorageAccess) {
+    #[test]
+    fn test_append_vec_append_many() {
         let path = get_append_vec_path("test_append_many");
-        let av = AppendVec::new(&path.path, true, 1024 * 1024, storage_access);
+        let av = AppendVec::new(&path.path, true, 1024 * 1024);
         let size = 1000;
         let mut indexes = vec![];
         let now = Instant::now();
@@ -1806,9 +1544,8 @@ mod tests {
         trace!("sequential read time: {} ms", now.elapsed().as_millis());
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_new_from_file_crafted_zero_lamport_account(storage_access: StorageAccess) {
+    #[test]
+    fn test_new_from_file_crafted_zero_lamport_account() {
         // This test verifies that when we sanitize on load, that we fail sanitizing if we load an account with zero lamports that does not have all default value fields.
         // This test writes an account with zero lamports, but with 3 bytes of data. On load, it asserts that load fails.
         // It used to be possible to use the append vec api to write an account to an append vec with zero lamports, but with non-default values for other account fields.
@@ -1875,18 +1612,17 @@ mod tests {
             writer.write_all(append_vec_data.as_slice()).unwrap();
         }
 
-        let result = AppendVec::new_from_file(path, accounts_len, storage_access);
+        let result = AppendVec::new_from_file(path, accounts_len);
         assert_matches!(result, Err(ref message) if message.to_string().contains("incorrect layout/length/data"));
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_new_from_file_crafted_data_len(storage_access: StorageAccess) {
+    #[test]
+    fn test_new_from_file_crafted_data_len() {
         let file = get_append_vec_path("test_new_from_file_crafted_data_len");
         let path = &file.path;
         let accounts_len = {
             // wrap AppendVec in ManuallyDrop to ensure we do not remove the backing file when dropped
-            let av = ManuallyDrop::new(AppendVec::new(path, true, 1024 * 1024, storage_access));
+            let av = ManuallyDrop::new(AppendVec::new(path, true, 1024 * 1024));
 
             av.append_account_test(&create_test_account(10)).unwrap();
             av.flush().unwrap();
@@ -1895,8 +1631,7 @@ mod tests {
 
         // Assert that the file is currently valid.
         {
-            let av =
-                ManuallyDrop::new(AppendVec::new_from_file(path, accounts_len, storage_access));
+            let av = ManuallyDrop::new(AppendVec::new_from_file(path, accounts_len));
             assert!(av.is_ok());
         }
 
@@ -1911,35 +1646,32 @@ mod tests {
             file.flush().unwrap();
         }
 
-        let result = AppendVec::new_from_file(path, accounts_len, storage_access);
+        let result = AppendVec::new_from_file(path, accounts_len);
         assert_matches!(result, Err(ref message) if message.to_string().contains("incorrect layout/length/data"));
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_append_vec_flush(storage_access: StorageAccess) {
+    #[test]
+    fn test_append_vec_flush() {
         let file = get_append_vec_path("test_append_vec_flush");
         let path = &file.path;
         let accounts_len = {
             // wrap AppendVec in ManuallyDrop to ensure we do not remove the backing file when dropped
-            let av = ManuallyDrop::new(AppendVec::new(path, true, 1024 * 1024, storage_access));
+            let av = ManuallyDrop::new(AppendVec::new(path, true, 1024 * 1024));
             av.append_account_test(&create_test_account(10)).unwrap();
             av.len()
         };
 
-        let (av, num_account) =
-            AppendVec::new_from_file(path, accounts_len, storage_access).unwrap();
+        let (av, num_account) = AppendVec::new_from_file(path, accounts_len).unwrap();
         av.flush().unwrap();
         assert_eq!(num_account, 1);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_append_vec_reopen_as_readonly(storage_access: StorageAccess) {
+    #[test]
+    fn test_append_vec_reopen_as_readonly() {
         let file = get_append_vec_path("test_append_vec_flush");
         let path = &file.path;
         let accounts_len = {
-            let av = AppendVec::new(path, true, 1024 * 1024, storage_access);
+            let av = AppendVec::new(path, true, 1024 * 1024);
             av.append_account_test(&create_test_account(10)).unwrap();
             // wrap AppendVec in ManuallyDrop to ensure we do not remove the backing file when dropped
             let ro_av = ManuallyDrop::new(
@@ -1949,24 +1681,19 @@ mod tests {
             ro_av.len()
         };
 
-        let (av, _) = AppendVec::new_from_file(path, accounts_len, storage_access).unwrap();
+        let (av, _) = AppendVec::new_from_file(path, accounts_len).unwrap();
         let reopen = av.reopen_as_readonly_file_io();
-        // even if AppendVec is already read-only, but uses mmap, it should reopen as file_io
-        if storage_access == StorageAccess::File {
-            assert!(reopen.is_none());
-        } else {
-            assert!(reopen.is_some());
-        }
+        // The AppendVec is already read-only and backed by file I/O, so re-opening is a no-op.
+        assert!(reopen.is_none());
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_new_from_file_too_large_data_len(storage_access: StorageAccess) {
+    #[test]
+    fn test_new_from_file_too_large_data_len() {
         let file = get_append_vec_path("test_new_from_file_too_large_data_len");
         let path = &file.path;
         let accounts_len = {
             // wrap AppendVec in ManuallyDrop to ensure we do not remove the backing file when dropped
-            let av = ManuallyDrop::new(AppendVec::new(path, true, 1024 * 1024, storage_access));
+            let av = ManuallyDrop::new(AppendVec::new(path, true, 1024 * 1024));
 
             av.append_account_test(&create_test_account(10)).unwrap();
 
@@ -1976,8 +1703,7 @@ mod tests {
 
         // Assert that the file is currently valid.
         {
-            let av =
-                ManuallyDrop::new(AppendVec::new_from_file(path, accounts_len, storage_access));
+            let av = ManuallyDrop::new(AppendVec::new_from_file(path, accounts_len));
             assert!(av.is_ok());
         }
 
@@ -1992,20 +1718,19 @@ mod tests {
             file.flush().unwrap();
         }
 
-        let result = AppendVec::new_from_file(path, accounts_len, storage_access);
+        let result = AppendVec::new_from_file(path, accounts_len);
         assert_matches!(result, Err(ref message) if message.to_string().contains("incorrect layout/length/data"));
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_new_from_file_crafted_executable(storage_access: StorageAccess) {
+    #[test]
+    fn test_new_from_file_crafted_executable() {
         let file = get_append_vec_path("test_new_from_crafted_executable");
         let path = &file.path;
 
         // Write a valid append vec file.
         let accounts_len = {
             // wrap AppendVec in ManuallyDrop to ensure we do not remove the backing file when dropped
-            let av = ManuallyDrop::new(AppendVec::new(path, true, 1024 * 1024, storage_access));
+            let av = ManuallyDrop::new(AppendVec::new(path, true, 1024 * 1024));
             av.append_account_test(&create_test_account(10)).unwrap();
             let offset_1 = {
                 let mut executable_account = create_test_account(10);
@@ -2030,8 +1755,7 @@ mod tests {
 
         // Assert that the file is currently valid.
         {
-            let av =
-                ManuallyDrop::new(AppendVec::new_from_file(path, accounts_len, storage_access));
+            let av = ManuallyDrop::new(AppendVec::new_from_file(path, accounts_len));
             assert!(av.is_ok());
         }
 
@@ -2049,7 +1773,7 @@ mod tests {
             file.flush().unwrap();
         }
 
-        let result = AppendVec::new_from_file(path, accounts_len, storage_access);
+        let result = AppendVec::new_from_file(path, accounts_len);
         assert_matches!(result, Err(ref message) if message.to_string().contains("incorrect layout/length/data"));
     }
 
@@ -2067,9 +1791,8 @@ mod tests {
         assert_eq!(mem::size_of::<AccountMeta>(), 0x38);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_get_account_shared_data_from_truncated_file(storage_access: StorageAccess) {
+    #[test]
+    fn test_get_account_shared_data_from_truncated_file() {
         let file = get_append_vec_path("test_get_account_shared_data_from_truncated_file");
         let path = &file.path;
 
@@ -2083,7 +1806,6 @@ mod tests {
                 path,
                 true,
                 AppendVec::calculate_stored_size(data_len),
-                storage_access,
             ));
             av.append_account_test(&account).unwrap();
             av.flush().unwrap();
@@ -2091,15 +1813,9 @@ mod tests {
 
         // Truncate the AppendVec to PAGESIZE. This will cause get_account* to fail to load the account.
         let truncated_accounts_len: usize = PAGE_SIZE;
-        #[allow(deprecated)]
-        let is_writable = storage_access == StorageAccess::Mmap;
-        let file_info = FileInfo::new_from_path_writable(path, is_writable).unwrap();
-        let av = AppendVec::new_from_file_info_unchecked(
-            file_info,
-            truncated_accounts_len,
-            storage_access,
-        )
-        .unwrap();
+        let file_info = FileInfo::new_from_path_writable(path, false).unwrap();
+        let av =
+            AppendVec::new_from_file_info_unchecked(file_info, truncated_accounts_len).unwrap();
         let account = av.get_account_shared_data(0);
         assert!(account.is_none()); // Expect None to be returned.
 
@@ -2107,9 +1823,8 @@ mod tests {
         assert!(result.is_none()); // Expect None to be returned.
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_get_account_sizes(storage_access: StorageAccess) {
+    #[test]
+    fn test_get_account_sizes() {
         const NUM_ACCOUNTS: usize = 37;
         let pubkeys: Vec<_> = std::iter::repeat_with(Pubkey::new_unique)
             .take(NUM_ACCOUNTS)
@@ -2131,8 +1846,7 @@ mod tests {
 
         let temp_file = get_append_vec_path("test_get_account_sizes");
         let account_offsets = {
-            let append_vec =
-                AppendVec::new(&temp_file.path, true, total_stored_size, storage_access);
+            let append_vec = AppendVec::new(&temp_file.path, true, total_stored_size);
             // wrap AppendVec in ManuallyDrop to ensure we do not remove the backing file when dropped
             let append_vec = ManuallyDrop::new(append_vec);
             let slot = 77; // the specific slot does not matter
@@ -2144,10 +1858,8 @@ mod tests {
             stored_accounts_info.offsets
         };
 
-        // now open the append vec with the given storage access method
-        // then get the account sizes to ensure they are correct
-        let (append_vec, _) =
-            AppendVec::new_from_file(&temp_file.path, total_stored_size, storage_access).unwrap();
+        // re-open the append vec and get the account sizes to ensure they are correct
+        let (append_vec, _) = AppendVec::new_from_file(&temp_file.path, total_stored_size).unwrap();
 
         let account_sizes = append_vec
             .get_account_data_lens(account_offsets.as_slice())
@@ -2162,7 +1874,6 @@ mod tests {
     /// `modify_fn` is used to (optionally) modify the append vec before checks are performed.
     /// `check_fn` performs the check for the scan.
     fn test_scan_helper(
-        storage_access: StorageAccess,
         modify_fn: impl Fn(&PathBuf, usize) -> usize,
         check_fn: impl Fn(&AppendVec, &[Pubkey], &[usize], &[AccountSharedData]),
     ) {
@@ -2187,12 +1898,8 @@ mod tests {
         let temp_file = get_append_vec_path("test_scan");
         let account_offsets = {
             // wrap AppendVec in ManuallyDrop to ensure we do not remove the backing file when dropped
-            let append_vec = ManuallyDrop::new(AppendVec::new(
-                &temp_file.path,
-                true,
-                total_stored_size,
-                storage_access,
-            ));
+            let append_vec =
+                ManuallyDrop::new(AppendVec::new(&temp_file.path, true, total_stored_size));
             let slot = 42; // the specific slot does not matter
             let storable_accounts: Vec<_> = std::iter::zip(&pubkeys, &accounts).collect();
             let stored_accounts_info = append_vec
@@ -2203,26 +1910,18 @@ mod tests {
         };
 
         let total_stored_size = modify_fn(&temp_file.path, total_stored_size);
-        // now open the append vec with the given storage access method
-        // then perform the scan and check it is correct
-        #[allow(deprecated)]
-        let is_writable = storage_access == StorageAccess::Mmap;
-        let file_info = FileInfo::new_from_path_writable(&temp_file.path, is_writable).unwrap();
+        // now re-open the append vec and perform the scan and check it is correct
+        let file_info = FileInfo::new_from_path_writable(&temp_file.path, false).unwrap();
         let append_vec = ManuallyDrop::new(
-            AppendVec::new_from_file_info_unchecked(file_info, total_stored_size, storage_access)
-                .unwrap(),
+            AppendVec::new_from_file_info_unchecked(file_info, total_stored_size).unwrap(),
         );
 
         check_fn(&append_vec, &pubkeys, &account_offsets, &accounts);
     }
 
     /// A helper fn to test `scan_pubkeys`.
-    fn test_scan_pubkeys_helper(
-        storage_access: StorageAccess,
-        modify_fn: impl Fn(&PathBuf, usize) -> usize,
-    ) {
+    fn test_scan_pubkeys_helper(modify_fn: impl Fn(&PathBuf, usize) -> usize) {
         test_scan_helper(
-            storage_access,
             modify_fn,
             |append_vec, pubkeys, _account_offsets, _accounts| {
                 let mut i = 0;
@@ -2238,17 +1937,15 @@ mod tests {
     }
 
     /// Test `scan_pubkey` for a valid account storage.
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_scan_pubkeys(storage_access: StorageAccess) {
-        test_scan_pubkeys_helper(storage_access, |_, size| size);
+    #[test]
+    fn test_scan_pubkeys() {
+        test_scan_pubkeys_helper(|_, size| size);
     }
 
     /// Test `scan_pubkey` for storage with incomplete account meta data.
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_scan_pubkeys_incomplete_data(storage_access: StorageAccess) {
-        test_scan_pubkeys_helper(storage_access, |path, size| {
+    #[test]
+    fn test_scan_pubkeys_incomplete_data() {
+        test_scan_pubkeys_helper(|path, size| {
             // Append 1 byte of data at the end of the storage file to simulate
             // incomplete account's meta data.
             let mut f = OpenOptions::new()
@@ -2262,10 +1959,9 @@ mod tests {
     }
 
     /// Test `scan_pubkey` for storage which is missing the last account data
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_scan_pubkeys_missing_account_data(storage_access: StorageAccess) {
-        test_scan_pubkeys_helper(storage_access, |path, size| {
+    #[test]
+    fn test_scan_pubkeys_missing_account_data() {
+        test_scan_pubkeys_helper(|path, size| {
             let fake_stored_meta = StoredMeta {
                 write_version_obsolete: 0,
                 data_len: 100,
@@ -2305,12 +2001,8 @@ mod tests {
     }
 
     /// A helper fn to test scan_stored_accounts_no_data
-    fn test_scan_stored_accounts_no_data_helper(
-        storage_access: StorageAccess,
-        modify_fn: impl Fn(&PathBuf, usize) -> usize,
-    ) {
+    fn test_scan_stored_accounts_no_data_helper(modify_fn: impl Fn(&PathBuf, usize) -> usize) {
         test_scan_helper(
-            storage_access,
             modify_fn,
             |append_vec, pubkeys, account_offsets, accounts| {
                 let mut i = 0;
@@ -2337,17 +2029,15 @@ mod tests {
         )
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_scan_stored_accounts_no_data(storage_access: StorageAccess) {
-        test_scan_stored_accounts_no_data_helper(storage_access, |_, size| size);
+    #[test]
+    fn test_scan_stored_accounts_no_data() {
+        test_scan_stored_accounts_no_data_helper(|_, size| size);
     }
 
     /// Test `scan_stored_accounts_no_data` for storage with incomplete account meta data.
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_scan_stored_accounts_no_data_incomplete_data(storage_access: StorageAccess) {
-        test_scan_stored_accounts_no_data_helper(storage_access, |path, size| {
+    #[test]
+    fn test_scan_stored_accounts_no_data_incomplete_data() {
+        test_scan_stored_accounts_no_data_helper(|path, size| {
             // Append 1 byte of data at the end of the storage file to simulate
             // incomplete account's meta data.
             let mut f = OpenOptions::new()
@@ -2361,10 +2051,9 @@ mod tests {
     }
 
     /// Test `scan_stored_accounts_no_data` for storage which is missing the last account data
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_scan_stored_accounts_no_data_missing_account_data(storage_access: StorageAccess) {
-        test_scan_stored_accounts_no_data_helper(storage_access, |path, size| {
+    #[test]
+    fn test_scan_stored_accounts_no_data_missing_account_data() {
+        test_scan_stored_accounts_no_data_helper(|path, size| {
             let fake_stored_meta = StoredMeta {
                 write_version_obsolete: 0,
                 data_len: 100,
@@ -2406,12 +2095,8 @@ mod tests {
     /// A helper fn to test scan_accounts_stored_meta
     ///
     /// `modify_fn` is used to (optionally) modify the append vec before checks are performed.
-    fn test_scan_accounts_stored_meta_helper(
-        storage_access: StorageAccess,
-        modify_fn: impl Fn(&PathBuf, usize) -> usize,
-    ) {
+    fn test_scan_accounts_stored_meta_helper(modify_fn: impl Fn(&PathBuf, usize) -> usize) {
         test_scan_helper(
-            storage_access,
             modify_fn,
             |append_vec, pubkeys, account_offsets, accounts| {
                 let mut reader = new_scan_accounts_reader();
@@ -2435,17 +2120,15 @@ mod tests {
     }
 
     /// Test `scan_accounts_stored_meta` for a normal/good storage.
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_scan_accounts_stored_meta(storage_access: StorageAccess) {
-        test_scan_accounts_stored_meta_helper(storage_access, |_, size| size);
+    #[test]
+    fn test_scan_accounts_stored_meta() {
+        test_scan_accounts_stored_meta_helper(|_, size| size);
     }
 
     /// Test `scan_accounts_stored_meta` for a storage with incomplete account meta data.
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_scan_accounts_stored_meta_incomplete_meta_data(storage_access: StorageAccess) {
-        test_scan_accounts_stored_meta_helper(storage_access, |path, size| {
+    #[test]
+    fn test_scan_accounts_stored_meta_incomplete_meta_data() {
+        test_scan_accounts_stored_meta_helper(|path, size| {
             // Append 1 byte of data at the end of the storage file to simulate
             // incomplete account's meta data.
             let mut f = OpenOptions::new()
@@ -2459,10 +2142,9 @@ mod tests {
     }
 
     /// Test `scan_accounts_stored_meta` for a storage that is missing the last account data.
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_scan_accounts_stored_meta_missing_account_data(storage_access: StorageAccess) {
-        test_scan_accounts_stored_meta_helper(storage_access, |path, size| {
+    #[test]
+    fn test_scan_accounts_stored_meta_missing_account_data() {
+        test_scan_accounts_stored_meta_helper(|path, size| {
             let fake_stored_meta = StoredMeta {
                 write_version_obsolete: 0,
                 data_len: 100,
@@ -2504,11 +2186,12 @@ mod tests {
     // Test to make sure that `is_dirty` is tracked properly
     // * `reopen_as_readonly()` moves `is_dirty`
     // * `flush()` clears `is_dirty`
-    #[test_matrix([false, true], [#[allow(deprecated)] StorageAccess::Mmap, StorageAccess::File])]
-    fn test_is_dirty(begins_dirty: bool, storage_access: StorageAccess) {
+    #[test_case(false)]
+    #[test_case(true)]
+    fn test_is_dirty(begins_dirty: bool) {
         let file = get_append_vec_path("test_is_dirty");
 
-        let mut av1 = AppendVec::new(&file.path, true, 1024 * 1024, storage_access);
+        let mut av1 = AppendVec::new(&file.path, true, 1024 * 1024);
         // don't delete the file when the AppendVec is dropped (let TempFile do it)
         *av1.remove_file_on_drop.get_mut() = false;
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -333,7 +333,7 @@ impl AppendVec {
 
     #[cfg(feature = "dev-context-only-utils")]
     pub fn new_from_file(path: impl Into<PathBuf>, current_len: usize) -> Result<(Self, usize)> {
-        let file_info = FileInfo::new_from_path_writable(path, false)?;
+        let file_info = FileInfo::new_from_path(path)?;
         let new = Self::new_from_file_info_unchecked(file_info, current_len)?;
 
         let num_accounts = new.sanitize_layout_and_length()?;
@@ -1813,7 +1813,7 @@ mod tests {
 
         // Truncate the AppendVec to PAGESIZE. This will cause get_account* to fail to load the account.
         let truncated_accounts_len: usize = PAGE_SIZE;
-        let file_info = FileInfo::new_from_path_writable(path, false).unwrap();
+        let file_info = FileInfo::new_from_path(path).unwrap();
         let av =
             AppendVec::new_from_file_info_unchecked(file_info, truncated_accounts_len).unwrap();
         let account = av.get_account_shared_data(0);
@@ -1911,7 +1911,7 @@ mod tests {
 
         let total_stored_size = modify_fn(&temp_file.path, total_stored_size);
         // now re-open the append vec and perform the scan and check it is correct
-        let file_info = FileInfo::new_from_path_writable(&temp_file.path, false).unwrap();
+        let file_info = FileInfo::new_from_path(&temp_file.path).unwrap();
         let append_vec = ManuallyDrop::new(
             AppendVec::new_from_file_info_unchecked(file_info, total_stored_size).unwrap(),
         );

--- a/accounts-db/src/append_vec/meta.rs
+++ b/accounts-db/src/append_vec/meta.rs
@@ -43,6 +43,8 @@ pub struct StoredAccountMeta<'append_vec> {
     pub account_meta: &'append_vec AccountMeta,
     pub(crate) data: &'append_vec [u8],
     pub(crate) offset: usize,
+    /// Only read via `stored_size()` under `dev-context-only-utils` (tests, store-tool).
+    #[allow(dead_code)]
     pub(crate) stored_size: usize,
 }
 
@@ -51,6 +53,7 @@ impl<'append_vec> StoredAccountMeta<'append_vec> {
         &self.meta.pubkey
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn stored_size(&self) -> usize {
         self.stored_size
     }

--- a/accounts-db/src/sorted_storages.rs
+++ b/accounts-db/src/sorted_storages.rs
@@ -197,7 +197,7 @@ mod tests {
         crate::{
             account_storage_entry::AccountStorageEntry,
             accounts_db::AccountsFileId,
-            accounts_file::{AccountsFile, AccountsFileProvider, StorageAccess},
+            accounts_file::{AccountsFile, AccountsFileProvider},
             append_vec::AppendVec,
         },
         std::sync::Arc,
@@ -449,14 +449,8 @@ mod tests {
             id,
             size as u64,
             AccountsFileProvider::AppendVec,
-            StorageAccess::File,
         );
-        let av = AccountsFile::AppendVec(AppendVec::new(
-            &tf.path,
-            true,
-            1024 * 1024,
-            StorageAccess::File,
-        ));
+        let av = AccountsFile::AppendVec(AppendVec::new(&tf.path, true, 1024 * 1024));
         data.accounts = av;
 
         Arc::new(data)

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -687,7 +687,6 @@ mod tests {
             id,
             file_size,
             AccountsFileProvider::AppendVec,
-            db.storage_access(),
         );
         let storage = Arc::new(data);
         db.storage.insert(storage.clone());

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6193,7 +6193,6 @@ dependencies = [
  "dashmap",
  "itertools 0.14.0",
  "log",
- "memmap2 0.9.10",
  "modular-bitfield",
  "num_cpus",
  "qualifier_attr",

--- a/fs/src/file_info.rs
+++ b/fs/src/file_info.rs
@@ -1,8 +1,4 @@
-use std::{
-    fs::{File, OpenOptions},
-    io,
-    path::PathBuf,
-};
+use std::{fs::File, io, path::PathBuf};
 
 /// Open `File` coupled with its filesystem location and most useful information
 ///
@@ -22,20 +18,6 @@ impl FileInfo {
     pub fn new_from_path(path: impl Into<PathBuf>) -> io::Result<Self> {
         let path = path.into();
         let file = File::open(&path)?;
-        Self::new_from_path_and_file(path, file)
-    }
-
-    /// Create new instance by opening file with R/RW mode from a given `path` and reading its metadata
-    ///
-    /// `is_writable` indicates whether the file should be opened in write mode. Note that file needs
-    /// to exist, so even if `is_writable` is true, the file will not be created when missing.
-    pub fn new_from_path_writable(path: impl Into<PathBuf>, is_writable: bool) -> io::Result<Self> {
-        let path = path.into();
-        let file = OpenOptions::new()
-            .read(true)
-            .create(false)
-            .write(is_writable)
-            .open(&path)?;
         Self::new_from_path_and_file(path, file)
     }
 

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -5,7 +5,6 @@ use {
     solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
     solana_accounts_db::{
         accounts_db::{AccountShrinkThreshold, AccountsDbConfig},
-        accounts_file::StorageAccess,
         accounts_index::{
             AccountsIndexConfig, DEFAULT_NUM_ENTRIES_OVERHEAD, DEFAULT_NUM_ENTRIES_TO_EVICT,
             IndexLimit, IndexLimitThreshold, ScanFilter,
@@ -135,7 +134,11 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .value_name("METHOD")
             .takes_value(true)
             .possible_values(&["mmap", "file"])
-            .help("Access account storages using this method"),
+            .help(
+                "[DEPRECATED] Access account storages using this method. This flag is now a \
+                 no-op: storages are always accessed via file I/O. The flag is preserved for \
+                 backward compatibility and will be removed in a future release.",
+            ),
         Arg::with_name("accounts_db_ancient_storage_ideal_size")
             .long("accounts-db-ancient-storage-ideal-size")
             .value_name("BYTES")
@@ -329,21 +332,18 @@ pub fn get_accounts_db_config(
         ..AccountsIndexConfig::default()
     };
 
-    let storage_access = arg_matches
+    // The `--accounts-db-access-storages-method` flag is now a no-op. Storages are
+    // always accessed via file I/O. The flag is preserved for backward compatibility,
+    // but the value is ignored with a warning.
+    if arg_matches
         .value_of("accounts_db_access_storages_method")
-        .map(|method| match method {
-            "mmap" => {
-                warn!("Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.");
-                #[allow(deprecated)]
-                StorageAccess::Mmap
-            }
-            "file" => StorageAccess::File,
-            _ => {
-                // clap will enforce one of the above values is given
-                unreachable!("invalid value given to accounts-db-access-storages-method")
-            }
-        })
-        .unwrap_or_default();
+        .is_some()
+    {
+        warn!(
+            "`--accounts-db-access-storages-method` is now a no-op; storages are always accessed \
+             via file I/O."
+        );
+    }
 
     let scan_filter_for_shrinking = arg_matches
         .value_of("accounts_db_scan_filter_for_shrinking")
@@ -380,7 +380,6 @@ pub fn get_accounts_db_config(
         exhaustively_verify_refcounts: arg_matches.is_present("accounts_db_verify_refcounts"),
         skip_initial_hash_calc: arg_matches.is_present("accounts_db_skip_initial_hash_calculation"),
         partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig::default(),
-        storage_access,
         scan_filter_for_shrinking,
         num_background_threads: None,
         num_foreground_threads: None,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5929,7 +5929,6 @@ dependencies = [
  "dashmap",
  "itertools 0.14.0",
  "log",
- "memmap2 0.9.10",
  "modular-bitfield",
  "num_cpus",
  "qualifier_attr",

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -23,7 +23,7 @@ mod tests {
                 ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDb, AtomicAccountsFileId,
                 get_temp_accounts_paths,
             },
-            accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
+            accounts_file::{AccountsFile, AccountsFileError},
         },
         solana_epoch_schedule::EpochSchedule,
         solana_hash::Hash,
@@ -37,14 +37,12 @@ mod tests {
             sync::{Arc, OnceLock},
         },
         tempfile::TempDir,
-        test_case::{test_case, test_matrix},
     };
 
     /// Simulates the unpacking & storage reconstruction done during snapshot unpacking
     fn copy_append_vecs<P: AsRef<Path>>(
         accounts_db: &AccountsDb,
         output_dir: P,
-        storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
         let storage_entries = accounts_db.get_storages(RangeFull).0;
         let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
@@ -57,11 +55,8 @@ mod tests {
             std::fs::copy(storage_path, &output_path)?;
 
             // Read new file into append-vec and build new entry
-            let (accounts_file, _num_accounts) = AccountsFile::new_from_file(
-                output_path,
-                storage_entry.accounts.len(),
-                storage_access,
-            )?;
+            let (accounts_file, _num_accounts) =
+                AccountsFile::new_from_file(output_path, storage_entry.accounts.len())?;
             let new_storage_entry = AccountStorageEntry::new_existing(
                 storage_entry.slot(),
                 storage_entry.id(),
@@ -79,10 +74,8 @@ mod tests {
     }
 
     /// Test roundtrip serialize/deserialize of a bank
-    #[test_matrix(
-        [#[allow(deprecated)] StorageAccess::Mmap, StorageAccess::File]
-    )]
-    fn test_serialize_bank_snapshot(storage_access: StorageAccess) {
+    #[test]
+    fn test_serialize_bank_snapshot() {
         let leader_id = Pubkey::new_unique();
         let GenesisConfigInfo {
             mut genesis_config, ..
@@ -160,7 +153,7 @@ mod tests {
         // Create a directory to simulate AppendVecs unpackaged from a snapshot tar
         let copied_accounts = TempDir::new().unwrap();
         let storage_and_next_append_vec_id =
-            copy_append_vecs(accounts_db, copied_accounts.path(), storage_access).unwrap();
+            copy_append_vecs(accounts_db, copied_accounts.path()).unwrap();
 
         let cursor = Cursor::new(buf.as_slice());
         let mut reader = BufReader::new(cursor);
@@ -198,9 +191,8 @@ mod tests {
         bank.force_flush_accounts_cache();
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_extra_fields_eof(storage_access: StorageAccess) {
+    #[test]
+    fn test_extra_fields_eof() {
         agave_logger::setup();
         let leader_id = Pubkey::new_unique();
         let GenesisConfigInfo { genesis_config, .. } =
@@ -252,12 +244,8 @@ mod tests {
         };
         let (_accounts_dir, dbank_paths) = get_temp_accounts_paths(4).unwrap();
         let copied_accounts = TempDir::new().unwrap();
-        let storage_and_next_append_vec_id = copy_append_vecs(
-            &bank.rc.accounts.accounts_db,
-            copied_accounts.path(),
-            storage_access,
-        )
-        .unwrap();
+        let storage_and_next_append_vec_id =
+            copy_append_vecs(&bank.rc.accounts.accounts_db, copied_accounts.path()).unwrap();
         let (dbank, _) = crate::serde_snapshot::bank_from_streams(
             &mut snapshot_streams,
             &dbank_paths,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -25,7 +25,7 @@ use {
         accounts_db::{
             AccountsDb, AccountsDbConfig, AccountsFileId, AtomicAccountsFileId, IndexGenerationInfo,
         },
-        accounts_file::{AccountsFile, StorageAccess},
+        accounts_file::AccountsFile,
         accounts_hash::AccountsLtHash,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         blockhash_queue::BlockhashQueue,
@@ -867,7 +867,6 @@ pub(crate) fn reconstruct_single_storage(
     append_vec_file_info: FileInfo,
     current_len: usize,
     id: AccountsFileId,
-    storage_access: StorageAccess,
     obsolete_accounts: Option<(ObsoleteAccounts, AccountsFileId, usize)>,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
     // When restoring from an archive, obsolete accounts will always be `None`
@@ -887,8 +886,7 @@ pub(crate) fn reconstruct_single_storage(
         (current_len, ObsoleteAccounts::default())
     };
 
-    let accounts_file =
-        AccountsFile::new_for_startup(append_vec_file_info, current_len, storage_access)?;
+    let accounts_file = AccountsFile::new_for_startup(append_vec_file_info, current_len)?;
     Ok(Arc::new(AccountStorageEntry::new_existing(
         *slot,
         id,
@@ -986,7 +984,6 @@ pub(crate) fn remap_and_reconstruct_single_storage(
     append_vec_file_info: FileInfo,
     next_append_vec_id: &AtomicAccountsFileId,
     num_collisions: &AtomicUsize,
-    storage_access: StorageAccess,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
     let (remapped_append_vec_id, remapped_append_vec_file_info) = remap_append_vec_file(
         slot,
@@ -1000,7 +997,6 @@ pub(crate) fn remap_and_reconstruct_single_storage(
         remapped_append_vec_file_info,
         current_len,
         remapped_append_vec_id,
-        storage_access,
         None,
     )?;
     Ok(storage)

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -24,7 +24,7 @@ mod serde_snapshot_tests {
                 ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDb, AccountsDbConfig, AtomicAccountsFileId,
                 get_temp_accounts_paths,
             },
-            accounts_file::{AccountsFile, AccountsFileError, StorageAccess},
+            accounts_file::{AccountsFile, AccountsFileError},
             ancestors::Ancestors,
         },
         solana_clock::Slot,
@@ -40,7 +40,7 @@ mod serde_snapshot_tests {
             },
         },
         tempfile::TempDir,
-        test_case::{test_case, test_matrix},
+        test_case::test_case,
     };
 
     fn linear_ancestors(end_slot: u64) -> Ancestors {
@@ -119,7 +119,6 @@ mod serde_snapshot_tests {
     fn copy_append_vecs(
         accounts_db: &AccountsDb,
         output_dir: impl AsRef<Path>,
-        storage_access: StorageAccess,
     ) -> Result<StorageAndNextAccountsFileId, AccountsFileError> {
         let storage_entries = accounts_db.get_storages(RangeFull).0;
         let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
@@ -134,7 +133,7 @@ mod serde_snapshot_tests {
 
             // Read new file into append-vec and build new entry
             let (accounts_file, _num_accounts) =
-                AccountsFile::new_from_file(output_path, reader.len(), storage_access)?;
+                AccountsFile::new_from_file(output_path, reader.len())?;
             let new_storage_entry = AccountStorageEntry::new_existing(
                 storage_entry.slot(),
                 storage_entry.id(),
@@ -154,7 +153,6 @@ mod serde_snapshot_tests {
     fn reconstruct_accounts_db_via_serialization(
         accounts: &AccountsDb,
         slot: Slot,
-        storage_access: StorageAccess,
         accounts_db_config: AccountsDbConfig,
     ) -> AccountsDb {
         let mut writer = Cursor::new(vec![]);
@@ -167,7 +165,7 @@ mod serde_snapshot_tests {
 
         // Simulate obtaining a copy of the AppendVecs from a tarball
         let storage_and_next_append_vec_id =
-            copy_append_vecs(accounts, copied_accounts.path(), storage_access).unwrap();
+            copy_append_vecs(accounts, copied_accounts.path()).unwrap();
         let mut accounts_db = accountsdb_from_stream(
             &mut reader,
             &[],
@@ -200,8 +198,8 @@ mod serde_snapshot_tests {
         }
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    fn test_accounts_serialize(storage_access: StorageAccess) {
+    #[test]
+    fn test_accounts_serialize() {
         agave_logger::setup();
         let (_accounts_dir, paths) = get_temp_accounts_paths(4).unwrap();
         let accounts_db = AccountsDb::new_for_tests(paths);
@@ -234,12 +232,8 @@ mod serde_snapshot_tests {
         let copied_accounts = TempDir::new().unwrap();
 
         // Simulate obtaining a copy of the AppendVecs from a tarball
-        let storage_and_next_append_vec_id = copy_append_vecs(
-            &accounts.accounts_db,
-            copied_accounts.path(),
-            storage_access,
-        )
-        .unwrap();
+        let storage_and_next_append_vec_id =
+            copy_append_vecs(&accounts.accounts_db, copied_accounts.path()).unwrap();
 
         let buf = writer.into_inner();
         let mut reader = BufReader::new(&buf[..]);
@@ -260,9 +254,8 @@ mod serde_snapshot_tests {
         assert_eq!(accounts_hash, daccounts_hash);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_remove_unrooted_slot_snapshot(storage_access: StorageAccess) {
+    #[test]
+    fn test_remove_unrooted_slot_snapshot() {
         agave_logger::setup();
         let unrooted_slot = 9;
         let unrooted_bank_id = 9;
@@ -284,7 +277,6 @@ mod serde_snapshot_tests {
         let db = reconstruct_accounts_db_via_serialization(
             &db,
             new_root,
-            storage_access,
             ACCOUNTS_DB_CONFIG_FOR_TESTING,
         );
 
@@ -295,10 +287,8 @@ mod serde_snapshot_tests {
         db.assert_not_load_account(unrooted_slot, key);
     }
 
-    #[test_matrix(
-        [StorageAccess::File, #[allow(deprecated)] StorageAccess::Mmap]
-    )]
-    fn test_accounts_db_serialize1(storage_access: StorageAccess) {
+    #[test]
+    fn test_accounts_db_serialize1() {
         for pass in 0..2 {
             agave_logger::setup();
             let accounts = AccountsDb::new_single_for_tests();
@@ -374,7 +364,6 @@ mod serde_snapshot_tests {
             let daccounts = reconstruct_accounts_db_via_serialization(
                 &accounts,
                 latest_slot,
-                storage_access,
                 ACCOUNTS_DB_CONFIG_FOR_TESTING,
             );
 
@@ -401,9 +390,8 @@ mod serde_snapshot_tests {
         }
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_accounts_db_serialize_zero_and_free(storage_access: StorageAccess) {
+    #[test]
+    fn test_accounts_db_serialize_zero_and_free() {
         agave_logger::setup();
 
         let some_lamport = 223;
@@ -441,7 +429,6 @@ mod serde_snapshot_tests {
         let accounts = reconstruct_accounts_db_via_serialization(
             &accounts,
             current_slot,
-            storage_access,
             ACCOUNTS_DB_CONFIG_FOR_TESTING,
         );
 
@@ -515,9 +502,8 @@ mod serde_snapshot_tests {
         assert_eq!(calculated_capitalization, expected_capitalization);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_accounts_purge_chained_purge_before_snapshot_restore(storage_access: StorageAccess) {
+    #[test]
+    fn test_accounts_purge_chained_purge_before_snapshot_restore() {
         agave_logger::setup();
         with_chained_zero_lamport_accounts(|accounts, current_slot| {
             // If there is no latest full snapshot, zero lamport accounts can be cleaned and
@@ -528,21 +514,18 @@ mod serde_snapshot_tests {
             reconstruct_accounts_db_via_serialization(
                 &accounts,
                 current_slot,
-                storage_access,
                 ACCOUNTS_DB_CONFIG_FOR_TESTING,
             )
         });
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_accounts_purge_chained_purge_after_snapshot_restore(storage_access: StorageAccess) {
+    #[test]
+    fn test_accounts_purge_chained_purge_after_snapshot_restore() {
         agave_logger::setup();
         with_chained_zero_lamport_accounts(|accounts, current_slot| {
             let accounts = reconstruct_accounts_db_via_serialization(
                 &accounts,
                 current_slot,
-                storage_access,
                 ACCOUNTS_DB_CONFIG_FOR_TESTING,
             );
             accounts.print_accounts_stats("after_reconstruct");
@@ -551,15 +534,13 @@ mod serde_snapshot_tests {
             reconstruct_accounts_db_via_serialization(
                 &accounts,
                 current_slot,
-                storage_access,
                 ACCOUNTS_DB_CONFIG_FOR_TESTING,
             )
         });
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_accounts_purge_long_chained_after_snapshot_restore(storage_access: StorageAccess) {
+    #[test]
+    fn test_accounts_purge_long_chained_after_snapshot_restore() {
         agave_logger::setup();
         let old_lamport = 223;
         let zero_lamport = 0;
@@ -618,7 +599,6 @@ mod serde_snapshot_tests {
         let accounts = reconstruct_accounts_db_via_serialization(
             &accounts,
             current_slot,
-            storage_access,
             ACCOUNTS_DB_CONFIG_FOR_TESTING,
         );
         accounts.set_latest_full_snapshot_slot(0);
@@ -631,9 +611,8 @@ mod serde_snapshot_tests {
         accounts.assert_load_account(current_slot, purged_pubkey2, 0);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_accounts_clean_after_snapshot_restore_then_old_revives(storage_access: StorageAccess) {
+    #[test]
+    fn test_accounts_clean_after_snapshot_restore_then_old_revives() {
         agave_logger::setup();
         let old_lamport = 223;
         let zero_lamport = 0;
@@ -727,7 +706,6 @@ mod serde_snapshot_tests {
         let accounts = reconstruct_accounts_db_via_serialization(
             &accounts,
             current_slot,
-            storage_access,
             ACCOUNTS_DB_CONFIG_FOR_TESTING,
         );
 
@@ -762,9 +740,8 @@ mod serde_snapshot_tests {
         accounts.assert_load_account(current_slot, dummy_pubkey, dummy_lamport);
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_shrink_stale_slots_processed(storage_access: StorageAccess) {
+    #[test]
+    fn test_shrink_stale_slots_processed() {
         agave_logger::setup();
 
         for startup in &[false, true] {
@@ -823,7 +800,6 @@ mod serde_snapshot_tests {
             let accounts = reconstruct_accounts_db_via_serialization(
                 &accounts,
                 current_slot,
-                storage_access,
                 ACCOUNTS_DB_CONFIG_FOR_TESTING,
             );
             let accounts_lt_hash_post =

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -9,7 +9,6 @@ use {
         },
     },
     agave_snapshots::SnapshotVersion,
-    solana_accounts_db::accounts_file::StorageAccess,
     tempfile::TempDir,
 };
 use {
@@ -66,7 +65,6 @@ use {
 #[cfg(feature = "dev-context-only-utils")]
 pub fn bank_fields_from_snapshot_archives(
     snapshot_config: &SnapshotConfig,
-    storage_access: StorageAccess,
 ) -> agave_snapshots::Result<BankFieldsToDeserialize> {
     let full_snapshot_archive_info =
         get_highest_full_snapshot_archive_info(&snapshot_config.full_snapshot_archives_dir)
@@ -102,7 +100,6 @@ pub fn bank_fields_from_snapshot_archives(
         &full_snapshot_archive_info,
         incremental_snapshot_archive_info.as_ref(),
         &account_paths,
-        storage_access,
         &io_setup,
     )?;
 
@@ -193,7 +190,6 @@ pub fn bank_from_snapshot_archives(
         full_snapshot_archive_info,
         incremental_snapshot_archive_info,
         account_paths,
-        accounts_db_config.storage_access,
         &io_setup,
     )?;
 
@@ -393,7 +389,6 @@ pub fn bank_from_snapshot_dir(
             bank_snapshot,
             account_paths,
             next_append_vec_id.clone(),
-            accounts_db_config.storage_access,
         )?,
         "rebuild storages from snapshot dir"
     );
@@ -857,9 +852,7 @@ mod tests {
             SnapshotVersion, error::VerifySlotDeltasError, paths::get_bank_snapshot_dir,
         },
         semver::Version,
-        solana_accounts_db::{
-            accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING, accounts_file::StorageAccess,
-        },
+        solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_native_token::LAMPORTS_PER_SOL,
@@ -1637,9 +1630,8 @@ mod tests {
         );
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_bank_fields_from_snapshot(storage_access: StorageAccess) {
+    #[test]
+    fn test_bank_fields_from_snapshot() {
         let key1 = Keypair::new();
 
         let GenesisConfigInfo {
@@ -1677,8 +1669,7 @@ mod tests {
 
         bank_to_incremental_snapshot_archive(&snapshot_config, &bank2, full_snapshot_slot).unwrap();
 
-        let bank_fields =
-            bank_fields_from_snapshot_archives(&snapshot_config, storage_access).unwrap();
+        let bank_fields = bank_fields_from_snapshot_archives(&snapshot_config).unwrap();
         assert_eq!(bank_fields.slot, bank2.slot());
         assert_eq!(bank_fields.parent_slot, bank2.parent_slot());
     }
@@ -1921,9 +1912,8 @@ mod tests {
     ///     - remove Account2's reference back to slot 2 by transferring from the mint to Account2
     ///     - take a full snap shot
     ///     - verify that recovery from full snapshot does not bring account1 back to life
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_snapshots_handle_zero_lamport_accounts(storage_access: StorageAccess) {
+    #[test]
+    fn test_snapshots_handle_zero_lamport_accounts() {
         let key1 = Keypair::new();
         let key2 = Keypair::new();
         let key3 = Keypair::new();
@@ -1942,10 +1932,7 @@ mod tests {
 
         let lamports_to_transfer = 123_456 * LAMPORTS_PER_SOL;
         let bank_test_config = BankTestConfig {
-            accounts_db_config: AccountsDbConfig {
-                storage_access,
-                ..ACCOUNTS_DB_CONFIG_FOR_TESTING
-            },
+            accounts_db_config: ACCOUNTS_DB_CONFIG_FOR_TESTING,
         };
 
         let bank0 =
@@ -2183,9 +2170,8 @@ mod tests {
         .unwrap();
     }
 
-    #[test_case(#[allow(deprecated)] StorageAccess::Mmap)]
-    #[test_case(StorageAccess::File)]
-    fn test_bank_from_snapshot_dir_good(storage_access: StorageAccess) {
+    #[test]
+    fn test_bank_from_snapshot_dir_good() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config_with_leader(
             1_000_000 * LAMPORTS_PER_SOL,
             &Pubkey::new_unique(),
@@ -2219,10 +2205,7 @@ mod tests {
             None, // leader_for_tests
             None,
             false,
-            AccountsDbConfig {
-                storage_access,
-                ..ACCOUNTS_DB_CONFIG_FOR_TESTING
-            },
+            ACCOUNTS_DB_CONFIG_FOR_TESTING,
             None,
             Arc::default(),
         )

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -43,7 +43,7 @@ use {
         account_storage::AccountStorageMap,
         account_storage_entry::AccountStorageEntry,
         accounts_db::AtomicAccountsFileId,
-        accounts_file::{AccountsFile, StorageAccess},
+        accounts_file::AccountsFile,
         utils::{ACCOUNTS_RUN_DIR, ACCOUNTS_SNAPSHOT_DIR, move_and_async_delete_path},
     },
     solana_clock::Slot,
@@ -1072,7 +1072,6 @@ pub fn verify_and_unarchive_snapshots(
     full_snapshot_archive_info: &FullSnapshotArchiveInfo,
     incremental_snapshot_archive_info: Option<&IncrementalSnapshotArchiveInfo>,
     account_paths: &[PathBuf],
-    storage_access: StorageAccess,
     io_setup: &IoSetupState,
 ) -> Result<(UnarchivedSnapshots, UnarchivedSnapshotsGuard)> {
     check_are_snapshots_compatible(
@@ -1097,7 +1096,6 @@ pub fn verify_and_unarchive_snapshots(
         full_snapshot_archive_info.archive_format(),
         next_append_vec_id.clone(),
         None,
-        storage_access,
         io_setup,
     )?;
 
@@ -1125,7 +1123,6 @@ pub fn verify_and_unarchive_snapshots(
             incremental_snapshot_archive_info.archive_format(),
             next_append_vec_id.clone(),
             Some(incremental_snapshot_archive_info.base_slot()),
-            storage_access,
             io_setup,
         )?;
         (
@@ -1318,7 +1315,6 @@ fn unarchive_snapshot(
     archive_format: ArchiveFormat,
     next_append_vec_id: Arc<AtomicAccountsFileId>,
     base_slot: Option<Slot>,
-    storage_access: StorageAccess,
     io_setup: &IoSetupState,
 ) -> Result<UnarchivedSnapshot> {
     let unpack_dir = tempfile::Builder::new()
@@ -1357,7 +1353,6 @@ fn unarchive_snapshot(
                         num_rebuilder_threads,
                         next_append_vec_id,
                         SnapshotFrom::Archive,
-                        storage_access,
                         None,
                     )?,
                     measure_name
@@ -1390,7 +1385,6 @@ fn spawn_streaming_snapshot_dir_files(
     snapshot_file_path: PathBuf,
     snapshot_version_path: PathBuf,
     account_paths: &[PathBuf],
-    writable: bool,
 ) -> (Receiver<FileInfo>, thread::JoinHandle<Result<()>>) {
     let (file_sender, file_receiver) = crossbeam_channel::unbounded();
     let account_paths = account_paths.to_vec();
@@ -1407,7 +1401,7 @@ fn spawn_streaming_snapshot_dir_files(
                 for dir_entry_result in fs::read_dir(account_path)? {
                     let dir_entry = dir_entry_result?;
                     let path = dir_entry.path();
-                    let file_info = FileInfo::new_from_path_writable(path, writable)?;
+                    let file_info = FileInfo::new_from_path(path)?;
                     file_sender.send(file_info)?;
                 }
             }
@@ -1426,7 +1420,6 @@ pub(crate) fn rebuild_storages_from_snapshot_dir(
     snapshot_info: &BankSnapshotInfo,
     account_paths: &[PathBuf],
     next_append_vec_id: Arc<AtomicAccountsFileId>,
-    storage_access: StorageAccess,
 ) -> Result<(
     AccountStorageMap,
     BankFieldsToDeserialize,
@@ -1505,12 +1498,10 @@ pub(crate) fn rebuild_storages_from_snapshot_dir(
 
     let snapshot_file_path = snapshot_info.snapshot_path();
     let snapshot_version_path = bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_VERSION_FILENAME);
-    #[expect(deprecated)]
     let (file_receiver, stream_files_handle) = spawn_streaming_snapshot_dir_files(
         snapshot_file_path,
         snapshot_version_path,
         account_paths,
-        storage_access == StorageAccess::Mmap,
     );
 
     let SnapshotFieldsBundle {
@@ -1531,7 +1522,6 @@ pub(crate) fn rebuild_storages_from_snapshot_dir(
         num_rebuilder_threads,
         next_append_vec_id,
         SnapshotFrom::Dir,
-        storage_access,
         obsolete_accounts,
     )?;
     stream_files_handle
@@ -2708,7 +2698,6 @@ mod tests {
                 i as u32, // Incrementing id
                 1024,
                 AccountsFileProvider::AppendVec,
-                StorageAccess::File,
             ));
             snapshot_storages.push(storage);
         }
@@ -2752,7 +2741,6 @@ mod tests {
                 i as u32, // Incrementing id
                 1024,
                 AccountsFileProvider::AppendVec,
-                StorageAccess::File,
             ));
             snapshot_storages.push(storage);
         }
@@ -2788,7 +2776,6 @@ mod tests {
                 i as u32, // Incrementing id
                 1024,
                 AccountsFileProvider::AppendVec,
-                StorageAccess::File,
             ));
             snapshot_storages.push(storage);
         }

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -17,7 +17,6 @@ use {
     solana_accounts_db::{
         account_storage::AccountStorageMap,
         accounts_db::{AccountsFileId, AtomicAccountsFileId},
-        accounts_file::StorageAccess,
     },
     solana_clock::Slot,
     std::{
@@ -51,8 +50,6 @@ pub(crate) struct SnapshotStorageRebuilder {
     num_collisions: AtomicUsize,
     /// Rebuild from the snapshot files or archives
     snapshot_from: SnapshotFrom,
-    /// specify how storages are accessed
-    storage_access: StorageAccess,
     /// obsolete accounts for all storages
     obsolete_accounts: DashMap<Slot, SerdeObsoleteAccounts>,
 }
@@ -66,7 +63,6 @@ impl SnapshotStorageRebuilder {
         next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_storage_lengths: HashMap<Slot, usize>,
         snapshot_from: SnapshotFrom,
-        storage_access: StorageAccess,
         obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
     ) -> Self {
         let storage = AccountStorageMap::with_capacity(snapshot_storage_lengths.len());
@@ -79,7 +75,6 @@ impl SnapshotStorageRebuilder {
             processed_slot_count: AtomicUsize::new(0),
             num_collisions: AtomicUsize::new(0),
             snapshot_from,
-            storage_access,
             obsolete_accounts: obsolete_accounts
                 .map(|map| map.into_dashmap())
                 .unwrap_or_default(),
@@ -96,7 +91,6 @@ impl SnapshotStorageRebuilder {
         num_threads: usize,
         next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_from: SnapshotFrom,
-        storage_access: StorageAccess,
         obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
     ) -> Result<AccountStorageMap, SnapshotError> {
         let rebuilder = Arc::new(SnapshotStorageRebuilder::new(
@@ -105,7 +99,6 @@ impl SnapshotStorageRebuilder {
             next_append_vec_id,
             snapshot_storage_lengths,
             snapshot_from,
-            storage_access,
             obsolete_accounts,
         ));
 
@@ -197,14 +190,12 @@ impl SnapshotStorageRebuilder {
                 file_info,
                 &self.next_append_vec_id,
                 &self.num_collisions,
-                self.storage_access,
             )?,
             SnapshotFrom::Dir => reconstruct_single_storage(
                 &slot,
                 file_info,
                 current_len,
                 old_append_vec_id as AccountsFileId,
-                self.storage_access,
                 self.obsolete_accounts
                     .remove(&slot)
                     .map(|(_, accounts)| accounts.into_tuple()),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -139,8 +139,9 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .help("Path to accounts shrink path which can hold a compacted account set."),
     );
     add_arg!(
-        // deprecated in v4.0.0; mmap mode was removed and the only remaining mode (file) is now
-        // the default and only behavior, so this flag is now a no-op.
+        // deprecated in v4.2.0; the `mmap` value was deprecated in v4.0.0, and now mmap mode has
+        // been removed entirely. The only remaining mode (`file`) is the default and only
+        // behavior, so this flag is now a no-op.
         Arg::with_name("accounts_db_access_storages_method")
             .long("accounts-db-access-storages-method")
             .value_name("METHOD")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -139,6 +139,16 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .help("Path to accounts shrink path which can hold a compacted account set."),
     );
     add_arg!(
+        // deprecated in v4.0.0; mmap mode was removed and the only remaining mode (file) is now
+        // the default and only behavior, so this flag is now a no-op.
+        Arg::with_name("accounts_db_access_storages_method")
+            .long("accounts-db-access-storages-method")
+            .value_name("METHOD")
+            .takes_value(true)
+            .possible_values(&["mmap", "file"])
+            .help("No-op; account storages are always accessed via file I/O"),
+    );
+    add_arg!(
         // deprecated in v4.0.0
         Arg::with_name("enable_accounts_disk_index")
             .long("enable-accounts-disk-index")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -949,18 +949,6 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .hidden(hidden_unless_forced()),
     )
     .arg(
-        Arg::with_name("accounts_db_access_storages_method")
-            .long("accounts-db-access-storages-method")
-            .value_name("METHOD")
-            .takes_value(true)
-            .possible_values(&["mmap", "file"])
-            .help(
-                "[DEPRECATED] Access account storages using this method. This flag is now a \
-                 no-op: storages are always accessed via file I/O. The flag is preserved for \
-                 backward compatibility and will be removed in a future release.",
-            ),
-    )
-    .arg(
         Arg::with_name("accounts_db_ancient_append_vecs")
             .long("accounts-db-ancient-append-vecs")
             .value_name("SLOT-OFFSET")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -954,7 +954,11 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("METHOD")
             .takes_value(true)
             .possible_values(&["mmap", "file"])
-            .help("Access account storages using this method"),
+            .help(
+                "[DEPRECATED] Access account storages using this method. This flag is now a \
+                 no-op: storages are always accessed via file I/O. The flag is preserved for \
+                 backward compatibility and will be removed in a future release.",
+            ),
     )
     .arg(
         Arg::with_name("accounts_db_ancient_append_vecs")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -19,7 +19,6 @@ use {
     rand::{rng, seq::SliceRandom},
     solana_accounts_db::{
         accounts_db::{AccountShrinkThreshold, AccountsDbConfig},
-        accounts_file::StorageAccess,
         accounts_index::{
             AccountSecondaryIndexes, AccountsIndexConfig, DEFAULT_NUM_ENTRIES_OVERHEAD,
             DEFAULT_NUM_ENTRIES_TO_EVICT, IndexLimit, IndexLimitThreshold, ScanFilter,
@@ -683,21 +682,18 @@ pub fn execute(
             }
         });
 
-    let storage_access = matches
+    // The `--accounts-db-access-storages-method` flag is now a no-op. Storages are
+    // always accessed via file I/O. The flag is preserved for backward compatibility,
+    // but the value is ignored with a warning.
+    if matches
         .value_of("accounts_db_access_storages_method")
-        .map(|method| match method {
-            "mmap" => {
-                warn!("Using `mmap` for `--accounts-db-access-storages-method` is now deprecated.");
-                #[allow(deprecated)]
-                StorageAccess::Mmap
-            }
-            "file" => StorageAccess::File,
-            _ => {
-                // clap will enforce one of the above values is given
-                unreachable!("invalid value given to accounts-db-access-storages-method")
-            }
-        })
-        .unwrap_or_default();
+        .is_some()
+    {
+        warn!(
+            "`--accounts-db-access-storages-method` is now a no-op; storages are always accessed \
+             via file I/O."
+        );
+    }
 
     let scan_filter_for_shrinking = matches
         .value_of("accounts_db_scan_filter_for_shrinking")
@@ -735,7 +731,6 @@ pub fn execute(
         skip_initial_hash_calc: false,
         exhaustively_verify_refcounts: matches.is_present("accounts_db_verify_refcounts"),
         partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig::default(),
-        storage_access,
         scan_filter_for_shrinking,
         num_background_threads: Some(accounts_db_background_threads),
         num_foreground_threads: Some(accounts_db_foreground_threads),

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -682,19 +682,6 @@ pub fn execute(
             }
         });
 
-    // The `--accounts-db-access-storages-method` flag is now a no-op. Storages are
-    // always accessed via file I/O. The flag is preserved for backward compatibility,
-    // but the value is ignored with a warning.
-    if matches
-        .value_of("accounts_db_access_storages_method")
-        .is_some()
-    {
-        warn!(
-            "`--accounts-db-access-storages-method` is now a no-op; storages are always accessed \
-             via file I/O."
-        );
-    }
-
     let scan_filter_for_shrinking = matches
         .value_of("accounts_db_scan_filter_for_shrinking")
         .map(|filter| match filter {


### PR DESCRIPTION
#### Problem
The `StorageAccess` enum let callers pick between `Mmap` and `File` I/O for account storages. The `Mmap` variant has been deprecated since 4.0.0; mmap-backed storages don't play well with direct/uring I/O and have bad performance due to page-faults late in the account access hot-path, the default has been `File` for some time. The variant continued to gate two parallel implementations of every read/write path in `AppendVec`, doubled test surface, and held back further I/O changes.

#### Summary of Changes
- Removed the `StorageAccess` enum from `accounts_file.rs`. Dropped the `storage_access` parameter from every caller (`AppendVec::new`, `new_from_file`, `new_for_startup`, `new_from_file_info_unchecked`, `AccountsFileProvider::new_writable`, `AccountStorageEntry::new`, `reopen_as_readonly`, snapshot rebuilders, etc.).
- Removed the `storage_access` field from `AccountsDb`, `AccountsDbConfig`, and the `set_storage_access`/`storage_access` accessors.
- Replaced the `AppendVecFileBacking { Mmap, File }` enum with a plain `File` field on `AppendVec`. Collapsed ~13 match arms across read/scan/append/flush/drop paths. Removed `get_valid_slice_from_mmap`, the `open_as_mmap` stat, and the `memmap2` dependency.
- Simplified `InternalsForArchive` from a `{ Mmap, FileIo }` enum to a struct holding just the backing file path. `AccountStorageReader` is no longer generic over a lifetime — it always opens the file.
- Rewrote `test_scan_useless_accounts` to mutate the on-disk storage through direct file I/O (it previously mutated the mmap in place). `test_scan_accounts_correctness` no longer needs an Mmap-vs-File round-trip. All other parameterized `#[test_case]` tests collapsed to single `#[test]` functions.
- `--accounts-db-access-storages-method` is preserved on both `agave-validator` and `agave-ledger-tool` for backward compatibility but is now a no-op (emits a deprecation warning when used; help text marked `[DEPRECATED]`).
- All 3 callers in append_vec.rs switched from FileInfo::new_from_path_writable(path, false) to FileInfo::new_from_path(path) (they’re functionally equivalent — both open read-only).
- Removed the now-unused FileInfo::new_from_path_writable function from fs/src/file_info.rs and dropped the OpenOptions import.