### PR TITLE
votor: serialize bank forks writes back to replay thread

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -32,6 +32,7 @@ use {
     solana_runtime::{
         bank::{Bank, NewBankOptions},
         bank_forks::BankForks,
+        bank_forks_controller::{BankForksController, BankForksControllerError},
         block_component_processor::BlockComponentProcessor,
         leader_schedule_utils::{last_of_consecutive_leader_slots, leader_slot_index},
         validated_block_finalization::ValidatedBlockFinalizationCert,
@@ -80,6 +81,7 @@ pub struct BlockCreationLoopConfig {
 
     // Shared state
     pub bank_forks: Arc<RwLock<BankForks>>,
+    pub bank_forks_controller: Arc<dyn BankForksController>,
     pub blockstore: Arc<Blockstore>,
     pub cluster_info: Arc<ClusterInfo>,
     pub poh_recorder: Arc<RwLock<PohRecorder>>,
@@ -117,6 +119,7 @@ struct LeaderContext {
     poh_recorder: Arc<RwLock<PohRecorder>>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
     bank_forks: Arc<RwLock<BankForks>>,
+    bank_forks_controller: Arc<dyn BankForksController>,
     rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
     slot_status_notifier: Option<SlotStatusNotifier>,
     banking_tracer: Arc<BankingTracer>,
@@ -154,6 +157,10 @@ enum StartLeaderError {
         /* parent ready slot */ Slot,
         /* leader slot */ Slot,
     ),
+
+    /// Failed to insert our leader bank
+    #[error("Failed to insert leader bank: {0}")]
+    InsertBankError(#[from] BankForksControllerError),
 }
 
 /// The block creation loop.
@@ -165,6 +172,7 @@ fn start_loop(config: BlockCreationLoopConfig) {
     let BlockCreationLoopConfig {
         exit,
         bank_forks,
+        bank_forks_controller,
         blockstore,
         cluster_info,
         poh_recorder,
@@ -218,6 +226,7 @@ fn start_loop(config: BlockCreationLoopConfig) {
         poh_recorder,
         leader_schedule_cache,
         bank_forks,
+        bank_forks_controller,
         rpc_subscriptions,
         slot_status_notifier,
         banking_tracer,
@@ -668,13 +677,16 @@ fn maybe_start_leader(
     }
 
     // Create and insert the bank
-    create_and_insert_leader_bank(slot, parent_bank, ctx);
-    Ok(())
+    create_and_insert_leader_bank(slot, parent_bank, ctx)
 }
 
 /// Creates and inserts the leader bank `slot` of this window with
 /// parent `parent_bank`
-fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut LeaderContext) {
+fn create_and_insert_leader_bank(
+    slot: Slot,
+    parent_bank: Arc<Bank>,
+    ctx: &mut LeaderContext,
+) -> Result<(), StartLeaderError> {
     let parent_slot = parent_bank.slot();
     let root_slot = ctx.bank_forks.read().unwrap().root();
     trace!(
@@ -734,7 +746,8 @@ fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut L
     );
 
     // Insert the bank
-    let tpu_bank = ctx.bank_forks.write().unwrap().insert(tpu_bank);
+    let tpu_bank = ctx.bank_forks_controller.insert_bank(tpu_bank)?;
+
     let bank_id = tpu_bank.bank_id();
     ctx.poh_recorder.write().unwrap().set_bank(tpu_bank);
 
@@ -749,6 +762,7 @@ fn create_and_insert_leader_bank(slot: Slot, parent_bank: Arc<Bank>, ctx: &mut L
         "{}: new fork:{} parent:{} (leader) root:{}",
         ctx.my_pubkey, slot, parent_slot, root_slot
     );
+    Ok(())
 }
 
 ///  If this the very first alpenglow block, include the genesis certificate

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -45,7 +45,7 @@ use {
         migration::{GENESIS_VOTE_REFRESH, MigrationStatus},
         vote::Vote,
     },
-    crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
+    crossbeam_channel::{Receiver, Sender, TryRecvError, select},
     rayon::{ThreadPool, prelude::*},
     solana_accounts_db::contains::Contains,
     solana_clock::{BankId, NUM_CONSECUTIVE_LEADER_SLOTS, Slot},
@@ -82,6 +82,7 @@ use {
     solana_runtime::{
         bank::{Bank, NewBankOptions, bank_hash_details},
         bank_forks::BankForks,
+        bank_forks_controller::{BankForksCommand, BankForksCommandReceiver},
         commitment::BlockCommitmentCache,
         installed_scheduler_pool::BankWithScheduler,
         leader_schedule_utils::first_of_consecutive_leader_slots,
@@ -96,7 +97,7 @@ use {
     solana_vote::vote_transaction::VoteTransaction,
     solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY,
     std::{
-        collections::{HashMap, HashSet},
+        collections::{BTreeSet, HashMap, HashSet},
         num::{NonZeroUsize, Saturating},
         result,
         sync::{
@@ -220,6 +221,16 @@ struct ProcessActiveBanksContext {
     replay_tx_thread_pool: ThreadPool,
     prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
     migration_status: Arc<MigrationStatus>,
+}
+
+struct ProcessBankForksContext {
+    bank_forks: Arc<RwLock<BankForks>>,
+    blockstore: Arc<Blockstore>,
+    snapshot_controller: Option<Arc<SnapshotController>>,
+    bank_notification_sender: Option<BankNotificationSenderConfig>,
+    rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
+    drop_bank_sender: Sender<Vec<BankWithScheduler>>,
+    leader_schedule_cache: Arc<LeaderScheduleCache>,
 }
 
 #[cfg(test)]
@@ -406,6 +417,7 @@ pub struct ReplayReceivers {
     pub duplicate_confirmed_slots_receiver: Receiver<Vec<(u64, Hash)>>,
     pub gossip_verified_vote_hash_receiver: Receiver<(Pubkey, u64, Hash)>,
     pub popular_pruned_forks_receiver: Receiver<Vec<u64>>,
+    pub bank_forks_controller_receiver: BankForksCommandReceiver,
 }
 
 /// Timing information for the ReplayStage main processing loop
@@ -717,6 +729,7 @@ impl ReplayStage {
             duplicate_confirmed_slots_receiver,
             gossip_verified_vote_hash_receiver,
             popular_pruned_forks_receiver,
+            bank_forks_controller_receiver,
         } = receivers;
 
         trace!("replay stage");
@@ -845,6 +858,15 @@ impl ReplayStage {
                 prioritization_fee_cache: prioritization_fee_cache.clone(),
                 migration_status: migration_status.clone(),
             };
+            let process_bank_forks_context = ProcessBankForksContext {
+                bank_forks: bank_forks.clone(),
+                blockstore: blockstore.clone(),
+                snapshot_controller: snapshot_controller.clone(),
+                bank_notification_sender: bank_notification_sender.clone(),
+                rpc_subscriptions: rpc_subscriptions.clone(),
+                drop_bank_sender: drop_bank_sender.clone(),
+                leader_schedule_cache: leader_schedule_cache.clone(),
+            };
 
             let poh_shared_leader_state = poh_recorder.read().unwrap().shared_leader_state();
             if !migration_status.is_alpenglow_enabled() {
@@ -863,6 +885,18 @@ impl ReplayStage {
             loop {
                 // Stop getting entries if we get exit signal
                 if exit.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                if matches!(
+                    Self::process_bank_forks_commands(
+                        &bank_forks_controller_receiver,
+                        &process_bank_forks_context,
+                        &mut progress,
+                        &mut async_verification_freelist,
+                    ),
+                    Err(TryRecvError::Disconnected)
+                ) {
                     break;
                 }
 
@@ -1399,12 +1433,24 @@ impl ReplayStage {
                     // only wait for the signal if we did not just process a bank; maybe there are more slots available
 
                     let timer = Duration::from_millis(100);
-                    let result = ledger_signal_receiver.recv_timeout(timer);
-                    match result {
-                        Err(RecvTimeoutError::Timeout) => (),
-                        Err(_) => break,
-                        Ok(_) => trace!("blockstore signal"),
-                    };
+                    select! {
+                        recv(ledger_signal_receiver) -> result => match result {
+                            Err(_) => break,
+                            Ok(_) => trace!("blockstore signal"),
+                        },
+                        recv(bank_forks_controller_receiver.receiver()) -> result => match result {
+                            Err(_) => break,
+                            Ok(command) => {
+                                Self::process_bank_forks_command(
+                                    command,
+                                    &process_bank_forks_context,
+                                    &mut progress,
+                                    &mut async_verification_freelist,
+                                );
+                            }
+                        },
+                        default(timer) => (),
+                    }
                 }
                 wait_receive_time.stop();
 
@@ -2161,6 +2207,88 @@ impl ReplayStage {
         descendants
             .remove(&slot)
             .expect("must exist based on earlier check");
+    }
+
+    /// For slots to clear, clear the bank from progress, bank forks, and recycle the async verification
+    fn clear_banks(
+        slots_to_clear: &BTreeSet<Slot>,
+        bank_forks: &RwLock<BankForks>,
+        progress: &mut ProgressMap,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+    ) {
+        if slots_to_clear.is_empty() {
+            return;
+        }
+
+        // Wait for async verify to complete
+        for slot in slots_to_clear {
+            if let Some(replay_progress) = progress.remove(slot) {
+                let mut w_replay_progress = replay_progress.replay_progress.write().unwrap();
+                let _ = w_replay_progress.wait_for_all_verification_results(&mut 0, &mut 0);
+                Self::recycle_async_verification(
+                    async_verification_freelist,
+                    w_replay_progress.take_async_verification(),
+                );
+            }
+        }
+
+        let banks_to_remove = {
+            let bank_forks = bank_forks.read().unwrap();
+            slots_to_clear
+                .iter()
+                .filter_map(|slot| bank_forks.get_with_scheduler(*slot))
+                .collect::<Vec<_>>()
+        };
+
+        // Wait for any in progress execution
+        for bank in banks_to_remove {
+            let _ = bank.wait_for_completed_scheduler();
+        }
+
+        // Dump the banks from bank forks
+        let (root_bank, slots_to_purge, removed_banks) = {
+            let mut w_bank_forks = bank_forks.write().unwrap();
+            let slots_to_clear = slots_to_clear
+                .iter()
+                .copied()
+                .filter(|slot| w_bank_forks.get(*slot).is_some())
+                .collect::<BTreeSet<_>>();
+            if slots_to_clear.is_empty() {
+                return;
+            }
+
+            let root_bank = w_bank_forks.root_bank();
+            let (slots_to_purge, removed_banks) =
+                w_bank_forks.dump_slots(slots_to_clear.iter(), true);
+            (root_bank, slots_to_purge, removed_banks)
+        };
+
+        // Clear the accounts for these slots so that any ongoing RPC scans fail.
+        // These have to be atomically cleared together in the same batch, in order
+        // to prevent RPC from seeing inconsistent results in scans.
+        root_bank.remove_unrooted_slots(&slots_to_purge);
+
+        // Once the slots above have been purged, now it's safe to remove the banks from
+        // BankForks, allowing the Bank::drop() purging to run and not race with the
+        // `remove_unrooted_slots()` call.
+        drop(removed_banks);
+
+        // Clear slot signatures from status cache and programs from program cache
+        for (slot, _) in slots_to_purge {
+            root_bank.clear_slot_signatures(slot);
+            root_bank.prune_program_cache_by_deployment_slot(slot);
+        }
+    }
+
+    fn recycle_async_verification(
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+        async_verification: Option<AsyncVerificationProgress>,
+    ) {
+        if let Some(async_verification) = async_verification {
+            if async_verification_freelist.len() < ASYNC_VERIFICATION_FREELIST_CAPACITY {
+                async_verification_freelist.push(async_verification);
+            }
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -3531,12 +3659,10 @@ impl ReplayStage {
                         stats.poh_verify_elapsed += poh_verify_elapsed;
                         stats.transaction_verify_elapsed += tx_verify_elapsed;
                     }
-                    if let Some(async_verification) = async_verification {
-                        if async_verification_freelist.len() < ASYNC_VERIFICATION_FREELIST_CAPACITY
-                        {
-                            async_verification_freelist.push(async_verification);
-                        }
-                    };
+                    Self::recycle_async_verification(
+                        async_verification_freelist,
+                        async_verification,
+                    );
                     res
                 };
                 // we send this whether the block was valid or not. It's only
@@ -4590,6 +4716,102 @@ impl ReplayStage {
                 )
             },
         );
+    }
+
+    /// Process any commands from the bank forks controller
+    fn process_bank_forks_commands(
+        bank_forks_controller_receiver: &BankForksCommandReceiver,
+        context: &ProcessBankForksContext,
+        progress: &mut ProgressMap,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+    ) -> Result<(), TryRecvError> {
+        loop {
+            let command = bank_forks_controller_receiver.receiver().try_recv()?;
+            Self::process_bank_forks_command(
+                command,
+                context,
+                progress,
+                async_verification_freelist,
+            );
+        }
+    }
+
+    /// Process a bank forks command
+    fn process_bank_forks_command(
+        command: BankForksCommand,
+        context: &ProcessBankForksContext,
+        progress: &mut ProgressMap,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+    ) {
+        debug_assert!(
+            context
+                .bank_forks
+                .read()
+                .unwrap()
+                .migration_status()
+                .is_alpenglow_enabled()
+        );
+        match command {
+            BankForksCommand::InsertBank {
+                bank,
+                response_sender,
+            } => {
+                // Check that the bank is still valid to be inserted
+                let bank = {
+                    let mut bank_forks = context.bank_forks.write().unwrap();
+                    if bank_forks.get(bank.slot()).is_none()
+                        && bank_forks.get(bank.parent_slot()).is_some()
+                    {
+                        Some(bank_forks.insert(*bank))
+                    } else {
+                        None
+                    }
+                };
+
+                response_sender.send(bank).unwrap_or_else(|_| {
+                    warn!("bank forks controller insert-bank response receiver dropped")
+                });
+            }
+            BankForksCommand::SetRoot {
+                my_pubkey,
+                parent_slot,
+                new_root,
+                highest_super_majority_root,
+                response_sender,
+            } => {
+                root_utils::check_and_handle_new_root(
+                    parent_slot,
+                    new_root,
+                    context.snapshot_controller.as_deref(),
+                    highest_super_majority_root,
+                    &context.bank_notification_sender,
+                    &context.drop_bank_sender,
+                    &context.blockstore,
+                    &context.leader_schedule_cache,
+                    &context.bank_forks,
+                    context.rpc_subscriptions.as_deref(),
+                    &my_pubkey,
+                    |_| {},
+                );
+                response_sender.send(()).unwrap_or_else(|_| {
+                    warn!("bank forks controller set-root response receiver dropped")
+                });
+            }
+            BankForksCommand::ClearBank {
+                slot,
+                response_sender,
+            } => {
+                Self::clear_banks(
+                    &BTreeSet::from([slot]),
+                    &context.bank_forks,
+                    progress,
+                    async_verification_freelist,
+                );
+                response_sender.send(()).unwrap_or_else(|_| {
+                    warn!("bank forks controller clear-bank response receiver dropped")
+                });
+            }
+        }
     }
 
     fn generate_new_bank_forks(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -63,8 +63,12 @@ use {
         rpc_subscriptions::RpcSubscriptions, slot_status_notifier::SlotStatusNotifier,
     },
     solana_runtime::{
-        bank::MAX_ALPENGLOW_VOTE_ACCOUNTS, bank_forks::BankForks, commitment::BlockCommitmentCache,
-        prioritization_fee_cache::PrioritizationFeeCache, snapshot_controller::SnapshotController,
+        bank::MAX_ALPENGLOW_VOTE_ACCOUNTS,
+        bank_forks::BankForks,
+        bank_forks_controller::{BankForksCommandReceiver, BankForksController},
+        commitment::BlockCommitmentCache,
+        prioritization_fee_cache::PrioritizationFeeCache,
+        snapshot_controller::SnapshotController,
         validated_block_finalization::ValidatedBlockFinalizationCert,
         vote_sender_types::ReplayVoteSender,
     },
@@ -167,6 +171,8 @@ pub struct AlpenglowInitializationState {
     pub replay_highest_frozen: Arc<ReplayHighestFrozen>,
     pub highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
     pub highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
+    pub bank_forks_controller: Arc<dyn BankForksController>,
+    pub bank_forks_controller_receiver: BankForksCommandReceiver,
 
     // Main communication channel
     pub votor_event_sender: VotorEventSender,
@@ -253,6 +259,8 @@ impl Tvu {
             leader_window_info_sender,
             replay_highest_frozen,
             highest_parent_ready,
+            bank_forks_controller,
+            bank_forks_controller_receiver,
             votor_event_sender,
             votor_event_receiver,
             cancel,
@@ -487,31 +495,29 @@ impl Tvu {
             wait_to_vote_slot,
             vote_history,
             vote_history_storage: vote_history_storage.clone(),
+            generated_cert_types,
             authorized_voter_keypairs: authorized_voter_keypairs.clone(),
             blockstore: blockstore.clone(),
             bank_forks: bank_forks.clone(),
             cluster_info: cluster_info.clone(),
             leader_schedule_cache: leader_schedule_cache.clone(),
-            rpc_subscriptions: rpc_subscriptions.clone(),
-            snapshot_controller: snapshot_controller.clone(),
+            consensus_metrics_sender,
+            highest_finalized,
+            bank_forks_controller,
             bls_sender: bls_sender.clone(),
             commitment_sender: votor_commitment_sender,
-            drop_bank_sender: drop_bank_sender.clone(),
             bank_notification_sender: bank_notification_sender.clone(),
             leader_window_info_sender,
             highest_parent_ready,
             event_sender: votor_event_sender.clone(),
-            event_receiver: votor_event_receiver,
             own_vote_sender: consensus_message_sender.clone(),
-            consensus_message_receiver,
-            consensus_metrics_sender,
+            reward_certs_sender,
             repair_event_sender,
+            event_receiver: votor_event_receiver,
+            consensus_message_receiver,
             consensus_metrics_receiver,
             reward_votes_receiver,
-            reward_certs_sender,
             build_reward_certs_receiver,
-            generated_cert_types,
-            highest_finalized,
         };
         let votor = Votor::new(votor_config);
 
@@ -543,6 +549,7 @@ impl Tvu {
             duplicate_confirmed_slots_receiver,
             gossip_verified_vote_hash_receiver,
             popular_pruned_forks_receiver,
+            bank_forks_controller_receiver,
         };
 
         let replay_stage_config = ReplayStageConfig {
@@ -716,7 +723,7 @@ pub mod tests {
         solana_net_utils::SocketAddrSpace,
         solana_poh::poh_recorder::create_test_recorder,
         solana_rpc::optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
-        solana_runtime::bank::Bank,
+        solana_runtime::{bank::Bank, bank_forks_controller::BankForksControllerHandle},
         solana_signer::Signer,
         solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_VOTE_USE_QUIC},
         std::{
@@ -811,6 +818,9 @@ pub mod tests {
         });
         let (reward_certs_sender, _reward_certs_receiver) = bounded(1);
         let (_build_reward_certs_sender, build_reward_certs_receiver) = bounded(1);
+        let (bank_forks_controller, bank_forks_controller_receiver) =
+            BankForksControllerHandle::new();
+        let bank_forks_controller = Arc::new(bank_forks_controller);
 
         let tvu = Tvu::new(
             &vote_keypair.pubkey(),
@@ -879,6 +889,8 @@ pub mod tests {
                 bls_connection_cache: Arc::new(bls_connection_cache),
                 voting_service_test_override: None,
                 highest_finalized: Arc::new(RwLock::new(None)),
+                bank_forks_controller,
+                bank_forks_controller_receiver,
                 build_reward_certs_receiver,
                 reward_certs_sender,
             },

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -121,6 +121,7 @@ use {
         },
         bank::Bank,
         bank_forks::BankForks,
+        bank_forks_controller::BankForksControllerHandle,
         commitment::BlockCommitmentCache,
         dependency_tracker::DependencyTracker,
         prioritization_fee_cache::PrioritizationFeeCache,
@@ -1062,6 +1063,9 @@ impl Validator {
         let transaction_recorder = TransactionRecorder::new(record_sender);
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
         let (poh_controller, poh_service_message_receiver) = PohController::new();
+        let (bank_forks_controller, bank_forks_controller_receiver) =
+            BankForksControllerHandle::new();
+        let bank_forks_controller = Arc::new(bank_forks_controller);
 
         let (banking_tracer, tracer_thread) =
             BankingTracer::new((config.banking_trace_dir_byte_limit > 0).then_some((
@@ -1468,6 +1472,7 @@ impl Validator {
         let block_creation_loop_config = BlockCreationLoopConfig {
             exit: exit.clone(),
             bank_forks: bank_forks.clone(),
+            bank_forks_controller: bank_forks_controller.clone(),
             blockstore: blockstore.clone(),
             cluster_info: cluster_info.clone(),
             poh_recorder: poh_recorder.clone(),
@@ -1619,6 +1624,8 @@ impl Validator {
                 leader_window_info_sender,
                 replay_highest_frozen,
                 highest_parent_ready,
+                bank_forks_controller,
+                bank_forks_controller_receiver,
                 votor_event_sender: votor_event_sender.clone(),
                 votor_event_receiver,
                 cancel: cancel.clone(),

--- a/runtime/src/bank_forks_controller.rs
+++ b/runtime/src/bank_forks_controller.rs
@@ -1,0 +1,275 @@
+use {
+    crate::{bank::Bank, installed_scheduler_pool::BankWithScheduler},
+    crossbeam_channel::{Receiver, RecvTimeoutError, Sender, bounded},
+    log::warn,
+    solana_clock::Slot,
+    solana_metrics::datapoint_info,
+    solana_pubkey::Pubkey,
+    std::{
+        fmt,
+        time::{Duration, Instant},
+    },
+    thiserror::Error,
+};
+
+const CHANNEL_SIZE: usize = 16;
+
+#[derive(Debug, Error)]
+pub enum BankForksControllerError {
+    #[error("bank forks controller is disconnected")]
+    Disconnected,
+    #[error("bank to insert for slot {0} was stale, failed to insert")]
+    UnableToInsertStaleBank(Slot),
+}
+
+pub enum BankForksCommand {
+    InsertBank {
+        bank: Box<Bank>,
+        response_sender: Sender<Option<BankWithScheduler>>,
+    },
+    SetRoot {
+        my_pubkey: Pubkey,
+        parent_slot: Slot,
+        new_root: Slot,
+        highest_super_majority_root: Option<Slot>,
+        response_sender: Sender<()>,
+    },
+    ClearBank {
+        slot: Slot,
+        response_sender: Sender<()>,
+    },
+}
+
+impl BankForksCommand {
+    fn metric_slot(&self) -> Slot {
+        match self {
+            Self::InsertBank { bank, .. } => bank.slot(),
+            Self::SetRoot { new_root, .. } => *new_root,
+            Self::ClearBank { slot, .. } => *slot,
+        }
+    }
+}
+
+impl fmt::Display for BankForksCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InsertBank { .. } => write!(f, "insert_bank"),
+            Self::SetRoot { .. } => write!(f, "set_root"),
+            Self::ClearBank { .. } => write!(f, "clear_bank"),
+        }
+    }
+}
+
+pub trait BankForksController: Send + Sync {
+    fn insert_bank(&self, bank: Bank) -> Result<BankWithScheduler, BankForksControllerError>;
+
+    fn set_root(
+        &self,
+        my_pubkey: Pubkey,
+        parent_slot: Slot,
+        new_root: Slot,
+        highest_super_majority_root: Option<Slot>,
+    ) -> Result<(), BankForksControllerError>;
+
+    fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError>;
+}
+
+/// Handle used by non-replay threads to serialize BankForks writes onto ReplayStage.
+#[derive(Clone)]
+pub struct BankForksControllerHandle {
+    sender: Sender<BankForksCommand>,
+}
+
+impl BankForksControllerHandle {
+    pub fn new() -> (Self, BankForksCommandReceiver) {
+        let (sender, receiver) = bounded(CHANNEL_SIZE);
+        (Self { sender }, BankForksCommandReceiver { receiver })
+    }
+
+    fn send_command<T>(
+        &self,
+        command: BankForksCommand,
+        response_receiver: Receiver<T>,
+    ) -> Result<T, BankForksControllerError> {
+        let command_name = command.to_string();
+        let slot = command.metric_slot();
+        let queue_len_before_send = self.sender.len();
+        let total_start = Instant::now();
+        let send_start = Instant::now();
+        if self.sender.send(command).is_err() {
+            return Err(BankForksControllerError::Disconnected);
+        }
+        let send_us = send_start.elapsed().as_micros() as i64;
+
+        let response_wait_start = Instant::now();
+        let response = loop {
+            match response_receiver.recv_timeout(Duration::from_millis(100)) {
+                Ok(response) => break response,
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(BankForksControllerError::Disconnected);
+                }
+                Err(RecvTimeoutError::Timeout) => (),
+            }
+            warn!(
+                "Replay is stuck, waiting for {}ms no response to {command_name} for {slot}",
+                response_wait_start.elapsed().as_millis()
+            );
+        };
+
+        let response_wait_us = response_wait_start.elapsed().as_micros() as i64;
+        let total_us = total_start.elapsed().as_micros() as i64;
+        datapoint_info!(
+            "bank_forks_controller-command",
+            ("command", command_name, String),
+            ("slot", slot as i64, i64),
+            ("queue_len_before_send", queue_len_before_send as i64, i64),
+            ("send_us", send_us, i64),
+            ("response_wait_us", response_wait_us, i64),
+            ("total_us", total_us, i64),
+        );
+
+        Ok(response)
+    }
+}
+
+impl BankForksController for BankForksControllerHandle {
+    fn insert_bank(&self, bank: Bank) -> Result<BankWithScheduler, BankForksControllerError> {
+        let slot = bank.slot();
+        let (response_sender, response_receiver) = bounded(1);
+        let bank = self.send_command(
+            BankForksCommand::InsertBank {
+                bank: Box::new(bank),
+                response_sender,
+            },
+            response_receiver,
+        )?;
+        bank.ok_or(BankForksControllerError::UnableToInsertStaleBank(slot))
+    }
+
+    fn set_root(
+        &self,
+        my_pubkey: Pubkey,
+        parent_slot: Slot,
+        new_root: Slot,
+        highest_super_majority_root: Option<Slot>,
+    ) -> Result<(), BankForksControllerError> {
+        let (response_sender, response_receiver) = bounded(1);
+        self.send_command(
+            BankForksCommand::SetRoot {
+                my_pubkey,
+                parent_slot,
+                new_root,
+                highest_super_majority_root,
+                response_sender,
+            },
+            response_receiver,
+        )
+    }
+
+    fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError> {
+        let (response_sender, response_receiver) = bounded(1);
+        self.send_command(
+            BankForksCommand::ClearBank {
+                slot,
+                response_sender,
+            },
+            response_receiver,
+        )
+    }
+}
+
+pub struct BankForksCommandReceiver {
+    receiver: Receiver<BankForksCommand>,
+}
+
+impl BankForksCommandReceiver {
+    pub fn receiver(&self) -> &Receiver<BankForksCommand> {
+        &self.receiver
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{bank::SlotLeader, bank_forks::BankForks, genesis_utils::create_genesis_config},
+        std::thread,
+    };
+
+    #[test]
+    fn test_bank_forks_controller_insert_and_set_root() {
+        let genesis = create_genesis_config(10_000);
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis.genesis_config));
+        let (controller, receiver) = BankForksControllerHandle::new();
+        let replay_bank_forks = bank_forks.clone();
+        let replay_thread = thread::spawn(move || {
+            loop {
+                let Ok(command) = receiver.receiver().recv() else {
+                    break;
+                };
+                match command {
+                    BankForksCommand::InsertBank {
+                        bank,
+                        response_sender,
+                    } => {
+                        let bank = {
+                            let mut bank_forks = replay_bank_forks.write().unwrap();
+                            bank_forks.insert(*bank)
+                        };
+                        response_sender.send(Some(bank)).unwrap();
+                    }
+                    BankForksCommand::SetRoot {
+                        new_root,
+                        response_sender,
+                        ..
+                    } => {
+                        {
+                            let mut bank_forks = replay_bank_forks.write().unwrap();
+                            bank_forks.set_root(new_root, None, None);
+                        }
+                        response_sender.send(()).unwrap();
+                    }
+                    BankForksCommand::ClearBank {
+                        slot,
+                        response_sender,
+                    } => {
+                        let bank_to_clear =
+                            replay_bank_forks.read().unwrap().get_with_scheduler(slot);
+                        if let Some(bank) = bank_to_clear {
+                            let _ = bank.wait_for_completed_scheduler();
+                        }
+
+                        {
+                            let mut bank_forks = replay_bank_forks.write().unwrap();
+                            bank_forks.clear_bank(slot, false);
+                        }
+                        response_sender.send(()).unwrap();
+                    }
+                }
+            }
+        });
+
+        let parent_bank = bank_forks.read().unwrap().root_bank();
+        let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), 1);
+        bank.freeze();
+        let inserted_bank = controller.insert_bank(bank).unwrap();
+        assert_eq!(inserted_bank.slot(), 1);
+        assert!(bank_forks.read().unwrap().get(1).is_some());
+
+        controller.set_root(Pubkey::default(), 1, 1, None).unwrap();
+        assert_eq!(bank_forks.read().unwrap().root(), 1);
+
+        let parent_bank = bank_forks.read().unwrap().root_bank();
+        let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), 2);
+        bank.freeze();
+        let inserted_bank = controller.insert_bank(bank).unwrap();
+        assert_eq!(inserted_bank.slot(), 2);
+        assert!(bank_forks.read().unwrap().get(2).is_some());
+
+        controller.clear_bank(2).unwrap();
+        assert!(bank_forks.read().unwrap().get(2).is_none());
+
+        drop(controller);
+        replay_thread.join().unwrap();
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -10,6 +10,7 @@ pub mod accounts_background_service;
 pub mod bank;
 pub mod bank_client;
 pub mod bank_forks;
+pub mod bank_forks_controller;
 pub mod bank_utils;
 pub mod block_component_processor;
 pub mod commitment;

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -23,6 +23,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank,
+        bank_forks_controller::BankForksControllerError,
         leader_schedule_utils::{
             first_of_consecutive_leader_slots, last_of_consecutive_leader_slots, leader_slot_index,
         },
@@ -73,6 +74,9 @@ enum EventLoopError {
 
     #[error("Set identity error")]
     SetIdentityError(#[from] VoteHistoryError),
+
+    #[error("Bank forks controller error")]
+    BankForksControllerError(#[from] BankForksControllerError),
 }
 
 pub(crate) struct EventHandler {
@@ -292,7 +296,7 @@ impl EventHandler {
                     finalized_blocks,
                     received_shred,
                     stats,
-                );
+                )?;
                 if let Some(parent_block) =
                     Self::add_missing_parent_ready(block, ctx, vctx, local_context)
                 {
@@ -428,7 +432,7 @@ impl EventHandler {
                     finalized_blocks,
                     received_shred,
                     stats,
-                );
+                )?;
 
                 if let Some(slot) = *standstill_slot {
                     if block.0 > slot {
@@ -801,7 +805,7 @@ impl EventHandler {
         finalized_blocks: &mut BTreeSet<Block>,
         received_shred: &mut BTreeSet<Slot>,
         stats: &mut EventHandlerStats,
-    ) {
+    ) -> Result<(), BankForksControllerError> {
         let bank_forks_r = ctx.bank_forks.read().unwrap();
         let old_root = bank_forks_r.root();
         let Some(new_root) = finalized_blocks
@@ -817,7 +821,7 @@ impl EventHandler {
             .max()
         else {
             // No rootable banks
-            return;
+            return Ok(());
         };
         drop(bank_forks_r);
         root_utils::set_root(
@@ -829,8 +833,9 @@ impl EventHandler {
             pending_blocks,
             finalized_blocks,
             received_shred,
-        );
+        )?;
         stats.set_root(new_root);
+        Ok(())
     }
 
     pub(crate) fn join(self) -> thread::Result<()> {
@@ -883,7 +888,7 @@ mod tests {
             consensus_message::{BLS_KEYPAIR_DERIVE_SEED, ConsensusMessage, VoteMessage},
             vote::Vote,
         },
-        crossbeam_channel::{Receiver, TryRecvError, unbounded},
+        crossbeam_channel::{Receiver, Sender, TryRecvError, unbounded},
         parking_lot::RwLock as PlRwLock,
         solana_bls_signatures::{
             keypair::Keypair as BLSKeypair, signature::Signature as BLSSignature,
@@ -898,6 +903,7 @@ mod tests {
         solana_runtime::{
             bank::{Bank, SlotLeader},
             bank_forks::BankForks,
+            bank_forks_controller::{BankForksController, BankForksControllerError},
             genesis_utils::{
                 ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
             },
@@ -931,6 +937,53 @@ mod tests {
         root_context: RootContext,
         local_context: LocalContext,
         bls_ops: Vec<BLSOp>,
+    }
+
+    struct DirectBankForksController {
+        bank_forks: Arc<RwLock<BankForks>>,
+        blockstore: Arc<Blockstore>,
+        leader_schedule_cache: Arc<LeaderScheduleCache>,
+        drop_bank_sender: Sender<Vec<BankWithScheduler>>,
+    }
+
+    impl BankForksController for DirectBankForksController {
+        fn insert_bank(&self, bank: Bank) -> Result<BankWithScheduler, BankForksControllerError> {
+            Ok(self.bank_forks.write().unwrap().insert(bank))
+        }
+
+        fn set_root(
+            &self,
+            my_pubkey: Pubkey,
+            parent_slot: Slot,
+            new_root: Slot,
+            highest_super_majority_root: Option<Slot>,
+        ) -> Result<(), BankForksControllerError> {
+            root_utils::check_and_handle_new_root(
+                parent_slot,
+                new_root,
+                None,
+                highest_super_majority_root,
+                &None,
+                &self.drop_bank_sender,
+                &self.blockstore,
+                &self.leader_schedule_cache,
+                &self.bank_forks,
+                None,
+                &my_pubkey,
+                |_| {},
+            );
+            Ok(())
+        }
+
+        fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError> {
+            let bank_to_clear = self.bank_forks.read().unwrap().get_with_scheduler(slot);
+            if let Some(bank) = bank_to_clear {
+                let _ = bank.wait_for_completed_scheduler();
+            }
+
+            self.bank_forks.write().unwrap().clear_bank(slot, false);
+            Ok(())
+        }
     }
 
     fn setup() -> EventHandlerTestContext {
@@ -982,6 +1035,15 @@ mod tests {
             )
             .unwrap(),
         );
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(
+            &bank_forks.read().unwrap().root_bank(),
+        ));
+        let bank_forks_controller = Arc::new(DirectBankForksController {
+            bank_forks: bank_forks.clone(),
+            blockstore: blockstore.clone(),
+            leader_schedule_cache,
+            drop_bank_sender: drop_bank_sender.clone(),
+        });
         let highest_parent_ready = Arc::new(RwLock::default());
 
         let shared_context = SharedContext {
@@ -989,8 +1051,7 @@ mod tests {
             bank_forks: bank_forks.clone(),
             vote_history_storage: Arc::new(FileVoteHistoryStorage::default()),
             leader_window_info_sender,
-            blockstore,
-            rpc_subscriptions: None,
+            blockstore: blockstore.clone(),
             highest_parent_ready: highest_parent_ready.clone(),
             repair_event_sender,
         };
@@ -1011,12 +1072,8 @@ mod tests {
         };
 
         let root_context = RootContext {
-            leader_schedule_cache: Arc::new(LeaderScheduleCache::new_from_bank(
-                &bank_forks.read().unwrap().root_bank(),
-            )),
-            snapshot_controller: None,
             bank_notification_sender: None,
-            drop_bank_sender,
+            bank_forks_controller,
         };
 
         let local_context = LocalContext {

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -11,7 +11,9 @@ use {
         rpc_subscriptions::RpcSubscriptions,
     },
     solana_runtime::{
-        bank_forks::BankForks, installed_scheduler_pool::BankWithScheduler,
+        bank_forks::BankForks,
+        bank_forks_controller::{BankForksController, BankForksControllerError},
+        installed_scheduler_pool::BankWithScheduler,
         snapshot_controller::SnapshotController,
     },
     solana_time_utils::timestamp,
@@ -24,10 +26,8 @@ use {
 /// Structures that are not used in the event loop, but need to be updated
 /// or notified when setting root
 pub(crate) struct RootContext {
-    pub(crate) leader_schedule_cache: Arc<LeaderScheduleCache>,
-    pub(crate) snapshot_controller: Option<Arc<SnapshotController>>,
     pub(crate) bank_notification_sender: Option<BankNotificationSenderConfig>,
-    pub(crate) drop_bank_sender: Sender<Vec<BankWithScheduler>>,
+    pub(crate) bank_forks_controller: Arc<dyn BankForksController>,
 }
 
 /// Sets the root for the votor event handling loop. Handles rooting all things
@@ -41,27 +41,15 @@ pub(crate) fn set_root(
     pending_blocks: &mut PendingBlocks,
     finalized_blocks: &mut BTreeSet<Block>,
     received_shred: &mut BTreeSet<Slot>,
-) {
+) -> Result<(), BankForksControllerError> {
     info!("{my_pubkey}: setting root {new_root}");
     vctx.vote_history.set_root(new_root);
     *pending_blocks = pending_blocks.split_off(&new_root);
     *finalized_blocks = finalized_blocks.split_off(&(new_root, Hash::default()));
     *received_shred = received_shred.split_off(&new_root);
 
-    check_and_handle_new_root(
-        new_root,
-        new_root,
-        rctx.snapshot_controller.as_deref(),
-        Some(new_root),
-        &rctx.bank_notification_sender,
-        &rctx.drop_bank_sender,
-        &ctx.blockstore,
-        &rctx.leader_schedule_cache,
-        &ctx.bank_forks,
-        ctx.rpc_subscriptions.as_deref(),
-        my_pubkey,
-        |_| {},
-    );
+    rctx.bank_forks_controller
+        .set_root(*my_pubkey, new_root, new_root, Some(new_root))?;
 
     // Distinguish between duplicate versions of same slot
     let hash = ctx.bank_forks.read().unwrap().bank_hash(new_root).unwrap();
@@ -90,6 +78,7 @@ pub(crate) fn set_root(
             dependency_work,
         ));
     }
+    Ok(())
 }
 
 /// Sets the new root, additionally performs the callback after setting the bank forks root

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -73,13 +73,9 @@ use {
     solana_keypair::Keypair,
     solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
     solana_pubkey::Pubkey,
-    solana_rpc::{
-        optimistically_confirmed_bank_tracker::BankNotificationSenderConfig,
-        rpc_subscriptions::RpcSubscriptions,
-    },
+    solana_rpc::optimistically_confirmed_bank_tracker::BankNotificationSenderConfig,
     solana_runtime::{
-        bank_forks::BankForks, installed_scheduler_pool::BankWithScheduler,
-        snapshot_controller::SnapshotController,
+        bank_forks::BankForks, bank_forks_controller::BankForksController,
         validated_block_finalization::ValidatedBlockFinalizationCert,
     },
     std::{
@@ -106,15 +102,13 @@ pub struct VotorConfig {
     pub bank_forks: Arc<RwLock<BankForks>>,
     pub cluster_info: Arc<ClusterInfo>,
     pub leader_schedule_cache: Arc<LeaderScheduleCache>,
-    pub rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
     pub consensus_metrics_sender: ConsensusMetricsEventSender,
     pub highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
+    pub bank_forks_controller: Arc<dyn BankForksController>,
 
     // Senders / Notifiers
-    pub snapshot_controller: Option<Arc<SnapshotController>>,
     pub bls_sender: Sender<BLSOp>,
     pub commitment_sender: Sender<CommitmentAggregationData>,
-    pub drop_bank_sender: Sender<Vec<BankWithScheduler>>,
     pub bank_notification_sender: Option<BankNotificationSenderConfig>,
     pub leader_window_info_sender: Sender<LeaderWindowInfo>,
     pub highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
@@ -136,7 +130,6 @@ pub(crate) struct SharedContext {
     pub(crate) blockstore: Arc<Blockstore>,
     pub(crate) bank_forks: Arc<RwLock<BankForks>>,
     pub(crate) cluster_info: Arc<ClusterInfo>,
-    pub(crate) rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
     pub(crate) leader_window_info_sender: Sender<LeaderWindowInfo>,
     pub(crate) highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
     pub(crate) vote_history_storage: Arc<dyn VoteHistoryStorage>,
@@ -164,11 +157,8 @@ impl Votor {
             bank_forks,
             cluster_info,
             leader_schedule_cache,
-            rpc_subscriptions,
-            snapshot_controller,
             bls_sender,
             commitment_sender,
-            drop_bank_sender,
             bank_notification_sender,
             leader_window_info_sender,
             highest_parent_ready,
@@ -184,6 +174,7 @@ impl Votor {
             reward_certs_sender,
             generated_cert_types,
             highest_finalized,
+            bank_forks_controller,
         } = config;
 
         let migration_status = bank_forks.read().unwrap().migration_status();
@@ -196,7 +187,6 @@ impl Votor {
             blockstore: blockstore.clone(),
             bank_forks,
             cluster_info: cluster_info.clone(),
-            rpc_subscriptions,
             highest_parent_ready,
             leader_window_info_sender,
             vote_history_storage,
@@ -218,10 +208,8 @@ impl Votor {
         };
 
         let root_context = RootContext {
-            leader_schedule_cache: leader_schedule_cache.clone(),
-            snapshot_controller,
             bank_notification_sender,
-            drop_bank_sender,
+            bank_forks_controller,
         };
 
         let timer_manager = Arc::new(PlRwLock::new(TimerManager::new(


### PR DESCRIPTION
#### Problem
In votor we split up bank forks write responsibilities from replay stage into 3 threads:
- (same as tower) insert non-leader banks in replay_stage
- insert leader banks in bcl
- set root in votor

This has caused a multitude of problems. Whenever we fix existing issues new ones pop up and this is all pretty brittle.
For V1 lets move all writes back into the replay stage thread and reattempt this split at a later time.

#### Summary of Changes
Add a bank forks controller for use in bcl and votor to send insert and set root messages. Have replay stage act on these messages.

Fixes #12043 
