### PR TITLE
ci: add trigger-buildkite-pipeline.yml

### DIFF
--- a/.github/workflows/trigger-buildkite-pipeline.yml
+++ b/.github/workflows/trigger-buildkite-pipeline.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          USERNAME: ${{ github.event.pull_request.user.login }}
+          USERNAME: ${{ github.event.sender.login }}
         run: |
           ROLE_NAME=$(curl -sS -L \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/trigger-buildkite-pipeline.yml
+++ b/.github/workflows/trigger-buildkite-pipeline.yml
@@ -11,12 +11,17 @@ on:
       - reopened
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   member_check:
     runs-on: ubuntu-24.04
     if: github.repository == 'anza-xyz/agave' && github.event.action != 'labeled'
     outputs:
       should_trigger: ${{ steps.check.outputs.should_trigger }}
+    permissions:
+      contents: read
     steps:
       - name: Check permission
         id: check
@@ -46,6 +51,9 @@ jobs:
     if: github.repository == 'anza-xyz/agave' && github.event.action == 'labeled' && github.event.label.name == 'CI'
     outputs:
       should_trigger: ${{ steps.check.outputs.should_trigger }}
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Remove CI label
         id: check
@@ -70,6 +78,7 @@ jobs:
     if: >-
       always() &&
       (needs.member_check.outputs.should_trigger == 'true' || needs.label_check.outputs.should_trigger == 'true')
+    permissions: {}
     steps:
       - name: Prepare Buildkite pipeline info
         id: prepare

--- a/.github/workflows/trigger-buildkite-pipeline.yml
+++ b/.github/workflows/trigger-buildkite-pipeline.yml
@@ -1,0 +1,120 @@
+name: Trigger Buildkite Pipeline (Pull Request)
+
+on:
+  pull_request_target:
+    branches:
+      - master
+      - v[0-9]+.[0-9]+
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+
+jobs:
+  member_check:
+    runs-on: ubuntu-24.04
+    if: github.repository == 'anza-xyz/agave' && github.event.action != 'labeled'
+    outputs:
+      should_trigger: ${{ steps.check.outputs.should_trigger }}
+    steps:
+      - name: Check permission
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          USERNAME: ${{ github.event.pull_request.user.login }}
+        run: |
+          ROLE_NAME=$(curl -sS -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            https://api.github.com/repos/$REPO/collaborators/$USERNAME/permission | jq -r ".role_name")
+
+          case "$ROLE_NAME" in
+            admin|maintain|write|triage)
+              echo "should_trigger=true" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "should_trigger=false" >> $GITHUB_OUTPUT
+              exit 1
+              ;;
+          esac
+
+  label_check:
+    runs-on: ubuntu-24.04
+    if: github.repository == 'anza-xyz/agave' && github.event.action == 'labeled' && github.event.label.name == 'CI'
+    outputs:
+      should_trigger: ${{ steps.check.outputs.should_trigger }}
+    steps:
+      - name: Remove CI label
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "should_trigger=true" >> $GITHUB_OUTPUT
+
+          curl -sS -X DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/labels/CI" \
+            || echo "CI label was already removed."
+
+  trigger:
+    runs-on: ubuntu-24.04
+    needs:
+      - member_check
+      - label_check
+    if: >-
+      always() &&
+      (needs.member_check.outputs.should_trigger == 'true' || needs.label_check.outputs.should_trigger == 'true')
+    steps:
+      - name: Prepare Buildkite pipeline info
+        id: prepare
+        env:
+          BUILDKITE_PIPELINE: ${{ vars.BUILDKITE_PIPELINE }}
+          COMMIT: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          COMMIT_SHORT="${COMMIT:0:8}"
+          BRANCH="pull/${PR_NUMBER}/head"
+          MESSAGE="PR#${PR_NUMBER} - ${COMMIT_SHORT}"
+          BUILD_META_DATA="{\"pr_number\":\"${PR_NUMBER}\"}"
+
+          echo "branch=$BRANCH" | tee -a $GITHUB_OUTPUT
+          echo "build_meta_data=$BUILD_META_DATA" | tee -a $GITHUB_OUTPUT
+          echo "commit=$COMMIT" | tee -a $GITHUB_OUTPUT
+          echo "message=$MESSAGE" | tee -a $GITHUB_OUTPUT
+          echo "pipeline=$BUILDKITE_PIPELINE" | tee -a $GITHUB_OUTPUT
+          echo "pr_number=$PR_NUMBER" | tee -a $GITHUB_OUTPUT
+
+      - name: Trigger a Buildkite Build
+        uses: "buildkite/trigger-pipeline-action@909fed762c73d5ae2b5d555ab910d66b3fae2670" # v2.4.1
+        with:
+          pipeline: ${{ steps.prepare.outputs.pipeline }}
+          buildkite_api_access_token: ${{ secrets.BUILDKITE_API_ACCESS_TOKEN }}
+          branch: "${{ steps.prepare.outputs.branch }}"
+          build_meta_data: "${{ steps.prepare.outputs.build_meta_data }}"
+          commit: "${{ steps.prepare.outputs.commit }}"
+          message: "${{ steps.prepare.outputs.message }}"
+
+      - name: Summary
+        env:
+          BRANCH: ${{ steps.prepare.outputs.branch }}
+          BUILDKITE_PIPELINE: ${{ vars.BUILDKITE_PIPELINE }}
+          COMMIT: ${{ github.event.pull_request.head.sha }}
+          MESSAGE: ${{ steps.prepare.outputs.message }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          {
+            echo "## Buildkite Pipeline Info"
+            echo ""
+            echo "| Key | Value |"
+            echo "|-----|-------|"
+            echo "| Pipeline | \`$BUILDKITE_PIPELINE\` |"
+            echo "| Branch | \`$BRANCH\` |"
+            echo "| Commit | \`$COMMIT\` |"
+            echo "| PR Number | #$PR_NUMBER |"
+            echo "| Message | $MESSAGE |"
+          } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/trigger-buildkite-pipeline.yml
+++ b/.github/workflows/trigger-buildkite-pipeline.yml
@@ -51,6 +51,7 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           echo "should_trigger=true" >> $GITHUB_OUTPUT
@@ -58,7 +59,7 @@ jobs:
           curl -sS -X DELETE \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/labels/CI" \
+            "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/CI" \
             || echo "CI label was already removed."
 
   trigger:

--- a/.github/workflows/trigger-buildkite-pipeline.yml
+++ b/.github/workflows/trigger-buildkite-pipeline.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   member_check:
     runs-on: ubuntu-24.04

--- a/.github/workflows/trigger-buildkite-pipeline.yml
+++ b/.github/workflows/trigger-buildkite-pipeline.yml
@@ -4,7 +4,6 @@ on:
   pull_request_target:
     branches:
       - master
-      - v[0-9]+.[0-9]+
     types:
       - opened
       - synchronize


### PR DESCRIPTION
### Problem

copied from https://github.com/anza-xyz/agave/pull/12449#issuecomment-4433140520

> the motivation is that, afaics, we will likely have many different forks that need to use our Buildkite agents. the existing ci-gate is quite old and no longer actively maintained. this new approach makes the process more visible and easier to migrate. it also allows us to use Buildkite for these forks without having to modify the legacy ci-gate code.

### Summary of Changes

introduces a new pipeline for triggering buildkite pipelines.

the pipeline can only be triggered if either:

- you have admin, maintain, write, or triage access to the repository or
- someone adds `CI` label to your pull request.

(I'll disable the existing pipeline immediately after this is merged and choose a quiet weekend to perform the migration)

### CI Examples


<details>
<summary>get block by member check</summary>

<img width="690" height="311" alt="Screenshot 2026-05-13 at 11 39 56" src="https://github.com/user-attachments/assets/83b1aba1-f22b-4bdf-b6e8-caf27e155d96" />

</details>

<details>
<summary>add a unrelated tag</summary>

<img width="821" height="140" alt="Screenshot 2026-05-13 at 11 41 01" src="https://github.com/user-attachments/assets/de1465d8-a69d-43f1-bd03-2005ed47ea12" />

</details>

<details>
<summary>add a CI tag</summary>

<img width="427" height="111" alt="Screenshot 2026-05-13 at 11 41 32" src="https://github.com/user-attachments/assets/f9d50566-1387-450d-aa26-d65f5b9e961b" />
<img width="774" height="757" alt="Screenshot 2026-05-13 at 11 42 37" src="https://github.com/user-attachments/assets/782b10f8-ddd7-408a-b31f-f96ffe3c40cc" />

</details>

### Member Check

| User Type | Can Trigger Pipeline |
|----------|:--------------------:|
| Outside contributor (not a member or collaborator) | ❌ |
| Organization member, but not added to the repository | ❌ |
| Team member with read-only access to the repository | ❌ |
| Team member with triage access or higher | ✅ |
| Direct collaborator with triage access or higher | ✅ |
