### PR TITLE
Call do_load in index_scan_accounts

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3520,19 +3520,14 @@ impl AccountsDb {
             if config.is_aborted() {
                 break;
             }
-            self.accounts_index.get_with_and_then(
-                &pubkey,
+            if let Some((account, slot)) = self.do_load(
                 ancestors,
-                true,
-                |(slot, account_info)| {
-                    let account_slot = self
-                        .get_account_accessor(slot, &pubkey, &account_info.storage_location())
-                        .get_loaded_account(|loaded_account| {
-                            (&pubkey, loaded_account.take_account(), slot)
-                        });
-                    scan_func(account_slot)
-                },
-            );
+                &pubkey,
+                LoadHint::Unspecified,
+                PopulateReadCache::False,
+            ) {
+                scan_func(Some((&pubkey, account, slot)));
+            }
         }
 
         // Check whether the bank was removed while the scan was in progress.


### PR DESCRIPTION
#### Problem
index_scan_accounts currently bypasses the accounts_cache, this is ok for now, but will not work if the cached accounts are moved to the index cache 

#### Summary of Changes
- Move index_scan_accounts to call do_load
- Note that this has an additional cost of a lookup from the read cache, which should be relatively cheap

Fixes #
