### PR TITLE
votor: introduce `DELTA_FIRST_SLICE`, use in `TimerManager`

### DIFF
--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -4,6 +4,7 @@ use {
         fraction::Fraction,
         vote::{Vote, VoteType},
     },
+    solana_clock::DEFAULT_MS_PER_SLOT,
     std::time::Duration,
 };
 
@@ -73,8 +74,21 @@ pub const DELTA: Duration = Duration::from_millis(250);
 /// validators.
 const DELTA_BLOCK_PROPAGATION: Duration = DELTA.checked_mul(3).unwrap();
 
-/// Base timeout for when leader's first slice should arrive if they sent it immediately.
+/// Base leader handover timeout: Time after parent-ready that a validator would
+/// see a leaders first slice if that leader sent it at the very start of their
+/// window.
+///
+/// This accounts for up to `DELTA` difference between the leader and the other
+/// validator triggering the parent ready event and for block propagation delay.
 pub(crate) const DELTA_TIMEOUT: Duration = DELTA.checked_add(DELTA_BLOCK_PROPAGATION).unwrap();
+
+/// Time budget we allow a leader to build and send their first slice after
+/// their leader window starts. `TimeoutCrashedLeader` must therefore fire
+/// no earlier than `DELTA_TIMEOUT + DELTA_FIRST_SLICE` from the start of the
+/// window, otherwise we may declare a correct leader crashed.
+///
+/// Conservatively initialized to the slot time.
+pub(crate) const DELTA_FIRST_SLICE: Duration = Duration::from_millis(DEFAULT_MS_PER_SLOT);
 
 /// Timeout for standstill detection mechanism.
 pub(crate) const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -4,6 +4,7 @@
 use {
     crate::{
         commitment::{CommitmentType, update_commitment_cache},
+        common::DELTA_FIRST_SLICE,
         consensus_metrics::ConsensusMetricsEvent,
         event::{CompletedBlock, RepairEvent, RepairEventSender, VotorEvent, VotorEventReceiver},
         event_handler::stats::EventHandlerStats,
@@ -219,10 +220,15 @@ impl EventHandler {
         let should_set_timeouts = vctx.vote_history.add_parent_ready(slot, parent_block);
         Self::check_pending_blocks(my_pubkey, &mut local_context.pending_blocks, vctx, votes)?;
         if should_set_timeouts {
+            // TODO: configure delta_first_slice in bank
+            let delta_first_slice = DELTA_FIRST_SLICE;
             let delta_block = Duration::from_nanos_u128(vctx.sharable_banks.root().ns_per_slot);
-            timer_manager
-                .write()
-                .set_timeouts(slot, local_context.standstill_slot, delta_block);
+            timer_manager.write().set_timeouts(
+                slot,
+                local_context.standstill_slot,
+                delta_first_slice,
+                delta_block,
+            );
             local_context.stats.timeout_set = local_context.stats.timeout_set.saturating_add(1);
         }
 

--- a/votor/src/timer_manager.rs
+++ b/votor/src/timer_manager.rs
@@ -61,11 +61,16 @@ impl TimerManager {
         &self,
         slot: Slot,
         standstill_slot: Option<Slot>,
+        delta_first_slice: Duration,
         delta_block: Duration,
     ) {
-        self.timers
-            .write()
-            .set_timeouts(slot, Instant::now(), standstill_slot, delta_block);
+        self.timers.write().set_timeouts(
+            slot,
+            Instant::now(),
+            standstill_slot,
+            delta_first_slice,
+            delta_block,
+        );
     }
 
     pub(crate) fn join(self) {
@@ -81,8 +86,11 @@ impl TimerManager {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::event::VotorEvent, crossbeam_channel::unbounded,
-        solana_clock::DEFAULT_MS_PER_SLOT, std::time::Duration,
+        super::*,
+        crate::{common::DELTA_FIRST_SLICE, event::VotorEvent},
+        crossbeam_channel::unbounded,
+        solana_clock::DEFAULT_MS_PER_SLOT,
+        std::time::Duration,
     };
 
     #[test]
@@ -94,10 +102,11 @@ mod tests {
             exit.clone(),
             Arc::new(MigrationStatus::post_migration_status()),
         );
+        let delta_first_slice = DELTA_FIRST_SLICE;
         let delta_block = Duration::from_millis(DEFAULT_MS_PER_SLOT);
         let slot = 52;
         let start = Instant::now();
-        timer_manager.set_timeouts(slot, None, delta_block);
+        timer_manager.set_timeouts(slot, None, delta_first_slice, delta_block);
         // Should see two timeouts at delta_block and DELTA_TIMEOUT
         let mut timeouts_received = 0;
         while timeouts_received < 2 && Instant::now().duration_since(start) < Duration::from_secs(2)
@@ -114,7 +123,10 @@ mod tests {
                     }
                     VotorEvent::TimeoutCrashedLeader(s) => {
                         assert_eq!(s, slot);
-                        assert!(Instant::now().duration_since(start) >= DELTA_TIMEOUT);
+                        assert!(
+                            Instant::now().duration_since(start)
+                                >= DELTA_TIMEOUT + DELTA_FIRST_SLICE
+                        );
                         timeouts_received += 1;
                     }
                     _ => panic!("Unexpected event: {event:?}"),

--- a/votor/src/timer_manager/timers.rs
+++ b/votor/src/timer_manager/timers.rs
@@ -32,17 +32,19 @@ fn calculate_timeout_multiplier(slot: Slot, standstill_slot: Option<Slot>) -> f6
 /// Encodes a basic state machine of the different stages involved in handling
 /// timeouts for a window of slots.
 enum TimerState {
-    /// Waiting for the DELTA_TIMEOUT stage.
-    WaitDeltaTimeout {
+    /// Waiting for initial DELTA_TIMEOUT + DELTA_FIRST_SLICE stage.
+    WaitForFirstSlice {
         /// The slots in the window.  Must not be empty.
         window: VecDeque<Slot>,
         /// Time when this stage will end.
         timeout: Instant,
-        /// Protocol slot time, used in [`TimerState::WaitDeltaBlock`].
+        /// The maximum allowed time for producing the first slice.
+        delta_first_slice: Duration,
+        /// Protocol slot time, used in [`TimerState::WaitForBlock`].
         delta_block: Duration,
     },
-    /// Waiting for the DELTA_BLOCK stage.
-    WaitDeltaBlock {
+    /// Waiting for DELTA_TIMEOUT + i * DELTA_BLOCK for each block i in window.
+    WaitForBlock {
         /// The slots in the window.  Must not be empty.
         window: VecDeque<Slot>,
         /// Time when this stage will end.
@@ -58,12 +60,13 @@ impl TimerState {
     /// Creates a new instance of the state machine.
     ///
     /// The `timeout_multiplier` extends only the network-DELTA-derived timeout
-    /// (`delta_timeout`). `delta_block` is protocol pacing, not a function of
-    /// network delays, so it is not scaled. Also returns the next time the
-    /// timer should fire.
+    /// (`delta_timeout`). `delta_first_slice` and `delta_block` are protocol
+    /// pacing, not a function of network delays, so they are not scaled. Also
+    /// returns the next time the timer should fire.
     fn new(
         slot: Slot,
         delta_timeout: Duration,
+        delta_first_slice: Duration,
         delta_block: Duration,
         now: Instant,
         timeout_multiplier: f64,
@@ -73,11 +76,20 @@ impl TimerState {
         let scaled_delta_timeout = Duration::from_secs_f64(
             (delta_timeout.as_secs_f64() * timeout_multiplier).min(MAX_TIMEOUT_SECS),
         );
-        let timeout = now.checked_add(scaled_delta_timeout).unwrap();
+
+        // A correct leader may take up to `DELTA_FIRST_SLICE` to send their first slice,
+        // so the earliest sound point to declare them crashed is
+        // `DELTA_FIRST_SLICE + delta_timeout` after their window starts.
+        let timeout = now
+            .checked_add(scaled_delta_timeout)
+            .unwrap()
+            .checked_add(delta_first_slice)
+            .unwrap();
         (
-            Self::WaitDeltaTimeout {
+            Self::WaitForFirstSlice {
                 window,
                 timeout,
+                delta_first_slice,
                 delta_block,
             },
             timeout,
@@ -89,9 +101,10 @@ impl TimerState {
     /// Returns a potentially empty list of events that should be sent.
     fn progress(&mut self, now: Instant) -> Option<VotorEvent> {
         match self {
-            Self::WaitDeltaTimeout {
+            Self::WaitForFirstSlice {
                 window,
                 timeout,
+                delta_first_slice,
                 delta_block,
             } => {
                 assert!(!window.is_empty());
@@ -99,15 +112,21 @@ impl TimerState {
                     return None;
                 }
                 let slot = *window.front().unwrap();
-                let new_timeout = timeout.checked_add(*delta_block).unwrap();
-                *self = Self::WaitDeltaBlock {
+                // Slot 0's block deadline is `T + delta_block + scaled_delta_timeout`;
+                // subtract the `delta_first_slice` paid up-front to `WaitForFirstSlice`.
+                let new_timeout = timeout
+                    .checked_add(*delta_block)
+                    .unwrap()
+                    .checked_sub(*delta_first_slice)
+                    .unwrap();
+                *self = Self::WaitForBlock {
                     window: window.to_owned(),
                     timeout: new_timeout,
                     delta_block: *delta_block,
                 };
                 Some(VotorEvent::TimeoutCrashedLeader(slot))
             }
-            Self::WaitDeltaBlock {
+            Self::WaitForBlock {
                 window,
                 timeout,
                 delta_block,
@@ -133,7 +152,7 @@ impl TimerState {
     /// When would this state machine next be able to make progress.
     fn next_fire(&self) -> Option<Instant> {
         match self {
-            Self::WaitDeltaTimeout { timeout, .. } | Self::WaitDeltaBlock { timeout, .. } => {
+            Self::WaitForFirstSlice { timeout, .. } | Self::WaitForBlock { timeout, .. } => {
                 Some(*timeout)
             }
             Self::Done => None,
@@ -173,6 +192,7 @@ impl Timers {
         slot: Slot,
         now: Instant,
         standstill_slot: Option<Slot>,
+        delta_first_slice: Duration,
         delta_block: Duration,
     ) {
         assert_eq!(self.heap.len(), self.timers.len());
@@ -180,6 +200,7 @@ impl Timers {
         let (timer, next_fire) = TimerState::new(
             slot,
             self.delta_timeout,
+            delta_first_slice,
             delta_block,
             now,
             timeout_multiplier,
@@ -243,7 +264,9 @@ impl Timers {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::common::DELTA_TIMEOUT, crossbeam_channel::unbounded,
+        super::*,
+        crate::common::{DELTA_FIRST_SLICE, DELTA_TIMEOUT},
+        crossbeam_channel::unbounded,
         solana_clock::DEFAULT_MS_PER_SLOT,
     };
 
@@ -252,7 +275,8 @@ mod tests {
         let one_micro = Duration::from_micros(1);
         let now = Instant::now();
         let slot = 0;
-        let (mut timer_state, next_fire) = TimerState::new(slot, one_micro, one_micro, now, 1.0);
+        let (mut timer_state, next_fire) =
+            TimerState::new(slot, one_micro, one_micro, one_micro, now, 1.0);
 
         assert!(matches!(
             timer_state.progress(next_fire).unwrap(),
@@ -298,7 +322,13 @@ mod tests {
         assert!(timers.progress(now).is_none());
         assert!(receiver.try_recv().unwrap_err().is_empty());
 
-        timers.set_timeouts(0, now, None, Duration::from_millis(DEFAULT_MS_PER_SLOT));
+        timers.set_timeouts(
+            0,
+            now,
+            None,
+            DELTA_FIRST_SLICE,
+            Duration::from_millis(DEFAULT_MS_PER_SLOT),
+        );
         while timers.progress(now).is_some() {
             now = now.checked_add(one_micro).unwrap();
         }
@@ -323,16 +353,24 @@ mod tests {
     fn timer_state_with_multiplier() {
         // Test that timeout multiplier correctly extends the timeout duration
         let delta_timeout = Duration::from_millis(100);
+        let delta_first_slice = Duration::from_millis(10);
         let delta_block = Duration::from_millis(50);
         let now = Instant::now();
         let slot = 0;
         let multiplier = 1.5; // 50% longer timeouts
 
-        let (mut timer_state, next_fire) =
-            TimerState::new(slot, delta_timeout, delta_block, now, multiplier);
+        let (mut timer_state, next_fire) = TimerState::new(
+            slot,
+            delta_timeout,
+            delta_first_slice,
+            delta_block,
+            now,
+            multiplier,
+        );
 
-        // The first timeout should fire at now + (delta_timeout * 1.5) = now + 150ms
-        let expected_first_fire = now + Duration::from_millis(150);
+        // The first timeout should fire at now + (delta_timeout * 1.5) + delta_first_slice
+        // = now + 150ms + delta_first_slice
+        let expected_first_fire = now + Duration::from_millis(150) + delta_first_slice;
         assert!(
             next_fire >= expected_first_fire - Duration::from_micros(100)
                 && next_fire <= expected_first_fire + Duration::from_micros(100),
@@ -345,15 +383,18 @@ mod tests {
             VotorEvent::TimeoutCrashedLeader(0)
         ));
 
-        // delta_block is protocol pacing and is NOT scaled by the multiplier.
-        // The next fire should be at next_fire + delta_block = next_fire + 50ms.
+        // Slot 0's block deadline is `now + delta_block + scaled_delta_timeout`
+        // = now + 50ms + 150ms = now + 200ms (unaffected by delta_first_slice).
         let next = timer_state.next_fire().unwrap();
-        let expected_delta = delta_block;
-        let actual_delta = next - next_fire;
+        let expected_next = now + Duration::from_millis(200);
+        let skew = if next >= expected_next {
+            next - expected_next
+        } else {
+            expected_next - next
+        };
         assert!(
-            actual_delta >= expected_delta - Duration::from_micros(100)
-                && actual_delta <= expected_delta + Duration::from_micros(100),
-            "Expected delta around {expected_delta:?}, got {actual_delta:?}",
+            skew <= Duration::from_micros(100),
+            "Expected slot-0 deadline around {expected_next:?}, got {next:?}",
         );
     }
 
@@ -391,11 +432,18 @@ mod tests {
         let multiplier = 1000000.0;
         let delta_block = Duration::from_millis(DEFAULT_MS_PER_SLOT);
 
-        let (mut timer_state, next_fire) =
-            TimerState::new(100, DELTA_TIMEOUT, delta_block, now, multiplier);
+        let (mut timer_state, next_fire) = TimerState::new(
+            100,
+            DELTA_TIMEOUT,
+            DELTA_FIRST_SLICE,
+            delta_block,
+            now,
+            multiplier,
+        );
 
-        // The first timeout should be capped at MAX_TIMEOUT
-        let expected_first_fire = now + Duration::from_secs(MAX_TIMEOUT_SECS as u64);
+        // The first timeout should be capped at MAX_TIMEOUT (+ unscaled DELTA_FIRST_SLICE).
+        let expected_first_fire =
+            now + Duration::from_secs(MAX_TIMEOUT_SECS as u64) + DELTA_FIRST_SLICE;
         assert_eq!(next_fire, expected_first_fire);
 
         // Progress the timer to get TimeoutCrashedLeader
@@ -404,10 +452,10 @@ mod tests {
             VotorEvent::TimeoutCrashedLeader(100)
         ));
 
-        // delta_block is not scaled by the multiplier, so the inter-slot gap
-        // stays at the protocol pacing value regardless of standstill state.
+        // Slot 0's block deadline is `T + delta_block + scaled_delta_timeout`, so
+        // the gap from the (DELTA_FIRST_SLICE-shifted) first fire is `delta_block - DELTA_FIRST_SLICE`.
         let next = timer_state.next_fire().unwrap();
         let actual_delta = next - next_fire;
-        assert_eq!(actual_delta, delta_block);
+        assert_eq!(actual_delta, delta_block - DELTA_FIRST_SLICE);
     }
 }


### PR DESCRIPTION
#### Problem
See #12226

#### Summary of Changes
- Add `DELTA_FIRST_SLICE`, initially set to `DEFAULT_MS_PER_SLOT` for maximum compatibility.
- Pass to and use in `TimerManager`.

Fixes #12226
