### PR TITLE
gen-syscall-list: print the actual syscall list differences

### DIFF
--- a/syscalls/gen-syscall-list/build.rs
+++ b/syscalls/gen-syscall-list/build.rs
@@ -1,6 +1,7 @@
 use {
     regex::Regex,
     std::{
+        collections::HashSet,
         fs::File,
         io::{BufReader, BufWriter, prelude::*},
         path::PathBuf,
@@ -27,12 +28,13 @@ fn main() {
         syscalls_txt_path.display(),
     );
 
-    let old_num_syscalls = File::open(&syscalls_txt_path)
-        .map(|file| {
+    let old_syscalls = File::open(&syscalls_txt_path)
+        .and_then(|file| {
             let reader = BufReader::new(file);
-            reader.lines().count()
+            reader.lines().collect::<Result<HashSet<_>, _>>()
         })
-        .unwrap_or(0);
+        .unwrap_or_else(|_| HashSet::new());
+    let old_num_syscalls = old_syscalls.len();
 
     let mut file = match File::open(&syscalls_rs_path) {
         Ok(x) => x,
@@ -45,14 +47,20 @@ fn main() {
         Regex::new(r#"(?m)::register\([ \n]*&mut result,[ \n]*"([^"]+)"[, \n]*\)"#).unwrap();
     let feature_gate_syscall_re =
         Regex::new(r#"register_feature_gated_function!\([^"]+"([^"]+)","#).unwrap();
-    let new_num_syscalls = sysc_re
+    let new_syscalls = sysc_re
         .captures_iter(text)
         .chain(feature_gate_syscall_re.captures_iter(text))
-        .count();
+        .map(|c| c.extract::<1>().1[0].to_string())
+        .collect::<HashSet<_>>();
+    let new_num_syscalls = new_syscalls.len();
     if new_num_syscalls < old_num_syscalls {
         println!(
             "cargo:error=Number of syscalls reduced from {old_num_syscalls} to \
              {new_num_syscalls}, parsing logic in build.rs likely needs to be fixed."
+        );
+        println!(
+            "cargo:warning=Difference is {:?}",
+            old_syscalls.symmetric_difference(&new_syscalls)
         );
         std::process::exit(1);
     }


### PR DESCRIPTION
#### Problem

It can be pretty difficult to investigate issues when all you get is “things are wrong!” as the feedback.

#### Summary of Changes

Print out the actual symmetric difference between the text file and parsed list.
