### PR TITLE
fix: account for Turbine latency in `DELTA_TIMEOUT`

### DIFF
--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -68,8 +68,13 @@ pub const SAFE_TO_SKIP_THRESHOLD: Fraction = Fraction::from_percentage(40);
 /// Time bound assumed on network transmission delays during periods of synchrony.
 pub const DELTA: Duration = Duration::from_millis(250);
 
+/// Time bound for propagation delay in the block propagation sub-protocol. For
+/// Turbine this is a maximum of `3 * DELTA` for the current maximum number of
+/// validators.
+const DELTA_BLOCK_PROPAGATION: Duration = DELTA.checked_mul(3).unwrap();
+
 /// Base timeout for when leader's first slice should arrive if they sent it immediately.
-pub(crate) const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
+pub(crate) const DELTA_TIMEOUT: Duration = DELTA.checked_add(DELTA_BLOCK_PROPAGATION).unwrap();
 
 /// Timeout for standstill detection mechanism.
 pub(crate) const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);


### PR DESCRIPTION
#### Problem
Currently `DELTA_TIMEOUT` is defined as `3 * DELTA`, which is only correct for Rotor. In general, for Turbine the propagation delay is up to `3 * DELTA` and therefore `DELTA_TIMEOUT` needs to be `4 * DELTA`.

#### Summary of Changes
- Introduce a new constant `DELTA_BLOCK_PROPAGATION`, defined as `3 * DELTA` for Turbine
- Calculate `DELTA_TIMEOUT` based on `DELTA` and `DELTA_BLOCK_PROPAGATION`.