### PR TITLE
fix(snapshots): disable direct I/O when serializing snapshot before archive

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -118,11 +118,12 @@ impl SnapshotPackagerService {
                     }
 
                     let archive_time = Instant::now();
-                    // Regular operation, saved data is unlikely being read back soon, so allow direct-io.
-                    let io_setup = IoSetupState::default()
-                        .with_buffers_registered(snapshot_config.use_registered_io_uring_buffers)
-                        .with_direct_io(snapshot_config.use_direct_io);
 
+                    // Don't use direct IO to serialize snapshot, since it's re-read when creating archive
+                    // a moment later.
+                    let io_setup = IoSetupState::default()
+                        .with_direct_io(false)
+                        .with_buffers_registered(snapshot_config.use_registered_io_uring_buffers);
                     // Serializing the snapshot package is not allowed to fail, as archiving is
                     // not allowed to fail (see comment on archive_snapshot_package below
                     let bank_snapshot_info = snapshot_utils::serialize_snapshot(
@@ -145,6 +146,8 @@ impl SnapshotPackagerService {
                         break;
                     };
 
+                    // Snapshot archive is unlikely to be read back soon, so allow direct-io now.
+                    let io_setup = io_setup.with_direct_io(snapshot_config.use_direct_io);
                     if let SnapshotKind::Archive(snapshot_archive_kind) = snapshot_kind {
                         // Archiving the snapshot package is not allowed to fail.
                         // AccountsBackgroundService calls `clean_accounts()` with a value for


### PR DESCRIPTION
#### Problem
When creating snapshot archives we first serialize snapshot manifest to disk, which is re-read immediately after to create tar.zst archive. Using direct-io for this write doesn't make sense, since it prevents the immediate read from using cached data (in kernel file buffer cache).

#### Summary of Changes
Don't enable direct I/O when serializing snapshot to disk. Allow direct-io for archive operation itself.

Note: 
* currently tar adds the snapshot data through its built-in sync IO when adding snapshot directory
* we don't use `IoSetupState` yet for reading accounts data, so that part is done using sync io without using direct-io settings

##### Performance

On the left master has read rate bumps during snapshot archivals, on the right this PR removes them
<img width="2706" height="926" alt="obraz" src="https://github.com/user-attachments/assets/55a96762-6ccd-4ebe-82d8-81acffda5021" />

