### PR TITLE
do_load: return cache directly when it has a slot >= the index slot

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4024,6 +4024,18 @@ impl AccountsDb {
             self.read_index_for_accessor_or_load_slow(ancestors, pubkey, false)?;
         // Notice the subtle `?` at previous line, we bail out pretty early if missing.
 
+        if let Some((cached_account, cached_slot, _)) = &cache_result {
+            if *cached_slot >= slot {
+                // The write cache holds a version at a slot at least as new as what the
+                // index returned, so it represents the freshest visible value and can be
+                // returned directly without going through the storage accessor.
+                self.load_account_stats
+                    .num_loaded_from_write_cache
+                    .fetch_add(1, Ordering::Relaxed);
+                return Some((cached_account.account.clone(), *cached_slot));
+            }
+        }
+
         let in_write_cache = storage_location.is_cached();
         if !in_write_cache {
             let result = self.read_only_accounts_cache.load(*pubkey, slot);


### PR DESCRIPTION
#### Problem
Return cache directly if slot >= slot fetched from the accounts_index.

#### Summary of Changes
- Return early if we know that the version found in the cache is the newest

This is required once the index is fully split, but correct currently as well. 


Data:
Started running baseline on RoryP (blue-line). Restarted to run with this change at 11:45. I can't really see much difference after the restart in perf.  
<img width="893" height="286" alt="image" src="https://github.com/user-attachments/assets/3f569dde-d3c9-42c8-9703-53a2628d42de" />




Fixes #
