### PR TITLE
Updates accounts lt hash in a thread pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,13 +2125,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.18"
+name = "crossbeam-queue"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
- "cfg-if 1.0.4",
+ "crossbeam-utils",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -9949,6 +9955,8 @@ dependencies = [
  "bytemuck",
  "criterion",
  "crossbeam-channel",
+ "crossbeam-queue",
+ "crossbeam-utils",
  "dashmap",
  "imbl",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9986,6 +9995,7 @@ dependencies = [
  "bytemuck",
  "criterion",
  "crossbeam-channel",
+ "crossbeam-queue",
  "dashmap",
  "imbl",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,6 +226,8 @@ const_format = "0.2.36"
 core_affinity = "0.8.3"
 criterion = "0.8.2"
 crossbeam-channel = "0.5.15"
+crossbeam-queue = "0.3.12"
+crossbeam-utils = "0.8.21"
 csv = "1.4.0"
 ctrlc = "3.5.2"
 curve25519-dalek = { version = "4.1.3", features = ["digest", "rand_core"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,6 +236,7 @@ const_format = "0.2.36"
 core_affinity = "0.8.3"
 criterion = "0.8.2"
 crossbeam-channel = "0.5.15"
+crossbeam-queue = "0.3.12"
 csv = "1.4.0"
 ctrlc = "3.5.2"
 curve25519-dalek = { version = "4.1.3", features = ["digest", "rand_core"] }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -1775,6 +1775,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8346,6 +8355,8 @@ dependencies = [
  "bitvec",
  "bytemuck",
  "crossbeam-channel",
+ "crossbeam-queue",
+ "crossbeam-utils",
  "dashmap",
  "imbl",
  "itertools 0.14.0",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -1792,6 +1792,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8563,6 +8572,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "crossbeam-channel",
+ "crossbeam-queue",
  "dashmap",
  "imbl",
  "itertools 0.14.0",

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -32,7 +32,7 @@ use {
     solana_metrics::datapoint_error,
     solana_pubkey::Pubkey,
     solana_runtime::{
-        bank::{Bank, PreCommitResult, TransactionBalancesSet},
+        bank::{Bank, PreCommitResult, TransactionBalancesSet, replay_hash_thread_pool},
         bank_forks::BankForks,
         bank_utils,
         block_component_processor::BlockComponentProcessorError,
@@ -71,7 +71,7 @@ use {
         ops::Index,
         path::PathBuf,
         result,
-        sync::{Arc, Mutex, OnceLock, RwLock, atomic::AtomicBool},
+        sync::{Arc, Mutex, RwLock, atomic::AtomicBool},
         time::{Duration, Instant},
         vec::Drain,
     },
@@ -160,18 +160,6 @@ fn create_thread_pool(num_threads: usize) -> ThreadPool {
         .thread_name(|i| format!("solReplayTx{i:02}"))
         .build()
         .expect("new rayon threadpool")
-}
-
-fn transaction_hash_verify_thread_pool() -> &'static ThreadPool {
-    const TX_HASH_VERIFY_THREAD_POOL_SIZE: usize = 4;
-    static TX_HASH_VERIFY_THREAD_POOL: OnceLock<ThreadPool> = OnceLock::new();
-    TX_HASH_VERIFY_THREAD_POOL.get_or_init(|| {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(TX_HASH_VERIFY_THREAD_POOL_SIZE)
-            .thread_name(|i| format!("solReplayHash{i:02}"))
-            .build()
-            .expect("new transaction hash verify rayon threadpool")
-    })
 }
 
 pub fn execute_batch<'a>(
@@ -2027,7 +2015,7 @@ fn confirm_slot_entries(
     } = match entry::validate_and_hash_transactions(
         entries,
         num_txs,
-        transaction_hash_verify_thread_pool(),
+        replay_hash_thread_pool(),
         validate_and_hash_transaction,
     ) {
         Ok(txs) => txs,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1692,6 +1692,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8195,6 +8204,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "crossbeam-channel",
+ "crossbeam-queue",
  "dashmap",
  "imbl",
  "itertools 0.14.0",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1709,13 +1709,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.18"
+name = "crossbeam-queue"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
- "cfg-if 1.0.4",
+ "crossbeam-utils",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -8166,6 +8172,8 @@ dependencies = [
  "bitvec",
  "bytemuck",
  "crossbeam-channel",
+ "crossbeam-queue",
+ "crossbeam-utils",
  "dashmap",
  "imbl",
  "itertools 0.14.0",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -68,6 +68,8 @@ bincode = { workspace = true }
 bitvec = { workspace = true }
 bytemuck = { workspace = true }
 crossbeam-channel = { workspace = true }
+crossbeam-queue = { workspace = true }
+crossbeam-utils = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api", "serde"] }
 imbl = { workspace = true, features = ["rayon", "serde"] }
 itertools = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -68,6 +68,7 @@ base64 = { workspace = true }
 bincode = { workspace = true }
 bytemuck = { workspace = true }
 crossbeam-channel = { workspace = true }
+crossbeam-queue = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api", "serde"] }
 imbl = { workspace = true, features = ["rayon", "serde"] }
 itertools = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -66,7 +66,7 @@ use {
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
-    accounts_lt_hash::{CacheValue as AccountsLtHashCacheValue, Stats as AccountsLtHashStats},
+    accounts_lt_hash::AccountsLtHashAsyncProgress,
     agave_bls_cert_verify::cert_verify::{self, Error as CertVerifyError},
     agave_feature_set::{self as feature_set, FeatureSet},
     agave_precompiles::{get_precompile, get_precompiles, is_precompile},
@@ -76,7 +76,6 @@ use {
         consensus_message::Certificate, migration::GENESIS_CERTIFICATE_ACCOUNT,
     },
     ahash::AHashSet,
-    dashmap::DashMap,
     log::*,
     partitioned_epoch_rewards::PartitionedRewardsCalculation,
     rayon::{ThreadPool, ThreadPoolBuilder},
@@ -257,6 +256,22 @@ static NANOSECOND_CLOCK_ACCOUNT: LazyLock<Pubkey> = LazyLock::new(|| {
         Pubkey::find_program_address(&[b"alpenclock"], &agave_feature_set::alpenglow::id());
     pubkey
 });
+
+/// Number of threads for the replay hashing thread pool
+pub const NUM_REPLAY_HASH_THREADS: usize = 4;
+
+/// Thread pool for replay hashing
+pub fn replay_hash_thread_pool() -> &'static ThreadPool {
+    static REPLAY_HASH_THREAD_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
+        ThreadPoolBuilder::new()
+            .num_threads(NUM_REPLAY_HASH_THREADS)
+            .thread_name(|i| format!("solReplayHash{i:02}"))
+            .build()
+            .expect("new replay hash rayon threadpool")
+    });
+
+    &REPLAY_HASH_THREAD_POOL
+}
 
 pub type BankStatusCache = StatusCache<Result<()>>;
 #[cfg_attr(
@@ -639,8 +654,7 @@ impl PartialEq for Bank {
             compute_budget: _,
             transaction_account_lock_limit: _,
             fee_structure: _,
-            cache_for_accounts_lt_hash: _,
-            stats_for_accounts_lt_hash: _,
+            accounts_lt_hash_async_progress: _,
             block_id,
             expected_bank_hash: _,
             bank_hash_stats: _,
@@ -969,17 +983,8 @@ pub struct Bank {
     /// The value is only meaningful after freezing.
     accounts_lt_hash: Mutex<AccountsLtHash>,
 
-    /// A cache of *the initial state* of accounts modified in this slot
-    ///
-    /// The accounts lt hash needs both the initial and final state of each
-    /// account that was modified in this slot.  Cache the initial state here.
-    ///
-    /// Note: The initial state must be strictly from an ancestor,
-    /// and not an intermediate state within this slot.
-    cache_for_accounts_lt_hash: DashMap<Pubkey, AccountsLtHashCacheValue, ahash::RandomState>,
-
-    /// Stats related to the accounts lt hash
-    stats_for_accounts_lt_hash: AccountsLtHashStats,
+    /// Track progress of the asynchronous accounts lt hashing for this Bank.
+    accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress,
 
     /// The unique identifier for the corresponding block for this bank.
     /// None for banks that have not yet completed replay or for leader banks as we cannot populate block_id
@@ -1185,8 +1190,7 @@ impl Bank {
             #[cfg(feature = "dev-context-only-utils")]
             hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
             accounts_lt_hash: Mutex::new(AccountsLtHash(LtHash::identity())),
-            cache_for_accounts_lt_hash: DashMap::default(),
-            stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
+            accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress::new(),
             block_id: RwLock::new(None),
             expected_bank_hash: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
@@ -1442,8 +1446,7 @@ impl Bank {
             #[cfg(feature = "dev-context-only-utils")]
             hash_overrides: parent.hash_overrides.clone(),
             accounts_lt_hash: Mutex::new(parent.accounts_lt_hash.lock().unwrap().clone()),
-            cache_for_accounts_lt_hash: DashMap::default(),
-            stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
+            accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress::new(),
             block_id: RwLock::new(None),
             expected_bank_hash: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
@@ -1473,7 +1476,6 @@ impl Bank {
             slot,
             parent.slot(),
             new.block_height,
-            prepare_timings.num_accounts_modified_this_slot,
             NewBankTimings {
                 bank_rc_creation_time_us,
                 total_elapsed_time_us: time.as_us(),
@@ -1493,8 +1495,6 @@ impl Bank {
                 cache_preparation_time_us: prepare_timings.cache_preparation_time_us,
                 update_sysvars_time_us: prepare_timings.update_sysvars_time_us,
                 fill_sysvar_cache_time_us: prepare_timings.fill_sysvar_cache_time_us,
-                populate_cache_for_accounts_lt_hash_us: prepare_timings
-                    .populate_cache_for_accounts_lt_hash_us,
             },
         );
 
@@ -1908,34 +1908,12 @@ impl Bank {
                 .fill_missing_sysvar_cache_entries(self)
         );
 
-        let (num_accounts_modified_this_slot, populate_cache_for_accounts_lt_hash_us) =
-            measure_us!({
-                // The cache for accounts lt hash needs to be made aware of accounts modified
-                // before transaction processing begins.  Otherwise we may calculate the wrong
-                // accounts lt hash due to having the wrong initial state of the account.  The
-                // lt hash cache's initial state must always be from an ancestor, and cannot be
-                // an intermediate state within this Bank's slot.  If the lt hash cache has the
-                // wrong initial account state, we'll mix out the wrong lt hash value, and thus
-                // have the wrong overall accounts lt hash, and diverge.
-                let accounts_modified_this_slot =
-                    self.rc.accounts.accounts_db.get_pubkeys_for_slot(slot);
-                let num_accounts_modified_this_slot = accounts_modified_this_slot.len();
-                for pubkey in accounts_modified_this_slot {
-                    self.cache_for_accounts_lt_hash
-                        .entry(pubkey)
-                        .or_insert(AccountsLtHashCacheValue::BankNew);
-                }
-                num_accounts_modified_this_slot
-            });
-
         PrepareBlockExecutionStats {
             update_epoch_time_us,
             distribute_rewards_time_us,
             cache_preparation_time_us,
             update_sysvars_time_us,
             fill_sysvar_cache_time_us,
-            num_accounts_modified_this_slot,
-            populate_cache_for_accounts_lt_hash_us,
         }
     }
 
@@ -2087,8 +2065,7 @@ impl Bank {
             #[cfg(feature = "dev-context-only-utils")]
             hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
             accounts_lt_hash: Mutex::new(fields.accounts_lt_hash),
-            cache_for_accounts_lt_hash: DashMap::default(),
-            stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
+            accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress::new(),
             block_id: RwLock::new(fields.block_id),
             bank_hash_stats: AtomicBankHashStats::new(&fields.bank_hash_stats),
             epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
@@ -2755,7 +2732,7 @@ impl Bank {
             self.freeze_started.store(true, Relaxed);
             // updating the accounts lt hash must happen *outside* of hash_internal_state() so
             // that rehash() can be called and *not* modify self.accounts_lt_hash.
-            self.update_accounts_lt_hash();
+            self.finish_accounts_lt_hash_updates();
             *hash = self.hash_internal_state();
             self.rc.accounts.accounts_db.mark_slot_frozen(self.slot());
         }
@@ -4019,6 +3996,7 @@ impl Bank {
 
             let to_store = (self.slot(), accounts_to_store.as_slice());
             self.update_bank_hash_stats(&to_store);
+            self.enqueue_accounts_lt_hash_updates(&to_store);
             // See https://github.com/solana-labs/solana/pull/31455 for discussion
             // on *not* updating the index within a threadpool.
             self.rc
@@ -4395,10 +4373,7 @@ impl Bank {
                 )
             })
         });
-        self.update_bank_hash_stats(&accounts);
-        self.rc
-            .accounts
-            .store_accounts_par(accounts, None, &self.ancestors);
+        self.store_accounts_without_stakes_cache(accounts);
         m.stop();
         self.rc
             .accounts
@@ -4415,6 +4390,7 @@ impl Bank {
     fn store_accounts_without_stakes_cache<'a>(&self, accounts: impl StorableAccounts<'a>) {
         assert!(!self.freeze_started());
         self.update_bank_hash_stats(&accounts);
+        self.enqueue_accounts_lt_hash_updates(&accounts);
         self.rc
             .accounts
             .store_accounts_par(accounts, None, &self.ancestors);
@@ -6274,8 +6250,8 @@ impl TransactionProcessingCallback for Bank {
             .load_with_fixed_root(&self.ancestors, pubkey)
     }
 
-    fn inspect_account(&self, address: &Pubkey, account_state: AccountState, is_writable: bool) {
-        self.inspect_account_for_accounts_lt_hash(address, &account_state, is_writable);
+    fn inspect_account(&self, _address: &Pubkey, _account_state: AccountState, _is_writable: bool) {
+        // nothing to do here
     }
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -73,7 +73,7 @@ use {
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
-    accounts_lt_hash::{CacheValue as AccountsLtHashCacheValue, Stats as AccountsLtHashStats},
+    accounts_lt_hash::AccountsLtHashAsyncProgress,
     agave_bls_cert_verify::cert_verify::{self, Error as CertVerifyError},
     agave_feature_set::{self as feature_set, FeatureSet},
     agave_precompiles::{get_precompile, get_precompiles, is_precompile},
@@ -81,7 +81,6 @@ use {
     agave_snapshots::snapshot_hash::SnapshotHash,
     agave_votor_messages::{certificate::Certificate, migration::GENESIS_CERTIFICATE_ACCOUNT},
     ahash::AHashSet,
-    dashmap::DashMap,
     log::*,
     partitioned_epoch_rewards::PartitionedRewardsCalculation,
     rayon::ThreadPool,
@@ -649,8 +648,7 @@ impl PartialEq for Bank {
             compute_budget: _,
             transaction_account_lock_limit: _,
             fee_structure: _,
-            cache_for_accounts_lt_hash: _,
-            stats_for_accounts_lt_hash: _,
+            accounts_lt_hash_async_progress: _,
             block_id,
             expected_bank_hash: _,
             bank_hash_stats: _,
@@ -985,17 +983,8 @@ pub struct Bank {
     /// The value is only meaningful after freezing.
     accounts_lt_hash: Mutex<AccountsLtHash>,
 
-    /// A cache of *the initial state* of accounts modified in this slot
-    ///
-    /// The accounts lt hash needs both the initial and final state of each
-    /// account that was modified in this slot.  Cache the initial state here.
-    ///
-    /// Note: The initial state must be strictly from an ancestor,
-    /// and not an intermediate state within this slot.
-    cache_for_accounts_lt_hash: DashMap<Pubkey, AccountsLtHashCacheValue, ahash::RandomState>,
-
-    /// Stats related to the accounts lt hash
-    stats_for_accounts_lt_hash: AccountsLtHashStats,
+    /// Track progress of the asynchronous accounts lt hashing for this Bank.
+    accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress,
 
     /// The unique identifier for the corresponding block for this bank.
     /// None for banks that have not yet completed replay or for leader banks as we cannot populate block_id
@@ -1225,8 +1214,7 @@ impl Bank {
             #[cfg(feature = "dev-context-only-utils")]
             hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
             accounts_lt_hash: Mutex::new(AccountsLtHash(LtHash::identity())),
-            cache_for_accounts_lt_hash: DashMap::default(),
-            stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
+            accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress::new(),
             block_id: RwLock::new(None),
             expected_bank_hash: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
@@ -1485,8 +1473,7 @@ impl Bank {
             #[cfg(feature = "dev-context-only-utils")]
             hash_overrides: parent.hash_overrides.clone(),
             accounts_lt_hash: Mutex::new(parent.accounts_lt_hash.lock().unwrap().clone()),
-            cache_for_accounts_lt_hash: DashMap::default(),
-            stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
+            accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress::new(),
             block_id: RwLock::new(None),
             expected_bank_hash: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
@@ -1516,7 +1503,6 @@ impl Bank {
             slot,
             parent.slot(),
             new.block_height,
-            prepare_timings.num_accounts_modified_this_slot,
             NewBankTimings {
                 bank_rc_creation_time_us,
                 total_elapsed_time_us: time.as_us(),
@@ -1536,8 +1522,6 @@ impl Bank {
                 cache_preparation_time_us: prepare_timings.cache_preparation_time_us,
                 update_sysvars_time_us: prepare_timings.update_sysvars_time_us,
                 fill_sysvar_cache_time_us: prepare_timings.fill_sysvar_cache_time_us,
-                populate_cache_for_accounts_lt_hash_us: prepare_timings
-                    .populate_cache_for_accounts_lt_hash_us,
             },
         );
 
@@ -1984,34 +1968,12 @@ impl Bank {
                 .fill_missing_sysvar_cache_entries(self)
         );
 
-        let (num_accounts_modified_this_slot, populate_cache_for_accounts_lt_hash_us) =
-            measure_us!({
-                // The cache for accounts lt hash needs to be made aware of accounts modified
-                // before transaction processing begins.  Otherwise we may calculate the wrong
-                // accounts lt hash due to having the wrong initial state of the account.  The
-                // lt hash cache's initial state must always be from an ancestor, and cannot be
-                // an intermediate state within this Bank's slot.  If the lt hash cache has the
-                // wrong initial account state, we'll mix out the wrong lt hash value, and thus
-                // have the wrong overall accounts lt hash, and diverge.
-                let accounts_modified_this_slot =
-                    self.rc.accounts.accounts_db.get_pubkeys_for_slot(slot);
-                let num_accounts_modified_this_slot = accounts_modified_this_slot.len();
-                for pubkey in accounts_modified_this_slot {
-                    self.cache_for_accounts_lt_hash
-                        .entry(pubkey)
-                        .or_insert(AccountsLtHashCacheValue::BankNew);
-                }
-                num_accounts_modified_this_slot
-            });
-
         PrepareBlockExecutionStats {
             update_epoch_time_us,
             distribute_rewards_time_us,
             cache_preparation_time_us,
             update_sysvars_time_us,
             fill_sysvar_cache_time_us,
-            num_accounts_modified_this_slot,
-            populate_cache_for_accounts_lt_hash_us,
         }
     }
 
@@ -2170,8 +2132,7 @@ impl Bank {
             #[cfg(feature = "dev-context-only-utils")]
             hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
             accounts_lt_hash: Mutex::new(fields.accounts_lt_hash),
-            cache_for_accounts_lt_hash: DashMap::default(),
-            stats_for_accounts_lt_hash: AccountsLtHashStats::default(),
+            accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress::new(),
             block_id: RwLock::new(fields.block_id),
             bank_hash_stats: AtomicBankHashStats::new(&fields.bank_hash_stats),
             epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
@@ -3022,7 +2983,7 @@ impl Bank {
             self.freeze_started.store(true, Relaxed);
             // updating the accounts lt hash must happen *outside* of hash_internal_state() so
             // that rehash() can be called and *not* modify self.accounts_lt_hash.
-            self.update_accounts_lt_hash();
+            self.finish_accounts_lt_hash_updates();
             *hash = self.hash_internal_state();
             self.rc.accounts.accounts_db.mark_slot_frozen(self.slot());
         }
@@ -4294,6 +4255,7 @@ impl Bank {
 
             let to_store = (self.slot(), accounts_to_store.as_slice());
             self.update_bank_hash_stats(&to_store);
+            self.enqueue_accounts_lt_hash_updates(&to_store);
             // See https://github.com/solana-labs/solana/pull/31455 for discussion
             // on *not* updating the index within a threadpool.
             self.rc
@@ -4689,6 +4651,7 @@ impl Bank {
     fn store_accounts_without_stakes_cache<'a>(&self, accounts: impl StorableAccounts<'a>) {
         assert!(!self.freeze_started());
         self.update_bank_hash_stats(&accounts);
+        self.enqueue_accounts_lt_hash_updates(&accounts);
         self.rc
             .accounts
             .store_accounts_par(accounts, None, &self.ancestors);
@@ -6679,8 +6642,8 @@ impl TransactionProcessingCallback for Bank {
             .load_with_fixed_root(&self.ancestors, pubkey)
     }
 
-    fn inspect_account(&self, address: &Pubkey, account_state: AccountState, is_writable: bool) {
-        self.inspect_account_for_accounts_lt_hash(address, &account_state, is_writable);
+    fn inspect_account(&self, _address: &Pubkey, _account_state: AccountState, _is_writable: bool) {
+        // nothing to do here
     }
 }
 

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -1,388 +1,437 @@
 use {
-    super::Bank,
-    rayon::prelude::*,
-    solana_account::{AccountSharedData, accounts_equal},
-    solana_accounts_db::accounts_db::AccountsDb,
-    solana_hash::Hash,
+    super::{Bank, NUM_REPLAY_HASH_THREADS, replay_hash_thread_pool},
+    ahash::AHashSet,
+    crossbeam_queue::SegQueue,
+    rayon::ThreadPool,
+    solana_account::{AccountSharedData, ReadableAccount, accounts_equal},
+    solana_accounts_db::{accounts_db::AccountsDb, storable_accounts::StorableAccounts},
     solana_lattice_hash::lt_hash::LtHash,
-    solana_measure::{meas_dur, measure::Measure},
+    solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
-    solana_svm_callback::AccountState,
     std::{
-        ops::AddAssign,
-        sync::atomic::{AtomicU64, Ordering},
-        time::Duration,
+        any::Any,
+        cmp, iter,
+        num::Saturating,
+        panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
+        sync::{
+            Arc, LazyLock, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
     },
 };
 
 impl Bank {
-    /// Updates the accounts lt hash
+    /// Enqueues the accounts lt hash updates for `accounts` to the replay-hash thread pool.
+    pub fn enqueue_accounts_lt_hash_updates<'a>(&self, accounts: &impl StorableAccounts<'a>) {
+        if accounts.is_empty() {
+            return;
+        }
+
+        let pending_updates_freelist = pending_updates_freelist();
+        let mut pending_updates = pending_updates_freelist.pop().unwrap_or_default();
+        let mut seen = AHashSet::with_capacity(accounts.len());
+        // process accounts in reverse because we must only count the latest version of each account
+        for index in (0..accounts.len()).rev() {
+            let address = accounts.pubkey(index);
+            if !seen.insert(*address) {
+                // we've already enqueued a newer update for the same account; skip this one
+                continue;
+            }
+            let prev_account = self
+                .rc
+                .accounts
+                .load_with_fixed_root_do_not_populate_read_cache(&self.ancestors, address)
+                .map(|(account, _slot)| account);
+            let curr_account = accounts.account(index, |account| {
+                (account.lamports() != 0).then(|| account.take_account())
+            });
+            match (&prev_account, &curr_account) {
+                (None, None) => {
+                    // the account is ephemeral; skip it
+                }
+                (Some(a), Some(b)) if accounts_equal(a, b) => {
+                    // the account was not modified; skip it
+                }
+                _ => {
+                    // the account was modified; enqueue this update
+                    let hash_cost = calc_hash_cost(prev_account.as_ref())
+                        + calc_hash_cost(curr_account.as_ref());
+                    pending_updates.push(PendingUpdate {
+                        hash_cost,
+                        update: AccountsLtHashUpdate {
+                            address: *address,
+                            prev_account,
+                            curr_account,
+                        },
+                    });
+                }
+            }
+        }
+
+        // Split the pending updates in batches; minimum one per replay-hash thread.
+        // Attempt to evenly distribute the hashing work, based on the "hash cost",
+        // which is effectively the number of bytes to hash per update.
+        let num_updates = pending_updates.len();
+        let num_batches = num_updates.div_ceil(MAX_BATCHED_UPDATES_PER_VEC);
+        let num_batches = cmp::max(num_batches, NUM_REPLAY_HASH_THREADS);
+        let batched_updates_freelist = batched_updates_freelist();
+        let mut batches: Box<_> = iter::repeat_with(|| AccountsLtHashBatch {
+            updates: batched_updates_freelist
+                .pop()
+                .unwrap_or_else(|| Vec::with_capacity(MAX_BATCHED_UPDATES_PER_VEC)),
+            hash_cost: 0,
+        })
+        .take(num_batches)
+        .collect();
+
+        pending_updates
+            .sort_unstable_by_key(|pending_update| cmp::Reverse(pending_update.hash_cost));
+        for pending_update in pending_updates.drain(..) {
+            let batch = batches
+                .iter_mut()
+                .min_by_key(|batch| batch.hash_cost)
+                .unwrap();
+            let PendingUpdate { update, hash_cost } = pending_update;
+            batch.hash_cost += hash_cost;
+            batch.updates.push(update);
+        }
+
+        // Dispatch the batched updates to the replay-hash thread pool.
+        // If any of the batches were unused, reclaim them and add them
+        // back to the freelist.
+        let async_progress = &self.accounts_lt_hash_async_progress;
+        let thread_pool = replay_hash_thread_pool();
+        for batch in batches {
+            let updates = batch.updates;
+            if !updates.is_empty() {
+                async_progress.spawn(thread_pool, updates);
+            } else {
+                batched_updates_freelist.push(updates);
+            }
+        }
+
+        // Reclaim the pending updates too!
+        pending_updates_freelist.push(pending_updates);
+    }
+
+    /// Updates the accounts lt hash.
     ///
     /// When freezing a bank, we compute and update the accounts lt hash.
     /// For each account modified in this bank, we:
     /// - mix out its previous state, and
     /// - mix in its current state
     ///
+    /// This function waits for any in-flight jobs on the replay-hash threads,
+    /// computes their combined delta lt hash, then mixes it into the bank.
+    ///
     /// Since this function is non-idempotent, it should only be called once per bank.
-    pub fn update_accounts_lt_hash(&self) {
-        let delta_lt_hash = self.calculate_delta_lt_hash();
-        let mut accounts_lt_hash = self.accounts_lt_hash.lock().unwrap();
-        accounts_lt_hash.0.mix_in(&delta_lt_hash);
-    }
-
-    /// Calculates the lt hash *of only this slot*
-    ///
-    /// This can be thought of as akin to the accounts delta hash.
-    ///
-    /// For each account modified in this bank, we:
-    /// - mix out its previous state, and
-    /// - mix in its current state
-    ///
-    /// This function is idempotent, and may be called more than once.
-    fn calculate_delta_lt_hash(&self) -> LtHash {
-        let measure_total = Measure::start("");
-        let slot = self.slot();
-
-        // If we don't find the account in the cache, we need to go load it.
-        // We want the version of the account *before* it was written in this slot.
-        // Bank::ancestors *includes* this slot, so we need to remove it before loading.
-        let strictly_ancestors = {
-            let mut ancestors = self.ancestors.clone();
-            ancestors.remove(&self.slot());
-            ancestors
-        };
-
-        if slot == 0 {
-            // Slot 0 is special when calculating the accounts lt hash.
-            // Primordial accounts (those in genesis) that are modified by transaction processing
-            // in slot 0 will have Alive entries in the accounts lt hash cache.
-            // When calculating the accounts lt hash, if an account was initially alive, we mix
-            // *out* its previous lt hash value.  In slot 0, we haven't stored any previous lt hash
-            // values (since it is in the first slot), yet we'd still mix out these accounts!
-            // This produces the incorrect accounts lt hash.
-            // From the perspective of the accounts lt hash, in slot 0 we cannot have any accounts
-            // as previously alive.  So to work around this issue, we clear the cache.
-            // And since `strictly_ancestors` is empty, loading the previous version of the account
-            // from accounts db will return `None` (aka Dead), which is the correct behavior.
-            assert!(strictly_ancestors.is_empty());
-            self.cache_for_accounts_lt_hash.clear();
+    pub(crate) fn finish_accounts_lt_hash_updates(&self) {
+        let finish_time = Measure::start("");
+        let (delta_lt_hash, stats, num_jobs_total, should_mix_in) =
+            self.accounts_lt_hash_async_progress.finish();
+        if should_mix_in {
+            self.accounts_lt_hash
+                .lock()
+                .unwrap()
+                .0
+                .mix_in(&delta_lt_hash);
         }
-
-        // Get all the accounts stored in this slot.
-        // Since this bank is in the middle of being frozen, it hasn't been rooted.
-        // That means the accounts should all be in the write cache, and loading will be fast.
-        let (accounts_curr, time_loading_accounts_curr) = meas_dur!({
-            self.rc
-                .accounts
-                .accounts_db
-                .get_pubkey_account_for_slot(slot)
-        });
-        let num_accounts_total = accounts_curr.len();
-
-        #[derive(Debug, Default)]
-        struct Stats {
-            num_cache_misses: usize,
-            num_accounts_unmodified: usize,
-            time_loading_accounts_prev: Duration,
-            time_comparing_accounts: Duration,
-            time_computing_hashes: Duration,
-            time_mixing_hashes: Duration,
-        }
-        impl AddAssign for Stats {
-            fn add_assign(&mut self, other: Self) {
-                self.num_cache_misses += other.num_cache_misses;
-                self.num_accounts_unmodified += other.num_accounts_unmodified;
-                self.time_loading_accounts_prev += other.time_loading_accounts_prev;
-                self.time_comparing_accounts += other.time_comparing_accounts;
-                self.time_computing_hashes += other.time_computing_hashes;
-                self.time_mixing_hashes += other.time_mixing_hashes;
-            }
-        }
-
-        let do_calculate_delta_lt_hash = || {
-            // Work on chunks of 128 pubkeys, which is 4 KiB.
-            // And 4 KiB is likely the smallest a real page size will be.
-            // And a single page is likely the smallest size a disk read will actually read.
-            // This can be tuned larger, but likely not smaller.
-            const CHUNK_SIZE: usize = 128;
-            accounts_curr
-                .par_iter()
-                .fold_chunks(
-                    CHUNK_SIZE,
-                    || (LtHash::identity(), Stats::default()),
-                    |mut accum, (pubkey, curr_account)| {
-                        // load the initial state of the account
-                        let (initial_state_of_account, measure_load) = meas_dur!({
-                            let cache_value = self
-                                .cache_for_accounts_lt_hash
-                                .get(pubkey)
-                                .map(|entry| entry.value().clone());
-                            match cache_value {
-                                Some(CacheValue::InspectAccount(initial_state_of_account)) => {
-                                    initial_state_of_account
-                                }
-                                Some(CacheValue::BankNew) | None => {
-                                    accum.1.num_cache_misses += 1;
-                                    // If the initial state of the account is not in the accounts
-                                    // lt hash cache, or is explicitly unknown, then it is likely
-                                    // this account was stored *outside* of transaction processing
-                                    // (e.g. creating a new bank).
-                                    // Do not populate the read cache, as this account likely will
-                                    // not be accessed again soon.
-                                    let account_slot = self
-                                        .rc
-                                        .accounts
-                                        .load_with_fixed_root_do_not_populate_read_cache(
-                                            &strictly_ancestors,
-                                            pubkey,
-                                        );
-                                    match account_slot {
-                                        Some((account, _slot)) => {
-                                            InitialStateOfAccount::Alive(account)
-                                        }
-                                        None => InitialStateOfAccount::Dead,
-                                    }
-                                }
-                            }
-                        });
-                        accum.1.time_loading_accounts_prev += measure_load;
-
-                        // mix out the previous version of the account
-                        match initial_state_of_account {
-                            InitialStateOfAccount::Dead => {
-                                // nothing to do here
-                            }
-                            InitialStateOfAccount::Alive(prev_account) => {
-                                let (are_accounts_equal, measure_is_equal) =
-                                    meas_dur!(accounts_equal(curr_account, &prev_account));
-                                accum.1.time_comparing_accounts += measure_is_equal;
-                                if are_accounts_equal {
-                                    // this account didn't actually change, so skip it for lt hashing
-                                    accum.1.num_accounts_unmodified += 1;
-                                    return accum;
-                                }
-                                let (prev_lt_hash, measure_hashing) =
-                                    meas_dur!(AccountsDb::lt_hash_account(&prev_account, pubkey));
-                                let (_, measure_mixing) =
-                                    meas_dur!(accum.0.mix_out(&prev_lt_hash.0));
-                                accum.1.time_computing_hashes += measure_hashing;
-                                accum.1.time_mixing_hashes += measure_mixing;
-                            }
-                        }
-
-                        // mix in the new version of the account
-                        let (curr_lt_hash, measure_hashing) =
-                            meas_dur!(AccountsDb::lt_hash_account(curr_account, pubkey));
-                        let (_, measure_mixing) = meas_dur!(accum.0.mix_in(&curr_lt_hash.0));
-                        accum.1.time_computing_hashes += measure_hashing;
-                        accum.1.time_mixing_hashes += measure_mixing;
-
-                        accum
-                    },
-                )
-                .reduce(
-                    || (LtHash::identity(), Stats::default()),
-                    |mut accum, elem| {
-                        accum.0.mix_in(&elem.0);
-                        accum.1 += elem.1;
-                        accum
-                    },
-                )
-        };
-        let (delta_lt_hash, stats) = self
-            .rc
-            .accounts
-            .accounts_db
-            .thread_pool_foreground
-            .install(do_calculate_delta_lt_hash);
-
-        let total_time = measure_total.end_as_duration();
-        let num_accounts_modified =
-            num_accounts_total.saturating_sub(stats.num_accounts_unmodified);
+        let finish_us = finish_time.end_as_us();
+        let batched_updates_freelist = batched_updates_freelist();
+        let batched_updates_freelist_capacity = batched_updates_freelist
+            .total_capacity
+            .load(Ordering::Relaxed);
+        let pending_updates_freelist = pending_updates_freelist();
+        let pending_updates_freelist_capacity = pending_updates_freelist
+            .total_capacity
+            .load(Ordering::Relaxed);
         datapoint_info!(
             "bank-accounts_lt_hash",
-            ("slot", slot, i64),
-            ("num_accounts_total", num_accounts_total, i64),
-            ("num_accounts_modified", num_accounts_modified, i64),
+            ("slot", self.slot(), i64),
+            ("num_jobs", num_jobs_total.0, i64),
+            ("num_updates", stats.num_updates.0, i64),
+            ("finish_us", finish_us, i64),
             (
-                "num_accounts_unmodified",
-                stats.num_accounts_unmodified,
-                i64
-            ),
-            ("num_cache_misses", stats.num_cache_misses, i64),
-            ("total_us", total_time.as_micros(), i64),
-            (
-                "loading_accounts_curr_us",
-                time_loading_accounts_curr.as_micros(),
+                "batched_updates_freelist_num_vecs",
+                batched_updates_freelist.num_vecs.load(Ordering::Relaxed),
                 i64
             ),
             (
-                "par_loading_accounts_prev_us",
-                stats.time_loading_accounts_prev.as_micros(),
+                "batched_updates_freelist_capacity_elems",
+                batched_updates_freelist_capacity,
                 i64
             ),
             (
-                "par_comparing_accounts_us",
-                stats.time_comparing_accounts.as_micros(),
+                "batched_updates_freelist_capacity_bytes",
+                batched_updates_freelist_capacity * size_of::<AccountsLtHashUpdate>(),
                 i64
             ),
             (
-                "par_computing_hashes_us",
-                stats.time_computing_hashes.as_micros(),
+                "pending_updates_freelist_num_vecs",
+                pending_updates_freelist.num_vecs.load(Ordering::Relaxed),
                 i64
             ),
             (
-                "par_mixing_hashes_us",
-                stats.time_mixing_hashes.as_micros(),
+                "pending_updates_freelist_capacity_elems",
+                pending_updates_freelist_capacity,
                 i64
             ),
             (
-                "num_inspect_account_hits",
-                self.stats_for_accounts_lt_hash
-                    .num_inspect_account_hits
-                    .load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_inspect_account_misses",
-                self.stats_for_accounts_lt_hash
-                    .num_inspect_account_misses
-                    .load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_inspect_account_after_frozen",
-                self.stats_for_accounts_lt_hash
-                    .num_inspect_account_after_frozen
-                    .load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "inspect_account_lookup_ns",
-                self.stats_for_accounts_lt_hash
-                    .inspect_account_lookup_time_ns
-                    .load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "inspect_account_insert_ns",
-                self.stats_for_accounts_lt_hash
-                    .inspect_account_insert_time_ns
-                    .load(Ordering::Relaxed),
+                "pending_updates_freelist_capacity_bytes",
+                pending_updates_freelist_capacity * size_of::<PendingUpdate>(),
                 i64
             ),
         );
+    }
+}
 
-        delta_lt_hash
+/// Struct for tracking progress of the asynchronous accounts lt hashing for a Bank.
+pub struct AccountsLtHashAsyncProgress {
+    accumulator: Arc<Mutex<AccountsLtHashAccumulator>>,
+    num_jobs_pending: Arc<AtomicUsize>,
+    state: Mutex<AsyncProgressState>,
+}
+
+impl AccountsLtHashAsyncProgress {
+    /// Creates a new AccountsLtHashAsyncProgress variable, which is suitable for a new Bank.
+    pub fn new() -> Self {
+        let accumulator = AccountsLtHashAccumulator {
+            lt_hash: LtHash::identity(),
+            stats: UpdateStats::default(),
+            first_panic: None,
+        };
+        Self {
+            accumulator: Arc::new(Mutex::new(accumulator)),
+            num_jobs_pending: Arc::new(AtomicUsize::new(0)),
+            state: Mutex::new(AsyncProgressState {
+                num_jobs_total: Saturating(0),
+                is_finalized: false,
+            }),
+        }
     }
 
-    /// Caches initial state of writeable accounts
+    /// Enqueues `updates` into `thread_pool` for asynchronous processing.
     ///
-    /// If a transaction account is writeable, cache its initial account state.
-    /// The initial state is needed when computing the accounts lt hash for the slot, and caching
-    /// the initial state saves us from having to look it up on disk later.
-    pub fn inspect_account_for_accounts_lt_hash(
-        &self,
-        address: &Pubkey,
-        account_state: &AccountState,
-        is_writable: bool,
-    ) {
-        if !is_writable {
-            // if the account is not writable, then it cannot be modified; nothing to do here
-            return;
+    /// Panics if `updates` is empty, or if `self` was already finalized.
+    fn spawn(&self, thread_pool: &'static ThreadPool, updates: Vec<AccountsLtHashUpdate>) {
+        debug_assert!(!updates.is_empty());
+        {
+            let mut state = self.state.lock().unwrap();
+            assert!(!state.is_finalized);
+            state.num_jobs_total += 1;
+            self.num_jobs_pending.fetch_add(1, Ordering::Relaxed);
         }
+        let accumulator = Arc::clone(&self.accumulator);
+        let num_jobs_pending = Arc::clone(&self.num_jobs_pending);
+        thread_pool.spawn(move || {
+            let mut updates = updates;
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                let num_updates = Saturating(updates.len() as u64);
+                let lt_hash = Self::process(&mut updates);
+                let mut accumulator = accumulator.lock().unwrap_or_else(|err| err.into_inner());
+                accumulator.lt_hash.mix_in(&lt_hash);
+                accumulator.stats.num_updates += num_updates;
+            }));
 
-        // Only insert the account the *first* time we see it.
-        // We want to capture the value of the account *before* any modifications during this slot.
-        let (is_in_cache, lookup_time) =
-            meas_dur!(self.cache_for_accounts_lt_hash.contains_key(address));
-        if !is_in_cache {
-            // We need to check if the bank is frozen.  In order to do that safely, we
-            // must hold a read lock on Bank::hash to read the frozen state.
-            let freeze_guard = self.freeze_lock();
-            let is_frozen = *freeze_guard != Hash::default();
-            if is_frozen {
-                // If the bank is frozen, do not add this account to the cache.
-                // It is possible for the leader to be executing transactions after freeze has
-                // started, i.e. while any deferred changes to account state is finishing up.
-                // This means the transaction could load an account *after* it was modified by the
-                // deferred changes, which would be the wrong initial state of the account.
-                // Inserting the wrong initial state of an account into the cache will end up
-                // producing the wrong accounts lt hash.
-                self.stats_for_accounts_lt_hash
-                    .num_inspect_account_after_frozen
-                    .fetch_add(1, Ordering::Relaxed);
-                return;
+            // make sure to clear the updates vec just in case the drain() was interrupted
+            updates.clear();
+            batched_updates_freelist().push(updates);
+
+            if let Err(payload) = result {
+                let mut accumulator = accumulator.lock().unwrap_or_else(|err| err.into_inner());
+                if accumulator.first_panic.is_none() {
+                    accumulator.first_panic = Some(payload);
+                }
             }
-            let (_, insert_time) = meas_dur!({
-                self.cache_for_accounts_lt_hash
-                    .entry(*address)
-                    .or_insert_with(|| {
-                        let initial_state_of_account = match account_state {
-                            AccountState::Dead => InitialStateOfAccount::Dead,
-                            AccountState::Alive(account) => {
-                                InitialStateOfAccount::Alive((*account).clone())
-                            }
-                        };
-                        CacheValue::InspectAccount(initial_state_of_account)
-                    });
-            });
-            drop(freeze_guard);
 
-            self.stats_for_accounts_lt_hash
-                .num_inspect_account_misses
-                .fetch_add(1, Ordering::Relaxed);
-            self.stats_for_accounts_lt_hash
-                .inspect_account_insert_time_ns
-                // N.B. this needs to be nanoseconds because it can be so fast
-                .fetch_add(insert_time.as_nanos() as u64, Ordering::Relaxed);
-        } else {
-            // The account is already in the cache, so nothing to do here other than update stats.
-            self.stats_for_accounts_lt_hash
-                .num_inspect_account_hits
-                .fetch_add(1, Ordering::Relaxed);
+            num_jobs_pending.fetch_sub(1, Ordering::Release);
+        });
+    }
+
+    /// Processes `updates` and returns their overall accounts lt hash.
+    fn process(updates: &mut Vec<AccountsLtHashUpdate>) -> LtHash {
+        let mut accum_lt_hash = LtHash::identity();
+        for update in updates.drain(..) {
+            let AccountsLtHashUpdate {
+                address,
+                prev_account,
+                curr_account,
+            } = update;
+            if let Some(prev_account) = prev_account {
+                let prev_lt_hash = AccountsDb::lt_hash_account(&prev_account, &address);
+                accum_lt_hash.mix_out(&prev_lt_hash.0);
+            }
+            if let Some(curr_account) = curr_account {
+                let curr_lt_hash = AccountsDb::lt_hash_account(&curr_account, &address);
+                accum_lt_hash.mix_in(&curr_lt_hash.0);
+            }
+        }
+        accum_lt_hash
+    }
+
+    /// Finalizes the asynchronous accounts lt hash updates.
+    ///
+    /// This fn waits for all pending jobs to complete, then returns:
+    /// * the overall accounts lt hash
+    /// * the stats from all the updates
+    /// * the number of asynchronous jobs
+    /// * if this was the first time finish() was called
+    fn finish(&self) -> (LtHash, UpdateStats, Saturating<u64>, bool) {
+        // make sure to lock `state` before spinning on num_jobs_pending
+        // to ensure no new jobs are added
+        let mut state = self.state.lock().unwrap();
+        while self.num_jobs_pending.load(Ordering::Acquire) > 0 {
+            // Spin, do not yield! This is called by Bank::freeze() and we want to be fast.
         }
 
-        self.stats_for_accounts_lt_hash
-            .inspect_account_lookup_time_ns
-            // N.B. this needs to be nanoseconds because it can be so fast
-            .fetch_add(lookup_time.as_nanos() as u64, Ordering::Relaxed);
+        let mut accumulator = self
+            .accumulator
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        if let Some(payload) = accumulator.first_panic.take() {
+            resume_unwind(payload);
+        }
+        let was_finalized = state.is_finalized;
+        state.is_finalized = true;
+        (
+            accumulator.lt_hash.clone(),
+            accumulator.stats.clone(),
+            state.num_jobs_total,
+            !was_finalized,
+        )
     }
 }
 
-/// Stats related to accounts lt hash
-#[derive(Debug, Default)]
-pub struct Stats {
-    /// the number of times the cache already contained the account being inspected
-    num_inspect_account_hits: AtomicU64,
-    /// the number of times the cache *did not* already contain the account being inspected
-    num_inspect_account_misses: AtomicU64,
-    /// the number of times an account was inspected after the bank was frozen
-    num_inspect_account_after_frozen: AtomicU64,
-    /// time spent checking if accounts are in the cache
-    inspect_account_lookup_time_ns: AtomicU64,
-    /// time spent inserting accounts into the cache
-    inspect_account_insert_time_ns: AtomicU64,
+/// A batch of accounts lt hash updates to process.
+#[derive(Default)]
+struct AccountsLtHashBatch {
+    updates: Vec<AccountsLtHashUpdate>,
+    hash_cost: usize,
 }
 
-/// The initial state of an account prior to being modified in this slot/transaction
-#[derive(Debug, Clone, PartialEq)]
-pub enum InitialStateOfAccount {
-    /// The account was initially dead
-    Dead,
-    /// The account was initially alive
-    Alive(AccountSharedData),
+/// The struct to accumulate results from processing a batch of updates.
+struct AccountsLtHashAccumulator {
+    lt_hash: LtHash,
+    stats: UpdateStats,
+    first_panic: Option<Box<dyn Any + Send + 'static>>,
 }
 
-/// The value type for the accounts lt hash cache
-#[derive(Debug, Clone, PartialEq)]
-pub enum CacheValue {
-    /// The value was inserted by `inspect_account()`.
-    /// This means we will have the initial state of the account.
-    InspectAccount(InitialStateOfAccount),
-    /// The value was inserted by `Bank::new()`.
-    /// This means we will *not* have the initial state of the account.
-    BankNew,
+/// Stats from processing a batch of updates.
+#[derive(Clone, Debug, Default)]
+struct UpdateStats {
+    num_updates: Saturating<u64>,
+}
+
+/// The state of the asynchronous progress itself.
+#[derive(Debug)]
+struct AsyncProgressState {
+    num_jobs_total: Saturating<u64>,
+    is_finalized: bool,
+}
+
+/// A single accounts lt hash update to process.
+#[derive(Debug)]
+struct AccountsLtHashUpdate {
+    address: Pubkey,
+    prev_account: Option<AccountSharedData>,
+    curr_account: Option<AccountSharedData>,
+}
+
+// brooks TODO: doc
+//│ 23 │/// The number of lt hash updates to batch up before sending to the async thread pool.                                      │    │
+//│ 24 │///                                                                                                                         │    │
+//│ 25 │/// The 14 KiB number is the current largest size of jemalloc's "small slab" bins,                                          │    │
+//│ 26 │/// which should help with reuse.                                                                                           │    │
+//│ 27 │const MAX_BATCH_SIZE: usize = 14 * 1024 / size_of::<AccountsLtHashUpdate>();                                                │    │
+const MAX_BATCHED_UPDATES_VEC_BYTES: usize = 14 * 1024;
+const MAX_BATCHED_UPDATES_PER_VEC: usize =
+    MAX_BATCHED_UPDATES_VEC_BYTES / size_of::<AccountsLtHashUpdate>();
+const _: () = assert!(MAX_BATCHED_UPDATES_PER_VEC > 0);
+
+/// Get the freelist of vectors to use for batching updates.
+fn batched_updates_freelist() -> &'static VecFreelist<AccountsLtHashUpdate> {
+    static FREELIST: LazyLock<VecFreelist<AccountsLtHashUpdate>> = LazyLock::new(VecFreelist::new);
+    &FREELIST
+}
+
+/// A pending update, used to put into batches for processing.
+#[derive(Debug)]
+struct PendingUpdate {
+    update: AccountsLtHashUpdate,
+    hash_cost: usize,
+}
+
+/// Get the freelist of vectors to use for holding pending updates.
+fn pending_updates_freelist() -> &'static VecFreelist<PendingUpdate> {
+    static FREELIST: LazyLock<VecFreelist<PendingUpdate>> = LazyLock::new(VecFreelist::new);
+    &FREELIST
+}
+
+/// Freelist of vectors, to avoid repeat allocations/deallocations.
+#[derive(Debug)]
+struct VecFreelist<T> {
+    list: SegQueue<Vec<T>>,
+
+    // stats
+    num_vecs: AtomicUsize,
+    total_capacity: AtomicUsize,
+}
+
+impl<T> VecFreelist<T> {
+    /// Creates a new, empty, freelist.
+    fn new() -> Self {
+        Self {
+            list: SegQueue::new(),
+            num_vecs: AtomicUsize::new(0),
+            total_capacity: AtomicUsize::new(0),
+        }
+    }
+
+    /// Pushes `vec` on to the freelist (IFF its capacity is greater than zero).
+    ///
+    /// Panics if `vec` is not empty.
+    fn push(&self, vec: Vec<T>) {
+        // If the capacity is zero, then the Vec never allocated.  In that case, don't waste time
+        // putting it back into the freelist, since there's nothing of value to reuse.
+        let capacity = vec.capacity();
+        if capacity != 0 {
+            assert!(vec.is_empty());
+            self.list.push(vec);
+            self.num_vecs.fetch_add(1, Ordering::Relaxed);
+            self.total_capacity.fetch_add(capacity, Ordering::Relaxed);
+        }
+    }
+
+    /// Pops a vec off the freelist and returns it.
+    ///
+    /// The returned vec will always be empty.
+    fn pop(&self) -> Option<Vec<T>> {
+        let vec = self.list.pop()?;
+        assert!(vec.is_empty());
+        self.num_vecs.fetch_sub(1, Ordering::Relaxed);
+        self.total_capacity
+            .fetch_sub(vec.capacity(), Ordering::Relaxed);
+        Some(vec)
+    }
+}
+
+/// Calculates the cost of hashing an account.
+///
+/// Which is an approximation based on the number of bytes to hash.
+#[inline]
+fn calc_hash_cost(account: Option<&impl ReadableAccount>) -> usize {
+    const ACCOUNT_HASH_METADATA_BYTES: usize = 8 /* lamports */
+    + 1 /* executable */
+    + 32 /* owner */
+    + 32 /* address */;
+
+    account.map_or(0, |account| {
+        if account.lamports() == 0 {
+            0
+        } else {
+            account.data().len() + ACCOUNT_HASH_METADATA_BYTES
+        }
+    })
 }
 
 #[cfg(test)]
@@ -395,7 +444,6 @@ mod tests {
         },
         agave_feature_set::FeatureSet,
         agave_snapshots::snapshot_config::SnapshotConfig,
-        solana_account::{ReadableAccount as _, WritableAccount as _},
         solana_accounts_db::{
             accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
             accounts_index::{ACCOUNTS_INDEX_CONFIG_FOR_TESTING, AccountsIndexConfig, IndexLimit},
@@ -403,13 +451,20 @@ mod tests {
         solana_cluster_type::ClusterType,
         solana_fee_calculator::FeeRateGovernor,
         solana_genesis_config::{self, GenesisConfig},
+        solana_hash::Hash,
         solana_keypair::Keypair,
         solana_leader_schedule::SlotLeader,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_pubkey::{self as pubkey, Pubkey},
         solana_rent::Rent,
         solana_signer::Signer as _,
-        std::{cmp, iter, str::FromStr as _, sync::Arc},
+        std::{
+            cmp, iter,
+            str::FromStr as _,
+            sync::Arc,
+            thread,
+            time::{Duration, Instant},
+        },
         tempfile::TempDir,
         test_case::{test_case, test_matrix},
     };
@@ -495,7 +550,7 @@ mod tests {
         bank.transfer(amount, &mint_keypair, &keypair5.pubkey())
             .unwrap();
 
-        // manually freeze the bank to trigger update_accounts_lt_hash() to run
+        // manually freeze the bank to trigger updating the accounts lt hash
         bank.freeze();
         let prev_accounts_lt_hash = bank.accounts_lt_hash.lock().unwrap().clone();
 
@@ -550,11 +605,19 @@ mod tests {
         // store account 5 into this new bank, unchanged
         bank.store_account(&keypair5.pubkey(), prev_account5.as_ref().unwrap());
 
-        // freeze the bank to trigger update_accounts_lt_hash() to run
+        // freeze the bank to trigger updating the accounts lt hash
         bank.freeze();
 
-        let actual_delta_lt_hash = bank.calculate_delta_lt_hash();
         let post_accounts_lt_hash = bank.accounts_lt_hash.lock().unwrap().clone();
+
+        // ensure the bank's accounts lt hash is only updated once,
+        // even if finish() is called multiple times
+        bank.finish_accounts_lt_hash_updates();
+        assert_eq!(
+            *bank.accounts_lt_hash.lock().unwrap(),
+            post_accounts_lt_hash,
+        );
+
         let post_mint = bank.get_account_with_fixed_root(&mint_keypair.pubkey());
         let post_account1 = bank.get_account_with_fixed_root(&keypair1.pubkey());
         let post_account2 = bank.get_account_with_fixed_root(&keypair2.pubkey());
@@ -574,21 +637,18 @@ mod tests {
             .map(|address| bank.get_account_with_fixed_root(address))
             .collect();
 
-        let mut expected_delta_lt_hash = LtHash::identity();
         let mut expected_accounts_lt_hash = prev_accounts_lt_hash;
         let mut updater =
             |address: &Pubkey, prev: Option<AccountSharedData>, post: Option<AccountSharedData>| {
                 // if there was an alive account, mix out
                 if let Some(prev) = prev {
                     let prev_lt_hash = AccountsDb::lt_hash_account(&prev, address);
-                    expected_delta_lt_hash.mix_out(&prev_lt_hash.0);
                     expected_accounts_lt_hash.0.mix_out(&prev_lt_hash.0);
                 }
 
                 // mix in the new one
                 let post = post.unwrap_or_default();
                 let post_lt_hash = AccountsDb::lt_hash_account(&post, address);
-                expected_delta_lt_hash.mix_in(&post_lt_hash.0);
                 expected_accounts_lt_hash.0.mix_in(&post_lt_hash.0);
             };
         updater(&mint_keypair.pubkey(), prev_mint, post_mint);
@@ -605,15 +665,7 @@ mod tests {
             );
         }
 
-        // now make sure the delta lt hashes match
-        let expected = expected_delta_lt_hash.checksum();
-        let actual = actual_delta_lt_hash.checksum();
-        assert_eq!(
-            expected, actual,
-            "delta_lt_hash, expected: {expected}, actual: {actual}",
-        );
-
-        // ...and the accounts lt hashes match too
+        // now make sure the accounts lt hashes match
         let expected = expected_accounts_lt_hash.0.checksum();
         let actual = post_accounts_lt_hash.0.checksum();
         assert_eq!(
@@ -626,7 +678,7 @@ mod tests {
     ///
     /// This test does a simple transfer in slot 0 so that a primordial account is modified.
     ///
-    /// See the comments in calculate_delta_lt_hash() for more information.
+    /// Slot 0 is special because primordial accounts have no previous accounts lt hash entry.
     #[test_case(Features::None; "no features")]
     #[test_case(Features::All; "all features")]
     fn test_slot0_accounts_lt_hash(features: Features) {
@@ -640,7 +692,7 @@ mod tests {
         bank.transfer(LAMPORTS_PER_SOL, &mint_keypair, &Pubkey::new_unique())
             .unwrap();
 
-        // manually freeze the bank to trigger update_accounts_lt_hash() to run
+        // manually freeze the bank to trigger updating the accounts lt hash
         bank.freeze();
         let actual_accounts_lt_hash = bank.accounts_lt_hash.lock().unwrap().clone();
 
@@ -651,114 +703,6 @@ mod tests {
             .accounts_db
             .calculate_accounts_lt_hash_at_startup_from_index(&bank.ancestors);
         assert_eq!(actual_accounts_lt_hash, calculated_accounts_lt_hash);
-    }
-
-    #[test_case(Features::None; "no features")]
-    #[test_case(Features::All; "all features")]
-    fn test_inspect_account_for_accounts_lt_hash(features: Features) {
-        let (genesis_config, _mint_keypair) = genesis_config_with(features);
-        let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-
-        // the cache should start off empty
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 0);
-
-        // ensure non-writable accounts are *not* added to the cache
-        bank.inspect_account_for_accounts_lt_hash(
-            &Pubkey::new_unique(),
-            &AccountState::Dead,
-            false,
-        );
-        bank.inspect_account_for_accounts_lt_hash(
-            &Pubkey::new_unique(),
-            &AccountState::Alive(&AccountSharedData::default()),
-            false,
-        );
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 0);
-
-        // ensure *new* accounts are added to the cache
-        let address = Pubkey::new_unique();
-        bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Dead, true);
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 1);
-        assert!(bank.cache_for_accounts_lt_hash.contains_key(&address));
-
-        // ensure *existing* accounts are added to the cache
-        let address = Pubkey::new_unique();
-        let initial_lamports = 123;
-        let mut account = AccountSharedData::new(initial_lamports, 0, &Pubkey::default());
-        bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Alive(&account), true);
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 2);
-        if let CacheValue::InspectAccount(InitialStateOfAccount::Alive(cached_account)) = bank
-            .cache_for_accounts_lt_hash
-            .get(&address)
-            .unwrap()
-            .value()
-        {
-            assert_eq!(*cached_account, account);
-        } else {
-            panic!("wrong initial state for account");
-        };
-
-        // ensure if an account is modified multiple times that we only cache the *first* one
-        let updated_lamports = account.lamports() + 1;
-        account.set_lamports(updated_lamports);
-        bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Alive(&account), true);
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 2);
-        if let CacheValue::InspectAccount(InitialStateOfAccount::Alive(cached_account)) = bank
-            .cache_for_accounts_lt_hash
-            .get(&address)
-            .unwrap()
-            .value()
-        {
-            assert_eq!(cached_account.lamports(), initial_lamports);
-        } else {
-            panic!("wrong initial state for account");
-        };
-
-        // and ensure multiple updates are handled correctly when the account is initially dead
-        {
-            let address = Pubkey::new_unique();
-            bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Dead, true);
-            assert_eq!(bank.cache_for_accounts_lt_hash.len(), 3);
-            match bank
-                .cache_for_accounts_lt_hash
-                .get(&address)
-                .unwrap()
-                .value()
-            {
-                CacheValue::InspectAccount(InitialStateOfAccount::Dead) => {
-                    // this is expected, nothing to do here
-                }
-                _ => panic!("wrong initial state for account"),
-            };
-
-            bank.inspect_account_for_accounts_lt_hash(
-                &address,
-                &AccountState::Alive(&AccountSharedData::default()),
-                true,
-            );
-            assert_eq!(bank.cache_for_accounts_lt_hash.len(), 3);
-            match bank
-                .cache_for_accounts_lt_hash
-                .get(&address)
-                .unwrap()
-                .value()
-            {
-                CacheValue::InspectAccount(InitialStateOfAccount::Dead) => {
-                    // this is expected, nothing to do here
-                }
-                _ => panic!("wrong initial state for account"),
-            };
-        }
-
-        // ensure accounts are *not* added to the cache if the bank is frozen
-        // N.B. this test should remain *last*, as Bank::freeze() is not meant to be undone
-        bank.freeze();
-        let address = Pubkey::new_unique();
-        let num_cache_entries_prev = bank.cache_for_accounts_lt_hash.len();
-        bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Dead, true);
-        let num_cache_entries_curr = bank.cache_for_accounts_lt_hash.len();
-        assert_eq!(num_cache_entries_curr, num_cache_entries_prev);
-        assert!(!bank.cache_for_accounts_lt_hash.contains_key(&address));
     }
 
     #[test_case(Features::None; "no features")]
@@ -924,45 +868,11 @@ mod tests {
         )
         .unwrap();
 
-        // Correctly calculating the accounts lt hash in Bank::new_from_snapshot() depends on the
-        // bank being frozen.  This is so we don't call `update_accounts_lt_hash()` twice on the
-        // same bank!
+        // Correctly restoring the accounts lt hash in Bank::new_from_snapshot() depends on the
+        // bank already being frozen so pending per-slot LT hash updates cannot be replayed.
         assert!(roundtrip_bank.is_frozen());
 
         assert_eq!(roundtrip_bank, *bank);
-    }
-
-    /// Ensure that accounts written in Bank::new() are added to the accounts lt hash cache.
-    #[test_case(Features::None; "no features")]
-    #[test_case(Features::All; "all features")]
-    fn test_accounts_lt_hash_cache_values_from_bank_new(features: Features) {
-        let (genesis_config, _mint_keypair) = genesis_config_with(features);
-        let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-
-        let slot = bank.slot() + 1;
-        bank =
-            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), slot);
-
-        // These are the two accounts *currently* added to the bank during Bank::new().
-        // More accounts could be added later, so if the test fails, inspect the actual cache
-        // accounts and update the expected cache accounts as necessary.
-        let expected_cache = &[
-            (
-                Pubkey::from_str_const("SysvarC1ock11111111111111111111111111111111"),
-                CacheValue::BankNew,
-            ),
-            (
-                Pubkey::from_str_const("SysvarS1otHashes111111111111111111111111111"),
-                CacheValue::BankNew,
-            ),
-        ];
-        let mut actual_cache: Vec<_> = bank
-            .cache_for_accounts_lt_hash
-            .iter()
-            .map(|entry| (*entry.key(), entry.value().clone()))
-            .collect();
-        actual_cache.sort_unstable_by_key(|a| a.0);
-        assert_eq!(expected_cache, actual_cache.as_slice());
     }
 
     /// Ensure that the snapshot hash is correct
@@ -1023,5 +933,78 @@ mod tests {
         .unwrap();
 
         assert_eq!(roundtrip_bank, *bank);
+    }
+
+    /// Ensure that spawn() and finish() do not race.
+    #[test]
+    fn test_finish_prevents_subsequent_spawn() {
+        fn new_accounts_lt_hash_update() -> AccountsLtHashUpdate {
+            let curr_account = Some(AccountSharedData::new(42, 0, &Pubkey::default()));
+            AccountsLtHashUpdate {
+                address: Pubkey::new_unique(),
+                prev_account: None,
+                curr_account,
+            }
+        }
+
+        // spin up a thread pool that'll process the async updates
+        let thread_pool: &'static ThreadPool = Box::leak(Box::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .unwrap(),
+        ));
+
+        // create some channels that'll initially block the thread pool,
+        // then unblock later after spawn() and finish() have been called
+        let (block_sender, block_receiver) = crossbeam_channel::unbounded();
+        let (unblock_sender, unblock_receiver) = crossbeam_channel::unbounded();
+        thread_pool.spawn(move || {
+            block_sender.send(()).unwrap();
+            unblock_receiver.recv().unwrap();
+        });
+        block_receiver.recv().unwrap();
+
+        // send updates to be processed asynchronously
+        let async_progress = Arc::new(AccountsLtHashAsyncProgress::new());
+        async_progress.spawn(thread_pool, vec![new_accounts_lt_hash_update()]);
+        assert_eq!(async_progress.num_jobs_pending.load(Ordering::Acquire), 1);
+
+        // call finish() to prevent additional async updates from being processed
+        let finish_thread = thread::spawn({
+            let async_progress = Arc::clone(&async_progress);
+            move || async_progress.finish()
+        });
+
+        // wait and ensure finish() has started
+        let start = Instant::now();
+        while async_progress.state.try_lock().is_ok() {
+            assert!(start.elapsed() < Duration::from_secs(1));
+            thread::yield_now();
+        }
+
+        // Send more async updates, which is not allowed since finish() already ran.
+        // We do this in another thread and catch the panic to not abort the test.
+        let spawn_thread = thread::spawn({
+            let async_progress = Arc::clone(&async_progress);
+            move || {
+                catch_unwind(AssertUnwindSafe(|| {
+                    async_progress.spawn(thread_pool, vec![new_accounts_lt_hash_update()]);
+                }))
+            }
+        });
+
+        // unblock the thread pool, which allows the async job to finally be processed
+        unblock_sender.send(()).unwrap();
+
+        // ensure after finish() completes that only a single job ran
+        let (_lt_hash, _stats, num_jobs_total, should_mix) = finish_thread.join().unwrap();
+        assert!(should_mix);
+        assert_eq!(num_jobs_total.0, 1);
+        assert_eq!(async_progress.num_jobs_pending.load(Ordering::Acquire), 0);
+
+        // and ensure the second spawn() fails
+        assert!(spawn_thread.join().unwrap().is_err());
+        assert_eq!(async_progress.num_jobs_pending.load(Ordering::Acquire), 0);
     }
 }

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -337,12 +337,9 @@ struct AccountsLtHashUpdate {
     curr_account: Option<AccountSharedData>,
 }
 
-// brooks TODO: doc
-//│ 23 │/// The number of lt hash updates to batch up before sending to the async thread pool.                                      │    │
-//│ 24 │///                                                                                                                         │    │
-//│ 25 │/// The 14 KiB number is the current largest size of jemalloc's "small slab" bins,                                          │    │
-//│ 26 │/// which should help with reuse.                                                                                           │    │
-//│ 27 │const MAX_BATCH_SIZE: usize = 14 * 1024 / size_of::<AccountsLtHashUpdate>();                                                │    │
+/// The number of lt hash updates to batch up before sending to the async thread pool.
+///
+/// The 14 KiB number is the current largest size of jemalloc's "small slab" bins.
 const MAX_BATCHED_UPDATES_VEC_BYTES: usize = 14 * 1024;
 const MAX_BATCHED_UPDATES_PER_VEC: usize =
     MAX_BATCHED_UPDATES_VEC_BYTES / size_of::<AccountsLtHashUpdate>();

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -1,388 +1,361 @@
 use {
     super::Bank,
-    rayon::prelude::*,
-    solana_account::{AccountSharedData, accounts_equal},
-    solana_accounts_db::accounts_db::AccountsDb,
-    solana_hash::Hash,
+    crossbeam_queue::ArrayQueue,
+    crossbeam_utils::CachePadded,
+    rayon::{ThreadPool, ThreadPoolBuilder},
+    solana_account::{AccountSharedData, ReadableAccount},
+    solana_accounts_db::{accounts_db::AccountsDb, storable_accounts::StorableAccounts},
     solana_lattice_hash::lt_hash::LtHash,
-    solana_measure::{meas_dur, measure::Measure},
     solana_pubkey::Pubkey,
-    solana_svm_callback::AccountState,
     std::{
-        ops::AddAssign,
-        sync::atomic::{AtomicU64, Ordering},
-        time::Duration,
+        array, hint,
+        mem::size_of,
+        sync::{
+            Arc, LazyLock, Mutex,
+            atomic::{AtomicU64, AtomicUsize, Ordering},
+        },
+        time::Instant,
     },
 };
 
+/// Number of threads for the async accounts hasher thread pool.
+const NUM_ACCOUNTS_HASHER_THREADS: usize = 4;
+
+// Maximum size, in bytes, for the seen-accounts freelist.
+const MAX_BYTES_SEEN_ACCOUNTS_FREELIST: usize = 10_000_000;
+
 impl Bank {
-    /// Updates the accounts lt hash
+    /// Enqueues the accounts lt hash updates for `accounts` to the accounts hasher thread pool.
+    pub fn enqueue_accounts_lt_hash_updates<'a>(&self, accounts: &impl StorableAccounts<'a>) {
+        if accounts.is_empty() {
+            return;
+        }
+
+        let seen_accounts_freelist = seen_accounts_freelist();
+        let mut seen_accounts = seen_accounts_freelist.try_pop().unwrap_or_default();
+        let async_progress = &self.accounts_lt_hash_async_progress;
+        let thread_pool = accounts_hasher_thread_pool();
+
+        // process accounts in reverse because we must only count the latest version of each account
+        for index in (0..accounts.len()).rev() {
+            let address = accounts.pubkey(index);
+            if !seen_accounts.insert(*address) {
+                // we've already enqueued a newer update for the same account; skip this one
+                continue;
+            }
+            let prev_account = self
+                .rc
+                .accounts
+                .load_with_fixed_root_do_not_populate_read_cache(&self.ancestors, address)
+                .map(|(account, _slot)| account);
+            let curr_account = accounts.account(index, |account| {
+                (account.lamports() != 0).then(|| account.take_account())
+            });
+            if prev_account.is_none() && curr_account.is_none() {
+                // the account was ephemeral; skip it
+            } else {
+                // the account was modified; enqueue this update
+                async_progress.spawn(
+                    thread_pool,
+                    AccountsLtHashUpdate {
+                        address: *address,
+                        prev_account,
+                        curr_account,
+                    },
+                );
+            }
+        }
+
+        // reclaim the seen accounts hashset
+        seen_accounts_freelist.try_push(seen_accounts);
+    }
+
+    /// Updates the accounts lt hash.
     ///
     /// When freezing a bank, we compute and update the accounts lt hash.
     /// For each account modified in this bank, we:
     /// - mix out its previous state, and
     /// - mix in its current state
     ///
-    /// Since this function is non-idempotent, it should only be called once per bank.
-    pub fn update_accounts_lt_hash(&self) {
-        let delta_lt_hash = self.calculate_delta_lt_hash();
-        let mut accounts_lt_hash = self.accounts_lt_hash.lock().unwrap();
-        accounts_lt_hash.0.mix_in(&delta_lt_hash);
-    }
-
-    /// Calculates the lt hash *of only this slot*
-    ///
-    /// This can be thought of as akin to the accounts delta hash.
-    ///
-    /// For each account modified in this bank, we:
-    /// - mix out its previous state, and
-    /// - mix in its current state
-    ///
-    /// This function is idempotent, and may be called more than once.
-    fn calculate_delta_lt_hash(&self) -> LtHash {
-        let measure_total = Measure::start("");
-        let slot = self.slot();
-
-        // If we don't find the account in the cache, we need to go load it.
-        // We want the version of the account *before* it was written in this slot.
-        // Bank::ancestors *includes* this slot, so we need to remove it before loading.
-        let strictly_ancestors = {
-            let mut ancestors = self.ancestors.clone();
-            ancestors.remove(&self.slot());
-            ancestors
+    /// This function waits for any in-flight jobs on the accounts hasher threads,
+    /// computes their combined delta lt hash, then mixes it into the bank.
+    pub fn finish_accounts_lt_hash_updates(&self) {
+        let timer = Instant::now();
+        let num_jobs_total = {
+            let mut accounts_lt_hash = self.accounts_lt_hash.lock().unwrap();
+            self.accounts_lt_hash_async_progress
+                .finish(&mut accounts_lt_hash.0)
         };
+        let finish_time = timer.elapsed();
 
-        if slot == 0 {
-            // Slot 0 is special when calculating the accounts lt hash.
-            // Primordial accounts (those in genesis) that are modified by transaction processing
-            // in slot 0 will have Alive entries in the accounts lt hash cache.
-            // When calculating the accounts lt hash, if an account was initially alive, we mix
-            // *out* its previous lt hash value.  In slot 0, we haven't stored any previous lt hash
-            // values (since it is in the first slot), yet we'd still mix out these accounts!
-            // This produces the incorrect accounts lt hash.
-            // From the perspective of the accounts lt hash, in slot 0 we cannot have any accounts
-            // as previously alive.  So to work around this issue, we clear the cache.
-            // And since `strictly_ancestors` is empty, loading the previous version of the account
-            // from accounts db will return `None` (aka Dead), which is the correct behavior.
-            assert!(strictly_ancestors.is_empty());
-            self.cache_for_accounts_lt_hash.clear();
-        }
-
-        // Get all the accounts stored in this slot.
-        // Since this bank is in the middle of being frozen, it hasn't been rooted.
-        // That means the accounts should all be in the write cache, and loading will be fast.
-        let (accounts_curr, time_loading_accounts_curr) = meas_dur!({
-            self.rc
-                .accounts
-                .accounts_db
-                .get_pubkey_account_for_slot(slot)
-        });
-        let num_accounts_total = accounts_curr.len();
-
-        #[derive(Debug, Default)]
-        struct Stats {
-            num_cache_misses: usize,
-            num_accounts_unmodified: usize,
-            time_loading_accounts_prev: Duration,
-            time_comparing_accounts: Duration,
-            time_computing_hashes: Duration,
-            time_mixing_hashes: Duration,
-        }
-        impl AddAssign for Stats {
-            fn add_assign(&mut self, other: Self) {
-                self.num_cache_misses += other.num_cache_misses;
-                self.num_accounts_unmodified += other.num_accounts_unmodified;
-                self.time_loading_accounts_prev += other.time_loading_accounts_prev;
-                self.time_comparing_accounts += other.time_comparing_accounts;
-                self.time_computing_hashes += other.time_computing_hashes;
-                self.time_mixing_hashes += other.time_mixing_hashes;
-            }
-        }
-
-        let do_calculate_delta_lt_hash = || {
-            // Work on chunks of 128 pubkeys, which is 4 KiB.
-            // And 4 KiB is likely the smallest a real page size will be.
-            // And a single page is likely the smallest size a disk read will actually read.
-            // This can be tuned larger, but likely not smaller.
-            const CHUNK_SIZE: usize = 128;
-            accounts_curr
-                .par_iter()
-                .fold_chunks(
-                    CHUNK_SIZE,
-                    || (LtHash::identity(), Stats::default()),
-                    |mut accum, (pubkey, curr_account)| {
-                        // load the initial state of the account
-                        let (initial_state_of_account, measure_load) = meas_dur!({
-                            let cache_value = self
-                                .cache_for_accounts_lt_hash
-                                .get(pubkey)
-                                .map(|entry| entry.value().clone());
-                            match cache_value {
-                                Some(CacheValue::InspectAccount(initial_state_of_account)) => {
-                                    initial_state_of_account
-                                }
-                                Some(CacheValue::BankNew) | None => {
-                                    accum.1.num_cache_misses += 1;
-                                    // If the initial state of the account is not in the accounts
-                                    // lt hash cache, or is explicitly unknown, then it is likely
-                                    // this account was stored *outside* of transaction processing
-                                    // (e.g. creating a new bank).
-                                    // Do not populate the read cache, as this account likely will
-                                    // not be accessed again soon.
-                                    let account_slot = self
-                                        .rc
-                                        .accounts
-                                        .load_with_fixed_root_do_not_populate_read_cache(
-                                            &strictly_ancestors,
-                                            pubkey,
-                                        );
-                                    match account_slot {
-                                        Some((account, _slot)) => {
-                                            InitialStateOfAccount::Alive(account)
-                                        }
-                                        None => InitialStateOfAccount::Dead,
-                                    }
-                                }
-                            }
-                        });
-                        accum.1.time_loading_accounts_prev += measure_load;
-
-                        // mix out the previous version of the account
-                        match initial_state_of_account {
-                            InitialStateOfAccount::Dead => {
-                                // nothing to do here
-                            }
-                            InitialStateOfAccount::Alive(prev_account) => {
-                                let (are_accounts_equal, measure_is_equal) =
-                                    meas_dur!(accounts_equal(curr_account, &prev_account));
-                                accum.1.time_comparing_accounts += measure_is_equal;
-                                if are_accounts_equal {
-                                    // this account didn't actually change, so skip it for lt hashing
-                                    accum.1.num_accounts_unmodified += 1;
-                                    return accum;
-                                }
-                                let (prev_lt_hash, measure_hashing) =
-                                    meas_dur!(AccountsDb::lt_hash_account(&prev_account, pubkey));
-                                let (_, measure_mixing) =
-                                    meas_dur!(accum.0.mix_out(&prev_lt_hash.0));
-                                accum.1.time_computing_hashes += measure_hashing;
-                                accum.1.time_mixing_hashes += measure_mixing;
-                            }
-                        }
-
-                        // mix in the new version of the account
-                        let (curr_lt_hash, measure_hashing) =
-                            meas_dur!(AccountsDb::lt_hash_account(curr_account, pubkey));
-                        let (_, measure_mixing) = meas_dur!(accum.0.mix_in(&curr_lt_hash.0));
-                        accum.1.time_computing_hashes += measure_hashing;
-                        accum.1.time_mixing_hashes += measure_mixing;
-
-                        accum
-                    },
-                )
-                .reduce(
-                    || (LtHash::identity(), Stats::default()),
-                    |mut accum, elem| {
-                        accum.0.mix_in(&elem.0);
-                        accum.1 += elem.1;
-                        accum
-                    },
-                )
-        };
-        let (delta_lt_hash, stats) = self
-            .rc
-            .accounts
-            .accounts_db
-            .thread_pool_foreground
-            .install(do_calculate_delta_lt_hash);
-
-        let total_time = measure_total.end_as_duration();
-        let num_accounts_modified =
-            num_accounts_total.saturating_sub(stats.num_accounts_unmodified);
+        let seen_accounts_freelist_stats = seen_accounts_freelist().stats();
         datapoint_info!(
             "bank-accounts_lt_hash",
-            ("slot", slot, i64),
-            ("num_accounts_total", num_accounts_total, i64),
-            ("num_accounts_modified", num_accounts_modified, i64),
+            ("slot", self.slot(), i64),
+            ("num_jobs", num_jobs_total, i64),
+            ("finish_us", finish_time.as_micros(), i64),
             (
-                "num_accounts_unmodified",
-                stats.num_accounts_unmodified,
-                i64
-            ),
-            ("num_cache_misses", stats.num_cache_misses, i64),
-            ("total_us", total_time.as_micros(), i64),
-            (
-                "loading_accounts_curr_us",
-                time_loading_accounts_curr.as_micros(),
+                "seen_accounts_freelist_num_containers",
+                seen_accounts_freelist_stats.num_containers,
                 i64
             ),
             (
-                "par_loading_accounts_prev_us",
-                stats.time_loading_accounts_prev.as_micros(),
+                "seen_accounts_freelist_capacity_elems",
+                seen_accounts_freelist_stats.capacity_elems,
                 i64
             ),
             (
-                "par_comparing_accounts_us",
-                stats.time_comparing_accounts.as_micros(),
-                i64
-            ),
-            (
-                "par_computing_hashes_us",
-                stats.time_computing_hashes.as_micros(),
-                i64
-            ),
-            (
-                "par_mixing_hashes_us",
-                stats.time_mixing_hashes.as_micros(),
-                i64
-            ),
-            (
-                "num_inspect_account_hits",
-                self.stats_for_accounts_lt_hash
-                    .num_inspect_account_hits
-                    .load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_inspect_account_misses",
-                self.stats_for_accounts_lt_hash
-                    .num_inspect_account_misses
-                    .load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_inspect_account_after_frozen",
-                self.stats_for_accounts_lt_hash
-                    .num_inspect_account_after_frozen
-                    .load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "inspect_account_lookup_ns",
-                self.stats_for_accounts_lt_hash
-                    .inspect_account_lookup_time_ns
-                    .load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "inspect_account_insert_ns",
-                self.stats_for_accounts_lt_hash
-                    .inspect_account_insert_time_ns
-                    .load(Ordering::Relaxed),
+                "seen_accounts_freelist_capacity_bytes",
+                seen_accounts_freelist_stats.capacity_bytes,
                 i64
             ),
         );
+    }
+}
 
-        delta_lt_hash
+/// Struct for tracking progress of the asynchronous accounts lt hashing for a Bank.
+pub struct AccountsLtHashAsyncProgress {
+    // Note: use [Mutex<CachePadded<LtHash>>] and *not* [CachePadded<Mutex<LtHash>>].
+    // - In both ways each mutex is on its own separate cache line.
+    // - In both ways the size used for each element, including padding, is the same.
+    // - Only this way ensures that each LtHash is placed for aligned SIMD/AVX access.
+    //
+    // Here's the layout of [Mutex<CachePadded<LtHash>>; 2]
+    //
+    //  │element 0                         │element 1
+    //  │                                  │
+    //  ▼───────┬─────────┬────────────────▼───────┬─────────┬────────────────┐
+    //  │ Mutex │ padding │     LtHash     │ Mutex │ padding │     LtHash     │
+    //  ├───────┼─────────┼────────────────┼───────┼─────────┼────────────────┤
+    //  │       │         │                │       │         │                │
+    //  │0      │6        │128 <-- aligned │2176   │2182     │2304            │4352
+    //
+    //
+    // And here's the layout of [CachePadded<Mutex<LtHash>>; 2]
+    //
+    //  │element 0                         │element 1
+    //  │                                  │
+    //  ▼───────┬────────────────┬─────────▼───────┬────────────────┬─────────┐
+    //  │ Mutex │     LtHash     │ padding │ Mutex │     LtHash     │ padding │
+    //  ├───────┼────────────────┼─────────┼───────┼────────────────┼─────────┤
+    //  │       │                │         │       │                │         │
+    //  │0      │6 <-- unaligned │2054     │2176   │2182            │4230     │4352
+    //
+    accumulators: Arc<[Mutex<CachePadded<LtHash>>; NUM_ACCOUNTS_HASHER_THREADS]>,
+    num_jobs_pending: Arc<AtomicUsize>,
+    num_jobs_total: AtomicU64,
+}
+
+impl AccountsLtHashAsyncProgress {
+    /// Creates a new AccountsLtHashAsyncProgress variable, which is suitable for a new Bank.
+    pub fn new() -> Self {
+        Self {
+            accumulators: Arc::new(array::from_fn(|_| {
+                Mutex::new(CachePadded::new(LtHash::identity()))
+            })),
+            num_jobs_pending: Arc::new(AtomicUsize::new(0)),
+            num_jobs_total: AtomicU64::new(0),
+        }
     }
 
-    /// Caches initial state of writeable accounts
-    ///
-    /// If a transaction account is writeable, cache its initial account state.
-    /// The initial state is needed when computing the accounts lt hash for the slot, and caching
-    /// the initial state saves us from having to look it up on disk later.
-    pub fn inspect_account_for_accounts_lt_hash(
-        &self,
-        address: &Pubkey,
-        account_state: &AccountState,
-        is_writable: bool,
-    ) {
-        if !is_writable {
-            // if the account is not writable, then it cannot be modified; nothing to do here
-            return;
-        }
+    /// Enqueues `update` into `thread_pool` for asynchronous processing.
+    fn spawn(&self, thread_pool: &'static ThreadPool, update: AccountsLtHashUpdate) {
+        self.num_jobs_pending.fetch_add(1, Ordering::Relaxed);
+        self.num_jobs_total.fetch_add(1, Ordering::Relaxed);
+        thread_pool.spawn({
+            let accumulators = Arc::clone(&self.accumulators);
+            let num_jobs_pending = Arc::clone(&self.num_jobs_pending);
+            move || {
+                // SAFETY: We always call from the same/correct Rayon thread pool.
+                let worker_index = thread_pool.current_thread_index().unwrap();
 
-        // Only insert the account the *first* time we see it.
-        // We want to capture the value of the account *before* any modifications during this slot.
-        let (is_in_cache, lookup_time) =
-            meas_dur!(self.cache_for_accounts_lt_hash.contains_key(address));
-        if !is_in_cache {
-            // We need to check if the bank is frozen.  In order to do that safely, we
-            // must hold a read lock on Bank::hash to read the frozen state.
-            let freeze_guard = self.freeze_lock();
-            let is_frozen = *freeze_guard != Hash::default();
-            if is_frozen {
-                // If the bank is frozen, do not add this account to the cache.
-                // It is possible for the leader to be executing transactions after freeze has
-                // started, i.e. while any deferred changes to account state is finishing up.
-                // This means the transaction could load an account *after* it was modified by the
-                // deferred changes, which would be the wrong initial state of the account.
-                // Inserting the wrong initial state of an account into the cache will end up
-                // producing the wrong accounts lt hash.
-                self.stats_for_accounts_lt_hash
-                    .num_inspect_account_after_frozen
-                    .fetch_add(1, Ordering::Relaxed);
-                return;
+                // SAFETY: There are num_threads accumulators, and each
+                // thread's index shall always be in range 0..num_threads.
+                debug_assert!(worker_index < accumulators.len());
+                let accumulator = unsafe { accumulators.get_unchecked(worker_index) };
+
+                Self::process(&mut accumulator.lock().unwrap(), update);
+
+                // Decrementing the number of pending jobs MUST happen *after*
+                // accumulating the result.  This ensures `finish()` cannot
+                // observe zero pending jobs until all workers are done.
+                num_jobs_pending.fetch_sub(1, Ordering::Relaxed);
             }
-            let (_, insert_time) = meas_dur!({
-                self.cache_for_accounts_lt_hash
-                    .entry(*address)
-                    .or_insert_with(|| {
-                        let initial_state_of_account = match account_state {
-                            AccountState::Dead => InitialStateOfAccount::Dead,
-                            AccountState::Alive(account) => {
-                                InitialStateOfAccount::Alive((*account).clone())
-                            }
-                        };
-                        CacheValue::InspectAccount(initial_state_of_account)
-                    });
-            });
-            drop(freeze_guard);
+        });
+    }
 
-            self.stats_for_accounts_lt_hash
-                .num_inspect_account_misses
-                .fetch_add(1, Ordering::Relaxed);
-            self.stats_for_accounts_lt_hash
-                .inspect_account_insert_time_ns
-                // N.B. this needs to be nanoseconds because it can be so fast
-                .fetch_add(insert_time.as_nanos() as u64, Ordering::Relaxed);
-        } else {
-            // The account is already in the cache, so nothing to do here other than update stats.
-            self.stats_for_accounts_lt_hash
-                .num_inspect_account_hits
-                .fetch_add(1, Ordering::Relaxed);
+    /// Waits for all pending jobs to complete, then mixes the results into `lt_hash`.
+    ///
+    /// Returns the number of asynchronous jobs completed.
+    ///
+    /// Note: Since an LtHash is large, `lt_hash` is passed as an in-out parameter.
+    /// This it to avoid Rust compiler bug that fails to perform return value optimization.
+    fn finish(&self, lt_hash: &mut LtHash) -> u64 {
+        while self.num_jobs_pending.load(Ordering::Relaxed) > 0 {
+            // Spin, do not yield! This is called by Bank::freeze() and we want to be fast.
+            hint::spin_loop();
         }
 
-        self.stats_for_accounts_lt_hash
-            .inspect_account_lookup_time_ns
-            // N.B. this needs to be nanoseconds because it can be so fast
-            .fetch_add(lookup_time.as_nanos() as u64, Ordering::Relaxed);
+        for thread_accumulator in self.accumulators.iter() {
+            lt_hash.mix_in(&thread_accumulator.lock().unwrap());
+        }
+        self.num_jobs_total.load(Ordering::Relaxed)
+    }
+
+    /// Processes `update` and mixes the result into `accum_lt_hash`.
+    ///
+    /// Note: Since an LtHash is large, `accum_lt_hash` is passed as an in-out parameter.
+    /// This it to avoid Rust compiler bug that fails to perform return value optimization.
+    fn process(accum_lt_hash: &mut LtHash, update: AccountsLtHashUpdate) {
+        let AccountsLtHashUpdate {
+            address,
+            prev_account,
+            curr_account,
+        } = update;
+        if let Some(prev_account) = prev_account {
+            let prev_lt_hash = AccountsDb::lt_hash_account(&prev_account, &address);
+            accum_lt_hash.mix_out(&prev_lt_hash.0);
+        }
+        if let Some(curr_account) = curr_account {
+            let curr_lt_hash = AccountsDb::lt_hash_account(&curr_account, &address);
+            accum_lt_hash.mix_in(&curr_lt_hash.0);
+        }
     }
 }
 
-/// Stats related to accounts lt hash
-#[derive(Debug, Default)]
-pub struct Stats {
-    /// the number of times the cache already contained the account being inspected
-    num_inspect_account_hits: AtomicU64,
-    /// the number of times the cache *did not* already contain the account being inspected
-    num_inspect_account_misses: AtomicU64,
-    /// the number of times an account was inspected after the bank was frozen
-    num_inspect_account_after_frozen: AtomicU64,
-    /// time spent checking if accounts are in the cache
-    inspect_account_lookup_time_ns: AtomicU64,
-    /// time spent inserting accounts into the cache
-    inspect_account_insert_time_ns: AtomicU64,
+/// A single accounts lt hash update to process.
+#[derive(Debug)]
+struct AccountsLtHashUpdate {
+    address: Pubkey,
+    prev_account: Option<AccountSharedData>,
+    curr_account: Option<AccountSharedData>,
 }
 
-/// The initial state of an account prior to being modified in this slot/transaction
-#[derive(Debug, Clone, PartialEq)]
-pub enum InitialStateOfAccount {
-    /// The account was initially dead
-    Dead,
-    /// The account was initially alive
-    Alive(AccountSharedData),
+/// Get the freelist of hashsets to use for seen accounts.
+fn seen_accounts_freelist() -> &'static HashSetFreelist<Pubkey> {
+    // Derived empirically while observing an unstaked node on mnb.
+    // Should end up being the same number as replay threads.
+    const MAX_CONTAINERS: usize = 50;
+    static FREELIST: LazyLock<HashSetFreelist<Pubkey>> = LazyLock::new(|| {
+        HashSetFreelist::new(MAX_CONTAINERS, Some(MAX_BYTES_SEEN_ACCOUNTS_FREELIST))
+    });
+    &FREELIST
 }
 
-/// The value type for the accounts lt hash cache
-#[derive(Debug, Clone, PartialEq)]
-pub enum CacheValue {
-    /// The value was inserted by `inspect_account()`.
-    /// This means we will have the initial state of the account.
-    InspectAccount(InitialStateOfAccount),
-    /// The value was inserted by `Bank::new()`.
-    /// This means we will *not* have the initial state of the account.
-    BankNew,
+/// Freelist of containers, to avoid repeat allocations/deallocations.
+#[derive(Debug)]
+struct HashSetFreelist<T> {
+    list: ArrayQueue<ahash::HashSet<T>>,
+
+    /// the maximum capacity, in elements, this freelist will hold
+    max_capacity: Option<usize>,
+
+    // stats
+    num_containers: AtomicUsize,
+    total_capacity: AtomicUsize,
+}
+
+impl<T> HashSetFreelist<T> {
+    /// Creates a new, empty, freelist.
+    ///
+    /// max_containers:
+    /// * The maximum number of containers this freelist can hold.
+    ///
+    /// max_bytes:
+    /// * The maximum number of bytes this freelist can hold.
+    /// * This value corresponds to the total capacity across all the containers in the freelist.
+    /// * If `None`, there is no maximum.
+    fn new(max_containers: usize, max_bytes: Option<usize>) -> Self {
+        let max_capacity = max_bytes.map(|max_bytes| max_bytes / size_of::<T>());
+        Self {
+            list: ArrayQueue::new(max_containers),
+            max_capacity,
+            num_containers: AtomicUsize::new(0),
+            total_capacity: AtomicUsize::new(0),
+        }
+    }
+
+    /// Pushes `container` on to the freelist (IFF its capacity is greater than zero).
+    fn try_push(&self, mut container: ahash::HashSet<T>) {
+        // If the capacity is zero, then the container never allocated.
+        // In that case, don't waste time putting it back into the freelist,
+        // since there's nothing of value to reuse.
+        //
+        // Else, check if pushing the container would exceed the max capacity of the freelist.
+        // If so, also do not put it back into the freelist.
+        let capacity = container.capacity();
+        if capacity != 0
+            && self.max_capacity.is_none_or(|max_capacity| {
+                // only check the `total_capacity` atomic if a max capacity is set
+                if let Some(new_total_capacity) = self
+                    .total_capacity
+                    .load(Ordering::Relaxed)
+                    .checked_add(capacity)
+                {
+                    new_total_capacity <= max_capacity
+                } else {
+                    // if the total capacity would overflow, do not push
+                    false
+                }
+            })
+        {
+            container.clear();
+            let result = self.list.push(container);
+            if result.is_ok() {
+                // pushing the container may fail if the freelist is full,
+                // so only update the stats once we know push succeeded
+                self.num_containers.fetch_add(1, Ordering::Relaxed);
+                self.total_capacity.fetch_add(capacity, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Pops a container off the freelist and returns it.
+    ///
+    /// The returned container will always be empty.
+    fn try_pop(&self) -> Option<ahash::HashSet<T>> {
+        let container = self.list.pop()?;
+        assert!(container.is_empty());
+        self.num_containers.fetch_sub(1, Ordering::Relaxed);
+        self.total_capacity
+            .fetch_sub(container.capacity(), Ordering::Relaxed);
+        Some(container)
+    }
+
+    /// Returns a snapshot of the freelist's stats.
+    fn stats(&self) -> FreelistStats {
+        let capacity_elems = self.total_capacity.load(Ordering::Relaxed);
+        FreelistStats {
+            num_containers: self.num_containers.load(Ordering::Relaxed),
+            capacity_elems,
+            capacity_bytes: capacity_elems * size_of::<T>(),
+        }
+    }
+}
+
+/// A snapshot of a freelist's stats.
+#[derive(Debug, Eq, PartialEq)]
+struct FreelistStats {
+    /// the number of containers held by the freelist
+    num_containers: usize,
+    /// the capacity, in elements, across all the containers in the freelist
+    capacity_elems: usize,
+    /// the capacity, in bytes, across all the containers in the freelist
+    capacity_bytes: usize,
+}
+
+/// Returns the thread pool for asynchronous accounts hashing.
+///
+/// Note, the thread pool will be created on first call.
+fn accounts_hasher_thread_pool() -> &'static ThreadPool {
+    static THREAD_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
+        ThreadPoolBuilder::new()
+            .num_threads(NUM_ACCOUNTS_HASHER_THREADS)
+            .thread_name(|i| format!("solAcctsHashr{i:02}"))
+            .build()
+            .expect("new accounts hasher rayon threadpool")
+    });
+    &THREAD_POOL
 }
 
 #[cfg(test)]
@@ -395,7 +368,6 @@ mod tests {
         },
         agave_feature_set::FeatureSet,
         agave_snapshots::snapshot_config::SnapshotConfig,
-        solana_account::{ReadableAccount as _, WritableAccount as _},
         solana_accounts_db::{
             accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
             accounts_index::{ACCOUNTS_INDEX_CONFIG_FOR_TESTING, AccountsIndexConfig, IndexLimit},
@@ -403,6 +375,7 @@ mod tests {
         solana_cluster_type::ClusterType,
         solana_fee_calculator::FeeRateGovernor,
         solana_genesis_config::{self, GenesisConfig},
+        solana_hash::Hash,
         solana_keypair::Keypair,
         solana_leader_schedule::SlotLeader,
         solana_native_token::LAMPORTS_PER_SOL,
@@ -495,7 +468,7 @@ mod tests {
         bank.transfer(amount, &mint_keypair, &keypair5.pubkey())
             .unwrap();
 
-        // manually freeze the bank to trigger update_accounts_lt_hash() to run
+        // manually freeze the bank to trigger updating the accounts lt hash
         bank.freeze();
         let prev_accounts_lt_hash = bank.accounts_lt_hash.lock().unwrap().clone();
 
@@ -550,10 +523,9 @@ mod tests {
         // store account 5 into this new bank, unchanged
         bank.store_account(&keypair5.pubkey(), prev_account5.as_ref().unwrap());
 
-        // freeze the bank to trigger update_accounts_lt_hash() to run
+        // freeze the bank to trigger updating the accounts lt hash
         bank.freeze();
 
-        let actual_delta_lt_hash = bank.calculate_delta_lt_hash();
         let post_accounts_lt_hash = bank.accounts_lt_hash.lock().unwrap().clone();
         let post_mint = bank.get_account_with_fixed_root(&mint_keypair.pubkey());
         let post_account1 = bank.get_account_with_fixed_root(&keypair1.pubkey());
@@ -574,21 +546,18 @@ mod tests {
             .map(|address| bank.get_account_with_fixed_root(address))
             .collect();
 
-        let mut expected_delta_lt_hash = LtHash::identity();
         let mut expected_accounts_lt_hash = prev_accounts_lt_hash;
         let mut updater =
             |address: &Pubkey, prev: Option<AccountSharedData>, post: Option<AccountSharedData>| {
                 // if there was an alive account, mix out
                 if let Some(prev) = prev {
                     let prev_lt_hash = AccountsDb::lt_hash_account(&prev, address);
-                    expected_delta_lt_hash.mix_out(&prev_lt_hash.0);
                     expected_accounts_lt_hash.0.mix_out(&prev_lt_hash.0);
                 }
 
                 // mix in the new one
                 let post = post.unwrap_or_default();
                 let post_lt_hash = AccountsDb::lt_hash_account(&post, address);
-                expected_delta_lt_hash.mix_in(&post_lt_hash.0);
                 expected_accounts_lt_hash.0.mix_in(&post_lt_hash.0);
             };
         updater(&mint_keypair.pubkey(), prev_mint, post_mint);
@@ -605,15 +574,7 @@ mod tests {
             );
         }
 
-        // now make sure the delta lt hashes match
-        let expected = expected_delta_lt_hash.checksum();
-        let actual = actual_delta_lt_hash.checksum();
-        assert_eq!(
-            expected, actual,
-            "delta_lt_hash, expected: {expected}, actual: {actual}",
-        );
-
-        // ...and the accounts lt hashes match too
+        // now make sure the accounts lt hashes match
         let expected = expected_accounts_lt_hash.0.checksum();
         let actual = post_accounts_lt_hash.0.checksum();
         assert_eq!(
@@ -626,7 +587,7 @@ mod tests {
     ///
     /// This test does a simple transfer in slot 0 so that a primordial account is modified.
     ///
-    /// See the comments in calculate_delta_lt_hash() for more information.
+    /// Slot 0 is special because primordial accounts have no previous accounts lt hash entry.
     #[test_case(Features::None; "no features")]
     #[test_case(Features::All; "all features")]
     fn test_slot0_accounts_lt_hash(features: Features) {
@@ -640,7 +601,7 @@ mod tests {
         bank.transfer(LAMPORTS_PER_SOL, &mint_keypair, &Pubkey::new_unique())
             .unwrap();
 
-        // manually freeze the bank to trigger update_accounts_lt_hash() to run
+        // manually freeze the bank to trigger updating the accounts lt hash
         bank.freeze();
         let actual_accounts_lt_hash = bank.accounts_lt_hash.lock().unwrap().clone();
 
@@ -651,114 +612,6 @@ mod tests {
             .accounts_db
             .calculate_accounts_lt_hash_at_startup_from_index(&bank.ancestors);
         assert_eq!(actual_accounts_lt_hash, calculated_accounts_lt_hash);
-    }
-
-    #[test_case(Features::None; "no features")]
-    #[test_case(Features::All; "all features")]
-    fn test_inspect_account_for_accounts_lt_hash(features: Features) {
-        let (genesis_config, _mint_keypair) = genesis_config_with(features);
-        let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-
-        // the cache should start off empty
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 0);
-
-        // ensure non-writable accounts are *not* added to the cache
-        bank.inspect_account_for_accounts_lt_hash(
-            &Pubkey::new_unique(),
-            &AccountState::Dead,
-            false,
-        );
-        bank.inspect_account_for_accounts_lt_hash(
-            &Pubkey::new_unique(),
-            &AccountState::Alive(&AccountSharedData::default()),
-            false,
-        );
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 0);
-
-        // ensure *new* accounts are added to the cache
-        let address = Pubkey::new_unique();
-        bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Dead, true);
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 1);
-        assert!(bank.cache_for_accounts_lt_hash.contains_key(&address));
-
-        // ensure *existing* accounts are added to the cache
-        let address = Pubkey::new_unique();
-        let initial_lamports = 123;
-        let mut account = AccountSharedData::new(initial_lamports, 0, &Pubkey::default());
-        bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Alive(&account), true);
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 2);
-        if let CacheValue::InspectAccount(InitialStateOfAccount::Alive(cached_account)) = bank
-            .cache_for_accounts_lt_hash
-            .get(&address)
-            .unwrap()
-            .value()
-        {
-            assert_eq!(*cached_account, account);
-        } else {
-            panic!("wrong initial state for account");
-        };
-
-        // ensure if an account is modified multiple times that we only cache the *first* one
-        let updated_lamports = account.lamports() + 1;
-        account.set_lamports(updated_lamports);
-        bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Alive(&account), true);
-        assert_eq!(bank.cache_for_accounts_lt_hash.len(), 2);
-        if let CacheValue::InspectAccount(InitialStateOfAccount::Alive(cached_account)) = bank
-            .cache_for_accounts_lt_hash
-            .get(&address)
-            .unwrap()
-            .value()
-        {
-            assert_eq!(cached_account.lamports(), initial_lamports);
-        } else {
-            panic!("wrong initial state for account");
-        };
-
-        // and ensure multiple updates are handled correctly when the account is initially dead
-        {
-            let address = Pubkey::new_unique();
-            bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Dead, true);
-            assert_eq!(bank.cache_for_accounts_lt_hash.len(), 3);
-            match bank
-                .cache_for_accounts_lt_hash
-                .get(&address)
-                .unwrap()
-                .value()
-            {
-                CacheValue::InspectAccount(InitialStateOfAccount::Dead) => {
-                    // this is expected, nothing to do here
-                }
-                _ => panic!("wrong initial state for account"),
-            };
-
-            bank.inspect_account_for_accounts_lt_hash(
-                &address,
-                &AccountState::Alive(&AccountSharedData::default()),
-                true,
-            );
-            assert_eq!(bank.cache_for_accounts_lt_hash.len(), 3);
-            match bank
-                .cache_for_accounts_lt_hash
-                .get(&address)
-                .unwrap()
-                .value()
-            {
-                CacheValue::InspectAccount(InitialStateOfAccount::Dead) => {
-                    // this is expected, nothing to do here
-                }
-                _ => panic!("wrong initial state for account"),
-            };
-        }
-
-        // ensure accounts are *not* added to the cache if the bank is frozen
-        // N.B. this test should remain *last*, as Bank::freeze() is not meant to be undone
-        bank.freeze();
-        let address = Pubkey::new_unique();
-        let num_cache_entries_prev = bank.cache_for_accounts_lt_hash.len();
-        bank.inspect_account_for_accounts_lt_hash(&address, &AccountState::Dead, true);
-        let num_cache_entries_curr = bank.cache_for_accounts_lt_hash.len();
-        assert_eq!(num_cache_entries_curr, num_cache_entries_prev);
-        assert!(!bank.cache_for_accounts_lt_hash.contains_key(&address));
     }
 
     #[test_case(Features::None; "no features")]
@@ -932,39 +785,6 @@ mod tests {
         assert_eq!(roundtrip_bank, *bank);
     }
 
-    /// Ensure that accounts written in Bank::new() are added to the accounts lt hash cache.
-    #[test_case(Features::None; "no features")]
-    #[test_case(Features::All; "all features")]
-    fn test_accounts_lt_hash_cache_values_from_bank_new(features: Features) {
-        let (genesis_config, _mint_keypair) = genesis_config_with(features);
-        let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-
-        let slot = bank.slot() + 1;
-        bank =
-            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), slot);
-
-        // These are the two accounts *currently* added to the bank during Bank::new().
-        // More accounts could be added later, so if the test fails, inspect the actual cache
-        // accounts and update the expected cache accounts as necessary.
-        let expected_cache = &[
-            (
-                Pubkey::from_str_const("SysvarC1ock11111111111111111111111111111111"),
-                CacheValue::BankNew,
-            ),
-            (
-                Pubkey::from_str_const("SysvarS1otHashes111111111111111111111111111"),
-                CacheValue::BankNew,
-            ),
-        ];
-        let mut actual_cache: Vec<_> = bank
-            .cache_for_accounts_lt_hash
-            .iter()
-            .map(|entry| (*entry.key(), entry.value().clone()))
-            .collect();
-        actual_cache.sort_unstable_by_key(|a| a.0);
-        assert_eq!(expected_cache, actual_cache.as_slice());
-    }
-
     /// Ensure that the snapshot hash is correct
     #[test_case(Features::None; "no features")]
     #[test_case(Features::All; "all features")]
@@ -1023,5 +843,51 @@ mod tests {
         .unwrap();
 
         assert_eq!(roundtrip_bank, *bank);
+    }
+
+    /// Ensure freelist respects max size.
+    #[test]
+    fn test_freelist_max_capacity() {
+        use ahash::HashSetExt as _;
+        type Container = ahash::HashSet<u64>;
+
+        // This test uses a hashbrown container, which has some special power-of-two sizing plus
+        // a buffer.  So create the container first, and use that to derive the max capacity.
+        let container = Container::with_capacity(77);
+
+        let max_capacity = container.capacity();
+        let max_bytes = max_capacity * size_of::<u64>();
+        let mut freelist = HashSetFreelist::new(10, Some(max_bytes));
+
+        // pushing a container that is too big will not actually push
+        freelist.try_push(Container::with_capacity(max_capacity + 1));
+        let stats0 = freelist.stats();
+        assert_eq!(stats0.num_containers, 0);
+        assert_eq!(stats0.capacity_elems, 0);
+        assert_eq!(stats0.capacity_bytes, 0);
+
+        // pushing a container that is not too big will actually push
+        freelist.try_push(container);
+        let stats1 = freelist.stats();
+        assert_eq!(stats1.num_containers, 1);
+        assert_eq!(stats1.capacity_elems, max_capacity);
+        assert_eq!(stats1.capacity_bytes, max_bytes);
+
+        // pushing a container that would exceed capacity will not push
+        freelist.try_push(Container::with_capacity(1));
+        assert_eq!(freelist.stats(), stats1);
+
+        // ...but, if we remove the limit, push should work again
+        freelist.max_capacity = None;
+        let container = Container::with_capacity(1);
+        let container_capacity = container.capacity();
+        freelist.try_push(container);
+        let stats2 = freelist.stats();
+        assert_eq!(stats2.num_containers, 2);
+        assert_eq!(stats2.capacity_elems, max_capacity + container_capacity);
+        assert_eq!(
+            stats2.capacity_bytes,
+            max_bytes + container_capacity * size_of::<u64>(),
+        );
     }
 }

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -44,7 +44,6 @@ pub(crate) struct NewBankTimings {
     pub(crate) cache_preparation_time_us: u64,
     pub(crate) update_sysvars_time_us: u64,
     pub(crate) fill_sysvar_cache_time_us: u64,
-    pub(crate) populate_cache_for_accounts_lt_hash_us: u64,
 }
 
 pub(crate) struct PrepareBlockExecutionStats {
@@ -53,8 +52,6 @@ pub(crate) struct PrepareBlockExecutionStats {
     pub(crate) cache_preparation_time_us: u64,
     pub(crate) update_sysvars_time_us: u64,
     pub(crate) fill_sysvar_cache_time_us: u64,
-    pub(crate) num_accounts_modified_this_slot: usize,
-    pub(crate) populate_cache_for_accounts_lt_hash_us: u64,
 }
 
 pub(crate) fn report_new_epoch_metrics(
@@ -122,7 +119,6 @@ pub(crate) fn report_new_bank_metrics(
     slot: Slot,
     parent_slot: Slot,
     block_height: u64,
-    num_accounts_modified_this_slot: usize,
     timings: NewBankTimings,
 ) {
     datapoint_info!(
@@ -170,16 +166,6 @@ pub(crate) fn report_new_bank_metrics(
         (
             "fill_sysvar_cache_us",
             timings.fill_sysvar_cache_time_us,
-            i64
-        ),
-        (
-            "num_accounts_modified_this_slot",
-            num_accounts_modified_this_slot,
-            i64
-        ),
-        (
-            "populate_cache_for_accounts_lt_hash_us",
-            timings.populate_cache_for_accounts_lt_hash_us,
             i64
         ),
     );

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -34,6 +34,7 @@ use {
     ahash::AHashMap,
     assert_matches::assert_matches,
     crossbeam_channel::{TrySendError, bounded},
+    dashmap::DashMap,
     itertools::Itertools,
     rand::Rng,
     rayon::{ThreadPool, ThreadPoolBuilder, iter::IntoParallelIterator},

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -28,6 +28,7 @@ use {
     ahash::AHashMap,
     assert_matches::assert_matches,
     crossbeam_channel::{bounded, unbounded},
+    dashmap::DashMap,
     itertools::Itertools,
     rand::Rng,
     rayon::{ThreadPool, ThreadPoolBuilder, iter::IntoParallelIterator},


### PR DESCRIPTION
# Problem

`Bank::freeze()` takes a few milliseconds, which is mostly spent updating the accounts lt hash. This is too long.

Here's two of the edge canaries and the time they spend updating the accounts lt hash. This happens entirely at Bank::freeze() time. I chose `mce1` and `sce2` since they represent one of the faster and one of the slower nodes.

First the mean:

<img width="920" height="440" alt="Screenshot 2026-05-14 at 1 14 16 PM" src="https://github.com/user-attachments/assets/81e0fa06-bb58-449d-a55c-55ae0ae396d2" />

Then the max:

<img width="924" height="444" alt="Screenshot 2026-05-14 at 1 14 21 PM" src="https://github.com/user-attachments/assets/918edc7b-8ff5-474b-90b2-bc93189c5816" />

And finally 99th percentile:

<img width="920" height="445" alt="Screenshot 2026-05-14 at 1 24 25 PM" src="https://github.com/user-attachments/assets/d4643d26-2523-40ea-b005-b10959331764" />

So a few milliseconds on average, but gets up to the 4/8 milliseconds often.


# Summary of Changes

Similar to https://github.com/anza-xyz/agave/pull/8157, which moved the accounts lt hash updating inline with transaction processing, this PR moves the updating to a new thread pool for accounts hashing.

When committing transactions, right before we store the updated accounts, we send those updates to the accounts hasher thread pool to compute the accounts lt hash. So we pay a little bit in commit_transactions() with the goal to avoid paying during Bank::freeze().


# Results

### Bank::freeze() time

Here's this PR on a different node. Note that ~10:08 was an epoch boundary too!

Mean: 

<img width="925" height="447" alt="Screenshot 2026-06-06 at 10 42 31 AM" src="https://github.com/user-attachments/assets/3b2d7e83-7a19-4546-9034-6b9cb2b0b98a" />

99th percentile:

<img width="920" height="447" alt="Screenshot 2026-06-06 at 10 42 36 AM" src="https://github.com/user-attachments/assets/51034487-23de-474a-977e-a9294aaae0f9" />

Max:

<img width="921" height="446" alt="Screenshot 2026-06-06 at 10 42 44 AM" src="https://github.com/user-attachments/assets/3ee0707c-1bef-4e0f-aabe-947329a4876c" />

Time spent on the accounts lt hash during `Bank::freeze()` is *much* faster. This is because the actual account hashing has already been completed.

Note that in Max we still have spikes to a few milliseconds. When looking at slowlana profiles during this time, I saw that we're waiting for an account hash to complete on one of the accounts hasher threads. Note that large accounts take longer to hash. So if a large account is modified by a transaction late in the slot, we will always have the potential of needing to wait for its hash to complete. (Maybe we speed up the blake3 hasher next?)


### Commit transaction time

We do new work when committing transactions, and that takes some time. Here's what `replay-slot-stats.store_us` looks like:

Mean:

<img width="927" height="446" alt="Screenshot 2026-06-06 at 10 49 58 AM" src="https://github.com/user-attachments/assets/1a1f3d13-dd42-49d9-9894-1931d73ad516" />

99th percentile:

<img width="924" height="443" alt="Screenshot 2026-06-06 at 10 50 03 AM" src="https://github.com/user-attachments/assets/cabdf4b9-f788-46be-9c6d-1ceea9e10025" />

So definitely longer. Note these stats are parallel across multiple threads, so it isn't strictly wall clock time. When looking at overall slot times, they were unaffected by the PR.


### Epoch boundary

The epoch boundary is a special case, as we store many more accounts as part of rewards payout. This happens over a few slots, since vote accounts are updated in the first slot of the epoch, and stake accounts are partitioned over the next few slots.

#### Bank::freeze()

Here's how long Bank::freeze() takes currently:

<img width="927" height="442" alt="Screenshot 2026-06-06 at 10 14 59 AM" src="https://github.com/user-attachments/assets/9b6ee6ac-22a4-45d9-b9d8-3fe7e7f8c51a" />

And with this PR:

<img width="924" height="443" alt="Screenshot 2026-06-06 at 10 14 47 AM" src="https://github.com/user-attachments/assets/4b92c04c-8c10-4bbe-a620-98791a710eb3" />

So we no longer have the 40-50 millisecond wait here.