### PR TITLE
[bls-cert-verify] Remove unnecessary vec allocation of messages in base3 cert verification

### DIFF
--- a/bls-cert-verify/src/cert_verify.rs
+++ b/bls-cert-verify/src/cert_verify.rs
@@ -191,15 +191,15 @@ fn verify_base3(
                 let agg_pubkey = aggregate_pubkeys(&primary_pubkeys)?;
                 Ok(agg_pubkey.verify_signature(signature, payload)?)
             } else {
-                let mut all_pubkeys = Vec::with_capacity(
-                    primary_pubkeys.len().saturating_add(fallback_pubkeys.len()),
-                );
-                all_pubkeys.extend_from_slice(&primary_pubkeys);
-                all_pubkeys.extend_from_slice(&fallback_pubkeys);
+                let agg_primary = aggregate_pubkeys(&primary_pubkeys)?;
+                let agg_fallback = aggregate_pubkeys(&fallback_pubkeys)?;
 
-                let mut all_messages = Vec::with_capacity(all_pubkeys.len());
-                all_messages.resize(primary_pubkeys.len(), payload);
-                all_messages.resize(all_pubkeys.len(), fallback_payload);
+                let all_pubkeys = [
+                    unsafe { PopVerified::new_unchecked(*agg_primary) },
+                    unsafe { PopVerified::new_unchecked(*agg_fallback) },
+                ];
+
+                let all_messages = [payload, fallback_payload];
 
                 if rayon::current_num_threads() < THREAD_POOL_THRESHOLD {
                     Ok(SignatureProjective::verify_distinct_aggregated(

--- a/bls-cert-verify/src/cert_verify.rs
+++ b/bls-cert-verify/src/cert_verify.rs
@@ -194,6 +194,11 @@ fn verify_base3(
                 let agg_primary = aggregate_pubkeys(&primary_pubkeys)?;
                 let agg_fallback = aggregate_pubkeys(&fallback_pubkeys)?;
 
+                // SAFETY: `aggregate_pubkeys` strictly requires `PopVerified` public keys
+                // as input. Because every constituent key has already proven possession,
+                // the resulting aggregated key inherits this property and is mathematically
+                // protected against rogue-key attacks, making it safe to bypass the
+                // cryptographic check here.
                 let all_pubkeys = [
                     unsafe { PopVerified::new_unchecked(*agg_primary) },
                     unsafe { PopVerified::new_unchecked(*agg_fallback) },


### PR DESCRIPTION
#### Problem

Currently, the base3 cert verification logic has some inefficiencies: Even though we know that there are exactly two distinct messages to verify, we create a vector of messages for each public key and perform an expensive hash-to-curve function. This can be improved by aggregating the public keys inside the `bls-cert-verify` crate.

#### Summary of Changes
Aggregate the public keys inside the `bls-cert-verify` crate. By pre-aggregating the primary and fallback signers independently, we now pass exactly two aggregated public keys and two messages to the underlying BLS library, reducing the heavy cryptographic preprocessing from `O(N)` to an `O(1)` constant time operation.