### PR TITLE
streamer: only wire rustls KeyLogFile in debug builds

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -15,6 +15,7 @@ use {
         Endpoint, IdleTimeout, ServerConfig, VarInt,
         crypto::rustls::{NoInitialCipherSuite, QuicServerConfig},
     },
+    #[cfg(debug_assertions)]
     rustls::KeyLogFile,
     solana_keypair::Keypair,
     solana_packet::PACKET_DATA_SIZE,
@@ -100,7 +101,14 @@ pub(crate) fn configure_server(
     let mut server_tls_config =
         tls_server_config_builder().with_single_cert(vec![cert], priv_key)?;
     server_tls_config.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
-    server_tls_config.key_log = Arc::new(KeyLogFile::new());
+    // Only wire the SSLKEYLOGFILE-reading key logger in debug builds. Release
+    // validators should never silently honor SSLKEYLOGFILE: an operator who
+    // accidentally exports it would otherwise leak TPU TLS session secrets to
+    // disk. Developers who need rustls key-log decryption can run a debug build.
+    #[cfg(debug_assertions)]
+    {
+        server_tls_config.key_log = Arc::new(KeyLogFile::new());
+    }
     let quic_server_config = QuicServerConfig::try_from(server_tls_config)?;
 
     let mut server_config = ServerConfig::with_crypto(Arc::new(quic_server_config));


### PR DESCRIPTION
### Problem

`streamer/src/quic.rs` configures the TPU QUIC server's TLS context with:

```rust
server_tls_config.key_log = Arc::new(KeyLogFile::new());
```

`rustls::KeyLogFile::new()` reads the `SSLKEYLOGFILE` environment variable at runtime. If an operator exports `SSLKEYLOGFILE` on the validator process (e.g. left over from local TLS debugging, picked up from a parent shell, set via a systemd `Environment=` line copied from a tutorial, …) the TPU QUIC server will write per-connection TLS session secrets to that path on every accepted handshake.

This is purely an operator-misconfiguration amplifier rather than a remote-reachable bug — the attacker cannot set the env var — but the cost of leaving it wired in release builds is asymmetric: an unintentional `SSLKEYLOGFILE` on a production validator silently produces a file from which someone with read access to the host can decrypt recorded TPU traffic.

### Fix

Gate `KeyLogFile` behind `#[cfg(debug_assertions)]` so release validators never honor `SSLKEYLOGFILE`. Developers who actually want rustls key-log decryption for debugging can still get it by running a debug build, which is the situation the API is intended for.

### Diff

One file, +9 / -1.

```rust
    server_tls_config.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
    // Only wire the SSLKEYLOGFILE-reading key logger in debug builds. Release
    // validators should never silently honor SSLKEYLOGFILE: an operator who
    // accidentally exports it would otherwise leak TPU TLS session secrets to
    // disk. Developers who need rustls key-log decryption can run a debug build.
    #[cfg(debug_assertions)]
    {
        server_tls_config.key_log = Arc::new(KeyLogFile::new());
    }
```

`rustls::KeyLogFile` import is also gated by `#[cfg(debug_assertions)]` so release builds don't pull in an unused symbol.

### Compatibility / risk

- No release-build behavior change for anyone NOT setting `SSLKEYLOGFILE`.
- For release builds with `SSLKEYLOGFILE` accidentally set: the var stops being honored on TPU. Intentional rustls debugging on production was never the design intent, so this matches the API's expected usage.
- Debug builds keep the previous behavior.
- Verified `cargo check -p solana-streamer` passes in both `--release` and dev profiles.

### Why this isn't filed as a security advisory

Not remotely reachable; requires operator misconfiguration. Defense-in-depth only.
