### PR TITLE
accounts-db: return None on malformed AppendVec records instead of panic

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -576,7 +576,10 @@ impl AppendVec {
             callback(account)
         } else {
             // not enough was read from file to get `data`
-            assert!(data_len <= MAX_PERMITTED_DATA_LENGTH, "{data_len}");
+            if data_len > MAX_PERMITTED_DATA_LENGTH {
+                // malformed record: data_len exceeds protocol max; bail like the rest of the scan-callback contract
+                return None;
+            }
             let mut data: Box<[MaybeUninit<u8>]> = Box::new_uninit_slice(data_len as usize);
             // instead, we could piece together what we already read here. Maybe we just needed 1 more byte.
             // Note here `next` is a 0-based offset from the beginning of this account.
@@ -674,7 +677,10 @@ impl AppendVec {
             create_account_shared_data(&account)
         } else {
             // not enough was read from file to get `data`
-            assert!(data_len <= MAX_PERMITTED_DATA_LENGTH, "{data_len}");
+            if data_len > MAX_PERMITTED_DATA_LENGTH {
+                // malformed record: data_len exceeds protocol max; bail like the rest of the scan-callback contract
+                return None;
+            }
             let mut data = Vec::with_capacity(data_len as usize);
             let slice = data.spare_capacity_mut();
             // Note here `next` is a 0-based offset from the beginning of this account.


### PR DESCRIPTION
## Summary

The file-backed AppendVec read paths in `get_stored_account_meta_callback` and `get_account_shared_data` already return `Option<_>`, and the surrounding deserializers (`get_type`, `get_slice`, `read_into_buffer`) bail with `None` on any short or invalid read. Three sites broke that contract by panicking instead:

- two `assert!(data_len <= MAX_PERMITTED_DATA_LENGTH)` calls that fire when a record's declared `data_len` exceeds the protocol max,
- one `.expect("stored size cannot overflow")` in `next_account_offset` that fires when `STORE_META_OVERHEAD + data_len` would overflow `usize`.

This change converts all three to graceful early-returns so malformed records are handled the same way as every other short/invalid read in the same match arms. `next_account_offset` now returns `Option<AccountOffsets>`, and the two call sites in `get_account_data_lens` treat `None` exactly like a short `StoredMeta` read (break the scan loop). The two callback paths return `None` alongside the other malformed-record return paths.

## Behavior

Well-formed input is unchanged. Malformed input no longer panics; callers see `None` and stop iterating, matching the rest of the scan-callback contract.

## Test plan

- [x] `cargo check -p solana-accounts-db`
- [x] `cargo check -p solana-accounts-db --release`
