### PR TITLE
feat(storage-proto): switch all bincode to wincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10530,7 +10530,6 @@ dependencies = [
 name = "solana-storage-proto"
 version = "4.1.0-alpha.0"
 dependencies = [
- "bincode",
  "bs58",
  "enum-iterator",
  "prost 0.14.3",
@@ -10548,6 +10547,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status",
  "test-case",
+ "thiserror 2.0.18",
  "tonic-prost-build",
  "wincode",
 ]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9022,7 +9022,6 @@ dependencies = [
 name = "solana-storage-proto"
 version = "4.1.0-alpha.0"
 dependencies = [
- "bincode",
  "bs58",
  "prost 0.14.3",
  "protobuf-src",
@@ -9038,6 +9037,7 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
+ "thiserror 2.0.18",
  "tonic-prost-build",
  "wincode",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9380,7 +9380,6 @@ dependencies = [
 name = "solana-storage-proto"
 version = "4.1.0-alpha.0"
 dependencies = [
- "bincode",
  "bs58",
  "prost",
  "protobuf-src",
@@ -9396,6 +9395,7 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
+ "thiserror 2.0.18",
  "tonic-prost-build",
  "wincode",
 ]

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -20,7 +20,6 @@ name = "solana_storage_proto"
 agave-unstable-api = []
 
 [dependencies]
-bincode = { workspace = true }
 bs58 = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }
@@ -35,6 +34,7 @@ solana-transaction = { workspace = true }
 solana-transaction-context = { workspace = true, features = ["serde", "wincode"] }
 solana-transaction-error = { workspace = true, features = ["wincode"] }
 solana-transaction-status = { workspace = true }
+thiserror = { workspace = true }
 wincode = { workspace = true }
 
 [build-dependencies]

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -25,6 +25,7 @@ use {
         convert::{TryFrom, TryInto},
         str::FromStr,
     },
+    wincode::ReadError,
 };
 
 pub mod generated {
@@ -43,6 +44,14 @@ pub mod tx_by_addr {
 
 pub mod entries {
     include!(concat!(env!("OUT_DIR"), "/solana.storage.entries.rs"));
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("failed to decode {bytes:?}: {source}")]
+pub struct DecodeError {
+    pub bytes: Vec<u8>,
+    #[source]
+    pub source: ReadError,
 }
 
 impl From<Vec<Reward>> for generated::Rewards {
@@ -185,7 +194,7 @@ impl From<VersionedConfirmedBlock> for generated::ConfirmedBlock {
 }
 
 impl TryFrom<generated::ConfirmedBlock> for ConfirmedBlock {
-    type Error = bincode::Error;
+    type Error = DecodeError;
     fn try_from(
         confirmed_block: generated::ConfirmedBlock,
     ) -> std::result::Result<Self, Self::Error> {
@@ -239,7 +248,7 @@ impl From<VersionedTransactionWithStatusMeta> for generated::ConfirmedTransactio
 }
 
 impl TryFrom<generated::ConfirmedTransaction> for TransactionWithStatusMeta {
-    type Error = bincode::Error;
+    type Error = DecodeError;
     fn try_from(value: generated::ConfirmedTransaction) -> std::result::Result<Self, Self::Error> {
         let meta = value.meta.map(|meta| meta.try_into()).transpose()?;
         let transaction = value.transaction.expect("transaction is required").into();
@@ -470,7 +479,7 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
         let err = match status {
             Ok(()) => None,
             Err(err) => Some(generated::TransactionError {
-                err: bincode::serialize(&err).expect("transaction error to serialize to bytes"),
+                err: wincode::serialize(&err).expect("transaction error to serialize to bytes"),
             }),
         };
         let inner_instructions_none = inner_instructions.is_none();
@@ -539,7 +548,7 @@ impl From<StoredTransactionStatusMeta> for generated::TransactionStatusMeta {
 }
 
 impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
-    type Error = bincode::Error;
+    type Error = DecodeError;
 
     fn try_from(value: generated::TransactionStatusMeta) -> std::result::Result<Self, Self::Error> {
         let generated::TransactionStatusMeta {
@@ -561,9 +570,16 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             compute_units_consumed,
             cost_units,
         } = value;
-        let status = match &err {
+        let status = match err {
             None => Ok(()),
-            Some(tx_error) => Err(bincode::deserialize(&tx_error.err)?),
+            Some(tx_error) => {
+                let tx_error =
+                    wincode::deserialize(&tx_error.err).map_err(|source| DecodeError {
+                        bytes: tx_error.err,
+                        source,
+                    })?;
+                Err(tx_error)
+            }
         };
         let inner_instructions = if inner_instructions_none {
             None
@@ -598,17 +614,17 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
                 .into_iter()
                 .map(Pubkey::try_from)
                 .collect::<Result<_, _>>()
-                .map_err(|err| {
-                    let err = format!("Invalid writable address: {err:?}");
-                    Self::Error::new(bincode::ErrorKind::Custom(err))
+                .map_err(|bytes| DecodeError {
+                    bytes,
+                    source: ReadError::Custom("Invalid writable address"),
                 })?,
             readonly: loaded_readonly_addresses
                 .into_iter()
                 .map(Pubkey::try_from)
                 .collect::<Result<_, _>>()
-                .map_err(|err| {
-                    let err = format!("Invalid readonly address: {err:?}");
-                    Self::Error::new(bincode::ErrorKind::Custom(err))
+                .map_err(|bytes| DecodeError {
+                    bytes,
+                    source: ReadError::Custom("Invalid readonly address"),
                 })?,
         };
         let return_data = if return_data_none {

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -14,6 +14,7 @@ use {
         InnerInstructions, Reward, RewardType, TransactionStatusMeta, TransactionTokenBalance,
     },
     std::str::FromStr,
+    wincode::ReadError,
 };
 
 pub mod convert;
@@ -180,13 +181,13 @@ struct StoredTransactionError(Vec<u8>);
 impl From<StoredTransactionError> for TransactionError {
     fn from(value: StoredTransactionError) -> Self {
         let bytes = value.0;
-        bincode::deserialize(&bytes).expect("transaction error to deserialize from bytes")
+        wincode::deserialize(&bytes).expect("transaction error to deserialize from bytes")
     }
 }
 
 impl From<TransactionError> for StoredTransactionError {
     fn from(value: TransactionError) -> Self {
-        let bytes = bincode::serialize(&value).expect("transaction error to serialize to bytes");
+        let bytes = wincode::serialize(&value).expect("transaction error to serialize to bytes");
         StoredTransactionError(bytes)
     }
 }
@@ -316,7 +317,7 @@ impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
 }
 
 impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
-    type Error = bincode::Error;
+    type Error = ReadError;
     fn try_from(value: TransactionStatusMeta) -> std::result::Result<Self, Self::Error> {
         let TransactionStatusMeta {
             status,
@@ -335,11 +336,9 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
         } = value;
 
         if !loaded_addresses.is_empty() {
-            // Deprecated bincode serialized status metadata doesn't support
-            // loaded addresses.
-            return Err(
-                bincode::ErrorKind::Custom("Bincode serialization is deprecated".into()).into(),
-            );
+            return Err(ReadError::Custom(
+                "deprecated stored transaction status metadata does not support loaded addresses",
+            ));
         }
 
         Ok(Self {


### PR DESCRIPTION
#### Problem
A few uses bincode still exist in `storage-proto`, primarly for serialization of `TransactionError`. This can be already handled by wincode.

#### Summary of Changes
The most significant change here is introducing an aux error struct, since wincode's ReadError doesn't allow holding arbitrary data / string.
