### PR TITLE
transaction-view: invert svm-transaction dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,13 +322,12 @@ dependencies = [
  "solana-keypair",
  "solana-message",
  "solana-packet 4.1.0",
- "solana-program-runtime",
+ "solana-program-entrypoint",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-signature",
  "solana-signer",
- "solana-svm-transaction",
  "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-context",
@@ -10692,6 +10691,7 @@ dependencies = [
 name = "solana-svm-transaction"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "agave-transaction-view",
  "solana-hash 4.3.0",
  "solana-message",
  "solana-nonce",

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -35,7 +35,9 @@ use {
         transaction_with_meta::TransactionWithMeta,
     },
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
-    solana_svm_transaction::svm_message::SVMMessage,
+    solana_svm_transaction::{
+        message_address_table_lookup::SVMMessageAddressTableLookup, svm_message::SVMMessage,
+    },
     solana_transaction::sanitized::MessageHash,
     solana_transaction_error::TransactionError,
     std::{collections::HashSet, sync::Arc, time::Instant},
@@ -508,7 +510,10 @@ pub(crate) fn load_addresses_for_view<D: TransactionData>(
     match view.version() {
         TransactionVersion::Legacy | TransactionVersion::V1 => Ok((None, u64::MAX)),
         TransactionVersion::V0 => bank
-            .load_addresses_from_ref(view.address_table_lookup_iter())
+            .load_addresses_from_ref(
+                view.address_table_lookup_iter()
+                    .map(SVMMessageAddressTableLookup::from),
+            )
             .map(|(loaded_addresses, deactivation_slot)| {
                 (Some(loaded_addresses), deactivation_slot)
             })

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -23,6 +23,7 @@ use {
         runtime_transaction::RuntimeTransaction, transaction_meta::TransactionMeta,
     },
     solana_streamer::sendmmsg::{SendPktsError, batch_send},
+    solana_svm_transaction::instruction::SVMInstruction,
     solana_tls_utils::NotifyKeyUpdate,
     solana_tpu_client_next::{
         ConnectionWorkersScheduler,
@@ -613,7 +614,9 @@ fn calculate_priority(
 
     let cost = CostModel::estimate_cost(
         transaction,
-        transaction.program_instructions_iter(),
+        transaction
+            .program_instructions_iter()
+            .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix))),
         transaction.num_requested_write_locks(),
         &bank.feature_set,
     );

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -332,12 +332,11 @@ dependencies = [
  "solana-hash 4.3.0",
  "solana-message",
  "solana-packet 4.1.0",
- "solana-program-runtime",
+ "solana-program-entrypoint",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-signature",
- "solana-svm-transaction",
  "solana-transaction",
  "solana-transaction-context",
 ]
@@ -8967,6 +8966,7 @@ dependencies = [
 name = "solana-svm-transaction"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "agave-transaction-view",
  "solana-hash 4.3.0",
  "solana-message",
  "solana-pubkey 4.2.0",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -239,12 +239,11 @@ dependencies = [
  "solana-hash 4.3.0",
  "solana-message",
  "solana-packet 4.1.0",
- "solana-program-runtime",
+ "solana-program-entrypoint",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-signature",
- "solana-svm-transaction",
  "solana-transaction",
  "solana-transaction-context",
 ]
@@ -9488,6 +9487,7 @@ dependencies = [
 name = "solana-svm-transaction"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "agave-transaction-view",
  "solana-hash 4.3.0",
  "solana-message",
  "solana-pubkey 4.2.0",

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -21,7 +21,7 @@ use {
     },
     solana_program_entrypoint::HEAP_LENGTH,
     solana_pubkey::Pubkey,
-    solana_svm_transaction::svm_message::SVMMessage,
+    solana_svm_transaction::{instruction::SVMInstruction, svm_message::SVMMessage},
     solana_transaction::{
         sanitized::{MessageHash, SanitizedTransaction},
         simple_vote_transaction_checker::is_simple_vote_transaction_impl,
@@ -83,7 +83,11 @@ where
     let InstructionMeta {
         precompile_signature_details,
         instruction_data_len,
-    } = InstructionMeta::try_new(transaction.program_instructions_iter())?;
+    } = InstructionMeta::try_new(
+        transaction
+            .program_instructions_iter()
+            .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix))),
+    )?;
 
     let signature_details = TransactionSignatureDetails::new(
         u64::from(transaction.num_required_signatures()),
@@ -91,25 +95,28 @@ where
         precompile_signature_details.num_ed25519_instruction_signatures,
         precompile_signature_details.num_secp256r1_instruction_signatures,
     );
-    let versioned_transaction_config =
-        if let Some(transaction_config_view) = transaction.transaction_config() {
-            // NOTE: only txv1 has `transaction_config_view`, which must have been validated for
-            // SanitizedTransactionView.
-            VersionedTransactionConfiguration::V1(TransactionConfiguration {
-                priority_fee_lamports: transaction_config_view.priority_fee_lamports().unwrap_or(0),
-                compute_unit_limit: transaction_config_view.compute_unit_limit().unwrap_or(0),
-                loaded_accounts_data_size_limit: transaction_config_view
-                    .loaded_accounts_data_size_limit()
-                    .unwrap_or(0),
-                updated_heap_bytes: transaction_config_view
-                    .requested_heap_size()
-                    .unwrap_or(HEAP_LENGTH as u32),
-            })
-        } else {
-            VersionedTransactionConfiguration::LegacyAndV0(
-                ComputeBudgetInstructionDetails::try_from(transaction.program_instructions_iter())?,
-            )
-        };
+    let versioned_transaction_config = if let Some(transaction_config_view) =
+        transaction.transaction_config()
+    {
+        // NOTE: only txv1 has `transaction_config_view`, which must have been validated for
+        // SanitizedTransactionView.
+        VersionedTransactionConfiguration::V1(TransactionConfiguration {
+            priority_fee_lamports: transaction_config_view.priority_fee_lamports().unwrap_or(0),
+            compute_unit_limit: transaction_config_view.compute_unit_limit().unwrap_or(0),
+            loaded_accounts_data_size_limit: transaction_config_view
+                .loaded_accounts_data_size_limit()
+                .unwrap_or(0),
+            updated_heap_bytes: transaction_config_view
+                .requested_heap_size()
+                .unwrap_or(HEAP_LENGTH as u32),
+        })
+    } else {
+        VersionedTransactionConfiguration::LegacyAndV0(ComputeBudgetInstructionDetails::try_from(
+            transaction
+                .program_instructions_iter()
+                .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix))),
+        )?)
+    };
 
     Ok(CachedTransactionMeta {
         message_hash,

--- a/svm-transaction/Cargo.toml
+++ b/svm-transaction/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2024"
 agave-unstable-api = []
 
 [dependencies]
+agave-transaction-view = { workspace = true }
 solana-hash = { workspace = true }
 solana-message = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/svm-transaction/src/instruction.rs
+++ b/svm-transaction/src/instruction.rs
@@ -22,3 +22,13 @@ impl<'a> From<&'a CompiledInstruction> for SVMInstruction<'a> {
         }
     }
 }
+
+impl<'a> From<agave_transaction_view::InstructionView<'a>> for SVMInstruction<'a> {
+    fn from(ix: agave_transaction_view::InstructionView<'a>) -> Self {
+        Self {
+            program_id_index: ix.program_id_index,
+            accounts: ix.accounts,
+            data: ix.data,
+        }
+    }
+}

--- a/svm-transaction/src/lib.rs
+++ b/svm-transaction/src/lib.rs
@@ -5,3 +5,4 @@ pub mod svm_message;
 pub mod svm_transaction;
 
 mod tests;
+mod transaction_view;

--- a/svm-transaction/src/message_address_table_lookup.rs
+++ b/svm-transaction/src/message_address_table_lookup.rs
@@ -21,3 +21,15 @@ impl<'a> From<&'a v0::MessageAddressTableLookup> for SVMMessageAddressTableLooku
         }
     }
 }
+
+impl<'a> From<agave_transaction_view::MessageAddressTableLookupView<'a>>
+    for SVMMessageAddressTableLookup<'a>
+{
+    fn from(lookup: agave_transaction_view::MessageAddressTableLookupView<'a>) -> Self {
+        Self {
+            account_key: lookup.account_key,
+            writable_indexes: lookup.writable_indexes,
+            readonly_indexes: lookup.readonly_indexes,
+        }
+    }
+}

--- a/svm-transaction/src/transaction_view.rs
+++ b/svm-transaction/src/transaction_view.rs
@@ -1,0 +1,205 @@
+use {
+    crate::{
+        instruction::SVMInstruction,
+        message_address_table_lookup::SVMMessageAddressTableLookup,
+        svm_message::{SVMMessage, SVMStaticMessage},
+        svm_transaction::SVMTransaction,
+    },
+    agave_transaction_view::{
+        resolved_transaction_view::ResolvedTransactionView, transaction_data::TransactionData,
+        transaction_view::TransactionView,
+    },
+    solana_hash::Hash,
+    solana_message::AccountKeys,
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
+    solana_transaction::versioned::TransactionVersion,
+};
+
+impl<D: TransactionData> SVMStaticMessage for TransactionView<true, D> {
+    fn version(&self) -> TransactionVersion {
+        self.version().into()
+    }
+
+    fn num_transaction_signatures(&self) -> u64 {
+        u64::from(self.num_required_signatures())
+    }
+
+    fn num_write_locks(&self) -> u64 {
+        self.num_requested_write_locks()
+    }
+
+    fn recent_blockhash(&self) -> &Hash {
+        self.recent_blockhash()
+    }
+
+    fn num_instructions(&self) -> usize {
+        usize::from(self.num_instructions())
+    }
+
+    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
+        TransactionView::instructions_iter(self).map(SVMInstruction::from)
+    }
+
+    fn program_instructions_iter(
+        &self,
+    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
+        TransactionView::program_instructions_iter(self)
+            .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix)))
+    }
+
+    fn static_account_keys(&self) -> &[Pubkey] {
+        self.static_account_keys()
+    }
+
+    fn fee_payer(&self) -> &Pubkey {
+        &self.static_account_keys()[0]
+    }
+
+    fn num_lookup_tables(&self) -> usize {
+        usize::from(self.num_address_table_lookups())
+    }
+
+    fn message_address_table_lookups(
+        &self,
+    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
+        self.address_table_lookup_iter()
+            .map(SVMMessageAddressTableLookup::from)
+    }
+}
+
+impl<D: TransactionData> SVMStaticMessage for &TransactionView<true, D> {
+    fn version(&self) -> TransactionVersion {
+        TransactionView::version(self).into()
+    }
+
+    fn num_transaction_signatures(&self) -> u64 {
+        u64::from(TransactionView::num_required_signatures(self))
+    }
+
+    fn num_write_locks(&self) -> u64 {
+        TransactionView::num_requested_write_locks(self)
+    }
+
+    fn recent_blockhash(&self) -> &Hash {
+        TransactionView::recent_blockhash(self)
+    }
+
+    fn num_instructions(&self) -> usize {
+        usize::from(TransactionView::num_instructions(self))
+    }
+
+    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
+        TransactionView::instructions_iter(self).map(SVMInstruction::from)
+    }
+
+    fn program_instructions_iter(
+        &self,
+    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
+        TransactionView::program_instructions_iter(self)
+            .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix)))
+    }
+
+    fn static_account_keys(&self) -> &[Pubkey] {
+        TransactionView::static_account_keys(self)
+    }
+
+    fn fee_payer(&self) -> &Pubkey {
+        &TransactionView::static_account_keys(self)[0]
+    }
+
+    fn num_lookup_tables(&self) -> usize {
+        usize::from(TransactionView::num_address_table_lookups(self))
+    }
+
+    fn message_address_table_lookups(
+        &self,
+    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
+        TransactionView::address_table_lookup_iter(self).map(SVMMessageAddressTableLookup::from)
+    }
+}
+
+impl<D: TransactionData> SVMStaticMessage for ResolvedTransactionView<D> {
+    fn version(&self) -> TransactionVersion {
+        TransactionView::version(self).into()
+    }
+
+    fn num_transaction_signatures(&self) -> u64 {
+        u64::from(TransactionView::num_required_signatures(self))
+    }
+
+    fn num_write_locks(&self) -> u64 {
+        TransactionView::num_requested_write_locks(self)
+    }
+
+    fn recent_blockhash(&self) -> &Hash {
+        TransactionView::recent_blockhash(self)
+    }
+
+    fn num_instructions(&self) -> usize {
+        usize::from(TransactionView::num_instructions(self))
+    }
+
+    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
+        TransactionView::instructions_iter(self).map(SVMInstruction::from)
+    }
+
+    fn program_instructions_iter(
+        &self,
+    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
+        TransactionView::program_instructions_iter(self)
+            .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix)))
+    }
+
+    fn static_account_keys(&self) -> &[Pubkey] {
+        TransactionView::static_account_keys(self)
+    }
+
+    fn fee_payer(&self) -> &Pubkey {
+        &TransactionView::static_account_keys(self)[0]
+    }
+
+    fn num_lookup_tables(&self) -> usize {
+        usize::from(TransactionView::num_address_table_lookups(self))
+    }
+
+    fn message_address_table_lookups(
+        &self,
+    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
+        TransactionView::address_table_lookup_iter(self).map(SVMMessageAddressTableLookup::from)
+    }
+}
+
+impl<D: TransactionData> SVMMessage for ResolvedTransactionView<D> {
+    fn account_keys(&self) -> AccountKeys<'_> {
+        AccountKeys::new(
+            TransactionView::static_account_keys(self),
+            self.loaded_addresses(),
+        )
+    }
+
+    fn is_writable(&self, index: usize) -> bool {
+        ResolvedTransactionView::is_writable(self, index)
+    }
+
+    fn is_signer(&self, index: usize) -> bool {
+        index < usize::from(TransactionView::num_required_signatures(self))
+    }
+
+    fn is_invoked(&self, key_index: usize) -> bool {
+        let Ok(index) = u8::try_from(key_index) else {
+            return false;
+        };
+        TransactionView::instructions_iter(self).any(|ix| ix.program_id_index == index)
+    }
+}
+
+impl<D: TransactionData> SVMTransaction for ResolvedTransactionView<D> {
+    fn signature(&self) -> &Signature {
+        &TransactionView::signatures(self)[0]
+    }
+
+    fn signatures(&self) -> &[Signature] {
+        TransactionView::signatures(self)
+    }
+}

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -17,12 +17,11 @@ dev-context-only-utils = []
 solana-hash = { workspace = true }
 solana-message = { workspace = true }
 solana-packet = { workspace = true }
-solana-program-runtime = { workspace = true }
+solana-program-entrypoint = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true }
 solana-signature = { workspace = true }
-solana-svm-transaction = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-context = { workspace = true }
 

--- a/transaction-view/src/address_table_lookup_frame.rs
+++ b/transaction-view/src/address_table_lookup_frame.rs
@@ -8,11 +8,45 @@ use {
     },
     core::fmt::{Debug, Formatter},
     solana_hash::Hash,
+    solana_message::v0,
     solana_packet::PACKET_DATA_SIZE,
     solana_pubkey::Pubkey,
     solana_signature::Signature,
-    solana_svm_transaction::message_address_table_lookup::SVMMessageAddressTableLookup,
 };
+
+/// A non-owning version of [`v0::MessageAddressTableLookup`] that references
+/// slices of writable and readonly lookup indexes.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct MessageAddressTableLookupView<'a> {
+    /// Address lookup table account key.
+    pub account_key: &'a Pubkey,
+    /// List of indexes used to load writable account addresses.
+    pub writable_indexes: &'a [u8],
+    /// List of indexes used to load readonly account addresses.
+    pub readonly_indexes: &'a [u8],
+}
+
+impl<'a> From<&'a v0::MessageAddressTableLookup> for MessageAddressTableLookupView<'a> {
+    fn from(address_table_lookup: &'a v0::MessageAddressTableLookup) -> Self {
+        Self {
+            account_key: &address_table_lookup.account_key,
+            writable_indexes: address_table_lookup.writable_indexes.as_slice(),
+            readonly_indexes: address_table_lookup.readonly_indexes.as_slice(),
+        }
+    }
+}
+
+impl<'a> From<MessageAddressTableLookupView<'a>>
+    for solana_svm_transaction::message_address_table_lookup::SVMMessageAddressTableLookup<'a>
+{
+    fn from(address_table_lookup: MessageAddressTableLookupView<'a>) -> Self {
+        Self {
+            account_key: address_table_lookup.account_key,
+            writable_indexes: address_table_lookup.writable_indexes,
+            readonly_indexes: address_table_lookup.readonly_indexes,
+        }
+    }
+}
 
 // Each ATL has at least a Pubkey, one byte for the number of write indexes,
 // and one byte for the number of read indexes. Additionally, for validity
@@ -141,7 +175,7 @@ pub struct AddressTableLookupIterator<'a> {
 }
 
 impl<'a> Iterator for AddressTableLookupIterator<'a> {
-    type Item = SVMMessageAddressTableLookup<'a>;
+    type Item = MessageAddressTableLookupView<'a>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -189,7 +223,7 @@ impl<'a> Iterator for AddressTableLookupIterator<'a> {
                 unsafe { read_slice_data::<u8>(self.bytes, &mut self.offset, num_read_accounts) }
                     .ok()?;
 
-            Some(SVMMessageAddressTableLookup {
+            Some(MessageAddressTableLookupView {
                 account_key,
                 writable_indexes,
                 readonly_indexes,

--- a/transaction-view/src/address_table_lookup_frame.rs
+++ b/transaction-view/src/address_table_lookup_frame.rs
@@ -13,7 +13,7 @@ use {
     solana_signature::Signature,
 };
 
-/// A non-owning version of [`v0::MessageAddressTableLookup`] that references
+/// A non-owning version of [`solana_message::v0::MessageAddressTableLookup`] that references
 /// slices of writable and readonly lookup indexes.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct MessageAddressTableLookupView<'a> {

--- a/transaction-view/src/address_table_lookup_frame.rs
+++ b/transaction-view/src/address_table_lookup_frame.rs
@@ -8,7 +8,6 @@ use {
     },
     core::fmt::{Debug, Formatter},
     solana_hash::Hash,
-    solana_message::v0,
     solana_packet::PACKET_DATA_SIZE,
     solana_pubkey::Pubkey,
     solana_signature::Signature,
@@ -24,16 +23,6 @@ pub struct MessageAddressTableLookupView<'a> {
     pub writable_indexes: &'a [u8],
     /// List of indexes used to load readonly account addresses.
     pub readonly_indexes: &'a [u8],
-}
-
-impl<'a> From<&'a v0::MessageAddressTableLookup> for MessageAddressTableLookupView<'a> {
-    fn from(address_table_lookup: &'a v0::MessageAddressTableLookup) -> Self {
-        Self {
-            account_key: &address_table_lookup.account_key,
-            writable_indexes: address_table_lookup.writable_indexes.as_slice(),
-            readonly_indexes: address_table_lookup.readonly_indexes.as_slice(),
-        }
-    }
 }
 
 // Each ATL has at least a Pubkey, one byte for the number of write indexes,

--- a/transaction-view/src/address_table_lookup_frame.rs
+++ b/transaction-view/src/address_table_lookup_frame.rs
@@ -36,18 +36,6 @@ impl<'a> From<&'a v0::MessageAddressTableLookup> for MessageAddressTableLookupVi
     }
 }
 
-impl<'a> From<MessageAddressTableLookupView<'a>>
-    for solana_svm_transaction::message_address_table_lookup::SVMMessageAddressTableLookup<'a>
-{
-    fn from(address_table_lookup: MessageAddressTableLookupView<'a>) -> Self {
-        Self {
-            account_key: address_table_lookup.account_key,
-            writable_indexes: address_table_lookup.writable_indexes,
-            readonly_indexes: address_table_lookup.readonly_indexes,
-        }
-    }
-}
-
 // Each ATL has at least a Pubkey, one byte for the number of write indexes,
 // and one byte for the number of read indexes. Additionally, for validity
 // the ATL must have at least one write or read index giving a minimum size

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -7,7 +7,6 @@ use {
         result::{Result, TransactionViewError},
     },
     core::fmt::{Debug, Formatter},
-    solana_message::compiled_instruction::CompiledInstruction,
 };
 
 /// A non-owning version of [`CompiledInstruction`] that references
@@ -21,16 +20,6 @@ pub struct InstructionView<'a> {
     pub accounts: &'a [u8],
     /// The program input data.
     pub data: &'a [u8],
-}
-
-impl<'a> From<&'a CompiledInstruction> for InstructionView<'a> {
-    fn from(ix: &'a CompiledInstruction) -> Self {
-        Self {
-            program_id_index: ix.program_id_index,
-            accounts: ix.accounts.as_slice(),
-            data: ix.data.as_slice(),
-        }
-    }
 }
 
 /// Contains metadata about the instructions in a transaction packet.

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -33,16 +33,6 @@ impl<'a> From<&'a CompiledInstruction> for InstructionView<'a> {
     }
 }
 
-impl<'a> From<InstructionView<'a>> for solana_svm_transaction::instruction::SVMInstruction<'a> {
-    fn from(ix: InstructionView<'a>) -> Self {
-        Self {
-            program_id_index: ix.program_id_index,
-            accounts: ix.accounts,
-            data: ix.data,
-        }
-    }
-}
-
 /// Contains metadata about the instructions in a transaction packet.
 #[derive(Debug)]
 pub(crate) enum InstructionsFrame {

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -9,7 +9,7 @@ use {
     core::fmt::{Debug, Formatter},
 };
 
-/// A non-owning version of [`CompiledInstruction`] that references
+/// A non-owning version of [`solana_message::compiled_instruction::CompiledInstruction`] that references
 /// slices of account indexes and data.
 // `program_id_index` is still owned, as it is a simple u8.
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/transaction-view/src/instructions_frame.rs
+++ b/transaction-view/src/instructions_frame.rs
@@ -7,8 +7,41 @@ use {
         result::{Result, TransactionViewError},
     },
     core::fmt::{Debug, Formatter},
-    solana_svm_transaction::instruction::SVMInstruction,
+    solana_message::compiled_instruction::CompiledInstruction,
 };
+
+/// A non-owning version of [`CompiledInstruction`] that references
+/// slices of account indexes and data.
+// `program_id_index` is still owned, as it is a simple u8.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct InstructionView<'a> {
+    /// Index into the transaction keys array indicating the program account that executes this instruction.
+    pub program_id_index: u8,
+    /// Ordered indices into the transaction keys array indicating which accounts to pass to the program.
+    pub accounts: &'a [u8],
+    /// The program input data.
+    pub data: &'a [u8],
+}
+
+impl<'a> From<&'a CompiledInstruction> for InstructionView<'a> {
+    fn from(ix: &'a CompiledInstruction) -> Self {
+        Self {
+            program_id_index: ix.program_id_index,
+            accounts: ix.accounts.as_slice(),
+            data: ix.data.as_slice(),
+        }
+    }
+}
+
+impl<'a> From<InstructionView<'a>> for solana_svm_transaction::instruction::SVMInstruction<'a> {
+    fn from(ix: InstructionView<'a>) -> Self {
+        Self {
+            program_id_index: ix.program_id_index,
+            accounts: ix.accounts,
+            data: ix.data,
+        }
+    }
+}
 
 /// Contains metadata about the instructions in a transaction packet.
 #[derive(Debug)]
@@ -227,7 +260,7 @@ pub enum InstructionsIterator<'a> {
 }
 
 impl<'a> Iterator for InstructionsIterator<'a> {
-    type Item = SVMInstruction<'a>;
+    type Item = InstructionView<'a>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -291,7 +324,7 @@ impl<'a> Iterator for InstructionsIterator<'a> {
     }
 }
 
-/// Builds SNVInstruction from legacy/v0 pre-validated frame metadata.
+/// Builds InstructionView from legacy/v0 pre-validated frame metadata.
 ///
 /// # Safety
 /// The caller must ensure that:
@@ -314,7 +347,7 @@ unsafe fn for_legacy_and_v0<'a>(
     num_accounts_len: u8,
     data_len: u16,
     data_len_len: u8,
-) -> SVMInstruction<'a> {
+) -> InstructionView<'a> {
     // Each instruction has 3 pieces:
     // 1. Program ID index (u8)
     // 2. Accounts indexes ([u8])
@@ -346,14 +379,14 @@ unsafe fn for_legacy_and_v0<'a>(
     // - Offset and length checks have been done in the initial parsing.
     let data = unsafe { unchecked_read_slice_data::<u8>(bytes, offset, data_len) };
 
-    SVMInstruction {
+    InstructionView {
         program_id_index,
         accounts,
         data,
     }
 }
 
-/// Builds SMVInstruction from v1 pre-validated frame metadata.
+/// Builds InstructionView from v1 pre-validated frame metadata.
 ///
 /// # Safety
 /// The caller must ensure that:
@@ -381,7 +414,7 @@ unsafe fn for_v1<'a>(
     program_id_index: u8,
     num_accounts: u16,
     data_len: u16,
-) -> SVMInstruction<'a> {
+) -> InstructionView<'a> {
     // SAFETY:
     // - The offset is checked to be valid in the byte slice.
     // - The alignment of u8 is 1.
@@ -397,7 +430,7 @@ unsafe fn for_v1<'a>(
     // - Offset and length checks have been done in the initial parsing.
     let data = unsafe { unchecked_read_slice_data::<u8>(bytes, payloads_offset, data_len) };
 
-    SVMInstruction {
+    InstructionView {
         program_id_index,
         accounts,
         data,
@@ -567,7 +600,7 @@ mod tests {
         let mut iter = instructions_frame.iter(&serialized);
         assert_eq!(
             iter.next(),
-            Some(SVMInstruction {
+            Some(InstructionView {
                 program_id_index: 0,
                 accounts: &[1, 2, 3],
                 data: &[4, 5, 6, 7, 8, 9, 10]
@@ -575,7 +608,7 @@ mod tests {
         );
         assert_eq!(
             iter.next(),
-            Some(SVMInstruction {
+            Some(InstructionView {
                 program_id_index: 10,
                 accounts: &[11, 12],
                 data: &[13, 14, 15, 16, 17, 18, 19, 20]

--- a/transaction-view/src/lib.rs
+++ b/transaction-view/src/lib.rs
@@ -18,3 +18,7 @@ pub mod transaction_data;
 mod transaction_frame;
 pub mod transaction_version;
 pub mod transaction_view;
+
+pub use {
+    address_table_lookup_frame::MessageAddressTableLookupView, instructions_frame::InstructionView,
+};

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -179,18 +179,15 @@ impl<D: TransactionData> SVMStaticMessage for ResolvedTransactionView<D> {
     }
 
     fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
-        self.view.instructions_iter()
+        self.view.instructions_iter().map(SVMInstruction::from)
     }
 
     fn program_instructions_iter(
         &self,
-    ) -> impl Iterator<
-        Item = (
-            &solana_pubkey::Pubkey,
-            solana_svm_transaction::instruction::SVMInstruction<'_>,
-        ),
-    > + Clone {
-        self.view.program_instructions_iter()
+    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
+        self.view
+            .program_instructions_iter()
+            .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix)))
     }
 
     fn static_account_keys(&self) -> &[Pubkey] {
@@ -208,7 +205,9 @@ impl<D: TransactionData> SVMStaticMessage for ResolvedTransactionView<D> {
     fn message_address_table_lookups(
         &self,
     ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
-        self.view.address_table_lookup_iter()
+        self.view
+            .address_table_lookup_iter()
+            .map(SVMMessageAddressTableLookup::from)
     }
 }
 

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -9,17 +9,9 @@ use {
         fmt::{Debug, Formatter},
         ops::Deref,
     },
-    solana_hash::Hash,
     solana_message::{AccountKeys, v0::LoadedAddresses},
     solana_pubkey::Pubkey,
     solana_sdk_ids::bpf_loader_upgradeable,
-    solana_signature::Signature,
-    solana_svm_transaction::{
-        instruction::SVMInstruction,
-        message_address_table_lookup::SVMMessageAddressTableLookup,
-        svm_message::{SVMMessage, SVMStaticMessage},
-        svm_transaction::SVMTransaction,
-    },
     std::collections::HashSet,
 };
 
@@ -152,98 +144,12 @@ impl<D: TransactionData> ResolvedTransactionView<D> {
         self.resolved_addresses.as_ref()
     }
 
-    pub fn into_view(self) -> TransactionView<true, D> {
-        self.view
-    }
-}
-
-impl<D: TransactionData> SVMStaticMessage for ResolvedTransactionView<D> {
-    fn version(&self) -> solana_transaction::versioned::TransactionVersion {
-        self.view.version().into()
-    }
-
-    fn num_transaction_signatures(&self) -> u64 {
-        u64::from(self.view.num_required_signatures())
-    }
-
-    fn num_write_locks(&self) -> u64 {
-        self.view.num_requested_write_locks()
-    }
-
-    fn recent_blockhash(&self) -> &Hash {
-        self.view.recent_blockhash()
-    }
-
-    fn num_instructions(&self) -> usize {
-        usize::from(self.view.num_instructions())
-    }
-
-    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
-        self.view.instructions_iter().map(SVMInstruction::from)
-    }
-
-    fn program_instructions_iter(
-        &self,
-    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
-        self.view
-            .program_instructions_iter()
-            .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix)))
-    }
-
-    fn static_account_keys(&self) -> &[Pubkey] {
-        self.view.static_account_keys()
-    }
-
-    fn fee_payer(&self) -> &Pubkey {
-        &self.view.static_account_keys()[0]
-    }
-
-    fn num_lookup_tables(&self) -> usize {
-        usize::from(self.view.num_address_table_lookups())
-    }
-
-    fn message_address_table_lookups(
-        &self,
-    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
-        self.view
-            .address_table_lookup_iter()
-            .map(SVMMessageAddressTableLookup::from)
-    }
-}
-
-impl<D: TransactionData> SVMMessage for ResolvedTransactionView<D> {
-    fn account_keys(&self) -> AccountKeys<'_> {
-        AccountKeys::new(
-            self.view.static_account_keys(),
-            self.resolved_addresses.as_ref(),
-        )
-    }
-
-    fn is_writable(&self, index: usize) -> bool {
+    pub fn is_writable(&self, index: usize) -> bool {
         self.writable_cache.get(index).copied().unwrap_or(false)
     }
 
-    fn is_signer(&self, index: usize) -> bool {
-        index < usize::from(self.view.num_required_signatures())
-    }
-
-    fn is_invoked(&self, key_index: usize) -> bool {
-        let Ok(index) = u8::try_from(key_index) else {
-            return false;
-        };
+    pub fn into_view(self) -> TransactionView<true, D> {
         self.view
-            .instructions_iter()
-            .any(|ix| ix.program_id_index == index)
-    }
-}
-
-impl<D: TransactionData> SVMTransaction for ResolvedTransactionView<D> {
-    fn signature(&self) -> &Signature {
-        &self.view.signatures()[0]
-    }
-
-    fn signatures(&self) -> &[Signature] {
-        self.view.signatures()
     }
 }
 
@@ -260,6 +166,7 @@ mod tests {
     use {
         super::*,
         crate::transaction_view::SanitizedTransactionView,
+        solana_hash::Hash,
         solana_message::{
             MessageHeader, VersionedMessage,
             compiled_instruction::CompiledInstruction,

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -6,8 +6,11 @@ use {
         transaction_version::TransactionVersion,
         transaction_view::UnsanitizedTransactionView,
     },
-    solana_program_runtime::execution_budget::{MAX_HEAP_FRAME_BYTES, MIN_HEAP_FRAME_BYTES},
+    solana_program_entrypoint::HEAP_LENGTH,
 };
+
+const MAX_HEAP_FRAME_BYTES: u32 = 256 * 1024;
+const MIN_HEAP_FRAME_BYTES: u32 = HEAP_LENGTH as u32;
 
 pub(crate) fn sanitize(
     view: &UnsanitizedTransactionView<impl TransactionData>,

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -13,10 +13,6 @@ use {
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_signature::Signature,
-    solana_svm_transaction::{
-        instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
-        svm_message::SVMStaticMessage,
-    },
 };
 
 // alias for convenience
@@ -269,108 +265,6 @@ impl<const SANITIZED: bool, D: TransactionData> Debug for TransactionView<SANITI
             .field("instructions", &self.instructions_iter())
             .field("address_table_lookups", &self.address_table_lookup_iter())
             .finish()
-    }
-}
-
-impl<D: TransactionData> SVMStaticMessage for TransactionView<true, D> {
-    fn version(&self) -> solana_transaction::versioned::TransactionVersion {
-        self.version().into()
-    }
-
-    fn num_transaction_signatures(&self) -> u64 {
-        self.num_required_signatures() as u64
-    }
-
-    fn num_write_locks(&self) -> u64 {
-        self.num_requested_write_locks()
-    }
-
-    fn recent_blockhash(&self) -> &Hash {
-        self.recent_blockhash()
-    }
-
-    fn num_instructions(&self) -> usize {
-        self.num_instructions() as usize
-    }
-
-    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
-        TransactionView::instructions_iter(self).map(SVMInstruction::from)
-    }
-
-    fn program_instructions_iter(
-        &self,
-    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
-        TransactionView::program_instructions_iter(self)
-            .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix)))
-    }
-
-    fn static_account_keys(&self) -> &[Pubkey] {
-        self.static_account_keys()
-    }
-
-    fn fee_payer(&self) -> &Pubkey {
-        &self.static_account_keys()[0]
-    }
-
-    fn num_lookup_tables(&self) -> usize {
-        self.num_address_table_lookups() as usize
-    }
-
-    fn message_address_table_lookups(
-        &self,
-    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
-        self.address_table_lookup_iter()
-            .map(SVMMessageAddressTableLookup::from)
-    }
-}
-
-impl<D: TransactionData> SVMStaticMessage for &TransactionView<true, D> {
-    fn version(&self) -> solana_transaction::versioned::TransactionVersion {
-        <TransactionView<true, D> as SVMStaticMessage>::version(self)
-    }
-
-    fn num_transaction_signatures(&self) -> u64 {
-        <TransactionView<true, D> as SVMStaticMessage>::num_transaction_signatures(self)
-    }
-
-    fn num_write_locks(&self) -> u64 {
-        <TransactionView<true, D> as SVMStaticMessage>::num_write_locks(self)
-    }
-
-    fn recent_blockhash(&self) -> &Hash {
-        <TransactionView<true, D> as SVMStaticMessage>::recent_blockhash(self)
-    }
-
-    fn num_instructions(&self) -> usize {
-        <TransactionView<true, D> as SVMStaticMessage>::num_instructions(self)
-    }
-
-    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
-        <TransactionView<true, D> as SVMStaticMessage>::instructions_iter(self)
-    }
-
-    fn program_instructions_iter(
-        &self,
-    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
-        <TransactionView<true, D> as SVMStaticMessage>::program_instructions_iter(self)
-    }
-
-    fn static_account_keys(&self) -> &[Pubkey] {
-        <TransactionView<true, D> as SVMStaticMessage>::static_account_keys(self)
-    }
-
-    fn fee_payer(&self) -> &Pubkey {
-        <TransactionView<true, D> as SVMStaticMessage>::fee_payer(self)
-    }
-
-    fn num_lookup_tables(&self) -> usize {
-        <TransactionView<true, D> as SVMStaticMessage>::num_lookup_tables(self)
-    }
-
-    fn message_address_table_lookups(
-        &self,
-    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
-        <TransactionView<true, D> as SVMStaticMessage>::message_address_table_lookups(self)
     }
 }
 

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -1,9 +1,13 @@
 use {
     crate::{
         address_table_lookup_frame::AddressTableLookupIterator,
-        instructions_frame::InstructionsIterator, result::Result, sanitize::sanitize,
-        transaction_config_frame::TransactionConfigView, transaction_data::TransactionData,
-        transaction_frame::TransactionFrame, transaction_version::TransactionVersion,
+        instructions_frame::{InstructionView, InstructionsIterator},
+        result::Result,
+        sanitize::sanitize,
+        transaction_config_frame::TransactionConfigView,
+        transaction_data::TransactionData,
+        transaction_frame::TransactionFrame,
+        transaction_version::TransactionVersion,
     },
     core::fmt::{Debug, Formatter},
     solana_hash::Hash,
@@ -202,7 +206,7 @@ impl<D: TransactionData> TransactionView<true, D> {
     /// Return an iterator over the instructions paired with their program ids.
     pub fn program_instructions_iter(
         &self,
-    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
+    ) -> impl Iterator<Item = (&Pubkey, InstructionView<'_>)> + Clone {
         self.instructions_iter().map(|ix| {
             let program_id_index = usize::from(ix.program_id_index);
             let program_id = &self.static_account_keys()[program_id_index];
@@ -290,13 +294,14 @@ impl<D: TransactionData> SVMStaticMessage for TransactionView<true, D> {
     }
 
     fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
-        self.instructions_iter()
+        TransactionView::instructions_iter(self).map(SVMInstruction::from)
     }
 
     fn program_instructions_iter(
         &self,
     ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
-        self.program_instructions_iter()
+        TransactionView::program_instructions_iter(self)
+            .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix)))
     }
 
     fn static_account_keys(&self) -> &[Pubkey] {
@@ -315,6 +320,7 @@ impl<D: TransactionData> SVMStaticMessage for TransactionView<true, D> {
         &self,
     ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
         self.address_table_lookup_iter()
+            .map(SVMMessageAddressTableLookup::from)
     }
 }
 


### PR DESCRIPTION
#### Problem
- transaction-view is a type now fundamental to agave's transaction processing
- we want to move transaction-view to an external repo (either sdk or another) so that we can have saner release process wrt external schedulers which also rely on the crate
- transaction-view currently depends on svm-transaction

#### Summary of Changes
- invert dependency so that svm-transaction depends on transaction-view

Fixes #
