### PR TITLE
fix: `REPAIR_REQUEST_TIMEOUT_MS` too short, define as `2 * DELTA`

### DIFF
--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -65,11 +65,7 @@ const DEFER_REPAIR_THRESHOLD: Duration = Duration::from_millis(250);
 // This is the amount of time we will wait for a repair request to be fulfilled
 // before making another request. Value is based on reasonable upper bound of
 // expected network delays in requesting repairs and receiving shreds.
-pub(crate) const REPAIR_REQUEST_TIMEOUT_MS: u64 = {
-    let ms = 2 * agave_votor::common::DELTA.as_millis();
-    assert!(ms <= u64::MAX as u128);
-    ms as u64
-};
+pub(crate) const REPAIR_REQUEST_TIMEOUT_MS: u64 = 2 * agave_votor::common::DELTA.as_millis() as u64;
 
 // When requesting repair for a specific shred through the admin RPC, we will
 // request up to NUM_PEERS_TO_SAMPLE_FOR_REPAIRS in the event a specific, valid

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -65,7 +65,11 @@ const DEFER_REPAIR_THRESHOLD: Duration = Duration::from_millis(250);
 // This is the amount of time we will wait for a repair request to be fulfilled
 // before making another request. Value is based on reasonable upper bound of
 // expected network delays in requesting repairs and receiving shreds.
-pub(crate) const REPAIR_REQUEST_TIMEOUT_MS: u64 = 150;
+pub(crate) const REPAIR_REQUEST_TIMEOUT_MS: u64 = {
+    let ms = 2 * agave_votor::common::DELTA.as_millis();
+    assert!(ms <= u64::MAX as u128);
+    ms as u64
+};
 
 // When requesting repair for a specific shred through the admin RPC, we will
 // request up to NUM_PEERS_TO_SAMPLE_FOR_REPAIRS in the event a specific, valid


### PR DESCRIPTION
#### Problem
The timeout `REPAIR_REQUEST_TIMEOUT_MS` is too short for our synchrony bound `DELTA`.

#### Summary of Changes
Set `REPAIR_REQUEST_TIMEOUT_MS` to `2 * DELTA`.

Fixes #12491
