### PR TITLE
refactor(syscalls): address aliasing mutable reference in memmove

### DIFF
--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -223,7 +223,13 @@ pub struct CallerAccount<'a> {
 }
 
 impl<'a> CallerAccount<'a> {
-    pub fn get_serialized_data(
+    /// # Safety
+    ///
+    /// * The caller must ensure that this function does not violate mutable reference uniqueness
+    ///   constraints;
+    /// * The caller must ensure that the lifetime of the returned slice does not outlive the
+    ///   backing data.
+    pub unsafe fn get_serialized_data(
         memory_mapping: &solana_sbpf::memory_region::MemoryMapping,
         check_aligned: bool,
         vm_addr: u64,
@@ -250,27 +256,31 @@ impl<'a> CallerAccount<'a> {
             Ok(&mut [])
         } else if virtual_address_space_adjustments {
             // Workaround the memory permissions (as these are from the PoV of being inside the VM)
-            let serialization_ptr = translate_slice_mut_for_cpi::<u8>(
-                memory_mapping,
-                solana_sbpf::ebpf::MM_INPUT_START,
-                1,
-                false, // Don't care since it is byte aligned
-            )?
-            .as_mut_ptr();
             unsafe {
+                // SAFETY: Invariants for constructing a mutable reference delegated to the caller.
+                let serialization_ptr: &'a mut [u8] = translate_slice_mut_for_cpi::<u8>(
+                    memory_mapping,
+                    solana_sbpf::ebpf::MM_INPUT_START,
+                    1,
+                    false, // Don't care since it is byte aligned
+                )?;
                 Ok(std::slice::from_raw_parts_mut(
                     serialization_ptr
+                        .as_mut_ptr()
                         .add(vm_addr.saturating_sub(solana_sbpf::ebpf::MM_INPUT_START) as usize),
                     len,
                 ))
             }
         } else {
-            translate_slice_mut_for_cpi::<u8>(
-                memory_mapping,
-                vm_addr,
-                len as u64,
-                false, // Don't care since it is byte aligned
-            )
+            unsafe {
+                // SAFETY: Invariants for constructing a mutable reference delegated to the caller.
+                translate_slice_mut_for_cpi::<u8>(
+                    memory_mapping,
+                    vm_addr,
+                    len as u64,
+                    false, // Don't care since it is byte aligned
+                )
+            }
         }
     }
 
@@ -381,20 +391,22 @@ impl<'a> CallerAccount<'a> {
             let ref_to_len_in_vm =
                 translate_type_mut_for_cpi::<u64>(memory_mapping, vm_len_addr, false)?;
             let vm_data_addr = data.as_ptr() as u64;
-            let serialized_data = CallerAccount::get_serialized_data(
-                memory_mapping,
-                check_aligned,
-                vm_data_addr,
-                account_metadata.original_data_len,
-                if syscall_parameter_address_restrictions {
-                    *ref_to_len_in_vm as usize
-                } else {
-                    data.len()
-                },
-                syscall_parameter_address_restrictions,
-                virtual_address_space_adjustments,
-                account_data_direct_mapping,
-            )?;
+            let serialized_data = unsafe {
+                CallerAccount::get_serialized_data(
+                    memory_mapping,
+                    check_aligned,
+                    vm_data_addr,
+                    account_metadata.original_data_len,
+                    if syscall_parameter_address_restrictions {
+                        *ref_to_len_in_vm as usize
+                    } else {
+                        data.len()
+                    },
+                    syscall_parameter_address_restrictions,
+                    virtual_address_space_adjustments,
+                    account_data_direct_mapping,
+                )?
+            };
             (serialized_data, vm_data_addr, ref_to_len_in_vm)
         };
 
@@ -498,20 +510,22 @@ impl<'a> CallerAccount<'a> {
         }
         let ref_to_len_in_vm =
             translate_type_mut_for_cpi::<u64>(memory_mapping, vm_len_addr, false)?;
-        let serialized_data = CallerAccount::get_serialized_data(
-            memory_mapping,
-            check_aligned,
-            account_info.data_addr,
-            account_metadata.original_data_len,
-            if syscall_parameter_address_restrictions {
-                *ref_to_len_in_vm as usize
-            } else {
-                account_info.data_len as usize
-            },
-            syscall_parameter_address_restrictions,
-            virtual_address_space_adjustments,
-            account_data_direct_mapping,
-        )?;
+        let serialized_data = unsafe {
+            CallerAccount::get_serialized_data(
+                memory_mapping,
+                check_aligned,
+                account_info.data_addr,
+                account_metadata.original_data_len,
+                if syscall_parameter_address_restrictions {
+                    *ref_to_len_in_vm as usize
+                } else {
+                    account_info.data_len as usize
+                },
+                syscall_parameter_address_restrictions,
+                virtual_address_space_adjustments,
+                account_data_direct_mapping,
+            )?
+        };
 
         Ok(CallerAccount {
             lamports,
@@ -1180,16 +1194,18 @@ fn update_callee_account(
             if !account_data_direct_mapping && post_len < prev_len {
                 // If the account has been shrunk, we're going to zero the unused memory
                 // *that was previously used*.
-                let serialized_data = CallerAccount::get_serialized_data(
-                    memory_mapping,
-                    check_aligned,
-                    caller_account.vm_data_addr,
-                    caller_account.original_data_len,
-                    prev_len,
-                    syscall_parameter_address_restrictions,
-                    virtual_address_space_adjustments,
-                    account_data_direct_mapping,
-                )?;
+                let serialized_data = unsafe {
+                    CallerAccount::get_serialized_data(
+                        memory_mapping,
+                        check_aligned,
+                        caller_account.vm_data_addr,
+                        caller_account.original_data_len,
+                        prev_len,
+                        syscall_parameter_address_restrictions,
+                        virtual_address_space_adjustments,
+                        account_data_direct_mapping,
+                    )?
+                };
                 serialized_data
                     .get_mut(post_len..)
                     .ok_or_else(|| Box::new(InstructionError::AccountDataTooSmall) as Error)?
@@ -1333,16 +1349,18 @@ fn update_caller_account(
                     .fill(0);
             }
             // Set the length of caller_account.serialized_data to post_len.
-            caller_account.serialized_data = CallerAccount::get_serialized_data(
-                memory_mapping,
-                check_aligned,
-                caller_account.vm_data_addr,
-                caller_account.original_data_len,
-                post_len,
-                syscall_parameter_address_restrictions,
-                virtual_address_space_adjustments,
-                account_data_direct_mapping,
-            )?;
+            unsafe {
+                caller_account.serialized_data = CallerAccount::get_serialized_data(
+                    memory_mapping,
+                    check_aligned,
+                    caller_account.vm_data_addr,
+                    caller_account.original_data_len,
+                    post_len,
+                    syscall_parameter_address_restrictions,
+                    virtual_address_space_adjustments,
+                    account_data_direct_mapping,
+                )?;
+            }
         }
         // this is the len field in the AccountInfo::data slice
         *caller_account.ref_to_len_in_vm = post_len as u64;
@@ -1997,18 +2015,25 @@ mod tests {
         };
         let memory_mapping =
             unsafe { MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap() };
-
-        assert_matches!(
+        let serialized_data = unsafe {
             CallerAccount::get_serialized_data(
                 &memory_mapping,
                 true, // check_aligned
                 MM_INPUT_START,
                 account.data().len(),
-                account.data().len().saturating_add(MAX_PERMITTED_DATA_INCREASE).saturating_add(1),
-                true, // syscall_parameter_address_restrictions
-                true, // virtual_address_space_adjustments
+                account
+                    .data()
+                    .len()
+                    .saturating_add(MAX_PERMITTED_DATA_INCREASE)
+                    .saturating_add(1),
+                true,  // syscall_parameter_address_restrictions
+                true,  // virtual_address_space_adjustments
                 false, // account_data_direct_mapping
-            ),
+            )
+        };
+
+        assert_matches!(
+            serialized_data,
             Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::InvalidRealloc
         );
     }

--- a/program-runtime/src/memory.rs
+++ b/program-runtime/src/memory.rs
@@ -116,7 +116,12 @@ pub fn translate_slice<T>(
         T,
         check_aligned,
     )
-    .map(|value| unsafe { &*value })
+    .map(|value| unsafe {
+        // SAFETY: `translate_slice_inner` is guaranteed to return a dereferenceable memory region.
+        // This is producing a shared/read-only slice to the memory, so the uniqueness invariants
+        // aren't relevant.
+        &*value
+    })
 }
 
 /// CPI-specific version with intentionally different lifetime signature.

--- a/program-runtime/src/memory.rs
+++ b/program-runtime/src/memory.rs
@@ -3,7 +3,7 @@
 use {
     solana_sbpf::memory_region::{AccessType, MemoryMapping},
     solana_transaction_context::vm_slice::VmSlice,
-    std::{mem::align_of, slice::from_raw_parts_mut},
+    std::mem::align_of,
 };
 
 /// Error types for memory translation operations.
@@ -60,18 +60,36 @@ macro_rules! translate_type_inner {
 macro_rules! translate_slice_inner {
     ($memory_mapping:expr, $access_type:expr, $vm_addr:expr, $len:expr, $T:ty, $check_aligned:expr $(,)?) => {{
         if $len == 0 {
-            return Ok(&mut []);
+            Ok(std::ptr::slice_from_raw_parts_mut(
+                std::ptr::dangling_mut::<$T>(),
+                0,
+            ))
+        } else {
+            let total_size = $len.saturating_mul(size_of::<$T>() as u64);
+            if isize::try_from(total_size).is_err() {
+                Err($crate::memory::MemoryTranslationError::InvalidLength.into())
+            } else {
+                match $crate::translate_inner!(
+                    $memory_mapping,
+                    map,
+                    $access_type,
+                    $vm_addr,
+                    total_size
+                ) {
+                    Err(e) => Err(e),
+                    Ok(host_addr)
+                        if $check_aligned
+                            && !$crate::memory::address_is_aligned::<$T>(host_addr) =>
+                    {
+                        Err($crate::memory::MemoryTranslationError::UnalignedPointer.into())
+                    }
+                    Ok(host_addr) => Ok(std::ptr::slice_from_raw_parts_mut(
+                        host_addr as *mut $T,
+                        $len as usize,
+                    )),
+                }
+            }
         }
-        let total_size = $len.saturating_mul(size_of::<$T>() as u64);
-        if isize::try_from(total_size).is_err() {
-            return Err($crate::memory::MemoryTranslationError::InvalidLength.into());
-        }
-        let host_addr =
-            $crate::translate_inner!($memory_mapping, map, $access_type, $vm_addr, total_size)?;
-        if $check_aligned && !$crate::memory::address_is_aligned::<$T>(host_addr) {
-            return Err($crate::memory::MemoryTranslationError::UnalignedPointer.into());
-        }
-        Ok(unsafe { from_raw_parts_mut(host_addr as *mut $T, $len as usize) })
     }};
 }
 
@@ -98,7 +116,7 @@ pub fn translate_slice<T>(
         T,
         check_aligned,
     )
-    .map(|value| &*value)
+    .map(|value| unsafe { &*value })
 }
 
 /// CPI-specific version with intentionally different lifetime signature.
@@ -113,7 +131,14 @@ pub fn translate_type_mut_for_cpi<'a, T>(
 
 /// CPI-specific version with intentionally different lifetime signature.
 /// This version is missing lifetime 'a of the return type in the parameter &MemoryMapping.
-pub fn translate_slice_mut_for_cpi<'a, T>(
+///
+/// # Safety
+///
+/// * The caller must ensure that this function does not violate mutable reference uniqueness
+///   constraints;
+/// * The caller must ensure that the lifetime of the returned slice does not outlive the backing
+///   data.
+pub unsafe fn translate_slice_mut_for_cpi<'a, T>(
     memory_mapping: &MemoryMapping,
     vm_addr: u64,
     len: u64,
@@ -127,6 +152,10 @@ pub fn translate_slice_mut_for_cpi<'a, T>(
         T,
         check_aligned,
     )
+    .map(|p| unsafe {
+        // SAFETY: the invariants for producing mutable references delegated to the callers.
+        &mut *p
+    })
 }
 
 pub fn translate_vm_slice<'a, T>(

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -49,7 +49,6 @@ use {
     std::{
         alloc::Layout,
         mem::{MaybeUninit, align_of, size_of},
-        slice::from_raw_parts_mut,
         str::{Utf8Error, from_utf8},
     },
     thiserror::Error as ThisError,
@@ -583,7 +582,12 @@ fn translate_slice<T>(
         T,
         check_aligned,
     )
-    .map(|value| &*value)
+    .map(|value| unsafe {
+        // SAFETY: `translate_slice_inner` is guaranteed to return a dereferenceable memory region.
+        // This is producing a shared/read-only slice to the memory, so the uniqueness invariants
+        // aren't relevant.
+        &*value
+    })
 }
 
 /// Take a virtual pointer to a string (points to SBF VM memory space), translate it
@@ -627,6 +631,12 @@ fn translate_slice_mut<T>(
         T,
         check_aligned,
     )
+    .map(|p| unsafe {
+        // SAFETY: `translate_slice_inner` is guaranteed to return a dereferenceable memory region.
+        // `translate_mut`, which is the only use of this function ensures that the ranges are
+        // non-overlapping.
+        &mut *p
+    })
 }
 
 fn touch_type_mut<T>(memory_mapping: &mut MemoryMapping, vm_addr: u64) -> Result<(), Error> {
@@ -682,7 +692,7 @@ macro_rules! translate_mut {
             $vm_addr_and_element_count.1,
             $check_aligned,
         )?;
-        let host_addr = slice.as_ptr() as usize;
+        let host_addr = slice.as_ptr().addr();
         (slice, host_addr, std::mem::size_of::<$T>().saturating_mul($vm_addr_and_element_count.1 as usize))
     }};
     (internal, $memory_mapping:expr, $check_aligned:expr, &mut $T:ty, $vm_addr:expr) => {{

--- a/syscalls/src/mem_ops.rs
+++ b/syscalls/src/mem_ops.rs
@@ -141,15 +141,19 @@ fn memmove(
 ) -> Result<u64, Error> {
     let check_aligned = invoke_context.get_check_aligned();
     let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
-    translate_mut!(
+    // In a rare exception to the rule we manually translate addresses to a raw pointer rather than
+    // using `translate_mut!` because the src and dst memory regions may overlap for this syscall.
+    touch_slice_mut::<MaybeUninit<u8>>(memory_mapping, dst_addr, n)?;
+    let slice = translate_slice_inner!(
         memory_mapping,
+        AccessType::Store,
+        dst_addr,
+        n,
+        MaybeUninit<u8>,
         check_aligned,
-        let dst_ref_mut: (&mut [MaybeUninit<u8>]) = map(dst_addr, n)?;
-    );
-    let dst_ptr = dst_ref_mut.as_mut_ptr();
+    )?;
     let src_ptr = translate_slice::<u8>(memory_mapping, src_addr, n, check_aligned)?.as_ptr();
-
-    unsafe { std::ptr::copy(src_ptr.cast(), dst_ptr, n as usize) };
+    unsafe { std::ptr::copy(src_ptr.cast(), slice as *mut MaybeUninit<u8>, n as usize) };
     Ok(0)
 }
 


### PR DESCRIPTION
`memmove` allows overlapping addresses and will figure out how to copy as-if the source data was copied via an intermediate buffer.

The implementation of the syscall creates a `&mut [u8]` which is technically supposed to be a unique ptr, which is incompatible with the intended behaviour of the function. In practice this probably is not problematic, but since does run afoul of the strictest interpretation of Rust's rules, it is a code smell.

Addressing this turned out to have a blast radius larger than minimal due to me having to introduce `unsafe` and downgrade the returned values to raw pointers through most layers of the memory translation infrastructure.