### PR TITLE
Dynamic repair timing

### DIFF
--- a/core/src/repair/repair_generic_traversal.rs
+++ b/core/src/repair/repair_generic_traversal.rs
@@ -1,7 +1,10 @@
 use {
     crate::{
         consensus::{heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice, tree_diff::TreeDiff},
-        repair::{repair_service::RepairService, serve_repair::ShredRepairType},
+        repair::{
+            repair_service::{RepairEligibility, RepairService},
+            serve_repair::ShredRepairType,
+        },
     },
     solana_clock::Slot,
     solana_hash::Hash,
@@ -40,8 +43,12 @@ impl Iterator for GenericTraversal<'_> {
     }
 }
 
-/// Does a generic traversal and inserts all slots that have a missing last index prioritized by how
-/// many shreds have been received
+/// Does a generic traversal and requests `HighestShred` for slots that have an
+/// unknown last index.
+///
+/// This preserves the legacy aggressive probing policy by bypassing
+/// `RepairEligibility`. Candidates are prioritized by the number of data shreds
+/// currently present in blockstore.
 pub fn get_unknown_last_index(
     tree: &HeaviestSubtreeForkChoice,
     blockstore: &Blockstore,
@@ -72,7 +79,7 @@ pub fn get_unknown_last_index(
             }
         }
     }
-    // prioritize slots with more received shreds
+    // Prioritize slots with more data shreds currently present in blockstore.
     unknown_last.sort_by(|(_, _, count1), (_, _, count2)| count2.cmp(count1));
     unknown_last
         .iter()
@@ -114,7 +121,8 @@ fn get_unrepaired_path(
 }
 
 /// Finds repairs for slots that are closest to completion (# of missing shreds).
-/// Additionally we repair up to their oldest full ancestor (using blockstore fork info).
+/// Additionally repairs their incomplete ancestor path until the first full or
+/// previously visited ancestor.
 pub fn get_closest_completion(
     tree: &HeaviestSubtreeForkChoice,
     blockstore: &Blockstore,
@@ -122,7 +130,7 @@ pub fn get_closest_completion(
     slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
     processed_slots: &mut HashSet<Slot>,
     limit: usize,
-    ticks_per_second: u64,
+    repair_eligibility: &mut RepairEligibility,
     outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
 ) -> (Vec<ShredRepairType>, /* processed slots */ usize) {
     let mut slot_dists: Vec<(Slot, u64)> = Vec::default();
@@ -200,7 +208,7 @@ pub fn get_closest_completion(
                 blockstore,
                 path_slot,
                 slot_meta,
-                ticks_per_second,
+                repair_eligibility,
                 limit - repairs.len(),
                 outstanding_repairs,
             );
@@ -216,8 +224,6 @@ pub fn get_closest_completion(
 pub mod test {
     use {
         super::*,
-        crate::repair::repair_service::sleep_shred_deferment_period,
-        solana_clock::DEFAULT_TICKS_PER_SECOND,
         solana_hash::Hash,
         solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path},
         trees::{Tree, TreeWalk, tr},
@@ -272,7 +278,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut processed_slots,
             10,
-            DEFAULT_TICKS_PER_SECOND,
+            &mut RepairEligibility::default(),
             &mut outstanding_requests,
         );
         assert_eq!(repairs, []);
@@ -293,7 +299,8 @@ pub mod test {
         let mut slot_meta_cache = HashMap::default();
         let mut processed_slots = HashSet::default();
         outstanding_requests = HashMap::new();
-        sleep_shred_deferment_period();
+        let mut repair_eligibility =
+            RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=5);
         let (repairs, _) = get_closest_completion(
             &heaviest_subtree_fork_choice,
             &blockstore,
@@ -301,7 +308,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut processed_slots,
             1,
-            DEFAULT_TICKS_PER_SECOND,
+            &mut repair_eligibility,
             &mut outstanding_requests,
         );
         assert_eq!(repairs, [ShredRepairType::Shred(1, 30)]);
@@ -314,7 +321,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut processed_slots,
             4,
-            DEFAULT_TICKS_PER_SECOND,
+            &mut repair_eligibility,
             &mut outstanding_requests,
         );
         assert_eq!(repairs.len(), 4);
@@ -328,7 +335,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut processed_slots,
             1,
-            DEFAULT_TICKS_PER_SECOND,
+            &mut repair_eligibility,
             &mut outstanding_requests,
         );
         assert_eq!(repairs.len(), 0);

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -53,14 +53,12 @@ use {
     },
 };
 #[cfg(test)]
-use {
-    crate::repair::duplicate_repair_status::DuplicateSlotRepairStatus,
-    solana_clock::{DEFAULT_MS_PER_SLOT, DEFAULT_TICKS_PER_SECOND},
-    solana_keypair::Keypair,
-};
+use {crate::repair::duplicate_repair_status::DuplicateSlotRepairStatus, solana_keypair::Keypair};
 
-// Time to defer repair requests to allow for turbine propagation
-const DEFER_REPAIR_THRESHOLD: Duration = Duration::from_millis(250);
+// Time to defer repair requests after repair observes, or infers from a later
+// FEC, that the missing shred's FEC set has started arriving. Value was derived
+// empirically observing slot times vs. repair activity on mainnet nodes.
+const FEC_REPAIR_DELAY: Duration = Duration::from_millis(250);
 
 // This is the amount of time we will wait for a repair request to be fulfilled
 // before making another request. Value is based on reasonable upper bound of
@@ -73,8 +71,191 @@ pub(crate) const REPAIR_REQUEST_TIMEOUT_MS: u64 = 150;
 // chance of sampling duplicate in the event of cluster partition.
 const NUM_PEERS_TO_SAMPLE_FOR_REPAIRS: usize = 10;
 
-fn defer_repair_threshold_ticks(ticks_per_second: u64) -> u64 {
-    DEFER_REPAIR_THRESHOLD.as_millis() as u64 * ticks_per_second / 1_000
+// Minimum initial capacity for FEC set observations in a slot. This is to avoid
+// frequent reallocations for typical mainnet blocks while still letting unusually
+// large blocks grow lazily.
+const MIN_FEC_SET_OBSERVATION_CAPACITY: usize = 32;
+
+/// Returns the fixed-size FEC set ordinal containing `shred_index`.
+fn fec_set_ordinal(shred_index: u64) -> usize {
+    shred_index as usize / shred::DATA_SHREDS_PER_FEC_BLOCK
+}
+
+/// Per-slot repair timing tracked at FEC granularity.
+///
+/// This intentionally avoids per-shred timestamps. `first_observed_at_ms`
+/// is indexed by FEC set ordinal and stores when repair first observed, or
+/// inferred from a later FEC, that the FEC set had started arriving. Observation
+/// is based on `SlotMeta::received`, which is the highest received data shred
+/// index plus one.
+#[derive(Debug)]
+struct SlotRepairFecTimes {
+    /// Timestamp each FEC set in this slot was first observed, keyed by its
+    /// ordinal. Observed here means a valid shred in this FEC set or a later
+    /// FEC set was received.
+    first_observed_at_ms: Vec<u64>,
+}
+
+impl SlotRepairFecTimes {
+    /// Creates per-slot FEC timing state with enough capacity for the expected
+    /// number of observed FEC sets.
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            first_observed_at_ms: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Records that repair observed a shred from `fec_set_ordinal` at `now_ms`.
+    ///
+    /// Resizing with `now_ms` is intentional: if repair observes a future FEC
+    /// before an earlier one, the skipped FECs inherit the future observation
+    /// time. This lets missing FEC `N` become eligible based on observing FEC
+    /// `N+1` without storing anything per shred.
+    fn observe_fec(&mut self, fec_set_ordinal: usize, now_ms: u64) {
+        let target_len = fec_set_ordinal.saturating_add(1);
+        if self.first_observed_at_ms.len() < target_len {
+            self.first_observed_at_ms.resize(target_len, now_ms);
+        }
+    }
+
+    /// Returns the first observed or inferred time for the FEC set containing
+    /// `shred_index`.
+    fn first_shred_observed_at(&self, shred_index: u64) -> Option<u64> {
+        self.first_observed_at_ms
+            .get(fec_set_ordinal(shred_index))
+            .copied()
+    }
+}
+
+/// Tracks when missing shred repairs should become eligible.
+///
+/// Normal missing-shred repairs wait until repair has observed, or inferred from
+/// a later FEC, the missing shred's FEC set for at least `FEC_REPAIR_DELAY`.
+/// Highest-shred repairs generated from normal slot traversal use the last
+/// observed FEC set as their quiet-period anchor. The generic unknown-last-index
+/// traversal intentionally bypasses this state to preserve legacy aggressive
+/// probing.
+#[derive(Debug, Default)]
+pub struct RepairEligibility {
+    slots: HashMap<Slot, SlotRepairFecTimes>,
+}
+
+impl RepairEligibility {
+    /// Drops timing state for slots below the current root.
+    fn set_root(&mut self, root: Slot) {
+        self.slots.retain(|slot, _| *slot >= root);
+    }
+
+    /// Records observed or inferred FEC timing based on `SlotMeta::received`
+    /// advancing.
+    ///
+    /// `first_observed_at_ms.len()` is the next unseen FEC ordinal. If the
+    /// highest received shred falls in an older FEC, that FEC was already
+    /// timestamped; if it falls in a future FEC, resizing the vector backfills
+    /// any skipped FECs with the same timestamp.
+    fn observe_slot(&mut self, slot: Slot, slot_meta: &SlotMeta) {
+        let Some(last_received_index) = slot_meta.received.checked_sub(1) else {
+            // Have not observed any shreds for this slot yet.
+            return;
+        };
+        let last_received_fec = fec_set_ordinal(last_received_index);
+
+        // Grab the FEC set observation meta for this slot. New slots start with
+        // enough capacity for typical mainnet blocks, while unusually large
+        // blocks grow lazily when a new FEC is actually observed.
+        let observed_fec_sets = last_received_fec.saturating_add(1);
+        let slot_repair = self.slots.entry(slot).or_insert_with(|| {
+            SlotRepairFecTimes::with_capacity(
+                observed_fec_sets.max(MIN_FEC_SET_OBSERVATION_CAPACITY),
+            )
+        });
+
+        if slot_repair.first_observed_at_ms.len() > last_received_fec {
+            // No new FECs observed.
+            return;
+        }
+        let now_ms = timestamp();
+
+        // Backfills skipped FEC ordinals with the same timestamp.
+        slot_repair.observe_fec(last_received_fec, now_ms);
+    }
+
+    /// Returns whether a missing shred's FEC timestamp is old enough to request
+    /// repair.
+    pub(crate) fn is_missing_shred_eligible(
+        &self,
+        slot: Slot,
+        shred_index: u64,
+        now_ms: u64,
+    ) -> bool {
+        self.slots
+            .get(&slot)
+            .and_then(|slot_repair| slot_repair.first_shred_observed_at(shred_index))
+            .map(|first_shred_time| {
+                now_ms.saturating_sub(first_shred_time) >= FEC_REPAIR_DELAY.as_millis() as u64
+            })
+            .unwrap_or(false)
+    }
+
+    /// Returns whether normal slot traversal should request `HighestShred` for
+    /// `slot`.
+    ///
+    /// This path only applies while the slot's true last index is unknown. Empty
+    /// slots are eligible immediately so parent-slot repair can make progress;
+    /// otherwise the highest observed FEC set must have been quiet for
+    /// `FEC_REPAIR_DELAY`.
+    pub(crate) fn is_highest_shred_eligible(
+        &self,
+        slot: Slot,
+        slot_meta: &SlotMeta,
+        now_ms: u64,
+    ) -> bool {
+        if slot_meta.last_index.is_some() {
+            return false;
+        }
+        if slot_meta.received == 0 {
+            return true;
+        }
+        self.slots
+            .get(&slot)
+            .and_then(|slot_repair| slot_repair.first_observed_at_ms.last().copied())
+            .map(|last_observed_fec_time| {
+                now_ms.saturating_sub(last_observed_fec_time) >= FEC_REPAIR_DELAY.as_millis() as u64
+            })
+            .unwrap_or(false)
+    }
+
+    /// Marks already-observed FEC sets as old enough for repair tests.
+    ///
+    /// This keeps traversal tests focused on ordering and duplicate suppression
+    /// without sleeping in every setup path.
+    #[cfg(test)]
+    pub(crate) fn observe_slot_as_elapsed_for_tests(&mut self, slot: Slot, slot_meta: &SlotMeta) {
+        self.observe_slot(slot, slot_meta);
+        if let Some(slot_repair) = self.slots.get_mut(&slot) {
+            let elapsed_time = timestamp().saturating_sub(FEC_REPAIR_DELAY.as_millis() as u64);
+            slot_repair
+                .first_observed_at_ms
+                .iter_mut()
+                .for_each(|first_shred_time| *first_shred_time = elapsed_time);
+        }
+    }
+
+    /// Builds test eligibility state with elapsed observations for several
+    /// slots.
+    #[cfg(test)]
+    pub(crate) fn elapsed_for_slots_for_tests(
+        blockstore: &Blockstore,
+        slots: impl IntoIterator<Item = Slot>,
+    ) -> Self {
+        let mut repair_eligibility = Self::default();
+        for slot in slots {
+            if let Some(slot_meta) = blockstore.meta(slot).unwrap() {
+                repair_eligibility.observe_slot_as_elapsed_for_tests(slot, &slot_meta);
+            }
+        }
+        repair_eligibility
+    }
 }
 
 pub type AncestorDuplicateSlotsSender = CrossbeamSender<AncestorDuplicateSlotToRepair>;
@@ -423,6 +604,7 @@ struct RepairTracker {
     popular_pruned_forks_requests: HashSet<Slot>,
     // Maps a repair that may still be outstanding to the timestamp it was requested.
     outstanding_repairs: HashMap<ShredRepairType, u64>,
+    repair_eligibility: RepairEligibility,
 }
 
 pub struct RepairService {
@@ -550,9 +732,9 @@ impl RepairService {
     fn identify_repairs(
         blockstore: &Blockstore,
         root_bank: Arc<Bank>,
-        ticks_per_second: u64,
         _repair_info: &RepairInfo,
         repair_weight: &mut RepairWeight,
+        repair_eligibility: &mut RepairEligibility,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
         repair_metrics: &mut RepairMetrics,
     ) -> Vec<ShredRepairType> {
@@ -563,6 +745,7 @@ impl RepairService {
         });
         purge_outstanding_repairs.stop();
         repair_metrics.timing.purge_outstanding_repairs = purge_outstanding_repairs.as_us();
+        repair_eligibility.set_root(root_bank.slot());
 
         repair_weight.get_best_weighted_repairs(
             blockstore,
@@ -572,7 +755,7 @@ impl RepairService {
             MAX_REPAIR_LENGTH,
             MAX_UNKNOWN_LAST_INDEX_REPAIRS,
             MAX_CLOSEST_COMPLETION_REPAIRS,
-            ticks_per_second,
+            repair_eligibility,
             repair_metrics,
             outstanding_repairs,
         )
@@ -685,12 +868,9 @@ impl RepairService {
             peers_cache,
             popular_pruned_forks_requests,
             outstanding_repairs,
+            repair_eligibility,
         } = repair_tracker;
         let root_bank = sharable_banks.root();
-        // The tick rate can change, which changes the tick -> wall clock math
-        // for how long we're willing to wait on turbine shreds. Re-check every
-        // iteration.
-        let ticks_per_second = sharable_banks.root().ticks_per_second().max(1);
 
         Self::update_weighting_heuristic(
             blockstore,
@@ -705,9 +885,9 @@ impl RepairService {
         let repairs = Self::identify_repairs(
             blockstore,
             root_bank.clone(),
-            ticks_per_second,
             repair_info,
             repair_weight,
+            repair_eligibility,
             outstanding_repairs,
             repair_metrics,
         );
@@ -763,6 +943,7 @@ impl RepairService {
             peers_cache: LruCache::new(REPAIR_PEERS_CACHE_CAPACITY),
             popular_pruned_forks_requests: HashSet::new(),
             outstanding_repairs: HashMap::new(),
+            repair_eligibility: RepairEligibility::default(),
         };
 
         while !exit.load(Ordering::Relaxed) {
@@ -779,38 +960,25 @@ impl RepairService {
         }
     }
 
-    /// If this slot is missing shreds generate repairs
+    /// Generates deferred repairs for missing shreds, or for the highest shred
+    /// when the slot has no known gaps but its last index is still unknown.
     pub(crate) fn generate_repairs_for_slot(
         blockstore: &Blockstore,
         slot: Slot,
         slot_meta: &SlotMeta,
-        ticks_per_second: u64,
+        repair_eligibility: &mut RepairEligibility,
         max_repairs: usize,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) -> Vec<ShredRepairType> {
-        let defer_repair_threshold_ticks = defer_repair_threshold_ticks(ticks_per_second);
         if max_repairs == 0 || slot_meta.is_full() {
             vec![]
         } else if slot_meta.consumed == slot_meta.received {
-            // check delay time of last shred
-            if let Some(reference_tick) = slot_meta
-                .received
-                .checked_sub(1)
-                .and_then(|index| blockstore.get_data_shred(slot, index).ok()?)
-                .and_then(|shred| shred::layout::get_reference_tick(&shred).ok())
-                .map(u64::from)
-            {
-                // System time is not monotonic
-                let ticks_since_first_insert = ticks_per_second
-                    .saturating_mul(timestamp().saturating_sub(slot_meta.first_shred_timestamp))
-                    / 1_000;
-                if ticks_since_first_insert
-                    < reference_tick.saturating_add(defer_repair_threshold_ticks)
-                {
-                    return vec![];
-                }
+            // No gaps. Request the highest shred if eligible.
+            repair_eligibility.observe_slot(slot, slot_meta);
+            let now_ms = timestamp();
+            if !repair_eligibility.is_highest_shred_eligible(slot, slot_meta, now_ms) {
+                return vec![];
             }
-
             match RepairService::request_repair_if_needed(
                 outstanding_repairs,
                 ShredRepairType::HighestShred(slot, slot_meta.received),
@@ -819,16 +987,18 @@ impl RepairService {
                 None => vec![],
             }
         } else {
+            // There are gaps. Request missing shreds if eligible.
+            repair_eligibility.observe_slot(slot, slot_meta);
+            let now_ms = timestamp();
             blockstore
                 .find_missing_data_indexes(
                     slot,
-                    slot_meta.first_shred_timestamp,
-                    defer_repair_threshold_ticks,
                     slot_meta.consumed,
                     slot_meta.received,
                     max_repairs,
                 )
                 .into_iter()
+                .filter(|i| repair_eligibility.is_missing_shred_eligible(slot, *i, now_ms))
                 .filter_map(|i| {
                     RepairService::request_repair_if_needed(
                         outstanding_repairs,
@@ -845,7 +1015,7 @@ impl RepairService {
         repairs: &mut Vec<ShredRepairType>,
         max_repairs: usize,
         slot: Slot,
-        ticks_per_second: u64,
+        repair_eligibility: &mut RepairEligibility,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) {
         let mut pending_slots = vec![slot];
@@ -856,7 +1026,7 @@ impl RepairService {
                     blockstore,
                     slot,
                     &slot_meta,
-                    ticks_per_second,
+                    repair_eligibility,
                     max_repairs - repairs.len(),
                     outstanding_repairs,
                 );
@@ -1024,6 +1194,7 @@ impl RepairService {
     ) -> Vec<ShredRepairType> {
         // Slot height and shred indexes for shreds we want to repair
         let mut repairs: Vec<ShredRepairType> = vec![];
+        let mut repair_eligibility = RepairEligibility::default();
         for slot in repair_range.start..=repair_range.end {
             if repairs.len() >= max_repairs {
                 break;
@@ -1036,12 +1207,13 @@ impl RepairService {
                     slot,
                     ..SlotMeta::default()
                 });
+            repair_eligibility.observe_slot_as_elapsed_for_tests(slot, &meta);
 
             let new_repairs = Self::generate_repairs_for_slot(
                 blockstore,
                 slot,
                 &meta,
-                DEFAULT_TICKS_PER_SECOND,
+                &mut repair_eligibility,
                 max_repairs - repairs.len(),
                 &mut HashMap::default(),
             );
@@ -1061,11 +1233,13 @@ impl RepairService {
                 // If the slot is full, no further need to repair this slot
                 None
             } else {
+                let mut repair_eligibility = RepairEligibility::default();
+                repair_eligibility.observe_slot_as_elapsed_for_tests(slot, &slot_meta);
                 Some(Self::generate_repairs_for_slot(
                     blockstore,
                     slot,
                     &slot_meta,
-                    DEFAULT_TICKS_PER_SECOND,
+                    &mut repair_eligibility,
                     MAX_REPAIR_PER_DUPLICATE,
                     &mut HashMap::default(),
                 ))
@@ -1210,9 +1384,7 @@ impl RepairService {
 #[cfg(test)]
 pub(crate) fn sleep_shred_deferment_period() {
     // sleep to bypass shred deferment window
-    sleep(Duration::from_millis(
-        DEFAULT_MS_PER_SLOT + DEFER_REPAIR_THRESHOLD.as_millis() as u64,
-    ));
+    sleep(FEC_REPAIR_DELAY);
 }
 
 #[cfg(test)]
@@ -1309,7 +1481,7 @@ mod test {
                 MAX_REPAIR_LENGTH,
                 MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                 MAX_CLOSEST_COMPLETION_REPAIRS,
-                DEFAULT_TICKS_PER_SECOND,
+                &mut RepairEligibility::default(),
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
             ),
@@ -1342,7 +1514,7 @@ mod test {
                 MAX_REPAIR_LENGTH,
                 MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                 MAX_CLOSEST_COMPLETION_REPAIRS,
-                DEFAULT_TICKS_PER_SECOND,
+                &mut RepairEligibility::default(),
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
             ),
@@ -1390,6 +1562,23 @@ mod test {
             .collect();
 
         let mut repair_weight = RepairWeight::new(0);
+        let mut repair_eligibility = RepairEligibility::default();
+        assert_eq!(
+            repair_weight.get_best_weighted_repairs(
+                &blockstore,
+                &HashMap::new(),
+                &EpochSchedule::default(),
+                MAX_ORPHANS,
+                MAX_REPAIR_LENGTH,
+                MAX_UNKNOWN_LAST_INDEX_REPAIRS,
+                MAX_CLOSEST_COMPLETION_REPAIRS,
+                &mut repair_eligibility,
+                &mut RepairMetrics::default(),
+                &mut HashMap::default(),
+            ),
+            vec![]
+        );
+
         sleep_shred_deferment_period();
         assert_eq!(
             repair_weight.get_best_weighted_repairs(
@@ -1400,7 +1589,7 @@ mod test {
                 MAX_REPAIR_LENGTH,
                 MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                 MAX_CLOSEST_COMPLETION_REPAIRS,
-                DEFAULT_TICKS_PER_SECOND,
+                &mut repair_eligibility,
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
             ),
@@ -1416,11 +1605,111 @@ mod test {
                 expected.len() - 2,
                 MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                 MAX_CLOSEST_COMPLETION_REPAIRS,
-                DEFAULT_TICKS_PER_SECOND,
+                &mut repair_eligibility,
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
             )[..],
             expected[0..expected.len() - 2]
+        );
+    }
+
+    #[test]
+    pub fn test_repair_empty_middle_fec() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let make_shreds_by_index = |slot, parent_slot, min_index| {
+            let mut num_entries = 1_000;
+            loop {
+                let (shreds, _) = make_slot_entries(slot, parent_slot, num_entries);
+                let shreds_by_index: HashMap<_, _> = shreds
+                    .into_iter()
+                    .map(|shred| (u64::from(shred.index()), shred))
+                    .collect();
+                if shreds_by_index.contains_key(&min_index) {
+                    break shreds_by_index;
+                }
+                num_entries *= 2;
+            }
+        };
+
+        let slot = 0;
+        let missing_index = 1;
+        let shreds_by_index = make_shreds_by_index(slot, 0, missing_index + 1);
+        blockstore
+            .insert_shreds(
+                vec![
+                    shreds_by_index.get(&0).unwrap().clone(),
+                    shreds_by_index.get(&(missing_index + 1)).unwrap().clone(),
+                ],
+                None,
+                false,
+            )
+            .unwrap();
+        let slot_meta = blockstore.meta(slot).unwrap().unwrap();
+        let mut repair_eligibility = RepairEligibility::default();
+        assert_eq!(
+            RepairService::generate_repairs_for_slot(
+                &blockstore,
+                slot,
+                &slot_meta,
+                &mut repair_eligibility,
+                usize::MAX,
+                &mut HashMap::default(),
+            ),
+            vec![]
+        );
+
+        sleep_shred_deferment_period();
+        assert_eq!(
+            RepairService::generate_repairs_for_slot(
+                &blockstore,
+                slot,
+                &slot_meta,
+                &mut repair_eligibility,
+                usize::MAX,
+                &mut HashMap::default(),
+            ),
+            vec![ShredRepairType::Shred(slot, missing_index)]
+        );
+
+        let slot = 1;
+        let missing_fec_start = shred::DATA_SHREDS_PER_FEC_BLOCK as u64;
+        let future_fec_start = 2 * missing_fec_start;
+        let shreds_by_index = make_shreds_by_index(slot, 0, future_fec_start);
+        let shreds_to_insert: Vec<_> = (0..missing_fec_start)
+            .chain(std::iter::once(future_fec_start))
+            .map(|index| shreds_by_index.get(&index).unwrap().clone())
+            .collect();
+        blockstore
+            .insert_shreds(shreds_to_insert, None, false)
+            .unwrap();
+
+        let slot_meta = blockstore.meta(slot).unwrap().unwrap();
+        let mut repair_eligibility = RepairEligibility::default();
+        assert_eq!(
+            RepairService::generate_repairs_for_slot(
+                &blockstore,
+                slot,
+                &slot_meta,
+                &mut repair_eligibility,
+                1,
+                &mut HashMap::default(),
+            ),
+            vec![]
+        );
+
+        sleep_shred_deferment_period();
+        assert_eq!(
+            RepairService::generate_repairs_for_slot(
+                &blockstore,
+                slot,
+                &slot_meta,
+                &mut repair_eligibility,
+                1,
+                &mut HashMap::default(),
+            ),
+            vec![ShredRepairType::Shred(slot, missing_fec_start)]
         );
     }
 
@@ -1448,8 +1737,8 @@ mod test {
         let expected: Vec<ShredRepairType> =
             vec![ShredRepairType::HighestShred(0, num_shreds_per_slot - 1)];
 
-        sleep_shred_deferment_period();
         let mut repair_weight = RepairWeight::new(0);
+        let mut repair_eligibility = RepairEligibility::default();
         assert_eq!(
             repair_weight.get_best_weighted_repairs(
                 &blockstore,
@@ -1459,11 +1748,85 @@ mod test {
                 MAX_REPAIR_LENGTH,
                 MAX_UNKNOWN_LAST_INDEX_REPAIRS,
                 MAX_CLOSEST_COMPLETION_REPAIRS,
-                DEFAULT_TICKS_PER_SECOND,
+                &mut repair_eligibility,
+                &mut RepairMetrics::default(),
+                &mut HashMap::default(),
+            ),
+            vec![]
+        );
+
+        sleep_shred_deferment_period();
+        assert_eq!(
+            repair_weight.get_best_weighted_repairs(
+                &blockstore,
+                &HashMap::new(),
+                &EpochSchedule::default(),
+                MAX_ORPHANS,
+                MAX_REPAIR_LENGTH,
+                MAX_UNKNOWN_LAST_INDEX_REPAIRS,
+                MAX_CLOSEST_COMPLETION_REPAIRS,
+                &mut repair_eligibility,
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
             ),
             expected
+        );
+    }
+
+    #[test]
+    pub fn test_highest_repair_waits() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let (shreds, _) = make_slot_entries(0, 0, 100);
+        let shreds_by_index: HashMap<_, _> = shreds
+            .into_iter()
+            .map(|shred| (u64::from(shred.index()), shred))
+            .collect();
+
+        blockstore
+            .insert_shreds(vec![shreds_by_index.get(&0).unwrap().clone()], None, false)
+            .unwrap();
+        let mut repair_eligibility = RepairEligibility::default();
+        let slot_meta = blockstore.meta(0).unwrap().unwrap();
+        assert_eq!(
+            RepairService::generate_repairs_for_slot(
+                &blockstore,
+                0,
+                &slot_meta,
+                &mut repair_eligibility,
+                usize::MAX,
+                &mut HashMap::default(),
+            ),
+            vec![]
+        );
+
+        blockstore
+            .insert_shreds(vec![shreds_by_index.get(&1).unwrap().clone()], None, false)
+            .unwrap();
+        let slot_meta = blockstore.meta(0).unwrap().unwrap();
+        assert_eq!(
+            RepairService::generate_repairs_for_slot(
+                &blockstore,
+                0,
+                &slot_meta,
+                &mut repair_eligibility,
+                usize::MAX,
+                &mut HashMap::default(),
+            ),
+            vec![]
+        );
+
+        sleep_shred_deferment_period();
+        assert_eq!(
+            RepairService::generate_repairs_for_slot(
+                &blockstore,
+                0,
+                &slot_meta,
+                &mut repair_eligibility,
+                usize::MAX,
+                &mut HashMap::default(),
+            ),
+            vec![ShredRepairType::HighestShred(0, 2)]
         );
     }
 

--- a/core/src/repair/repair_weight.rs
+++ b/core/src/repair/repair_weight.rs
@@ -3,7 +3,7 @@ use {
         consensus::{heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice, tree_diff::TreeDiff},
         repair::{
             repair_generic_traversal::{get_closest_completion, get_unknown_last_index},
-            repair_service::{RepairMetrics, RepairService},
+            repair_service::{RepairEligibility, RepairMetrics, RepairService},
             repair_weighted_traversal,
             serve_repair::ShredRepairType,
         },
@@ -208,7 +208,7 @@ impl RepairWeight {
         max_new_shreds: usize,
         max_unknown_last_index_repairs: usize,
         max_closest_completion_repairs: usize,
-        ticks_per_second: u64,
+        repair_eligibility: &mut RepairEligibility,
         repair_metrics: &mut RepairMetrics,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) -> Vec<ShredRepairType> {
@@ -240,7 +240,7 @@ impl RepairWeight {
             &mut slot_meta_cache,
             &mut best_shreds_repairs,
             max_new_shreds,
-            ticks_per_second,
+            repair_eligibility,
             outstanding_repairs,
         );
         let num_best_shreds_repairs = best_shreds_repairs.len();
@@ -277,7 +277,7 @@ impl RepairWeight {
             &mut slot_meta_cache,
             &mut processed_slots,
             max_closest_completion_repairs,
-            ticks_per_second,
+            repair_eligibility,
             outstanding_repairs,
         );
         let num_closest_completion_repairs = closest_completion_repairs.len();
@@ -505,7 +505,7 @@ impl RepairWeight {
         slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
         repairs: &mut Vec<ShredRepairType>,
         max_new_shreds: usize,
-        ticks_per_second: u64,
+        repair_eligibility: &mut RepairEligibility,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) {
         let root_tree = self.trees.get(&self.root).expect("Root tree must exist");
@@ -515,7 +515,7 @@ impl RepairWeight {
             slot_meta_cache,
             repairs,
             max_new_shreds,
-            ticks_per_second,
+            repair_eligibility,
             outstanding_repairs,
         );
     }
@@ -595,8 +595,8 @@ impl RepairWeight {
         }
     }
 
-    /// For all remaining trees (orphan and rooted), generate repairs for slots missing last_index info
-    /// prioritized by # shreds received.
+    /// For all remaining trees (orphan and rooted), generate legacy
+    /// unknown-last-index probes prioritized by known data shred count.
     fn get_best_unknown_last_index(
         &mut self,
         blockstore: &Blockstore,
@@ -633,7 +633,7 @@ impl RepairWeight {
         slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
         processed_slots: &mut HashSet<Slot>,
         max_new_repairs: usize,
-        ticks_per_second: u64,
+        repair_eligibility: &mut RepairEligibility,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) -> (Vec<ShredRepairType>, /* processed slots */ usize) {
         let mut repairs = Vec::default();
@@ -649,7 +649,7 @@ impl RepairWeight {
                 slot_meta_cache,
                 processed_slots,
                 max_new_repairs - repairs.len(),
-                ticks_per_second,
+                repair_eligibility,
                 outstanding_repairs,
             );
             repairs.extend(new_repairs);

--- a/core/src/repair/repair_weighted_traversal.rs
+++ b/core/src/repair/repair_weighted_traversal.rs
@@ -1,7 +1,10 @@
 use {
     crate::{
         consensus::{heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice, tree_diff::TreeDiff},
-        repair::{repair_service::RepairService, serve_repair::ShredRepairType},
+        repair::{
+            repair_service::{RepairEligibility, RepairService},
+            serve_repair::ShredRepairType,
+        },
     },
     solana_clock::Slot,
     solana_hash::Hash,
@@ -79,15 +82,18 @@ pub fn get_best_repair_shreds(
     slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
     repairs: &mut Vec<ShredRepairType>,
     max_new_shreds: usize,
-    ticks_per_second: u64,
+    repair_eligibility: &mut RepairEligibility,
     outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
 ) {
     let initial_len = repairs.len();
     let max_repairs = initial_len + max_new_shreds;
+    if repairs.len() >= max_repairs {
+        return;
+    }
     let weighted_iter = RepairWeightTraversal::new(tree);
     let mut visited_set = HashSet::new();
     for next in weighted_iter {
-        if repairs.len() > max_repairs {
+        if repairs.len() >= max_repairs {
             break;
         }
 
@@ -105,7 +111,7 @@ pub fn get_best_repair_shreds(
                         blockstore,
                         slot,
                         slot_meta,
-                        ticks_per_second,
+                        repair_eligibility,
                         max_repairs - repairs.len(),
                         outstanding_repairs,
                     );
@@ -127,7 +133,7 @@ pub fn get_best_repair_shreds(
                                 repairs,
                                 max_repairs,
                                 *new_child_slot,
-                                ticks_per_second,
+                                repair_eligibility,
                                 outstanding_repairs,
                             );
                         }
@@ -143,8 +149,6 @@ pub fn get_best_repair_shreds(
 pub mod test {
     use {
         super::*,
-        crate::repair::repair_service::sleep_shred_deferment_period,
-        solana_clock::DEFAULT_TICKS_PER_SECOND,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::{
@@ -231,15 +235,16 @@ pub mod test {
         let mut outstanding_repairs = HashMap::new();
         let mut slot_meta_cache = HashMap::default();
         let last_shred = blockstore.meta(0).unwrap().unwrap().received;
+        let mut repair_eligibility =
+            RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=5);
 
-        sleep_shred_deferment_period();
         get_best_repair_shreds(
             &heaviest_subtree_fork_choice,
             &blockstore,
             &mut slot_meta_cache,
             &mut repairs,
             6,
-            DEFAULT_TICKS_PER_SECOND,
+            &mut repair_eligibility,
             &mut outstanding_repairs,
         );
         assert_eq!(
@@ -265,14 +270,15 @@ pub mod test {
             2,
             Hash::default(),
         );
-        sleep_shred_deferment_period();
+        let mut repair_eligibility =
+            RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=7);
         get_best_repair_shreds(
             &heaviest_subtree_fork_choice,
             &blockstore,
             &mut slot_meta_cache,
             &mut repairs,
             6,
-            DEFAULT_TICKS_PER_SECOND,
+            &mut repair_eligibility,
             &mut outstanding_repairs,
         );
         assert_eq!(
@@ -311,14 +317,15 @@ pub mod test {
         blockstore
             .insert_shreds(completed_shreds, None, false)
             .unwrap();
-        sleep_shred_deferment_period();
+        let mut repair_eligibility =
+            RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=7);
         get_best_repair_shreds(
             &heaviest_subtree_fork_choice,
             &blockstore,
             &mut slot_meta_cache,
             &mut repairs,
             4,
-            DEFAULT_TICKS_PER_SECOND,
+            &mut repair_eligibility,
             &mut outstanding_repairs,
         );
         assert_eq!(
@@ -336,14 +343,15 @@ pub mod test {
         outstanding_repairs = HashMap::new();
         slot_meta_cache = HashMap::default();
         blockstore.add_tree(tr(2) / (tr(8)), true, false, 2, Hash::default());
-        sleep_shred_deferment_period();
+        let mut repair_eligibility =
+            RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=8);
         get_best_repair_shreds(
             &heaviest_subtree_fork_choice,
             &blockstore,
             &mut slot_meta_cache,
             &mut repairs,
             5,
-            DEFAULT_TICKS_PER_SECOND,
+            &mut repair_eligibility,
             &mut outstanding_repairs,
         );
         let expected_repairs = [1, 7, 8, 3, 5]
@@ -360,7 +368,7 @@ pub mod test {
             &mut slot_meta_cache,
             &mut repairs,
             1,
-            DEFAULT_TICKS_PER_SECOND,
+            &mut repair_eligibility,
             &mut outstanding_repairs,
         );
         assert_eq!(repairs, expected_repairs);
@@ -374,17 +382,18 @@ pub mod test {
         // 4 again when the Unvisited(2) event happens
         blockstore.add_tree(tr(2) / (tr(6) / tr(7)), true, false, 2, Hash::default());
 
-        sleep_shred_deferment_period();
         let mut repairs = vec![];
         let mut outstanding_repairs = HashMap::new();
         let mut slot_meta_cache = HashMap::default();
+        let mut repair_eligibility =
+            RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=7);
         get_best_repair_shreds(
             &heaviest_subtree_fork_choice,
             &blockstore,
             &mut slot_meta_cache,
             &mut repairs,
             usize::MAX,
-            DEFAULT_TICKS_PER_SECOND,
+            &mut repair_eligibility,
             &mut outstanding_repairs,
         );
         let last_shred = blockstore.meta(0).unwrap().unwrap().received;
@@ -396,6 +405,30 @@ pub mod test {
                 .collect::<Vec<_>>()
         );
         assert_eq!(repairs.len(), outstanding_repairs.len());
+    }
+
+    #[test]
+    fn test_get_best_repair_shreds_stops_at_limit() {
+        let (blockstore, heaviest_subtree_fork_choice) = setup_forks();
+        let mut repairs = vec![];
+        let mut outstanding_repairs = HashMap::new();
+        let mut slot_meta_cache = HashMap::default();
+        let mut repair_eligibility =
+            RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=5);
+
+        get_best_repair_shreds(
+            &heaviest_subtree_fork_choice,
+            &blockstore,
+            &mut slot_meta_cache,
+            &mut repairs,
+            1,
+            &mut repair_eligibility,
+            &mut outstanding_repairs,
+        );
+
+        assert_eq!(repairs.len(), 1);
+        assert_eq!(repairs.len(), outstanding_repairs.len());
+        assert_eq!(slot_meta_cache.len(), 1);
     }
 
     fn setup_forks() -> (Blockstore, HeaviestSubtreeForkChoice) {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -37,7 +37,7 @@ use {
     rocksdb::{DBRawIterator, LiveFile},
     solana_account::ReadableAccount,
     solana_address_lookup_table_interface::state::AddressLookupTable,
-    solana_clock::{DEFAULT_TICKS_PER_SECOND, Slot, UnixTimestamp},
+    solana_clock::{Slot, UnixTimestamp},
     solana_entry::{
         block_component::{
             BlockComponent, VersionedBlockHeader, VersionedBlockMarker, VersionedUpdateParent,
@@ -1494,7 +1494,7 @@ impl Blockstore {
     }
 
     /// Attempts to insert shreds into blockstore and updates relevant metrics
-    /// based on the results, split out by shred source (tubine vs. repair).
+    /// based on the results, split out by shred source (turbine vs. repair).
     fn attempt_shred_insertion<'a>(
         &self,
         shreds: impl IntoIterator<
@@ -3336,7 +3336,6 @@ impl Blockstore {
             slot_meta,
             index as u32,
             new_consumed,
-            shred.reference_tick(),
             data_index,
         )
         .map(move |indices| CompletedDataSetInfo { slot, indices });
@@ -3699,26 +3698,17 @@ impl Blockstore {
     }
 
     /// Find missing shred indices for a given `slot` within the range
-    /// [`start_index`, `end_index`]. Missing shreds will only be reported as
-    /// missing if they should be present by the time this function is called,
-    /// as controlled by`first_timestamp` and `defer_threshold_ticks`.
+    /// [`start_index`, `end_index`].
     ///
     /// Arguments:
     ///  - `db_iterator`: Iterator to run search over.
     ///  - `slot`: The slot to search for missing shreds for.
-    ///  - 'first_timestamp`: Timestamp (ms) for slot's first shred insertion.
-    ///  - `defer_threshold_ticks`: A grace period to allow shreds that are
-    ///    missing to be excluded from the reported missing list. This allows
-    ///    tuning on how aggressively missing shreds should be reported and
-    ///    acted upon.
     ///  - `start_index`: Begin search (inclusively) at this shred index.
     ///  - `end_index`: Finish search (exclusively) at this shred index.
     ///  - `max_missing`: Limit result to this many indices.
     fn find_missing_indexes<C>(
         db_iterator: &mut DBRawIterator,
         slot: Slot,
-        first_timestamp: u64,
-        defer_threshold_ticks: u64,
         start_index: u64,
         end_index: u64,
         max_missing: usize,
@@ -3731,9 +3721,6 @@ impl Blockstore {
         }
 
         let mut missing_indexes = vec![];
-        // System time is not monotonic
-        let ticks_since_first_insert =
-            DEFAULT_TICKS_PER_SECOND * timestamp().saturating_sub(first_timestamp) / 1000;
 
         // Seek to the first shred with index >= start_index
         db_iterator.seek(C::key(&(slot, start_index)));
@@ -3757,14 +3744,6 @@ impl Blockstore {
             };
 
             let upper_index = cmp::min(current_index, end_index);
-            // the tick that will be used to figure out the timeout for this hole
-            let data = db_iterator.value().expect("couldn't read value");
-            let reference_tick = u64::from(shred::layout::get_reference_tick(data).unwrap());
-            if ticks_since_first_insert < reference_tick + defer_threshold_ticks {
-                // The higher index holes have not timed out yet
-                break;
-            }
-
             let num_to_take = max_missing - missing_indexes.len();
             missing_indexes.extend((prev_index..upper_index).take(num_to_take));
 
@@ -3788,8 +3767,6 @@ impl Blockstore {
     pub fn find_missing_data_indexes(
         &self,
         slot: Slot,
-        first_timestamp: u64,
-        defer_threshold_ticks: u64,
         start_index: u64,
         end_index: u64,
         max_missing: usize,
@@ -3801,8 +3778,6 @@ impl Blockstore {
         Self::find_missing_indexes::<cf::ShredData>(
             &mut db_iterator,
             slot,
-            first_timestamp,
-            defer_threshold_ticks,
             start_index,
             end_index,
             max_missing,
@@ -5874,7 +5849,6 @@ fn update_slot_meta<'a>(
     slot_meta: &mut SlotMeta,
     index: u32,
     new_consumed: u64,
-    reference_tick: u8,
     received_data_shreds: &'a ShredIndex,
 ) -> impl Iterator<Item = Range<u32>> + 'a + use<'a> {
     let first_insert = slot_meta.received == 0;
@@ -5882,9 +5856,7 @@ fn update_slot_meta<'a>(
     // so received = index + 1 for the same shred.
     slot_meta.received = cmp::max(u64::from(index) + 1, slot_meta.received);
     if first_insert {
-        // predict the timestamp of what would have been the first shred in this slot
-        let slot_time_elapsed = u64::from(reference_tick) * 1000 / DEFAULT_TICKS_PER_SECOND;
-        slot_meta.first_shred_timestamp = timestamp() - slot_time_elapsed;
+        slot_meta.first_shred_timestamp = timestamp();
     }
     slot_meta.consumed = new_consumed;
     // If the last index in the slot hasn't been set before, then

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -1541,8 +1541,6 @@ fn test_find_missing_data_indexes() {
     assert_eq!(
         blockstore.find_missing_data_indexes(
             slot,
-            0,            // first_timestamp
-            0,            // defer_threshold_ticks
             0,            // start_index
             gap,          // end_index
             gap as usize, // max_missing
@@ -1552,8 +1550,6 @@ fn test_find_missing_data_indexes() {
     assert_eq!(
         blockstore.find_missing_data_indexes(
             slot,
-            0,                  // first_timestamp
-            0,                  // defer_threshold_ticks
             1,                  // start_index
             gap,                // end_index
             (gap - 1) as usize, // max_missing
@@ -1563,8 +1559,6 @@ fn test_find_missing_data_indexes() {
     assert_eq!(
         blockstore.find_missing_data_indexes(
             slot,
-            0,                  // first_timestamp
-            0,                  // defer_threshold_ticks
             0,                  // start_index
             gap - 1,            // end_index
             (gap - 1) as usize, // max_missing
@@ -1574,8 +1568,6 @@ fn test_find_missing_data_indexes() {
     assert_eq!(
         blockstore.find_missing_data_indexes(
             slot,
-            0,            // first_timestamp
-            0,            // defer_threshold_ticks
             gap - 2,      // start_index
             gap,          // end_index
             gap as usize, // max_missing
@@ -1585,8 +1577,6 @@ fn test_find_missing_data_indexes() {
     assert_eq!(
         blockstore.find_missing_data_indexes(
             slot,    // slot
-            0,       // first_timestamp
-            0,       // defer_threshold_ticks
             gap - 2, // start_index
             gap,     // end_index
             1,       // max_missing
@@ -1596,8 +1586,6 @@ fn test_find_missing_data_indexes() {
     assert_eq!(
         blockstore.find_missing_data_indexes(
             slot, // slot
-            0,    // first_timestamp
-            0,    // defer_threshold_ticks
             0,    // start_index
             gap,  // end_index
             1,    // max_missing
@@ -1612,8 +1600,6 @@ fn test_find_missing_data_indexes() {
     assert_eq!(
         blockstore.find_missing_data_indexes(
             slot,
-            0,                  // first_timestamp
-            0,                  // defer_threshold_ticks
             0,                  // start_index
             gap + 2,            // end_index
             (gap + 2) as usize, // max_missing
@@ -1623,8 +1609,6 @@ fn test_find_missing_data_indexes() {
     assert_eq!(
         blockstore.find_missing_data_indexes(
             slot,
-            0,                  // first_timestamp
-            0,                  // defer_threshold_ticks
             0,                  // start_index
             gap + 2,            // end_index
             (gap - 1) as usize, // max_missing
@@ -1644,8 +1628,6 @@ fn test_find_missing_data_indexes() {
             assert_eq!(
                 blockstore.find_missing_data_indexes(
                     slot,
-                    0,                        // first_timestamp
-                    0,                        // defer_threshold_ticks
                     j * gap,                  // start_index
                     i * gap,                  // end_index
                     ((i - j) * gap) as usize, // max_missing
@@ -1654,72 +1636,6 @@ fn test_find_missing_data_indexes() {
             );
         }
     }
-}
-
-#[test]
-fn test_find_missing_data_indexes_timeout() {
-    let slot = 1;
-    let ledger_path = get_tmp_ledger_path_auto_delete!();
-    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-
-    // Blockstore::find_missing_data_indexes() compares timestamps, so
-    // set a small value for defer_threshold_ticks to avoid flakiness.
-    let defer_threshold_ticks = DEFAULT_TICKS_PER_SECOND / 16;
-    let start_index = 0;
-    let end_index = 50;
-    let max_missing = 9;
-
-    // Write entries
-    let gap: u64 = 10;
-
-    let keypair = Keypair::new();
-    let reed_solomon_cache = ReedSolomonCache::default();
-    let mut stats = ProcessShredsStats::default();
-    let shreds: Vec<_> = (0u64..64)
-        .map(|i| {
-            let shredder = Shredder::new(slot, slot - 1, i as u8, 42).unwrap();
-
-            let mut shreds = shredder
-                .make_shreds_from_data_slice(
-                    &keypair,
-                    &[],
-                    false,
-                    Hash::default(), // merkle_root
-                    (i * gap) as u32,
-                    (i * gap) as u32,
-                    &reed_solomon_cache,
-                    &mut stats,
-                )
-                .unwrap();
-            shreds.next().unwrap()
-        })
-        .collect();
-    blockstore.insert_shreds(shreds, None, false).unwrap();
-
-    let empty: Vec<u64> = vec![];
-    assert_eq!(
-        blockstore.find_missing_data_indexes(
-            slot,
-            timestamp(), // first_timestamp
-            defer_threshold_ticks,
-            start_index,
-            end_index,
-            max_missing,
-        ),
-        empty
-    );
-    let expected: Vec<_> = (1..=9).collect();
-    assert_eq!(
-        blockstore.find_missing_data_indexes(
-            slot,
-            timestamp() - 1000, // first_timestamp
-            defer_threshold_ticks,
-            start_index,
-            end_index,
-            max_missing,
-        ),
-        expected
-    );
 }
 
 #[test]
@@ -1734,8 +1650,6 @@ fn test_find_missing_data_indexes_sanity() {
     assert_eq!(
         blockstore.find_missing_data_indexes(
             slot, // slot
-            0,    // first_timestamp
-            0,    // defer_threshold_ticks
             0,    // start_index
             0,    // end_index
             1,    // max_missing
@@ -1745,8 +1659,6 @@ fn test_find_missing_data_indexes_sanity() {
     assert_eq!(
         blockstore.find_missing_data_indexes(
             slot, // slot
-            0,    // first_timestamp
-            0,    // defer_threshold_ticks
             5,    // start_index
             5,    // end_index
             1,    // max_missing
@@ -1756,8 +1668,6 @@ fn test_find_missing_data_indexes_sanity() {
     assert_eq!(
         blockstore.find_missing_data_indexes(
             slot, // slot
-            0,    // first_timestamp
-            0,    // defer_threshold_ticks
             4,    // start_index
             3,    // end_index
             1,    // max_missing
@@ -1767,8 +1677,6 @@ fn test_find_missing_data_indexes_sanity() {
     assert_eq!(
         blockstore.find_missing_data_indexes(
             slot, // slot
-            0,    // first_timestamp
-            0,    // defer_threshold_ticks
             1,    // start_index
             2,    // end_index
             0,    // max_missing
@@ -1797,8 +1705,6 @@ fn test_find_missing_data_indexes_sanity() {
     for start in 0..STARTS {
         let result = blockstore.find_missing_data_indexes(
             slot,  // slot
-            0,     // first_timestamp
-            0,     // defer_threshold_ticks
             start, // start_index
             END,   // end_index
             MAX,   // max_missing
@@ -1828,8 +1734,6 @@ fn test_no_missing_shred_indexes() {
             assert_eq!(
                 blockstore.find_missing_data_indexes(
                     slot,
-                    0,                // first_timestamp
-                    0,                // defer_threshold_ticks
                     j,                // start_index
                     i,                // end_index
                     (i - j) as usize, // max_missing

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -121,9 +121,9 @@ pub struct SlotMetaBase<T> {
     /// At the same time, it is also an index of the first missing shred for this slot, while the
     /// slot is incomplete.
     pub consumed: u64,
-    /// The index *plus one* of the highest shred received for this slot.  Useful
+    /// The index *plus one* of the highest shred received for this slot. Useful
     /// for checking if the slot has received any shreds yet, and to calculate the
-    /// range where there is one or more holes: `(consumed..received)`.
+    /// range that may contain holes: `(consumed..received)`.
     pub received: u64,
     /// The timestamp of the first time a shred was added for this slot
     pub first_shred_timestamp: u64,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -516,6 +516,7 @@ impl Shred {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn reference_tick(&self) -> u8 {
         match self {
             Self::ShredCode(_) => ShredFlags::SHRED_TICK_REFERENCE_MASK.bits(),

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -226,6 +226,7 @@ impl ShredData {
             .contains(ShredFlags::DATA_COMPLETE_SHRED)
     }
 
+    #[cfg(test)]
     pub(super) fn reference_tick(&self) -> u8 {
         (self.data_header.flags & ShredFlags::SHRED_TICK_REFERENCE_MASK).bits()
     }


### PR DESCRIPTION
## Summary

Replaces reference-tick based repair deferment with FEC-granularity timing tracker.

Previously, repair used the following to decide when to repair:

1. Time of first shred arrival (backdated based on received shred’s reference tick + ticks-per-second constant)
2. Ticks + slot time as a reference for how far time-wise we are into the block
3. Constant delay meant to represent ~`t_delta` for network

This made repair timing depend on slot timing and PoH tick calculations. This change instead tracks when repair first observes shreds at FEC granularity and uses a fixed 200ms delay before requesting repair for missing shreds in that FEC set.

There are a few problems with the current, tick based repair:

1. Alpenglow basically gets rid of ticks. Need to do something different.
2. We're changing slot times, which changes ticks per second math, which screws up repair because it's using hard coded constant.
3. Turbine metrics `shred_insert_is_full` is misleading because we estimate theoretical time for the first shred arrival. This also uses hard coded constant which makes the time wrong after changing slot times.

## Details

- Adds lightweight repair-side FEC timing state:
  - one timestamp per observed FEC set (no per-shred timing)
  - skipped FECs inherit the timestamp of the first later observed FEC
- Missing shred repair becomes eligible once its FEC set has been observed for at least 200ms.
- `HighestShred` repair from `generate_repairs_for_slot` waits until the last observed FEC has been quiet for 200ms.
- `get_unknown_last_index` keeps legacy behavior and requests `HighestShred(slot, received)` without additional deferment.
- Simplifies blockstore missing-index lookup to only find raw missing data indexes; repair now owns timing eligibility.
- We record the actual timestamp for first shred arrival instead of backdating it. Only used for metrics now.

## Performance

Performance was my main concern in working through this. My expectation is the compute/memory impact of this should be tiny.

Assumptions:
- `DATA_SHREDS_PER_FEC_BLOCK = 32`
- tracker stores one `u64` timestamp per FEC set
- min prealloc is 32 FECs
- current slot time is 400ms, so ~2.5 slots/sec

### Memory Per Tracked Slot

1k shreds --> 32 FEC sets --> ~256B of timing data per slot

Add in a couple hundred bytes of static overhead for: `Vec` header, `next_scan_index`, hash map entry/control overhead, allocator rounding, etc. --> ~500B per slot

At 400ms slots:
- 1 minute of tracked slots: ~150 slots → ~75 KB

Even a pathological 32k-shred slot is about `1000 FECs * 8 = 8 KB` for the vector, plus overhead.

In short, it's just not that much memory.. so as long as we're not allocating like crazy, which we shouldn't given we're allocating enough for a typical slot upfront, seems we should be fine.

### Compute

- Observation is O(1) per slot repair pass.
- No shred index scan.
- No `get_data_shred` payload read to inspect reference ticks.
- Repeated passes with no new FECs are just hash lookup + bounds checks.

Net: this should be well under noise compared with repair’s existing blockstore reads, traversal, networking, and outstanding-request bookkeeping. It should even be cheaper than the prior timing plumbing in most paths because we no longer read shred payloads just to inspect reference ticks.

On mainnet unstaked node, I'm measuring:
<10% of a CPU core consumed during steady state (dominated by ~115ms per 2s reporting interval in `get-best-shreds`)
~190% of a CPU core consumed during catch up

## Testing

unstaked mainnet node shows it is catching up during restart at a rate of ~6.5 slots per second (vs. cluster advancing at ~2.5 slots per second) with these changes.

My unstaked node (Node A) in Chicago on Latitude running these changes:
<img width="2299" height="545" alt="image" src="https://github.com/user-attachments/assets/0ed07d2e-8488-4ac4-b28f-365f439cc6b8" />

Different unstaked node (node B) in New York on Latitude running v3.1:
<img width="2292" height="551" alt="image" src="https://github.com/user-attachments/assets/18ef1de5-5992-4abf-8209-f48e16cb3344" />
Comparing the 2, a couple things to notice:
1. There was a spike around `07:00:50` for turbine delivery. Node B was aggressively spamming repair while Node A was not, but they got the block around the same time (maybe slightly faster for Node A). This seems to indicate shred delivery was progressing slowly for the block and so the repair was useless (and maybe harmful). The legacy algorithm doesn't understand that turbine might just be slow and it's not a "me" problem 
2. Node A is requesting fewer overall repairs (~21 per second) but landing (i.e. a shred delivered via repair lands first into blockstore) more repairs!

Node A:
<img width="2297" height="539" alt="image" src="https://github.com/user-attachments/assets/d5d225d5-5328-46f5-b2b9-3b2c10436b89" />
Node B:
<img width="2294" height="555" alt="image" src="https://github.com/user-attachments/assets/bc7e10cb-75ac-431d-8a50-fcfdd0527884" />
