### PR TITLE
perf(bank): Reuse `rewards_calculation_thread_pool` in snapshot restore

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -79,7 +79,7 @@ use {
     dashmap::DashMap,
     log::*,
     partitioned_epoch_rewards::PartitionedRewardsCalculation,
-    rayon::{ThreadPool, ThreadPoolBuilder},
+    rayon::ThreadPool,
     serde::{Deserialize, Serialize},
     solana_account::{
         Account, AccountSharedData, InheritableAccountFields, ReadableAccount, WritableAccount,
@@ -2122,12 +2122,7 @@ impl Bank {
         );
         assert_eq!(bank.epoch_schedule, genesis_config.epoch_schedule);
 
-        bank.initialize_after_snapshot_restore(|| {
-            ThreadPoolBuilder::new()
-                .thread_name(|i| format!("solBnkClcRwds{i:02}"))
-                .build()
-                .expect("new rayon threadpool")
-        });
+        bank.initialize_after_snapshot_restore(rewards_calculation_thread_pool);
 
         datapoint_info!(
             "bank-new-from-fields",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1956,7 +1956,7 @@ impl Bank {
         let ancestors = Ancestors::from(vec![slot]);
         // Initialize the rewards thread pool while creating the first bank so
         // the first epoch boundary crossing does not pay the cost.
-        let _rewards_calculation_thread_pool = rewards_calculation_thread_pool();
+        let rewards_calculation_thread_pool = rewards_calculation_thread_pool();
         // For backward compatibility, we can only serialize and deserialize
         // Stakes<Delegation> in BankFieldsTo{Serialize,Deserialize}. But Bank
         // caches Stakes<StakeAccount>. Below Stakes<StakeAccount> is obtained
@@ -2122,7 +2122,7 @@ impl Bank {
         );
         assert_eq!(bank.epoch_schedule, genesis_config.epoch_schedule);
 
-        bank.initialize_after_snapshot_restore(rewards_calculation_thread_pool);
+        bank.initialize_after_snapshot_restore(|| rewards_calculation_thread_pool);
 
         datapoint_info!(
             "bank-new-from-fields",


### PR DESCRIPTION
Use the existing `rewards_calculation_thread_pool` helper instead of creating a separate pool during snapshot restore.

Creating the additional pool takes ~13ms:

```
rewards_pool_us=13785i
```

(This metric was added locally for measurement purposes and is not part of the committed code.)

This is safe because the only other user, epoch boundary reward processing, cannot run concurrently with snapshot restore.

Snapshot restore timings also indicate a small improvement after the change, although this metric can vary by ~200ms across runs due to nondeterministic I/O behavior.

Before:

```
rebuild_bank_us=65870158i
rebuild_bank_us=66023810i
rebuild_bank_us=66028951i
```

After:

```
rebuild_bank_us=65295642i
rebuild_bank_us=65610324i
rebuild_bank_us=65616597i
```