### PR TITLE
xdp: propagate error from TxLoopBuilder instead of panic on socket creation

### DIFF
--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -219,7 +219,7 @@ impl TransmitterBuilder {
         use {
             caps::Capability::{CAP_BPF, CAP_NET_ADMIN, CAP_NET_RAW, CAP_PERFMON},
             log::debug,
-            std::collections::HashSet,
+            std::{collections::HashSet, io},
         };
         let XdpConfig {
             interface: maybe_interface,
@@ -285,7 +285,7 @@ impl TransmitterBuilder {
         let tx_loops = tx_loop_builders
             .into_iter()
             .map(|tx_loop_builder| tx_loop_builder.build())
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, io::Error>>()?;
 
         let tables_result = RoutingTables::from_netlink(RouteTable::Main);
 

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -21,6 +21,7 @@ use {
     crossbeam_channel::{Receiver, Sender, TryRecvError},
     libc::{_SC_PAGESIZE, sysconf},
     std::{
+        io,
         net::{IpAddr, SocketAddr, SocketAddrV4},
         thread,
         time::Duration,
@@ -81,7 +82,6 @@ pub struct TxLoopConfig {
 
 pub struct TxLoopBuilder<U: Umem> {
     cpu_id: usize,
-    queue_id: QueueId,
     zero_copy: bool,
     src_mac: MacAddress,
     queue: DeviceQueue,
@@ -138,7 +138,6 @@ impl TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
 
         TxLoopBuilder {
             cpu_id,
-            queue_id,
             zero_copy,
             src_mac,
             queue,
@@ -147,10 +146,9 @@ impl TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
         }
     }
 
-    pub fn build(self) -> TxLoop<OwnedUmem<PageAlignedMemory>> {
+    pub fn build(self) -> Result<TxLoop<OwnedUmem<PageAlignedMemory>>, io::Error> {
         let TxLoopBuilder {
             cpu_id,
-            queue_id,
             zero_copy,
             src_mac,
             queue,
@@ -158,8 +156,16 @@ impl TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
             umem,
         } = self;
 
-        let Ok((socket, tx)) = Socket::tx(queue, umem, zero_copy, tx_size * 2, tx_size) else {
-            panic!("failed to create AF_XDP socket on queue {queue_id:?}");
+        let queue_id = queue.id();
+        let (socket, tx) = match Socket::tx(queue, umem, zero_copy, tx_size * 2, tx_size) {
+            Ok(socket_tx) => socket_tx,
+            Err(err) => {
+                log::error!(
+                    "failed to create AF_XDP TX socket for queue {queue_id:?} on CPU {cpu_id}: \
+                     {err}"
+                );
+                return Err(err);
+            }
         };
 
         let Tx {
@@ -170,13 +176,13 @@ impl TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
         } = tx;
         let ring = ring.unwrap();
 
-        TxLoop {
+        Ok(TxLoop {
             cpu_id,
             src_mac,
             socket,
             ring,
             completion,
-        }
+        })
     }
 }
 


### PR DESCRIPTION
#### Problem

When socket creation fails in builder, it panics and hides the error message. 

#### Summary of Changes

Instead of just adding the error message to the panic message, I propagate error.

