### PR TITLE
fix(repair): include FEC set count in double-Merkle leaf

### DIFF
--- a/core/src/repair/block_id_repair_service.rs
+++ b/core/src/repair/block_id_repair_service.rs
@@ -1404,7 +1404,11 @@ mod tests {
 
         // Create valid merkle tree for the response
         let fec_set_roots: Vec<Hash> = (0..fec_set_count).map(|_| Hash::new_unique()).collect();
-        let parent_info_leaf = hashv(&[&parent_slot.to_le_bytes(), parent_block_id.as_ref()]);
+        let parent_info_leaf = hashv(&[
+            &parent_slot.to_le_bytes(),
+            parent_block_id.as_ref(),
+            &fec_set_count.to_le_bytes(),
+        ]);
         let mut leaves = fec_set_roots.clone();
         leaves.push(parent_info_leaf);
         let (block_id, proofs) = build_merkle_tree(&leaves);

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -289,8 +289,11 @@ impl RequestResponse for BlockIdRepairType {
                     return false;
                 }
 
-                let parent_info_leaf =
-                    hashv(&[&parent_slot.to_le_bytes(), parent_block_id.as_ref()]);
+                let parent_info_leaf = hashv(&[
+                    &parent_slot.to_le_bytes(),
+                    parent_block_id.as_ref(),
+                    &fec_set_count.to_le_bytes(),
+                ]);
                 merkle_tree::verify_merkle_proof(
                     parent_info_leaf,
                     *fec_set_count as usize,
@@ -3207,6 +3210,54 @@ mod tests {
         assert!(
             cache.add(&pong1, remote_socket, within_delay),
             "pong for original ping must still be valid — token was not overwritten"
+        );
+    }
+
+    #[test]
+    fn test_verify_fec_set_count_non_malleable() {
+        let parent_slot = 99u64;
+        let parent_block_id = Hash::new_unique();
+        let fec_set_count: u32 = 2; // even => total leaves = 3, last leaf duplicated
+        let fec_set_roots: Vec<Hash> = (0..fec_set_count).map(|_| Hash::new_unique()).collect();
+        let real_parent_leaf = hashv(&[
+            &parent_slot.to_le_bytes(),
+            parent_block_id.as_ref(),
+            &fec_set_count.to_le_bytes(),
+        ]);
+        let mut leaves: Vec<Hash> = fec_set_roots;
+        leaves.push(real_parent_leaf);
+        let tree =
+            merkle_tree::MerkleTree::try_new_with_len(leaves.iter().copied().map(Ok), leaves.len())
+                .unwrap();
+        let block_id = *tree.root();
+        let real_parent_proof: Vec<u8> = tree
+            .make_merkle_proof(fec_set_count as usize, leaves.len())
+            .flat_map(|entry| entry.unwrap().iter().copied())
+            .collect();
+
+        let request = BlockIdRepairType::ParentAndFecSetCount {
+            slot: 100,
+            block_id,
+        };
+
+        // honest response verifies
+        assert!(
+            request.verify_response(&BlockIdRepairResponse::ParentFecSetCount {
+                fec_set_count,
+                parent_info: (parent_slot, parent_block_id),
+                parent_proof: real_parent_proof.clone(),
+            })
+        );
+
+        // Attack: claim N+1 and reuse the honest proof. The padded tree puts
+        // `real_parent_leaf` at both positions N and N+1, so without binding
+        // `fec_set_count` into the leaf this proof would verify.
+        assert!(
+            !request.verify_response(&BlockIdRepairResponse::ParentFecSetCount {
+                fec_set_count: fec_set_count + 1,
+                parent_info: (parent_slot, parent_block_id),
+                parent_proof: real_parent_proof.clone(),
+            })
         );
     }
 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1880,10 +1880,15 @@ impl Blockstore {
                     .map_err(|_| shred::Error::InvalidMerkleRoot)
                     .and_then(|mr| mr.ok_or(shred::Error::InvalidMerkleRoot))
             })
-            // Add parent info as the last leaf
+            // Add parent info as the last leaf. The `fec_set_count` is bound
+            // into this leaf so that an adversary cannot convince a verifier
+            // that the count is off-by-one when the number of FEC sets is
+            // even (which makes the total leaf count odd and causes the last
+            // leaf to be hashed with itself during tree construction).
             .chain(std::iter::once(Ok(hashv(&[
                 &parent_slot.to_le_bytes(),
                 parent_block_id.as_ref(),
+                &fec_set_count.to_le_bytes(),
             ]))));
 
         MerkleTree::try_new_with_len(merkle_tree_leaves, fec_set_count as usize + 1)

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -6655,7 +6655,12 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
         }
     }
 
-    let parent_info_hash = hashv(&[&parent_slot.to_le_bytes(), parent_block_id.as_ref()]);
+    let fec_set_count = u32::try_from(fec_set_roots.len()).unwrap();
+    let parent_info_hash = hashv(&[
+        &parent_slot.to_le_bytes(),
+        parent_block_id.as_ref(),
+        &fec_set_count.to_le_bytes(),
+    ]);
     let merkle_tree_leaves: Vec<_> = fec_set_roots
         .iter()
         .copied()

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -288,10 +288,11 @@ impl StandardBroadcastRun {
     }
 
     /// Leaf that binds the current replay parent into the double-merkle block id.
-    fn parent_info_leaf(&self) -> Hash {
+    fn parent_info_leaf(&self, fec_set_count: u32) -> Hash {
         hashv(&[
             &self.parent_for_double_merkle.0.to_le_bytes(),
             self.parent_for_double_merkle.1.as_bytes(),
+            &fec_set_count.to_le_bytes(),
         ])
     }
 
@@ -482,15 +483,16 @@ impl StandardBroadcastRun {
                 .should_use_double_merkle_block_id(bank.slot())
             {
                 // Block id is the double merkle root
-                let fec_set_count = self.double_merkle_leaves.len();
+                let fec_set_count = u32::try_from(self.double_merkle_leaves.len()).unwrap();
                 // Add the final leaf (parent info)
-                self.double_merkle_leaves.push(self.parent_info_leaf());
+                self.double_merkle_leaves
+                    .push(self.parent_info_leaf(fec_set_count));
 
                 // Compute the double merkle root
                 // Blockstore population of the DoubleMerkleMeta happens asynchronously when shreds are inserted
                 let merkle_tree = MerkleTree::try_new_with_len(
                     self.double_merkle_leaves.drain(..).map(Ok),
-                    fec_set_count + 1,
+                    fec_set_count as usize + 1,
                 )
                 .expect("Double merkle tree construction cannot fail");
                 *merkle_tree.root()
@@ -1286,11 +1288,13 @@ mod test {
             bs.parent_for_double_merkle,
             (new_parent_slot, new_parent_block_id)
         );
+        let fec_set_count = 3u32;
         assert_eq!(
-            bs.parent_info_leaf(),
+            bs.parent_info_leaf(fec_set_count),
             hashv(&[
                 &new_parent_slot.to_le_bytes(),
-                new_parent_block_id.as_bytes()
+                new_parent_block_id.as_bytes(),
+                &fec_set_count.to_le_bytes(),
             ])
         );
 


### PR DESCRIPTION
#### Problem
The current double-Merkle construction allows an adversary to prove different FEC set counts. See #12496 for more details.

#### Summary of Changes
Include `fec_set_count` in the last leaf of the double-Merkle tree, alongside the parent slot and block ID.

Fixes #12496.