### PR TITLE
fix: v1 transactions over 1232 bytes

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -587,6 +587,8 @@ impl ValidatorTpuConfig {
         let tpu_quic_server_config = SwQosQuicStreamerConfig {
             quic_streamer_config: QuicStreamerConfig {
                 max_connections_per_ipaddr_per_min: 32,
+                stream_receive_window_size: solana_message::v1::MAX_TRANSACTION_SIZE as u32,
+                max_stream_data_bytes: solana_message::v1::MAX_TRANSACTION_SIZE as u32,
                 ..Default::default()
             },
             qos_config: SwQosConfig::default(),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4363,8 +4363,11 @@ fn rpc_perf_sample_from_perf_sample(slot: u64, sample: PerfSample) -> RpcPerfSam
     }
 }
 
-const MAX_BASE58_SIZE: usize = 1683; // Golden, bump if PACKET_DATA_SIZE changes
-const MAX_BASE64_SIZE: usize = 1644; // Golden, bump if PACKET_DATA_SIZE changes
+// Encoded-size caps sized for the largest supported raw transaction
+// (V1 transactions, up to 4096 bytes). The raw cap is
+// applied per-version after decoding.
+const MAX_BASE58_SIZE: usize = 5594; // ceil(4096 * log_58(256))
+const MAX_BASE64_SIZE: usize = 5464; // ceil(4096 / 3) * 4
 fn decode_and_deserialize<T>(
     encoded: String,
     encoding: TransactionBinaryEncoding,
@@ -4381,7 +4384,7 @@ where
                     type_name::<T>(),
                     encoded.len(),
                     MAX_BASE58_SIZE,
-                    PACKET_DATA_SIZE,
+                    solana_message::v1::MAX_TRANSACTION_SIZE,
                 )));
             }
             bs58::decode(encoded)
@@ -4396,7 +4399,7 @@ where
                     type_name::<T>(),
                     encoded.len(),
                     MAX_BASE64_SIZE,
-                    PACKET_DATA_SIZE,
+                    solana_message::v1::MAX_TRANSACTION_SIZE,
                 )));
             }
             BASE64_STANDARD
@@ -4404,12 +4407,19 @@ where
                 .map_err(|e| Error::invalid_params(format!("invalid base64 encoding: {e:?}")))?
         }
     };
-    if wire_output.len() > PACKET_DATA_SIZE {
+    // V1 transactions/messages start with V1_PREFIX (0x81) and may be up to
+    // 4096 bytes; legacy/v0 are still capped at PACKET_DATA_SIZE (1232).
+    let max_raw_size = if wire_output.first().copied() == Some(solana_message::v1::V1_PREFIX) {
+        solana_message::v1::MAX_TRANSACTION_SIZE
+    } else {
+        PACKET_DATA_SIZE
+    };
+    if wire_output.len() > max_raw_size {
         return Err(Error::invalid_params(format!(
             "decoded {} too large: {} bytes (max: {} bytes)",
             type_name::<T>(),
             wire_output.len(),
-            PACKET_DATA_SIZE
+            max_raw_size
         )));
     }
 
@@ -9108,7 +9118,7 @@ pub mod tests {
 
     #[test]
     fn test_worst_case_encoded_tx_goldens() {
-        let ff_tx = vec![0xffu8; PACKET_DATA_SIZE];
+        let ff_tx = vec![0xffu8; solana_message::v1::MAX_TRANSACTION_SIZE];
         let tx58 = bs58::encode(&ff_tx).into_string();
         assert_eq!(tx58.len(), MAX_BASE58_SIZE);
         let tx64 = BASE64_STANDARD.encode(&ff_tx);
@@ -9117,8 +9127,8 @@ pub mod tests {
 
     #[test]
     fn test_decode_and_deserialize_too_large_payloads_fail() {
-        // +2 because +1 still fits in base64 encoded worst-case
-        let too_big = PACKET_DATA_SIZE + 2;
+        // +3 to exceed both MAX_BASE58_SIZE and MAX_BASE64_SIZE for a V1-sized payload.
+        let too_big = solana_message::v1::MAX_TRANSACTION_SIZE + 3;
         let tx_ser = vec![0xffu8; too_big];
 
         let tx58 = bs58::encode(&tx_ser).into_string();
@@ -9128,7 +9138,8 @@ pub mod tests {
                 .unwrap_err(),
             Error::invalid_params(format!(
                 "base58 encoded solana_transaction::Transaction too large: {tx58_len} bytes (max: \
-                 encoded/raw {MAX_BASE58_SIZE}/{PACKET_DATA_SIZE})",
+                 encoded/raw {MAX_BASE58_SIZE}/{})",
+                solana_message::v1::MAX_TRANSACTION_SIZE,
             ))
         );
 
@@ -9139,7 +9150,8 @@ pub mod tests {
                 .unwrap_err(),
             Error::invalid_params(format!(
                 "base64 encoded solana_transaction::Transaction too large: {tx64_len} bytes (max: \
-                 encoded/raw {MAX_BASE64_SIZE}/{PACKET_DATA_SIZE})",
+                 encoded/raw {MAX_BASE64_SIZE}/{})",
+                solana_message::v1::MAX_TRANSACTION_SIZE,
             ))
         );
 
@@ -9201,6 +9213,49 @@ pub mod tests {
                 "invalid base58 encoding: InvalidCharacter { character: '!', index: 1680 }"
                     .to_string(),
             )
+        );
+    }
+
+    #[test]
+    fn test_decode_and_deserialize_v1_sized_payload_passes_size_checks() {
+        // V1-prefixed payload at the V1 max size. Random bytes will fail
+        // wincode deserialization, but should pass the size gates — proving
+        // V1 transactions above PACKET_DATA_SIZE are accepted by the decoder.
+        let mut tx_ser = vec![0xffu8; solana_message::v1::MAX_TRANSACTION_SIZE];
+        tx_ser[0] = solana_message::v1::V1_PREFIX;
+
+        let tx64 = BASE64_STANDARD.encode(&tx_ser);
+        let err =
+            decode_and_deserialize::<VersionedTransaction>(tx64, TransactionBinaryEncoding::Base64)
+                .unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(
+            err.message.starts_with(
+                "failed to deserialize solana_transaction::versioned::VersionedTransaction"
+            ),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn test_decode_and_deserialize_v1_oversize_payload_fails() {
+        // V1-prefixed payload one byte over the V1 max. Uses base64 because a
+        // base58-encoded V1-prefixed payload of this size would trip the
+        // encoded-size cap first.
+        let too_big = solana_message::v1::MAX_TRANSACTION_SIZE + 1;
+        let mut tx_ser = vec![0xffu8; too_big];
+        tx_ser[0] = solana_message::v1::V1_PREFIX;
+
+        let tx64 = BASE64_STANDARD.encode(&tx_ser);
+        assert_eq!(
+            decode_and_deserialize::<VersionedTransaction>(tx64, TransactionBinaryEncoding::Base64)
+                .unwrap_err(),
+            Error::invalid_params(format!(
+                "decoded solana_transaction::versioned::VersionedTransaction too large: {too_big} \
+                 bytes (max: {} bytes)",
+                solana_message::v1::MAX_TRANSACTION_SIZE,
+            ))
         );
     }
 


### PR DESCRIPTION
#### Problem

While testing v1 transactions I found 2 issues that mean they don't work correctly when they are larger than the existing 1232 byte limit.

- The `sendTransaction` RPC call rejects transactions larger than 1232 bytes (based on their size encoded as base58 or base64)
- The quic streaming drops packets over 1232 bytes, meaning that these larger transactions never land

#### Summary of Changes

- rpc: 
  - `MAX_BASE58_SIZE` and `MAX_BASE64_SIZE` are updated to support up to 4096 bytes encoded
  - The size check after decoding is now version aware, and allows up to 4096 bytes for v1 transactions. Legacy/v0 transactions over 1232 bytes are rejected here.

- validator: configure quic with packet size increased to 4096 bytes

With both these changes, I am able to land v1 transactions larger than 1232 bytes on a local test validator. 
