### PR TITLE
Extract solana-transaction-return-data crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7081,8 +7081,8 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "solana-sysvar",
  "solana-transaction",
- "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "tarpc",
  "thiserror 2.0.18",
  "tokio",
@@ -7102,8 +7102,8 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "tarpc",
 ]
 
@@ -7568,7 +7568,7 @@ dependencies = [
  "solana-stake-interface",
  "solana-system-interface 3.2.0",
  "solana-transaction",
- "solana-transaction-context",
+ "solana-transaction-return-data",
  "solana-transaction-status",
  "solana-transaction-status-client-types",
  "solana-vote-program",
@@ -8878,6 +8878,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "solana-transaction-status",
  "solana-vote",
  "solana-vote-program",
@@ -9561,6 +9562,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "solana-vote-program",
  "spl-generic-token",
  "test-case",
@@ -10087,6 +10089,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
@@ -10508,8 +10511,8 @@ dependencies = [
  "solana-system-transaction",
  "solana-time-utils",
  "solana-transaction",
- "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "solana-transaction-status",
  "thiserror 2.0.18",
  "tokio",
@@ -10535,8 +10538,8 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "solana-transaction-status",
  "test-case",
  "thiserror 2.0.18",
@@ -10655,6 +10658,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "spl-generic-token",
  "spl-token-interface",
  "test-case",
@@ -11149,8 +11153,8 @@ dependencies = [
  "solana-signature",
  "solana-system-interface 3.2.0",
  "solana-transaction-context",
+ "solana-transaction-return-data",
  "static_assertions",
- "wincode",
 ]
 
 [[package]]
@@ -11165,6 +11169,15 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-instruction-error",
  "solana-sanitize",
+ "wincode",
+]
+
+[[package]]
+name = "solana-transaction-return-data"
+version = "4.2.0-alpha.0"
+dependencies = [
+ "serde",
+ "solana-address 2.6.0",
  "wincode",
 ]
 
@@ -11228,8 +11241,8 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "test-case",
  "thiserror 2.0.18",
  "wincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ members = [
     "tpu-client",
     "tpu-client-next",
     "transaction-context",
+    "transaction-return-data",
     "transaction-status",
     "transaction-status-client-types",
     "transaction-view",
@@ -520,6 +521,7 @@ solana-tpu-client-next = { path = "tpu-client-next", version = "=4.2.0-alpha.0",
 solana-transaction = "4.1.1"
 solana-transaction-context = { path = "transaction-context", version = "=4.2.0-alpha.0", features = ["agave-unstable-api", "bincode"] }
 solana-transaction-error = "3.2.0"
+solana-transaction-return-data = { path = "transaction-return-data", version = "=4.2.0-alpha.0" }
 solana-transaction-status = { path = "transaction-status", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-turbine = { path = "turbine", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -521,7 +521,7 @@ solana-tpu-client-next = { path = "tpu-client-next", version = "=4.2.0-alpha.0",
 solana-transaction = "4.1.1"
 solana-transaction-context = { path = "transaction-context", version = "=4.2.0-alpha.0", features = ["agave-unstable-api", "bincode"] }
 solana-transaction-error = "3.2.0"
-solana-transaction-return-data = { path = "transaction-return-data", version = "=4.2.0-alpha.0" }
+solana-transaction-return-data = { path = "transaction-return-data", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-transaction-status = { path = "transaction-status", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-turbine = { path = "turbine", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -34,8 +34,8 @@ solana-rent = { workspace = true }
 solana-signature = { workspace = true }
 solana-sysvar = { workspace = true, features = ["bincode"] }
 solana-transaction = { workspace = true }
-solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
+solana-transaction-return-data = { workspace = true }
 tarpc = { workspace = true, features = ["full"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/banks-client/src/error.rs
+++ b/banks-client/src/error.rs
@@ -1,6 +1,6 @@
 use {
-    solana_transaction_context::transaction::TransactionReturnData,
     solana_transaction_error::{TransactionError, TransportError},
+    solana_transaction_return_data::TransactionReturnData,
     std::io,
     tarpc::client::RpcError,
     thiserror::Error,

--- a/banks-interface/Cargo.toml
+++ b/banks-interface/Cargo.toml
@@ -29,6 +29,6 @@ solana-message = { workspace = true, features = ["serde"] }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true, features = ["serde"] }
 solana-transaction = { workspace = true, features = ["serde"] }
-solana-transaction-context = { workspace = true, features = ["serde"] }
 solana-transaction-error = { workspace = true, features = ["serde"] }
+solana-transaction-return-data = { workspace = true, features = ["serde"] }
 tarpc = { workspace = true, features = ["full"] }

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -11,8 +11,8 @@ use {
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_transaction::versioned::VersionedTransaction,
-    solana_transaction_context::transaction::TransactionReturnData,
     solana_transaction_error::TransactionError,
+    solana_transaction_return_data::TransactionReturnData,
 };
 
 mod transaction {

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -54,4 +54,4 @@ spl-memo-interface = { workspace = true }
 solana-keypair = { workspace = true }
 solana-seed-derivable = { workspace = true }
 solana-signer = { workspace = true }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-return-data = { workspace = true }

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -738,7 +738,7 @@ mod test {
         solana_seed_derivable::SeedDerivable,
         solana_signer::Signer,
         solana_transaction::Transaction,
-        solana_transaction_context::transaction::TransactionReturnData,
+        solana_transaction_return_data::TransactionReturnData,
         solana_transaction_status::{Reward, RewardType, TransactionStatusMeta},
         std::io::BufWriter,
     };

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6313,8 +6313,8 @@ dependencies = [
  "solana-signature",
  "solana-sysvar",
  "solana-transaction",
- "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "tarpc",
  "thiserror 2.0.18",
  "tokio",
@@ -6334,8 +6334,8 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "tarpc",
 ]
 
@@ -8656,6 +8656,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
@@ -9035,8 +9036,8 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "solana-transaction-status",
  "thiserror 2.0.18",
  "tonic-prost-build",
@@ -9116,6 +9117,7 @@ dependencies = [
  "solana-sysvar-id",
  "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "spl-generic-token",
  "thiserror 2.0.18",
 ]
@@ -9574,7 +9576,7 @@ dependencies = [
  "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
- "wincode",
+ "solana-transaction-return-data",
 ]
 
 [[package]]
@@ -9587,6 +9589,15 @@ dependencies = [
  "serde_derive",
  "solana-instruction-error",
  "solana-sanitize",
+ "wincode",
+]
+
+[[package]]
+name = "solana-transaction-return-data"
+version = "4.2.0-alpha.0"
+dependencies = [
+ "serde",
+ "solana-address 2.6.0",
  "wincode",
 ]
 
@@ -9646,8 +9657,8 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "thiserror 2.0.18",
  "wincode",
 ]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -143,6 +143,7 @@ solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-signature = { workspace = true, features = ["rand"] }
+solana-transaction-return-data = { workspace = true }
 solana-vote = { path = "../vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
 spl-generic-token = { workspace = true }
 spl-pod = { workspace = true }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -6363,8 +6363,8 @@ pub mod tests {
         solana_storage_proto::convert::generated,
         solana_streamer::evicting_sender::EvictingSender,
         solana_transaction::Transaction,
-        solana_transaction_context::transaction::TransactionReturnData,
         solana_transaction_error::TransactionError,
+        solana_transaction_return_data::TransactionReturnData,
         solana_transaction_status::{
             InnerInstruction, InnerInstructions, Reward, Rewards, TransactionTokenBalance,
         },

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -72,4 +72,5 @@ tokio = { workspace = true, features = ["full"] }
 solana-cpi = { workspace = true }
 solana-program = { workspace = true }
 solana-program-test = { path = ".", features = ["agave-unstable-api"] }
+solana-transaction-return-data = { workspace = true }
 test-case = { workspace = true }

--- a/program-test/tests/return_data.rs
+++ b/program-test/tests/return_data.rs
@@ -11,7 +11,7 @@ use {
     solana_pubkey::Pubkey,
     solana_signer::Signer,
     solana_transaction::Transaction,
-    solana_transaction_context::transaction::TransactionReturnData,
+    solana_transaction_return_data::TransactionReturnData,
     std::{slice, str::from_utf8},
 };
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6049,8 +6049,8 @@ dependencies = [
  "solana-signature",
  "solana-sysvar",
  "solana-transaction",
- "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "tarpc",
  "thiserror 2.0.18",
  "tokio",
@@ -6070,8 +6070,8 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "tarpc",
 ]
 
@@ -8288,6 +8288,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
@@ -9393,8 +9394,8 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "solana-transaction-status",
  "thiserror 2.0.18",
  "tonic-prost-build",
@@ -9474,6 +9475,7 @@ dependencies = [
  "solana-sysvar-id",
  "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "spl-generic-token",
  "thiserror 2.0.18",
 ]
@@ -9886,7 +9888,7 @@ dependencies = [
  "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
- "wincode",
+ "solana-transaction-return-data",
 ]
 
 [[package]]
@@ -9899,6 +9901,15 @@ dependencies = [
  "serde_derive",
  "solana-instruction-error",
  "solana-sanitize",
+ "wincode",
+]
+
+[[package]]
+name = "solana-transaction-return-data"
+version = "4.2.0-alpha.0"
+dependencies = [
+ "serde",
+ "solana-address 2.6.0",
  "wincode",
 ]
 
@@ -9958,8 +9969,8 @@ dependencies = [
  "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-return-data",
  "thiserror 2.0.18",
  "wincode",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -169,6 +169,7 @@ solana-time-utils = { workspace = true }
 solana-transaction = { workspace = true, features = ["verify"] }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
+solana-transaction-return-data = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
 solana-unified-scheduler-logic = { workspace = true }
 solana-version = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -176,10 +176,9 @@ use {
         sanitized::{MAX_TX_ACCOUNT_LOCKS, MessageHash, SanitizedTransaction},
         versioned::{TransactionVersion, VersionedTransaction},
     },
-    solana_transaction_context::{
-        transaction::TransactionReturnData, transaction_accounts::KeyedAccountSharedData,
-    },
+    solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
+    solana_transaction_return_data::TransactionReturnData,
     solana_vote::{
         vote_account::{VoteAccount, VoteAccounts, VoteAccountsHashMap},
         vote_parser,

--- a/runtime/src/bank/bank_hash_details.rs
+++ b/runtime/src/bank/bank_hash_details.rs
@@ -15,8 +15,8 @@ use {
     solana_message::inner_instruction::InnerInstructionsList,
     solana_pubkey::Pubkey,
     solana_svm::transaction_commit_result::CommittedTransaction,
-    solana_transaction_context::transaction::TransactionReturnData,
     solana_transaction_error::TransactionResult,
+    solana_transaction_return_data::TransactionReturnData,
     solana_transaction_status_client_types::UiInstruction,
     std::str::FromStr,
 };

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -56,4 +56,4 @@ solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-return-data = { workspace = true }

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -1014,7 +1014,7 @@ mod tests {
         solana_storage_proto::convert::generated,
         solana_system_transaction as system_transaction,
         solana_transaction::versioned::VersionedTransaction,
-        solana_transaction_context::transaction::TransactionReturnData,
+        solana_transaction_return_data::TransactionReturnData,
         solana_transaction_status::{
             ConfirmedBlock, TransactionStatusMeta, TransactionWithStatusMeta,
             VersionedTransactionWithStatusMeta,

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -31,8 +31,8 @@ solana-pubkey = { workspace = true }
 solana-serde = { workspace = true }
 solana-signature = { workspace = true, features = ["std"] }
 solana-transaction = { workspace = true }
-solana-transaction-context = { workspace = true, features = ["serde", "wincode"] }
 solana-transaction-error = { workspace = true, features = ["wincode"] }
+solana-transaction-return-data = { workspace = true, features = ["serde", "wincode"] }
 solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }
 wincode = { workspace = true }

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -13,8 +13,8 @@ use {
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_transaction::{Transaction, versioned::VersionedTransaction},
-    solana_transaction_context::transaction::TransactionReturnData,
     solana_transaction_error::TransactionError,
+    solana_transaction_return_data::TransactionReturnData,
     solana_transaction_status::{
         ConfirmedBlock, EntrySummary, InnerInstruction, InnerInstructions, Reward, RewardType,
         RewardsAndNumPartitions, TransactionByAddrInfo, TransactionStatusMeta,

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -8,8 +8,8 @@ use {
     solana_message::v0::LoadedAddresses,
     solana_serde::default_on_eof,
     solana_transaction::{SchemaRead, SchemaWrite},
-    solana_transaction_context::transaction::TransactionReturnData,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
+    solana_transaction_return_data::TransactionReturnData,
     solana_transaction_status::{
         InnerInstructions, Reward, RewardType, TransactionStatusMeta, TransactionTokenBalance,
     },

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -77,6 +77,7 @@ solana-system-interface = { workspace = true }
 solana-sysvar-id = { workspace = true }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
+solana-transaction-return-data = { workspace = true }
 spl-generic-token = { workspace = true }
 thiserror = { workspace = true }
 

--- a/svm/src/transaction_commit_result.rs
+++ b/svm/src/transaction_commit_result.rs
@@ -1,8 +1,8 @@
 use {
     crate::transaction_execution_result::TransactionLoadedAccountsStats,
     solana_fee_structure::FeeDetails, solana_message::inner_instruction::InnerInstructionsList,
-    solana_transaction_context::transaction::TransactionReturnData,
     solana_transaction_error::TransactionResult,
+    solana_transaction_return_data::TransactionReturnData,
 };
 
 pub type TransactionCommitResult = TransactionResult<CommittedTransaction>;

--- a/svm/src/transaction_execution_result.rs
+++ b/svm/src/transaction_execution_result.rs
@@ -3,8 +3,8 @@ use {
     solana_message::inner_instruction::InnerInstructionsList,
     solana_program_runtime::program_cache_entry::ProgramCacheEntry,
     solana_pubkey::Pubkey,
-    solana_transaction_context::transaction::TransactionReturnData,
     solana_transaction_error::TransactionResult,
+    solana_transaction_return_data::TransactionReturnData,
     std::{collections::HashMap, sync::Arc},
 };
 

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -59,8 +59,8 @@ use {
     solana_system_transaction as system_transaction,
     solana_sysvar::rent::Rent,
     solana_transaction::{Transaction, sanitized::SanitizedTransaction},
-    solana_transaction_context::transaction::TransactionReturnData,
     solana_transaction_error::TransactionError,
+    solana_transaction_return_data::TransactionReturnData,
     std::{collections::HashMap, num::NonZeroU32, slice, sync::atomic::Ordering},
     test_case::test_case,
 };

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -16,9 +16,9 @@ rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 agave-unstable-api = []
-bincode = ["dep:bincode", "dep:serde", "solana-account/bincode"]
+bincode = ["dep:bincode", "serde", "solana-account/bincode"]
 dev-context-only-utils = ["bincode", "solana-account/dev-context-only-utils", "dep:qualifier_attr"]
-serde = ["solana-pubkey/serde", "solana-transaction-return-data/serde"]
+serde = ["dep:serde", "solana-pubkey/serde", "solana-transaction-return-data/serde"]
 wincode = ["solana-pubkey/wincode", "solana-transaction-return-data/wincode"]
 
 [dependencies]

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -16,17 +16,17 @@ rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 agave-unstable-api = []
-bincode = ["dep:bincode", "serde", "solana-account/bincode"]
+bincode = ["dep:bincode", "dep:serde", "solana-account/bincode"]
 dev-context-only-utils = ["bincode", "solana-account/dev-context-only-utils", "dep:qualifier_attr"]
-serde = ["serde/derive", "solana-pubkey/serde"]
-wincode = ["dep:wincode", "solana-pubkey/wincode"]
+serde = ["solana-pubkey/serde", "solana-transaction-return-data/serde"]
+wincode = ["solana-pubkey/wincode", "solana-transaction-return-data/wincode"]
 
 [dependencies]
 solana-account = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-instructions-sysvar = { workspace = true }
 solana-pubkey = { workspace = true }
-wincode = { workspace = true, optional = true }
+solana-transaction-return-data = { workspace = true }
 
 [target.'cfg(not(any(target_arch = "sbf", target_arch = "bpf")))'.dependencies]
 bincode = { workspace = true, optional = true }

--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -19,6 +19,9 @@ use {
     std::{borrow::Cow, cell::Cell, rc::Rc},
 };
 
+#[doc(inline)]
+pub use solana_transaction_return_data::TransactionReturnData;
+
 /// Used only in fn `take_instruction_trace` for deconstructing TransactionContext
 pub type InstructionTrace<'ix_data> = (
     Vec<InstructionFrame>,
@@ -595,16 +598,6 @@ impl<'ix_data> TransactionContext<'ix_data> {
     pub fn number_of_cpis_in_trace(&self) -> usize {
         self.transaction_frame.number_of_cpis_in_trace as usize
     }
-}
-
-/// Return data at the end of a transaction
-#[cfg(not(any(target_arch = "bpf", target_arch = "sbf")))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "wincode", derive(wincode::SchemaRead, wincode::SchemaWrite))]
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct TransactionReturnData {
-    pub program_id: Pubkey,
-    pub data: Vec<u8>,
 }
 
 /// Everything that needs to be recorded from a TransactionContext after execution

--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -19,7 +19,6 @@ use {
     std::{borrow::Cow, cell::Cell, rc::Rc},
 };
 
-#[doc(inline)]
 pub use solana_transaction_return_data::TransactionReturnData;
 
 /// Used only in fn `take_instruction_trace` for deconstructing TransactionContext

--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -1,3 +1,4 @@
+pub use solana_transaction_return_data::TransactionReturnData;
 use {
     crate::{
         IndexOfAccount, MAX_ACCOUNT_DATA_GROWTH_PER_TRANSACTION, MAX_ACCOUNT_DATA_LEN,
@@ -18,8 +19,6 @@ use {
     solana_sbpf::memory_region::{AccessType, AccessViolationHandler, MemoryRegion},
     std::{borrow::Cow, cell::Cell, rc::Rc},
 };
-
-pub use solana_transaction_return_data::TransactionReturnData;
 
 /// Used only in fn `take_instruction_trace` for deconstructing TransactionContext
 pub type InstructionTrace<'ix_data> = (

--- a/transaction-return-data/Cargo.toml
+++ b/transaction-return-data/Cargo.toml
@@ -7,7 +7,7 @@ authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-edition = "2024"
+edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-return-data/Cargo.toml
+++ b/transaction-return-data/Cargo.toml
@@ -15,6 +15,7 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
+agave-unstable-api = []
 serde = ["dep:serde", "solana-address/serde"]
 wincode = ["dep:wincode", "solana-address/wincode"]
 

--- a/transaction-return-data/Cargo.toml
+++ b/transaction-return-data/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "solana-transaction-return-data"
+description = "TransactionReturnData type emitted at the end of a Solana transaction."
+documentation = "https://docs.rs/solana-transaction-return-data"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = "2024"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+serde = ["dep:serde", "solana-address/serde"]
+wincode = ["dep:wincode", "solana-address/wincode"]
+
+[dependencies]
+serde = { workspace = true, optional = true }
+solana-address = { workspace = true }
+wincode = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/transaction-return-data/src/lib.rs
+++ b/transaction-return-data/src/lib.rs
@@ -1,0 +1,13 @@
+//! The [`TransactionReturnData`] value returned at the end of a Solana
+//! transaction.
+
+use solana_address::Address;
+
+/// Return data at the end of a transaction.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaRead, wincode::SchemaWrite))]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TransactionReturnData {
+    pub program_id: Address,
+    pub data: Vec<u8>,
+}

--- a/transaction-return-data/src/lib.rs
+++ b/transaction-return-data/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "agave-unstable-api")]
 //! The [`TransactionReturnData`] value returned at the end of a Solana
 //! transaction.
 

--- a/transaction-status-client-types/Cargo.toml
+++ b/transaction-status-client-types/Cargo.toml
@@ -28,8 +28,8 @@ solana-message = { workspace = true, features = ["wincode"] }
 solana-reward-info = { workspace = true, features = ["serde", "wincode"] }
 solana-signature = { workspace = true, default-features = false }
 solana-transaction = { workspace = true, features = ["serde", "wincode"] }
-solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true, features = ["serde"] }
+solana-transaction-return-data = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
 wincode = { workspace = true }
 

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -24,8 +24,8 @@ use {
         SchemaRead, SchemaWrite,
         versioned::{TransactionVersion, VersionedTransaction},
     },
-    solana_transaction_context::transaction::TransactionReturnData,
     solana_transaction_error::{TransactionError, TransactionResult},
+    solana_transaction_return_data::TransactionReturnData,
     thiserror::Error,
 };
 pub mod option_serializer;


### PR DESCRIPTION
#### Problem
This tiny struct gets used in solana-transaction-status-client-types and hence solana-rpc-client. It currently brings with it 40k LOC via dependencies

#### Summary of Changes
Move it to its own crate. I looked for anything else worth moving and didn't find anything, nor did I find a suitable existing crate to move it to