### PR TITLE
fix(votor): rooting should not require our vote

### DIFF
--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -791,7 +791,6 @@ impl EventHandler {
     /// The block must be:
     /// - Present in bank forks
     /// - Newer than the current root
-    /// - We must have already voted on bank.slot()
     /// - Bank is frozen and finished shredding
     /// - Block has a finalization certificate
     ///
@@ -813,7 +812,6 @@ impl EventHandler {
             .filter_map(|&(slot, block_id)| {
                 let bank = bank_forks_r.get(slot)?;
                 (slot > old_root
-                    && vctx.vote_history.voted(slot)
                     && bank.is_frozen()
                     && bank.block_id().is_some_and(|bid| bid == block_id))
                 .then_some(slot)

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -44,7 +44,10 @@ pub(crate) fn set_root(
 ) -> Result<(), BankForksControllerError> {
     info!("{my_pubkey}: setting root {new_root}");
     vctx.vote_history.set_root(new_root);
-    *pending_blocks = pending_blocks.split_off(&new_root);
+    // Drop pending entries at the rooted slot itself: their `parent_block`
+    // sits at `new_root - 1`, and a subsequent `try_notar` would query
+    // `voted_notar(parent_slot)` and trip its `slot >= root` assertion.
+    *pending_blocks = pending_blocks.split_off(&new_root.saturating_add(1));
     *finalized_blocks = finalized_blocks.split_off(&(new_root, Hash::default()));
     *received_shred = received_shred.split_off(&new_root);
 


### PR DESCRIPTION
#### Problem
Before marking a block as "root", we first check whether we voted in that slot. There is no clear reason why this should be the case.

#### Summary of Changes
Drop the requirement of having voted in a slot to root a block.