### PR TITLE
refactor(metrics): remove dead query() helper

### DIFF
--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod counter;
 pub mod datapoint;
 pub mod metrics;
-pub use crate::metrics::{flush, query, set_host_id, set_panic_hook, submit};
+pub use crate::metrics::{flush, set_host_id, set_panic_hook, submit};
 use std::sync::{
     Arc,
     atomic::{AtomicU64, Ordering},

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -26,8 +26,6 @@ type CounterMap = HashMap<(&'static str, u64), CounterPoint>;
 pub enum MetricsError {
     #[error(transparent)]
     VarError(#[from] env::VarError),
-    #[error(transparent)]
-    ReqwestError(#[from] reqwest::Error),
     #[error("SOLANA_METRICS_CONFIG is invalid: '{0}'")]
     ConfigInvalid(String),
     #[error("SOLANA_METRICS_CONFIG is incomplete")]
@@ -489,18 +487,6 @@ pub fn metrics_config_sanity_check(cluster_type: ClusterType) -> Result<(), Metr
     let (host, db) = (&config.host, &config.db);
     let msg = format!("cluster_type={cluster_type:?} host={host} database={db}");
     Err(MetricsError::DbMismatch(msg))
-}
-
-pub fn query(q: &str) -> Result<String, MetricsError> {
-    let config = get_metrics_config()?;
-    let query_url = format!(
-        "{}/query?u={}&p={}&q={}",
-        &config.host, &config.username, &config.password, &q
-    );
-
-    let response = reqwest::blocking::get(query_url.as_str())?.text()?;
-
-    Ok(response)
 }
 
 /// Blocks until all pending points from previous calls to `submit` have been


### PR DESCRIPTION
#### Problem

`solana_metrics::query` has no callers and has been unused since the metrics crate was extracted.

#### Summary of Changes

Drop it along with the now-unused MetricsError::ReqwestError variant.

Fixes #
