### PR TITLE
repair: do not use epoch slots for peer selection in alpenglow

### DIFF
--- a/core/src/repair/block_id_repair_service.rs
+++ b/core/src/repair/block_id_repair_service.rs
@@ -27,7 +27,7 @@ use {
         common::DELTA,
         event::{RepairEvent, RepairEventReceiver},
     },
-    agave_votor_messages::{consensus_message::Block, migration::MigrationStatus},
+    agave_votor_messages::consensus_message::Block,
     crossbeam_channel::select,
     lazy_lru::LruCache,
     log::{debug, info},
@@ -309,12 +309,13 @@ impl BlockIdRepairService {
             .name("solBlockIdRep".to_string())
             .spawn(move || {
                 info!("BlockIdRepairService started");
-                let sharable_banks = context
-                    .repair_info
-                    .bank_forks
-                    .read()
-                    .unwrap()
-                    .sharable_banks();
+                let (sharable_banks, migration_status) = {
+                    let bank_forks_r = context.repair_info.bank_forks.read().unwrap();
+                    (
+                        bank_forks_r.sharable_banks(),
+                        bank_forks_r.migration_status(),
+                    )
+                };
                 let mut state = RepairState {
                     // One day we'll actually split out the build request functionality from the full ServeRepair :'(
                     serve_repair: ServeRepair::new(
@@ -322,8 +323,7 @@ impl BlockIdRepairService {
                         sharable_banks.clone(),
                         context.repair_info.repair_whitelist.clone(),
                         Box::new(StandardRepairHandler::new(context.blockstore.clone())),
-                        // Doesn't matter this serve_repair isn't used to respond
-                        Arc::new(MigrationStatus::default()),
+                        migration_status,
                     ),
                     peers_cache: LruCache::new(REPAIR_PEERS_CACHE_CAPACITY),
                     outstanding_requests: OutstandingBlockIdRepairs::default(),
@@ -931,8 +931,6 @@ impl BlockIdRepairService {
             Vec::with_capacity(max_batch_len);
         let mut shred_socket_batch = Vec::with_capacity(max_batch_len);
 
-        let root_bank = repair_info.bank_forks.read().unwrap().root_bank();
-        let staked_nodes = root_bank.current_epoch_staked_nodes();
         let now = timestamp();
 
         while block_id_socket_batch
@@ -955,10 +953,10 @@ impl BlockIdRepairService {
                         .block_id_repair_request(
                             &repair_info.repair_validators,
                             block_id_repair_type,
+                            &repair_info.cluster_slots,
                             &mut state.peers_cache,
                             &mut state.outstanding_requests,
                             &repair_info.cluster_info.keypair(),
-                            &staked_nodes,
                         )
                         .inspect_err(|e| {
                             error!(

--- a/core/src/repair/block_id_repair_service.rs
+++ b/core/src/repair/block_id_repair_service.rs
@@ -951,12 +951,10 @@ impl BlockIdRepairService {
                     let Ok((bytes, addr, peer_pubkey)) = state
                         .serve_repair
                         .block_id_repair_request(
-                            &repair_info.repair_validators,
+                            repair_info,
                             block_id_repair_type,
-                            &repair_info.cluster_slots,
                             &mut state.peers_cache,
                             &mut state.outstanding_requests,
-                            &repair_info.cluster_info.keypair(),
                         )
                         .inspect_err(|e| {
                             error!(
@@ -988,13 +986,11 @@ impl BlockIdRepairService {
                     let Ok(Some((addr, bytes))) = state
                         .serve_repair
                         .repair_request(
-                            &repair_info.cluster_slots,
+                            repair_info,
                             shred_request,
                             &mut state.peers_cache,
                             &mut RepairStats::default(),
-                            &repair_info.repair_validators,
                             &mut state.outstanding_shred_requests.write().unwrap(),
-                            &repair_info.cluster_info.keypair(),
                         )
                         .inspect_err(|e| {
                             error!(

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -803,7 +803,6 @@ impl RepairService {
         repair_metrics: &mut RepairMetrics,
     ) {
         let mut build_repairs_batch_elapsed = Measure::start("build_repairs_batch_elapsed");
-        let identity_keypair = repair_info.cluster_info.keypair();
         let batch: Vec<(Vec<u8>, SocketAddr)> = {
             let mut outstanding_requests = outstanding_requests.write().unwrap();
             repairs
@@ -811,13 +810,11 @@ impl RepairService {
                 .filter_map(|repair_request| {
                     let (to, req) = serve_repair
                         .repair_request(
-                            &repair_info.cluster_slots,
+                            repair_info,
                             repair_request,
                             peers_cache,
                             &mut repair_metrics.stats,
-                            &repair_info.repair_validators,
                             &mut outstanding_requests,
-                            &identity_keypair,
                         )
                         .ok()??;
                     Some((req, to))
@@ -836,7 +833,7 @@ impl RepairService {
                     error!(
                         "{} batch_send failed to send {num_failed}/{num_pkts} packets first error \
                          {err:?}",
-                        identity_keypair.pubkey()
+                        repair_info.cluster_info.id()
                     );
                 }
             }

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -805,7 +805,9 @@ impl ServeRepair {
         identity_keypair: &Keypair,
         weight_source: RepairPeerWeightSource,
     ) -> Result<&'a RepairPeers> {
-        if matches!(peers_cache.get(&slot), Some(entry) if entry.is_valid_for(weight_source)) {
+        if let Some(entry) = peers_cache.get(&slot)
+            && entry.is_valid_for(weight_source)
+        {
             return Ok(peers_cache.get(&slot).unwrap());
         }
 

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1602,7 +1602,7 @@ impl ServeRepair {
         Self::repair_proto_to_bytes(&request, keypair)
     }
 
-    /// Finds a peer to send this repair request too and returns their address and the raw bytes to send.
+    /// Finds a peer to send this repair request to and returns their address and the raw bytes to send.
     ///
     /// For TowerBFT blocks we do a weighted selection where:
     /// - `x` is `1` if the peer has indicated they have the block via publishing an EpochSlots gossip message and `0` otherwise

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1940,8 +1940,6 @@ mod tests {
         super::*,
         crate::repair::repair_response,
         agave_feature_set::FeatureSet,
-        agave_votor_messages::consensus_message::{Certificate, CertificateType},
-        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_gossip::{contact_info::ContactInfo, socketaddr, socketaddr_any},
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -1961,22 +1959,6 @@ mod tests {
         solana_time_utils::timestamp,
         std::{io::Cursor, net::Ipv4Addr},
     };
-
-    fn enable_alpenglow_for_tests(bank_forks: &Arc<RwLock<BankForks>>) {
-        let migration_status = bank_forks.read().unwrap().migration_status();
-        let genesis_block = (0, Hash::new_unique());
-        migration_status.record_feature_activation(0);
-        migration_status.set_genesis_block(genesis_block);
-        migration_status.set_genesis_certificate(Arc::new(Certificate {
-            cert_type: CertificateType::Genesis(genesis_block.0, genesis_block.1),
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            bitmap: vec![],
-        }));
-        assert_eq!(
-            migration_status.enable_alpenglow_during_startup(),
-            genesis_block.0
-        );
-    }
 
     fn discard_malformed_repair_requests(
         requests: &mut Vec<BytesPacket>,
@@ -2843,7 +2825,11 @@ mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
-        enable_alpenglow_for_tests(&bank_forks);
+        bank_forks
+            .read()
+            .unwrap()
+            .migration_status()
+            .enable_alpenglow_for_tests();
 
         let staked_nodes = bank_forks
             .read()

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -773,7 +773,16 @@ impl ServeRepair {
                 cluster_slots.compute_weights(slot, repair_peers)
             }
             RepairPeerWeightSource::CurrentEpochStake => {
-                let staked_nodes = self.sharable_banks.root().current_epoch_staked_nodes();
+                let staked_nodes = {
+                    let root_bank = self.sharable_banks.root();
+                    let slot_epoch = root_bank.epoch_schedule().get_epoch(slot);
+                    root_bank
+                        .epoch_staked_nodes(slot_epoch.saturating_add(1))
+                        // Fall back to current stakes if our root is so far behind that we
+                        // have not computed the current staked nodes for `slot_epoch` yet.
+                        // This can happen if we're catching up on a test cluster with short epochs.
+                        .unwrap_or_else(|| root_bank.current_epoch_staked_nodes())
+                };
                 Self::stake_weighted_repair_peer_weights(repair_peers, &staked_nodes)
             }
         }

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -2895,6 +2895,64 @@ mod tests {
     }
 
     #[test]
+    fn repair_requests_return_error_for_all_zero_peer_weights() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let bank_forks = BankForks::new_rw_arc(bank);
+        bank_forks
+            .read()
+            .unwrap()
+            .migration_status()
+            .enable_alpenglow_for_tests();
+
+        let slot = 1;
+        let cluster_slots = Arc::new(ClusterSlots::default_for_tests());
+        let cluster_info = Arc::new(new_test_cluster_info());
+        let unstaked_pubkey = Pubkey::new_unique();
+        cluster_info.insert_info(ContactInfo::new_localhost(&unstaked_pubkey, timestamp()));
+        let repair_info = new_test_repair_info(
+            cluster_info.clone(),
+            bank_forks.clone(),
+            cluster_slots,
+            Some(HashSet::from([unstaked_pubkey])),
+        );
+        let serve_repair = ServeRepair::new_for_test(
+            cluster_info,
+            bank_forks,
+            Arc::new(RwLock::new(HashSet::default())),
+        );
+
+        let mut peers_cache = LruCache::new(100);
+        let mut outstanding_shred_requests = OutstandingShredRepairs::default();
+        assert_matches!(
+            serve_repair.repair_request(
+                &repair_info,
+                ShredRepairType::Shred(slot, 0),
+                &mut peers_cache,
+                &mut RepairStats::default(),
+                &mut outstanding_shred_requests,
+            ),
+            Err(Error::WeightedIndex(WeightedError::InsufficientNonZero))
+        );
+        assert!(peers_cache.get(&slot).is_none());
+
+        let mut outstanding_block_id_requests = OutstandingRequests::default();
+        assert_matches!(
+            serve_repair.block_id_repair_request(
+                &repair_info,
+                BlockIdRepairType::ParentAndFecSetCount {
+                    slot,
+                    block_id: Hash::new_unique(),
+                },
+                &mut peers_cache,
+                &mut outstanding_block_id_requests,
+            ),
+            Err(Error::WeightedIndex(WeightedError::InsufficientNonZero))
+        );
+        assert!(peers_cache.get(&slot).is_none());
+    }
+
+    #[test]
     fn test_repair_with_repair_validators() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -625,8 +625,15 @@ pub struct ServeRepair {
 // Cache entry for repair peers for a slot.
 pub(crate) struct RepairPeers {
     asof: Instant,
+    weight_source: RepairPeerWeightSource,
     peers: Vec<Node>,
     weighted_index: WeightedIndex<u64>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RepairPeerWeightSource {
+    ClusterSlots,
+    CurrentEpochStake,
 }
 
 struct Node {
@@ -635,7 +642,12 @@ struct Node {
 }
 
 impl RepairPeers {
-    fn new(asof: Instant, peers: &[ContactInfo], weights: &[u64]) -> Result<Self> {
+    fn new(
+        asof: Instant,
+        weight_source: RepairPeerWeightSource,
+        peers: &[ContactInfo],
+        weights: &[u64],
+    ) -> Result<Self> {
         if peers.len() != weights.len() {
             return Err(Error::from(WeightedError::InvalidWeight));
         }
@@ -656,6 +668,7 @@ impl RepairPeers {
         let weighted_index = WeightedIndex::new(weights)?;
         Ok(Self {
             asof,
+            weight_source,
             peers,
             weighted_index,
         })
@@ -664,6 +677,10 @@ impl RepairPeers {
     fn sample<R: Rng>(&self, rng: &mut R) -> &Node {
         let index = self.weighted_index.sample(rng);
         &self.peers[index]
+    }
+
+    fn is_valid_for(&self, weight_source: RepairPeerWeightSource) -> bool {
+        self.asof.elapsed() < REPAIR_PEERS_CACHE_TTL && self.weight_source == weight_source
     }
 }
 
@@ -732,6 +749,64 @@ impl ServeRepair {
     #[cfg(test)]
     pub(crate) fn my_id(&self) -> Pubkey {
         self.cluster_info.id()
+    }
+
+    fn stake_weighted_repair_peer_weights(
+        repair_peers: &[ContactInfo],
+        staked_nodes: &HashMap<Pubkey, u64>,
+    ) -> Vec<u64> {
+        repair_peers
+            .iter()
+            .map(|peer| staked_nodes.get(peer.pubkey()).copied().unwrap_or(0))
+            .collect()
+    }
+
+    fn repair_peer_weights(
+        &self,
+        slot: Slot,
+        cluster_slots: &ClusterSlots,
+        repair_peers: &[ContactInfo],
+        weight_source: RepairPeerWeightSource,
+    ) -> Vec<u64> {
+        match weight_source {
+            RepairPeerWeightSource::ClusterSlots => {
+                cluster_slots.compute_weights(slot, repair_peers)
+            }
+            RepairPeerWeightSource::CurrentEpochStake => {
+                let staked_nodes = self.sharable_banks.root().current_epoch_staked_nodes();
+                Self::stake_weighted_repair_peer_weights(repair_peers, &staked_nodes)
+            }
+        }
+    }
+
+    fn repair_peer_weight_source(&self, slot: Slot) -> RepairPeerWeightSource {
+        if self.migration_status.should_publish_epoch_slots(slot) {
+            RepairPeerWeightSource::ClusterSlots
+        } else {
+            RepairPeerWeightSource::CurrentEpochStake
+        }
+    }
+
+    fn repair_peers_from_cache<'a>(
+        &self,
+        slot: Slot,
+        cluster_slots: &ClusterSlots,
+        repair_validators: &Option<HashSet<Pubkey>>,
+        peers_cache: &'a mut LruCache<Slot, RepairPeers>,
+        identity_keypair: &Keypair,
+        weight_source: RepairPeerWeightSource,
+    ) -> Result<&'a RepairPeers> {
+        if matches!(peers_cache.get(&slot), Some(entry) if entry.is_valid_for(weight_source)) {
+            return Ok(peers_cache.get(&slot).unwrap());
+        }
+
+        peers_cache.pop(&slot);
+        let repair_peers = self.repair_peers(repair_validators, slot, &identity_keypair.pubkey());
+        let weights = self.repair_peer_weights(slot, cluster_slots, &repair_peers, weight_source);
+        let repair_peers =
+            RepairPeers::new(Instant::now(), weight_source, &repair_peers, &weights)?;
+        peers_cache.put(slot, repair_peers);
+        Ok(peers_cache.get(&slot).unwrap())
     }
 
     fn handle_repair(
@@ -1517,6 +1592,13 @@ impl ServeRepair {
     }
 
     #[allow(clippy::too_many_arguments)]
+    /// Finds a peer to send this repair request too and returns their address and the raw bytes to send.
+    ///
+    /// For TowerBFT blocks we do a weighted selection where:
+    /// - `x` is `1` if the peer has indicated they have the block via publishing an EpochSlots gossip message and `0` otherwise
+    /// - weights are `(peer_stake / 2 + peer_stake / 2 * x)`
+    ///
+    /// For Alpenglow blocks we do a weighted selection where the weights are `peer_stake`
     pub(crate) fn repair_request(
         &self,
         cluster_slots: &ClusterSlots,
@@ -1530,18 +1612,15 @@ impl ServeRepair {
         // find a peer that appears to be accepting replication and has the desired slot, as indicated
         // by a valid tvu port location
         let slot = repair_request.slot();
-        let repair_peers = match peers_cache.get(&slot) {
-            Some(entry) if entry.asof.elapsed() < REPAIR_PEERS_CACHE_TTL => entry,
-            _ => {
-                peers_cache.pop(&slot);
-                let repair_peers =
-                    self.repair_peers(repair_validators, slot, &identity_keypair.pubkey());
-                let weights = cluster_slots.compute_weights(slot, &repair_peers);
-                let repair_peers = RepairPeers::new(Instant::now(), &repair_peers, &weights)?;
-                peers_cache.put(slot, repair_peers);
-                peers_cache.get(&slot).unwrap()
-            }
-        };
+        let weight_source = self.repair_peer_weight_source(slot);
+        let repair_peers = self.repair_peers_from_cache(
+            slot,
+            cluster_slots,
+            repair_validators,
+            peers_cache,
+            identity_keypair,
+            weight_source,
+        )?;
         let peer = repair_peers.sample(&mut rand::rng());
         let location = repair_request
             .block_id()
@@ -1572,33 +1651,27 @@ impl ServeRepair {
         Ok(Some((peer.serve_repair, out)))
     }
 
-    /// Similar to [`Self::repair_request`] but for [`BlockIdRepairType`] requests.
-    /// Uses stake-weighted peer selection rather than cluster_slots weights.
+    /// [`Self::repair_request`] but for [`BlockIdRepairType`] requests
+    /// Only for use in Alpenglow blocks, peer selection is based on `peer_stake`
     pub(crate) fn block_id_repair_request(
         &self,
         repair_validators: &Option<HashSet<Pubkey>>,
         repair_request: BlockIdRepairType,
+        cluster_slots: &ClusterSlots,
         peers_cache: &mut LruCache<Slot, RepairPeers>,
         outstanding_requests: &mut OutstandingRequests<BlockIdRepairType>,
         identity_keypair: &Keypair,
-        staked_nodes: &HashMap<Pubkey, u64>,
     ) -> Result<(Vec<u8>, SocketAddr, Pubkey)> {
         let slot = repair_request.slot();
-        let repair_peers = match peers_cache.get(&slot) {
-            Some(entry) if entry.asof.elapsed() < REPAIR_PEERS_CACHE_TTL => entry,
-            _ => {
-                peers_cache.pop(&slot);
-                let repair_peers =
-                    self.repair_peers(repair_validators, slot, &identity_keypair.pubkey());
-                let weights: Vec<u64> = repair_peers
-                    .iter()
-                    .map(|peer| staked_nodes.get(peer.pubkey()).copied().unwrap_or(0))
-                    .collect();
-                let repair_peers = RepairPeers::new(Instant::now(), &repair_peers, &weights)?;
-                peers_cache.put(slot, repair_peers);
-                peers_cache.get(&slot).unwrap()
-            }
-        };
+        let weight_source = RepairPeerWeightSource::CurrentEpochStake;
+        let repair_peers = self.repair_peers_from_cache(
+            slot,
+            cluster_slots,
+            repair_validators,
+            peers_cache,
+            identity_keypair,
+            weight_source,
+        )?;
         let peer = repair_peers.sample(&mut rand::rng());
         let nonce = outstanding_requests.add_request(repair_request, timestamp());
 
@@ -1858,6 +1931,8 @@ mod tests {
         super::*,
         crate::repair::repair_response,
         agave_feature_set::FeatureSet,
+        agave_votor_messages::consensus_message::{Certificate, CertificateType},
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_gossip::{contact_info::ContactInfo, socketaddr, socketaddr_any},
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -1877,6 +1952,22 @@ mod tests {
         solana_time_utils::timestamp,
         std::{io::Cursor, net::Ipv4Addr},
     };
+
+    fn enable_alpenglow_for_tests(bank_forks: &Arc<RwLock<BankForks>>) {
+        let migration_status = bank_forks.read().unwrap().migration_status();
+        let genesis_block = (0, Hash::new_unique());
+        migration_status.record_feature_activation(0);
+        migration_status.set_genesis_block(genesis_block);
+        migration_status.set_genesis_certificate(Arc::new(Certificate {
+            cert_type: CertificateType::Genesis(genesis_block.0, genesis_block.1),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        }));
+        assert_eq!(
+            migration_status.enable_alpenglow_during_startup(),
+            genesis_block.0
+        );
+    }
 
     fn discard_malformed_repair_requests(
         requests: &mut Vec<BytesPacket>,
@@ -2732,6 +2823,57 @@ mod tests {
                 panic!("unexpected response: {:?}", &ancestor_hashes_response);
             }
         }
+    }
+
+    #[test]
+    fn repair_request_uses_current_epoch_stake_weights_for_alpenglow_slots() {
+        let GenesisConfigInfo {
+            genesis_config,
+            validator_pubkey,
+            ..
+        } = create_genesis_config(10_000);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let bank_forks = BankForks::new_rw_arc(bank);
+        enable_alpenglow_for_tests(&bank_forks);
+
+        let staked_nodes = bank_forks
+            .read()
+            .unwrap()
+            .root_bank()
+            .current_epoch_staked_nodes();
+        let validator_stake = staked_nodes[&validator_pubkey];
+        let unstaked_pubkey = Pubkey::new_unique();
+        let slot = 1;
+        let cluster_slots = ClusterSlots::default_for_tests();
+        cluster_slots.fake_epoch_info_for_tests(HashMap::from([
+            (validator_pubkey, 1),
+            (unstaked_pubkey, validator_stake.saturating_add(1)),
+        ]));
+        let repair_peers = vec![
+            ContactInfo::new_localhost(&validator_pubkey, timestamp()),
+            ContactInfo::new_localhost(&unstaked_pubkey, timestamp()),
+        ];
+        assert_ne!(
+            cluster_slots.compute_weights(slot, &repair_peers),
+            vec![validator_stake, 0]
+        );
+
+        let cluster_info = Arc::new(new_test_cluster_info());
+        let serve_repair = ServeRepair::new_for_test(
+            cluster_info,
+            bank_forks,
+            Arc::new(RwLock::new(HashSet::default())),
+        );
+
+        assert_eq!(
+            serve_repair.repair_peer_weights(
+                slot,
+                &cluster_slots,
+                &repair_peers,
+                serve_repair.repair_peer_weight_source(slot),
+            ),
+            vec![validator_stake, 0]
+        );
     }
 
     #[test]

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -11,7 +11,7 @@ use {
             duplicate_repair_status::get_ancestor_hash_repair_sample_size,
             outstanding_requests::OutstandingRequests,
             repair_handler::RepairHandler,
-            repair_service::{OutstandingShredRepairs, REPAIR_MS, RepairStats},
+            repair_service::{OutstandingShredRepairs, REPAIR_MS, RepairInfo, RepairStats},
             request_response::RequestResponse,
             result::{Error, RepairVerifyError, Result},
         },
@@ -1600,7 +1600,6 @@ impl ServeRepair {
         Self::repair_proto_to_bytes(&request, keypair)
     }
 
-    #[allow(clippy::too_many_arguments)]
     /// Finds a peer to send this repair request too and returns their address and the raw bytes to send.
     ///
     /// For TowerBFT blocks we do a weighted selection where:
@@ -1610,24 +1609,23 @@ impl ServeRepair {
     /// For Alpenglow blocks we do a weighted selection where the weights are `peer_stake`
     pub(crate) fn repair_request(
         &self,
-        cluster_slots: &ClusterSlots,
+        repair_info: &RepairInfo,
         repair_request: ShredRepairType,
         peers_cache: &mut LruCache<Slot, RepairPeers>,
         repair_stats: &mut RepairStats,
-        repair_validators: &Option<HashSet<Pubkey>>,
         outstanding_requests: &mut OutstandingShredRepairs,
-        identity_keypair: &Keypair,
     ) -> Result<Option<(SocketAddr, Vec<u8>)>> {
+        let identity_keypair = repair_info.cluster_info.keypair();
         // find a peer that appears to be accepting replication and has the desired slot, as indicated
         // by a valid tvu port location
         let slot = repair_request.slot();
         let weight_source = self.repair_peer_weight_source(slot);
         let repair_peers = self.repair_peers_from_cache(
             slot,
-            cluster_slots,
-            repair_validators,
+            &repair_info.cluster_slots,
+            &repair_info.repair_validators,
             peers_cache,
-            identity_keypair,
+            &identity_keypair,
             weight_source,
         )?;
         let peer = repair_peers.sample(&mut rand::rng());
@@ -1649,7 +1647,7 @@ impl ServeRepair {
             &peer.pubkey,
             repair_stats,
             nonce,
-            identity_keypair,
+            &identity_keypair,
         )?;
         debug!(
             "Sending repair request from {} to {} for {:#?}",
@@ -1664,21 +1662,20 @@ impl ServeRepair {
     /// Only for use in Alpenglow blocks, peer selection is based on `peer_stake`
     pub(crate) fn block_id_repair_request(
         &self,
-        repair_validators: &Option<HashSet<Pubkey>>,
+        repair_info: &RepairInfo,
         repair_request: BlockIdRepairType,
-        cluster_slots: &ClusterSlots,
         peers_cache: &mut LruCache<Slot, RepairPeers>,
         outstanding_requests: &mut OutstandingRequests<BlockIdRepairType>,
-        identity_keypair: &Keypair,
     ) -> Result<(Vec<u8>, SocketAddr, Pubkey)> {
+        let identity_keypair = repair_info.cluster_info.keypair();
         let slot = repair_request.slot();
         let weight_source = RepairPeerWeightSource::CurrentEpochStake;
         let repair_peers = self.repair_peers_from_cache(
             slot,
-            cluster_slots,
-            repair_validators,
+            &repair_info.cluster_slots,
+            &repair_info.repair_validators,
             peers_cache,
-            identity_keypair,
+            &identity_keypair,
             weight_source,
         )?;
         let peer = repair_peers.sample(&mut rand::rng());
@@ -1688,7 +1685,7 @@ impl ServeRepair {
             &repair_request,
             &peer.pubkey,
             nonce,
-            identity_keypair,
+            &identity_keypair,
         )?;
         debug!(
             "Sending block_id repair request from {} to {} for {:#?}",
@@ -2532,28 +2529,56 @@ mod tests {
         ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
     }
 
+    fn new_test_repair_info(
+        cluster_info: Arc<ClusterInfo>,
+        bank_forks: Arc<RwLock<BankForks>>,
+        cluster_slots: Arc<ClusterSlots>,
+        repair_validators: Option<HashSet<Pubkey>>,
+    ) -> RepairInfo {
+        let epoch_schedule = bank_forks
+            .read()
+            .unwrap()
+            .root_bank()
+            .epoch_schedule()
+            .clone();
+        let (ancestor_duplicate_slots_sender, _ancestor_duplicate_slots_receiver) =
+            crossbeam_channel::unbounded();
+        RepairInfo {
+            bank_forks,
+            cluster_info,
+            cluster_slots,
+            epoch_schedule,
+            ancestor_duplicate_slots_sender,
+            repair_validators,
+            repair_whitelist: Arc::new(RwLock::new(HashSet::default())),
+        }
+    }
+
     #[test]
     fn window_index_request() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
-        let cluster_slots = ClusterSlots::default_for_tests();
+        let cluster_slots = Arc::new(ClusterSlots::default_for_tests());
         let cluster_info = Arc::new(new_test_cluster_info());
+        let repair_info = new_test_repair_info(
+            cluster_info.clone(),
+            bank_forks.clone(),
+            cluster_slots,
+            None,
+        );
         let serve_repair = ServeRepair::new_for_test(
             cluster_info.clone(),
             bank_forks,
             Arc::new(RwLock::new(HashSet::default())),
         );
-        let identity_keypair = cluster_info.keypair();
         let mut outstanding_requests = OutstandingShredRepairs::default();
         let rv = serve_repair.repair_request(
-            &cluster_slots,
+            &repair_info,
             ShredRepairType::Shred(0, 0),
             &mut LruCache::new(100),
             &mut RepairStats::default(),
-            &None,
             &mut outstanding_requests,
-            &identity_keypair,
         );
         assert_matches!(rv, Err(Error::ClusterInfo(ClusterInfoError::NoPeers)));
 
@@ -2573,13 +2598,11 @@ mod tests {
         cluster_info.insert_info(nxt.clone());
         let rv = serve_repair
             .repair_request(
-                &cluster_slots,
+                &repair_info,
                 ShredRepairType::Shred(0, 0),
                 &mut LruCache::new(100),
                 &mut RepairStats::default(),
-                &None,
                 &mut outstanding_requests,
-                &identity_keypair,
             )
             .unwrap()
             .unwrap();
@@ -2606,13 +2629,11 @@ mod tests {
             //this randomly picks an option, so eventually it should pick both
             let rv = serve_repair
                 .repair_request(
-                    &cluster_slots,
+                    &repair_info,
                     ShredRepairType::Shred(0, 0),
                     &mut LruCache::new(100),
                     &mut RepairStats::default(),
-                    &None,
                     &mut outstanding_requests,
-                    &identity_keypair,
                 )
                 .unwrap()
                 .unwrap();
@@ -2876,7 +2897,7 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
-        let cluster_slots = ClusterSlots::default_for_tests();
+        let cluster_slots = Arc::new(ClusterSlots::default_for_tests());
         let cluster_info = Arc::new(new_test_cluster_info());
         let me = cluster_info.my_contact_info();
         // Insert two peers on the network
@@ -2885,6 +2906,12 @@ mod tests {
         cluster_info.insert_info(contact_info2.clone());
         cluster_info.insert_info(contact_info3.clone());
         let identity_keypair = cluster_info.keypair();
+        let mut repair_info = new_test_repair_info(
+            cluster_info.clone(),
+            bank_forks.clone(),
+            cluster_slots,
+            None,
+        );
         let serve_repair = ServeRepair::new_for_test(
             cluster_info,
             bank_forks,
@@ -2897,6 +2924,7 @@ mod tests {
         // then no repairs should be generated
         for pubkey in &[solana_pubkey::new_rand(), *me.pubkey()] {
             let known_validators = Some(vec![*pubkey].into_iter().collect());
+            repair_info.repair_validators = known_validators.clone();
             assert!(
                 serve_repair
                     .repair_peers(&known_validators, 1, &identity_keypair.pubkey())
@@ -2904,13 +2932,11 @@ mod tests {
             );
             assert_matches!(
                 serve_repair.repair_request(
-                    &cluster_slots,
+                    &repair_info,
                     ShredRepairType::Shred(0, 0),
                     &mut LruCache::new(100),
                     &mut RepairStats::default(),
-                    &known_validators,
                     &mut OutstandingShredRepairs::default(),
-                    &identity_keypair,
                 ),
                 Err(Error::ClusterInfo(ClusterInfoError::NoPeers))
             );
@@ -2918,25 +2944,25 @@ mod tests {
 
         // If known validator exists in gossip, should return repair successfully
         let known_validators = Some(vec![*contact_info2.pubkey()].into_iter().collect());
+        repair_info.repair_validators = known_validators.clone();
         let repair_peers =
             serve_repair.repair_peers(&known_validators, 1, &identity_keypair.pubkey());
         assert_eq!(repair_peers.len(), 1);
         assert_eq!(repair_peers[0].pubkey(), contact_info2.pubkey());
         assert_matches!(
             serve_repair.repair_request(
-                &cluster_slots,
+                &repair_info,
                 ShredRepairType::Shred(0, 0),
                 &mut LruCache::new(100),
                 &mut RepairStats::default(),
-                &known_validators,
                 &mut OutstandingShredRepairs::default(),
-                &identity_keypair,
             ),
             Ok(Some(_))
         );
 
         // Using no known validators should default to all
         // validator's available in gossip, excluding myself
+        repair_info.repair_validators = None;
         let repair_peers: HashSet<Pubkey> = serve_repair
             .repair_peers(&None, 1, &identity_keypair.pubkey())
             .into_iter()
@@ -2947,13 +2973,11 @@ mod tests {
         assert!(repair_peers.contains(contact_info3.pubkey()));
         assert_matches!(
             serve_repair.repair_request(
-                &cluster_slots,
+                &repair_info,
                 ShredRepairType::Shred(0, 0),
                 &mut LruCache::new(100),
                 &mut RepairStats::default(),
-                &None,
                 &mut OutstandingShredRepairs::default(),
-                &identity_keypair,
             ),
             Ok(Some(_))
         );

--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -36,7 +36,7 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-hash = { workspace = true, features = ["serde", "copy", "decode", "wincode"] }
+solana-hash = { workspace = true, features = ["serde", "copy", "decode", "wincode", "atomic"] }
 solana-pubkey = { workspace = true }
 solana-short-vec = { workspace = true, features = ["wincode"] }
 solana-signer-store = { workspace = true }

--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -355,6 +355,20 @@ impl MigrationStatus {
         })
     }
 
+    /// Enable alpenglow for testing code
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn enable_alpenglow_for_tests(&self) {
+        let genesis_block = (0, Hash::new_unique());
+        self.record_feature_activation(0);
+        self.set_genesis_block(genesis_block);
+        self.set_genesis_certificate(Arc::new(Certificate {
+            cert_type: CertificateType::Genesis(genesis_block.0, genesis_block.1),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        }));
+        assert_eq!(self.enable_alpenglow_during_startup(), genesis_block.0);
+    }
+
     /// Initialize migration status based on feature flag activation and genesis certificate
     pub fn initialize(
         root_epoch: Epoch,


### PR DESCRIPTION
#### Problem
In alpenglow we stop publishing epoch slots.
The current eager repair peer selection uses epoch slots to determine what peers to select.
Because epoch slots is missing we spam these lines:
```
ERRROR No epoch_metadata record for epoch {epoch}
```
and use the failsafe which equally weights everyone 
https://github.com/anza-xyz/agave/blob/295a7af4d5eef0d0ecffbd08ad5cb1608c9a0a8d/core/src/cluster_slots_service/cluster_slots.rs#L459

#### Summary of Changes
Instead for alpenglow slots, do not use epoch slots, and only use stake weighted selection

Adapted from https://github.com/anza-xyz/agave/pull/3246
Once alpenglow is active we can continue and remove the epoch slots dead code