### PR TITLE
Refactors Accounts/AccountsDb fns that load accounts

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -10,6 +10,7 @@ use {
         accounts_scan::{ScanConfig, ScanError, ScanResult},
         ancestors::Ancestors,
         is_loadable::IsLoadable as _,
+        is_zero_lamport::IsZeroLamport as _,
         storable_accounts::StorableAccounts,
     },
     log::*,
@@ -166,7 +167,7 @@ impl Accounts {
         ancestors: &Ancestors,
         pubkey: &Pubkey,
     ) -> Option<(AccountSharedData, Slot)> {
-        self.accounts_db.load(
+        self._load(
             ancestors,
             pubkey,
             LoadHint::FixedMaxRoot,
@@ -181,7 +182,7 @@ impl Accounts {
         ancestors: &Ancestors,
         pubkey: &Pubkey,
     ) -> Option<(AccountSharedData, Slot)> {
-        self.accounts_db.load(
+        self._load(
             ancestors,
             pubkey,
             LoadHint::FixedMaxRoot,
@@ -194,12 +195,28 @@ impl Accounts {
         ancestors: &Ancestors,
         pubkey: &Pubkey,
     ) -> Option<(AccountSharedData, Slot)> {
-        self.accounts_db.load(
+        self._load(
             ancestors,
             pubkey,
             LoadHint::Unspecified,
             PopulateReadCache::True,
         )
+    }
+
+    /// Loads account for `pubkey` that is visible from `ancestors`.
+    ///
+    /// If no account, returns None.
+    /// If account is zero lamport, returns None.
+    fn _load(
+        &self,
+        ancestors: &Ancestors,
+        pubkey: &Pubkey,
+        load_hint: LoadHint,
+        populate_read_cache: PopulateReadCache,
+    ) -> Option<(AccountSharedData, Slot)> {
+        self.accounts_db
+            .load(ancestors, pubkey, load_hint, populate_read_cache)
+            .filter(|(account, _)| !account.is_zero_lamport())
     }
 
     /// scans underlying accounts_db for this delta (slot) with a map function

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -621,7 +621,7 @@ type ReclaimResult = (AccountSlots, SlotOffsets);
 type PubkeysRemovedFromAccountsIndex = HashSet<Pubkey>;
 type ShrinkCandidates = IntSet<Slot>;
 
-// Some hints for applicability of additional sanity checks for the do_load fast-path;
+// Some hints for applicability of additional sanity checks for the load() fast-path;
 // Slower fallback code path will be taken if the fast path has failed over the retry
 // threshold, regardless of these hints. Also, load cannot fail not-deterministically
 // even under very rare circumstances, unlike previously did allow.
@@ -3510,7 +3510,7 @@ impl AccountsDb {
             if config.is_aborted() {
                 break;
             }
-            if let Some((account, slot)) = self.do_load(
+            if let Some((account, slot)) = self.load(
                 ancestors,
                 &pubkey,
                 LoadHint::Unspecified,
@@ -3626,18 +3626,6 @@ impl AccountsDb {
 
             ScanStorageResult::Stored(retval)
         }
-    }
-
-    /// note this returns None for accounts with zero lamports
-    pub fn load(
-        &self,
-        ancestors: &Ancestors,
-        pubkey: &Pubkey,
-        load_hint: LoadHint,
-        populate_read_cache: PopulateReadCache,
-    ) -> Option<(AccountSharedData, Slot)> {
-        self.do_load(ancestors, pubkey, load_hint, populate_read_cache)
-            .filter(|(account, _)| !account.is_zero_lamport())
     }
 
     fn read_index_for_accessor_or_load_slow<'a>(
@@ -3910,7 +3898,7 @@ impl AccountsDb {
                 // fetched from storage. This means a race occurred between this function and clean
                 // accounts/purge_slots
                 let message = format!(
-                    "do_load() failed to get key: {pubkey} from storage, latest attempt was for \
+                    "load() failed to get key: {pubkey} from storage, latest attempt was for \
                      slot: {slot}, storage_location: {storage_location:?}, load_hint: \
                      {load_hint:?}",
                 );
@@ -3984,7 +3972,11 @@ impl AccountsDb {
         }
     }
 
-    fn do_load(
+    /// Loads account for `pubkey` that is visible from `ancestors`.
+    ///
+    /// If no account, returns None.
+    /// If account is zero lamport, returns Some.
+    pub fn load(
         &self,
         ancestors: &Ancestors,
         pubkey: &Pubkey,
@@ -4087,9 +4079,9 @@ impl AccountsDb {
             let ending_max_root = self.accounts_index.max_root_inclusive();
             if starting_max_root != ending_max_root {
                 warn!(
-                    "do_load_with_populate_read_cache() scanning pubkey {pubkey} called with \
-                     fixed max root, but max root changed from {starting_max_root} to \
-                     {ending_max_root} during function call"
+                    "load_with_populate_read_cache() scanning pubkey {pubkey} called with fixed \
+                     max root, but max root changed from {starting_max_root} to {ending_max_root} \
+                     during function call"
                 );
             }
         }
@@ -6704,12 +6696,12 @@ impl AccountsDb {
     /// Note that this is non-deterministic if clean is running asynchronously.
     /// If a zero lamport account exists in the index, then Some is returned.
     /// Once it is cleaned from the index, None is returned.
-    fn load_without_fixed_root(
+    pub(crate) fn load_without_fixed_root(
         &self,
         ancestors: &Ancestors,
         pubkey: &Pubkey,
     ) -> Option<(AccountSharedData, Slot)> {
-        self.do_load(
+        self.load(
             ancestors,
             pubkey,
             LoadHint::Unspecified,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -2880,7 +2880,7 @@ fn test_read_only_accounts_cache() {
             PopulateReadCache::True,
         )
         .map(|(account, _)| account);
-    assert!(account.is_none());
+    assert!(account.unwrap().is_zero_lamport());
     assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
 }
 
@@ -2933,7 +2933,7 @@ fn test_load_with_read_only_accounts_cache() {
         LoadHint::Unspecified,
         PopulateReadCache::False,
     );
-    assert!(account.is_none());
+    assert!(account.unwrap().0.is_zero_lamport());
     assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
 
     db.read_only_accounts_cache.reset_for_tests();
@@ -2944,7 +2944,7 @@ fn test_load_with_read_only_accounts_cache() {
         LoadHint::Unspecified,
         PopulateReadCache::True,
     );
-    assert!(account.is_none());
+    assert!(account.unwrap().0.is_zero_lamport());
     assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
 
     let slot2_account = AccountSharedData::new(2, 1, AccountSharedData::default().owner());
@@ -3060,14 +3060,12 @@ fn test_flush_cache_dont_clean_zero_lamport_account() {
     );
 
     // The zero-lamport account in slot 2 should not be purged yet, because
-    // it is newer than the latest full snapshot, which blocks cleanup
-    // Use `do_load` directly (rather than `load`) to verify the zero-lamport account
-    // is still present in storage; `load` filters out zero-lamport accounts and
-    // would return None here. FixedMaxRoot is safe since we are only using
+    // it is newer than the latest full snapshot, which blocks cleanup.
+    // FixedMaxRoot is safe since we are only using
     // clean_accounts, with no out-of-band removals.
     let load_hint = LoadHint::FixedMaxRoot;
     assert_eq!(
-        db.do_load(
+        db.load(
             &Ancestors::default(),
             &zero_lamport_account_key,
             load_hint,
@@ -4024,7 +4022,7 @@ fn start_load_thread(
 
                 // Load should never be unable to find this key
                 let loaded_account = db
-                    .do_load(&ancestors, &pubkey, load_hint, PopulateReadCache::True)
+                    .load(&ancestors, &pubkey, load_hint, PopulateReadCache::True)
                     .unwrap();
                 // slot + 1 == account.lamports because of the account-cache-flush thread
                 assert_eq!(


### PR DESCRIPTION
#### Problem

There are a lot of functions that load accounts spread across Bank, Accounts, and AccountsDb. For this PR, we'll only look at the accounts-db crate, so the methods on Accounts and AccountsDb.

These two should have a clear separation of responsibility, but currently do not. Specifically w.r.t. how to handle zero lamport accounts. Should they be returned as Some or None?

For Accounts, these load functions should all return None for zero lamport accounts.

For AccountsDb, I propose that these load functions should all return Some for zero lamport accounts. However, that's not the case. `load()` currently filters out zero lamport account and returns None. Whereas `do_load()` returns Some.


#### Summary of Changes

Make it so AccountsDb load() fns return Some for zero lamport accounts.

Specifically we:
* remove AccountsDb::load().
* rename existing AccountsDb::do_load() to AccountsDb::load() and make it public.
* Add a helper to Accounts that does the filtering to return None for zero lamport accounts.
* Update tests/etc.