### PR TITLE
Deduper: arc-swapped seeds and timer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9208,6 +9208,7 @@ dependencies = [
  "agave-random",
  "agave-transaction-view",
  "ahash 0.8.12",
+ "arc-swap",
  "assert_matches",
  "bencher",
  "bincode",

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -303,7 +303,7 @@ impl SigVerifyStage {
             .name(thread_name.to_string())
             .spawn(move || {
                 let mut rng = rand::rng();
-                let mut deduper = Deduper::<2, [u8]>::new(&mut rng, DEDUPER_NUM_BITS);
+                let deduper = Deduper::<2, [u8]>::new(&mut rng, DEDUPER_NUM_BITS);
                 loop {
                     if deduper.maybe_reset(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, MAX_DEDUPER_AGE) {
                         stats.num_deduper_saturations += 1;

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7988,6 +7988,7 @@ version = "4.2.0-alpha.0"
 dependencies = [
  "agave-transaction-view",
  "ahash 0.8.12",
+ "arc-swap",
  "bincode",
  "bytes",
  "caps",

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -39,6 +39,7 @@ frozen-abi = [
 [dependencies]
 agave-transaction-view = { workspace = true }
 ahash = { workspace = true }
+arc-swap = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true, features = ["serde"] }
 log = { workspace = true }

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -26,7 +26,7 @@ fn test_packet_with_size(size: usize, rng: &mut ThreadRng) -> Vec<u8> {
 fn do_bench_dedup_packets(b: &mut Bencher, mut batches: Vec<PacketBatch>) {
     // verify packets
     let mut rng = rand::rng();
-    let mut deduper = Deduper::<2, [u8]>::new(&mut rng, /*num_bits:*/ 63_999_979);
+    let deduper = Deduper::<2, [u8]>::new(&mut rng, /*num_bits:*/ 63_999_979);
     b.iter(|| {
         let _ans = deduper::dedup_packets_and_count_discards(&deduper, &mut batches);
         deduper.maybe_reset(
@@ -106,7 +106,7 @@ fn bench_dedup_baseline(b: &mut Bencher) {
 
 fn bench_dedup_reset(b: &mut Bencher) {
     let mut rng = rand::rng();
-    let mut deduper = Deduper::<2, [u8]>::new(&mut rng, /*num_bits:*/ 63_999_979);
+    let deduper = Deduper::<2, [u8]>::new(&mut rng, /*num_bits:*/ 63_999_979);
     b.iter(|| {
         deduper.maybe_reset(
             &mut rng,

--- a/perf/src/deduper.rs
+++ b/perf/src/deduper.rs
@@ -3,12 +3,16 @@
 use {
     crate::packet::PacketBatch,
     ahash::RandomState,
+    arc_swap::ArcSwap,
     rand::Rng,
     std::{
         hash::Hash,
         iter::repeat_with,
         marker::PhantomData,
-        sync::atomic::{AtomicU64, Ordering},
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicU64, Ordering},
+        },
         time::{Duration, Instant},
     },
 };
@@ -16,10 +20,24 @@ use {
 pub struct Deduper<const K: usize, T: ?Sized> {
     num_bits: u64,
     bits: Vec<AtomicU64>,
-    state: [RandomState; K],
-    clock: Instant,
+    state: ArcSwap<DeduperGeneration<K>>,
     popcount: AtomicU64, // Number of one bits in self.bits.
+    reset_guard: Mutex<()>,
     _phantom: PhantomData<T>,
+}
+
+struct DeduperGeneration<const K: usize> {
+    random_states: [RandomState; K],
+    started_at: Instant,
+}
+
+impl<const K: usize> DeduperGeneration<K> {
+    fn new<R: Rng>(rng: &mut R) -> Self {
+        Self {
+            random_states: new_random_states(rng),
+            started_at: Instant::now(),
+        }
+    }
 }
 
 impl<const K: usize, T: ?Sized + Hash> Deduper<K, T> {
@@ -28,10 +46,10 @@ impl<const K: usize, T: ?Sized + Hash> Deduper<K, T> {
         let size = usize::try_from(size).unwrap();
         Self {
             num_bits,
-            state: std::array::from_fn(|_| new_random_state(rng)),
-            clock: Instant::now(),
+            state: ArcSwap::from_pointee(DeduperGeneration::new(rng)),
             bits: repeat_with(AtomicU64::default).take(size).collect(),
             popcount: AtomicU64::default(),
+            reset_guard: Mutex::default(),
             _phantom: PhantomData::<T>,
         }
     }
@@ -42,22 +60,36 @@ impl<const K: usize, T: ?Sized + Hash> Deduper<K, T> {
         ones_ratio.powi(K as i32)
     }
 
+    /// Reset is not synchronized with concurrent `dedup()` calls. A caller can
+    /// see an inconsistent snapshot across the old/new hash state and the
+    /// cleared/refilled bitset, but that is acceptable because reset already
+    /// starts a fresh deduplication window.
+    fn reset<R: Rng>(&self, rng: &mut R) {
+        for bits in &self.bits {
+            bits.store(0, Ordering::Relaxed);
+        }
+        self.popcount.store(0, Ordering::Relaxed);
+        self.state.store(Arc::new(DeduperGeneration::new(rng)));
+    }
+
     /// Resets the Deduper if either it is older than the reset_cycle or it is
     /// saturated enough that false positive rate exceeds specified threshold.
+    ///
+    /// This is not intended to be run in parallel with other resets, only in
+    /// parallel with `dedup()` calls.
+    ///
     /// Returns true if the deduper was saturated.
     pub fn maybe_reset<R: Rng>(
-        &mut self,
+        &self,
         rng: &mut R,
         false_positive_rate: f64,
         reset_cycle: Duration,
     ) -> bool {
         assert!(0.0 < false_positive_rate && false_positive_rate < 1.0);
+        let _reset_guard = self.reset_guard.lock().unwrap();
         let saturated = self.false_positive_rate() >= false_positive_rate;
-        if saturated || self.clock.elapsed() >= reset_cycle {
-            self.state = std::array::from_fn(|_| new_random_state(rng));
-            self.clock = Instant::now();
-            self.bits.fill_with(AtomicU64::default);
-            self.popcount = AtomicU64::default();
+        if saturated || self.state.load().started_at.elapsed() >= reset_cycle {
+            self.reset(rng);
         }
         saturated
     }
@@ -67,7 +99,8 @@ impl<const K: usize, T: ?Sized + Hash> Deduper<K, T> {
     #[allow(clippy::arithmetic_side_effects)]
     pub fn dedup(&self, data: &T) -> bool {
         let mut out = true;
-        for random_state in &self.state {
+        let state = self.state.load();
+        for random_state in state.random_states.iter() {
             let hash: u64 = random_state.hash_one(data) % self.num_bits;
             let index = (hash >> 6) as usize;
             let mask: u64 = 1u64 << (hash & 63);
@@ -79,6 +112,10 @@ impl<const K: usize, T: ?Sized + Hash> Deduper<K, T> {
         }
         out
     }
+}
+
+fn new_random_states<const K: usize, R: Rng>(rng: &mut R) -> [RandomState; K] {
+    std::array::from_fn(|_| new_random_state(rng))
 }
 
 fn new_random_state<R: Rng>(rng: &mut R) -> RandomState {
@@ -141,7 +178,7 @@ mod tests {
     #[test]
     fn test_dedup_diff() {
         let mut rng = rand::rng();
-        let mut filter = Deduper::<2, [u8]>::new(&mut rng, NUM_BITS);
+        let filter = Deduper::<2, [u8]>::new(&mut rng, NUM_BITS);
         let mut batches = to_packet_batches(&(0..1024).map(|_| test_tx()).collect::<Vec<_>>(), 128);
         let discard = dedup_packets_and_count_discards(&filter, &mut batches) as usize;
         // because dedup uses a threadpool, there maybe up to N threads of txs that go through
@@ -166,7 +203,7 @@ mod tests {
         const NUM_BITS: u64 = 1_000_000;
         const FALSE_POSITIVE_RATE: f64 = 0.001;
         let mut rng = rand::rng();
-        let mut filter = Deduper::<2, [u8]>::new(&mut rng, NUM_BITS);
+        let filter = Deduper::<2, [u8]>::new(&mut rng, NUM_BITS);
         let capacity = get_capacity::<2>(NUM_BITS, FALSE_POSITIVE_RATE);
         let mut discard = 0;
         assert!(filter.popcount.load(Ordering::Relaxed) < capacity);
@@ -186,6 +223,37 @@ mod tests {
             FALSE_POSITIVE_RATE,
             Duration::from_millis(0), // reset_cycle
         ));
+        assert_eq!(filter.popcount.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_reset_reseeds() {
+        let mut rng = ChaChaRng::from_seed([0u8; 32]);
+        let deduper = Deduper::<2, [u8]>::new(&mut rng, NUM_BITS);
+        let data: &[u8] = b"reseed reset test";
+        let hashes_before_reset = deduper
+            .state
+            .load()
+            .random_states
+            .iter()
+            .map(|state| state.hash_one(data))
+            .collect::<Vec<_>>();
+        assert!(!deduper.dedup(data));
+        assert!(deduper.dedup(data));
+
+        deduper.reset(&mut rng);
+
+        let hashes_after_reset = deduper
+            .state
+            .load()
+            .random_states
+            .iter()
+            .map(|state| state.hash_one(data))
+            .collect::<Vec<_>>();
+        assert_ne!(hashes_before_reset, hashes_after_reset);
+        assert_eq!(deduper.popcount.load(Ordering::Relaxed), 0);
+        assert!(!deduper.dedup(data));
+        assert!(deduper.dedup(data));
     }
 
     #[test]
@@ -217,7 +285,7 @@ mod tests {
     fn test_dedup_capacity(num_bits: u64, false_positive_rate: f64, capacity: u64) {
         let mut rng = rand::rng();
         assert_eq!(get_capacity::<2>(num_bits, false_positive_rate), capacity);
-        let mut deduper = Deduper::<2, [u8]>::new(&mut rng, num_bits);
+        let deduper = Deduper::<2, [u8]>::new(&mut rng, num_bits);
         assert_eq!(deduper.false_positive_rate(), 0.0);
         deduper.popcount.store(capacity, Ordering::Relaxed);
         assert!(deduper.false_positive_rate() < false_positive_rate);
@@ -228,6 +296,7 @@ mod tests {
             false_positive_rate,
             Duration::from_millis(0), // reset_cycle
         ));
+        assert_eq!(deduper.popcount.load(Ordering::Relaxed), 0);
     }
 
     #[test_case([0xf9; 32],  3_199_997, 101_192,  51_414,  77, 101_083)]
@@ -246,7 +315,7 @@ mod tests {
     ) {
         const FALSE_POSITIVE_RATE: f64 = 0.001;
         let mut rng = ChaChaRng::from_seed(seed);
-        let mut deduper = Deduper::<2, [u8]>::new(&mut rng, num_bits);
+        let deduper = Deduper::<2, [u8]>::new(&mut rng, num_bits);
         assert_eq!(get_capacity::<2>(num_bits, FALSE_POSITIVE_RATE), capacity);
         let mut packet = Packet::new([0u8; PACKET_DATA_SIZE], Meta::default());
         let mut dup_count = 0usize;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7579,6 +7579,7 @@ version = "4.2.0-alpha.0"
 dependencies = [
  "agave-transaction-view",
  "ahash 0.8.12",
+ "arc-swap",
  "bincode",
  "bytes",
  "caps",

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -190,12 +190,7 @@ impl<const K: usize> ShredDeduper<K> {
         }
     }
 
-    fn maybe_reset<R: Rng>(
-        &mut self,
-        rng: &mut R,
-        false_positive_rate: f64,
-        reset_cycle: Duration,
-    ) {
+    fn maybe_reset<R: Rng>(&self, rng: &mut R, false_positive_rate: f64, reset_cycle: Duration) {
         self.deduper
             .maybe_reset(rng, false_positive_rate, reset_cycle);
         self.shred_id_filter
@@ -296,7 +291,7 @@ fn retransmit(
     stats: &mut RetransmitStats,
     cluster_nodes_cache: &ClusterNodesCache<RetransmitStage>,
     addr_cache: &mut AddrCache,
-    shred_deduper: &mut ShredDeduper,
+    shred_deduper: &ShredDeduper,
     max_slots: &MaxSlots,
     rpc_subscriptions: Option<&RpcSubscriptions>,
     slot_status_notifier: Option<&SlotStatusNotifier>,
@@ -652,7 +647,7 @@ impl RetransmitStage {
         let mut rng = rand::rng();
         let mut stats = RetransmitStats::new(Instant::now());
         let mut addr_cache = AddrCache::with_capacity(/*capacity:*/ 4);
-        let mut shred_deduper = ShredDeduper::new(&mut rng, DEDUPER_NUM_BITS);
+        let shred_deduper = ShredDeduper::new(&mut rng, DEDUPER_NUM_BITS);
 
         let thread_pool = {
             let num_threads = retransmit_sockets.len();
@@ -679,7 +674,7 @@ impl RetransmitStage {
                         &mut stats,
                         &cluster_nodes_cache,
                         &mut addr_cache,
-                        &mut shred_deduper,
+                        &shred_deduper,
                         &max_slots,
                         rpc_subscriptions.as_deref(),
                         slot_status_notifier.as_ref(),

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -99,7 +99,7 @@ pub fn spawn_shred_sigverify(
         .expect("new rayon threadpool");
     let run_shred_sigverify = move || {
         let mut rng = rand::rng();
-        let mut deduper = Deduper::<2, [u8]>::new(&mut rng, DEDUPER_NUM_BITS);
+        let deduper = Deduper::<2, [u8]>::new(&mut rng, DEDUPER_NUM_BITS);
         let mut shred_buffer = Vec::with_capacity(SIGVERIFY_SHRED_BATCH_SIZE);
         loop {
             if deduper.maybe_reset(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, DEDUPER_RESET_CYCLE) {


### PR DESCRIPTION
#### Problem
- We want to use the Deduper in parallel in SigVerify, but that conflicts with the current mutability used to reseed and reset the timer

#### Summary of Changes
- ArcSwap the cached RandomStates and timer
- Allow concurrent maybe_reset

Fixes #
