### PR TITLE
Revert "fix: `REPAIR_REQUEST_TIMEOUT_MS` ... (#12494)"

### DIFF
--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -65,7 +65,7 @@ const DEFER_REPAIR_THRESHOLD: Duration = Duration::from_millis(250);
 // This is the amount of time we will wait for a repair request to be fulfilled
 // before making another request. Value is based on reasonable upper bound of
 // expected network delays in requesting repairs and receiving shreds.
-pub(crate) const REPAIR_REQUEST_TIMEOUT_MS: u64 = 2 * agave_votor::common::DELTA.as_millis() as u64;
+pub(crate) const REPAIR_REQUEST_TIMEOUT_MS: u64 = 150;
 
 // When requesting repair for a specific shred through the admin RPC, we will
 // request up to NUM_PEERS_TO_SAMPLE_FOR_REPAIRS in the event a specific, valid


### PR DESCRIPTION
#### Problem
The reverted commit may have "fixed" something for the AG case while inadvertently breaking something for Tower. Regardless, the PR (https://github.com/anza-xyz/agave/pull/12494) does not indicate that any testing was done before merging and several SME's raised concerns about the validity of the change

#### Summary of Changes
This reverts commit d3dc6a31806f4aa05b2daf2bcfe74dd8d0f1641b.