### PR TITLE
Adding is_ancestor_zero_lamport helper that checks the write cache as well

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5624,11 +5624,45 @@ impl AccountsDb {
         }
     }
 
+    /// Returns whether the latest version of pubkey from ancestors is zero-lamport
+    /// Returns `None` if the account doesn't exist
+    fn is_ancestor_zero_lamport(&self, pubkey: &Pubkey, ancestors: &Ancestors) -> Option<bool> {
+        if let Some((cached_account, cache_slot, status)) =
+            self.accounts_cache.load_latest(pubkey, ancestors)
+        {
+            let cache_is_zero_lamport = cached_account.account.lamports() == 0;
+            // When the slot isn't being flushed, the cache is definitely the newest
+            if matches!(status, SlotStatus::Ancestor | SlotStatus::UnflushedRoot) {
+                return Some(cache_is_zero_lamport);
+            }
+
+            // Slot is being flushed; a newer version may already exist in storage.
+            if let Some((index_slot, index_is_zero_lamport)) = self
+                .accounts_index
+                .get_with_and_then(pubkey, ancestors, true, |(slot, account)| {
+                    (slot, account.is_zero_lamport())
+                })
+            {
+                // Return the zero lamport status of the newest version between the cache and index
+                // If slots are the same it doesn't matter which is returned (They are identical)
+                if index_slot > cache_slot {
+                    return Some(index_is_zero_lamport);
+                }
+            }
+            Some(cache_is_zero_lamport)
+        } else {
+            self.accounts_index
+                .get_with_and_then(pubkey, ancestors, true, |(_, account)| {
+                    account.is_zero_lamport()
+                })
+        }
+    }
+
     // Stores accounts in the write cache. If an account is zero-lamport and not present in the
-    // index, there is no need to store it in the write cache as it will not effect the accounts
-    // hash. The function returns a BitVec indicating whether each account was stored in the cache.
-    // Ordering of account is important as duplicate pubkeys are possible. The last account in
-    // accounts_and_meta_to_store for each pubkey is stored in the write cache
+    // cache or index, there is no need to store it in the write cache as it will not affect the
+    // accounts hash. The function returns a BitVec indicating whether each account was stored in
+    // the cache. Ordering of accounts is important as duplicate pubkeys are possible. The last
+    // account in accounts_and_meta_to_store for each pubkey is stored in the write cache.
     fn write_accounts_to_cache<'a, 'b>(
         &self,
         slot: Slot,
@@ -5654,12 +5688,7 @@ impl AccountsDb {
                     return;
                 }
                 if account.is_zero_lamport() {
-                    match self.accounts_index.get_with_and_then(
-                        pubkey,
-                        ancestors,
-                        true,
-                        |(_, info)| info.is_zero_lamport(),
-                    ) {
+                    match self.is_ancestor_zero_lamport(pubkey, ancestors) {
                         None => {
                             stats.num_ephemeral_accounts_skipped += 1;
                             return;

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6391,14 +6391,14 @@ fn test_is_ancestor_zero_lamport_being_flushed_picks_higher_slot(
     let db = AccountsDb::new_single_for_tests();
     let pubkey = Pubkey::new_unique();
 
-    // Non-zero entry in the index. Set up first: flushing goes through the cache,
+    // Non-zero lamport entry in the index. Set up first: flushing goes through the cache,
     // so doing it after the cache setup would conflict with `begin_flush_roots`.
     let account = AccountSharedData::new(100, 0, &Pubkey::default());
     db.store_for_tests((index_slot, [(&pubkey, &account)].as_slice()));
     db.add_root_and_flush_write_cache(index_slot);
     assert!(!db.accounts_cache.contains_pubkey(&pubkey));
 
-    // Zero entry in the cache. Note: this entry may be older than the slot that was
+    // Zero lamport entry in the cache. Note: this entry may be older than the slot that was
     // flushed above which is normally not allowed to be added to the cache. However,
     // this state is a valid intermediate state when flushing the cache so needs
     // test coverage

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6318,6 +6318,104 @@ fn test_write_accounts_to_cache_scenarios(
     );
 }
 
+/// Verifies that when the accounts cache holds the latest ancestor, is_ancestor_zero_lamport
+/// returns the zero lamport status of the cached account.
+#[test]
+fn test_is_ancestor_zero_lamport_cache_ancestor() {
+    let db = AccountsDb::new_single_for_tests();
+    let pubkey = Pubkey::new_unique();
+    let slot = 5;
+    let ancestors = Ancestors::from(vec![slot]);
+
+    assert_eq!(db.is_ancestor_zero_lamport(&pubkey, &ancestors), None);
+
+    // Insert a non-zero lamport account and verify the function returns Some(false).
+    let nonzero_account = AccountSharedData::new(100, 0, &Pubkey::default());
+    db.accounts_cache.store(slot, &pubkey, nonzero_account);
+    assert_eq!(
+        db.is_ancestor_zero_lamport(&pubkey, &ancestors),
+        Some(false)
+    );
+
+    // Update the account to zero lamports and verify the function returns Some(true).
+    let zero_account = AccountSharedData::new(0, 0, &Pubkey::default());
+    db.accounts_cache.store(slot, &pubkey, zero_account);
+    assert_eq!(db.is_ancestor_zero_lamport(&pubkey, &ancestors), Some(true));
+}
+
+/// Verifies that when the latest version of an account lives on an unflushed root in the cache
+/// (with the root itself not in ancestors), is_ancestor_zero_lamport returns the zero lamport
+/// status of the cached account.
+#[test]
+fn test_is_ancestor_zero_lamport_unflushed_root_in_cache() {
+    let db = AccountsDb::new_single_for_tests();
+    let pubkey = Pubkey::new_unique();
+    let slot = 5;
+
+    let zero_account = AccountSharedData::new(0, 0, &Pubkey::default());
+    db.accounts_cache.store(slot, &pubkey, zero_account);
+    db.accounts_cache.add_root(slot);
+
+    // The slot is not in ancestors, but is a root and returns the zero lamport UnflushedRoot
+    let ancestors = Ancestors::from(vec![slot + 5]);
+    assert_eq!(db.is_ancestor_zero_lamport(&pubkey, &ancestors), Some(true));
+}
+
+/// Verifies that when the accounts cache does not contain the pubkey, is_ancestor_zero_lamport
+/// falls back to the index and returns the zero lamport status of the indexed account.
+#[test]
+fn test_is_ancestor_zero_lamport_index_only() {
+    let db = AccountsDb::new_single_for_tests();
+    let pubkey = Pubkey::new_unique();
+    let slot = 5;
+
+    let zero_account = AccountSharedData::new(0, 0, &Pubkey::default());
+    db.store_for_tests((slot, [(&pubkey, &zero_account)].as_slice()));
+    db.add_root_and_flush_write_cache(slot);
+    assert!(!db.accounts_cache.contains_pubkey(&pubkey));
+
+    let ancestors = Ancestors::from(vec![slot]);
+    assert_eq!(db.is_ancestor_zero_lamport(&pubkey, &ancestors), Some(true));
+}
+
+/// Verifies that when the cache entry is in a `*BeingFlushed` state, is_ancestor_zero_lamport
+/// also consults the index and returns the zero lamport status of whichever version sits on the
+/// higher slot, regardless of whether that version is in the cache or the index.
+#[test_case(10, 5, true; "newer_cache_wins")]
+#[test_case(5, 10, false; "newer_index_wins")]
+fn test_is_ancestor_zero_lamport_being_flushed_picks_higher_slot(
+    cache_slot: Slot,
+    index_slot: Slot,
+    expected: bool,
+) {
+    let db = AccountsDb::new_single_for_tests();
+    let pubkey = Pubkey::new_unique();
+
+    // Non-zero entry in the index. Set up first: flushing goes through the cache,
+    // so doing it after the cache setup would conflict with `begin_flush_roots`.
+    let account = AccountSharedData::new(100, 0, &Pubkey::default());
+    db.store_for_tests((index_slot, [(&pubkey, &account)].as_slice()));
+    db.add_root_and_flush_write_cache(index_slot);
+    assert!(!db.accounts_cache.contains_pubkey(&pubkey));
+
+    // Zero entry in the cache. Note: this entry may be older than the slot that was
+    // flushed above which is normally not allowed to be added to the cache. However,
+    // this state is a valid intermediate state when flushing the cache so needs
+    // test coverage
+    let account = AccountSharedData::new(0, 0, &Pubkey::default());
+    db.accounts_cache.store(cache_slot, &pubkey, account);
+    db.accounts_cache.add_root(cache_slot);
+    db.accounts_cache.begin_flush_roots(Some(cache_slot));
+
+    let ancestors = Ancestors::from(vec![cache_slot, index_slot]);
+    assert_eq!(
+        db.is_ancestor_zero_lamport(&pubkey, &ancestors),
+        Some(expected)
+    );
+
+    db.accounts_cache.end_flush_roots();
+}
+
 /// loading an account through an older bank must not return
 /// data from a rooted slot that is not an ancestor of the querying bank.
 ///


### PR DESCRIPTION
#### Problem
When cached accounts are no longer tracked in the index, this function will need to search the cache as well 

#### Summary of Changes
- Added a helper function to determine if a pubkeys ancestor is zero_lamport 

RoryP is running this, other validators are running baseline: No delta in perf seen
<img width="1627" height="523" alt="image" src="https://github.com/user-attachments/assets/07738cf5-a66e-46b2-959f-e8b657123536" />


Fixes #
