### PR TITLE
[gen-syscall-list] Allow the number of syscalls to be reduced

### DIFF
--- a/syscalls/gen-syscall-list/build.rs
+++ b/syscalls/gen-syscall-list/build.rs
@@ -51,8 +51,8 @@ fn main() {
         .count();
     if new_num_syscalls < old_num_syscalls {
         println!(
-            "LOG: Number of syscalls reduced from {old_num_syscalls} to \
-             {new_num_syscalls}, parsing logic in build.rs may need to be fixed."
+            "LOG: Number of syscalls reduced from {old_num_syscalls} to {new_num_syscalls}, \
+             parsing logic in build.rs may need to be fixed."
         );
     }
 

--- a/syscalls/gen-syscall-list/build.rs
+++ b/syscalls/gen-syscall-list/build.rs
@@ -51,10 +51,9 @@ fn main() {
         .count();
     if new_num_syscalls < old_num_syscalls {
         println!(
-            "cargo:error=Number of syscalls reduced from {old_num_syscalls} to \
-             {new_num_syscalls}, parsing logic in build.rs likely needs to be fixed."
+            "LOG: Number of syscalls reduced from {old_num_syscalls} to \
+             {new_num_syscalls}, parsing logic in build.rs may need to be fixed."
         );
-        std::process::exit(1);
     }
 
     let txt_file = match File::create(&syscalls_txt_path) {


### PR DESCRIPTION
#### Problem

The `build.rs` script of `gen-syscall-list` errors if the number of syscalls decreases. This prevent syscalls from being removed.

#### Summary of Changes

Updated the script so that instead of giving an error and terminating, it logs that the number of syscalls have decreased.

Fixes #
