### PR TITLE
runtime: stop re-filtering vote accounts for `num_vote_accounts` metric

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -216,6 +216,7 @@ impl Bank {
             stake_rewards,
             capitalization,
             point_value,
+            num_filtered_vote_accounts,
             ..
         } = rewards_calculation;
 
@@ -249,15 +250,8 @@ impl Bank {
             total_reward_commissions, point_value.rewards, total_stake_rewards_lamports
         );
 
-        let (num_stake_accounts, num_vote_accounts) = {
-            let stakes = self.stakes_cache.stakes();
-            let filtered_vote_accounts =
-                self.maybe_filter_vote_accounts_for_vat(stakes.vote_accounts());
-            (
-                stakes.stake_delegations().len(),
-                filtered_vote_accounts.len(),
-            )
-        };
+        let num_stake_accounts = self.stakes_cache.stakes().stake_delegations().len();
+        let num_vote_accounts = *num_filtered_vote_accounts;
         self.capitalization
             .fetch_add(total_reward_commissions, Relaxed);
 
@@ -316,6 +310,11 @@ impl Bank {
         let capitalization = self.capitalization();
         let validator_rewards_lamports =
             self.calculate_epoch_inflation_rewards(capitalization, rewarded_epoch);
+        // `distribution_epoch_vote_accounts` is the post-VAT-filter snapshot
+        // produced upstream of this call (or unfiltered when VAT is off),
+        // so its length is the right value for the `epoch_rewards` metric.
+        let num_filtered_vote_accounts =
+            cached_vote_accounts.distribution_epoch_vote_accounts.len();
 
         let CalculateValidatorRewardsResult {
             reward_commissions,
@@ -344,6 +343,7 @@ impl Bank {
             stake_rewards,
             capitalization,
             point_value,
+            num_filtered_vote_accounts,
         }
     }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -281,6 +281,11 @@ pub(super) struct PartitionedRewardsCalculation {
     stake_rewards: StakeRewardCalculation,
     capitalization: u64,
     point_value: PointValue,
+    /// Number of vote accounts in the distribution-epoch snapshot after
+    /// SIMD-0357 VAT filtering (or the unfiltered count when VAT is off).
+    /// Surfaced for the `epoch_rewards` datapoint without re-running the
+    /// filter at distribution time.
+    num_filtered_vote_accounts: usize,
 }
 
 pub(crate) type StakeRewards = Vec<StakeReward>;


### PR DESCRIPTION
#### Problem
As mentioned in https://github.com/anza-xyz/agave/issues/11645, we recompute a VAT-filtered list of vote accounts in one callsite purely for a metric. We can just capture this value earlier on and plumb it down.

#### Summary of Changes
Stop re-filtering vote accounts for the `num_vote_accounts` metric by capturing this value earlier - during `calculate_rewards_for_partitioning` and passing it along via the `PartitionedRewardsCalculation` intermediate payload.