### PR TITLE
builtins: align account data with mainnet

### DIFF
--- a/builtins/src/lib.rs
+++ b/builtins/src/lib.rs
@@ -34,7 +34,7 @@ pub static BUILTINS: &[BuiltinPrototype] = &[
         core_bpf_migration_config: None,
         #[cfg(feature = "dev-context-only-utils")]
         core_bpf_migration_config: Some(test_only::system_program::CONFIG),
-        name: "system_program",
+        name: "solana_system_program",
         enable_feature_id: None,
         program_id: solana_system_program::id(),
         register_fn: solana_system_program::system_processor::Entrypoint::register,
@@ -44,7 +44,7 @@ pub static BUILTINS: &[BuiltinPrototype] = &[
         core_bpf_migration_config: None,
         #[cfg(feature = "dev-context-only-utils")]
         core_bpf_migration_config: Some(test_only::vote_program::CONFIG),
-        name: "vote_program",
+        name: "solana_vote_program",
         enable_feature_id: None,
         program_id: solana_vote_program::id(),
         register_fn: solana_vote_program::vote_processor::Entrypoint::register,
@@ -54,7 +54,7 @@ pub static BUILTINS: &[BuiltinPrototype] = &[
         core_bpf_migration_config: None,
         #[cfg(feature = "dev-context-only-utils")]
         core_bpf_migration_config: Some(test_only::solana_bpf_loader_deprecated_program::CONFIG),
-        name: "solana_bpf_loader_deprecated_program",
+        name: "solana_bpf_loader_program",
         enable_feature_id: None,
         program_id: bpf_loader_deprecated::id(),
         register_fn: solana_bpf_loader_program::Entrypoint::register,

--- a/builtins/src/lib.rs
+++ b/builtins/src/lib.rs
@@ -23,91 +23,92 @@ use {
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable},
 };
 
-macro_rules! testable_prototype {
-    ($prototype:ident {
-        core_bpf_migration_config: $core_bpf_migration_config:expr,
-        name: $name:ident,
-        $($field:ident : $value:expr),* $(,)?
-    }) => {
-        $prototype {
-            core_bpf_migration_config: {
-                #[cfg(not(feature = "dev-context-only-utils"))]
-                {
-                    $core_bpf_migration_config
-                }
-                #[cfg(feature = "dev-context-only-utils")]
-                {
-                    Some( test_only::$name::CONFIG )
-                }
-            },
-            name: stringify!($name),
-            $($field: $value),*
-        }
-    };
-}
-
 /// DEVELOPER: when a builtin is migrated to sbpf, please add its corresponding
 /// migration feature ID to solana-builtin-default-costs::BUILTIN_INSTRUCTION_COSTS,
 /// so the builtin's default cost can be determined properly based on feature status.
 /// When migration completed, and the feature gate is enabled everywhere, please
 /// remove that builtin entry from solana-builtin-default-costs::BUILTIN_INSTRUCTION_COSTS.
 pub static BUILTINS: &[BuiltinPrototype] = &[
-    testable_prototype!(BuiltinPrototype {
+    BuiltinPrototype {
+        #[cfg(not(feature = "dev-context-only-utils"))]
         core_bpf_migration_config: None,
-        name: system_program,
+        #[cfg(feature = "dev-context-only-utils")]
+        core_bpf_migration_config: Some(test_only::system_program::CONFIG),
+        name: "system_program",
         enable_feature_id: None,
         program_id: solana_system_program::id(),
         register_fn: solana_system_program::system_processor::Entrypoint::register,
-    }),
-    testable_prototype!(BuiltinPrototype {
+    },
+    BuiltinPrototype {
+        #[cfg(not(feature = "dev-context-only-utils"))]
         core_bpf_migration_config: None,
-        name: vote_program,
+        #[cfg(feature = "dev-context-only-utils")]
+        core_bpf_migration_config: Some(test_only::vote_program::CONFIG),
+        name: "vote_program",
         enable_feature_id: None,
         program_id: solana_vote_program::id(),
-        register_fn: solana_vote_program::vote_processor::Entrypoint::register
-    }),
-    testable_prototype!(BuiltinPrototype {
+        register_fn: solana_vote_program::vote_processor::Entrypoint::register,
+    },
+    BuiltinPrototype {
+        #[cfg(not(feature = "dev-context-only-utils"))]
         core_bpf_migration_config: None,
-        name: solana_bpf_loader_deprecated_program,
+        #[cfg(feature = "dev-context-only-utils")]
+        core_bpf_migration_config: Some(test_only::solana_bpf_loader_deprecated_program::CONFIG),
+        name: "solana_bpf_loader_deprecated_program",
         enable_feature_id: None,
         program_id: bpf_loader_deprecated::id(),
-        register_fn: solana_bpf_loader_program::Entrypoint::register
-    }),
-    testable_prototype!(BuiltinPrototype {
+        register_fn: solana_bpf_loader_program::Entrypoint::register,
+    },
+    BuiltinPrototype {
+        #[cfg(not(feature = "dev-context-only-utils"))]
         core_bpf_migration_config: None,
-        name: solana_bpf_loader_program,
+        #[cfg(feature = "dev-context-only-utils")]
+        core_bpf_migration_config: Some(test_only::solana_bpf_loader_program::CONFIG),
+        name: "solana_bpf_loader_program",
         enable_feature_id: None,
         program_id: bpf_loader::id(),
-        register_fn: solana_bpf_loader_program::Entrypoint::register
-    }),
-    testable_prototype!(BuiltinPrototype {
+        register_fn: solana_bpf_loader_program::Entrypoint::register,
+    },
+    BuiltinPrototype {
+        #[cfg(not(feature = "dev-context-only-utils"))]
         core_bpf_migration_config: None,
-        name: solana_bpf_loader_upgradeable_program,
+        #[cfg(feature = "dev-context-only-utils")]
+        core_bpf_migration_config: Some(test_only::solana_bpf_loader_upgradeable_program::CONFIG),
+        name: "solana_bpf_loader_upgradeable_program",
         enable_feature_id: None,
         program_id: bpf_loader_upgradeable::id(),
-        register_fn: solana_bpf_loader_program::Entrypoint::register
-    }),
-    testable_prototype!(BuiltinPrototype {
+        register_fn: solana_bpf_loader_program::Entrypoint::register,
+    },
+    BuiltinPrototype {
+        #[cfg(not(feature = "dev-context-only-utils"))]
         core_bpf_migration_config: None,
-        name: compute_budget_program,
+        #[cfg(feature = "dev-context-only-utils")]
+        core_bpf_migration_config: Some(test_only::compute_budget_program::CONFIG),
+        name: "compute_budget_program",
         enable_feature_id: None,
         program_id: solana_sdk_ids::compute_budget::id(),
         register_fn: solana_compute_budget_program::Entrypoint::register,
-    }),
-    testable_prototype!(BuiltinPrototype {
+    },
+    BuiltinPrototype {
+        #[cfg(not(feature = "dev-context-only-utils"))]
         core_bpf_migration_config: None,
-        name: zk_token_proof_program,
+        #[cfg(feature = "dev-context-only-utils")]
+        core_bpf_migration_config: Some(test_only::zk_token_proof_program::CONFIG),
+        name: "zk_token_proof_program",
         enable_feature_id: Some(feature_set::zk_token_sdk_enabled::id()),
         program_id: solana_sdk_ids::zk_token_proof_program::id(),
         register_fn: solana_zk_token_proof_program::Entrypoint::register,
-    }),
-    testable_prototype!(BuiltinPrototype {
+    },
+    BuiltinPrototype {
+        #[cfg(not(feature = "dev-context-only-utils"))]
         core_bpf_migration_config: None,
-        name: zk_elgamal_proof_program,
+        #[cfg(feature = "dev-context-only-utils")]
+        core_bpf_migration_config: Some(test_only::zk_elgamal_proof_program::CONFIG),
+        name: "zk_elgamal_proof_program",
         enable_feature_id: Some(feature_set::zk_elgamal_proof_program_enabled::id()),
         program_id: solana_sdk_ids::zk_elgamal_proof_program::id(),
         register_fn: solana_zk_elgamal_proof_program::Entrypoint::register,
-    }),
+    },
 ];
 
 pub static STATELESS_BUILTINS: &[StatelessBuiltinPrototype] = &[StatelessBuiltinPrototype {
@@ -313,7 +314,7 @@ pub mod test_only {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "dev-context-only-utils"))]
 mod tests {
     // Since a macro is used to initialize the test IDs from the `test_only`
     // module, best to ensure the lists have the expected values within a test

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1967,7 +1967,7 @@ fn test_load_and_execute_commit_transactions_failure() {
             fee_details: FeeDetails::new(5000, 0),
             loaded_account_stats: TransactionLoadedAccountsStats {
                 loaded_accounts_count: 3,
-                loaded_accounts_data_size: 142, // size of system account (initially recipient does not exist)
+                loaded_accounts_data_size: 149, // size of system account (initially recipient does not exist)
             },
             fee_payer_post_balance: starting_balance - 5000,
         })]
@@ -2034,7 +2034,7 @@ fn test_load_and_execute_commit_transactions_success() {
             fee_details: FeeDetails::new(5000, 0),
             loaded_account_stats: TransactionLoadedAccountsStats {
                 loaded_accounts_count: 3,
-                loaded_accounts_data_size: 142, // size of system account (initially recipient does not exist)
+                loaded_accounts_data_size: 149, // size of system account (initially recipient does not exist)
             },
             fee_payer_post_balance: starting_balance - 5000 - transfer_amount,
         })]
@@ -5231,9 +5231,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "HLHFxvKMzPVeV1cPFZ7a15BZeBHjLKbBuMVWepwoY42Y"
+                    "5aBbXvZ6LXfuMEEG3KZ35U3JsJ8fhDVTsYgtDfjoNcfe"
                 } else {
-                    "FajfXWTy5KiU1NNEDi2faY8Cav1QnBKnQcwcQJADRYTG"
+                    "7oDjEoqPnjqyj1cSekUdNHrfmXhwvdxuZPy6ZqgiGvgy"
                 },
             );
         }
@@ -5243,9 +5243,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "DxyFxUsAXMtJUgB9SxgemBPg7jU8NcHoVgHMgihQ8xuB"
+                    "8xa8W2GxXP2fVXgY6EaTQFfWnL3jW9apWuu6FueGZPXs"
                 } else {
-                    "xq1FdoZAgR6xBMRG7ArTKptb1rE5VPYDhxU1UvDMt7h"
+                    "CeTjbRdS8Nt2Wb1QMuMf8rXQL3YGsUGLwsdT4Ahkvhut"
                 },
             );
         }
@@ -5254,9 +5254,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "A2zek43hceCKySHyYbNrHerdLGSBZAoj6Qf9UyBoMjTv"
+                    "748qUop2J7kyQjtYs9SDrxKRswjbeJPNT3mJqCJWmGfA"
                 } else {
-                    "BYUDXrsqms4Brvv4dNUUY8BJqpeoJuydCgN2jAn6auF1"
+                    "9Kr5dG4tSeS6gSboWMDHJ3GWs85uFXKh9yaHLHP73MJ4"
                 },
             );
             break;


### PR DESCRIPTION
#### Problem

`BuiltinPrototype::name` is written verbatim as on-chain account data by `Bank::add_builtin_account`, so the `name` field is essentially consensus state.

The current strings disagree with mainnet-beta and testnet for System, Vote, and BPFLoader1.

The drift is silent on running networks because `add_builtin_account` is idempotent against an existing
native-loader-owned account. However, this can still bite test clusters, test infrastructure, and more.

#### Summary of Changes

First, inline the silly `testable_prototype!` macro, which makes the `name` field serve triple-duty. Then, fix the values for each builtin's `name` field to match what's on mainnet-beta.