### PR TITLE
fix: handle dumped_slots_sender send error during shutdown

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2108,7 +2108,9 @@ impl ReplayStage {
 
         // Notify repair of the dumped slots along with the correct hash
         trace!("Dumped {} slots", dumped.len());
-        dumped_slots_sender.send(dumped).unwrap();
+        dumped_slots_sender
+            .send(dumped)
+            .unwrap_or_else(|err| warn!("dumped_slots_sender_failed: {err:?}"));
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION

Problem
dumped_slots_sender.send(dumped).unwrap() in ReplayStage::dump_then_repair_correct_slots can panic during shutdown because Tvu::join() shuts down WindowService (which holds the receiver) before ReplayStage.

Summary of Changes
Changed .unwrap() to .unwrap_or_else(|err| warn!(...)) to gracefully handle the case where the repair service receiver has already been dropped during shutdown, matching the error handling pattern used by every other .send() call in replay_stage.rs.