### PR TITLE
clippy(ledger-tool): fix let_and_return lint

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -168,12 +168,12 @@ fn slot_contains_nonvote_tx(blockstore: &Blockstore, slot: Slot) -> bool {
     let (entries, _, _) = blockstore
         .get_slot_entries_with_shred_info(slot, 0, false)
         .expect("Failed to get slot entries");
-    let contains_nonvote = entries
+
+    entries
         .iter()
         .flat_map(|entry| entry.transactions.iter())
         .flat_map(get_program_ids)
-        .any(|program_id| *program_id != solana_vote_program::id());
-    contains_nonvote
+        .any(|program_id| *program_id != solana_vote_program::id())
 }
 
 type OptimisticSlotInfo = (Slot, Option<(Hash, UnixTimestamp)>, bool);

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -95,8 +95,8 @@ fn load_blockstore(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -> Arc<Bank
         process_options,
         None,
     );
-    let bank = bank_forks.read().unwrap().working_bank();
-    bank
+
+    bank_forks.read().unwrap().working_bank()
 }
 
 pub trait ProgramSubCommand {


### PR DESCRIPTION
#### Problem
Defining local var and then returning raises warning in Rust Edition 2024

#### Summary of Changes
Collapse local var and return
