### PR TITLE
accounts-db: Avoid `mut` on test stake creator

### DIFF
--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -226,14 +226,20 @@ fn create_stake_account(
         ..Meta::default()
     };
 
-    let mut stake = Stake {
-        delegation: Delegation::new(voter_pubkey, stake_amount, Epoch::MAX),
+    let stake = Stake {
+        delegation: Delegation {
+            voter_pubkey: *voter_pubkey,
+            stake: stake_amount,
+            activation_epoch: Epoch::MAX,
+            deactivation_epoch: if stake_amount == 0 {
+                last_epoch
+            } else {
+                Epoch::MAX
+            },
+            ..Default::default()
+        },
         credits_observed,
     };
-
-    if stake_amount == 0 {
-        stake.delegation.deactivation_epoch = last_epoch;
-    }
 
     stake_account
         .set_state(&StakeStateV2::Stake(meta, stake, StakeFlags::empty()))


### PR DESCRIPTION
#### Problem

As pointed out at [this comment](https://github.com/anza-xyz/agave/pull/12408/changes/BASE..5945d73bcbc38b0abff64955dd7c327efe031acd#r3251012342), we don't need a `mut` variable.

#### Summary of changes

Construct the correct `Delegation` directly.