### PR TITLE
gossip: re-land FFI harness with pure-Agave accessors gatted on DCOU

### DIFF
--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -28,7 +28,13 @@ frozen-abi = [
     "solana-vote-program/frozen-abi",
 ]
 agave-unstable-api = []
-dev-context-only-utils = ["dep:prost", "dep:protosol", "solana-bloom/dev-context-only-utils"]
+dev-context-only-utils = ["solana-bloom/dev-context-only-utils"]
+conformance = [
+    "dep:prost",
+    "dep:protosol",
+    "dev-context-only-utils",
+]
+dummy-for-ci-check = ["conformance"]
 
 [dependencies]
 agave-logger = { workspace = true }
@@ -98,7 +104,7 @@ bs58 = { workspace = true }
 criterion = { workspace = true }
 num_cpus = { workspace = true }
 serial_test = { workspace = true }
-solana-gossip = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-gossip = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils", "conformance"] }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-perf = { path = "../perf", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -29,11 +29,7 @@ frozen-abi = [
 ]
 agave-unstable-api = []
 dev-context-only-utils = ["solana-bloom/dev-context-only-utils"]
-conformance = [
-    "dep:prost",
-    "dep:protosol",
-    "dev-context-only-utils",
-]
+conformance = ["dep:prost", "dep:protosol", "dev-context-only-utils"]
 dummy-for-ci-check = ["conformance"]
 
 [dependencies]

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -248,12 +248,13 @@ impl ContactInfo {
         &self.version
     }
 
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    // Conformance-only accessors; unused under DCOU.
+    #[cfg(any(test, feature = "conformance"))]
     pub(crate) fn addrs(&self) -> &[IpAddr] {
         &self.addrs
     }
 
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    #[cfg(any(test, feature = "conformance"))]
     pub(crate) fn sockets(&self) -> &[SocketEntry] {
         &self.sockets
     }

--- a/gossip/src/crds_data.rs
+++ b/gossip/src/crds_data.rs
@@ -254,12 +254,13 @@ pub struct LowestSlot {
 }
 
 impl LowestSlot {
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    // Conformance-only accessors; unused under DCOU.
+    #[cfg(any(test, feature = "conformance"))]
     pub(crate) fn wallclock(&self) -> u64 {
         self.wallclock
     }
 
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    #[cfg(any(test, feature = "conformance"))]
     pub(crate) fn from(&self) -> &Pubkey {
         &self.from
     }
@@ -365,12 +366,13 @@ impl Vote {
         &self.transaction
     }
 
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    // Conformance-only accessors; unused under DCOU.
+    #[cfg(any(test, feature = "conformance"))]
     pub(crate) fn from(&self) -> &Pubkey {
         &self.from
     }
 
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    #[cfg(any(test, feature = "conformance"))]
     pub(crate) fn wallclock(&self) -> u64 {
         self.wallclock
     }

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -90,12 +90,13 @@ impl solana_sanitize::Sanitize for CrdsFilter {
 }
 
 impl CrdsFilter {
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    // Conformance-only accessors; unused under DCOU.
+    #[cfg(any(test, feature = "conformance"))]
     pub(crate) fn mask(&self) -> u64 {
         self.mask
     }
 
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    #[cfg(any(test, feature = "conformance"))]
     pub(crate) fn get_mask_bits(&self) -> u32 {
         self.mask_bits
     }

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -52,25 +52,26 @@ impl DuplicateShred {
         self.chunk_index
     }
 
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    // Conformance-only accessors; unused under DCOU.
+    #[cfg(any(test, feature = "conformance"))]
     #[inline]
     pub(crate) fn from(&self) -> &Pubkey {
         &self.from
     }
 
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    #[cfg(any(test, feature = "conformance"))]
     #[inline]
     pub(crate) fn wallclock(&self) -> u64 {
         self.wallclock
     }
 
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    #[cfg(any(test, feature = "conformance"))]
     #[inline]
     pub(crate) fn slot(&self) -> Slot {
         self.slot
     }
 
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    #[cfg(any(test, feature = "conformance"))]
     #[inline]
     pub(crate) fn chunk(&self) -> &[u8] {
         &self.chunk

--- a/gossip/src/harness.rs
+++ b/gossip/src/harness.rs
@@ -1,0 +1,59 @@
+use {crate::protocol::gossip_decode_to_effects, prost::Message, std::ffi::c_int};
+
+/// Conformance harness entry point for gossip message decoding.
+///
+/// Deserializes a binary-encoded gossip message from the input buffer,
+/// decodes it into effects, and writes the Protobuf-encoded result into
+/// the output buffer.
+///
+/// # Parameters
+/// - `out_ptr`: Pointer to the output buffer where the Protobuf-encoded
+///   result will be written.
+/// - `out_psz`: Pointer to a `u64` that on entry holds the capacity of the
+///   output buffer and on successful return is updated to the number of
+///   bytes actually written.
+/// - `in_ptr`: Pointer to the input buffer containing the binary-encoded
+///   gossip message. May be null when `in_sz` is 0.
+/// - `in_sz`: Length of the input buffer in bytes.
+///
+/// # Returns
+/// `1` on success, `0` on failure (null pointers, zero-length input, or
+/// output buffer too small).
+///
+/// # Safety
+/// - `out_ptr` must point to a writable buffer whose capacity is stored at
+///   `*out_psz`.
+/// - `out_psz` must be a valid, aligned pointer to a `u64`.
+/// - `in_ptr` must point to a readable buffer of at least `in_sz` bytes
+///   (or be null/ignored when `in_sz` is 0).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sol_compat_gossip_decode_v1(
+    out_ptr: *mut u8,
+    out_psz: *mut u64,
+    in_ptr: *const u8,
+    in_sz: u64,
+) -> c_int {
+    if out_ptr.is_null() || out_psz.is_null() {
+        return 0;
+    }
+
+    let in_slice = if in_sz == 0 {
+        &[]
+    } else if in_ptr.is_null() {
+        return 0;
+    } else {
+        unsafe { std::slice::from_raw_parts(in_ptr, in_sz as usize) }
+    };
+
+    let effects = gossip_decode_to_effects(in_slice);
+    let out_vec = effects.encode_to_vec();
+
+    let out_cap = unsafe { *out_psz } as usize;
+    if out_vec.len() > out_cap {
+        return 0;
+    }
+    let out_slice = unsafe { std::slice::from_raw_parts_mut(out_ptr, out_cap) };
+    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
+    unsafe { *out_psz = out_vec.len() as u64 };
+    1
+}

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -47,7 +47,10 @@ extern crate solana_frozen_abi_macro;
 #[macro_use]
 extern crate solana_metrics;
 
-#[cfg(feature = "dev-context-only-utils")]
+#[cfg(feature = "conformance")]
 pub use protocol::gossip_decode_to_effects;
+
+#[cfg(feature = "conformance")]
+mod harness;
 
 mod wire_format_tests;

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -255,7 +255,7 @@ pub(crate) fn split_gossip_messages<T: Serialize + Debug>(
     })
 }
 
-#[cfg(feature = "dev-context-only-utils")]
+#[cfg(feature = "conformance")]
 pub fn gossip_decode_to_effects(input: &[u8]) -> protosol::protos::GossipEffects {
     use {
         crate::{

--- a/gossip/tests/conformance/main.rs
+++ b/gossip/tests/conformance/main.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "dev-context-only-utils")]
+#![cfg(feature = "conformance")]
 
 //! Gossip conformance tests and fixture generation.
 


### PR DESCRIPTION
Based on pre-requisite revert PR: https://github.com/anza-xyz/agave/pull/12595

#### Problem
Due to concerns raised on Discord, we decided that it would be better to confine the `conformance` feature to the FFI bindings, protosol only.  By scoping the feature to the FFI/protosol layer, we can safely introduce our new test harnesses while protecting Agave's core build integrity.

<img width="1126" height="189" alt="image" src="https://github.com/user-attachments/assets/d5d696e9-cd22-4a95-b625-4375a5423c69" />

#### Summary of Changes
- All conformance code that touched pure Agave has been moved back under DCOU ownership.
- `conformance` remains implemented for the FFI/protosol layer only.
- This new approach has been reviewed and agreed upon by JoeC, Trent, Faycel, and Brennan.