### PR TITLE
Revert "fix: v1 transactions over 1232 bytes"

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -587,8 +587,6 @@ impl ValidatorTpuConfig {
         let tpu_quic_server_config = SwQosQuicStreamerConfig {
             quic_streamer_config: QuicStreamerConfig {
                 max_connections_per_ipaddr_per_min: 32,
-                stream_receive_window_size: solana_message::v1::MAX_TRANSACTION_SIZE as u32,
-                max_stream_data_bytes: solana_message::v1::MAX_TRANSACTION_SIZE as u32,
                 ..Default::default()
             },
             qos_config: SwQosConfig::default(),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4368,11 +4368,8 @@ fn rpc_perf_sample_from_perf_sample(slot: u64, sample: PerfSample) -> RpcPerfSam
     }
 }
 
-// Encoded-size caps sized for the largest supported raw transaction
-// (V1 transactions, up to 4096 bytes). The raw cap is
-// applied per-version after decoding.
-const MAX_BASE58_SIZE: usize = 5594; // ceil(4096 * log_58(256))
-const MAX_BASE64_SIZE: usize = 5464; // ceil(4096 / 3) * 4
+const MAX_BASE58_SIZE: usize = 1683; // Golden, bump if PACKET_DATA_SIZE changes
+const MAX_BASE64_SIZE: usize = 1644; // Golden, bump if PACKET_DATA_SIZE changes
 fn decode_and_deserialize<T>(
     encoded: String,
     encoding: TransactionBinaryEncoding,
@@ -4389,7 +4386,7 @@ where
                     type_name::<T>(),
                     encoded.len(),
                     MAX_BASE58_SIZE,
-                    solana_message::v1::MAX_TRANSACTION_SIZE,
+                    PACKET_DATA_SIZE,
                 )));
             }
             bs58::decode(encoded)
@@ -4404,7 +4401,7 @@ where
                     type_name::<T>(),
                     encoded.len(),
                     MAX_BASE64_SIZE,
-                    solana_message::v1::MAX_TRANSACTION_SIZE,
+                    PACKET_DATA_SIZE,
                 )));
             }
             BASE64_STANDARD
@@ -4412,19 +4409,12 @@ where
                 .map_err(|e| Error::invalid_params(format!("invalid base64 encoding: {e:?}")))?
         }
     };
-    // V1 transactions/messages start with V1_PREFIX (0x81) and may be up to
-    // 4096 bytes; legacy/v0 are still capped at PACKET_DATA_SIZE (1232).
-    let max_raw_size = if wire_output.first().copied() == Some(solana_message::v1::V1_PREFIX) {
-        solana_message::v1::MAX_TRANSACTION_SIZE
-    } else {
-        PACKET_DATA_SIZE
-    };
-    if wire_output.len() > max_raw_size {
+    if wire_output.len() > PACKET_DATA_SIZE {
         return Err(Error::invalid_params(format!(
             "decoded {} too large: {} bytes (max: {} bytes)",
             type_name::<T>(),
             wire_output.len(),
-            max_raw_size
+            PACKET_DATA_SIZE
         )));
     }
 
@@ -9123,7 +9113,7 @@ pub mod tests {
 
     #[test]
     fn test_worst_case_encoded_tx_goldens() {
-        let ff_tx = vec![0xffu8; solana_message::v1::MAX_TRANSACTION_SIZE];
+        let ff_tx = vec![0xffu8; PACKET_DATA_SIZE];
         let tx58 = bs58::encode(&ff_tx).into_string();
         assert_eq!(tx58.len(), MAX_BASE58_SIZE);
         let tx64 = BASE64_STANDARD.encode(&ff_tx);
@@ -9132,8 +9122,8 @@ pub mod tests {
 
     #[test]
     fn test_decode_and_deserialize_too_large_payloads_fail() {
-        // +3 to exceed both MAX_BASE58_SIZE and MAX_BASE64_SIZE for a V1-sized payload.
-        let too_big = solana_message::v1::MAX_TRANSACTION_SIZE + 3;
+        // +2 because +1 still fits in base64 encoded worst-case
+        let too_big = PACKET_DATA_SIZE + 2;
         let tx_ser = vec![0xffu8; too_big];
 
         let tx58 = bs58::encode(&tx_ser).into_string();
@@ -9143,8 +9133,7 @@ pub mod tests {
                 .unwrap_err(),
             Error::invalid_params(format!(
                 "base58 encoded solana_transaction::Transaction too large: {tx58_len} bytes (max: \
-                 encoded/raw {MAX_BASE58_SIZE}/{})",
-                solana_message::v1::MAX_TRANSACTION_SIZE,
+                 encoded/raw {MAX_BASE58_SIZE}/{PACKET_DATA_SIZE})",
             ))
         );
 
@@ -9155,8 +9144,7 @@ pub mod tests {
                 .unwrap_err(),
             Error::invalid_params(format!(
                 "base64 encoded solana_transaction::Transaction too large: {tx64_len} bytes (max: \
-                 encoded/raw {MAX_BASE64_SIZE}/{})",
-                solana_message::v1::MAX_TRANSACTION_SIZE,
+                 encoded/raw {MAX_BASE64_SIZE}/{PACKET_DATA_SIZE})",
             ))
         );
 
@@ -9218,49 +9206,6 @@ pub mod tests {
                 "invalid base58 encoding: InvalidCharacter { character: '!', index: 1680 }"
                     .to_string(),
             )
-        );
-    }
-
-    #[test]
-    fn test_decode_and_deserialize_v1_sized_payload_passes_size_checks() {
-        // V1-prefixed payload at the V1 max size. Random bytes will fail
-        // wincode deserialization, but should pass the size gates — proving
-        // V1 transactions above PACKET_DATA_SIZE are accepted by the decoder.
-        let mut tx_ser = vec![0xffu8; solana_message::v1::MAX_TRANSACTION_SIZE];
-        tx_ser[0] = solana_message::v1::V1_PREFIX;
-
-        let tx64 = BASE64_STANDARD.encode(&tx_ser);
-        let err =
-            decode_and_deserialize::<VersionedTransaction>(tx64, TransactionBinaryEncoding::Base64)
-                .unwrap_err();
-        assert_eq!(err.code, ErrorCode::InvalidParams);
-        assert!(
-            err.message.starts_with(
-                "failed to deserialize solana_transaction::versioned::VersionedTransaction"
-            ),
-            "unexpected error: {}",
-            err.message
-        );
-    }
-
-    #[test]
-    fn test_decode_and_deserialize_v1_oversize_payload_fails() {
-        // V1-prefixed payload one byte over the V1 max. Uses base64 because a
-        // base58-encoded V1-prefixed payload of this size would trip the
-        // encoded-size cap first.
-        let too_big = solana_message::v1::MAX_TRANSACTION_SIZE + 1;
-        let mut tx_ser = vec![0xffu8; too_big];
-        tx_ser[0] = solana_message::v1::V1_PREFIX;
-
-        let tx64 = BASE64_STANDARD.encode(&tx_ser);
-        assert_eq!(
-            decode_and_deserialize::<VersionedTransaction>(tx64, TransactionBinaryEncoding::Base64)
-                .unwrap_err(),
-            Error::invalid_params(format!(
-                "decoded solana_transaction::versioned::VersionedTransaction too large: {too_big} \
-                 bytes (max: {} bytes)",
-                solana_message::v1::MAX_TRANSACTION_SIZE,
-            ))
         );
     }
 


### PR DESCRIPTION
Revert of https://github.com/anza-xyz/agave/pull/12508

See https://github.com/anza-xyz/agave/pull/12528#discussion_r3250313657

Will follow up with a PR that doesn't increase base58 size. 