### PR TITLE
fixes clientID list with new entries from solana-validator-client-ids

### DIFF
--- a/version/src/client_ids.rs
+++ b/version/src/client_ids.rs
@@ -10,6 +10,12 @@ pub enum ClientId {
     Firedancer,
     AgaveBam,
     Sig,
+    Rakurai,
+    HarmonicFiredancer,
+    HarmonicAgave,
+    HarmonicFrankendancer,
+    FireBAM,
+    Raiku,
     // If new variants are added, update From<u16> and TryFrom<ClientId>.
     Unknown(u16),
 }
@@ -25,6 +31,12 @@ impl fmt::Display for ClientId {
             Self::Firedancer => write!(f, "Firedancer"),
             Self::AgaveBam => write!(f, "AgaveBam"),
             Self::Sig => write!(f, "Sig"),
+            Self::Rakurai => write!(f, "Rakurai"),
+            Self::HarmonicFiredancer => write!(f, "HarmonicFiredancer"),
+            Self::HarmonicAgave => write!(f, "HarmonicAgave"),
+            Self::HarmonicFrankendancer => write!(f, "HarmonicFrankendancer"),
+            Self::FireBAM => write!(f, "FireBAM"),
+            Self::Raiku => write!(f, "Raiku"),
             Self::Unknown(id) => write!(f, "Unknown({id})"),
         }
     }
@@ -41,6 +53,12 @@ impl From<u16> for ClientId {
             5u16 => Self::Firedancer,
             6u16 => Self::AgaveBam,
             7u16 => Self::Sig,
+            8u16 => Self::Rakurai,
+            9u16 => Self::HarmonicFiredancer,
+            10u16 => Self::HarmonicAgave,
+            11u16 => Self::HarmonicFrankendancer,
+            12u16 => Self::FireBAM,
+            13u16 => Self::Raiku,
             _ => Self::Unknown(client),
         }
     }
@@ -59,7 +77,13 @@ impl TryFrom<ClientId> for u16 {
             ClientId::Firedancer => Ok(5u16),
             ClientId::AgaveBam => Ok(6u16),
             ClientId::Sig => Ok(7u16),
-            ClientId::Unknown(client @ 0u16..=7u16) => Err(format!("Invalid client: {client}")),
+            ClientId::Rakurai => Ok(8u16),
+            ClientId::HarmonicFiredancer => Ok(9u16),
+            ClientId::HarmonicAgave => Ok(10u16),
+            ClientId::HarmonicFrankendancer => Ok(11u16),
+            ClientId::FireBAM => Ok(12u16),
+            ClientId::Raiku => Ok(13u16),
+            ClientId::Unknown(client @ 0u16..=13u16) => Err(format!("Invalid client: {client}")),
             ClientId::Unknown(client) => Ok(client),
         }
     }
@@ -86,7 +110,13 @@ mod test {
         assert_eq!(ClientId::from(5u16), ClientId::Firedancer);
         assert_eq!(ClientId::from(6u16), ClientId::AgaveBam);
         assert_eq!(ClientId::from(7u16), ClientId::Sig);
-        for client in 8u16..=u16::MAX {
+        assert_eq!(ClientId::from(8u16), ClientId::Rakurai);
+        assert_eq!(ClientId::from(9u16), ClientId::HarmonicFiredancer);
+        assert_eq!(ClientId::from(10u16), ClientId::HarmonicAgave);
+        assert_eq!(ClientId::from(11u16), ClientId::HarmonicFrankendancer);
+        assert_eq!(ClientId::from(12u16), ClientId::FireBAM);
+        assert_eq!(ClientId::from(13u16), ClientId::Raiku);
+        for client in 14u16..=u16::MAX {
             assert_eq!(ClientId::from(client), ClientId::Unknown(client));
         }
         assert_eq!(u16::try_from(ClientId::SolanaLabs), Ok(0u16));
@@ -97,13 +127,19 @@ mod test {
         assert_eq!(u16::try_from(ClientId::Firedancer), Ok(5u16));
         assert_eq!(u16::try_from(ClientId::AgaveBam), Ok(6u16));
         assert_eq!(u16::try_from(ClientId::Sig), Ok(7u16));
-        for client in 0..=7u16 {
+        assert_eq!(u16::try_from(ClientId::Rakurai), Ok(8u16));
+        assert_eq!(u16::try_from(ClientId::HarmonicFiredancer), Ok(9u16));
+        assert_eq!(u16::try_from(ClientId::HarmonicAgave), Ok(10u16));
+        assert_eq!(u16::try_from(ClientId::HarmonicFrankendancer), Ok(11u16));
+        assert_eq!(u16::try_from(ClientId::FireBAM), Ok(12u16));
+        assert_eq!(u16::try_from(ClientId::Raiku), Ok(13u16));
+        for client in 0..=13u16 {
             assert_eq!(
                 u16::try_from(ClientId::Unknown(client)),
                 Err(format!("Invalid client: {client}"))
             );
         }
-        for client in 8u16..=u16::MAX {
+        for client in 14u16..=u16::MAX {
             assert_eq!(u16::try_from(ClientId::Unknown(client)), Ok(client));
         }
     }
@@ -118,6 +154,12 @@ mod test {
         assert_eq!(format!("{}", ClientId::Firedancer), "Firedancer");
         assert_eq!(format!("{}", ClientId::AgaveBam), "AgaveBam");
         assert_eq!(format!("{}", ClientId::Sig), "Sig");
+        assert_eq!(format!("{}", ClientId::Rakurai), "Rakurai");
+        assert_eq!(format!("{}", ClientId::HarmonicFiredancer), "HarmonicFiredancer");
+        assert_eq!(format!("{}", ClientId::HarmonicAgave), "HarmonicAgave");
+        assert_eq!(format!("{}", ClientId::HarmonicFrankendancer), "HarmonicFrankendancer");
+        assert_eq!(format!("{}", ClientId::FireBAM), "FireBAM");
+        assert_eq!(format!("{}", ClientId::Raiku), "Raiku");
         assert_eq!(format!("{}", ClientId::Unknown(0)), "Unknown(0)");
         assert_eq!(format!("{}", ClientId::Unknown(u16::MAX)), "Unknown(65535)");
     }


### PR DESCRIPTION
adds missing entries for clientID enum based off of https://github.com/solana-foundation/solana-validator-client-ids

quoting the repo above "All existing Solana validator clients are expected to monitor this repository and implement any changes to client-ids.csv as soon as possible in their client codebase."