### PR TITLE
Resolving flaky test: Entirely fill the hashmap

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -3208,15 +3208,18 @@ mod tests {
     /// tombstones consuming `growth_left`.
     #[test]
     fn test_reallocate_to_clear_tombstones_preserves_entries() {
-        // Reallocate only runs in Threshold mode. Pick high_water_mark=99 so
-        // target_entries=100, matching the natural backing size for 100 inserts.
+        // Reallocate only runs in Threshold mode. For this test HWM must be less
+        // than the number of inserts to ensure the calculated bucket size is
+        // the same for hwm and num_inserts
         let hwm = 99;
         let lwm = 70;
         let index = new_should_write_through_for_test(Some((hwm, lwm)));
 
-        // Insert enough entries to settle the bin's hashmap at a stable capacity.
-        let num_inserts = 100;
-        let num_removes = 30;
+        // Fill the bin's hashmap exactly to hashbrown's max_load (7/8 of 128 buckets).
+        // At 100% load every remove is guaranteed to create a tombstone
+        let num_inserts = 112;
+        // Then remove enough entries to drop down to the low water mark
+        let num_removes = 42;
         let pubkeys: Vec<_> = (0..num_inserts)
             .map(|_| solana_pubkey::new_rand())
             .collect();


### PR DESCRIPTION
#### Problem
Test was flaky on x86 architecture. This is because of Group::WIDTH. 

With hashbrown: Capacity = (num_items + growth_left). When an item is removed from the hashmap, the capacity will stay constant if growth_left is increased (num_items--, growth_left++). 

growth_left is increased on item removal if an empty entry in the hashmap can be found within a Group::WIDTH span of the removed item. Since Group::WIDTH is 8 on ARM architecture and 16 on x86, finding an empty entry within 16 entries of the removed entry is much more likely, leading to an increased chance of growth_left increasing. 

According to Claude it's a 10% failure rate on x86 architecture (16 search window) and 0% on arm (8 search window) for the current test parameters. No idea how accurate that is though.


#### Summary of Changes
- Increase the number of items inserted to 7/8th of the hashmap capacity. This guarantees tombstones will be added as there are no empty entries. 

Fixes #
