### PR TITLE
wip: `delta_first_slice` from bank

### DIFF
--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -226,6 +226,7 @@ impl EventHandler {
         if should_set_timeouts {
             let root_bank = vctx.sharable_banks.root();
             let delta_block = Duration::from_nanos_u128(root_bank.ns_per_slot_at_slot(slot));
+            // Conservatively give a leader the full slot time to send their first slice.
             let delta_first_slice = delta_block;
             timer_manager.write().set_timeouts(
                 slot,

--- a/votor/src/timer_manager/timers.rs
+++ b/votor/src/timer_manager/timers.rs
@@ -53,7 +53,7 @@ impl TimeoutConfig {
 /// Encodes a basic state machine of the different stages involved in handling
 /// timeouts for a window of slots.
 enum TimerState {
-    /// Waiting for initial DELTA_TIMEOUT + delta_first_slice stage.
+    /// Waiting for initial `delta_timeout + delta_first_slice` stage.
     WaitForFirstSlice {
         /// The slots in the window.  Must not be empty.
         window: VecDeque<Slot>,
@@ -203,6 +203,7 @@ impl Timers {
         delta_block: Duration,
     ) {
         assert_eq!(self.heap.len(), self.timers.len());
+        assert!(delta_first_slice <= delta_block);
         let timeout_config = TimeoutConfig {
             delta_timeout: self.delta_timeout,
             delta_first_slice,
@@ -329,8 +330,8 @@ mod tests {
         let mut timers = Timers::new(one_micro, sender);
         assert!(timers.progress(now).is_none());
         assert!(receiver.try_recv().unwrap_err().is_empty());
-        let delta_block = Duration::from_millis(DEFAULT_MS_PER_SLOT);
 
+        let delta_block = Duration::from_millis(DEFAULT_MS_PER_SLOT);
         timers.set_timeouts(0, now, None, delta_block, delta_block);
         while timers.progress(now).is_some() {
             now = now.checked_add(one_micro).unwrap();


### PR DESCRIPTION
#### Problem
`DELTA_FIRST_SLICE` is currently a global constant set to `DEFAULT_MS_PER_SLOT`, which is currently correct in production. However, in preparation for changing slot times, there is already a field `ns_per_slot` on the bank. Also, some tests seem to already use different slot times. That is also, why an assertion `delta_first_slice <= delta_block` would previously fail.

#### Summary of Changes
- Derive `delta_first_slice` from the banks' `ns_per_slot`, just like `delta_block`.
- Assert `delta_first_slice <= delta_block` in `set_timeouts()`.