### PR TITLE
remove unnecessary key rotation in PingPong

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8532,7 +8532,6 @@ dependencies = [
  "serde-big-array",
  "serde_bytes",
  "serial_test",
- "siphasher 1.0.2",
  "solana-bloom",
  "solana-client",
  "solana-clock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -333,7 +333,6 @@ serial_test = "3.4.0"
 shaq = { version = "3.0.0" }
 shuttle = "0.7.1"
 signal-hook = "0.4.4"
-siphasher = "1.0.2"
 slab = "0.4.12"
 slotmap = "1.0.7"
 smallvec = { version = "1.15.1", default-features = false, features = ["union"] }

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1253,8 +1253,6 @@ impl ServeRepair {
         assert!(REPAIR_PING_CACHE_RATE_LIMIT_DELAY > Duration::from_millis(REPAIR_MS));
 
         let mut ping_cache = PingCache::new(
-            &mut rand::rng(),
-            Instant::now(),
             REPAIR_PING_CACHE_TTL,
             REPAIR_PING_CACHE_RATE_LIMIT_DELAY,
             REPAIR_PING_CACHE_CAPACITY,
@@ -1875,7 +1873,10 @@ mod tests {
         solana_pubkey::Pubkey,
         solana_runtime::bank::Bank,
         solana_time_utils::timestamp,
-        std::{io::Cursor, net::Ipv4Addr},
+        std::{
+            io::Cursor,
+            net::{Ipv4Addr, SocketAddrV4},
+        },
     };
 
     fn discard_malformed_repair_requests(
@@ -1917,8 +1918,6 @@ mod tests {
         let remote_keypair = Keypair::new();
         let from_addr = socketaddr!(Ipv4Addr::LOCALHOST, 1234);
         let mut ping_cache = PingCache::new(
-            &mut rand::rng(),
-            Instant::now(),
             REPAIR_PING_CACHE_TTL,
             REPAIR_PING_CACHE_RATE_LIMIT_DELAY,
             REPAIR_PING_CACHE_CAPACITY,
@@ -2951,5 +2950,42 @@ mod tests {
         // over the allowed limit, should fail
         response.push((request_slot, Hash::new_unique()));
         assert!(!repair.verify_response(&AncestorHashesResponse::Hashes(response)));
+    }
+
+    // A second check() within REPAIR_PING_CACHE_RATE_LIMIT_DELAY must not generate
+    // a new ping. If it did, it would overwrite the stored token and invalidate the Pong,
+    // making Ping fail for no reason.
+    #[test]
+    fn test_repair_no_ping_overwrite_within_rate_limit_delay() {
+        let mut rng = rand::rng();
+        let this_node = Keypair::new();
+        let remote_socket = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8001));
+        let remote_keypair = Keypair::new();
+        let remote_node = (remote_keypair.pubkey(), remote_socket);
+        let mut cache = PingCache::new(
+            REPAIR_PING_CACHE_TTL,
+            REPAIR_PING_CACHE_RATE_LIMIT_DELAY,
+            REPAIR_PING_CACHE_CAPACITY,
+        );
+        let now = Instant::now();
+
+        let (_, ping1) = cache.check(&mut rng, &this_node, now, remote_node);
+        let ping1 = ping1.expect("should generate ping for unknown node");
+
+        // Second check within REPAIR_PING_CACHE_RATE_LIMIT_DELAY must not generate
+        // a new ping — that would overwrite the stored hash and invalidate the in-flight pong.
+        let within_delay = now + REPAIR_PING_CACHE_RATE_LIMIT_DELAY - Duration::from_millis(1);
+        let (_, ping2) = cache.check(&mut rng, &this_node, within_delay, remote_node);
+        assert!(
+            ping2.is_none(),
+            "must not generate a second ping within REPAIR_PING_CACHE_RATE_LIMIT_DELAY"
+        );
+
+        // Pong for ping1 must still be valid — token was not overwritten.
+        let pong1 = solana_gossip::ping_pong::Pong::new(&ping1, &remote_keypair);
+        assert!(
+            cache.add(&pong1, remote_socket, within_delay),
+            "pong for original ping must still be valid — token was not overwritten"
+        );
     }
 }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7422,7 +7422,6 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_bytes",
- "siphasher 1.0.2",
  "solana-bloom",
  "solana-client",
  "solana-clock",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -55,7 +55,6 @@ rayon = { workspace = true }
 serde = { workspace = true }
 serde-big-array = { workspace = true }
 serde_bytes = { workspace = true }
-siphasher = { workspace = true }
 solana-bloom = { workspace = true }
 solana-client = { workspace = true }
 solana-clock = { workspace = true }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -182,8 +182,6 @@ impl ClusterInfo {
             outbound_budget: DataBudget::default(),
             my_contact_info: RwLock::new(contact_info),
             ping_cache: Mutex::new(PingCache::new(
-                &mut rand::rng(),
-                Instant::now(),
                 GOSSIP_PING_CACHE_TTL,
                 GOSSIP_PING_CACHE_RATE_LIMIT_DELAY,
                 GOSSIP_PING_CACHE_CAPACITY,

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -414,8 +414,6 @@ mod test {
             )
             .unwrap();
         let ping_cache = PingCache::new(
-            &mut rand::rng(),
-            Instant::now(),
             Duration::from_secs(20 * 60),      // ttl
             Duration::from_secs(20 * 60) / 64, // rate_limit_delay
             128,                               // capacity

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -728,8 +728,6 @@ pub(crate) mod tests {
 
     fn new_ping_cache() -> PingCache {
         PingCache::new(
-            &mut rand::rng(),
-            Instant::now(),
             Duration::from_secs(20 * 60),      // ttl
             Duration::from_secs(20 * 60) / 64, // rate_limit_delay
             128,                               // capacity

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -294,8 +294,6 @@ mod tests {
 
     fn new_ping_cache() -> PingCache {
         PingCache::new(
-            &mut rand::rng(),
-            Instant::now(),
             Duration::from_secs(20 * 60),      // ttl
             Duration::from_secs(20 * 60) / 64, // rate_limit_delay
             128,                               // capacity

--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -4,7 +4,6 @@ use {
     rand::{CryptoRng, Rng},
     serde::{Deserialize, Serialize},
     serde_big_array::BigArray,
-    siphasher::sip::SipHasher24,
     solana_hash::Hash,
     solana_keypair::{Keypair, signable::Signable},
     solana_pubkey::Pubkey,
@@ -13,13 +12,11 @@ use {
     solana_signer::Signer,
     std::{
         borrow::Cow,
-        hash::{Hash as _, Hasher},
         net::{IpAddr, SocketAddr},
         time::{Duration, Instant},
     },
 };
 
-const KEY_REFRESH_CADENCE: Duration = Duration::from_secs(60);
 const PING_PONG_HASH_PREFIX: &[u8] = "SOLANA_PING_PONG".as_bytes();
 const PONG_SIGNATURE_SAMPLE_LEADING_ZEROS: u32 = 5;
 
@@ -52,15 +49,9 @@ pub struct PingCache<const N: usize> {
     ttl: Duration,
     // Rate limit delay to generate pings for a given address
     rate_limit_delay: Duration,
-    // Hashers initialized with random keys, rotated at KEY_REFRESH_CADENCE.
-    // Because at the moment that the keys are rotated some pings might already
-    // be in the flight, we need to keep the two most recent hashers.
-    hashers: [SipHasher24; 2],
-    // When hashers were last refreshed.
-    key_refresh: Instant,
-    // Timestamp of last ping message sent to a remote node.
-    // Used to rate limit pings to remote nodes.
-    pings: LruCache<(Pubkey, SocketAddr), Instant>,
+    // Timestamp and expected pong hash for each pinged remote node.
+    // Used for rate-limiting and pong validation.
+    pings: LruCache<(Pubkey, SocketAddr), (Instant, Hash)>,
     // Verified pong responses from remote nodes.
     pongs: LruCache<(Pubkey, SocketAddr), Instant>,
     // Timestamp of last ping message sent to a remote IP.
@@ -154,38 +145,27 @@ impl Signable for Pong {
 }
 
 impl<const N: usize> PingCache<N> {
-    pub fn new<R: Rng + CryptoRng>(
-        rng: &mut R,
-        now: Instant,
-        ttl: Duration,
-        rate_limit_delay: Duration,
-        cap: usize,
-    ) -> Self {
+    pub fn new(ttl: Duration, rate_limit_delay: Duration, cap: usize) -> Self {
         // Sanity check ttl/rate_limit_delay
         assert!(rate_limit_delay <= ttl / 2);
         Self {
             ttl,
             rate_limit_delay,
-            hashers: std::array::from_fn(|_| SipHasher24::new_with_key(&rng.random())),
-            key_refresh: now,
             pings: LruCache::new(cap),
             pongs: LruCache::new(cap),
             ping_times: LruCache::new(cap),
         }
     }
 
-    /// Checks if the pong hash, pubkey and socket match a ping message sent
-    /// out previously. If so records current timestamp for the remote node and
-    /// returns true.
+    /// Checks if the pong hash matches a ping message sent out previously.
+    /// If so records current timestamp for the remote node and returns true.
     /// Note: Does not verify the signature.
     pub fn add(&mut self, pong: &Pong, socket: SocketAddr, now: Instant) -> bool {
         let remote_node = (pong.pubkey(), socket);
-        if !self.hashers.iter().copied().any(|hasher| {
-            let token = make_ping_token::<N>(hasher, &remote_node);
-            hash_ping_token(&token) == pong.hash
-        }) {
+        if !matches!(self.pings.peek(&remote_node), Some((_, h)) if *h == pong.hash) {
             return false;
         };
+        self.pings.pop(&remote_node);
         self.pongs.put(remote_node, now);
         if let Some(sent_time) = self.ping_times.pop(&socket.ip())
             && should_report_message_signature(
@@ -215,13 +195,23 @@ impl<const N: usize> PingCache<N> {
     ) -> Option<Ping<N>> {
         // Rate limit consecutive pings sent to a remote node.
         if matches!(self.pings.peek(&remote_node),
-            Some(&t) if now.saturating_duration_since(t) < self.rate_limit_delay)
+            Some((t, _)) if now.saturating_duration_since(*t) < self.rate_limit_delay)
         {
             return None;
         }
-        self.pings.put(remote_node, now);
-        self.maybe_refresh_key(rng, now);
-        let token = make_ping_token::<N>(self.hashers[0], &remote_node);
+        let token = {
+            let mut token = [0u8; N];
+            const FILL: usize = std::mem::size_of::<u64>();
+            const { assert!(N >= FILL, "N must be >= size_of::<u64>()") };
+            let entropy: [u8; FILL] = rng.random();
+            *token
+                .first_chunk_mut::<FILL>()
+                .expect("token is known to fit FILL bytes") = entropy;
+            token
+        };
+        // The hash we expect to see in the Pong message
+        let ping_hash = hash_ping_token(&token);
+        self.pings.put(remote_node, (now, ping_hash));
         self.ping_times.put(remote_node.1.ip(), Instant::now());
         Some(Ping::new(token, keypair))
     }
@@ -262,31 +252,10 @@ impl<const N: usize> PingCache<N> {
         (check, ping)
     }
 
-    fn maybe_refresh_key<R: Rng + CryptoRng>(&mut self, rng: &mut R, now: Instant) {
-        if now.checked_duration_since(self.key_refresh) > Some(KEY_REFRESH_CADENCE) {
-            let hasher = SipHasher24::new_with_key(&rng.random());
-            self.hashers[1] = std::mem::replace(&mut self.hashers[0], hasher);
-            self.key_refresh = now;
-        }
-    }
-
     /// Only for tests and simulations.
     pub fn mock_pong(&mut self, node: Pubkey, socket: SocketAddr, now: Instant) {
         self.pongs.put((node, socket), now);
     }
-}
-
-fn make_ping_token<const N: usize>(
-    mut hasher: SipHasher24,
-    remote_node: &(Pubkey, SocketAddr),
-) -> [u8; N] {
-    // TODO: Consider including local node's (pubkey, socket-addr).
-    remote_node.hash(&mut hasher);
-    let hash = hasher.finish().to_le_bytes();
-    debug_assert!(N >= std::mem::size_of::<u64>());
-    let mut token = [0u8; N];
-    token[..std::mem::size_of::<u64>()].copy_from_slice(&hash);
-    token
 }
 
 fn hash_ping_token<const N: usize>(token: &[u8; N]) -> Hash {
@@ -327,7 +296,7 @@ mod tests {
         let mut rng = rand::rng();
         let ttl = Duration::from_millis(256);
         let delay = ttl / 64;
-        let mut cache = PingCache::new(&mut rng, Instant::now(), ttl, delay, /*cap=*/ 1000);
+        let mut cache = PingCache::new(ttl, delay, /*cap=*/ 1000);
         let this_node = Keypair::new();
         let sockets: Vec<_> = (1u8..=3)
             .map(|i| {
@@ -456,7 +425,7 @@ mod tests {
         let ttl = Duration::from_secs(20 * 60); // 20 minutes
         let delay = ttl / 64;
         let mut now = Instant::now();
-        let mut cache = PingCache::<32>::new(&mut rng, now, ttl, delay, /*cap=*/ 1000);
+        let mut cache = PingCache::<32>::new(ttl, delay, /*cap=*/ 1000);
 
         // Add a pong for the remote node
         cache.mock_pong(remote_node.0, remote_node.1, now);

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -663,8 +663,6 @@ fn build_gossip_thread_pool() -> ThreadPool {
 
 fn new_ping_cache() -> Mutex<PingCache> {
     let ping_cache = PingCache::new(
-        &mut rand::rng(),
-        Instant::now(),
         Duration::from_secs(20 * 60),      // ttl
         Duration::from_secs(20 * 60) / 64, // rate_limit_delay
         2048,                              // capacity

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7080,7 +7080,6 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_bytes",
- "siphasher 1.0.2",
  "solana-bloom",
  "solana-client",
  "solana-clock",


### PR DESCRIPTION
#### Problem

- We use siphasher to produce tokens for Ping challenges based on remote's pubkey and address. The whole point there is to make sure they are random and remote attacker can not guess them. 
- We then proceed to store the tokens in a hashmap, so we actually have access to them on receive side. We could do stateless validation here, but we do not.
- The hasher for token generation is rotated periodically, creating complexity without any benefit.

#### Summary of Changes

- Instead of periodic rotation gossip and repair will now make unique tokens for every Ping they send. Validation and wire format stay the same.
- This also removes dep on siphasher crate, and reduces complexity of repair protocols (they are also using PingPong)
- Side-effect - when a node is re-pinged, it has to reply to the latest Ping for the answer to be valid (previously it could reply to any Ping sent in the last 60 seconds). For repair specifically this means Pong must arrive within 2s, or peer will not be considered eligible.

Closes #12580
