### PR TITLE
runtime: gate `RewardCommission.commission_bps` on SIMD-0232

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -476,7 +476,7 @@ impl Bank {
                         stake_pubkey,
                         stake,
                         stake_reward: 0,
-                        commission_bps: 0,
+                        commission_bps: (!custom_commission_collector).then_some(0),
                     };
                     let reward_commission = RewardCommission {
                         commission_bps: (!custom_commission_collector).then_some(0),
@@ -541,7 +541,7 @@ impl Bank {
                     stake_pubkey,
                     stake,
                     stake_reward,
-                    commission_bps,
+                    commission_bps: (!custom_commission_collector).then_some(commission_bps),
                 };
                 let reward_commission = RewardCommission {
                     commission_bps: (!custom_commission_collector).then_some(commission_bps),
@@ -1790,7 +1790,6 @@ mod tests {
         assert_eq!(vote_rewards_accounts.len(), 1);
         let reward_commission = vote_rewards_accounts.get(vote_pubkey).unwrap();
         let vote_rewards = 0;
-        let commission_bps = vote_state.inflation_rewards_commission_bps;
         assert_eq!(reward_commission.commission_lamports, vote_rewards);
         assert_eq!(reward_commission.commission_bps, None);
 
@@ -1805,7 +1804,7 @@ mod tests {
                 stake,
                 stake_pubkey,
                 stake_reward,
-                commission_bps,
+                commission_bps: None,
             }
         };
         assert_eq!(

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -431,6 +431,7 @@ impl Bank {
         delay_commission_updates: bool,
         commission_rate_in_basis_points: bool,
         adjust_delegations_for_rent: bool,
+        custom_commission_collector: bool,
     ) -> Option<DelegationRewards> {
         // curry closure to add the contextual stake_pubkey
         let reward_calc_tracer = reward_calc_tracer.as_ref().map(|outer| {
@@ -478,7 +479,7 @@ impl Bank {
                         commission_bps: 0,
                     };
                     let reward_commission = RewardCommission {
-                        commission_bps: 0,
+                        commission_bps: (!custom_commission_collector).then_some(0),
                         commission_lamports: 0,
                     };
                     return Some(DelegationRewards {
@@ -543,7 +544,7 @@ impl Bank {
                     commission_bps,
                 };
                 let reward_commission = RewardCommission {
-                    commission_bps,
+                    commission_bps: (!custom_commission_collector).then_some(commission_bps),
                     commission_lamports,
                 };
                 Some(DelegationRewards {
@@ -579,6 +580,7 @@ impl Bank {
         // Name intentionally doesn't match -- "adjust delegations for rent" is
         // part of relaxing post-exec min balance checks.
         let adjust_delegations_for_rent = feature_snapshot.relax_post_exec_min_balance_check;
+        let custom_commission_collector = feature_snapshot.custom_commission_collector;
 
         let mut measure_redeem_rewards = Measure::start("redeem-rewards");
         // For N stake delegations, where N is >1,000,000, we produce:
@@ -609,6 +611,7 @@ impl Bank {
                         delay_commission_updates,
                         commission_rate_in_basis_points,
                         adjust_delegations_for_rent,
+                        custom_commission_collector,
                     );
 
                     let (stake_reward, maybe_reward_record) = match maybe_reward_record {
@@ -847,7 +850,7 @@ impl Bank {
                                 reward_type: RewardType::Voting,
                                 lamports: *commission_lamports as i64,
                                 post_balance: commission_account.lamports(),
-                                commission_bps: Some(*commission_bps),
+                                commission_bps: *commission_bps,
                             },
                             commission_account,
                         ))
@@ -1140,7 +1143,7 @@ mod tests {
 
     #[derive(Default)]
     struct VoteOperations {
-        expected_reward_commission: Option<u8>,
+        expect_reward: bool,
         // ops to perform before epoch ends
         create_with_balance: Option<u64>,
         delegate_stake_amount: Option<u64>,
@@ -1191,7 +1194,7 @@ mod tests {
                 reward_type: RewardType::Voting,
                 lamports: rc.commission_lamports as i64,
                 post_balance,
-                commission_bps: Some(rc.commission_bps),
+                commission_bps: rc.commission_bps,
             }
         })
     }
@@ -1320,7 +1323,6 @@ mod tests {
             Bank::new_from_parent_with_bank_forks(bank_forks, bank, SlotLeader::new_unique(), slot);
 
         for (vote_address, vote_op) in &op.vote_operations {
-            let expected_commission = vote_op.expected_reward_commission;
             let recalculated_vote_reward =
                 recalculate_reward_commission_for_tests(&bank, vote_address);
             let vote_reward = bank
@@ -1337,13 +1339,13 @@ mod tests {
                 .lamports();
             let vote_balance = bank.get_balance(vote_address);
 
-            if let Some(expected_commission) = &expected_commission {
+            if vote_op.expect_reward {
                 let reward_lamports = vote_balance - prev_vote_balance;
                 let expected_vote_reward = RewardInfo {
                     reward_type: RewardType::Voting,
                     lamports: reward_lamports as i64,
                     post_balance: vote_balance,
-                    commission_bps: Some(*expected_commission as u16 * 100),
+                    commission_bps: None,
                 };
 
                 assert_eq!(
@@ -1422,27 +1424,23 @@ mod tests {
         // Check that if a vote account didn't exist two epochs ago (normal for
         // new vote accounts), that the reward commission falls back to the
         // commission from the end of the rewarded epoch.
-        bank = {
-            let expected_commission = if delay_commission_updates { 1 } else { 2 };
-            apply_epoch_operations(
-                bank,
-                bank_forks.as_ref(),
-                EpochOperations {
-                    epoch: 1,
-                    vote_operations: vec![(
-                        vote_address,
-                        VoteOperations {
-                            new_commission: Some(2),
-                            earned_credits: Some(1000),
-                            expected_reward_commission: Some(expected_commission),
-                            ..VoteOperations::default()
-                        },
-                    )],
-                },
-            )
-        };
+        bank = apply_epoch_operations(
+            bank,
+            bank_forks.as_ref(),
+            EpochOperations {
+                epoch: 1,
+                vote_operations: vec![(
+                    vote_address,
+                    VoteOperations {
+                        new_commission: Some(2),
+                        earned_credits: Some(1000),
+                        expect_reward: true,
+                        ..VoteOperations::default()
+                    },
+                )],
+            },
+        );
 
-        let expected_commission = if delay_commission_updates { 1 } else { 3 };
         apply_epoch_operations(
             bank,
             bank_forks.as_ref(),
@@ -1453,7 +1451,7 @@ mod tests {
                     VoteOperations {
                         new_commission: Some(3),
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(expected_commission),
+                        expect_reward: true,
                         ..VoteOperations::default()
                     },
                 )],
@@ -1506,7 +1504,7 @@ mod tests {
                         create_with_balance: Some(LAMPORTS_PER_SOL),
                         new_commission: Some(1),
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(1),
+                        expect_reward: true,
                         ..VoteOperations::default()
                     },
                 )],
@@ -1526,7 +1524,7 @@ mod tests {
                     VoteOperations {
                         new_commission: Some(2),
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(1),
+                        expect_reward: true,
                         ..VoteOperations::default()
                     },
                 )],
@@ -1543,7 +1541,7 @@ mod tests {
                     VoteOperations {
                         new_commission: Some(3),
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(1),
+                        expect_reward: true,
                         ..VoteOperations::default()
                     },
                 )],
@@ -1661,7 +1659,7 @@ mod tests {
                     VoteOperations {
                         new_commission: Some(1),
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(0),
+                        expect_reward: true,
                         ..VoteOperations::default()
                     },
                 )],
@@ -1680,7 +1678,7 @@ mod tests {
                     VoteOperations {
                         new_commission: Some(2),
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(0),
+                        expect_reward: true,
                         ..VoteOperations::default()
                     },
                 )],
@@ -1696,7 +1694,7 @@ mod tests {
                     genesis_vote_address,
                     VoteOperations {
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(1),
+                        expect_reward: true,
                         ..VoteOperations::default()
                     },
                 )],
@@ -1712,7 +1710,7 @@ mod tests {
                     genesis_vote_address,
                     VoteOperations {
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(2),
+                        expect_reward: true,
                         ..VoteOperations::default()
                     },
                 )],
@@ -1728,7 +1726,7 @@ mod tests {
                     genesis_vote_address,
                     VoteOperations {
                         earned_credits: Some(1000),
-                        expected_reward_commission: Some(2),
+                        expect_reward: true,
                         ..VoteOperations::default()
                     },
                 )],
@@ -1794,7 +1792,7 @@ mod tests {
         let vote_rewards = 0;
         let commission_bps = vote_state.inflation_rewards_commission_bps;
         assert_eq!(reward_commission.commission_lamports, vote_rewards);
-        assert_eq!(reward_commission.commission_bps, commission_bps);
+        assert_eq!(reward_commission.commission_bps, None);
 
         assert_eq!(stake_reward_calculation.stake_rewards.num_rewards(), 1);
         let expected_reward = {
@@ -2246,7 +2244,7 @@ mod tests {
         accumulator1.add_reward(
             commission_pubkey_a,
             RewardCommission {
-                commission_bps: 1_000,
+                commission_bps: Some(1_000),
                 commission_lamports: 50,
             },
             50,
@@ -2254,7 +2252,7 @@ mod tests {
         accumulator1.add_reward(
             commission_pubkey_b,
             RewardCommission {
-                commission_bps: 1_000,
+                commission_bps: Some(1_000),
                 commission_lamports: 50,
             },
             50,
@@ -2262,7 +2260,7 @@ mod tests {
         accumulator2.add_reward(
             commission_pubkey_b,
             RewardCommission {
-                commission_bps: 1_000,
+                commission_bps: Some(1_000),
                 commission_lamports: 30,
             },
             30,
@@ -2270,7 +2268,7 @@ mod tests {
         accumulator2.add_reward(
             commission_pubkey_c,
             RewardCommission {
-                commission_bps: 1_000,
+                commission_bps: Some(1_000),
                 commission_lamports: 50,
             },
             50,
@@ -2282,28 +2280,28 @@ mod tests {
             .reward_commissions
             .get(&commission_pubkey_a)
             .unwrap();
-        assert_eq!(reward_commission_a_1.commission_bps, 1_000);
+        assert_eq!(reward_commission_a_1.commission_bps, Some(1_000));
         assert_eq!(reward_commission_a_1.commission_lamports, 50);
 
         let reward_commission_b_1 = accumulator1
             .reward_commissions
             .get(&commission_pubkey_b)
             .unwrap();
-        assert_eq!(reward_commission_b_1.commission_bps, 1_000);
+        assert_eq!(reward_commission_b_1.commission_bps, Some(1_000));
         assert_eq!(reward_commission_b_1.commission_lamports, 50);
 
         let reward_commission_b_2 = accumulator2
             .reward_commissions
             .get(&commission_pubkey_b)
             .unwrap();
-        assert_eq!(reward_commission_b_2.commission_bps, 1_000);
+        assert_eq!(reward_commission_b_2.commission_bps, Some(1_000));
         assert_eq!(reward_commission_b_2.commission_lamports, 30);
 
         let reward_commission_c_2 = accumulator2
             .reward_commissions
             .get(&commission_pubkey_c)
             .unwrap();
-        assert_eq!(reward_commission_c_2.commission_bps, 1_000);
+        assert_eq!(reward_commission_c_2.commission_bps, Some(1_000));
         assert_eq!(reward_commission_c_2.commission_lamports, 50);
 
         let accumulator = accumulator1.accumulate_into_larger(accumulator2);
@@ -2314,14 +2312,14 @@ mod tests {
             .reward_commissions
             .get(&commission_pubkey_a)
             .unwrap();
-        assert_eq!(reward_commission_a.commission_bps, 1_000);
+        assert_eq!(reward_commission_a.commission_bps, Some(1_000));
         assert_eq!(reward_commission_a.commission_lamports, 50);
 
         let reward_commission_b = accumulator
             .reward_commissions
             .get(&commission_pubkey_b)
             .unwrap();
-        assert_eq!(reward_commission_b.commission_bps, 1_000);
+        assert_eq!(reward_commission_b.commission_bps, Some(1_000));
         // sum of the reward commissions from both accumulators
         assert_eq!(reward_commission_b.commission_lamports, 80);
 
@@ -2329,7 +2327,7 @@ mod tests {
             .reward_commissions
             .get(&commission_pubkey_c)
             .unwrap();
-        assert_eq!(reward_commission_c.commission_bps, 1_000);
+        assert_eq!(reward_commission_c.commission_bps, Some(1_000));
         assert_eq!(reward_commission_c.commission_lamports, 50);
     }
 
@@ -2597,7 +2595,7 @@ mod tests {
         reward_commissions.insert(
             pubkey,
             RewardCommission {
-                commission_bps: 0,
+                commission_bps: Some(0),
                 commission_lamports: 1, // enough to overflow
             },
         );
@@ -2623,7 +2621,7 @@ mod tests {
         reward_commissions.insert(
             pubkey,
             RewardCommission {
-                commission_bps: 500,
+                commission_bps: Some(500),
                 commission_lamports,
             },
         );
@@ -2671,7 +2669,7 @@ mod tests {
                 reward_commissions.insert(
                     pubkey,
                     RewardCommission {
-                        commission_bps,
+                        commission_bps: Some(commission_bps),
                         commission_lamports,
                     },
                 );

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -262,7 +262,7 @@ impl Bank {
                 reward_type,
                 lamports: i64::try_from(partitioned_stake_reward.stake_reward).unwrap(),
                 post_balance: account.lamports(),
-                commission_bps: Some(partitioned_stake_reward.commission_bps),
+                commission_bps: partitioned_stake_reward.commission_bps,
             },
             stake_account: account,
         })
@@ -711,7 +711,7 @@ mod tests {
             stake_pubkey: nonexistent_account,
             stake: new_stake,
             stake_reward,
-            commission_bps,
+            commission_bps: Some(commission_bps),
         };
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
@@ -748,7 +748,7 @@ mod tests {
             stake_pubkey: overflowing_account,
             stake: new_stake,
             stake_reward,
-            commission_bps,
+            commission_bps: Some(commission_bps),
         };
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
@@ -795,7 +795,7 @@ mod tests {
             stake_pubkey: successful_account,
             stake: new_stake,
             stake_reward,
-            commission_bps,
+            commission_bps: Some(commission_bps),
         };
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
@@ -876,7 +876,7 @@ mod tests {
             stake_pubkey: deactivating_account,
             stake: deactivating_stake,
             stake_reward,
-            commission_bps,
+            commission_bps: Some(commission_bps),
         };
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -150,7 +150,9 @@ pub(crate) enum EpochRewardPhase {
 
 #[derive(Debug)]
 pub(super) struct RewardCommission {
-    pub(super) commission_bps: u16,
+    // Note: This field becomes always `None` once SIMD-0232 is activated.
+    // After full activation, it can be removed on feature cleanup.
+    pub(super) commission_bps: Option<u16>,
     pub(super) commission_lamports: u64,
 }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -35,7 +35,10 @@ pub(crate) struct PartitionedStakeReward {
     pub stake_reward: u64,
     /// Reward commission in basis points (0-10,000 representing 0-100%) for
     /// recording reward info.
-    pub commission_bps: u16,
+    //
+    // Note: This field becomes always `None` once SIMD-0232 is activated.
+    // After full activation, it can be removed on feature cleanup.
+    pub commission_bps: Option<u16>,
 }
 
 /// A vector of stake rewards.
@@ -429,7 +432,7 @@ mod tests {
                     stake_pubkey: stake_reward.stake_pubkey,
                     stake,
                     stake_reward: stake_reward.stake_reward_info.lamports as u64,
-                    commission_bps: stake_reward.stake_reward_info.commission_bps.unwrap(),
+                    commission_bps: stake_reward.stake_reward_info.commission_bps,
                 })
             } else {
                 None


### PR DESCRIPTION
Feature-gates the `commission_bps` field on `RewardCommission` (and the outward-facing `RewardInfo.commission_bps` it populates) on `custom_commission_collector` (SIMD-0232). The field becomes `Option<u16>` and is populated as `None` once the feature is active, dropped at the lowest level so the field can be deleted outright on feature cleanup.

#### Problem
In a post-SIMD-0232 world, where commission collectors can be mixed and matched, reporting commission BPS in an accumulated reward payload doesn't make sense anymore.

The external-facing `Reward` schema - which feeds similar payloads in the RPC's `getBlock` response and Geyser's `blockSubscribe` message - contains a `commission_bps: Option<u16>`. Once SIMD-0232 is enabled, these should be always `None`.

#### Summary of Changes
Gate the setting of `commission_bps` as a valid `Some` value behind SIMD-0232 (disabled-side). Once SIMD-0232 is active, always set the field to `None`.