### PR TITLE
Refactor - `filter_executable_program_accounts()`

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -184,7 +184,7 @@ impl EpochBoundaryPreparation {
 }
 
 /// Input of ProgramCache::extract()
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct ProgramToLoad<'a> {
     /// The program address
     pub program_id: &'a Pubkey,
@@ -352,7 +352,7 @@ impl ProgramCacheForTxBatch {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum ProgramCacheMatchCriteria {
     DeployedOnOrAfterSlot(Slot),
     Tombstone,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -185,9 +185,9 @@ impl EpochBoundaryPreparation {
 
 /// Input of ProgramCache::extract()
 #[derive(Clone)]
-pub struct ProgramToLoad {
+pub struct ProgramToLoad<'a> {
     /// The program address
-    pub program_id: Pubkey,
+    pub program_id: &'a Pubkey,
     /// Potentially filter out / ignore some entries during the start up / catch up phase
     pub match_criteria: ProgramCacheMatchCriteria,
     /// When the program account was last written to (might be after the deployment slot)
@@ -600,7 +600,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                 loading_entries,
             } => {
                 search_for.retain(|program_to_load| {
-                    if let Some(second_level) = entries.get(&program_to_load.program_id) {
+                    if let Some(second_level) = entries.get(program_to_load.program_id) {
                         let mut filter_by_deployment_slot = None;
                         for entry in second_level.iter().rev() {
                             let required_deployment_slot =
@@ -671,20 +671,20 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 }
                                 loaded_programs_for_tx_batch
                                     .entries
-                                    .insert(program_to_load.program_id, entry_to_return);
+                                    .insert(*program_to_load.program_id, entry_to_return);
                                 return false;
                             }
                         }
                     }
                     if cooperative_loading_task.is_none() {
                         let mut loading_entries = loading_entries.lock().unwrap();
-                        let entry = loading_entries.entry(program_to_load.program_id);
+                        let entry = loading_entries.entry(*program_to_load.program_id);
                         if let Entry::Vacant(entry) = entry {
                             entry.insert((
                                 loaded_programs_for_tx_batch.slot,
                                 thread::current().id(),
                             ));
-                            cooperative_loading_task = Some(program_to_load.program_id);
+                            cooperative_loading_task = Some(*program_to_load.program_id);
                         }
                     }
                     true
@@ -1808,11 +1808,11 @@ pub(crate) mod tests {
         }
     }
 
-    fn get_entries_to_load(
+    fn get_entries_to_load<'a>(
         cache: &ProgramCache<TestForkGraphSpecific>,
         loading_slot: Slot,
-        keys: &[Pubkey],
-    ) -> Vec<ProgramToLoad> {
+        keys: &'a [Pubkey],
+    ) -> Vec<ProgramToLoad<'a>> {
         let fork_graph = cache.fork_graph.as_ref().unwrap().upgrade().unwrap();
         let locked_fork_graph = fork_graph.read().unwrap();
         let entries = cache.get_flattened_entries_for_tests();
@@ -1828,8 +1828,8 @@ pub(crate) mod tests {
                                 BlockRelation::Equal | BlockRelation::Ancestor,
                             )
                     })
-                    .map(|(program_id, entry)| ProgramToLoad {
-                        program_id: *program_id,
+                    .map(|(_program_id, entry)| ProgramToLoad {
+                        program_id: key,
                         match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                         last_modification_slot: entry.deployment_slot,
                     })
@@ -1856,7 +1856,7 @@ pub(crate) mod tests {
         program_id: &Pubkey,
         expected_result: bool,
     ) -> bool {
-        missing.iter().any(|entry| &entry.program_id == program_id) == expected_result
+        missing.iter().any(|entry| entry.program_id == program_id) == expected_result
     }
 
     #[test]
@@ -1931,8 +1931,8 @@ pub(crate) mod tests {
         //                     23
 
         // Testing fork 0 - 10 - 20 - 22 with current slot at 22
-        let mut missing =
-            get_entries_to_load(&cache, 22, &[program1, program2, program3, program4]);
+        let keys = &[program1, program2, program3, program4];
+        let mut missing = get_entries_to_load(&cache, 22, keys);
         assert!(match_missing(&missing, &program2, false));
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(22);
@@ -1941,8 +1941,7 @@ pub(crate) mod tests {
         assert!(match_slot(&extracted, &program4, 0, 22));
 
         // Testing fork 0 - 5 - 11 - 15 - 16 with current slot at 15
-        let mut missing =
-            get_entries_to_load(&cache, 15, &[program1, program2, program3, program4]);
+        let mut missing = get_entries_to_load(&cache, 15, keys);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(15);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -1957,8 +1956,7 @@ pub(crate) mod tests {
         assert_eq!(tombstone.deployment_slot, 15);
 
         // Testing the same fork above, but current slot is now 18 (equal to effective slot of program4).
-        let mut missing =
-            get_entries_to_load(&cache, 18, &[program1, program2, program3, program4]);
+        let mut missing = get_entries_to_load(&cache, 18, keys);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(18);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -1968,8 +1966,7 @@ pub(crate) mod tests {
         assert!(match_slot(&extracted, &program4, 15, 18));
 
         // Testing the same fork above, but current slot is now 23 (future slot than effective slot of program4).
-        let mut missing =
-            get_entries_to_load(&cache, 23, &[program1, program2, program3, program4]);
+        let mut missing = get_entries_to_load(&cache, 23, keys);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(23);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -1979,8 +1976,7 @@ pub(crate) mod tests {
         assert!(match_slot(&extracted, &program4, 15, 23));
 
         // Testing fork 0 - 5 - 11 - 15 - 16 with current slot at 11
-        let mut missing =
-            get_entries_to_load(&cache, 11, &[program1, program2, program3, program4]);
+        let mut missing = get_entries_to_load(&cache, 11, keys);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(11);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -2011,8 +2007,7 @@ pub(crate) mod tests {
         //                  23
 
         // Testing fork 11 - 15 - 16- 19 - 22 with root at 5 and current slot at 22
-        let mut missing =
-            get_entries_to_load(&cache, 21, &[program1, program2, program3, program4]);
+        let mut missing = get_entries_to_load(&cache, 21, keys);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(21);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -2022,8 +2017,7 @@ pub(crate) mod tests {
         assert!(match_slot(&extracted, &program4, 15, 21));
 
         // Testing fork 0 - 5 - 11 - 25 - 27 with current slot at 27
-        let mut missing =
-            get_entries_to_load(&cache, 27, &[program1, program2, program3, program4]);
+        let mut missing = get_entries_to_load(&cache, 27, keys);
         let mut extracted = ProgramCacheForTxBatch::new(27);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
         assert!(match_slot(&extracted, &program1, 0, 27));
@@ -2049,8 +2043,7 @@ pub(crate) mod tests {
         //                  23
 
         // Testing fork 16, 19, 23, with root at 15, current slot at 23
-        let mut missing =
-            get_entries_to_load(&cache, 23, &[program1, program2, program3, program4]);
+        let mut missing = get_entries_to_load(&cache, 23, keys);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(23);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -2099,7 +2092,8 @@ pub(crate) mod tests {
         cache.assign_program(&env, program3, 25, new_test_entry(25, 26));
 
         // Testing fork 0 - 5 - 11 - 15 - 16 - 19 - 21 - 23 with current slot at 19
-        let mut missing = get_entries_to_load(&cache, 12, &[program1, program2, program3]);
+        let keys = &[program1, program2, program3];
+        let mut missing = get_entries_to_load(&cache, 12, keys);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(12);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -2107,7 +2101,7 @@ pub(crate) mod tests {
         assert!(match_slot(&extracted, &program2, 11, 12));
 
         // Test the same fork, but request the program modified at a later slot than what's in the cache.
-        let mut missing = get_entries_to_load(&cache, 12, &[program1, program2, program3]);
+        let mut missing = get_entries_to_load(&cache, 12, keys);
         missing.get_mut(0).unwrap().match_criteria =
             ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(5);
         missing.get_mut(1).unwrap().match_criteria =
@@ -2174,7 +2168,8 @@ pub(crate) mod tests {
         );
 
         // Testing fork 0 - 5 - 11 - 15 - 16 - 19 - 21 - 23 with current slot at 19
-        let mut missing = get_entries_to_load(&cache, 19, &[program1, program2, program3]);
+        let keys = &[program1, program2, program3];
+        let mut missing = get_entries_to_load(&cache, 19, keys);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(19);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -2182,7 +2177,7 @@ pub(crate) mod tests {
         assert!(match_slot(&extracted, &program2, 11, 19));
 
         // Testing fork 0 - 5 - 11 - 25 - 27 with current slot at 27
-        let mut missing = get_entries_to_load(&cache, 27, &[program1, program2, program3]);
+        let mut missing = get_entries_to_load(&cache, 27, keys);
         let mut extracted = ProgramCacheForTxBatch::new(27);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
         assert!(match_slot(&extracted, &program1, 0, 27));
@@ -2190,7 +2185,7 @@ pub(crate) mod tests {
         assert!(match_missing(&missing, &program3, true));
 
         // Testing fork 0 - 10 - 20 - 22 with current slot at 22
-        let mut missing = get_entries_to_load(&cache, 22, &[program1, program2, program3]);
+        let mut missing = get_entries_to_load(&cache, 22, keys);
         assert!(match_missing(&missing, &program2, false));
         let mut extracted = ProgramCacheForTxBatch::new(22);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -2233,13 +2228,14 @@ pub(crate) mod tests {
         cache.assign_program(&env, program1, 20, new_test_entry(20, 21));
 
         // Testing fork 0 - 10 - 20 - 22 with current slot at 22
-        let mut missing = get_entries_to_load(&cache, 22, &[program1]);
+        let keys = &[program1];
+        let mut missing = get_entries_to_load(&cache, 22, keys);
         let mut extracted = ProgramCacheForTxBatch::new(22);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
         assert!(match_slot(&extracted, &program1, 20, 22));
 
         // Looking for a different environment
-        let mut missing = get_entries_to_load(&cache, 22, &[program1]);
+        let mut missing = get_entries_to_load(&cache, 22, keys);
         let mut extracted = ProgramCacheForTxBatch::new(22);
         cache.extract(&mut missing, &mut extracted, &other_env, true, true);
         assert!(match_missing(&missing, &program1, true));
@@ -2255,7 +2251,7 @@ pub(crate) mod tests {
 
         let program1 = Pubkey::new_unique();
         let mut missing = vec![ProgramToLoad {
-            program_id: program1,
+            program_id: &program1,
             match_criteria: ProgramCacheMatchCriteria::NoCriteria,
             last_modification_slot: 0,
         }];
@@ -2338,7 +2334,8 @@ pub(crate) mod tests {
 
         cache.prune(10, None, &fork_graph.read().unwrap());
 
-        let mut missing = get_entries_to_load(&cache, 20, &[program1]);
+        let keys = &[program1];
+        let mut missing = get_entries_to_load(&cache, 20, keys);
         let mut extracted = ProgramCacheForTxBatch::new(20);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
 
@@ -2380,13 +2377,14 @@ pub(crate) mod tests {
         let program2 = Pubkey::new_unique();
         cache.assign_program(&env, program2, 10, new_test_entry(10, 11));
 
-        let mut missing = get_entries_to_load(&cache, 20, &[program1, program2]);
+        let keys = &[program1, program2];
+        let mut missing = get_entries_to_load(&cache, 20, keys);
         let mut extracted = ProgramCacheForTxBatch::new(20);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
         assert!(match_slot(&extracted, &program1, 0, 20));
         assert!(match_slot(&extracted, &program2, 10, 20));
 
-        let mut missing = get_entries_to_load(&cache, 6, &[program1, program2]);
+        let mut missing = get_entries_to_load(&cache, 6, keys);
         assert!(match_missing(&missing, &program2, false));
         let mut extracted = ProgramCacheForTxBatch::new(6);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -2396,13 +2394,13 @@ pub(crate) mod tests {
         // On fork chaining from slot 5, the entry deployed at slot 0 will become visible.
         cache.prune_by_deployment_slot(5);
 
-        let mut missing = get_entries_to_load(&cache, 20, &[program1, program2]);
+        let mut missing = get_entries_to_load(&cache, 20, keys);
         let mut extracted = ProgramCacheForTxBatch::new(20);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
         assert!(match_slot(&extracted, &program1, 0, 20));
         assert!(match_slot(&extracted, &program2, 10, 20));
 
-        let mut missing = get_entries_to_load(&cache, 6, &[program1, program2]);
+        let mut missing = get_entries_to_load(&cache, 6, keys);
         assert!(match_missing(&missing, &program2, false));
         let mut extracted = ProgramCacheForTxBatch::new(6);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -2412,7 +2410,7 @@ pub(crate) mod tests {
         // As there is no other entry for program2, extract() will return it as missing.
         cache.prune_by_deployment_slot(10);
 
-        let mut missing = get_entries_to_load(&cache, 20, &[program1, program2]);
+        let mut missing = get_entries_to_load(&cache, 20, keys);
         assert!(match_missing(&missing, &program2, false));
         let mut extracted = ProgramCacheForTxBatch::new(20);
         cache.extract(&mut missing, &mut extracted, &env, true, true);

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -341,7 +341,6 @@ impl ProgramCacheForTxBatch {
     }
 }
 
-#[derive(Clone, Copy)]
 pub enum ProgramCacheMatchCriteria {
     DeployedOnOrAfterSlot(Slot),
     Tombstone,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -183,6 +183,17 @@ impl EpochBoundaryPreparation {
     }
 }
 
+/// Input of ProgramCache::extract()
+#[derive(Clone)]
+pub struct ProgramToLoad {
+    /// The program address
+    pub program_id: Pubkey,
+    /// Potentially filter out / ignore some entries during the start up / catch up phase
+    pub match_criteria: ProgramCacheMatchCriteria,
+    /// When the program account was last written to (might be after the deployment slot)
+    pub last_modification_slot: Slot,
+}
+
 #[derive(Debug)]
 pub(crate) enum IndexImplementation {
     /// Fork-graph aware index implementation
@@ -341,6 +352,7 @@ impl ProgramCacheForTxBatch {
     }
 }
 
+#[derive(Clone)]
 pub enum ProgramCacheMatchCriteria {
     DeployedOnOrAfterSlot(Slot),
     Tombstone,
@@ -572,7 +584,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     /// and returns which program accounts the accounts DB needs to load.
     pub fn extract(
         &self,
-        search_for: &mut Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)>,
+        search_for: &mut Vec<ProgramToLoad>,
         loaded_programs_for_tx_batch: &mut ProgramCacheForTxBatch,
         program_runtime_environment_for_execution: &ProgramRuntimeEnvironment,
         increment_usage_counter: bool,
@@ -587,8 +599,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                 entries,
                 loading_entries,
             } => {
-                search_for.retain(|(key, match_criteria, _slot)| {
-                    if let Some(second_level) = entries.get(key) {
+                search_for.retain(|program_to_load| {
+                    if let Some(second_level) = entries.get(&program_to_load.program_id) {
                         let mut filter_by_deployment_slot = None;
                         for entry in second_level.iter().rev() {
                             let required_deployment_slot =
@@ -625,7 +637,10 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                             .or(Some(entry.deployment_slot));
                                         continue;
                                     }
-                                    if !Self::matches_criteria(entry, match_criteria) {
+                                    if !Self::matches_criteria(
+                                        entry,
+                                        &program_to_load.match_criteria,
+                                    ) {
                                         break;
                                     }
                                     if let ProgramCacheEntryType::Unloaded(_environment) =
@@ -656,20 +671,20 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 }
                                 loaded_programs_for_tx_batch
                                     .entries
-                                    .insert(*key, entry_to_return);
+                                    .insert(program_to_load.program_id, entry_to_return);
                                 return false;
                             }
                         }
                     }
                     if cooperative_loading_task.is_none() {
                         let mut loading_entries = loading_entries.lock().unwrap();
-                        let entry = loading_entries.entry(*key);
+                        let entry = loading_entries.entry(program_to_load.program_id);
                         if let Entry::Vacant(entry) = entry {
                             entry.insert((
                                 loaded_programs_for_tx_batch.slot,
                                 thread::current().id(),
                             ));
-                            cooperative_loading_task = Some(*key);
+                            cooperative_loading_task = Some(program_to_load.program_id);
                         }
                     }
                     true
@@ -941,7 +956,7 @@ pub(crate) mod tests {
         crate::{
             loaded_programs::{
                 BlockRelation, ForkGraph, ProgramCache, ProgramCacheForTxBatch,
-                ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
+                ProgramCacheMatchCriteria, ProgramRuntimeEnvironment, ProgramToLoad,
                 get_mock_program_runtime_environment,
             },
             program_cache_entry::{
@@ -1797,7 +1812,7 @@ pub(crate) mod tests {
         cache: &ProgramCache<TestForkGraphSpecific>,
         loading_slot: Slot,
         keys: &[Pubkey],
-    ) -> Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)> {
+    ) -> Vec<ProgramToLoad> {
         let fork_graph = cache.fork_graph.as_ref().unwrap().upgrade().unwrap();
         let locked_fork_graph = fork_graph.read().unwrap();
         let entries = cache.get_flattened_entries_for_tests();
@@ -1813,12 +1828,10 @@ pub(crate) mod tests {
                                 BlockRelation::Equal | BlockRelation::Ancestor,
                             )
                     })
-                    .map(|(program_id, entry)| {
-                        (
-                            *program_id,
-                            ProgramCacheMatchCriteria::NoCriteria,
-                            entry.deployment_slot,
-                        )
+                    .map(|(program_id, entry)| ProgramToLoad {
+                        program_id: *program_id,
+                        match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                        last_modification_slot: entry.deployment_slot,
                     })
             })
             .collect()
@@ -1839,11 +1852,11 @@ pub(crate) mod tests {
     }
 
     fn match_missing(
-        missing: &[(Pubkey, ProgramCacheMatchCriteria, Slot)],
-        program: &Pubkey,
+        missing: &[ProgramToLoad],
+        program_id: &Pubkey,
         expected_result: bool,
     ) -> bool {
-        missing.iter().any(|(key, _, _)| key == program) == expected_result
+        missing.iter().any(|entry| &entry.program_id == program_id) == expected_result
     }
 
     #[test]
@@ -2095,8 +2108,10 @@ pub(crate) mod tests {
 
         // Test the same fork, but request the program modified at a later slot than what's in the cache.
         let mut missing = get_entries_to_load(&cache, 12, &[program1, program2, program3]);
-        missing.get_mut(0).unwrap().1 = ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(5);
-        missing.get_mut(1).unwrap().1 = ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(5);
+        missing.get_mut(0).unwrap().match_criteria =
+            ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(5);
+        missing.get_mut(1).unwrap().match_criteria =
+            ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(5);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(12);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -2239,7 +2254,11 @@ pub(crate) mod tests {
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
         let program1 = Pubkey::new_unique();
-        let mut missing = vec![(program1, ProgramCacheMatchCriteria::NoCriteria, 0)];
+        let mut missing = vec![ProgramToLoad {
+            program_id: program1,
+            match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+            last_modification_slot: 0,
+        }];
         let mut extracted = ProgramCacheForTxBatch::new(0);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
         assert!(match_missing(&missing, &program1, true));

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -341,6 +341,7 @@ impl ProgramCacheForTxBatch {
     }
 }
 
+#[derive(Clone, Copy)]
 pub enum ProgramCacheMatchCriteria {
     DeployedOnOrAfterSlot(Slot),
     Tombstone,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -249,7 +249,8 @@ pub fn filter_executable_program_accounts<CB: TransactionProcessingCallback>(
     tx: &impl SVMMessage,
     check_program_deployment_slot: bool,
 ) -> Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)> {
-    let mut program_accounts_set: HashMap<Pubkey, Slot> = HashMap::default();
+    let mut program_accounts_set: HashMap<Pubkey, (ProgramCacheMatchCriteria, Slot)> =
+        HashMap::default();
     for account_key in tx.account_keys().iter() {
         if let Some(cache_entry) = program_cache_for_tx_batch.find(account_key) {
             cache_entry.stats.uses.fetch_add(1, Ordering::Relaxed);
@@ -257,22 +258,21 @@ pub fn filter_executable_program_accounts<CB: TransactionProcessingCallback>(
             callbacks.get_account_shared_data(account_key)
             && PROGRAM_OWNERS.contains(account.owner())
         {
-            program_accounts_set.insert(*account_key, last_modification_slot);
-        }
-    }
-    program_accounts_set
-        .iter()
-        .map(|(pubkey, last_modification_slot)| {
             let match_criteria = if check_program_deployment_slot {
-                let (program, _slot) = callbacks.get_account_shared_data(pubkey).unwrap();
-                get_program_deployment_slot(callbacks, &program)
+                get_program_deployment_slot(callbacks, &account)
                     .map_or(ProgramCacheMatchCriteria::Tombstone, |slot| {
                         ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot)
                     })
             } else {
                 ProgramCacheMatchCriteria::NoCriteria
             };
-            (*pubkey, match_criteria, *last_modification_slot)
+            program_accounts_set.insert(*account_key, (match_criteria, last_modification_slot));
+        }
+    }
+    program_accounts_set
+        .iter()
+        .map(|(pubkey, (match_criteria, last_modification_slot))| {
+            (*pubkey, *match_criteria, *last_modification_slot)
         })
         .collect()
 }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -10,6 +10,7 @@ use {
     solana_program_runtime::{
         loaded_programs::{
             ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
+            ProgramToLoad,
         },
         program_cache_entry::{
             DELAY_VISIBILITY_SLOT_OFFSET, ProgramCacheEntry, ProgramCacheEntryOwner,
@@ -248,7 +249,7 @@ pub fn filter_executable_program_accounts<CB: TransactionProcessingCallback>(
     program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
     tx: &impl SVMMessage,
     check_program_deployment_slot: bool,
-) -> Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)> {
+) -> Vec<ProgramToLoad> {
     let mut result = Vec::new();
     for account_key in tx.account_keys().iter() {
         if let Some(cache_entry) = program_cache_for_tx_batch.find(account_key) {
@@ -265,7 +266,11 @@ pub fn filter_executable_program_accounts<CB: TransactionProcessingCallback>(
             } else {
                 ProgramCacheMatchCriteria::NoCriteria
             };
-            result.push((*account_key, match_criteria, last_modification_slot));
+            result.push(ProgramToLoad {
+                program_id: *account_key,
+                match_criteria,
+                last_modification_slot,
+            });
         }
     }
     result
@@ -866,13 +871,13 @@ mod tests {
         assert!(
             missing_programs
                 .iter()
-                .position(|(key, _, _)| key == &key1)
+                .position(|program_to_load| program_to_load.program_id == key1)
                 .is_some()
         );
         assert!(
             missing_programs
                 .iter()
-                .position(|(key, _, _)| key == &key2)
+                .position(|program_to_load| program_to_load.program_id == key2)
                 .is_some()
         );
     }
@@ -955,7 +960,7 @@ mod tests {
         assert!(
             missing_programs
                 .iter()
-                .position(|(key, _, _)| key == &account3_pubkey)
+                .position(|program_to_load| program_to_load.program_id == account3_pubkey)
                 .is_some()
         );
 
@@ -969,13 +974,13 @@ mod tests {
         assert!(
             missing_programs
                 .iter()
-                .position(|(key, _, _)| key == &account3_pubkey)
+                .position(|program_to_load| program_to_load.program_id == account3_pubkey)
                 .is_some()
         );
         assert!(
             missing_programs
                 .iter()
-                .position(|(key, _, _)| key == &account4_pubkey)
+                .position(|program_to_load| program_to_load.program_id == account4_pubkey)
                 .is_some()
         );
     }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -1,13 +1,16 @@
 #[cfg(feature = "metrics")]
 use solana_program_runtime::program_metrics::LoadProgramMetrics;
 use {
+    crate::account_loader::PROGRAM_OWNERS,
     solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMut},
     solana_clock::Slot,
     solana_instruction::error::InstructionError,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_loader_v4_interface::state::{LoaderV4State, LoaderV4Status},
     solana_program_runtime::{
-        loaded_programs::ProgramRuntimeEnvironment,
+        loaded_programs::{
+            ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
+        },
         program_cache_entry::{
             DELAY_VISIBILITY_SLOT_OFFSET, ProgramCacheEntry, ProgramCacheEntryOwner,
             ProgramCacheEntryType,
@@ -17,8 +20,10 @@ use {
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4},
     solana_svm_callback::TransactionProcessingCallback,
     solana_svm_timings::ExecuteTimings,
+    solana_svm_transaction::svm_message::SVMMessage,
     solana_svm_type_overrides::sync::Arc,
     solana_transaction_error::{TransactionError, TransactionResult},
+    std::{collections::HashMap, sync::atomic::Ordering},
 };
 
 #[derive(Debug)]
@@ -239,6 +244,41 @@ pub(crate) fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
     }
 }
 
+/// Appends to a set of executable program accounts (all accounts owned by any loader)
+/// for transactions with a valid blockhash or nonce.
+pub fn filter_executable_program_accounts<CB: TransactionProcessingCallback>(
+    callbacks: &CB,
+    program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
+    tx: &impl SVMMessage,
+    check_program_deployment_slot: bool,
+) -> Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)> {
+    let mut program_accounts_set: HashMap<Pubkey, Slot> = HashMap::default();
+    for account_key in tx.account_keys().iter() {
+        if let Some(cache_entry) = program_cache_for_tx_batch.find(account_key) {
+            cache_entry.stats.uses.fetch_add(1, Ordering::Relaxed);
+        } else if let Some((account, last_modification_slot)) =
+            callbacks.get_account_shared_data(account_key)
+            && PROGRAM_OWNERS.contains(account.owner())
+        {
+            program_accounts_set.insert(*account_key, last_modification_slot);
+        }
+    }
+    program_accounts_set
+        .iter()
+        .map(|(pubkey, last_modification_slot)| {
+            let match_criteria = if check_program_deployment_slot {
+                get_program_deployment_slot(callbacks, pubkey)
+                    .map_or(ProgramCacheMatchCriteria::Tombstone, |slot| {
+                        ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot)
+                    })
+            } else {
+                ProgramCacheMatchCriteria::NoCriteria
+            };
+            (*pubkey, match_criteria, *last_modification_slot)
+        })
+        .collect()
+}
+
 // Plucked from the now-removed Loader V4 program library.
 fn loader_v4_get_state(data: &[u8]) -> Result<&LoaderV4State, InstructionError> {
     unsafe {
@@ -260,6 +300,12 @@ mod tests {
         super::*,
         crate::transaction_processor::TransactionBatchProcessor,
         solana_account::WritableAccount,
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_message::{
+            LegacyMessage, Message, MessageHeader, SanitizedMessage,
+            compiled_instruction::CompiledInstruction,
+        },
         solana_program_runtime::{
             loaded_programs::{
                 BlockRelation, ForkGraph, ProgramRuntimeEnvironment,
@@ -268,15 +314,21 @@ mod tests {
             solana_sbpf::program::BuiltinProgram,
         },
         solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable},
+        solana_signature::Signature,
         solana_svm_callback::InvokeContextCallback,
+        solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         std::{
             cell::RefCell,
-            collections::HashMap,
+            collections::{HashMap, HashSet},
             env,
             fs::{self, File},
             io::Read,
         },
     };
+
+    fn new_unchecked_sanitized_message(message: Message) -> SanitizedMessage {
+        SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()))
+    }
 
     struct TestForkGraph {}
 
@@ -759,5 +811,172 @@ mod tests {
 
         let result = get_program_deployment_slot(&mock_bank, &key2);
         assert_eq!(result.unwrap(), 0);
+    }
+
+    #[test]
+    fn test_filter_executable_program_accounts() {
+        let mock_bank = MockBankCallback::default();
+        let key1 = Pubkey::new_unique();
+        let owner1 = bpf_loader::id();
+        let key2 = Pubkey::new_unique();
+        let owner2 = bpf_loader_upgradeable::id();
+
+        let mut data1 = AccountSharedData::default();
+        data1.set_owner(owner1);
+        data1.set_lamports(93);
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key1, (data1, 0));
+
+        let mut data2 = AccountSharedData::default();
+        data2.set_owner(owner2);
+        data2.set_lamports(90);
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key2, (data2, 0));
+
+        let message = Message {
+            account_keys: vec![key1, key2],
+            header: MessageHeader::default(),
+            instructions: vec![CompiledInstruction {
+                program_id_index: 0,
+                accounts: vec![],
+                data: vec![],
+            }],
+            recent_blockhash: Hash::default(),
+        };
+
+        let sanitized_message = new_unchecked_sanitized_message(message);
+
+        let sanitized_transaction = SanitizedTransaction::new_for_tests(
+            sanitized_message,
+            vec![Signature::new_unique()],
+            false,
+        );
+
+        let missing_programs = filter_executable_program_accounts(
+            &mock_bank,
+            &mut ProgramCacheForTxBatch::default(),
+            &sanitized_transaction,
+            false,
+        );
+        assert_eq!(missing_programs.len(), 2);
+        assert!(
+            missing_programs
+                .iter()
+                .position(|(key, _, _)| key == &key1)
+                .is_some()
+        );
+        assert!(
+            missing_programs
+                .iter()
+                .position(|(key, _, _)| key == &key2)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn test_filter_executable_program_accounts_no_errors() {
+        let keypair1 = Keypair::new();
+        let keypair2 = Keypair::new();
+
+        let non_program_pubkey1 = Pubkey::new_unique();
+        let non_program_pubkey2 = Pubkey::new_unique();
+        let program1_pubkey = bpf_loader::id();
+        let program2_pubkey = bpf_loader_upgradeable::id();
+        let account1_pubkey = Pubkey::new_unique();
+        let account2_pubkey = Pubkey::new_unique();
+        let account3_pubkey = Pubkey::new_unique();
+        let account4_pubkey = Pubkey::new_unique();
+
+        let account5_pubkey = Pubkey::new_unique();
+
+        let mock_bank = MockBankCallback::default();
+        mock_bank.account_shared_data.borrow_mut().insert(
+            non_program_pubkey1,
+            (AccountSharedData::new(1, 10, &account5_pubkey), 0),
+        );
+        mock_bank.account_shared_data.borrow_mut().insert(
+            non_program_pubkey2,
+            (AccountSharedData::new(1, 10, &account5_pubkey), 0),
+        );
+        mock_bank.account_shared_data.borrow_mut().insert(
+            program1_pubkey,
+            (AccountSharedData::new(40, 1, &account5_pubkey), 0),
+        );
+        mock_bank.account_shared_data.borrow_mut().insert(
+            program2_pubkey,
+            (AccountSharedData::new(40, 1, &account5_pubkey), 0),
+        );
+        mock_bank.account_shared_data.borrow_mut().insert(
+            account1_pubkey,
+            (AccountSharedData::new(1, 10, &non_program_pubkey1), 0),
+        );
+        mock_bank.account_shared_data.borrow_mut().insert(
+            account2_pubkey,
+            (AccountSharedData::new(1, 10, &non_program_pubkey2), 0),
+        );
+        mock_bank.account_shared_data.borrow_mut().insert(
+            account3_pubkey,
+            (AccountSharedData::new(40, 1, &program1_pubkey), 0),
+        );
+        mock_bank.account_shared_data.borrow_mut().insert(
+            account4_pubkey,
+            (AccountSharedData::new(40, 1, &program2_pubkey), 0),
+        );
+
+        let tx1 = Transaction::new_with_compiled_instructions(
+            &[&keypair1],
+            &[non_program_pubkey1],
+            Hash::new_unique(),
+            vec![account1_pubkey, account2_pubkey, account3_pubkey],
+            vec![CompiledInstruction::new(1, &(), vec![0])],
+        );
+        let sanitized_tx1 = SanitizedTransaction::from_transaction_for_tests(tx1);
+
+        let tx2 = Transaction::new_with_compiled_instructions(
+            &[&keypair2],
+            &[non_program_pubkey2],
+            Hash::new_unique(),
+            vec![account4_pubkey, account3_pubkey, account2_pubkey],
+            vec![CompiledInstruction::new(1, &(), vec![0])],
+        );
+        let sanitized_tx2 = SanitizedTransaction::from_transaction_for_tests(tx2);
+
+        let missing_programs = filter_executable_program_accounts(
+            &mock_bank,
+            &mut ProgramCacheForTxBatch::default(),
+            &sanitized_tx1,
+            false,
+        );
+        assert_eq!(missing_programs.len(), 1);
+        assert!(
+            missing_programs
+                .iter()
+                .position(|(key, _, _)| key == &account3_pubkey)
+                .is_some()
+        );
+
+        let missing_programs = filter_executable_program_accounts(
+            &mock_bank,
+            &mut ProgramCacheForTxBatch::default(),
+            &sanitized_tx2,
+            false,
+        );
+        assert_eq!(missing_programs.len(), 2);
+        assert!(
+            missing_programs
+                .iter()
+                .position(|(key, _, _)| key == &account3_pubkey)
+                .is_some()
+        );
+        assert!(
+            missing_programs
+                .iter()
+                .position(|(key, _, _)| key == &account4_pubkey)
+                .is_some()
+        );
     }
 }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -244,12 +244,12 @@ pub(crate) fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
 
 /// Appends to a set of executable program accounts (all accounts owned by any loader)
 /// for transactions with a valid blockhash or nonce.
-pub fn filter_executable_program_accounts<CB: TransactionProcessingCallback>(
+pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>(
     callbacks: &CB,
     program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
-    tx: &impl SVMMessage,
+    tx: &'a impl SVMMessage,
     check_program_deployment_slot: bool,
-) -> Vec<ProgramToLoad> {
+) -> Vec<ProgramToLoad<'a>> {
     let mut result = Vec::new();
     for account_key in tx.account_keys().iter() {
         if let Some(cache_entry) = program_cache_for_tx_batch.find(account_key) {
@@ -267,7 +267,7 @@ pub fn filter_executable_program_accounts<CB: TransactionProcessingCallback>(
                 ProgramCacheMatchCriteria::NoCriteria
             };
             result.push(ProgramToLoad {
-                program_id: *account_key,
+                program_id: account_key,
                 match_criteria,
                 last_modification_slot,
             });
@@ -871,13 +871,13 @@ mod tests {
         assert!(
             missing_programs
                 .iter()
-                .position(|program_to_load| program_to_load.program_id == key1)
+                .position(|program_to_load| program_to_load.program_id == &key1)
                 .is_some()
         );
         assert!(
             missing_programs
                 .iter()
-                .position(|program_to_load| program_to_load.program_id == key2)
+                .position(|program_to_load| program_to_load.program_id == &key2)
                 .is_some()
         );
     }
@@ -960,7 +960,7 @@ mod tests {
         assert!(
             missing_programs
                 .iter()
-                .position(|program_to_load| program_to_load.program_id == account3_pubkey)
+                .position(|program_to_load| program_to_load.program_id == &account3_pubkey)
                 .is_some()
         );
 
@@ -974,13 +974,13 @@ mod tests {
         assert!(
             missing_programs
                 .iter()
-                .position(|program_to_load| program_to_load.program_id == account3_pubkey)
+                .position(|program_to_load| program_to_load.program_id == &account3_pubkey)
                 .is_some()
         );
         assert!(
             missing_programs
                 .iter()
-                .position(|program_to_load| program_to_load.program_id == account4_pubkey)
+                .position(|program_to_load| program_to_load.program_id == &account4_pubkey)
                 .is_some()
         );
     }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -299,10 +299,7 @@ mod tests {
         solana_account::WritableAccount,
         solana_hash::Hash,
         solana_keypair::Keypair,
-        solana_message::{
-            LegacyMessage, Message, MessageHeader, SanitizedMessage,
-            compiled_instruction::CompiledInstruction,
-        },
+        solana_message::compiled_instruction::CompiledInstruction,
         solana_program_runtime::{
             loaded_programs::{
                 BlockRelation, ForkGraph, ProgramRuntimeEnvironment,
@@ -310,22 +307,18 @@ mod tests {
             },
             solana_sbpf::program::BuiltinProgram,
         },
-        solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable},
-        solana_signature::Signature,
+        solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, native_loader},
         solana_svm_callback::InvokeContextCallback,
+        solana_svm_type_overrides::sync::atomic::AtomicU64,
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         std::{
             cell::RefCell,
-            collections::{HashMap, HashSet},
+            collections::HashMap,
             env,
             fs::{self, File},
             io::Read,
         },
     };
-
-    fn new_unchecked_sanitized_message(message: Message) -> SanitizedMessage {
-        SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()))
-    }
 
     struct TestForkGraph {}
 
@@ -820,168 +813,115 @@ mod tests {
 
     #[test]
     fn test_filter_executable_program_accounts() {
+        let feepayer = Keypair::new();
+        let loader_ids = [
+            bpf_loader_deprecated::id(),
+            bpf_loader::id(),
+            bpf_loader_upgradeable::id(),
+            native_loader::id(),
+        ];
+        let program_ids = [
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+        ];
+        let account_ids = [
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+        ];
+
+        let mut loaded_programs_for_tx_batch = ProgramCacheForTxBatch::default();
         let mock_bank = MockBankCallback::default();
-        let key1 = Pubkey::new_unique();
-        let owner1 = bpf_loader::id();
-        let key2 = Pubkey::new_unique();
-        let owner2 = bpf_loader_upgradeable::id();
+        for i in 0..3 {
+            loaded_programs_for_tx_batch.replenish(
+                loader_ids[i],
+                Arc::new(ProgramCacheEntry {
+                    program: ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
+                    account_owner: ProgramCacheEntryOwner::NativeLoader,
+                    account_size: 0,
+                    deployment_slot: 0,
+                    effective_slot: 0,
+                    stats: Arc::default(),
+                    latest_access_slot: AtomicU64::default(),
+                }),
+            );
+            mock_bank.account_shared_data.borrow_mut().insert(
+                loader_ids[i],
+                (AccountSharedData::new(1, 1, &program_ids[3]), 0),
+            );
+            mock_bank.account_shared_data.borrow_mut().insert(
+                program_ids[i],
+                (AccountSharedData::new(1, 1, &loader_ids[i]), 0),
+            );
+            mock_bank.account_shared_data.borrow_mut().insert(
+                account_ids[i],
+                (AccountSharedData::new(1, 1, &program_ids[i]), 0),
+            );
+        }
 
-        let mut data1 = AccountSharedData::default();
-        data1.set_owner(owner1);
-        data1.set_lamports(93);
-        mock_bank
-            .account_shared_data
-            .borrow_mut()
-            .insert(key1, (data1, 0));
-
-        let mut data2 = AccountSharedData::default();
-        data2.set_owner(owner2);
-        data2.set_lamports(90);
-        mock_bank
-            .account_shared_data
-            .borrow_mut()
-            .insert(key2, (data2, 0));
-
-        let message = Message {
-            account_keys: vec![key1, key2],
-            header: MessageHeader::default(),
-            instructions: vec![CompiledInstruction {
-                program_id_index: 0,
-                accounts: vec![],
-                data: vec![],
-            }],
-            recent_blockhash: Hash::default(),
-        };
-
-        let sanitized_message = new_unchecked_sanitized_message(message);
-
-        let sanitized_transaction = SanitizedTransaction::new_for_tests(
-            sanitized_message,
-            vec![Signature::new_unique()],
-            false,
-        );
-
-        let missing_programs = filter_executable_program_accounts(
-            &mock_bank,
-            &mut ProgramCacheForTxBatch::default(),
-            &sanitized_transaction,
-            false,
-        );
-        assert_eq!(missing_programs.len(), 2);
-        assert!(
-            missing_programs
-                .iter()
-                .position(|program_to_load| program_to_load.program_id == &key1)
-                .is_some()
-        );
-        assert!(
-            missing_programs
-                .iter()
-                .position(|program_to_load| program_to_load.program_id == &key2)
-                .is_some()
-        );
-    }
-
-    #[test]
-    fn test_filter_executable_program_accounts_no_errors() {
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
-
-        let non_program_pubkey1 = Pubkey::new_unique();
-        let non_program_pubkey2 = Pubkey::new_unique();
-        let program1_pubkey = bpf_loader::id();
-        let program2_pubkey = bpf_loader_upgradeable::id();
-        let account1_pubkey = Pubkey::new_unique();
-        let account2_pubkey = Pubkey::new_unique();
-        let account3_pubkey = Pubkey::new_unique();
-        let account4_pubkey = Pubkey::new_unique();
-
-        let account5_pubkey = Pubkey::new_unique();
-
-        let mock_bank = MockBankCallback::default();
-        mock_bank.account_shared_data.borrow_mut().insert(
-            non_program_pubkey1,
-            (AccountSharedData::new(1, 10, &account5_pubkey), 0),
-        );
-        mock_bank.account_shared_data.borrow_mut().insert(
-            non_program_pubkey2,
-            (AccountSharedData::new(1, 10, &account5_pubkey), 0),
-        );
-        mock_bank.account_shared_data.borrow_mut().insert(
-            program1_pubkey,
-            (AccountSharedData::new(40, 1, &account5_pubkey), 0),
-        );
-        mock_bank.account_shared_data.borrow_mut().insert(
-            program2_pubkey,
-            (AccountSharedData::new(40, 1, &account5_pubkey), 0),
-        );
-        mock_bank.account_shared_data.borrow_mut().insert(
-            account1_pubkey,
-            (AccountSharedData::new(1, 10, &non_program_pubkey1), 0),
-        );
-        mock_bank.account_shared_data.borrow_mut().insert(
-            account2_pubkey,
-            (AccountSharedData::new(1, 10, &non_program_pubkey2), 0),
-        );
-        mock_bank.account_shared_data.borrow_mut().insert(
-            account3_pubkey,
-            (AccountSharedData::new(40, 1, &program1_pubkey), 0),
-        );
-        mock_bank.account_shared_data.borrow_mut().insert(
-            account4_pubkey,
-            (AccountSharedData::new(40, 1, &program2_pubkey), 0),
-        );
-
-        let tx1 = Transaction::new_with_compiled_instructions(
-            &[&keypair1],
-            &[non_program_pubkey1],
+        let tx = Transaction::new_with_compiled_instructions(
+            &[&feepayer],
+            &[program_ids[1], program_ids[2], loader_ids[2]],
             Hash::new_unique(),
-            vec![account1_pubkey, account2_pubkey, account3_pubkey],
-            vec![CompiledInstruction::new(1, &(), vec![0])],
+            vec![
+                account_ids[0],
+                account_ids[1],
+                account_ids[2],
+                account_ids[3],
+            ],
+            vec![
+                CompiledInstruction::new(1, &(), vec![0, 1, 2, 3]),
+                CompiledInstruction::new(2, &(), vec![0, 1, 2, 3]),
+                CompiledInstruction::new(3, &(), vec![0, 1, 2, 3]),
+            ],
         );
-        let sanitized_tx1 = SanitizedTransaction::from_transaction_for_tests(tx1);
-
-        let tx2 = Transaction::new_with_compiled_instructions(
-            &[&keypair2],
-            &[non_program_pubkey2],
-            Hash::new_unique(),
-            vec![account4_pubkey, account3_pubkey, account2_pubkey],
-            vec![CompiledInstruction::new(1, &(), vec![0])],
-        );
-        let sanitized_tx2 = SanitizedTransaction::from_transaction_for_tests(tx2);
-
-        let missing_programs = filter_executable_program_accounts(
-            &mock_bank,
-            &mut ProgramCacheForTxBatch::default(),
-            &sanitized_tx1,
-            false,
-        );
-        assert_eq!(missing_programs.len(), 1);
-        assert!(
-            missing_programs
-                .iter()
-                .position(|program_to_load| program_to_load.program_id == &account3_pubkey)
-                .is_some()
-        );
+        let sanitized_tx = SanitizedTransaction::from_transaction_for_tests(tx);
 
         let missing_programs = filter_executable_program_accounts(
             &mock_bank,
-            &mut ProgramCacheForTxBatch::default(),
-            &sanitized_tx2,
+            &loaded_programs_for_tx_batch,
+            &sanitized_tx,
             false,
         );
-        assert_eq!(missing_programs.len(), 2);
-        assert!(
-            missing_programs
-                .iter()
-                .position(|program_to_load| program_to_load.program_id == &account3_pubkey)
-                .is_some()
+        assert_eq!(
+            missing_programs,
+            &[
+                ProgramToLoad {
+                    program_id: &program_ids[1],
+                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                    last_modification_slot: 0,
+                },
+                ProgramToLoad {
+                    program_id: &program_ids[2],
+                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                    last_modification_slot: 0,
+                },
+            ]
         );
-        assert!(
-            missing_programs
-                .iter()
-                .position(|program_to_load| program_to_load.program_id == &account4_pubkey)
-                .is_some()
+
+        let missing_programs = filter_executable_program_accounts(
+            &mock_bank,
+            &loaded_programs_for_tx_batch,
+            &sanitized_tx,
+            true,
+        );
+        assert_eq!(
+            missing_programs,
+            &[
+                ProgramToLoad {
+                    program_id: &program_ids[1],
+                    match_criteria: ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0),
+                    last_modification_slot: 0,
+                },
+                ProgramToLoad {
+                    program_id: &program_ids[2],
+                    match_criteria: ProgramCacheMatchCriteria::Tombstone,
+                    last_modification_slot: 0,
+                },
+            ]
         );
     }
 }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -213,11 +213,8 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
 /// Returns an error if the program's account state can not be found or parsed.
 pub(crate) fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
     callbacks: &CB,
-    pubkey: &Pubkey,
+    program: &AccountSharedData,
 ) -> TransactionResult<Slot> {
-    let (program, _slot) = callbacks
-        .get_account_shared_data(pubkey)
-        .ok_or(TransactionError::ProgramAccountNotFound)?;
     if bpf_loader_upgradeable::check_id(program.owner()) {
         if let Ok(UpgradeableLoaderState::Program {
             programdata_address,
@@ -267,7 +264,8 @@ pub fn filter_executable_program_accounts<CB: TransactionProcessingCallback>(
         .iter()
         .map(|(pubkey, last_modification_slot)| {
             let match_criteria = if check_program_deployment_slot {
-                get_program_deployment_slot(callbacks, pubkey)
+                let (program, _slot) = callbacks.get_account_shared_data(pubkey).unwrap();
+                get_program_deployment_slot(callbacks, &program)
                     .map_or(ProgramCacheMatchCriteria::Tombstone, |slot| {
                         ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot)
                     })
@@ -738,11 +736,7 @@ mod tests {
     #[test]
     fn test_program_modification_slot_account_not_found() {
         let mock_bank = MockBankCallback::default();
-
         let key = Pubkey::new_unique();
-
-        let result = get_program_deployment_slot(&mock_bank, &key);
-        assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
 
         let mut account_data = AccountSharedData::new(100, 100, &bpf_loader_upgradeable::id());
         mock_bank
@@ -750,7 +744,10 @@ mod tests {
             .borrow_mut()
             .insert(key, (account_data.clone(), 0));
 
-        let result = get_program_deployment_slot(&mock_bank, &key);
+        let result = get_program_deployment_slot(
+            &mock_bank,
+            &mock_bank.get_account_shared_data(&key).unwrap().0,
+        );
         assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
 
         let state = UpgradeableLoaderState::Program {
@@ -762,7 +759,10 @@ mod tests {
             .borrow_mut()
             .insert(key, (account_data.clone(), 0));
 
-        let result = get_program_deployment_slot(&mock_bank, &key);
+        let result = get_program_deployment_slot(
+            &mock_bank,
+            &mock_bank.get_account_shared_data(&key).unwrap().0,
+        );
         assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
     }
 
@@ -800,7 +800,10 @@ mod tests {
             .borrow_mut()
             .insert(key2, (account_data.clone(), 0));
 
-        let result = get_program_deployment_slot(&mock_bank, &key1);
+        let result = get_program_deployment_slot(
+            &mock_bank,
+            &mock_bank.get_account_shared_data(&key1).unwrap().0,
+        );
         assert_eq!(result.unwrap(), 77);
 
         account_data.set_owner(Pubkey::new_unique());
@@ -809,7 +812,10 @@ mod tests {
             .borrow_mut()
             .insert(key2, (account_data, 0));
 
-        let result = get_program_deployment_slot(&mock_bank, &key2);
+        let result = get_program_deployment_slot(
+            &mock_bank,
+            &mock_bank.get_account_shared_data(&key2).unwrap().0,
+        );
         assert_eq!(result.unwrap(), 0);
     }
 

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -246,7 +246,7 @@ pub(crate) fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
 /// for transactions with a valid blockhash or nonce.
 pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>(
     callbacks: &CB,
-    program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
+    program_cache_for_tx_batch: &ProgramCacheForTxBatch,
     tx: &'a impl SVMMessage,
     check_program_deployment_slot: bool,
 ) -> Vec<ProgramToLoad<'a>> {

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -23,7 +23,7 @@ use {
     solana_svm_transaction::svm_message::SVMMessage,
     solana_svm_type_overrides::sync::Arc,
     solana_transaction_error::{TransactionError, TransactionResult},
-    std::{collections::HashMap, sync::atomic::Ordering},
+    std::sync::atomic::Ordering,
 };
 
 #[derive(Debug)]
@@ -249,8 +249,7 @@ pub fn filter_executable_program_accounts<CB: TransactionProcessingCallback>(
     tx: &impl SVMMessage,
     check_program_deployment_slot: bool,
 ) -> Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)> {
-    let mut program_accounts_set: HashMap<Pubkey, (ProgramCacheMatchCriteria, Slot)> =
-        HashMap::default();
+    let mut result = Vec::new();
     for account_key in tx.account_keys().iter() {
         if let Some(cache_entry) = program_cache_for_tx_batch.find(account_key) {
             cache_entry.stats.uses.fetch_add(1, Ordering::Relaxed);
@@ -266,15 +265,10 @@ pub fn filter_executable_program_accounts<CB: TransactionProcessingCallback>(
             } else {
                 ProgramCacheMatchCriteria::NoCriteria
             };
-            program_accounts_set.insert(*account_key, (match_criteria, last_modification_slot));
+            result.push((*account_key, match_criteria, last_modification_slot));
         }
     }
-    program_accounts_set
-        .iter()
-        .map(|(pubkey, (match_criteria, last_modification_slot))| {
-            (*pubkey, *match_criteria, *last_modification_slot)
-        })
-        .collect()
+    result
 }
 
 // Plucked from the now-removed Loader V4 program library.

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1,14 +1,14 @@
 use {
     crate::{
         account_loader::{
-            AccountLoader, CheckedTransactionDetails, LoadedTransaction, PROGRAM_OWNERS,
-            TransactionCheckResult, TransactionLoadResult, ValidatedTransactionDetails,
-            load_transaction, update_rent_exempt_status_for_account, validate_fee_payer,
+            AccountLoader, CheckedTransactionDetails, LoadedTransaction, TransactionCheckResult,
+            TransactionLoadResult, ValidatedTransactionDetails, load_transaction,
+            update_rent_exempt_status_for_account, validate_fee_payer,
         },
         account_overrides::AccountOverrides,
         message_processor::process_message,
         nonce_info::NonceInfo,
-        program_loader::{get_program_deployment_slot, load_program_with_pubkey},
+        program_loader::{filter_executable_program_accounts, load_program_with_pubkey},
         rollback_accounts::RollbackAccounts,
         transaction_account_state_info::{
             TransactionAccountStateInfo, get_uninitialized_accounts_size, verify_changes,
@@ -57,11 +57,11 @@ use {
     solana_svm_measure::{measure::Measure, measure_us},
     solana_svm_timings::{ExecuteTimingType, ExecuteTimings},
     solana_svm_transaction::{svm_message::SVMMessage, svm_transaction::SVMTransaction},
-    solana_svm_type_overrides::sync::{Arc, RwLock, RwLockReadGuard, atomic::Ordering},
+    solana_svm_type_overrides::sync::{Arc, RwLock, RwLockReadGuard},
     solana_transaction_context::transaction::{ExecutionRecord, TransactionContext},
     solana_transaction_error::{TransactionError, TransactionResult},
     std::{
-        collections::{HashMap, HashSet},
+        collections::HashSet,
         fmt::{Debug, Formatter},
         rc::Rc,
     },
@@ -498,7 +498,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 },
                 TransactionLoadResult::Loaded(loaded_transaction) => {
                     let (missing_programs, filter_executable_us) =
-                        measure_us!(Self::filter_executable_program_accounts(
+                        measure_us!(filter_executable_program_accounts(
                             &account_loader,
                             &mut program_cache_for_tx_batch,
                             tx,
@@ -810,41 +810,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             error_counters.blockhash_not_found += 1;
             Err(TransactionError::BlockhashNotFound)
         }
-    }
-
-    /// Appends to a set of executable program accounts (all accounts owned by any loader)
-    /// for transactions with a valid blockhash or nonce.
-    fn filter_executable_program_accounts<CB: TransactionProcessingCallback>(
-        account_loader: &AccountLoader<CB>,
-        program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
-        tx: &impl SVMMessage,
-        check_program_deployment_slot: bool,
-    ) -> Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)> {
-        let mut program_accounts_set: HashMap<Pubkey, Slot> = HashMap::default();
-        for account_key in tx.account_keys().iter() {
-            if let Some(cache_entry) = program_cache_for_tx_batch.find(account_key) {
-                cache_entry.stats.uses.fetch_add(1, Ordering::Relaxed);
-            } else if let Some((account, last_modification_slot)) =
-                account_loader.get_account_shared_data(account_key)
-                && PROGRAM_OWNERS.contains(account.owner())
-            {
-                program_accounts_set.insert(*account_key, last_modification_slot);
-            }
-        }
-        program_accounts_set
-            .iter()
-            .map(|(pubkey, last_modification_slot)| {
-                let match_criteria = if check_program_deployment_slot {
-                    get_program_deployment_slot(account_loader, pubkey)
-                        .map_or(ProgramCacheMatchCriteria::Tombstone, |slot| {
-                            ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot)
-                        })
-                } else {
-                    ProgramCacheMatchCriteria::NoCriteria
-                };
-                (*pubkey, match_criteria, *last_modification_slot)
-            })
-            .collect()
     }
 
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
@@ -1275,7 +1240,6 @@ mod tests {
         solana_fee_calculator::FeeCalculator,
         solana_fee_structure::FeeDetails,
         solana_hash::Hash,
-        solana_keypair::Keypair,
         solana_message::{LegacyMessage, Message, MessageHeader, SanitizedMessage},
         solana_nonce as nonce,
         solana_program_runtime::{
@@ -1288,11 +1252,11 @@ mod tests {
         },
         solana_rent::Rent,
         solana_sbpf::vm,
-        solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, system_program, sysvar},
+        solana_sdk_ids::{bpf_loader, system_program, sysvar},
         solana_signature::Signature,
         solana_svm_callback::{AccountState, InvokeContextCallback},
         solana_system_interface::instruction as system_instruction,
-        solana_transaction::{Transaction, sanitized::SanitizedTransaction},
+        solana_transaction::sanitized::SanitizedTransaction,
         solana_transaction_context::transaction::TransactionContext,
         solana_transaction_error::TransactionError,
         std::{borrow::Cow, collections::HashMap},
@@ -1785,180 +1749,6 @@ mod tests {
             ));
         }
         assert!(loaded_missing > 0);
-    }
-
-    #[test]
-    fn test_filter_executable_program_accounts() {
-        let mock_bank = MockBankCallback::default();
-        let key1 = Pubkey::new_unique();
-        let owner1 = bpf_loader::id();
-        let key2 = Pubkey::new_unique();
-        let owner2 = bpf_loader_upgradeable::id();
-
-        let mut data1 = AccountSharedData::default();
-        data1.set_owner(owner1);
-        data1.set_lamports(93);
-        mock_bank
-            .account_shared_data
-            .write()
-            .unwrap()
-            .insert(key1, data1);
-
-        let mut data2 = AccountSharedData::default();
-        data2.set_owner(owner2);
-        data2.set_lamports(90);
-        mock_bank
-            .account_shared_data
-            .write()
-            .unwrap()
-            .insert(key2, data2);
-        let account_loader = (&mock_bank).into();
-
-        let message = Message {
-            account_keys: vec![key1, key2],
-            header: MessageHeader::default(),
-            instructions: vec![CompiledInstruction {
-                program_id_index: 0,
-                accounts: vec![],
-                data: vec![],
-            }],
-            recent_blockhash: Hash::default(),
-        };
-
-        let sanitized_message = new_unchecked_sanitized_message(message);
-
-        let sanitized_transaction = SanitizedTransaction::new_for_tests(
-            sanitized_message,
-            vec![Signature::new_unique()],
-            false,
-        );
-
-        let missing_programs =
-            TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
-                &account_loader,
-                &mut ProgramCacheForTxBatch::default(),
-                &sanitized_transaction,
-                false,
-            );
-        assert_eq!(missing_programs.len(), 2);
-        assert!(
-            missing_programs
-                .iter()
-                .position(|(key, _, _)| key == &key1)
-                .is_some()
-        );
-        assert!(
-            missing_programs
-                .iter()
-                .position(|(key, _, _)| key == &key2)
-                .is_some()
-        );
-    }
-
-    #[test]
-    fn test_filter_executable_program_accounts_no_errors() {
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
-
-        let non_program_pubkey1 = Pubkey::new_unique();
-        let non_program_pubkey2 = Pubkey::new_unique();
-        let program1_pubkey = bpf_loader::id();
-        let program2_pubkey = bpf_loader_upgradeable::id();
-        let account1_pubkey = Pubkey::new_unique();
-        let account2_pubkey = Pubkey::new_unique();
-        let account3_pubkey = Pubkey::new_unique();
-        let account4_pubkey = Pubkey::new_unique();
-
-        let account5_pubkey = Pubkey::new_unique();
-
-        let bank = MockBankCallback::default();
-        bank.account_shared_data.write().unwrap().insert(
-            non_program_pubkey1,
-            AccountSharedData::new(1, 10, &account5_pubkey),
-        );
-        bank.account_shared_data.write().unwrap().insert(
-            non_program_pubkey2,
-            AccountSharedData::new(1, 10, &account5_pubkey),
-        );
-        bank.account_shared_data.write().unwrap().insert(
-            program1_pubkey,
-            AccountSharedData::new(40, 1, &account5_pubkey),
-        );
-        bank.account_shared_data.write().unwrap().insert(
-            program2_pubkey,
-            AccountSharedData::new(40, 1, &account5_pubkey),
-        );
-        bank.account_shared_data.write().unwrap().insert(
-            account1_pubkey,
-            AccountSharedData::new(1, 10, &non_program_pubkey1),
-        );
-        bank.account_shared_data.write().unwrap().insert(
-            account2_pubkey,
-            AccountSharedData::new(1, 10, &non_program_pubkey2),
-        );
-        bank.account_shared_data.write().unwrap().insert(
-            account3_pubkey,
-            AccountSharedData::new(40, 1, &program1_pubkey),
-        );
-        bank.account_shared_data.write().unwrap().insert(
-            account4_pubkey,
-            AccountSharedData::new(40, 1, &program2_pubkey),
-        );
-        let account_loader = (&bank).into();
-
-        let tx1 = Transaction::new_with_compiled_instructions(
-            &[&keypair1],
-            &[non_program_pubkey1],
-            Hash::new_unique(),
-            vec![account1_pubkey, account2_pubkey, account3_pubkey],
-            vec![CompiledInstruction::new(1, &(), vec![0])],
-        );
-        let sanitized_tx1 = SanitizedTransaction::from_transaction_for_tests(tx1);
-
-        let tx2 = Transaction::new_with_compiled_instructions(
-            &[&keypair2],
-            &[non_program_pubkey2],
-            Hash::new_unique(),
-            vec![account4_pubkey, account3_pubkey, account2_pubkey],
-            vec![CompiledInstruction::new(1, &(), vec![0])],
-        );
-        let sanitized_tx2 = SanitizedTransaction::from_transaction_for_tests(tx2);
-
-        let missing_programs =
-            TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
-                &account_loader,
-                &mut ProgramCacheForTxBatch::default(),
-                &sanitized_tx1,
-                false,
-            );
-        assert_eq!(missing_programs.len(), 1);
-        assert!(
-            missing_programs
-                .iter()
-                .position(|(key, _, _)| key == &account3_pubkey)
-                .is_some()
-        );
-
-        let missing_programs =
-            TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
-                &account_loader,
-                &mut ProgramCacheForTxBatch::default(),
-                &sanitized_tx2,
-                false,
-            );
-        assert_eq!(missing_programs.len(), 2);
-        assert!(
-            missing_programs
-                .iter()
-                .position(|(key, _, _)| key == &account3_pubkey)
-                .is_some()
-        );
-        assert!(
-            missing_programs
-                .iter()
-                .position(|(key, _, _)| key == &account4_pubkey)
-                .is_some()
-        );
     }
 
     #[test]

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -44,6 +44,7 @@ use {
         loaded_programs::{
             EpochBoundaryPreparation, ForkGraph, ProgramCache, ProgramCacheForTxBatch,
             ProgramCacheMatchCriteria, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
+            ProgramToLoad,
         },
         program_cache_entry::ProgramCacheEntry,
         solana_sbpf::{program::BuiltinProgram, vm::Config as VmConfig},
@@ -316,9 +317,13 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         // Pre-populate the builtin program cache from the global cache.
         // This is done once per block rather than once per batch.
         let mut builtin_program_cache = ProgramCacheForTxBatch::new(slot);
-        let mut search_for: Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)> = builtin_program_ids
+        let mut search_for: Vec<ProgramToLoad> = builtin_program_ids
             .iter()
-            .map(|key| (*key, ProgramCacheMatchCriteria::NoCriteria, 0))
+            .map(|program_id| ProgramToLoad {
+                program_id: *program_id,
+                match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                last_modification_slot: 0,
+            })
             .collect();
         self.global_program_cache.read().unwrap().extract(
             &mut search_for,
@@ -816,7 +821,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     fn replenish_program_cache<CB: TransactionProcessingCallback>(
         &self,
         account_loader: &AccountLoader<CB>,
-        mut missing_programs: Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)>,
+        mut missing_programs: Vec<ProgramToLoad>,
         program_runtime_environment_for_execution: &ProgramRuntimeEnvironment,
         program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
         execute_timings: &mut ExecuteTimings,
@@ -1696,7 +1701,11 @@ mod tests {
 
         batch_processor.replenish_program_cache(
             &account_loader,
-            vec![(key, ProgramCacheMatchCriteria::NoCriteria, 0)],
+            vec![ProgramToLoad {
+                program_id: key,
+                match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                last_modification_slot: 0,
+            }],
             &program_runtime_environment_for_execution,
             &mut program_cache_for_tx_batch,
             &mut ExecuteTimings::default(),
@@ -1730,7 +1739,11 @@ mod tests {
 
             batch_processor.replenish_program_cache(
                 &account_loader,
-                vec![(key, ProgramCacheMatchCriteria::NoCriteria, 0)],
+                vec![ProgramToLoad {
+                    program_id: key,
+                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                    last_modification_slot: 0,
+                }],
                 &program_runtime_environment_for_execution,
                 &mut program_cache_for_tx_batch,
                 &mut ExecuteTimings::default(),
@@ -1948,7 +1961,11 @@ mod tests {
             .write()
             .unwrap()
             .extract(
-                &mut vec![(key, ProgramCacheMatchCriteria::NoCriteria, 0)],
+                &mut vec![ProgramToLoad {
+                    program_id: key,
+                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                    last_modification_slot: 0,
+                }],
                 &mut loaded_programs_for_tx_batch,
                 &program_runtime_environment,
                 true,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -320,7 +320,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let mut search_for: Vec<ProgramToLoad> = builtin_program_ids
             .iter()
             .map(|program_id| ProgramToLoad {
-                program_id: *program_id,
+                program_id,
                 match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                 last_modification_slot: 0,
             })
@@ -1702,7 +1702,7 @@ mod tests {
         batch_processor.replenish_program_cache(
             &account_loader,
             vec![ProgramToLoad {
-                program_id: key,
+                program_id: &key,
                 match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                 last_modification_slot: 0,
             }],
@@ -1740,7 +1740,7 @@ mod tests {
             batch_processor.replenish_program_cache(
                 &account_loader,
                 vec![ProgramToLoad {
-                    program_id: key,
+                    program_id: &key,
                     match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                     last_modification_slot: 0,
                 }],
@@ -1962,7 +1962,7 @@ mod tests {
             .unwrap()
             .extract(
                 &mut vec![ProgramToLoad {
-                    program_id: key,
+                    program_id: &key,
                     match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                     last_modification_slot: 0,
                 }],

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -498,7 +498,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 },
                 TransactionLoadResult::Loaded(loaded_transaction) => {
                     let (missing_programs, filter_executable_us) =
-                        measure_us!(self.filter_executable_program_accounts(
+                        measure_us!(Self::filter_executable_program_accounts(
                             &account_loader,
                             &mut program_cache_for_tx_batch,
                             tx,
@@ -815,7 +815,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     /// Appends to a set of executable program accounts (all accounts owned by any loader)
     /// for transactions with a valid blockhash or nonce.
     fn filter_executable_program_accounts<CB: TransactionProcessingCallback>(
-        &self,
         account_loader: &AccountLoader<CB>,
         program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
         tx: &impl SVMMessage,
@@ -1834,13 +1833,13 @@ mod tests {
             false,
         );
 
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        let missing_programs = batch_processor.filter_executable_program_accounts(
-            &account_loader,
-            &mut ProgramCacheForTxBatch::default(),
-            &sanitized_transaction,
-            false,
-        );
+        let missing_programs =
+            TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
+                &account_loader,
+                &mut ProgramCacheForTxBatch::default(),
+                &sanitized_transaction,
+                false,
+            );
         assert_eq!(missing_programs.len(), 2);
         assert!(
             missing_programs
@@ -1925,14 +1924,13 @@ mod tests {
         );
         let sanitized_tx2 = SanitizedTransaction::from_transaction_for_tests(tx2);
 
-        let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-
-        let missing_programs = batch_processor.filter_executable_program_accounts(
-            &account_loader,
-            &mut ProgramCacheForTxBatch::default(),
-            &sanitized_tx1,
-            false,
-        );
+        let missing_programs =
+            TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
+                &account_loader,
+                &mut ProgramCacheForTxBatch::default(),
+                &sanitized_tx1,
+                false,
+            );
         assert_eq!(missing_programs.len(), 1);
         assert!(
             missing_programs
@@ -1941,12 +1939,13 @@ mod tests {
                 .is_some()
         );
 
-        let missing_programs = batch_processor.filter_executable_program_accounts(
-            &account_loader,
-            &mut ProgramCacheForTxBatch::default(),
-            &sanitized_tx2,
-            false,
-        );
+        let missing_programs =
+            TransactionBatchProcessor::<TestForkGraph>::filter_executable_program_accounts(
+                &account_loader,
+                &mut ProgramCacheForTxBatch::default(),
+                &sanitized_tx2,
+                false,
+            );
         assert_eq!(missing_programs.len(), 2);
         assert!(
             missing_programs

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -497,11 +497,12 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     }
                 },
                 TransactionLoadResult::Loaded(loaded_transaction) => {
-                    let (program_accounts_set, filter_executable_us) =
+                    let (missing_programs, filter_executable_us) =
                         measure_us!(self.filter_executable_program_accounts(
                             &account_loader,
                             &mut program_cache_for_tx_batch,
                             tx,
+                            config.check_program_deployment_slot,
                         ));
                     execute_timings.saturating_add_in_place(
                         ExecuteTimingType::FilterExecutableUs,
@@ -511,13 +512,12 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     let ((), program_cache_us) = measure_us!({
                         self.replenish_program_cache(
                             &account_loader,
-                            &program_accounts_set,
+                            missing_programs,
                             environment
                                 .program_runtime_environments
                                 .get_env_for_execution(),
                             &mut program_cache_for_tx_batch,
                             &mut execute_timings,
-                            config.check_program_deployment_slot,
                             config.limit_to_load_programs,
                             true, // increment_usage_counter
                         );
@@ -819,8 +819,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         account_loader: &AccountLoader<CB>,
         program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
         tx: &impl SVMMessage,
-    ) -> HashMap<Pubkey, Slot> {
-        let mut program_accounts_set = HashMap::default();
+        check_program_deployment_slot: bool,
+    ) -> Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)> {
+        let mut program_accounts_set: HashMap<Pubkey, Slot> = HashMap::default();
         for account_key in tx.account_keys().iter() {
             if let Some(cache_entry) = program_cache_for_tx_batch.find(account_key) {
                 cache_entry.stats.uses.fetch_add(1, Ordering::Relaxed);
@@ -832,36 +833,32 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             }
         }
         program_accounts_set
+            .iter()
+            .map(|(pubkey, last_modification_slot)| {
+                let match_criteria = if check_program_deployment_slot {
+                    get_program_deployment_slot(account_loader, pubkey)
+                        .map_or(ProgramCacheMatchCriteria::Tombstone, |slot| {
+                            ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot)
+                        })
+                } else {
+                    ProgramCacheMatchCriteria::NoCriteria
+                };
+                (*pubkey, match_criteria, *last_modification_slot)
+            })
+            .collect()
     }
 
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn replenish_program_cache<CB: TransactionProcessingCallback>(
         &self,
         account_loader: &AccountLoader<CB>,
-        program_accounts_set: &HashMap<Pubkey, Slot>,
+        mut missing_programs: Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)>,
         program_runtime_environment_for_execution: &ProgramRuntimeEnvironment,
         program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
         execute_timings: &mut ExecuteTimings,
-        check_program_deployment_slot: bool,
         limit_to_load_programs: bool,
         increment_usage_counter: bool,
     ) {
-        let mut missing_programs: Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)> =
-            program_accounts_set
-                .iter()
-                .map(|(pubkey, last_modification_slot)| {
-                    let match_criteria = if check_program_deployment_slot {
-                        get_program_deployment_slot(account_loader, pubkey)
-                            .map_or(ProgramCacheMatchCriteria::Tombstone, |slot| {
-                                ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot)
-                            })
-                    } else {
-                        ProgramCacheMatchCriteria::NoCriteria
-                    };
-                    (*pubkey, match_criteria, *last_modification_slot)
-                })
-                .collect();
-
         let mut count_hits_and_misses = true;
         loop {
             // Lock the global cache.
@@ -1732,18 +1729,14 @@ mod tests {
             batch_processor.program_runtime_environment_for_epoch(0);
         let key = Pubkey::new_unique();
 
-        let mut account_set = HashMap::new();
-        account_set.insert(key, 0);
-
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(batch_processor.slot);
 
         batch_processor.replenish_program_cache(
             &account_loader,
-            &account_set,
+            vec![(key, ProgramCacheMatchCriteria::NoCriteria, 0)],
             &program_runtime_environment_for_execution,
             &mut program_cache_for_tx_batch,
             &mut ExecuteTimings::default(),
-            false,
             true,
             true,
         );
@@ -1768,20 +1761,16 @@ mod tests {
             .insert(key, account_data);
         let account_loader = (&mock_bank).into();
 
-        let mut account_set = HashMap::new();
-        account_set.insert(key, 0);
         let mut loaded_missing = 0;
-
         for limit_to_load_programs in [false, true] {
             let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(batch_processor.slot);
 
             batch_processor.replenish_program_cache(
                 &account_loader,
-                &account_set,
+                vec![(key, ProgramCacheMatchCriteria::NoCriteria, 0)],
                 &program_runtime_environment_for_execution,
                 &mut program_cache_for_tx_batch,
                 &mut ExecuteTimings::default(),
-                false,
                 limit_to_load_programs,
                 true,
             );
@@ -1846,15 +1835,25 @@ mod tests {
         );
 
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
-        let program_accounts_set = batch_processor.filter_executable_program_accounts(
+        let missing_programs = batch_processor.filter_executable_program_accounts(
             &account_loader,
             &mut ProgramCacheForTxBatch::default(),
             &sanitized_transaction,
+            false,
         );
-
-        assert_eq!(program_accounts_set.len(), 2);
-        assert!(program_accounts_set.contains_key(&key1));
-        assert!(program_accounts_set.contains_key(&key2));
+        assert_eq!(missing_programs.len(), 2);
+        assert!(
+            missing_programs
+                .iter()
+                .position(|(key, _, _)| key == &key1)
+                .is_some()
+        );
+        assert!(
+            missing_programs
+                .iter()
+                .position(|(key, _, _)| key == &key2)
+                .is_some()
+        );
     }
 
     #[test]
@@ -1928,32 +1927,38 @@ mod tests {
 
         let batch_processor = TransactionBatchProcessor::<TestForkGraph>::default();
 
-        let tx1_programs = batch_processor.filter_executable_program_accounts(
+        let missing_programs = batch_processor.filter_executable_program_accounts(
             &account_loader,
             &mut ProgramCacheForTxBatch::default(),
             &sanitized_tx1,
+            false,
         );
-
-        assert_eq!(tx1_programs.len(), 1);
+        assert_eq!(missing_programs.len(), 1);
         assert!(
-            tx1_programs.contains_key(&account3_pubkey),
-            "failed to find the program account",
+            missing_programs
+                .iter()
+                .position(|(key, _, _)| key == &account3_pubkey)
+                .is_some()
         );
 
-        let tx2_programs = batch_processor.filter_executable_program_accounts(
+        let missing_programs = batch_processor.filter_executable_program_accounts(
             &account_loader,
             &mut ProgramCacheForTxBatch::default(),
             &sanitized_tx2,
+            false,
         );
-
-        assert_eq!(tx2_programs.len(), 2);
+        assert_eq!(missing_programs.len(), 2);
         assert!(
-            tx2_programs.contains_key(&account3_pubkey),
-            "failed to find the program account",
+            missing_programs
+                .iter()
+                .position(|(key, _, _)| key == &account3_pubkey)
+                .is_some()
         );
         assert!(
-            tx2_programs.contains_key(&account4_pubkey),
-            "failed to find the program account",
+            missing_programs
+                .iter()
+                .position(|(key, _, _)| key == &account4_pubkey)
+                .is_some()
         );
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -505,7 +505,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     let (missing_programs, filter_executable_us) =
                         measure_us!(filter_executable_program_accounts(
                             &account_loader,
-                            &mut program_cache_for_tx_batch,
+                            &program_cache_for_tx_batch,
                             tx,
                             config.check_program_deployment_slot,
                         ));

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -45,7 +45,7 @@ fn program_cache_execution(threads: usize) {
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
     let batch_processor = TransactionBatchProcessor::new(5, 5, Arc::downgrade(&fork_graph), None);
 
-    let programs = vec![
+    let programs = [
         deploy_program("hello-solana".to_string(), 0, &mut mock_bank),
         deploy_program("simple-transfer".to_string(), 0, &mut mock_bank),
         deploy_program("clock-sysvar".to_string(), 0, &mut mock_bank),
@@ -53,12 +53,16 @@ fn program_cache_execution(threads: usize) {
 
     let missing_programs: Vec<ProgramToLoad> = programs
         .iter()
-        .map(|key| ProgramToLoad {
-            program_id: *key,
+        .map(|program_id| ProgramToLoad {
+            program_id,
             match_criteria: ProgramCacheMatchCriteria::NoCriteria,
             last_modification_slot: 0,
         })
         .collect();
+
+    // Borrow checker does not understand that all threads are joined (thus terminated) before this function exits
+    let missing_programs: &[ProgramToLoad<'static>] =
+        unsafe { std::mem::transmute(missing_programs.as_slice()) };
 
     let ths: Vec<_> = (0..threads)
         .map(|_| {
@@ -68,8 +72,6 @@ fn program_cache_execution(threads: usize) {
                 batch_processor.slot,
                 batch_processor.epoch,
             );
-            let missing_programs = missing_programs.clone();
-            let programs = programs.clone();
             thread::spawn(move || {
                 let feature_set = SVMFeatureSet::all_enabled();
                 let account_loader = AccountLoader::new_with_loaded_accounts_capacity(
@@ -83,14 +85,14 @@ fn program_cache_execution(threads: usize) {
                     processor.program_runtime_environment_for_epoch(processor.epoch);
                 processor.replenish_program_cache(
                     &account_loader,
-                    missing_programs,
+                    missing_programs.to_vec(),
                     &program_runtime_environment_for_execution,
                     &mut result,
                     &mut ExecuteTimings::default(),
                     true,
                     true,
                 );
-                for key in &programs {
+                for key in programs.iter() {
                     let cache_entry = result.find(key);
                     assert!(matches!(
                         cache_entry.unwrap().program,

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -14,7 +14,9 @@ use {
     solana_instruction::{AccountMeta, Instruction},
     solana_program_runtime::{
         execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
-        loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments},
+        loaded_programs::{
+            ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironments,
+        },
         program_cache_entry::ProgramCacheEntryType,
     },
     solana_pubkey::Pubkey,
@@ -31,7 +33,7 @@ use {
     solana_svm_feature_set::SVMFeatureSet,
     solana_svm_timings::ExecuteTimings,
     solana_transaction::{Transaction, sanitized::SanitizedTransaction},
-    std::collections::{HashMap, HashSet},
+    std::collections::HashSet,
 };
 
 mod mock_bank;
@@ -49,7 +51,10 @@ fn program_cache_execution(threads: usize) {
         deploy_program("clock-sysvar".to_string(), 0, &mut mock_bank),
     ];
 
-    let account_maps: HashMap<Pubkey, Slot> = programs.iter().map(|key| (*key, 0)).collect();
+    let missing_programs: Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)> = programs
+        .iter()
+        .map(|key| (*key, ProgramCacheMatchCriteria::NoCriteria, 0))
+        .collect();
 
     let ths: Vec<_> = (0..threads)
         .map(|_| {
@@ -59,7 +64,7 @@ fn program_cache_execution(threads: usize) {
                 batch_processor.slot,
                 batch_processor.epoch,
             );
-            let maps = account_maps.clone();
+            let missing_programs = missing_programs.clone();
             let programs = programs.clone();
             thread::spawn(move || {
                 let feature_set = SVMFeatureSet::all_enabled();
@@ -74,11 +79,10 @@ fn program_cache_execution(threads: usize) {
                     processor.program_runtime_environment_for_epoch(processor.epoch);
                 processor.replenish_program_cache(
                     &account_loader,
-                    &maps,
+                    missing_programs,
                     &program_runtime_environment_for_execution,
                     &mut result,
                     &mut ExecuteTimings::default(),
-                    false,
                     true,
                     true,
                 );

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -10,12 +10,12 @@ use {
         thread,
     },
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
-    solana_clock::Slot,
     solana_instruction::{AccountMeta, Instruction},
     solana_program_runtime::{
         execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
         loaded_programs::{
             ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironments,
+            ProgramToLoad,
         },
         program_cache_entry::ProgramCacheEntryType,
     },
@@ -51,9 +51,13 @@ fn program_cache_execution(threads: usize) {
         deploy_program("clock-sysvar".to_string(), 0, &mut mock_bank),
     ];
 
-    let missing_programs: Vec<(Pubkey, ProgramCacheMatchCriteria, Slot)> = programs
+    let missing_programs: Vec<ProgramToLoad> = programs
         .iter()
-        .map(|key| (*key, ProgramCacheMatchCriteria::NoCriteria, 0))
+        .map(|key| ProgramToLoad {
+            program_id: *key,
+            match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+            last_modification_slot: 0,
+        })
         .collect();
 
     let ths: Vec<_> = (0..threads)

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -44,25 +44,11 @@ fn program_cache_execution(threads: usize) {
     let mut mock_bank = MockBankCallback::default();
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
     let batch_processor = TransactionBatchProcessor::new(5, 5, Arc::downgrade(&fork_graph), None);
-
     let programs = [
         deploy_program("hello-solana".to_string(), 0, &mut mock_bank),
         deploy_program("simple-transfer".to_string(), 0, &mut mock_bank),
         deploy_program("clock-sysvar".to_string(), 0, &mut mock_bank),
     ];
-
-    let missing_programs: Vec<ProgramToLoad> = programs
-        .iter()
-        .map(|program_id| ProgramToLoad {
-            program_id,
-            match_criteria: ProgramCacheMatchCriteria::NoCriteria,
-            last_modification_slot: 0,
-        })
-        .collect();
-
-    // Borrow checker does not understand that all threads are joined (thus terminated) before this function exits
-    let missing_programs: &[ProgramToLoad<'static>] =
-        unsafe { std::mem::transmute(missing_programs.as_slice()) };
 
     let ths: Vec<_> = (0..threads)
         .map(|_| {
@@ -73,6 +59,14 @@ fn program_cache_execution(threads: usize) {
                 batch_processor.epoch,
             );
             thread::spawn(move || {
+                let missing_programs: Vec<ProgramToLoad> = programs
+                    .iter()
+                    .map(|program_id| ProgramToLoad {
+                        program_id,
+                        match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                        last_modification_slot: 0,
+                    })
+                    .collect();
                 let feature_set = SVMFeatureSet::all_enabled();
                 let account_loader = AccountLoader::new_with_loaded_accounts_capacity(
                     None,
@@ -85,7 +79,7 @@ fn program_cache_execution(threads: usize) {
                     processor.program_runtime_environment_for_epoch(processor.epoch);
                 processor.replenish_program_cache(
                     &account_loader,
-                    missing_programs.to_vec(),
+                    missing_programs,
                     &program_runtime_environment_for_execution,
                     &mut result,
                     &mut ExecuteTimings::default(),


### PR DESCRIPTION
#### Problem

There are multiple inefficiencies around `TransactionBatchProcessor::filter_executable_program_accounts()`:

- `get_account_shared_data()` can be called multiple times per program id, but once is sufficient.
- For the missing programs list a `HashMap` is constructed and then converted into a `Vec`.
- The `Pubkey` in the missing programs list is passed around by value, not by reference and the missing programs list can be copied multiple times in `ProgramCache::extract()` via `retain()`.

Furthermore style wise:

- The obscure `(Pubkey, ProgramCacheMatchCriteria, Slot)` tuple which is used five times in different function signatures should be a struct.
- `filter_executable_program_accounts()` does not need the `self: &TransactionBatchProcessor` and should go into the program loader instead.
- The `program_cache_for_tx_batch` parameter of `filter_executable_program_accounts()` does not need to be `mut`.
- Finding the match criteria should not be done in `TransactionBatchProcessor::replenish_program_cache()`.

#### Summary of Changes

- Moves `ProgramCacheMatchCriteria` from `TransactionBatchProcessor::replenish_program_cache()` into `TransactionBatchProcessor::filter_executable_program_accounts()`.
- Removes `&self` parameter from `TransactionBatchProcessor::filter_executable_program_accounts()`.
- Moves `filter_executable_program_accounts()` into `program_loader.rs`
- Moves `get_account_shared_data()` from `get_program_deployment_slot()` into `filter_executable_program_accounts()`.
- Merges `get_account_shared_data()` calls into one.
- Directly construct the resulting `Vec` instead of going through a `HashMap`.
- Creates `ProgramToLoad` struct for the result type of `filter_executable_program_accounts()`.
- Turns `ProgramToLoad::program_id` into a reference.
- Removes `mut` from the `program_cache_for_tx_batch` parameter of `filter_executable_program_accounts()`.