### PR TITLE
chore(clippy): apply workspace level lints to all crates

### DIFF
--- a/account-decoder-client-types/Cargo.toml
+++ b/account-decoder-client-types/Cargo.toml
@@ -26,3 +26,6 @@ serde_json = { workspace = true }
 solana-account = { workspace = true }
 solana-pubkey = { workspace = true }
 zstd = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -58,3 +58,6 @@ solana-native-token = { workspace = true }
 solana-poh-config = { workspace = true }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-test-validator = { path = "../test-validator" }
+
+[lints]
+workspace = true

--- a/accounts-db/store-histogram/Cargo.toml
+++ b/accounts-db/store-histogram/Cargo.toml
@@ -16,3 +16,6 @@ dev-context-only-utils = []
 [dependencies]
 clap = { workspace = true }
 solana-version = { workspace = true }
+
+[lints]
+workspace = true

--- a/accounts-db/store-tool/Cargo.toml
+++ b/accounts-db/store-tool/Cargo.toml
@@ -25,3 +25,6 @@ solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-version = { workspace = true }
+
+[lints]
+workspace = true

--- a/banking-stage-ingress-types/Cargo.toml
+++ b/banking-stage-ingress-types/Cargo.toml
@@ -15,3 +15,6 @@ agave-unstable-api = []
 [dependencies]
 crossbeam-channel = { workspace = true }
 solana-perf = { workspace = true }
+
+[lints]
+workspace = true

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -47,3 +47,6 @@ solana-pubkey = { workspace = true }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
+
+[lints]
+workspace = true

--- a/banks-interface/Cargo.toml
+++ b/banks-interface/Cargo.toml
@@ -32,3 +32,6 @@ solana-transaction = { workspace = true, features = ["serde"] }
 solana-transaction-context = { workspace = true, features = ["serde"] }
 solana-transaction-error = { workspace = true, features = ["serde"] }
 tarpc = { workspace = true, features = ["full"] }
+
+[lints]
+workspace = true

--- a/banks-server/Cargo.toml
+++ b/banks-server/Cargo.toml
@@ -42,3 +42,6 @@ tarpc = { workspace = true, features = ["full"] }
 tokio = { workspace = true, features = ["full"] }
 tokio-serde = { workspace = true, features = ["bincode"] }
 tokio-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -84,3 +84,6 @@ solana-sdk-ids = { workspace = true }
 solana-test-validator = { workspace = true }
 solana-tps-client = { workspace = true, features = ["bank-client"] }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -37,3 +37,6 @@ fs_extra = { workspace = true }
 rayon = { workspace = true }
 solana-bucket-map = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
+
+[lints]
+workspace = true

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -47,3 +47,6 @@ assert_matches = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -52,3 +52,6 @@ solana-clap-v3-utils = { path = ".", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/cli-config/Cargo.toml
+++ b/cli-config/Cargo.toml
@@ -25,3 +25,6 @@ url = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+
+[lints]
+workspace = true

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -55,3 +55,6 @@ solana-keypair = { workspace = true }
 solana-seed-derivable = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode"] }
+
+[lints]
+workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -109,3 +109,6 @@ solana-sha256-hasher = { workspace = true }
 solana-test-validator = { path = "../test-validator" }
 tempfile = { workspace = true }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -47,3 +47,6 @@ agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-rpc = { path = "../rpc", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+
+[lints]
+workspace = true

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -49,3 +49,6 @@ tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 crossbeam-channel = { workspace = true }
+
+[lints]
+workspace = true

--- a/connection-cache/Cargo.toml
+++ b/connection-cache/Cargo.toml
@@ -29,3 +29,6 @@ thiserror = { workspace = true }
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 rand_chacha = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
+
+[lints]
+workspace = true

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -29,3 +29,6 @@ solana-runtime = { workspace = true }
 
 [dev-dependencies]
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+
+[lints]
+workspace = true

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -66,3 +66,6 @@ solana-transaction = { workspace = true, features = ["verify"] }
 [[bench]]
 name = "verify_signatures"
 harness = false
+
+[lints]
+workspace = true

--- a/faucet-cli/Cargo.toml
+++ b/faucet-cli/Cargo.toml
@@ -27,3 +27,6 @@ solana-keypair = { workspace = true }
 solana-metrics = { workspace = true }
 solana-version = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+
+[lints]
+workspace = true

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -43,3 +43,6 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 solana-faucet = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+
+[lints]
+workspace = true

--- a/fee/Cargo.toml
+++ b/fee/Cargo.toml
@@ -16,3 +16,6 @@ agave-unstable-api = []
 agave-feature-set = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-svm-transaction = { workspace = true }
+
+[lints]
+workspace = true

--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -35,3 +35,6 @@ tempfile = { workspace = true }
 rand = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/genesis-utils/Cargo.toml
+++ b/genesis-utils/Cargo.toml
@@ -27,3 +27,6 @@ solana-genesis-config = { workspace = true }
 solana-hash = { workspace = true }
 solana-rpc-client = { workspace = true }
 thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -74,3 +74,6 @@ solana-pubkey = { workspace = true, features = ["rand"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-vote = { path = "../vote", features = ["agave-unstable-api"] }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -24,3 +24,6 @@ solana-signature = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -44,3 +44,6 @@ solana-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/gossip-cli/Cargo.toml
+++ b/gossip-cli/Cargo.toml
@@ -26,3 +26,6 @@ solana-gossip = { workspace = true, features = ["agave-unstable-api"] }
 solana-net-utils = { workspace = true, features = ["agave-unstable-api"] }
 solana-pubkey = { version = "=4.2.0", features = ["rand"] }
 solana-version = { workspace = true }
+
+[lints]
+workspace = true

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -58,3 +58,6 @@ url = { workspace = true }
 [target."cfg(windows)".dependencies]
 winapi = { workspace = true, features = ["minwindef", "winuser"] }
 winreg = { workspace = true }
+
+[lints]
+workspace = true

--- a/io-uring/Cargo.toml
+++ b/io-uring/Cargo.toml
@@ -20,3 +20,6 @@ smallvec = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { workspace = true }
+
+[lints]
+workspace = true

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -46,3 +46,6 @@ tiny-bip39 = { workspace = true }
 [dev-dependencies]
 solana-pubkey = { workspace = true, features = ["rand"] }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/lattice-hash/Cargo.toml
+++ b/lattice-hash/Cargo.toml
@@ -26,3 +26,6 @@ solana-lattice-hash = { path = ".", features = ["agave-unstable-api"] }
 [[bench]]
 name = "bench_lt_hash"
 harness = false
+
+[lints]
+workspace = true

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -99,3 +99,6 @@ signal-hook = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -95,3 +95,6 @@ solana-genesis-utils = { path = "../genesis-utils", features = ["agave-unstable-
 solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-local-cluster = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+
+[lints]
+workspace = true

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -25,3 +25,6 @@ log = { workspace = true }
 [target."cfg(unix)".dependencies]
 libc = { workspace = true }
 signal-hook = { workspace = true }
+
+[lints]
+workspace = true

--- a/measure/Cargo.toml
+++ b/measure/Cargo.toml
@@ -14,3 +14,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 agave-unstable-api = []
+
+[lints]
+workspace = true

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -26,3 +26,6 @@ solana-sha256-hasher = { workspace = true }
 
 [dev-dependencies]
 hex = { workspace = true }
+
+[lints]
+workspace = true

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -39,3 +39,6 @@ solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 [[bench]]
 name = "metrics"
 harness = false
+
+[lints]
+workspace = true

--- a/notifier/Cargo.toml
+++ b/notifier/Cargo.toml
@@ -23,3 +23,6 @@ log = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 serde_json = { workspace = true }
 solana-hash = { workspace = true, features = ["std", "decode"] }
+
+[lints]
+workspace = true

--- a/poh-bench/Cargo.toml
+++ b/poh-bench/Cargo.toml
@@ -24,3 +24,6 @@ solana-entry = { workspace = true }
 solana-measure = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-version = { workspace = true }
+
+[lints]
+workspace = true

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -66,3 +66,6 @@ name = "poh"
 [[bench]]
 name = "transaction_recorder"
 harness = false
+
+[lints]
+workspace = true

--- a/program-binaries/Cargo.toml
+++ b/program-binaries/Cargo.toml
@@ -19,3 +19,6 @@ solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 spl-generic-token = { workspace = true }
+
+[lints]
+workspace = true

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -73,3 +73,6 @@ solana-cpi = { workspace = true }
 solana-program = { workspace = true }
 solana-program-test = { path = ".", features = ["agave-unstable-api"] }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/programs/bpf-loader-tests/Cargo.toml
+++ b/programs/bpf-loader-tests/Cargo.toml
@@ -34,3 +34,6 @@ solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
+
+[lints]
+workspace = true

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -78,3 +78,6 @@ harness = false
 [[bench]]
 name = "bpf_loader_upgradeable"
 harness = false
+
+[lints]
+workspace = true

--- a/programs/compute-budget-bench/Cargo.toml
+++ b/programs/compute-budget-bench/Cargo.toml
@@ -27,3 +27,6 @@ solana-svm-transaction = { workspace = true }
 [[bench]]
 name = "compute_budget"
 harness = false
+
+[lints]
+workspace = true

--- a/programs/compute-budget/Cargo.toml
+++ b/programs/compute-budget/Cargo.toml
@@ -21,3 +21,6 @@ agave-unstable-api = []
 
 [dependencies]
 solana-program-runtime = { workspace = true }
+
+[lints]
+workspace = true

--- a/programs/ed25519-tests/Cargo.toml
+++ b/programs/ed25519-tests/Cargo.toml
@@ -25,3 +25,6 @@ solana-program-test = { path = "../../program-test", features = ["agave-unstable
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
+
+[lints]
+workspace = true

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -53,3 +53,6 @@ solana-transaction-context = { path = "../../transaction-context", features = ["
 [[bench]]
 name = "system"
 harness = false
+
+[lints]
+workspace = true

--- a/programs/zk-elgamal-proof-tests/Cargo.toml
+++ b/programs/zk-elgamal-proof-tests/Cargo.toml
@@ -24,3 +24,6 @@ solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-zk-sdk = { workspace = true }
+
+[lints]
+workspace = true

--- a/programs/zk-elgamal-proof/Cargo.toml
+++ b/programs/zk-elgamal-proof/Cargo.toml
@@ -26,3 +26,6 @@ curve25519-dalek = { workspace = true }
 [[bench]]
 name = "verify_proofs"
 harness = false
+
+[lints]
+workspace = true

--- a/programs/zk-token-proof/Cargo.toml
+++ b/programs/zk-token-proof/Cargo.toml
@@ -13,3 +13,6 @@ agave-unstable-api = []
 
 [dependencies]
 solana-program-runtime = { workspace = true }
+
+[lints]
+workspace = true

--- a/pubsub-client/Cargo.toml
+++ b/pubsub-client/Cargo.toml
@@ -37,3 +37,6 @@ url = { workspace = true }
 anyhow = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
+
+[lints]
+workspace = true

--- a/quic-client/Cargo.toml
+++ b/quic-client/Cargo.toml
@@ -41,3 +41,6 @@ solana-perf = { path = "../perf", features = ["agave-unstable-api"] }
 solana-quic-client = { path = ".", features = ["agave-unstable-api"] }
 solana-streamer = { path = "../streamer", features = ["agave-unstable-api", "dev-context-only-utils"] }
 tokio-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/random/Cargo.toml
+++ b/random/Cargo.toml
@@ -28,3 +28,6 @@ rand_chacha = { workspace = true }
 solana-hash = { workspace = true, features = ["decode"] }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/rayon-threadlimit/Cargo.toml
+++ b/rayon-threadlimit/Cargo.toml
@@ -21,3 +21,6 @@ num_cpus = { workspace = true }
 
 [dev-dependencies]
 solana-rayon-threadlimit = { path = ".", features = ["agave-unstable-api"] }
+
+[lints]
+workspace = true

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -14,3 +14,6 @@ edition = { workspace = true }
 agave-unstable-api = []
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -42,3 +42,6 @@ uriparse = { workspace = true }
 assert_matches = { workspace = true }
 serial_test = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
+
+[lints]
+workspace = true

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -31,3 +31,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/rpc-client-nonce-utils/Cargo.toml
+++ b/rpc-client-nonce-utils/Cargo.toml
@@ -43,3 +43,6 @@ solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+
+[lints]
+workspace = true

--- a/rpc-client-types/Cargo.toml
+++ b/rpc-client-types/Cargo.toml
@@ -38,3 +38,6 @@ thiserror = { workspace = true }
 const_format = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signature = { workspace = true }
+
+[lints]
+workspace = true

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -67,3 +67,6 @@ solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -51,3 +51,6 @@ solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-transaction = { workspace = true }
+
+[lints]
+workspace = true

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -124,3 +124,6 @@ solana-vote-interface = { workspace = true }
 spl-pod = { workspace = true }
 symlink = { workspace = true }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -47,3 +47,6 @@ solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-c
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-system-transaction = { workspace = true }
+
+[lints]
+workspace = true

--- a/snapshots/Cargo.toml
+++ b/snapshots/Cargo.toml
@@ -48,3 +48,6 @@ zstd = { workspace = true }
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 solana-hash = { workspace = true, features = ["atomic"] }
+
+[lints]
+workspace = true

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -47,3 +47,6 @@ solana-version = { workspace = true }
 solana-client-traits = { workspace = true }
 solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+
+[lints]
+workspace = true

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -57,3 +57,6 @@ solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
 solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode"] }
+
+[lints]
+workspace = true

--- a/storage-bigtable/build-proto/Cargo.toml
+++ b/storage-bigtable/build-proto/Cargo.toml
@@ -19,3 +19,6 @@ tonic-prost-build = { workspace = true }
 # envar to point to the installed binary
 [target."cfg(not(windows))".dependencies]
 protobuf-src = { workspace = true }
+
+[lints]
+workspace = true

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -48,3 +48,6 @@ protobuf-src = { workspace = true }
 [dev-dependencies]
 enum-iterator = { workspace = true }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -61,3 +61,6 @@ clap = { version = "4.5.31", features = ["cargo", "derive", "error-context"] }
 solana-message = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-streamer = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+
+[lints]
+workspace = true

--- a/svm-log-collector/Cargo.toml
+++ b/svm-log-collector/Cargo.toml
@@ -17,3 +17,6 @@ agave-unstable-api = []
 
 [dependencies]
 log = { workspace = true }
+
+[lints]
+workspace = true

--- a/svm-measure/Cargo.toml
+++ b/svm-measure/Cargo.toml
@@ -14,3 +14,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 agave-unstable-api = []
+
+[lints]
+workspace = true

--- a/svm-timings/Cargo.toml
+++ b/svm-timings/Cargo.toml
@@ -22,3 +22,6 @@ solana-pubkey = { workspace = true }
 
 [dev-dependencies]
 solana-pubkey = { workspace = true, features = ["rand"] }
+
+[lints]
+workspace = true

--- a/svm-transaction/Cargo.toml
+++ b/svm-transaction/Cargo.toml
@@ -27,3 +27,6 @@ solana-pubkey = { workspace = true, features = ["std"] }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/svm-type-overrides/Cargo.toml
+++ b/svm-type-overrides/Cargo.toml
@@ -17,3 +17,6 @@ executor = ["dep:futures"]
 futures = { workspace = true, optional = true }
 rand = { workspace = true }
 shuttle = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/syscalls/gen-syscall-list/Cargo.toml
+++ b/syscalls/gen-syscall-list/Cargo.toml
@@ -13,3 +13,6 @@ agave-unstable-api = []
 
 [build-dependencies]
 regex = { workspace = true }
+
+[lints]
+workspace = true

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -65,3 +65,6 @@ tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 solana-sdk-ids = { workspace = true }
+
+[lints]
+workspace = true

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -63,3 +63,6 @@ assert_matches = { workspace = true }
 bincode = { workspace = true }
 solana-test-validator = { path = "../test-validator" }
 solana-transaction-error = { workspace = true }
+
+[lints]
+workspace = true

--- a/tps-client/Cargo.toml
+++ b/tps-client/Cargo.toml
@@ -47,3 +47,6 @@ thiserror = { workspace = true }
 [dev-dependencies]
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -56,3 +56,6 @@ solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
 solana-streamer = { path = "../streamer", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-tpu-client-next = { path = ".", features = ["agave-unstable-api", "websocket-node-address-service", "dev-context-only-utils"] }
+
+[lints]
+workspace = true

--- a/tpu-client/Cargo.toml
+++ b/tpu-client/Cargo.toml
@@ -41,3 +41,6 @@ solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 wincode = { workspace = true }
+
+[lints]
+workspace = true

--- a/transaction-status-client-types/Cargo.toml
+++ b/transaction-status-client-types/Cargo.toml
@@ -35,3 +35,6 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -61,3 +61,6 @@ spl-token-confidential-transfer-proof-extraction = { workspace = true }
 [[bench]]
 name = "extract_memos"
 harness = false
+
+[lints]
+workspace = true

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -47,3 +47,6 @@ harness = false
 [[bench]]
 name = "transaction_view"
 harness = false
+
+[lints]
+workspace = true

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -76,3 +76,6 @@ harness = false
 [[bench]]
 name = "cluster_nodes"
 harness = false
+
+[lints]
+workspace = true

--- a/udp-client/Cargo.toml
+++ b/udp-client/Cargo.toml
@@ -25,3 +25,6 @@ solana-transaction-error = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-packet = { workspace = true }
 solana-streamer = { path = "../streamer", features = ["agave-unstable-api", "dev-context-only-utils"] }
+
+[lints]
+workspace = true

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -27,3 +27,6 @@ solana-instruction = { workspace = true }
 solana-message = { workspace = true }
 solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -51,3 +51,6 @@ solana-system-transaction = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
 solana-unified-scheduler-pool = { path = ".", features = ["dev-context-only-utils"] }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -115,3 +115,6 @@ solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-c
 solana-time-utils = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -31,3 +31,6 @@ solana-pubkey = { version = "=4.2.0", default-features = false }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-version = { workspace = true }
+
+[lints]
+workspace = true

--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -25,3 +25,6 @@ arrayvec = { workspace = true }
 aya = { workspace = true }
 caps = { workspace = true }
 core_affinity = { workspace = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
#### Problem
Lint config specified on workspace `Cargo.toml` is often ineffective, the reason is that many crates do not inherit it from workspace, which is necessary for them to work.

#### Summary of Changes
* Apply
```
[lints]
workspace = true
```

to all crates missing it.

* move `check-cfg = ['cfg(build_target_feature_avx)', 'cfg(build_target_feature_avx2)']` from `perf` to elements defined on workspace level