### PR TITLE
fix tx-v1 binary transaction encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11215,6 +11215,7 @@ dependencies = [
  "spl-token-interface",
  "spl-token-metadata-interface",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9633,6 +9633,7 @@ dependencies = [
  "spl-token-interface",
  "spl-token-metadata-interface",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9945,6 +9945,7 @@ dependencies = [
  "spl-token-interface",
  "spl-token-metadata-interface",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -182,11 +182,11 @@ impl EncodedTransaction {
             TransactionBinaryEncoding::Base58 => bs58::decode(blob)
                 .into_vec()
                 .ok()
-                .and_then(|bytes| bincode::deserialize(&bytes).ok()),
+                .and_then(|bytes| wincode::deserialize(&bytes).ok()),
             TransactionBinaryEncoding::Base64 => BASE64_STANDARD
                 .decode(blob)
                 .ok()
-                .and_then(|bytes| bincode::deserialize(&bytes).ok()),
+                .and_then(|bytes| wincode::deserialize(&bytes).ok()),
         };
 
         transaction.filter(|transaction| transaction.sanitize().is_ok())
@@ -804,6 +804,30 @@ mod test {
             TransactionBinaryEncoding::Base58,
         );
         assert!(unsanitary_transaction.decode().is_none());
+    }
+
+    #[test]
+    fn test_decode_v1_wire_transaction() {
+        let transaction = VersionedTransaction {
+            signatures: vec![solana_signature::Signature::default()],
+            message: solana_message::VersionedMessage::V1(solana_message::v1::Message::new(
+                solana_message::MessageHeader {
+                    num_required_signatures: 1,
+                    num_readonly_signed_accounts: 0,
+                    num_readonly_unsigned_accounts: 0,
+                },
+                solana_message::v1::TransactionConfig::empty(),
+                Default::default(),
+                vec![Default::default()],
+                vec![],
+            )),
+        };
+        let encoded = EncodedTransaction::Binary(
+            BASE64_STANDARD.encode(wincode::serialize(&transaction).unwrap()),
+            TransactionBinaryEncoding::Base64,
+        );
+
+        assert_eq!(encoded.decode(), Some(transaction));
     }
 
     #[test]

--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -817,8 +817,8 @@ mod test {
                     num_readonly_unsigned_accounts: 0,
                 },
                 solana_message::v1::TransactionConfig::empty(),
-                Default::default(),
-                vec![Default::default()],
+                solana_message::Hash::default(),
+                vec![solana_message::Address::default()],
                 vec![],
             )),
         };

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -50,6 +50,7 @@ spl-token-group-interface = { workspace = true }
 spl-token-interface = { workspace = true }
 spl-token-metadata-interface = { workspace = true }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 bencher = { workspace = true }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -60,6 +60,10 @@ pub mod parse_token;
 pub mod parse_vote;
 pub mod token_balances;
 
+fn serialize_versioned_transaction(transaction: &VersionedTransaction) -> Vec<u8> {
+    wincode::serialize(transaction).expect("serialize versioned transaction")
+}
+
 pub struct BlockEncodingOptions {
     pub transaction_details: TransactionDetails,
     pub show_rewards: bool,
@@ -634,14 +638,14 @@ impl EncodableWithMeta for VersionedTransaction {
     ) -> Self::Encoded {
         match encoding {
             UiTransactionEncoding::Binary => EncodedTransaction::LegacyBinary(
-                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
+                bs58::encode(serialize_versioned_transaction(self)).into_string(),
             ),
             UiTransactionEncoding::Base58 => EncodedTransaction::Binary(
-                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
+                bs58::encode(serialize_versioned_transaction(self)).into_string(),
                 TransactionBinaryEncoding::Base58,
             ),
             UiTransactionEncoding::Base64 => EncodedTransaction::Binary(
-                BASE64_STANDARD.encode(bincode::serialize(self).unwrap()),
+                BASE64_STANDARD.encode(serialize_versioned_transaction(self)),
                 TransactionBinaryEncoding::Base64,
             ),
             UiTransactionEncoding::Json => self.json_encode(),
@@ -678,14 +682,14 @@ impl Encodable for VersionedTransaction {
     fn encode(&self, encoding: UiTransactionEncoding) -> Self::Encoded {
         match encoding {
             UiTransactionEncoding::Binary => EncodedTransaction::LegacyBinary(
-                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
+                bs58::encode(serialize_versioned_transaction(self)).into_string(),
             ),
             UiTransactionEncoding::Base58 => EncodedTransaction::Binary(
-                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
+                bs58::encode(serialize_versioned_transaction(self)).into_string(),
                 TransactionBinaryEncoding::Base58,
             ),
             UiTransactionEncoding::Base64 => EncodedTransaction::Binary(
-                BASE64_STANDARD.encode(bincode::serialize(self).unwrap()),
+                BASE64_STANDARD.encode(serialize_versioned_transaction(self)),
                 TransactionBinaryEncoding::Base64,
             ),
             UiTransactionEncoding::Json | UiTransactionEncoding::JsonParsed => {
@@ -1074,5 +1078,41 @@ mod test {
         assert_eq!(encoded.slot, 42);
         assert_eq!(encoded.block_time, Some(1234567890));
         assert_eq!(encoded.transaction_index, Some(7));
+    }
+
+    #[test]
+    fn test_v1_binary_encoding_uses_wire_format() {
+        let message = solana_message::v1::Message::new(
+            solana_message::MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 1,
+            },
+            solana_message::v1::TransactionConfig::empty(),
+            solana_hash::Hash::new_from_array([7; solana_hash::HASH_BYTES]),
+            vec![
+                solana_pubkey::Pubkey::new_unique(),
+                solana_pubkey::Pubkey::new_unique(),
+            ],
+            vec![],
+        );
+        let transaction = VersionedTransaction {
+            signatures: vec![solana_signature::Signature::default()],
+            message: solana_message::VersionedMessage::V1(message),
+        };
+
+        let EncodedTransaction::Binary(encoded, TransactionBinaryEncoding::Base64) =
+            transaction.encode(UiTransactionEncoding::Base64)
+        else {
+            panic!("expected binary base64 output");
+        };
+        let bytes = BASE64_STANDARD.decode(&encoded).unwrap();
+
+        assert_eq!(bytes[0], solana_message::v1::V1_PREFIX);
+        assert_eq!(bytes, wincode::serialize(&transaction).unwrap());
+        assert_eq!(
+            EncodedTransaction::Binary(encoded, TransactionBinaryEncoding::Base64).decode(),
+            Some(transaction)
+        );
     }
 }


### PR DESCRIPTION
Problem

transaction-status was still using bincode for binary VersionedTransaction output, so tx-v1 transactions were not emitted in wire format.

Summary of Changes

- use wincode for VersionedTransaction binary encoding
- decode binary encoded transactions with wincode
- add regression coverage for tx-v1 wire bytes

Closes #12587