### PR TITLE
clippy(programs): gate asm feature declaration with solana target

### DIFF
--- a/programs/sbf/rust/divide_by_zero/src/lib.rs
+++ b/programs/sbf/rust/divide_by_zero/src/lib.rs
@@ -1,6 +1,6 @@
 //! Example/test program to trigger vm error by dividing by zero
 
-#![feature(asm_experimental_arch)]
+#![cfg_attr(target_os = "solana", feature(asm_experimental_arch))]
 
 use {
     solana_account_info::AccountInfo, solana_program_error::ProgramResult, solana_pubkey::Pubkey,


### PR DESCRIPTION
#### Problem
Signaled by rust 1.96 clippy that the feature is not used. It is actually used, but only on solana target, which the clippy doesn't check.

#### Summary of Changes
Gate `#![feature(asm_experimental_arch)]` with solana target
