### PR TITLE
refactor: replace `SwitchBankEvent` channel with a single shared cell

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -34,8 +34,7 @@ use {
     },
     agave_votor::{
         event::{
-            CompletedBlock, LeaderWindowInfo, SwitchBankEvent, SwitchBankEventReceiver, VotorEvent,
-            VotorEventSender,
+            CompletedBlock, LatestSwitchRequest, LeaderWindowInfo, VotorEvent, VotorEventSender,
         },
         root_utils,
         vote_history_storage::SavedVoteHistory,
@@ -461,7 +460,7 @@ pub struct ReplayReceivers {
     pub gossip_verified_vote_hash_receiver: Receiver<(Pubkey, u64, Hash)>,
     pub popular_pruned_forks_receiver: Receiver<Vec<u64>>,
     pub bank_forks_controller_receiver: BankForksCommandReceiver,
-    pub switch_bank_receiver: SwitchBankEventReceiver,
+    pub latest_switch_request: LatestSwitchRequest,
 }
 
 /// Timing information for the ReplayStage main processing loop
@@ -776,7 +775,7 @@ impl ReplayStage {
             gossip_verified_vote_hash_receiver,
             popular_pruned_forks_receiver,
             bank_forks_controller_receiver,
-            switch_bank_receiver,
+            latest_switch_request,
         } = receivers;
 
         trace!("replay stage");
@@ -1045,7 +1044,7 @@ impl ReplayStage {
                     );
                     Self::process_switch_bank_events(
                         &my_pubkey,
-                        &switch_bank_receiver,
+                        &latest_switch_request,
                         &mut pending_switch,
                         &blockstore,
                         &bank_forks,
@@ -2359,7 +2358,7 @@ impl ReplayStage {
     /// this in `pending_switch`
     fn process_switch_bank_events(
         my_pubkey: &Pubkey,
-        switch_bank_receiver: &SwitchBankEventReceiver,
+        latest_switch_request: &LatestSwitchRequest,
         pending_switch: &mut Option<(Slot, Hash)>,
         blockstore: &Blockstore,
         bank_forks: &RwLock<BankForks>,
@@ -2368,13 +2367,11 @@ impl ReplayStage {
     ) -> Result<(), BlockstoreError> {
         let root = bank_forks.read().unwrap().root();
 
-        if let Some(switch_bank_event) = switch_bank_receiver
-            .try_iter()
-            .max()
-            .filter(|SwitchBankEvent::Switch { slot, .. }| *slot > root)
+        if let Some((slot, block_id)) = latest_switch_request
+            .take()
+            .map(|ev| ev.block())
+            .filter(|(slot, _)| *slot > root)
         {
-            let (slot, block_id) = switch_bank_event.block();
-
             // Overwrite the pending switch, later switches take precedence
             if Some(slot) >= pending_switch.map(|(slot, _)| slot) {
                 if let Some(prev_switch_request) = pending_switch.replace((slot, block_id)) {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -30,7 +30,7 @@ use {
     },
     agave_votor::{
         consensus_metrics::MAX_IN_FLIGHT_CONSENSUS_EVENTS,
-        event::{LeaderWindowInfo, VotorEventReceiver, VotorEventSender},
+        event::{LatestSwitchRequest, LeaderWindowInfo, VotorEventReceiver, VotorEventSender},
         generated_cert_types::GeneratedCertTypes,
         vote_history::VoteHistory,
         vote_history_storage::VoteHistoryStorage,
@@ -428,12 +428,8 @@ impl Tvu {
             completed_slots_receiver,
         };
 
-        // Create switch block event channel for ReplayStage
-        // We emit a switch bank event when we observe a ParentReady.
-        // The event is immediately consumed and the latest is stored in ReplayStage.
-        // We overprovision at 100 leader windows - we would require almost 3 minutes of stuck
-        // replay to hit the limit.
-        let (switch_bank_sender, switch_bank_receiver) = bounded(100);
+        // Shared latest switch-bank request from Votor to ReplayStage.
+        let latest_switch_request = LatestSwitchRequest::default();
 
         let window_service = {
             let epoch_schedule = bank_forks
@@ -522,7 +518,7 @@ impl Tvu {
             leader_window_info_sender,
             highest_parent_ready,
             event_sender: votor_event_sender.clone(),
-            switch_bank_sender,
+            latest_switch_request: latest_switch_request.clone(),
             own_vote_sender: consensus_message_sender.clone(),
             reward_certs_sender,
             repair_event_sender,
@@ -566,7 +562,7 @@ impl Tvu {
             gossip_verified_vote_hash_receiver,
             popular_pruned_forks_receiver,
             bank_forks_controller_receiver,
-            switch_bank_receiver,
+            latest_switch_request,
         };
 
         let replay_stage_config = ReplayStageConfig {

--- a/votor/src/event.rs
+++ b/votor/src/event.rs
@@ -4,7 +4,10 @@ use {
     solana_clock::Slot,
     solana_hash::Hash,
     solana_runtime::bank::Bank,
-    std::{sync::Arc, time::Instant},
+    std::{
+        sync::{Arc, Mutex},
+        time::Instant,
+    },
 };
 
 #[derive(Debug, Clone)]
@@ -119,13 +122,10 @@ impl RepairEvent {
     }
 }
 
-pub type SwitchBankEventSender = Sender<SwitchBankEvent>;
-pub type SwitchBankEventReceiver = Receiver<SwitchBankEvent>;
-
-/// Event sent to replay_stage when a bank needs to be switched as a result of a ParentReady
+/// Event sent to replay_stage when a bank needs to be switched as a result of a ParentReady.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SwitchBankEvent {
-    /// We need to switch any existing banks to this bank including ancestors
+    /// We need to switch any existing banks to this bank including ancestors.
     Switch { slot: Slot, block_id: Hash },
 }
 
@@ -134,5 +134,31 @@ impl SwitchBankEvent {
         match self {
             SwitchBankEvent::Switch { slot, block_id } => (*slot, *block_id),
         }
+    }
+}
+
+/// Shared single-cell holding the most recent switch-bank request from votor to replay.
+///
+/// Used instead of a channel because replay only ever acts on the latest event — buffering
+/// older events doesn't help, and blocking on a full channel could lead to a stall in Votor.
+/// Writer (votor) advances monotonically via [`Self::try_advance`]; reader (replay) pulls the
+/// current value via [`Self::take`].
+#[derive(Clone, Default)]
+pub struct LatestSwitchRequest(Arc<Mutex<Option<SwitchBankEvent>>>);
+
+impl LatestSwitchRequest {
+    /// Records `event` as the latest pending request, iff it is strictly newer than what's
+    /// currently held. Returns the previous value (if any) when it was overwritten.
+    pub fn try_advance(&self, event: SwitchBankEvent) -> Option<SwitchBankEvent> {
+        let mut guard = self.0.lock().unwrap();
+        match guard.as_ref() {
+            Some(cur) if event <= *cur => None,
+            _ => guard.replace(event),
+        }
+    }
+
+    /// Atomically takes the current request, leaving the cell empty.
+    pub fn take(&self) -> Option<SwitchBankEvent> {
+        self.0.lock().unwrap().take()
     }
 }

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -7,7 +7,7 @@ use {
         common::DELTA_FIRST_SLICE,
         consensus_metrics::ConsensusMetricsEvent,
         event::{
-            CompletedBlock, RepairEvent, RepairEventSender, SwitchBankEvent, SwitchBankEventSender,
+            CompletedBlock, LatestSwitchRequest, RepairEvent, RepairEventSender, SwitchBankEvent,
             VotorEvent, VotorEventReceiver,
         },
         event_handler::stats::EventHandlerStats,
@@ -223,7 +223,7 @@ impl EventHandler {
 
         // We need to ensure that we've replayed the parent bank.
         if parent_slot > vctx.sharable_banks.root().slot() {
-            request_switch(&ctx.switch_bank_sender, *my_pubkey, parent_block)?;
+            request_switch(&ctx.latest_switch_request, *my_pubkey, parent_block);
         }
 
         let should_set_timeouts = vctx.vote_history.add_parent_ready(slot, parent_block);
@@ -883,28 +883,14 @@ fn request_repair(
     }
 }
 
-/// Sends a switch bank event to replay.
-fn request_switch(
-    sender: &SwitchBankEventSender,
-    my_pubkey: Pubkey,
-    block: Block,
-) -> Result<(), EventLoopError> {
+/// Updates the latest switch-bank request for replay to consume.
+fn request_switch(latest: &LatestSwitchRequest, my_pubkey: Pubkey, block: Block) {
     let (slot, block_id) = block;
     let event = SwitchBankEvent::Switch { slot, block_id };
-    match sender.try_send(event) {
-        Ok(()) => Ok(()),
-        Err(TrySendError::Full(event)) => {
-            error!(
-                "{my_pubkey}: Switch bank event channel is full, this should not happen. Blocking \
-                 to send event for slot {slot}"
-            );
-            sender
-                .send(event)
-                .map_err(|_| EventLoopError::SenderDisconnected(SendError(())))
-        }
-        Err(TrySendError::Disconnected(_)) => {
-            Err(EventLoopError::SenderDisconnected(SendError(())))
-        }
+    if let Some(prev) = latest.try_advance(event) {
+        trace!(
+            "{my_pubkey}: Overwriting previous switch request {prev:?} with ({slot}, {block_id})"
+        );
     }
 }
 
@@ -915,7 +901,7 @@ mod tests {
         crate::{
             commitment::CommitmentAggregationData,
             consensus_metrics::ConsensusMetricsEventReceiver,
-            event::{LeaderWindowInfo, RepairEventReceiver, SwitchBankEventReceiver},
+            event::{LeaderWindowInfo, RepairEventReceiver},
             vote_history_storage::{
                 FileVoteHistoryStorage, SavedVoteHistory, SavedVoteHistoryVersions,
                 VoteHistoryStorage,
@@ -970,8 +956,6 @@ mod tests {
         consensus_metrics_receiver: ConsensusMetricsEventReceiver,
         #[allow(dead_code)] // Keep receiver alive to prevent SenderDisconnected errors
         repair_event_receiver: RepairEventReceiver,
-        #[allow(dead_code)]
-        switch_bank_receiver: SwitchBankEventReceiver,
         shared_context: SharedContext,
         voting_context: VotingContext,
         root_context: RootContext,
@@ -1036,7 +1020,7 @@ mod tests {
         let (consensus_metrics_sender, consensus_metrics_receiver) = unbounded();
         let (leader_window_info_sender, leader_window_info_receiver) = unbounded();
         let (repair_event_sender, repair_event_receiver) = unbounded();
-        let (switch_bank_sender, switch_bank_receiver) = unbounded();
+        let latest_switch_request = LatestSwitchRequest::default();
         let timer_manager = Arc::new(PlRwLock::new(TimerManager::new(
             event_sender,
             exit,
@@ -1095,7 +1079,7 @@ mod tests {
             blockstore: blockstore.clone(),
             highest_parent_ready: highest_parent_ready.clone(),
             repair_event_sender,
-            switch_bank_sender,
+            latest_switch_request,
         };
 
         let vote_history = VoteHistory::new(my_node_keypair.pubkey(), 0);
@@ -1139,7 +1123,6 @@ mod tests {
             cluster_info,
             consensus_metrics_receiver,
             repair_event_receiver,
-            switch_bank_receiver,
             highest_parent_ready,
             shared_context,
             voting_context,

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -52,7 +52,7 @@ use {
         consensus_pool_service::{ConsensusPoolContext, ConsensusPoolService},
         consensus_rewards::ConsensusRewardsService,
         event::{
-            LeaderWindowInfo, RepairEventSender, SwitchBankEventSender, VotorEventReceiver,
+            LatestSwitchRequest, LeaderWindowInfo, RepairEventSender, VotorEventReceiver,
             VotorEventSender,
         },
         event_handler::{EventHandler, EventHandlerContext},
@@ -119,7 +119,7 @@ pub struct VotorConfig {
     pub own_vote_sender: Sender<Vec<ConsensusMessage>>,
     pub reward_certs_sender: Sender<BuildRewardCertsResponse>,
     pub repair_event_sender: RepairEventSender,
-    pub switch_bank_sender: SwitchBankEventSender,
+    pub latest_switch_request: LatestSwitchRequest,
 
     // Receivers
     pub event_receiver: VotorEventReceiver,
@@ -138,7 +138,7 @@ pub(crate) struct SharedContext {
     pub(crate) highest_parent_ready: Arc<RwLock<(Slot, (Slot, Hash))>>,
     pub(crate) vote_history_storage: Arc<dyn VoteHistoryStorage>,
     pub(crate) repair_event_sender: RepairEventSender,
-    pub(crate) switch_bank_sender: SwitchBankEventSender,
+    pub(crate) latest_switch_request: LatestSwitchRequest,
 }
 
 pub struct Votor {
@@ -170,7 +170,7 @@ impl Votor {
             event_sender,
             own_vote_sender,
             repair_event_sender,
-            switch_bank_sender,
+            latest_switch_request,
             event_receiver,
             consensus_message_receiver,
             consensus_metrics_sender,
@@ -197,7 +197,7 @@ impl Votor {
             leader_window_info_sender,
             vote_history_storage,
             repair_event_sender: repair_event_sender.clone(),
-            switch_bank_sender,
+            latest_switch_request,
         };
 
         let voting_context = VotingContext {


### PR DESCRIPTION
#### Problem
Since #11753 we are using a bounded channel to send `SwitchBankEvents` from Votor to ReplayStage. Consuming from the channel happens via `.try_iter().max()`, i.e., only the latest event is considered. Instead, we can simplify the entire thing by storing only the latest event in a shared `Arc<Mutex<Option<SwitchBankEvents>>>`. This also prevents any issues of the channel filling up and having to either block on sending to a full channel or drop events instead of sending them.

#### Summary of Changes
Introduce new struct `LatestSwitchRequest` that is a wrapper around `Arc<Mutex<Option<SwitchBankEvents>>>` and replace the previous channel with it.