### PR TITLE
fix: v1 transactions over 1232 bytes

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -591,6 +591,8 @@ impl ValidatorTpuConfig {
         let tpu_quic_server_config = SwQosQuicStreamerConfig {
             quic_streamer_config: QuicStreamerConfig {
                 max_connections_per_ipaddr_per_min: 32,
+                stream_receive_window_size: solana_message::v1::MAX_TRANSACTION_SIZE as u32,
+                max_stream_data_bytes: solana_message::v1::MAX_TRANSACTION_SIZE as u32,
                 ..Default::default()
             },
             qos_config: SwQosConfig::default(),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4366,8 +4366,11 @@ fn rpc_perf_sample_from_perf_sample(slot: u64, sample: PerfSample) -> RpcPerfSam
     }
 }
 
+// Base58 encoding is deprecated, not increased for v1 transactions
 const MAX_BASE58_SIZE: usize = 1683; // Golden, bump if PACKET_DATA_SIZE changes
-const MAX_BASE64_SIZE: usize = 1644; // Golden, bump if PACKET_DATA_SIZE changes
+// Cap base64 based on the largest supported transaction version,
+// which is v1 (4096 bytes).
+const MAX_BASE64_SIZE: usize = 5464; // ceil(4096 / 3) * 4
 fn decode_and_deserialize<T>(
     encoded: String,
     encoding: TransactionBinaryEncoding,
@@ -4399,7 +4402,7 @@ where
                     type_name::<T>(),
                     encoded.len(),
                     MAX_BASE64_SIZE,
-                    PACKET_DATA_SIZE,
+                    solana_message::v1::MAX_TRANSACTION_SIZE,
                 )));
             }
             BASE64_STANDARD
@@ -4407,12 +4410,19 @@ where
                 .map_err(|e| Error::invalid_params(format!("invalid base64 encoding: {e:?}")))?
         }
     };
-    if wire_output.len() > PACKET_DATA_SIZE {
+    // V1 transactions/messages start with V1_PREFIX (0x81) and may be up to
+    // 4096 bytes; legacy/v0 are still capped at PACKET_DATA_SIZE (1232).
+    let max_raw_size = if wire_output.first().copied() == Some(solana_message::v1::V1_PREFIX) {
+        solana_message::v1::MAX_TRANSACTION_SIZE
+    } else {
+        PACKET_DATA_SIZE
+    };
+    if wire_output.len() > max_raw_size {
         return Err(Error::invalid_params(format!(
             "decoded {} too large: {} bytes (max: {} bytes)",
             type_name::<T>(),
             wire_output.len(),
-            PACKET_DATA_SIZE
+            max_raw_size
         )));
     }
 
@@ -9111,17 +9121,21 @@ pub mod tests {
 
     #[test]
     fn test_worst_case_encoded_tx_goldens() {
-        let ff_tx = vec![0xffu8; PACKET_DATA_SIZE];
-        let tx58 = bs58::encode(&ff_tx).into_string();
+        // Base58 is capped at the legacy PACKET_DATA_SIZE since base58 encoding
+        // is deprecated and not extended to v1-sized transactions.
+        let ff_tx58_input = vec![0xffu8; PACKET_DATA_SIZE];
+        let tx58 = bs58::encode(&ff_tx58_input).into_string();
         assert_eq!(tx58.len(), MAX_BASE58_SIZE);
-        let tx64 = BASE64_STANDARD.encode(&ff_tx);
+
+        // Base64 is sized for the largest supported transaction version (v1).
+        let ff_tx64_input = vec![0xffu8; solana_message::v1::MAX_TRANSACTION_SIZE];
+        let tx64 = BASE64_STANDARD.encode(&ff_tx64_input);
         assert_eq!(tx64.len(), MAX_BASE64_SIZE);
     }
 
     #[test]
-    fn test_decode_and_deserialize_too_large_payloads_fail() {
-        // +2 because +1 still fits in base64 encoded worst-case
-        let too_big = PACKET_DATA_SIZE + 2;
+    fn test_decode_and_deserialize_too_large_encoded_base58_payload_fails() {
+        let too_big = PACKET_DATA_SIZE + 1;
         let tx_ser = vec![0xffu8; too_big];
 
         let tx58 = bs58::encode(&tx_ser).into_string();
@@ -9134,6 +9148,13 @@ pub mod tests {
                  encoded/raw {MAX_BASE58_SIZE}/{PACKET_DATA_SIZE})",
             ))
         );
+    }
+
+    #[test]
+    fn test_decode_and_deserialize_too_large_encoded_base64_payload_fails() {
+        // +3 because +2 still fits in base64 encoded worst-case
+        let too_big = solana_message::v1::MAX_TRANSACTION_SIZE + 3;
+        let tx_ser = vec![0xffu8; too_big];
 
         let tx64 = BASE64_STANDARD.encode(&tx_ser);
         let tx64_len = tx64.len();
@@ -9142,10 +9163,14 @@ pub mod tests {
                 .unwrap_err(),
             Error::invalid_params(format!(
                 "base64 encoded solana_transaction::Transaction too large: {tx64_len} bytes (max: \
-                 encoded/raw {MAX_BASE64_SIZE}/{PACKET_DATA_SIZE})",
+                 encoded/raw {MAX_BASE64_SIZE}/{})",
+                solana_message::v1::MAX_TRANSACTION_SIZE,
             ))
         );
+    }
 
+    #[test]
+    fn test_decode_and_deserialize_too_large_payloads_fail() {
         let too_big = PACKET_DATA_SIZE + 1;
         let tx_ser = vec![0x00u8; too_big];
         let tx58 = bs58::encode(&tx_ser).into_string();
@@ -9204,6 +9229,46 @@ pub mod tests {
                 "invalid base58 encoding: InvalidCharacter { character: '!', index: 1680 }"
                     .to_string(),
             )
+        );
+    }
+
+    #[test]
+    fn test_decode_and_deserialize_v1_sized_payload_passes_size_checks() {
+        // V1-prefixed payload at the V1 max size. Random bytes will fail
+        // wincode deserialization, but should pass the size gates.
+        let mut tx_ser = vec![0xffu8; solana_message::v1::MAX_TRANSACTION_SIZE];
+        tx_ser[0] = solana_message::v1::V1_PREFIX;
+
+        let tx64 = BASE64_STANDARD.encode(&tx_ser);
+        let err =
+            decode_and_deserialize::<VersionedTransaction>(tx64, TransactionBinaryEncoding::Base64)
+                .unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(
+            err.message.starts_with(
+                "failed to deserialize solana_transaction::versioned::VersionedTransaction"
+            ),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn test_decode_and_deserialize_v1_oversize_payload_fails() {
+        // V1-prefixed payload one byte over the V1 max.
+        let too_big = solana_message::v1::MAX_TRANSACTION_SIZE + 1;
+        let mut tx_ser = vec![0xffu8; too_big];
+        tx_ser[0] = solana_message::v1::V1_PREFIX;
+
+        let tx64 = BASE64_STANDARD.encode(&tx_ser);
+        assert_eq!(
+            decode_and_deserialize::<VersionedTransaction>(tx64, TransactionBinaryEncoding::Base64)
+                .unwrap_err(),
+            Error::invalid_params(format!(
+                "decoded solana_transaction::versioned::VersionedTransaction too large: {too_big} \
+                 bytes (max: {} bytes)",
+                solana_message::v1::MAX_TRANSACTION_SIZE,
+            ))
         );
     }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4371,6 +4371,8 @@ const MAX_BASE58_SIZE: usize = 1683; // Golden, bump if PACKET_DATA_SIZE changes
 // Cap base64 based on the largest supported transaction version,
 // which is v1 (4096 bytes).
 const MAX_BASE64_SIZE: usize = 5464; // ceil(4096 / 3) * 4
+// Legacy/v0 transactions are still capped at PACKET_DATA_SIZE (1232 bytes).
+const MAX_BASE64_LEGACY_SIZE: usize = 1644; // ceil(1232 / 3) * 4
 
 // V1+ messages start with 0x81 (or higher). In base64 the top 6 bits of 0x81
 // Comparing the first two chars against "gQ" detects V1+ before decoding.
@@ -4404,22 +4406,22 @@ where
         }
         TransactionBinaryEncoding::Base64 => {
             inc_new_counter_info!("rpc-base64_encoded_tx", 1);
-            let max_raw_size = if encoded
+            let (max_encoded_size, max_raw_size) = if encoded
                 .as_bytes()
                 .get(..2)
                 .is_some_and(|p| p >= V1_BASE64_PREFIX_LOWER_BOUND)
             {
-                solana_message::v1::MAX_TRANSACTION_SIZE
+                (MAX_BASE64_SIZE, solana_message::v1::MAX_TRANSACTION_SIZE)
             } else {
-                PACKET_DATA_SIZE
+                (MAX_BASE64_LEGACY_SIZE, PACKET_DATA_SIZE)
             };
-            if encoded.len() > MAX_BASE64_SIZE {
+            if encoded.len() > max_encoded_size {
                 return Err(Error::invalid_params(format!(
                     "base64 encoded {} too large: {} bytes (max: encoded/raw {}/{})",
                     type_name::<T>(),
                     encoded.len(),
-                    MAX_BASE64_SIZE,
-                    solana_message::v1::MAX_TRANSACTION_SIZE,
+                    max_encoded_size,
+                    max_raw_size,
                 )));
             }
             let bytes = BASE64_STANDARD
@@ -9162,10 +9164,11 @@ pub mod tests {
     }
 
     #[test]
-    fn test_decode_and_deserialize_too_large_encoded_base64_payload_fails() {
+    fn test_decode_and_deserialize_too_large_encoded_base64_v1_payload_fails() {
         // +3 because +2 still fits in base64 encoded worst-case
         let too_big = solana_message::v1::MAX_TRANSACTION_SIZE + 3;
-        let tx_ser = vec![0xffu8; too_big];
+        let mut tx_ser = vec![0xffu8; too_big];
+        tx_ser[0] = solana_message::v1::V1_PREFIX;
 
         let tx64 = BASE64_STANDARD.encode(&tx_ser);
         let tx64_len = tx64.len();
@@ -9176,6 +9179,26 @@ pub mod tests {
                 "base64 encoded solana_transaction::Transaction too large: {tx64_len} bytes (max: \
                  encoded/raw {MAX_BASE64_SIZE}/{})",
                 solana_message::v1::MAX_TRANSACTION_SIZE,
+            ))
+        );
+    }
+
+    #[test]
+    fn test_decode_and_deserialize_too_large_encoded_base64_legacy_payload_fails() {
+        // Legacy/v0 payloads must bail out before decoding when they exceed the
+        // legacy base64 cap, even if they would fit under the v1 cap.
+        let too_big = PACKET_DATA_SIZE + 3;
+        let tx_ser = vec![0x00u8; too_big];
+
+        let tx64 = BASE64_STANDARD.encode(&tx_ser);
+        let tx64_len = tx64.len();
+        assert!(tx64_len > MAX_BASE64_LEGACY_SIZE && tx64_len < MAX_BASE64_SIZE);
+        assert_eq!(
+            decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
+                .unwrap_err(),
+            Error::invalid_params(format!(
+                "base64 encoded solana_transaction::Transaction too large: {tx64_len} bytes (max: \
+                 encoded/raw {MAX_BASE64_LEGACY_SIZE}/{PACKET_DATA_SIZE})",
             ))
         );
     }
@@ -9279,24 +9302,6 @@ pub mod tests {
                 "decoded solana_transaction::versioned::VersionedTransaction too large: {too_big} \
                  bytes (max: {} bytes)",
                 solana_message::v1::MAX_TRANSACTION_SIZE,
-            ))
-        );
-    }
-
-    #[test]
-    fn test_decode_and_deserialize_oversize_non_v1_base64_payload_fails() {
-        // +2 because +1 still fits in base64 encoded worst-case
-        let too_big = PACKET_DATA_SIZE + 2;
-        let tx_ser = vec![0x00u8; too_big];
-        assert_ne!(tx_ser[0], solana_message::v1::V1_PREFIX);
-
-        let tx64 = BASE64_STANDARD.encode(&tx_ser);
-        assert_eq!(
-            decode_and_deserialize::<VersionedTransaction>(tx64, TransactionBinaryEncoding::Base64)
-                .unwrap_err(),
-            Error::invalid_params(format!(
-                "decoded solana_transaction::versioned::VersionedTransaction too large: {too_big} \
-                 bytes (max: {PACKET_DATA_SIZE} bytes)",
             ))
         );
     }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4371,6 +4371,12 @@ const MAX_BASE58_SIZE: usize = 1683; // Golden, bump if PACKET_DATA_SIZE changes
 // Cap base64 based on the largest supported transaction version,
 // which is v1 (4096 bytes).
 const MAX_BASE64_SIZE: usize = 5464; // ceil(4096 / 3) * 4
+
+// V1+ messages start with 0x81 (or higher). In base64 the top 6 bits of 0x81
+// Comparing the first two chars against "gQ" detects V1+ before decoding.
+// Revisit before V3 which will break this shortcut
+const V1_BASE64_PREFIX_LOWER_BOUND: &[u8] = b"gQ";
+
 fn decode_and_deserialize<T>(
     encoded: String,
     encoding: TransactionBinaryEncoding,
@@ -4378,7 +4384,7 @@ fn decode_and_deserialize<T>(
 where
     T: for<'a> wincode::SchemaRead<'a, wincode::config::DefaultConfig, Dst = T>,
 {
-    let wire_output = match encoding {
+    let (wire_output, max_raw_size) = match encoding {
         TransactionBinaryEncoding::Base58 => {
             inc_new_counter_info!("rpc-base58_encoded_tx", 1);
             if encoded.len() > MAX_BASE58_SIZE {
@@ -4390,12 +4396,23 @@ where
                     PACKET_DATA_SIZE,
                 )));
             }
-            bs58::decode(encoded)
+            let bytes = bs58::decode(encoded)
                 .into_vec()
-                .map_err(|e| Error::invalid_params(format!("invalid base58 encoding: {e:?}")))?
+                .map_err(|e| Error::invalid_params(format!("invalid base58 encoding: {e:?}")))?;
+            // base58 is deprecated, unchanged max size
+            (bytes, PACKET_DATA_SIZE)
         }
         TransactionBinaryEncoding::Base64 => {
             inc_new_counter_info!("rpc-base64_encoded_tx", 1);
+            let max_raw_size = if encoded
+                .as_bytes()
+                .get(..2)
+                .is_some_and(|p| p >= V1_BASE64_PREFIX_LOWER_BOUND)
+            {
+                solana_message::v1::MAX_TRANSACTION_SIZE
+            } else {
+                PACKET_DATA_SIZE
+            };
             if encoded.len() > MAX_BASE64_SIZE {
                 return Err(Error::invalid_params(format!(
                     "base64 encoded {} too large: {} bytes (max: encoded/raw {}/{})",
@@ -4405,17 +4422,11 @@ where
                     solana_message::v1::MAX_TRANSACTION_SIZE,
                 )));
             }
-            BASE64_STANDARD
+            let bytes = BASE64_STANDARD
                 .decode(encoded)
-                .map_err(|e| Error::invalid_params(format!("invalid base64 encoding: {e:?}")))?
+                .map_err(|e| Error::invalid_params(format!("invalid base64 encoding: {e:?}")))?;
+            (bytes, max_raw_size)
         }
-    };
-    // V1 transactions/messages start with V1_PREFIX (0x81) and may be up to
-    // 4096 bytes; legacy/v0 are still capped at PACKET_DATA_SIZE (1232).
-    let max_raw_size = if wire_output.first().copied() == Some(solana_message::v1::V1_PREFIX) {
-        solana_message::v1::MAX_TRANSACTION_SIZE
-    } else {
-        PACKET_DATA_SIZE
     };
     if wire_output.len() > max_raw_size {
         return Err(Error::invalid_params(format!(
@@ -9268,6 +9279,24 @@ pub mod tests {
                 "decoded solana_transaction::versioned::VersionedTransaction too large: {too_big} \
                  bytes (max: {} bytes)",
                 solana_message::v1::MAX_TRANSACTION_SIZE,
+            ))
+        );
+    }
+
+    #[test]
+    fn test_decode_and_deserialize_oversize_non_v1_base64_payload_fails() {
+        // +2 because +1 still fits in base64 encoded worst-case
+        let too_big = PACKET_DATA_SIZE + 2;
+        let tx_ser = vec![0x00u8; too_big];
+        assert_ne!(tx_ser[0], solana_message::v1::V1_PREFIX);
+
+        let tx64 = BASE64_STANDARD.encode(&tx_ser);
+        assert_eq!(
+            decode_and_deserialize::<VersionedTransaction>(tx64, TransactionBinaryEncoding::Base64)
+                .unwrap_err(),
+            Error::invalid_params(format!(
+                "decoded solana_transaction::versioned::VersionedTransaction too large: {too_big} \
+                 bytes (max: {PACKET_DATA_SIZE} bytes)",
             ))
         );
     }


### PR DESCRIPTION
Updated version of https://github.com/anza-xyz/agave/pull/12508 (now reverted)

#### Problem

While testing v1 transactions I found 2 issues that mean they don't work correctly when they are larger than the existing 1232 byte limit.

- The `sendTransaction` RPC call rejects transactions larger than 1232 bytes (based on their size encoded as base58 or base64)
- The quic streaming drops packets over 1232 bytes, meaning that these larger transactions never land

#### Summary of Changes

- rpc: 
  - `MAX_BASE64_SIZE` is updated to support up to 4096 bytes encoded. `MAX_BASE58_SIZE` is left unchanged, base58 is deprecated and will not support larger v1 transactions
  - The size check after decoding is now version aware, and allows up to 4096 bytes for v1 transactions. Legacy/v0 transactions over 1232 bytes are rejected here.

- validator: configure quic with packet size increased to 4096 bytes

With both these changes, I am able to land v1 transactions larger than 1232 bytes on a local test validator.