### PR TITLE
Bank::get_slot_history() is fallible

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1768,7 +1768,9 @@ impl ReplayStage {
     ) -> Result<Tower, TowerError> {
         let tower = Tower::restore(tower_storage, node_pubkey).and_then(|restored_tower| {
             let root_bank = bank_forks.read().unwrap().root_bank();
-            let slot_history = root_bank.get_slot_history();
+            let slot_history = root_bank
+                .get_slot_history()
+                .expect("slot history must exist");
             restored_tower.adjust_lockouts_after_replay(root_bank.slot(), &slot_history)
         });
         match tower {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2057,7 +2057,9 @@ fn post_process_restored_tower(
 
     let restored_tower = restored_tower.and_then(|tower| {
         let root_bank = bank_forks.root_bank();
-        let slot_history = root_bank.get_slot_history();
+        let slot_history = root_bank
+            .get_slot_history()
+            .expect("slot history must exist");
         // make sure tower isn't corrupted first before the following hard fork check
         let tower = tower.adjust_lockouts_after_replay(root_bank.slot(), &slot_history);
 

--- a/rpc-client-api/src/custom_error.rs
+++ b/rpc-client-api/src/custom_error.rs
@@ -29,6 +29,7 @@ pub const JSON_RPC_SERVER_ERROR_EPOCH_REWARDS_PERIOD_ACTIVE: i64 = -32017;
 pub const JSON_RPC_SERVER_ERROR_SLOT_NOT_EPOCH_BOUNDARY: i64 = -32018;
 pub const JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE: i64 = -32019;
 pub const JSON_RPC_SERVER_ERROR_FILTER_TRANSACTION_NOT_FOUND: i64 = -32020;
+pub const JSON_RPC_SERVER_ERROR_NO_SLOT_HISTORY: i64 = -32021;
 
 #[derive(Error, Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -83,6 +84,8 @@ pub enum RpcCustomError {
     LongTermStorageUnreachable,
     #[error("FilterTransactionNotFound")]
     FilterTransactionNotFound { signature: String },
+    #[error("NoSlotHistory")]
+    NoSlotHistory,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -265,6 +268,11 @@ impl From<RpcCustomError> for Error {
             RpcCustomError::FilterTransactionNotFound { signature } => Self {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_FILTER_TRANSACTION_NOT_FOUND),
                 message: format!("Transaction {signature} not found"),
+                data: None,
+            },
+            RpcCustomError::NoSlotHistory => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_NO_SLOT_HISTORY),
+                message: "No slot history".to_string(),
                 data: None,
             },
         }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3136,7 +3136,9 @@ pub mod rpc_bank {
                 }
             };
 
-            let slot_history = bank.get_slot_history();
+            let Some(slot_history) = bank.get_slot_history() else {
+                return Err(RpcCustomError::NoSlotHistory.into());
+            };
             if first_slot < slot_history.oldest() {
                 return Err(Error::invalid_params(format!(
                     "firstSlot, {}, is too small; min {}",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2469,8 +2469,8 @@ impl Bank {
         });
     }
 
-    pub fn get_slot_history(&self) -> SlotHistory {
-        from_account(&self.get_account(&sysvar::slot_history::id()).unwrap()).unwrap()
+    pub fn get_slot_history(&self) -> Option<SlotHistory> {
+        from_account(&self.get_account(&sysvar::slot_history::id())?)
     }
 
     fn update_epoch_stakes(&mut self, leader_schedule_epoch: Epoch) {

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -527,12 +527,10 @@ fn verify_slot_deltas(
 ) -> std::result::Result<(), VerifySlotDeltasError> {
     let max_root_entries = bank.status_cache.read().unwrap().max_root_entries();
     let info = verify_slot_deltas_structural(slot_deltas, bank.slot(), max_root_entries)?;
-    verify_slot_deltas_with_history(
-        &info.slots,
-        &bank.get_slot_history(),
-        bank.slot(),
-        max_root_entries,
-    )
+    let slot_history = bank
+        .get_slot_history()
+        .expect("snapshot bank must have slot history");
+    verify_slot_deltas_with_history(&info.slots, &slot_history, bank.slot(), max_root_entries)
 }
 
 /// Verify that the snapshot's slot deltas are not corrupt/invalid


### PR DESCRIPTION
#### Problem

`Bank::get_slot_history()` double unwraps, which causes a panic on error. Instead, let the caller decide if this error is fatal or not.


#### Summary of Changes

* Makes `Bank::get_slot_history()` return an Option
* Updates callers to call `.unwrap()` (this maintains the current behavior--happy to adjust!)
* Add a new RPC error