### PR TITLE
XDP for Repair TX path

### DIFF
--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -18,6 +18,7 @@ use {
         },
     },
     agave_votor_messages::{VerifiedVoterSlotsReceiver, migration::MigrationStatus},
+    bytes::Bytes,
     crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender},
     lazy_lru::LruCache,
     rand::prelude::IndexedRandom as _,
@@ -33,6 +34,7 @@ use {
         shred,
     },
     solana_measure::measure::Measure,
+    solana_net_utils::PinnedXdpSender,
     solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank,
@@ -625,6 +627,7 @@ impl RepairService {
         repair_info: RepairInfo,
         outstanding_requests: Arc<RwLock<OutstandingShredRepairs>>,
         repair_service_channels: RepairServiceChannels,
+        xdp_sender: Option<PinnedXdpSender>,
     ) -> Self {
         let t_repair = {
             let blockstore = blockstore.clone();
@@ -640,6 +643,7 @@ impl RepairService {
                         repair_service_channels.repair_channels,
                         repair_info,
                         &outstanding_requests,
+                        xdp_sender,
                     )
                 })
                 .unwrap()
@@ -804,6 +808,7 @@ impl RepairService {
         repair_info: &RepairInfo,
         outstanding_requests: &RwLock<OutstandingShredRepairs>,
         repair_socket: &UdpSocket,
+        xdp_sender: Option<&PinnedXdpSender>,
         repair_metrics: &mut RepairMetrics,
     ) {
         let mut build_repairs_batch_elapsed = Measure::start("build_repairs_batch_elapsed");
@@ -830,15 +835,23 @@ impl RepairService {
         let mut batch_send_repairs_elapsed = Measure::start("batch_send_repairs_elapsed");
         if !batch.is_empty() {
             let num_pkts = batch.len();
-            let batch = batch.iter().map(|(bytes, addr)| (bytes, addr));
-            match batch_send(repair_socket, batch) {
-                Ok(()) => (),
-                Err(SendPktsError::IoError(err, num_failed)) => {
-                    error!(
-                        "{} batch_send failed to send {num_failed}/{num_pkts} packets first error \
-                         {err:?}",
-                        repair_info.cluster_info.id()
-                    );
+            if let Some(xdp) = xdp_sender {
+                for (i, (bytes, addr)) in batch.into_iter().enumerate() {
+                    if let Err(e) = xdp.try_send(i, addr, Bytes::from(bytes)) {
+                        warn!("repair xdp send failed: {e:?}");
+                    }
+                }
+            } else {
+                let batch = batch.iter().map(|(bytes, addr)| (bytes, addr));
+                match batch_send(repair_socket, batch) {
+                    Ok(()) => (),
+                    Err(SendPktsError::IoError(err, num_failed)) => {
+                        error!(
+                            "{} batch_send failed to send {num_failed}/{num_pkts} packets first \
+                             error {err:?}",
+                            repair_info.cluster_info.id()
+                        );
+                    }
                 }
             }
         }
@@ -855,6 +868,7 @@ impl RepairService {
         repair_tracker: &mut RepairTracker,
         outstanding_requests: &RwLock<OutstandingShredRepairs>,
         repair_socket: &UdpSocket,
+        xdp_sender: Option<&PinnedXdpSender>,
         migration_status: &MigrationStatus,
     ) {
         let RepairChannels {
@@ -911,6 +925,7 @@ impl RepairService {
             repair_info,
             outstanding_requests,
             repair_socket,
+            xdp_sender,
             repair_metrics,
         );
     }
@@ -922,6 +937,7 @@ impl RepairService {
         repair_channels: RepairChannels,
         repair_info: RepairInfo,
         outstanding_requests: &RwLock<OutstandingShredRepairs>,
+        xdp_sender: Option<PinnedXdpSender>,
     ) {
         let (sharable_banks, migration_status) = {
             let bank_forks_r = repair_info.bank_forks.read().unwrap();
@@ -958,6 +974,7 @@ impl RepairService {
                 &mut repair_tracker,
                 outstanding_requests,
                 repair_socket,
+                xdp_sender.as_ref(),
                 migration_status.as_ref(),
             );
             repair_tracker.repair_metrics.maybe_report();

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -59,6 +59,7 @@ use {
         leader_schedule_cache::LeaderScheduleCache,
         shred::filter::TurbineMode,
     },
+    solana_net_utils::PinnedXdpSender,
     solana_poh::{poh_controller::PohController, poh_recorder::PohRecorder},
     solana_pubkey::Pubkey,
     solana_rpc::{
@@ -155,6 +156,7 @@ pub struct TvuConfig {
     pub shred_sigverify_threads: NonZeroUsize,
     pub bls_sigverify_threads: NonZeroUsize,
     pub turbine_xdp_sender: Option<TurbineXdpSender>,
+    pub repair_xdp_sender: Option<PinnedXdpSender>,
 }
 
 impl Default for TvuConfig {
@@ -170,6 +172,7 @@ impl Default for TvuConfig {
             shred_sigverify_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             bls_sigverify_threads: NonZeroUsize::new(1).expect("1 is non-zero"),
             turbine_xdp_sender: None,
+            repair_xdp_sender: None,
         }
     }
 }
@@ -479,6 +482,7 @@ impl Tvu {
                 leader_schedule_cache.clone(),
                 tvu_config.shred_version,
                 outstanding_repair_requests,
+                tvu_config.repair_xdp_sender,
             )
         };
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -96,7 +96,7 @@ use {
     },
     solana_measure::measure::Measure,
     solana_metrics::{datapoint_info, metrics::metrics_config_sanity_check},
-    solana_net_utils::SocketAddrSpace,
+    solana_net_utils::{PinnedXdpSender, SocketAddrSpace},
     solana_poh::{
         poh_controller::PohController,
         poh_recorder::PohRecorder,
@@ -1566,7 +1566,7 @@ impl Validator {
         // This channel backing up indicates a serious problem in votor
         let (votor_event_sender, votor_event_receiver) = bounded(1000);
 
-        let (xdp_transmitter, turbine_xdp_sender, quic_xdp_sender) =
+        let (xdp_transmitter, turbine_xdp_sender, quic_xdp_sender, repair_xdp_sender) =
             if let Some(XdpTransmitSetup {
                 transmitter_builder,
                 src_ip,
@@ -1576,6 +1576,12 @@ impl Validator {
                     .local_addr()
                     .expect("retransmit socket should have local address")
                     .port();
+                let repair_src_port = node
+                    .sockets
+                    .repair
+                    .local_addr()
+                    .expect("repair socket should have local address")
+                    .port();
 
                 let (transmitter, sender) = transmitter_builder.build();
                 (
@@ -1584,10 +1590,14 @@ impl Validator {
                         sender.clone(),
                         SocketAddrV4::new(src_ip, turbine_src_port),
                     )),
-                    Some((sender, src_ip)),
+                    Some((sender.clone(), src_ip)),
+                    Some(PinnedXdpSender::new(
+                        sender,
+                        SocketAddrV4::new(src_ip, repair_src_port),
+                    )),
                 )
             } else {
-                (None, None, None)
+                (None, None, None, None)
             };
 
         // disable Alpenglow votor networking if not allowed for cluster type
@@ -1648,6 +1658,7 @@ impl Validator {
                 shred_sigverify_threads: config.tvu_shred_sigverify_threads,
                 bls_sigverify_threads: config.tvu_bls_sigverify_threads,
                 turbine_xdp_sender: turbine_xdp_sender.clone(),
+                repair_xdp_sender,
             },
             &max_slots,
             block_metadata_notifier,

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -25,6 +25,7 @@ use {
         shred::{self, ReedSolomonCache, Shred, filter::ShredRecoveryContext},
     },
     solana_measure::measure::Measure,
+    solana_net_utils::PinnedXdpSender,
     solana_rayon_threadlimit::get_thread_count,
     solana_runtime::bank_forks::{BankForks, SharableBanks},
     solana_streamer::evicting_sender::EvictingSender,
@@ -299,6 +300,7 @@ impl WindowService {
         leader_schedule_cache: Arc<LeaderScheduleCache>,
         shred_version: u16,
         outstanding_repair_requests: Arc<RwLock<OutstandingShredRepairs>>,
+        repair_xdp_sender: Option<PinnedXdpSender>,
     ) -> WindowService {
         let cluster_info = repair_info.cluster_info.clone();
         let bank_forks = repair_info.bank_forks.clone();
@@ -320,6 +322,7 @@ impl WindowService {
             repair_info.clone(),
             outstanding_repair_requests.clone(),
             repair_service_channels,
+            repair_xdp_sender,
         );
 
         let block_id_repair_service = BlockIdRepairService::new(


### PR DESCRIPTION
Added XDP to repair request TX path at build_and_send_repair_batch and request_repair_for_shred_from_address.

This uses the same XDP_PASS that is already attached to NIC by TransmitterBuilder and uses the TX loop threads as turbine.
