### PR TITLE
Remove redundant account owner check

### DIFF
--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -2530,7 +2530,7 @@ mod tests {
                 virtual_address_space_adjustments,
                 account_data_direct_mapping,
             ),
-            Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::AccountDataSizeChanged
+            Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ExternalAccountDataModified
         );
 
         // truncating resize
@@ -2548,7 +2548,7 @@ mod tests {
                 virtual_address_space_adjustments,
                 account_data_direct_mapping,
             ),
-            Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::AccountDataSizeChanged
+            Err(error) if error.downcast_ref::<InstructionError>().unwrap() == &InstructionError::ExternalAccountDataModified
         );
     }
 }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3039,7 +3039,7 @@ fn test_program_sbf_realloc() {
                 )
                 .unwrap_err()
                 .unwrap(),
-            TransactionError::InstructionError(0, InstructionError::AccountDataSizeChanged)
+            TransactionError::InstructionError(0, InstructionError::ExternalAccountDataModified)
         );
 
         // realloc and assign to self via cpi
@@ -3066,7 +3066,7 @@ fn test_program_sbf_realloc() {
                 )
                 .unwrap_err()
                 .unwrap(),
-            TransactionError::InstructionError(0, InstructionError::AccountDataSizeChanged)
+            TransactionError::InstructionError(0, InstructionError::ExternalAccountDataModified)
         );
 
         // Assign to self and realloc via cpi
@@ -3344,7 +3344,7 @@ fn test_program_sbf_realloc_invoke() {
             )
             .unwrap_err()
             .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::AccountDataSizeChanged)
+        TransactionError::InstructionError(0, InstructionError::ExternalAccountDataModified)
     );
 
     // realloc and assign to self via system program
@@ -3375,7 +3375,7 @@ fn test_program_sbf_realloc_invoke() {
             )
             .unwrap_err()
             .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::AccountDataSizeChanged)
+        TransactionError::InstructionError(0, InstructionError::ExternalAccountDataModified)
     );
 
     // Assign to self and realloc via system program
@@ -4328,7 +4328,7 @@ fn test_cpi_account_data_updates() {
                     if virtual_address_space_adjustments {
                         InstructionError::InvalidRealloc
                     } else {
-                        InstructionError::AccountDataSizeChanged
+                        InstructionError::ExternalAccountDataModified
                     }
                 )
             );
@@ -4371,7 +4371,7 @@ fn test_cpi_account_data_updates() {
                     if virtual_address_space_adjustments && deprecated_callee {
                         InstructionError::InvalidRealloc
                     } else {
-                        InstructionError::AccountDataSizeChanged
+                        InstructionError::ExternalAccountDataModified
                     }
                 )
             );

--- a/transaction-context/src/instruction_accounts.rs
+++ b/transaction-context/src/instruction_accounts.rs
@@ -350,10 +350,6 @@ impl BorrowedInstructionAccount<'_, '_> {
     /// Returns an error if the account data can not be resized to the given length
     pub fn can_data_be_resized(&self, new_len: usize) -> Result<(), InstructionError> {
         let old_len = self.get_data().len();
-        // Only the owner can change the length of the data
-        if new_len != old_len && !self.is_owned_by_current_program() {
-            return Err(InstructionError::AccountDataSizeChanged);
-        }
         self.transaction_context
             .accounts
             .can_data_be_resized(old_len, new_len)?;


### PR DESCRIPTION
#### Problem

In fn `can_data_be_resized`, we check if an account is owned by the current program before modifying it. The same check is performed again right after when the function invokes `can_data_be_changed`.

#### Summary of Changes

Remove the redundant check. 

This change is not consensus breaking, because the error is still there, even if `old_len == new_len` as the second check would be verified anyways. The only change is the type of error.