### PR TITLE
votor: do not block on SetRoot

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1421,19 +1421,17 @@ mod tests {
             Ok(self.bank_forks.write().unwrap().insert(bank))
         }
 
-        fn set_root(
+        fn enqueue_set_root(
             &self,
-            _my_pubkey: Pubkey,
             _parent_slot: Slot,
             new_root: Slot,
             highest_super_majority_root: Option<Slot>,
-        ) -> Result<(), BankForksControllerError> {
+        ) {
             // Test code only so we allow writing bank forks directly.
             self.bank_forks
                 .write()
                 .unwrap()
                 .set_root(new_root, None, highest_super_majority_root);
-            Ok(())
         }
 
         fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError> {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -84,7 +84,7 @@ use {
     solana_runtime::{
         bank::{Bank, NewBankOptions, bank_hash_details},
         bank_forks::BankForks,
-        bank_forks_controller::{BankForksCommand, BankForksCommandReceiver},
+        bank_forks_controller::{BankForksCommand, BankForksCommandReceiver, SetRootCommand},
         block_component_processor::BlockComponentProcessorError,
         commitment::BlockCommitmentCache,
         installed_scheduler_pool::BankWithScheduler,
@@ -939,6 +939,7 @@ impl ReplayStage {
                     Self::process_bank_forks_commands(
                         &bank_forks_controller_receiver,
                         &process_bank_forks_context,
+                        &my_pubkey,
                         &mut progress,
                         &mut async_verification_freelist,
                     ),
@@ -1515,12 +1516,15 @@ impl ReplayStage {
                     // only wait for the signal if we did not just process a bank; maybe there are more slots available
 
                     let timer = Duration::from_millis(100);
+                    let bank_forks_command_receiver = bank_forks_controller_receiver.receiver();
+                    let set_root_signal_receiver =
+                        bank_forks_controller_receiver.set_root_signal_receiver();
                     select! {
                         recv(ledger_signal_receiver) -> result => match result {
                             Err(_) => break,
                             Ok(_) => trace!("blockstore signal"),
                         },
-                        recv(bank_forks_controller_receiver.receiver()) -> result => match result {
+                        recv(bank_forks_command_receiver) -> result => match result {
                             Err(_) => break,
                             Ok(command) => {
                                 Self::process_bank_forks_command(
@@ -1530,6 +1534,10 @@ impl ReplayStage {
                                     &mut async_verification_freelist,
                                 );
                             }
+                        },
+                        recv(set_root_signal_receiver) -> result => match result {
+                            Err(_) => break,
+                            Ok(()) => trace!("bank forks set-root signal"),
                         },
                         default(timer) => (),
                     }
@@ -5006,9 +5014,14 @@ impl ReplayStage {
     fn process_bank_forks_commands(
         bank_forks_controller_receiver: &BankForksCommandReceiver,
         context: &ProcessBankForksContext,
+        my_pubkey: &Pubkey,
         progress: &mut ProgressMap,
         async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
     ) -> Result<(), TryRecvError> {
+        if let Some(command) = bank_forks_controller_receiver.take_set_root_command() {
+            Self::process_set_root_command(command, context, my_pubkey);
+        }
+
         loop {
             let command = bank_forks_controller_receiver.receiver().try_recv()?;
             Self::process_bank_forks_command(
@@ -5018,6 +5031,32 @@ impl ReplayStage {
                 async_verification_freelist,
             );
         }
+    }
+
+    fn process_set_root_command(
+        command: SetRootCommand,
+        context: &ProcessBankForksContext,
+        my_pubkey: &Pubkey,
+    ) {
+        let SetRootCommand {
+            parent_slot,
+            new_root,
+            highest_super_majority_root,
+        } = command;
+        root_utils::check_and_handle_new_root(
+            parent_slot,
+            new_root,
+            context.snapshot_controller.as_deref(),
+            highest_super_majority_root,
+            &context.bank_notification_sender,
+            &context.drop_bank_sender,
+            &context.blockstore,
+            &context.leader_schedule_cache,
+            &context.bank_forks,
+            context.rpc_subscriptions.as_deref(),
+            my_pubkey,
+            |_| {},
+        );
     }
 
     /// Process a bank forks command
@@ -5054,31 +5093,6 @@ impl ReplayStage {
 
                 response_sender.send(bank).unwrap_or_else(|_| {
                     warn!("bank forks controller insert-bank response receiver dropped")
-                });
-            }
-            BankForksCommand::SetRoot {
-                my_pubkey,
-                parent_slot,
-                new_root,
-                highest_super_majority_root,
-                response_sender,
-            } => {
-                root_utils::check_and_handle_new_root(
-                    parent_slot,
-                    new_root,
-                    context.snapshot_controller.as_deref(),
-                    highest_super_majority_root,
-                    &context.bank_notification_sender,
-                    &context.drop_bank_sender,
-                    &context.blockstore,
-                    &context.leader_schedule_cache,
-                    &context.bank_forks,
-                    context.rpc_subscriptions.as_deref(),
-                    &my_pubkey,
-                    |_| {},
-                );
-                response_sender.send(()).unwrap_or_else(|_| {
-                    warn!("bank forks controller set-root response receiver dropped")
                 });
             }
             BankForksCommand::ClearBank {

--- a/runtime/src/bank_forks_controller.rs
+++ b/runtime/src/bank_forks_controller.rs
@@ -4,9 +4,9 @@ use {
     log::warn,
     solana_clock::Slot,
     solana_metrics::datapoint_info,
-    solana_pubkey::Pubkey,
     std::{
         fmt,
+        sync::{Arc, Mutex},
         time::{Duration, Instant},
     },
     thiserror::Error,
@@ -27,24 +27,22 @@ pub enum BankForksCommand {
         bank: Box<Bank>,
         response_sender: Sender<Option<BankWithScheduler>>,
     },
-    SetRoot {
-        my_pubkey: Pubkey,
-        parent_slot: Slot,
-        new_root: Slot,
-        highest_super_majority_root: Option<Slot>,
-        response_sender: Sender<()>,
-    },
     ClearBank {
         slot: Slot,
         response_sender: Sender<()>,
     },
 }
 
+pub struct SetRootCommand {
+    pub parent_slot: Slot,
+    pub new_root: Slot,
+    pub highest_super_majority_root: Option<Slot>,
+}
+
 impl BankForksCommand {
     fn metric_slot(&self) -> Slot {
         match self {
             Self::InsertBank { bank, .. } => bank.slot(),
-            Self::SetRoot { new_root, .. } => *new_root,
             Self::ClearBank { slot, .. } => *slot,
         }
     }
@@ -54,7 +52,6 @@ impl fmt::Display for BankForksCommand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InsertBank { .. } => write!(f, "insert_bank"),
-            Self::SetRoot { .. } => write!(f, "set_root"),
             Self::ClearBank { .. } => write!(f, "clear_bank"),
         }
     }
@@ -63,13 +60,12 @@ impl fmt::Display for BankForksCommand {
 pub trait BankForksController: Send + Sync {
     fn insert_bank(&self, bank: Bank) -> Result<BankWithScheduler, BankForksControllerError>;
 
-    fn set_root(
+    fn enqueue_set_root(
         &self,
-        my_pubkey: Pubkey,
         parent_slot: Slot,
         new_root: Slot,
         highest_super_majority_root: Option<Slot>,
-    ) -> Result<(), BankForksControllerError>;
+    );
 
     fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError>;
 }
@@ -78,12 +74,27 @@ pub trait BankForksController: Send + Sync {
 #[derive(Clone)]
 pub struct BankForksControllerHandle {
     sender: Sender<BankForksCommand>,
+    pending_set_root: Arc<Mutex<Option<SetRootCommand>>>,
+    set_root_signal_sender: Sender<()>,
 }
 
 impl BankForksControllerHandle {
     pub fn new() -> (Self, BankForksCommandReceiver) {
         let (sender, receiver) = bounded(CHANNEL_SIZE);
-        (Self { sender }, BankForksCommandReceiver { receiver })
+        let (set_root_signal_sender, set_root_signal_receiver) = bounded(1);
+        let pending_set_root = Arc::new(Mutex::new(None));
+        (
+            Self {
+                sender,
+                pending_set_root: pending_set_root.clone(),
+                set_root_signal_sender,
+            },
+            BankForksCommandReceiver {
+                receiver,
+                pending_set_root,
+                set_root_signal_receiver,
+            },
+        )
     }
 
     fn send_command<T>(
@@ -146,24 +157,39 @@ impl BankForksController for BankForksControllerHandle {
         bank.ok_or(BankForksControllerError::UnableToInsertStaleBank(slot))
     }
 
-    fn set_root(
+    fn enqueue_set_root(
         &self,
-        my_pubkey: Pubkey,
         parent_slot: Slot,
         new_root: Slot,
         highest_super_majority_root: Option<Slot>,
-    ) -> Result<(), BankForksControllerError> {
-        let (response_sender, response_receiver) = bounded(1);
-        self.send_command(
-            BankForksCommand::SetRoot {
-                my_pubkey,
-                parent_slot,
-                new_root,
-                highest_super_majority_root,
-                response_sender,
-            },
-            response_receiver,
-        )
+    ) {
+        let total_start = Instant::now();
+        let command = SetRootCommand {
+            parent_slot,
+            new_root,
+            highest_super_majority_root,
+        };
+
+        {
+            let mut pending_set_root = self.pending_set_root.lock().unwrap();
+            // Replay only needs to process the highest pending root.
+            if pending_set_root
+                .as_ref()
+                .is_none_or(|pending| command.new_root > pending.new_root)
+            {
+                *pending_set_root = Some(command);
+            }
+        }
+        let _ = self.set_root_signal_sender.try_send(());
+
+        let total_us = total_start.elapsed().as_micros() as i64;
+
+        datapoint_info!(
+            "bank_forks_controller-command",
+            ("command", "set_root", String),
+            ("slot", new_root as i64, i64),
+            ("total_us", total_us, i64),
+        );
     }
 
     fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError> {
@@ -180,11 +206,21 @@ impl BankForksController for BankForksControllerHandle {
 
 pub struct BankForksCommandReceiver {
     receiver: Receiver<BankForksCommand>,
+    pending_set_root: Arc<Mutex<Option<SetRootCommand>>>,
+    set_root_signal_receiver: Receiver<()>,
 }
 
 impl BankForksCommandReceiver {
     pub fn receiver(&self) -> &Receiver<BankForksCommand> {
         &self.receiver
+    }
+
+    pub fn set_root_signal_receiver(&self) -> &Receiver<()> {
+        &self.set_root_signal_receiver
+    }
+
+    pub fn take_set_root_command(&self) -> Option<SetRootCommand> {
+        self.pending_set_root.lock().unwrap().take()
     }
 }
 
@@ -193,8 +229,43 @@ mod tests {
     use {
         super::*,
         crate::{bank::SlotLeader, bank_forks::BankForks, genesis_utils::create_genesis_config},
-        std::thread,
+        std::{thread, time::Duration},
     };
+
+    #[test]
+    fn test_bank_forks_controller_keeps_highest_pending_set_root() {
+        let (controller, receiver) = BankForksControllerHandle::new();
+
+        controller.enqueue_set_root(5, 5, Some(5));
+        controller.enqueue_set_root(3, 3, Some(3));
+        assert_eq!(receiver.take_set_root_command().unwrap().new_root, 5);
+        assert!(receiver.take_set_root_command().is_none());
+
+        controller.enqueue_set_root(3, 3, Some(3));
+        controller.enqueue_set_root(5, 5, Some(5));
+        assert_eq!(receiver.take_set_root_command().unwrap().new_root, 5);
+    }
+
+    #[test]
+    fn test_bank_forks_controller_signals_pending_set_root() {
+        let (controller, receiver) = BankForksControllerHandle::new();
+
+        controller.enqueue_set_root(1, 1, Some(1));
+        receiver
+            .set_root_signal_receiver()
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        assert_eq!(receiver.take_set_root_command().unwrap().new_root, 1);
+
+        controller.enqueue_set_root(2, 2, Some(2));
+        controller.enqueue_set_root(3, 3, Some(3));
+        receiver
+            .set_root_signal_receiver()
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        assert!(receiver.set_root_signal_receiver().try_recv().is_err());
+        assert_eq!(receiver.take_set_root_command().unwrap().new_root, 3);
+    }
 
     #[test]
     fn test_bank_forks_controller_insert_and_set_root() {
@@ -202,10 +273,20 @@ mod tests {
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis.genesis_config));
         let (controller, receiver) = BankForksControllerHandle::new();
         let replay_bank_forks = bank_forks.clone();
+        let (root_sender, root_receiver) = bounded(1);
         let replay_thread = thread::spawn(move || {
             loop {
-                let Ok(command) = receiver.receiver().recv() else {
-                    break;
+                if let Some(command) = receiver.take_set_root_command() {
+                    {
+                        let mut bank_forks = replay_bank_forks.write().unwrap();
+                        bank_forks.set_root(command.new_root, None, None);
+                    }
+                    root_sender.send(command.new_root).unwrap();
+                }
+                let command = match receiver.receiver().recv_timeout(Duration::from_millis(10)) {
+                    Ok(command) => command,
+                    Err(RecvTimeoutError::Timeout) => continue,
+                    Err(RecvTimeoutError::Disconnected) => break,
                 };
                 match command {
                     BankForksCommand::InsertBank {
@@ -217,17 +298,6 @@ mod tests {
                             bank_forks.insert(*bank)
                         };
                         response_sender.send(Some(bank)).unwrap();
-                    }
-                    BankForksCommand::SetRoot {
-                        new_root,
-                        response_sender,
-                        ..
-                    } => {
-                        {
-                            let mut bank_forks = replay_bank_forks.write().unwrap();
-                            bank_forks.set_root(new_root, None, None);
-                        }
-                        response_sender.send(()).unwrap();
                     }
                     BankForksCommand::ClearBank {
                         slot,
@@ -256,7 +326,8 @@ mod tests {
         assert_eq!(inserted_bank.slot(), 1);
         assert!(bank_forks.read().unwrap().get(1).is_some());
 
-        controller.set_root(Pubkey::default(), 1, 1, None).unwrap();
+        controller.enqueue_set_root(1, 1, None);
+        assert_eq!(root_receiver.recv().unwrap(), 1);
         assert_eq!(bank_forks.read().unwrap().root(), 1);
 
         let parent_bank = bank_forks.read().unwrap().root_bank();

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -27,7 +27,6 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank,
-        bank_forks_controller::BankForksControllerError,
         leader_schedule_utils::{
             first_of_consecutive_leader_slots, last_of_consecutive_leader_slots, leader_slot_index,
         },
@@ -78,9 +77,6 @@ enum EventLoopError {
 
     #[error("Set identity error")]
     SetIdentityError(#[from] VoteHistoryError),
-
-    #[error("Bank forks controller error")]
-    BankForksControllerError(#[from] BankForksControllerError),
 }
 
 pub(crate) struct EventHandler {
@@ -173,7 +169,7 @@ impl EventHandler {
                 .saturating_add(receive_event_time.as_us() as u32);
 
             let root_bank = vctx.sharable_banks.root();
-            if event.should_ignore(root_bank.slot()) {
+            if event.should_ignore(root_bank.slot().max(vctx.vote_history.root())) {
                 local_context.stats.ignored = local_context.stats.ignored.saturating_add(1);
                 continue;
             }
@@ -311,7 +307,7 @@ impl EventHandler {
                     finalized_blocks,
                     received_shred,
                     stats,
-                )?;
+                );
                 if let Some(parent_block) =
                     Self::add_missing_parent_ready(block, ctx, vctx, local_context)
                 {
@@ -447,7 +443,7 @@ impl EventHandler {
                     finalized_blocks,
                     received_shred,
                     stats,
-                )?;
+                );
 
                 if let Some(slot) = *standstill_slot {
                     if block.0 > slot {
@@ -764,10 +760,13 @@ impl EventHandler {
         // In case we set root in the middle of a leader window,
         // it's not necessary to vote skip prior to it and we won't
         // be able to check vote history if we've already voted on it
-        let root_bank = voting_context.sharable_banks.root();
+        let root_slot = voting_context
+            .vote_history
+            .root()
+            .max(voting_context.sharable_banks.root().slot());
         // No matter what happens, we should not vote skip for slot 0
         let start = first_of_consecutive_leader_slots(slot)
-            .max(root_bank.slot())
+            .max(root_slot)
             .max(1);
         for s in start..=last_of_consecutive_leader_slots(slot) {
             if voting_context.vote_history.voted(s) {
@@ -820,9 +819,9 @@ impl EventHandler {
         finalized_blocks: &mut BTreeSet<Block>,
         received_shred: &mut BTreeSet<Slot>,
         stats: &mut EventHandlerStats,
-    ) -> Result<(), BankForksControllerError> {
+    ) {
         let bank_forks_r = ctx.bank_forks.read().unwrap();
-        let old_root = bank_forks_r.root();
+        let old_root = bank_forks_r.root().max(vctx.vote_history.root());
         let Some(new_root) = finalized_blocks
             .iter()
             .filter_map(|&(slot, block_id)| {
@@ -836,7 +835,7 @@ impl EventHandler {
             .max()
         else {
             // No rootable banks
-            return Ok(());
+            return;
         };
         drop(bank_forks_r);
         root_utils::set_root(
@@ -848,9 +847,8 @@ impl EventHandler {
             pending_blocks,
             finalized_blocks,
             received_shred,
-        )?;
+        );
         stats.set_root(new_root);
-        Ok(())
     }
 
     pub(crate) fn join(self) -> thread::Result<()> {
@@ -980,6 +978,7 @@ mod tests {
     }
 
     struct DirectBankForksController {
+        my_pubkey: Pubkey,
         bank_forks: Arc<RwLock<BankForks>>,
         blockstore: Arc<Blockstore>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
@@ -991,13 +990,12 @@ mod tests {
             Ok(self.bank_forks.write().unwrap().insert(bank))
         }
 
-        fn set_root(
+        fn enqueue_set_root(
             &self,
-            my_pubkey: Pubkey,
             parent_slot: Slot,
             new_root: Slot,
             highest_super_majority_root: Option<Slot>,
-        ) -> Result<(), BankForksControllerError> {
+        ) {
             root_utils::check_and_handle_new_root(
                 parent_slot,
                 new_root,
@@ -1009,10 +1007,9 @@ mod tests {
                 &self.leader_schedule_cache,
                 &self.bank_forks,
                 None,
-                &my_pubkey,
+                &self.my_pubkey,
                 |_| {},
             );
-            Ok(())
         }
 
         fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError> {
@@ -1080,6 +1077,7 @@ mod tests {
             &bank_forks.read().unwrap().root_bank(),
         ));
         let bank_forks_controller = Arc::new(DirectBankForksController {
+            my_pubkey: my_node_keypair.pubkey(),
             bank_forks: bank_forks.clone(),
             blockstore: blockstore.clone(),
             leader_schedule_cache,

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -11,10 +11,8 @@ use {
         rpc_subscriptions::RpcSubscriptions,
     },
     solana_runtime::{
-        bank_forks::BankForks,
-        bank_forks_controller::{BankForksController, BankForksControllerError},
-        installed_scheduler_pool::BankWithScheduler,
-        snapshot_controller::SnapshotController,
+        bank_forks::BankForks, bank_forks_controller::BankForksController,
+        installed_scheduler_pool::BankWithScheduler, snapshot_controller::SnapshotController,
     },
     solana_time_utils::timestamp,
     std::{
@@ -41,7 +39,7 @@ pub(crate) fn set_root(
     pending_blocks: &mut PendingBlocks,
     finalized_blocks: &mut BTreeSet<Block>,
     received_shred: &mut BTreeSet<Slot>,
-) -> Result<(), BankForksControllerError> {
+) {
     info!("{my_pubkey}: setting root {new_root}");
     vctx.vote_history.set_root(new_root);
     *pending_blocks = pending_blocks.split_off(&new_root);
@@ -49,7 +47,7 @@ pub(crate) fn set_root(
     *received_shred = received_shred.split_off(&new_root);
 
     rctx.bank_forks_controller
-        .set_root(*my_pubkey, new_root, new_root, Some(new_root))?;
+        .enqueue_set_root(new_root, new_root, Some(new_root));
 
     // Distinguish between duplicate versions of same slot
     let hash = ctx.bank_forks.read().unwrap().bank_hash(new_root).unwrap();
@@ -78,7 +76,6 @@ pub(crate) fn set_root(
             dependency_work,
         ));
     }
-    Ok(())
 }
 
 /// Sets the new root, additionally performs the callback after setting the bank forks root


### PR DESCRIPTION
#### Problem
As part of #12448 we moved the bank fork writes back to the replay thread.
This shows large amounts of latency in set root when load is applied due to replay being too busy executing transactions in order to respond.
Leading to `Replay is stuck` messages being spammed

<img width="1084" height="666" alt="image" src="https://github.com/user-attachments/assets/e4b416ae-8173-418b-9a5a-1a29abbe08d7" />


#### Summary of Changes
There is no reason for `SetRoot` to actually block - votor doesn't care if the root is set or not.
Make it fire and forget.

`InsertBank` and `ClearBank` still block, but these actions are taken during the leader pipeline where we expect that replay has little work to do.

If needed in the future we could spin out `BankForksController` into a completely separate thread, but that would add latency for the commonly used `insert_bank` in `generate_new_bank_forks`

Results with this change:

<img width="879" height="419" alt="image" src="https://github.com/user-attachments/assets/eb209f65-f146-410f-a5ef-d28ab95ba3ab" />
