### PR TITLE
rpc: fix leader targetting for alpenglow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9693,6 +9693,7 @@ dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
  "agave-snapshots",
+ "agave-votor-messages",
  "base64 0.22.1",
  "bs58",
  "crossbeam-channel",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8174,6 +8174,7 @@ version = "4.2.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
+ "agave-votor-messages",
  "base64 0.22.1",
  "bs58",
  "crossbeam-channel",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7981,6 +7981,7 @@ version = "4.2.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
+ "agave-votor-messages",
  "base64 0.22.1",
  "bs58",
  "crossbeam-channel",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -18,11 +18,16 @@ name = "solana_rpc"
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = ["solana-ledger/dev-context-only-utils", "solana-rpc/dev-context-only-utils"]
+dev-context-only-utils = [
+    "agave-votor-messages/dev-context-only-utils",
+    "solana-ledger/dev-context-only-utils",
+    "solana-rpc/dev-context-only-utils",
+]
 
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-snapshots = { workspace = true }
+agave-votor-messages = { workspace = true }
 base64 = { workspace = true }
 bs58 = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -1,8 +1,12 @@
 use {
+    agave_votor_messages::migration::MigrationStatus,
+    solana_clock::Slot,
     solana_gossip::{cluster_info::ClusterInfo, contact_info::Protocol},
     solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
+    solana_ledger::leader_schedule_cache::LeaderScheduleCache,
     solana_poh::poh_recorder::PohRecorder,
     solana_pubkey::Pubkey,
+    solana_runtime::commitment::BlockCommitmentCache,
     solana_send_transaction_service::tpu_info::TpuInfo,
     std::{
         collections::HashMap,
@@ -16,16 +20,77 @@ use {
 pub struct ClusterTpuInfo {
     cluster_info: Arc<ClusterInfo>,
     poh_recorder: Arc<RwLock<PohRecorder>>,
+    block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
+    leader_schedule_cache: Arc<LeaderScheduleCache>,
+    migration_status: Arc<MigrationStatus>,
     recent_peers: HashMap<Pubkey, SocketAddr>, // values are socket address for QUIC protocol
 }
 
 impl ClusterTpuInfo {
-    pub fn new(cluster_info: Arc<ClusterInfo>, poh_recorder: Arc<RwLock<PohRecorder>>) -> Self {
+    pub fn new(
+        cluster_info: Arc<ClusterInfo>,
+        poh_recorder: Arc<RwLock<PohRecorder>>,
+        block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
+        leader_schedule_cache: Arc<LeaderScheduleCache>,
+        migration_status: Arc<MigrationStatus>,
+    ) -> Self {
         Self {
             cluster_info,
             poh_recorder,
+            block_commitment_cache,
+            leader_schedule_cache,
+            migration_status,
             recent_peers: HashMap::new(),
         }
+    }
+
+    fn leader_pubkeys(&self, max_count: u64) -> Vec<Pubkey> {
+        let current_slot = self.commitment_current_slot();
+        // Commitment-cache slots represent banks we have already processed, so
+        // transactions can only land in later slots.
+        let target_slot = current_slot.saturating_add(1);
+        if self
+            .migration_status
+            .should_have_alpenglow_ticks(target_slot)
+        {
+            self.alpenglow_leader_pubkeys(target_slot, max_count)
+        } else {
+            self.poh_leader_pubkeys(max_count)
+        }
+    }
+
+    fn commitment_current_slot(&self) -> Slot {
+        let commitment_slots = self
+            .block_commitment_cache
+            .read()
+            .unwrap()
+            .commitment_slots();
+        commitment_slots
+            .slot
+            .max(commitment_slots.root)
+            .max(commitment_slots.highest_confirmed_slot)
+            .max(commitment_slots.highest_super_majority_root)
+    }
+
+    fn alpenglow_leader_pubkeys(&self, current_slot: Slot, max_count: u64) -> Vec<Pubkey> {
+        (0..max_count)
+            .filter_map(|i| {
+                let target_slot = current_slot
+                    .saturating_add(i.saturating_mul(NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64));
+                self.leader_schedule_cache
+                    .slot_leader_at(target_slot, None)
+                    .map(|leader| leader.id)
+            })
+            .collect()
+    }
+
+    fn poh_leader_pubkeys(&self, max_count: u64) -> Vec<Pubkey> {
+        let recorder = self.poh_recorder.read().unwrap();
+        (0..max_count)
+            .filter_map(|i| {
+                recorder.leader_after_n_slots(i * NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64)
+            })
+            .collect()
     }
 }
 
@@ -41,13 +106,7 @@ impl TpuInfo for ClusterTpuInfo {
     }
 
     fn get_leader_tpus(&self, max_count: u64) -> Vec<&SocketAddr> {
-        let recorder = self.poh_recorder.read().unwrap();
-        let leaders: Vec<_> = (0..max_count)
-            .filter_map(|i| {
-                recorder.leader_after_n_slots(i * NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64)
-            })
-            .collect();
-        drop(recorder);
+        let leaders = self.leader_pubkeys(max_count);
         let mut unique_leaders = vec![];
         for leader in leaders.iter() {
             if let Some(addr) = self.recent_peers.get(leader) {
@@ -60,14 +119,7 @@ impl TpuInfo for ClusterTpuInfo {
     }
 
     fn get_not_unique_leader_tpus(&self, max_count: u64) -> Vec<&SocketAddr> {
-        let recorder = self.poh_recorder.read().unwrap();
-        let leader_pubkeys: Vec<_> = (0..max_count)
-            .filter_map(|i| {
-                recorder.leader_after_n_slots(i * NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64)
-            })
-            .collect();
-        drop(recorder);
-        leader_pubkeys
+        self.leader_pubkeys(max_count)
             .iter()
             .filter_map(|leader_pubkey| self.recent_peers.get(leader_pubkey))
             .collect()
@@ -78,7 +130,6 @@ impl TpuInfo for ClusterTpuInfo {
 mod test {
     use {
         super::*,
-        solana_clock::Slot,
         solana_gossip::contact_info::ContactInfo,
         solana_keypair::Keypair,
         solana_ledger::{
@@ -92,6 +143,7 @@ mod test {
             genesis_utils::{
                 GenesisConfigInfo, ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts,
             },
+            leader_schedule_utils::slot_leader_at,
         },
         solana_signer::Signer,
         solana_time_utils::timestamp,
@@ -124,6 +176,7 @@ mod test {
         );
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let (poh_recorder, _entry_receiver) = PohRecorder::new(
             0,
             bank.last_blockhash(),
@@ -131,7 +184,7 @@ mod test {
             Some((2, 2)),
             bank.ticks_per_slot(),
             Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &leader_schedule_cache,
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
@@ -156,8 +209,13 @@ mod test {
         cluster_info.insert_info(validator1_contact_info);
         cluster_info.insert_info(validator2_contact_info);
 
-        let mut leader_info =
-            ClusterTpuInfo::new(cluster_info, Arc::new(RwLock::new(poh_recorder)));
+        let mut leader_info = ClusterTpuInfo::new(
+            cluster_info,
+            Arc::new(RwLock::new(poh_recorder)),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests())),
+            leader_schedule_cache,
+            Arc::new(MigrationStatus::default()),
+        );
         leader_info.refresh_recent_peers();
         let mut refreshed_recent_peers =
             leader_info.recent_peers.keys().copied().collect::<Vec<_>>();
@@ -186,6 +244,7 @@ mod test {
         );
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let (poh_recorder, _entry_receiver) = PohRecorder::new(
             0,
             bank.last_blockhash(),
@@ -193,7 +252,7 @@ mod test {
             Some((2, 2)),
             bank.ticks_per_slot(),
             Arc::new(blockstore),
-            &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+            &leader_schedule_cache,
             &PohConfig::default(),
             Arc::new(AtomicBool::default()),
         );
@@ -225,11 +284,14 @@ mod test {
         .iter()
         .cloned()
         .collect();
-        let leader_info = ClusterTpuInfo {
+        let mut leader_info = ClusterTpuInfo::new(
             cluster_info,
-            poh_recorder: Arc::new(RwLock::new(poh_recorder)),
-            recent_peers: recent_peers.clone(),
-        };
+            Arc::new(RwLock::new(poh_recorder)),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests())),
+            leader_schedule_cache,
+            Arc::new(MigrationStatus::default()),
+        );
+        leader_info.recent_peers = recent_peers.clone();
 
         let slot = bank.slot();
         let first_leader =
@@ -284,5 +346,98 @@ mod test {
             assert!(leader_info.get_leader_tpus(x).len() <= recent_peers.len());
             assert_eq!(leader_info.get_not_unique_leader_tpus(x).len(), x as usize);
         }
+    }
+
+    #[test]
+    fn test_get_leader_tpus_uses_commitment_slot_after_alpenglow() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let validator_vote_keypairs0 = ValidatorVoteKeypairs::new_rand();
+        let validator_vote_keypairs1 = ValidatorVoteKeypairs::new_rand();
+        let validator_vote_keypairs2 = ValidatorVoteKeypairs::new_rand();
+        let validator_keypairs = vec![
+            &validator_vote_keypairs0,
+            &validator_vote_keypairs1,
+            &validator_vote_keypairs2,
+        ];
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config_with_vote_accounts(
+            1_000_000_000,
+            &validator_keypairs,
+            vec![10_000; 3],
+        );
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
+
+        let (poh_recorder, _entry_receiver) = PohRecorder::new(
+            0,
+            bank.last_blockhash(),
+            bank.clone(),
+            Some((2, 2)),
+            bank.ticks_per_slot(),
+            Arc::new(blockstore),
+            &leader_schedule_cache,
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+
+        let node_keypair = Arc::new(Keypair::new());
+        let cluster_info = Arc::new(ClusterInfo::new(
+            ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
+            node_keypair,
+            SocketAddrSpace::Unspecified,
+        ));
+
+        let validator0_socket = SocketAddr::from((Ipv4Addr::LOCALHOST, 1112));
+        let validator1_socket = SocketAddr::from((Ipv4Addr::LOCALHOST, 2223));
+        let validator2_socket = SocketAddr::from((Ipv4Addr::LOCALHOST, 3334));
+        let recent_peers: HashMap<_, _> = [
+            (
+                validator_vote_keypairs0.node_keypair.pubkey(),
+                validator0_socket,
+            ),
+            (
+                validator_vote_keypairs1.node_keypair.pubkey(),
+                validator1_socket,
+            ),
+            (
+                validator_vote_keypairs2.node_keypair.pubkey(),
+                validator2_socket,
+            ),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        let completed_alpenglow_slot = (1..64)
+            .find(|slot| {
+                slot_leader_at(*slot, &bank).unwrap()
+                    != slot_leader_at(slot.saturating_add(1), &bank).unwrap()
+            })
+            .expect("leader schedule should rotate within 64 slots");
+        let completed_slot_leader = slot_leader_at(completed_alpenglow_slot, &bank).unwrap();
+        let target_slot_leader =
+            slot_leader_at(completed_alpenglow_slot.saturating_add(1), &bank).unwrap();
+
+        let mut leader_info = ClusterTpuInfo::new(
+            cluster_info,
+            Arc::new(RwLock::new(poh_recorder)),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_slots(
+                completed_alpenglow_slot,
+                completed_alpenglow_slot,
+            ))),
+            leader_schedule_cache,
+            Arc::new(MigrationStatus::post_migration_status()),
+        );
+        leader_info.recent_peers = recent_peers.clone();
+
+        assert_eq!(
+            leader_info.get_not_unique_leader_tpus(1),
+            vec![recent_peers.get(&target_slot_leader).unwrap()]
+        );
+        assert_ne!(
+            leader_info.get_not_unique_leader_tpus(1),
+            vec![recent_peers.get(&completed_slot_leader).unwrap()]
+        );
     }
 }

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -512,9 +512,16 @@ impl JsonRpcService {
             config.rpc_config.rpc_blocking_threads,
             config.rpc_config.rpc_niceness_adj,
         );
-        let leader_info = config
-            .poh_recorder
-            .map(|recorder| ClusterTpuInfo::new(config.cluster_info.clone(), recorder));
+        let migration_status = config.bank_forks.read().unwrap().migration_status();
+        let leader_info = config.poh_recorder.clone().map(|recorder| {
+            ClusterTpuInfo::new(
+                config.cluster_info.clone(),
+                recorder,
+                config.block_commitment_cache.clone(),
+                config.leader_schedule_cache.clone(),
+                migration_status.clone(),
+            )
+        });
 
         let RpcTpuClientArgs(identity_keypair, tpu_client_socket, client_runtime, cancel) =
             config.rpc_tpu_client_args;


### PR DESCRIPTION
#### Problem
RPC uses leader targeting based on PoH.
This doesn't work for alpenglow blocks.

#### Summary of Changes
Instead use a fanout based on the block commitment cache for alpenglow slots.

An improvement could be to use some shred based heuristics here as well, but I think the default implementation can be kept simple. Ecosystem already has many ways to send transactions that are better than PoH targeting. 


## Testing
Without change 30+ seconds. Note most cases it will completely fail:
```
$ time ~/agave/bin/solana -ul transfer faucet.json 1

Signature: 2TRG8RAP6jCyHXvbXxxPUeiDTnVaAXhDMGiWygsH7sYB5hV7JEFJYQsUDtywLsMxuVwizT4Xwev6eCWPazoFP3JN

~/agave/bin/solana -ul transfer  1  0.01s user 0.03s system 0% cpu 32.374 total
```

With change 0.5s:
```
$ time ~/agave/bin/solana -ul transfer faucet.json 1

Signature: 5kz6JTstHd4wWFZa8g3B55Vv7HU51SJNK1Tkki74QkD2kAEqWUEPwQc6bQvg45dQfmydAc18osubLY8vZbymQEZS

~/agave/bin/solana -ul transfer 1  0.00s user 0.02s system 3% cpu 0.512 total
```