### PR TITLE
Bump sbpf to 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10150,9 +10150,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b120fcbbc0d8562997183bef32c76a28400ecae7d8c9fff279d33002783a29"
+checksum = "7f84c593fa3d4131045b606dec5acf9d8eac73791bc786ca9911057aec8f43ec"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -460,7 +460,7 @@ solana-rpc-client-types = { path = "rpc-client-types", version = "=4.2.0-alpha.0
 solana-runtime = { path = "runtime", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-sanitize = "3.0.1"
-solana-sbpf = { version = "=0.20.0", default-features = false }
+solana-sbpf = { version = "=0.21.0", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-secp256k1-program = "3.0.1"
 solana-secp256k1-recover = "3.1.1"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8696,9 +8696,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b120fcbbc0d8562997183bef32c76a28400ecae7d8c9fff279d33002783a29"
+checksum = "7f84c593fa3d4131045b606dec5acf9d8eac73791bc786ca9911057aec8f43ec"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -120,7 +120,7 @@ solana-rpc-client = { path = "../rpc-client", version = "=4.2.0-alpha.0", defaul
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=4.2.0-alpha.0" }
 solana-runtime = { path = "../runtime", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-runtime-transaction = { path = "../runtime-transaction", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
-solana-sbpf = { version = "=0.20.0", default-features = false }
+solana-sbpf = { version = "=0.21.0", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-shred-version = "3.0.1"
 solana-signature = { version = "3.4.0", default-features = false }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9049,9 +9049,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sbpf"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b120fcbbc0d8562997183bef32c76a28400ecae7d8c9fff279d33002783a29"
+checksum = "7f84c593fa3d4131045b606dec5acf9d8eac73791bc786ca9911057aec8f43ec"
 dependencies = [
  "byteorder",
  "combine 3.8.1",


### PR DESCRIPTION
From https://github.com/anza-xyz/sbpf/pull/180

### Problem

JIT compilation directly mmaps/munmaps memory for page alignment / permissions reasons. Because this circumvents jemalloc, memory is never recycled; this creates continuous fault churn, resulting in programs sometimes taking upwards of 15ms to compile.

<img width="4082" height="2336" alt="image" src="https://github.com/user-attachments/assets/fb0090c4-f1e9-4b8d-84ca-6a187ec09491" />
Yellow here is almost entirely page faults


<img width="3825" height="1527" alt="image" src="https://github.com/user-attachments/assets/973f0ad5-b89c-4e95-ad15-03d5cca3cbc2" />


### Solution

This PR implements a bucketed free list allocator to back JIT compilation memory. Buckets are organized by power-of-two, 128KiB-256MiB, and lazily allocated as needed. This style of allocator is a good fit due to program cache utilization being steady and predictable, and affords us a very simple and easily maintainable implementation.

Buckets are warmed up on validator start and reach steady state once we start executing transactions. Distribution of utilization remains quite stable across long runs.
<img width="3715" height="825" alt="image" src="https://github.com/user-attachments/assets/04d8a92e-57bf-4c91-8beb-377d641f4b8c" />

Page faults are eliminated during steady state
<img width="3024" height="1004" alt="image" src="https://github.com/user-attachments/assets/3cc09e96-9b0b-4ff3-9835-29f082867d69" />
