### PR TITLE
Dynamic ns per slot

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -410,13 +410,10 @@ fn reset_poh_recorder(bank: &Arc<Bank>, ctx: &LeaderContext) {
         .reset(bank.clone(), next_leader_slot);
 }
 
-/// From the passed in bank (used for determining slot times) and leader block
-/// index within the leader window, returns the duration after which we should
-/// publish the final shred for the block with starting point being the start of
-/// the leader window.
-fn block_timeout(bank: &Bank, leader_block_index: usize) -> Duration {
-    Duration::from_nanos_u128(bank.ns_per_slot)
-        .saturating_mul((leader_block_index as u32).saturating_add(1))
+/// Returns the elapsed leader-window time at which `slot` must be completed.
+fn block_timeout(bank: &Bank, slot: Slot) -> Duration {
+    Duration::from_nanos_u128(bank.ns_per_slot_at_slot(slot))
+        .saturating_mul((leader_slot_index(slot) as u32).saturating_add(1))
 }
 
 /// Select the freshest leader-window notification within one source.
@@ -519,7 +516,7 @@ fn produce_block_footer(
             .get_nanosecond_clock()
             .unwrap_or_else(|| bank.clock().unix_timestamp.saturating_mul(1_000_000_000));
         let parent_slot = parent_bank.slot();
-        let ns_per_slot = u64::try_from(bank.ns_per_slot).unwrap_or(u64::MAX);
+        let ns_per_slot = u64::try_from(bank.ns_per_slot_at_slot(slot)).unwrap_or(u64::MAX);
 
         block_producer_time_nanos = skew_block_producer_time_nanos(
             parent_slot,
@@ -571,7 +568,7 @@ fn produce_window(
     let mut slot = start_slot;
 
     while !ctx.exit.load(Ordering::Relaxed) && slot <= end_slot {
-        let timeout = block_timeout(&working_bank, leader_slot_index(slot));
+        let timeout = block_timeout(&working_bank, slot);
         trace!(
             "{my_pubkey}: waiting for leader bank {slot} to finish, remaining time: {}ms",
             timeout.saturating_sub(block_timer.elapsed()).as_millis()
@@ -1068,10 +1065,7 @@ fn start_leader_wait_for_parent_replay(
         ctx.my_pubkey
     );
     let my_pubkey = ctx.my_pubkey;
-    let timeout = block_timeout(
-        &ctx.bank_forks.read().unwrap().root_bank(),
-        leader_slot_index(slot),
-    );
+    let timeout = block_timeout(&ctx.bank_forks.read().unwrap().root_bank(), slot);
     let end_slot = last_of_consecutive_leader_slots(slot);
 
     let mut slot_delay_start = Measure::start("slot_delay");

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2641,6 +2641,11 @@ impl Bank {
         self.epoch_schedule().get_slots_in_epoch(epoch) as f64 / self.slots_per_year
     }
 
+    /// Returns the slot duration to use for `slot`.
+    pub fn ns_per_slot_at_slot(&self, _slot: Slot) -> u128 {
+        self.ns_per_slot
+    }
+
     pub fn max_processing_age(&self) -> usize {
         self.max_processing_age
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6581,6 +6581,18 @@ fn poh_estimate_offset(bank: &Bank) -> Duration {
 }
 
 #[test]
+fn test_ns_per_slot() {
+    let (genesis_config, _) = create_genesis_config(1);
+    let bank = Bank::new_for_tests(&genesis_config);
+
+    assert_eq!(bank.ns_per_slot_at_slot(bank.slot()), bank.ns_per_slot);
+    assert_eq!(
+        bank.ns_per_slot_at_slot(bank.slot().saturating_add(1)),
+        bank.ns_per_slot
+    );
+}
+
+#[test]
 fn test_timestamp_slow() {
     fn max_allowable_delta_since_epoch(bank: &Bank, max_allowable_drift: u32) -> i64 {
         let poh_estimate_offset = poh_estimate_offset(bank);

--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -4,7 +4,6 @@ use {
         fraction::Fraction,
         vote::{Vote, VoteType},
     },
-    solana_clock::DEFAULT_MS_PER_SLOT,
     std::time::Duration,
 };
 
@@ -81,14 +80,6 @@ const DELTA_BLOCK_PROPAGATION: Duration = DELTA.checked_mul(3).unwrap();
 /// This accounts for up to `DELTA` difference between the leader and the other
 /// validator triggering the parent ready event and for block propagation delay.
 pub(crate) const DELTA_TIMEOUT: Duration = DELTA.checked_add(DELTA_BLOCK_PROPAGATION).unwrap();
-
-/// Time budget we allow a leader to build and send their first slice after
-/// their leader window starts. `TimeoutCrashedLeader` must therefore fire
-/// no earlier than `DELTA_TIMEOUT + DELTA_FIRST_SLICE` from the start of the
-/// window, otherwise we may declare a correct leader crashed.
-///
-/// Conservatively initialized to the slot time.
-pub(crate) const DELTA_FIRST_SLICE: Duration = Duration::from_millis(DEFAULT_MS_PER_SLOT);
 
 /// Timeout for standstill detection mechanism.
 pub(crate) const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -4,7 +4,6 @@
 use {
     crate::{
         commitment::{CommitmentType, update_commitment_cache},
-        common::DELTA_FIRST_SLICE,
         consensus_metrics::ConsensusMetricsEvent,
         event::{
             CompletedBlock, RepairEvent, RepairEventSender, SwitchBankEvent, SwitchBankEventSender,
@@ -229,9 +228,9 @@ impl EventHandler {
         let should_set_timeouts = vctx.vote_history.add_parent_ready(slot, parent_block);
         Self::check_pending_blocks(my_pubkey, &mut local_context.pending_blocks, vctx, votes)?;
         if should_set_timeouts {
-            // TODO: configure delta_first_slice in bank
-            let delta_first_slice = DELTA_FIRST_SLICE;
-            let delta_block = Duration::from_nanos_u128(vctx.sharable_banks.root().ns_per_slot);
+            let root_bank = vctx.sharable_banks.root();
+            let delta_block = Duration::from_nanos_u128(root_bank.ns_per_slot_at_slot(slot));
+            let delta_first_slice = delta_block;
             timer_manager.write().set_timeouts(
                 slot,
                 local_context.standstill_slot,

--- a/votor/src/timer_manager.rs
+++ b/votor/src/timer_manager.rs
@@ -86,11 +86,8 @@ impl TimerManager {
 #[cfg(test)]
 mod tests {
     use {
-        super::*,
-        crate::{common::DELTA_FIRST_SLICE, event::VotorEvent},
-        crossbeam_channel::unbounded,
-        solana_clock::DEFAULT_MS_PER_SLOT,
-        std::time::Duration,
+        super::*, crate::event::VotorEvent, crossbeam_channel::unbounded,
+        solana_clock::DEFAULT_MS_PER_SLOT, std::time::Duration,
     };
 
     #[test]
@@ -102,8 +99,8 @@ mod tests {
             exit.clone(),
             Arc::new(MigrationStatus::post_migration_status()),
         );
-        let delta_first_slice = DELTA_FIRST_SLICE;
         let delta_block = Duration::from_millis(DEFAULT_MS_PER_SLOT);
+        let delta_first_slice = delta_block;
         let slot = 52;
         let start = Instant::now();
         timer_manager.set_timeouts(slot, None, delta_first_slice, delta_block);
@@ -125,7 +122,7 @@ mod tests {
                         assert_eq!(s, slot);
                         assert!(
                             Instant::now().duration_since(start)
-                                >= DELTA_TIMEOUT + DELTA_FIRST_SLICE
+                                >= DELTA_TIMEOUT + delta_first_slice
                         );
                         timeouts_received += 1;
                     }

--- a/votor/src/timer_manager/timers.rs
+++ b/votor/src/timer_manager/timers.rs
@@ -32,7 +32,7 @@ fn calculate_timeout_multiplier(slot: Slot, standstill_slot: Option<Slot>) -> f6
 /// Encodes a basic state machine of the different stages involved in handling
 /// timeouts for a window of slots.
 enum TimerState {
-    /// Waiting for initial DELTA_TIMEOUT + DELTA_FIRST_SLICE stage.
+    /// Waiting for initial DELTA_TIMEOUT + delta_first_slice stage.
     WaitForFirstSlice {
         /// The slots in the window.  Must not be empty.
         window: VecDeque<Slot>,
@@ -77,9 +77,9 @@ impl TimerState {
             (delta_timeout.as_secs_f64() * timeout_multiplier).min(MAX_TIMEOUT_SECS),
         );
 
-        // A correct leader may take up to `DELTA_FIRST_SLICE` to send their first slice,
+        // A correct leader may take up to `delta_first_slice` to send their first slice,
         // so the earliest sound point to declare them crashed is
-        // `DELTA_FIRST_SLICE + delta_timeout` after their window starts.
+        // `delta_first_slice + delta_timeout` after their window starts.
         let timeout = now
             .checked_add(scaled_delta_timeout)
             .unwrap()
@@ -264,9 +264,7 @@ impl Timers {
 #[cfg(test)]
 mod tests {
     use {
-        super::*,
-        crate::common::{DELTA_FIRST_SLICE, DELTA_TIMEOUT},
-        crossbeam_channel::unbounded,
+        super::*, crate::common::DELTA_TIMEOUT, crossbeam_channel::unbounded,
         solana_clock::DEFAULT_MS_PER_SLOT,
     };
 
@@ -321,14 +319,9 @@ mod tests {
         let mut timers = Timers::new(one_micro, sender);
         assert!(timers.progress(now).is_none());
         assert!(receiver.try_recv().unwrap_err().is_empty());
+        let delta_block = Duration::from_millis(DEFAULT_MS_PER_SLOT);
 
-        timers.set_timeouts(
-            0,
-            now,
-            None,
-            DELTA_FIRST_SLICE,
-            Duration::from_millis(DEFAULT_MS_PER_SLOT),
-        );
+        timers.set_timeouts(0, now, None, delta_block, delta_block);
         while timers.progress(now).is_some() {
             now = now.checked_add(one_micro).unwrap();
         }
@@ -431,19 +424,20 @@ mod tests {
         // Use a large multiplier that would exceed MAX_TIMEOUT
         let multiplier = 1000000.0;
         let delta_block = Duration::from_millis(DEFAULT_MS_PER_SLOT);
+        let delta_first_slice = delta_block;
 
         let (mut timer_state, next_fire) = TimerState::new(
             100,
             DELTA_TIMEOUT,
-            DELTA_FIRST_SLICE,
+            delta_first_slice,
             delta_block,
             now,
             multiplier,
         );
 
-        // The first timeout should be capped at MAX_TIMEOUT (+ unscaled DELTA_FIRST_SLICE).
+        // The first timeout should be capped at MAX_TIMEOUT (+ unscaled delta_first_slice).
         let expected_first_fire =
-            now + Duration::from_secs(MAX_TIMEOUT_SECS as u64) + DELTA_FIRST_SLICE;
+            now + Duration::from_secs(MAX_TIMEOUT_SECS as u64) + delta_first_slice;
         assert_eq!(next_fire, expected_first_fire);
 
         // Progress the timer to get TimeoutCrashedLeader
@@ -453,9 +447,9 @@ mod tests {
         ));
 
         // Slot 0's block deadline is `T + delta_block + scaled_delta_timeout`, so
-        // the gap from the (DELTA_FIRST_SLICE-shifted) first fire is `delta_block - DELTA_FIRST_SLICE`.
+        // the gap from the (delta_first_slice-shifted) first fire is `delta_block - delta_first_slice`.
         let next = timer_state.next_fire().unwrap();
         let actual_delta = next - next_fire;
-        assert_eq!(actual_delta, delta_block - DELTA_FIRST_SLICE);
+        assert_eq!(actual_delta, delta_block - delta_first_slice);
     }
 }


### PR DESCRIPTION
## Summary

Adds behavior-preserving plumbing for querying slot duration by slot.

Today `Bank::ns_per_slot_at_slot()` returns the bank's fixed `ns_per_slot`, so this does not change runtime behavior. It gives BCL and votor callsites a slot-scoped API ahead of future slot-duration changes.

## Changes

- Add `Bank::ns_per_slot_at_slot(slot)`.
- Use it in BCL block timeout calculation.
- Use it for BCL Alpenglow block producer timestamp bounds.
- Use it in votor timeout setup.
- Add a focused test asserting current fixed-duration behavior.
- Replace `DELTA_FIRST_SLICE` w/ bank derived slot time value