### PR TITLE
Dynamic PER stores

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -586,6 +586,7 @@ impl PartialEq for Bank {
             status_cache: _,
             blockhash_queue,
             max_processing_age,
+            partitioned_rewards_stake_account_stores_per_block,
             ancestors: _,
             hash,
             parent_hash,
@@ -656,6 +657,8 @@ impl PartialEq for Bank {
         } = self;
         *blockhash_queue.read().unwrap() == *other.blockhash_queue.read().unwrap()
             && *max_processing_age == other.max_processing_age
+            && *partitioned_rewards_stake_account_stores_per_block
+                == other.partitioned_rewards_stake_account_stores_per_block
             && *hash.read().unwrap() == *other.hash.read().unwrap()
             && parent_hash == &other.parent_hash
             && parent_slot == &other.parent_slot
@@ -810,6 +813,9 @@ pub struct Bank {
 
     /// Maximum age in slots a blockhash can be for a tx to be processed.
     max_processing_age: usize,
+
+    /// Number of stake accounts to store in each block during partitioned rewards.
+    partitioned_rewards_stake_account_stores_per_block: u64,
 
     /// The set of parents including this bank
     pub ancestors: Ancestors,
@@ -1134,11 +1140,16 @@ struct NewEpochBundle {
 
 impl Bank {
     fn default_with_accounts(accounts: Accounts) -> Self {
+        let partitioned_rewards_stake_account_stores_per_block = accounts
+            .accounts_db
+            .partitioned_epoch_rewards_config
+            .stake_account_stores_per_block;
         let mut bank = Self {
             rc: BankRc::new(accounts),
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
             blockhash_queue: RwLock::<BlockhashQueue>::default(),
             max_processing_age: MAX_PROCESSING_AGE,
+            partitioned_rewards_stake_account_stores_per_block,
             ancestors: Ancestors::default(),
             hash: RwLock::<Hash>::default(),
             parent_hash: Hash::default(),
@@ -1381,6 +1392,8 @@ impl Bank {
             epoch,
             blockhash_queue,
             max_processing_age: parent.max_processing_age,
+            partitioned_rewards_stake_account_stores_per_block: parent
+                .partitioned_rewards_stake_account_stores_per_block,
             // TODO: clean this up, so much special-case copying...
             hashes_per_tick: parent.hashes_per_tick,
             ticks_per_slot: parent.ticks_per_slot,
@@ -2046,11 +2059,17 @@ impl Bank {
 
         let stakes_accounts_load_duration = now.elapsed();
         let rent = Self::load_rent_from_account_for_snapshot_load(&bank_rc.accounts, &ancestors);
+        let partitioned_rewards_stake_account_stores_per_block = bank_rc
+            .accounts
+            .accounts_db
+            .partitioned_epoch_rewards_config
+            .stake_account_stores_per_block;
         let mut bank = Self {
             rc: bank_rc,
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
             blockhash_queue: RwLock::new(fields.blockhash_queue),
             max_processing_age: MAX_PROCESSING_AGE,
+            partitioned_rewards_stake_account_stores_per_block,
             ancestors,
             hash: RwLock::new(fields.hash),
             parent_hash: fields.parent_hash,

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -354,11 +354,7 @@ impl Bank {
 
     /// # stake accounts to store in one block during partitioned reward interval
     pub(super) fn partitioned_rewards_stake_account_stores_per_block(&self) -> u64 {
-        self.rc
-            .accounts
-            .accounts_db
-            .partitioned_epoch_rewards_config
-            .stake_account_stores_per_block
+        self.partitioned_rewards_stake_account_stores_per_block
     }
 
     /// Calculate the number of blocks required to distribute rewards to all stake accounts.
@@ -694,6 +690,14 @@ mod tests {
         let stake_account_stores_per_block =
             bank.partitioned_rewards_stake_account_stores_per_block();
         assert_eq!(stake_account_stores_per_block, 10);
+
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+        let bank =
+            Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), 1);
+        assert_eq!(
+            bank.partitioned_rewards_stake_account_stores_per_block(),
+            stake_account_stores_per_block
+        );
 
         let check_num_reward_distribution_blocks =
             |num_stakes: u64, expected_num_reward_distribution_blocks: u64| {


### PR DESCRIPTION
## Description
This PR moves the partitioned epoch rewards `stake_account_stores_per_block` budget onto `Bank` state instead of reading it directly from `AccountsDb` config at use time.

This is behavior-preserving today. The bank-scoped value is initialized from the existing `AccountsDbConfig.partitioned_epoch_rewards_config`, inherited by child banks, and reconstructed on snapshot restore from the same config source.

Keeping this value bank-scoped makes future runtime migrations simpler because the effective PER write budget can become bank-local state instead of a global accounts-db config lookup.

## Changes

- Add `Bank::partitioned_rewards_stake_account_stores_per_block`.
- Initialize the value during bank construction.
- Copy the value from parent to child banks.
- Initialize the value during snapshot restore.
- Update partitioned epoch rewards logic to read the bank-scoped value.
- Add test coverage that child banks preserve the configured PER budget.

Note: Snapshot serialization format is unchanged.