### PR TITLE
Check current channel version according to updated release procedures

### DIFF
--- a/ci/check-channel-version.sh
+++ b/ci/check-channel-version.sh
@@ -1,5 +1,4 @@
- # Ensure the current channel version is not equal ("greater") than
-# the version of the latest tag
+# Ensure the current channel version is equal to the version of the latest tag
 if [[ -z $CI_TAG ]]; then
   echo "--- channel version check"
   (
@@ -12,8 +11,8 @@ if [[ -z $CI_TAG ]]; then
       echo "latest channel tag: $CHANNEL_LATEST_TAG"
       echo "current version: v$version"
 
-      if [[ $CHANNEL_LATEST_TAG = v$version ]]; then
-        echo -e "\033[31mError:\033[0m A release has been tagged since your feature branch was last rebased. <current version> must be greater than <latest channel tag>..
+      if [[ $CHANNEL_LATEST_TAG != v$version ]]; then
+        echo -e "\033[31mError:\033[0m A release has been tagged since your feature branch was last rebased. <current version> must be equal to <latest channel tag>..
         Possible solutions (in the order they should be tried):
         1. rebase your feature branch on the base branch
         2. merge the PR: \"Bump Version to ...\" once it has passed ci/checks, then rebase


### PR DESCRIPTION
#### Problem

During new release procedures we bump the version and tag the new release at exactly the same time. Therefore the version of the branch should match the latest tag.

#### Summary of Changes

Reverse the condition.