### PR TITLE
feat(snapshots): replace hardlinking with storages map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10085,7 +10085,6 @@ dependencies = [
  "static_assertions",
  "strum",
  "strum_macros",
- "symlink",
  "tempfile",
  "test-case",
  "thiserror 2.0.18",

--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -211,6 +211,12 @@ impl AccountStorageEntry {
         self.accounts.flush()
     }
 
+    /// Detach the on-disk file from this storage's lifetime; see
+    /// [`AccountsFile::disable_remove_on_drop`].
+    pub fn disable_remove_on_drop(&self) {
+        self.accounts.disable_remove_on_drop();
+    }
+
     pub(crate) fn add_accounts(&self, num_accounts: usize, num_bytes: usize) {
         self.num_alive_accounts
             .fetch_add(num_accounts, Ordering::Release);

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -76,6 +76,14 @@ impl AccountsFile {
         }
     }
 
+    /// Detach the on-disk file from this storage's lifetime; see
+    /// [`AppendVec::disable_remove_on_drop`].
+    pub fn disable_remove_on_drop(&self) {
+        match self {
+            Self::AppendVec(av) => av.disable_remove_on_drop(),
+        }
+    }
+
     /// Return the total number of bytes of the zero lamport single ref accounts in the storage.
     /// Those bytes are "dead" and can be shrunk away.
     pub(crate) fn dead_bytes_due_to_zero_lamport_single_ref(&self, count: usize) -> usize {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -283,6 +283,13 @@ impl AppendVec {
         Ok(())
     }
 
+    /// Detach the on-disk file from this AppendVec's lifetime so dropping the AppendVec no
+    /// longer removes the file. Used when ownership of the file is being handed off (e.g. to a
+    /// bank snapshot's storages list that needs the file to outlive validator exit).
+    pub fn disable_remove_on_drop(&self) {
+        self.remove_file_on_drop.store(false, Ordering::Release);
+    }
+
     /// Return AppendVec opened in read-only file-io mode or `None` if it already is such
     pub(crate) fn reopen_as_readonly_file_io(&self) -> Option<Self> {
         if matches!(self.read_write_state, ReadWriteState::ReadOnly) {

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -286,6 +286,11 @@ impl SnapshotPackagerService {
                 // the "storages flushed" file, so return early.
                 return;
             }
+            // Pin the storage file so it outlives the validator-exit Drop chain (which would
+            // otherwise remove it via AppendVec::drop) and is available for fastboot on restart.
+            // The next startup opens a fresh AppendVec over the file; that one defaults back to
+            // removing-on-drop, so normal runtime cleanup (shrink, clean) still applies later.
+            storage.disable_remove_on_drop();
         }
         info!("Flushing account storages... Done in {:?}", start.elapsed());
 
@@ -294,21 +299,21 @@ impl SnapshotPackagerService {
             snapshot_slot,
         );
 
-        info!("Hard linking account storages...");
+        info!("Writing account storages list...");
         let start = Instant::now();
-        let result = snapshot_utils::hard_link_storages_to_snapshot(
+        let result = snapshot_utils::write_storages_list_to_snapshot(
             &bank_snapshot_dir,
-            snapshot_slot,
             &snapshot_storages,
+            &io_setup,
         );
         if let Err(err) = result {
-            warn!("Failed to hard link account storages: {err}");
-            // If hard linking the storages failed, we do *NOT* want to mark the bank snapshot as
+            warn!("Failed to write account storages list: {err}");
+            // If writing the storages list failed, we do *NOT* want to mark the bank snapshot as
             // loadable so return early.
             return;
         }
         info!(
-            "Hard linking account storages... Done in {:?}",
+            "Writing account storages list... Done in {:?}",
             start.elapsed(),
         );
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -836,11 +836,8 @@ impl Validator {
 
         info!("Cleaning orphaned account snapshot directories...");
         let mut timer = Measure::start("clean_orphaned_account_snapshot_dirs");
-        clean_orphaned_account_snapshot_dirs(
-            &config.snapshot_config.bank_snapshots_dir,
-            &config.account_snapshot_paths,
-        )
-        .context("failed to clean orphaned account snapshot directories")?;
+        clean_orphaned_account_snapshot_dirs(&config.account_snapshot_paths)
+            .context("failed to clean orphaned account snapshot directories")?;
         timer.stop();
         info!("Cleaning orphaned account snapshot directories done. {timer}");
 
@@ -2900,8 +2897,16 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
 }
 
 fn cleanup_accounts_paths(config: &ValidatorConfig) {
-    for account_path in &config.account_paths {
-        move_and_async_delete_path_contents(account_path);
+    // Clean account storages only when we'll load from a snapshot archive. Fastboot loads from
+    // the existing storages in `<account_path>/run/`, and the rebuild path prunes any leftover
+    // stale storages itself.
+    let cleanup_account_paths =
+        snapshot_utils::get_highest_loadable_bank_snapshot(&config.snapshot_config).is_none()
+            || config.use_snapshot_archives_at_startup == UseSnapshotArchivesAtStartup::Always;
+    if cleanup_account_paths {
+        for account_path in &config.account_paths {
+            move_and_async_delete_path_contents(account_path);
+        }
     }
 }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2243,6 +2243,11 @@ fn load_blockstore(
 
     let (bank_forks, starting_snapshot_hashes) = bank_from_snapshot_opt
         .unwrap_or_else(|| {
+            // Clean run from genesis — must not use any existing state from previous runs.
+            bank_forks_utils::discard_previous_run_state(
+                &config.snapshot_config.bank_snapshots_dir,
+                &config.account_paths,
+            );
             bank_forks_utils::load_bank_forks_from_genesis(
                 genesis_config,
                 &blockstore,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -46,7 +46,7 @@ use {
     solana_accounts_db::{
         accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
-        utils::{move_and_async_delete_path_contents, validate_account_paths_for_direct_io},
+        utils::validate_account_paths_for_direct_io,
     },
     solana_client::connection_cache::{ConnectionCache, Protocol},
     solana_clock::Slot,
@@ -821,13 +821,12 @@ impl Validator {
         let genesis_config = load_genesis(config, ledger_path)?;
         metrics_config_sanity_check(genesis_config.cluster_type)?;
 
-        info!("Validating and cleaning accounts paths...");
+        info!("Validating accounts paths...");
         *start_progress.write().unwrap() = ValidatorStartProgress::CleaningAccounts;
-        let mut timer = Measure::start("validate_and_clean_accounts_paths");
+        let mut timer = Measure::start("validate_account_paths");
         validate_account_paths(config)?;
-        cleanup_accounts_paths(config);
         timer.stop();
-        info!("Validating and cleaning accounts paths done. {timer}");
+        info!("Validating accounts paths done. {timer}");
 
         snapshot_utils::purge_incomplete_bank_snapshots(&config.snapshot_config.bank_snapshots_dir);
         snapshot_utils::purge_old_bank_snapshots_at_startup(
@@ -2894,20 +2893,6 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
     }
 
     online_stake_percentage as u64
-}
-
-fn cleanup_accounts_paths(config: &ValidatorConfig) {
-    // Clean account storages only when we'll load from a snapshot archive. Fastboot loads from
-    // the existing storages in `<account_path>/run/`, and the rebuild path prunes any leftover
-    // stale storages itself.
-    let cleanup_account_paths =
-        snapshot_utils::get_highest_loadable_bank_snapshot(&config.snapshot_config).is_none()
-            || config.use_snapshot_archives_at_startup == UseSnapshotArchivesAtStartup::Always;
-    if cleanup_account_paths {
-        for account_path in &config.account_paths {
-            move_and_async_delete_path_contents(account_path);
-        }
-    }
 }
 
 fn validate_account_paths(config: &ValidatorConfig) -> std::io::Result<()> {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -39,7 +39,7 @@ use {
         voting_service::VotingServiceOverride,
     },
     agave_xdp::transmitter::{Transmitter, TransmitterBuilder},
-    anyhow::{Context, Result, anyhow},
+    anyhow::{Result, anyhow},
     crossbeam_channel::{Receiver, bounded, unbounded},
     serde::{Deserialize, Serialize},
     solana_account::ReadableAccount,
@@ -132,7 +132,7 @@ use {
         runtime_config::RuntimeConfig,
         snapshot_bank_utils,
         snapshot_controller::SnapshotController,
-        snapshot_utils::{self, clean_orphaned_account_snapshot_dirs},
+        snapshot_utils,
     },
     solana_send_transaction_service::send_transaction_service::Config as SendTransactionServiceConfig,
     solana_shred_version::compute_shred_version,
@@ -832,13 +832,6 @@ impl Validator {
         snapshot_utils::purge_old_bank_snapshots_at_startup(
             &config.snapshot_config.bank_snapshots_dir,
         );
-
-        info!("Cleaning orphaned account snapshot directories...");
-        let mut timer = Measure::start("clean_orphaned_account_snapshot_dirs");
-        clean_orphaned_account_snapshot_dirs(&config.account_snapshot_paths)
-            .context("failed to clean orphaned account snapshot directories")?;
-        timer.stop();
-        info!("Cleaning orphaned account snapshot directories done. {timer}");
 
         // token used to cancel tpu-client-next, streamer and BLS streamer.
         let cancel = CancellationToken::new();

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8468,7 +8468,6 @@ dependencies = [
  "static_assertions",
  "strum",
  "strum_macros",
- "symlink",
  "tempfile",
  "thiserror 2.0.18",
  "wincode",

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -45,7 +45,7 @@ use {
         },
         bank_forks::BankForks,
         snapshot_controller::SnapshotController,
-        snapshot_utils::{self, clean_orphaned_account_snapshot_dirs},
+        snapshot_utils,
     },
     solana_transaction::versioned::VersionedTransaction,
     solana_unified_scheduler_pool::DefaultSchedulerPool,
@@ -81,9 +81,6 @@ const PROCESS_SLOTS_HELP_STRING: &str =
 
 #[derive(Error, Debug)]
 pub(crate) enum LoadAndProcessLedgerError {
-    #[error("failed to clean orphaned account snapshot directories: {0}")]
-    CleanOrphanedAccountSnapshotDirectories(#[source] std::io::Error),
-
     #[error("failed to create all run and snapshot directories: {0}")]
     CreateAllAccountsRunAndSnapshotDirectories(#[source] std::io::Error),
 
@@ -291,10 +288,6 @@ pub fn load_and_process_ledger(
     info!("{measure_clean_account_paths}");
 
     snapshot_utils::purge_incomplete_bank_snapshots(&snapshot_config.bank_snapshots_dir);
-
-    info!("Cleaning contents of account snapshot paths: {account_snapshot_paths:?}");
-    clean_orphaned_account_snapshot_dirs(&account_snapshot_paths)
-        .map_err(LoadAndProcessLedgerError::CleanOrphanedAccountSnapshotDirectories)?;
 
     let geyser_plugin_active = arg_matches.is_present("geyser_plugin_config");
     let (accounts_update_notifier, transaction_notifier) = if geyser_plugin_active {

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -293,11 +293,8 @@ pub fn load_and_process_ledger(
     snapshot_utils::purge_incomplete_bank_snapshots(&snapshot_config.bank_snapshots_dir);
 
     info!("Cleaning contents of account snapshot paths: {account_snapshot_paths:?}");
-    clean_orphaned_account_snapshot_dirs(
-        &snapshot_config.bank_snapshots_dir,
-        &account_snapshot_paths,
-    )
-    .map_err(LoadAndProcessLedgerError::CleanOrphanedAccountSnapshotDirectories)?;
+    clean_orphaned_account_snapshot_dirs(&account_snapshot_paths)
+        .map_err(LoadAndProcessLedgerError::CleanOrphanedAccountSnapshotDirectories)?;
 
     let geyser_plugin_active = arg_matches.is_present("geyser_plugin_config");
     let (accounts_update_notifier, transaction_notifier) = if geyser_plugin_active {

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -365,6 +365,11 @@ pub fn load_and_process_ledger(
         )
         .transpose()
         .unwrap_or_else(|| {
+            // Clean run from genesis — must not use any existing state from previous runs.
+            bank_forks_utils::discard_previous_run_state(
+                &snapshot_config.bank_snapshots_dir,
+                &account_paths,
+            );
             bank_forks_utils::load_bank_forks_from_genesis(
                 genesis_config,
                 &blockstore,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -367,6 +367,26 @@ pub fn load_and_process_ledger(
             )
         })
         .map_err(LoadAndProcessLedgerError::LoadBankForks)?;
+
+    // With hard-linking gone, an AppendVec's Drop removes the only copy of the storage file by
+    // default. For a fastboot load we don't want that — the files belong to the validator's
+    // local state and need to outlive this process. Storages ledger-tool creates itself (archive
+    // or genesis load) can be cleaned up normally. We detect fastboot via the bank snapshot dir
+    // at the root slot: archive/genesis paths went through `discard_previous_run_state`, which
+    // purges those dirs, so its presence here means we loaded from it.
+    {
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let loaded_from_fastboot = snapshot_config
+            .bank_snapshots_dir
+            .join(root_bank.slot().to_string())
+            .is_dir();
+        if loaded_from_fastboot {
+            for storage in root_bank.get_snapshot_storages(None) {
+                storage.disable_remove_on_drop();
+            }
+        }
+    }
+
     let leader_schedule_cache =
         LeaderScheduleCache::new_from_bank(&bank_forks.read().unwrap().root_bank());
 

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -10,10 +10,7 @@ use {
     log::*,
     solana_accounts_db::{
         accounts_db::TOTAL_IO_URING_BUFFERS_SIZE_LIMIT,
-        utils::{
-            create_all_accounts_run_and_snapshot_dirs, move_and_async_delete_path_contents,
-            validate_account_paths_for_direct_io,
-        },
+        utils::{create_all_accounts_run_and_snapshot_dirs, validate_account_paths_for_direct_io},
     },
     solana_clock::Slot,
     solana_core::{
@@ -35,7 +32,6 @@ use {
         leader_schedule_cache::LeaderScheduleCache,
         use_snapshot_archives_at_startup::UseSnapshotArchivesAtStartup,
     },
-    solana_measure::measure_time,
     solana_pubkey::Pubkey,
     solana_rpc::transaction_status_service::TransactionStatusService,
     solana_runtime::{
@@ -275,17 +271,6 @@ pub fn load_and_process_ledger(
             ]),
     )
     .map_err(LoadAndProcessLedgerError::ValidateAccountPaths)?;
-
-    let (_, measure_clean_account_paths) = measure_time!(
-        account_paths.iter().for_each(|path| {
-            if path.exists() {
-                info!("Cleaning contents of account path: {}", path.display());
-                move_and_async_delete_path_contents(path);
-            }
-        }),
-        "Cleaning account paths"
-    );
-    info!("{measure_clean_account_paths}");
 
     snapshot_utils::purge_incomplete_bank_snapshots(&snapshot_config.bank_snapshots_dir);
 

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -68,12 +68,12 @@ pub type BankAndHashes = (Arc<RwLock<BankForks>>, Option<StartingSnapshotHashes>
 ///
 /// Call from any load path that commits to NOT fastbooting (archive load, genesis boot) —
 /// i.e. anywhere the existing storages must not be loaded.
-pub fn discard_previous_run_state(bank_snapshots_dir: &Path, account_paths: &[PathBuf]) {
+pub fn discard_previous_run_state(bank_snapshots_dir: &Path, account_run_paths: &[PathBuf]) {
     snapshot_utils::purge_all_bank_snapshots(bank_snapshots_dir);
-    for account_path in account_paths {
-        move_and_async_delete_path_contents(account_path);
+    for account_run_path in account_run_paths {
+        move_and_async_delete_path_contents(account_run_path);
     }
-    snapshot_utils::wipe_account_snapshot_dirs(account_paths);
+    snapshot_utils::wipe_account_snapshot_dirs(account_run_paths);
 }
 
 /// Load the banks via genesis

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -24,7 +24,7 @@ use {
     solana_genesis_config::GenesisConfig,
     solana_runtime::{bank_forks::BankForks, snapshot_bank_utils, snapshot_utils},
     std::{
-        path::PathBuf,
+        path::{Path, PathBuf},
         sync::{Arc, RwLock, atomic::AtomicBool},
     },
     thiserror::Error,
@@ -62,6 +62,19 @@ pub enum BankForksUtilsError {
 }
 
 pub type BankAndHashes = (Arc<RwLock<BankForks>>, Option<StartingSnapshotHashes>);
+
+/// Tear down state left over from a previous run: purges old bank snapshots, wipes the account
+/// run dirs, and wipes the legacy snapshot sibling trees.
+///
+/// Call from any load path that commits to NOT fastbooting (archive load, genesis boot) —
+/// i.e. anywhere the existing storages must not be loaded.
+pub fn discard_previous_run_state(bank_snapshots_dir: &Path, account_paths: &[PathBuf]) {
+    snapshot_utils::purge_all_bank_snapshots(bank_snapshots_dir);
+    for account_path in account_paths {
+        move_and_async_delete_path_contents(account_path);
+    }
+    snapshot_utils::wipe_account_snapshot_dirs(account_paths);
+}
 
 /// Load the banks via genesis
 pub fn load_bank_forks_from_genesis(
@@ -212,19 +225,10 @@ pub fn try_load_bank_forks_from_snapshot(
             path: fastboot_snapshot.snapshot_path(),
         })?
     } else {
-        // Given that we are going to boot from an archive, the append vecs held in the snapshot dirs for fast-boot should
-        // be released.  They will be released by the account_background_service anyway.  But in the case of the account_paths
-        // using memory-mounted file system, they are not released early enough to give space for the new append-vecs from
-        // the archives, causing the out-of-memory problem.  So, purge the snapshot dirs upfront before loading from the archive.
-        snapshot_utils::purge_all_bank_snapshots(&snapshot_config.bank_snapshots_dir);
-
-        // Storages on disk from a previous run are kept around so fastboot can use them. Now
-        // that we've committed to loading from an archive instead, drop them — the archive will
-        // be extracted into the run dirs and any leftover files would just be orphans.
-        for account_path in account_paths {
-            move_and_async_delete_path_contents(account_path);
-        }
-        snapshot_utils::wipe_account_snapshot_dirs(account_paths);
+        // Committed to loading from a snapshot archive — the existing storages a previous run
+        // left around (kept for fastboot) are now orphans, and the archive will be extracted
+        // into the (cleared) run dirs.
+        discard_previous_run_state(&snapshot_config.bank_snapshots_dir, account_paths);
 
         snapshot_bank_utils::bank_from_snapshot_archives(
             account_paths,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -17,7 +17,10 @@ use {
         snapshot_hash::{FullSnapshotHash, IncrementalSnapshotHash, StartingSnapshotHashes},
     },
     log::*,
-    solana_accounts_db::accounts_update_notifier_interface::AccountsUpdateNotifier,
+    solana_accounts_db::{
+        accounts_update_notifier_interface::AccountsUpdateNotifier,
+        utils::move_and_async_delete_path_contents,
+    },
     solana_genesis_config::GenesisConfig,
     solana_runtime::{bank_forks::BankForks, snapshot_bank_utils, snapshot_utils},
     std::{
@@ -214,6 +217,13 @@ pub fn try_load_bank_forks_from_snapshot(
         // using memory-mounted file system, they are not released early enough to give space for the new append-vecs from
         // the archives, causing the out-of-memory problem.  So, purge the snapshot dirs upfront before loading from the archive.
         snapshot_utils::purge_all_bank_snapshots(&snapshot_config.bank_snapshots_dir);
+
+        // Storages on disk from a previous run are kept around so fastboot can use them. Now
+        // that we've committed to loading from an archive instead, drop them — the archive will
+        // be extracted into these dirs and any leftover files would just be orphans.
+        for account_path in account_paths {
+            move_and_async_delete_path_contents(account_path);
+        }
 
         snapshot_bank_utils::bank_from_snapshot_archives(
             account_paths,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -220,10 +220,11 @@ pub fn try_load_bank_forks_from_snapshot(
 
         // Storages on disk from a previous run are kept around so fastboot can use them. Now
         // that we've committed to loading from an archive instead, drop them — the archive will
-        // be extracted into these dirs and any leftover files would just be orphans.
+        // be extracted into the run dirs and any leftover files would just be orphans.
         for account_path in account_paths {
             move_and_async_delete_path_contents(account_path);
         }
+        snapshot_utils::wipe_account_snapshot_dirs(account_paths);
 
         snapshot_bank_utils::bank_from_snapshot_archives(
             account_paths,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8275,7 +8275,6 @@ dependencies = [
  "static_assertions",
  "strum",
  "strum_macros",
- "symlink",
  "tempfile",
  "thiserror 2.0.18",
  "wincode",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -179,7 +179,6 @@ spl-generic-token = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }
-symlink = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 wincode = { workspace = true }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -66,6 +66,7 @@ use {
 mod obsolete_accounts;
 mod status_cache;
 mod storage;
+mod storages_list;
 mod tests;
 mod types;
 mod utils;
@@ -74,6 +75,7 @@ pub(crate) use {
     obsolete_accounts::{SerdeObsoleteAccounts, SerdeObsoleteAccountsMap},
     status_cache::{deserialize_status_cache, serialize_status_cache},
     storage::{SerializableAccountStorageEntry, SerializedAccountsFileId},
+    storages_list::StoragesList,
 };
 
 const MAX_STREAM_SIZE: usize = 32 * 1024 * 1024 * 1024;

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -75,7 +75,7 @@ pub(crate) use {
     obsolete_accounts::{SerdeObsoleteAccounts, SerdeObsoleteAccountsMap},
     status_cache::{deserialize_status_cache, serialize_status_cache},
     storage::{SerializableAccountStorageEntry, SerializedAccountsFileId},
-    storages_list::StoragesList,
+    storages_list::{StorageListItem, StoragesList},
 };
 
 const MAX_STREAM_SIZE: usize = 32 * 1024 * 1024 * 1024;

--- a/runtime/src/serde_snapshot/storages_list.rs
+++ b/runtime/src/serde_snapshot/storages_list.rs
@@ -1,0 +1,78 @@
+use {
+    solana_accounts_db::{account_storage_entry::AccountStorageEntry, accounts_db::AccountsFileId},
+    solana_clock::Slot,
+    std::{collections::HashSet, sync::Arc},
+    wincode::{SchemaRead, SchemaWrite},
+};
+
+/// Identifies a storage file belonging to a bank snapshot, by `(slot, id)`.
+///
+/// The file is local-only (never archived) and gated behind `SNAPSHOT_FASTBOOT_VERSION`, so the
+/// on-disk encoding can use `AccountsFileId` (`u32`) directly without worrying about
+/// forward-compat with potential future widening.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
+pub struct StorageListItem {
+    pub slot: Slot,
+    pub id: AccountsFileId,
+}
+
+/// On-disk format of the storages list file.
+///
+/// Written next to the bank snapshot on graceful exit to record which storages in the account
+/// run dirs make up the snapshot; read on startup to prune anything else before fastboot.
+#[derive(Debug, SchemaRead, SchemaWrite)]
+pub struct StoragesList {
+    list: Vec<StorageListItem>,
+}
+
+impl StoragesList {
+    pub fn new_from_storages(snapshot_storages: &[Arc<AccountStorageEntry>]) -> Self {
+        let list = snapshot_storages
+            .iter()
+            .map(|storage| StorageListItem {
+                slot: storage.slot(),
+                id: storage.id(),
+            })
+            .collect();
+        Self { list }
+    }
+
+    pub fn into_slot_file_id_set(self) -> HashSet<(Slot, AccountsFileId)> {
+        self.list
+            .into_iter()
+            .map(|item| (item.slot, item.id))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::serde_snapshot::{deserialize_wincode_from, serialize_into},
+        std::io::Cursor,
+    };
+
+    #[test]
+    fn test_roundtrip_storages_list() {
+        let list = StoragesList {
+            list: vec![
+                StorageListItem { slot: 7, id: 42 },
+                StorageListItem { slot: 11, id: 13 },
+                StorageListItem {
+                    slot: Slot::MAX,
+                    id: AccountsFileId::MAX,
+                },
+            ],
+        };
+        let expected_set: HashSet<(Slot, AccountsFileId)> =
+            HashSet::from([(7, 42), (11, 13), (Slot::MAX, AccountsFileId::MAX)]);
+
+        let mut buf = Vec::new();
+        serialize_into(Cursor::new(&mut buf), &list).unwrap();
+
+        let decoded: StoragesList = deserialize_wincode_from(Cursor::new(&buf)).unwrap();
+        assert_eq!(decoded.into_slot_file_id_set(), expected_set);
+    }
+}

--- a/runtime/src/serde_snapshot/storages_list.rs
+++ b/runtime/src/serde_snapshot/storages_list.rs
@@ -28,13 +28,19 @@ pub struct StoragesList {
 
 impl StoragesList {
     pub fn new_from_storages(snapshot_storages: &[Arc<AccountStorageEntry>]) -> Self {
-        let list = snapshot_storages
-            .iter()
-            .map(|storage| StorageListItem {
-                slot: storage.slot(),
-                id: storage.id(),
-            })
-            .collect();
+        Self::from_items(
+            snapshot_storages
+                .iter()
+                .map(|storage| StorageListItem {
+                    slot: storage.slot(),
+                    id: storage.id(),
+                })
+                .collect(),
+        )
+    }
+
+    /// Build a `StoragesList` from an existing `Vec` of items.
+    pub fn from_items(list: Vec<StorageListItem>) -> Self {
         Self { list }
     }
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -25,7 +25,7 @@ use {
             rebuild_storages_from_snapshot_dir, verify_and_unarchive_snapshots,
         },
     },
-    agave_fs::{dirs, io_setup::IoSetupState},
+    agave_fs::io_setup::IoSetupState,
     agave_snapshots::{
         SnapshotArchiveKind, SnapshotKind,
         error::{
@@ -376,11 +376,9 @@ pub fn bank_from_snapshot_dir(
         bank_snapshot.snapshot_dir.display()
     );
 
-    // Clear the contents of the account paths run directories.  When constructing the bank, the appendvec
-    // files will be extracted from the snapshot hardlink directories into these run/ directories.
-    for path in account_paths {
-        dirs::remove_dir_contents(path);
-    }
+    // Storages from this snapshot already live under `account_paths`; the storages list
+    // list inside the bank snapshot dir tells us which ones belong to it, and stale files
+    // (e.g. from later slots) are pruned by `rebuild_storages_from_snapshot_dir`.
 
     let next_append_vec_id = Arc::new(AtomicAccountsFileId::new(0));
 
@@ -886,7 +884,7 @@ mod tests {
         genesis_config: &GenesisConfig,
         bank_snapshots_dir: impl AsRef<Path>,
         num_total: usize,
-        should_flush_and_hard_link_storages: bool,
+        should_finalize: bool,
     ) -> Arc<Bank> {
         let (bank0, bank_forks) =
             Bank::new_for_tests(genesis_config).wrap_with_bank_forks_for_tests();
@@ -906,7 +904,7 @@ mod tests {
                 &bank_snapshots_dir,
                 &bank,
                 SnapshotVersion::default(),
-                should_flush_and_hard_link_storages,
+                should_finalize,
             )
             .unwrap();
         }
@@ -915,7 +913,7 @@ mod tests {
     }
 
     /// Creates a bank snapshot from a bank, regardless of state. The Bank will be frozen during
-    /// the process. Passing in should_flush_and_hard_link_storages as true will create a
+    /// the process. Passing in should_finalize as true will create a
     /// a fastbootable bank snapshot
     ///
     /// Requires:
@@ -925,7 +923,7 @@ mod tests {
         bank_snapshots_dir: impl AsRef<Path>,
         bank: &Bank,
         snapshot_version: SnapshotVersion,
-        should_flush_and_hard_link_storages: bool,
+        should_finalize: bool,
     ) -> agave_snapshots::Result<()> {
         assert!(bank.is_complete());
         assert!(bank.block_id().is_some());
@@ -948,7 +946,7 @@ mod tests {
             snapshot_version,
             bank_snapshot_package,
             snapshot_storages.as_slice(),
-            should_flush_and_hard_link_storages,
+            should_finalize,
             &IoSetupState::default(),
         )?;
 
@@ -1673,7 +1671,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bank_snapshot_dir_accounts_hardlinks() {
+    fn test_bank_snapshot_dir_storages_list() {
         let bank = Bank::new_for_tests(&GenesisConfig::default());
         bank.fill_bank_with_ticks_for_tests();
         bank.set_block_id(Some(Hash::default()));
@@ -1687,25 +1685,13 @@ mod tests {
         )
         .unwrap();
 
-        let accounts_hardlinks_dir = get_bank_snapshot_dir(&bank_snapshots_dir, bank.slot())
-            .join(snapshot_paths::SNAPSHOT_ACCOUNTS_HARDLINKS);
-        assert!(fs::metadata(&accounts_hardlinks_dir).is_ok());
-
-        let mut hardlink_dirs = Vec::new();
-        // This directory contain symlinks to all accounts snapshot directories.
-        for entry in fs::read_dir(accounts_hardlinks_dir).unwrap() {
-            let entry = entry.unwrap();
-            let symlink = entry.path();
-            let dst_path = fs::read_link(symlink).unwrap();
-            assert!(fs::metadata(&dst_path).is_ok());
-            hardlink_dirs.push(dst_path);
-        }
-
         let bank_snapshot_dir = get_bank_snapshot_dir(&bank_snapshots_dir, bank.slot());
-        assert!(purge_bank_snapshot(bank_snapshot_dir).is_ok());
+        let storages_list_file =
+            bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_STORAGES_LIST_FILENAME);
+        assert!(fs::metadata(&storages_list_file).is_ok());
 
-        // When the bank snapshot is removed, all the snapshot hardlink directories should be removed.
-        assert!(hardlink_dirs.iter().all(|dir| fs::metadata(dir).is_err()));
+        assert!(purge_bank_snapshot(&bank_snapshot_dir).is_ok());
+        assert!(fs::metadata(&bank_snapshot_dir).is_err());
     }
 
     /// Test versioning when fastbooting
@@ -1765,14 +1751,14 @@ mod tests {
 
     #[test_case(false)]
     #[test_case(true)]
-    fn test_get_highest_bank_snapshot(should_flush_and_hard_link_storages: bool) {
+    fn test_get_highest_bank_snapshot(should_finalize: bool) {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let _bank = create_snapshot_dirs_for_tests(
             &genesis_config,
             &bank_snapshots_dir,
             4,
-            should_flush_and_hard_link_storages,
+            should_finalize,
         );
 
         let snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
@@ -1803,83 +1789,47 @@ mod tests {
         assert_eq!(snapshot.slot, 1);
     }
 
+    /// Simulates a leftover `<account_path>/snapshot/<slot>/` dir from a pre-refactor version
+    /// and verifies the cleanup helper removes it.
     #[test]
     fn test_clean_orphaned_account_snapshot_dirs() {
-        let genesis_config = GenesisConfig::default();
-        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
-        let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 2, true);
+        let account_snapshot_path = tempfile::TempDir::new().unwrap();
+        let legacy_slot_dir = account_snapshot_path.path().join("123");
+        fs::create_dir_all(&legacy_slot_dir).unwrap();
+        fs::write(legacy_slot_dir.join("123.0"), b"junk").unwrap();
+        assert!(legacy_slot_dir.exists());
 
-        let snapshot_dir_slot_2 = bank_snapshots_dir.path().join("2");
-        let accounts_link_dir_slot_2 =
-            snapshot_dir_slot_2.join(snapshot_paths::SNAPSHOT_ACCOUNTS_HARDLINKS);
+        clean_orphaned_account_snapshot_dirs(slice::from_ref(
+            &account_snapshot_path.path().to_path_buf(),
+        ))
+        .unwrap();
 
-        // the symlinks point to the account snapshot hardlink directories <account_path>/snapshot/<slot>/ for slot 2
-        // get them via read_link
-        let hardlink_dirs_slot_2: Vec<PathBuf> = fs::read_dir(accounts_link_dir_slot_2)
-            .unwrap()
-            .map(|entry| {
-                let symlink = entry.unwrap().path();
-                fs::read_link(symlink).unwrap()
-            })
-            .collect();
-
-        // remove the bank snapshot directory for slot 2, so the account snapshot slot 2 directories become orphaned
-        fs::remove_dir_all(snapshot_dir_slot_2).unwrap();
-
-        // verify the orphaned account snapshot hardlink directories are still there
-        assert!(
-            hardlink_dirs_slot_2
-                .iter()
-                .all(|dir| fs::metadata(dir).is_ok())
-        );
-
-        let account_snapshot_paths: Vec<PathBuf> = hardlink_dirs_slot_2
-            .iter()
-            .map(|dir| dir.parent().unwrap().parent().unwrap().to_path_buf())
-            .collect();
-        // clean the orphaned hardlink directories
-        clean_orphaned_account_snapshot_dirs(&bank_snapshots_dir, &account_snapshot_paths).unwrap();
-
-        // verify the hardlink directories are gone
-        assert!(
-            hardlink_dirs_slot_2
-                .iter()
-                .all(|dir| fs::metadata(dir).is_err())
-        );
+        // move_and_async_delete_path renames before async-deleting, so the original is gone
+        // even if the eventual deletion hasn't completed.
+        assert!(!legacy_slot_dir.exists());
     }
 
-    // Ensure that `clean_orphaned_account_snapshot_dirs()` works correctly for bank snapshots
-    // that *do not* hard link the storages into their staging dir.
+    /// Cleanup should tolerate empty / missing account snapshot dirs.
     #[test]
-    fn test_clean_orphaned_account_snapshot_dirs_no_hard_link() {
-        let genesis_config = GenesisConfig::default();
-        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
-        let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 2, false);
-
-        // Ensure the bank snapshot dir does exist.
-        let bank_snapshot_dir = get_bank_snapshot_dir(&bank_snapshots_dir, 2);
-        assert!(fs::exists(&bank_snapshot_dir).unwrap());
-
-        // Ensure the accounts hard links dir does *not* exist for this bank snapshot
-        // (since we asked create_snapshot_dirs_for_tests() to *not* hard link).
-        let bank_snapshot_accounts_hard_link_dir =
-            bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_ACCOUNTS_HARDLINKS);
-        assert!(!fs::exists(&bank_snapshot_accounts_hard_link_dir).unwrap());
-
-        // Now make sure clean_orphaned_account_snapshot_dirs() doesn't error.
-        clean_orphaned_account_snapshot_dirs(&bank_snapshots_dir, &[]).unwrap();
+    fn test_clean_orphaned_account_snapshot_dirs_empty() {
+        let account_snapshot_path = tempfile::TempDir::new().unwrap();
+        clean_orphaned_account_snapshot_dirs(slice::from_ref(
+            &account_snapshot_path.path().to_path_buf(),
+        ))
+        .unwrap();
+        clean_orphaned_account_snapshot_dirs(&[]).unwrap();
     }
 
     #[test_case(false)]
     #[test_case(true)]
-    fn test_purge_incomplete_bank_snapshots(should_flush_and_hard_link_storages: bool) {
+    fn test_purge_incomplete_bank_snapshots(should_finalize: bool) {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let _bank = create_snapshot_dirs_for_tests(
             &genesis_config,
             &bank_snapshots_dir,
             2,
-            should_flush_and_hard_link_storages,
+            should_finalize,
         );
 
         // remove the "version" files so the snapshots will be purged
@@ -2097,7 +2047,7 @@ mod tests {
         bank2.set_block_id(Some(Hash::default()));
         assert_eq!(bank2.get_balance(&key2.pubkey()), 0);
 
-        // Take a bank snapshot, passing `true` for `should_flush_and_hard_link_storages`.
+        // Take a bank snapshot, passing `true` for `should_finalize`.
         // This ensures that `serialize_snapshot` performs all necessary steps to create
         // a snapshot that supports fastbooting.
         create_bank_snapshot_from_bank(
@@ -2180,7 +2130,7 @@ mod tests {
         bank.fill_bank_with_ticks_for_tests();
         bank.set_block_id(Some(Hash::default()));
 
-        // Take a bank snapshot, passing `true` for `should_flush_and_hard_link_storages`.
+        // Take a bank snapshot, passing `true` for `should_finalize`.
         // This ensures that `serialize_snapshot` performs all necessary steps to create
         // a snapshot that supports fastbooting.
         create_bank_snapshot_from_bank(
@@ -2280,14 +2230,14 @@ mod tests {
 
     #[test_case(false)]
     #[test_case(true)]
-    fn test_purge_all_bank_snapshots(should_flush_and_hard_link_storages: bool) {
+    fn test_purge_all_bank_snapshots(should_finalize: bool) {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let _bank = create_snapshot_dirs_for_tests(
             &genesis_config,
             &bank_snapshots_dir,
             10,
-            should_flush_and_hard_link_storages,
+            should_finalize,
         );
         // Keep bank in this scope so that its account_paths tmp dirs are not released, and purge_all_bank_snapshots
         // can clear the account hardlinks correctly.
@@ -2299,14 +2249,14 @@ mod tests {
 
     #[test_case(false)]
     #[test_case(true)]
-    fn test_purge_old_bank_snapshots(should_flush_and_hard_link_storages: bool) {
+    fn test_purge_old_bank_snapshots(should_finalize: bool) {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
         let _bank = create_snapshot_dirs_for_tests(
             &genesis_config,
             &bank_snapshots_dir,
             10,
-            should_flush_and_hard_link_storages,
+            should_finalize,
         );
         // Keep bank in this scope so that its account_paths tmp dirs are not released, and purge_old_bank_snapshots
         // can clear the account hardlinks correctly.
@@ -2326,7 +2276,7 @@ mod tests {
 
     #[test_case(false)]
     #[test_case(true)]
-    fn test_purge_bank_snapshots_older_than_slot(should_flush_and_hard_link_storages: bool) {
+    fn test_purge_bank_snapshots_older_than_slot(should_finalize: bool) {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
 
@@ -2335,7 +2285,7 @@ mod tests {
             &genesis_config,
             &bank_snapshots_dir,
             9,
-            should_flush_and_hard_link_storages,
+            should_finalize,
         );
         let bank_snapshots_before = get_bank_snapshots(&bank_snapshots_dir);
 
@@ -2359,7 +2309,7 @@ mod tests {
 
     #[test_case(false)]
     #[test_case(true)]
-    fn test_purge_old_bank_snapshots_at_startup(should_flush_and_hard_link_storages: bool) {
+    fn test_purge_old_bank_snapshots_at_startup(should_finalize: bool) {
         let genesis_config = GenesisConfig::default();
         let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
 
@@ -2368,7 +2318,7 @@ mod tests {
             &genesis_config,
             &bank_snapshots_dir,
             9,
-            should_flush_and_hard_link_storages,
+            should_finalize,
         );
 
         purge_old_bank_snapshots_at_startup(&bank_snapshots_dir);

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -847,7 +847,10 @@ mod tests {
             SnapshotVersion, error::VerifySlotDeltasError, paths::get_bank_snapshot_dir,
         },
         semver::Version,
-        solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsFileId},
+        solana_accounts_db::{
+            accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsFileId},
+            accounts_file::AccountsFile,
+        },
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_native_token::LAMPORTS_PER_SOL,
@@ -2149,7 +2152,6 @@ mod tests {
     /// storage files in place and producing a working bank.
     #[test]
     fn test_bank_from_snapshot_dir_prunes_stale_storage() {
-        use solana_accounts_db::accounts_file::AccountsFile;
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config_with_leader(
             1_000_000 * LAMPORTS_PER_SOL,
             &Pubkey::new_unique(),

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -848,7 +848,7 @@ mod tests {
             SnapshotVersion, error::VerifySlotDeltasError, paths::get_bank_snapshot_dir,
         },
         semver::Version,
-        solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING,
+        solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsFileId},
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_native_token::LAMPORTS_PER_SOL,
@@ -2173,6 +2173,93 @@ mod tests {
         }
         let next_id = bank.accounts().accounts_db.next_id.load(Ordering::Relaxed) as usize;
         assert_eq!(max_id, next_id - 1);
+    }
+
+    /// Drop a stale `<slot>.<id>` file into the account_paths run dir before calling
+    /// `bank_from_snapshot_dir`, and verify that the fastboot rebuild path removes it (because
+    /// the `(slot, id)` pair isn't in the storages list) while keeping the snapshot's own
+    /// storage files in place and producing a working bank.
+    #[test]
+    fn test_bank_from_snapshot_dir_prunes_stale_storage() {
+        use solana_accounts_db::accounts_file::AccountsFile;
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config_with_leader(
+            1_000_000 * LAMPORTS_PER_SOL,
+            &Pubkey::new_unique(),
+            1_000_000 * LAMPORTS_PER_SOL,
+        );
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let bank = Bank::new_for_tests(&genesis_config);
+        bank.fill_bank_with_ticks_for_tests();
+        bank.set_block_id(Some(Hash::default()));
+
+        create_bank_snapshot_from_bank(
+            &bank_snapshots_dir,
+            &bank,
+            SnapshotVersion::default(),
+            true,
+        )
+        .unwrap();
+        let bank_snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
+        let account_paths = &bank.rc.accounts.accounts_db.paths;
+
+        // Collect the legit paths (created by `create_bank_snapshot_from_bank` above) before
+        // we drop any stale files, so we can assert they survive the prune.
+        let pre_load_legit_files: Vec<_> = account_paths
+            .iter()
+            .flat_map(|account_path| {
+                fs::read_dir(account_path)
+                    .unwrap()
+                    .map(|e| e.unwrap().path())
+            })
+            .collect();
+        assert!(
+            !pre_load_legit_files.is_empty(),
+            "expected at least one accounts storage file"
+        );
+
+        // Pick a `(slot, id)` that the snapshot doesn't reference. The snapshot only covers
+        // storages up to `bank.slot()`, so a far-future slot is guaranteed to be stale.
+        let stale_slot = bank.slot() + 1_000;
+        let stale_id = AccountsFileId::MAX;
+        let stale_files: Vec<_> = account_paths
+            .iter()
+            .map(|account_path| {
+                let stale = account_path.join(AccountsFile::file_name(stale_slot, stale_id));
+                fs::write(&stale, b"junk").unwrap();
+                stale
+            })
+            .collect();
+
+        let bank_constructed = bank_from_snapshot_dir(
+            account_paths,
+            &bank_snapshot,
+            &genesis_config,
+            &RuntimeConfig::default(),
+            None,
+            None,
+            None,
+            false,
+            ACCOUNTS_DB_CONFIG_FOR_TESTING,
+            None,
+            Arc::default(),
+        )
+        .unwrap();
+        assert_eq!(bank_constructed, bank);
+
+        for stale in stale_files {
+            assert!(
+                !stale.exists(),
+                "stale storage file '{}' should have been pruned",
+                stale.display(),
+            );
+        }
+        for legit in pre_load_legit_files {
+            assert!(
+                legit.exists(),
+                "snapshot storage file '{}' should have survived the prune",
+                legit.display(),
+            );
+        }
     }
 
     /// Ensure bank_from_snapshot_dir() catches a snapshot with incorrect capitalization.

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -835,9 +835,8 @@ mod tests {
             genesis_utils::{GenesisConfigInfo, create_genesis_config_with_leader},
             snapshot_package::BankSnapshotPackage,
             snapshot_utils::{
-                clean_orphaned_account_snapshot_dirs, create_tmp_accounts_dir_for_tests,
-                get_bank_snapshots, get_highest_bank_snapshot, get_highest_loadable_bank_snapshot,
-                purge_all_bank_snapshots, purge_bank_snapshot,
+                create_tmp_accounts_dir_for_tests, get_bank_snapshots, get_highest_bank_snapshot,
+                get_highest_loadable_bank_snapshot, purge_all_bank_snapshots, purge_bank_snapshot,
                 purge_bank_snapshots_older_than_slot, purge_incomplete_bank_snapshots,
                 purge_old_bank_snapshots, purge_old_bank_snapshots_at_startup,
                 snapshot_storage_rebuilder::get_slot_and_append_vec_id,
@@ -1787,37 +1786,6 @@ mod tests {
         fs::remove_file(status_cache_file).unwrap();
         let snapshot = get_highest_bank_snapshot(&bank_snapshots_dir).unwrap();
         assert_eq!(snapshot.slot, 1);
-    }
-
-    /// Simulates a leftover `<account_path>/snapshot/<slot>/` dir from a pre-refactor version
-    /// and verifies the cleanup helper removes it.
-    #[test]
-    fn test_clean_orphaned_account_snapshot_dirs() {
-        let account_snapshot_path = tempfile::TempDir::new().unwrap();
-        let legacy_slot_dir = account_snapshot_path.path().join("123");
-        fs::create_dir_all(&legacy_slot_dir).unwrap();
-        fs::write(legacy_slot_dir.join("123.0"), b"junk").unwrap();
-        assert!(legacy_slot_dir.exists());
-
-        clean_orphaned_account_snapshot_dirs(slice::from_ref(
-            &account_snapshot_path.path().to_path_buf(),
-        ))
-        .unwrap();
-
-        // move_and_async_delete_path renames before async-deleting, so the original is gone
-        // even if the eventual deletion hasn't completed.
-        assert!(!legacy_slot_dir.exists());
-    }
-
-    /// Cleanup should tolerate empty / missing account snapshot dirs.
-    #[test]
-    fn test_clean_orphaned_account_snapshot_dirs_empty() {
-        let account_snapshot_path = tempfile::TempDir::new().unwrap();
-        clean_orphaned_account_snapshot_dirs(slice::from_ref(
-            &account_snapshot_path.path().to_path_buf(),
-        ))
-        .unwrap();
-        clean_orphaned_account_snapshot_dirs(&[]).unwrap();
     }
 
     #[test_case(false)]

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -377,7 +377,7 @@ pub fn bank_from_snapshot_dir(
     );
 
     // Storages from this snapshot already live under `account_paths`; the storages list
-    // list inside the bank snapshot dir tells us which ones belong to it, and stale files
+    // inside the bank snapshot dir tells us which ones belong to it, and stale files
     // (e.g. from later slots) are pruned by `rebuild_storages_from_snapshot_dir`.
 
     let next_append_vec_id = Arc::new(AtomicAccountsFileId::new(0));

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1333,7 +1333,8 @@ fn spawn_streaming_snapshot_dir_files(
 /// `accounts_hardlinks/` symlink dir and the whole `<account_path>/snapshot/` tree) on success
 /// so subsequent restarts go through the normal new-format path.
 fn migrate_legacy_hardlinks(bank_snapshot_dir: &Path, account_run_paths: &[PathBuf]) -> Result<()> {
-    let accounts_hardlinks_dir = bank_snapshot_dir.join("accounts_hardlinks");
+    let accounts_hardlinks_dir =
+        bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_ACCOUNTS_HARDLINKS);
     let mut items: Vec<StorageListItem> = Vec::new();
 
     for entry in fs::read_dir(&accounts_hardlinks_dir).map_err(|err| {
@@ -1808,7 +1809,9 @@ pub fn purge_bank_snapshot(bank_snapshot_dir: impl AsRef<Path>) -> Result<()> {
     // subdir of symlinks pointing at hardlink dirs under `<account_path>/snapshot/<slot>/`.
     // Follow them so the hardlink dirs don't outlive the owning bank snapshot when we purge at
     // runtime (startup-time cleanup catches any leftovers).
-    let accounts_hardlinks_dir = bank_snapshot_dir.as_ref().join("accounts_hardlinks");
+    let accounts_hardlinks_dir = bank_snapshot_dir
+        .as_ref()
+        .join(snapshot_paths::SNAPSHOT_ACCOUNTS_HARDLINKS);
     if accounts_hardlinks_dir.is_dir() {
         let read_dir = fs::read_dir(&accounts_hardlinks_dir).map_err(|err| {
             IoError::other(format!(

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1326,7 +1326,7 @@ fn spawn_streaming_snapshot_dir_files(
 /// the storages list file).
 fn migrate_legacy_hardlinks(
     bank_snapshot_dir: &Path,
-    account_paths: &[PathBuf],
+    account_run_paths: &[PathBuf],
 ) -> Result<StoragesList> {
     let accounts_hardlinks_dir = bank_snapshot_dir.join("accounts_hardlinks");
     let mut items: Vec<StorageListItem> = Vec::new();
@@ -1360,14 +1360,14 @@ fn migrate_legacy_hardlinks(
         // those have changed (e.g. the operator reconfigured `account_paths` while upgrading
         // Agave), the run dir we just derived isn't one we're loading into — bail rather than
         // silently writing files into a location nobody's reading from.
-        if !account_paths.contains(&run_dir) {
+        if !account_run_paths.contains(&run_dir) {
             return Err(IoError::other(format!(
                 "legacy hardlink target '{}' points to run dir '{}' which is not in the current \
                  account paths ({:?}); the account paths configuration has changed since this \
                  snapshot was taken — load from a snapshot archive instead",
                 snapshot_slot_dir.display(),
                 run_dir.display(),
-                account_paths,
+                account_run_paths,
             ))
             .into());
         }
@@ -1407,7 +1407,7 @@ fn migrate_legacy_hardlinks(
             accounts_hardlinks_dir.display(),
         ))
     })?;
-    wipe_account_snapshot_dirs(account_paths);
+    wipe_account_snapshot_dirs(account_run_paths);
 
     Ok(StoragesList::from_items(items))
 }
@@ -1718,7 +1718,7 @@ pub enum VerifyBank {
 /// For each account run dir, wipes the sibling `snapshot/` dir.
 ///
 /// Validator account paths are laid out as a parent containing two siblings: `run/` (the live
-/// storage files) and `snapshot/` (legacy per-slot hardlink dirs, pre-3.0). `account_paths`
+/// storage files) and `snapshot/` (legacy per-slot hardlink dirs, pre-3.0). `account_run_paths`
 /// here holds the `run/` paths, so for each entry we walk up to the parent and wipe the
 /// `snapshot/` sibling. Nothing new is written under `snapshot/` anymore, so any content is
 /// either legacy hardlink dirs (written by pre-3.0 validators during fastboot) or orphans

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -762,6 +762,14 @@ pub fn write_storages_list_to_snapshot(
     io_setup: &IoSetupState,
 ) -> Result<FileSize> {
     let storages_list = StoragesList::new_from_storages(snapshot_storages);
+    serialize_storages_list_to_snapshot(bank_snapshot_dir, storages_list, io_setup)
+}
+
+fn serialize_storages_list_to_snapshot(
+    bank_snapshot_dir: impl AsRef<Path>,
+    storages_list: StoragesList,
+    io_setup: &IoSetupState,
+) -> Result<FileSize> {
     let storages_list_path = bank_snapshot_dir
         .as_ref()
         .join(snapshot_paths::SNAPSHOT_STORAGES_LIST_FILENAME);
@@ -1320,14 +1328,11 @@ fn spawn_streaming_snapshot_dir_files(
 ///
 /// Walks `<bank_snapshot_dir>/accounts_hardlinks/`, follows each symlink to its
 /// `<account_path>/snapshot/<slot>/` target, and renames each storage file there back into
-/// `<account_path>/run/`. Returns the derived storages list. Tears down the legacy directories
-/// (the `accounts_hardlinks/` symlink dir and the whole `<account_path>/snapshot/` tree) on
-/// success so subsequent restarts go through the normal new-format path (next teardown writes
-/// the storages list file).
-fn migrate_legacy_hardlinks(
-    bank_snapshot_dir: &Path,
-    account_run_paths: &[PathBuf],
-) -> Result<StoragesList> {
+/// `<account_path>/run/`. Writes the derived storages list into the bank snapshot dir so the
+/// load path can always read it from disk. Tears down the legacy directories (the
+/// `accounts_hardlinks/` symlink dir and the whole `<account_path>/snapshot/` tree) on success
+/// so subsequent restarts go through the normal new-format path.
+fn migrate_legacy_hardlinks(bank_snapshot_dir: &Path, account_run_paths: &[PathBuf]) -> Result<()> {
     let accounts_hardlinks_dir = bank_snapshot_dir.join("accounts_hardlinks");
     let mut items: Vec<StorageListItem> = Vec::new();
 
@@ -1398,6 +1403,14 @@ fn migrate_legacy_hardlinks(
         }
     }
 
+    // Persist the derived list to disk before tearing down legacy state, so a crash mid-migration
+    // doesn't leave us with neither the hardlinks nor the new-format file.
+    serialize_storages_list_to_snapshot(
+        bank_snapshot_dir,
+        StoragesList::from_items(items),
+        &IoSetupState::default(),
+    )?;
+
     // Tear down the legacy state so we don't repeat this migration: drop the bank snapshot's
     // `accounts_hardlinks/` symlink dir and wipe each `<account_path>/snapshot/` tree (catches
     // both the per-slot dirs we just emptied and any orphans from older purged snapshots).
@@ -1409,7 +1422,11 @@ fn migrate_legacy_hardlinks(
     })?;
     wipe_account_snapshot_dirs(account_run_paths);
 
-    Ok(StoragesList::from_items(items))
+    // Bump the fastboot version so subsequent loads take the normal 3.0+ path instead of
+    // re-running the migration (which would fail now that the hardlinks dir is gone).
+    mark_bank_snapshot_as_loadable(bank_snapshot_dir)?;
+
+    Ok(())
 }
 
 /// Removes storage files from `account_paths` whose `(slot, id)` pair isn't listed in the
@@ -1481,17 +1498,16 @@ pub(crate) fn rebuild_storages_from_snapshot_dir(
     // lt hash check at startup verifies the surviving storages.
     let storages_list_path =
         bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_STORAGES_LIST_FILENAME);
-    let storages_list = if storages_list_path.exists() {
-        deserialize_storages_list(&storages_list_path, MAX_STORAGES_LIST_FILE_SIZE)?
-    } else {
+    if !storages_list_path.exists() {
         // Legacy (2.0.0) bank snapshot: storages live as hardlinks under
         // `<account_path>/snapshot/<slot>/`, with symlinks in
         // `<bank_snapshot_dir>/accounts_hardlinks/` tying them to the bank snapshot. Move the
-        // files back into `<account_path>/run/` and derive the storages list on the fly. The
-        // legacy dirs are torn down here — next teardown will write the new-format storages
-        // list so subsequent restarts go through the normal path.
-        migrate_legacy_hardlinks(bank_snapshot_dir, account_paths)?
-    };
+        // files back into `<account_path>/run/` and write out the storages list so the load
+        // path below can read it like any other 3.0+ snapshot.
+        migrate_legacy_hardlinks(bank_snapshot_dir, account_paths)?;
+    }
+    let storages_list =
+        deserialize_storages_list(&storages_list_path, MAX_STORAGES_LIST_FILE_SIZE)?;
     prune_stale_storages(account_paths, storages_list)?;
 
     let snapshot_file_path = snapshot_info.snapshot_path();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1363,7 +1363,7 @@ fn prune_stale_storages(account_paths: &[PathBuf], storages_list: StoragesList) 
                     "Removing stale storage file '{}' not in storages list",
                     path.display(),
                 );
-                move_and_async_delete_path(&path);
+                fs::remove_file(&path)?
             }
         }
     }
@@ -1759,7 +1759,7 @@ mod tests {
         },
         assert_matches::assert_matches,
         bincode::{deserialize_from, serialize_into},
-        solana_accounts_db::accounts_file::AccountsFileProvider,
+        solana_accounts_db::accounts_file::{AccountsFile, AccountsFileProvider},
         solana_hash::Hash,
         std::{convert::TryFrom, mem::size_of},
         tempfile::NamedTempFile,
@@ -2725,5 +2725,35 @@ mod tests {
 
         // scenario 9: all good
         assert!(is_bank_snapshot_complete(bank_snapshot_dir));
+    }
+
+    #[test]
+    fn test_prune_stale_storages() {
+        let account_path = tempfile::TempDir::new().unwrap();
+        // Files that belong to the snapshot.
+        let keep_a = account_path.path().join(AccountsFile::file_name(100, 1));
+        let keep_b = account_path.path().join(AccountsFile::file_name(200, 2));
+        // A stale storage file that should be removed.
+        let stale = account_path.path().join(AccountsFile::file_name(300, 3));
+        // A non-storage filename — should be left alone.
+        let untouched = account_path.path().join("something_else.txt");
+        for path in [&keep_a, &keep_b, &stale, &untouched] {
+            fs::write(path, b"x").unwrap();
+        }
+
+        let storages_list = StoragesList::from_items(vec![
+            StorageListItem { slot: 100, id: 1 },
+            StorageListItem { slot: 200, id: 2 },
+        ]);
+        prune_stale_storages(
+            std::slice::from_ref(&account_path.path().to_path_buf()),
+            storages_list,
+        )
+        .unwrap();
+
+        assert!(keep_a.exists(), "expected storage file was deleted");
+        assert!(keep_b.exists(), "expected storage file was deleted");
+        assert!(!stale.exists(), "stale storage file was not removed");
+        assert!(untouched.exists(), "non-storage file was wrongly removed");
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -6,7 +6,7 @@ use {
         serde_snapshot::{
             self, AccountsDbFields, ExtraFieldsToSerialize, SerdeObsoleteAccountsMap,
             SerializableAccountStorageEntry, SnapshotAccountsDbFields, SnapshotBankFields,
-            SnapshotStreams,
+            SnapshotStreams, StoragesList,
         },
         snapshot_package::BankSnapshotPackage,
         snapshot_utils::snapshot_storage_rebuilder::{
@@ -14,7 +14,7 @@ use {
         },
     },
     agave_fs::{
-        FileInfo,
+        FileInfo, FileSize,
         buffered_reader::large_file_buf_reader,
         buffered_writer::{SizeLimitedWriter, large_file_buf_writer},
         io_setup::IoSetupState,
@@ -22,9 +22,7 @@ use {
     agave_snapshots::{
         ArchiveFormat, Result, SnapshotArchiveKind, SnapshotVersion, archive_snapshot,
         error::{
-            AddBankSnapshotError, GetSnapshotAccountsHardLinkDirError,
-            HardLinkStoragesToSnapshotError, SnapshotError, SnapshotFastbootError,
-            SnapshotNewFromDirError,
+            AddBankSnapshotError, SnapshotError, SnapshotFastbootError, SnapshotNewFromDirError,
         },
         paths::{self as snapshot_paths, incremental_snapshot_archives_iter},
         snapshot_archive_info::{
@@ -42,9 +40,8 @@ use {
     solana_accounts_db::{
         account_storage::AccountStorageMap,
         account_storage_entry::AccountStorageEntry,
-        accounts_db::AtomicAccountsFileId,
-        accounts_file::AccountsFile,
-        utils::{ACCOUNTS_RUN_DIR, ACCOUNTS_SNAPSHOT_DIR, move_and_async_delete_path},
+        accounts_db::{AccountsFileId, AtomicAccountsFileId},
+        utils::move_and_async_delete_path,
     },
     solana_clock::Slot,
     solana_measure::{measure::Measure, measure_time, measure_us},
@@ -71,10 +68,15 @@ pub mod snapshot_storage_rebuilder;
 /// Limit is set assuming 24 bytes per entry, 5% of 10 billion accounts
 /// = 500 million entries * 24 bytes = 12 GB
 pub const MAX_OBSOLETE_ACCOUNTS_FILE_SIZE: u64 = 1024 * 1024 * 1024 * 12; // 12 GB
+/// Limit the size of the storages list file.
+/// Each `(slot, id)` entry encodes to 12 bytes; 100 MiB covers ~8.7 million entries, well past
+/// any realistic storage count.
+pub const MAX_STORAGES_LIST_FILE_SIZE: u64 = 100 * 1024 * 1024; // 100 MiB
 pub const MAX_SNAPSHOT_DATA_FILE_SIZE: u64 = 32 * 1024 * 1024 * 1024; // 32 GiB
 const MAX_SNAPSHOT_VERSION_FILE_SIZE: u64 = 8; // byte
-/// Buffer size that allows several concurrent reads using default io-uring reader read size (1MiB)
-const OBSOLETE_ACCOUNTS_READ_BUF_SIZE: usize = 4 * 1024 * 1024;
+/// Buffer size for reading auxiliary per-snapshot files (obsolete accounts, storages list).
+/// Sized to allow several concurrent reads at the default io-uring reader read size (1MiB).
+const AUX_SNAPSHOT_FILE_READ_BUF_SIZE: usize = 4 * 1024 * 1024;
 
 // Snapshot Fastboot Version History
 // Legacy - No fastboot version file, storages flushed file presence determines if snapshot is loadable
@@ -82,7 +84,12 @@ const OBSOLETE_ACCOUNTS_READ_BUF_SIZE: usize = 4 * 1024 * 1024;
 // 2.0.0 - Obsolete Accounts File added, storages flushed file not written anymore
 //         Snapshots created with version 2.0.0 will not fastboot to older versions
 //         Snapshots created with versions <2.0.0 will fastboot to version 2.0.0
-const SNAPSHOT_FASTBOOT_VERSION: Version = Version::new(2, 0, 0);
+// 3.0.0 - Storages List file added, replaces the per-storage hardlink dirs
+//         Required to know which storages on disk belong to the snapshot before fastboot;
+//         snapshots created with versions <3.0.0 lack the file and fall back to archive loading.
+//         Note: 2.0.0 validators cannot fastboot from 3.0.0 snapshots because the per-storage
+//         hardlink dirs they rely on are no longer written; they too must fall back to archive.
+const SNAPSHOT_FASTBOOT_VERSION: Version = Version::new(3, 0, 0);
 
 /// Information about a bank snapshot. Namely the slot of the bank, the path to the snapshot, and
 /// the kind of the snapshot.
@@ -252,65 +259,30 @@ pub(crate) struct StorageAndNextAccountsFileId {
     pub next_append_vec_id: AtomicAccountsFileId,
 }
 
-/// The account snapshot directories under <account_path>/snapshot/<slot> contain account files hardlinked
-/// from <account_path>/run taken at snapshot <slot> time.  They are referenced by the symlinks from the
-/// bank snapshot dir snapshot/<slot>/accounts_hardlinks/.  We observed that sometimes the bank snapshot dir
-/// could be deleted but the account snapshot directories were left behind, possibly by some manual operations
-/// or some legacy code not using the symlinks to clean up the account snapshot hardlink directories.
-/// This function cleans up any account snapshot directories that are no longer referenced by the bank
-/// snapshot dirs, to ensure proper snapshot operations.
-pub fn clean_orphaned_account_snapshot_dirs(
-    bank_snapshots_dir: impl AsRef<Path>,
-    account_snapshot_paths: &[PathBuf],
-) -> io::Result<()> {
-    // Create the HashSet of the account snapshot hardlink directories referenced by the snapshot dirs.
-    // This is used to clean up any hardlinks that are no longer referenced by the snapshot dirs.
-    let mut account_snapshot_dirs_referenced = HashSet::new();
-    let snapshots = get_bank_snapshots(bank_snapshots_dir);
-    for snapshot in snapshots {
-        let account_hardlinks_dir = snapshot
-            .snapshot_dir
-            .join(snapshot_paths::SNAPSHOT_ACCOUNTS_HARDLINKS);
-        // loop through entries in the snapshot_hardlink_dir, read the symlinks, add the target to the HashSet
-        let Ok(read_dir) = fs::read_dir(&account_hardlinks_dir) else {
-            // The bank snapshot may not have a hard links dir with the storages.
-            // This is fine, and happens for bank snapshots we do *not* fastboot from.
-            // In this case, log it and go to the next bank snapshot.
-            debug!(
-                "failed to read account hardlinks dir '{}'",
-                account_hardlinks_dir.display(),
-            );
-            continue;
+/// Removes any leftover entries under each `<account_path>/snapshot/` directory.
+///
+/// In prior versions, bank snapshot dirs used during fastboot stored per-slot hardlinks here;
+/// we no longer write anything to `<account_path>/snapshot/`, so anything still present is a
+/// migration leftover and can be deleted unconditionally.
+pub fn clean_orphaned_account_snapshot_dirs(account_snapshot_paths: &[PathBuf]) -> io::Result<()> {
+    for account_snapshot_path in account_snapshot_paths {
+        let read_dir = match fs::read_dir(account_snapshot_path) {
+            Ok(read_dir) => read_dir,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                return Err(IoError::other(format!(
+                    "failed to read account snapshot dir '{}': {err}",
+                    account_snapshot_path.display(),
+                )));
+            }
         };
         for entry in read_dir {
             let path = entry?.path();
-            let target = fs::read_link(&path).map_err(|err| {
-                IoError::other(format!(
-                    "failed to read symlink '{}': {err}",
-                    path.display(),
-                ))
-            })?;
-            account_snapshot_dirs_referenced.insert(target);
-        }
-    }
-
-    // loop through the account snapshot hardlink directories, if the directory is not in the account_snapshot_dirs_referenced set, delete it
-    for account_snapshot_path in account_snapshot_paths {
-        let read_dir = fs::read_dir(account_snapshot_path).map_err(|err| {
-            IoError::other(format!(
-                "failed to read account snapshot dir '{}': {err}",
-                account_snapshot_path.display(),
-            ))
-        })?;
-        for entry in read_dir {
-            let path = entry?.path();
-            if !account_snapshot_dirs_referenced.contains(&path) {
-                info!(
-                    "Removing orphaned account snapshot hardlink directory '{}'...",
-                    path.display()
-                );
-                move_and_async_delete_path(&path);
-            }
+            info!(
+                "Removing orphaned account snapshot directory '{}'...",
+                path.display()
+            );
+            move_and_async_delete_path(&path);
         }
     }
 
@@ -423,10 +395,12 @@ fn is_bank_snapshot_loadable(
 fn is_snapshot_fastboot_compatible(
     version: &Version,
 ) -> std::result::Result<bool, SnapshotFastbootError> {
-    if version.major <= SNAPSHOT_FASTBOOT_VERSION.major {
-        Ok(true)
-    } else {
-        Err(SnapshotFastbootError::IncompatibleVersion(version.clone()))
+    match version.major.cmp(&SNAPSHOT_FASTBOOT_VERSION.major) {
+        Ordering::Greater => Err(SnapshotFastbootError::IncompatibleVersion(version.clone())),
+        Ordering::Equal => Ok(true),
+        // Older format lacks files required by the current fastboot path (e.g. the storages
+        // list added in 3.0.0). Caller should fall back to loading from archive.
+        Ordering::Less => Ok(false),
     }
 }
 
@@ -533,7 +507,7 @@ pub fn serialize_snapshot(
     snapshot_version: SnapshotVersion,
     bank_snapshot_package: BankSnapshotPackage,
     snapshot_storages: &[Arc<AccountStorageEntry>],
-    should_flush_and_hard_link_storages: bool,
+    should_finalize: bool,
     io_setup: &IoSetupState,
 ) -> Result<BankSnapshotInfo> {
     let BankSnapshotPackage {
@@ -604,8 +578,8 @@ pub fn serialize_snapshot(
                 .map_err(|err| AddBankSnapshotError::WriteSnapshotVersionFile(err, version_path))?
         );
 
-        let (flush_storages_us, hard_link_storages_us, serialize_obsolete_accounts_us) =
-            if should_flush_and_hard_link_storages {
+        let (flush_storages_us, serialize_obsolete_accounts_us, write_storages_list_us) =
+            if should_finalize {
                 let flush_measure = Measure::start("");
                 for storage in snapshot_storages {
                     storage.flush().map_err(|err| {
@@ -613,10 +587,6 @@ pub fn serialize_snapshot(
                     })?;
                 }
                 let flush_us = flush_measure.end_as_us();
-                let (_, hard_link_us) = measure_us!(
-                    hard_link_storages_to_snapshot(&bank_snapshot_dir, slot, snapshot_storages)
-                        .map_err(AddBankSnapshotError::HardLinkStorages)?
-                );
 
                 let (_, serialize_obsolete_accounts_us) = measure_us!({
                     write_obsolete_accounts_to_snapshot(
@@ -628,13 +598,22 @@ pub fn serialize_snapshot(
                     .map_err(|err| AddBankSnapshotError::SerializeObsoleteAccounts(Box::new(err)))?
                 });
 
+                let (_, write_storages_list_us) = measure_us!(
+                    write_storages_list_to_snapshot(
+                        &bank_snapshot_dir,
+                        snapshot_storages,
+                        io_setup,
+                    )
+                    .map_err(|err| AddBankSnapshotError::WriteStoragesList(Box::new(err)))?
+                );
+
                 mark_bank_snapshot_as_loadable(&bank_snapshot_dir)
                     .map_err(AddBankSnapshotError::MarkSnapshotLoadable)?;
 
                 (
                     Some(flush_us),
-                    Some(hard_link_us),
                     Some(serialize_obsolete_accounts_us),
+                    Some(write_storages_list_us),
                 )
             } else {
                 (None, None, None)
@@ -649,8 +628,8 @@ pub fn serialize_snapshot(
             ("bank_size", bank_snapshot_consumed_size, i64),
             ("status_cache_size", status_cache_consumed_size, i64),
             ("flush_storages_us", flush_storages_us, Option<i64>),
-            ("hard_link_storages_us", hard_link_storages_us, Option<i64>),
             ("serialize_obsolete_accounts_us", serialize_obsolete_accounts_us, Option<i64>),
+            ("write_storages_list_us", write_storages_list_us, Option<i64>),
             ("bank_serialize_us", bank_serialize.as_us(), i64),
             ("status_cache_serialize_us", status_cache_serialize_us, i64),
             ("write_version_file_us", write_version_file_us, i64),
@@ -775,7 +754,7 @@ fn deserialize_obsolete_accounts(
         .join(snapshot_paths::SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME);
     let obsolete_accounts_reader = ReadAdapter::new(large_file_buf_reader(
         &obsolete_accounts_path,
-        OBSOLETE_ACCOUNTS_READ_BUF_SIZE,
+        AUX_SNAPSHOT_FILE_READ_BUF_SIZE,
         &IoSetupState::default(),
     )?);
     // If the file is too large return error
@@ -792,6 +771,57 @@ fn deserialize_obsolete_accounts(
 
     Ok(serde_snapshot::deserialize_wincode_from(
         obsolete_accounts_reader,
+    )?)
+}
+
+pub fn write_storages_list_to_snapshot(
+    bank_snapshot_dir: impl AsRef<Path>,
+    snapshot_storages: &[Arc<AccountStorageEntry>],
+    io_setup: &IoSetupState,
+) -> Result<FileSize> {
+    let storages_list = StoragesList::new_from_storages(snapshot_storages);
+    let storages_list_path = bank_snapshot_dir
+        .as_ref()
+        .join(snapshot_paths::SNAPSHOT_STORAGES_LIST_FILENAME);
+    let mut file_stream = SizeLimitedWriter::new(
+        large_file_buf_writer(&storages_list_path, io_setup)?,
+        MAX_STORAGES_LIST_FILE_SIZE,
+    );
+    serde_snapshot::serialize_into(&mut file_stream, &storages_list).map_err(|err| {
+        IoError::other(format!(
+            "unable to serialize storages list to file '{}': {err}",
+            storages_list_path.display(),
+        ))
+    })?;
+    Ok(file_stream.bytes_written())
+}
+
+fn deserialize_storages_list(
+    bank_snapshot_dir: impl AsRef<Path>,
+    maximum_storages_list_file_size: u64,
+) -> Result<StoragesList> {
+    let storages_list_path = bank_snapshot_dir
+        .as_ref()
+        .join(snapshot_paths::SNAPSHOT_STORAGES_LIST_FILENAME);
+    let storages_list_reader = ReadAdapter::new(large_file_buf_reader(
+        &storages_list_path,
+        AUX_SNAPSHOT_FILE_READ_BUF_SIZE,
+        &IoSetupState::default(),
+    )?);
+    // If the file is too large return error
+    let storages_list_file_metadata = fs::metadata(&storages_list_path)?;
+    if storages_list_file_metadata.len() > maximum_storages_list_file_size {
+        let error_message = format!(
+            "too large storages list file to deserialize: '{}' has {} bytes (max size is \
+             {maximum_storages_list_file_size} bytes)",
+            storages_list_path.display(),
+            storages_list_file_metadata.len(),
+        );
+        return Err(IoError::other(error_message).into());
+    }
+
+    Ok(serde_snapshot::deserialize_wincode_from(
+        storages_list_reader,
     )?)
 }
 
@@ -958,111 +988,6 @@ fn check_deserialize_file_consumed(
         return Err(IoError::other(error_message).into());
     }
 
-    Ok(())
-}
-
-/// Return account path from the appendvec path after checking its format.
-fn get_account_path_from_appendvec_path(appendvec_path: &Path) -> Option<PathBuf> {
-    let run_path = appendvec_path.parent()?;
-    let run_file_name = run_path.file_name()?;
-    // All appendvec files should be under <account_path>/run/.
-    // When generating the bank snapshot directory, they are hardlinked to <account_path>/snapshot/<slot>/
-    if run_file_name != ACCOUNTS_RUN_DIR {
-        error!(
-            "The account path {} does not have run/ as its immediate parent directory.",
-            run_path.display()
-        );
-        return None;
-    }
-    let account_path = run_path.parent()?;
-    Some(account_path.to_path_buf())
-}
-
-/// From an appendvec path, derive the snapshot hardlink path.  If the corresponding snapshot hardlink
-/// directory does not exist, create it.
-fn get_snapshot_accounts_hardlink_dir(
-    appendvec_path: &Path,
-    bank_slot: Slot,
-    account_paths: &mut HashSet<PathBuf>,
-    hardlinks_dir: impl AsRef<Path>,
-) -> std::result::Result<PathBuf, GetSnapshotAccountsHardLinkDirError> {
-    let account_path = get_account_path_from_appendvec_path(appendvec_path).ok_or_else(|| {
-        GetSnapshotAccountsHardLinkDirError::GetAccountPath(appendvec_path.to_path_buf())
-    })?;
-
-    let snapshot_hardlink_dir = account_path
-        .join(ACCOUNTS_SNAPSHOT_DIR)
-        .join(bank_slot.to_string());
-
-    // Use the hashset to track, to avoid checking the file system.  Only set up the hardlink directory
-    // and the symlink to it at the first time of seeing the account_path.
-    if !account_paths.contains(&account_path) {
-        let idx = account_paths.len();
-        debug!(
-            "for appendvec_path {}, create hard-link path {}",
-            appendvec_path.display(),
-            snapshot_hardlink_dir.display()
-        );
-        fs::create_dir_all(&snapshot_hardlink_dir).map_err(|err| {
-            GetSnapshotAccountsHardLinkDirError::CreateSnapshotHardLinkDir(
-                err,
-                snapshot_hardlink_dir.clone(),
-            )
-        })?;
-        let symlink_path = hardlinks_dir.as_ref().join(format!("account_path_{idx}"));
-        symlink::symlink_dir(&snapshot_hardlink_dir, &symlink_path).map_err(|err| {
-            GetSnapshotAccountsHardLinkDirError::SymlinkSnapshotHardLinkDir {
-                source: err,
-                original: snapshot_hardlink_dir.clone(),
-                link: symlink_path,
-            }
-        })?;
-        account_paths.insert(account_path);
-    };
-
-    Ok(snapshot_hardlink_dir)
-}
-
-/// Hard-link the files from accounts/ to snapshot/<bank_slot>/accounts/
-/// This keeps the appendvec files alive and with the bank snapshot.  The slot and id
-/// in the file names are also updated in case its file is a recycled one with inconsistent slot
-/// and id.
-pub fn hard_link_storages_to_snapshot(
-    bank_snapshot_dir: impl AsRef<Path>,
-    bank_slot: Slot,
-    snapshot_storages: &[Arc<AccountStorageEntry>],
-) -> std::result::Result<(), HardLinkStoragesToSnapshotError> {
-    let accounts_hardlinks_dir = bank_snapshot_dir
-        .as_ref()
-        .join(snapshot_paths::SNAPSHOT_ACCOUNTS_HARDLINKS);
-    fs::create_dir_all(&accounts_hardlinks_dir).map_err(|err| {
-        HardLinkStoragesToSnapshotError::CreateAccountsHardLinksDir(
-            err,
-            accounts_hardlinks_dir.clone(),
-        )
-    })?;
-
-    let mut account_paths: HashSet<PathBuf> = HashSet::new();
-    for storage in snapshot_storages {
-        let storage_path = storage.accounts.path();
-        let snapshot_hardlink_dir = get_snapshot_accounts_hardlink_dir(
-            storage_path,
-            bank_slot,
-            &mut account_paths,
-            &accounts_hardlinks_dir,
-        )?;
-        // The appendvec could be recycled, so its filename may not be consistent to the slot and id.
-        // Use the storage slot and id to compose a consistent file name for the hard-link file.
-        let hardlink_filename = AccountsFile::file_name(storage.slot(), storage.id());
-        let hard_link_path = snapshot_hardlink_dir.join(hardlink_filename);
-        fs::hard_link(storage_path, &hard_link_path).map_err(|err| {
-            HardLinkStoragesToSnapshotError::HardLinkStorage(
-                err,
-                storage_path.to_path_buf(),
-                hard_link_path,
-            )
-        })?;
-    }
     Ok(())
 }
 
@@ -1412,6 +1337,39 @@ fn spawn_streaming_snapshot_dir_files(
     (file_receiver, handle)
 }
 
+/// Removes storage files from `account_paths` whose `(slot, id)` pair isn't listed in the
+/// storages list (i.e. they don't belong to the snapshot being loaded). Files whose names
+/// don't parse as `<slot>.<id>` storage filenames are left alone.
+fn prune_stale_storages(account_paths: &[PathBuf], storages_list: StoragesList) -> Result<()> {
+    let expected_storages = storages_list.into_slot_file_id_set();
+    for account_path in account_paths {
+        let read_dir = fs::read_dir(account_path).map_err(|err| {
+            IoError::other(format!(
+                "failed to read account path '{}': {err}",
+                account_path.display(),
+            ))
+        })?;
+        for entry in read_dir {
+            let path = entry?.path();
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            let Ok((slot, id)) = get_slot_and_append_vec_id(name) else {
+                // Not a storage file name — leave it alone.
+                continue;
+            };
+            if !expected_storages.contains(&(slot, id as AccountsFileId)) {
+                info!(
+                    "Removing stale storage file '{}' not in storages list",
+                    path.display(),
+                );
+                move_and_async_delete_path(&path);
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Performs the common tasks when deserializing a snapshot
 ///
 /// Handles reading the snapshot file and version file,
@@ -1426,8 +1384,6 @@ pub(crate) fn rebuild_storages_from_snapshot_dir(
     AccountsDbFields<SerializableAccountStorageEntry>,
 )> {
     let bank_snapshot_dir = &snapshot_info.snapshot_dir;
-    let accounts_hardlinks = bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_ACCOUNTS_HARDLINKS);
-    let account_run_paths: HashSet<_> = HashSet::from_iter(account_paths);
 
     // With fastboot_version >= 2, obsolete accounts are tracked and stored in the snapshot
     // Even if obsolete accounts are not enabled, the snapshot may still contain obsolete accounts
@@ -1445,56 +1401,11 @@ pub(crate) fn rebuild_storages_from_snapshot_dir(
             ))
         })?;
 
-    let read_dir = fs::read_dir(&accounts_hardlinks).map_err(|err| {
-        IoError::other(format!(
-            "failed to read accounts hardlinks dir '{}': {err}",
-            accounts_hardlinks.display(),
-        ))
-    })?;
-    for dir_entry in read_dir {
-        let symlink_path = dir_entry?.path();
-        // The symlink point to <account_path>/snapshot/<slot> which contain the account files hardlinks
-        // The corresponding run path should be <account_path>/run/
-        let account_snapshot_path = fs::read_link(&symlink_path).map_err(|err| {
-            IoError::other(format!(
-                "failed to read symlink '{}': {err}",
-                symlink_path.display(),
-            ))
-        })?;
-        let account_run_path = account_snapshot_path
-            .parent()
-            .ok_or_else(|| SnapshotError::InvalidAccountPath(account_snapshot_path.clone()))?
-            .parent()
-            .ok_or_else(|| SnapshotError::InvalidAccountPath(account_snapshot_path.clone()))?
-            .join(ACCOUNTS_RUN_DIR);
-        if !account_run_paths.contains(&account_run_path) {
-            // The appendvec from the bank snapshot storage does not match any of the provided account_paths set.
-            // The account paths have changed so the snapshot is no longer usable.
-            return Err(SnapshotError::AccountPathsMismatch);
-        }
-        // Generate hard-links to make the account files available in the main accounts/, and let the new appendvec
-        // paths be in accounts/
-        let read_dir = fs::read_dir(&account_snapshot_path).map_err(|err| {
-            IoError::other(format!(
-                "failed to read account snapshot dir '{}': {err}",
-                account_snapshot_path.display(),
-            ))
-        })?;
-        for file in read_dir {
-            let file_path = file?.path();
-            let file_name = file_path
-                .file_name()
-                .ok_or_else(|| SnapshotError::InvalidAppendVecPath(file_path.to_path_buf()))?;
-            let dest_path = account_run_path.join(file_name);
-            fs::hard_link(&file_path, &dest_path).map_err(|err| {
-                IoError::other(format!(
-                    "failed to hard link from '{}' to '{}': {err}",
-                    file_path.display(),
-                    dest_path.display(),
-                ))
-            })?;
-        }
-    }
+    // The bank snapshot lists the storage files belonging to it. Anything else in the account
+    // paths is from a later (post-snapshot) slot and must be removed before we load — the
+    // lt hash check at startup verifies the surviving storages.
+    let storages_list = deserialize_storages_list(bank_snapshot_dir, MAX_STORAGES_LIST_FILE_SIZE)?;
+    prune_stale_storages(account_paths, storages_list)?;
 
     let snapshot_file_path = snapshot_info.snapshot_path();
     let snapshot_version_path = bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_VERSION_FILENAME);
@@ -1773,12 +1684,12 @@ fn purge_bank_snapshots<'a>(bank_snapshots: impl IntoIterator<Item = &'a BankSna
 /// Remove the bank snapshot at this path
 pub fn purge_bank_snapshot(bank_snapshot_dir: impl AsRef<Path>) -> Result<()> {
     const FN_ERR: &str = "failed to purge bank snapshot";
-    let accounts_hardlinks_dir = bank_snapshot_dir
-        .as_ref()
-        .join(snapshot_paths::SNAPSHOT_ACCOUNTS_HARDLINKS);
+    // Migration: snapshots written by pre-storages-list versions kept an `accounts_hardlinks/`
+    // subdir of symlinks pointing at hardlink dirs under `<account_path>/snapshot/<slot>/`.
+    // Follow them so the hardlink dirs don't outlive the owning bank snapshot when we purge at
+    // runtime (startup-time cleanup catches any leftovers).
+    let accounts_hardlinks_dir = bank_snapshot_dir.as_ref().join("accounts_hardlinks");
     if accounts_hardlinks_dir.is_dir() {
-        // This directory contain symlinks to all accounts snapshot directories.
-        // They should all be removed.
         let read_dir = fs::read_dir(&accounts_hardlinks_dir).map_err(|err| {
             IoError::other(format!(
                 "{FN_ERR}: failed to read accounts hardlinks dir '{}': {err}",
@@ -2619,49 +2530,6 @@ mod tests {
             incremental_snapshot_archives_iter(incremental_snapshot_archives_dir.path())
                 .collect::<Vec<_>>();
         assert!(remaining_incremental_snapshot_archives.is_empty());
-    }
-
-    #[test]
-    fn test_get_snapshot_accounts_hardlink_dir() {
-        let slot: Slot = 1;
-
-        let mut account_paths_set: HashSet<PathBuf> = HashSet::new();
-
-        let bank_snapshots_dir_tmp = tempfile::TempDir::new().unwrap();
-        let bank_snapshot_dir = bank_snapshots_dir_tmp.path().join(slot.to_string());
-        let accounts_hardlinks_dir =
-            bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_ACCOUNTS_HARDLINKS);
-        fs::create_dir_all(&accounts_hardlinks_dir).unwrap();
-
-        let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
-        let appendvec_filename = format!("{slot}.0");
-        let appendvec_path = accounts_dir.join(appendvec_filename);
-
-        let ret = get_snapshot_accounts_hardlink_dir(
-            &appendvec_path,
-            slot,
-            &mut account_paths_set,
-            &accounts_hardlinks_dir,
-        );
-        assert!(ret.is_ok());
-
-        let wrong_appendvec_path = appendvec_path
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join(appendvec_path.file_name().unwrap());
-        let ret = get_snapshot_accounts_hardlink_dir(
-            &wrong_appendvec_path,
-            slot,
-            &mut account_paths_set,
-            accounts_hardlinks_dir,
-        );
-
-        assert_matches!(
-            ret,
-            Err(GetSnapshotAccountsHardLinkDirError::GetAccountPath(_))
-        );
     }
 
     #[test]

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1404,8 +1404,10 @@ fn migrate_legacy_hardlinks(bank_snapshot_dir: &Path, account_run_paths: &[PathB
         }
     }
 
-    // Persist the derived list to disk before tearing down legacy state, so a crash mid-migration
-    // doesn't leave us with neither the hardlinks nor the new-format file.
+    // Persist the derived list now: migration is destructive (it removes the legacy hardlinks
+    // below), and writing the storages list is what actually brings the bank snapshot to
+    // fastboot version >=3 compatibility. Doing it here means the snapshot stays loadable even
+    // if the validator never performs a proper teardown (e.g. crashes).
     serialize_storages_list_to_snapshot(
         bank_snapshot_dir,
         StoragesList::from_items(items),

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -564,6 +564,9 @@ pub fn serialize_snapshot(
                     storage.flush().map_err(|err| {
                         AddBankSnapshotError::FlushStorage(err, storage.path().to_path_buf())
                     })?;
+                    // We're about to mark this snapshot fastboot-loadable. Pin the storage
+                    // file so it outlives the validator-exit Drop chain.
+                    storage.disable_remove_on_drop();
                 }
                 let flush_us = flush_measure.end_as_us();
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1344,8 +1344,8 @@ fn migrate_legacy_hardlinks(
                 symlink_path.display(),
             ))
         })?;
-        // snapshot_slot_dir = `<account_path>/snapshot/<slot>/`. The account run dir is its
-        // grandparent + `run`.
+        // snapshot_slot_dir = `<X>/snapshot/<slot>/`. The account run dir is its
+        // grandparent + `run` (i.e. `<X>/run`).
         let run_dir = snapshot_slot_dir
             .parent()
             .and_then(Path::parent)
@@ -1356,6 +1356,21 @@ fn migrate_legacy_hardlinks(
                 ))
             })?
             .join(ACCOUNTS_RUN_DIR);
+        // The legacy snapshot was taken against the account paths in use at the time. If
+        // those have changed (e.g. the operator reconfigured `account_paths` while upgrading
+        // Agave), the run dir we just derived isn't one we're loading into — bail rather than
+        // silently writing files into a location nobody's reading from.
+        if !account_paths.contains(&run_dir) {
+            return Err(IoError::other(format!(
+                "legacy hardlink target '{}' points to run dir '{}' which is not in the current \
+                 account paths ({:?}); the account paths configuration has changed since this \
+                 snapshot was taken — load from a snapshot archive instead",
+                snapshot_slot_dir.display(),
+                run_dir.display(),
+                account_paths,
+            ))
+            .into());
+        }
 
         for file_entry in fs::read_dir(&snapshot_slot_dir).map_err(|err| {
             IoError::other(format!(

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -6,7 +6,7 @@ use {
         serde_snapshot::{
             self, AccountsDbFields, ExtraFieldsToSerialize, SerdeObsoleteAccountsMap,
             SerializableAccountStorageEntry, SnapshotAccountsDbFields, SnapshotBankFields,
-            SnapshotStreams, StoragesList,
+            SnapshotStreams, StorageListItem, StoragesList,
         },
         snapshot_package::BankSnapshotPackage,
         snapshot_utils::snapshot_storage_rebuilder::{
@@ -41,7 +41,10 @@ use {
         account_storage::AccountStorageMap,
         account_storage_entry::AccountStorageEntry,
         accounts_db::{AccountsFileId, AtomicAccountsFileId},
-        utils::move_and_async_delete_path,
+        utils::{
+            ACCOUNTS_RUN_DIR, ACCOUNTS_SNAPSHOT_DIR, move_and_async_delete_path,
+            move_and_async_delete_path_contents,
+        },
     },
     solana_clock::Slot,
     solana_measure::{measure::Measure, measure_time, measure_us},
@@ -84,11 +87,12 @@ const AUX_SNAPSHOT_FILE_READ_BUF_SIZE: usize = 4 * 1024 * 1024;
 // 2.0.0 - Obsolete Accounts File added, storages flushed file not written anymore
 //         Snapshots created with version 2.0.0 will not fastboot to older versions
 //         Snapshots created with versions <2.0.0 will fastboot to version 2.0.0
-// 3.0.0 - Storages List file added, replaces the per-storage hardlink dirs
-//         Required to know which storages on disk belong to the snapshot before fastboot;
-//         snapshots created with versions <3.0.0 lack the file and fall back to archive loading.
+// 3.0.0 - Storages List file added, replaces the per-storage hardlink dirs.
+//         3.0.0 validators can still fastboot from 2.0.0 snapshots: the legacy hardlinks are
+//         migrated back into the account run dirs at load time (see `migrate_legacy_hardlinks`),
+//         and the next teardown writes the new-format storages list.
 //         Note: 2.0.0 validators cannot fastboot from 3.0.0 snapshots because the per-storage
-//         hardlink dirs they rely on are no longer written; they too must fall back to archive.
+//         hardlink dirs they rely on are no longer written; they must fall back to archive.
 const SNAPSHOT_FASTBOOT_VERSION: Version = Version::new(3, 0, 0);
 
 /// Information about a bank snapshot. Namely the slot of the bank, the path to the snapshot, and
@@ -259,36 +263,6 @@ pub(crate) struct StorageAndNextAccountsFileId {
     pub next_append_vec_id: AtomicAccountsFileId,
 }
 
-/// Removes any leftover entries under each `<account_path>/snapshot/` directory.
-///
-/// In prior versions, bank snapshot dirs used during fastboot stored per-slot hardlinks here;
-/// we no longer write anything to `<account_path>/snapshot/`, so anything still present is a
-/// migration leftover and can be deleted unconditionally.
-pub fn clean_orphaned_account_snapshot_dirs(account_snapshot_paths: &[PathBuf]) -> io::Result<()> {
-    for account_snapshot_path in account_snapshot_paths {
-        let read_dir = match fs::read_dir(account_snapshot_path) {
-            Ok(read_dir) => read_dir,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
-            Err(err) => {
-                return Err(IoError::other(format!(
-                    "failed to read account snapshot dir '{}': {err}",
-                    account_snapshot_path.display(),
-                )));
-            }
-        };
-        for entry in read_dir {
-            let path = entry?.path();
-            info!(
-                "Removing orphaned account snapshot directory '{}'...",
-                path.display()
-            );
-            move_and_async_delete_path(&path);
-        }
-    }
-
-    Ok(())
-}
-
 /// Purges incomplete bank snapshots
 pub fn purge_incomplete_bank_snapshots(bank_snapshots_dir: impl AsRef<Path>) {
     let Ok(read_dir_iter) = std::fs::read_dir(&bank_snapshots_dir) else {
@@ -395,12 +369,17 @@ fn is_bank_snapshot_loadable(
 fn is_snapshot_fastboot_compatible(
     version: &Version,
 ) -> std::result::Result<bool, SnapshotFastbootError> {
-    match version.major.cmp(&SNAPSHOT_FASTBOOT_VERSION.major) {
-        Ordering::Greater => Err(SnapshotFastbootError::IncompatibleVersion(version.clone())),
-        Ordering::Equal => Ok(true),
-        // Older format lacks files required by the current fastboot path (e.g. the storages
-        // list added in 3.0.0). Caller should fall back to loading from archive.
-        Ordering::Less => Ok(false),
+    match version.major {
+        // Current format: storages list lives next to the bank snapshot file.
+        3 => Ok(true),
+        // Legacy format: per-storage hardlink dirs. `rebuild_storages_from_snapshot_dir`
+        // migrates them to the new format at load time.
+        2 => Ok(true),
+        v if v > SNAPSHOT_FASTBOOT_VERSION.major => {
+            Err(SnapshotFastbootError::IncompatibleVersion(version.clone()))
+        }
+        // Older format we no longer know how to load — fall back to archive.
+        _ => Ok(false),
     }
 }
 
@@ -797,19 +776,16 @@ pub fn write_storages_list_to_snapshot(
 }
 
 fn deserialize_storages_list(
-    bank_snapshot_dir: impl AsRef<Path>,
+    storages_list_path: &Path,
     maximum_storages_list_file_size: u64,
 ) -> Result<StoragesList> {
-    let storages_list_path = bank_snapshot_dir
-        .as_ref()
-        .join(snapshot_paths::SNAPSHOT_STORAGES_LIST_FILENAME);
     let storages_list_reader = ReadAdapter::new(large_file_buf_reader(
-        &storages_list_path,
+        storages_list_path,
         AUX_SNAPSHOT_FILE_READ_BUF_SIZE,
         &IoSetupState::default(),
     )?);
     // If the file is too large return error
-    let storages_list_file_metadata = fs::metadata(&storages_list_path)?;
+    let storages_list_file_metadata = fs::metadata(storages_list_path)?;
     if storages_list_file_metadata.len() > maximum_storages_list_file_size {
         let error_message = format!(
             "too large storages list file to deserialize: '{}' has {} bytes (max size is \
@@ -1337,6 +1313,87 @@ fn spawn_streaming_snapshot_dir_files(
     (file_receiver, handle)
 }
 
+/// Migrates a legacy (2.0.0) bank snapshot's hardlink-based storages into the new format.
+///
+/// Walks `<bank_snapshot_dir>/accounts_hardlinks/`, follows each symlink to its
+/// `<account_path>/snapshot/<slot>/` target, and renames each storage file there back into
+/// `<account_path>/run/`. Returns the derived storages list. Tears down the legacy directories
+/// (the `accounts_hardlinks/` symlink dir and the whole `<account_path>/snapshot/` tree) on
+/// success so subsequent restarts go through the normal new-format path (next teardown writes
+/// the storages list file).
+fn migrate_legacy_hardlinks(
+    bank_snapshot_dir: &Path,
+    account_paths: &[PathBuf],
+) -> Result<StoragesList> {
+    let accounts_hardlinks_dir = bank_snapshot_dir.join("accounts_hardlinks");
+    let mut items: Vec<StorageListItem> = Vec::new();
+
+    for entry in fs::read_dir(&accounts_hardlinks_dir).map_err(|err| {
+        IoError::other(format!(
+            "failed to read legacy accounts hardlinks dir '{}': {err}",
+            accounts_hardlinks_dir.display(),
+        ))
+    })? {
+        let symlink_path = entry?.path();
+        let snapshot_slot_dir = fs::read_link(&symlink_path).map_err(|err| {
+            IoError::other(format!(
+                "failed to read symlink '{}': {err}",
+                symlink_path.display(),
+            ))
+        })?;
+        // snapshot_slot_dir = `<account_path>/snapshot/<slot>/`. The account run dir is its
+        // grandparent + `run`.
+        let run_dir = snapshot_slot_dir
+            .parent()
+            .and_then(Path::parent)
+            .ok_or_else(|| {
+                IoError::other(format!(
+                    "invalid legacy hardlink target '{}'",
+                    snapshot_slot_dir.display(),
+                ))
+            })?
+            .join(ACCOUNTS_RUN_DIR);
+
+        for file_entry in fs::read_dir(&snapshot_slot_dir).map_err(|err| {
+            IoError::other(format!(
+                "failed to read legacy hardlink dir '{}': {err}",
+                snapshot_slot_dir.display(),
+            ))
+        })? {
+            let src = file_entry?.path();
+            let Some(name) = src.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            let (slot, id) = get_slot_and_append_vec_id(name)?;
+            let dest = run_dir.join(name);
+            fs::rename(&src, &dest).map_err(|err| {
+                IoError::other(format!(
+                    "failed to migrate legacy storage from '{}' to '{}': {err}",
+                    src.display(),
+                    dest.display(),
+                ))
+            })?;
+            items.push(StorageListItem {
+                slot,
+                id: id as AccountsFileId,
+            });
+        }
+    }
+
+    // Tear down the legacy state so we don't repeat this migration: drop the bank snapshot's
+    // `accounts_hardlinks/` symlink dir and wipe each `<account_path>/snapshot/` tree (catches
+    // both the per-slot dirs we just emptied and any orphans from older purged snapshots).
+    fs::remove_dir_all(&accounts_hardlinks_dir).map_err(|err| {
+        IoError::other(format!(
+            "failed to remove legacy accounts hardlinks dir '{}': {err}",
+            accounts_hardlinks_dir.display(),
+        ))
+    })?;
+    wipe_account_snapshot_dirs(account_paths);
+
+    Ok(StoragesList::from_items(items))
+}
+
 /// Removes storage files from `account_paths` whose `(slot, id)` pair isn't listed in the
 /// storages list (i.e. they don't belong to the snapshot being loaded). Files whose names
 /// don't parse as `<slot>.<id>` storage filenames are left alone.
@@ -1404,7 +1461,19 @@ pub(crate) fn rebuild_storages_from_snapshot_dir(
     // The bank snapshot lists the storage files belonging to it. Anything else in the account
     // paths is from a later (post-snapshot) slot and must be removed before we load — the
     // lt hash check at startup verifies the surviving storages.
-    let storages_list = deserialize_storages_list(bank_snapshot_dir, MAX_STORAGES_LIST_FILE_SIZE)?;
+    let storages_list_path =
+        bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_STORAGES_LIST_FILENAME);
+    let storages_list = if storages_list_path.exists() {
+        deserialize_storages_list(&storages_list_path, MAX_STORAGES_LIST_FILE_SIZE)?
+    } else {
+        // Legacy (2.0.0) bank snapshot: storages live as hardlinks under
+        // `<account_path>/snapshot/<slot>/`, with symlinks in
+        // `<bank_snapshot_dir>/accounts_hardlinks/` tying them to the bank snapshot. Move the
+        // files back into `<account_path>/run/` and derive the storages list on the fly. The
+        // legacy dirs are torn down here — next teardown will write the new-format storages
+        // list so subsequent restarts go through the normal path.
+        migrate_legacy_hardlinks(bank_snapshot_dir, account_paths)?
+    };
     prune_stale_storages(account_paths, storages_list)?;
 
     let snapshot_file_path = snapshot_info.snapshot_path();
@@ -1626,6 +1695,23 @@ pub enum VerifyBank {
     /// the serialized bank was 'reserialized' into a non-deterministic format
     /// so, deserialize both files and compare deserialized results
     NonDeterministic,
+}
+
+/// For each account run dir, wipes the sibling `snapshot/` dir.
+///
+/// Validator account paths are laid out as a parent containing two siblings: `run/` (the live
+/// storage files) and `snapshot/` (legacy per-slot hardlink dirs, pre-3.0). `account_paths`
+/// here holds the `run/` paths, so for each entry we walk up to the parent and wipe the
+/// `snapshot/` sibling. Nothing new is written under `snapshot/` anymore, so any content is
+/// either legacy hardlink dirs (written by pre-3.0 validators during fastboot) or orphans
+/// from purged bank snapshots. Used by the legacy-hardlink migration path and the
+/// archive-load path to drop that leftover state.
+pub fn wipe_account_snapshot_dirs(account_run_paths: &[PathBuf]) {
+    for account_run_path in account_run_paths {
+        if let Some(parent) = account_run_path.parent() {
+            move_and_async_delete_path_contents(parent.join(ACCOUNTS_SNAPSHOT_DIR));
+        }
+    }
 }
 
 /// Purges all bank snapshots

--- a/snapshots/src/error.rs
+++ b/snapshots/src/error.rs
@@ -199,9 +199,6 @@ pub enum AddBankSnapshotError {
     #[error("failed to flush storage '{1}': {0}")]
     FlushStorage(#[source] AccountsFileError, PathBuf),
 
-    #[error("failed to hard link storages: {0}")]
-    HardLinkStorages(#[source] HardLinkStoragesToSnapshotError),
-
     #[error("failed to serialize bank: {0}")]
     SerializeBank(#[source] Box<SnapshotError>),
 
@@ -210,6 +207,9 @@ pub enum AddBankSnapshotError {
 
     #[error("failed to serialize obsolete accounts: {0}")]
     SerializeObsoleteAccounts(#[source] Box<SnapshotError>),
+
+    #[error("failed to write storages list: {0}")]
+    WriteStoragesList(#[source] Box<SnapshotError>),
 
     #[error("failed to write snapshot version file '{1}': {0}")]
     WriteSnapshotVersionFile(#[source] io::Error, PathBuf),
@@ -274,34 +274,4 @@ pub enum ArchiveSnapshotPackageError {
 
     #[error("failed to initialize file buffered reader: {0}")]
     StorageFileBufReaderError(#[source] io::Error),
-}
-
-/// Errors that can happen in `hard_link_storages_to_snapshot()`
-#[derive(Error, Debug)]
-pub enum HardLinkStoragesToSnapshotError {
-    #[error("failed to create accounts hard links dir '{1}': {0}")]
-    CreateAccountsHardLinksDir(#[source] io::Error, PathBuf),
-
-    #[error("failed to get the snapshot's accounts hard link dir: {0}")]
-    GetSnapshotHardLinksDir(#[from] GetSnapshotAccountsHardLinkDirError),
-
-    #[error("failed to hard link storage from '{1}' to '{2}': {0}")]
-    HardLinkStorage(#[source] io::Error, PathBuf, PathBuf),
-}
-
-/// Errors that can happen in `get_snapshot_accounts_hardlink_dir()`
-#[derive(Error, Debug)]
-pub enum GetSnapshotAccountsHardLinkDirError {
-    #[error("invalid account storage path '{0}'")]
-    GetAccountPath(PathBuf),
-
-    #[error("failed to create the snapshot hard link dir '{1}': {0}")]
-    CreateSnapshotHardLinkDir(#[source] io::Error, PathBuf),
-
-    #[error("failed to symlink snapshot hard link dir '{link}' to '{original}': {source}")]
-    SymlinkSnapshotHardLinkDir {
-        source: io::Error,
-        original: PathBuf,
-        link: PathBuf,
-    },
 }

--- a/snapshots/src/paths.rs
+++ b/snapshots/src/paths.rs
@@ -21,7 +21,7 @@ use {
 pub const SNAPSHOT_STATUS_CACHE_FILENAME: &str = "status_cache";
 pub const SNAPSHOT_VERSION_FILENAME: &str = "version";
 pub const SNAPSHOT_FASTBOOT_VERSION_FILENAME: &str = "fastboot_version";
-pub const SNAPSHOT_ACCOUNTS_HARDLINKS: &str = "accounts_hardlinks";
+pub const SNAPSHOT_STORAGES_LIST_FILENAME: &str = "storages_list";
 pub const SNAPSHOT_ARCHIVE_DOWNLOAD_DIR: &str = "remote";
 pub const SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME: &str = "obsolete_accounts";
 /// When a snapshot is taken of a bank, the state is serialized under this directory.

--- a/snapshots/src/paths.rs
+++ b/snapshots/src/paths.rs
@@ -21,6 +21,7 @@ use {
 pub const SNAPSHOT_STATUS_CACHE_FILENAME: &str = "status_cache";
 pub const SNAPSHOT_VERSION_FILENAME: &str = "version";
 pub const SNAPSHOT_FASTBOOT_VERSION_FILENAME: &str = "fastboot_version";
+pub const SNAPSHOT_ACCOUNTS_HARDLINKS: &str = "accounts_hardlinks";
 pub const SNAPSHOT_STORAGES_LIST_FILENAME: &str = "storages_list";
 pub const SNAPSHOT_ARCHIVE_DOWNLOAD_DIR: &str = "remote";
 pub const SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME: &str = "obsolete_accounts";


### PR DESCRIPTION
Problem

Fastboot snapshots use hardlinks to keep account-storage files alive across the bank-snapshot lifecycle: every storage file under `<account_path>/run/` is also hardlinked into `<account_path>/snapshot/<slot>/`, with a `<bank_snapshot_dir>/accounts_hardlinks/` directory of symlinks tying the two together. This dual-tree design is complex, scatters `fs::hard_link` / `fs::read_link` calls across the snapshot code, and the `accounts_hardlinks` symlink layer is the load-bearing piece that tells the validator which storages on disk belong to a fastboot snapshot vs. are stale leftovers from later slots. It's also slow: the hardlinking pass on graceful exit and the read-link pass on startup each take >3s on a real validator.

Replace it with a much simpler invariant: a single `storages_list` file written next to the bank snapshot on graceful exit listing `(slot, id)` pairs for the storages that make it up. The storage files themselves are pinned across validator exit via a new `disable_remove_on_drop` flag on `AppendVec`, so they're still on disk at the next startup. The lt-hash check at startup provides integrity verification.

### Summary of Changes

- Add the storages list type in a new `runtime/src/serde_snapshot/storages_list.rs` (`StorageListItem { slot, id }` + `StoragesList`, both wincode-serialized with `#[repr(C)]`).

- Switch the graceful-exit path (`core/src/snapshot_packager_service.rs`) to call `write_storages_list_to_snapshot` in place of `hard_link_storages_to_snapshot`. Wire the same call into `serialize_snapshot`'s `should_finalize` branch.

- Pin storage files across validator exit: add `AppendVec::disable_remove_on_drop` (and pass-through accessors on `AccountsFile` and `AccountStorageEntry`). At teardown, alongside `flush()` for each snapshot storage, call `disable_remove_on_drop()` so the file isn't removed by `AppendVec::drop` during validator join. On the next startup, fresh `AppendVec`s opened on those files default back to `remove_file_on_drop = true`, so normal runtime cleanup (shrink, clean) still removes them later — no leak.

- Bump `SNAPSHOT_FASTBOOT_VERSION` to 3.0.0. `is_snapshot_fastboot_compatible` now matches explicitly: `v=3` (current) and `v=2` (legacy, see below) both `Ok(true)`, `v > 3` returns `IncompatibleVersion`, older `Ok(false)` (falls back to archive in `get_highest_loadable_bank_snapshot`).

- **Backward-compat fastboot from 2.0.0 snapshots.** When the storages list file is absent but a legacy `accounts_hardlinks/` dir is present, `rebuild_storages_from_snapshot_dir` calls a new `migrate_legacy_hardlinks`: follows each symlink to its `<account_path>/snapshot/<slot>/` target, `fs::rename`s the storage files back into `<account_path>/run/`, returns a derived `StoragesList`, and tears down the legacy state (`accounts_hardlinks/` dir + the per-slot dirs via `wipe_account_snapshot_dirs`). The next teardown writes the new-format list, so subsequent restarts go through the normal path.

- Remove the hardlink machinery in `runtime/src/snapshot_utils.rs`: `hard_link_storages_to_snapshot`, `get_snapshot_accounts_hardlink_dir`, `get_account_path_from_appendvec_path`, the `SNAPSHOT_ACCOUNTS_HARDLINKS` constant, and the matching `HardLinkStoragesToSnapshotError` / `GetSnapshotAccountsHardLinkDirError` / `AddBankSnapshotError::HardLinkStorages` error types. Drop the `symlink` crate dep from `runtime/Cargo.toml`.

- Rewrite the fastboot startup path. `rebuild_storages_from_snapshot_dir` reads (or migrates to) the storages list and calls a new `prune_stale_storages` that walks each `<account_path>/run/`, parses every filename via `get_slot_and_append_vec_id`, and removes any storage whose `(slot, id)` isn't in the list. Non-storage filenames are left alone. Two new unit tests cover this path: `test_prune_stale_storages` directly, and `test_bank_from_snapshot_dir_prunes_stale_storage` end-to-end through `bank_from_snapshot_dir`.

- Move account-paths cleanup from validator startup into the load decision. `cleanup_accounts_paths` (which used to wipe `<account_path>/run/` unconditionally at validator startup) is gone — fastboot needs the existing storages on disk to remain in place. Instead, in `bank_forks_utils::try_load_bank_forks_from_snapshot`'s archive-load branch, each `account_path` is wiped right before extracting the archive, and a new `snapshot_utils::wipe_account_snapshot_dirs` wipes the sibling `<account_path>/snapshot/` tree there too (also called at the end of legacy migration). Decision and action are co-located.

- Remove `clean_orphaned_account_snapshot_dirs` entirely (and its two unit tests, its `LoadAndProcessLedgerError::CleanOrphanedAccountSnapshotDirectories` variant in ledger-tool, and the calls from `validator.rs` and `ledger-tool/src/ledger_utils.rs`). The legacy-migration path and the archive-load path each do their own cleanup, so there are no leftovers worth catching at startup.

- Keep a small `fs::read_link` branch in `purge_bank_snapshot` for the legacy `accounts_hardlinks/` subdir so runtime purges of pre-refactor snapshots still tear down their target dirs.
