### PR TITLE
v4.0: Freeze cargo-build-sbf version

### DIFF
--- a/scripts/cargo-build-sbf-version.sh
+++ b/scripts/cargo-build-sbf-version.sh
@@ -1,6 +1,6 @@
 # populate this on the stable branch
-cargoBuildSbfVersion=
-cargoTestSbfVersion=
+cargoBuildSbfVersion=4.0.0
+cargoTestSbfVersion=4.0.0
 
 maybeCargoBuildSbfVersionArg=
 if [[ -n "$cargoBuildSbfVersion" ]]; then


### PR DESCRIPTION
#### Problem

As the part of v4.0 stabilization the version of cargo-build-sbf should be frozen

#### Summary of Changes

Freeze the version to 4.0.0