### PR TITLE
v4.0: freeze spl-token-cli version

### DIFF
--- a/scripts/spl-token-cli-version.sh
+++ b/scripts/spl-token-cli-version.sh
@@ -1,5 +1,5 @@
 # populate this on the stable branch
-splTokenCliVersion=
+splTokenCliVersion=5.5.0
 
 maybeSplTokenCliVersionArg=
 if [[ -n "$splTokenCliVersion" ]]; then


### PR DESCRIPTION
#### Problem

As the part of v4.0 stabilization the version of spl-token-cli has to be frozen.

#### Summary of Changes

Pin the version to 5.5.0