### PR TITLE
fix tests

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1964,12 +1964,14 @@ fn do_test_future_tower(cluster_mode: ClusterMode) {
     let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
 
     let val_a_ledger_path = cluster.ledger_path(&validator_a_pubkey);
+    let root_before_restart;
 
     loop {
         sleep(Duration::from_millis(100));
 
         if let Some(root) = root_in_tower(&val_a_ledger_path, &validator_a_pubkey) {
             if root >= 15 {
+                root_before_restart = root;
                 break;
             }
         }
@@ -1993,7 +1995,7 @@ fn do_test_future_tower(cluster_mode: ClusterMode) {
     );
 
     let mut newly_rooted = false;
-    let some_root_after_restart = purged_slot_before_restart + 25; // 25 is arbitrary; just wait a bit
+    let some_root_after_restart = root_before_restart + 1;
     for _ in 0..600 {
         sleep(Duration::from_millis(100));
 
@@ -6197,8 +6199,7 @@ fn test_alpenglow_migration(
     let node_stakes = vec![DEFAULT_NODE_STAKE; num_nodes];
 
     // We want the epochs to be as short as possible to reduce test time without being flaky.
-    // We start the migration at an offset of 32, so use 64 as the epoch length.
-    let slots_per_epoch = 2 * MINIMUM_SLOTS_PER_EPOCH;
+    let slots_per_epoch = 4 * MINIMUM_SLOTS_PER_EPOCH;
     assert!(slots_per_epoch > MIGRATION_SLOT_OFFSET);
     let mut cluster_config = ClusterConfig {
         validator_configs: make_identical_validator_configs(&validator_config, num_nodes),

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -588,13 +588,15 @@ mod tests {
         bank: &Bank,
         total_stake: u64,
         stake_voted: u64,
-    ) -> u64 {
+    ) -> (u64, u64) {
         let epoch_inflation =
             bank.calculate_epoch_inflation_rewards(prev_bank.capitalization(), prev_bank.epoch());
         let numerator = epoch_inflation as u128 * stake_voted as u128;
         let denominator = bank.epoch_schedule.slots_per_epoch as u128 * total_stake as u128;
         let reward: u64 = (numerator / denominator).try_into().unwrap();
-        reward / 2
+        let validator_reward = reward / 2;
+        let leader_reward = reward - validator_reward;
+        (validator_reward, leader_reward)
     }
 
     #[test]
@@ -660,18 +662,25 @@ mod tests {
                     .epoch_stakes_from_slot(reward_slot)
                     .unwrap()
                     .total_stake();
-                let expected_validator_reward =
+                let (expected_validator_reward, expected_leader_reward_per_validator) =
                     calc_reward_for_test(&prev_bank, &bank, total_stake, per_validator_stake);
                 if *validator != leader_vote_pubkey {
                     assert_eq!(got_reward, expected_validator_reward);
                 }
-                got_reward
+                (
+                    got_reward,
+                    expected_validator_reward,
+                    expected_leader_reward_per_validator,
+                )
             })
             .collect::<Vec<_>>();
-        let expected_leader_reward = rewards.last().unwrap()
-            * validator_pubkeys_to_reward.len() as u64
-            + rewards.last().unwrap();
-        assert_eq!(expected_leader_reward, rewards[0]);
+        let (leader_reward, expected_validator_reward, expected_leader_reward_per_validator) =
+            rewards[0];
+        assert_eq!(
+            expected_validator_reward
+                + expected_leader_reward_per_validator * validator_pubkeys_to_reward.len() as u64,
+            leader_reward
+        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Fixing 2 separate landmines in tests that were uncovered as part of moving to 200ms slot times:
1. test helper `fn do_test_future_tower` waits until we root a slot >=15, restarts, then it waits until we root slot >=35 and expects info for slots >=35 to be present. The problem is timing on local cluster tests is extremely non-deterministic, so if we happen to sleep too long and not observe the initial root until slot 35 or after, the test fails.
2. test `calculate_and_pay_works` assumes reward will be even. In the event reward is odd, it incorrectly rounds down leader rewards.

#### Summary of Changes

1. Record which slot we're actually at when we check and decide to restart. Use this slot to determine which slot we need to observe after restart to build a continuous set of slot info.
2. Match runtime reward behavior to avoid rounding down leader rewards