### PR TITLE
Create a set of slots with zero lamport accounts to shrink after full snapshot

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1648,7 +1648,7 @@ impl AccountsDb {
         (candidates, min_dirty_slot)
     }
 
-    /// Loop through slots in `(last_swept_full_snapshot_slot + 1, latest_full_snapshot_slot]` and
+    /// Loop through slots in `[last_swept_full_snapshot_slot + 1, latest_full_snapshot_slot]` and
     /// check each storage to determine if it is eligible for shrink, since zero-lamport single-ref
     /// accounts become shrinkable after a full snapshot advances past their slot. Advances the
     /// `last_swept_full_snapshot_slot` to `latest_full_snapshot_slot` on completion.

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1615,8 +1615,8 @@ impl AccountsDb {
         );
 
         // Cleaning up zero lamport accounts is gated by a full snapshot because they need to be
-        // retained for incremental snapshots. Once a snapshot occurs, drain the list and look for
-        // newly shrinkable storages.
+        // retained for incremental snapshots. Once a full snapshot occurs, drain the list and look
+        // for newly shrinkable storages.
         if self
             .latest_full_snapshot_slot_advanced_since_clean
             .swap(false, Ordering::Acquire)
@@ -1638,13 +1638,13 @@ impl AccountsDb {
                             prev,
                             latest_full_snapshot_slot
                         ));
-                    timings.zero_lamport_single_ref_slots_added_to_shrink_count =
+                    timings.zero_lamport_single_ref_slots_added_to_shrink_count +=
                         added_to_shrink_count;
-                    timings.zero_lamport_sweep_us = sweep_us;
+                    timings.zero_lamport_sweep_us += sweep_us;
                 } else {
-                    // First snapshot we've observed (this will be the snapshot set on boot). Initialize
-                    // the last swept full snapshot slot to this snapshot since we know all zero-lamport
-                    // single ref accounts were checked during index generation
+                    // First full snapshot we've observed (this will be the snapshot set on boot).
+                    // Initialize the last swept full snapshot slot to this snapshot since we know
+                    // all zero-lamport single ref accounts were checked during index generation
                     *self.last_swept_full_snapshot_slot.lock_write() =
                         Some(latest_full_snapshot_slot);
                 }
@@ -1660,10 +1660,10 @@ impl AccountsDb {
     /// `last_swept_full_snapshot_slot` watermark to `latest_full_snapshot_slot` on completion.
     fn check_shrink_eligibility_after_snapshot(
         &self,
-        prev_swept_exclusive: Slot,
+        last_swept_full_snapshot_slot: Slot,
         latest_full_snapshot_slot: Slot,
     ) -> u64 {
-        let start = prev_swept_exclusive.saturating_add(1);
+        let start = last_swept_full_snapshot_slot.saturating_add(1);
 
         let mut added_to_shrink_count = 0;
         // Held for the full scan. Safe because the only paths that take this lock in production
@@ -1675,8 +1675,9 @@ impl AccountsDb {
                 && self.is_shrinking_productive(&store)
                 && self.is_candidate_for_shrink(&store)
             {
-                shrink_candidates.insert(slot);
-                added_to_shrink_count += 1;
+                if shrink_candidates.insert(slot) {
+                    added_to_shrink_count += 1;
+                }
             }
         }
         drop(shrink_candidates);
@@ -2129,7 +2130,7 @@ impl AccountsDb {
             ("delta_key_count", key_timings.delta_key_count, i64),
             ("dirty_pubkeys_count", key_timings.dirty_pubkeys_count, i64),
             (
-                "zero_lamport_single_ref_slots_added_to_shrink",
+                "zero_lamport_single_ref_slots_added_to_shrink_count",
                 key_timings.zero_lamport_single_ref_slots_added_to_shrink_count,
                 i64
             ),

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6139,7 +6139,7 @@ impl AccountsDb {
         // last_swept_full_snapshot_slot value must be less than or equal to it.
         assert!(
             self.latest_full_snapshot_slot()
-                .map_or(false, |latest| slot <= latest),
+                .is_some_and(|snapshot_slot| slot <= snapshot_slot),
             "last swept full snapshot slot {slot} cannot be greater than latest full snapshot \
              slot {:?}",
             self.latest_full_snapshot_slot()

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -821,6 +821,8 @@ struct CleanKeyTimings {
     delta_key_count: u64,
     dirty_pubkeys_count: u64,
     oldest_dirty_slot: Slot,
+    zero_lamport_single_ref_slots_added_to_shrink_count: u64,
+    zero_lamport_sweep_us: u64,
 }
 
 pub fn get_temp_accounts_paths(count: u32) -> io::Result<(Vec<TempDir>, Vec<PathBuf>)> {
@@ -989,6 +991,10 @@ pub struct AccountsDb {
     /// Note, this is None if we're told to *not* take snapshots
     latest_full_snapshot_slot: SeqLock<Option<Slot>>,
 
+    /// The full snapshot slot we last swept for zero-lamport-single-ref shrink
+    /// eligibility.
+    last_swept_full_snapshot_slot: SeqLock<Option<Slot>>,
+
     /// These are the ancient storages that could be valuable to
     /// shrink, sorted by amount of dead bytes.  The elements
     /// are sorted from the largest dead bytes to the smallest.
@@ -1154,6 +1160,7 @@ impl AccountsDb {
             latest_full_snapshot_slot_advanced_since_clean: AtomicBool::default(),
             accounts_file_provider: AccountsFileProvider::default(),
             latest_full_snapshot_slot: SeqLock::new(None),
+            last_swept_full_snapshot_slot: SeqLock::new(None),
             best_ancient_slots_to_shrink: RwLock::default(),
         };
 
@@ -1607,8 +1614,9 @@ impl AccountsDb {
              be empty"
         );
 
-        // Cleaning up zero lamport accounts is gated by a full snapshot because they need to be retained
-        // for incremental snapshots. Once a snapshot occurs, drain the list
+        // Cleaning up zero lamport accounts is gated by a full snapshot because they need to be
+        // retained for incremental snapshots. Once a snapshot occurs, drain the list and look for
+        // newly shrinkable storages.
         if self
             .latest_full_snapshot_slot_advanced_since_clean
             .swap(false, Ordering::Acquire)
@@ -1623,10 +1631,58 @@ impl AccountsDb {
                         }
                         !is_candidate_for_clean
                     });
+
+                if let Some(prev) = self.last_swept_full_snapshot_slot.read() {
+                    let (added_to_shrink_count, sweep_us) =
+                        measure_us!(self.check_shrink_eligibility_after_snapshot(
+                            prev,
+                            latest_full_snapshot_slot
+                        ));
+                    timings.zero_lamport_single_ref_slots_added_to_shrink_count =
+                        added_to_shrink_count;
+                    timings.zero_lamport_sweep_us = sweep_us;
+                } else {
+                    // First snapshot we've observed (this will be the snapshot set on boot). Initialize
+                    // the last swept full snapshot slot to this snapshot since we know all zero-lamport
+                    // single ref accounts were checked during index generation
+                    *self.last_swept_full_snapshot_slot.lock_write() =
+                        Some(latest_full_snapshot_slot);
+                }
             }
         }
 
         (candidates, min_dirty_slot)
+    }
+
+    /// Loop through slots in `(prev_swept_exclusive, latest_full_snapshot_slot]` and check each
+    /// storage to determine if it is eligible for shrink, since zero-lamport single-ref accounts
+    /// become shrinkable after a full snapshot advances past their slot. Advances the
+    /// `last_swept_full_snapshot_slot` watermark to `latest_full_snapshot_slot` on completion.
+    fn check_shrink_eligibility_after_snapshot(
+        &self,
+        prev_swept_exclusive: Slot,
+        latest_full_snapshot_slot: Slot,
+    ) -> u64 {
+        let start = prev_swept_exclusive.saturating_add(1);
+
+        let mut added_to_shrink_count = 0;
+        // Held for the full scan. Safe because the only paths that take this lock in production
+        // validator code run in earlier/later phases of the same AccountsBackgroundService
+        // iteration, never concurrently with clean_accounts.
+        let mut shrink_candidates = self.shrink_candidate_slots.lock().unwrap();
+        for slot in start..=latest_full_snapshot_slot {
+            if let Some(store) = self.storage.get_slot_storage_entry(slot)
+                && self.is_shrinking_productive(&store)
+                && self.is_candidate_for_shrink(&store)
+            {
+                shrink_candidates.insert(slot);
+                added_to_shrink_count += 1;
+            }
+        }
+        drop(shrink_candidates);
+
+        *self.last_swept_full_snapshot_slot.lock_write() = Some(latest_full_snapshot_slot);
+        added_to_shrink_count
     }
 
     /// called with cli argument to verify refcounts are correct on all accounts
@@ -2072,6 +2128,12 @@ impl AccountsDb {
             ("delta_insert_us", key_timings.delta_insert_us, i64),
             ("delta_key_count", key_timings.delta_key_count, i64),
             ("dirty_pubkeys_count", key_timings.dirty_pubkeys_count, i64),
+            (
+                "zero_lamport_single_ref_slots_added_to_shrink",
+                key_timings.zero_lamport_single_ref_slots_added_to_shrink_count,
+                i64
+            ),
+            ("zero_lamport_sweep_us", key_timings.zero_lamport_sweep_us, i64),
             ("useful_keys", useful_accum.load(Ordering::Relaxed), i64),
             ("total_keys_count", num_candidates, i64),
             ("retained_keys_count", retained_keys_count, i64),

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -993,7 +993,7 @@ pub struct AccountsDb {
 
     /// The full snapshot slot we last swept for zero-lamport-single-ref shrink
     /// eligibility.
-    last_swept_full_snapshot_slot: SeqLock<Option<Slot>>,
+    last_swept_full_snapshot_slot: AtomicU64,
 
     /// These are the ancient storages that could be valuable to
     /// shrink, sorted by amount of dead bytes.  The elements
@@ -1160,7 +1160,7 @@ impl AccountsDb {
             latest_full_snapshot_slot_advanced_since_clean: AtomicBool::default(),
             accounts_file_provider: AccountsFileProvider::default(),
             latest_full_snapshot_slot: SeqLock::new(None),
-            last_swept_full_snapshot_slot: SeqLock::new(None),
+            last_swept_full_snapshot_slot: AtomicU64::new(0),
             best_ancient_slots_to_shrink: RwLock::default(),
         };
 
@@ -1615,8 +1615,8 @@ impl AccountsDb {
         );
 
         // Cleaning up zero lamport accounts is gated by a full snapshot because they need to be
-        // retained for incremental snapshots. Once a full snapshot occurs, drain the list and look
-        // for newly shrinkable storages.
+        // retained for incremental snapshots. Once a full snapshot occurs, drain the list and
+        // search for newly shrinkable storages.
         if self
             .latest_full_snapshot_slot_advanced_since_clean
             .swap(false, Ordering::Acquire)
@@ -1632,32 +1632,28 @@ impl AccountsDb {
                         !is_candidate_for_clean
                     });
 
-                if let Some(prev) = self.last_swept_full_snapshot_slot.read() {
-                    let (added_to_shrink_count, sweep_us) =
-                        measure_us!(self.check_shrink_eligibility_after_snapshot(
-                            prev,
-                            latest_full_snapshot_slot
-                        ));
-                    timings.zero_lamport_single_ref_slots_added_to_shrink_count +=
-                        added_to_shrink_count;
-                    timings.zero_lamport_sweep_us += sweep_us;
-                } else {
-                    // First full snapshot we've observed (this will be the snapshot set on boot).
-                    // Initialize the last swept full snapshot slot to this snapshot since we know
-                    // all zero-lamport single ref accounts were checked during index generation
-                    *self.last_swept_full_snapshot_slot.lock_write() =
-                        Some(latest_full_snapshot_slot);
-                }
+                let last_swept_full_snapshot_slot =
+                    self.last_swept_full_snapshot_slot.load(Ordering::Relaxed);
+                let (added_to_shrink_count, sweep_us) =
+                    measure_us!(self.check_shrink_eligibility_after_snapshot(
+                        last_swept_full_snapshot_slot,
+                        latest_full_snapshot_slot
+                    ));
+                timings.zero_lamport_single_ref_slots_added_to_shrink_count +=
+                    added_to_shrink_count;
+                timings.zero_lamport_sweep_us += sweep_us;
             }
         }
 
         (candidates, min_dirty_slot)
     }
 
-    /// Loop through slots in `(prev_swept_exclusive, latest_full_snapshot_slot]` and check each
-    /// storage to determine if it is eligible for shrink, since zero-lamport single-ref accounts
-    /// become shrinkable after a full snapshot advances past their slot. Advances the
-    /// `last_swept_full_snapshot_slot` watermark to `latest_full_snapshot_slot` on completion.
+    /// Loop through slots in `(last_swept_full_snapshot_slot + 1, latest_full_snapshot_slot]` and
+    /// check each storage to determine if it is eligible for shrink, since zero-lamport single-ref
+    /// accounts become shrinkable after a full snapshot advances past their slot. Advances the
+    /// `last_swept_full_snapshot_slot` to `latest_full_snapshot_slot` on completion.
+    ///
+    /// Returns the count of storages that were added to the shrink candidates set
     fn check_shrink_eligibility_after_snapshot(
         &self,
         last_swept_full_snapshot_slot: Slot,
@@ -1682,7 +1678,8 @@ impl AccountsDb {
         }
         drop(shrink_candidates);
 
-        *self.last_swept_full_snapshot_slot.lock_write() = Some(latest_full_snapshot_slot);
+        self.last_swept_full_snapshot_slot
+            .store(latest_full_snapshot_slot, Ordering::Relaxed);
         added_to_shrink_count
     }
 
@@ -6134,6 +6131,21 @@ impl AccountsDb {
         *self.latest_full_snapshot_slot.lock_write() = Some(slot);
         self.latest_full_snapshot_slot_advanced_since_clean
             .store(true, Ordering::Release);
+    }
+
+    /// Marks slots <= slot as already swept for zero-lamport-single-ref shrink eligibility
+    pub fn set_last_swept_full_snapshot_slot(&self, slot: Slot) {
+        // Prior to setting this, the latest full snapshot slot must be set, and
+        // last_swept_full_snapshot_slot value must be less than or equal to it.
+        assert!(
+            self.latest_full_snapshot_slot()
+                .map_or(false, |latest| slot <= latest),
+            "last swept full snapshot slot {slot} cannot be greater than latest full snapshot \
+             slot {:?}",
+            self.latest_full_snapshot_slot()
+        );
+        self.last_swept_full_snapshot_slot
+            .store(slot, Ordering::Relaxed);
     }
 
     fn generate_index_for_slot<'a>(

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3606,7 +3606,6 @@ define_accounts_db_test!(
 /// zero lamport single ref accounts can be removed by shrink
 #[test]
 fn test_zero_lamport_single_ref_resweep_after_snapshot_advances() {
-    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests_with_provider_and_config(
         AccountsFileProvider::default(),
         AccountsDbConfig {
@@ -3637,10 +3636,8 @@ fn test_zero_lamport_single_ref_resweep_after_snapshot_advances() {
     db.add_root_and_flush_write_cache(zero_lamport_single_ref_slot);
 
     // First clean: slot 1 is reclaimed, making slot key_zero a ZLSR. The unref path marks
-    // marks key_zero on slot 2's storage, but because the snapshot is still at 0 it does not
+    // key_zero on slot 2's storage, but because the snapshot is still at 0 it does not
     // mark the slot shrinkable yet.
-    // is still at 0 we clear shrink_candidate_slots
-    // so the second clean's sweep is the only thing that can re-add it.
     db.clean_accounts(Some(zero_lamport_single_ref_slot), false);
     assert!(
         !db.shrink_candidate_slots

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3601,66 +3601,76 @@ define_accounts_db_test!(
     }
 );
 
-/// When the full snapshot advances past a slot that still holds zero-lamport single-ref
-/// accounts, the next clean's range sweep must re-queue that slot for shrink so the
-/// zero lamport single ref accounts can be removed by shrink
-#[test]
-fn test_zero_lamport_single_ref_resweep_after_snapshot_advances() {
-    let db = AccountsDb::new_single_for_tests_with_provider_and_config(
-        AccountsFileProvider::default(),
-        AccountsDbConfig {
-            shrink_ratio: AccountShrinkThreshold::IndividualStore { shrink_ratio: 1.0 },
-            ..ACCOUNTS_DB_CONFIG_FOR_TESTING
-        },
-    );
+/// When the full snapshot advances past slots that still hold zero-lamport single-ref
+/// accounts, the next clean's range sweep must re-queue those slots for shrink so the
+/// zero lamport single ref accounts can be removed by shrink.
+#[test_case(false; "without_last_swept_set_queues_both_slots")]
+#[test_case(true; "with_last_swept_set_skips_only_at_last_swept")]
+fn test_zero_lamport_single_ref_resweep_respects_last_swept(set_last_swept: bool) {
+    let db = AccountsDb::new_single_for_tests();
 
-    let key_zero = Pubkey::new_unique();
-    let key_alive = Pubkey::new_unique();
-    let one = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
-    let zero = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
-    let zero_lamport_single_ref_slot = 2;
+    let one_lamport_account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
+    let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
+    let slot_at_last_swept = 2;
+    let slot_above_last_swept = 3;
+    let full_snapshot_slot = 4;
 
-    // Seed the snapshot at slot 0 so the watermark starts at Some(0).
+    // Seed the snapshot at slot 0 to avoid cleaning zero lamport single ref accounts
     db.set_latest_full_snapshot_slot(0);
 
-    // slot 1: older non-zero version of key_zero, on its own so the slot dies once
-    // clean reclaims it (keeps the test focused on slot 2's sweep behavior).
-    db.store_for_tests((1, &[(&key_zero, &one)][..]));
-    db.add_root_and_flush_write_cache(1);
-    // slot 2: zero-lamport version of key_zero plus an unrelated live account so the
-    // storage still has alive bytes once key_zero becomes a single-ref zero-lamport.
+    // slot 1: older non-zero versions of both keys. Both entries are overwritten by the
+    // stores below, so slot1 is reclaimed
+    let key_zero_at_last_swept = Pubkey::new_unique();
+    let key_zero_above_last_swept = Pubkey::new_unique();
     db.store_for_tests((
-        zero_lamport_single_ref_slot,
-        &[(&key_zero, &zero), (&key_alive, &one)][..],
+        1,
+        &[
+            (&key_zero_at_last_swept, &one_lamport_account),
+            (&key_zero_above_last_swept, &one_lamport_account),
+        ][..],
     ));
-    db.add_root_and_flush_write_cache(zero_lamport_single_ref_slot);
+    db.add_root_and_flush_write_cache(1);
 
-    // First clean: slot 1 is reclaimed, making slot key_zero a ZLSR. The unref path marks
-    // key_zero on slot 2's storage, but because the snapshot is still at 0 it does not
-    // mark the slot shrinkable yet.
-    db.clean_accounts(Some(zero_lamport_single_ref_slot), false);
-    assert!(
-        !db.shrink_candidate_slots
-            .lock()
-            .unwrap()
-            .contains(&zero_lamport_single_ref_slot)
-    );
+    // slot 2: zero-lamport account plus an unrelated live account so the storage still
+    // has alive bytes now that key_zero is a single-ref zero-lamport.
+    db.store_for_tests((
+        slot_at_last_swept,
+        &[
+            (&key_zero_at_last_swept, &zero_lamport_account),
+            (&Pubkey::new_unique(), &one_lamport_account),
+        ][..],
+    ));
+    db.add_root_and_flush_write_cache(slot_at_last_swept);
 
-    // Advance the snapshot past slot 2. Clean will sweep from slot 0 to 2 and
-    // must re-queue slot 2 — its zero-lamport single-ref is now shrinkable
-    db.set_latest_full_snapshot_slot(zero_lamport_single_ref_slot);
-    db.clean_accounts(Some(zero_lamport_single_ref_slot), false);
-    assert!(
-        db.shrink_candidate_slots
-            .lock()
-            .unwrap()
-            .contains(&zero_lamport_single_ref_slot)
-    );
+    // slot 3: same pattern, but for a key whose slot sits *above* the seeded
+    // last-swept slot, so it must be queued in both variants — proving the sweep
+    // walks past the last-swept slot.
+    db.store_for_tests((
+        slot_above_last_swept,
+        &[
+            (&key_zero_above_last_swept, &zero_lamport_account),
+            (&Pubkey::new_unique(), &one_lamport_account),
+        ][..],
+    ));
+    db.add_root_and_flush_write_cache(slot_above_last_swept);
 
-    // Shrink now runs below and removes key_zero
-    db.shrink_candidate_slots(&EpochSchedule::default());
-    assert!(!db.contains(&key_zero));
-    assert!(db.contains(&key_alive));
+    // Optionally mark slot 2 as already swept. `set_last_swept_full_snapshot_slot`
+    // requires `last_swept <= latest`, so advance latest to slot 2 first (it gets
+    // advanced again to `full_snapshot_slot` below).
+    if set_last_swept {
+        db.set_latest_full_snapshot_slot(slot_at_last_swept);
+        db.set_last_swept_full_snapshot_slot(slot_at_last_swept);
+    }
+
+    // Advance the snapshot past both ZLSR slots and clean
+    // The sweep range is (0, 4] when not set, queueing both slot 2 and slot 3.
+    // The sweep range is (2, 4] when set, queueing only slot 3.
+    db.set_latest_full_snapshot_slot(full_snapshot_slot);
+    db.clean_accounts(Some(full_snapshot_slot), false);
+
+    let queued = db.shrink_candidate_slots.lock().unwrap();
+    assert_eq!(queued.contains(&slot_at_last_swept), !set_last_swept);
+    assert!(queued.contains(&slot_above_last_swept));
 }
 
 fn setup_accounts_db_cache_clean(

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3601,6 +3601,71 @@ define_accounts_db_test!(
     }
 );
 
+/// When the full snapshot advances past a slot that still holds zero-lamport single-ref
+/// accounts, the next clean's range sweep must re-queue that slot for shrink so the
+/// zero lamport single ref accounts can be removed by shrink
+#[test]
+fn test_zero_lamport_single_ref_resweep_after_snapshot_advances() {
+    agave_logger::setup();
+    let db = AccountsDb::new_single_for_tests_with_provider_and_config(
+        AccountsFileProvider::default(),
+        AccountsDbConfig {
+            shrink_ratio: AccountShrinkThreshold::IndividualStore { shrink_ratio: 1.0 },
+            ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+        },
+    );
+
+    let key_zero = Pubkey::new_unique();
+    let key_alive = Pubkey::new_unique();
+    let one = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
+    let zero = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
+    let zero_lamport_single_ref_slot = 2;
+
+    // Seed the snapshot at slot 0 so the watermark starts at Some(0).
+    db.set_latest_full_snapshot_slot(0);
+
+    // slot 1: older non-zero version of key_zero, on its own so the slot dies once
+    // clean reclaims it (keeps the test focused on slot 2's sweep behavior).
+    db.store_for_tests((1, &[(&key_zero, &one)][..]));
+    db.add_root_and_flush_write_cache(1);
+    // slot 2: zero-lamport version of key_zero plus an unrelated live account so the
+    // storage still has alive bytes once key_zero becomes a single-ref zero-lamport.
+    db.store_for_tests((
+        zero_lamport_single_ref_slot,
+        &[(&key_zero, &zero), (&key_alive, &one)][..],
+    ));
+    db.add_root_and_flush_write_cache(zero_lamport_single_ref_slot);
+
+    // First clean: slot 1 is reclaimed, making slot key_zero a ZLSR. The unref path marks
+    // marks key_zero on slot 2's storage, but because the snapshot is still at 0 it does not
+    // mark the slot shrinkable yet.
+    // is still at 0 we clear shrink_candidate_slots
+    // so the second clean's sweep is the only thing that can re-add it.
+    db.clean_accounts(Some(zero_lamport_single_ref_slot), false);
+    assert!(
+        !db.shrink_candidate_slots
+            .lock()
+            .unwrap()
+            .contains(&zero_lamport_single_ref_slot)
+    );
+
+    // Advance the snapshot past slot 2. Clean will sweep from slot 0 to 2 and
+    // must re-queue slot 2 — its zero-lamport single-ref is now shrinkable
+    db.set_latest_full_snapshot_slot(zero_lamport_single_ref_slot);
+    db.clean_accounts(Some(zero_lamport_single_ref_slot), false);
+    assert!(
+        db.shrink_candidate_slots
+            .lock()
+            .unwrap()
+            .contains(&zero_lamport_single_ref_slot)
+    );
+
+    // Shrink now runs below and removes key_zero
+    db.shrink_candidate_slots(&EpochSchedule::default());
+    assert!(!db.contains(&key_zero));
+    assert!(db.contains(&key_alive));
+}
+
 fn setup_accounts_db_cache_clean(
     num_slots: usize,
     scan_slot: Option<Slot>,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -267,6 +267,13 @@ pub fn try_load_bank_forks_from_snapshot(
             .accounts
             .accounts_db
             .set_latest_full_snapshot_slot(full_snapshot_archive_info.slot());
+        // Set the last swept slot so the first full snapshot only triggers
+        // cleaning of zero lamport single ref accounts between the previous
+        // full snapshot and the new full snapshot
+        bank.rc
+            .accounts
+            .accounts_db
+            .set_last_swept_full_snapshot_slot(full_snapshot_archive_info.slot());
     } else {
         assert!(
             bank.rc


### PR DESCRIPTION
#### Problem
Zero lamport single ref accounts that inserted into stores prior to the latest full snapshot may not be revisited for shrink. This causes them to take up storage until squash handles them (after a full epoch). 

#### Summary of Changes
- Add an intset of accounts with zero lamport accounts that are newer than the latest full snapshot
- Revisit those sets after a full snapshot occurs and add them to shrink if appropriate. 

#### Notes
Originally tried creating an int set, but it basically included every storage in the window, so just switched to iterating over all: 99.4/100k stores in the window have ZLSRs. 
<img width="862" height="238" alt="image" src="https://github.com/user-attachments/assets/052d1cc1-eaf8-442a-b24c-33ace03be574" />

This also causes a fairly large spike on clean timing. Using a par_iter had roughly the same timing, as inserting into the shrink set had the same effect. One other option was par_iter and collecting into a vec...
<img width="862" height="238" alt="image" src="https://github.com/user-attachments/assets/93dd9cab-f959-443f-b9d7-8cb43734928b" />

And it very aggressively shrinks 300-500MB of accounts
<img width="862" height="238" alt="image" src="https://github.com/user-attachments/assets/e8d04cbf-43d0-4d0b-9f31-513585203230" />

You can see 3XU on this graph which has remarking of zero lamport accounts, but doesn't have this change. 


Fixes #
