### PR TITLE
Calculates 'alive bytes' for shrink consistently

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -31,7 +31,7 @@ pub struct AccountStorageEntry {
 
     pub(crate) num_alive_bytes: AtomicUsize,
 
-    /// offsets to accounts that are zero lamport single ref stored in this
+    /// offsets to accounts that are zero lamport single ref (ZLSR) stored in this
     /// storage. These are still alive. But, shrink will be able to remove them.
     ///
     /// NOTE: It's possible that one of these zero lamport single ref accounts

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2381,6 +2381,8 @@ impl AccountsDb {
         stats: &ShrinkStats,
         slot_to_shrink: Slot,
     ) -> LoadAccountsIndexForShrink<'a, T> {
+        let can_purge_zero_lamport_single_ref =
+            self.can_purge_zero_lamport_single_ref_after_shrink(slot_to_shrink);
         let count = accounts.len();
         let mut alive_accounts = T::with_capacity(count, slot_to_shrink);
         let mut pubkeys_to_unref = Vec::with_capacity(count);
@@ -2392,7 +2394,6 @@ impl AccountsDb {
         let mut index_scan_returned_some_count = 0;
         let mut index_scan_returned_none_count = 0;
         let mut all_are_zero_lamports = true;
-        let latest_full_snapshot_slot = self.latest_full_snapshot_slot();
         self.accounts_index.scan(
             accounts.iter().map(|account| account.pubkey()),
             |pubkey, slots_refs| {
@@ -2400,11 +2401,7 @@ impl AccountsDb {
                 let mut do_populate_accounts_for_shrink = |ref_count, slot_list| {
                     if stored_account.is_zero_lamport()
                         && ref_count == 1
-                        && latest_full_snapshot_slot
-                            .map(|latest_full_snapshot_slot| {
-                                latest_full_snapshot_slot >= slot_to_shrink
-                            })
-                            .unwrap_or(true)
+                        && can_purge_zero_lamport_single_ref
                     {
                         // only do this if our slot is prior to the latest full snapshot
                         // we found a zero lamport account that is the only instance of this account. We can delete it completely.
@@ -2790,7 +2787,7 @@ impl AccountsDb {
                     self.shrink_stats
                         .num_dead_slots_added_to_clean
                         .fetch_add(1, Ordering::Relaxed);
-                } else if Self::is_shrinking_productive(&store)
+                } else if self.is_shrinking_productive(&store)
                     && self.is_candidate_for_shrink(&store)
                 {
                     // this store might be eligible for shrinking now
@@ -3028,7 +3025,7 @@ impl AccountsDb {
             .storage
             .get_slot_storage_entry_shrinking_in_progress_ok(slot)
         {
-            if Self::is_shrinking_productive(&store) {
+            if self.is_shrinking_productive(&store) {
                 self.shrink_storage(store)
             }
         }
@@ -3053,26 +3050,28 @@ impl AccountsDb {
         struct StoreUsageInfo {
             slot: Slot,
             alive_ratio: f64,
+            alive_bytes_after_shrink: u64,
             store: Arc<AccountStorageEntry>,
         }
-        let mut store_usage: Vec<StoreUsageInfo> = Vec::with_capacity(shrink_slots.len());
+        let mut store_usages = Vec::with_capacity(shrink_slots.len());
         let mut total_alive_bytes: u64 = 0;
         let mut total_bytes: u64 = 0;
         for slot in shrink_slots {
             let Some(store) = self.storage.get_slot_storage_entry(*slot) else {
                 continue;
             };
-            let alive_bytes = store.alive_bytes();
-            total_alive_bytes += alive_bytes as u64;
+            let alive_bytes_after_shrink = self.alive_bytes_after_shrink(&store) as u64;
+            total_alive_bytes += alive_bytes_after_shrink;
             total_bytes += store.capacity();
-            let alive_ratio = alive_bytes as f64 / store.capacity() as f64;
-            store_usage.push(StoreUsageInfo {
+            let alive_ratio = alive_bytes_after_shrink as f64 / store.capacity() as f64;
+            store_usages.push(StoreUsageInfo {
                 slot: *slot,
                 alive_ratio,
+                alive_bytes_after_shrink,
                 store: store.clone(),
             });
         }
-        store_usage.sort_by(|a, b| {
+        store_usages.sort_by(|a, b| {
             a.alive_ratio
                 .partial_cmp(&b.alive_ratio)
                 .unwrap_or(std::cmp::Ordering::Equal)
@@ -3082,15 +3081,15 @@ impl AccountsDb {
         // shrinking while still achieving the overall goals.
         let mut shrink_slots = IntMap::default();
         let mut shrink_slots_next_batch = ShrinkCandidates::default();
-        for usage in &store_usage {
-            let store = &usage.store;
+        for store_usage in &store_usages {
+            let store = &store_usage.store;
             let alive_ratio = (total_alive_bytes as f64) / (total_bytes as f64);
             debug!(
                 "alive_ratio: {:?} store_id: {:?}, store_ratio: {:?} requirement: {:?}, \
                  total_bytes: {:?} total_alive_bytes: {:?}",
                 alive_ratio,
-                usage.store.id(),
-                usage.alive_ratio,
+                store_usage.store.id(),
+                store_usage.alive_ratio,
                 shrink_ratio,
                 total_bytes,
                 total_alive_bytes
@@ -3100,19 +3099,19 @@ impl AccountsDb {
                 debug!(
                     "Shrinking goal can be achieved at slot {:?}, total_alive_bytes: {:?} \
                      total_bytes: {:?}, alive_ratio: {:}, shrink_ratio: {:?}",
-                    usage.slot, total_alive_bytes, total_bytes, alive_ratio, shrink_ratio
+                    store_usage.slot, total_alive_bytes, total_bytes, alive_ratio, shrink_ratio
                 );
-                if usage.alive_ratio < shrink_ratio {
-                    shrink_slots_next_batch.insert(usage.slot);
+                if store_usage.alive_ratio < shrink_ratio {
+                    shrink_slots_next_batch.insert(store_usage.slot);
                 } else {
                     break;
                 }
             } else {
                 let current_store_size = store.capacity();
-                let after_shrink_size = store.alive_bytes() as u64;
+                let after_shrink_size = store_usage.alive_bytes_after_shrink;
                 let bytes_saved = current_store_size.saturating_sub(after_shrink_size);
                 total_bytes -= bytes_saved;
-                shrink_slots.insert(usage.slot, Arc::clone(store));
+                shrink_slots.insert(store_usage.slot, Arc::clone(store));
             }
         }
         (shrink_slots, shrink_slots_next_batch)
@@ -3241,9 +3240,10 @@ impl AccountsDb {
                 if let Some(store) = self.storage.get_slot_storage_entry(slot) {
                     if !shrink_slots.contains(&slot)
                         && capacity == store.capacity()
-                        && Self::is_candidate_for_shrink(self, &store)
+                        && self.is_candidate_for_shrink(&store)
                     {
-                        let ancient_bytes_added_to_shrink = store.alive_bytes() as u64;
+                        let ancient_bytes_added_to_shrink =
+                            self.alive_bytes_after_shrink(&store) as u64;
                         shrink_slots.insert(slot, store);
                         self.shrink_stats
                             .ancient_bytes_added_to_shrink
@@ -5130,10 +5130,28 @@ impl AccountsDb {
         alive_bytes >= total_bytes
     }
 
-    fn is_shrinking_productive(store: &AccountStorageEntry) -> bool {
+    /// Can zero lamport single ref accounts in `slot` be purged?
+    fn can_purge_zero_lamport_single_ref_after_shrink(&self, slot: Slot) -> bool {
+        self.latest_full_snapshot_slot()
+            .is_none_or(|latest_full_snapshot_slot| slot <= latest_full_snapshot_slot)
+    }
+
+    /// Returns the expected alive bytes after shrinking `store`.
+    pub(crate) fn alive_bytes_after_shrink(&self, store: &AccountStorageEntry) -> usize {
+        // Obsolete accounts are already excluded from `store.alive_bytes()`.
+        // Zero-lamport single-ref accounts are counted as alive until shrink can purge them,
+        // which is gated by the latest full snapshot slot.
+        if self.can_purge_zero_lamport_single_ref_after_shrink(store.slot()) {
+            store.alive_bytes_exclude_zero_lamport_single_ref_accounts()
+        } else {
+            store.alive_bytes()
+        }
+    }
+
+    fn is_shrinking_productive(&self, store: &AccountStorageEntry) -> bool {
         let alive_count = store.count();
         let total_bytes = store.capacity();
-        let alive_bytes = store.alive_bytes_exclude_zero_lamport_single_ref_accounts() as u64;
+        let alive_bytes = self.alive_bytes_after_shrink(store) as u64;
         if Self::should_not_shrink(alive_bytes, total_bytes) {
             trace!(
                 "shrink_slot_forced ({}): not able to shrink at all: num alive: {}, bytes alive: \
@@ -5157,7 +5175,7 @@ impl AccountsDb {
         // It is not possible to identify ancient append vecs when we pack, so no check for ancient when we are not appending.
         let total_bytes = store.capacity();
 
-        let alive_bytes = store.alive_bytes_exclude_zero_lamport_single_ref_accounts() as u64;
+        let alive_bytes = self.alive_bytes_after_shrink(store) as u64;
         match self.shrink_ratio {
             AccountShrinkThreshold::TotalSpace { shrink_ratio: _ } => alive_bytes < total_bytes,
             AccountShrinkThreshold::IndividualStore { shrink_ratio } => {
@@ -5253,7 +5271,7 @@ impl AccountsDb {
                 if remaining_accounts == 0 {
                     self.dirty_stores.insert(*slot, store);
                     dead_slots.insert(*slot);
-                } else if Self::is_shrinking_productive(&store)
+                } else if self.is_shrinking_productive(&store)
                     && self.is_candidate_for_shrink(&store)
                 {
                     // Checking that this single storage entry is ready for shrinking,
@@ -5818,7 +5836,7 @@ impl AccountsDb {
             // If any zero lamport accounts were marked, the storage may be valid for shrinking
             if num_marked > 0
                 && self.is_candidate_for_shrink(storage)
-                && Self::is_shrinking_productive(storage)
+                && self.is_shrinking_productive(storage)
             {
                 self.shrink_candidate_slots
                     .lock()

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1145,6 +1145,83 @@ fn test_shrink_zero_lamport_single_ref_account() {
     }
 }
 
+/// unit test for `alive_bytes_after_shrink()`
+///
+/// Check all the permutations of latest full snapshot slot w.r.t. if/how
+/// zero lamport single ref accounts are counted as alive bytes or not.
+#[test]
+fn test_alive_bytes_after_shrink() {
+    let accounts_db = AccountsDb::new_single_for_tests();
+    let slot = 5;
+    // note the initial alive bytes should be big enough so that subtracting
+    // all the zero lamport single ref accounts does not saturate at zero.
+    let initial_alive_bytes = 123_456;
+    let store = create_store_for_shrink_candidate_tests(
+        &accounts_db,
+        slot,
+        4096, // <-- file size
+        initial_alive_bytes,
+        2, // <-- num zero lamport single ref accounts
+    );
+
+    // test case: latest full snapshot slot is None -- ZLSR accounts are dead
+    {
+        // latest full snapshot slot starts off as None
+        assert!(accounts_db.latest_full_snapshot_slot().is_none());
+
+        // ensure ZLSR accounts are dead bytes
+        let alive_bytes_after_shrink1 = accounts_db.alive_bytes_after_shrink(&store);
+        assert!(alive_bytes_after_shrink1 < initial_alive_bytes);
+
+        // add a ZLSR account, and ensure alive bytes reduces
+        store.insert_zero_lamport_single_ref_account_offset(2);
+        let alive_bytes_after_shrink2 = accounts_db.alive_bytes_after_shrink(&store);
+        assert!(alive_bytes_after_shrink2 < alive_bytes_after_shrink1);
+    }
+
+    // test case: slot > latest full snapshot -- ZLSR accounts are alive
+    {
+        accounts_db.set_latest_full_snapshot_slot(slot - 1);
+
+        // ensure ZLSR accounts are *not* dead bytes
+        let alive_bytes_after_shrink1 = accounts_db.alive_bytes_after_shrink(&store);
+        assert_eq!(alive_bytes_after_shrink1, initial_alive_bytes);
+
+        // add a ZLSR account, and ensure alive bytes is unchanged
+        store.insert_zero_lamport_single_ref_account_offset(3);
+        let alive_bytes_after_shrink2 = accounts_db.alive_bytes_after_shrink(&store);
+        assert_eq!(alive_bytes_after_shrink2, initial_alive_bytes);
+    }
+
+    // test case: slot == latest full snapshot -- ZLSR accounts are dead
+    {
+        accounts_db.set_latest_full_snapshot_slot(slot);
+
+        // ensure ZLSR accounts are dead bytes
+        let alive_bytes_after_shrink1 = accounts_db.alive_bytes_after_shrink(&store);
+        assert!(alive_bytes_after_shrink1 < initial_alive_bytes);
+
+        // add a ZLSR account, and ensure alive bytes reduces
+        store.insert_zero_lamport_single_ref_account_offset(4);
+        let alive_bytes_after_shrink2 = accounts_db.alive_bytes_after_shrink(&store);
+        assert!(alive_bytes_after_shrink2 < alive_bytes_after_shrink1);
+    }
+
+    // test case: slot < latest full snapshot -- ZLSR accounts are dead
+    {
+        accounts_db.set_latest_full_snapshot_slot(slot + 1);
+
+        // ensure ZLSR accounts are dead bytes
+        let alive_bytes_after_shrink1 = accounts_db.alive_bytes_after_shrink(&store);
+        assert!(alive_bytes_after_shrink1 < initial_alive_bytes);
+
+        // add a ZLSR account, and ensure alive bytes reduces
+        store.insert_zero_lamport_single_ref_account_offset(5);
+        let alive_bytes_after_shrink2 = accounts_db.alive_bytes_after_shrink(&store);
+        assert!(alive_bytes_after_shrink2 < alive_bytes_after_shrink1);
+    }
+}
+
 /// Ensure that shrinking a storage...
 /// * with zero lamport single ref accounts
 /// * in a slot *older* than the latest full snapshot slot

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1145,6 +1145,88 @@ fn test_shrink_zero_lamport_single_ref_account() {
     }
 }
 
+/// Ensure that shrinking a storage...
+/// * with zero lamport single ref accounts
+/// * in a slot *older* than the latest full snapshot slot
+///
+/// Results in...
+/// * the zero lamport single ref accounts *not* in the shrunk storage
+/// * the expected number of alive bytes
+#[test]
+fn test_alive_bytes_after_shrink_with_zero_lamport_single_ref_accounts() {
+    let accounts_db = AccountsDb::new_single_for_tests();
+    let slot = 1;
+    let dead_account = AccountSharedData::new(0, 123, &Pubkey::default());
+    let dead_pubkeys = [
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+    ];
+    let alive_account = AccountSharedData::new(11, 17, &Pubkey::default());
+    let alive_pubkey = Pubkey::new_unique();
+
+    accounts_db.store_for_tests((
+        slot,
+        [
+            (&dead_pubkeys[0], &dead_account),
+            (&dead_pubkeys[1], &dead_account),
+            (&dead_pubkeys[2], &dead_account),
+            (&alive_pubkey, &alive_account),
+        ]
+        .as_slice(),
+    ));
+    accounts_db.add_root_and_flush_write_cache(slot);
+
+    // We must set the latest full snapshot slot to `slot` or greater
+    // to ensure that ZLSR accounts are treated as dead for `shrink`.
+    accounts_db.set_latest_full_snapshot_slot(slot);
+
+    let storage = accounts_db.get_storage_for_slot(slot).unwrap();
+    accounts_db.accounts_index.scan(
+        dead_pubkeys.iter(),
+        |_pubkey, slots_refs| {
+            let (slot_list, ref_count) = slots_refs.unwrap();
+            assert_eq!(slot_list.len(), 1);
+            assert_eq!(ref_count, 1);
+
+            let (indexed_slot, acct_info) = slot_list.first().unwrap();
+            assert_eq!(*indexed_slot, slot);
+            assert!(acct_info.is_zero_lamport());
+            accounts_db.zero_lamport_single_ref_found(*indexed_slot, acct_info.offset());
+            AccountsIndexScanResult::KeepInMemory
+        },
+        None,
+        ScanFilter::All,
+    );
+
+    assert_eq!(
+        storage.num_zero_lamport_single_ref_accounts(),
+        dead_pubkeys.len(),
+    );
+
+    let alive_bytes_before_shrink = storage.alive_bytes();
+    let expected_alive_bytes_after_shrink = accounts_db.alive_bytes_after_shrink(&storage);
+    assert_ne!(expected_alive_bytes_after_shrink, 0);
+    assert!(expected_alive_bytes_after_shrink < alive_bytes_before_shrink);
+    assert_eq!(
+        expected_alive_bytes_after_shrink,
+        AppendVec::calculate_stored_size(alive_account.data().len()),
+    );
+
+    accounts_db.shrink_slot_forced(slot);
+
+    let storage_after_shrink = accounts_db.get_storage_for_slot(slot).unwrap();
+    assert_eq!(
+        storage_after_shrink.alive_bytes(),
+        expected_alive_bytes_after_shrink,
+    );
+    assert_eq!(storage_after_shrink.count(), 1);
+    assert!(accounts_db.contains(&alive_pubkey));
+    for pubkey in &dead_pubkeys {
+        assert!(!accounts_db.contains(pubkey));
+    }
+}
+
 #[test]
 fn test_clean_multiple_zero_lamport_decrements_index_ref_count() {
     agave_logger::setup();
@@ -2334,6 +2416,141 @@ fn test_select_candidates_by_total_usage_all_clean() {
     assert!(selected_candidates.contains(&store1_slot));
     assert!(selected_candidates.contains(&store2_slot));
     assert_eq!(0, next_candidates.len());
+}
+
+fn create_store_for_shrink_candidate_tests(
+    accounts_db: &AccountsDb,
+    slot: Slot,
+    file_size: u64,
+    alive_bytes: usize,
+    num_zero_lamport_single_ref_accounts: usize,
+) -> Arc<AccountStorageEntry> {
+    let store = Arc::new(AccountStorageEntry::new(
+        Path::new(""),
+        slot,
+        slot as AccountsFileId,
+        file_size,
+        AccountsFileProvider::AppendVec,
+    ));
+    accounts_db.storage.insert(Arc::clone(&store));
+    store.add_accounts(num_zero_lamport_single_ref_accounts.max(1), alive_bytes);
+    for offset in 0..num_zero_lamport_single_ref_accounts {
+        store.insert_zero_lamport_single_ref_account_offset(offset);
+    }
+    store
+}
+
+/// Ensure selecting shrink candidates respects zero-lamport single-ref accounts,
+/// when a latest full snapshot is *not* set.
+#[test]
+fn test_select_candidates_by_total_usage_zlsr_no_latest_full_snapshot() {
+    let accounts_db = AccountsDb::new_single_for_tests();
+    let mut shrink_candidates = ShrinkCandidates::default();
+
+    let num_zero_lamport_single_ref_accounts = 4;
+    let file_size = AppendVec::calculate_stored_size(0) * num_zero_lamport_single_ref_accounts;
+
+    let slot_with_zlsr = 11;
+    let store_with_zlsr = create_store_for_shrink_candidate_tests(
+        &accounts_db,
+        slot_with_zlsr,
+        file_size as u64,
+        file_size,
+        num_zero_lamport_single_ref_accounts,
+    );
+    shrink_candidates.insert(slot_with_zlsr);
+
+    let slot_no_zlsr = 22;
+    let store_no_zlsr = create_store_for_shrink_candidate_tests(
+        &accounts_db,
+        slot_no_zlsr,
+        file_size as u64,
+        file_size * 9 / 10,
+        0,
+    );
+    shrink_candidates.insert(slot_no_zlsr);
+
+    // With no latest full snapshot slot, shrink can purge zero-lamport
+    // single-ref accounts.
+    assert!(accounts_db.latest_full_snapshot_slot().is_none());
+
+    // Bytes from ZLSR accounts are alive, but would be dead after shrink.
+    assert_eq!(store_with_zlsr.alive_bytes(), file_size);
+    assert_eq!(accounts_db.alive_bytes_after_shrink(&store_with_zlsr), 0);
+    assert!(accounts_db.is_candidate_for_shrink(&store_with_zlsr));
+    assert!(accounts_db.is_shrinking_productive(&store_with_zlsr));
+
+    // Stores without ZLSR accounts use the raw alive bytes.
+    assert_eq!(
+        accounts_db.alive_bytes_after_shrink(&store_no_zlsr),
+        store_no_zlsr.alive_bytes(),
+    );
+
+    let (selected_candidates, next_candidates) = accounts_db
+        .select_candidates_by_total_usage(&shrink_candidates, DEFAULT_ACCOUNTS_SHRINK_RATIO);
+
+    assert_eq!(1, selected_candidates.len());
+    assert!(selected_candidates.contains_key(&slot_with_zlsr));
+
+    // slot 22 is above the shrink ratio, so ensure it is not a candidate
+    assert!(next_candidates.is_empty());
+}
+
+/// Ensure selecting shrink candidates respects zero-lamport single-ref accounts,
+/// when a latest full snapshot *is* set.
+#[test]
+fn test_select_candidates_by_total_usage_zlsr_latest_full_snapshot() {
+    let accounts_db = AccountsDb::new_single_for_tests();
+    let mut candidates = ShrinkCandidates::default();
+
+    let num_zero_lamport_single_ref_accounts = 4;
+    let file_size = AppendVec::calculate_stored_size(0) * num_zero_lamport_single_ref_accounts;
+
+    let slot_with_zlsr = 11;
+    let store_with_zlsr = create_store_for_shrink_candidate_tests(
+        &accounts_db,
+        slot_with_zlsr,
+        file_size as u64,
+        file_size,
+        num_zero_lamport_single_ref_accounts,
+    );
+    candidates.insert(slot_with_zlsr);
+
+    let slot_no_zlsr = 22;
+    let store_no_zlsr = create_store_for_shrink_candidate_tests(
+        &accounts_db,
+        slot_no_zlsr,
+        file_size as u64,
+        file_size * 9 / 10,
+        0,
+    );
+    candidates.insert(slot_no_zlsr);
+
+    // Set the latest full snapshot slot *older* than the
+    // store with zero lamport single ref accounts.
+    // This ensures shrink will see ZLSR accounts as *alive*.
+    accounts_db.set_latest_full_snapshot_slot(slot_with_zlsr - 1);
+
+    // Bytes from ZLSR accounts are alive, and will stay alive after shrink.
+    assert_eq!(
+        accounts_db.alive_bytes_after_shrink(&store_with_zlsr),
+        store_with_zlsr.alive_bytes(),
+    );
+    assert!(!accounts_db.is_candidate_for_shrink(&store_with_zlsr));
+    assert!(!accounts_db.is_shrinking_productive(&store_with_zlsr));
+
+    // Stores without ZLSR accounts use the raw alive bytes.
+    assert_eq!(
+        accounts_db.alive_bytes_after_shrink(&store_no_zlsr),
+        store_no_zlsr.alive_bytes(),
+    );
+
+    let (selected_candidates, next_candidates) =
+        accounts_db.select_candidates_by_total_usage(&candidates, DEFAULT_ACCOUNTS_SHRINK_RATIO);
+
+    // both slots are above the shrink ratio, so neither should be shrink candidates
+    assert!(selected_candidates.is_empty());
+    assert!(next_candidates.is_empty());
 }
 
 #[test]
@@ -4246,6 +4463,7 @@ fn test_remove_uncleaned_slots_and_collect_pubkeys_up_to_slot() {
 #[test]
 fn test_shrink_productive() {
     agave_logger::setup();
+    let accounts = AccountsDb::new_single_for_tests();
     let path = Path::new("");
     let file_size = 100;
     let slot = 11;
@@ -4258,7 +4476,7 @@ fn test_shrink_productive() {
         AccountsFileProvider::AppendVec,
     ));
     store.add_account(file_size as usize);
-    assert!(!AccountsDb::is_shrinking_productive(&store));
+    assert!(!accounts.is_shrinking_productive(&store));
 
     let store = Arc::new(AccountStorageEntry::new(
         path,
@@ -4270,10 +4488,10 @@ fn test_shrink_productive() {
     store.add_account(file_size as usize / 2);
     store.add_account(file_size as usize / 4);
     store.remove_accounts(file_size as usize / 4, 1);
-    assert!(AccountsDb::is_shrinking_productive(&store));
+    assert!(accounts.is_shrinking_productive(&store));
 
     store.add_account(file_size as usize / 2);
-    assert!(!AccountsDb::is_shrinking_productive(&store));
+    assert!(!accounts.is_shrinking_productive(&store));
 }
 
 #[test]

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -107,6 +107,28 @@ impl AccountStorageEntry {
     }
 }
 
+fn create_store_for_shrink_tests(
+    accounts_db: &AccountsDb,
+    slot: Slot,
+    file_size: u64,
+    alive_bytes: usize,
+    num_zero_lamport_single_ref_accounts: usize,
+) -> Arc<AccountStorageEntry> {
+    let store = Arc::new(AccountStorageEntry::new(
+        Path::new(""),
+        slot,
+        slot as AccountsFileId,
+        file_size,
+        AccountsFileProvider::AppendVec,
+    ));
+    accounts_db.storage.insert(Arc::clone(&store));
+    store.add_accounts(num_zero_lamport_single_ref_accounts.max(1), alive_bytes);
+    for offset in 0..num_zero_lamport_single_ref_accounts {
+        store.insert_zero_lamport_single_ref_account_offset(offset);
+    }
+    store
+}
+
 /// Macro to define tests for all permutations of accounts-db configs
 ///
 /// E.g. account storage file format
@@ -1156,7 +1178,7 @@ fn test_alive_bytes_after_shrink() {
     // note the initial alive bytes should be big enough so that subtracting
     // all the zero lamport single ref accounts does not saturate at zero.
     let initial_alive_bytes = 123_456;
-    let store = create_store_for_shrink_candidate_tests(
+    let store = create_store_for_shrink_tests(
         &accounts_db,
         slot,
         4096, // <-- file size
@@ -2495,32 +2517,9 @@ fn test_select_candidates_by_total_usage_all_clean() {
     assert_eq!(0, next_candidates.len());
 }
 
-fn create_store_for_shrink_candidate_tests(
-    accounts_db: &AccountsDb,
-    slot: Slot,
-    file_size: u64,
-    alive_bytes: usize,
-    num_zero_lamport_single_ref_accounts: usize,
-) -> Arc<AccountStorageEntry> {
-    let store = Arc::new(AccountStorageEntry::new(
-        Path::new(""),
-        slot,
-        slot as AccountsFileId,
-        file_size,
-        AccountsFileProvider::AppendVec,
-    ));
-    accounts_db.storage.insert(Arc::clone(&store));
-    store.add_accounts(num_zero_lamport_single_ref_accounts.max(1), alive_bytes);
-    for offset in 0..num_zero_lamport_single_ref_accounts {
-        store.insert_zero_lamport_single_ref_account_offset(offset);
-    }
-    store
-}
-
-/// Ensure selecting shrink candidates respects zero-lamport single-ref accounts,
-/// when a latest full snapshot is *not* set.
+/// Ensure selecting shrink candidates respects zero-lamport single-ref accounts.
 #[test]
-fn test_select_candidates_by_total_usage_zlsr_no_latest_full_snapshot() {
+fn test_select_candidates_by_total_usage_with_zero_lamport_single_ref_accounts() {
     let accounts_db = AccountsDb::new_single_for_tests();
     let mut shrink_candidates = ShrinkCandidates::default();
 
@@ -2528,7 +2527,7 @@ fn test_select_candidates_by_total_usage_zlsr_no_latest_full_snapshot() {
     let file_size = AppendVec::calculate_stored_size(0) * num_zero_lamport_single_ref_accounts;
 
     let slot_with_zlsr = 11;
-    let store_with_zlsr = create_store_for_shrink_candidate_tests(
+    let store_with_zlsr = create_store_for_shrink_tests(
         &accounts_db,
         slot_with_zlsr,
         file_size as u64,
@@ -2538,7 +2537,7 @@ fn test_select_candidates_by_total_usage_zlsr_no_latest_full_snapshot() {
     shrink_candidates.insert(slot_with_zlsr);
 
     let slot_no_zlsr = 22;
-    let store_no_zlsr = create_store_for_shrink_candidate_tests(
+    let store_no_zlsr = create_store_for_shrink_tests(
         &accounts_db,
         slot_no_zlsr,
         file_size as u64,
@@ -2547,87 +2546,69 @@ fn test_select_candidates_by_total_usage_zlsr_no_latest_full_snapshot() {
     );
     shrink_candidates.insert(slot_no_zlsr);
 
-    // With no latest full snapshot slot, shrink can purge zero-lamport
-    // single-ref accounts.
-    assert!(accounts_db.latest_full_snapshot_slot().is_none());
+    // test case: The latest full snapshot slot is *older* than
+    // the store with zero lamport single ref accounts.
+    // Ensure shrink will see ZLSR accounts as *alive*.
+    {
+        accounts_db.set_latest_full_snapshot_slot(slot_with_zlsr - 1);
 
-    // Bytes from ZLSR accounts are alive, but would be dead after shrink.
-    assert_eq!(store_with_zlsr.alive_bytes(), file_size);
-    assert_eq!(accounts_db.alive_bytes_after_shrink(&store_with_zlsr), 0);
-    assert!(accounts_db.is_candidate_for_shrink(&store_with_zlsr));
-    assert!(accounts_db.is_shrinking_productive(&store_with_zlsr));
+        // Bytes from ZLSR accounts are alive, and will stay alive after shrink.
+        assert_eq!(
+            accounts_db.alive_bytes_after_shrink(&store_with_zlsr),
+            store_with_zlsr.alive_bytes(),
+        );
+        assert!(!accounts_db.is_candidate_for_shrink(&store_with_zlsr));
+        assert!(!accounts_db.is_shrinking_productive(&store_with_zlsr));
 
-    // Stores without ZLSR accounts use the raw alive bytes.
-    assert_eq!(
-        accounts_db.alive_bytes_after_shrink(&store_no_zlsr),
-        store_no_zlsr.alive_bytes(),
-    );
+        // Stores without ZLSR accounts use the raw alive bytes.
+        assert_eq!(
+            accounts_db.alive_bytes_after_shrink(&store_no_zlsr),
+            store_no_zlsr.alive_bytes(),
+        );
 
-    let (selected_candidates, next_candidates) = accounts_db
-        .select_candidates_by_total_usage(&shrink_candidates, DEFAULT_ACCOUNTS_SHRINK_RATIO);
+        let (selected_candidates, next_candidates) = accounts_db
+            .select_candidates_by_total_usage(&shrink_candidates, DEFAULT_ACCOUNTS_SHRINK_RATIO);
 
-    assert_eq!(1, selected_candidates.len());
-    assert!(selected_candidates.contains_key(&slot_with_zlsr));
+        // both slots are above the shrink ratio, so neither should be shrink candidates
+        assert!(selected_candidates.is_empty());
+        assert!(next_candidates.is_empty());
+    }
 
-    // slot 22 is above the shrink ratio, so ensure it is not a candidate
-    assert!(next_candidates.is_empty());
-}
+    // test case: The latest full snapshot slot is either:
+    // * newer than the store with ZLSR accounts
+    // * the same as the store with ZLSR accounts
+    // * unset
+    // Ensure shrink will see ZLSR accounts as *dead*.
+    {
+        for latest_full_snapshot_slot in [Some(slot_with_zlsr + 1), Some(slot_with_zlsr), None] {
+            *accounts_db.latest_full_snapshot_slot.lock_write() = latest_full_snapshot_slot;
 
-/// Ensure selecting shrink candidates respects zero-lamport single-ref accounts,
-/// when a latest full snapshot *is* set.
-#[test]
-fn test_select_candidates_by_total_usage_zlsr_latest_full_snapshot() {
-    let accounts_db = AccountsDb::new_single_for_tests();
-    let mut candidates = ShrinkCandidates::default();
+            // Bytes from ZLSR accounts are alive, but would be dead after shrink.
+            assert_eq!(store_with_zlsr.alive_bytes(), file_size);
+            assert_eq!(accounts_db.alive_bytes_after_shrink(&store_with_zlsr), 0);
+            assert!(accounts_db.is_candidate_for_shrink(&store_with_zlsr));
+            assert!(accounts_db.is_shrinking_productive(&store_with_zlsr));
 
-    let num_zero_lamport_single_ref_accounts = 4;
-    let file_size = AppendVec::calculate_stored_size(0) * num_zero_lamport_single_ref_accounts;
+            // Stores without ZLSR accounts use the raw alive bytes.
+            assert_eq!(
+                accounts_db.alive_bytes_after_shrink(&store_no_zlsr),
+                store_no_zlsr.alive_bytes(),
+            );
 
-    let slot_with_zlsr = 11;
-    let store_with_zlsr = create_store_for_shrink_candidate_tests(
-        &accounts_db,
-        slot_with_zlsr,
-        file_size as u64,
-        file_size,
-        num_zero_lamport_single_ref_accounts,
-    );
-    candidates.insert(slot_with_zlsr);
+            let (selected_candidates, next_candidates) = accounts_db
+                .select_candidates_by_total_usage(
+                    &shrink_candidates,
+                    DEFAULT_ACCOUNTS_SHRINK_RATIO,
+                );
 
-    let slot_no_zlsr = 22;
-    let store_no_zlsr = create_store_for_shrink_candidate_tests(
-        &accounts_db,
-        slot_no_zlsr,
-        file_size as u64,
-        file_size * 9 / 10,
-        0,
-    );
-    candidates.insert(slot_no_zlsr);
+            // slot 11 with the ZLSR accounts *is* selected for shrink
+            assert_eq!(1, selected_candidates.len());
+            assert!(selected_candidates.contains_key(&slot_with_zlsr));
 
-    // Set the latest full snapshot slot *older* than the
-    // store with zero lamport single ref accounts.
-    // This ensures shrink will see ZLSR accounts as *alive*.
-    accounts_db.set_latest_full_snapshot_slot(slot_with_zlsr - 1);
-
-    // Bytes from ZLSR accounts are alive, and will stay alive after shrink.
-    assert_eq!(
-        accounts_db.alive_bytes_after_shrink(&store_with_zlsr),
-        store_with_zlsr.alive_bytes(),
-    );
-    assert!(!accounts_db.is_candidate_for_shrink(&store_with_zlsr));
-    assert!(!accounts_db.is_shrinking_productive(&store_with_zlsr));
-
-    // Stores without ZLSR accounts use the raw alive bytes.
-    assert_eq!(
-        accounts_db.alive_bytes_after_shrink(&store_no_zlsr),
-        store_no_zlsr.alive_bytes(),
-    );
-
-    let (selected_candidates, next_candidates) =
-        accounts_db.select_candidates_by_total_usage(&candidates, DEFAULT_ACCOUNTS_SHRINK_RATIO);
-
-    // both slots are above the shrink ratio, so neither should be shrink candidates
-    assert!(selected_candidates.is_empty());
-    assert!(next_candidates.is_empty());
+            // slot 22 is above the shrink ratio, so ensure it is not a candidate
+            assert!(next_candidates.is_empty());
+        }
+    }
 }
 
 #[test]

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -61,7 +61,7 @@ struct SlotInfo {
     slot: Slot,
     /// total capacity of storage
     capacity: u64,
-    /// # alive bytes in storage
+    /// # alive bytes in storage *after* shrinking
     alive_bytes: u64,
     /// true if this should be shrunk due to ratio
     should_shrink: bool,
@@ -95,14 +95,14 @@ impl AncientSlotInfos {
         &mut self,
         slot: Slot,
         storage: Arc<AccountStorageEntry>,
+        alive_bytes_after_shrink: u64,
         can_randomly_shrink: bool,
         ideal_size: NonZeroU64,
         is_high_slot: bool,
         is_candidate_for_shrink: bool,
     ) -> bool {
         let mut was_randomly_shrunk = false;
-        let alive_bytes = storage.alive_bytes() as u64;
-        if alive_bytes > 0 {
+        if alive_bytes_after_shrink > 0 {
             let capacity = storage.accounts.capacity();
             let should_shrink = if capacity > 0 {
                 if is_candidate_for_shrink {
@@ -123,11 +123,11 @@ impl AncientSlotInfos {
             if should_shrink {
                 // alive ratio is too low, so prioritize combining this slot with others
                 // to reduce disk space used
-                self.total_alive_bytes_shrink += alive_bytes;
+                self.total_alive_bytes_shrink += alive_bytes_after_shrink;
                 self.shrink_indexes.push(self.all_infos.len());
             } else {
                 let already_ideal_size = u64::from(ideal_size) * 80 / 100;
-                if alive_bytes > already_ideal_size {
+                if alive_bytes_after_shrink > already_ideal_size {
                     // do not include this append vec at all. It is already ideal size and not a candidate for shrink.
                     return was_randomly_shrunk;
                 }
@@ -136,11 +136,11 @@ impl AncientSlotInfos {
                 slot,
                 capacity,
                 storage,
-                alive_bytes,
+                alive_bytes: alive_bytes_after_shrink,
                 should_shrink,
                 is_high_slot,
             });
-            self.total_alive_bytes += alive_bytes;
+            self.total_alive_bytes += alive_bytes_after_shrink;
         }
         was_randomly_shrunk
     }
@@ -602,9 +602,11 @@ impl AccountsDb {
         for slot in &slots {
             if let Some(storage) = self.storage.get_slot_storage_entry(*slot) {
                 let is_candidate_for_shrink = self.is_candidate_for_shrink(&storage);
+                let alive_bytes_after_shrink = self.alive_bytes_after_shrink(&storage) as u64;
                 if infos.add(
                     *slot,
                     storage,
+                    alive_bytes_after_shrink,
                     tuning.can_randomly_shrink,
                     tuning.ideal_storage_size,
                     is_high_slot(*slot),
@@ -2432,6 +2434,7 @@ mod tests {
                         infos.add(
                             slot1,
                             Arc::clone(&storage),
+                            db.alive_bytes_after_shrink(&storage) as u64,
                             can_randomly_shrink,
                             NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
                             high_slot,
@@ -2487,6 +2490,7 @@ mod tests {
                 infos.add(
                     slot1,
                     Arc::clone(&storage),
+                    db.alive_bytes_after_shrink(&storage) as u64,
                     can_randomly_shrink,
                     NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
                     high_slot,


### PR DESCRIPTION
#### Problem

`shrink` is inconsistent when checking if a storage is worth shrinking or not (i.e. `is_shrinking_productive()` and `is_candidate_for_shrink()`) vs when actually selecting the storages to shrink (i.e. `select_candidates_by_total_usage()`).

This is apparent when a storage has zero lamport single ref accounts marked in the AccountStorageEntry, and older than the latest full snapshot slot. One will consider these bytes dead, and the other considers the bytes alive.


#### Summary of Changes

Add a new fn, `alive_bytes_after_shrink()`, that all shrink code paths will use. The new fn is aware of zero lamport single ref accounts, and the latest full snapshot slot.