### PR TITLE
Split Store Accounts Stats into Flush/Shrink

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -40,8 +40,8 @@ use {
         accounts_db::stats::{
             AccountsStats, CleanAccountsStats, FlushStats, LoadAccountsStats,
             ObsoleteAccountsStats, PurgeStats, ShrinkAncientStats, ShrinkStats, ShrinkStatsSub,
-            StoreAccountsFrozenStats, StoreAccountsTiming, StoreAccountsUnfrozenStats,
-            WriteAccountsToCacheStats,
+            StoreAccountsForFlushStats, StoreAccountsForShrinkStats, StoreAccountsTiming,
+            StoreAccountsUnfrozenStats, WriteAccountsToCacheStats,
         },
         accounts_file::{AccountsFile, AccountsFileProvider},
         accounts_hash::{AccountLtHash, AccountsLtHash, ZERO_LAMPORT_ACCOUNT_LT_HASH},
@@ -921,8 +921,11 @@ pub struct AccountsDb {
     /// Stats from storing accounts unfrozen
     store_accounts_unfrozen_stats: StoreAccountsUnfrozenStats,
 
-    /// Stats from storing accounts frozen
-    store_accounts_frozen_stats: StoreAccountsFrozenStats,
+    /// Stats from storing accounts for shrink
+    store_accounts_for_shrink_stats: StoreAccountsForShrinkStats,
+
+    /// Stats from storing accounts for flush
+    store_accounts_for_flush_stats: StoreAccountsForFlushStats,
 
     clean_accounts_stats: CleanAccountsStats,
 
@@ -1143,7 +1146,8 @@ impl AccountsDb {
             stats: AccountsStats::default(),
             load_account_stats: LoadAccountsStats::default(),
             store_accounts_unfrozen_stats: StoreAccountsUnfrozenStats::default(),
-            store_accounts_frozen_stats: StoreAccountsFrozenStats::default(),
+            store_accounts_for_shrink_stats: StoreAccountsForShrinkStats::default(),
+            store_accounts_for_flush_stats: StoreAccountsForFlushStats::default(),
             #[cfg(test)]
             load_delay: u64::default(),
             #[cfg(test)]
@@ -5508,7 +5512,7 @@ impl AccountsDb {
     ) -> StoreAccountsTiming {
         let slot = accounts.target_slot();
         let num_accounts_stored = accounts.len();
-        let stats = &self.store_accounts_frozen_stats;
+        let stats = &self.store_accounts_for_shrink_stats;
 
         debug_assert!(self.accounts_index.is_alive_root(slot));
 
@@ -5574,7 +5578,7 @@ impl AccountsDb {
     ) -> StoreAccountsTiming {
         let slot = accounts.target_slot();
         let num_accounts_stored = accounts.len();
-        let stats = &self.store_accounts_frozen_stats;
+        let stats = &self.store_accounts_for_flush_stats;
 
         debug_assert!(self.accounts_index.is_alive_root(slot));
 

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -121,7 +121,7 @@ impl StoreAccountsForShrinkStats {
         }
 
         datapoint_info!(
-            "accounts_db_store_accounts_shrink",
+            "accounts_db_store_accounts_for_shrink",
             (
                 "flush_read_cache_us",
                 self.flush_read_cache_us.swap(0, Ordering::Relaxed),

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -101,11 +101,55 @@ impl StoreAccountsUnfrozenStats {
     }
 }
 
-/// Stats from storing accounts frozen (i.e. to an account storage file)
+/// Stats from storing accounts for shrink (i.e. moving accounts between storage files)
 #[derive(Debug, Default)]
-pub struct StoreAccountsFrozenStats {
+pub struct StoreAccountsForShrinkStats {
     pub last_report: AtomicInterval,
     pub flush_read_cache_us: AtomicU64,
+    pub write_to_storage_us: AtomicU64,
+    pub update_index_us: AtomicU64,
+    pub num_accounts_stored: AtomicU64,
+}
+
+impl StoreAccountsForShrinkStats {
+    const REPORT_INTERVAL_MS: u64 = Duration::from_secs(1).as_millis() as u64;
+
+    pub fn report(&self) {
+        let should_report = self.last_report.should_update(Self::REPORT_INTERVAL_MS);
+        if !should_report {
+            return;
+        }
+
+        datapoint_info!(
+            "accounts_db_store_accounts_shrink",
+            (
+                "flush_read_cache_us",
+                self.flush_read_cache_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "write_to_storage_us",
+                self.write_to_storage_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "update_index_us",
+                self.update_index_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "num_accounts_stored",
+                self.num_accounts_stored.swap(0, Ordering::Relaxed),
+                i64
+            ),
+        );
+    }
+}
+
+/// Stats from storing accounts for flush (i.e. flushing the write cache to a storage file)
+#[derive(Debug, Default)]
+pub struct StoreAccountsForFlushStats {
+    pub last_report: AtomicInterval,
     pub write_to_storage_us: AtomicU64,
     pub update_index_us: AtomicU64,
     pub mark_zero_lamport_single_ref_accounts_us: AtomicU64,
@@ -117,7 +161,7 @@ pub struct StoreAccountsFrozenStats {
     pub num_obsolete_bytes_removed: AtomicU64,
 }
 
-impl StoreAccountsFrozenStats {
+impl StoreAccountsForFlushStats {
     const REPORT_INTERVAL_MS: u64 = Duration::from_secs(1).as_millis() as u64;
 
     pub fn report(&self) {
@@ -127,12 +171,7 @@ impl StoreAccountsFrozenStats {
         }
 
         datapoint_info!(
-            "accounts_db_store_accounts_frozen",
-            (
-                "flush_read_cache_us",
-                self.flush_read_cache_us.swap(0, Ordering::Relaxed),
-                i64
-            ),
+            "accounts_db_store_accounts_for_flush",
             (
                 "write_to_storage_us",
                 self.write_to_storage_us.swap(0, Ordering::Relaxed),


### PR DESCRIPTION
#### Problem
Flush stats and shrink status are useful to look at individually, but are stored in the same datapoint right now 

#### Summary of Changes
Split them into two

Fixes #
