### PR TITLE
quic-client: remove block_on for set-identity

### DIFF
--- a/quic-client/src/quic_client.rs
+++ b/quic-client/src/quic_client.rs
@@ -184,5 +184,13 @@ impl ClientConnection for QuicClientConnection {
 pub(crate) fn close_quic_connection(connection: Arc<QuicClient>) {
     // Close the connection and release resources
     trace!("Closing QUIC connection to {}", connection.server_addr());
-    RUNTIME.block_on(connection.close());
+    // Connection caches can be dropped by async callers, such as admin RPC set-identity;
+    // blocking on RUNTIME from a Tokio worker would panic.
+    if tokio::runtime::Handle::try_current().is_ok() {
+        let _handle = RUNTIME.spawn(async move {
+            connection.close().await;
+        });
+    } else {
+        RUNTIME.block_on(connection.close());
+    }
 }

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -60,6 +60,30 @@ mod tests {
         )
     }
 
+    #[tokio::test]
+    async fn test_quic_connection_cache_update_key_from_tokio_runtime() {
+        use {
+            solana_connection_cache::connection_cache::{ConnectionCache, NewConnectionConfig},
+            solana_quic_client::{QuicConfig, QuicConnectionManager},
+        };
+
+        let keypair = Keypair::new();
+        let mut config = QuicConfig::new().unwrap();
+        config.update_client_certificate(&keypair, IpAddr::V4(Ipv4Addr::LOCALHOST));
+        let connection_manager = QuicConnectionManager::new_with_connection_config(config);
+        let connection_cache = ConnectionCache::new(
+            "quic_connection_cache_update_key_test",
+            connection_manager,
+            1,
+        )
+        .unwrap();
+
+        let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 12345);
+        let _connection = connection_cache.get_nonblocking_connection(&server_addr);
+
+        connection_cache.update_key(&Keypair::new()).unwrap();
+    }
+
     #[test]
     fn test_quic_client_multiple_writes() {
         use {


### PR DESCRIPTION
#### Problem
We panic as soon as we set-identity due to starting a runtime within a runtime:

```sh
~/agave/bin/agave-validator -l ledger set-identity dummy.json
```

```sh
thread 'solAdminRpcEl' (114545) panicked at /home/sol/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.52.3/src/runtime/scheduler/multi_thread/mod.rs:91:9:
Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted to block the current thread while the thread is being used to drive asynchronous tasks. 
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: tokio::runtime::context::runtime::enter_runtime
   3: tokio::runtime::runtime::Runtime::block_on
   4: solana_quic_client::quic_client::close_quic_connection
   5: <solana_quic_client::QuicPool as core::ops::drop::Drop>::drop
   6: core::ptr::drop_in_place<solana_quic_client::QuicPool>
   7: solana_connection_cache::connection_cache::ConnectionCache<P,M,C>::update_key
   8: <solana_client::connection_cache::ConnectionCache as solana_tls_utils::notify_key_update::NotifyKeyUpdate>::update_key
   9: agave_validator::admin_rpc_service::AdminRpcImpl::set_identity_keypair
  10: <agave_validator::admin_rpc_service::AdminRpcImpl as agave_validator::admin_rpc_service::rpc_impl_AdminRpc::gen_server
```

#### Summary of Changes
If we're already in the runtime, the clanker said we can just close the connection. Open to suggestions if there is a better way to handle this,

Fixes #12633 
