### PR TITLE
dev-bins: drop stale svm-test-harness workspace deps

### DIFF
--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -125,8 +125,6 @@ solana-svm = { path = "../svm", version = "=4.2.0-alpha.0", features = ["agave-u
 solana-svm-callback = { path = "../svm-callback", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm-feature-set = { path = "../svm-feature-set", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm-log-collector = { path = "../svm-log-collector", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm-test-harness-fixture = { path = "../svm-test-harness/fixture", version = "=4.2.0-alpha.0" }
-solana-svm-test-harness-instr = { path = "../svm-test-harness/instr", version = "=4.2.0-alpha.0" }
 solana-svm-timings = { path = "../svm-timings", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm-transaction = { path = "../svm-transaction", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-syscalls = { path = "../syscalls", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }


### PR DESCRIPTION
#### Problem
The svm-test-harness tree was removed when the harness was folded into `solana-svm::conformance` in #12384, but two dangling entries in `[workspace.dependencies]` pointed at the deleted paths. No member crate references them, so the workspace still resolved.

#### Summary of Changes
Remove the dead declarations.
