### PR TITLE
program-runtime: drop Option from mock_compile_message

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -915,7 +915,7 @@ pub fn mock_compile_message<A>(
     accounts: &[(Pubkey, A)],
     program_id: &Pubkey,
     loader_key: &Pubkey,
-) -> Option<(SanitizedMessage, Vec<(Pubkey, AccountSharedData)>)>
+) -> (SanitizedMessage, Vec<(Pubkey, AccountSharedData)>)
 where
     AccountSharedData: From<A>,
     A: Clone,
@@ -944,7 +944,7 @@ where
 
     let sanitized_message = SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()));
 
-    Some((sanitized_message, transaction_accounts))
+    (sanitized_message, transaction_accounts)
 }
 
 #[cfg(feature = "dev-context-only-utils")]
@@ -976,7 +976,7 @@ pub fn mock_process_instruction_with_feature_set<
     let instruction =
         Instruction::new_with_bytes(*program_id, instruction_data, instruction_account_metas);
     let (sanitized_message, transaction_accounts) =
-        mock_compile_message(&instruction, &accounts, program_id, &native_loader::id()).unwrap();
+        mock_compile_message(&instruction, &accounts, program_id, &native_loader::id());
 
     let program_owner = accounts
         .iter()
@@ -1977,7 +1977,7 @@ mod tests {
         )];
 
         let (message, tx_accounts) =
-            mock_compile_message(&instruction, &accounts, &program_id, &loader_key).unwrap();
+            mock_compile_message(&instruction, &accounts, &program_id, &loader_key);
 
         assert_eq!(message.instructions().len(), 1);
         assert_eq!(tx_accounts.len(), 2);

--- a/svm/src/conformance/harness.rs
+++ b/svm/src/conformance/harness.rs
@@ -94,7 +94,7 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
     let loader_key = program_cache.find(program_id)?.account_owner();
 
     let (sanitized_message, transaction_accounts) =
-        mock_compile_message(&input.instruction, &input.accounts, program_id, &loader_key)?;
+        mock_compile_message(&input.instruction, &input.accounts, program_id, &loader_key);
 
     let mut transaction_context = TransactionContext::new(
         transaction_accounts,


### PR DESCRIPTION
#### Problem
`mock_compile_message` was always returning `Some`.

#### Summary of Changes
Lose the `Option`.