### PR TITLE
perf(snapshots): prefetch storage files while archiving

### DIFF
--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -16,6 +16,18 @@ use {
 // file fits entirely within the buffer.
 pub const ACCOUNT_STORAGE_MAX_BUFFER_SIZE: usize = 10 * 1024 * 1024;
 
+#[cfg(not(target_os = "linux"))]
+const READER_STACK_BUFFER_SIZE: usize = 64 * 1024;
+
+/// Concrete reader type returned by [`storage_file_buf_reader`].
+///
+/// The concrete type is exposed (rather than `impl FileBufRead<'a>`) so callers
+/// can use inherent methods like `rebind`.
+#[cfg(target_os = "linux")]
+type StorageFileBufReader<'a> = buffered_reader::SequentialFileReader<'a>;
+#[cfg(not(target_os = "linux"))]
+type StorageFileBufReader<'a> = buffered_reader::BufferedReader<'a, READER_STACK_BUFFER_SIZE>;
+
 /// When `use_page_cache` is `true`, direct I/O is forced off regardless of
 /// `io_setup.use_direct_io` so that reads can hit the kernel's page cache.
 /// Otherwise, the `io_setup.use_direct_io` setting is honored.
@@ -23,35 +35,31 @@ pub fn storage_file_buf_reader<'a>(
     max_buf_size: usize,
     use_page_cache: bool,
     io_setup: &IoSetupState,
-) -> io::Result<impl FileBufRead<'a> + use<'a>> {
+) -> io::Result<StorageFileBufReader<'a>> {
     #[cfg(target_os = "linux")]
-    let reader = buffered_reader::SequentialFileReaderBuilder::new()
-        .shared_sqpoll(io_setup.shared_sqpoll_fd())
-        .use_direct_io(io_setup.use_direct_io && !use_page_cache)
-        .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
-        .build(max_buf_size)?;
+    {
+        buffered_reader::SequentialFileReaderBuilder::new()
+            .shared_sqpoll(io_setup.shared_sqpoll_fd())
+            .use_direct_io(io_setup.use_direct_io && !use_page_cache)
+            .use_registered_buffers(io_setup.use_registered_io_uring_buffers)
+            .build(max_buf_size)
+    }
     #[cfg(not(target_os = "linux"))]
-    let reader = {
+    {
         let _ = (max_buf_size, use_page_cache, io_setup);
-        const READER_STACK_BUFFER_SIZE: usize = 64 * 1024;
-        buffered_reader::BufferedReader::<READER_STACK_BUFFER_SIZE>::new()
-    };
-    Ok(reader)
+        Ok(StorageFileBufReader::new())
+    }
 }
 
-/// Returns a file handle for each storage suitable for archive-style reads
-/// matching `use_direct_io` (see [`OpenFileForArchive`]).
-///
-/// Returned as a `Vec` so the handles outlive the buffered reader they'll be
-/// fed into.
+/// Lazy iterator yielding a file handle for each storage suitable for
+/// archive-style reads matching `use_direct_io` (see [`OpenFileForArchive`]).
 pub fn open_storage_files<'s>(
-    storages: impl IntoIterator<Item = &'s AccountStorageEntry>,
+    storages: impl IntoIterator<Item = &'s AccountStorageEntry> + 's,
     use_direct_io: bool,
-) -> io::Result<Vec<OpenFileForArchive<'s>>> {
+) -> impl Iterator<Item = io::Result<OpenFileForArchive<'s>>> + 's {
     storages
         .into_iter()
-        .map(|storage| storage.accounts.open_file_for_archive(use_direct_io))
-        .collect()
+        .map(move |storage| storage.accounts.open_file_for_archive(use_direct_io))
 }
 
 /// A wrapper type around `AccountStorageEntry` that implements the `Read` trait.
@@ -207,7 +215,9 @@ mod tests {
 
         storage.accounts.write_accounts(&(slot, &accounts[..]), 0);
 
-        let files = open_storage_files(iter::once(&storage), false).unwrap();
+        let files = open_storage_files(iter::once(&storage), false)
+            .collect::<io::Result<Vec<_>>>()
+            .unwrap();
         let mut buf_reader = storage_file_buf_reader(
             ACCOUNT_STORAGE_MAX_BUFFER_SIZE,
             false,
@@ -284,7 +294,9 @@ mod tests {
         let storage = storage.reopen_as_readonly().unwrap_or(storage);
 
         // Create the reader and check the length
-        let files = open_storage_files(iter::once(&storage), false).unwrap();
+        let files = open_storage_files(iter::once(&storage), false)
+            .collect::<io::Result<Vec<_>>>()
+            .unwrap();
         let mut file_reader = storage_file_buf_reader(
             ACCOUNT_STORAGE_MAX_BUFFER_SIZE,
             false,
@@ -406,7 +418,9 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
 
         // Now iterate through all the possible snapshot slots and verify correctness
-        let files = open_storage_files(iter::once(&storage), false).unwrap();
+        let files = open_storage_files(iter::once(&storage), false)
+            .collect::<io::Result<Vec<_>>>()
+            .unwrap();
         let mut file_reader = storage_file_buf_reader(
             ACCOUNT_STORAGE_MAX_BUFFER_SIZE,
             false,

--- a/fs/src/buffered_reader.rs
+++ b/fs/src/buffered_reader.rs
@@ -14,7 +14,9 @@
 //! When reading full accounts data whose sizes exceed the small stack buffer, the `BufReaderWithOverflow`
 //! should be used, which supports dynamically allocated buffer for preparing contiguous data slices.
 #[cfg(target_os = "linux")]
-pub use crate::io_uring::sequential_file_reader::SequentialFileReaderBuilder;
+pub use crate::io_uring::sequential_file_reader::{
+    SequentialFileReader, SequentialFileReaderBuilder,
+};
 use {
     crate::{
         FileSize,
@@ -71,7 +73,20 @@ pub trait FileBufRead<'a>: BufRead {
     ///
     /// `read_limit` provides a pre-defined limit on the number of bytes that can be read
     /// from the file (unless EOF is reached).
+    ///
+    /// If the file was previously queued via `add_file_to_prefetch`, the reader
+    /// advances to that file (validating identity / `read_limit`) rather than
+    /// re-queueing it.
     fn set_file(&mut self, file: &'a File, read_limit: FileSize) -> io::Result<()>;
+
+    /// Queue `file` for read-ahead (prefetch). Files are processed in FIFO order
+    /// by subsequent `set_file` calls.
+    ///
+    /// This is a hint to keep the read pipeline saturated for readers that
+    /// support concurrent read-ahead. Implementations without read-ahead may
+    /// ignore the call. Callers must still invoke `set_file` to switch the
+    /// active file.
+    fn add_file_to_prefetch(&mut self, file: &'a File, read_limit: FileSize) -> io::Result<()>;
 
     /// Returns the current file offset corresponding to the start of the buffer
     /// that will be returned by the next call to `fill_buf`.
@@ -155,11 +170,29 @@ impl<'a, const N: usize> BufferedReader<'a, N> {
         self.file_offset_of_next_read = 0;
         self.buf_valid_bytes = 0..0;
     }
+
+    /// Reset to idle state and re-type with a fresh lifetime `'b`.
+    pub fn rebind<'b>(self) -> io::Result<BufferedReader<'b, N>> {
+        Ok(BufferedReader {
+            file_offset_of_next_read: 0,
+            buf: self.buf,
+            buf_valid_bytes: 0..0,
+            file_last_offset: 0,
+            file_len_valid: 0,
+            file: None,
+        })
+    }
 }
 
 impl<'a, const N: usize> FileBufRead<'a> for BufferedReader<'a, N> {
     fn set_file(&mut self, file: &'a File, read_limit: FileSize) -> io::Result<()> {
         self.do_set_file(file, read_limit);
+        Ok(())
+    }
+
+    /// `BufferedReader` does not perform read-ahead — the call is a no-op and
+    /// the file becomes active only when `set_file` is later invoked.
+    fn add_file_to_prefetch(&mut self, _file: &'a File, _read_limit: FileSize) -> io::Result<()> {
         Ok(())
     }
 
@@ -358,6 +391,10 @@ impl<'a, R: FileBufRead<'a>> FileBufRead<'a> for BufReaderWithOverflow<R> {
     fn set_file(&mut self, file: &'a File, read_limit: FileSize) -> io::Result<()> {
         self.overflow_buf.clear();
         self.reader.set_file(file, read_limit)
+    }
+
+    fn add_file_to_prefetch(&mut self, file: &'a File, read_limit: FileSize) -> io::Result<()> {
+        self.reader.add_file_to_prefetch(file, read_limit)
     }
 
     fn get_file_offset(&self) -> FileSize {

--- a/fs/src/io_uring/sequential_file_reader.rs
+++ b/fs/src/io_uring/sequential_file_reader.rs
@@ -139,7 +139,7 @@ impl<'sp> SequentialFileReaderBuilder<'sp> {
 
         if self.register_buffer {
             // Safety: kernel holds unsafe pointers to `buffer`, struct field declaration order
-            // guarantees that the ring is destroyed before `_backing_buffer` is dropped.
+            // guarantees that the ring is destroyed before `backing_buffer` is dropped.
             unsafe { IoBufferChunk::register(buf_slice_mut, &ring)? };
         }
 
@@ -166,7 +166,7 @@ impl<'sp> SequentialFileReaderBuilder<'sp> {
             ring,
             state: SequentialFileReaderState::default(),
             open_file_flags,
-            _backing_buffer: buffer,
+            backing_buffer: buffer,
             _phantom: PhantomData,
         })
     }
@@ -200,14 +200,14 @@ impl<'sp> SequentialFileReaderBuilder<'sp> {
 ///
 /// Implements read-ahead using io_uring.
 pub struct SequentialFileReader<'a> {
-    // Note: ring's state is tied to `_backing_buffer` - contains unsafe pointer references
-    // to the buffer. Ring should be drained and dropped before `_backing_buffer`.
+    // Note: ring's state is tied to `backing_buffer` - contains unsafe pointer references
+    // to the buffer. Ring should be drained and dropped before `backing_buffer`.
     ring: Ring<BuffersState, ReadOp>,
     open_file_flags: i32,
     state: SequentialFileReaderState,
     /// Owned buffer used (chunked into `FixedIoBuffer` items) across lifespan of `inner`
     /// (should get dropped last)
-    _backing_buffer: PageAlignedMemory,
+    backing_buffer: PageAlignedMemory,
     _phantom: PhantomData<&'a ()>,
 }
 
@@ -251,8 +251,20 @@ impl<'a> SequentialFileReader<'a> {
         Ok(())
     }
 
-    fn add_file_to_prefetch(&mut self, file: &'a File, read_limit: FileSize) -> io::Result<()> {
-        self.add_file_by_fd(file.as_raw_fd(), read_limit)
+    /// Reset to idle state and re-type with a fresh lifetime `'b`.
+    ///
+    /// Drains the prefetch queue (cancels in-flight reads) before returning.
+    pub fn rebind<'b>(mut self) -> io::Result<SequentialFileReader<'b>> {
+        while !self.state.files.is_empty() {
+            self.move_to_next_file()?;
+        }
+        Ok(SequentialFileReader {
+            ring: self.ring,
+            open_file_flags: self.open_file_flags,
+            state: self.state,
+            backing_buffer: self.backing_buffer,
+            _phantom: PhantomData,
+        })
     }
 
     /// Caller must ensure that the file is not closed while the reader is using it.
@@ -488,6 +500,10 @@ impl<'a> FileBufRead<'a> for SequentialFileReader<'a> {
             self.add_file_to_prefetch(file, read_limit)?;
         }
         Ok(())
+    }
+
+    fn add_file_to_prefetch(&mut self, file: &'a File, read_limit: FileSize) -> io::Result<()> {
+        self.add_file_by_fd(file.as_raw_fd(), read_limit)
     }
 
     fn get_file_offset(&self) -> FileSize {

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -126,7 +126,8 @@ mod serde_snapshot_tests {
         let storage: AccountStorageMap = AccountStorageMap::with_capacity(storage_entries.len());
         let mut next_append_vec_id = 0;
         const MAX_BUFFER_SIZE: usize = 2 * 1024 * 1024;
-        let storage_files = open_storage_files(storage_entries.iter().map(|s| s.as_ref()), false)?;
+        let storage_files = open_storage_files(storage_entries.iter().map(|s| s.as_ref()), false)
+            .collect::<io::Result<Vec<_>>>()?;
         let mut buf_reader =
             storage_file_buf_reader(MAX_BUFFER_SIZE, false, &IoSetupState::default())?;
         for (storage_entry, file) in storage_entries.iter().zip(storage_files.iter()) {

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -4,7 +4,7 @@ use {
         snapshot_archive_info::SnapshotArchiveInfo, snapshot_hash::SnapshotHash,
     },
     agave_fs::{
-        buffered_reader::FileBufRead as _, buffered_writer::large_file_buf_writer,
+        FileSize, buffered_reader::FileBufRead as _, buffered_writer::large_file_buf_writer,
         io_setup::IoSetupState,
     },
     log::info,
@@ -27,6 +27,13 @@ use {
 // such that during unpacking large writes are mixed with file metadata operations
 // and towards the end of archive (sizes equalize) writes are >256KiB / file.
 const INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO: (usize, usize) = (4, 1);
+
+// Max number of storage files to open at once for archiving. Bounds extra fd
+// usage and io_uring prefetch queue depth. A multiple of the interleave ratio
+// sum keeps each chunk balanced between small and large files.
+const STORAGE_FILE_OPEN_CHUNK_SIZE: usize = 25
+    * (INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO.0
+        + INTERLEAVE_TAR_ENTRIES_SMALL_TO_LARGE_RATIO.1);
 
 /// Archives a snapshot into `archive_path`
 pub fn archive_snapshot(
@@ -130,37 +137,64 @@ pub fn archive_snapshot(
             let use_page_cache =
                 matches!(snapshot_archive_kind, SnapshotArchiveKind::Incremental(_));
             let use_direct_io = io_setup.use_direct_io && !use_page_cache;
-            // Pre-open every storage file (with the buffered reader's
-            // direct-IO setting) so they outlive `buf_reader` — the reader's
-            // `'a` lifetime needs to borrow into them across loop iterations.
-            let storage_files = open_storage_files(storages_orderer.iter(), use_direct_io)
-                .map_err(E::StorageFileBufReaderError)?;
+
+            // Walk storages and their (lazily-opened) file handles in chunks,
+            // bounding how many archive-mode fds are simultaneously open.
+            let mut storage_file_pairs = storages_orderer
+                .iter()
+                .zip(open_storage_files(storages_orderer.iter(), use_direct_io));
             let mut buf_reader =
                 storage_file_buf_reader(ACCOUNT_STORAGE_MAX_BUFFER_SIZE, use_page_cache, io_setup)
                     .map_err(E::StorageFileBufReaderError)?;
-            for (storage, file) in storages_orderer.iter().zip(storage_files.iter()) {
-                let path_in_archive = Path::new(ACCOUNTS_DIR)
-                    .join(AccountsFile::file_name(storage.slot(), storage.id()));
+            let mut chunk = Vec::with_capacity(STORAGE_FILE_OPEN_CHUNK_SIZE);
+            loop {
+                chunk.clear();
+                for (storage, file) in (&mut storage_file_pairs).take(STORAGE_FILE_OPEN_CHUNK_SIZE)
+                {
+                    chunk.push((storage, file.map_err(E::StorageFileBufReaderError)?));
+                }
+                if chunk.is_empty() {
+                    break;
+                }
+                // Cheaply re-bind the reader to scope file borrows to this chunk.
+                let mut chunk_reader = buf_reader.rebind().map_err(E::StorageFileBufReaderError)?;
 
-                buf_reader
-                    .set_file(file.as_ref(), storage.accounts.len() as u64)
-                    .map_err(|err| {
-                        E::AccountStorageReaderError(err, storage.path().to_path_buf())
-                    })?;
-                let reader =
-                    AccountStorageReader::new(storage, Some(snapshot_slot), &mut buf_reader)
+                // Queue the whole chunk for read-ahead before consuming any of
+                // it, so the io_uring pipeline can saturate across files.
+                for (storage, file) in &chunk {
+                    chunk_reader
+                        .add_file_to_prefetch(file.as_ref(), storage.accounts.len() as FileSize)
+                        .map_err(E::StorageFileBufReaderError)?;
+                }
+
+                for (storage, file) in &chunk {
+                    let path_in_archive = Path::new(ACCOUNTS_DIR)
+                        .join(AccountsFile::file_name(storage.slot(), storage.id()));
+
+                    chunk_reader
+                        .set_file(file.as_ref(), storage.accounts.len() as FileSize)
                         .map_err(|err| {
                             E::AccountStorageReaderError(err, storage.path().to_path_buf())
                         })?;
-                let mut header = tar::Header::new_gnu();
-                header.set_path(path_in_archive).map_err(|err| {
-                    E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
-                })?;
-                header.set_size(reader.len() as u64);
-                header.set_cksum();
-                archive.append(&header, reader).map_err(|err| {
-                    E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
-                })?;
+                    let reader =
+                        AccountStorageReader::new(storage, Some(snapshot_slot), &mut chunk_reader)
+                            .map_err(|err| {
+                                E::AccountStorageReaderError(err, storage.path().to_path_buf())
+                            })?;
+                    let mut header = tar::Header::new_gnu();
+                    header.set_path(path_in_archive).map_err(|err| {
+                        E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
+                    })?;
+                    header.set_size(reader.len() as u64);
+                    header.set_cksum();
+                    archive.append(&header, reader).map_err(|err| {
+                        E::ArchiveAccountStorageFile(err, storage.path().to_path_buf())
+                    })?;
+                }
+
+                buf_reader = chunk_reader
+                    .rebind()
+                    .map_err(E::StorageFileBufReaderError)?;
             }
 
             archive.into_inner().map_err(E::FinishArchive)?;


### PR DESCRIPTION
#### Problem
The buffered reader processed storage files strictly one at a time: it could not start reading the next storage until the current one was fully consumed. Because `AccountStoragesOrderer` interleaves small and large files (4:1) to balance the tar layout, the reader frequently sat idle on a large file when it could have already pulled several upcoming small files into its io_uring buffer.

A side effect of the previous design was that all archive-mode fds had to be opened up front (so they outlived the buffered reader's `'a` borrow). For full snapshots that meant a fresh `O_DIRECT` fd per storage held open for the whole archive run — not a perf hotspot, but unnecessary fd pressure.

#### Summary of Changes
Snapshot archiving now walks AccountsDB storages in bounded chunks, reusing a single buffered reader (its inner io_uring instance and allocated buffer) across the entire archive.

- `open_storage_files` returns a lazy iterator instead of eagerly collecting fds into a `Vec` (and is set up for future open-ahead).
- `FileBufRead` gains `add_file_to_prefetch`, so callers can queue a whole chunk for io_uring read-ahead before consuming any of it — small files in the chunk can be read concurrently with the current large one.
- Each concrete reader gains an inherent `rebind<'b>` that resets state and re-types the reader to a fresh lifetime, letting the same reader be borrowed against a per-chunk file scope without rebuilding io_uring resources.
- `archive_snapshot` walks storages + lazy files together, fills a reused 125-entry chunk buffer (a multiple of the small/large interleave ratio so chunks stay balanced), rebinds the reader into the chunk's borrow scope, prefetches the chunk, archives it, and rebinds back. Concurrently-open extra fds are bounded by chunk size; the io_uring reader is constructed once for the whole archive.

##### Performance impact
* reduces full snapshot archive further - previous result ~820s, now 794s
* near all CPU is now consumed by zstd compressor even at the beggining of archival (previously it did hit lots of `submit` syscalls, since moving through each file caused syscall to wait on io-uring to deliver first data)

<img width="2878" height="1722" alt="pr" src="https://github.com/user-attachments/assets/90ada996-f141-4526-ac1a-474665f2966c" />

