### PR TITLE
fix: possible panic when fetching double Merkle meta for block ID repair

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -989,10 +989,11 @@ impl Blockstore {
             return Ok(None);
         };
 
-        // Get the doulbe merkle meta - the block must be full, so we can unwrap here
-        let dmm = self
-            .get_double_merkle_meta_maybe_populate_proofs(slot, location)?
-            .expect("block is full, double merkle meta must exist");
+        // Block was full above, get_block_location returned Some, but may have
+        // been purged by BlockstoreCleanupService in between.
+        let Some(dmm) = self.get_double_merkle_meta_maybe_populate_proofs(slot, location)? else {
+            return Ok(None);
+        };
         Ok(Some((dmm, location)))
     }
 


### PR DESCRIPTION
#### Problem
Addresses the particular crash laid out in #12668.

#### Summary of Changes
Return `Ok(None)` instead of panicking in `Blockstore::get_double_merkle_meta_maybe_populate_proofs_for_block_id()` if the block was purged concurrently.