### PR TITLE
clippy: move allow of collapsible_if to Cargo.toml lint definitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,8 @@ used_underscore_binding = "deny"
 
 # Allowed lints
 new_without_default = "allow"
+## Due to recent switch to Rust 2024, should be removed after repo auto-fix before release cut
+collapsible_if = "allow"
 
 [workspace.dependencies]
 Inflector = "0.11.4"

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -29,6 +29,8 @@ used_underscore_binding = "deny"
 
 # Allowed lints
 new_without_default = "allow"
+## Due to recent switch to Rust 2024, should be removed after repo auto-fix before release cut
+collapsible_if = "allow"
 
 [workspace.dependencies]
 agave-feature-set = { path = "../feature-set", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }

--- a/scripts/cargo-clippy-nightly.sh
+++ b/scripts/cargo-clippy-nightly.sh
@@ -22,8 +22,6 @@ source "$here/../ci/rust-version.sh" nightly
 # Similarly, nightly is desired to run clippy over all of bench files because
 # the bench itself isn't stabilized yet...
 #   ref: https://github.com/rust-lang/rust/issues/66287
-#
-# allow arguments are temporary, violations should be fixed after migration to Rust 2024
 "$here/cargo-for-all-lock-files.sh" -- \
   "+${rust_nightly}" clippy \
   --workspace --all-targets --features dummy-for-ci-check,frozen-abi -- \
@@ -32,5 +30,4 @@ source "$here/../ci/rust-version.sh" nightly
   --deny=clippy::arithmetic_side_effects \
   --deny=clippy::manual_let_else \
   --deny=clippy::uninlined-format-args \
-  --deny=clippy::used_underscore_binding \
-  --allow=clippy::collapsible_if
+  --deny=clippy::used_underscore_binding


### PR DESCRIPTION
#### Problem
After Rust edition switch (https://github.com/anza-xyz/agave/pull/9663) we are temporarily allowing collapsible_if lint. The allow lives at the CI scripts level, so it still shows up in IDEs.
The lint errors can be automatically fixed, but it's a large diff, so it should be best done near release cut to not interfere with backports.

#### Summary of Changes
Move allow from `scripts/cargo-clippy-nightly.sh` to `Cargo.toml` of two workspaces.
