### PR TITLE
Refactor - program owner in `ProgramCache::extract()`

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -412,6 +412,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     at.effective_slot
                         .cmp(&entry.effective_slot)
                         .then(at.deployment_slot.cmp(&entry.deployment_slot))
+                        .then(at.account_owner.cmp(&entry.account_owner))
                         .then(
                             // This `.then()` has no effect during normal operation.
                             // Only during the cache preparation phase this does allow entries

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -2,7 +2,9 @@ use {
     crate::{
         invoke_context::InvokeContext,
         loading_task::LoadingTaskWaiter,
-        program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryType, retention_score},
+        program_cache_entry::{
+            ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType, retention_score,
+        },
         program_metrics::{EMA_SCALE, ProgramCacheStats},
     },
     log::error,
@@ -188,6 +190,8 @@ impl EpochBoundaryPreparation {
 pub struct ProgramToLoad<'a> {
     /// The program address
     pub program_id: &'a Pubkey,
+    /// The program loader
+    pub loader: ProgramCacheEntryOwner,
     /// Potentially filter out / ignore some entries during the start up / catch up phase
     pub match_criteria: ProgramCacheMatchCriteria,
     /// When the program account was last written to (might be after the deployment slot)
@@ -1830,6 +1834,7 @@ pub(crate) mod tests {
                     })
                     .map(|(_program_id, entry)| ProgramToLoad {
                         program_id: key,
+                        loader: entry.account_owner,
                         match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                         last_modification_slot: entry.deployment_slot,
                     })
@@ -2252,6 +2257,7 @@ pub(crate) mod tests {
         let program1 = Pubkey::new_unique();
         let mut missing = vec![ProgramToLoad {
             program_id: &program1,
+            loader: ProgramCacheEntryOwner::LoaderV3,
             match_criteria: ProgramCacheMatchCriteria::NoCriteria,
             last_modification_slot: 0,
         }];

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -610,7 +610,9 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                         for entry in second_level.iter().rev() {
                             let required_deployment_slot =
                                 filter_by_deployment_slot.unwrap_or(entry.deployment_slot);
-                            if required_deployment_slot != entry.deployment_slot {
+                            if required_deployment_slot != entry.deployment_slot
+                                || program_to_load.loader != entry.account_owner
+                            {
                                 continue;
                             }
                             let entry_in_same_branch = entry.deployment_slot

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -439,8 +439,6 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 ProgramCacheEntryType::Unloaded(_),
                                 ProgramCacheEntryType::Loaded(_),
                             ) => {}
-                            (ProgramCacheEntryType::Closed, ProgramCacheEntryType::Closed)
-                                if existing.account_owner != entry.account_owner => {}
                             _ => {
                                 // Something is wrong, I can feel it ...
                                 error!(

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -21,7 +21,7 @@ use {
 pub const DELAY_VISIBILITY_SLOT_OFFSET: Slot = 1;
 
 /// The owner of a programs accounts, thus the loader of a program
-#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Debug)]
 pub enum ProgramCacheEntryOwner {
     #[default]
     NativeLoader,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "metrics")]
 use solana_program_runtime::program_metrics::LoadProgramMetrics;
 use {
-    crate::account_loader::PROGRAM_OWNERS,
     solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMut},
     solana_clock::Slot,
     solana_instruction::error::InstructionError,
@@ -256,8 +255,18 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
             cache_entry.stats.uses.fetch_add(1, Ordering::Relaxed);
         } else if let Some((account, last_modification_slot)) =
             callbacks.get_account_shared_data(account_key)
-            && PROGRAM_OWNERS.contains(account.owner())
         {
+            let _loader = if loader_v4::check_id(account.owner()) {
+                ProgramCacheEntryOwner::LoaderV4
+            } else if bpf_loader_upgradeable::check_id(account.owner()) {
+                ProgramCacheEntryOwner::LoaderV3
+            } else if bpf_loader::check_id(account.owner()) {
+                ProgramCacheEntryOwner::LoaderV2
+            } else if bpf_loader_deprecated::check_id(account.owner()) {
+                ProgramCacheEntryOwner::LoaderV1
+            } else {
+                continue;
+            };
             let match_criteria = if check_program_deployment_slot {
                 get_program_deployment_slot(callbacks, &account)
                     .map_or(ProgramCacheMatchCriteria::Tombstone, |slot| {

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -214,30 +214,34 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
 pub(crate) fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
     callbacks: &CB,
     program: &AccountSharedData,
+    loader: ProgramCacheEntryOwner,
 ) -> TransactionResult<Slot> {
-    if bpf_loader_upgradeable::check_id(program.owner()) {
-        if let Ok(UpgradeableLoaderState::Program {
-            programdata_address,
-        }) = program.state()
-        {
-            let (programdata, _slot) = callbacks
-                .get_account_shared_data(&programdata_address)
-                .ok_or(TransactionError::ProgramAccountNotFound)?;
-            if let Ok(UpgradeableLoaderState::ProgramData {
-                slot,
-                upgrade_authority_address: _,
-            }) = programdata.state()
+    match loader {
+        ProgramCacheEntryOwner::LoaderV1 | ProgramCacheEntryOwner::LoaderV2 => Ok(0),
+        ProgramCacheEntryOwner::LoaderV3 => {
+            if let Ok(UpgradeableLoaderState::Program {
+                programdata_address,
+            }) = program.state()
             {
-                return Ok(slot);
+                let (programdata, _slot) = callbacks
+                    .get_account_shared_data(&programdata_address)
+                    .ok_or(TransactionError::ProgramAccountNotFound)?;
+                if let Ok(UpgradeableLoaderState::ProgramData {
+                    slot,
+                    upgrade_authority_address: _,
+                }) = programdata.state()
+                {
+                    return Ok(slot);
+                }
             }
+            Err(TransactionError::ProgramAccountNotFound)
         }
-        Err(TransactionError::ProgramAccountNotFound)
-    } else if loader_v4::check_id(program.owner()) {
-        let state = loader_v4_get_state(program.data())
-            .map_err(|_| TransactionError::ProgramAccountNotFound)?;
-        Ok(state.slot)
-    } else {
-        Ok(0)
+        ProgramCacheEntryOwner::LoaderV4 => {
+            let state = loader_v4_get_state(program.data())
+                .map_err(|_| TransactionError::ProgramAccountNotFound)?;
+            Ok(state.slot)
+        }
+        ProgramCacheEntryOwner::NativeLoader => unreachable!(),
     }
 }
 
@@ -256,7 +260,7 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
         } else if let Some((account, last_modification_slot)) =
             callbacks.get_account_shared_data(account_key)
         {
-            let _loader = if loader_v4::check_id(account.owner()) {
+            let loader = if loader_v4::check_id(account.owner()) {
                 ProgramCacheEntryOwner::LoaderV4
             } else if bpf_loader_upgradeable::check_id(account.owner()) {
                 ProgramCacheEntryOwner::LoaderV3
@@ -268,7 +272,7 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
                 continue;
             };
             let match_criteria = if check_program_deployment_slot {
-                get_program_deployment_slot(callbacks, &account)
+                get_program_deployment_slot(callbacks, &account, loader)
                     .map_or(ProgramCacheMatchCriteria::Tombstone, |slot| {
                         ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot)
                     })
@@ -277,6 +281,7 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
             };
             result.push(ProgramToLoad {
                 program_id: account_key,
+                loader,
                 match_criteria,
                 last_modification_slot,
             });
@@ -748,6 +753,7 @@ mod tests {
         let result = get_program_deployment_slot(
             &mock_bank,
             &mock_bank.get_account_shared_data(&key).unwrap().0,
+            ProgramCacheEntryOwner::LoaderV3,
         );
         assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
 
@@ -763,6 +769,7 @@ mod tests {
         let result = get_program_deployment_slot(
             &mock_bank,
             &mock_bank.get_account_shared_data(&key).unwrap().0,
+            ProgramCacheEntryOwner::LoaderV3,
         );
         assert_eq!(result.err(), Some(TransactionError::ProgramAccountNotFound));
     }
@@ -787,7 +794,7 @@ mod tests {
             .borrow_mut()
             .insert(key1, (account_data, 0));
 
-        let mut account_data = AccountSharedData::new_data(
+        let account_data = AccountSharedData::new_data(
             100,
             &UpgradeableLoaderState::ProgramData {
                 slot: 77,
@@ -804,20 +811,9 @@ mod tests {
         let result = get_program_deployment_slot(
             &mock_bank,
             &mock_bank.get_account_shared_data(&key1).unwrap().0,
+            ProgramCacheEntryOwner::LoaderV3,
         );
         assert_eq!(result.unwrap(), 77);
-
-        account_data.set_owner(Pubkey::new_unique());
-        mock_bank
-            .account_shared_data
-            .borrow_mut()
-            .insert(key2, (account_data, 0));
-
-        let result = get_program_deployment_slot(
-            &mock_bank,
-            &mock_bank.get_account_shared_data(&key2).unwrap().0,
-        );
-        assert_eq!(result.unwrap(), 0);
     }
 
     #[test]
@@ -900,11 +896,13 @@ mod tests {
             &[
                 ProgramToLoad {
                     program_id: &program_ids[1],
+                    loader: ProgramCacheEntryOwner::LoaderV2,
                     match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                     last_modification_slot: 0,
                 },
                 ProgramToLoad {
                     program_id: &program_ids[2],
+                    loader: ProgramCacheEntryOwner::LoaderV3,
                     match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                     last_modification_slot: 0,
                 },
@@ -922,11 +920,13 @@ mod tests {
             &[
                 ProgramToLoad {
                     program_id: &program_ids[1],
+                    loader: ProgramCacheEntryOwner::LoaderV2,
                     match_criteria: ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0),
                     last_modification_slot: 0,
                 },
                 ProgramToLoad {
                     program_id: &program_ids[2],
+                    loader: ProgramCacheEntryOwner::LoaderV3,
                     match_criteria: ProgramCacheMatchCriteria::Tombstone,
                     last_modification_slot: 0,
                 },

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -46,7 +46,7 @@ use {
             ProgramCacheMatchCriteria, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
             ProgramToLoad,
         },
-        program_cache_entry::ProgramCacheEntry,
+        program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryOwner},
         solana_sbpf::{program::BuiltinProgram, vm::Config as VmConfig},
         sysvar_cache::SysvarCache,
     },
@@ -321,6 +321,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .iter()
             .map(|program_id| ProgramToLoad {
                 program_id,
+                loader: ProgramCacheEntryOwner::NativeLoader,
                 match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                 last_modification_slot: 0,
             })
@@ -1703,6 +1704,7 @@ mod tests {
             &account_loader,
             vec![ProgramToLoad {
                 program_id: &key,
+                loader: ProgramCacheEntryOwner::LoaderV3,
                 match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                 last_modification_slot: 0,
             }],
@@ -1741,6 +1743,7 @@ mod tests {
                 &account_loader,
                 vec![ProgramToLoad {
                     program_id: &key,
+                    loader: ProgramCacheEntryOwner::LoaderV2,
                     match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                     last_modification_slot: 0,
                 }],
@@ -1963,6 +1966,7 @@ mod tests {
             .extract(
                 &mut vec![ProgramToLoad {
                     program_id: &key,
+                    loader: ProgramCacheEntryOwner::NativeLoader,
                     match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                     last_modification_slot: 0,
                 }],

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -17,7 +17,7 @@ use {
             ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironments,
             ProgramToLoad,
         },
-        program_cache_entry::ProgramCacheEntryType,
+        program_cache_entry::{ProgramCacheEntryOwner, ProgramCacheEntryType},
     },
     solana_pubkey::Pubkey,
     solana_svm::{
@@ -63,6 +63,7 @@ fn program_cache_execution(threads: usize) {
                     .iter()
                     .map(|program_id| ProgramToLoad {
                         program_id,
+                        loader: ProgramCacheEntryOwner::LoaderV3,
                         match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                         last_modification_slot: 0,
                     })


### PR DESCRIPTION
#### Problem

We already check the program owner during transaction account loading and can reuse the result as an enum (`ProgramCacheEntryOwner`) to ignore unrelated entries, thus skipping over more complex logic inexpensively.

#### Summary of Changes

- Splits `PROGRAM_OWNERS.contains()` into individual checks.
- Adds loader field to `ProgramToLoad`.
- Makes `ProgramCache::extract()` skip over entries of different loaders.
- Allows entries to only differ by their account_owner in `ProgramCache::assign_program()`.
