### PR TITLE
Bump stake-interface to v4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6133,7 +6133,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -10446,9 +10446,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "3.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49eb5c77484214c3484921e2cdda79d185373118b5458c1b2df0f1a04c3bc30"
+checksum = "19f34562cda7df74d85fcb1f7063d8cdec3e14f3d402aa3062605c116d8b8115"
 dependencies = [
  "borsh",
  "num-traits",
@@ -12064,7 +12064,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -479,7 +479,7 @@ solana-signer-store = "0.1.0"
 solana-slot-hashes = "3.0.2"
 solana-slot-history = "3.0.1"
 solana-stable-layout = "3.0.1"
-solana-stake-interface = "3.1.0"
+solana-stake-interface = "4.2.0"
 solana-storage-bigtable = { path = "storage-bigtable", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-storage-proto = { path = "storage-proto", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-streamer = { path = "streamer", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }

--- a/account-decoder/src/parse_stake.rs
+++ b/account-decoder/src/parse_stake.rs
@@ -194,7 +194,7 @@ mod test {
                 stake: 20,
                 activation_epoch: 2,
                 deactivation_epoch: u64::MAX,
-                warmup_cooldown_rate: 0.25,
+                _reserved: [0; 8],
             },
             credits_observed: 10,
         };

--- a/account-decoder/src/parse_sysvar.rs
+++ b/account-decoder/src/parse_sysvar.rs
@@ -266,8 +266,11 @@ mod test {
     #[allow(deprecated)]
     use solana_sysvar::recent_blockhashes::IterItem;
     use {
-        super::*, solana_account::create_account_for_test, solana_fee_calculator::FeeCalculator,
+        super::*,
+        solana_account::{Account, create_account_for_test},
+        solana_fee_calculator::FeeCalculator,
         solana_hash::Hash,
+        solana_stake_interface::stake_history::SIZE,
     };
 
     #[test]
@@ -362,7 +365,8 @@ mod test {
             deactivating: 3,
         };
         stake_history.add(1, stake_history_entry.clone());
-        let stake_history_sysvar = create_account_for_test(&stake_history);
+        let stake_history_sysvar =
+            Account::new_data_with_space(1, &stake_history, SIZE, &sysvar::id()).unwrap();
         assert_eq!(
             parse_sysvar(&stake_history_sysvar.data, &sysvar::stake_history::id()).unwrap(),
             SysvarAccountType::StakeHistory(vec![UiStakeHistoryEntry {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -41,7 +41,7 @@ use {
     solana_sdk_ids::sysvar::{self, stake_history},
     solana_signature::Signature,
     solana_slot_history::{self as slot_history, SlotHistory},
-    solana_stake_interface::{self as stake, state::StakeStateV2},
+    solana_stake_interface::{self as stake, stake_history::StakeHistory, state::StakeStateV2},
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     solana_transaction_status::{
         EncodableWithMeta, EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding,
@@ -1654,9 +1654,10 @@ pub async fn process_show_stakes(
     let clock: Clock = from_account(&clock_account).ok_or_else(|| {
         CliError::RpcRequestError("Failed to deserialize clock sysvar".to_string())
     })?;
-    let stake_history = from_account(&stake_history_account).ok_or_else(|| {
-        CliError::RpcRequestError("Failed to deserialize stake history".to_string())
-    })?;
+    let stake_history: StakeHistory =
+        bincode::deserialize(&stake_history_account.data).map_err(|_| {
+            CliError::RpcRequestError("Failed to deserialize stake history".to_string())
+        })?;
     let new_rate_activation_epoch = get_feature_activation_epoch(
         rpc_client,
         &agave_feature_set::reduce_stake_warmup_cooldown::id(),

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2456,6 +2456,7 @@ pub fn build_stake_state(
             _,
         ) => {
             let current_epoch = clock.epoch;
+            #[allow(deprecated)]
             let StakeActivationStatus {
                 effective,
                 activating,
@@ -2719,9 +2720,10 @@ pub async fn get_account_stake_state(
     match stake_account.state() {
         Ok(stake_state) => {
             let stake_history_account = rpc_client.get_account(&stake_history::id()).await?;
-            let stake_history = from_account(&stake_history_account).ok_or_else(|| {
-                CliError::RpcRequestError("Failed to deserialize stake history".to_string())
-            })?;
+            let stake_history: StakeHistory = bincode::deserialize(&stake_history_account.data)
+                .map_err(|_| {
+                    CliError::RpcRequestError("Failed to deserialize stake history".to_string())
+                })?;
             let clock_account = rpc_client.get_account(&clock::id()).await?;
             let clock: Clock = from_account(&clock_account).ok_or_else(|| {
                 CliError::RpcRequestError("Failed to deserialize clock sysvar".to_string())
@@ -2779,7 +2781,7 @@ pub async fn process_show_stake_history(
 ) -> ProcessResult {
     let stake_history_account = rpc_client.get_account(&stake_history::id()).await?;
     let stake_history =
-        from_account::<StakeHistory, _>(&stake_history_account).ok_or_else(|| {
+        bincode::deserialize::<StakeHistory>(&stake_history_account.data).map_err(|_| {
             CliError::RpcRequestError("Failed to deserialize stake history".to_string())
         })?;
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -531,7 +531,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -542,7 +542,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2398,7 +2398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5348,7 +5348,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5406,7 +5406,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5876,7 +5876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6546,9 +6546,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clock"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cf11109c3b6115cc510f1e31f06fdd52f504271bc24ef5f1249fbbcae5f9f3"
+checksum = "5ea35d8f69b67daddb921a9da7f78ca591b533cf5e98833cd9ae62fdc2e4652c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -8767,9 +8767,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "3.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49eb5c77484214c3484921e2cdda79d185373118b5458c1b2df0f1a04c3bc30"
+checksum = "19f34562cda7df74d85fcb1f7063d8cdec3e14f3d402aa3062605c116d8b8115"
 dependencies = [
  "borsh",
  "num-traits",
@@ -10160,7 +10160,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11137,7 +11137,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -118,7 +118,7 @@ solana-sdk-ids = "3.1.0"
 solana-shred-version = "3.0.1"
 solana-signature = { version = "3.4.0", default-features = false }
 solana-signer = "3.0.0"
-solana-stake-interface = "3.0.0"
+solana-stake-interface = "4.2.0"
 solana-storage-bigtable = { path = "../storage-bigtable", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-streamer = { path = "../streamer", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm = { path = "../svm", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -366,7 +366,10 @@ pub mod get_sysvar_with_account_check {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, test_case::test_case};
+    use {
+        super::*, solana_stake_interface::stake_history::SIZE as STAKE_HISTORY_ACCOUNT_SIZE,
+        test_case::test_case,
+    };
 
     // sysvar cache provides the full account data of a sysvar
     // the setters MUST NOT be changed to serialize an object representation
@@ -375,17 +378,17 @@ mod tests {
     // * account data is larger than struct sysvar
     // * vector sysvar has fewer than its maximum entries
     // if at any point the data is roundtripped through bincode, the vector will shrink
-    #[test_case(Clock::default(); "clock")]
-    #[test_case(EpochSchedule::default(); "epoch_schedule")]
-    #[test_case(EpochRewards::default(); "epoch_rewards")]
-    #[test_case(Rent::default(); "rent")]
-    #[test_case(SlotHashes::default(); "slot_hashes")]
-    #[test_case(StakeHistory::default(); "stake_history")]
-    #[test_case(LastRestartSlot::default(); "last_restart_slot")]
-    fn test_sysvar_cache_preserves_bytes<T: SysvarSerialize>(_: T) {
+    #[test_case(Clock::default(), 40; "clock")]
+    #[test_case(EpochSchedule::default(), 33; "epoch_schedule")]
+    #[test_case(EpochRewards::default(), 81; "epoch_rewards")]
+    #[test_case(Rent::default(), 17; "rent")]
+    #[test_case(SlotHashes::default(), 20_488; "slot_hashes")]
+    #[test_case(StakeHistory::default(), STAKE_HISTORY_ACCOUNT_SIZE; "stake_history")]
+    #[test_case(LastRestartSlot::default(), 8; "last_restart_slot")]
+    fn test_sysvar_cache_preserves_bytes<T: SysvarId>(_: T, account_size: usize) {
         let id = T::id();
-        let size = T::size_of().saturating_mul(2);
-        let in_buf = vec![0; size];
+        let account_size = account_size.saturating_mul(2);
+        let in_buf = vec![0; account_size];
 
         let mut sysvar_cache = SysvarCache::default();
         sysvar_cache.fill_missing_entries(|pubkey, callback| {

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -194,10 +194,13 @@ async fn stake_rewards_from_warp() {
     let stake_history: StakeHistory = deserialize(&stake_history_account.data).unwrap();
     let clock: Clock = deserialize(&clock_account.data).unwrap();
     let stake = stake_state.stake().unwrap();
-    assert_eq!(
+    #[allow(deprecated)]
+    let stake_activation_status =
         stake
             .delegation
-            .stake_activating_and_deactivating(clock.epoch, &stake_history, None),
+            .stake_activating_and_deactivating(clock.epoch, &stake_history, None);
+    assert_eq!(
+        stake_activation_status,
         StakeActivationStatus::with_effective(stake.delegation.stake),
     );
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5269,7 +5269,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -5764,7 +5764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6393,9 +6393,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clock"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cf11109c3b6115cc510f1e31f06fdd52f504271bc24ef5f1249fbbcae5f9f3"
+checksum = "5ea35d8f69b67daddb921a9da7f78ca591b533cf5e98833cd9ae62fdc2e4652c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -9289,9 +9289,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "3.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49eb5c77484214c3484921e2cdda79d185373118b5458c1b2df0f1a04c3bc30"
+checksum = "19f34562cda7df74d85fcb1f7063d8cdec3e14f3d402aa3062605c116d8b8115"
 dependencies = [
  "num-traits",
  "serde",
@@ -10641,7 +10641,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -108,7 +108,7 @@ solana-account-view = "=2.0.0"
 solana-address = "=2.6.0"
 solana-blake3-hasher = { version = "=3.1.0", features = ["blake3"] }
 solana-bn254 = "=3.2.1"
-solana-clock = { version = "=3.0.1", features = ["serde", "sysvar"] }
+solana-clock = { version = "=3.1.0", features = ["serde", "sysvar"] }
 solana-compute-budget = { path = "../../compute-budget", version = "=4.2.0-alpha.0" }
 solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=4.2.0-alpha.0" }
 solana-cpi = "=3.1.0"
@@ -140,7 +140,7 @@ solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version
 solana-sdk-ids = "=3.1.0"
 solana-secp256k1-recover = "=3.1.1"
 solana-sha256-hasher = { version = "=3.1.0", features = ["sha2"] }
-solana-stake-interface = { version = "=3.1.0", features = ["bincode"] }
+solana-stake-interface = { version = "=4.2.0", features = ["bincode"] }
 solana-svm = { path = "../../svm", version = "=4.2.0-alpha.0" }
 solana-svm-feature-set = { path = "../../svm-feature-set", version = "=4.2.0-alpha.0" }
 solana-svm-timings = { path = "../../svm-timings", version = "=4.2.0-alpha.0" }
@@ -201,7 +201,7 @@ solana-sbf-rust-realloc-dep = { workspace = true }
 solana-sbf-rust-realloc-invoke-dep = { workspace = true }
 solana-sdk-ids = "3.1.0"
 solana-signer = "3.0.0"
-solana-stake-interface = "3.0.0"
+solana-stake-interface = "4.2.0"
 solana-svm = { workspace = true, features = ["dev-context-only-utils"] }
 solana-svm-feature-set = { workspace = true }
 solana-svm-timings = { workspace = true }

--- a/programs/sbf/rust/sysvar/src/lib.rs
+++ b/programs/sbf/rust/sysvar/src/lib.rs
@@ -185,7 +185,14 @@ pub fn process_instruction(
             {
                 msg!("StakeHistory identifier:");
                 sysvar::stake_history::id().log();
-                let _ = StakeHistory::from_account_info(&accounts[9]).unwrap();
+                let _: StakeHistory =
+                    if sysvar::stake_history::check_id(accounts[9].unsigned_key()) {
+                        bincode::deserialize(&accounts[9].data.borrow())
+                            .map_err(|_| ProgramError::InvalidArgument)
+                    } else {
+                        Err(ProgramError::InvalidArgument)
+                    }
+                    .unwrap();
                 // Syscall `sol_get_sysvar`.
                 let stake_history_sysvar = StakeHistorySysvar(1);
                 assert!(stake_history_sysvar.get_entry(0).is_some());

--- a/programs/sbf/tests/sysvar.rs
+++ b/programs/sbf/tests/sysvar.rs
@@ -2,6 +2,7 @@
 
 use {
     agave_feature_set::disable_fees_sysvar,
+    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_instruction::{AccountMeta, Instruction},
     solana_message::Message,
     solana_pubkey::Pubkey,
@@ -15,15 +16,38 @@ use {
     solana_sdk_ids::{
         bpf_loader_upgradeable,
         sysvar::{
-            clock, epoch_schedule, instructions, recent_blockhashes, rent, slot_hashes,
+            self, clock, epoch_schedule, instructions, recent_blockhashes, rent, slot_hashes,
             slot_history, stake_history,
         },
     },
     solana_signer::Signer,
-    solana_stake_interface::stake_history::{StakeHistory, StakeHistoryEntry},
+    solana_stake_interface::stake_history::{
+        SIZE as STAKE_HISTORY_ACCOUNT_SIZE, StakeHistory, StakeHistoryEntry,
+    },
     solana_sysvar::epoch_rewards,
     solana_transaction::Transaction,
 };
+
+fn set_stake_history_sysvar_for_tests(bank: &Bank, stake_history: &StakeHistory) {
+    let stake_history_account_size =
+        STAKE_HISTORY_ACCOUNT_SIZE.max(bincode::serialized_size(stake_history).unwrap() as usize);
+    let old_stake_history_account = bank.get_account(&stake_history::id()).unwrap();
+    let lamports = old_stake_history_account
+        .lamports()
+        .max(bank.get_minimum_balance_for_rent_exemption(stake_history_account_size));
+    let mut stake_history_account = AccountSharedData::new_data_with_space(
+        lamports,
+        stake_history,
+        stake_history_account_size,
+        &sysvar::id(),
+    )
+    .unwrap();
+    stake_history_account.set_rent_epoch(old_stake_history_account.rent_epoch());
+    bank.store_account(&stake_history::id(), &stake_history_account);
+    bank.get_transaction_processor().reset_sysvar_cache();
+    bank.get_transaction_processor()
+        .fill_missing_sysvar_cache_entries(bank);
+}
 
 #[test]
 fn test_sysvar_syscalls() {
@@ -59,7 +83,7 @@ fn test_sysvar_syscalls() {
         );
         stake_history
     };
-    bank.set_sysvar_for_tests(&stake_history);
+    set_stake_history_sysvar_for_tests(&bank, &stake_history);
 
     let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
     let program_id = create_program(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -140,13 +140,17 @@ use {
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
     },
-    solana_sdk_ids::{bpf_loader_upgradeable, incinerator, native_loader, system_program},
+    solana_sdk_ids::{
+        bpf_loader_upgradeable, incinerator, native_loader, system_program, sysvar as sysvar_id,
+    },
     solana_sha256_hasher::hashv,
     solana_signature::Signature,
     solana_slot_hashes::SlotHashes,
     solana_slot_history::{Check, SlotHistory},
     solana_stake_interface::{
-        stake_history::StakeHistory, state::Delegation, sysvar::stake_history,
+        stake_history::{SIZE as STAKE_HISTORY_ACCOUNT_SIZE, StakeHistory},
+        state::Delegation,
+        sysvar::stake_history,
     },
     solana_svm::{
         account_loader::LoadedTransaction,
@@ -1136,6 +1140,18 @@ struct NewEpochBundle {
     rewards_calculation: Arc<PartitionedRewardsCalculation>,
     calculate_activated_stake_time_us: u64,
     update_rewards_with_thread_pool_time_us: u64,
+}
+
+fn create_stake_history_account(
+    stake_history: &StakeHistory,
+    (lamports, rent_epoch): InheritableAccountFields,
+) -> AccountSharedData {
+    let data_len =
+        STAKE_HISTORY_ACCOUNT_SIZE.max(bincode::serialized_size(stake_history).unwrap() as usize);
+    let mut account = AccountSharedData::new(lamports, data_len, &sysvar_id::id());
+    account.serialize_data(stake_history).unwrap();
+    account.set_rent_epoch(rent_epoch);
+    account
 }
 
 impl Bank {
@@ -2646,7 +2662,7 @@ impl Bank {
         }
         // if I'm the first Bank in an epoch, ensure stake_history is updated
         self.update_sysvar_account(&stake_history::id(), |account| {
-            create_account::<StakeHistory>(
+            create_stake_history_account(
                 self.stakes_cache.stakes().history(),
                 self.inherit_specially_retained_account_fields(account),
             )

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -246,12 +246,13 @@ impl Bank {
             ))
             .map_err(|_| DistributionError::UnableToSetState)?;
 
-        let reward_type = if partitioned_stake_reward.stake.delegation.stake(
+        #[allow(deprecated)]
+        let stake_at_distribution_epoch = partitioned_stake_reward.stake.delegation.stake(
             distribution_epoch,
             stake_history,
             new_warmup_cooldown_rate_epoch,
-        ) == 0
-        {
+        );
+        let reward_type = if stake_at_distribution_epoch == 0 {
             RewardType::DeactivatedStake
         } else {
             RewardType::Staking

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -366,7 +366,7 @@ mod tests {
         #[cfg_attr(
             feature = "frozen-abi",
             derive(AbiExample),
-            frozen_abi(digest = "5ESyZ9Aseo4v1XA2xnC8dENK8MueieQESYfeNcxByCmd")
+            frozen_abi(digest = "HPAeeQDtsPexZuCjrCRv1MU6oo8MLHForsk1bXy1863V")
         )]
         #[derive(serde::Serialize)]
         pub struct BankAbiTestWrapper {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2917,8 +2917,10 @@ fn test_bank_epoch_vote_accounts() {
 
         // epoch_stakes are a snapshot at the leader_schedule_slot_offset boundary
         //   in the prior epoch (0 in this case)
+        #[allow(deprecated)]
+        let expected_stake = leader_stake.stake(0, &StakeHistory::default(), None);
         assert_eq!(
-            leader_stake.stake(0, &StakeHistory::default(), None),
+            expected_stake,
             vote_accounts.unwrap().get(&leader_vote_account).unwrap().0
         );
 
@@ -2933,8 +2935,10 @@ fn test_bank_epoch_vote_accounts() {
     );
 
     assert!(child.epoch_vote_accounts(epoch).is_some());
+    #[allow(deprecated)]
+    let expected_stake = leader_stake.stake(child.epoch(), &StakeHistory::default(), None);
     assert_eq!(
-        leader_stake.stake(child.epoch(), &StakeHistory::default(), None),
+        expected_stake,
         child
             .epoch_vote_accounts(epoch)
             .unwrap()
@@ -2951,8 +2955,10 @@ fn test_bank_epoch_vote_accounts() {
         SLOTS_PER_EPOCH - (LEADER_SCHEDULE_SLOT_OFFSET % SLOTS_PER_EPOCH) + 1,
     );
     assert!(child.epoch_vote_accounts(epoch).is_some());
+    #[allow(deprecated)]
+    let expected_stake = leader_stake.stake(child.epoch(), &StakeHistory::default(), None);
     assert_eq!(
-        leader_stake.stake(child.epoch(), &StakeHistory::default(), None),
+        expected_stake,
         child
             .epoch_vote_accounts(epoch)
             .unwrap()

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -45,12 +45,13 @@ pub(crate) fn redeem_rewards<'a>(
             commission_rate_in_basis_points,
             ..
         } = calculation_environment;
+        #[allow(deprecated)]
+        let effective_stake_at_rewarded_epoch =
+            stake.stake(rewarded_epoch, stake_history, new_rate_activation_epoch);
         inflation_point_calc_tracer(
-            &InflationPointCalculationEvent::EffectiveStakeAtRewardedEpoch(stake.stake(
-                rewarded_epoch,
-                stake_history,
-                new_rate_activation_epoch,
-            )),
+            &InflationPointCalculationEvent::EffectiveStakeAtRewardedEpoch(
+                effective_stake_at_rewarded_epoch,
+            ),
         );
         inflation_point_calc_tracer(&InflationPointCalculationEvent::PriorTotalLamports(
             current_lamports,

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -191,6 +191,7 @@ pub(crate) fn calculate_stake_points_and_credits(
 
     for epoch_credits_item in vote_state.epoch_credits_iter {
         let (epoch, final_epoch_credits, initial_epoch_credits) = epoch_credits_item;
+        #[allow(deprecated)]
         let stake_amount = u128::from(stake.delegation.stake(
             epoch,
             stake_history,

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -269,6 +269,7 @@ impl Stakes<StakeAccount> {
                     StakeAccount::try_from(create_account_shared_data(account))
                 {
                     let delegation = stake_account.delegation();
+                    #[allow(deprecated)]
                     let stake = delegation.stake(epoch, &stake_history, new_rate_activation_epoch);
                     *delegated_stakes.entry(delegation.voter_pubkey).or_default() += stake;
                     stake_delegations.insert(*pubkey, stake_account);
@@ -398,11 +399,13 @@ impl Stakes<StakeAccount> {
                     StakeActivationStatus::default,
                     |acc, (_stake_pubkey, stake_account)| {
                         let delegation = stake_account.delegation();
-                        acc + delegation.stake_activating_and_deactivating(
+                        #[allow(deprecated)]
+                        let activation_status = delegation.stake_activating_and_deactivating(
                             self.epoch,
                             &self.stake_history,
                             new_rate_activation_epoch,
-                        )
+                        );
+                        acc + activation_status
                     },
                 )
                 .reduce(StakeActivationStatus::default, Add::add)
@@ -434,6 +437,7 @@ impl Stakes<StakeAccount> {
     }
 
     /// Sum the stakes that point to the given voter_pubkey
+    #[allow(deprecated)]
     fn calculate_stake(
         stake_delegations: &ImblHashMap<Pubkey, StakeAccount>,
         voter_pubkey: &Pubkey,
@@ -460,6 +464,7 @@ impl Stakes<StakeAccount> {
     ) {
         if let Some(stake_account) = self.stake_delegations.remove(stake_pubkey) {
             let removed_delegation = stake_account.delegation();
+            #[allow(deprecated)]
             let removed_stake = removed_delegation.stake(
                 self.epoch,
                 &self.stake_history,
@@ -499,12 +504,14 @@ impl Stakes<StakeAccount> {
         debug_assert_ne!(stake_account.lamports(), 0u64);
         let delegation = stake_account.delegation();
         let voter_pubkey = delegation.voter_pubkey;
+        #[allow(deprecated)]
         let stake = delegation.stake(self.epoch, &self.stake_history, new_rate_activation_epoch);
         match self.stake_delegations.insert(stake_pubkey, stake_account) {
             None => self.vote_accounts.add_stake(&voter_pubkey, stake),
             Some(old_stake_account) => {
                 let old_delegation = old_stake_account.delegation();
                 let old_voter_pubkey = old_delegation.voter_pubkey;
+                #[allow(deprecated)]
                 let old_stake = old_delegation.stake(
                     self.epoch,
                     &self.stake_history,
@@ -644,7 +651,9 @@ fn refresh_vote_accounts(
                 |mut delegated_stakes, (_stake_pubkey, stake_account)| {
                     let delegation = stake_account.delegation();
                     let entry = delegated_stakes.entry(delegation.voter_pubkey).or_default();
-                    *entry += delegation.stake(epoch, stake_history, new_rate_activation_epoch);
+                    #[allow(deprecated)]
+                    let stake = delegation.stake(epoch, stake_history, new_rate_activation_epoch);
+                    *entry += stake;
                     delegated_stakes
                 },
             )
@@ -768,9 +777,11 @@ pub(crate) mod tests {
                 let stakes = stakes_cache.stakes();
                 let vote_accounts = stakes.vote_accounts();
                 assert!(vote_accounts.get(&vote_pubkey).is_some());
+                #[allow(deprecated)]
+                let expected_stake = stake.stake(i, &StakeHistory::default(), None);
                 assert_eq!(
                     vote_accounts.get_delegated_stake(&vote_pubkey),
-                    stake.stake(i, &StakeHistory::default(), None)
+                    expected_stake
                 );
             }
 
@@ -780,9 +791,11 @@ pub(crate) mod tests {
                 let stakes = stakes_cache.stakes();
                 let vote_accounts = stakes.vote_accounts();
                 assert!(vote_accounts.get(&vote_pubkey).is_some());
+                #[allow(deprecated)]
+                let expected_stake = stake.stake(i, &StakeHistory::default(), None);
                 assert_eq!(
                     vote_accounts.get_delegated_stake(&vote_pubkey),
-                    stake.stake(i, &StakeHistory::default(), None)
+                    expected_stake
                 ); // stays old stake, because only 10 is activated
             }
 
@@ -799,9 +812,11 @@ pub(crate) mod tests {
                 let stakes = stakes_cache.stakes();
                 let vote_accounts = stakes.vote_accounts();
                 assert!(vote_accounts.get(&vote_pubkey).is_some());
+                #[allow(deprecated)]
+                let expected_stake = stake.stake(i, &StakeHistory::default(), None);
                 assert_eq!(
                     vote_accounts.get_delegated_stake(&vote_pubkey),
-                    stake.stake(i, &StakeHistory::default(), None)
+                    expected_stake
                 ); // now stake of 42 is activated
             }
 
@@ -956,9 +971,11 @@ pub(crate) mod tests {
             let stakes = stakes_cache.stakes();
             let vote_accounts = stakes.vote_accounts();
             assert!(vote_accounts.get(&vote_pubkey).is_some());
+            #[allow(deprecated)]
+            let expected_stake = stake.stake(stakes.epoch, &stakes.stake_history, None);
             assert_eq!(
                 vote_accounts.get_delegated_stake(&vote_pubkey),
-                stake.stake(stakes.epoch, &stakes.stake_history, None)
+                expected_stake
             );
             assert!(vote_accounts.get(&vote_pubkey2).is_some());
             assert_eq!(vote_accounts.get_delegated_stake(&vote_pubkey2), 0);
@@ -973,9 +990,11 @@ pub(crate) mod tests {
             assert!(vote_accounts.get(&vote_pubkey).is_some());
             assert_eq!(vote_accounts.get_delegated_stake(&vote_pubkey), 0);
             assert!(vote_accounts.get(&vote_pubkey2).is_some());
+            #[allow(deprecated)]
+            let expected_stake = stake.stake(stakes.epoch, &stakes.stake_history, None);
             assert_eq!(
                 vote_accounts.get_delegated_stake(&vote_pubkey2),
-                stake.stake(stakes.epoch, &stakes.stake_history, None)
+                expected_stake
             );
         }
     }
@@ -1026,9 +1045,11 @@ pub(crate) mod tests {
         {
             let stakes = stakes_cache.stakes();
             let vote_accounts = stakes.vote_accounts();
+            #[allow(deprecated)]
+            let expected_stake = stake.stake(stakes.epoch, &stakes.stake_history, None);
             assert_eq!(
                 vote_accounts.get_delegated_stake(&vote_pubkey),
-                stake.stake(stakes.epoch, &stakes.stake_history, None)
+                expected_stake
             );
         }
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
@@ -1042,9 +1063,11 @@ pub(crate) mod tests {
         {
             let stakes = stakes_cache.stakes();
             let vote_accounts = stakes.vote_accounts();
+            #[allow(deprecated)]
+            let expected_stake = stake.stake(stakes.epoch, &stakes.stake_history, None);
             assert_eq!(
                 vote_accounts.get_delegated_stake(&vote_pubkey),
-                stake.stake(stakes.epoch, &stakes.stake_history, None)
+                expected_stake
             );
         }
     }

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2701,7 +2701,9 @@ mod tests {
         solana_sha256_hasher::hashv,
         solana_slot_hashes::{self as slot_hashes, SlotHashes},
         solana_stable_layout::stable_instruction::StableInstruction,
-        solana_stake_interface::stake_history::{self, StakeHistory, StakeHistoryEntry},
+        solana_stake_interface::stake_history::{
+            self, SIZE as STAKE_HISTORY_ACCOUNT_SIZE, StakeHistory, StakeHistoryEntry,
+        },
         solana_sysvar_id::SysvarId,
         solana_transaction_context::instruction_accounts::InstructionAccount,
         std::{
@@ -2711,6 +2713,14 @@ mod tests {
         },
         test_case::test_case,
     };
+
+    fn create_stake_history_account_for_test(stake_history: &StakeHistory) -> AccountSharedData {
+        let data_len = STAKE_HISTORY_ACCOUNT_SIZE
+            .max(bincode::serialized_size(stake_history).unwrap() as usize);
+        let mut account = AccountSharedData::new(1, data_len, &sysvar::id());
+        account.serialize_data(stake_history).unwrap();
+        account
+    }
 
     macro_rules! assert_access_violation {
         ($result:expr, $va:expr, $len:expr) => {
@@ -4529,17 +4539,17 @@ mod tests {
 
         let src_history = src_history;
 
-        let mut src_history_buf = vec![0; StakeHistory::size_of()];
+        let mut src_history_buf = vec![0; STAKE_HISTORY_ACCOUNT_SIZE];
         bincode::serialize_into(&mut src_history_buf, &src_history).unwrap();
 
         let transaction_accounts = vec![(
             sysvar::stake_history::id(),
-            create_account_shared_data_for_test(&src_history),
+            create_stake_history_account_for_test(&src_history),
         )];
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
 
         {
-            let mut got_history_buf = vec![0; StakeHistory::size_of()];
+            let mut got_history_buf = vec![0; STAKE_HISTORY_ACCOUNT_SIZE];
             let got_history_buf_va = 0x100000000;
             let history_id_va = 0x200000000;
             let history_id = StakeHistory::id().to_bytes();
@@ -4564,7 +4574,7 @@ mod tests {
                 history_id_va,
                 got_history_buf_va,
                 0,
-                StakeHistory::size_of() as u64,
+                STAKE_HISTORY_ACCOUNT_SIZE as u64,
                 0,
             );
             assert_eq!(result.unwrap(), 0);


### PR DESCRIPTION
Related: https://github.com/anza-xyz/agave/pull/12123 https://github.com/anza-xyz/agave/pull/12245

Updates `solana-stake-interface` dep to 4.2.0. This unblocks wincode updates as well as support for https://github.com/solana-program/stake/pull/152 methods.

Note: this also requires dropping SysvarSerialize reliance for solana-stake-history. Hence the diffs moving to bincode directly.