### PR TITLE
Removes AccountsDb::shrink_paths

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -902,8 +902,6 @@ pub struct AccountsDb {
     /// directory for bank hash details files
     bank_hash_details_dir: PathBuf,
 
-    shrink_paths: Vec<PathBuf>,
-
     /// Directory of paths this accounts_db needs to hold/remove
     #[allow(dead_code)]
     pub temp_paths: Option<Vec<TempDir>>,
@@ -1060,11 +1058,6 @@ impl AccountsDb {
             (paths, None)
         };
 
-        let shrink_paths = accounts_db_config
-            .shrink_paths
-            .clone()
-            .unwrap_or_else(|| paths.clone());
-
         let read_cache_size = accounts_db_config.read_cache_limit_bytes.unwrap_or((
             Self::DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_LO,
             Self::DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_HI,
@@ -1105,7 +1098,6 @@ impl AccountsDb {
             paths,
             bank_hash_details_dir: accounts_db_config.bank_hash_details_dir,
             temp_paths,
-            shrink_paths,
             skip_initial_hash_calc: accounts_db_config.skip_initial_hash_calc,
             ancient_append_vec_offset: accounts_db_config
                 .ancient_append_vec_offset
@@ -3018,7 +3010,7 @@ impl AccountsDb {
         old_store: Arc<AccountStorageEntry>,
         size: u64,
     ) -> ShrinkInProgress<'_> {
-        let shrunken_store = self.create_store(slot, size, "shrink", self.shrink_paths.as_slice());
+        let shrunken_store = self.create_store(slot, size, "shrink", self.paths.as_slice());
         self.storage
             .shrinking_in_progress(slot, old_store, shrunken_store)
     }

--- a/accounts-db/src/accounts_db/accounts_db_config.rs
+++ b/accounts-db/src/accounts_db/accounts_db_config.rs
@@ -17,7 +17,6 @@ pub struct AccountsDbConfig {
     pub index: Option<AccountsIndexConfig>,
     pub account_indexes: Option<AccountSecondaryIndexes>,
     pub bank_hash_details_dir: PathBuf,
-    pub shrink_paths: Option<Vec<PathBuf>>,
     pub shrink_ratio: AccountShrinkThreshold,
     /// The low and high watermark sizes for the read cache, in bytes.
     /// If None, defaults will be used.
@@ -48,7 +47,6 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
     account_indexes: None,
     bank_hash_details_dir: PathBuf::new(), // tests don't use bank hash details
-    shrink_paths: None,
     shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     read_cache_limit_bytes: None,
     read_cache_evict_sample_size: None,
@@ -69,7 +67,6 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
     account_indexes: None,
     bank_hash_details_dir: PathBuf::new(), // benches don't use bank hash details
-    shrink_paths: None,
     shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     read_cache_limit_bytes: None,
     read_cache_evict_sample_size: None,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2903,11 +2903,6 @@ fn cleanup_accounts_paths(config: &ValidatorConfig) {
     for account_path in &config.account_paths {
         move_and_async_delete_path_contents(account_path);
     }
-    if let Some(shrink_paths) = &config.accounts_db_config.shrink_paths {
-        for shrink_path in shrink_paths {
-            move_and_async_delete_path_contents(shrink_path);
-        }
-    }
 }
 
 fn validate_account_paths(config: &ValidatorConfig) -> std::io::Result<()> {

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -362,7 +362,6 @@ pub fn get_accounts_db_config(
         index: Some(accounts_index_config),
         account_indexes: None,
         bank_hash_details_dir: ledger_tool_ledger_path,
-        shrink_paths: None,
         shrink_ratio: AccountShrinkThreshold::default(),
         read_cache_limit_bytes: None,
         read_cache_evict_sample_size: None,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -137,6 +137,7 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .takes_value(true)
             .multiple(true)
             .help("Path to accounts shrink path which can hold a compacted account set."),
+        usage_warning: "Shrink paths are no longer used.",
     );
     add_arg!(
         // deprecated in v4.2.0; the `mmap` value was deprecated in v4.0.0, and now mmap mode has

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -656,26 +656,6 @@ pub fn execute(
 
     const MB: usize = 1_024 * 1_024;
 
-    let account_shrink_paths: Option<Vec<PathBuf>> =
-        values_t!(matches, "account_shrink_path", String)
-            .map(|shrink_paths| shrink_paths.into_iter().map(PathBuf::from).collect())
-            .ok();
-    let account_shrink_paths = account_shrink_paths
-        .as_ref()
-        .map(|paths| {
-            create_and_canonicalize_directories(paths)
-                .map_err(|err| format!("unable to access account shrink path: {err}"))
-        })
-        .transpose()?;
-
-    let (account_shrink_run_paths, account_shrink_snapshot_paths) = account_shrink_paths
-        .map(|paths| {
-            create_all_accounts_run_and_snapshot_dirs(&paths)
-                .map_err(|err| format!("unable to create account subdirectories: {err}"))
-        })
-        .transpose()?
-        .unzip();
-
     let read_cache_limit_bytes =
         values_of::<usize>(matches, "accounts_db_read_cache_limit").map(|limits| {
             match limits.len() {
@@ -704,7 +684,6 @@ pub fn execute(
         index: Some(accounts_index_config),
         account_indexes: Some(account_indexes.clone()),
         bank_hash_details_dir: ledger_path.clone(),
-        shrink_paths: account_shrink_run_paths,
         shrink_ratio,
         read_cache_limit_bytes,
         read_cache_evict_sample_size: None,
@@ -758,17 +737,6 @@ pub fn execute(
     let (account_run_paths, account_snapshot_paths) =
         create_all_accounts_run_and_snapshot_dirs(&account_paths)
             .map_err(|err| format!("unable to create account directories: {err}"))?;
-
-    // These snapshot paths are only used for initial clean up, add in shrink paths if they exist.
-    let account_snapshot_paths =
-        if let Some(account_shrink_snapshot_paths) = account_shrink_snapshot_paths {
-            account_snapshot_paths
-                .into_iter()
-                .chain(account_shrink_snapshot_paths)
-                .collect()
-        } else {
-            account_snapshot_paths
-        };
 
     let snapshot_config = new_snapshot_config(
         matches,


### PR DESCRIPTION
#### Problem

Please first see https://github.com/anza-xyz/agave/pull/11531.

Since the cli arg is deprecated, we don't need to support shrink paths anymore.


#### Summary of Changes

Remove the `AccountsDb::shrink_paths` field, but purposely leave the `--account-shrink-path` cli arg.