### PR TITLE
streamer: set lower max discoverable Quic UDP payload

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -12,7 +12,7 @@ use {
     crossbeam_channel::Sender,
     pem::Pem,
     quinn::{
-        Endpoint, IdleTimeout, ServerConfig, VarInt,
+        Endpoint, IdleTimeout, MtuDiscoveryConfig, ServerConfig, VarInt,
         crypto::rustls::{NoInitialCipherSuite, QuicServerConfig},
     },
     rustls::KeyLogFile,
@@ -65,6 +65,13 @@ pub const DEFAULT_QUIC_ENDPOINTS: usize = 1;
 /// on the number of concurrent streams. This does not affect the memory allocation
 /// in Quinn, that is driven primarily by MAX_STREAMS, not MAX_DATA.
 const CONNECTION_RECEIVE_WINDOW_BYTES: VarInt = VarInt::from_u32(8 * 1024 * 1024);
+
+/// Conservative max Quic UDP payload size to take into consideration GRE case.
+///
+/// Quinn computes default max Quic UDP payload size as 1500 (common MTU) - 40 (IPv6 header)
+/// - 8 (UDP header) = 1452 bytes. Yet in case of GRE, we will instead have 1500 (common MTU) - 20
+///   (outer IPv4 header) - 4 (GRE header) - 20 (inner IPv4 header) - 8 (UDP header) = 1448 bytes.
+const MAX_QUIC_UDP_PAYLOAD: u16 = 1448;
 
 pub fn default_num_tpu_transaction_forward_receive_threads() -> usize {
     num_cpus::get().min(16)
@@ -128,6 +135,12 @@ pub(crate) fn configure_server(
     // quinn_proto::Connection::poll_transmit allocate only 1 MTU vs 10 * MTU for _each_ transmit.
     // See https://github.com/anza-xyz/agave/pull/1647.
     config.enable_segmentation_offload(false);
+
+    config.mtu_discovery_config(Some({
+        let mut mtu_config = MtuDiscoveryConfig::default();
+        mtu_config.upper_bound(MAX_QUIC_UDP_PAYLOAD);
+        mtu_config
+    }));
 
     Ok((server_config, cert_chain_pem))
 }


### PR DESCRIPTION
#### Problem

Quinn performs PLPMTUD  by sending PING packets padded to a target UDP payload size. It uses missed ACK for sent packet as a signal that probed MTU exceeds actual MTU on the given route.
Quinn allows to configure max UDP payload for MTU discovery. Currently used default value is `1452` which is computed as `1500 (common MTU) - 40 (IPv6 header) - 8 (UDP header) = 1452 bytes`. But if the it is GRE route, we will have in fact `1500 (common MTU) - 20 (outer IPv4 header) - 4 (GRE header) - 20 (inner IPv4 header) - 8 (UDP header) = 1448 bytes`.
If we use `1452`, it will discover that it is too large and may finish around `1420` because  quinn's min change defaults to 20.

I reproduced the problem on testnet. If MTU discovery is disabled, I don't see WARN for dropped packets.

In logs I observe:
```
[TRACE quinn_proto::connection] writing MTUD probe probe_size=1326
[TRACE quinn_proto::connection] writing MTUD probe probe_size=1389
[TRACE quinn_proto::connection] writing MTUD probe probe_size=1420
[TRACE quinn_proto::connection] writing MTUD probe probe_size=1452
```

After the fix:
```
[2026-05-25T16:32:48.298322435Z TRACE quinn_proto::connection::mtud] new MTU detected current_mtu=1448
```

#### Summary of Changes

Conservatively set the max Quinn UDP discoverable UDP payload to `1448`.
This will increase the typical discovered MTU for the case of GRE by up to 20b. At the same time, it will reduce the typical discovered MTU for non-GRE case by 4b.

