### PR TITLE
fix(votor): only add vote to vote_history if voting

### DIFF
--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -235,11 +235,6 @@ fn insert_vote_and_create_bls_message(
     is_refresh: bool,
     context: &mut VotingContext,
 ) -> Result<BLSOp, VoteError> {
-    // Update and save the vote history
-    if !is_refresh {
-        context.vote_history.add_vote(vote);
-    }
-
     let bank = context.sharable_banks.root();
     let message = match generate_vote_tx(
         vote,
@@ -259,6 +254,15 @@ fn insert_vote_and_create_bls_message(
             }
         }
     };
+
+    // Only record after generate_vote_tx has produced a signed message.
+    // Recording before would leave vote_history claiming we voted for the
+    // slot when HotSpare/NonVoting/NoRankFound short-circuited the broadcast,
+    // permanently blocking us from voting for that slot.
+    if !is_refresh {
+        context.vote_history.add_vote(vote);
+    }
+
     context
         .own_vote_sender
         .send(vec![message.clone()])


### PR DESCRIPTION
#### Problem
Currently we record the vote in vote history before determining whether we are supposed to be voting (or whether we are non-voting, hot spare, not in the rank map). This could lead to some votes never being cast, that could otherwise be cast, especially around epoch boundary and when switching to a hot spare.

#### Summary of Changes
Move `vote_history.add_vote()` until after `generate_vote_tx()` succeeded.

We still add the vote to the vote history before the actual broadcast. So, we should still never be sending out a vote without recording it.