### PR TITLE
fix: migration status race condition

### DIFF
--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -431,6 +431,9 @@ impl MigrationStatus {
 
     /// Record that PohService has started and must be coordinated with when enabling Alpenglow.
     pub fn set_poh_service_started(&self) {
+        // Hold `migration_wait` while flipping the bit so the decision in
+        // `enable_alpenglow_during_startup` is serialized against PohService startup.
+        let _guard = self.migration_wait.0.lock().unwrap();
         self.poh_service_started.store(true, Ordering::Release);
     }
 
@@ -680,7 +683,15 @@ impl MigrationStatus {
         };
 
         let genesis_slot = genesis_cert.cert_type.slot();
+
+        // Take `migration_wait` so the check + phase swap is atomic against
+        // `set_poh_service_started`; otherwise PohService could start between
+        // the load and the write, leaving its tick thread in the bring-up loop
+        // while the phase says AlpenglowEnabled.
+        let (is_alpenglow_enabled, _condvar) = &self.migration_wait;
+        let mut guard = is_alpenglow_enabled.lock().unwrap();
         if self.poh_service_started.load(Ordering::Acquire) {
+            drop(guard);
             // If `PohService` is started, use the full enable pathway
             // We do not respect the exit flag during startup replay
             let exit = AtomicBool::new(false);
@@ -691,8 +702,7 @@ impl MigrationStatus {
         // If `PohService` has not yet started, enable in this single thread
         self.shutdown_poh.store(true, Ordering::Release);
         *self.phase.write().unwrap() = MigrationPhase::AlpenglowEnabled { genesis_cert };
-        let (is_alpenglow_enabled, _condvar) = &self.migration_wait;
-        *is_alpenglow_enabled.lock().unwrap() = true;
+        *guard = true;
         // No need to condvar as we're in startup and no one is waiting for us.
         warn!(
             "{}: Alpenglow enabled during startup! Genesis slot {genesis_slot}",


### PR DESCRIPTION
#### Problem
Right now, the following execution is possible:
1. Startup loads poh_service_started = false
2. PohService::new sets flag, spawns thread
3. Thread checks is_alpenglow_enabled() at poh_service.rs:115 → false → enters the tick loop
   (only checks once on startup, then only polls shutdown_poh)
4. Startup writes phase = AlpenglowEnabled, sets shutdown_poh = true
5. Tick loop observes shutdown_poh, exits, hands off record_receiver to BlockCreationLoop,
  then calls poh_service_is_shutting_down() at poh_service.rs:187
6. That function (migration.rs:653) let-else matches phase against ReadyToEnable; phase is
  now AlpenglowEnabled, so it hits unreachable!()

#### Summary of Changes
Hold the same `self.migration_wait.0` lock over each of the two critical regions.