### PR TITLE
A2A: don't broadcast certificates if unstaked

### DIFF
--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -84,6 +84,7 @@ impl ConsensusPoolService {
     fn maybe_update_root_and_send_new_certificates(
         consensus_pool: &mut ConsensusPool,
         sharable_banks: &SharableBanks,
+        my_pubkey: &Pubkey,
         bls_sender: &Sender<BLSOp>,
         new_finalized_slot: Option<Slot>,
         new_certificates_to_send: Vec<Arc<Certificate>>,
@@ -103,10 +104,45 @@ impl ConsensusPoolService {
         consensus_pool.maybe_prune(bank.slot());
         stats.prune_old_state_called += 1;
         // Send new certificates to peers
-        Self::send_certificates(bls_sender, new_certificates_to_send, stats)
+        Self::send_certificates(
+            sharable_banks,
+            my_pubkey,
+            bls_sender,
+            new_certificates_to_send,
+            stats,
+        )
     }
 
     fn send_certificates(
+        sharable_banks: &SharableBanks,
+        my_pubkey: &Pubkey,
+        bls_sender: &Sender<BLSOp>,
+        certificates_to_send: Vec<Arc<Certificate>>,
+        stats: &mut ConsensusPoolServiceStats,
+    ) -> Result<(), AddVoteError> {
+        let num_certs = certificates_to_send.len();
+        if num_certs == 0 {
+            return Ok(());
+        }
+        // If we are not a staked identity (hot spare / RPC / new validator / failed VAT)
+        // we should not send out the certificate. A2A quic only accepts connections
+        // from staked identities
+        if !Self::is_current_identity_staked(sharable_banks, my_pubkey) {
+            stats.certificates_skipped_unstaked += num_certs;
+            return Ok(());
+        }
+        Self::enqueue_certificates(bls_sender, certificates_to_send, stats)
+    }
+
+    fn is_current_identity_staked(sharable_banks: &SharableBanks, my_pubkey: &Pubkey) -> bool {
+        sharable_banks
+            .root()
+            .current_epoch_staked_nodes()
+            .get(my_pubkey)
+            .is_some_and(|stake| *stake > 0)
+    }
+
+    fn enqueue_certificates(
         bls_sender: &Sender<BLSOp>,
         certificates_to_send: Vec<Arc<Certificate>>,
         stats: &mut ConsensusPoolServiceStats,
@@ -164,6 +200,7 @@ impl ConsensusPoolService {
         Self::maybe_update_root_and_send_new_certificates(
             consensus_pool,
             &ctx.sharable_banks,
+            &ctx.cluster_info.id(),
             &ctx.bls_sender,
             new_finalized_slot,
             new_certificates_to_send,
@@ -265,6 +302,8 @@ impl ConsensusPoolService {
                 stats.standstill = true;
                 standstill_timer = Instant::now();
                 match Self::send_certificates(
+                    &ctx.sharable_banks,
+                    &ctx.cluster_info.id(),
                     &ctx.bls_sender,
                     consensus_pool.get_certs_for_standstill(),
                     &mut stats,
@@ -697,6 +736,7 @@ mod tests {
                 ConsensusPoolService::maybe_update_root_and_send_new_certificates(
                     &mut ctx.consensus_pool,
                     &ctx.sharable_banks,
+                    &ctx.my_pubkey,
                     &ctx.bls_sender,
                     new_finalized_slot,
                     new_certificates_to_send,
@@ -778,6 +818,7 @@ mod tests {
         ConsensusPoolService::maybe_update_root_and_send_new_certificates(
             &mut ctx.consensus_pool,
             &ctx.sharable_banks,
+            &ctx.my_pubkey,
             &ctx.bls_sender,
             new_finalized_slot,
             new_certificates_to_send,
@@ -902,6 +943,8 @@ mod tests {
 
         let mut stats = ConsensusPoolServiceStats::new();
         let result = ConsensusPoolService::send_certificates(
+            &ctx.sharable_banks,
+            &ctx.my_pubkey,
             &ctx.bls_sender,
             certificates.clone(),
             &mut stats,
@@ -924,6 +967,38 @@ mod tests {
     }
 
     #[test]
+    fn test_send_certificates_skips_unstaked_identity() {
+        let ctx = TestContext::default();
+        let certificates = vec![
+            Arc::new(Certificate {
+                cert_type: CertificateType::Skip(1),
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: vec![],
+            }),
+            Arc::new(Certificate {
+                cert_type: CertificateType::Skip(2),
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: vec![],
+            }),
+        ];
+        let unstaked_identity = Pubkey::new_unique();
+        let mut stats = ConsensusPoolServiceStats::new();
+
+        let result = ConsensusPoolService::send_certificates(
+            &ctx.sharable_banks,
+            &unstaked_identity,
+            &ctx.bls_sender,
+            certificates,
+            &mut stats,
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(stats.certificates_sent.0, 0);
+        assert_eq!(stats.certificates_skipped_unstaked.0, 2);
+        assert!(ctx.bls_receiver.try_recv().is_err());
+    }
+
+    #[test]
     fn test_send_certificates_channel_disconnected() {
         let ctx = TestContext::default();
         drop(ctx.bls_receiver); // Disconnect channel
@@ -935,8 +1010,13 @@ mod tests {
         })];
 
         let mut stats = ConsensusPoolServiceStats::new();
-        let result =
-            ConsensusPoolService::send_certificates(&ctx.bls_sender, certificates, &mut stats);
+        let result = ConsensusPoolService::send_certificates(
+            &ctx.sharable_banks,
+            &ctx.my_pubkey,
+            &ctx.bls_sender,
+            certificates,
+            &mut stats,
+        );
 
         assert!(matches!(result, Err(AddVoteError::ChannelDisconnected(_))));
     }
@@ -958,6 +1038,7 @@ mod tests {
         let result = ConsensusPoolService::maybe_update_root_and_send_new_certificates(
             &mut ctx.consensus_pool,
             &ctx.sharable_banks,
+            &ctx.my_pubkey,
             &ctx.bls_sender,
             Some(5), // new finalized slot
             certificates,

--- a/votor/src/consensus_pool_service/stats.rs
+++ b/votor/src/consensus_pool_service/stats.rs
@@ -13,6 +13,7 @@ pub(super) struct ConsensusPoolServiceStats {
     pub(super) add_message_failed: Saturating<usize>,
     pub(super) certificates_sent: Saturating<usize>,
     pub(super) certificates_dropped: Saturating<usize>,
+    pub(super) certificates_skipped_unstaked: Saturating<usize>,
     pub(super) new_finalized_slot: Saturating<usize>,
     pub(super) parent_ready_missed_window: Saturating<usize>,
     pub(super) parent_ready_produce_window: Saturating<usize>,
@@ -31,6 +32,7 @@ impl ConsensusPoolServiceStats {
             add_message_failed: Saturating(0),
             certificates_sent: Saturating(0),
             certificates_dropped: Saturating(0),
+            certificates_skipped_unstaked: Saturating(0),
             new_finalized_slot: Saturating(0),
             parent_ready_missed_window: Saturating(0),
             parent_ready_produce_window: Saturating(0),
@@ -49,6 +51,7 @@ impl ConsensusPoolServiceStats {
             add_message_failed: Saturating(add_message_failed),
             certificates_sent: Saturating(certificates_sent),
             certificates_dropped: Saturating(certificates_dropped),
+            certificates_skipped_unstaked: Saturating(certificates_skipped_unstaked),
             new_finalized_slot: Saturating(new_finalized_slot),
             parent_ready_missed_window: Saturating(parent_ready_missed_window),
             parent_ready_produce_window: Saturating(parent_ready_produce_window),
@@ -65,6 +68,11 @@ impl ConsensusPoolServiceStats {
             ("add_message_failed", add_message_failed, i64),
             ("certificates_sent", certificates_sent, i64),
             ("certificates_dropped", certificates_dropped, i64),
+            (
+                "certificates_skipped_unstaked",
+                certificates_skipped_unstaked,
+                i64
+            ),
             ("new_finalized_slot", new_finalized_slot, i64),
             (
                 "parent_ready_missed_window",


### PR DESCRIPTION
#### Problem
When we are unstaked, we correctly do not send out votes:
https://github.com/anza-xyz/agave/blob/6c0aa19a3494b738d5bb74dd6da8bf673552c7a2/votor/src/voting_utils.rs#L169

However we don't have a similar check for broadcast of certificates.
This leads to a lot of spam as we try to send out certificates, but our peers reject us for being unstaked:

```
[2026-05-20T19:28:13.686926345Z INFO  solana_quic_client::nonblocking::quic_client] Ran into an error sending data Some(ConnectionError(ApplicationClosed(ApplicationClose { error_code: 0, reason: b"" }))), exhausted retries to 213.239.141.16:9010
[2026-05-20T19:28:13.686946362Z WARN  solana_quic_client::nonblocking::quic_client] Failed to send data async to 213.239.141.16:9010, error: Custom("ConnectionError(ApplicationClosed(ApplicationClose { error_code: 0, reason: b\"\" }))")
[2026-05-20T19:28:13.697201454Z INFO  solana_quic_client::quic_client] Timedout sending data 69.10.43.150:9011
[2026-05-20T19:28:13.701267892Z INFO  solana_quic_client::quic_client] Timedout sending data 193.243.164.199:9011
[2026-05-20T19:28:13.703334272Z INFO  solana_quic_client::quic_client] Timedout sending data 151.123.172.30:9011
[2026-05-20T19:28:13.705399189Z INFO  solana_quic_client::quic_client] Timedout sending data 94.158.242.54:50011
[2026-05-20T19:28:13.708462443Z INFO  solana_quic_client::quic_client] Timedout sending data 195.3.223.155:9011
[2026-05-20T19:28:13.715012432Z INFO  solana_quic_client::quic_client] Timedout sending data 208.85.23.4:9011
[2026-05-20T19:28:13.719079300Z INFO  solana_quic_client::quic_client] Timedout sending data 209.189.242.12:9011
[2026-05-20T19:28:13.743212715Z INFO  solana_quic_client::quic_client] Timedout sending data 64.31.24.26:8011
[2026-05-20T19:28:13.746356800Z INFO  solana_quic_client::quic_client] Timedout sending data 84.32.32.237:9011
[2026-05-20T19:28:13.746356860Z INFO  solana_quic_client::quic_client] Timedout sending data 38.58.177.100:9011
[2026-05-20T19:28:13.749599200Z INFO  solana_quic_client::quic_client] Timedout sending data 155.138.243.35:9011
[2026-05-20T19:28:13.749693990Z INFO  solana_quic_client::nonblocking::quic_client] Made 0rtt connection to 213.239.141.18:9011 with id 125130517993488 try_count 0, last_connection_id: 125130404574224, last_error: Some(ConnectionError(ApplicationClosed(ApplicationClose { error_code: 0, reason: b"" })))
[2026-05-20T19:28:13.759786058Z INFO  solana_quic_client::quic_client] Timedout sending data 104.204.141.114:9011
```

#### Summary of Changes
If we're unstaked, don't attempt to broadcast certificates either