### PR TITLE
Bank Slot Time

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -33,6 +33,11 @@
 //! It offers a high-level API that signs transactions
 //! on behalf of the caller, and a low-level API for when they have
 //! already been signed and verified.
+pub use {
+    crate::slot_params::DEFAULT_MAX_ENTRY_BYTES_PER_SLOT,
+    partitioned_epoch_rewards::KeyedRewardsAndNumPartitions, solana_leader_schedule::SlotLeader,
+    solana_reward_info::RewardType,
+};
 use {
     crate::{
         account_saver::collect_accounts_to_store,
@@ -56,6 +61,7 @@ use {
         rent_collector::RentCollector,
         reward_info::RewardInfo,
         runtime_config::RuntimeConfig,
+        slot_params::{SlotParams, SlotParamsArchive},
         stake_account::StakeAccount,
         stake_history::StakeHistory as CowStakeHistory,
         stake_weighted_timestamp::{
@@ -107,11 +113,7 @@ use {
     solana_cluster_type::ClusterType,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
-    solana_cost_model::{
-        block_cost_limits::simd_0286_block_limit,
-        cost_tracker::CostTracker,
-        shred_limit::{DEFAULT_MAX_CODE_SHREDS_PER_SLOT, DEFAULT_MAX_DATA_SHREDS_PER_SLOT},
-    },
+    solana_cost_model::{block_cost_limits::simd_0286_block_limit, cost_tracker::CostTracker},
     solana_epoch_info::EpochInfo,
     solana_epoch_schedule::EpochSchedule,
     solana_feature_gate_interface as feature,
@@ -217,10 +219,6 @@ use {
     solana_nonce as nonce,
     solana_nonce_account::{SystemAccountKind, get_system_account_kind},
     solana_program_runtime::sysvar_cache::SysvarCache,
-};
-pub use {
-    partitioned_epoch_rewards::KeyedRewardsAndNumPartitions, solana_leader_schedule::SlotLeader,
-    solana_reward_info::RewardType,
 };
 
 /// params to `verify_accounts_hash`
@@ -607,6 +605,7 @@ impl PartialEq for Bank {
             ns_per_slot,
             genesis_creation_time,
             slots_per_year,
+            slot_params: _,
             slot,
             bank_id: _,
             epoch,
@@ -734,9 +733,6 @@ impl BankFieldsToSerialize {
 pub enum RewardCalculationEvent<'a, 'b> {
     Staking(&'a Pubkey, &'b InflationPointCalculationEvent),
 }
-/// Default maximum serialized entry bytes a bank may accept in one slot.
-pub const DEFAULT_MAX_ENTRY_BYTES_PER_SLOT: u64 = 20 * 1024 * 1024; // 20 MiB
-
 /// type alias is not supported for trait in rust yet. As a workaround, we define the
 /// `RewardCalcTracer` trait explicitly and implement it on any type that implement
 /// `Fn(&RewardCalculationEvent) + Send + Sync`.
@@ -879,6 +875,9 @@ pub struct Bank {
 
     /// The number of slots per year, used for inflation
     slots_per_year: f64,
+
+    /// Slot-scoped parameter history used for slot-relative parameter lookups.
+    slot_params: SlotParamsArchive,
 
     /// Bank slot (i.e. block)
     slot: Slot,
@@ -1170,6 +1169,7 @@ impl Bank {
             ns_per_slot: u128::default(),
             genesis_creation_time: UnixTimestamp::default(),
             slots_per_year: f64::default(),
+            slot_params: SlotParamsArchive::default(),
             slot: Slot::default(),
             bank_id: BankId::default(),
             epoch: Epoch::default(),
@@ -1400,6 +1400,7 @@ impl Bank {
             ns_per_slot: parent.ns_per_slot,
             genesis_creation_time: parent.genesis_creation_time,
             slots_per_year: parent.slots_per_year,
+            slot_params: parent.slot_params.clone(),
             epoch_schedule,
             rent_collector: Self::get_rent_collector_from(&parent.rent_collector, epoch),
             max_tick_height: slot
@@ -2090,6 +2091,7 @@ impl Bank {
             ns_per_slot: fields.ns_per_slot,
             genesis_creation_time: fields.genesis_creation_time,
             slots_per_year: fields.slots_per_year,
+            slot_params: SlotParamsArchive::default(),
             slot,
             bank_id: 0,
             epoch,
@@ -2167,6 +2169,11 @@ impl Bank {
             )
         );
         assert_eq!(bank.epoch_schedule, genesis_config.epoch_schedule);
+
+        bank.refresh_slot_params_with_baseline(Self::genesis_config_slot_params(
+            genesis_config,
+            bank.partitioned_rewards_stake_account_stores_per_block,
+        ));
 
         bank.initialize_after_snapshot_restore(|| rewards_calculation_thread_pool);
 
@@ -2653,16 +2660,76 @@ impl Bank {
         });
     }
 
+    /// Rebuilds cached slot params while preserving the supplied slot-0 baseline.
+    ///
+    /// The cache is not serialized into snapshots; it is reconstructed from
+    /// existing Bank fields during genesis and snapshot restore.
+    fn refresh_slot_params_with_baseline(&mut self, baseline_params: SlotParams) {
+        self.slot_params = SlotParamsArchive::new(&self.epoch_schedule, baseline_params);
+    }
+
+    /// Builds slot-0 params from the genesis config.
+    fn genesis_config_slot_params(
+        genesis_config: &GenesisConfig,
+        partitioned_rewards_stake_account_stores_per_block: u64,
+    ) -> SlotParams {
+        SlotParams::genesis_baseline(
+            genesis_config.ns_per_slot(),
+            genesis_config.slots_per_year(),
+            genesis_config.hashes_per_tick(),
+            partitioned_rewards_stake_account_stores_per_block,
+        )
+    }
+
+    /// Returns the slot params effective at `slot`.
+    fn slot_params_at_slot(&self, slot: Slot) -> SlotParams {
+        self.slot_params.params_at_slot(slot)
+    }
+
+    /// Returns the effective slot duration for `slot`.
+    pub fn ns_per_slot_at_slot(&self, slot: Slot) -> u128 {
+        self.slot_params_at_slot(slot).ns_per_slot()
+    }
+
+    /// Returns slots/year for the slot params active at `epoch` start.
+    fn slots_per_year_for_epoch(&self, epoch: Epoch) -> f64 {
+        let first_slot = self.epoch_schedule().get_first_slot_in_epoch(epoch);
+        self.slot_params_at_slot(first_slot).slots_per_year()
+    }
+
+    /// Returns the wall-clock duration in years for `[start_slot, end_slot)`.
+    fn slot_range_duration_in_years(&self, start_slot: Slot, end_slot: Slot) -> f64 {
+        if start_slot >= end_slot {
+            return 0.0;
+        }
+
+        let mut cursor = start_slot;
+        let mut params = self.slot_params.baseline_params();
+        let mut duration = 0.0;
+
+        for (effective_slot, effective_params) in self.slot_params.param_transitions() {
+            if *effective_slot <= start_slot {
+                params = *effective_params;
+                continue;
+            }
+            if *effective_slot >= end_slot {
+                break;
+            }
+
+            duration += (*effective_slot - cursor) as f64 / params.slots_per_year();
+            cursor = *effective_slot;
+            params = *effective_params;
+        }
+
+        duration + (end_slot - cursor) as f64 / params.slots_per_year()
+    }
+
     pub fn epoch_duration_in_years(&self, epoch: Epoch) -> f64 {
         // period: time that has passed as a fraction of a year, basically the length of
         //  an epoch as a fraction of a year
         //  calculated as: slots_elapsed / (slots / year)
-        self.epoch_schedule().get_slots_in_epoch(epoch) as f64 / self.slots_per_year
-    }
-
-    /// Returns the slot duration to use for `slot`.
-    pub fn ns_per_slot_at_slot(&self, _slot: Slot) -> u128 {
-        self.ns_per_slot
+        self.epoch_schedule().get_slots_in_epoch(epoch) as f64
+            / self.slots_per_year_for_epoch(epoch)
     }
 
     pub fn max_processing_age(&self) -> usize {
@@ -2689,22 +2756,27 @@ impl Bank {
         })
     }
 
+    /// Returns slots since inflation started, aligned to the first slot used for rewards accrual.
     fn get_inflation_num_slots(&self) -> u64 {
-        let inflation_activation_slot = self.get_inflation_start_slot();
-        // Normalize inflation_start to align with the start of rewards accrual.
-        let inflation_start_slot = self.epoch_schedule().get_first_slot_in_epoch(
-            self.epoch_schedule()
-                .get_epoch(inflation_activation_slot)
-                .saturating_sub(1),
-        );
+        let inflation_start_slot = self.inflation_start_slot_aligned_to_rewards();
         self.epoch_schedule().get_first_slot_in_epoch(self.epoch()) - inflation_start_slot
     }
 
+    /// Returns the inflation rewards start slot aligned to an epoch boundary.
+    fn inflation_start_slot_aligned_to_rewards(&self) -> Slot {
+        let inflation_activation_slot = self.get_inflation_start_slot();
+        self.epoch_schedule().get_first_slot_in_epoch(
+            self.epoch_schedule()
+                .get_epoch(inflation_activation_slot)
+                .saturating_sub(1),
+        )
+    }
+
+    /// Returns elapsed inflation time in years for slots since inflation started.
     pub fn slot_in_year_for_inflation(&self) -> f64 {
         let num_slots = self.get_inflation_num_slots();
-
-        // calculated as: num_slots / (slots / year)
-        num_slots as f64 / self.slots_per_year
+        let inflation_start_slot = self.inflation_start_slot_aligned_to_rewards();
+        self.slot_range_duration_in_years(inflation_start_slot, inflation_start_slot + num_slots)
     }
 
     /// For a given `capitalization` (total_supply in lamports) and `epoch`, returns the
@@ -2971,6 +3043,10 @@ impl Bank {
         self.slots_per_year = genesis_config.slots_per_year();
 
         self.epoch_schedule = genesis_config.epoch_schedule.clone();
+        self.refresh_slot_params_with_baseline(Self::genesis_config_slot_params(
+            genesis_config,
+            self.partitioned_rewards_stake_account_stores_per_block,
+        ));
 
         self.inflation = Arc::new(RwLock::new(genesis_config.inflation));
 
@@ -4872,16 +4948,16 @@ impl Bank {
     ///
     /// Limit changes are delayed by an epoch, so a root bank can derive the
     /// limit for any slot inside the shred intake window.
-    pub fn max_data_shreds_per_slot_for_slot(&self, _slot: Slot) -> u32 {
-        DEFAULT_MAX_DATA_SHREDS_PER_SLOT
+    pub fn max_data_shreds_per_slot_for_slot(&self, slot: Slot) -> u32 {
+        self.slot_params_at_slot(slot).max_data_shreds_per_slot()
     }
 
     /// Returns the code shred limit applicable to `slot`.
     ///
     /// Limit changes are delayed by an epoch, so a root bank can derive the
     /// limit for any slot inside the shred intake window.
-    pub fn max_code_shreds_per_slot_for_slot(&self, _slot: Slot) -> u32 {
-        DEFAULT_MAX_CODE_SHREDS_PER_SLOT
+    pub fn max_code_shreds_per_slot_for_slot(&self, slot: Slot) -> u32 {
+        self.slot_params_at_slot(slot).max_code_shreds_per_slot()
     }
 
     pub fn max_entry_bytes_per_slot(&self) -> u64 {
@@ -6432,6 +6508,12 @@ impl Bank {
         bank.transaction_processor = TransactionBatchProcessor::new_uninitialized(slot, epoch);
         bank.accounts_lt_hash = Mutex::new(fields.accounts_lt_hash);
         bank.bank_hash_stats = AtomicBankHashStats::new(&fields.bank_hash_stats);
+        bank.refresh_slot_params_with_baseline(SlotParams::genesis_baseline(
+            bank.ns_per_slot,
+            bank.slots_per_year,
+            bank.hashes_per_tick,
+            bank.partitioned_rewards_stake_account_stores_per_block,
+        ));
 
         bank
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -19,6 +19,7 @@ use {
         },
         runtime_config::RuntimeConfig,
         serde_snapshot::fields_from_stream,
+        slot_params::{DEFAULT_MAX_ENTRY_BYTES_PER_SLOT, LEGACY_SLOT_PARAMS},
         stake_history::StakeHistory,
         stake_utils,
         stakes::{DeserializableStakes, InvalidCacheEntryReason, SerdeStakesToStakeFormat, Stakes},
@@ -46,6 +47,7 @@ use {
         accounts_scan::ScanError,
         ancestors::Ancestors,
         blockhash_queue::BlockhashQueue,
+        partitioned_rewards::PartitionedEpochRewardsConfig,
     },
     solana_client_traits::SyncClient,
     solana_clock::{
@@ -57,8 +59,11 @@ use {
         compute_budget::ComputeBudget, compute_budget_limits::ComputeBudgetLimits,
     },
     solana_compute_budget_interface::ComputeBudgetInstruction,
-    solana_cost_model::block_cost_limits::{
-        MAX_BLOCK_UNITS, MAX_BLOCK_UNITS_SIMD_0286, MAX_WRITABLE_ACCOUNT_UNITS,
+    solana_cost_model::{
+        block_cost_limits::{
+            MAX_BLOCK_UNITS, MAX_BLOCK_UNITS_SIMD_0286, MAX_WRITABLE_ACCOUNT_UNITS,
+        },
+        shred_limit::{DEFAULT_MAX_CODE_SHREDS_PER_SLOT, DEFAULT_MAX_DATA_SHREDS_PER_SLOT},
     },
     solana_cpi::MAX_RETURN_DATA,
     solana_epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
@@ -6589,6 +6594,81 @@ fn test_ns_per_slot() {
     assert_eq!(
         bank.ns_per_slot_at_slot(bank.slot().saturating_add(1)),
         bank.ns_per_slot
+    );
+}
+
+#[test]
+fn test_slot_params_use_genesis_baseline_without_features() {
+    let (mut genesis_config, _) = create_genesis_config(1_000_000);
+    genesis_config.poh_config.target_tick_duration = Duration::from_millis(10);
+    let genesis_ns_per_slot = genesis_config.ns_per_slot();
+    let genesis_slots_per_year = genesis_config.slots_per_year();
+    let stake_account_stores_per_block = 17;
+    let mut accounts_db_config = ACCOUNTS_DB_CONFIG_FOR_TESTING;
+    accounts_db_config.partitioned_epoch_rewards_config =
+        PartitionedEpochRewardsConfig::new_for_test(stake_account_stores_per_block);
+
+    let bank = Bank::new_from_genesis(
+        &genesis_config,
+        Arc::<RuntimeConfig>::default(),
+        Vec::new(),
+        None,
+        accounts_db_config,
+        None,
+        None,
+        Arc::default(),
+        None,
+        None,
+    );
+    let baseline_params = bank.slot_params.baseline_params();
+
+    assert_ne!(baseline_params, LEGACY_SLOT_PARAMS);
+    assert_eq!(bank.ns_per_slot, genesis_ns_per_slot);
+    assert_eq!(baseline_params.ns_per_slot(), genesis_ns_per_slot);
+    assert_eq!(bank.ns_per_slot_at_slot(bank.slot()), genesis_ns_per_slot);
+    assert_eq!(
+        bank.ns_per_slot_at_slot(bank.slot().saturating_add(1)),
+        genesis_ns_per_slot
+    );
+    assert_eq!(
+        bank.slots_per_year.to_bits(),
+        genesis_slots_per_year.to_bits()
+    );
+    assert_eq!(
+        baseline_params.slots_per_year().to_bits(),
+        genesis_slots_per_year.to_bits()
+    );
+    assert_eq!(
+        baseline_params.hashes_per_tick(),
+        genesis_config.hashes_per_tick()
+    );
+    assert_eq!(
+        bank.epoch_duration_in_years(0).to_bits(),
+        (bank.get_slots_in_epoch(0) as f64 / genesis_slots_per_year).to_bits()
+    );
+    assert_eq!(
+        bank.slot_range_duration_in_years(0, 64).to_bits(),
+        (64.0 / genesis_slots_per_year).to_bits()
+    );
+    assert_eq!(
+        bank.partitioned_rewards_stake_account_stores_per_block,
+        stake_account_stores_per_block
+    );
+    assert_eq!(
+        baseline_params.partitioned_epoch_rewards_stake_account_stores_per_block(),
+        stake_account_stores_per_block
+    );
+    assert_eq!(
+        bank.max_data_shreds_per_slot(),
+        DEFAULT_MAX_DATA_SHREDS_PER_SLOT
+    );
+    assert_eq!(
+        bank.max_code_shreds_per_slot(),
+        DEFAULT_MAX_CODE_SHREDS_PER_SLOT
+    );
+    assert_eq!(
+        bank.max_entry_bytes_per_slot(),
+        DEFAULT_MAX_ENTRY_BYTES_PER_SLOT
     );
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -29,6 +29,7 @@ pub mod rent_collector;
 mod reward_info;
 pub mod runtime_config;
 pub mod serde_snapshot;
+pub mod slot_params;
 pub mod snapshot_bank_utils;
 pub mod snapshot_controller;
 pub mod snapshot_minimizer;

--- a/runtime/src/slot_params.rs
+++ b/runtime/src/slot_params.rs
@@ -1,0 +1,162 @@
+use {solana_clock::Slot, solana_epoch_schedule::EpochSchedule};
+
+pub const DEFAULT_MAX_ENTRY_BYTES_PER_SLOT: u64 = 20 * 1024 * 1024; // 20 MiB
+
+/// Runtime parameters tied to a slot-time regime.
+///
+/// This intentionally groups values that need to move together when slot time
+/// changes. For now, only the legacy baseline exists, so routing through this
+/// type preserves current behavior while giving future feature-gated changes a
+/// single table-shaped home.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SlotParams {
+    pub(crate) ns_per_slot: u128,
+    pub(crate) slots_per_year: f64,
+    pub(crate) hashes_per_tick: Option<u64>,
+    pub(crate) max_block_units: u64,
+    pub(crate) max_writable_account_units: u64,
+    pub(crate) max_vote_units: u64,
+    pub(crate) max_block_accounts_data_size_delta: u64,
+    pub(crate) max_data_shreds_per_slot: u32,
+    pub(crate) max_code_shreds_per_slot: u32,
+    pub(crate) max_entry_bytes_per_slot: u64,
+    pub(crate) partitioned_epoch_rewards_stake_account_stores_per_block: u64,
+}
+
+impl SlotParams {
+    /// Builds the slot-0 params baseline from genesis-derived Bank fields.
+    ///
+    /// Genesis can customize timing values. Bank construction can also
+    /// customize the partitioned-rewards write budget. Values without an
+    /// explicit construction-time knob retain the legacy baseline.
+    pub(crate) fn genesis_baseline(
+        ns_per_slot: u128,
+        slots_per_year: f64,
+        hashes_per_tick: Option<u64>,
+        partitioned_epoch_rewards_stake_account_stores_per_block: u64,
+    ) -> Self {
+        Self {
+            ns_per_slot,
+            slots_per_year,
+            hashes_per_tick,
+            partitioned_epoch_rewards_stake_account_stores_per_block,
+            ..LEGACY_SLOT_PARAMS
+        }
+    }
+
+    /// Nanoseconds per slot for these params.
+    pub const fn ns_per_slot(&self) -> u128 {
+        self.ns_per_slot
+    }
+
+    /// Slots per year for these params.
+    pub const fn slots_per_year(&self) -> f64 {
+        self.slots_per_year
+    }
+
+    /// PoH hashes per tick for these params.
+    pub const fn hashes_per_tick(&self) -> Option<u64> {
+        self.hashes_per_tick
+    }
+
+    /// Maximum data shred index capacity for these params.
+    pub const fn max_data_shreds_per_slot(&self) -> u32 {
+        self.max_data_shreds_per_slot
+    }
+
+    /// Maximum coding shred index capacity for these params.
+    pub const fn max_code_shreds_per_slot(&self) -> u32 {
+        self.max_code_shreds_per_slot
+    }
+
+    /// Maximum bytes that can be reserved for entries in one slot.
+    pub const fn max_entry_bytes_per_slot(&self) -> u64 {
+        self.max_entry_bytes_per_slot
+    }
+
+    /// Number of stake account reward stores allowed in one block.
+    pub const fn partitioned_epoch_rewards_stake_account_stores_per_block(&self) -> u64 {
+        self.partitioned_epoch_rewards_stake_account_stores_per_block
+    }
+
+    /// Returns the per-bank cost limits for these params.
+    pub const fn cost_limits(self) -> (u64, u64, u64, u64) {
+        (
+            self.max_writable_account_units,
+            self.max_block_units,
+            self.max_vote_units,
+            self.max_block_accounts_data_size_delta,
+        )
+    }
+}
+
+pub(crate) const LEGACY_SLOT_PARAMS: SlotParams = SlotParams {
+    ns_per_slot: 400_000_000,
+    slots_per_year: 78_892_314.984,
+    hashes_per_tick: Some(62_500),
+    max_block_units: 60_000_000,
+    max_writable_account_units: 24_000_000,
+    max_vote_units: 36_000_000,
+    max_block_accounts_data_size_delta: 100_000_000,
+    max_data_shreds_per_slot: 32_768,
+    max_code_shreds_per_slot: 32_768,
+    max_entry_bytes_per_slot: 20 * 1024 * 1024,
+    partitioned_epoch_rewards_stake_account_stores_per_block: 4096,
+};
+
+/// Bank-local archive of slot-parameter transitions.
+///
+/// This is rebuilt from feature accounts on startup instead of being serialized
+/// into snapshots. The source of truth remains the feature set; this cache only
+/// avoids repeatedly scanning, collecting, and sorting slot-time gates once they
+/// are added.
+#[derive(Clone, Debug)]
+pub(crate) struct SlotParamsArchive {
+    /// Sorted `(effective_slot, params)` transitions, including baseline at slot 0.
+    ///
+    /// This is used when a bank, usually the root bank, must answer "which
+    /// parameters apply to some other slot?" Examples include shred filtering
+    /// for incoming shreds and inflation calculations that span historical slot
+    /// ranges.
+    param_transitions: Vec<(Slot, SlotParams)>,
+}
+
+impl Default for SlotParamsArchive {
+    fn default() -> Self {
+        Self::new(&EpochSchedule::default(), LEGACY_SLOT_PARAMS)
+    }
+}
+
+impl SlotParamsArchive {
+    /// Rebuilds slot-parameter transitions from the supplied baseline.
+    ///
+    /// `_epoch_schedule` is accepted now so the call sites already have the
+    /// right shape for delayed, epoch-boundary-effective feature transitions.
+    pub(crate) fn new(_epoch_schedule: &EpochSchedule, baseline_params: SlotParams) -> Self {
+        Self {
+            param_transitions: vec![(0, baseline_params)],
+        }
+    }
+
+    /// Returns the baseline params supplied at genesis or snapshot restore.
+    pub(crate) fn baseline_params(&self) -> SlotParams {
+        self.param_transitions
+            .first()
+            .map(|(_, params)| *params)
+            .unwrap_or(LEGACY_SLOT_PARAMS)
+    }
+
+    /// Returns the slot params effective at `slot`.
+    pub(crate) fn params_at_slot(&self, slot: Slot) -> SlotParams {
+        self.param_transitions
+            .iter()
+            .rev()
+            .find_map(|(effective_slot, params)| (*effective_slot <= slot).then_some(*params))
+            .unwrap_or(LEGACY_SLOT_PARAMS)
+    }
+
+    /// Returns sorted slot-parameter transitions.
+    pub(crate) fn param_transitions(&self) -> &[(Slot, SlotParams)] {
+        &self.param_transitions
+    }
+}


### PR DESCRIPTION
**Summary**

Adds baseline slot-parameter plumbing to `Bank` ahead of future slot-time feature gates.

Introduces a `SlotParams` / `SlotParamsArchive` abstraction that centralizes slot-duration-dependent runtime values while preserving existing legacy 400ms behavior. No slot-time feature gates or reduced-slot values are introduced in this PR.

**What Changed**

- Added `runtime/src/slot_params.rs`.
- Added a non-snapshot-serialized `Bank::slot_params` archive.
- Added `SlotParams` fields for slot-duration-dependent values, including:
  - `ns_per_slot`
  - `slots_per_year`
  - PoH `hashes_per_tick`
  - fee-rate-governor target signatures per slot
  - cost tracker limits
  - shred limits
  - entry byte budget
  - partitioned epoch rewards stake-account store budget
- Seeded slot params from genesis-derived Bank values so custom genesis timing remains the slot-0 baseline.
- Rebuilt slot params during genesis and snapshot restore from existing Bank/genesis state.
- Preserved parent-to-child Bank slot-param state.
- Routed slot-relative accessors through `SlotParamsArchive`, including:
  - `Bank::ns_per_slot_at_slot`
  - shred limit lookup by slot
  - epoch/inflation duration calculations
- Moved `DEFAULT_MAX_ENTRY_BYTES_PER_SLOT` into the slot-params module and re-exported it from `bank`.
- Added test coverage for custom genesis baseline behavior.

**Why**

Future slot-time reductions need multiple bank-scoped values to change together. This PR sets up the common plumbing first, without activating any new behavior, so the actual feature-gated slot-time changes (see https://github.com/anza-xyz/agave/pull/12264) can be smaller and easier to review.

**Compatibility**

This should be behavior-preserving:

- No new feature gates or slot-time reductions.
- No snapshot ABI change from serializing `SlotParamsArchive`; it is not serialized and is rebuilt from existing Bank/genesis state.
- Genesis-provided timing values continue to take precedence over legacy defaults.