### PR TITLE
chore: Remove deleted teams from mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,6 @@
 pull_request_rules:
   - name: label changes from community
     conditions:
-      - author≠@agave-external-triage
       - author≠@anza
       - author≠mergify[bot]
       - author≠dependabot[bot]
@@ -14,7 +13,6 @@ pull_request_rules:
           - need:merge-assist
   - name: request review for community changes
     conditions:
-      - author≠@agave-external-triage
       - author≠@anza
       - author≠mergify[bot]
       - author≠dependabot[bot]
@@ -30,17 +28,6 @@ pull_request_rules:
       request_reviews:
         teams:
           - "@anza-xyz/community-pr-subscribers"
-  - name: label changes from agave-external-triage
-    conditions:
-      - author≠@anza
-      - author≠mergify[bot]
-      - author≠dependabot[bot]
-      - author≠github-actions[bot]
-      - author=@agave-external-triage
-    actions:
-      label:
-        add:
-          - need:merge-assist
   - name: automatic merge (squash) on CI success
     conditions:
       - and:


### PR DESCRIPTION
#### Problem
The team in question (`agave-external-triage`) has been deleted from our GH org. Having a team in mergify config that doesn't exist in the org breaks all workflows.

#### Summary of Changes
Remove the deleted team + one action specific to that deleted team