### PR TITLE
Fix secondary index memory

### DIFF
--- a/accounts-db/src/accounts_index/secondary.rs
+++ b/accounts-db/src/accounts_index/secondary.rs
@@ -132,7 +132,11 @@ impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
     /// Inserts `inner_key` into `key`'s map.
     pub fn insert(&self, key: &Pubkey, inner_key: &Pubkey) {
         // Note: Always lock the reverse index first, so we synchronize with remove().
-        let reverse_index_entry = self.reverse_index.entry(*inner_key).or_default();
+        // Pre-size to 1 to avoid push() over-allocating an empty Vec to capacity 4.
+        let reverse_index_entry = self
+            .reverse_index
+            .entry(*inner_key)
+            .or_insert_with(|| RwLock::new(Vec::with_capacity(1)));
         let mut outer_keys = reverse_index_entry.write().unwrap();
 
         // Now insert into the index.
@@ -368,5 +372,48 @@ mod tests {
             secondary_index.stats.num_inner_keys.load(Ordering::Relaxed),
             0,
         );
+    }
+
+    /// Regression guard for reverse-index entry capacity. Each entry must be
+    /// created with capacity 1. An empty Vec plus push() would over-allocate to
+    /// capacity 4 (Rust RawVec rule), wasting 96 bytes per entry.
+    #[test]
+    fn test_reverse_index_entry_not_over_allocated() {
+        let secondary_index =
+            SecondaryIndex::<RwLockSecondaryIndexEntry>::new("test_secondary_index");
+        let outer_key = Pubkey::new_unique();
+        let inner_key = Pubkey::new_unique();
+
+        secondary_index.insert(&outer_key, &inner_key);
+
+        let reverse_entry = secondary_index
+            .reverse_index
+            .get(&inner_key)
+            .expect("reverse index entry should exist after insert");
+        let outer_keys = reverse_entry.read().unwrap();
+        assert_eq!(outer_keys.len(), 1);
+        assert_eq!(outer_keys[0], outer_key);
+        // Regression guard: `or_default()` + push() would make this 4.
+        assert_eq!(outer_keys.capacity(), 1);
+    }
+
+    /// A reverse entry with multiple outer keys still grows correctly when
+    /// started at capacity 1, exercising the push() realloc path.
+    #[test]
+    fn test_reverse_index_multiple_outer_keys() {
+        let secondary_index =
+            SecondaryIndex::<RwLockSecondaryIndexEntry>::new("test_secondary_index");
+        let inner_key = Pubkey::new_unique();
+        let outer_key_1 = Pubkey::new_unique();
+        let outer_key_2 = Pubkey::new_unique();
+
+        secondary_index.insert(&outer_key_1, &inner_key);
+        secondary_index.insert(&outer_key_2, &inner_key);
+
+        let reverse_entry = secondary_index.reverse_index.get(&inner_key).unwrap();
+        let outer_keys = reverse_entry.read().unwrap();
+        assert_eq!(outer_keys.len(), 2);
+        assert!(outer_keys.contains(&outer_key_1));
+        assert!(outer_keys.contains(&outer_key_2));
     }
 }


### PR DESCRIPTION
#### Problem
when upgrading our RPC nodes from 3.1.14 to 4.0.0 we noticed a significant growth in RAM after sync and OOM shortly after a few calls, no changes were made to any of the CLI commands, we use `program-id` and `spl-token-owner` indexes and this would force us to upgrade our machines to accommodate for the increase

3.1.14 - 580GB vs 4.0.0 - 745GB

`SecondaryIndex::insert()` creates each reverse-index entry with `or_default()` (empty `Vec`), then `push()`es the outer key, rust's [`RawVec::min_non_zero_cap`](https://github.com/rust-lang/rust/blob/main/library/alloc/src/raw_vec/mod.rs#L153) is 4 for element types ≤ 1024 bytes, so the first push jumps capacity to 4 instead of 1. `Pubkey` is 32 bytes, so each single owner reverse entry permanently holds 128 bytes (4 × 32) instead of 32. That is 96 bytes wasted per entry.

this was introduced by #10908 (backported to v4.0 as #10965), which replaced `Vec::with_capacity(1)` with `or_default()` + `push()` while fixing an insert/remove race. the race fix is preserved by this change, the allocation behavior was an unintended side effect.

#### Summary of Changes
- replace `or_default()` with `or_insert_with(|| RwLock::new(Vec::with_capacity(1)))` in `SecondaryIndex::insert`. the reverse-lock-first ordering is preserved, `entry()` still write-locks the reverse shard first and the closure only runs for new keys.

- tests for regression and multi owner growth

#### Note
We deployed the patch on one of our nodes, RAM went back to ~580GB at the same index counts.

Fixes #
