### PR TITLE
test-validator: Cleanup TestValidatorNodeConfig for CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10932,6 +10932,7 @@ dependencies = [
  "solana-signer",
  "solana-streamer",
  "solana-syscalls",
+ "solana-test-validator",
  "solana-transaction",
  "solana-validator-exit",
  "tokio",

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -57,7 +57,7 @@ solana-local-cluster = { path = "../local-cluster", features = ["agave-unstable-
 solana-native-token = { workspace = true }
 solana-poh-config = { workspace = true }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-test-validator = { path = "../test-validator" }
+solana-test-validator = { path = "../test-validator", features = ["dev-context-only-utils"] }
 
 [lints]
 workspace = true

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -81,7 +81,7 @@ solana-local-cluster = { workspace = true }
 solana-rent = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk-ids = { workspace = true }
-solana-test-validator = { workspace = true }
+solana-test-validator = { workspace = true, features = ["dev-context-only-utils"] }
 solana-tps-client = { workspace = true, features = ["bank-client"] }
 tempfile = { workspace = true }
 

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -86,7 +86,7 @@ fn create_test_validator_and_client() -> (
         0,    /* port */
     );
 
-    let test_validator = TestValidatorGenesis::default()
+    let test_validator = TestValidatorGenesis::default_for_tests()
         .fee_rate_governor(FeeRateGovernor::new(0, 0))
         .rent(Rent {
             lamports_per_byte: 1,

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -106,7 +106,7 @@ solana-nonce-account = { workspace = true }
 solana-presigner = { workspace = true }
 solana-rpc = { path = "../rpc", features = ["agave-unstable-api"] }
 solana-sha256-hasher = { workspace = true }
-solana-test-validator = { path = "../test-validator" }
+solana-test-validator = { path = "../test-validator", features = ["dev-context-only-utils"] }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -59,7 +59,7 @@ fn test_validator_genesis(
     mint_keypair: &Keypair,
     features: LoaderV3Features,
 ) -> TestValidatorGenesis {
-    let mut genesis = TestValidatorGenesis::default();
+    let mut genesis = TestValidatorGenesis::default_for_tests();
     genesis
         .fee_rate_governor(FeeRateGovernor::new(0, 0))
         .rent(Rent {
@@ -3235,7 +3235,7 @@ async fn test_cli_program_deploy_with_args(compute_unit_price: Option<u64>, use_
 
     let mint_keypair = Keypair::new();
     let faucet_addr = run_local_faucet_with_unique_port_for_tests(mint_keypair.insecure_clone());
-    let test_validator = TestValidatorGenesis::default()
+    let test_validator = TestValidatorGenesis::default_for_tests()
         .fee_rate_governor(FeeRateGovernor::new(0, 0))
         .rent(Rent {
             lamports_per_byte: 1,

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -40,7 +40,7 @@ async fn test_stake_delegation_force() {
     let authorized_withdrawer = Keypair::new().pubkey();
     let faucet_addr = run_local_faucet_with_unique_port_for_tests(mint_keypair.insecure_clone());
     let slots_per_epoch = 32;
-    let test_validator = TestValidatorGenesis::default()
+    let test_validator = TestValidatorGenesis::default_for_tests()
         .fee_rate_governor(FeeRateGovernor::new(0, 0))
         .rent(Rent {
             lamports_per_byte: 1,

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -35,7 +35,6 @@ solana-runtime = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-system-transaction = { workspace = true }
-solana-test-validator = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
 systemstat = { workspace = true }
@@ -47,6 +46,7 @@ agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-rpc = { path = "../rpc", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-test-validator = { path = "../test-validator", features = ["dev-context-only-utils"] }
 
 [lints]
 workspace = true

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8352,6 +8352,7 @@ dependencies = [
  "solana-svm-type-overrides",
  "solana-system-interface 3.2.0",
  "solana-sysvar",
+ "solana-test-validator",
  "solana-transaction",
  "solana-transaction-error",
  "solana-vote",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -148,6 +148,7 @@ solana-svm-transaction = { path = "../../svm-transaction", version = "=4.2.0-alp
 solana-svm-type-overrides = { path = "../../svm-type-overrides", version = "=4.2.0-alpha.0" }
 solana-system-interface = { version = "=3.2", features = ["bincode"] }
 solana-sysvar = "=4.0.0"
+solana-test-validator = { path = "../../test-validator", version = "=4.2.0-alpha.0" }
 solana-vote = { path = "../../vote", version = "=4.2.0-alpha.0" }
 solana-vote-interface = "6.0.0"
 solana-vote-program = { path = "../../programs/vote", version = "=4.2.0-alpha.0" }
@@ -208,6 +209,7 @@ solana-svm-transaction = { workspace = true }
 solana-svm-type-overrides = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-sysvar = "4.0.0"
+solana-test-validator = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction = "4.1.0"
 solana-transaction-error = "3.2.0"
 solana-vote = { workspace = true }

--- a/programs/sbf/tests/simulation.rs
+++ b/programs/sbf/tests/simulation.rs
@@ -61,7 +61,7 @@ fn test_no_panic_rpc_client() {
     agave_logger::setup();
 
     let program_id = Pubkey::new_unique();
-    let (test_validator, payer) = TestValidatorGenesis::default()
+    let (test_validator, payer) = TestValidatorGenesis::default_for_tests()
         .add_program("solana_sbf_rust_simulation", program_id)
         .start();
     let rpc_client = test_validator.get_rpc_client();

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -50,6 +50,7 @@ solana-rent = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
+solana-test-validator = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction = { workspace = true }
 
 [lints]

--- a/rpc-test/tests/nonblocking.rs
+++ b/rpc-test/tests/nonblocking.rs
@@ -15,7 +15,9 @@ use {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_tpu_send_transaction() {
-    let (test_validator, mint_keypair) = TestValidatorGenesis::default().start_async().await;
+    let (test_validator, mint_keypair) = TestValidatorGenesis::default_for_tests()
+        .start_async()
+        .await;
     let rpc_client = Arc::new(test_validator.get_async_rpc_client());
     let mut tpu_client = TpuClient::new(
         "tpu_client_test",
@@ -49,7 +51,9 @@ async fn test_tpu_send_transaction() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_tpu_cache_slot_updates() {
-    let (test_validator, _) = TestValidatorGenesis::default().start_async().await;
+    let (test_validator, _) = TestValidatorGenesis::default_for_tests()
+        .start_async()
+        .await;
     let rpc_client = Arc::new(test_validator.get_async_rpc_client());
     let exit = Arc::new(AtomicBool::new(false));
     let mut leader_tpu_service = LeaderTpuService::new(

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 agave-unstable-api = []
+dev-context-only-utils = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -65,6 +66,8 @@ tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 solana-sdk-ids = { workspace = true }
+# See order-crates-for-publishing.py for using this unusual `path = "."`
+solana-test-validator = { path = ".", features = ["dev-context-only-utils"] }
 
 [lints]
 workspace = true

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -107,9 +107,21 @@ pub struct TestValidatorNodeConfig {
 impl Default for TestValidatorNodeConfig {
     fn default() -> Self {
         let bind_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        #[cfg(not(debug_assertions))]
         let port_range = solana_net_utils::VALIDATOR_PORT_RANGE;
-        #[cfg(debug_assertions)]
+        Self {
+            gossip_addr: SocketAddr::new(bind_ip_addr, port_range.0),
+            port_range,
+            bind_ip_addr,
+        }
+    }
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl TestValidatorNodeConfig {
+    /// Defaults suitable for unit tests; a disjoint port range will be used to
+    /// avoid "port already in use" errors for tests running in parallel
+    pub fn default_for_tests() -> Self {
+        let bind_ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let port_range = solana_net_utils::sockets::localhost_port_range_for_tests();
         Self {
             gossip_addr: SocketAddr::new(bind_ip_addr, port_range.0),
@@ -184,6 +196,18 @@ impl Default for TestValidatorGenesis {
             geyser_plugin_manager: Arc::new(ArcSwap::new(Arc::new(GeyserPluginManager::default()))),
             admin_rpc_service_post_init:
                 Arc::<RwLock<Option<AdminRpcRequestMetadataPostInit>>>::default(),
+        }
+    }
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl TestValidatorGenesis {
+    /// Defaults suitable for unit tests; a disjoint port range will be used to
+    /// avoid "port already in use" errors for tests running in parallel
+    pub fn default_for_tests() -> Self {
+        Self {
+            node_config: TestValidatorNodeConfig::default_for_tests(),
+            ..Self::default()
         }
     }
 }
@@ -807,12 +831,13 @@ pub struct TestValidator {
 impl TestValidator {
     /// Create a configured genesis and start validator
     /// Sync only; calling from a tokio runtime will panic due to nested runtimes.
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn start_with_config(
         mint_address: Pubkey,
         faucet_addr: Option<SocketAddr>,
         socket_addr_space: SocketAddrSpace,
     ) -> Self {
-        TestValidatorGenesis::default()
+        TestValidatorGenesis::default_for_tests()
             .rent(Rent {
                 lamports_per_byte: 1,
                 ..Rent::default()
@@ -823,12 +848,13 @@ impl TestValidator {
     }
 
     /// Create a configured genesis and start validator (async version)
+    #[cfg(feature = "dev-context-only-utils")]
     pub async fn async_start_with_config(
         mint_keypair: &Keypair,
         faucet_addr: Option<SocketAddr>,
         socket_addr_space: SocketAddrSpace,
     ) -> Self {
-        TestValidatorGenesis::default()
+        TestValidatorGenesis::default_for_tests()
             .rent(Rent {
                 lamports_per_byte: 1,
                 ..Rent::default()
@@ -1364,14 +1390,16 @@ mod test {
 
     #[test]
     fn get_health() {
-        let (test_validator, _payer) = TestValidatorGenesis::default().start();
+        let (test_validator, _payer) = TestValidatorGenesis::default_for_tests().start();
         let rpc_client = test_validator.get_rpc_client();
         rpc_client.get_health().expect("health");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn nonblocking_get_health() {
-        let (test_validator, _payer) = TestValidatorGenesis::default().start_async().await;
+        let (test_validator, _payer) = TestValidatorGenesis::default_for_tests()
+            .start_async()
+            .await;
         let rpc_client = test_validator.get_async_rpc_client();
         rpc_client.get_health().await.expect("health");
     }
@@ -1379,7 +1407,7 @@ mod test {
     #[test]
     fn test_upgradeable_program_deploayment() {
         let program_id = Pubkey::new_unique();
-        let (test_validator, payer) = TestValidatorGenesis::default()
+        let (test_validator, payer) = TestValidatorGenesis::default_for_tests()
             .add_program("../programs/bpf-loader-tests/noop", program_id)
             .start();
         let rpc_client = test_validator.get_rpc_client();
@@ -1406,7 +1434,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_nonblocking_upgradeable_program_deploayment() {
         let program_id = Pubkey::new_unique();
-        let (test_validator, payer) = TestValidatorGenesis::default()
+        let (test_validator, payer) = TestValidatorGenesis::default_for_tests()
             .add_program("../programs/bpf-loader-tests/noop", program_id)
             .start_async()
             .await;
@@ -1436,7 +1464,7 @@ mod test {
     #[should_panic]
     async fn document_tokio_panic() {
         // `start()` blows up when run within tokio
-        let (_test_validator, _payer) = TestValidatorGenesis::default().start();
+        let (_test_validator, _payer) = TestValidatorGenesis::default_for_tests().start();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1460,7 +1488,7 @@ mod test {
         // Convert to `Vec` so we can get a slice.
         let control: Vec<Pubkey> = control.into_iter().collect();
 
-        let (test_validator, _payer) = TestValidatorGenesis::default()
+        let (test_validator, _payer) = TestValidatorGenesis::default_for_tests()
             .deactivate_features(&deactivate_features)
             .start_async()
             .await;
@@ -1495,7 +1523,7 @@ mod test {
         let owner = Pubkey::new_unique();
         let account = || AccountSharedData::new(100_000, 0, &owner);
 
-        let (test_validator, _payer) = TestValidatorGenesis::default()
+        let (test_validator, _payer) = TestValidatorGenesis::default_for_tests()
             .deactivate_features(&[with_deactivate_flag]) // Just deactivate one feature.
             .add_accounts([
                 (with_deactivate_flag, account()), // But add both accounts.
@@ -1527,7 +1555,9 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_core_bpf_programs() {
-        let (test_validator, _payer) = TestValidatorGenesis::default().start_async().await;
+        let (test_validator, _payer) = TestValidatorGenesis::default_for_tests()
+            .start_async()
+            .await;
 
         let rpc_client = test_validator.get_async_rpc_client();
 
@@ -1565,7 +1595,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_wait_for_program_with_unfunded_payer() {
         let program_id = Pubkey::new_unique();
-        let (test_validator, _mint_keypair) = TestValidatorGenesis::default()
+        let (test_validator, _mint_keypair) = TestValidatorGenesis::default_for_tests()
             .add_program("../programs/bpf-loader-tests/noop", program_id)
             .start_async()
             .await;

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -61,7 +61,7 @@ thiserror = { workspace = true }
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
-solana-test-validator = { path = "../test-validator" }
+solana-test-validator = { path = "../test-validator", features = ["dev-context-only-utils"] }
 solana-transaction-error = { workspace = true }
 
 [lints]


### PR DESCRIPTION
#### Problem
TestValidatorNodeConfig currently chooses a port_range field based on whether debug assertions are enabled. There are a handful of unit tests that create a TestValidator object so this logic aims to differentiate between the test-validator bin (disabled) and unit tests (enabled)

#### Summary of Changes
While this assumption is probably valid for most cases, it is a bit of a hack and complicates some other logic. So, remove the debug-assertion switch in favor of an extra default_for_tests() constructor.

For sake of papertrail, https://github.com/anza-xyz/agave/pull/5865 introduced the switch-on-debug-assertions-enabled logic