### PR TITLE
test-validator: Update outdated --dynamic-port-range help

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -654,8 +654,9 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .long("dynamic-port-range")
                 .value_name("MIN_PORT-MAX_PORT")
                 .takes_value(true)
+                .default_value(&default_args.dynamic_port_range)
                 .validator(port_range_validator)
-                .help("Range to use for dynamically assigned ports [default: 1024-65535]"),
+                .help("Range to use for dynamically assigned ports"),
         )
         .arg(
             Arg::with_name("bind_address")
@@ -877,6 +878,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
 pub struct DefaultTestArgs {
     pub rpc_port: String,
     pub faucet_port: String,
+    pub dynamic_port_range: String,
     pub limit_ledger_size: String,
     pub faucet_sol: String,
     pub faucet_time_slice_secs: String,
@@ -887,6 +889,7 @@ impl DefaultTestArgs {
         DefaultTestArgs {
             rpc_port: 8899.to_string(),
             faucet_port: FAUCET_PORT.to_string(),
+            dynamic_port_range: format!("{}-{}", VALIDATOR_PORT_RANGE.0, VALIDATOR_PORT_RANGE.1),
             /* 10,000 was derived empirically by watching the size
              * of the rocksdb/ directory self-limit itself to the
              * 40MB-150MB range when running `solana-test-validator`


### PR DESCRIPTION
#### Problem
Two minor things:
- The CLAP args lists an incorrect default value
- The default value is manually listed in `.help()` instead of within `.default_value()` where it will automatically get formatted onto end of help message

#### Summary of Changes
Use `.default_value()` with the actual value. The following links show that the value now explicitly being set matches the current default:

https://github.com/anza-xyz/agave/blob/28784debec727677144c7e739db48a787e1805a1/validator/src/bin/solana-test-validator.rs#L412

https://github.com/anza-xyz/agave/blob/28784debec727677144c7e739db48a787e1805a1/test-validator/src/lib.rs#L171

https://github.com/anza-xyz/agave/blob/28784debec727677144c7e739db48a787e1805a1/test-validator/src/lib.rs#L107-L120

Note that https://github.com/anza-xyz/agave/pull/12727 will aim to remove the logic that switches on debug assertions. Practically speaking, I don't expect people to be running the test-validator with debug assertions tho