### PR TITLE
clap-utils, clap-v3-utils: don't leak filesystem error for unrecognized signer source

### DIFF
--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -502,7 +502,7 @@ pub(crate) fn parse_signer_source<S: AsRef<str>>(
                         Ok(pubkey) => Ok(SignerSource::new(SignerSourceKind::Pubkey(pubkey))),
                         Err(_) => std::fs::metadata(source.as_str())
                             .map(|_| SignerSource::new(SignerSourceKind::Filepath(source)))
-                            .map_err(|err| err.into()),
+                            .map_err(|_| SignerSourceError::UnrecognizedSource),
                     },
                 }
             }
@@ -1245,12 +1245,24 @@ mod tests {
                 derivation_path: d,
                 legacy: false,
             } if u == expected_locator && d == expected_derivation_path);
-        // Catchall into SignerSource::Filepath fails
+        // An input that is neither a valid pubkey nor an existing file is
+        // reported as an unrecognized source rather than leaking the
+        // underlying filesystem error. This input parses as a (scheme-less)
+        // URI reference and so exercises the corresponding catchall branch.
         let junk = "sometextthatisnotapubkeyorfile".to_string();
         assert!(Pubkey::from_str(&junk).is_err());
         assert_matches!(
             parse_signer_source(&junk),
-            Err(SignerSourceError::IoError(_))
+            Err(SignerSourceError::UnrecognizedSource)
+        );
+        // An input that does not even parse as a URI reference (e.g. one
+        // containing spaces) is handled by the sibling catchall branch, which
+        // now maps to the same error.
+        let not_a_uri = "not a pubkey or a file".to_string();
+        assert!(Pubkey::from_str(&not_a_uri).is_err());
+        assert_matches!(
+            parse_signer_source(&not_a_uri),
+            Err(SignerSourceError::UnrecognizedSource)
         );
 
         let prompt = "prompt:".to_string();

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -273,7 +273,7 @@ impl SignerSource {
                             Ok(pubkey) => Ok(SignerSource::new(SignerSourceKind::Pubkey(pubkey))),
                             Err(_) => std::fs::metadata(source.as_str())
                                 .map(|_| SignerSource::new(SignerSourceKind::Filepath(source)))
-                                .map_err(|err| err.into()),
+                                .map_err(|_| SignerSourceError::UnrecognizedSource),
                         },
                     }
                 }
@@ -653,12 +653,24 @@ mod tests {
                 derivation_path: d,
                 legacy: false,
             } if u == expected_locator && d == expected_derivation_path);
-        // Catchall into SignerSource::Filepath fails
+        // An input that is neither a valid pubkey nor an existing file is
+        // reported as an unrecognized source rather than leaking the
+        // underlying filesystem error. This input parses as a (scheme-less)
+        // URI reference and so exercises the corresponding catchall branch.
         let junk = "sometextthatisnotapubkeyorfile".to_string();
         assert!(Pubkey::from_str(&junk).is_err());
         assert_matches!(
             SignerSource::parse(&junk),
-            Err(SignerSourceError::IoError(_))
+            Err(SignerSourceError::UnrecognizedSource)
+        );
+        // An input that does not even parse as a URI reference (e.g. one
+        // containing spaces) is handled by the sibling catchall branch, which
+        // now maps to the same error.
+        let not_a_uri = "not a pubkey or a file".to_string();
+        assert!(Pubkey::from_str(&not_a_uri).is_err());
+        assert_matches!(
+            SignerSource::parse(&not_a_uri),
+            Err(SignerSourceError::UnrecognizedSource)
         );
 
         let prompt = "prompt:".to_string();


### PR DESCRIPTION
## Problem

When an address/pubkey argument receives a value that is neither a valid
pubkey nor an existing keypair file, the CLI surfaces a misleading low-level
filesystem error. For example, a typo'd pubkey:

```
$ solana balance notapubkey
error: Invalid value for '<ACCOUNT_ADDRESS>': No such file or directory (os error 2)
```

"No such file or directory" implies a missing file, when the user most likely
intended (and mistyped) a public key.

## Root cause

`parse_signer_source` (and its `clap-v3-utils` twin `SignerSource::parse`) has
two parallel "fall back to a file path" branches that handle a failed
`std::fs::metadata` check inconsistently:

- when the input fails to parse as a URI reference, the metadata error is
  mapped to `SignerSourceError::UnrecognizedSource`;
- when the input parses as a (scheme-less) URI reference but is not a valid
  pubkey (the common case), the raw `io::Error` was propagated as
  `SignerSourceError::IoError`.

## Fix

Map the metadata error in the second branch to `UnrecognizedSource` too, so
both catchall branches behave identically, in both the `clap-utils` (clap v2,
used by the `solana` CLI) and `clap-v3-utils` (used by `solana-keygen`)
implementations. The error now reads:

```
error: Invalid value for '<ACCOUNT_ADDRESS>': unrecognized signer source
```

Updated each `test_parse_signer_source` accordingly and added a case covering
the sibling (non-URI-reference) branch.

## Notes

- Distinct from #10888 / #2266, which improve the `--keypair`
  `DefaultSigner::path()` message; this change covers positional
  address/pubkey argument value parsing. The `clap-utils/src/keypair.rs` edit
  is in a different function (`parse_signer_source`) but the same file, so a
  small textual rebase conflict with #10888 is possible if both land.
- Trade-off: a non-`NotFound` io error (e.g. permission denied) is now also
  reported as `UnrecognizedSource` rather than with its specific message,
  matching the existing sibling branch. Happy to preserve specific io errors
  if preferred.
