### PR TITLE
xdp: optionally log warning on packet mtu oversize drop

### DIFF
--- a/streamer/src/quic_socket.rs
+++ b/streamer/src/quic_socket.rs
@@ -266,10 +266,9 @@ impl QuicXdpSender {
         let src_addr = SocketAddrV4::new(src_ip, self.src_addr.port());
         let ecn = ecn.map(quinn_ecn_to_xdp);
 
-        self.xdp_sender.try_send(
-            sender_idx,
-            BytesTxPacket::new(src_addr, destination, ecn, payload),
-        )
+        let mut packet = BytesTxPacket::new(src_addr, destination, ecn, payload);
+        packet.set_allow_mtu_overflow(true);
+        self.xdp_sender.try_send(sender_idx, packet)
     }
 }
 

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -79,6 +79,7 @@ pub struct BytesTxPacket {
     src_addr: SocketAddrV4,
     dst_addrs: XdpAddrs,
     ecn: Option<EcnCodepoint>,
+    allow_mtu_overflow: bool,
     payload: Bytes,
 }
 
@@ -97,8 +98,14 @@ impl BytesTxPacket {
             src_addr,
             dst_addrs: dst_addrs.into(),
             ecn,
+            allow_mtu_overflow: false,
             payload,
         }
+    }
+
+    /// Sets whether MTU overflow is possible for this packet.
+    pub fn set_allow_mtu_overflow(&mut self, allow: bool) {
+        self.allow_mtu_overflow = allow;
     }
 }
 
@@ -112,6 +119,8 @@ impl BytesTxPacket {
     ) -> Self {
         Self
     }
+
+    pub fn set_allow_mtu_overflow(&mut self, _allow: bool) {}
 }
 
 #[cfg(target_os = "linux")]
@@ -133,6 +142,10 @@ impl TxPacket for BytesTxPacket {
 
     fn ecn(&self) -> Option<EcnCodepoint> {
         self.ecn
+    }
+
+    fn allow_mtu_overflow(&self) -> bool {
+        self.allow_mtu_overflow
     }
 }
 

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -211,6 +211,9 @@ pub trait TxPacket {
 
     /// Explicit congestion notification bits to set on the packet.
     fn ecn(&self) -> Option<EcnCodepoint>;
+
+    /// Returns true when this packet is expected to occasionally exceed the route MTU.
+    fn allow_mtu_overflow(&self) -> bool;
 }
 
 impl<U: Umem> TxLoop<U> {
@@ -290,6 +293,7 @@ impl<U: Umem> TxLoop<U> {
                 let src_ip = src_addr.ip();
                 let src_port = src_addr.port();
                 let ecn = item.ecn();
+                let can_overflow_mtu = item.allow_mtu_overflow();
                 for addr in item.dst_addrs().as_ref() {
                     if ring.available() == 0 || umem.available() == 0 {
                         commit_pending(&mut ring, &mut written_uncommitted);
@@ -343,14 +347,16 @@ impl<U: Umem> TxLoop<U> {
                         if l3_inner_packet_len > gre.mtu as usize
                             || l3_outer_gre_packet_len > next_hop.mtu as usize
                         {
-                            log::warn!(
-                                "dropping packet: GRE payload exceeds MTU for {addr}: L3 inner \
-                                 packet length {l3_inner_packet_len}, L3 outer GRE packet length \
-                                 {l3_outer_gre_packet_len}, MTU: {mtu}, underlay_mtu: \
-                                 {underlay_mtu}.",
-                                mtu = gre.mtu,
-                                underlay_mtu = next_hop.mtu
-                            );
+                            if !can_overflow_mtu {
+                                log::warn!(
+                                    "dropping packet: GRE payload exceeds MTU for {addr}: L3 \
+                                     inner packet length {l3_inner_packet_len}, L3 outer GRE \
+                                     packet length {l3_outer_gre_packet_len}, MTU: {mtu}, \
+                                     underlay_mtu: {underlay_mtu}.",
+                                    mtu = gre.mtu,
+                                    underlay_mtu = next_hop.mtu
+                                );
+                            }
                             batched_packets -= 1;
                             umem.release(frame.offset());
                             continue;
@@ -402,11 +408,13 @@ impl<U: Umem> TxLoop<U> {
 
                         let l3_packet_len = IP_HEADER_SIZE + UDP_HEADER_SIZE + len;
                         if l3_packet_len > next_hop.mtu as usize {
-                            log::warn!(
-                                "dropping packet: packet size {l3_packet_len} exceeds MTU {mtu} \
-                                 for {addr}",
-                                mtu = next_hop.mtu
-                            );
+                            if !can_overflow_mtu {
+                                log::warn!(
+                                    "dropping packet: packet size {l3_packet_len} exceeds MTU \
+                                     {mtu} for {addr}",
+                                    mtu = next_hop.mtu
+                                );
+                            }
                             batched_packets -= 1;
                             umem.release(frame.offset());
                             continue;


### PR DESCRIPTION
#### Problem

This PR adds optional flag to `TxPacket` to specify if we want to log dropping the packet due to MTU oversize.

MTU oversize happens in case of Quic traffic. Why:

Quinn performs PLPMTUD  by sending PING packets padded to a target UDP payload size. It uses missed ACK for sent packet as a signal that probed MTU exceeds actual MTU on the given route.
Quinn allows to configure max UDP payload for MTU discovery. Currently used default value is `1452` which is computed as `1500 (common MTU) - 40 (IPv6 header) - 8 (UDP header) = 1452 bytes`. But if the it is GRE route, we will have in fact `1500 (common MTU) - 20 (outer IPv4 header) - 4 (GRE header) - 20 (inner IPv4 header) - 8 (UDP header) = 1448 bytes`. Hence, in the process of discovery quinn will send oversized packets.

#### Summary of Changes

Optionally log packet drop in case of MTU oversize.

This PR is alternative to https://github.com/anza-xyz/agave/pull/12706
