### PR TITLE
clap-utils: fix CLI panic and silent overflow on malformed SOL amounts

### DIFF
--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -13,7 +13,7 @@ use {
     solana_cluster_type::ClusterType,
     solana_commitment_config::CommitmentConfig,
     solana_keypair::{Keypair, read_keypair_file},
-    solana_native_token::LAMPORTS_PER_SOL,
+    solana_native_token::sol_str_to_lamports,
     solana_pubkey::Pubkey,
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_signature::Signature,
@@ -233,28 +233,7 @@ pub fn resolve_signer(
 /// Accepts plain or decimal strings ("50", "0.03", ".5", "1.").
 /// Any decimal places beyond 9 are truncated.
 pub fn lamports_of_sol(matches: &ArgMatches<'_>, name: &str) -> Option<u64> {
-    matches.value_of(name).and_then(|value| {
-        if value == "." {
-            None
-        } else {
-            let (sol, lamports) = value.split_once('.').unwrap_or((value, ""));
-            let sol = if sol.is_empty() {
-                0
-            } else {
-                sol.parse::<u64>().ok()?
-            };
-            let lamports = if lamports.is_empty() {
-                0
-            } else {
-                format!("{lamports:0<9}")[..9].parse().ok()?
-            };
-            Some(
-                LAMPORTS_PER_SOL
-                    .saturating_mul(sol)
-                    .saturating_add(lamports),
-            )
-        }
-    })
+    matches.value_of(name).and_then(sol_str_to_lamports)
 }
 
 pub fn cluster_type_of(matches: &ArgMatches<'_>, name: &str) -> Option<ClusterType> {
@@ -548,6 +527,16 @@ mod tests {
         let matches = app().get_matches_from(vec!["test", "--single", "6,998"]);
         assert_eq!(lamports_of_sol(&matches, "single"), None);
         let matches = app().get_matches_from(vec!["test", "--single", "6,998.00"]);
+        assert_eq!(lamports_of_sol(&matches, "single"), None);
+        // Overflowing amounts return `None` instead of saturating to `u64::MAX`.
+        let matches = app().get_matches_from(vec!["test", "--single", "18446744073"]);
+        assert_eq!(
+            lamports_of_sol(&matches, "single"),
+            Some(18_446_744_073_000_000_000)
+        );
+        let matches = app().get_matches_from(vec!["test", "--single", "18446744074"]);
+        assert_eq!(lamports_of_sol(&matches, "single"), None);
+        let matches = app().get_matches_from(vec!["test", "--single", "999999999999"]);
         assert_eq!(lamports_of_sol(&matches, "single"), None);
     }
 }

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -7,6 +7,7 @@ use {
     solana_clock::{Epoch, Slot},
     solana_hash::Hash,
     solana_keypair::read_keypair_file,
+    solana_native_token::sol_str_to_lamports,
     solana_pubkey::{MAX_SEED_LEN, Pubkey},
     solana_signature::Signature,
     std::{fmt::Display, ops::RangeBounds, str::FromStr},
@@ -301,11 +302,11 @@ pub fn is_amount<T>(amount: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
-    if amount.as_ref().parse::<u64>().is_ok() || amount.as_ref().parse::<f64>().is_ok() {
+    if sol_str_to_lamports(amount.as_ref()).is_some() {
         Ok(())
     } else {
         Err(format!(
-            "Unable to parse input amount as integer or float, provided: {amount}"
+            "Unable to parse input amount as a number of SOL, provided: {amount}"
         ))
     }
 }
@@ -314,14 +315,11 @@ pub fn is_amount_or_all<T>(amount: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
-    if amount.as_ref().parse::<u64>().is_ok()
-        || amount.as_ref().parse::<f64>().is_ok()
-        || amount.as_ref() == "ALL"
-    {
+    if sol_str_to_lamports(amount.as_ref()).is_some() || amount.as_ref() == "ALL" {
         Ok(())
     } else {
         Err(format!(
-            "Unable to parse input amount as integer or float, provided: {amount}"
+            "Unable to parse input amount as a number of SOL or 'ALL', provided: {amount}"
         ))
     }
 }
@@ -330,15 +328,15 @@ pub fn is_amount_or_all_or_available<T>(amount: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
-    if amount.as_ref().parse::<u64>().is_ok()
-        || amount.as_ref().parse::<f64>().is_ok()
+    if sol_str_to_lamports(amount.as_ref()).is_some()
         || amount.as_ref() == "ALL"
         || amount.as_ref() == "AVAILABLE"
     {
         Ok(())
     } else {
         Err(format!(
-            "Unable to parse input amount as integer or float, provided: {amount}"
+            "Unable to parse input amount as a number of SOL, 'ALL', or 'AVAILABLE', provided: \
+             {amount}"
         ))
     }
 }
@@ -500,6 +498,39 @@ mod tests {
         assert!(is_derivation("4294967296").is_err());
         assert!(is_derivation("a/b").is_err());
         assert!(is_derivation("0/4294967296").is_err());
+    }
+
+    #[test]
+    fn test_is_amount() {
+        // Valid SOL amounts are accepted.
+        assert!(is_amount("0").is_ok());
+        assert!(is_amount("1").is_ok());
+        assert!(is_amount("1.5").is_ok());
+        assert!(is_amount("0.5025").is_ok());
+        // Largest whole-SOL amount that still fits in u64 lamports.
+        assert!(is_amount("18446744073").is_ok());
+
+        // Inputs the SOL parser cannot represent are now rejected up front.
+        // These previously passed validation as floats and then either panicked
+        // (`unwrap` on a `None`) or silently saturated when converted to lamports.
+        assert!(is_amount("1e9").is_err());
+        assert!(is_amount("1.5e3").is_err());
+        assert!(is_amount("inf").is_err());
+        assert!(is_amount("NaN").is_err());
+        assert!(is_amount("abc").is_err());
+        assert!(is_amount(".").is_err());
+        // Overflows u64 lamports (value * LAMPORTS_PER_SOL > u64::MAX).
+        assert!(is_amount("999999999999").is_err());
+        assert!(is_amount("18446744074").is_err());
+
+        // Keyword variants accept their keywords in addition to SOL amounts.
+        assert!(is_amount_or_all("1.5").is_ok());
+        assert!(is_amount_or_all("ALL").is_ok());
+        assert!(is_amount_or_all("AVAILABLE").is_err());
+        assert!(is_amount_or_all("1e9").is_err());
+        assert!(is_amount_or_all_or_available("ALL").is_ok());
+        assert!(is_amount_or_all_or_available("AVAILABLE").is_ok());
+        assert!(is_amount_or_all_or_available("1e9").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

With a valid signer configured, passing certain amounts to `solana` commands
that take a SOL amount panics:

```
$ solana airdrop 1e9
thread 'main' panicked at cli/src/wallet.rs:428:55:
called `Option::unwrap()` on a `None` value
```

The same happens for `1.5e3`, `inf`, `NaN`, `1e-3`, etc. (`solana transfer`
and other amount-taking commands share the root cause). Separately, an amount
that overflows `u64` lamports is silently saturated rather than rejected:

```
$ solana airdrop 999999999999
Requesting airdrop of 18446744073.709552765 SOL   # not the requested amount
```

## Root cause

The `is_amount` family of validators accepts anything that parses as a `u64`
*or* `f64` (so `1e9`, `inf`, `NaN` all pass), but `lamports_of_sol` only parses
a plain decimal string and returns `None` for those inputs. The parse sites
then `unwrap()` that `None` and panic. `lamports_of_sol` also used
`saturating_mul`/`saturating_add`, silently clamping out-of-range amounts to
`u64::MAX`.

## Fix

Align the validators and the parser on the canonical
`solana_native_token::sol_str_to_lamports`:

- `lamports_of_sol` now delegates to `sol_str_to_lamports` (which uses checked
  arithmetic, so an overflow returns `None`). This is the migration already
  sketched by the `#[ignore]`d `test_lamports_of_sol_origin` (added in #4988).
- `is_amount` / `is_amount_or_all` / `is_amount_or_all_or_available` now accept
  exactly what `sol_str_to_lamports` can parse (plus the `ALL` / `AVAILABLE`
  keywords), so malformed or out-of-range amounts are rejected at validation
  time with a clear message instead of panicking or saturating:

```
$ solana airdrop 1e9
error: Invalid value for '<AMOUNT>': Unable to parse input amount as a number of SOL, provided: 1e9
```

Valid amounts (including the `ALL` / `AVAILABLE` keywords) are unaffected.
Added `test_is_amount` and overflow cases to `test_lamports_of_sol`.

## Notes

- `clap-v3-utils` needs no change: its `lamports_of_sol` already uses
  `sol_str_to_lamports`, and its `is_amount*` validators are `#[deprecated]`
  (since 1.17.0) and unused.
- Related to, but orthogonal to, #5930 (SPL-Token `f64` rounding in
  `Amount::sol_to_lamport`); this change does not touch that path.
