### PR TITLE
svm: gate agave precompile deps behind conformance feature

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8885,8 +8885,6 @@ dependencies = [
 name = "solana-svm"
 version = "4.2.0-alpha.0"
 dependencies = [
- "agave-feature-set",
- "agave-precompiles",
  "ahash 0.8.12",
  "log",
  "percentage",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9406,8 +9406,6 @@ dependencies = [
 name = "solana-svm"
 version = "4.2.0-alpha.0"
 dependencies = [
- "agave-feature-set",
- "agave-precompiles",
  "ahash 0.8.12",
  "log",
  "percentage",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -20,6 +20,8 @@ name = "solana_svm"
 default = ["metrics"]
 agave-unstable-api = []
 conformance = [
+    "dep:agave-feature-set",
+    "dep:agave-precompiles",
     "dep:bincode",
     "dep:prost",
     "dep:protosol",
@@ -28,8 +30,6 @@ conformance = [
     "solana-pubkey/default",
 ]
 dev-context-only-utils = [
-    "dep:agave-feature-set",
-    "dep:agave-precompiles",
     "dep:qualifier_attr",
     "dep:solana-bpf-loader-program",
     "dep:solana-compute-budget",

--- a/svm/src/conformance/harness.rs
+++ b/svm/src/conformance/harness.rs
@@ -3,11 +3,8 @@
 use {
     super::context::{InstrContext, InstrEffects},
     crate::message_processor::process_message,
-    agave_feature_set::FeatureSet,
-    agave_precompiles::{get_precompile, is_precompile},
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_instruction::error::InstructionError,
-    solana_precompile_error::PrecompileError,
     solana_program_runtime::{
         invoke_context::{EnvironmentConfig, InvokeContext, mock_compile_message},
         loaded_programs::{
@@ -31,15 +28,25 @@ use {
         programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
         sysvar::fill_sysvar_cache_from_accounts,
     },
+    agave_feature_set::FeatureSet,
+    agave_precompiles::{get_precompile, is_precompile},
     prost::Message,
     protosol::protos::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
+    solana_precompile_error::PrecompileError,
     std::ffi::c_int,
 };
 
-/// Default callback. Full precompile support.
+/// Default callback. No precompile support.
 struct DefaultCallback;
 
-impl InvokeContextCallback for DefaultCallback {
+impl InvokeContextCallback for DefaultCallback {}
+
+/// Conformance callback. Full precompile support across all features.
+#[cfg(feature = "conformance")]
+struct ConformanceCallback;
+
+#[cfg(feature = "conformance")]
+impl InvokeContextCallback for ConformanceCallback {
     fn is_precompile(&self, program_id: &Pubkey) -> bool {
         is_precompile(program_id, |_| true)
     }
@@ -238,8 +245,9 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> ProtoInstrEffects {
         cache
     };
 
-    execute_instr(
+    execute_instr_with_callback(
         &instr_context,
+        &ConformanceCallback,
         &compute_budget,
         &mut program_cache,
         &sysvar_cache,


### PR DESCRIPTION
#### Problem
We want to use the `conformance` feature to gate additional dependencies that are only required for [conformance testing](https://github.com/anza-xyz/agave/issues/12378) behind. That way, we can keep those deps out of `dev-context-only-utils` and only enable them when necessary.

#### Summary of Changes
Splits the conformance harness callback into two:
- `DefaultCallback` (always available) — uses trait defaults, no precompile support.
- `ConformanceCallback` (gated on `conformance`) — full precompile support across all features, used by the protobuf FFI entrypoint.

`agave-feature-set` and `agave-precompiles` move from `dev-context-only-utils` to `conformance`, since they're only needed for the conformance callback's precompile verification path.
