### PR TITLE
Bound internal channels for tpu-banking stage path

### DIFF
--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -2,24 +2,40 @@ use {
     agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
     bincode::serialize_into,
     chrono::{DateTime, Local},
-    crossbeam_channel::{Receiver, SendError, Sender, TryRecvError, unbounded},
+    crossbeam_channel::{
+        Receiver, SendError, Sender, TryRecvError, TrySendError, bounded, unbounded,
+    },
     rolling_file::{RollingCondition, RollingConditionBasic, RollingFileAppender},
     serde::{Deserialize, Serialize},
     solana_clock::Slot,
     solana_hash::Hash,
+    solana_metrics::datapoint_info,
+    solana_streamer::{evicting_sender::EvictingSender, streamer::ChannelSend},
+    solana_time_utils::timestamp,
     std::{
         fs::{create_dir_all, remove_dir_all},
         io::{self, Write},
         path::PathBuf,
         sync::{
             Arc,
-            atomic::{AtomicBool, Ordering},
+            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         },
         thread::{self, JoinHandle, sleep},
         time::{Duration, SystemTime},
     },
     thiserror::Error,
 };
+
+/// Capacity of the vote channel between sigverify and the banking-stage.
+/// Sized to fit all votes from a reasonably sized cluster for 1 slot, + margin.
+const VOTE_CHANNEL_CAPACITY: usize = 1024 * 8;
+
+/// Capacity of the non-vote (transaction) channel between sigverify and the banking-stage.
+/// Larger than the vote channel to absorb bursty TPU load.
+const NON_VOTE_CHANNEL_CAPACITY: usize = 1024 * 16;
+
+/// Period between metric emissions per channel from inside `TracedSender::send`.
+const STATS_REPORT_INTERVAL: Duration = Duration::from_secs(5);
 
 pub type BankingPacketSender = TracedSender;
 pub type TracerThreadResult = Result<(), TraceError>;
@@ -83,6 +99,17 @@ pub enum ChannelLabel {
     TpuVote,
     GossipVote,
     Dummy,
+}
+
+impl ChannelLabel {
+    fn metric_name(&self) -> &'static str {
+        match self {
+            ChannelLabel::NonVote => "banking_trace_channel_non_vote",
+            ChannelLabel::TpuVote => "banking_trace_channel_tpu_vote",
+            ChannelLabel::GossipVote => "banking_trace_channel_gossip_vote",
+            ChannelLabel::Dummy => "banking_trace_channel_dummy",
+        }
+    }
 }
 
 struct RollingConditionGrouped {
@@ -252,10 +279,14 @@ impl BankingTracer {
     pub fn create_channels(&self) -> Channels {
         let (non_vote_sender, non_vote_receiver) = self.create_channel_non_vote();
 
-        let (tpu_vote_sender, tpu_vote_receiver) =
-            Self::channel(ChannelLabel::TpuVote, self.active_tracer.as_ref().cloned());
+        let (tpu_vote_sender, tpu_vote_receiver) = Self::channel(
+            ChannelLabel::TpuVote,
+            VOTE_CHANNEL_CAPACITY,
+            self.active_tracer.as_ref().cloned(),
+        );
         let (gossip_vote_sender, gossip_vote_receiver) = Self::channel(
             ChannelLabel::GossipVote,
+            VOTE_CHANNEL_CAPACITY,
             self.active_tracer.as_ref().cloned(),
         );
 
@@ -270,20 +301,26 @@ impl BankingTracer {
     }
 
     pub fn create_channel_non_vote(&self) -> (BankingPacketSender, BankingPacketReceiver) {
-        Self::channel(ChannelLabel::NonVote, self.active_tracer.as_ref().cloned())
+        Self::channel(
+            ChannelLabel::NonVote,
+            NON_VOTE_CHANNEL_CAPACITY,
+            self.active_tracer.as_ref().cloned(),
+        )
     }
 
     pub fn channel_for_test() -> (TracedSender, Receiver<BankingPacketBatch>) {
-        Self::channel(ChannelLabel::Dummy, None)
+        Self::channel(ChannelLabel::Dummy, VOTE_CHANNEL_CAPACITY, None)
     }
 
     fn channel(
         label: ChannelLabel,
+        capacity: usize,
         active_tracer: Option<ActiveTracer>,
     ) -> (TracedSender, Receiver<BankingPacketBatch>) {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(capacity);
+        let evicting = EvictingSender::new(sender, receiver.clone());
 
-        (TracedSender::new(label, sender, active_tracer), receiver)
+        (TracedSender::new(label, evicting, active_tracer), receiver)
     }
 
     pub fn ensure_cleanup_path(path: &PathBuf) -> Result<(), io::Error> {
@@ -357,19 +394,33 @@ impl BankingTracer {
 #[derive(Clone)]
 pub struct TracedSender {
     label: ChannelLabel,
-    sender: Sender<BankingPacketBatch>,
+    sender: EvictingSender<BankingPacketBatch>,
+    stats: Arc<TracedSenderStats>,
     active_tracer: Option<ActiveTracer>,
+}
+
+#[derive(Default)]
+struct TracedSenderStats {
+    /// Total number of batches sent downstream.
+    sent: AtomicU64,
+    /// Max channel length observed since last report.
+    max_len: AtomicUsize,
+    /// Number of batches the EvictingSender dropped due to a full channel since last report.
+    eviction_drops: AtomicU64,
+    /// `solana_time_utils::timestamp` of the last report.
+    last_report_ms: AtomicU64,
 }
 
 impl TracedSender {
     fn new(
         label: ChannelLabel,
-        sender: Sender<BankingPacketBatch>,
+        sender: EvictingSender<BankingPacketBatch>,
         active_tracer: Option<ActiveTracer>,
     ) -> Self {
         Self {
             label,
             sender,
+            stats: Arc::new(TracedSenderStats::default()),
             active_tracer,
         }
     }
@@ -388,7 +439,23 @@ impl TracedSender {
                     })?;
             }
         }
-        self.sender.send(batch)
+        let (result, sent) = match self.sender.try_send(batch) {
+            // New batch queued; nothing was evicted.
+            Ok(()) => (Ok(()), self.stats.sent.fetch_add(1, Ordering::Relaxed)),
+            // EvictingSender popped the oldest to make room.
+            Err(TrySendError::Full(_)) => {
+                self.stats.eviction_drops.fetch_add(1, Ordering::Relaxed);
+                (Ok(()), 0)
+            }
+            Err(TrySendError::Disconnected(b)) => (Err(SendError(b)), 0),
+        };
+        let len = self.sender.len();
+        self.stats.max_len.fetch_max(len, Ordering::Relaxed);
+        // if we've made reasonable progress, or dropped packets
+        if sent % 128 == 0 {
+            self.maybe_report_stats();
+        }
+        result
     }
 
     pub fn len(&self) -> usize {
@@ -397,6 +464,29 @@ impl TracedSender {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    fn maybe_report_stats(&self) {
+        let now_ms = timestamp();
+        let last = self.stats.last_report_ms.load(Ordering::Relaxed);
+        if Duration::from_millis(now_ms.saturating_sub(last)) < STATS_REPORT_INTERVAL {
+            return;
+        }
+        if self
+            .stats
+            .last_report_ms
+            .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            return;
+        }
+        let max_len = self.stats.max_len.swap(0, Ordering::Relaxed);
+        let eviction_drops = self.stats.eviction_drops.swap(0, Ordering::Relaxed);
+        datapoint_info!(
+            self.label.metric_name(),
+            ("max_len", max_len as i64, i64),
+            ("eviction_drops", eviction_drops as i64, i64),
+        );
     }
 }
 

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -7,12 +7,13 @@ use {
     solana_metrics::{inc_new_counter_debug, inc_new_counter_info},
     solana_packet::PacketFlags,
     solana_perf::{
-        packet::{PacketBatchRecycler, PacketRefMut},
+        packet::{PacketBatch, PacketBatchRecycler, PacketRefMut},
         recycler::Recycler,
     },
     solana_poh::poh_recorder::PohRecorder,
-    solana_streamer::streamer::{
-        self, PacketBatchReceiver, PacketBatchSender, StreamerReceiveStats,
+    solana_streamer::{
+        evicting_sender::EvictingSender,
+        streamer::{self, PacketBatchReceiver, PacketBatchSender, StreamerReceiveStats},
     },
     std::{
         net::UdpSocket,
@@ -37,7 +38,8 @@ impl FetchStage {
         coalesce: Option<Duration>,
     ) -> (Self, PacketBatchReceiver, PacketBatchReceiver) {
         let (sender, receiver) = unbounded();
-        let (vote_sender, vote_receiver) = unbounded();
+        let (vote_sender, vote_receiver) =
+            EvictingSender::new_bounded(crate::tpu::TPU_VOTE_CHANNEL_SIZE);
         let (_forward_sender, forward_receiver) = unbounded();
         (
             Self::new_with_sender(
@@ -58,7 +60,7 @@ impl FetchStage {
         tpu_vote_sockets: Vec<UdpSocket>,
         exit: Arc<AtomicBool>,
         sender: &PacketBatchSender,
-        vote_sender: &PacketBatchSender,
+        vote_sender: &EvictingSender<PacketBatch>,
         forward_receiver: PacketBatchReceiver,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         coalesce: Option<Duration>,
@@ -132,7 +134,7 @@ impl FetchStage {
         tpu_vote_sockets: Vec<Arc<UdpSocket>>,
         exit: Arc<AtomicBool>,
         sender: &PacketBatchSender,
-        vote_sender: &PacketBatchSender,
+        vote_sender: &EvictingSender<PacketBatch>,
         forward_receiver: PacketBatchReceiver,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         coalesce: Option<Duration>,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -48,6 +48,7 @@ use {
         vote_sender_types::{ReplayVoteReceiver, ReplayVoteSender},
     },
     solana_streamer::{
+        evicting_sender::EvictingSender,
         quic::{
             SimpleQosQuicStreamerConfig, SpawnServerResult, SwQosQuicStreamerConfig,
             spawn_simple_qos_server, spawn_stake_weighted_qos_server,
@@ -87,6 +88,10 @@ pub const MAX_VOTES_PER_SECOND: u64 = 20;
 /// Size of the channel between streamer and TPU sigverify stage. The values have been selected to
 /// be conservative max of obsersed on mnb during high-load events.
 const TPU_CHANNEL_SIZE: usize = 50_000;
+
+/// Size of the channel between the vote streamer and the TPU sigverify stage.
+/// Chosen based on nominal voting load for a cluster with ~2000 validators + some margin.
+pub(crate) const TPU_VOTE_CHANNEL_SIZE: usize = 4_000;
 
 pub struct Tpu {
     fetch_stage: FetchStage,
@@ -164,13 +169,15 @@ impl Tpu {
         } = sockets;
 
         let (packet_sender, packet_receiver) = bounded(TPU_CHANNEL_SIZE);
-        let (vote_packet_sender, vote_packet_receiver) = unbounded();
+        let (vote_packet_sender, vote_packet_receiver) = bounded(TPU_VOTE_CHANNEL_SIZE);
+        let evicting_vote_sender =
+            EvictingSender::new(vote_packet_sender.clone(), vote_packet_receiver.clone());
         let (forwarded_packet_sender, forwarded_packet_receiver) = unbounded();
         let fetch_stage = FetchStage::new_with_sender(
             tpu_vote_sockets,
             exit.clone(),
             &packet_sender,
-            &vote_packet_sender,
+            &evicting_vote_sender,
             forwarded_packet_receiver,
             poh_recorder,
             None, // coalesce


### PR DESCRIPTION
#### Problem

- Unbounded channels must go

#### Summary of Changes

- Replace unbounded ones with bounded in TPU and its banking stage connections. 
- Provision enough capacity for the bounded channels to ensure they never back up under normal load. If they do fill up, use EvictingSender to prefer newer packets where appropriate.


