### PR TITLE
Promote stable to v4.0 and beta to v4.1

### DIFF
--- a/ci/channel-overrides
+++ b/ci/channel-overrides
@@ -1,5 +1,5 @@
 # Channel override file consumed by ci/channel-info.sh.
 # Single source of truth: edit on master only, no backports.
 # Empty = auto-detect.
-PINNED_BETA_CHANNEL=v4.0
-PINNED_STABLE_CHANNEL=v3.1
+PINNED_BETA_CHANNEL=v4.1
+PINNED_STABLE_CHANNEL=v4.0


### PR DESCRIPTION
#### Problem

v4.0 is recommended for MB now and majority of the network updated to it.

#### Summary of Changes

Promote stable channel to v4.0 and beta channel to v4.1.
