### PR TITLE
transaction-scheduler: yield more frequently from receive_and_buffer_packets()

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -121,7 +121,8 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
         } = self.sharable_banks.load();
 
         // Receive packet batches.
-        const TIMEOUT: Duration = Duration::from_millis(10);
+        const RECV_TIMEOUT: Duration = Duration::from_millis(10);
+        const PACKET_BURST_TIMEOUT: Duration = Duration::from_millis(1);
         const PACKET_BURST_LIMIT: usize = 1000;
         let start = Instant::now();
 
@@ -156,7 +157,7 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
             //       overhead for wakers? But then risk not waking up when message
             //       received - as long as sleep is somewhat short, this should be
             //       fine.
-            match self.receiver.recv_timeout(TIMEOUT) {
+            match self.receiver.recv_timeout(RECV_TIMEOUT) {
                 Ok(packet_batch_message) => {
                     received_message = true;
                     stats.accumulate(self.handle_packet_batch_message(
@@ -177,7 +178,8 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
         }
 
         if !timed_out {
-            while start.elapsed() < TIMEOUT && stats.num_received < PACKET_BURST_LIMIT {
+            while start.elapsed() < PACKET_BURST_TIMEOUT && stats.num_received < PACKET_BURST_LIMIT
+            {
                 let receive_start = Instant::now();
                 match self.receiver.try_recv() {
                     Ok(packet_batch_message) => {


### PR DESCRIPTION
#### Problem

The scheduler thread (solBnkTxSched) roughly splits its time between two activities: (1) handling incoming transactions from sigverify and (2) scheduling the best transactions. Spending too long in (1) per call starves (2), so fewer transactions get scheduled.


#### Summary of Changes

Limit the time spent in (1) per call to roughly 1ms.

#### Results

The sender is solana's transaction-bench with 6 staked clients, each with 16 connections. Fees are random and uniformly distributed. I modified transaction-bench so that it sends a fixed number of transactions (hopefully this makes things more realistic). The results presented here are for 200K transactions. In each case, the test was repeated 10 times.

**TL;DR**
This PR appears to produce better blocks earlier: the 2nd block has >80M CU, whereas it's usually the 3rd block on master. I did look at each of the 10 runs, but I'm only presenting a few samples here.

Also, initial tests showed even better results with below 1ms PACKET_BURST_TIMEOUT (e.g 250us or 500us). The current draft PR uses 1ms (down from 10ms on master) as a more conservative approach.

**master**
<img width="4290" height="1746" alt="image" src="https://github.com/user-attachments/assets/00538ef7-9fa2-4b6f-b60d-690ad9a39d40" />

**This PR**
<img width="4316" height="1742" alt="image" src="https://github.com/user-attachments/assets/ef6bb200-ab7f-4ab3-a683-e400e5307235" />

**One obvious difference**: the scheduler (almost) doesn't drop transactions at capacity with 1ms. The block metrics (bottom, left-to-right: num-scheduler-txs, CU, collected-fees) look similar at first glance, but they aren't. CU and fees metrics are produced per block. Let's zoom in.

This is a single-validator cluster, so blocks are produced non-stop, which means transactions are always arriving during a leader slot — but we don't know exactly when. So let's ignore the data for the first block.

**master**
<img width="4268" height="864" alt="image" src="https://github.com/user-attachments/assets/55a74c9d-f8b6-4aba-8030-9659e483202f" />
<img width="4292" height="884" alt="image" src="https://github.com/user-attachments/assets/e0796a56-d6d3-49c5-9f44-9b7b5f6c790b" />

**This PR**
<img width="4276" height="1000" alt="image" src="https://github.com/user-attachments/assets/5e10dcad-3bd2-4e91-b262-fbab7de4d9d6" />
<img width="4286" height="876" alt="image" src="https://github.com/user-attachments/assets/7c4d1ef2-6217-4321-a973-cf16a1ea80ad" />