### PR TITLE
status cache: use fixed message hash offset

### DIFF
--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "shuttle-test")]
 use shuttle::sync::{Arc, Mutex};
+#[cfg(not(feature = "shuttle-test"))]
+use std::sync::{Arc, Mutex};
 use {
     ahash::{HashMap, HashMapExt as _},
     log::*,
@@ -11,11 +13,6 @@ use {
         collections::{HashSet, hash_map::Entry},
         num::{NonZero, NonZeroUsize},
     },
-};
-#[cfg(not(feature = "shuttle-test"))]
-use {
-    rand::{Rng, rng},
-    std::sync::{Arc, Mutex},
 };
 
 // The maximum number of entries to store in the cache. This is the same as the number of recent
@@ -220,15 +217,10 @@ impl<T: Serialize + Clone> StatusCache<T> {
         let max_key_index = key.as_ref().len().saturating_sub(CACHED_KEY_SIZE + 1);
 
         // Get the cache entry for this blockhash.
-        let (max_slot, key_index, hash_map) =
-            self.cache.entry(*transaction_blockhash).or_insert_with(|| {
-                // DFS tests need deterministic behavior
-                #[cfg(feature = "shuttle-test")]
-                let key_index = 0;
-                #[cfg(not(feature = "shuttle-test"))]
-                let key_index = rng().random_range(0..max_key_index + 1);
-                (slot, key_index, HashMap::new())
-            });
+        let (max_slot, key_index, hash_map) = self
+            .cache
+            .entry(*transaction_blockhash)
+            .or_insert_with(|| (slot, 0, HashMap::new()));
 
         // Update the max slot observed to contain txs using this blockhash.
         *max_slot = std::cmp::max(slot, *max_slot);


### PR DESCRIPTION
#### Problem

The status cache keys transactions by a random 20 byte subslice of the 32 byte message hash (key_index).

This behavior has no cryptographic or performance benefit and only complicates code.

#### Summary of Changes

For new slot deltas, use the first 20 bytes of the hash instead (key_index=0), which is equivalent to
BLAKE3-160(b"solana-tx-message-v1" + serialized_message).

For old/existing slot deltas, reuse the existing key_index to keep compatibility with older snapshots.

Once the entire network upgrades to Agave v4.2, all snapshots will use key_index=0, allowing us to clean up the random subslice code entirely.

Fixes #
