### PR TITLE
Gate full snapshot clean activity behind full snapshot occurring

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1598,8 +1598,6 @@ impl AccountsDb {
 
         timings.delta_key_count = Self::count_pubkeys(&candidates);
 
-        // Ensure that zero_lamport_accounts_to_purge_after_full_snapshot is empty if snapshots
-        // are enabled
         debug_assert!(
             self.latest_full_snapshot_slot().is_some()
                 || self

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -963,6 +963,10 @@ pub struct AccountsDb {
     /// for incremental snapshot support.
     zero_lamport_accounts_to_purge_after_full_snapshot: DashSet<(Slot, Pubkey)>,
 
+    /// Set by `set_latest_full_snapshot_slot` when the snapshot advances. Read and cleared by
+    /// clean
+    latest_full_snapshot_slot_advanced_since_clean: AtomicBool,
+
     /// GeyserPlugin accounts update notifier
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
 
@@ -1147,6 +1151,7 @@ impl AccountsDb {
             is_bank_drop_callback_enabled: AtomicBool::default(),
             dirty_stores: DashMap::default(),
             zero_lamport_accounts_to_purge_after_full_snapshot: DashSet::default(),
+            latest_full_snapshot_slot_advanced_since_clean: AtomicBool::default(),
             accounts_file_provider: AccountsFileProvider::default(),
             latest_full_snapshot_slot: SeqLock::new(None),
             best_ancient_slots_to_shrink: RwLock::default(),
@@ -1593,28 +1598,34 @@ impl AccountsDb {
 
         timings.delta_key_count = Self::count_pubkeys(&candidates);
 
-        // Check if we should purge any of the
-        // zero_lamport_accounts_to_purge_later, based on the
-        // latest_full_snapshot_slot.
-        let latest_full_snapshot_slot = self.latest_full_snapshot_slot();
-        assert!(
-            latest_full_snapshot_slot.is_some()
+        // Ensure that zero_lamport_accounts_to_purge_after_full_snapshot is empty if snapshots
+        // are enabled
+        debug_assert!(
+            self.latest_full_snapshot_slot().is_some()
                 || self
                     .zero_lamport_accounts_to_purge_after_full_snapshot
                     .is_empty(),
             "if snapshots are disabled, then zero_lamport_accounts_to_purge_later should always \
              be empty"
         );
-        if let Some(latest_full_snapshot_slot) = latest_full_snapshot_slot {
-            self.zero_lamport_accounts_to_purge_after_full_snapshot
-                .retain(|(slot, pubkey)| {
-                    let is_candidate_for_clean =
-                        max_slot_inclusive >= *slot && latest_full_snapshot_slot >= *slot;
-                    if is_candidate_for_clean {
-                        insert_candidate(*pubkey, true);
-                    }
-                    !is_candidate_for_clean
-                });
+
+        // Cleaning up zero lamport accounts is gated by a full snapshot because they need to be retained
+        // for incremental snapshots. Once a snapshot occurs, drain the list
+        if self
+            .latest_full_snapshot_slot_advanced_since_clean
+            .swap(false, Ordering::Acquire)
+        {
+            if let Some(latest_full_snapshot_slot) = self.latest_full_snapshot_slot() {
+                self.zero_lamport_accounts_to_purge_after_full_snapshot
+                    .retain(|(slot, pubkey)| {
+                        let is_candidate_for_clean =
+                            max_slot_inclusive >= *slot && latest_full_snapshot_slot >= *slot;
+                        if is_candidate_for_clean {
+                            insert_candidate(*pubkey, true);
+                        }
+                        !is_candidate_for_clean
+                    });
+            }
         }
 
         (candidates, min_dirty_slot)
@@ -5982,6 +5993,8 @@ impl AccountsDb {
     /// Sets the latest full snapshot slot to `slot`
     pub fn set_latest_full_snapshot_slot(&self, slot: Slot) {
         *self.latest_full_snapshot_slot.lock_write() = Some(slot);
+        self.latest_full_snapshot_slot_advanced_since_clean
+            .store(true, Ordering::Release);
     }
 
     fn generate_index_for_slot<'a>(


### PR DESCRIPTION
#### Problem
Full snapshot clean activity happens every iteration, despite not being needed unless a full snapshot occurs. This path is going to become more expensive, so gate it based on a full snapshot occurring

#### Summary of Changes
- Add a new variable that is set during clean
- Test coverage is provided by existing tests test_clean_accounts_with_latest_full_snapshot_slot and test_filter_zero_lamport_clean_for_incremental_snapshots
- Not much benefit now, but helps with https://github.com/anza-xyz/agave/pull/12665

Fixes #
