### PR TITLE
feature: remove DCOU Alpenglow feature

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1317,27 +1317,7 @@ pub mod formalize_loaded_transaction_data_size {
 }
 
 pub mod alpenglow {
-    #[cfg(feature = "dev-context-only-utils")]
-    use {
-        solana_keypair::{Keypair, Signer},
-        std::sync::LazyLock,
-    };
-
-    // Used to activate alpenglow in local-cluster tests without exposing the actual feature's private key
-    #[cfg(feature = "dev-context-only-utils")]
-    pub static TEST_KEYPAIR: LazyLock<Keypair> = LazyLock::new(|| {
-        let keypair = Keypair::from_base58_string(
-            "2Vzd6oTWU4RtM5UmsSyBH3tAhPSi1sKqMeMC8bF1jzHHLBMRhEWtrfmBV4EmwQbGSwkunk5Wy67kXNAL1ZL1xQhR",
-        );
-        assert_eq!(keypair.pubkey(), super::alpenglow::id());
-        keypair
-    });
-
-    #[cfg(not(feature = "dev-context-only-utils"))]
     solana_pubkey::declare_id!("mustRekeyVm2QHYB3JPefBiU4BY3Z6JkW2k3Scw5GWP");
-
-    #[cfg(feature = "dev-context-only-utils")]
-    solana_pubkey::declare_id!("8KpruRFrT59jQ9NfFX9DU6j8a1hW7y6xchvZNQ5rxD4P");
 }
 
 pub mod disable_zk_elgamal_proof_program {

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -16,7 +16,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 agave-unstable-api = []
 dev-context-only-utils = [
     "solana-core/dev-context-only-utils",
-    "agave-feature-set/dev-context-only-utils",
     "agave-votor-messages/dev-context-only-utils",
 ]
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -6211,6 +6211,15 @@ fn test_alpenglow_migration(
         skip_warmup_slots: false,
         ..ClusterConfig::default()
     };
+    // Seed the feature account as pending activation. The runtime activates it at the next epoch
+    // boundary without needing the Alpenglow feature authority keypair.
+    cluster_config.additional_accounts.push((
+        agave_feature_set::alpenglow::id(),
+        solana_feature_gate_interface::create_account(
+            &solana_feature_gate_interface::Feature::default(),
+            1,
+        ),
+    ));
 
     // Create local cluster with alpenglow accounts but feature not activated
     let cluster = LocalCluster::new(&mut cluster_config, SocketAddrSpace::Unspecified);
@@ -6221,35 +6230,10 @@ fn test_alpenglow_migration(
         .map(|v| v.info.keypair.clone())
         .collect();
 
-    // Send feature activation transaction
-    info!("Sending feature activation transaction");
     let client = RpcClient::new_socket_with_commitment(
         cluster.entry_point_info.rpc().unwrap(),
         CommitmentConfig::processed(),
     );
-    let faucet_keypair = &cluster.funding_keypair;
-    let feature_keypair = &*agave_feature_set::alpenglow::TEST_KEYPAIR;
-    let blockhash = client.get_latest_blockhash().unwrap();
-    let lamports = client
-        .get_minimum_balance_for_rent_exemption(solana_feature_gate_interface::Feature::size_of())
-        .unwrap();
-
-    let activation_message = solana_message::Message::new(
-        &solana_feature_gate_interface::activate_with_lamports(
-            &agave_feature_set::alpenglow::id(),
-            &faucet_keypair.pubkey(),
-            lamports,
-        ),
-        Some(&faucet_keypair.pubkey()),
-    );
-    let activation_tx = solana_transaction::Transaction::new(
-        &[&feature_keypair, &faucet_keypair],
-        activation_message,
-        blockhash,
-    );
-
-    client.send_and_confirm_transaction(&activation_tx).unwrap();
-    info!("Feature activation transaction confirmed");
 
     // Monitor for feature activation
     let activation_slot;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -19,7 +19,6 @@ name = "solana_runtime"
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "agave-feature-set/dev-context-only-utils",
     "agave-votor-messages/dev-context-only-utils",
     "solana-accounts-db/dev-context-only-utils",
     "solana-program-binaries",

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5246,9 +5246,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "8xa8W2GxXP2fVXgY6EaTQFfWnL3jW9apWuu6FueGZPXs"
+                    "9ycftRwjpQ17PrhnwhGPbVzDKd3Q9BybmLYU8UD1Pg1T"
                 } else {
-                    "CeTjbRdS8Nt2Wb1QMuMf8rXQL3YGsUGLwsdT4Ahkvhut"
+                    "4XzjZMjhP9s8iBeFQsnHFwaQ991dpiBGHEkzj1ifAcpS"
                 },
             );
         }
@@ -5257,9 +5257,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "748qUop2J7kyQjtYs9SDrxKRswjbeJPNT3mJqCJWmGfA"
+                    "7sbqfkN4W3PkBREyduDc3R2eiKu68JKYRXZt6gCWNt4N"
                 } else {
-                    "9Kr5dG4tSeS6gSboWMDHJ3GWs85uFXKh9yaHLHP73MJ4"
+                    "ArB3XNVLJsyV7AtrG3C3Bj4akb8s7AzpS5rHJnqGW5sw"
                 },
             );
             break;


### PR DESCRIPTION
#### Problem
We created a separate DCOU version of the alpenglow feature flag for use in migration tests to activate the feature.
This is confusing and also is problematic for things such as ledger tool which need to be built with DCOU

#### Summary of Changes
Remove the DCOU key, and instead rework the test by adding the feature account at genesis, which simulates activating it at epoch 1