### PR TITLE
Enable agave-unstable-api for self-referencing dev-dependencies

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -113,7 +113,7 @@ solana-nonce-account = { workspace = true }
 solana-program-option = { workspace = true }
 solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api"] }
 solana-rent = { workspace = true }
-solana-rpc = { path = ".", features = ["dev-context-only-utils"] }
+solana-rpc = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-sdk-ids = { workspace = true }

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -49,7 +49,7 @@ solana-keypair = { workspace = true }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-system-transaction = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
-solana-unified-scheduler-pool = { path = ".", features = ["dev-context-only-utils"] }
+solana-unified-scheduler-pool = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 test-case = { workspace = true }
 
 [lints]

--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -44,7 +44,7 @@ thiserror = { workspace = true }
 wincode = { workspace = true }
 
 [dev-dependencies]
-agave-votor-messages = { path = ".", features = ["dev-context-only-utils"] }
+agave-votor-messages = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 tempfile = { workspace = true }
 
 [lints]


### PR DESCRIPTION
#### Problem
These crates (rpc,  solana-unified-scheduler-pool, agave-votor-messages) are gated behind "agave-unstable-api" and have self-referencing dev-dependencies for their unit tests. So by default, the tests are skipped and I have to specify --feature agave-unstable-api when running in IDE or CLI. In CI, they are not skipped. So we must be doing that in wrapper scripts.

#### Summary of Changes
Default enable 'agave-unstable-api' in dev dependencies for these crates' self-reference.