### PR TITLE
Enable agave-unstable-api in program-runtime dev dependency

### DIFF
--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -81,7 +81,7 @@ solana-account-info = { workspace = true }
 solana-instruction = { workspace = true, features = ["bincode"] }
 solana-instruction-error = { workspace = true, features = ["serde"] }
 solana-keypair = { workspace = true }
-solana-program-runtime = { path = ".", features = ["dev-context-only-utils"] }
+solana-program-runtime = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -970,15 +970,11 @@ pub(crate) mod tests {
         solana_clock::Slot,
         solana_pubkey::Pubkey,
         solana_sbpf::{elf::Executable, program::BuiltinProgram},
-        std::{
-            fs::File,
-            io::Read,
-            ops::ControlFlow,
-            sync::{
-                Arc, RwLock,
-                atomic::{AtomicU64, Ordering},
-            },
+        solana_svm_type_overrides::sync::{
+            Arc, RwLock,
+            atomic::{AtomicU64, Ordering},
         },
+        std::{fs::File, io::Read, ops::ControlFlow},
         test_case::{test_case, test_matrix},
     };
 


### PR DESCRIPTION
#### Problem
program-runtime has agave-unstable-api feature, but it's not default enabled. The tests can be run with it enabled or disabled. However, when I enable the feature in dev dependencies, I get incompatible types error. The svm override types work whether the feature is enabled or disabled.

#### Summary of Changes
* Enable agave-unstable-api feature in self-referencing dev dependency
* Switch from std to solana_svm_type_overrides::sync types

Fixes #
