### PR TITLE
runtime: fix InvokeContext::push() ordering

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -296,8 +296,9 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
             }
         }
 
+        self.transaction_context.push()?;
         self.memory_contexts.push_placeholder();
-        self.transaction_context.push()
+        Ok(())
     }
 
     /// Pop a stack frame from the invocation stack


### PR DESCRIPTION
#### Problem
Any failures in the transaction context `push()` function leaves the memory contexts in a partially initialized state.

#### Summary of Changes
Push the memory context after the transaction context push succeeds.

