### PR TITLE
Guard solana-test-validator crate with agave-unstable-api feature

### DIFF
--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -57,7 +57,7 @@ solana-local-cluster = { path = "../local-cluster", features = ["agave-unstable-
 solana-native-token = { workspace = true }
 solana-poh-config = { workspace = true }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-test-validator = { path = "../test-validator", features = ["dev-context-only-utils"] }
+solana-test-validator = { path = "../test-validator", features = ["agave-unstable-api", "dev-context-only-utils"] }
 
 [lints]
 workspace = true

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -81,7 +81,7 @@ solana-local-cluster = { workspace = true }
 solana-rent = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk-ids = { workspace = true }
-solana-test-validator = { workspace = true, features = ["dev-context-only-utils"] }
+solana-test-validator = { workspace = true, features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-tps-client = { workspace = true, features = ["bank-client"] }
 tempfile = { workspace = true }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -106,7 +106,7 @@ solana-nonce-account = { workspace = true }
 solana-presigner = { workspace = true }
 solana-rpc = { path = "../rpc", features = ["agave-unstable-api"] }
 solana-sha256-hasher = { workspace = true }
-solana-test-validator = { path = "../test-validator", features = ["dev-context-only-utils"] }
+solana-test-validator = { path = "../test-validator", features = ["agave-unstable-api", "dev-context-only-utils"] }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -46,7 +46,7 @@ agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-rpc = { path = "../rpc", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-test-validator = { path = "../test-validator", features = ["dev-context-only-utils"] }
+solana-test-validator = { path = "../test-validator", features = ["agave-unstable-api", "dev-context-only-utils"] }
 
 [lints]
 workspace = true

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -209,7 +209,7 @@ solana-svm-transaction = { workspace = true }
 solana-svm-type-overrides = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-sysvar = "4.0.0"
-solana-test-validator = { workspace = true, features = ["dev-context-only-utils"] }
+solana-test-validator = { workspace = true, features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-transaction = "4.1.0"
 solana-transaction-error = "3.2.0"
 solana-vote = { workspace = true }

--- a/programs/sbf/tests/simulation.rs
+++ b/programs/sbf/tests/simulation.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "sbf_rust")]
 
 use {
-    agave_validator::test_validator::*,
     solana_instruction::{AccountMeta, Instruction},
     solana_message::Message,
     solana_pubkey::Pubkey,
@@ -15,6 +14,7 @@ use {
     solana_sdk_ids::bpf_loader_upgradeable,
     solana_signer::Signer,
     solana_sysvar::{clock, slot_history},
+    solana_test_validator::TestValidatorGenesis,
     solana_transaction::Transaction,
     std::{thread::sleep, time::Duration},
 };

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -31,7 +31,6 @@ solana-net-utils = { workspace = true }
 solana-pubsub-client = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
-solana-test-validator = { workspace = true }
 solana-tpu-client = { workspace = true }
 solana-tpu-client-next = { workspace = true }
 solana-transaction-status = { workspace = true }
@@ -50,7 +49,7 @@ solana-rent = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
-solana-test-validator = { workspace = true, features = ["dev-context-only-utils"] }
+solana-test-validator = { workspace = true, features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-transaction = { workspace = true }
 
 [lints]

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -67,7 +67,7 @@ tokio = { workspace = true, features = ["full"] }
 [dev-dependencies]
 solana-sdk-ids = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
-solana-test-validator = { path = ".", features = ["dev-context-only-utils"] }
+solana-test-validator = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 
 [lints]
 workspace = true

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "agave-unstable-api")]
 #![allow(clippy::arithmetic_side_effects)]
 use {
     agave_feature_set::{FEATURE_NAMES, FeatureSet, alpenglow, raise_cpi_nesting_limit_to_8},

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -61,7 +61,7 @@ thiserror = { workspace = true }
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
-solana-test-validator = { path = "../test-validator", features = ["dev-context-only-utils"] }
+solana-test-validator = { path = "../test-validator", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-transaction-error = { workspace = true }
 
 [lints]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -112,6 +112,7 @@ solana-core = { path = "../core", features = ["agave-unstable-api", "dev-context
 solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-test-validator = { workspace = true, features = ["agave-unstable-api"] }
 solana-time-utils = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }


### PR DESCRIPTION
#### Problem
solana-test-validator defines agave-unstable-api in Cargo file, but the lib source wasn't guarded behind the feature.

#### Summary of Changes
* Add agave-unstable-api feature to solana-test-validator
* Update dev dependencies for tests that need test validator to activate agave-unstable-api

Fixes #
