### PR TITLE
validator: add `--do-not-require-vote-history` for ag startup/set-identity

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -147,7 +147,7 @@ use {
     solana_turbine::{self, XdpSender, broadcast_stage::BroadcastStageType},
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     solana_validator_exit::Exit,
-    solana_vote_program::vote_state::VoteStateV4,
+    solana_vote_program::vote_state::{VoteStateV4, handler::VoteStateHandler},
     std::{
         borrow::Cow,
         cmp,
@@ -349,6 +349,7 @@ pub struct ValidatorConfig {
     /// processing.
     pub run_verification: bool,
     pub require_tower: bool,
+    pub require_vote_history: bool,
     pub tower_storage: Arc<dyn TowerStorage>,
     pub vote_history_storage: Arc<dyn VoteHistoryStorage>,
     pub debug_keys: Option<Arc<HashSet<Pubkey>>>,
@@ -429,6 +430,7 @@ impl ValidatorConfig {
             max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
             run_verification: true,
             require_tower: false,
+            require_vote_history: false,
             tower_storage: Arc::new(NullTowerStorage::default()),
             vote_history_storage: Arc::new(NullVoteHistoryStorage::default()),
             debug_keys: None,
@@ -1556,8 +1558,7 @@ impl Validator {
         };
         // Future upstream PR will handle reconciliation of VoteHistory against hard forks
         let vote_history =
-            VoteHistory::restore(config.vote_history_storage.as_ref(), &cluster_info.id())
-                .unwrap_or(VoteHistory::new(cluster_info.id(), 0));
+            restore_vote_history(config, &bank_forks, &cluster_info.id(), vote_account);
         migration_status.log_phase();
 
         let outstanding_repair_requests =
@@ -2004,6 +2005,65 @@ fn active_vote_account_exists_in_bank(bank: &Bank, vote_account: &Pubkey) -> boo
         }
     }
     false
+}
+
+pub fn active_vote_account_exists_in_bank_alpenglow(bank: &Bank, vote_account: &Pubkey) -> bool {
+    let Some(genesis_certificate) = bank.get_alpenglow_genesis_certificate() else {
+        return false;
+    };
+    let Some(Ok(vote_state)) = bank
+        .get_account(vote_account)
+        .map(|acct| acct.deserialize_data())
+    else {
+        return false;
+    };
+    let Ok(vote_state_handler) = VoteStateHandler::try_new_from_vote_state_versions(vote_state)
+    else {
+        return false;
+    };
+
+    let Some(last_voted_slot) = vote_state_handler.last_voted_slot() else {
+        return false;
+    };
+    let genesis_slot = genesis_certificate.cert_type.slot();
+
+    last_voted_slot > genesis_slot
+}
+
+fn restore_vote_history(
+    config: &ValidatorConfig,
+    bank_forks: &Arc<RwLock<BankForks>>,
+    identity: &Pubkey,
+    vote_account: &Pubkey,
+) -> VoteHistory {
+    match VoteHistory::restore(config.vote_history_storage.as_ref(), identity) {
+        Ok(vote_history) => vote_history,
+        Err(err) => {
+            let voting_has_been_active = {
+                let bank_forks = bank_forks.read().unwrap();
+                active_vote_account_exists_in_bank_alpenglow(
+                    &bank_forks.working_bank(),
+                    vote_account,
+                )
+            };
+            if config.require_vote_history && voting_has_been_active {
+                panic!(
+                    "Unable to retrieve vote history for identity {identity}. The vote account \
+                     {vote_account} has prior Alpenglow votes. If this is intentional, use \
+                     --do-not-require-vote-history: {err:?}"
+                );
+            }
+            if err.is_file_missing() && !voting_has_been_active {
+                info!(
+                    "Ignoring expected failed vote history restore because this vote account has \
+                     not voted before"
+                );
+            } else {
+                warn!("Unable to retrieve vote history: {err:?} creating default vote history...");
+            }
+            VoteHistory::new(*identity, 0)
+        }
+    }
 }
 
 fn check_poh_speed(bank: &Bank, maybe_hash_samples: Option<u64>) -> Result<(), ValidatorError> {
@@ -2956,8 +3016,88 @@ mod tests {
         },
         solana_poh_config::PohConfig,
         solana_sha256_hasher::hash,
+        solana_vote_program::vote_state::{LandedVote, Lockout, VoteStateVersions},
         std::{fs::remove_dir_all, num::NonZeroU64, thread, time::Duration},
     };
+
+    #[test]
+    fn active_vote_account_exists_in_bank_alpenglow_checks_genesis_certificate_and_votes() {
+        use {
+            agave_votor_messages::consensus_message::{Certificate, CertificateType},
+            solana_account::{AccountSharedData, state_traits::StateMut},
+            solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
+        };
+
+        let genesis_config = create_genesis_config(1_000_000).0;
+        let bank = Bank::new_for_tests(&genesis_config);
+        let vote_account_pubkey = Pubkey::new_unique();
+
+        assert!(!active_vote_account_exists_in_bank(
+            &bank,
+            &vote_account_pubkey
+        ));
+        assert!(!active_vote_account_exists_in_bank_alpenglow(
+            &bank,
+            &vote_account_pubkey
+        ));
+
+        let mut vote_state = VoteStateV4::default();
+        let mut vote_account =
+            AccountSharedData::new(1, VoteStateV4::size_of(), &solana_vote_program::id());
+        vote_account
+            .set_state(&VoteStateVersions::new_v4(vote_state.clone()))
+            .unwrap();
+        bank.store_account(&vote_account_pubkey, &vote_account);
+        assert!(!active_vote_account_exists_in_bank(
+            &bank,
+            &vote_account_pubkey
+        ));
+        assert!(!active_vote_account_exists_in_bank_alpenglow(
+            &bank,
+            &vote_account_pubkey
+        ));
+
+        vote_state.votes.push_back(LandedVote {
+            latency: 0,
+            lockout: Lockout::new(7),
+        });
+        vote_account
+            .set_state(&VoteStateVersions::new_v4(vote_state.clone()))
+            .unwrap();
+        bank.store_account(&vote_account_pubkey, &vote_account);
+        assert!(active_vote_account_exists_in_bank(
+            &bank,
+            &vote_account_pubkey
+        ));
+        assert!(!active_vote_account_exists_in_bank_alpenglow(
+            &bank,
+            &vote_account_pubkey
+        ));
+
+        bank.set_alpenglow_genesis_certificate(&Certificate {
+            cert_type: CertificateType::Genesis(40, Hash::new_unique()),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        });
+        assert!(!active_vote_account_exists_in_bank_alpenglow(
+            &bank,
+            &vote_account_pubkey
+        ));
+
+        vote_state.votes.push_back(LandedVote {
+            latency: 0,
+            lockout: Lockout::new(43),
+        });
+        vote_state.root_slot = Some(42);
+        vote_account
+            .set_state(&VoteStateVersions::new_v4(vote_state))
+            .unwrap();
+        bank.store_account(&vote_account_pubkey, &vote_account);
+        assert!(active_vote_account_exists_in_bank_alpenglow(
+            &bank,
+            &vote_account_pubkey
+        ));
+    }
 
     #[test]
     fn validator_exit() {

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -34,6 +34,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         max_genesis_archive_unpacked_size: config.max_genesis_archive_unpacked_size,
         run_verification: config.run_verification,
         require_tower: config.require_tower,
+        require_vote_history: config.require_vote_history,
         tower_storage: config.tower_storage.clone(),
         vote_history_storage: config.vote_history_storage.clone(),
         debug_keys: config.debug_keys.clone(),

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -1,5 +1,7 @@
 use {
-    agave_votor::event::VotorEvent,
+    agave_votor::{
+        event::VotorEvent, vote_history::VoteHistory, vote_history_storage::VoteHistoryStorage,
+    },
     crossbeam_channel::Sender,
     jsonrpc_core::{BoxFuture, ErrorCode, MetaIoHandler, Metadata, Result},
     jsonrpc_core_client::{RpcError, transports::ipc},
@@ -20,6 +22,7 @@ use {
         repair::repair_service,
         validator::{
             BlockProductionMethod, SchedulerPacing, TransactionStructure, ValidatorStartProgress,
+            active_vote_account_exists_in_bank_alpenglow,
         },
     },
     solana_geyser_plugin_manager::GeyserPluginManagerRequest,
@@ -56,6 +59,7 @@ pub struct AdminRpcRequestMetadata {
     pub validator_exit_backpressure: HashMap<String, Arc<AtomicBool>>,
     pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
     pub tower_storage: Arc<dyn TowerStorage>,
+    pub vote_history_storage: Arc<dyn VoteHistoryStorage>,
     pub staked_nodes_overrides: Arc<RwLock<HashMap<Pubkey, u64>>>,
     pub post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
     pub rpc_to_plugin_manager_sender: Option<Sender<GeyserPluginManagerRequest>>,
@@ -219,6 +223,7 @@ pub trait AdminRpc {
         meta: Self::Metadata,
         keypair_file: String,
         require_tower: bool,
+        require_vote_history: bool,
     ) -> Result<()>;
 
     #[rpc(meta, name = "setIdentityFromBytes")]
@@ -227,6 +232,7 @@ pub trait AdminRpc {
         meta: Self::Metadata,
         identity_keypair: Vec<u8>,
         require_tower: bool,
+        require_vote_history: bool,
     ) -> Result<()>;
 
     #[rpc(meta, name = "setStakedNodesOverrides")]
@@ -559,6 +565,7 @@ impl AdminRpc for AdminRpcImpl {
         meta: Self::Metadata,
         keypair_file: String,
         require_tower: bool,
+        require_vote_history: bool,
     ) -> Result<()> {
         debug!("set_identity request received");
 
@@ -568,7 +575,12 @@ impl AdminRpc for AdminRpcImpl {
             ))
         })?;
 
-        AdminRpcImpl::set_identity_keypair(meta, identity_keypair, require_tower)
+        AdminRpcImpl::set_identity_keypair(
+            meta,
+            identity_keypair,
+            require_tower,
+            require_vote_history,
+        )
     }
 
     fn set_identity_from_bytes(
@@ -576,6 +588,7 @@ impl AdminRpc for AdminRpcImpl {
         meta: Self::Metadata,
         identity_keypair: Vec<u8>,
         require_tower: bool,
+        require_vote_history: bool,
     ) -> Result<()> {
         debug!("set_identity_from_bytes request received");
 
@@ -585,7 +598,12 @@ impl AdminRpc for AdminRpcImpl {
             ))
         })?;
 
-        AdminRpcImpl::set_identity_keypair(meta, identity_keypair, require_tower)
+        AdminRpcImpl::set_identity_keypair(
+            meta,
+            identity_keypair,
+            require_tower,
+            require_vote_history,
+        )
     }
 
     fn set_staked_nodes_overrides(&self, meta: Self::Metadata, path: String) -> Result<()> {
@@ -880,6 +898,7 @@ impl AdminRpcImpl {
         meta: AdminRpcRequestMetadata,
         identity_keypair: Keypair,
         require_tower: bool,
+        require_vote_history: bool,
     ) -> Result<()> {
         meta.with_post_init(|post_init| {
             if require_tower {
@@ -891,6 +910,33 @@ impl AdminRpcImpl {
                             err
                         ))
                     })?;
+            }
+
+            if require_vote_history {
+                let voting_has_been_active = {
+                    let bank_forks = post_init.bank_forks.read().unwrap();
+                    active_vote_account_exists_in_bank_alpenglow(
+                        &bank_forks.root_bank(),
+                        &post_init.vote_account,
+                    )
+                };
+                if voting_has_been_active {
+                    let _ = VoteHistory::restore(
+                        meta.vote_history_storage.as_ref(),
+                        &identity_keypair.pubkey(),
+                    )
+                    .map_err(|err| {
+                        jsonrpc_core::error::Error::invalid_params(format!(
+                            "Unable to load vote history file for identity {}: {}. The vote \
+                             account {} has prior Alpenglow votes. Ensure the vote history file \
+                             is present or (dangerous) use --do-not-require-vote-history if you \
+                             know what you're doing",
+                            identity_keypair.pubkey(),
+                            err,
+                            post_init.vote_account
+                        ))
+                    })?;
+                }
             }
 
             for (key, notifier) in &*post_init.notifies.read().unwrap() {
@@ -1147,6 +1193,9 @@ mod tests {
                 validator_exit_backpressure: HashMap::default(),
                 authorized_voter_keypairs: Arc::new(RwLock::new(vec![vote_keypair])),
                 tower_storage: Arc::new(NullTowerStorage {}),
+                vote_history_storage: Arc::new(
+                    agave_votor::vote_history_storage::NullVoteHistoryStorage::default(),
+                ),
                 post_init: Arc::new(RwLock::new(Some(AdminRpcRequestMetadataPostInit {
                     cluster_info,
                     bank_forks,
@@ -1205,7 +1254,7 @@ mod tests {
         let validator_id_bytes = format!("{:?}", expected_validator_id.to_bytes());
 
         let set_id_request = format!(
-            r#"{{"jsonrpc":"2.0","id":1,"method":"setIdentityFromBytes","params":[{validator_id_bytes}, false]}}"#,
+            r#"{{"jsonrpc":"2.0","id":1,"method":"setIdentityFromBytes","params":[{validator_id_bytes}, false, false]}}"#,
         );
         let response = io.handle_request_sync(&set_id_request, meta.clone());
         let actual_parsed_response: Value =
@@ -1279,6 +1328,9 @@ mod tests {
                 validator_exit_backpressure: HashMap::default(),
                 authorized_voter_keypairs: authorized_voter_keypairs.clone(),
                 tower_storage: Arc::new(NullTowerStorage {}),
+                vote_history_storage: Arc::new(
+                    agave_votor::vote_history_storage::NullVoteHistoryStorage::default(),
+                ),
                 post_init: post_init.clone(),
                 staked_nodes_overrides: Arc::new(RwLock::new(HashMap::new())),
                 rpc_to_plugin_manager_sender: None,
@@ -1359,6 +1411,9 @@ mod tests {
             validator_exit_backpressure: HashMap::default(),
             authorized_voter_keypairs: authorized_voter_keypairs.clone(),
             tower_storage: Arc::new(NullTowerStorage {}),
+            vote_history_storage: Arc::new(
+                agave_votor::vote_history_storage::NullVoteHistoryStorage::default(),
+            ),
             post_init: post_init.clone(),
             staked_nodes_overrides: Arc::new(RwLock::new(HashMap::new())),
             rpc_to_plugin_manager_sender: None,
@@ -1376,7 +1431,7 @@ mod tests {
         let validator_id_bytes = format!("{:?}", expected_validator_id.to_bytes());
 
         let set_id_request = format!(
-            r#"{{"jsonrpc":"2.0","id":1,"method":"setIdentityFromBytes","params":[{validator_id_bytes}, false]}}"#,
+            r#"{{"jsonrpc":"2.0","id":1,"method":"setIdentityFromBytes","params":[{validator_id_bytes}, false, false]}}"#,
         );
         let response = test_validator.handle_request(&set_id_request);
         let actual_parsed_response: Value =
@@ -1452,6 +1507,9 @@ mod tests {
             validator_exit_backpressure: HashMap::default(),
             authorized_voter_keypairs,
             tower_storage: Arc::new(NullTowerStorage {}),
+            vote_history_storage: Arc::new(
+                agave_votor::vote_history_storage::NullVoteHistoryStorage::default(),
+            ),
             post_init: Arc::new(RwLock::new(None)),
             staked_nodes_overrides: Arc::new(RwLock::new(HashMap::new())),
             rpc_to_plugin_manager_sender: None,

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -3,6 +3,7 @@ use {
         admin_rpc_service, cli, commands::FromClapArgMatches, dashboard::Dashboard,
         ledger_lockfile, lock_ledger, println_name_value,
     },
+    agave_votor::vote_history_storage::FileVoteHistoryStorage,
     clap::{crate_name, value_t, value_t_or_exit, values_t_or_exit},
     crossbeam_channel::unbounded,
     itertools::Itertools,
@@ -418,6 +419,7 @@ fn main() {
     genesis.enable_scheduler_bindings = matches.is_present("enable_scheduler_bindings");
 
     let tower_storage = Arc::new(FileTowerStorage::new(ledger_path.clone()));
+    let vote_history_storage = Arc::new(FileVoteHistoryStorage::new(ledger_path.clone()));
 
     let admin_service_post_init = Arc::new(RwLock::new(None));
     // If geyser_plugin_config value is invalid, the validator will exit when the values are extracted below
@@ -440,6 +442,7 @@ fn main() {
             staked_nodes_overrides: genesis.staked_nodes_overrides.clone(),
             post_init: admin_service_post_init,
             tower_storage: tower_storage.clone(),
+            vote_history_storage: vote_history_storage.clone(),
             rpc_to_plugin_manager_sender,
         },
     );

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -547,6 +547,12 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Refuse to start if saved tower state is not found"),
     )
     .arg(
+        clap::Arg::with_name("do_not_require_vote_history")
+            .long("do-not-require-vote-history")
+            .takes_value(false)
+            .help("Do not require saved vote history state for startup"),
+    )
+    .arg(
         Arg::with_name("expected_genesis_hash")
             .long("expected-genesis-hash")
             .value_name("HASH")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -753,6 +753,7 @@ pub fn execute(
     let mut validator_config = ValidatorConfig {
         log_config,
         require_tower: matches.is_present("require_tower"),
+        require_vote_history: !matches.is_present("do_not_require_vote_history"),
         tower_storage,
         vote_history_storage,
         max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
@@ -932,6 +933,7 @@ pub fn execute(
             authorized_voter_keypairs: authorized_voter_keypairs.clone(),
             post_init: admin_service_post_init.clone(),
             tower_storage: validator_config.tower_storage.clone(),
+            vote_history_storage: validator_config.vote_history_storage.clone(),
             staked_nodes_overrides,
             rpc_to_plugin_manager_sender,
         },

--- a/validator/src/commands/set_identity/mod.rs
+++ b/validator/src/commands/set_identity/mod.rs
@@ -13,10 +13,20 @@ use {
 const COMMAND: &str = "set-identity";
 
 #[derive(Debug, PartialEq)]
-#[cfg_attr(test, derive(Default))]
 pub struct SetIdentityArgs {
     pub identity: Option<String>,
     pub require_tower: bool,
+    pub require_vote_history: bool,
+}
+
+impl Default for SetIdentityArgs {
+    fn default() -> Self {
+        Self {
+            identity: None,
+            require_tower: false,
+            require_vote_history: true,
+        }
+    }
 }
 
 impl FromClapArgMatches for SetIdentityArgs {
@@ -24,6 +34,7 @@ impl FromClapArgMatches for SetIdentityArgs {
         Ok(SetIdentityArgs {
             identity: value_t!(matches, "identity", String).ok(),
             require_tower: matches.is_present("require_tower"),
+            require_vote_history: !matches.is_present("do_not_require_vote_history"),
         })
     }
 }
@@ -45,6 +56,12 @@ pub fn command<'a>() -> App<'a, 'a> {
                 .takes_value(false)
                 .help("Refuse to set the validator identity if saved tower state is not found"),
         )
+        .arg(
+            clap::Arg::with_name("do_not_require_vote_history")
+                .long("do-not-require-vote-history")
+                .takes_value(false)
+                .help("Do not require saved vote history state for identity change"),
+        )
         .after_help(
             "Note: the new identity only applies to the currently running validator instance",
         )
@@ -54,6 +71,7 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
     let SetIdentityArgs {
         identity,
         require_tower,
+        require_vote_history,
     } = SetIdentityArgs::from_clap_arg_match(matches)?;
 
     if let Some(identity_keypair) = identity {
@@ -68,7 +86,11 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
         admin_rpc_service::runtime().block_on(async move {
             admin_client
                 .await?
-                .set_identity(identity_keypair.display().to_string(), require_tower)
+                .set_identity(
+                    identity_keypair.display().to_string(),
+                    require_tower,
+                    require_vote_history,
+                )
                 .await
         })?;
     } else {
@@ -81,7 +103,11 @@ pub fn execute(matches: &ArgMatches, ledger_path: &Path) -> Result<()> {
         admin_rpc_service::runtime().block_on(async move {
             admin_client
                 .await?
-                .set_identity_from_bytes(Vec::from(identity_keypair.to_bytes()), require_tower)
+                .set_identity_from_bytes(
+                    Vec::from(identity_keypair.to_bytes()),
+                    require_tower,
+                    require_vote_history,
+                )
                 .await
         })?;
     }
@@ -125,6 +151,18 @@ mod tests {
             vec![COMMAND, "--require-tower"],
             SetIdentityArgs {
                 require_tower: true,
+                ..SetIdentityArgs::default()
+            },
+        );
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_set_identity_do_not_require_vote_history() {
+        verify_args_struct_by_command(
+            command(),
+            vec![COMMAND, "--do-not-require-vote-history"],
+            SetIdentityArgs {
+                require_vote_history: false,
                 ..SetIdentityArgs::default()
             },
         );

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -600,8 +600,8 @@ impl EventHandler {
         if *my_pubkey != new_pubkey || vctx.vote_history.node_pubkey != new_pubkey {
             let my_old_pubkey = vctx.vote_history.node_pubkey;
             *my_pubkey = new_pubkey;
-            // The vote history file for the new identity must exist for set-identity to succeed
-            vctx.vote_history = VoteHistory::restore(ctx.vote_history_storage.as_ref(), my_pubkey)?;
+            vctx.vote_history = VoteHistory::restore(ctx.vote_history_storage.as_ref(), my_pubkey)
+                .unwrap_or_else(|_| VoteHistory::new(new_pubkey, 0));
             vctx.identity_keypair = new_identity;
             warn!("set-identity: from {my_old_pubkey} to {my_pubkey}");
         }


### PR DESCRIPTION
#### Problem
Agave exposes a `--require-tower` argument for both startup and set-identity that enforces the tower file is present before allowing startup. If this argument is not present we populate a default `Tower`. We then have logic to pull the latest `Tower` from the `VoteAccount`. While not perfect this gives us some resilience against operator error resulting in slashable votes.

In Alpenglow there is no `Tower`, instead we have a similar concept called `VoteHistory` (and similarly a `vote_history-XXX.bin` file in ledger). 

we no longer have the backup option of pulling the `VoteHistory` from a `VoteAccount`. This method is imperfect anyway. Instead always require that a `VoteHistory` file is present on startup or when calling set-identity.

#### Summary of Changes
If the validator specifies a vote account that has cast alpenglow votes before, fail to startup or `set-identity` if the `vote_history-XXX.bin` file is missing **unless** they explicitely specify `--do-not-require-vote-history`

This essentially matches the `--require-tower` workflow with the opposite default.

Note: the `VoteHistory` that is restored still needs to be reconciled against any potential hard forks - this will be upstreamed in a follow up