### PR TITLE
Split out update_index between shrink and flush

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3721,7 +3721,7 @@ impl AccountsDb {
         //          |                           |
         //          V                           |
         // S3 store_accounts_for_shrink()/      | index
-        //        update_index_shrunk_accounts()| (replaces existing store_id, offset in stores)
+        //        update_index_for_shrink()     | (replaces existing store_id, offset in stores)
         //          |                           |
         //          V                           |
         // S4 do_shrink_slot_store()/           | map of stores (removes old entry)
@@ -5142,7 +5142,7 @@ impl AccountsDb {
     /// Unlike `update_index_stored_accounts` this does not collect reclaims — the caller is
     /// responsible for the source storage's alive-bytes accounting. Secondary indexes are also
     /// not touched, since shrink only changes `(store_id, offset)` and they index by pubkey.
-    fn update_index_shrunk_accounts<'a>(
+    fn update_index_for_shrink<'a>(
         &self,
         infos: Vec<AccountInfo>,
         accounts: &impl StorableAccounts<'a>,
@@ -5606,7 +5606,7 @@ impl AccountsDb {
         let write_accounts_us = write_accounts_time.end_as_us();
 
         let update_index_time = Measure::start("update_index");
-        self.update_index_shrunk_accounts(
+        self.update_index_for_shrink(
             infos,
             &accounts,
             update_index_thread_selection,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3721,7 +3721,7 @@ impl AccountsDb {
         //          |                           |
         //          V                           |
         // S3 store_accounts_for_shrink()/      | index
-        //        update_index_stored_accounts()| (replaces existing store_id, offset in stores)
+        //        update_index_shrunk_accounts()| (replaces existing store_id, offset in stores)
         //          |                           |
         //          V                           |
         // S4 do_shrink_slot_store()/           | map of stores (removes old entry)
@@ -5136,6 +5136,54 @@ impl AccountsDb {
         }
     }
 
+    /// Updates the accounts index for the shrink path: each account at `accounts.slot(i)` has
+    /// its existing index entry replaced to point at the rewritten storage at `target_slot`.
+    ///
+    /// Unlike `update_index_stored_accounts` this does not collect reclaims — the caller is
+    /// responsible for the source storage's alive-bytes accounting. Secondary indexes are also
+    /// not touched, since shrink only changes `(store_id, offset)` and they index by pubkey.
+    fn update_index_shrunk_accounts<'a>(
+        &self,
+        infos: Vec<AccountInfo>,
+        accounts: &impl StorableAccounts<'a>,
+        update_index_thread_selection: UpdateIndexThreadSelection,
+        thread_pool: &ThreadPool,
+    ) {
+        let target_slot = accounts.target_slot();
+        let len = std::cmp::min(accounts.len(), infos.len());
+
+        let update = |start, end| {
+            (start..end).for_each(|i| {
+                let info: AccountInfo = infos[i];
+                debug_assert!(!info.is_cached());
+                accounts.account(i, |account| {
+                    let old_slot = accounts.slot(i);
+                    self.accounts_index
+                        .replace(target_slot, old_slot, account.pubkey(), info);
+                });
+            });
+        };
+
+        let threshold = 1;
+        if matches!(
+            update_index_thread_selection,
+            UpdateIndexThreadSelection::PoolWithThreshold,
+        ) && len > threshold
+        {
+            let chunk_size = len.div_ceil(thread_pool.current_num_threads());
+            let batches = 1 + len / chunk_size;
+            thread_pool.install(|| {
+                (0..batches).into_par_iter().for_each(|batch| {
+                    let start = batch * chunk_size;
+                    let end = std::cmp::min(start + chunk_size, len);
+                    update(start, end)
+                })
+            });
+        } else {
+            update(0, len);
+        }
+    }
+
     fn should_not_shrink(alive_bytes: u64, total_bytes: u64) -> bool {
         alive_bytes >= total_bytes
     }
@@ -5558,10 +5606,9 @@ impl AccountsDb {
         let write_accounts_us = write_accounts_time.end_as_us();
 
         let update_index_time = Measure::start("update_index");
-        self.update_index_stored_accounts(
+        self.update_index_shrunk_accounts(
             infos,
             &accounts,
-            UpsertReclaim::IgnoreReclaims,
             update_index_thread_selection,
             &self.thread_pool_background,
         );

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -957,16 +957,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     ///
     /// Panics if `old_slot` is not present in the slot list.
     pub fn replace(&self, new_slot: Slot, old_slot: Slot, pubkey: &Pubkey, account_info: T) {
-        // Updates must be to an item already in accounts index, so store as raw to avoid unnecessary allocations
-        let store_raw = true;
-        let new_item = PreAllocatedAccountMapEntry::new(
-            new_slot,
-            account_info,
-            &self.storage.storage,
-            store_raw,
-        );
         let map = self.get_bin(pubkey);
-        map.replace(pubkey, new_item, old_slot);
+        map.replace(pubkey, (new_slot, account_info), old_slot);
     }
 
     pub fn ref_count_from_storage(&self, pubkey: &Pubkey) -> RefCount {
@@ -2280,13 +2272,15 @@ mod tests {
         );
         assert_eq!(index.ref_count_from_storage(&key), 1);
 
-        index.replace(slot, slot, &key, 200);
+        let account_info = 200;
+
+        index.replace(slot, slot, &key, account_info);
 
         // Slot list now holds the new account_info at the same slot.
         let slot_list = index.get_and_then(&key, |entry| {
             (false, entry.unwrap().slot_list_read_lock().clone_list())
         });
-        assert_eq!(slot_list, SlotList::from([(slot, 200)]));
+        assert_eq!(slot_list, SlotList::from([(slot, account_info)]));
         // Replace doesn't change refcounts.
         assert_eq!(index.ref_count_from_storage(&key), 1);
     }
@@ -2300,6 +2294,7 @@ mod tests {
 
         let old_slot = 5;
         let new_slot = 10;
+        let account_info = 200;
         index.upsert(
             old_slot,
             old_slot,
@@ -2310,12 +2305,12 @@ mod tests {
         );
         assert_eq!(index.ref_count_from_storage(&key), 1);
 
-        index.replace(new_slot, old_slot, &key, 200);
+        index.replace(new_slot, old_slot, &key, account_info);
 
         let slot_list = index.get_and_then(&key, |entry| {
             (false, entry.unwrap().slot_list_read_lock().clone_list())
         });
-        assert_eq!(slot_list, SlotList::from([(new_slot, 200)]));
+        assert_eq!(slot_list, SlotList::from([(new_slot, account_info)]));
         // Moving an entry between slots must not change the ref count.
         assert_eq!(index.ref_count_from_storage(&key), 1);
     }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -949,6 +949,26 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         map.upsert(pubkey, new_item, Some(old_slot), reclaims, reclaim);
     }
 
+    /// Replaces the slot list entry at `old_slot` with `(new_slot, account_info)` for `pubkey`.
+    ///
+    /// Used by the shrink path: the account already exists in the index at `old_slot`, and
+    /// shrink is rewriting it into a new storage at `new_slot`. The previous entry is discarded
+    /// (no reclaims are returned — the caller manages the source storage's alive-bytes accounting).
+    ///
+    /// Panics if `old_slot` is not present in the slot list.
+    pub fn replace(&self, new_slot: Slot, old_slot: Slot, pubkey: &Pubkey, account_info: T) {
+        // Updates must be to an item already in accounts index, so store as raw to avoid unnecessary allocations
+        let store_raw = true;
+        let new_item = PreAllocatedAccountMapEntry::new(
+            new_slot,
+            account_info,
+            &self.storage.storage,
+            store_raw,
+        );
+        let map = self.get_bin(pubkey);
+        map.replace(pubkey, new_item, old_slot);
+    }
+
     pub fn ref_count_from_storage(&self, pubkey: &Pubkey) -> RefCount {
         let map = self.get_bin(pubkey);
         map.get_internal_inner(pubkey, |entry| {
@@ -2240,6 +2260,97 @@ mod tests {
             (false, entry.unwrap().slot_list_lock_read_len())
         });
         assert_eq!(slot_list_len, 1);
+    }
+
+    #[test]
+    fn test_replace_same_slot() {
+        // When new_slot == old_slot, replace acts as an in-place update of the account_info.
+        let key = solana_pubkey::new_rand();
+        let index = AccountsIndex::<u64, u64>::default_for_tests();
+        let mut gc = ReclaimsSlotList::new();
+
+        let slot = 5;
+        index.upsert(
+            slot,
+            slot,
+            &key,
+            100,
+            &mut gc,
+            UpsertReclaim::IgnoreReclaims,
+        );
+        assert_eq!(index.ref_count_from_storage(&key), 1);
+
+        index.replace(slot, slot, &key, 200);
+
+        // Slot list now holds the new account_info at the same slot.
+        let slot_list = index.get_and_then(&key, |entry| {
+            (false, entry.unwrap().slot_list_read_lock().clone_list())
+        });
+        assert_eq!(slot_list, SlotList::from([(slot, 200)]));
+        // Replace doesn't change refcounts.
+        assert_eq!(index.ref_count_from_storage(&key), 1);
+    }
+
+    #[test]
+    fn test_replace_moves_entry_to_new_slot() {
+        // Replace finds the entry at old_slot, swaps it out for one at new_slot.
+        let key = solana_pubkey::new_rand();
+        let index = AccountsIndex::<u64, u64>::default_for_tests();
+        let mut gc = ReclaimsSlotList::new();
+
+        let old_slot = 5;
+        let new_slot = 10;
+        index.upsert(
+            old_slot,
+            old_slot,
+            &key,
+            100,
+            &mut gc,
+            UpsertReclaim::IgnoreReclaims,
+        );
+        assert_eq!(index.ref_count_from_storage(&key), 1);
+
+        index.replace(new_slot, old_slot, &key, 200);
+
+        let slot_list = index.get_and_then(&key, |entry| {
+            (false, entry.unwrap().slot_list_read_lock().clone_list())
+        });
+        assert_eq!(slot_list, SlotList::from([(new_slot, 200)]));
+        // Moving an entry between slots must not change the ref count.
+        assert_eq!(index.ref_count_from_storage(&key), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected to find a slot to replace in the slot list")]
+    fn test_replace_missing_old_slot_panics() {
+        let key = solana_pubkey::new_rand();
+        let index = AccountsIndex::<u64, u64>::default_for_tests();
+        let mut gc = ReclaimsSlotList::new();
+
+        index.upsert(5, 5, &key, 100, &mut gc, UpsertReclaim::IgnoreReclaims);
+        // No entry at slot 99 — replace must panic rather than silently appending.
+        index.replace(10, 99, &key, 200);
+    }
+
+    #[test]
+    #[should_panic(expected = "Replace should only be used for uncached accounts")]
+    fn test_replace_cached_account_info_panics() {
+        // Shrink only ever rewrites uncached accounts; passing a cached AccountInfo to replace
+        // is a programming error and must trip the assertion.
+        let key = solana_pubkey::new_rand();
+        let index =
+            AccountsIndex::<CacheableIndexValueTest, CacheableIndexValueTest>::default_for_tests();
+        let mut gc = ReclaimsSlotList::new();
+
+        index.upsert(
+            5,
+            5,
+            &key,
+            CacheableIndexValueTest(false),
+            &mut gc,
+            UpsertReclaim::IgnoreReclaims,
+        );
+        index.replace(10, 5, &key, CacheableIndexValueTest(true));
     }
 
     fn account_maps_stats_len<T: IndexValue>(index: &AccountsIndex<T, T>) -> usize {

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -572,19 +572,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         }
     }
 
-    /// Replaces the slot list entry at `old_slot` with `(slot, account_info)`.
+    /// Replaces the slot list entry at `old_slot` with `new_item`.
     ///
     /// Panics if `old_slot` is not present in the slot list, or if more than one entry at
     /// `old_slot` is found (which would indicate prior corruption).
-    pub fn replace(
-        &self,
-        pubkey: &Pubkey,
-        new_value: PreAllocatedAccountMapEntry<T>,
-        old_slot: Slot,
-    ) {
-        let (slot, account_info) = new_value.into();
+    pub fn replace(&self, pubkey: &Pubkey, new_item: SlotListItem<T>, old_slot: Slot) {
         debug_assert!(
-            !account_info.is_cached(),
+            !new_item.1.is_cached(),
             "Replace should only be used for uncached accounts"
         );
         let mut should_write_through = false;
@@ -599,7 +593,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                         "duplicate entry at slot {old_slot} in slot_list"
                     );
                     found_slot = true;
-                    *cur_item = (slot, account_info);
+                    *cur_item = new_item;
                 }
                 true
             });
@@ -613,6 +607,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 self.should_write_through && slot_list_length == 1 && entry.ref_count() == 1;
         });
         if should_write_through {
+            let (slot, account_info) = new_item;
             self.write_through(pubkey, slot, account_info);
         }
     }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -572,6 +572,51 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         }
     }
 
+    /// Replaces the slot list entry at `old_slot` with `(slot, account_info)`.
+    ///
+    /// Panics if `old_slot` is not present in the slot list, or if more than one entry at
+    /// `old_slot` is found (which would indicate prior corruption).
+    pub fn replace(
+        &self,
+        pubkey: &Pubkey,
+        new_value: PreAllocatedAccountMapEntry<T>,
+        old_slot: Slot,
+    ) {
+        let (slot, account_info) = new_value.into();
+        debug_assert!(
+            !account_info.is_cached(),
+            "Replace should only be used for uncached accounts"
+        );
+        let mut should_write_through = false;
+
+        self.get_or_create_index_entry_for_pubkey(pubkey, |entry| {
+            let mut slot_list = entry.slot_list_write_lock();
+            let mut found_slot = false;
+            let slot_list_length = slot_list.retain_and_count(|cur_item| {
+                if cur_item.0 == old_slot {
+                    assert!(
+                        !found_slot,
+                        "duplicate entry at slot {old_slot} in slot_list"
+                    );
+                    found_slot = true;
+                    *cur_item = (slot, account_info);
+                }
+                true
+            });
+            assert!(
+                found_slot,
+                "Expected to find a slot to replace in the slot list"
+            );
+            entry.mark_dirty();
+
+            should_write_through =
+                self.should_write_through && slot_list_length == 1 && entry.ref_count() == 1;
+        });
+        if should_write_through {
+            self.write_through(pubkey, slot, account_info);
+        }
+    }
+
     /// Gets an entry for `pubkey` and calls `callback` with it.
     /// If the entry is not in the index, an empty entry will be created and passed to `callback`.
     /// If the entry is in the index, it will be passed to `callback` as is.


### PR DESCRIPTION
#### Problem
Shrink and flush both use the same path to save accounts to the index, but they have different requirements. Split out the paths to support future refactor. 

#### Summary of Changes
- Created new path for shrink to save entries to index (replace) 
- Left the upsert path alone. Could be simplified in a future PR (no concept of old_slot). 

Fixes #
