### PR TITLE
votor: return the proper error for NonVoting validators

### DIFF
--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -152,6 +152,9 @@ pub fn generate_vote_tx(
     wait_to_vote_slot: Option<u64>,
     derived_bls_keypairs: &mut HashMap<Pubkey, Arc<BLSKeypair>>,
 ) -> GenerateVoteTxResult {
+    if authorized_voter_keypairs.read().unwrap().is_empty() {
+        return GenerateVoteTxResult::NonVoting;
+    }
     if bank.get_vote_account(&vote_account_pubkey).is_none() {
         return GenerateVoteTxResult::VoteAccountNotFound(vote_account_pubkey);
     }
@@ -475,12 +478,18 @@ mod tests {
         // Empty authorized voter keypairs to simulate non voting node
         voting_context.authorized_voter_keypairs = Arc::new(std::sync::RwLock::new(vec![]));
         let vote = Vote::new_skip_vote(5);
-        // For non-voting nodes, we just return Ok(None)
-        assert!(
-            generate_vote_message(vote, false, &mut voting_context)
-                .unwrap()
-                .is_none()
-        );
+        assert!(matches!(
+            generate_vote_tx(
+                vote,
+                &voting_context.sharable_banks.root(),
+                voting_context.vote_account_pubkey,
+                &voting_context.identity_keypair,
+                &voting_context.authorized_voter_keypairs,
+                voting_context.wait_to_vote_slot,
+                &mut voting_context.derived_bls_keypairs,
+            ),
+            GenerateVoteTxResult::NonVoting
+        ));
 
         // Recover correct value to vote again
         voting_context.authorized_voter_keypairs = Arc::new(RwLock::new(vec![Arc::new(
@@ -504,23 +513,21 @@ mod tests {
         let mut voting_context =
             setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
 
-        // Wrong identity keypair
-        voting_context.identity_keypair = Arc::new(Keypair::new());
+        // Wrong identity keypair should return HotSpare based on rank_map.node_pubkey.
+        let wrong_identity_keypair = Arc::new(Keypair::new());
         let vote = Vote::new_notarization_vote(6, Hash::new_unique());
-        assert!(
-            generate_vote_message(vote, true, &mut voting_context)
-                .unwrap()
-                .is_none()
-        );
-
-        // Recover correct value to vote again
-        voting_context.identity_keypair =
-            Arc::new(validator_keypairs[my_index].node_keypair.insecure_clone());
-        assert!(
-            generate_vote_message(vote, true, &mut voting_context)
-                .unwrap()
-                .is_some()
-        );
+        assert!(matches!(
+            generate_vote_tx(
+                vote,
+                &voting_context.sharable_banks.root(),
+                voting_context.vote_account_pubkey,
+                &wrong_identity_keypair,
+                &voting_context.authorized_voter_keypairs,
+                voting_context.wait_to_vote_slot,
+                &mut voting_context.derived_bls_keypairs,
+            ),
+            GenerateVoteTxResult::HotSpare
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Split from #11814 

#### Problem
non voting validators have an empty authorized voter set:
https://github.com/anza-xyz/agave/blob/1989ee8fd1feea77b65dfc4c96ecddd8a0e93369/core/src/validator.rs#L803-L805

If this is the case we should return `NonVoting` rather than the current thing which returns 
```
[2026-05-23T15:30:29.082101113Z WARN  agave_votor::voting_utils] Failed to generate vote and push to votes: VoteAccountNotFound(Z6x2Wq6KpnCpfZ3zdE1wJ3Z4CJqVGUgRNKqzW1Cr9yG)
```
(a random vote account 🤦 since `vote_account` is a required option for `Validator::new` )
```rust
    let vote_account = pubkey_of(matches, "vote_account").unwrap_or_else(|| {
        if !validator_config.voting_disabled {
            warn!("--vote-account not specified, validator will not vote");
            validator_config.voting_disabled = true;
        }
        Keypair::new().pubkey()
    });
```

#### Summary of Changes
If authorized voters is empty, return `NonVoting`

Fixes https://github.com/anza-xyz/agave/issues/12704
