### PR TITLE
replay: add metrics around switch bank events

### DIFF
--- a/core/src/consensus/progress_map.rs
+++ b/core/src/consensus/progress_map.rs
@@ -287,6 +287,9 @@ impl PropagatedStats {
 #[derive(Default)]
 pub struct ProgressMap {
     progress_map: HashMap<Slot, ForkProgress>,
+    /// Tracks the number of times a slot was switched from an alternate location.
+    /// This persists even if the slot is removed from the progress_map due to a switch.
+    bank_switch_counts: HashMap<Slot, u64>,
 }
 
 impl std::ops::Deref for ProgressMap {
@@ -304,6 +307,12 @@ impl std::ops::DerefMut for ProgressMap {
 
 impl ProgressMap {
     pub fn insert(&mut self, slot: Slot, fork_progress: ForkProgress) {
+        let num_bank_switches = self.get_num_bank_switches(slot);
+        fork_progress
+            .replay_stats
+            .write()
+            .unwrap()
+            .num_bank_switches = num_bank_switches;
         self.progress_map.insert(slot, fork_progress);
     }
 
@@ -328,6 +337,15 @@ impl ProgressMap {
         self.progress_map
             .get(&slot)
             .map(|fork_progress| &fork_progress.fork_stats)
+    }
+
+    pub fn increment_num_bank_switches(&mut self, slot: Slot) {
+        let count = self.bank_switch_counts.entry(slot).or_insert(0);
+        *count = count.saturating_add(1);
+    }
+
+    pub fn get_num_bank_switches(&self, slot: Slot) -> u64 {
+        self.bank_switch_counts.get(&slot).cloned().unwrap_or(0)
     }
 
     pub fn get_fork_stats_mut(&mut self, slot: Slot) -> Option<&mut ForkStats> {
@@ -430,6 +448,8 @@ impl ProgressMap {
 
     pub fn handle_new_root(&mut self, bank_forks: &BankForks) {
         self.progress_map
+            .retain(|k, _| bank_forks.get(*k).is_some());
+        self.bank_switch_counts
             .retain(|k, _| bank_forks.get(*k).is_some());
     }
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -489,6 +489,7 @@ struct ReplayLoopTiming {
     process_duplicate_slots_elapsed_us: u64,
     process_unfrozen_gossip_verified_vote_hashes_elapsed_us: u64,
     process_popular_pruned_forks_elapsed_us: u64,
+    process_switch_bank_events_elapsed_us: u64,
     repair_correct_slots_elapsed_us: u64,
     retransmit_not_propagated_elapsed_us: u64,
     generate_new_bank_forks_read_lock_us: Saturating<u64>,
@@ -648,6 +649,11 @@ impl ReplayLoopTiming {
                 (
                     "process_popular_pruned_forks_elapsed_us",
                     self.process_popular_pruned_forks_elapsed_us as i64,
+                    i64
+                ),
+                (
+                    "process_switch_bank_events_elapsed_us",
+                    self.process_switch_bank_events_elapsed_us as i64,
                     i64
                 ),
                 (
@@ -1044,6 +1050,8 @@ impl ReplayStage {
                         &mut progress,
                         did_complete_bank,
                     );
+                    let mut process_switch_bank_events_time =
+                        Measure::start("process_switch_bank_events_time");
                     Self::process_switch_bank_events(
                         &my_pubkey,
                         &switch_bank_receiver,
@@ -1054,6 +1062,10 @@ impl ReplayStage {
                         &mut async_verification_freelist,
                     )
                     .expect("Blockstore operations must succeed");
+                    process_switch_bank_events_time.stop();
+                    replay_timing.process_switch_bank_events_elapsed_us +=
+                        process_switch_bank_events_time.as_us();
+
                     // Banks might have been switched above, these maps are no longer accurate
                     drop(ancestors);
                     drop(descendants);

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -47,7 +47,7 @@ use {
     solana_genesis_config::{DEFAULT_GENESIS_ARCHIVE, DEFAULT_GENESIS_FILE, GenesisConfig},
     solana_hash::{HASH_BYTES, Hash},
     solana_keypair::Keypair,
-    solana_measure::measure::Measure,
+    solana_measure::{measure::Measure, measure_us},
     solana_metrics::datapoint_error,
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
@@ -101,7 +101,7 @@ pub use {
         blockstore::error::{BlockstoreError, Result},
         blockstore_db::{default_num_compaction_threads, default_num_flush_threads},
         blockstore_meta::{OptimisticSlotMetaVersioned, SlotMeta},
-        blockstore_metrics::BlockstoreInsertionMetrics,
+        blockstore_metrics::{BlockstoreInsertionMetrics, BlockstoreSwitchBankMetrics},
     },
     blockstore_purge::PurgeType,
     rocksdb::properties as RocksProperties,
@@ -2363,9 +2363,15 @@ impl Blockstore {
             "Cannot switch from Original location"
         );
 
-        let lock = self.insert_shreds_lock.lock().unwrap();
+        let mut metrics = BlockstoreSwitchBankMetrics::default();
+
+        let mut total_measure = Measure::start("switch_block_from_alternate_total");
+
+        let (lock, lock_time_us) = measure_us!(self.insert_shreds_lock.lock().unwrap());
+        metrics.lock_elapsed_us = lock_time_us;
 
         // 1. Backup the original block if needed
+        let mut backup_measure = Measure::start("switch_block_from_alternate_backup");
         if let Some(dmr) = self.get_double_merkle_root(slot, BlockLocation::Original)? {
             let backup_location = BlockLocation::Alternate { block_id: dmr };
             if self
@@ -2375,8 +2381,11 @@ impl Blockstore {
                 self.copy_shreds_locked(&lock, slot, BlockLocation::Original, backup_location)?;
             }
         }
+        backup_measure.stop();
+        metrics.backup_elapsed_us = backup_measure.as_us();
 
         // 2. Purge the original column data, keeping alternate columns intact
+        let mut purge_measure = Measure::start("switch_block_from_alternate_purge");
         self.purge_slot_cleanup_chaining_keep_alt(slot)
             .or_else(|err| {
                 if matches!(err, BlockstoreError::SlotUnavailable) {
@@ -2386,14 +2395,19 @@ impl Blockstore {
                     Err(err)
                 }
             })?;
+        purge_measure.stop();
+        metrics.purge_elapsed_us = purge_measure.as_us();
 
         // 3. Copy shreds from alternate location to original
+        let mut copy_measure = Measure::start("switch_block_from_alternate_copy");
         let alt_meta = self
             .meta_from_location(slot, from_location)?
             .expect("Alternate slot must have SlotMeta");
         debug_assert!(alt_meta.is_full(), "Alternate slot must be full");
 
         self.copy_shreds_locked(&lock, slot, from_location, BlockLocation::Original)?;
+        copy_measure.stop();
+        metrics.copy_elapsed_us = copy_measure.as_us();
 
         // 4. Verify the switch was successful
         debug_assert!(
@@ -2402,7 +2416,10 @@ impl Blockstore {
                 .is_full(),
             "Slot must be full after switch"
         );
+        total_measure.stop();
+        metrics.total_elapsed_us = total_measure.as_us();
 
+        metrics.report_metrics(slot, from_location);
         Ok(())
     }
 
@@ -2833,7 +2850,12 @@ impl Blockstore {
             write_batch,
             shred_source,
         );
-        newly_completed_data_sets.extend(completed_data_sets);
+
+        if matches!(location, BlockLocation::Original) {
+            // We don't currently notify RPC when we complete data sets in alternate columns. This can be extended in the future
+            // if necessary.
+            newly_completed_data_sets.extend(completed_data_sets);
+        }
         merkle_root_metas
             .entry((location, erasure_set))
             .or_insert(WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
@@ -6475,6 +6497,34 @@ pub fn test_all_empty_or_min(blockstore: &Blockstore, min_slot: Slot) {
             .unwrap()
             .next()
             .map(|(slot, _)| slot >= min_slot)
+            .unwrap_or(true)
+        & blockstore
+            .alt_meta_cf
+            .iter(IteratorMode::Start)
+            .unwrap()
+            .next()
+            .map(|((slot, _), _)| slot >= min_slot)
+            .unwrap_or(true)
+        & blockstore
+            .alt_index_cf
+            .iter(IteratorMode::Start)
+            .unwrap()
+            .next()
+            .map(|((slot, _), _)| slot >= min_slot)
+            .unwrap_or(true)
+        & blockstore
+            .alt_data_shred_cf
+            .iter(IteratorMode::Start)
+            .unwrap()
+            .next()
+            .map(|((slot, _, _), _)| slot >= min_slot)
+            .unwrap_or(true)
+        & blockstore
+            .alt_merkle_root_meta_cf
+            .iter(IteratorMode::Start)
+            .unwrap()
+            .next()
+            .map(|((slot, _, _), _)| slot >= min_slot)
             .unwrap_or(true);
     assert!(condition_met);
 }

--- a/ledger/src/blockstore_metrics.rs
+++ b/ledger/src/blockstore_metrics.rs
@@ -1,9 +1,10 @@
 use {
-    crate::blockstore_options::LedgerColumnOptions,
+    crate::{blockstore_meta::BlockLocation, blockstore_options::LedgerColumnOptions},
     rocksdb::{
         PerfContext,
         perf::{PerfMetric, PerfStatsLevel, set_perf_stats},
     },
+    solana_clock::Slot,
     solana_metrics::datapoint_info,
     solana_time_utils::timestamp,
     std::{
@@ -41,6 +42,30 @@ pub struct BlockstoreInsertionMetrics {
     pub num_coding_shreds_invalid_erasure_config: usize,
     pub num_coding_shreds_blockstore_error: usize,
     pub num_coding_shreds_inserted: usize,
+}
+
+#[derive(Default)]
+pub struct BlockstoreSwitchBankMetrics {
+    pub total_elapsed_us: u64,
+    pub lock_elapsed_us: u64,
+    pub backup_elapsed_us: u64,
+    pub purge_elapsed_us: u64,
+    pub copy_elapsed_us: u64,
+}
+
+impl BlockstoreSwitchBankMetrics {
+    pub fn report_metrics(self, slot: Slot, from_location: BlockLocation) {
+        datapoint_info!(
+            "blockstore_switch_bank",
+            "from_location" => from_location.to_string(),
+            ("slot", slot as i64, i64),
+            ("total_elapsed_us", self.total_elapsed_us as i64, i64),
+            ("lock_elapsed_us", self.lock_elapsed_us as i64, i64),
+            ("backup_elapsed_us", self.backup_elapsed_us as i64, i64),
+            ("purge_elapsed_us", self.purge_elapsed_us as i64, i64),
+            ("copy_elapsed_us", self.copy_elapsed_us as i64, i64),
+        );
+    }
 }
 
 impl BlockstoreInsertionMetrics {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1203,6 +1203,9 @@ pub struct ConfirmationTiming {
 
     /// `batch_execute()` measurements.
     pub batch_execute: BatchExecutionTiming,
+
+    /// Number of times this slot was switched from an alternate location.
+    pub num_bank_switches: u64,
 }
 
 impl Default for ConfirmationTiming {
@@ -1216,6 +1219,7 @@ impl Default for ConfirmationTiming {
             fetch_elapsed: 0,
             fetch_fail_elapsed: 0,
             batch_execute: BatchExecutionTiming::default(),
+            num_bank_switches: 0,
         }
     }
 }
@@ -1378,6 +1382,7 @@ impl ReplaySlotStats {
                 (confirmation_elapsed, self.confirmation_elapsed as i64, i64),
                 (replay_elapsed, self.replay_elapsed as i64, i64),
                 ("execute_batches_us", execute_batches_us, Option<i64>),
+                ("num_bank_switches", self.num_bank_switches as i64, i64),
                 (
                     "replay_total_elapsed",
                     self.started.elapsed().as_micros() as i64,


### PR DESCRIPTION
Split from #11814 
Upstream of https://github.com/anza-xyz/alpenglow/pull/758

#### Problem
We have no metrics for the hopefully never used switch bank pathway in votor equivocation handling

#### Summary of Changes
Upstream the metrics
