### PR TITLE
Add `--tree` flag to `solana logs` for nested CPI rendering

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -84,6 +84,7 @@ pub enum CliCommand {
     LiveSlots,
     Logs {
         filter: RpcTransactionLogsFilter,
+        tree: bool,
     },
     Rent {
         data_length: usize,
@@ -917,7 +918,7 @@ pub async fn process_command(config: &CliConfig<'_>) -> ProcessResult {
             process_leader_schedule(&rpc_client, config, *epoch).await
         }
         CliCommand::LiveSlots => process_live_slots(config),
-        CliCommand::Logs { filter } => process_logs(config, filter),
+        CliCommand::Logs { filter, tree } => process_logs(config, filter, *tree),
         CliCommand::Rent {
             data_length,
             use_lamports_unit,

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -262,7 +262,11 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .takes_value(false)
                         .conflicts_with("address")
                         .help("Include vote transactions when monitoring all transactions"),
-                ),
+                )
+                .arg(Arg::with_name("tree").long("tree").takes_value(false).help(
+                    "Render each transaction's logs as a nested CPI invocation tree instead of a \
+                     flat line stream",
+                )),
         )
         .subcommand(
             SubCommand::with_name("block-production")
@@ -1456,6 +1460,7 @@ pub fn parse_logs(
 ) -> Result<CliCommandInfo, CliError> {
     let address = pubkey_of_signer(matches, "address", wallet_manager)?;
     let include_votes = matches.is_present("include_votes");
+    let tree = matches.is_present("tree");
 
     let filter = match address {
         None => {
@@ -1468,10 +1473,17 @@ pub fn parse_logs(
         Some(address) => RpcTransactionLogsFilter::Mentions(vec![address.to_string()]),
     };
 
-    Ok(CliCommandInfo::without_signers(CliCommand::Logs { filter }))
+    Ok(CliCommandInfo::without_signers(CliCommand::Logs {
+        filter,
+        tree,
+    }))
 }
 
-pub fn process_logs(config: &CliConfig, filter: &RpcTransactionLogsFilter) -> ProcessResult {
+pub fn process_logs(
+    config: &CliConfig,
+    filter: &RpcTransactionLogsFilter,
+    tree: bool,
+) -> ProcessResult {
     println!(
         "Streaming transaction logs{}. {:?} commitment",
         match filter {
@@ -1503,9 +1515,18 @@ pub fn process_logs(config: &CliConfig, filter: &RpcTransactionLogsFilter) -> Pr
                         .map(|err| err.to_string())
                         .unwrap_or_else(|| "Ok".to_string())
                 );
-                println!("  Log Messages:");
-                for log in logs.value.logs {
-                    println!("    {log}");
+                if tree {
+                    println!("  CPI Tree:");
+                    let frames = crate::log_tree::cpi_tree(&logs.value.logs);
+                    let rendered = crate::log_tree::format_cpi_tree(&frames);
+                    for line in rendered.lines() {
+                        println!("    {line}");
+                    }
+                } else {
+                    println!("  Log Messages:");
+                    for log in logs.value.logs {
+                        println!("    {log}");
+                    }
                 }
             }
             Err(err) => {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -265,7 +265,9 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                 )
                 .arg(Arg::with_name("tree").long("tree").takes_value(false).help(
                     "Render each transaction's logs as a nested CPI invocation tree instead of a \
-                     flat line stream",
+                     flat line stream. Each transaction also gets a Solana Explorer URL inferred \
+                     from --url (canonical RPCs map to named clusters; localhost or third-party \
+                     RPCs use Explorer's cluster=custom&customUrl=... form).",
                 )),
         )
         .subcommand(
@@ -1479,6 +1481,54 @@ pub fn parse_logs(
     }))
 }
 
+/// Map an RPC URL to the query string a Solana Explorer link should carry.
+/// Canonical Solana RPCs (mainnet-beta, testnet, devnet) round-trip to
+/// their named clusters; anything else (`localhost`, third-party RPCs, a
+/// raw IP, etc.) uses Explorer's `cluster=custom&customUrl=<encoded>` form
+/// so the link points at the same chain the user is watching.
+fn explorer_query_for_rpc(rpc_url: &str) -> String {
+    let trimmed = rpc_url.trim_end_matches('/');
+    match trimmed {
+        "https://api.mainnet-beta.solana.com" => "cluster=mainnet-beta".to_string(),
+        "https://api.testnet.solana.com" => "cluster=testnet".to_string(),
+        "https://api.devnet.solana.com" => "cluster=devnet".to_string(),
+        custom => format!(
+            "cluster=custom&customUrl={}",
+            percent_encode_component(custom)
+        ),
+    }
+}
+
+/// Percent-encode a string for use as a URL query parameter value, per
+/// RFC 3986 (only unreserved ASCII passes through; everything else gets
+/// `%XX`). Hand-rolled so we don't pull in a crate just for this.
+///
+/// Uses RFC 3986 encoding (space → `%20`) rather than form encoding
+/// (space → `+`). The two diverge only on space; Explorer's `customUrl`
+/// is decoded via `URLSearchParams` which would interpret `+` as space,
+/// so `%20` is unambiguous either way. Realistic inputs (RPC URLs) won't
+/// contain spaces, but we encode strictly to keep the behavior right
+/// under any input.
+fn percent_encode_component(s: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    // Worst case is 3x expansion: one byte -> `%XX`. Most realistic input
+    // stays close to 1x; sizing for the worst case avoids any reallocation.
+    let mut out = String::with_capacity(s.len() * 3);
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => {
+                out.push('%');
+                out.push(HEX[(byte >> 4) as usize] as char);
+                out.push(HEX[(byte & 0x0F) as usize] as char);
+            }
+        }
+    }
+    out
+}
+
 pub fn process_logs(
     config: &CliConfig,
     filter: &RpcTransactionLogsFilter,
@@ -1509,6 +1559,17 @@ pub fn process_logs(
                 println!(); // keep em separated
                 println!("Transaction executed in slot {}:", logs.context.slot);
                 println!("  Signature: {}", logs.value.signature);
+                // In tree mode, every transaction gets an Explorer URL
+                // inferred from --url. The two extra spaces after
+                // "Explorer:" align the URL with the value column under
+                // "Signature:".
+                if tree {
+                    println!(
+                        "  Explorer:  https://explorer.solana.com/tx/{}?{}",
+                        logs.value.signature,
+                        explorer_query_for_rpc(&config.json_rpc_url)
+                    );
+                }
                 println!(
                     "  Status: {}",
                     logs.value
@@ -2215,6 +2276,43 @@ mod tests {
         solana_keypair::{Keypair, write_keypair},
         tempfile::NamedTempFile,
     };
+
+    #[test]
+    fn explorer_query_maps_canonical_rpcs_to_named_clusters() {
+        assert_eq!(
+            explorer_query_for_rpc("https://api.mainnet-beta.solana.com"),
+            "cluster=mainnet-beta"
+        );
+        assert_eq!(
+            explorer_query_for_rpc("https://api.testnet.solana.com"),
+            "cluster=testnet"
+        );
+        assert_eq!(
+            explorer_query_for_rpc("https://api.devnet.solana.com"),
+            "cluster=devnet"
+        );
+        // Trailing slash should be tolerated.
+        assert_eq!(
+            explorer_query_for_rpc("https://api.devnet.solana.com/"),
+            "cluster=devnet"
+        );
+    }
+
+    #[test]
+    fn explorer_query_falls_back_to_custom_for_unknown_rpc() {
+        // Localhost (surfpool / solana-test-validator default).
+        assert_eq!(
+            explorer_query_for_rpc("http://localhost:8899"),
+            "cluster=custom&customUrl=http%3A%2F%2Flocalhost%3A8899"
+        );
+        // A third-party devnet RPC: the substring "devnet" must not trick
+        // us into the named cluster, because Explorer's `cluster=devnet`
+        // points to api.devnet.solana.com, not this URL.
+        assert_eq!(
+            explorer_query_for_rpc("https://devnet.helius-rpc.com"),
+            "cluster=custom&customUrl=https%3A%2F%2Fdevnet.helius-rpc.com"
+        );
+    }
 
     fn make_tmp_file() -> (String, NamedTempFile) {
         let tmp_file = NamedTempFile::new().unwrap();

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1560,20 +1560,20 @@ pub fn process_logs(
                 println!(); // keep em separated
                 println!("Transaction executed in slot {}:", logs.context.slot);
                 println!("  Signature: {}", logs.value.signature);
-                // In tree mode, every transaction gets an Explorer URL
-                // inferred from --url. The two extra spaces after
-                // "Explorer:" align the URL with the value column under
-                // "Signature:".
+                // Every transaction gets an Explorer URL inferred from
+                // --url, in both flat and tree mode. The two extra spaces
+                // after "Explorer:" align the URL with the value column
+                // under "Signature:".
                 //
                 // The validator occasionally ships `Signature::default()`
                 // (all-zero bytes; base58 = sixty-four `1`s) for real
                 // transactions whose signature wasn't available at the
                 // log-emission point. Any Explorer link built from that
                 // sig is dead on arrival, so suppress it; the user still
-                // sees the bogus signature and the (real) CPI tree below.
-                // See `is_default_signature` for the rationale on parse
+                // sees the bogus signature and the logs below. See
+                // `is_default_signature` for the rationale on parse
                 // failures.
-                if tree && !is_default_signature(&logs.value.signature) {
+                if !is_default_signature(&logs.value.signature) {
                     println!(
                         "  Explorer:  https://explorer.solana.com/tx/{}?{}",
                         logs.value.signature,

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1589,22 +1589,25 @@ pub fn process_logs(
                 );
                 if tree {
                     let frames = crate::log_tree::cpi_tree(&logs.value.logs);
-                    // Header shows `(consumed / budget CU)` when CU data is
-                    // available. `transaction_total_cu` returns `None` when
-                    // every top-level frame is a native program (BPF Loader,
-                    // top-level System Program, etc.) that doesn't emit
-                    // `consumed N of M compute units` lines; in that case
-                    // we fall back to the explicit note rather than
-                    // misreporting "0 CU".
+                    // Header shows `(N BPF CU / M budget)`. BPF CU because
+                    // `transaction_total_cu` sums only what the SBPF VM
+                    // reports via `Program X consumed N of M` lines; native
+                    // programs (`ComputeBudget`, precompiles, `BpfLoader`)
+                    // never emit those, so their cost is invisible here and
+                    // this number will be lower than the explorer's
+                    // `compute_units_consumed` whenever the tx has any
+                    // non-BPF instructions. When every top-level frame is
+                    // native, `transaction_total_cu` returns `None` and we
+                    // print the explicit fallback rather than "0".
                     let total = crate::log_tree::transaction_total_cu(&frames);
                     let budget = crate::log_tree::transaction_compute_budget(&frames);
                     let header = match (total, budget) {
                         (Some(t), Some(b)) => format!(
-                            "CPI Tree ({} / {} CU):",
+                            "CPI Tree ({} BPF CU / {} budget):",
                             crate::log_tree::with_commas(t),
                             crate::log_tree::with_commas(b)
                         ),
-                        _ => "CPI Tree (no compute units in logs):".to_string(),
+                        _ => "CPI Tree (no BPF CU in logs):".to_string(),
                     };
                     let rendered = crate::log_tree::format_cpi_tree(&header, &frames);
                     for line in rendered.lines() {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1478,6 +1478,10 @@ pub fn parse_logs(
     }))
 }
 
+fn is_default_signature(sig: &str) -> bool {
+    sig.parse::<Signature>().ok() == Some(Signature::default())
+}
+
 /// Map an RPC URL to the query string a Solana Explorer link should carry.
 /// Canonical Solana RPCs (mainnet-beta, testnet, devnet) round-trip to
 /// their named clusters; anything else (`localhost`, third-party RPCs, a
@@ -1560,7 +1564,16 @@ pub fn process_logs(
                 // inferred from --url. The two extra spaces after
                 // "Explorer:" align the URL with the value column under
                 // "Signature:".
-                if tree {
+                //
+                // The validator occasionally ships `Signature::default()`
+                // (all-zero bytes; base58 = sixty-four `1`s) for real
+                // transactions whose signature wasn't available at the
+                // log-emission point. Any Explorer link built from that
+                // sig is dead on arrival, so suppress it; the user still
+                // sees the bogus signature and the (real) CPI tree below.
+                // See `is_default_signature` for the rationale on parse
+                // failures.
+                if tree && !is_default_signature(&logs.value.signature) {
                     println!(
                         "  Explorer:  https://explorer.solana.com/tx/{}?{}",
                         logs.value.signature,
@@ -2293,6 +2306,44 @@ mod tests {
             explorer_query_for_rpc("https://api.devnet.solana.com/"),
             "cluster=devnet"
         );
+    }
+
+    #[test]
+    fn is_default_signature_recognizes_canonical_encoding() {
+        // The validator forwards whatever signature the transaction
+        // object reports, unconditionally:
+        //
+        //   https://github.com/anza-xyz/agave/blob/b54f7de2d3aeac1a56dbfbb72a17ec36fc1986e9/runtime/src/bank.rs#L4006
+        //
+        // So `Signature::default()` (sixty-four zero bytes) is a
+        // reachable wire value whenever some upstream path leaves the
+        // transaction's signature unset. The literal below is its base58
+        // encoding, hard-coded so the test pins the actual value the
+        // suppression has to recognize instead of asserting that the
+        // encoder and decoder agree with themselves.
+        let canonical_default =
+            "1111111111111111111111111111111111111111111111111111111111111111";
+        assert!(is_default_signature(canonical_default));
+    }
+
+    #[test]
+    fn is_default_signature_rejects_real_signature() {
+        // A real mainnet-beta signature lifted from the PR examples.
+        // Must NOT be suppressed: this is what a normal transaction looks
+        // like and the Explorer link is valid for it.
+        let real = "3AD5AKheyKxzenyABdmyN61TT9EgmYszgdCMkDduAeh6S8NDNJF8Bpj1woWp5qC9sHxPumLW7ZmyJvU2uMiqnzLL";
+        assert!(!is_default_signature(real));
+    }
+
+    #[test]
+    fn is_default_signature_rejects_unparseable_input() {
+        // Garbage in -> `false`, not `true`. The suppression only fires
+        // for the known default-signature case; we don't want to silently
+        // swallow Explorer links for any unrelated parse bug upstream.
+        assert!(!is_default_signature("not-a-signature"));
+        assert!(!is_default_signature(""));
+        // Right length, wrong alphabet (base58 excludes `0`, `O`, `I`, `l`).
+        assert!(!is_default_signature(&"0".repeat(64)));
     }
 
     #[test]

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1518,18 +1518,22 @@ pub fn process_logs(
                 );
                 if tree {
                     let frames = crate::log_tree::cpi_tree(&logs.value.logs);
-                    // Include the transaction-total CU on the header line.
-                    // `transaction_total_cu` returns `None` when every
-                    // top-level frame is a native program (BPF Loader,
-                    // top-level System Program, etc.) since those don't
-                    // emit `consumed N of M compute units` lines. Falling
-                    // back to `(0 CU)` in that case would misreport; the
-                    // honest text below makes the limitation explicit.
-                    let header = match crate::log_tree::transaction_total_cu(&frames) {
-                        Some(total) => {
-                            format!("CPI Tree ({} CU):", crate::log_tree::with_commas(total))
-                        }
-                        None => "CPI Tree (no compute units in logs):".to_string(),
+                    // Header shows `(consumed / budget CU)` when CU data is
+                    // available. `transaction_total_cu` returns `None` when
+                    // every top-level frame is a native program (BPF Loader,
+                    // top-level System Program, etc.) that doesn't emit
+                    // `consumed N of M compute units` lines; in that case
+                    // we fall back to the explicit note rather than
+                    // misreporting "0 CU".
+                    let total = crate::log_tree::transaction_total_cu(&frames);
+                    let budget = crate::log_tree::transaction_compute_budget(&frames);
+                    let header = match (total, budget) {
+                        (Some(t), Some(b)) => format!(
+                            "CPI Tree ({} / {} CU):",
+                            crate::log_tree::with_commas(t),
+                            crate::log_tree::with_commas(b)
+                        ),
+                        _ => "CPI Tree (no compute units in logs):".to_string(),
                     };
                     let rendered = crate::log_tree::format_cpi_tree(&header, &frames);
                     for line in rendered.lines() {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -264,10 +264,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .help("Include vote transactions when monitoring all transactions"),
                 )
                 .arg(Arg::with_name("tree").long("tree").takes_value(false).help(
-                    "Render each transaction's logs as a nested CPI invocation tree instead of a \
-                     flat line stream. Each transaction also gets a Solana Explorer URL inferred \
-                     from --url (canonical RPCs map to named clusters; localhost or third-party \
-                     RPCs use Explorer's cluster=custom&customUrl=... form).",
+                    "Render each transaction as a nested CPI invocation tree",
                 )),
         )
         .subcommand(

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1518,7 +1518,20 @@ pub fn process_logs(
                 );
                 if tree {
                     let frames = crate::log_tree::cpi_tree(&logs.value.logs);
-                    let rendered = crate::log_tree::format_cpi_tree("CPI Tree:", &frames);
+                    // Include the transaction-total CU on the header line.
+                    // `transaction_total_cu` returns `None` when every
+                    // top-level frame is a native program (BPF Loader,
+                    // top-level System Program, etc.) since those don't
+                    // emit `consumed N of M compute units` lines. Falling
+                    // back to `(0 CU)` in that case would misreport; the
+                    // honest text below makes the limitation explicit.
+                    let header = match crate::log_tree::transaction_total_cu(&frames) {
+                        Some(total) => {
+                            format!("CPI Tree ({} CU):", crate::log_tree::with_commas(total))
+                        }
+                        None => "CPI Tree (no compute units in logs):".to_string(),
+                    };
+                    let rendered = crate::log_tree::format_cpi_tree(&header, &frames);
                     for line in rendered.lines() {
                         println!("  {line}");
                     }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1506,6 +1506,7 @@ pub fn process_logs(
     loop {
         match receiver.recv() {
             Ok(logs) => {
+                println!(); // keep em separated
                 println!("Transaction executed in slot {}:", logs.context.slot);
                 println!("  Signature: {}", logs.value.signature);
                 println!(
@@ -1516,11 +1517,10 @@ pub fn process_logs(
                         .unwrap_or_else(|| "Ok".to_string())
                 );
                 if tree {
-                    println!("  CPI Tree:");
                     let frames = crate::log_tree::cpi_tree(&logs.value.logs);
-                    let rendered = crate::log_tree::format_cpi_tree(&frames);
+                    let rendered = crate::log_tree::format_cpi_tree("CPI Tree:", &frames);
                     for line in rendered.lines() {
-                        println!("    {line}");
+                        println!("  {line}");
                     }
                 } else {
                     println!("  Log Messages:");

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1476,6 +1476,10 @@ pub fn parse_logs(
     }))
 }
 
+fn is_default_signature(sig: &str) -> bool {
+    sig.parse::<Signature>().ok() == Some(Signature::default())
+}
+
 /// Map an RPC URL to the query string a Solana Explorer link should carry.
 /// Canonical Solana RPCs (mainnet-beta, testnet, devnet) round-trip to
 /// their named clusters; anything else (`localhost`, third-party RPCs, a
@@ -1561,7 +1565,16 @@ pub fn process_logs(
                 // inferred from --url. The two extra spaces after
                 // "Explorer:" align the URL with the value column under
                 // "Signature:".
-                if tree {
+                //
+                // The validator occasionally ships `Signature::default()`
+                // (all-zero bytes; base58 = sixty-four `1`s) for real
+                // transactions whose signature wasn't available at the
+                // log-emission point. Any Explorer link built from that
+                // sig is dead on arrival, so suppress it; the user still
+                // sees the bogus signature and the (real) CPI tree below.
+                // See `is_default_signature` for the rationale on parse
+                // failures.
+                if tree && !is_default_signature(&logs.value.signature) {
                     writeln_stdout(format_args!(
                         "  Explorer:  https://explorer.solana.com/tx/{}?{}",
                         logs.value.signature,
@@ -2302,6 +2315,44 @@ mod tests {
             explorer_query_for_rpc("https://api.devnet.solana.com/"),
             "cluster=devnet"
         );
+    }
+
+    #[test]
+    fn is_default_signature_recognizes_canonical_encoding() {
+        // The validator forwards whatever signature the transaction
+        // object reports, unconditionally:
+        //
+        //   https://github.com/anza-xyz/agave/blob/b54f7de2d3aeac1a56dbfbb72a17ec36fc1986e9/runtime/src/bank.rs#L4006
+        //
+        // So `Signature::default()` (sixty-four zero bytes) is a
+        // reachable wire value whenever some upstream path leaves the
+        // transaction's signature unset. The literal below is its base58
+        // encoding, hard-coded so the test pins the actual value the
+        // suppression has to recognize instead of asserting that the
+        // encoder and decoder agree with themselves.
+        let canonical_default =
+            "1111111111111111111111111111111111111111111111111111111111111111";
+        assert!(is_default_signature(canonical_default));
+    }
+
+    #[test]
+    fn is_default_signature_rejects_real_signature() {
+        // A real mainnet-beta signature lifted from the PR examples.
+        // Must NOT be suppressed: this is what a normal transaction looks
+        // like and the Explorer link is valid for it.
+        let real = "3AD5AKheyKxzenyABdmyN61TT9EgmYszgdCMkDduAeh6S8NDNJF8Bpj1woWp5qC9sHxPumLW7ZmyJvU2uMiqnzLL";
+        assert!(!is_default_signature(real));
+    }
+
+    #[test]
+    fn is_default_signature_rejects_unparseable_input() {
+        // Garbage in -> `false`, not `true`. The suppression only fires
+        // for the known default-signature case; we don't want to silently
+        // swallow Explorer links for any unrelated parse bug upstream.
+        assert!(!is_default_signature("not-a-signature"));
+        assert!(!is_default_signature(""));
+        // Right length, wrong alphabet (base58 excludes `0`, `O`, `I`, `l`).
+        assert!(!is_default_signature(&"0".repeat(64)));
     }
 
     #[test]

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1561,20 +1561,20 @@ pub fn process_logs(
                     logs.context.slot
                 ))?;
                 writeln_stdout(format_args!("  Signature: {}", logs.value.signature))?;
-                // In tree mode, every transaction gets an Explorer URL
-                // inferred from --url. The two extra spaces after
-                // "Explorer:" align the URL with the value column under
-                // "Signature:".
+                // Every transaction gets an Explorer URL inferred from
+                // --url, in both flat and tree mode. The two extra spaces
+                // after "Explorer:" align the URL with the value column
+                // under "Signature:".
                 //
                 // The validator occasionally ships `Signature::default()`
                 // (all-zero bytes; base58 = sixty-four `1`s) for real
                 // transactions whose signature wasn't available at the
                 // log-emission point. Any Explorer link built from that
                 // sig is dead on arrival, so suppress it; the user still
-                // sees the bogus signature and the (real) CPI tree below.
-                // See `is_default_signature` for the rationale on parse
+                // sees the bogus signature and the logs below. See
+                // `is_default_signature` for the rationale on parse
                 // failures.
-                if tree && !is_default_signature(&logs.value.signature) {
+                if !is_default_signature(&logs.value.signature) {
                     writeln_stdout(format_args!(
                         "  Explorer:  https://explorer.solana.com/tx/{}?{}",
                         logs.value.signature,

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -265,10 +265,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .help("Include vote transactions when monitoring all transactions"),
                 )
                 .arg(Arg::with_name("tree").long("tree").takes_value(false).help(
-                    "Render each transaction's logs as a nested CPI invocation tree instead of a \
-                     flat line stream. Each transaction also gets a Solana Explorer URL inferred \
-                     from --url (canonical RPCs map to named clusters; localhost or third-party \
-                     RPCs use Explorer's cluster=custom&customUrl=... form).",
+                    "Render each transaction as a nested CPI invocation tree",
                 )),
         )
         .subcommand(

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1590,22 +1590,25 @@ pub fn process_logs(
                 ))?;
                 if tree {
                     let frames = crate::log_tree::cpi_tree(&logs.value.logs);
-                    // Header shows `(consumed / budget CU)` when CU data is
-                    // available. `transaction_total_cu` returns `None` when
-                    // every top-level frame is a native program (BPF Loader,
-                    // top-level System Program, etc.) that doesn't emit
-                    // `consumed N of M compute units` lines; in that case
-                    // we fall back to the explicit note rather than
-                    // misreporting "0 CU".
+                    // Header shows `(N BPF CU / M budget)`. BPF CU because
+                    // `transaction_total_cu` sums only what the SBPF VM
+                    // reports via `Program X consumed N of M` lines; native
+                    // programs (`ComputeBudget`, precompiles, `BpfLoader`)
+                    // never emit those, so their cost is invisible here and
+                    // this number will be lower than the explorer's
+                    // `compute_units_consumed` whenever the tx has any
+                    // non-BPF instructions. When every top-level frame is
+                    // native, `transaction_total_cu` returns `None` and we
+                    // print the explicit fallback rather than "0".
                     let total = crate::log_tree::transaction_total_cu(&frames);
                     let budget = crate::log_tree::transaction_compute_budget(&frames);
                     let header = match (total, budget) {
                         (Some(t), Some(b)) => format!(
-                            "CPI Tree ({} / {} CU):",
+                            "CPI Tree ({} BPF CU / {} budget):",
                             crate::log_tree::with_commas(t),
                             crate::log_tree::with_commas(b)
                         ),
-                        _ => "CPI Tree (no compute units in logs):".to_string(),
+                        _ => "CPI Tree (no BPF CU in logs):".to_string(),
                     };
                     let rendered = crate::log_tree::format_cpi_tree(&header, &frames);
                     for line in rendered.lines() {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1519,18 +1519,22 @@ pub fn process_logs(
                 ))?;
                 if tree {
                     let frames = crate::log_tree::cpi_tree(&logs.value.logs);
-                    // Include the transaction-total CU on the header line.
-                    // `transaction_total_cu` returns `None` when every
-                    // top-level frame is a native program (BPF Loader,
-                    // top-level System Program, etc.) since those don't
-                    // emit `consumed N of M compute units` lines. Falling
-                    // back to `(0 CU)` in that case would misreport; the
-                    // honest text below makes the limitation explicit.
-                    let header = match crate::log_tree::transaction_total_cu(&frames) {
-                        Some(total) => {
-                            format!("CPI Tree ({} CU):", crate::log_tree::with_commas(total))
-                        }
-                        None => "CPI Tree (no compute units in logs):".to_string(),
+                    // Header shows `(consumed / budget CU)` when CU data is
+                    // available. `transaction_total_cu` returns `None` when
+                    // every top-level frame is a native program (BPF Loader,
+                    // top-level System Program, etc.) that doesn't emit
+                    // `consumed N of M compute units` lines; in that case
+                    // we fall back to the explicit note rather than
+                    // misreporting "0 CU".
+                    let total = crate::log_tree::transaction_total_cu(&frames);
+                    let budget = crate::log_tree::transaction_compute_budget(&frames);
+                    let header = match (total, budget) {
+                        (Some(t), Some(b)) => format!(
+                            "CPI Tree ({} / {} CU):",
+                            crate::log_tree::with_commas(t),
+                            crate::log_tree::with_commas(b)
+                        ),
+                        _ => "CPI Tree (no compute units in logs):".to_string(),
                     };
                     let rendered = crate::log_tree::format_cpi_tree(&header, &frames);
                     for line in rendered.lines() {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -263,7 +263,11 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .takes_value(false)
                         .conflicts_with("address")
                         .help("Include vote transactions when monitoring all transactions"),
-                ),
+                )
+                .arg(Arg::with_name("tree").long("tree").takes_value(false).help(
+                    "Render each transaction's logs as a nested CPI invocation tree instead of a \
+                     flat line stream",
+                )),
         )
         .subcommand(
             SubCommand::with_name("block-production")
@@ -1454,6 +1458,7 @@ pub fn parse_logs(
 ) -> Result<CliCommandInfo, CliError> {
     let address = pubkey_of_signer(matches, "address", wallet_manager)?;
     let include_votes = matches.is_present("include_votes");
+    let tree = matches.is_present("tree");
 
     let filter = match address {
         None => {
@@ -1466,10 +1471,17 @@ pub fn parse_logs(
         Some(address) => RpcTransactionLogsFilter::Mentions(vec![address.to_string()]),
     };
 
-    Ok(CliCommandInfo::without_signers(CliCommand::Logs { filter }))
+    Ok(CliCommandInfo::without_signers(CliCommand::Logs {
+        filter,
+        tree,
+    }))
 }
 
-pub fn process_logs(config: &CliConfig, filter: &RpcTransactionLogsFilter) -> ProcessResult {
+pub fn process_logs(
+    config: &CliConfig,
+    filter: &RpcTransactionLogsFilter,
+    tree: bool,
+) -> ProcessResult {
     writeln_stdout(format_args!(
         "Streaming transaction logs{}. {:?} commitment",
         match filter {
@@ -1504,9 +1516,18 @@ pub fn process_logs(config: &CliConfig, filter: &RpcTransactionLogsFilter) -> Pr
                         .map(|err| err.to_string())
                         .unwrap_or_else(|| "Ok".to_string())
                 ))?;
-                writeln_stdout(format_args!("  Log Messages:"))?;
-                for log in logs.value.logs {
-                    writeln_stdout(format_args!("    {log}"))?;
+                if tree {
+                    writeln_stdout(format_args!("  CPI Tree:"))?;
+                    let frames = crate::log_tree::cpi_tree(&logs.value.logs);
+                    let rendered = crate::log_tree::format_cpi_tree(&frames);
+                    for line in rendered.lines() {
+                        writeln_stdout(format_args!("    {line}"))?;
+                    }
+                } else {
+                    writeln_stdout(format_args!("  Log Messages:"))?;
+                    for log in logs.value.logs {
+                        writeln_stdout(format_args!("    {log}"))?;
+                    }
                 }
             }
             Err(err) => {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1519,7 +1519,20 @@ pub fn process_logs(
                 ))?;
                 if tree {
                     let frames = crate::log_tree::cpi_tree(&logs.value.logs);
-                    let rendered = crate::log_tree::format_cpi_tree("CPI Tree:", &frames);
+                    // Include the transaction-total CU on the header line.
+                    // `transaction_total_cu` returns `None` when every
+                    // top-level frame is a native program (BPF Loader,
+                    // top-level System Program, etc.) since those don't
+                    // emit `consumed N of M compute units` lines. Falling
+                    // back to `(0 CU)` in that case would misreport; the
+                    // honest text below makes the limitation explicit.
+                    let header = match crate::log_tree::transaction_total_cu(&frames) {
+                        Some(total) => {
+                            format!("CPI Tree ({} CU):", crate::log_tree::with_commas(total))
+                        }
+                        None => "CPI Tree (no compute units in logs):".to_string(),
+                    };
+                    let rendered = crate::log_tree::format_cpi_tree(&header, &frames);
                     for line in rendered.lines() {
                         writeln_stdout(format_args!("  {line}"))?;
                     }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1504,6 +1504,7 @@ pub fn process_logs(
     loop {
         match receiver.recv() {
             Ok(logs) => {
+                writeln_stdout(format_args!(""))?; // keep em separated
                 writeln_stdout(format_args!(
                     "Transaction executed in slot {}:",
                     logs.context.slot
@@ -1517,11 +1518,10 @@ pub fn process_logs(
                         .unwrap_or_else(|| "Ok".to_string())
                 ))?;
                 if tree {
-                    writeln_stdout(format_args!("  CPI Tree:"))?;
                     let frames = crate::log_tree::cpi_tree(&logs.value.logs);
-                    let rendered = crate::log_tree::format_cpi_tree(&frames);
+                    let rendered = crate::log_tree::format_cpi_tree("CPI Tree:", &frames);
                     for line in rendered.lines() {
-                        writeln_stdout(format_args!("    {line}"))?;
+                        writeln_stdout(format_args!("  {line}"))?;
                     }
                 } else {
                     writeln_stdout(format_args!("  Log Messages:"))?;

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -266,7 +266,9 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                 )
                 .arg(Arg::with_name("tree").long("tree").takes_value(false).help(
                     "Render each transaction's logs as a nested CPI invocation tree instead of a \
-                     flat line stream",
+                     flat line stream. Each transaction also gets a Solana Explorer URL inferred \
+                     from --url (canonical RPCs map to named clusters; localhost or third-party \
+                     RPCs use Explorer's cluster=custom&customUrl=... form).",
                 )),
         )
         .subcommand(
@@ -1477,6 +1479,54 @@ pub fn parse_logs(
     }))
 }
 
+/// Map an RPC URL to the query string a Solana Explorer link should carry.
+/// Canonical Solana RPCs (mainnet-beta, testnet, devnet) round-trip to
+/// their named clusters; anything else (`localhost`, third-party RPCs, a
+/// raw IP, etc.) uses Explorer's `cluster=custom&customUrl=<encoded>` form
+/// so the link points at the same chain the user is watching.
+fn explorer_query_for_rpc(rpc_url: &str) -> String {
+    let trimmed = rpc_url.trim_end_matches('/');
+    match trimmed {
+        "https://api.mainnet-beta.solana.com" => "cluster=mainnet-beta".to_string(),
+        "https://api.testnet.solana.com" => "cluster=testnet".to_string(),
+        "https://api.devnet.solana.com" => "cluster=devnet".to_string(),
+        custom => format!(
+            "cluster=custom&customUrl={}",
+            percent_encode_component(custom)
+        ),
+    }
+}
+
+/// Percent-encode a string for use as a URL query parameter value, per
+/// RFC 3986 (only unreserved ASCII passes through; everything else gets
+/// `%XX`). Hand-rolled so we don't pull in a crate just for this.
+///
+/// Uses RFC 3986 encoding (space → `%20`) rather than form encoding
+/// (space → `+`). The two diverge only on space; Explorer's `customUrl`
+/// is decoded via `URLSearchParams` which would interpret `+` as space,
+/// so `%20` is unambiguous either way. Realistic inputs (RPC URLs) won't
+/// contain spaces, but we encode strictly to keep the behavior right
+/// under any input.
+fn percent_encode_component(s: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    // Worst case is 3x expansion: one byte -> `%XX`. Most realistic input
+    // stays close to 1x; sizing for the worst case avoids any reallocation.
+    let mut out = String::with_capacity(s.len() * 3);
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => {
+                out.push('%');
+                out.push(HEX[(byte >> 4) as usize] as char);
+                out.push(HEX[(byte & 0x0F) as usize] as char);
+            }
+        }
+    }
+    out
+}
+
 pub fn process_logs(
     config: &CliConfig,
     filter: &RpcTransactionLogsFilter,
@@ -1510,6 +1560,17 @@ pub fn process_logs(
                     logs.context.slot
                 ))?;
                 writeln_stdout(format_args!("  Signature: {}", logs.value.signature))?;
+                // In tree mode, every transaction gets an Explorer URL
+                // inferred from --url. The two extra spaces after
+                // "Explorer:" align the URL with the value column under
+                // "Signature:".
+                if tree {
+                    writeln_stdout(format_args!(
+                        "  Explorer:  https://explorer.solana.com/tx/{}?{}",
+                        logs.value.signature,
+                        explorer_query_for_rpc(&config.json_rpc_url)
+                    ))?;
+                }
                 writeln_stdout(format_args!(
                     "  Status: {}",
                     logs.value
@@ -2224,6 +2285,43 @@ mod tests {
         solana_keypair::{Keypair, write_keypair},
         tempfile::NamedTempFile,
     };
+
+    #[test]
+    fn explorer_query_maps_canonical_rpcs_to_named_clusters() {
+        assert_eq!(
+            explorer_query_for_rpc("https://api.mainnet-beta.solana.com"),
+            "cluster=mainnet-beta"
+        );
+        assert_eq!(
+            explorer_query_for_rpc("https://api.testnet.solana.com"),
+            "cluster=testnet"
+        );
+        assert_eq!(
+            explorer_query_for_rpc("https://api.devnet.solana.com"),
+            "cluster=devnet"
+        );
+        // Trailing slash should be tolerated.
+        assert_eq!(
+            explorer_query_for_rpc("https://api.devnet.solana.com/"),
+            "cluster=devnet"
+        );
+    }
+
+    #[test]
+    fn explorer_query_falls_back_to_custom_for_unknown_rpc() {
+        // Localhost (surfpool / solana-test-validator default).
+        assert_eq!(
+            explorer_query_for_rpc("http://localhost:8899"),
+            "cluster=custom&customUrl=http%3A%2F%2Flocalhost%3A8899"
+        );
+        // A third-party devnet RPC: the substring "devnet" must not trick
+        // us into the named cluster, because Explorer's `cluster=devnet`
+        // points to api.devnet.solana.com, not this URL.
+        assert_eq!(
+            explorer_query_for_rpc("https://devnet.helius-rpc.com"),
+            "cluster=custom&customUrl=https%3A%2F%2Fdevnet.helius-rpc.com"
+        );
+    }
 
     fn make_tmp_file() -> (String, NamedTempFile) {
         let tmp_file = NamedTempFile::new().unwrap();

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -28,6 +28,7 @@ pub mod cluster_query;
 pub mod compute_budget;
 pub mod feature;
 pub mod inflation;
+pub mod log_tree;
 pub mod memo;
 pub mod nonce;
 pub mod program;

--- a/cli/src/log_tree.rs
+++ b/cli/src/log_tree.rs
@@ -1,97 +1,90 @@
-//! We have a transaction's logs as a flat `Vec<String>` and we want a nested
-//! invocation tree. This module does that fold.
+//! Solana transaction logs arrive as a flat `Vec<String>`. We want a tree so
+//! the natural CPI nesting surfaces instead of staying buried in line-by-line
+//! text.
 //!
-//! The runtime emits four kinds of structural lines that we destructure to
-//! build the tree:
+//! The logs nest cleanly: `invoke` opens a frame, `success|failed:` closes
+//! it. That's the Dyck language D-1 of balanced brackets, which a pushdown
+//! automaton recognizes by construction. See
+//! <https://en.wikipedia.org/wiki/Dyck_language>.
+//!
+//! So the parser is two layers: a per-line lexer (finite-state automaton,
+//! FSA) feeds a single-state pushdown automaton (PDA). The FSA has no
+//! memory across lines; the PDA's stack carries the nesting.
+//!
+//! # Layer 1: per-line classifier (FSA)
+//!
+//! `classify` plus the `strip_prefix` cascade maps one line to one token.
+//! No memory across lines; pure regular language.
 //!
 //! ```text
-//! Program <id> invoke [n]
-//! Program <id> consumed N of M compute units
-//! Program <id> success
-//! Program <id> failed: <message>
+//!              ┌─ "Program log: Instruction: <n>" -> Instruction(n)
+//!              ├─ "Program log: <t>"              -> Msg(t)
+//!              ├─ "Program data: <d>"             -> Data(d)
+//!              ├─ "Program <p> invoke [k]"        -> Invoke(p)
+//! [line] ──────┼─ "Program <p> success"           -> Status::Success
+//!              ├─ "Program <p> failed: <m>"       -> Status::Failed(m)
+//!              ├─ "Program <p> consumed N of M …" -> Consumed(N, M)
+//!              └─ <anything else>                 -> Other(line)
 //! ```
 //!
-//! Everything else a program (or the runtime) emits while a frame is open
-//! lands in `frame.logs`, a `Vec<FrameLog>` that preserves arrival order
-//! across two variants:
-//!   - `FrameLog::Msg(String)` for `Program log: <text>` (`msg!` /
-//!     `sol_log`), plus any unprefixed runtime diagnostic emitted in an
-//!     error-condition path (a line without our structural `Program `
-//!     prefix).
-//!   - `FrameLog::Data(String)` for `Program data: <base64>`
-//!     (`sol_log_data`, which Anchor's `emit!` macro uses).
+//! # Layer 2: stream parser (PDA)
 //!
-//! Both kinds are preserved regardless of outcome, and crucially the
-//! interleaving order between Msg and Data is preserved.
+//! One control state; the stack does all the work. Transitions read
+//! `input, stack-top -> new-stack`:
 //!
-//! When a program executes a CPI, the child's `invoke` / `success` lines
-//! interleave with the parent's own logging, and the bracket in `invoke [n]`
-//! reflects the call depth. (We don't actually use the bracket value to drive
-//! the parse; it's only there to validate that the line is shaped like an
-//! invoke. The depth falls out of how the stack pushes and pops naturally.)
+//! ```text
+//!      ┌─────────────────┐
+//!      │     running     │ ─┐   single state;
+//!      │  stack: γ       │  │   self-loop on every input
+//!      └─────────────────┘  │
+//!              ^            │
+//!              └────────────┘
 //!
-//! All that follows rests on one runtime invariant: a callee cannot outlive its
-//! caller. SBF physically can't return control to a parent CPI until every
-//! child it kicked off has finished. So the sequence of `invoke` and `success`
-//! / `failed:` lines is **well-nested**: every "open" is matched by a "close"
-//! that arrives before any earlier "open" closes. (Same property that makes
-//! `({[]})` a legal arithmetic expression and `({)[]}` a nonsensical one.)
+//!   Invoke(p),       γ          ->  Frame{p, Truncated} · γ     (PUSH)
+//!   Status::S,       Frame · γ  ->  γ; attach to parent/roots   (POP)
+//!   Status::F(m),    Frame · γ  ->  γ; attach to parent/roots   (POP)
+//!   Consumed(cu),    Frame · γ  ->  Frame{…cu=cu} · γ           (MUTATE top)
+//!   Msg/Data/Other,  Frame · γ  ->  Frame{…logs+=…} · γ         (MUTATE top)
+//!   Instruction(n),  Frame · γ  ->  Frame{…name=n} · γ          (MUTATE top)
+//!   EOF                         ->  drain stack as Truncated
+//! ```
 //!
-//! Equivalently: closes happen in reverse order of opens. Which is the access
-//! pattern of a stack, so the algorithm essentially writes itself:
+//! Payload-only tokens (`Msg`/`Data`/`Other`) cannot alter stack shape, so a
+//! stray runtime diagnostic mid-CPI can't corrupt the tree. Conversely,
+//! anything that affects the stack must match the exact tokenized shape: an
+//! invoke-shaped line with a malformed `[k]` bracket falls back to `Other`
+//! rather than pushing a half-known frame.
 //!
-//!   - `invoke` -> push a new frame
-//!   - `success` or `failed:` -> pop (it'll always be the right one to close,
-//!     by the invariant above)
-//!   - everything in between -> annotate whatever is on top
-//!
-//! The only way the brackets fail to balance is truncation: the log stream cuts
-//! off mid-transaction. (The process died, the RPC dropped frames, the buffer
-//! filled up; take your pick.) For that case, every frame is initialized with
-//! `outcome: Truncated` on push, so anything left on the stack at end-of-stream
-//! bubbles up with a useful, distinguishable outcome rather than being silently
-//! dropped or quietly misattributed as `Failed`. (It didn't technically fail;
-//! we just don't know what happened to it. "Absence of evidence" and "evidence
-//! of absence" are not the same thing, and the consumer of this tree may care
-//! about that distinction.)
+//! Truncation falls out of the EOF transition: pre-seeding `outcome:
+//! Truncated` on PUSH means the drain just pops unmodified frames; no special
+//! case for "stream ended mid-frame".
 
 use {
     solana_pubkey::Pubkey,
     std::{fmt::Write, str::FromStr},
 };
 
-// Connectors are written on the same line as a child's content. Spines are
-// continuation prefixes written under a frame on lines that follow its
-// header (other children, or the frame's own log entries).
-//
-// `CONN_BRANCH`/`CONN_LAST` are the standard `cargo tree` glyphs. Each is
-// 4 columns wide so that nested frames align consistently.
+// `cargo tree` glyphs. Connectors go on a child's line; spines continue
+// under a frame on lines that follow. 4 cols wide so nested frames align.
 const CONN_BRANCH: &str = "├── ";
 const CONN_LAST: &str = "└── ";
 const SPINE_CONTINUE: &str = "│   ";
 const SPINE_END: &str = "    ";
 
-// Log-block spines (used for the `>> log:` / `>> data:` rows). 2 columns
-// each so they slot just under the frame header without trying to align
-// with sibling connectors.
+// Narrower spines (2 cols) for `>> log:` / `>> data:` rows so they slot
+// under the header without aligning with sibling connectors.
 const LOG_SPINE_CONTINUE: &str = "│ ";
 const LOG_SPINE_END: &str = "  ";
 
-/// The two CU values the runtime reports together on a
-/// `Program X consumed N of M compute units` line. Paired in a single
-/// struct because either both are emitted (BPF programs) or neither is
-/// (native programs that don't run in the SBPF VM).
+/// Both values from a `Consumed(N, M)` token. Either both are emitted
+/// (BPF programs) or neither (native programs outside the SBPF VM).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ComputeUnits {
-    /// What this frame consumed. Cumulative: includes the program's CPI
-    /// children's consumption, so summing top-level frames gives the
-    /// transaction total (matches `TransactionStatusMeta::compute_units_consumed`).
+    /// CU consumed by this frame. Cumulative over CPI children, so summing
+    /// top-level frames matches `TransactionStatusMeta::compute_units_consumed`.
     pub consumed: u64,
-    /// Compute units remaining in the transaction's budget at the moment
-    /// this frame started executing. For the first top-level instruction
-    /// this equals the transaction's total CU budget; for subsequent
-    /// frames it's the running remainder after earlier frames consumed
-    /// from the same budget.
+    /// CU remaining in the transaction's budget when this frame started.
+    /// First top-level frame: full budget. Later frames: running remainder.
     pub available_at_start: u64,
 }
 
@@ -101,29 +94,21 @@ pub struct CpiFrame {
     pub outcome: CpiOutcome,
     pub compute_units: Option<ComputeUnits>,
     pub instruction_name: Option<String>,
-    /// Order preserving record of `msg!` strings, `emit!` payloads, and
-    /// unprefixed runtime diagnostics emitted while this frame was on the
-    /// stack. Both `Msg` and `Data` variants share the same Vec so the
-    /// interleaving the runtime produced survives the parse; a consumer can
-    /// reconstruct the flat-log content for this frame from `logs` alone.
-    /// Survives every outcome (unlike a diagnostics buffer that gets discarded
-    /// on success).
+    /// `Msg` / `Data` / `Other` tokens accumulated while this frame was on
+    /// the stack, in arrival order. Survives every outcome.
     pub logs: Vec<FrameLog>,
     pub children: Vec<CpiFrame>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FrameLog {
-    /// `Program log: <text>` from `msg!` / `sol_log` (excluding the special
-    /// `Program log: Instruction: <name>` form, which populates
-    /// `CpiFrame::instruction_name`). The parser also routes any unprefixed
-    /// runtime diagnostic into this variant (e.g. error-condition messages
-    /// without the structural `Program ` prefix): they don't have a
-    /// destructured shape, and `Msg` keeps the renderer logic uniform.
+    /// `Msg(t)` and `Other(line)` tokens (see module-level FSA). `Other`
+    /// lands here too: no destructured shape, and the renderer treats text
+    /// payloads uniformly.
     Msg(String),
-    /// `Program data: <base64>` from `sol_log_data`. Anchor's `emit!` macro
-    /// boils down to this syscall. We use the literal log term "data" rather
-    /// than "events"; event semantics layer above us via per-program IDLs.
+    /// `Data(d)` token: `sol_log_data` payload (Anchor's `emit!`). We keep
+    /// the log term "data"; "event" semantics layer above via per-program
+    /// IDLs.
     Data(String),
 }
 
@@ -133,42 +118,26 @@ pub enum CpiOutcome {
     Failed {
         message: Option<String>,
     },
-    /// Frame whose closing line never arrived: the stream ended with this
-    /// frame still open. Distinct from `Failed` because we don't actually
-    /// know what happened to it; we just lost sight of it.
+    /// Frame still open at EOF. Distinct from `Failed`: we lost sight of
+    /// it rather than observed it die.
     Truncated,
 }
 
-/// Walk the log stream once with a stack of in-progress frames. The mapping
-/// is the obvious one: `invoke` pushes a frame, `success` / `failed:` pops
-/// it, `consumed` annotates the top frame's compute count, and
-/// `Program log:` / `Program data:` / unprefixed runtime chatter all append
-/// to the top frame's `logs` (in arrival order, preserving the interleaving
-/// the runtime emitted).
+/// Drive the PDA from the module doc: one pass over `logs`, dispatch each
+/// token against the current stack top.
 pub fn cpi_tree(logs: &[String]) -> Vec<CpiFrame> {
     let mut roots: Vec<CpiFrame> = Vec::new();
     let mut stack: Vec<CpiFrame> = Vec::new();
 
     for log in logs {
         if let Some(name) = log.strip_prefix("Program log: Instruction: ") {
-            // The `Instruction:` line is what programs that follow the
-            // convention (Anchor's dispatch macro, SPL Token) emit right
-            // before the handler body runs. Anything `Msg` we've already
-            // buffered is pre-handler chatter and isn't what the user wants
-            // to see in this frame's logs; clear those. Any `Data` entries
-            // we keep, since `emit!` before the dispatcher's `Instruction:`
-            // line is an unusual but legitimate emission worth preserving.
-            //
-            // Start Condition
+            // `Instruction(n)`: dispatcher convention (Anchor, SPL Token).
+            // Drop any pre-handler `Msg` chatter; keep `Data` . First name
+            // wins.
             if let Some(frame) = stack.last_mut() {
                 frame
                     .logs
                     .retain(|entry| !matches!(entry, FrameLog::Msg(_)));
-                // First `Instruction:` line wins. In practice the programs
-                // I've looked at (Anchor's dispatch, SPL Token) emit exactly
-                // one per handler; this check is belt-and-braces in case a
-                // program ever emits a second one mid-handler (the first
-                // would still be the canonical dispatcher name).
                 if frame.instruction_name.is_none() {
                     frame.instruction_name = Some(name.to_string());
                 }
@@ -193,10 +162,8 @@ pub fn cpi_tree(logs: &[String]) -> Vec<CpiFrame> {
                 let Ok(program_id) = Pubkey::from_str(&program) else {
                     continue;
                 };
-                // Initialize `outcome: Truncated`. If the frame never sees a
-                // status line (because the stream got cut off), this is the
-                // outcome it'll bubble up with, no special case in the
-                // happy path needed.
+                // PUSH with `outcome: Truncated` pre-seeded; the EOF drain
+                // below leaves it untouched if no status line arrives.
                 stack.push(CpiFrame {
                     program_id,
                     outcome: CpiOutcome::Truncated,
@@ -222,17 +189,8 @@ pub fn cpi_tree(logs: &[String]) -> Vec<CpiFrame> {
                 push_into_parent_or_roots(frame, &mut stack, &mut roots);
             }
             LogLine::Other => {
-                // The catch-all: lines that aren't `invoke` / `consumed` /
-                // status and don't start with `Program log:` or `Program
-                // data:`. Covers any unprefixed runtime diagnostic that
-                // happens to land in the log stream (an error-condition
-                // line, for example). Bucketed as `Msg` because there's no
-                // structural shape to destructure and the renderer treats
-                // it the same as any other text payload on a frame.
-                //
-                // No current frame -> nowhere to attach -> drop it. (Doesn't
-                // happen today, but it's defined behavior rather than a
-                // panic so future runtime changes can't blow us up here.)
+                // `Other` bucketed as `Msg` per the PDA's payload-only row.
+                // No frame open: drop it (defined behavior, not a panic).
                 if let Some(frame) = stack.last_mut() {
                     frame.logs.push(FrameLog::Msg(log.clone()));
                 }
@@ -240,11 +198,7 @@ pub fn cpi_tree(logs: &[String]) -> Vec<CpiFrame> {
         }
     }
 
-    // Drain whatever's still on the stack with its pre-seeded `Truncated`
-    // outcome. Innermost-first pop order is what preserves the parent/child
-    // hierarchy in the truncated tail; the resulting tree shape matches
-    // what we'd have got from a complete stream, just with `Truncated`
-    // outcomes wherever we lost sight.
+    // EOF transition: drain remaining frames; pre-seeded `Truncated` carries.
     while let Some(frame) = stack.pop() {
         push_into_parent_or_roots(frame, &mut stack, &mut roots);
     }
@@ -264,17 +218,12 @@ fn push_into_parent_or_roots(
     }
 }
 
-/// Format an integer with US-style thousands separators (`53402` →
-/// `"53,402"`). Used for CU values in the renderer and on the
-/// transaction-total header so numbers stay scannable at the kind of
-/// magnitudes Solana transactions tend to land at (1.4M CU budget).
+/// Thousand-separated integer (`53402` -> `"53,402"`). Used wherever CU
+/// values land in user-facing output.
 pub fn with_commas(n: u64) -> String {
     let s = n.to_string();
     let mut out = String::with_capacity(s.len() + s.len() / 3);
     for (i, b) in s.bytes().enumerate() {
-        // Insert a separator before every group of three digits, counting
-        // back from the end. The `i > 0` guard skips a leading comma when
-        // the digit count is a clean multiple of three.
         if i > 0 && (s.len() - i) % 3 == 0 {
             out.push(',');
         }
@@ -283,16 +232,12 @@ pub fn with_commas(n: u64) -> String {
     out
 }
 
-/// Sum of the top-level frames' `compute_units`, or `None` if no frame
-/// contributes a value. Returning `None` distinguishes "no CU data in the
-/// logs" (e.g. a transaction whose only instruction is a native program
-/// like the BPF Loader or a top-level System Program transfer, neither of
-/// which emits `consumed N of M compute units` lines) from the impossible
-/// case of "every BPF program consumed exactly zero".
+/// Sum of top-level frames' `consumed`, or `None` if no frame reported CU
+/// (e.g. an all-native-program transaction). `None` distinguishes "no
+/// data" from the impossible "every program consumed zero".
 ///
-/// Children are intentionally not summed: Solana's per-frame `consumed`
-/// already includes any CPI children's consumption (verified against
-/// `TransactionStatusMeta::compute_units_consumed` / Explorer), so
+/// Children are skipped: per-frame `consumed` is already cumulative over
+/// CPIs (matches `TransactionStatusMeta::compute_units_consumed`), so
 /// descending would double-count.
 pub fn transaction_total_cu(frames: &[CpiFrame]) -> Option<u64> {
     frames
@@ -301,11 +246,8 @@ pub fn transaction_total_cu(frames: &[CpiFrame]) -> Option<u64> {
         .fold(None, |acc, cu| Some(acc.unwrap_or(0) + cu))
 }
 
-/// Transaction-wide CU budget: the `available_at_start` value of the first
-/// top-level frame that had any CU data. For Solana transactions this
-/// equals the per-instruction default (200,000) × instruction count, capped
-/// at 1,400,000, *unless* the tx used `ComputeBudgetInstruction::set_compute_unit_limit`
-/// to override. Returns `None` when no frame reported CU at all.
+/// Transaction CU budget: `available_at_start` of the first top-level
+/// frame with CU data. `None` if no frame reported CU.
 pub fn transaction_compute_budget(frames: &[CpiFrame]) -> Option<u64> {
     frames
         .iter()
@@ -324,11 +266,9 @@ enum Status {
     Failed { message: Option<String> },
 }
 
-/// Decide what kind of line we're looking at. Tokenize on single spaces and
-/// pattern-match the slice shape, anchoring on the keyword positions
-/// (`invoke`/`success`/`failed:`/`consumed` etc. at known indices) rather
-/// than scanning for keywords anywhere in the line. The program id at
-/// token[1] is opaque to us; we never compare against it.
+/// Layer-1 FSA: tokenize on spaces and match the slice shape at known
+/// indices. Malformed structural shapes degrade to `Other` rather than
+/// constructing partial tokens.
 fn classify(log: &str) -> LogLine {
     let tokens: Vec<&str> = log.split(' ').collect();
     match tokens.as_slice() {
@@ -337,11 +277,8 @@ fn classify(log: &str) -> LogLine {
         }
         ["Program", _, "success"] => LogLine::Status(Status::Success),
         ["Program", _, "failed:", ..] => {
-            // `splitn(4, ' ')` peels off the three structural tokens
-            // ("Program", program id, "failed:") and hands back the rest as
-            // a slice of the original log. We extract just enough to
-            // disambiguate the line shape; the message body comes through
-            // unmodified, whatever whitespace the runtime used.
+            // Pass the message body through unmodified, whatever whitespace
+            // the runtime used.
             let raw = log.splitn(4, ' ').nth(3).unwrap_or("").trim();
             let message = (!raw.is_empty()).then(|| raw.to_string());
             LogLine::Status(Status::Failed { message })
@@ -355,34 +292,20 @@ fn classify(log: &str) -> LogLine {
             available,
             "compute",
             "units",
-        ] => {
-            // Both values must parse; if either is malformed we fall back to
-            // `Other` rather than constructing a half-known `ComputeUnits`.
-            match (consumed.parse::<u64>(), available.parse::<u64>()) {
-                (Ok(consumed), Ok(available_at_start)) => LogLine::Consumed(ComputeUnits {
-                    consumed,
-                    available_at_start,
-                }),
-                _ => LogLine::Other,
-            }
-        }
+        ] => match (consumed.parse::<u64>(), available.parse::<u64>()) {
+            (Ok(consumed), Ok(available_at_start)) => LogLine::Consumed(ComputeUnits {
+                consumed,
+                available_at_start,
+            }),
+            _ => LogLine::Other,
+        },
         _ => LogLine::Other,
     }
 }
 
-/// Render `frames` as `cargo tree`-style box-art under a synthetic header.
-/// The header acts as a visible parent so the multiple top-level frames a
-/// transaction can contain (one per instruction) hang together as siblings
-/// rather than reading as flush-left strangers.
-///
-/// Rules:
-///   - First line is `header`, verbatim.
-///   - Each frame becomes a child of the header: non-last gets
-///     `CONN_BRANCH` (`├── `), the last gets `CONN_LAST` (`└── `).
-///   - Continuation under a non-last branch uses `SPINE_CONTINUE` (`│   `)
-///     to keep the vertical spine visible. Continuation under a last
-///     branch is `SPINE_END` (`    `); no spine, because nothing further
-///     down branches off it.
+/// `cargo tree`-style box-art under a synthetic header. The header acts as
+/// a visible parent so a transaction's multiple top-level frames read as
+/// siblings rather than flush-left strangers.
 pub fn format_cpi_tree(header: &str, frames: &[CpiFrame]) -> String {
     let mut out = String::new();
     writeln!(out, "{header}").unwrap();
@@ -422,9 +345,8 @@ fn write_frame(out: &mut String, frame: &CpiFrame, prefix: &str, is_last: bool) 
     } else {
         format!("{prefix}{SPINE_CONTINUE}")
     };
-    // Log entries sit between the frame header and any children, in arrival
-    // order. The spine continues to the children when any follow, terminates
-    // otherwise; keeps a stray `│` from dangling under a leaf frame.
+    // `LOG_SPINE_CONTINUE` (`│ `) when children follow; `LOG_SPINE_END`
+    // (`  `) otherwise, to avoid a dangling `│` under a leaf frame.
     let log_spine = if frame.children.is_empty() {
         LOG_SPINE_END
     } else {
@@ -648,6 +570,7 @@ mod tests {
         ];
         let tree = cpi_tree(&logs);
         let out = format_cpi_tree("CPI Tree:", &tree);
+        // TODO: declare tree DOM style
         assert_render_eq(
             &out,
             "

--- a/cli/src/log_tree.rs
+++ b/cli/src/log_tree.rs
@@ -1,0 +1,455 @@
+//! We have a transaction's logs as a flat `Vec<String>` and we want a nested
+//! invocation tree. This module does that fold.
+//!
+//! The runtime emits four kinds of structural lines that we destructure to
+//! build the tree:
+//!
+//! ```text
+//! Program <id> invoke [n]
+//! Program <id> consumed N of M compute units
+//! Program <id> success
+//! Program <id> failed: <message>
+//! ```
+//!
+//! Anything else (a program's own `Program log: ...` messages, `Program
+//! return: ...` data, runtime chatter like `account X signer_key().is_none()`,
+//! etc.) we capture verbatim as a diagnostic attached to whichever frame is
+//! currently open. We don't interpret it further; that's a layer above this
+//! module.
+//!
+//! When a program does a CPI, the child's `invoke` / `success` lines
+//! interleave with the parent's own logging, and the bracket in `invoke [n]`
+//! reflects the call depth. (We don't actually use the bracket value to drive
+//! the parse; it's only there to validate that the line is shaped like an
+//! invoke. The depth falls out of how the stack pushes and pops naturally.)
+//!
+//! Everything that follows rests on one runtime invariant: a callee cannot
+//! outlive its caller. SBF physically can't return control to a parent CPI
+//! until every child it kicked off has finished. So the sequence of `invoke`
+//! and `success` / `failed:` lines is **well-nested**: every "open" is
+//! matched by a "close" that arrives before any earlier "open" closes. (Same
+//! property that makes `({[]})` a legal arithmetic expression and `({)[]}` a
+//! nonsense one.)
+//!
+//! Equivalently: closes happen in reverse order of opens. Which is exactly
+//! the access pattern of a stack, so the algorithm essentially writes itself:
+//!
+//!   - `invoke` -> push a new frame
+//!   - `success` or `failed:` -> pop (it'll always be the right one to close,
+//!     by the invariant above)
+//!   - everything in between -> annotate whatever is on top
+//!
+//! The only way the brackets fail to balance is truncation: the log stream
+//! cuts off mid-transaction. (The process died, the RPC dropped frames,
+//! the buffer filled up; take your pick.) For that case, every frame gets
+//! seeded with `outcome: Truncated` on push, so anything left on the stack
+//! at end-of-stream bubbles up with a useful, distinguishable outcome rather
+//! than being silently dropped or quietly misattributed as `Failed`. (It
+//! didn't technically fail; we just don't know what happened to it. "Absence
+//! of evidence" and "evidence of absence" are not the same thing, and the
+//! consumer of this tree may care about that distinction.)
+
+use {
+    solana_pubkey::Pubkey,
+    std::{fmt::Write, str::FromStr},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CpiFrame {
+    pub program_id: Pubkey,
+    pub outcome: CpiOutcome,
+    pub compute_units: Option<u64>,
+    pub instruction_name: Option<String>,
+    pub children: Vec<CpiFrame>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CpiOutcome {
+    Success,
+    Failed {
+        message: Option<String>,
+        diagnostics: Vec<String>,
+    },
+    /// Frame whose closing line never arrived: the stream ended with this
+    /// frame still open. Distinct from `Failed` because we don't actually
+    /// know what happened to it; we just lost sight of it.
+    Truncated,
+}
+
+/// Walk the log stream once with a stack of in-progress frames. The mapping
+/// is the obvious one: `invoke` pushes a frame, `success` / `failed:` pops
+/// it, `consumed` and `Program log: ...` lines annotate whatever is on top.
+///
+/// `diags` runs as a second stack parallel to `stack` (one buffer per frame).
+/// Keeping the two separate means a successful pop can throw the diag buffer
+/// away cheaply rather than having to clone it into the frame just to then
+/// discard it; the buffer only ever gets embedded into a frame when the
+/// frame ends in `Failed`.
+pub fn cpi_tree(logs: &[String]) -> Vec<CpiFrame> {
+    let mut roots: Vec<CpiFrame> = Vec::new();
+    let mut stack: Vec<CpiFrame> = Vec::new();
+    let mut diags: Vec<Vec<String>> = Vec::new();
+
+    for log in logs {
+        if let Some(name) = log.strip_prefix("Program log: Instruction: ") {
+            // The `Instruction:` line is what programs that follow the
+            // convention (Anchor's dispatch macro, SPL Token) emit right
+            // before the handler body runs. Anything we've buffered up to
+            // this point is by definition pre-handler chatter, so clear it:
+            // we want this frame's diagnostics to be what the handler said,
+            // not what came before. In practice the buffer is usually empty
+            // here (Anchor and SPL Token don't emit logs between invoke and
+            // their Instruction: line), so this is mostly defensive.
+            if let Some(top) = diags.last_mut() {
+                top.clear();
+            }
+            // First `Instruction:` line wins. Defensive: in practice the
+            // programs I've looked at (Anchor's dispatch, SPL Token) emit
+            // exactly one such line per handler, so this check is just
+            // belt-and-braces. But if a program ever does emit a second one
+            // mid-handler, the first one is almost certainly the canonical
+            // name and last-wins would be the wrong default.
+            if let Some(frame) = stack.last_mut() {
+                if frame.instruction_name.is_none() {
+                    frame.instruction_name = Some(name.to_string());
+                }
+            }
+            continue;
+        }
+        if let Some(diag) = log.strip_prefix("Program log: ") {
+            if let Some(top) = diags.last_mut() {
+                top.push(diag.to_string());
+            }
+            continue;
+        }
+
+        match classify(log) {
+            LogLine::Invoke(program) => {
+                let Ok(program_id) = Pubkey::from_str(&program) else {
+                    continue;
+                };
+                // Pre-seed `outcome: Truncated`. If the frame never sees a
+                // status line (because the stream got cut off), this is the
+                // outcome it'll bubble up with, no special case in the
+                // happy path needed.
+                stack.push(CpiFrame {
+                    program_id,
+                    outcome: CpiOutcome::Truncated,
+                    compute_units: None,
+                    instruction_name: None,
+                    children: Vec::new(),
+                });
+                diags.push(Vec::new());
+            }
+            LogLine::Consumed(cu) => {
+                if let Some(frame) = stack.last_mut() {
+                    frame.compute_units = Some(cu);
+                }
+            }
+            LogLine::Status(status) => {
+                let Some(mut frame) = stack.pop() else {
+                    continue;
+                };
+                let frame_diags = diags.pop().unwrap_or_default();
+                frame.outcome = match status {
+                    Status::Success => CpiOutcome::Success,
+                    Status::Failed { message } => CpiOutcome::Failed {
+                        message,
+                        diagnostics: frame_diags,
+                    },
+                };
+                push_into_parent_or_roots(frame, &mut stack, &mut roots);
+            }
+            LogLine::Other => {
+                // The catch-all: lines that aren't `invoke` / `consumed` /
+                // status and don't start with `Program log:`. In practice
+                // this is where `process_instruction:` and `solana_runtime:`
+                // chatter ends up, plus the runtime's bare diagnostic lines
+                // (the classic example being `account X signer_key().is_none()`
+                // emitted before a Config-program signer-failure). These are
+                // often the most useful thing in a failure trace, so we keep
+                // them as raw diagnostics on the current frame.
+                //
+                // No current frame ⇒ nowhere to attach ⇒ drop it. (Doesn't
+                // happen today, but it's a defined behavior rather than a
+                // panic so future runtime changes can't blow us up here.)
+                if let Some(top) = diags.last_mut() {
+                    top.push(log.clone());
+                }
+            }
+        }
+    }
+
+    // End-of-stream drain. Anything still on the stack at this point is a
+    // frame we never saw close, so its pre-seeded `Truncated` outcome is what
+    // gets used. The innermost frame pops first, which means it attaches to
+    // its truncated parent as a child before the parent itself bubbles up;
+    // the resulting hierarchy mirrors what we *would* have seen if the
+    // stream had completed.
+    while let Some(frame) = stack.pop() {
+        let _ = diags.pop();
+        push_into_parent_or_roots(frame, &mut stack, &mut roots);
+    }
+
+    roots
+}
+
+fn push_into_parent_or_roots(
+    frame: CpiFrame,
+    stack: &mut Vec<CpiFrame>,
+    roots: &mut Vec<CpiFrame>,
+) {
+    if let Some(parent) = stack.last_mut() {
+        parent.children.push(frame);
+    } else {
+        roots.push(frame);
+    }
+}
+
+enum LogLine {
+    Invoke(String),
+    Consumed(u64),
+    Status(Status),
+    Other,
+}
+
+enum Status {
+    Success,
+    Failed { message: Option<String> },
+}
+
+/// Decide what kind of line we're looking at. Tokenize on single spaces and
+/// pattern-match the slice shape, anchoring on the keyword positions
+/// (`invoke`/`success`/`failed:`/`consumed` etc. at known indices) rather
+/// than scanning for keywords anywhere in the line. The program id at
+/// token[1] is opaque to us; we never compare against it.
+fn classify(log: &str) -> LogLine {
+    let tokens: Vec<&str> = log.split(' ').collect();
+    match tokens.as_slice() {
+        ["Program", _name, "invoke", bracket] if parse_depth_bracket(bracket).is_some() => {
+            LogLine::Invoke(tokens[1].to_string())
+        }
+        ["Program", _, "success"] => LogLine::Status(Status::Success),
+        ["Program", _, "failed:", ..] => {
+            // `splitn(4, ' ')` peels off the three structural tokens
+            // ("Program", program id, "failed:") and hands back the rest as
+            // a slice of the original log. We extract just enough to
+            // disambiguate the line shape; the message body comes through
+            // unmodified, whatever whitespace the runtime used.
+            let raw = log.splitn(4, ' ').nth(3).unwrap_or("").trim();
+            let message = (!raw.is_empty()).then(|| raw.to_string());
+            LogLine::Status(Status::Failed { message })
+        }
+        ["Program", _, "consumed", cu, "of", _, "compute", "units"] => {
+            cu.parse::<u64>().map_or(LogLine::Other, LogLine::Consumed)
+        }
+        _ => LogLine::Other,
+    }
+}
+
+/// Render `frames` as `cargo tree`-style box-art. Three rules cover it:
+///
+///   - root frames sit flush at column zero. (Yes, one transaction can have
+///     several roots; each top-level instruction is its own root.)
+///   - non-last children use `├── `, last child uses `└── `
+///   - continuation under a non-last branch uses `│   ` to keep the vertical
+///     spine visible. Continuation under a last branch is plain spaces; no
+///     spine, because nothing further down branches off it.
+pub fn format_cpi_tree(frames: &[CpiFrame]) -> String {
+    let mut out = String::new();
+    for frame in frames {
+        write_frame(&mut out, frame, "", true, true);
+    }
+    out
+}
+
+fn write_frame(out: &mut String, frame: &CpiFrame, prefix: &str, is_last: bool, is_root: bool) {
+    let connector = if is_root {
+        ""
+    } else if is_last {
+        "└── "
+    } else {
+        "├── "
+    };
+    write!(out, "{prefix}{connector}").unwrap();
+    if let Some(name) = &frame.instruction_name {
+        write!(out, "{name} ").unwrap();
+    }
+    match &frame.outcome {
+        CpiOutcome::Success => {}
+        CpiOutcome::Failed { message, .. } => {
+            write!(out, "FAILED: {} ", message.as_deref().unwrap_or("")).unwrap();
+        }
+        CpiOutcome::Truncated => write!(out, "TRUNCATED ").unwrap(),
+    }
+    if let Some(cu) = frame.compute_units {
+        write!(out, "({cu} CU) ").unwrap();
+    }
+    writeln!(out, "{}", frame.program_id).unwrap();
+
+    let child_prefix = if is_root {
+        String::new()
+    } else if is_last {
+        format!("{prefix}    ")
+    } else {
+        format!("{prefix}│   ")
+    };
+    let last_idx = frame.children.len().saturating_sub(1);
+    for (i, child) in frame.children.iter().enumerate() {
+        write_frame(out, child, &child_prefix, i == last_idx, false);
+    }
+}
+
+fn parse_depth_bracket(token: &str) -> Option<usize> {
+    token
+        .strip_prefix('[')?
+        .strip_suffix(']')?
+        .parse::<usize>()
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lines(s: &[&str]) -> Vec<String> {
+        s.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn empty_stream_yields_empty_tree() {
+        assert!(cpi_tree(&[]).is_empty());
+    }
+
+    #[test]
+    fn nested_cpi_attaches_child_under_parent() {
+        let logs = lines(&[
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 invoke [1]",
+            "Program log: Instruction: Mint",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+            "Program log: Instruction: MintTo",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 1500 of 198000 compute \
+             units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 consumed 5000 of 200000 compute \
+             units",
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 success",
+        ]);
+        let tree = cpi_tree(&logs);
+        assert_eq!(tree.len(), 1);
+        assert_eq!(tree[0].instruction_name.as_deref(), Some("Mint"));
+        assert_eq!(tree[0].compute_units, Some(5000));
+        assert_eq!(tree[0].outcome, CpiOutcome::Success);
+        assert_eq!(tree[0].children.len(), 1);
+        assert_eq!(
+            tree[0].children[0].instruction_name.as_deref(),
+            Some("MintTo")
+        );
+    }
+
+    #[test]
+    fn failed_frame_carries_message_and_diagnostics() {
+        let logs = lines(&[
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 invoke [1]",
+            "Program log: Instruction: Withdraw",
+            "Program log: AnchorError caused by account: vault. Error Code: ConstraintHasOne.",
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 failed: custom program error: \
+             0x7d1",
+        ]);
+        let tree = cpi_tree(&logs);
+        let CpiOutcome::Failed {
+            message,
+            diagnostics,
+        } = &tree[0].outcome
+        else {
+            panic!("expected Failed");
+        };
+        assert_eq!(message.as_deref(), Some("custom program error: 0x7d1"));
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].contains("ConstraintHasOne"));
+    }
+
+    #[test]
+    fn unclosed_frames_drain_as_truncated() {
+        let logs = lines(&[
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 invoke [1]",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+        ]);
+        let tree = cpi_tree(&logs);
+        assert_eq!(tree.len(), 1);
+        assert_eq!(tree[0].outcome, CpiOutcome::Truncated);
+        assert_eq!(tree[0].children[0].outcome, CpiOutcome::Truncated);
+    }
+
+    #[test]
+    fn unprefixed_runtime_diagnostic_captured() {
+        let logs = lines(&[
+            "Program Config1111111111111111111111111111111111111 invoke [1]",
+            "account J2kSTGu6eod7MUAy2nNZhFW5ye5ZdhAri6bcJJHRhhXy signer_key().is_none()",
+            "Program Config1111111111111111111111111111111111111 failed: missing required \
+             signature for instruction",
+        ]);
+        let tree = cpi_tree(&logs);
+        let CpiOutcome::Failed { diagnostics, .. } = &tree[0].outcome else {
+            panic!("expected Failed");
+        };
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].contains("signer_key().is_none()"));
+    }
+
+    #[test]
+    fn format_nested_grandchild_extends_pipe_through_non_last_branch() {
+        let logs = lines(&[
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 invoke [1]",
+            "Program log: Instruction: Mint",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+            "Program log: Instruction: MintTo",
+            "Program 11111111111111111111111111111111 invoke [3]",
+            "Program 11111111111111111111111111111111 consumed 50 of 197000 compute units",
+            "Program 11111111111111111111111111111111 success",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 1500 of 198000 compute \
+             units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program 22222222222222222222222222222222222222222222 invoke [2]",
+            "Program 22222222222222222222222222222222222222222222 consumed 100 of 198000 compute \
+             units",
+            "Program 22222222222222222222222222222222222222222222 success",
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 consumed 5000 of 200000 compute \
+             units",
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 success",
+        ]);
+        let tree = cpi_tree(&logs);
+        let out = format_cpi_tree(&tree);
+        assert_eq!(
+            out,
+            "Mint (5000 CU) GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2\n├── MintTo (1500 CU) \
+             TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\n│   └── (50 CU) \
+             11111111111111111111111111111111\n└── (100 CU) \
+             22222222222222222222222222222222222222222222\n"
+        );
+    }
+
+    #[test]
+    fn format_failed_frame_shows_message() {
+        let logs = lines(&[
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 invoke [1]",
+            "Program log: Instruction: Withdraw",
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 consumed 3100 of 200000 compute \
+             units",
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 failed: custom program error: \
+             0x7d1",
+        ]);
+        let tree = cpi_tree(&logs);
+        let out = format_cpi_tree(&tree);
+        assert_eq!(
+            out,
+            "Withdraw FAILED: custom program error: 0x7d1 (3100 CU) \
+             GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2\n"
+        );
+    }
+
+    #[test]
+    fn format_empty_tree_yields_empty_string() {
+        assert_eq!(format_cpi_tree(&[]), "");
+    }
+}

--- a/cli/src/log_tree.rs
+++ b/cli/src/log_tree.rs
@@ -77,11 +77,16 @@ const LOG_SPINE_CONTINUE: &str = "│ ";
 const LOG_SPINE_END: &str = "  ";
 
 /// Both values from a `Consumed(N, M)` token. Either both are emitted
-/// (BPF programs) or neither (native programs outside the SBPF VM).
+/// (BPF programs) or neither (native programs outside the SBPF VM:
+/// `ComputeBudget`, `BpfLoader`, precompiles). The native-program gap is
+/// load-bearing for the totals below; see `transaction_total_cu`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ComputeUnits {
-    /// CU consumed by this frame. Cumulative over CPI children, so summing
-    /// top-level frames matches `TransactionStatusMeta::compute_units_consumed`.
+    /// CU consumed by this frame as reported by the SBPF VM. Cumulative
+    /// over CPI children of the same frame (so descending the tree would
+    /// double-count), but does NOT include native-program CU sandwiched
+    /// at the top level: `ComputeBudget` instructions, precompiles, and
+    /// the `BpfLoader` never emit `Program X consumed N of M` lines.
     pub consumed: u64,
     /// CU remaining in the transaction's budget when this frame started.
     /// First top-level frame: full budget. Later frames: running remainder.
@@ -236,9 +241,18 @@ pub fn with_commas(n: u64) -> String {
 /// (e.g. an all-native-program transaction). `None` distinguishes "no
 /// data" from the impossible "every program consumed zero".
 ///
-/// Children are skipped: per-frame `consumed` is already cumulative over
-/// CPIs (matches `TransactionStatusMeta::compute_units_consumed`), so
-/// descending would double-count.
+/// Children are skipped because per-frame `consumed` is already cumulative
+/// over CPIs; descending would double-count.
+///
+/// N.B. this is BPF-visible CU, not transaction-total CU. Native-program
+/// instructions at the top level (`ComputeBudget`, precompiles, `BpfLoader`)
+/// don't emit `Program X consumed N of M compute units` lines, so their cost
+/// is invisible here. `TransactionStatusMeta::compute_units_consumed` sums
+/// everything (native + BPF) and is generally higher than this value; the
+/// two only agree for an all-BPF transaction with no `ComputeBudget` prefix.
+/// We surface the BPF-visible number because that's all `logsSubscribe`
+/// gives us; consumers that need parity with the explorer must hit
+/// `getTransaction` for the authoritative meta.
 pub fn transaction_total_cu(frames: &[CpiFrame]) -> Option<u64> {
     frames
         .iter()

--- a/cli/src/log_tree.rs
+++ b/cli/src/log_tree.rs
@@ -11,48 +11,71 @@
 //! Program <id> failed: <message>
 //! ```
 //!
-//! Anything else (a program's own `Program log: ...` messages, `Program
-//! return: ...` data, runtime chatter like `account X signer_key().is_none()`,
-//! etc.) we capture verbatim as a diagnostic attached to whichever frame is
-//! currently open. We don't interpret it further; that's a layer above this
-//! module.
+//! Everything else a program (or the runtime) emits while a frame is open
+//! lands in `frame.logs`, a `Vec<FrameLog>` that preserves arrival order
+//! across two variants:
+//!   - `FrameLog::Msg(String)` for `Program log: <text>` (`msg!` /
+//!     `sol_log`), plus any unprefixed runtime diagnostic emitted in an
+//!     error-condition path (a line without our structural `Program `
+//!     prefix).
+//!   - `FrameLog::Data(String)` for `Program data: <base64>`
+//!     (`sol_log_data`, which Anchor's `emit!` macro uses).
 //!
-//! When a program does a CPI, the child's `invoke` / `success` lines
+//! Both kinds are preserved regardless of outcome, and crucially the
+//! interleaving order between Msg and Data is preserved. 
+//!
+//! When a program executes a CPI, the child's `invoke` / `success` lines
 //! interleave with the parent's own logging, and the bracket in `invoke [n]`
 //! reflects the call depth. (We don't actually use the bracket value to drive
 //! the parse; it's only there to validate that the line is shaped like an
 //! invoke. The depth falls out of how the stack pushes and pops naturally.)
 //!
-//! Everything that follows rests on one runtime invariant: a callee cannot
-//! outlive its caller. SBF physically can't return control to a parent CPI
-//! until every child it kicked off has finished. So the sequence of `invoke`
-//! and `success` / `failed:` lines is **well-nested**: every "open" is
-//! matched by a "close" that arrives before any earlier "open" closes. (Same
-//! property that makes `({[]})` a legal arithmetic expression and `({)[]}` a
-//! nonsense one.)
+//! All that follows rests on one runtime invariant: a callee cannot outlive its
+//! caller. SBF physically can't return control to a parent CPI until every
+//! child it kicked off has finished. So the sequence of `invoke` and `success`
+//! / `failed:` lines is **well-nested**: every "open" is matched by a "close"
+//! that arrives before any earlier "open" closes. (Same property that makes
+//! `({[]})` a legal arithmetic expression and `({)[]}` a nonsensical one.)
 //!
-//! Equivalently: closes happen in reverse order of opens. Which is exactly
-//! the access pattern of a stack, so the algorithm essentially writes itself:
+//! Equivalently: closes happen in reverse order of opens. Which is the access
+//! pattern of a stack, so the algorithm essentially writes itself:
 //!
 //!   - `invoke` -> push a new frame
 //!   - `success` or `failed:` -> pop (it'll always be the right one to close,
 //!     by the invariant above)
 //!   - everything in between -> annotate whatever is on top
 //!
-//! The only way the brackets fail to balance is truncation: the log stream
-//! cuts off mid-transaction. (The process died, the RPC dropped frames,
-//! the buffer filled up; take your pick.) For that case, every frame gets
-//! seeded with `outcome: Truncated` on push, so anything left on the stack
-//! at end-of-stream bubbles up with a useful, distinguishable outcome rather
-//! than being silently dropped or quietly misattributed as `Failed`. (It
-//! didn't technically fail; we just don't know what happened to it. "Absence
-//! of evidence" and "evidence of absence" are not the same thing, and the
-//! consumer of this tree may care about that distinction.)
+//! The only way the brackets fail to balance is truncation: the log stream cuts
+//! off mid-transaction. (The process died, the RPC dropped frames, the buffer
+//! filled up; take your pick.) For that case, every frame is initialized with
+//! `outcome: Truncated` on push, so anything left on the stack at end-of-stream
+//! bubbles up with a useful, distinguishable outcome rather than being silently
+//! dropped or quietly misattributed as `Failed`. (It didn't technically fail;
+//! we just don't know what happened to it. "Absence of evidence" and "evidence
+//! of absence" are not the same thing, and the consumer of this tree may care
+//! about that distinction.)
 
 use {
     solana_pubkey::Pubkey,
     std::{fmt::Write, str::FromStr},
 };
+
+// Connectors are written on the same line as a child's content. Spines are
+// continuation prefixes written under a frame on lines that follow its
+// header (other children, or the frame's own log entries).
+//
+// `CONN_BRANCH`/`CONN_LAST` are the standard `cargo tree` glyphs. Each is
+// 4 columns wide so that nested frames align consistently.
+const CONN_BRANCH: &str = "├── ";
+const CONN_LAST: &str = "└── ";
+const SPINE_CONTINUE: &str = "│   ";
+const SPINE_END: &str = "    ";
+
+// Log-block spines (used for the `>> log:` / `>> data:` rows). 2 columns
+// each so they slot just under the frame header without trying to align
+// with sibling connectors.
+const LOG_SPINE_CONTINUE: &str = "│ ";
+const LOG_SPINE_END: &str = "  ";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CpiFrame {
@@ -60,7 +83,30 @@ pub struct CpiFrame {
     pub outcome: CpiOutcome,
     pub compute_units: Option<u64>,
     pub instruction_name: Option<String>,
+    /// Order preserving record of `msg!` strings, `emit!` payloads, and
+    /// unprefixed runtime diagnostics emitted while this frame was on the
+    /// stack. Both `Msg` and `Data` variants share the same Vec so the
+    /// interleaving the runtime produced survives the parse; a consumer can
+    /// reconstruct the flat-log content for this frame from `logs` alone.
+    /// Survives every outcome (unlike a diagnostics buffer that gets discarded
+    /// on success).
+    pub logs: Vec<FrameLog>,
     pub children: Vec<CpiFrame>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FrameLog {
+    /// `Program log: <text>` from `msg!` / `sol_log` (excluding the special
+    /// `Program log: Instruction: <name>` form, which populates
+    /// `CpiFrame::instruction_name`). The parser also routes any unprefixed
+    /// runtime diagnostic into this variant (e.g. error-condition messages
+    /// without the structural `Program ` prefix): they don't have a
+    /// destructured shape, and `Msg` keeps the renderer logic uniform.
+    Msg(String),
+    /// `Program data: <base64>` from `sol_log_data`. Anchor's `emit!` macro
+    /// boils down to this syscall. We use the literal log term "data" rather
+    /// than "events"; event semantics layer above us via per-program IDLs.
+    Data(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -68,7 +114,6 @@ pub enum CpiOutcome {
     Success,
     Failed {
         message: Option<String>,
-        diagnostics: Vec<String>,
     },
     /// Frame whose closing line never arrived: the stream ended with this
     /// frame still open. Distinct from `Failed` because we don't actually
@@ -78,47 +123,49 @@ pub enum CpiOutcome {
 
 /// Walk the log stream once with a stack of in-progress frames. The mapping
 /// is the obvious one: `invoke` pushes a frame, `success` / `failed:` pops
-/// it, `consumed` and `Program log: ...` lines annotate whatever is on top.
-///
-/// `diags` runs as a second stack parallel to `stack` (one buffer per frame).
-/// Keeping the two separate means a successful pop can throw the diag buffer
-/// away cheaply rather than having to clone it into the frame just to then
-/// discard it; the buffer only ever gets embedded into a frame when the
-/// frame ends in `Failed`.
+/// it, `consumed` annotates the top frame's compute count, and
+/// `Program log:` / `Program data:` / unprefixed runtime chatter all append
+/// to the top frame's `logs` (in arrival order, preserving the interleaving
+/// the runtime emitted).
 pub fn cpi_tree(logs: &[String]) -> Vec<CpiFrame> {
     let mut roots: Vec<CpiFrame> = Vec::new();
     let mut stack: Vec<CpiFrame> = Vec::new();
-    let mut diags: Vec<Vec<String>> = Vec::new();
 
     for log in logs {
         if let Some(name) = log.strip_prefix("Program log: Instruction: ") {
             // The `Instruction:` line is what programs that follow the
             // convention (Anchor's dispatch macro, SPL Token) emit right
-            // before the handler body runs. Anything we've buffered up to
-            // this point is by definition pre-handler chatter, so clear it:
-            // we want this frame's diagnostics to be what the handler said,
-            // not what came before. In practice the buffer is usually empty
-            // here (Anchor and SPL Token don't emit logs between invoke and
-            // their Instruction: line), so this is mostly defensive.
-            if let Some(top) = diags.last_mut() {
-                top.clear();
-            }
-            // First `Instruction:` line wins. Defensive: in practice the
-            // programs I've looked at (Anchor's dispatch, SPL Token) emit
-            // exactly one such line per handler, so this check is just
-            // belt-and-braces. But if a program ever does emit a second one
-            // mid-handler, the first one is almost certainly the canonical
-            // name and last-wins would be the wrong default.
+            // before the handler body runs. Anything `Msg` we've already
+            // buffered is pre-handler chatter and isn't what the user wants
+            // to see in this frame's logs; clear those. Any `Data` entries
+            // we keep, since `emit!` before the dispatcher's `Instruction:`
+            // line is an unusual but legitimate emission worth preserving.
+            //
+            // Start Condition
             if let Some(frame) = stack.last_mut() {
+                frame
+                    .logs
+                    .retain(|entry| !matches!(entry, FrameLog::Msg(_)));
+                // First `Instruction:` line wins. In practice the programs
+                // I've looked at (Anchor's dispatch, SPL Token) emit exactly
+                // one per handler; this check is belt-and-braces in case a
+                // program ever emits a second one mid-handler (the first
+                // would still be the canonical dispatcher name).
                 if frame.instruction_name.is_none() {
                     frame.instruction_name = Some(name.to_string());
                 }
             }
             continue;
         }
-        if let Some(diag) = log.strip_prefix("Program log: ") {
-            if let Some(top) = diags.last_mut() {
-                top.push(diag.to_string());
+        if let Some(text) = log.strip_prefix("Program log: ") {
+            if let Some(frame) = stack.last_mut() {
+                frame.logs.push(FrameLog::Msg(text.to_string()));
+            }
+            continue;
+        }
+        if let Some(payload) = log.strip_prefix("Program data: ") {
+            if let Some(frame) = stack.last_mut() {
+                frame.logs.push(FrameLog::Data(payload.to_string()));
             }
             continue;
         }
@@ -128,7 +175,7 @@ pub fn cpi_tree(logs: &[String]) -> Vec<CpiFrame> {
                 let Ok(program_id) = Pubkey::from_str(&program) else {
                     continue;
                 };
-                // Pre-seed `outcome: Truncated`. If the frame never sees a
+                // Initialize `outcome: Truncated`. If the frame never sees a
                 // status line (because the stream got cut off), this is the
                 // outcome it'll bubble up with, no special case in the
                 // happy path needed.
@@ -137,9 +184,9 @@ pub fn cpi_tree(logs: &[String]) -> Vec<CpiFrame> {
                     outcome: CpiOutcome::Truncated,
                     compute_units: None,
                     instruction_name: None,
+                    logs: Vec::new(),
                     children: Vec::new(),
                 });
-                diags.push(Vec::new());
             }
             LogLine::Consumed(cu) => {
                 if let Some(frame) = stack.last_mut() {
@@ -150,44 +197,37 @@ pub fn cpi_tree(logs: &[String]) -> Vec<CpiFrame> {
                 let Some(mut frame) = stack.pop() else {
                     continue;
                 };
-                let frame_diags = diags.pop().unwrap_or_default();
                 frame.outcome = match status {
                     Status::Success => CpiOutcome::Success,
-                    Status::Failed { message } => CpiOutcome::Failed {
-                        message,
-                        diagnostics: frame_diags,
-                    },
+                    Status::Failed { message } => CpiOutcome::Failed { message },
                 };
                 push_into_parent_or_roots(frame, &mut stack, &mut roots);
             }
             LogLine::Other => {
                 // The catch-all: lines that aren't `invoke` / `consumed` /
-                // status and don't start with `Program log:`. In practice
-                // this is where `process_instruction:` and `solana_runtime:`
-                // chatter ends up, plus the runtime's bare diagnostic lines
-                // (the classic example being `account X signer_key().is_none()`
-                // emitted before a Config-program signer-failure). These are
-                // often the most useful thing in a failure trace, so we keep
-                // them as raw diagnostics on the current frame.
+                // status and don't start with `Program log:` or `Program
+                // data:`. Covers any unprefixed runtime diagnostic that
+                // happens to land in the log stream (an error-condition
+                // line, for example). Bucketed as `Msg` because there's no
+                // structural shape to destructure and the renderer treats
+                // it the same as any other text payload on a frame.
                 //
-                // No current frame ⇒ nowhere to attach ⇒ drop it. (Doesn't
-                // happen today, but it's a defined behavior rather than a
+                // No current frame -> nowhere to attach -> drop it. (Doesn't
+                // happen today, but it's defined behavior rather than a
                 // panic so future runtime changes can't blow us up here.)
-                if let Some(top) = diags.last_mut() {
-                    top.push(log.clone());
+                if let Some(frame) = stack.last_mut() {
+                    frame.logs.push(FrameLog::Msg(log.clone()));
                 }
             }
         }
     }
 
-    // End-of-stream drain. Anything still on the stack at this point is a
-    // frame we never saw close, so its pre-seeded `Truncated` outcome is what
-    // gets used. The innermost frame pops first, which means it attaches to
-    // its truncated parent as a child before the parent itself bubbles up;
-    // the resulting hierarchy mirrors what we *would* have seen if the
-    // stream had completed.
+    // Drain whatever's still on the stack with its pre-seeded `Truncated`
+    // outcome. Innermost-first pop order is what preserves the parent/child
+    // hierarchy in the truncated tail; the resulting tree shape matches
+    // what we'd have got from a complete stream, just with `Truncated`
+    // outcomes wherever we lost sight.
     while let Some(frame) = stack.pop() {
-        let _ = diags.pop();
         push_into_parent_or_roots(frame, &mut stack, &mut roots);
     }
 
@@ -247,30 +287,31 @@ fn classify(log: &str) -> LogLine {
     }
 }
 
-/// Render `frames` as `cargo tree`-style box-art. Three rules cover it:
+/// Render `frames` as `cargo tree`-style box-art under a synthetic header.
+/// The header acts as a visible parent so the multiple top-level frames a
+/// transaction can contain (one per instruction) hang together as siblings
+/// rather than reading as flush-left strangers.
 ///
-///   - root frames sit flush at column zero. (Yes, one transaction can have
-///     several roots; each top-level instruction is its own root.)
-///   - non-last children use `├── `, last child uses `└── `
-///   - continuation under a non-last branch uses `│   ` to keep the vertical
-///     spine visible. Continuation under a last branch is plain spaces; no
-///     spine, because nothing further down branches off it.
-pub fn format_cpi_tree(frames: &[CpiFrame]) -> String {
+/// Rules:
+///   - First line is `header`, verbatim.
+///   - Each frame becomes a child of the header: non-last gets
+///     `CONN_BRANCH` (`├── `), the last gets `CONN_LAST` (`└── `).
+///   - Continuation under a non-last branch uses `SPINE_CONTINUE` (`│   `)
+///     to keep the vertical spine visible. Continuation under a last
+///     branch is `SPINE_END` (`    `); no spine, because nothing further
+///     down branches off it.
+pub fn format_cpi_tree(header: &str, frames: &[CpiFrame]) -> String {
     let mut out = String::new();
-    for frame in frames {
-        write_frame(&mut out, frame, "", true, true);
+    writeln!(out, "{header}").unwrap();
+    let last_idx = frames.len().saturating_sub(1);
+    for (i, frame) in frames.iter().enumerate() {
+        write_frame(&mut out, frame, "", i == last_idx);
     }
     out
 }
 
-fn write_frame(out: &mut String, frame: &CpiFrame, prefix: &str, is_last: bool, is_root: bool) {
-    let connector = if is_root {
-        ""
-    } else if is_last {
-        "└── "
-    } else {
-        "├── "
-    };
+fn write_frame(out: &mut String, frame: &CpiFrame, prefix: &str, is_last: bool) {
+    let connector = if is_last { CONN_LAST } else { CONN_BRANCH };
     write!(out, "{prefix}{connector}").unwrap();
     if let Some(name) = &frame.instruction_name {
         write!(out, "{name} ").unwrap();
@@ -287,16 +328,32 @@ fn write_frame(out: &mut String, frame: &CpiFrame, prefix: &str, is_last: bool, 
     }
     writeln!(out, "{}", frame.program_id).unwrap();
 
-    let child_prefix = if is_root {
-        String::new()
-    } else if is_last {
-        format!("{prefix}    ")
+    let child_prefix = if is_last {
+        format!("{prefix}{SPINE_END}")
     } else {
-        format!("{prefix}│   ")
+        format!("{prefix}{SPINE_CONTINUE}")
     };
+    // Log entries sit between the frame header and any children, in arrival
+    // order. The spine continues to the children when any follow, terminates
+    // otherwise; keeps a stray `│` from dangling under a leaf frame.
+    let log_spine = if frame.children.is_empty() {
+        LOG_SPINE_END
+    } else {
+        LOG_SPINE_CONTINUE
+    };
+    for entry in &frame.logs {
+        match entry {
+            FrameLog::Msg(text) => {
+                writeln!(out, "{child_prefix}{log_spine}>> log:  {text}").unwrap();
+            }
+            FrameLog::Data(payload) => {
+                writeln!(out, "{child_prefix}{log_spine}>> data: {payload}").unwrap();
+            }
+        }
+    }
     let last_idx = frame.children.len().saturating_sub(1);
     for (i, child) in frame.children.iter().enumerate() {
-        write_frame(out, child, &child_prefix, i == last_idx, false);
+        write_frame(out, child, &child_prefix, i == last_idx);
     }
 }
 
@@ -310,10 +367,93 @@ fn parse_depth_bracket(token: &str) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    // Aliased to dodge the crate-root `pubkey!` macro_rules in `lib.rs`,
+    // which has a totally unrelated clap-builder signature.
+    use {super::*, solana_pubkey::pubkey as pk};
 
-    fn lines(s: &[&str]) -> Vec<String> {
-        s.iter().map(|x| x.to_string()).collect()
+    // ---- Pubkey fixtures ----
+    // Named program ids referenced across tests. The `pk!` macro is
+    // `solana_pubkey::pubkey!`, which rejects invalid base58 or wrong byte
+    // length at compile time, so a typo here fails the build rather than
+    // silently dropping a frame from a test's expected tree.
+    const SYSTEM_PROG: Pubkey = pk!("11111111111111111111111111111111");
+    const TOKEN_PROG: Pubkey = pk!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+    const CONFIG_PROG: Pubkey = pk!("Config1111111111111111111111111111111111111");
+    // Generic test programs (no specific real-world program). The identity
+    // doesn't matter to the parser; we just need stable distinct pubkeys.
+    const PROG_A: Pubkey = pk!("GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2");
+    const PROG_B: Pubkey = pk!("6Ng7PojJBe6XjbsR65ftKKBpHUe2erD7E5dgGdMUjcgg");
+    const PROG_C: Pubkey = pk!("22222222222222222222222222222222222222222222");
+
+    // ---- Flat-log-line constructors ----
+    // The total-CU value in `consumed` doesn't affect parsing; we hard-code a
+    // generic 200000 so call sites stay short.
+    fn invoke(pk: &Pubkey, depth: u8) -> String {
+        format!("Program {pk} invoke [{depth}]")
+    }
+    fn instruction(name: &str) -> String {
+        format!("Program log: Instruction: {name}")
+    }
+    fn program_log(text: &str) -> String {
+        format!("Program log: {text}")
+    }
+    fn program_data(payload: &str) -> String {
+        format!("Program data: {payload}")
+    }
+    fn consumed(pk: &Pubkey, cu: u64) -> String {
+        format!("Program {pk} consumed {cu} of 200000 compute units")
+    }
+    fn success(pk: &Pubkey) -> String {
+        format!("Program {pk} success")
+    }
+    fn failed(pk: &Pubkey, msg: &str) -> String {
+        format!("Program {pk} failed: {msg}")
+    }
+
+    // ---- Render assertion ----
+    /// Compare a rendered tree against a multi-line literal, after dedenting
+    /// the literal by its common leading indent. Lets renderer tests write
+    /// the expected output as it should appear, with normal source-code
+    /// indentation, instead of as a long backslash-escaped string.
+    fn assert_render_eq(actual: &str, expected: &str) {
+        let normalized = dedent(expected);
+        if actual != normalized {
+            eprintln!("=== expected ===\n{normalized}");
+            eprintln!("=== actual ===\n{actual}");
+            panic!("render mismatch (diff above)");
+        }
+    }
+
+    fn dedent(s: &str) -> String {
+        // `trim_start_matches('\n')` drops the leading newline that comes
+        // from writing the literal across multiple source lines. `trim_end`
+        // drops any trailing whitespace, including the indent on the line
+        // that holds the closing quote, so we don't carry a phantom blank
+        // line into the output.
+        let trimmed = s.trim_start_matches('\n').trim_end();
+        let lines: Vec<&str> = trimmed.lines().collect();
+        // Min leading-whitespace count across non-blank lines: that's the
+        // common source indent. Blank lines are skipped or they'd pull the
+        // dedent down to zero.
+        let indent = lines
+            .iter()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| l.len() - l.trim_start().len())
+            .min()
+            .unwrap_or(0);
+        let stripped: Vec<String> = lines
+            .iter()
+            .map(|l| {
+                if l.len() >= indent {
+                    l[indent..].to_string()
+                } else {
+                    l.to_string()
+                }
+            })
+            .collect();
+        let mut out = stripped.join("\n");
+        out.push('\n'); // match the trailing-newline shape of writeln output
+        out
     }
 
     #[test]
@@ -323,18 +463,16 @@ mod tests {
 
     #[test]
     fn nested_cpi_attaches_child_under_parent() {
-        let logs = lines(&[
-            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 invoke [1]",
-            "Program log: Instruction: Mint",
-            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
-            "Program log: Instruction: MintTo",
-            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 1500 of 198000 compute \
-             units",
-            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
-            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 consumed 5000 of 200000 compute \
-             units",
-            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 success",
-        ]);
+        let logs = vec![
+            invoke(&PROG_A, 1),
+            instruction("Mint"),
+            invoke(&TOKEN_PROG, 2),
+            instruction("MintTo"),
+            consumed(&TOKEN_PROG, 1500),
+            success(&TOKEN_PROG),
+            consumed(&PROG_A, 5000),
+            success(&PROG_A),
+        ];
         let tree = cpi_tree(&logs);
         assert_eq!(tree.len(), 1);
         assert_eq!(tree[0].instruction_name.as_deref(), Some("Mint"));
@@ -348,33 +486,28 @@ mod tests {
     }
 
     #[test]
-    fn failed_frame_carries_message_and_diagnostics() {
-        let logs = lines(&[
-            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 invoke [1]",
-            "Program log: Instruction: Withdraw",
-            "Program log: AnchorError caused by account: vault. Error Code: ConstraintHasOne.",
-            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 failed: custom program error: \
-             0x7d1",
-        ]);
+    fn failed_frame_carries_message_and_logs() {
+        let logs = vec![
+            invoke(&PROG_A, 1),
+            instruction("Withdraw"),
+            program_log("AnchorError caused by account: vault. Error Code: ConstraintHasOne."),
+            failed(&PROG_A, "custom program error: 0x7d1"),
+        ];
         let tree = cpi_tree(&logs);
-        let CpiOutcome::Failed {
-            message,
-            diagnostics,
-        } = &tree[0].outcome
-        else {
+        let CpiOutcome::Failed { message } = &tree[0].outcome else {
             panic!("expected Failed");
         };
         assert_eq!(message.as_deref(), Some("custom program error: 0x7d1"));
-        assert_eq!(diagnostics.len(), 1);
-        assert!(diagnostics[0].contains("ConstraintHasOne"));
+        assert_eq!(tree[0].logs.len(), 1);
+        let FrameLog::Msg(text) = &tree[0].logs[0] else {
+            panic!("expected Msg variant");
+        };
+        assert!(text.contains("ConstraintHasOne"));
     }
 
     #[test]
     fn unclosed_frames_drain_as_truncated() {
-        let logs = lines(&[
-            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 invoke [1]",
-            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
-        ]);
+        let logs = vec![invoke(&PROG_A, 1), invoke(&TOKEN_PROG, 2)];
         let tree = cpi_tree(&logs);
         assert_eq!(tree.len(), 1);
         assert_eq!(tree[0].outcome, CpiOutcome::Truncated);
@@ -382,74 +515,261 @@ mod tests {
     }
 
     #[test]
-    fn unprefixed_runtime_diagnostic_captured() {
-        let logs = lines(&[
-            "Program Config1111111111111111111111111111111111111 invoke [1]",
-            "account J2kSTGu6eod7MUAy2nNZhFW5ye5ZdhAri6bcJJHRhhXy signer_key().is_none()",
-            "Program Config1111111111111111111111111111111111111 failed: missing required \
-             signature for instruction",
-        ]);
+    fn unprefixed_runtime_line_captured_as_msg() {
+        let logs = vec![
+            invoke(&CONFIG_PROG, 1),
+            // The bare runtime diagnostic. No `Program log:` prefix, no
+            // structural shape; it's the cause of the upcoming failure.
+            "account J2kSTGu6eod7MUAy2nNZhFW5ye5ZdhAri6bcJJHRhhXy signer_key().is_none()"
+                .to_string(),
+            failed(&CONFIG_PROG, "missing required signature for instruction"),
+        ];
         let tree = cpi_tree(&logs);
-        let CpiOutcome::Failed { diagnostics, .. } = &tree[0].outcome else {
-            panic!("expected Failed");
+        assert!(matches!(tree[0].outcome, CpiOutcome::Failed { .. }));
+        assert_eq!(tree[0].logs.len(), 1);
+        let FrameLog::Msg(text) = &tree[0].logs[0] else {
+            panic!("expected Msg variant");
         };
-        assert_eq!(diagnostics.len(), 1);
-        assert!(diagnostics[0].contains("signer_key().is_none()"));
+        assert!(text.contains("signer_key().is_none()"));
     }
 
     #[test]
     fn format_nested_grandchild_extends_pipe_through_non_last_branch() {
-        let logs = lines(&[
-            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 invoke [1]",
-            "Program log: Instruction: Mint",
-            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
-            "Program log: Instruction: MintTo",
-            "Program 11111111111111111111111111111111 invoke [3]",
-            "Program 11111111111111111111111111111111 consumed 50 of 197000 compute units",
-            "Program 11111111111111111111111111111111 success",
-            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 1500 of 198000 compute \
-             units",
-            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
-            "Program 22222222222222222222222222222222222222222222 invoke [2]",
-            "Program 22222222222222222222222222222222222222222222 consumed 100 of 198000 compute \
-             units",
-            "Program 22222222222222222222222222222222222222222222 success",
-            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 consumed 5000 of 200000 compute \
-             units",
-            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 success",
-        ]);
+        let logs = vec![
+            invoke(&PROG_A, 1),
+            instruction("Mint"),
+            invoke(&TOKEN_PROG, 2),
+            instruction("MintTo"),
+            invoke(&SYSTEM_PROG, 3),
+            consumed(&SYSTEM_PROG, 50),
+            success(&SYSTEM_PROG),
+            consumed(&TOKEN_PROG, 1500),
+            success(&TOKEN_PROG),
+            invoke(&PROG_C, 2),
+            consumed(&PROG_C, 100),
+            success(&PROG_C),
+            consumed(&PROG_A, 5000),
+            success(&PROG_A),
+        ];
         let tree = cpi_tree(&logs);
-        let out = format_cpi_tree(&tree);
-        assert_eq!(
-            out,
-            "Mint (5000 CU) GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2\n├── MintTo (1500 CU) \
-             TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\n│   └── (50 CU) \
-             11111111111111111111111111111111\n└── (100 CU) \
-             22222222222222222222222222222222222222222222\n"
+        let out = format_cpi_tree("CPI Tree:", &tree);
+        assert_render_eq(
+            &out,
+            "
+            CPI Tree:
+            └── Mint (5000 CU) GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
+                ├── MintTo (1500 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+                │   └── (50 CU) 11111111111111111111111111111111
+                └── (100 CU) 22222222222222222222222222222222222222222222
+            ",
         );
     }
 
     #[test]
     fn format_failed_frame_shows_message() {
-        let logs = lines(&[
-            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 invoke [1]",
-            "Program log: Instruction: Withdraw",
-            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 consumed 3100 of 200000 compute \
-             units",
-            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 failed: custom program error: \
-             0x7d1",
-        ]);
+        let logs = vec![
+            invoke(&PROG_A, 1),
+            instruction("Withdraw"),
+            consumed(&PROG_A, 3100),
+            failed(&PROG_A, "custom program error: 0x7d1"),
+        ];
         let tree = cpi_tree(&logs);
-        let out = format_cpi_tree(&tree);
-        assert_eq!(
-            out,
-            "Withdraw FAILED: custom program error: 0x7d1 (3100 CU) \
-             GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2\n"
+        let out = format_cpi_tree("CPI Tree:", &tree);
+        assert_render_eq(
+            &out,
+            "
+            CPI Tree:
+            └── Withdraw FAILED: custom program error: 0x7d1 (3100 CU) \
+             GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
+            ",
         );
     }
 
     #[test]
-    fn format_empty_tree_yields_empty_string() {
-        assert_eq!(format_cpi_tree(&[]), "");
+    fn format_empty_tree_yields_only_header() {
+        assert_eq!(format_cpi_tree("CPI Tree:", &[]), "CPI Tree:\n");
+    }
+
+    #[test]
+    fn format_multiple_roots_group_under_header() {
+        // The case the synthetic header was introduced for: a transaction
+        // with several top-level instructions reads as one tree, not as a
+        // flush-left list of strangers.
+        let logs = vec![
+            invoke(&SYSTEM_PROG, 1),
+            success(&SYSTEM_PROG),
+            invoke(&TOKEN_PROG, 1),
+            instruction("Foo"),
+            consumed(&TOKEN_PROG, 200),
+            success(&TOKEN_PROG),
+            invoke(&PROG_A, 1),
+            success(&PROG_A),
+        ];
+        let tree = cpi_tree(&logs);
+        let out = format_cpi_tree("CPI Tree:", &tree);
+        assert_render_eq(
+            &out,
+            "
+            CPI Tree:
+            ├── 11111111111111111111111111111111
+            ├── Foo (200 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+            └── GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
+            ",
+        );
+    }
+
+    #[test]
+    fn format_frame_with_data_no_children_uses_plain_pad() {
+        // Frame has data lines but no children; the data lines terminate
+        // under the frame so no spine is needed.
+        let logs = vec![
+            invoke(&PROG_B, 1),
+            instruction("EmitTwo"),
+            program_data("BqfPDIBaUMVcAAAA"),
+            program_data("AnotherBase64String"),
+            consumed(&PROG_B, 1500),
+            success(&PROG_B),
+        ];
+        let tree = cpi_tree(&logs);
+        let out = format_cpi_tree("CPI Tree:", &tree);
+        assert_render_eq(
+            &out,
+            "
+            CPI Tree:
+            └── EmitTwo (1500 CU) 6Ng7PojJBe6XjbsR65ftKKBpHUe2erD7E5dgGdMUjcgg
+                  >> data: BqfPDIBaUMVcAAAA
+                  >> data: AnotherBase64String
+            ",
+        );
+    }
+
+    #[test]
+    fn format_frame_with_data_and_children_uses_spine() {
+        // Frame has data AND children; the data lines use `│ ` so the spine
+        // visually connects them to the children branching below.
+        let logs = vec![
+            invoke(&PROG_A, 1),
+            instruction("Mint"),
+            program_data("ParentDataPayload"),
+            invoke(&TOKEN_PROG, 2),
+            instruction("MintTo"),
+            consumed(&TOKEN_PROG, 1500),
+            success(&TOKEN_PROG),
+            consumed(&PROG_A, 5000),
+            success(&PROG_A),
+        ];
+        let tree = cpi_tree(&logs);
+        let out = format_cpi_tree("CPI Tree:", &tree);
+        assert_render_eq(
+            &out,
+            "
+            CPI Tree:
+            └── Mint (5000 CU) GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
+                │ >> data: ParentDataPayload
+                └── MintTo (1500 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+            ",
+        );
+    }
+
+    #[test]
+    fn format_frame_with_no_data_omits_data_lines() {
+        let logs = vec![
+            invoke(&SYSTEM_PROG, 1),
+            consumed(&SYSTEM_PROG, 100),
+            success(&SYSTEM_PROG),
+        ];
+        let tree = cpi_tree(&logs);
+        let out = format_cpi_tree("CPI Tree:", &tree);
+        assert_render_eq(
+            &out,
+            "
+            CPI Tree:
+            └── (100 CU) 11111111111111111111111111111111
+            ",
+        );
+    }
+
+    #[test]
+    fn logs_and_data_preserve_interleaved_order() {
+        // A handler that alternates `msg!` and `emit!` should produce a
+        // `frame.logs` that interleaves Msg and Data variants in exactly the
+        // order the runtime emitted them.
+        let logs = vec![
+            invoke(&PROG_B, 1),
+            instruction("Mix"),
+            program_log("step 1"),
+            program_data("FirstData"),
+            program_log("step 2"),
+            program_data("SecondData"),
+            program_log("step 3"),
+            consumed(&PROG_B, 1500),
+            success(&PROG_B),
+        ];
+        let tree = cpi_tree(&logs);
+        assert_eq!(tree.len(), 1);
+        use FrameLog::*;
+        assert_eq!(
+            tree[0].logs,
+            vec![
+                Msg("step 1".to_string()),
+                Data("FirstData".to_string()),
+                Msg("step 2".to_string()),
+                Data("SecondData".to_string()),
+                Msg("step 3".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn format_interleaved_logs_and_data() {
+        // Renderer should emit `>> log:` and `>> data:` entries in the same
+        // arrival order they appear in `frame.logs`.
+        let logs = vec![
+            invoke(&PROG_B, 1),
+            instruction("Mix"),
+            program_log("step 1"),
+            program_data("FirstData"),
+            program_log("step 2"),
+            consumed(&PROG_B, 1500),
+            success(&PROG_B),
+        ];
+        let tree = cpi_tree(&logs);
+        let out = format_cpi_tree("CPI Tree:", &tree);
+        assert_render_eq(
+            &out,
+            "
+            CPI Tree:
+            └── Mix (1500 CU) 6Ng7PojJBe6XjbsR65ftKKBpHUe2erD7E5dgGdMUjcgg
+                  >> log:  step 1
+                  >> data: FirstData
+                  >> log:  step 2
+            ",
+        );
+    }
+
+    #[test]
+    fn success_frame_captures_data_entries() {
+        // `Program data: <base64>` lines come from `sol_log_data` (Anchor's
+        // `emit!`). They survive a `Success` pop, unlike pre-this-refactor
+        // diagnostics did not.
+        let logs = vec![
+            invoke(&PROG_B, 1),
+            instruction("EmitTwo"),
+            program_data("BqfPDIBaUMVcAAAA"),
+            program_data("AnotherBase64String"),
+            consumed(&PROG_B, 1500),
+            success(&PROG_B),
+        ];
+        let tree = cpi_tree(&logs);
+        assert_eq!(tree.len(), 1);
+        assert_eq!(tree[0].outcome, CpiOutcome::Success);
+        use FrameLog::*;
+        assert_eq!(
+            tree[0].logs,
+            vec![
+                Data("BqfPDIBaUMVcAAAA".to_string()),
+                Data("AnotherBase64String".to_string()),
+            ]
+        );
     }
 }

--- a/cli/src/log_tree.rs
+++ b/cli/src/log_tree.rs
@@ -22,7 +22,7 @@
 //!     (`sol_log_data`, which Anchor's `emit!` macro uses).
 //!
 //! Both kinds are preserved regardless of outcome, and crucially the
-//! interleaving order between Msg and Data is preserved. 
+//! interleaving order between Msg and Data is preserved.
 //!
 //! When a program executes a CPI, the child's `invoke` / `success` lines
 //! interleave with the parent's own logging, and the bracket in `invoke [n]`
@@ -246,6 +246,43 @@ fn push_into_parent_or_roots(
     }
 }
 
+/// Format an integer with US-style thousands separators (`53402` →
+/// `"53,402"`). Used for CU values in the renderer and on the
+/// transaction-total header so numbers stay scannable at the kind of
+/// magnitudes Solana transactions tend to land at (1.4M CU budget).
+pub fn with_commas(n: u64) -> String {
+    let s = n.to_string();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, b) in s.bytes().enumerate() {
+        // Insert a separator before every group of three digits, counting
+        // back from the end. The `i > 0` guard skips a leading comma when
+        // the digit count is a clean multiple of three.
+        if i > 0 && (s.len() - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(b as char);
+    }
+    out
+}
+
+/// Sum of the top-level frames' `compute_units`, or `None` if no frame
+/// contributes a value. Returning `None` distinguishes "no CU data in the
+/// logs" (e.g. a transaction whose only instruction is a native program
+/// like the BPF Loader or a top-level System Program transfer, neither of
+/// which emits `consumed N of M compute units` lines) from the impossible
+/// case of "every BPF program consumed exactly zero".
+///
+/// Children are intentionally not summed: Solana's per-frame `consumed`
+/// already includes any CPI children's consumption (verified against
+/// `TransactionStatusMeta::compute_units_consumed` / Explorer), so
+/// descending would double-count.
+pub fn transaction_total_cu(frames: &[CpiFrame]) -> Option<u64> {
+    frames
+        .iter()
+        .filter_map(|f| f.compute_units)
+        .fold(None, |acc, cu| Some(acc.unwrap_or(0) + cu))
+}
+
 enum LogLine {
     Invoke(String),
     Consumed(u64),
@@ -324,7 +361,7 @@ fn write_frame(out: &mut String, frame: &CpiFrame, prefix: &str, is_last: bool) 
         CpiOutcome::Truncated => write!(out, "TRUNCATED ").unwrap(),
     }
     if let Some(cu) = frame.compute_units {
-        write!(out, "({cu} CU) ").unwrap();
+        write!(out, "({} CU) ", with_commas(cu)).unwrap();
     }
     writeln!(out, "{}", frame.program_id).unwrap();
 
@@ -557,8 +594,8 @@ mod tests {
             &out,
             "
             CPI Tree:
-            └── Mint (5000 CU) GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
-                ├── MintTo (1500 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+            └── Mint (5,000 CU) GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
+                ├── MintTo (1,500 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
                 │   └── (50 CU) 11111111111111111111111111111111
                 └── (100 CU) 22222222222222222222222222222222222222222222
             ",
@@ -579,7 +616,7 @@ mod tests {
             &out,
             "
             CPI Tree:
-            └── Withdraw FAILED: custom program error: 0x7d1 (3100 CU) \
+            └── Withdraw FAILED: custom program error: 0x7d1 (3,100 CU) \
              GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
             ",
         );
@@ -636,7 +673,7 @@ mod tests {
             &out,
             "
             CPI Tree:
-            └── EmitTwo (1500 CU) 6Ng7PojJBe6XjbsR65ftKKBpHUe2erD7E5dgGdMUjcgg
+            └── EmitTwo (1,500 CU) 6Ng7PojJBe6XjbsR65ftKKBpHUe2erD7E5dgGdMUjcgg
                   >> data: BqfPDIBaUMVcAAAA
                   >> data: AnotherBase64String
             ",
@@ -664,9 +701,9 @@ mod tests {
             &out,
             "
             CPI Tree:
-            └── Mint (5000 CU) GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
+            └── Mint (5,000 CU) GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
                 │ >> data: ParentDataPayload
-                └── MintTo (1500 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+                └── MintTo (1,500 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
             ",
         );
     }
@@ -739,7 +776,7 @@ mod tests {
             &out,
             "
             CPI Tree:
-            └── Mix (1500 CU) 6Ng7PojJBe6XjbsR65ftKKBpHUe2erD7E5dgGdMUjcgg
+            └── Mix (1,500 CU) 6Ng7PojJBe6XjbsR65ftKKBpHUe2erD7E5dgGdMUjcgg
                   >> log:  step 1
                   >> data: FirstData
                   >> log:  step 2
@@ -771,5 +808,71 @@ mod tests {
                 Data("AnotherBase64String".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn with_commas_inserts_thousands_separators() {
+        assert_eq!(with_commas(0), "0");
+        assert_eq!(with_commas(42), "42");
+        assert_eq!(with_commas(999), "999");
+        assert_eq!(with_commas(1_000), "1,000");
+        assert_eq!(with_commas(53_402), "53,402");
+        assert_eq!(with_commas(1_234_567_890), "1,234,567,890");
+    }
+
+    #[test]
+    fn transaction_total_cu_sums_top_level_frames() {
+        // Three top-level frames with known CU; the helper should sum them.
+        // Mirrors the Phoenix-style transaction whose Explorer total (53,402)
+        // we verified matches the top-level-frame sum.
+        let logs = vec![
+            invoke(&PROG_A, 1),
+            consumed(&PROG_A, 4_817),
+            success(&PROG_A),
+            invoke(&PROG_B, 1),
+            consumed(&PROG_B, 9_497),
+            success(&PROG_B),
+            invoke(&TOKEN_PROG, 1),
+            consumed(&TOKEN_PROG, 17_173),
+            success(&TOKEN_PROG),
+        ];
+        let tree = cpi_tree(&logs);
+        assert_eq!(transaction_total_cu(&tree), Some(31_487));
+    }
+
+    #[test]
+    fn transaction_total_cu_returns_none_when_no_frame_has_cu() {
+        // BPF Loader-only and System-Program-only transactions are real:
+        // native programs don't emit `consumed` lines, so every top-level
+        // frame ends up with `compute_units: None`. The helper must
+        // distinguish that from a true zero so the renderer can label the
+        // case explicitly instead of misreporting "0 CU".
+        let logs = vec![invoke(&SYSTEM_PROG, 1), success(&SYSTEM_PROG)];
+        let tree = cpi_tree(&logs);
+        assert_eq!(tree[0].compute_units, None);
+        assert_eq!(transaction_total_cu(&tree), None);
+    }
+
+    #[test]
+    fn transaction_total_cu_does_not_double_count_children() {
+        // Per-frame `consumed` is cumulative in Solana: the parent's value
+        // already includes any CPI children's consumption (verified against
+        // Explorer for tx 2p5cKaWqMRiYZNfk7...). The helper must sum only
+        // root frames; descending into children would double-count.
+        let logs = vec![
+            invoke(&PROG_A, 1),
+            invoke(&TOKEN_PROG, 2),
+            consumed(&TOKEN_PROG, 500),
+            success(&TOKEN_PROG),
+            consumed(&PROG_A, 1_500),
+            success(&PROG_A),
+        ];
+        let tree = cpi_tree(&logs);
+        // Sanity: parent has Some(1_500), child has Some(500). The 500 is
+        // *included* in the 1_500, so the transaction total is 1_500, not
+        // 2_000.
+        assert_eq!(tree[0].compute_units, Some(1_500));
+        assert_eq!(tree[0].children[0].compute_units, Some(500));
+        assert_eq!(transaction_total_cu(&tree), Some(1_500));
     }
 }

--- a/cli/src/log_tree.rs
+++ b/cli/src/log_tree.rs
@@ -77,11 +77,29 @@ const SPINE_END: &str = "    ";
 const LOG_SPINE_CONTINUE: &str = "│ ";
 const LOG_SPINE_END: &str = "  ";
 
+/// The two CU values the runtime reports together on a
+/// `Program X consumed N of M compute units` line. Paired in a single
+/// struct because either both are emitted (BPF programs) or neither is
+/// (native programs that don't run in the SBPF VM).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ComputeUnits {
+    /// What this frame consumed. Cumulative: includes the program's CPI
+    /// children's consumption, so summing top-level frames gives the
+    /// transaction total (matches `TransactionStatusMeta::compute_units_consumed`).
+    pub consumed: u64,
+    /// Compute units remaining in the transaction's budget at the moment
+    /// this frame started executing. For the first top-level instruction
+    /// this equals the transaction's total CU budget; for subsequent
+    /// frames it's the running remainder after earlier frames consumed
+    /// from the same budget.
+    pub available_at_start: u64,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CpiFrame {
     pub program_id: Pubkey,
     pub outcome: CpiOutcome,
-    pub compute_units: Option<u64>,
+    pub compute_units: Option<ComputeUnits>,
     pub instruction_name: Option<String>,
     /// Order preserving record of `msg!` strings, `emit!` payloads, and
     /// unprefixed runtime diagnostics emitted while this frame was on the
@@ -279,13 +297,24 @@ pub fn with_commas(n: u64) -> String {
 pub fn transaction_total_cu(frames: &[CpiFrame]) -> Option<u64> {
     frames
         .iter()
-        .filter_map(|f| f.compute_units)
+        .filter_map(|f| f.compute_units.as_ref().map(|cu| cu.consumed))
         .fold(None, |acc, cu| Some(acc.unwrap_or(0) + cu))
+}
+
+/// Transaction-wide CU budget: the `available_at_start` value of the first
+/// top-level frame that had any CU data. For Solana transactions this
+/// equals the per-instruction default (200,000) × instruction count, capped
+/// at 1,400,000, *unless* the tx used `ComputeBudgetInstruction::set_compute_unit_limit`
+/// to override. Returns `None` when no frame reported CU at all.
+pub fn transaction_compute_budget(frames: &[CpiFrame]) -> Option<u64> {
+    frames
+        .iter()
+        .find_map(|f| f.compute_units.as_ref().map(|cu| cu.available_at_start))
 }
 
 enum LogLine {
     Invoke(String),
-    Consumed(u64),
+    Consumed(ComputeUnits),
     Status(Status),
     Other,
 }
@@ -317,8 +346,25 @@ fn classify(log: &str) -> LogLine {
             let message = (!raw.is_empty()).then(|| raw.to_string());
             LogLine::Status(Status::Failed { message })
         }
-        ["Program", _, "consumed", cu, "of", _, "compute", "units"] => {
-            cu.parse::<u64>().map_or(LogLine::Other, LogLine::Consumed)
+        [
+            "Program",
+            _,
+            "consumed",
+            consumed,
+            "of",
+            available,
+            "compute",
+            "units",
+        ] => {
+            // Both values must parse; if either is malformed we fall back to
+            // `Other` rather than constructing a half-known `ComputeUnits`.
+            match (consumed.parse::<u64>(), available.parse::<u64>()) {
+                (Ok(consumed), Ok(available_at_start)) => LogLine::Consumed(ComputeUnits {
+                    consumed,
+                    available_at_start,
+                }),
+                _ => LogLine::Other,
+            }
         }
         _ => LogLine::Other,
     }
@@ -361,7 +407,13 @@ fn write_frame(out: &mut String, frame: &CpiFrame, prefix: &str, is_last: bool) 
         CpiOutcome::Truncated => write!(out, "TRUNCATED ").unwrap(),
     }
     if let Some(cu) = frame.compute_units {
-        write!(out, "({} CU) ", with_commas(cu)).unwrap();
+        write!(
+            out,
+            "({} / {} CU) ",
+            with_commas(cu.consumed),
+            with_commas(cu.available_at_start)
+        )
+        .unwrap();
     }
     writeln!(out, "{}", frame.program_id).unwrap();
 
@@ -513,7 +565,13 @@ mod tests {
         let tree = cpi_tree(&logs);
         assert_eq!(tree.len(), 1);
         assert_eq!(tree[0].instruction_name.as_deref(), Some("Mint"));
-        assert_eq!(tree[0].compute_units, Some(5000));
+        assert_eq!(
+            tree[0].compute_units,
+            Some(ComputeUnits {
+                consumed: 5_000,
+                available_at_start: 200_000,
+            })
+        );
         assert_eq!(tree[0].outcome, CpiOutcome::Success);
         assert_eq!(tree[0].children.len(), 1);
         assert_eq!(
@@ -594,10 +652,10 @@ mod tests {
             &out,
             "
             CPI Tree:
-            └── Mint (5,000 CU) GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
-                ├── MintTo (1,500 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-                │   └── (50 CU) 11111111111111111111111111111111
-                └── (100 CU) 22222222222222222222222222222222222222222222
+            └── Mint (5,000 / 200,000 CU) GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
+                ├── MintTo (1,500 / 200,000 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+                │   └── (50 / 200,000 CU) 11111111111111111111111111111111
+                └── (100 / 200,000 CU) 22222222222222222222222222222222222222222222
             ",
         );
     }
@@ -616,7 +674,7 @@ mod tests {
             &out,
             "
             CPI Tree:
-            └── Withdraw FAILED: custom program error: 0x7d1 (3,100 CU) \
+            └── Withdraw FAILED: custom program error: 0x7d1 (3,100 / 200,000 CU) \
              GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
             ",
         );
@@ -649,7 +707,7 @@ mod tests {
             "
             CPI Tree:
             ├── 11111111111111111111111111111111
-            ├── Foo (200 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+            ├── Foo (200 / 200,000 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
             └── GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
             ",
         );
@@ -673,7 +731,7 @@ mod tests {
             &out,
             "
             CPI Tree:
-            └── EmitTwo (1,500 CU) 6Ng7PojJBe6XjbsR65ftKKBpHUe2erD7E5dgGdMUjcgg
+            └── EmitTwo (1,500 / 200,000 CU) 6Ng7PojJBe6XjbsR65ftKKBpHUe2erD7E5dgGdMUjcgg
                   >> data: BqfPDIBaUMVcAAAA
                   >> data: AnotherBase64String
             ",
@@ -701,9 +759,9 @@ mod tests {
             &out,
             "
             CPI Tree:
-            └── Mint (5,000 CU) GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
+            └── Mint (5,000 / 200,000 CU) GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2
                 │ >> data: ParentDataPayload
-                └── MintTo (1,500 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+                └── MintTo (1,500 / 200,000 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
             ",
         );
     }
@@ -721,7 +779,7 @@ mod tests {
             &out,
             "
             CPI Tree:
-            └── (100 CU) 11111111111111111111111111111111
+            └── (100 / 200,000 CU) 11111111111111111111111111111111
             ",
         );
     }
@@ -776,7 +834,7 @@ mod tests {
             &out,
             "
             CPI Tree:
-            └── Mix (1,500 CU) 6Ng7PojJBe6XjbsR65ftKKBpHUe2erD7E5dgGdMUjcgg
+            └── Mix (1,500 / 200,000 CU) 6Ng7PojJBe6XjbsR65ftKKBpHUe2erD7E5dgGdMUjcgg
                   >> log:  step 1
                   >> data: FirstData
                   >> log:  step 2
@@ -807,6 +865,30 @@ mod tests {
                 Data("BqfPDIBaUMVcAAAA".to_string()),
                 Data("AnotherBase64String".to_string()),
             ]
+        );
+    }
+
+    #[test]
+    fn parser_captures_consumed_and_available() {
+        // The flat log line carries both X (consumed) and Y (available at
+        // frame start). We must capture both so the renderer can surface
+        // them; dropping Y would silently lose information the runtime
+        // emitted.
+        let logs = vec![
+            invoke(&PROG_A, 1),
+            // 1,500 CU consumed of 198,000 available at frame start.
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 consumed 1500 of 198000 compute \
+             units"
+                .to_string(),
+            success(&PROG_A),
+        ];
+        let tree = cpi_tree(&logs);
+        assert_eq!(
+            tree[0].compute_units,
+            Some(ComputeUnits {
+                consumed: 1_500,
+                available_at_start: 198_000,
+            })
         );
     }
 
@@ -854,6 +936,27 @@ mod tests {
     }
 
     #[test]
+    fn transaction_compute_budget_reads_first_available() {
+        // The transaction budget is the `available_at_start` of the *first*
+        // top-level frame that reported CU. Frames that came before it
+        // without CU data (e.g. native ComputeBudget instructions) are
+        // skipped over by `find_map`.
+        let logs = vec![
+            // No-CU native instruction first.
+            invoke(&SYSTEM_PROG, 1),
+            success(&SYSTEM_PROG),
+            // Then a BPF program reporting `consumed 4817 of 1000000`.
+            invoke(&PROG_A, 1),
+            "Program GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2 consumed 4817 of 1000000 \
+             compute units"
+                .to_string(),
+            success(&PROG_A),
+        ];
+        let tree = cpi_tree(&logs);
+        assert_eq!(transaction_compute_budget(&tree), Some(1_000_000));
+    }
+
+    #[test]
     fn transaction_total_cu_does_not_double_count_children() {
         // Per-frame `consumed` is cumulative in Solana: the parent's value
         // already includes any CPI children's consumption (verified against
@@ -868,11 +971,14 @@ mod tests {
             success(&PROG_A),
         ];
         let tree = cpi_tree(&logs);
-        // Sanity: parent has Some(1_500), child has Some(500). The 500 is
-        // *included* in the 1_500, so the transaction total is 1_500, not
-        // 2_000.
-        assert_eq!(tree[0].compute_units, Some(1_500));
-        assert_eq!(tree[0].children[0].compute_units, Some(500));
+        // Sanity: parent's consumed is 1_500, child's is 500. The 500 is
+        // *included* in the 1_500 (per-frame consumed is cumulative), so
+        // the transaction total is 1_500, not 2_000.
+        assert_eq!(tree[0].compute_units.map(|cu| cu.consumed), Some(1_500));
+        assert_eq!(
+            tree[0].children[0].compute_units.map(|cu| cu.consumed),
+            Some(500)
+        );
         assert_eq!(transaction_total_cu(&tree), Some(1_500));
     }
 }


### PR DESCRIPTION
## tl;dr

`solana logs --tree` renders each transaction's log stream as a nested CPI invocation tree instead of a flat line sequence. Default behavior is unchanged; `--tree` is opt-in. The tree header carries the transaction-total compute units and the transaction's CU budget; each transaction also prints a Solana Explorer URL inferred from `--url`.

## Outstanding issues w/ PR

- [x] :heavy_check_mark: suppress URI when default signature is present. At least `Signature::default()` is passed on to the logs. At worse, shipping as is, presents a url 404, it doesn't change any information available in the current log format.
- [x] What's up with the CU mismatch between the tree-output and the explorer? 
  - :heavy_check_mark: My hypothesis is the explorer has more meta information about the TX by the time it renders it's CU Spent calculations; looking into it.

## Why

The `logsSubscribe` notification format is a flat `Vec<String>` of log lines. That's a reasonable wire format: compact, easy to filter (grep an error code, a signature, a program id), easy to ship over JSON-RPC, faithful to what the runtime emits. Scripts and log scrapers depend on it staying that way, and nothing here changes it.

What that format is, though, is opaque to the transaction's own structure. The CPI hierarchy is encoded *in* the stream (the bracket in `invoke [n]`, the well-nested ordering of `invoke` / `success` / `failed:` lines) without being presented *as* a structure. To answer "what called what, and what did each frame cost?" for a transaction with a few levels of CPI and some siblings, you fold a balanced-bracket sequence in your head from the flat output.

The flat output isn't the wrong format, it's just one of two useful presentations of the same data. The tree adds the second: a developer reasoning about a transaction sees invocation depth, sibling order, per-frame compute units, and failure attribution at a glance, without re-deriving the structure each time. So this PR adds `--tree` as an opt-in alternate rendering. Flat stays the default; the tree is one flag away when you want it.

## Premise

The tree stays faithful to the flat log: every line the runtime emits has a home in the tree, and nothing is fabricated on top. Ergonomic affordances that don't change the data are fair game (an inferred Explorer URL under each transaction, comma-separated CU values, dispatcher-emitted instruction names surfaced on the frame header). Cross-referencing context the runtime didn't emit (per-program IDLs, signer attribution, friendly program names) stays out of scope; see Scope below.

## Proposed Changes

- Add `cli/src/log_tree.rs`: stack-based parser folding the flat log stream into `Vec<CpiFrame>` (with `Success` / `Failed { message }` / `Truncated` outcomes), plus a `cargo tree`-style renderer. The module doc lays out the algorithm explicitly: CPI logs form a Dyck D-1 grammar of balanced brackets, recognized by a two-layer pipeline (a per-line FSA classifier feeds a single-state PDA whose stack carries the nesting). Truncation falls out of the EOF transition.
- Expose helpers alongside the parser: `transaction_total_cu`, `transaction_compute_budget`, `with_commas`. These are what the CLI uses to render the header; they're public so downstream tooling can lift the same numbers from the tree without re-walking the logs.
- Add a `--tree` flag to the `solana logs` subcommand in `cli/src/cluster_query.rs`.
- Extend `CliCommand::Logs` in `cli/src/cli.rs` to carry the flag through to `process_logs`.
- Branch `process_logs` on the flag: existing line-by-line output by default, tree rendering when `--tree` is set. The tree path also prints an `Explorer:` line per transaction (under `Signature:`) with a URL derived from `--url`; canonical cluster RPCs map to `?cluster=mainnet|testnet|devnet`, anything else falls through to `?cluster=custom&customUrl=…`.

## What `--tree` output looks like against mainnet-beta

Tree header carries `(consumed / budget CU)` when at least one frame reported compute units; otherwise it falls back to `CPI Tree (no compute units in logs):`. Frame-level CU values render as `(consumed / available_at_start CU)`, both comma-separated. The two extra spaces after `Explorer:` align the URL with the value column under `Signature:`.

A Jupiter `SharedAccountsRoute` aggregator swap, with named child instructions, `Program return` data inline, and two `>> data:` lines on a Manifest leg:

```console
$ ./target/debug/solana logs --url mainnet-beta --tree
Streaming transaction logs. Confirmed commitment

Transaction executed in slot 422652094:
  Signature: 3AD5AKheyKxzenyABdmyN61TT9EgmYszgdCMkDduAeh6S8NDNJF8Bpj1woWp5qC9sHxPumLW7ZmyJvU2uMiqnzLL
  Explorer:  https://explorer.solana.com/tx/3AD5AKheyKxzenyABdmyN61TT9EgmYszgdCMkDduAeh6S8NDNJF8Bpj1woWp5qC9sHxPumLW7ZmyJvU2uMiqnzLL?cluster=mainnet-beta
  Status: Ok
  CPI Tree (58,995 / 299,700 CU):
  ├── ComputeBudget111111111111111111111111111111
  ├── ComputeBudget111111111111111111111111111111
  └── SharedAccountsRoute (58,995 / 299,700 CU) JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4
      │ >> log:  Program return: JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 VJnaEgAAAAA=
      ├── (83 / 297,010 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
      ├── (25,928 / 294,557 CU) QuaNtZsgYRe5Z9Bk4LZ4cTD9tbkVoyCNf1R2BN9bBDv
      │   ├── (83 / 269,967 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
      │   └── (76 / 268,769 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
      ├── (106 / 267,114 CU) JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4
      ├── (19,970 / 264,530 CU) MNFSTqtC93rEfYHB6hF82sKdZpUDFWkViLByLd1k1Ms
      │   │ >> data: OubyA0txBKl1AOJoRI8glB8xFoZC+i+SOC0LoF+4ljKU3r53nOzhOgbEe8514YcJ+3w7ebXnxm2MVvsMjqP03XI1L4U8rEu7OriQP7c1yrHGfFmvSFft9hsK+DKlCnxZ4yGRng7IqbzOAQ5gr+2yJxe9YxkvVBRaP5ZaM7uC0scCnrLOHiCCZMb6evO+2606PWXzaqvJdDGxu+TC0vbg5HymAgNFL11h6lzqe7H02w0AAAAAAAAAAFSZ2hIAAAAAliLUEgAAAACa8uoAAAAAAMzy6gAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
      │   │ >> data: vWGf64gFAY11AOJoRI8glB8xFoZC+i+SOC0LoF+4ljKU3r53nOzhOjq4kD+3NcqxxnxZr0hX7fYbCvgypQp8WeMhkZ4OyKm8TfgYabgtBINZ72dL4fv7ksNQocrcjOWEjhdFwg2rtwAAAAAcLfM3BwBVddzSt1IAVJnaEgAAAADM8uoAAAAAAP////8AAAAAAQEAAAAAAAA=
      │   ├── (76 / 248,495 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
      │   └── (138 / 246,385 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
      ├── (106 / 243,045 CU) JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4
      └── (76 / 240,912 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
```

A compact failed transaction with the runtime message inline and the program's own log carrying through:

```console
Transaction executed in slot 422652094:
  Signature: 2oqwkG7i3Wind6741E79vzD9MRCM1rugRg3MFhPTwdH8voCstt4v6ppBZe3ADLf83CM71tv9vp1xkx6GkCd3oDdS
  Explorer:  https://explorer.solana.com/tx/2oqwkG7i3Wind6741E79vzD9MRCM1rugRg3MFhPTwdH8voCstt4v6ppBZe3ADLf83CM71tv9vp1xkx6GkCd3oDdS?cluster=mainnet-beta
  Status: Error processing Instruction 3: custom program error: 0x1
  CPI Tree (201 / 226 CU):
  ├── 11111111111111111111111111111111
  ├── ComputeBudget111111111111111111111111111111
  ├── ComputeBudget111111111111111111111111111111
  └── FAILED: custom program error: 0x1 (201 / 226 CU) ZERor4xhbUycZ6gb9ntrhqscUcZmAbQDjEAtCf4hbZY
        >> log:  7
```

<details><summary>👉👉👉  CLICK TO SEE MORE TXNS  👈👈👈</summary>

A Phoenix multi-leg with the program's emoji-tagged log carrying through, plus two sibling child invocations:

```console
Transaction executed in slot 422652094:
  Signature: 3YZC2e3VQk7kwZrj8dv54txGE2cBLMoZGikABbDcsGs5xkqhfCVmbF2xuMik6DvEybfbpAVami6iR5KjiukTvb9o
  Explorer:  https://explorer.solana.com/tx/3YZC2e3VQk7kwZrj8dv54txGE2cBLMoZGikABbDcsGs5xkqhfCVmbF2xuMik6DvEybfbpAVami6iR5KjiukTvb9o?cluster=mainnet-beta
  Status: Ok
  CPI Tree (24,827 / 27,000 CU):
  ├── (445 / 27,000 CU) EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih
  ├── (24,382 / 26,555 CU) EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih
  │   │ >> log:  Phoenix Eternal 🐦‍🔥: Update Spline Parameters
  │   │ >> log:  Spline parameters updated successfully (with ordering)
  │   ├── (640 / 4,639 CU) EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih
  │   └── (474 / 2,987 CU) EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih
  ├── ComputeBudget111111111111111111111111111111
  └── 11111111111111111111111111111111
```

`CreateIdempotent` ATA flow into a pAMM `Sell`, showing how dispatcher-emitted instruction names (Anchor, SPL) decode for free while raw frames remain opaque:

```console
Transaction executed in slot 422652094:
  Signature: 46idGBeS3iYVbsQr9YE7YMVLEPDYjkSQ4R9TvYzBBr5Xta6CPB2KkctmbmTJMtrBLp5YriDip7XJhQNyRvV1Po2X
  Explorer:  https://explorer.solana.com/tx/46idGBeS3iYVbsQr9YE7YMVLEPDYjkSQ4R9TvYzBBr5Xta6CPB2KkctmbmTJMtrBLp5YriDip7XJhQNyRvV1Po2X?cluster=mainnet-beta
  Status: Ok
  CPI Tree (105,334 / 208,931 CU):
  ├── ComputeBudget111111111111111111111111111111
  ├── ComputeBudget111111111111111111111111111111
  ├── (13,413 / 208,931 CU) ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL
  │   │ >> log:  CreateIdempotent
  │   │ >> log:  Initialize the associated token account
  │   ├── (179 / 203,580 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  │   │     >> log:  Program return: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA pQAAAAAAAAA=
  │   ├── 11111111111111111111111111111111
  │   ├── (37 / 198,491 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  │   └── (229 / 196,030 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  ├── Sell (91,803 / 195,518 CU) pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA
  │   │ >> data: Pi83CqUD3CqJyxdqAAAAALi8vO4ZAAAAeikiAQAAAAC4vLzuGQAAAAAAAAAAAAAAC+j79dziAABXLB++EAAAAJW56QEAAAAAAgAAAAAAAAATGQAAAAAAAF0AAAAAAAAA8I0EAAAAAACCoOkBAAAAAHaa4wEAAAAA96LeT/F079IBy6hB5UAZu6Oj122heBEe19Z7FHtoiTI63EMQCCQfO1eRiktzJXc1qnP/H11pRX/MFCfw+yzhuk5zpkaZWgMX61nANGLgfn16CHa2Hsw07SDA7sQwsXWy2BkoYFcJtldadoaeP5RuQ27Prc+9Fp5by8A2RBd/Jaxjg3MADqIssmTTSv9koEte+r+7dN3NBImXsZgVR9fREAe0ZyjFA6fIFZjsUWe5tjKg2nvc6Y8HxZZ7EO1veKHOcnPOa+2OU18usGhs5cFZjez/8j5Tgw/+gySm1SnX8gQAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAAAceAEAAAAAAIgTAAAAAAAA+EYCAAAAAAA=
  │   ├── GetFees (6,038 / 154,023 CU) pfeeUxB6jkeY1Hxd7CsFCAjcbHA9rWtchMGdZ6VojVZ
  │   │     >> log:  Program return: pfeeUxB6jkeY1Hxd7CsFCAjcbHA9rWtchMGdZ6VojVZ AgAAAAAAAABdAAAAAAAAAB4AAAAAAAAA
  │   ├── TransferChecked (2,475 / 143,994 CU) TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
  │   ├── (112 / 138,698 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  │   ├── (112 / 135,481 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  │   ├── (112 / 122,786 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  │   ├── (112 / 114,090 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  │   └── (2,054 / 107,165 CU) pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA
  ├── (118 / 103,715 CU) TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  ├── 11111111111111111111111111111111
  └── 11111111111111111111111111111111
```

A transaction whose only frames are native programs (no `consumed N of M compute units` lines emitted), illustrating the header fallback:

```console
Transaction executed in slot 422652094:
  Signature: 2TMLWF4C8VU3QHyyaqdfztKdfev785a33q2i2YguvrPA6uEDQcUcuNQ2fpi3KJHrvyrMfq685KDkGBDfkZZNfsw9
  Explorer:  https://explorer.solana.com/tx/2TMLWF4C8VU3QHyyaqdfztKdfev785a33q2i2YguvrPA6uEDQcUcuNQ2fpi3KJHrvyrMfq685KDkGBDfkZZNfsw9?cluster=mainnet-beta
  Status: Ok
  CPI Tree (no compute units in logs):
  ├── ComputeBudget111111111111111111111111111111
  ├── ComputeBudget111111111111111111111111111111
  └── 11111111111111111111111111111111
```

</details>

Truncated frames (status line never arrived) render as `<name> TRUNCATED ...` so a partial stream is distinguishable from a real failure.

## Scope

We stop at the transformation of the data `logsSubscribe` actually provides. The flat stream and the tree are two faithful presentations of the same source; neither adds information that wasn't already there. That transformation is already meaningful on its own: nested CPI structure, per-frame compute units, transaction-total CU against the budget, and failure attribution become legible at a glance.

Further enrichment is possible and often useful, but it requires context `logsSubscribe` doesn't carry. The kinds of things that can't be meaningfully scoped at agave's level:

- **Program-id -> friendly name.** There's no canonical Solana name registry, so the right table depends on the consumer. Program IDs print as base58 here.
- **Instruction names from discriminator bytes.** Anchor's IDL, SPL Token's variant table, and so on are framework-specific by construction. Programs that emit `Program log: Instruction: <name>` (Anchor's dispatch macro, SPL Token) are decoded for free; programs that don't (the System Program) aren't.
- **Signer attribution.** Signers live on the transaction message, which is a different RPC call.

These compositions belong in downstream tooling (test harnesses, explorers, litesvm, anchor-litesvm, surfpool, etc) already has the registries, the IDLs, and the transaction context. 

## Testing

Unit tests in `cli/src/log_tree.rs` cover each parser arm (empty stream, nested CPI, failed frame with diagnostics in `logs`, end-of-stream truncation, unprefixed runtime diagnostic, `msg!`/`emit!` interleaving) and each renderer case (single root with child, three-deep nesting exercising the `│   ` continuation, failed-frame inline message, multiple roots under the synthetic header, data-only frames, interleaved log+data rows, empty tree). Helpers (`transaction_total_cu`, `transaction_compute_budget`, `with_commas`) have their own tests. The Explorer URL mapping is covered in `cli/src/cluster_query.rs` (canonical RPCs -> named cluster, unknown RPC -> `cluster=custom&customUrl=…`).

```sh
cargo test -p solana-cli --lib log_tree
cargo test -p solana-cli --lib explorer_query
```

Sanity and check scripts should be run before submission:

```sh
./ci/test-sanity.sh
./ci/test-checks.sh
```

## Benchmarks

N/A. This is a CLI rendering change with no runtime, SVM, or RPC impact. The parser runs once per `logsSubscribe` notification on a `Vec<String>` that is already in memory; the additional work is O(n) in the number of log lines.

## Compatibility

- **No flag -> no change.** Default `solana logs` output is byte-identical to today.
- **`--tree`** is additive; composes with existing `--include-votes` and the positional address arg.
- **No protocol or RPC changes.** This is purely a CLI-side rendering change on the data we already receive.
- **No new dependencies.** `solana-pubkey` is already a workspace dep; the parser uses `Pubkey::from_str` plus `std::fmt`.
