### PR TITLE
replay: handle set-identity when ag is active

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1025,6 +1025,15 @@ impl ReplayStage {
                 }
 
                 if migration_status.is_alpenglow_enabled() {
+                    if my_pubkey != cluster_info.id() {
+                        identity_keypair = cluster_info.keypair();
+                        let my_old_pubkey = my_pubkey;
+                        my_pubkey = identity_keypair.pubkey();
+                        migration_status.set_pubkey(my_pubkey);
+
+                        warn!("Identity changed from {my_old_pubkey} to {my_pubkey}");
+                    }
+
                     process_soft_dead_slots(
                         &my_pubkey,
                         &blockstore,


### PR DESCRIPTION
#### Problem
When alpenglow is active we drop `set-identity` handling from replay stage (this portion is gated behind `!migration_status.is_alpenglow_enabled()`):
https://github.com/anza-xyz/agave/blob/0b9c64b563d0f4085cb76acb219664cb47c28619/core/src/replay_stage.rs#L1374-L1402

This is fine because there's no need to reload the `Tower` and `Votor` handles reloading the `VoteHistory`.
However `my_pubkey` is load bearing as it's used for the `leader_is_me` checks. This means a stale `my_pubkey` could lead to use trying to replay leader blocks, or (what was observed in the wild) trying to perform a bank hash mismatch check:

https://github.com/anza-xyz/agave/blob/0b9c64b563d0f4085cb76acb219664cb47c28619/core/src/replay_stage.rs#L3893-L3906

The bank hash mismatch info is intentionally not set for leader banks, so this will cause it to fail after a `set-identity` and replay to become stuck

#### Summary of Changes
Add back the minimal `set-identity` handling in replay stage when alpenglow is active
