### PR TITLE
docs: keep debug asserts guarding against vote equivocation

### DIFF
--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -164,8 +164,7 @@ impl VoteHistory {
     /// Add a new vote to the voting history
     pub fn add_vote(&mut self, vote: Vote) {
         assert!(vote.slot() >= self.root);
-        // TODO: these assert!s are for my debugging, can consider removing
-        // in final version
+        // Asserts here guard against vote equivocation.
         match vote {
             Vote::Notarize(vote) => {
                 assert!(self.voted.insert(vote.slot));


### PR DESCRIPTION
#### Problem
TODO comment suggests asserts in vote history should be removed.

#### Summary of Changes
I would argue these asserts should just stay as a last line of defense against equivocation due to any upstream bugs.