### PR TITLE
gossip: do not propagate duplicate proofs for alpenglow blocks

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -114,7 +114,10 @@ fn run_check_duplicate(
     duplicate_slots_sender: &DuplicateSlotSender,
     bank_forks: &RwLock<BankForks>,
 ) -> Result<()> {
-    let mut root_bank = bank_forks.read().unwrap().root_bank();
+    let (mut root_bank, migration_status) = {
+        let bank_forks_r = bank_forks.read().unwrap();
+        (bank_forks_r.root_bank(), bank_forks_r.migration_status())
+    };
     let mut last_updated = Instant::now();
     let check_duplicate = |shred: PossibleDuplicateShred| -> Result<()> {
         if last_updated.elapsed().as_nanos() > root_bank.ns_per_slot {
@@ -159,10 +162,19 @@ fn run_check_duplicate(
             }
         };
 
-        // Propagate duplicate proof through gossip
-        cluster_info.push_duplicate_shred(&shred1, &shred2)?;
-        // Notify duplicate consensus state machine
-        duplicate_slots_sender.send(shred_slot)?;
+        if migration_status.should_respond_to_ancestor_hashes_requests(shred_slot) {
+            // In alpenglow we store the duplicate block proofs in blockstore for the purposes of slashing,
+            // however we do not need to propagate the duplicate proof through gossip.
+            // We still propagate during the mixed migration epoch, to account for other nodes that are stuck
+            // and require a duplicate proof to proceed
+            cluster_info.push_duplicate_shred(&shred1, &shred2)?;
+        }
+
+        if !migration_status.is_alpenglow_enabled() {
+            // The state machine can be exited as soon as alpenglow is enabled.
+            // Notify duplicate consensus state machine
+            duplicate_slots_sender.send(shred_slot)?;
+        }
 
         Ok(())
     };


### PR DESCRIPTION
Split from #11814 

#### Problem
In Alpenglow we do not have ancestor hashes service or require any of the duplicate block state machine to run. As a result there's no reason to propagate the duplicate shred proof through gossip

#### Summary of Changes
Continue to store locally for the purposes of slashing
Only gossip if it's a TowerBFT block
Stop sending to the state machine as soon as alpenglow is active