### PR TITLE
fix(cli-config): Copy URL normalization function instead of depending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7655,6 +7655,7 @@ dependencies = [
  "clap 2.33.3",
  "rpassword",
  "solana-bls-signatures",
+ "solana-cli-config",
  "solana-clock",
  "solana-cluster-type",
  "solana-commitment-config",
@@ -7687,6 +7688,7 @@ dependencies = [
  "five8",
  "rpassword",
  "solana-clap-v3-utils",
+ "solana-cli-config",
  "solana-clock",
  "solana-cluster-type",
  "solana-commitment-config",
@@ -7805,7 +7807,6 @@ dependencies = [
  "dirs-next",
  "serde",
  "serde_yaml",
- "solana-clap-utils",
  "solana-commitment-config",
  "url 2.5.8",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7507,7 +7507,6 @@ dependencies = [
  "dirs-next",
  "serde",
  "serde_yaml",
- "solana-clap-utils",
  "solana-commitment-config",
  "url 2.5.8",
 ]

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { workspace = true, features = ["default"] }
 clap = { version = "2.33.0", default-features = false, features = ["suggestions"] }
 rpassword = { workspace = true }
 solana-bls-signatures = { workspace = true }
+solana-cli-config = { workspace = true }
 solana-clock = { workspace = true }
 solana-cluster-type = { workspace = true }
 solana-commitment-config = { workspace = true }

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -209,16 +209,7 @@ where
     }
 }
 
-pub fn normalize_to_url_if_moniker<T: AsRef<str>>(url_or_moniker: T) -> String {
-    match url_or_moniker.as_ref() {
-        "m" | "mainnet-beta" => "https://api.mainnet-beta.solana.com",
-        "t" | "testnet" => "https://api.testnet.solana.com",
-        "d" | "devnet" => "https://api.devnet.solana.com",
-        "l" | "localhost" => "http://localhost:8899",
-        url => url,
-    }
-    .to_string()
-}
+pub use solana_cli_config::normalize_to_url_if_moniker;
 
 pub fn is_epoch<T>(epoch: T) -> Result<(), String>
 where

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { workspace = true, features = ["default"] }
 clap = { version = "3.2.23", default-features = false, features = ["cargo", "std", "suggestions"] }
 five8 = { workspace = true }
 rpassword = { workspace = true }
+solana-cli-config = { workspace = true }
 solana-clock = { workspace = true }
 solana-cluster-type = { workspace = true }
 solana-commitment-config = { workspace = true }

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -264,16 +264,7 @@ where
     }
 }
 
-pub fn normalize_to_url_if_moniker<T: AsRef<str>>(url_or_moniker: T) -> String {
-    match url_or_moniker.as_ref() {
-        "m" | "mainnet-beta" => "https://api.mainnet-beta.solana.com",
-        "t" | "testnet" => "https://api.testnet.solana.com",
-        "d" | "devnet" => "https://api.devnet.solana.com",
-        "l" | "localhost" => "http://localhost:8899",
-        url => url,
-    }
-    .to_string()
-}
+pub use solana_cli_config::normalize_to_url_if_moniker;
 
 #[deprecated(
     since = "1.17.0",

--- a/cli-config/Cargo.toml
+++ b/cli-config/Cargo.toml
@@ -21,7 +21,6 @@ agave-unstable-api = []
 dirs-next = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
-solana-clap-utils = { workspace = true }
 solana-commitment-config = { workspace = true }
 url = { workspace = true }
 

--- a/cli-config/Cargo.toml
+++ b/cli-config/Cargo.toml
@@ -19,7 +19,6 @@ agave-unstable-api = []
 dirs-next = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
-solana-clap-utils = { workspace = true }
 solana-commitment-config = { workspace = true }
 url = { workspace = true }
 

--- a/cli-config/src/config_input.rs
+++ b/cli-config/src/config_input.rs
@@ -1,7 +1,4 @@
-use {
-    crate::Config, solana_clap_utils::input_validators::normalize_to_url_if_moniker,
-    solana_commitment_config::CommitmentConfig, std::str::FromStr,
-};
+use {crate::Config, solana_commitment_config::CommitmentConfig, std::str::FromStr};
 
 pub enum SettingType {
     Explicit,
@@ -123,4 +120,15 @@ impl Default for ConfigInput {
             commitment: CommitmentConfig::confirmed(),
         }
     }
+}
+
+fn normalize_to_url_if_moniker<T: AsRef<str>>(url_or_moniker: T) -> String {
+    match url_or_moniker.as_ref() {
+        "m" | "mainnet-beta" => "https://api.mainnet-beta.solana.com",
+        "t" | "testnet" => "https://api.testnet.solana.com",
+        "d" | "devnet" => "https://api.devnet.solana.com",
+        "l" | "localhost" => "http://localhost:8899",
+        url => url,
+    }
+    .to_string()
 }

--- a/cli-config/src/config_input.rs
+++ b/cli-config/src/config_input.rs
@@ -1,7 +1,4 @@
-use {
-    crate::Config, solana_clap_utils::input_validators::normalize_to_url_if_moniker,
-    solana_commitment_config::CommitmentConfig, std::str::FromStr,
-};
+use {crate::Config, solana_commitment_config::CommitmentConfig, std::str::FromStr};
 
 pub enum SettingType {
     Explicit,
@@ -123,4 +120,15 @@ impl Default for ConfigInput {
             commitment: CommitmentConfig::confirmed(),
         }
     }
+}
+
+pub fn normalize_to_url_if_moniker<T: AsRef<str>>(url_or_moniker: T) -> String {
+    match url_or_moniker.as_ref() {
+        "m" | "mainnet-beta" => "https://api.mainnet-beta.solana.com",
+        "t" | "testnet" => "https://api.testnet.solana.com",
+        "d" | "devnet" => "https://api.devnet.solana.com",
+        "l" | "localhost" => "http://localhost:8899",
+        url => url,
+    }
+    .to_string()
 }

--- a/cli-config/src/lib.rs
+++ b/cli-config/src/lib.rs
@@ -59,7 +59,7 @@ use std::{
 };
 pub use {
     config::{CONFIG_FILE, Config},
-    config_input::{ConfigInput, SettingType},
+    config_input::{ConfigInput, SettingType, normalize_to_url_if_moniker},
 };
 
 /// Load a value from a file in YAML format.

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6166,6 +6166,7 @@ dependencies = [
  "clap",
  "rpassword",
  "solana-bls-signatures",
+ "solana-cli-config",
  "solana-clock",
  "solana-cluster-type",
  "solana-commitment-config",
@@ -6192,7 +6193,6 @@ dependencies = [
  "dirs-next",
  "serde",
  "serde_yaml",
- "solana-clap-utils",
  "solana-commitment-config",
  "url 2.5.8",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6316,6 +6316,7 @@ dependencies = [
  "clap",
  "rpassword",
  "solana-bls-signatures",
+ "solana-cli-config",
  "solana-clock",
  "solana-cluster-type",
  "solana-commitment-config",
@@ -6342,7 +6343,6 @@ dependencies = [
  "dirs-next",
  "serde",
  "serde_yaml",
- "solana-clap-utils",
  "solana-commitment-config",
  "url 2.5.8",
 ]


### PR DESCRIPTION
#### Problem

`solana-cli-config` currently depends on `solana-clap-utils`, to use a URL normalization function. This pulls in a large dep tree, including `clap`.

#### Summary of Changes

Remove the dependency edge and copy the function into `cli-config`. Deps counts:
```sh
# Before
$ cargo tree --prefix none | grep -v '*' | wc -l
264
```
<details><summary>Tree Before</summary>
<p>


```
solana-cli-config v4.2.0-alpha.0 (agave/cli-config)
├── dirs-next v2.0.0
│   ├── cfg-if v1.0.4
│   └── dirs-sys-next v0.1.2
│       └── libc v0.2.186
├── serde v1.0.228
│   ├── serde_core v1.0.228
│   └── serde_derive v1.0.228 (proc-macro)
│       ├── proc-macro2 v1.0.106
│       │   └── unicode-ident v1.0.14
│       ├── quote v1.0.45
│       │   └── proc-macro2 v1.0.106 (*)
│       └── syn v2.0.117
│           ├── proc-macro2 v1.0.106 (*)
│           ├── quote v1.0.45 (*)
│           └── unicode-ident v1.0.14
├── serde_yaml v0.9.34+deprecated
│   ├── indexmap v2.14.0
│   │   ├── equivalent v1.0.0
│   │   └── hashbrown v0.17.0
│   ├── itoa v1.0.9
│   ├── ryu v1.0.5
│   ├── serde v1.0.228 (*)
│   └── unsafe-libyaml v0.2.11
├── solana-clap-utils v4.2.0-alpha.0 (agave/clap-utils)
│   ├── chrono v0.4.44
│   │   ├── iana-time-zone v0.1.46
│   │   └── num-traits v0.2.19
│   │       [build-dependencies]
│   │       └── autocfg v1.1.0
│   ├── clap v2.33.3
│   │   ├── bitflags v1.3.2
│   │   ├── strsim v0.8.0
│   │   ├── textwrap v0.11.0
│   │   │   └── unicode-width v0.1.9
│   │   └── unicode-width v0.1.9
│   ├── rpassword v7.5.3
│   │   ├── libc v0.2.186
│   │   └── rtoolbox v0.0.1
│   │       └── libc v0.2.186
│   ├── solana-bls-signatures v3.3.0
│   │   ├── base64 v0.22.1
│   │   ├── blst v0.3.16
│   │   │   ├── threadpool v1.8.1
│   │   │   │   └── num_cpus v1.17.0
│   │   │   │       └── libc v0.2.186
│   │   │   └── zeroize v1.8.2
│   │   │       └── zeroize_derive v1.4.2 (proc-macro)
│   │   │           ├── proc-macro2 v1.0.106 (*)
│   │   │           ├── quote v1.0.45 (*)
│   │   │           └── syn v2.0.117 (*)
│   │   │   [build-dependencies]
│   │   │   └── cc v1.2.56
│   │   │       ├── find-msvc-tools v0.1.9
│   │   │       └── shlex v1.3.0
│   │   ├── blstrs v0.7.1
│   │   │   ├── blst v0.3.16 (*)
│   │   │   ├── byte-slice-cast v1.2.3
│   │   │   ├── ff v0.13.1
│   │   │   │   ├── bitvec v1.0.1
│   │   │   │   │   ├── funty v2.0.0
│   │   │   │   │   ├── radium v0.7.0
│   │   │   │   │   ├── tap v1.0.1
│   │   │   │   │   └── wyz v0.5.1
│   │   │   │   │       └── tap v1.0.1
│   │   │   │   ├── rand_core v0.6.4
│   │   │   │   │   └── getrandom v0.2.15
│   │   │   │   │       ├── cfg-if v1.0.4
│   │   │   │   │       └── libc v0.2.186
│   │   │   │   └── subtle v2.6.1
│   │   │   ├── group v0.13.0
│   │   │   │   ├── ff v0.13.1 (*)
│   │   │   │   ├── rand v0.8.6
│   │   │   │   │   ├── libc v0.2.186
│   │   │   │   │   ├── rand_chacha v0.3.1
│   │   │   │   │   │   ├── ppv-lite86 v0.2.15
│   │   │   │   │   │   └── rand_core v0.6.4 (*)
│   │   │   │   │   └── rand_core v0.6.4 (*)
│   │   │   │   ├── rand_core v0.6.4 (*)
│   │   │   │   ├── rand_xorshift v0.3.0
│   │   │   │   │   └── rand_core v0.6.4 (*)
│   │   │   │   └── subtle v2.6.1
│   │   │   ├── pairing v0.23.0
│   │   │   │   └── group v0.13.0 (*)
│   │   │   ├── rand_core v0.6.4 (*)
│   │   │   ├── serde v1.0.228 (*)
│   │   │   └── subtle v2.6.1
│   │   ├── cfg_eval v0.1.2 (proc-macro)
│   │   │   ├── proc-macro2 v1.0.106 (*)
│   │   │   ├── quote v1.0.45 (*)
│   │   │   └── syn v2.0.117 (*)
│   │   ├── ff v0.13.1 (*)
│   │   ├── group v0.13.0 (*)
│   │   ├── pairing v0.23.0 (*)
│   │   ├── rand v0.8.6 (*)
│   │   ├── serde v1.0.228 (*)
│   │   ├── serde_json v1.0.150
│   │   │   ├── itoa v1.0.9
│   │   │   ├── memchr v2.6.3
│   │   │   ├── serde_core v1.0.228
│   │   │   └── zmij v1.0.10
│   │   ├── serde_with v3.20.0
│   │   │   ├── serde_core v1.0.228
│   │   │   └── serde_with_macros v3.20.0 (proc-macro)
│   │   │       ├── darling v0.23.0
│   │   │       │   ├── darling_core v0.23.0
│   │   │       │   │   ├── ident_case v1.0.1
│   │   │       │   │   ├── proc-macro2 v1.0.106 (*)
│   │   │       │   │   ├── quote v1.0.45 (*)
│   │   │       │   │   ├── strsim v0.11.1
│   │   │       │   │   └── syn v2.0.117 (*)
│   │   │       │   └── darling_macro v0.23.0 (proc-macro)
│   │   │       │       ├── darling_core v0.23.0 (*)
│   │   │       │       ├── quote v1.0.45 (*)
│   │   │       │       └── syn v2.0.117 (*)
│   │   │       ├── proc-macro2 v1.0.106 (*)
│   │   │       ├── quote v1.0.45 (*)
│   │   │       └── syn v2.0.117 (*)
│   │   ├── thiserror v2.0.18
│   │   │   └── thiserror-impl v2.0.18 (proc-macro)
│   │   │       ├── proc-macro2 v1.0.106 (*)
│   │   │       ├── quote v1.0.45 (*)
│   │   │       └── syn v2.0.117 (*)
│   │   └── zeroize v1.8.2 (*)
│   ├── solana-clock v3.1.0
│   │   └── solana-sdk-macro v3.0.1 (proc-macro)
│   │       ├── bs58 v0.5.1
│   │       ├── proc-macro2 v1.0.106 (*)
│   │       ├── quote v1.0.45 (*)
│   │       └── syn v2.0.117 (*)
│   ├── solana-cluster-type v3.1.0
│   │   └── solana-hash v4.3.0
│   │       ├── five8 v1.0.0
│   │       │   └── five8_core v1.0.0
│   │       ├── solana-atomic-u64 v3.0.1
│   │       └── solana-sanitize v3.0.1
│   ├── solana-commitment-config v3.1.1
│   ├── solana-derivation-path v3.0.0
│   │   ├── derivation-path v0.2.0
│   │   ├── qstring v0.7.2
│   │   │   └── percent-encoding v2.3.2
│   │   └── uriparse v0.6.4
│   │       ├── fnv v1.0.7
│   │       └── lazy_static v1.5.0
│   ├── solana-hash v4.3.0 (*)
│   ├── solana-keypair v3.1.2
│   │   ├── ed25519-dalek v2.2.0
│   │   │   ├── curve25519-dalek v4.1.3
│   │   │   │   ├── cfg-if v1.0.4
│   │   │   │   ├── cpufeatures v0.2.17
│   │   │   │   ├── curve25519-dalek-derive v0.1.1 (proc-macro)
│   │   │   │   │   ├── proc-macro2 v1.0.106 (*)
│   │   │   │   │   ├── quote v1.0.45 (*)
│   │   │   │   │   └── syn v2.0.117 (*)
│   │   │   │   ├── digest v0.10.7
│   │   │   │   │   ├── block-buffer v0.10.4
│   │   │   │   │   │   └── generic-array v0.14.7
│   │   │   │   │   │       └── typenum v1.19.0
│   │   │   │   │   │       [build-dependencies]
│   │   │   │   │   │       └── version_check v0.9.4
│   │   │   │   │   ├── crypto-common v0.1.6
│   │   │   │   │   │   ├── generic-array v0.14.7 (*)
│   │   │   │   │   │   └── typenum v1.19.0
│   │   │   │   │   └── subtle v2.6.1
│   │   │   │   ├── subtle v2.6.1
│   │   │   │   └── zeroize v1.8.2 (*)
│   │   │   │   [build-dependencies]
│   │   │   │   └── rustc_version v0.4.1
│   │   │   │       └── semver v1.0.28
│   │   │   ├── ed25519 v2.2.3
│   │   │   │   └── signature v2.2.0
│   │   │   ├── rand_core v0.6.4 (*)
│   │   │   ├── sha2 v0.10.9
│   │   │   │   ├── cfg-if v1.0.4
│   │   │   │   ├── cpufeatures v0.2.17
│   │   │   │   └── digest v0.10.7 (*)
│   │   │   ├── subtle v2.6.1
│   │   │   └── zeroize v1.8.2 (*)
│   │   ├── ed25519-dalek-bip32 v0.3.0
│   │   │   ├── derivation-path v0.2.0
│   │   │   ├── ed25519-dalek v2.2.0 (*)
│   │   │   ├── hmac v0.12.1
│   │   │   │   └── digest v0.10.7 (*)
│   │   │   └── sha2 v0.10.9 (*)
│   │   ├── five8 v1.0.0 (*)
│   │   ├── five8_core v1.0.0
│   │   ├── rand v0.9.4
│   │   │   ├── rand_chacha v0.9.0
│   │   │   │   ├── ppv-lite86 v0.2.15
│   │   │   │   └── rand_core v0.9.3
│   │   │   │       └── getrandom v0.3.4
│   │   │   │           ├── cfg-if v1.0.4
│   │   │   │           └── libc v0.2.186
│   │   │   └── rand_core v0.9.3 (*)
│   │   ├── solana-address v2.6.0
│   │   │   ├── five8 v1.0.0 (*)
│   │   │   ├── five8_const v1.0.0
│   │   │   │   └── five8_core v1.0.0
│   │   │   ├── sha2-const-stable v0.1.0
│   │   │   ├── solana-atomic-u64 v3.0.1
│   │   │   ├── solana-program-error v3.0.1
│   │   │   ├── solana-sanitize v3.0.1
│   │   │   └── solana-sha256-hasher v3.1.0
│   │   │       ├── sha2 v0.10.9 (*)
│   │   │       └── solana-hash v4.3.0 (*)
│   │   ├── solana-derivation-path v3.0.0 (*)
│   │   ├── solana-seed-derivable v3.0.0
│   │   │   └── solana-derivation-path v3.0.0 (*)
│   │   ├── solana-seed-phrase v3.0.0
│   │   │   ├── hmac v0.12.1 (*)
│   │   │   ├── pbkdf2 v0.11.0
│   │   │   │   └── digest v0.10.7 (*)
│   │   │   └── sha2 v0.10.9 (*)
│   │   ├── solana-signature v3.4.0
│   │   │   ├── ed25519-dalek v2.2.0 (*)
│   │   │   ├── five8 v1.0.0 (*)
│   │   │   └── solana-sanitize v3.0.1
│   │   └── solana-signer v3.0.0
│   │       ├── solana-pubkey v3.0.0
│   │       │   └── solana-address v1.1.0
│   │       │       └── solana-address v2.6.0 (*)
│   │       ├── solana-signature v3.4.0 (*)
│   │       └── solana-transaction-error v3.2.0
│   │           ├── solana-instruction-error v2.3.0
│   │           │   ├── num-traits v0.2.19 (*)
│   │           │   └── solana-program-error v3.0.1
│   │           └── solana-sanitize v3.0.1
│   ├── solana-message v4.1.1
│   │   ├── lazy_static v1.5.0
│   │   ├── solana-address v2.6.0 (*)
│   │   ├── solana-hash v4.3.0 (*)
│   │   ├── solana-instruction v3.4.0
│   │   │   ├── solana-instruction-error v2.3.0 (*)
│   │   │   └── solana-pubkey v4.2.0
│   │   │       └── solana-address v2.6.0 (*)
│   │   ├── solana-sanitize v3.0.1
│   │   ├── solana-sdk-ids v3.1.0
│   │   │   └── solana-address v2.6.0 (*)
│   │   └── solana-transaction-error v3.2.0 (*)
│   ├── solana-native-token v3.0.0
│   ├── solana-presigner v3.0.0
│   │   ├── solana-pubkey v3.0.0 (*)
│   │   ├── solana-signature v3.4.0 (*)
│   │   └── solana-signer v3.0.0 (*)
│   ├── solana-pubkey v4.2.0 (*)
│   ├── solana-remote-wallet v4.2.0-alpha.0 (agave/remote-wallet)
│   │   ├── console v0.16.3
│   │   │   ├── libc v0.2.186
│   │   │   └── unicode-width v0.2.0
│   │   ├── dialoguer v0.12.0
│   │   │   ├── console v0.16.3 (*)
│   │   │   ├── shell-words v1.1.0
│   │   │   ├── tempfile v3.27.0
│   │   │   │   ├── fastrand v2.1.1
│   │   │   │   ├── getrandom v0.3.4 (*)
│   │   │   │   ├── once_cell v1.21.3
│   │   │   │   └── rustix v1.1.4
│   │   │   │       ├── bitflags v2.11.1
│   │   │   │       └── linux-raw-sys v0.12.1
│   │   │   └── zeroize v1.8.2 (*)
│   │   ├── log v0.4.30
│   │   ├── num-derive v0.4.2 (proc-macro)
│   │   │   ├── proc-macro2 v1.0.106 (*)
│   │   │   ├── quote v1.0.45 (*)
│   │   │   └── syn v2.0.117 (*)
│   │   ├── num-traits v0.2.19 (*)
│   │   ├── parking_lot v0.12.3
│   │   │   ├── lock_api v0.4.10
│   │   │   │   └── scopeguard v1.2.0
│   │   │   │   [build-dependencies]
│   │   │   │   └── autocfg v1.1.0
│   │   │   └── parking_lot_core v0.9.8
│   │   │       ├── cfg-if v1.0.4
│   │   │       ├── libc v0.2.186
│   │   │       └── smallvec v1.15.1
│   │   ├── semver v1.0.28
│   │   ├── solana-derivation-path v3.0.0 (*)
│   │   ├── solana-offchain-message v3.0.0
│   │   │   ├── num_enum v0.7.6
│   │   │   │   ├── num_enum_derive v0.7.6 (proc-macro)
│   │   │   │   │   ├── proc-macro-crate v3.1.0
│   │   │   │   │   │   └── toml_edit v0.21.1
│   │   │   │   │   │       ├── indexmap v2.14.0 (*)
│   │   │   │   │   │       ├── toml_datetime v0.6.5
│   │   │   │   │   │       └── winnow v0.5.16
│   │   │   │   │   ├── proc-macro2 v1.0.106 (*)
│   │   │   │   │   ├── quote v1.0.45 (*)
│   │   │   │   │   └── syn v2.0.117 (*)
│   │   │   │   └── rustversion v1.0.17 (proc-macro)
│   │   │   ├── solana-hash v3.1.0
│   │   │   │   └── solana-hash v4.3.0 (*)
│   │   │   ├── solana-packet v3.0.0
│   │   │   │   └── bitflags v2.11.1
│   │   │   ├── solana-sanitize v3.0.1
│   │   │   ├── solana-sha256-hasher v3.1.0 (*)
│   │   │   ├── solana-signature v3.4.0 (*)
│   │   │   └── solana-signer v3.0.0 (*)
│   │   ├── solana-pubkey v4.2.0 (*)
│   │   ├── solana-signature v3.4.0 (*)
│   │   ├── solana-signer v3.0.0 (*)
│   │   ├── thiserror v2.0.18 (*)
│   │   ├── trezor-client v0.1.5
│   │   │   ├── byteorder v1.5.0
│   │   │   ├── hex v0.4.3
│   │   │   ├── protobuf v3.7.2
│   │   │   │   ├── once_cell v1.21.3
│   │   │   │   ├── protobuf-support v3.7.2
│   │   │   │   │   └── thiserror v1.0.69
│   │   │   │   │       └── thiserror-impl v1.0.69 (proc-macro)
│   │   │   │   │           ├── proc-macro2 v1.0.106 (*)
│   │   │   │   │           ├── quote v1.0.45 (*)
│   │   │   │   │           └── syn v2.0.117 (*)
│   │   │   │   └── thiserror v1.0.69 (*)
│   │   │   ├── rusb v0.9.4
│   │   │   │   ├── libc v0.2.186
│   │   │   │   └── libusb1-sys v0.7.0
│   │   │   │       └── libc v0.2.186
│   │   │   │       [build-dependencies]
│   │   │   │       ├── cc v1.2.56 (*)
│   │   │   │       └── pkg-config v0.3.22
│   │   │   ├── thiserror v2.0.18 (*)
│   │   │   └── tracing v0.1.41
│   │   │       ├── pin-project-lite v0.2.14
│   │   │       ├── tracing-attributes v0.1.30 (proc-macro)
│   │   │       │   ├── proc-macro2 v1.0.106 (*)
│   │   │       │   ├── quote v1.0.45 (*)
│   │   │       │   └── syn v2.0.117 (*)
│   │   │       └── tracing-core v0.1.34
│   │   │           └── once_cell v1.21.3
│   │   └── uriparse v0.6.4 (*)
│   ├── solana-seed-phrase v3.0.0 (*)
│   ├── solana-signature v3.4.0 (*)
│   ├── solana-signer v3.0.0 (*)
│   ├── thiserror v2.0.18 (*)
│   ├── tiny-bip39 v2.0.0
│   │   ├── once_cell v1.21.3
│   │   ├── pbkdf2 v0.12.2
│   │   │   ├── digest v0.10.7 (*)
│   │   │   └── hmac v0.12.1 (*)
│   │   ├── rand v0.8.6 (*)
│   │   ├── rustc-hash v1.1.0
│   │   ├── sha2 v0.10.9 (*)
│   │   ├── thiserror v1.0.69 (*)
│   │   ├── unicode-normalization v0.1.22
│   │   │   └── tinyvec v1.6.0
│   │   │       └── tinyvec_macros v0.1.0
│   │   └── zeroize v1.8.2 (*)
│   ├── uriparse v0.6.4 (*)
│   └── url v2.5.8
│       ├── form_urlencoded v1.2.2
│       │   └── percent-encoding v2.3.2
│       ├── idna v1.1.0
│       │   ├── idna_adapter v1.2.0
│       │   │   ├── icu_normalizer v1.5.0
│       │   │   │   ├── displaydoc v0.2.3 (proc-macro)
│       │   │   │   │   ├── proc-macro2 v1.0.106 (*)
│       │   │   │   │   ├── quote v1.0.45 (*)
│       │   │   │   │   └── syn v1.0.109
│       │   │   │   │       ├── proc-macro2 v1.0.106 (*)
│       │   │   │   │       ├── quote v1.0.45 (*)
│       │   │   │   │       └── unicode-ident v1.0.14
│       │   │   │   ├── icu_collections v1.5.0
│       │   │   │   │   ├── displaydoc v0.2.3 (proc-macro) (*)
│       │   │   │   │   ├── yoke v0.7.4
│       │   │   │   │   │   ├── stable_deref_trait v1.2.0
│       │   │   │   │   │   ├── yoke-derive v0.7.4 (proc-macro)
│       │   │   │   │   │   │   ├── proc-macro2 v1.0.106 (*)
│       │   │   │   │   │   │   ├── quote v1.0.45 (*)
│       │   │   │   │   │   │   ├── syn v2.0.117 (*)
│       │   │   │   │   │   │   └── synstructure v0.13.1
│       │   │   │   │   │   │       ├── proc-macro2 v1.0.106 (*)
│       │   │   │   │   │   │       ├── quote v1.0.45 (*)
│       │   │   │   │   │   │       └── syn v2.0.117 (*)
│       │   │   │   │   │   └── zerofrom v0.1.4
│       │   │   │   │   │       └── zerofrom-derive v0.1.4 (proc-macro)
│       │   │   │   │   │           ├── proc-macro2 v1.0.106 (*)
│       │   │   │   │   │           ├── quote v1.0.45 (*)
│       │   │   │   │   │           ├── syn v2.0.117 (*)
│       │   │   │   │   │           └── synstructure v0.13.1 (*)
│       │   │   │   │   ├── zerofrom v0.1.4 (*)
│       │   │   │   │   └── zerovec v0.10.4
│       │   │   │   │       ├── yoke v0.7.4 (*)
│       │   │   │   │       ├── zerofrom v0.1.4 (*)
│       │   │   │   │       └── zerovec-derive v0.10.3 (proc-macro)
│       │   │   │   │           ├── proc-macro2 v1.0.106 (*)
│       │   │   │   │           ├── quote v1.0.45 (*)
│       │   │   │   │           └── syn v2.0.117 (*)
│       │   │   │   ├── icu_normalizer_data v1.5.0
│       │   │   │   ├── icu_properties v1.5.1
│       │   │   │   │   ├── displaydoc v0.2.3 (proc-macro) (*)
│       │   │   │   │   ├── icu_collections v1.5.0 (*)
│       │   │   │   │   ├── icu_locid_transform v1.5.0
│       │   │   │   │   │   ├── displaydoc v0.2.3 (proc-macro) (*)
│       │   │   │   │   │   ├── icu_locid v1.5.0
│       │   │   │   │   │   │   ├── displaydoc v0.2.3 (proc-macro) (*)
│       │   │   │   │   │   │   ├── litemap v0.7.3
│       │   │   │   │   │   │   ├── tinystr v0.7.6
│       │   │   │   │   │   │   │   ├── displaydoc v0.2.3 (proc-macro) (*)
│       │   │   │   │   │   │   │   └── zerovec v0.10.4 (*)
│       │   │   │   │   │   │   ├── writeable v0.5.5
│       │   │   │   │   │   │   └── zerovec v0.10.4 (*)
│       │   │   │   │   │   ├── icu_locid_transform_data v1.5.0
│       │   │   │   │   │   ├── icu_provider v1.5.0
│       │   │   │   │   │   │   ├── displaydoc v0.2.3 (proc-macro) (*)
│       │   │   │   │   │   │   ├── icu_locid v1.5.0 (*)
│       │   │   │   │   │   │   ├── icu_provider_macros v1.5.0 (proc-macro)
│       │   │   │   │   │   │   │   ├── proc-macro2 v1.0.106 (*)
│       │   │   │   │   │   │   │   ├── quote v1.0.45 (*)
│       │   │   │   │   │   │   │   └── syn v2.0.117 (*)
│       │   │   │   │   │   │   ├── stable_deref_trait v1.2.0
│       │   │   │   │   │   │   ├── tinystr v0.7.6 (*)
│       │   │   │   │   │   │   ├── writeable v0.5.5
│       │   │   │   │   │   │   ├── yoke v0.7.4 (*)
│       │   │   │   │   │   │   ├── zerofrom v0.1.4 (*)
│       │   │   │   │   │   │   └── zerovec v0.10.4 (*)
│       │   │   │   │   │   ├── tinystr v0.7.6 (*)
│       │   │   │   │   │   └── zerovec v0.10.4 (*)
│       │   │   │   │   ├── icu_properties_data v1.5.0
│       │   │   │   │   ├── icu_provider v1.5.0 (*)
│       │   │   │   │   ├── tinystr v0.7.6 (*)
│       │   │   │   │   └── zerovec v0.10.4 (*)
│       │   │   │   ├── icu_provider v1.5.0 (*)
│       │   │   │   ├── smallvec v1.15.1
│       │   │   │   ├── utf16_iter v1.0.5
│       │   │   │   ├── utf8_iter v1.0.4
│       │   │   │   ├── write16 v1.0.0
│       │   │   │   └── zerovec v0.10.4 (*)
│       │   │   └── icu_properties v1.5.1 (*)
│       │   ├── smallvec v1.15.1
│       │   └── utf8_iter v1.0.4
│       └── percent-encoding v2.3.2
├── solana-commitment-config v3.1.1
└── url v2.5.8 (*)
```


</p>
</details> 

```sh
# After 
$ cargo tree --prefix none | grep -v '*' | wc -l
60
```

<details><summary>Tree After</summary>
<p>


```
solana-cli-config v4.2.0-alpha.0 (agave/cli-config)
├── dirs-next v2.0.0
│   ├── cfg-if v1.0.4
│   └── dirs-sys-next v0.1.2
│       └── libc v0.2.186
├── serde v1.0.228
│   ├── serde_core v1.0.228
│   └── serde_derive v1.0.228 (proc-macro)
│       ├── proc-macro2 v1.0.106
│       │   └── unicode-ident v1.0.14
│       ├── quote v1.0.45
│       │   └── proc-macro2 v1.0.106 (*)
│       └── syn v2.0.117
│           ├── proc-macro2 v1.0.106 (*)
│           ├── quote v1.0.45 (*)
│           └── unicode-ident v1.0.14
├── serde_yaml v0.9.34+deprecated
│   ├── indexmap v2.14.0
│   │   ├── equivalent v1.0.0
│   │   └── hashbrown v0.17.0
│   ├── itoa v1.0.9
│   ├── ryu v1.0.5
│   ├── serde v1.0.228 (*)
│   └── unsafe-libyaml v0.2.11
├── solana-commitment-config v3.1.1
└── url v2.5.8
    ├── form_urlencoded v1.2.2
    │   └── percent-encoding v2.3.2
    ├── idna v1.1.0
    │   ├── idna_adapter v1.2.0
    │   │   ├── icu_normalizer v1.5.0
    │   │   │   ├── displaydoc v0.2.3 (proc-macro)
    │   │   │   │   ├── proc-macro2 v1.0.106 (*)
    │   │   │   │   ├── quote v1.0.45 (*)
    │   │   │   │   └── syn v1.0.109
    │   │   │   │       ├── proc-macro2 v1.0.106 (*)
    │   │   │   │       ├── quote v1.0.45 (*)
    │   │   │   │       └── unicode-ident v1.0.14
    │   │   │   ├── icu_collections v1.5.0
    │   │   │   │   ├── displaydoc v0.2.3 (proc-macro) (*)
    │   │   │   │   ├── yoke v0.7.4
    │   │   │   │   │   ├── stable_deref_trait v1.2.0
    │   │   │   │   │   ├── yoke-derive v0.7.4 (proc-macro)
    │   │   │   │   │   │   ├── proc-macro2 v1.0.106 (*)
    │   │   │   │   │   │   ├── quote v1.0.45 (*)
    │   │   │   │   │   │   ├── syn v2.0.117 (*)
    │   │   │   │   │   │   └── synstructure v0.13.1
    │   │   │   │   │   │       ├── proc-macro2 v1.0.106 (*)
    │   │   │   │   │   │       ├── quote v1.0.45 (*)
    │   │   │   │   │   │       └── syn v2.0.117 (*)
    │   │   │   │   │   └── zerofrom v0.1.4
    │   │   │   │   │       └── zerofrom-derive v0.1.4 (proc-macro)
    │   │   │   │   │           ├── proc-macro2 v1.0.106 (*)
    │   │   │   │   │           ├── quote v1.0.45 (*)
    │   │   │   │   │           ├── syn v2.0.117 (*)
    │   │   │   │   │           └── synstructure v0.13.1 (*)
    │   │   │   │   ├── zerofrom v0.1.4 (*)
    │   │   │   │   └── zerovec v0.10.4
    │   │   │   │       ├── yoke v0.7.4 (*)
    │   │   │   │       ├── zerofrom v0.1.4 (*)
    │   │   │   │       └── zerovec-derive v0.10.3 (proc-macro)
    │   │   │   │           ├── proc-macro2 v1.0.106 (*)
    │   │   │   │           ├── quote v1.0.45 (*)
    │   │   │   │           └── syn v2.0.117 (*)
    │   │   │   ├── icu_normalizer_data v1.5.0
    │   │   │   ├── icu_properties v1.5.1
    │   │   │   │   ├── displaydoc v0.2.3 (proc-macro) (*)
    │   │   │   │   ├── icu_collections v1.5.0 (*)
    │   │   │   │   ├── icu_locid_transform v1.5.0
    │   │   │   │   │   ├── displaydoc v0.2.3 (proc-macro) (*)
    │   │   │   │   │   ├── icu_locid v1.5.0
    │   │   │   │   │   │   ├── displaydoc v0.2.3 (proc-macro) (*)
    │   │   │   │   │   │   ├── litemap v0.7.3
    │   │   │   │   │   │   ├── tinystr v0.7.6
    │   │   │   │   │   │   │   ├── displaydoc v0.2.3 (proc-macro) (*)
    │   │   │   │   │   │   │   └── zerovec v0.10.4 (*)
    │   │   │   │   │   │   ├── writeable v0.5.5
    │   │   │   │   │   │   └── zerovec v0.10.4 (*)
    │   │   │   │   │   ├── icu_locid_transform_data v1.5.0
    │   │   │   │   │   ├── icu_provider v1.5.0
    │   │   │   │   │   │   ├── displaydoc v0.2.3 (proc-macro) (*)
    │   │   │   │   │   │   ├── icu_locid v1.5.0 (*)
    │   │   │   │   │   │   ├── icu_provider_macros v1.5.0 (proc-macro)
    │   │   │   │   │   │   │   ├── proc-macro2 v1.0.106 (*)
    │   │   │   │   │   │   │   ├── quote v1.0.45 (*)
    │   │   │   │   │   │   │   └── syn v2.0.117 (*)
    │   │   │   │   │   │   ├── stable_deref_trait v1.2.0
    │   │   │   │   │   │   ├── tinystr v0.7.6 (*)
    │   │   │   │   │   │   ├── writeable v0.5.5
    │   │   │   │   │   │   ├── yoke v0.7.4 (*)
    │   │   │   │   │   │   ├── zerofrom v0.1.4 (*)
    │   │   │   │   │   │   └── zerovec v0.10.4 (*)
    │   │   │   │   │   ├── tinystr v0.7.6 (*)
    │   │   │   │   │   └── zerovec v0.10.4 (*)
    │   │   │   │   ├── icu_properties_data v1.5.0
    │   │   │   │   ├── icu_provider v1.5.0 (*)
    │   │   │   │   ├── tinystr v0.7.6 (*)
    │   │   │   │   └── zerovec v0.10.4 (*)
    │   │   │   ├── icu_provider v1.5.0 (*)
    │   │   │   ├── smallvec v1.15.1
    │   │   │   ├── utf16_iter v1.0.5
    │   │   │   ├── utf8_iter v1.0.4
    │   │   │   ├── write16 v1.0.0
    │   │   │   └── zerovec v0.10.4 (*)
    │   │   └── icu_properties v1.5.1 (*)
    │   ├── smallvec v1.15.1
    │   └── utf8_iter v1.0.4
    └── percent-encoding v2.3.2
```


</p>
</details> 