### PR TITLE
nit: add assert for `delta_first_slice <= delta_block`

### DIFF
--- a/votor/src/timer_manager/timers.rs
+++ b/votor/src/timer_manager/timers.rs
@@ -202,6 +202,7 @@ impl Timers {
         delta_first_slice: Duration,
         delta_block: Duration,
     ) {
+        assert!(delta_first_slice <= delta_block);
         assert_eq!(self.heap.len(), self.timers.len());
         let timeout_config = TimeoutConfig {
             delta_timeout: self.delta_timeout,


### PR DESCRIPTION
#### Problem
This is just additional defense-in-depth. If we currently had `delta_first_slice > delta_block`, we would successfully construct `TimeoutConfig` and `TimerState` and only fail on a `checked_sub()` sometime later.

#### Summary of Changes
Add the assert to `set_timeouts()`, before constructing the `TimeoutConfig`.