### PR TITLE
chore: Cleanup Cargo.toml dependencies

### DIFF
--- a/faucet-cli/Cargo.toml
+++ b/faucet-cli/Cargo.toml
@@ -22,7 +22,7 @@ clap = { workspace = true }
 log = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
-solana-faucet = { workspace = true, features = ["agave-unstable-api"] }
+solana-faucet = { workspace = true }
 solana-keypair = { workspace = true }
 solana-metrics = { workspace = true }
 solana-version = { workspace = true }

--- a/gossip-cli/Cargo.toml
+++ b/gossip-cli/Cargo.toml
@@ -22,8 +22,8 @@ agave-logger = { workspace = true }
 clap = { workspace = true }
 log = { workspace = true }
 solana-clap-utils = { workspace = true }
-solana-gossip = { workspace = true, features = ["agave-unstable-api"] }
-solana-net-utils = { workspace = true, features = ["agave-unstable-api"] }
+solana-gossip = { workspace = true }
+solana-net-utils = { workspace = true }
 solana-pubkey = { version = "=4.2.0", features = ["rand"] }
 solana-version = { workspace = true }
 

--- a/scheduling-utils/Cargo.toml
+++ b/scheduling-utils/Cargo.toml
@@ -14,7 +14,7 @@ agave-unstable-api = []
 dev-context-only-utils = ["dep:wincode", "dep:solana-transaction"]
 
 [dependencies]
-agave-feature-set = { workspace = true, features = ["agave-unstable-api"] }
+agave-feature-set = { workspace = true }
 agave-scheduler-bindings = { workspace = true }
 agave-transaction-view = { workspace = true }
 ahash = { workspace = true }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -57,7 +57,7 @@ solana-epoch-schedule = { workspace = true }
 solana-faucet = { workspace = true }
 solana-genesis-utils = { workspace = true }
 solana-geyser-plugin-manager = { workspace = true }
-solana-gossip = { workspace = true, features = ["agave-unstable-api"] }
+solana-gossip = { workspace = true }
 solana-hash = { workspace = true }
 solana-inflation = { workspace = true }
 solana-keypair = { workspace = true }


### PR DESCRIPTION
#### Problem
Several workspace members state dependencies and relist agave-unstable-api as a necessary feature. This feature is presumed to be required and is listed in the workspace Cargo.toml file. Thus, workspace members can simply use workspace = true

#### Summary of Changes
Remove redundant feature declaration