### PR TITLE
ci: Specify user-agent for crates.io curl

### DIFF
--- a/ci/check-crates.sh
+++ b/ci/check-crates.sh
@@ -88,7 +88,9 @@ for file in "${files[@]}"; do
     exit 1
   fi
 
-  response=$(curl -s https://crates.io/api/v1/crates/"$crate_name"/owners)
+  # crates.io API docs state to include a user-agent header:
+  # https://crates.io/data-access#api
+  response=$(curl -A 'Anza (https://github.com/anza-xyz/agave)' -s https://crates.io/api/v1/crates/"$crate_name"/owners)
   errors=$(echo "$response" | jq .errors)
   if [[ $errors != "null" ]]; then
     details=$(echo "$response" | jq .errors | jq -r ".[0].detail")


### PR DESCRIPTION
#### Problem
From https://crates.io/data-access#api

> you are welcome to use the crates.io API provided you abide by the following limits:
> ...
> A user-agent header that identifies your application. We strongly suggest providing a way for us to contact you (whether through a repository, or an e-mail address, or whatever is appropriate) so that we can reach out to work with you should there be issues.

#### Summary of Changes
Set the user agent header
