### PR TITLE
banking-trace: use bounded channel

### DIFF
--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -2,9 +2,7 @@ use {
     agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
     bincode::serialize_into,
     chrono::{DateTime, Local},
-    crossbeam_channel::{
-        Receiver, SendError, Sender, TryRecvError, TrySendError, bounded, unbounded,
-    },
+    crossbeam_channel::{Receiver, SendError, TryRecvError, TrySendError, bounded},
     rolling_file::{RollingCondition, RollingConditionBasic, RollingFileAppender},
     serde::{Deserialize, Serialize},
     solana_clock::Slot,
@@ -66,13 +64,12 @@ pub const DISABLED_BAKING_TRACE_DIR: DirByteLimit = 0;
 pub const BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT: DirByteLimit =
     TRACE_FILE_DEFAULT_ROTATE_BYTE_THRESHOLD * TRACE_FILE_ROTATE_COUNT;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 struct ActiveTracer {
-    trace_sender: Sender<TimedTracedEvent>,
+    trace_sender: EvictingSender<TimedTracedEvent>,
     exit: Arc<AtomicBool>,
 }
 
-#[derive(Debug)]
 pub struct BankingTracer {
     active_tracer: Option<ActiveTracer>,
 }
@@ -230,7 +227,9 @@ impl BankingTracer {
                     ));
                 }
 
-                let (trace_sender, trace_receiver) = unbounded();
+                const TRACING_CHANNEL_CAPACITY: usize = 50_000;
+                let (trace_sender, trace_receiver) =
+                    EvictingSender::new_bounded(TRACING_CHANNEL_CAPACITY);
 
                 let file_appender = Self::create_file_appender(path, rotate_threshold_size)?;
 
@@ -428,15 +427,11 @@ impl TracedSender {
     pub fn send(&self, batch: BankingPacketBatch) -> Result<(), SendError<BankingPacketBatch>> {
         if let Some(ActiveTracer { trace_sender, exit }) = &self.active_tracer {
             if !exit.load(Ordering::Relaxed) {
-                trace_sender
-                    .send(TimedTracedEvent(
-                        SystemTime::now(),
-                        TracedEvent::PacketBatch(self.label, BankingPacketBatch::clone(&batch)),
-                    ))
-                    .map_err(|err| {
-                        error!("unexpected error when tracing a banking event...: {err:?}");
-                        SendError(BankingPacketBatch::clone(&batch))
-                    })?;
+                // Ignore errors in sending to tracer - it is a non-critical component.
+                let _ = trace_sender.try_send(TimedTracedEvent(
+                    SystemTime::now(),
+                    TracedEvent::PacketBatch(self.label, BankingPacketBatch::clone(&batch)),
+                ));
             }
         }
         let (result, sent) = match self.sender.try_send(batch) {

--- a/streamer/src/evicting_sender.rs
+++ b/streamer/src/evicting_sender.rs
@@ -4,10 +4,19 @@ use {
 };
 
 /// A sender implementation that evicts the oldest message when the channel is full.
-#[derive(Clone)]
 pub struct EvictingSender<T> {
     sender: Sender<T>,
     receiver: Receiver<T>,
+}
+
+// Manual implementation of Clone since `T` is not required to implement Clone.
+impl<T> Clone for EvictingSender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            receiver: self.receiver.clone(),
+        }
+    }
 }
 
 impl<T> EvictingSender<T> {


### PR DESCRIPTION
#### Problem
- unbounded channels are dumb
- banking trace uses an unbounded channel

#### Summary of Changes
- use a bounded evicting sender for banking trace 

Fixes #
