### PR TITLE
blockstore_processor: fix BlockFooter race condition

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -733,7 +733,7 @@ fn record_and_complete_block(
         "optimistic_parent should be None after receiving ParentReady"
     );
 
-    // Alpentick and clear bank
+    // Alpentick, produce the footer, and clear bank
     let mut w_poh_recorder = ctx.poh_recorder.write().unwrap();
     let bank = w_poh_recorder
         .bank()
@@ -761,6 +761,10 @@ fn record_and_complete_block(
         let guard = ctx.highest_finalized.read().unwrap();
         let footer = produce_block_footer(&bank, skip, notar, guard.as_ref());
         let final_cert_input = guard.as_ref().map(|c| c.vote_rewards_input());
+
+        // BankingStage may still be executing batches that were already recorded.
+        // Footer processing mutates vote accounts directly, so wait for execution to complete first.
+        bank.wait_for_inflight_commits();
 
         BlockComponentProcessor::update_bank_with_footer_fields(
             &bank,

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -446,6 +446,20 @@ impl VersionedBlockMarker {
         let g = BlockMarkerV1::GenesisCertificate(LengthPrefixed::new(g));
         VersionedBlockMarker::V1(g)
     }
+
+    pub fn is_update_parent(&self) -> bool {
+        match self {
+            VersionedBlockMarker::V1(BlockMarkerV1::UpdateParent(_)) => true,
+            VersionedBlockMarker::V1(_) => false,
+        }
+    }
+
+    pub fn is_footer(&self) -> bool {
+        match self {
+            VersionedBlockMarker::V1(BlockMarkerV1::BlockFooter(_)) => true,
+            VersionedBlockMarker::V1(_) => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -22,7 +22,7 @@ use {
     solana_clock::Slot,
     solana_cost_model::{cost_model::CostModel, transaction_cost::TransactionCost},
     solana_entry::{
-        block_component::{BlockComponent, VersionedBlockMarker},
+        block_component::BlockComponent,
         entry::{self, Entry, EntrySlice, EntryType, create_ticks},
     },
     solana_genesis_config::GenesisConfig,
@@ -1861,13 +1861,17 @@ fn confirm_slot_with_components(
                 )?;
             }
             BlockComponent::BlockMarker(marker) => {
+                if marker.is_footer() {
+                    // The footer path mutates vote accounts directly to pay rewards.
+                    // All prior transactions must finish first so vote account view is deterministic.
+                    if let Some((result, execute_time)) = bank.wait_for_completed_scheduler() {
+                        timing.batch_execute.totals.accumulate(&execute_time);
+                        result?;
+                    }
+                }
                 if let Some(parent_bank) = bank.parent() {
-                    let allow_initial_update_parent = replay_starts_at_update_parent
-                        && matches!(
-                            &marker,
-                            VersionedBlockMarker::V1(marker)
-                                if marker.as_update_parent().is_some()
-                        );
+                    let allow_initial_update_parent =
+                        replay_starts_at_update_parent && marker.is_update_parent();
                     processor
                         .on_marker(
                             bank.clone_without_scheduler(),


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/issues/12698 for the full details

TLDR:
When the unified scheduler is active, txs are replayed asynchronously.
Processing the block footer directly updates the VoteAccounts by incrementing credits for rewards.
If a tx were to read the vote account during the same time, we could have a non deterministic view -> bank hash mismatch

#### Summary of Changes
Before processing the footer wait for the scheduler to finish.
Normally we would wait anyway shortly after in replay before freezing 
https://github.com/anza-xyz/agave/blob/201ccb236c8472a4df70755dd73bbaaf871f05e7/core/src/replay_stage.rs#L3806-L3816
This just moves it up, so I don't think there's really a performance hit here - but open to other suggestions

Fixes #https://github.com/anza-xyz/agave/issues/12698

Verified that a handful of ledger tool runs against the "bad" ledger from #12698 with this fix produces the correct bank hash