### PR TITLE
bank: update hashes_per_tick to None for Alpenglow banks

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1246,6 +1246,13 @@ fn create_and_insert_leader_bank(
         &parent_bank.hash(),
     );
 
+    // If this is the first alpenglow block, set PoH to low power mode.
+    // This is persisted in the recorder when we set bank.
+    // Replayers will update hashes_per_tick when they process the genesis certificate block marker.
+    if should_include_genesis_certificate(parent_slot, &ctx.genesis_cert) {
+        tpu_bank.set_hashes_per_tick(None);
+    }
+
     // Insert the bank
     let tpu_bank = ctx.bank_forks_controller.insert_bank(tpu_bank)?;
 
@@ -1279,7 +1286,7 @@ fn maybe_include_genesis_certificate(
     parent_slot: Slot,
     ctx: &LeaderContext,
 ) -> Result<(), PohRecorderError> {
-    if parent_slot != ctx.genesis_cert.slot || parent_slot == 0 {
+    if !should_include_genesis_certificate(parent_slot, &ctx.genesis_cert) {
         return Ok(());
     }
 
@@ -1299,6 +1306,13 @@ fn maybe_include_genesis_certificate(
         )
         .expect("Recording genesis certificate should not fail");
     Ok(())
+}
+
+fn should_include_genesis_certificate(
+    parent_slot: Slot,
+    genesis_cert: &GenesisCertificate,
+) -> bool {
+    parent_slot == genesis_cert.slot && parent_slot != 0
 }
 
 #[cfg(test)]

--- a/entry/src/poh.rs
+++ b/entry/src/poh.rs
@@ -52,6 +52,10 @@ impl Poh {
         self.hashes_per_tick
     }
 
+    pub fn hashes_per_tick_config(&self) -> Option<u64> {
+        (self.hashes_per_tick != LOW_POWER_MODE).then_some(self.hashes_per_tick)
+    }
+
     pub fn target_poh_time(&self, target_ns_per_tick: u64) -> Instant {
         assert!(self.hashes_per_tick > 0);
         let offset_tick_ns = target_ns_per_tick * self.tick_number;

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -205,6 +205,7 @@ impl LocalCluster {
     }
 
     pub fn new_alpenglow(config: &mut ClusterConfig, socket_addr_space: SocketAddrSpace) -> Self {
+        config.poh_config.hashes_per_tick = None;
         Self::init(config, socket_addr_space, AlpenglowMode::Enabled)
     }
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -16,9 +16,7 @@ use {
     solana_account::AccountSharedData,
     solana_accounts_db::utils::create_accounts_run_and_snapshot_dirs,
     solana_client_traits::AsyncClient,
-    solana_clock::{
-        self as clock, DEFAULT_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT, MAX_PROCESSING_AGE, Slot,
-    },
+    solana_clock::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT, MAX_PROCESSING_AGE, Slot},
     solana_cluster_type::ClusterType,
     solana_commitment_config::CommitmentConfig,
     solana_core::{
@@ -5858,7 +5856,7 @@ fn test_alpenglow_nodes_basic(num_nodes: usize, num_offline_nodes: usize) {
         stakers_slot_offset: MINIMUM_SLOTS_PER_EPOCH * 2,
         poh_config: PohConfig {
             target_tick_duration: PohConfig::default().target_tick_duration,
-            hashes_per_tick: Some(clock::DEFAULT_HASHES_PER_TICK),
+            hashes_per_tick: None,
             target_tick_count: None,
         },
         ..ClusterConfig::default()

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -218,11 +218,6 @@ pub struct PohRecorder {
 
     // Allocation to hold PohEntrys recorded into PoHStream.
     entries: Vec<PohEntry>,
-
-    /// When alpenglow is enabled there will be no ticks apart from a final one
-    /// to complete the block. This tick will not be verified, and we use this
-    /// flag to unset hashes_per_tick
-    alpenglow_enabled: bool,
 }
 
 impl PohRecorder {
@@ -305,7 +300,6 @@ impl PohRecorder {
                 last_reported_slot_for_pending_fork: Arc::default(),
                 is_exited,
                 entries: Vec::with_capacity(64),
-                alpenglow_enabled: false,
             },
             working_bank_receiver,
         )
@@ -479,18 +473,17 @@ impl PohRecorder {
         trace!("new working bank");
         assert_eq!(working_bank.bank.ticks_per_slot(), self.ticks_per_slot());
         let mut tick_height = self.tick_height();
-        if let Some(hashes_per_tick) = *working_bank.bank.hashes_per_tick() {
-            if self.poh.lock().unwrap().hashes_per_tick() != hashes_per_tick {
-                // We must clear/reset poh when changing hashes per tick because it's
-                // possible there are ticks in the cache created with the old hashes per
-                // tick value that would get flushed later. This would corrupt the leader's
-                // block and it would be disregarded by the network.
-                info!(
-                    "resetting poh due to hashes per tick change detected at {}",
-                    working_bank.bank.slot()
-                );
-                tick_height = self.reset_poh(working_bank.bank.clone(), false);
-            }
+        let hashes_per_tick = working_bank.bank.hashes_per_tick();
+        if self.poh.lock().unwrap().hashes_per_tick_config() != hashes_per_tick {
+            // We must clear/reset poh when changing hashes per tick because it's
+            // possible there are ticks in the cache created with the old hashes per
+            // tick value that would get flushed later. This would corrupt the leader's
+            // block and it would be disregarded by the network.
+            info!(
+                "resetting poh due to hashes per tick change detected at {}",
+                working_bank.bank.slot()
+            );
+            tick_height = self.reset_poh(working_bank.bank.clone(), false);
         }
 
         let leader_state = self.shared_leader_state.load();
@@ -568,11 +561,7 @@ impl PohRecorder {
     #[must_use]
     fn reset_poh(&mut self, reset_bank: Arc<Bank>, reset_start_bank: bool) -> u64 {
         let blockhash = reset_bank.last_blockhash();
-        let hashes_per_tick = if self.alpenglow_enabled {
-            None
-        } else {
-            *reset_bank.hashes_per_tick()
-        };
+        let hashes_per_tick = reset_bank.hashes_per_tick();
         let poh_hash = {
             let mut poh = self.poh.lock().unwrap();
             poh.reset(blockhash, hashes_per_tick);
@@ -1083,7 +1072,6 @@ impl PohRecorder {
 
     pub fn enable_alpenglow(&mut self) {
         info!("Enabling Alpenglow, migrating poh to low power mode");
-        self.alpenglow_enabled = true;
         self.tick_cache = vec![];
         {
             let mut poh = self.poh.lock().unwrap();
@@ -1497,6 +1485,64 @@ mod tests {
         ));
         assert!(poh_recorder.has_bank());
         assert!(!poh_recorder.tick_cache.is_empty());
+    }
+
+    #[test]
+    fn test_set_bank_resets_to_low_power_mode() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(
+            Blockstore::open(ledger_path.path()).expect("Expected to be able to open ledger"),
+        );
+        let GenesisConfigInfo {
+            mut genesis_config, ..
+        } = create_genesis_config(2);
+        genesis_config.poh_config.hashes_per_tick = Some(4);
+        let (parent, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        let child = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            parent.clone(),
+            SlotLeader::default(),
+            parent.slot() + 1,
+        );
+        child.set_hashes_per_tick(None);
+        child.set_tick_height(child.max_tick_height() - 1);
+
+        let prev_hash = parent.last_blockhash();
+        let (mut poh_recorder, _entry_receiver) = PohRecorder::new(
+            parent.tick_height(),
+            prev_hash,
+            parent.clone(),
+            Some((child.slot(), child.slot())),
+            parent.ticks_per_slot(),
+            blockstore,
+            &Arc::new(LeaderScheduleCache::new_from_bank(&parent)),
+            &genesis_config.poh_config,
+            Arc::new(AtomicBool::default()),
+        );
+        assert_eq!(
+            poh_recorder.poh.lock().unwrap().hashes_per_tick_config(),
+            Some(4)
+        );
+
+        poh_recorder.set_bank_for_test(child.clone());
+        assert_eq!(
+            poh_recorder.poh.lock().unwrap().hashes_per_tick_config(),
+            None
+        );
+
+        let bank_to_freeze = child.clone();
+        let freezer = std::thread::spawn(move || {
+            while bank_to_freeze.tick_height() < bank_to_freeze.max_tick_height() {
+                std::hint::spin_loop();
+            }
+            bank_to_freeze.freeze();
+        });
+        poh_recorder
+            .tick_alpenglow(child.max_tick_height(), test_footer())
+            .unwrap();
+        freezer.join().unwrap();
+        assert!(!poh_recorder.has_bank());
     }
 
     #[test]

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -729,7 +729,7 @@ mod tests {
             PohConfig::default().target_tick_duration.as_micros() as u64;
         let target_tick_duration = Duration::from_micros(default_target_tick_duration);
         let poh_config = PohConfig {
-            hashes_per_tick: *bank.hashes_per_tick(),
+            hashes_per_tick: bank.hashes_per_tick(),
             target_tick_duration,
             target_tick_count: None,
         };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -671,7 +671,7 @@ impl PartialEq for Bank {
             && signature_count.load(Relaxed) == other.signature_count.load(Relaxed)
             && capitalization.load(Relaxed) == other.capitalization.load(Relaxed)
             && max_tick_height == &other.max_tick_height
-            && hashes_per_tick == &other.hashes_per_tick
+            && *hashes_per_tick.read().unwrap() == *other.hashes_per_tick.read().unwrap()
             && ticks_per_slot == &other.ticks_per_slot
             && ns_per_slot == &other.ns_per_slot
             && genesis_creation_time == &other.genesis_creation_time
@@ -866,7 +866,7 @@ pub struct Bank {
     max_tick_height: u64,
 
     /// The number of hashes in each tick. None value means hashing is disabled.
-    hashes_per_tick: Option<u64>,
+    hashes_per_tick: RwLock<Option<u64>>,
 
     /// The number of ticks in each slot.
     ticks_per_slot: u64,
@@ -1180,7 +1180,7 @@ impl Bank {
             signature_count: AtomicU64::default(),
             capitalization: AtomicU64::default(),
             max_tick_height: u64::default(),
-            hashes_per_tick: Option::<u64>::default(),
+            hashes_per_tick: RwLock::default(),
             ticks_per_slot: u64::default(),
             ns_per_slot: u128::default(),
             genesis_creation_time: UnixTimestamp::default(),
@@ -1411,7 +1411,7 @@ impl Bank {
             partitioned_rewards_stake_account_stores_per_block: parent
                 .partitioned_rewards_stake_account_stores_per_block,
             // TODO: clean this up, so much special-case copying...
-            hashes_per_tick: parent.hashes_per_tick,
+            hashes_per_tick: RwLock::new(parent.hashes_per_tick()),
             ticks_per_slot: parent.ticks_per_slot,
             ns_per_slot: parent.ns_per_slot,
             genesis_creation_time: parent.genesis_creation_time,
@@ -2112,7 +2112,7 @@ impl Bank {
             signature_count: AtomicU64::new(fields.signature_count),
             capitalization: AtomicU64::new(fields.capitalization),
             max_tick_height: fields.max_tick_height,
-            hashes_per_tick: fields.hashes_per_tick,
+            hashes_per_tick: RwLock::new(fields.hashes_per_tick),
             ticks_per_slot: fields.ticks_per_slot,
             ns_per_slot: fields.ns_per_slot,
             genesis_creation_time: fields.genesis_creation_time,
@@ -2255,7 +2255,7 @@ impl Bank {
             signature_count: self.signature_count.load(Relaxed),
             capitalization: self.capitalization.load(Relaxed),
             max_tick_height: self.max_tick_height,
-            hashes_per_tick: self.hashes_per_tick,
+            hashes_per_tick: *self.hashes_per_tick.read().unwrap(),
             ticks_per_slot: self.ticks_per_slot,
             ns_per_slot: self.ns_per_slot,
             genesis_creation_time: self.genesis_creation_time,
@@ -3091,7 +3091,7 @@ impl Bank {
             genesis_config.fee_rate_governor.lamports_per_signature,
         );
 
-        self.hashes_per_tick = genesis_config.hashes_per_tick();
+        self.hashes_per_tick = RwLock::new(genesis_config.hashes_per_tick());
         self.ticks_per_slot = genesis_config.ticks_per_slot();
         self.ns_per_slot = genesis_config.ns_per_slot();
         self.genesis_creation_time = genesis_config.creation_time;
@@ -3166,8 +3166,8 @@ impl Bank {
         self.rent_collector.rent.burn_percent = burn_percent;
     }
 
-    pub fn set_hashes_per_tick(&mut self, hashes_per_tick: Option<u64>) {
-        self.hashes_per_tick = hashes_per_tick;
+    pub fn set_hashes_per_tick(&self, hashes_per_tick: Option<u64>) {
+        *self.hashes_per_tick.write().unwrap() = hashes_per_tick;
     }
 
     /// Return the last block hash registered.
@@ -5472,8 +5472,8 @@ impl Bank {
     }
 
     /// Return the number of hashes per tick
-    pub fn hashes_per_tick(&self) -> &Option<u64> {
-        &self.hashes_per_tick
+    pub fn hashes_per_tick(&self) -> Option<u64> {
+        *self.hashes_per_tick.read().unwrap()
     }
 
     /// Return the number of ticks per slot
@@ -6575,7 +6575,7 @@ impl Bank {
         bank.signature_count = AtomicU64::new(fields.signature_count);
         bank.capitalization = AtomicU64::new(fields.capitalization);
         bank.max_tick_height = fields.max_tick_height;
-        bank.hashes_per_tick = fields.hashes_per_tick;
+        bank.hashes_per_tick = RwLock::new(fields.hashes_per_tick);
         bank.ticks_per_slot = fields.ticks_per_slot;
         bank.ns_per_slot = fields.ns_per_slot;
         bank.genesis_creation_time = fields.genesis_creation_time;
@@ -6606,7 +6606,7 @@ impl Bank {
         bank.refresh_slot_params_with_baseline(SlotParams::genesis_baseline(
             bank.ns_per_slot,
             bank.slots_per_year,
-            bank.hashes_per_tick,
+            bank.hashes_per_tick(),
             bank.partitioned_rewards_stake_account_stores_per_block,
         ));
 

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -245,6 +245,7 @@ impl BlockComponentProcessor {
         let genesis_cert = Certificate::from(genesis_cert);
         Self::verify_genesis_certificate(&bank, &genesis_cert)?;
         bank.set_alpenglow_genesis_certificate(&genesis_cert);
+        bank.set_hashes_per_tick(None);
 
         if migration_status.is_alpenglow_enabled() {
             // We participated in the migration, nothing to do

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -322,6 +322,9 @@ pub fn create_genesis_config_with_leader_with_mint_keypair(
 pub fn activate_all_features_alpenglow(genesis_config: &mut GenesisConfig) {
     do_activate_all_features::<true>(genesis_config);
 
+    // PoH is in low power mode
+    genesis_config.poh_config.hashes_per_tick = None;
+
     // This is a dev cluster with alpenglow enabled at genesis. We don't want to test the migration pathway
     // so we add a fake genesis certificate.
     let cert = Certificate {


### PR DESCRIPTION
#### Problem
We currently hack `poh_recorder` to override the bank's `hashes_per_tick` value to `None` when alpenglow is enabled.
As a result the correct value is not set in the bank or snapshot

#### Summary of Changes
Remove the hack and instead make `hashes_per_tick` mutable. 
If alpenglow is enabled at genesis, set `hashes_per_tick = None` in genesis config.

Leader:
- When creating the first (contains genesis certificate marker) alpenglow bank set `hashes_per_tick` to `None` on the bank
- Have `poh_recorder::set_bank` read this value correctly and migrate poh to low power mode
- All further alpenglow banks must descend from a bank with the genesis certificate marker, so PoH will continue in low power mode

Replayer:
- In BCP when processing the genesis certificate update `hashes_per_tick` to `None`

#### SIMD-0525
Should just work
```diff rust
   fn apply_slot_time_persistent_changes(&mut self) {
        let params = self.current_slot_params();
        self.ns_per_slot = params.ns_per_slot;
        self.slots_per_year = params.slots_per_year;
        self.rent_collector.slots_per_year = params.slots_per_year;
        if !self.feature_set.is_active(&feature_set::alpenglow::id())
-            && self.hashes_per_tick.is_some()
+            && self.hashes_per_tick().is_some()
        {
-            self.hashes_per_tick = Some(params.hashes_per_tick);
+           self.set_hashes_per_tick(Some(params.hashes_per_tick));
        }
```
and poh recorder will update when you call `set_bank`