### PR TITLE
Gossip: drop all CRDS values alpenglow does not use post migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8728,6 +8728,7 @@ version = "4.3.0-alpha.0"
 dependencies = [
  "agave-logger",
  "agave-random",
+ "agave-votor-messages",
  "anyhow",
  "arc-swap",
  "assert_matches",

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -626,6 +626,7 @@ impl Tvu {
             exit.clone(),
         );
 
+        let migration_status = bank_forks.read().unwrap().migration_status();
         let epoch_specs: Box<dyn solana_gossip::epoch_specs::EpochSpecs> =
             Box::new(EpochSpecs::from(bank_forks));
 
@@ -638,6 +639,7 @@ impl Tvu {
                 epoch_specs,
                 duplicate_slots_sender,
                 tvu_config.shred_version,
+                migration_status,
             ),
         );
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -995,6 +995,7 @@ impl Validator {
         cluster_info.restore_contact_info(ledger_path, config.contact_save_interval);
         cluster_info.set_bind_ip_addrs(node.bind_ip_addrs.clone());
         let cluster_info = Arc::new(cluster_info);
+        cluster_info.set_migration_status(migration_status.clone());
         let node_multihoming = Arc::new(NodeMultihoming::from(&node));
         migration_status.set_pubkey(cluster_info.id());
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6901,6 +6901,7 @@ version = "4.3.0-alpha.0"
 dependencies = [
  "agave-logger",
  "agave-random",
+ "agave-votor-messages",
  "arc-swap",
  "assert_matches",
  "bv",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -34,13 +34,17 @@ frozen-abi = [
     "solana-vote-program/frozen-abi",
 ]
 agave-unstable-api = []
-dev-context-only-utils = ["solana-bloom/dev-context-only-utils"]
+dev-context-only-utils = [
+    "agave-votor-messages/dev-context-only-utils",
+    "solana-bloom/dev-context-only-utils",
+]
 conformance = ["dep:prost", "dep:protosol", "dev-context-only-utils"]
 dummy-for-ci-check = ["conformance"]
 
 [dependencies]
 agave-logger = { workspace = true }
 agave-random = { workspace = true }
+agave-votor-messages = { workspace = true }
 arc-swap = { workspace = true }
 assert_matches = { workspace = true }
 bv = { workspace = true, features = ["serde"] }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -41,6 +41,7 @@ use {
         sigverify_cache::SigVerifyCache,
         weighted_shuffle::WeightedShuffle,
     },
+    agave_votor_messages::migration::MigrationStatus,
     arc_swap::ArcSwap,
     crossbeam_channel::{Receiver, TrySendError},
     itertools::{Either, Itertools},
@@ -195,6 +196,8 @@ pub struct ClusterInfo {
     socket_addr_space: SocketAddrSpace,
     bind_ip_addrs: Arc<BindIpAddrs>,
     sigverify_cache: SigVerifyCache,
+    /// Alpenglow migration status
+    migration_status: OnceLock<Arc<MigrationStatus>>,
 }
 
 impl ClusterInfo {
@@ -233,9 +236,23 @@ impl ClusterInfo {
             socket_addr_space,
             bind_ip_addrs: Arc::new(BindIpAddrs::default()),
             sigverify_cache: SigVerifyCache::new(),
+            migration_status: OnceLock::new(),
         };
         me.refresh_my_gossip_contact_info();
         me
+    }
+
+    /// Wires in the Alpenglow MigrationStatus.
+    pub fn set_migration_status(&self, migration_status: Arc<MigrationStatus>) {
+        let _ = self.migration_status.set(migration_status);
+    }
+
+    /// Returns `true` iff the migration status has been wired AND the cluster
+    /// has completed the full Alpenglow epoch transition.
+    fn is_full_alpenglow_epoch(&self) -> bool {
+        self.migration_status
+            .get()
+            .is_some_and(|m| m.is_full_alpenglow_epoch())
     }
 
     pub fn set_contact_debug_interval(&mut self, new: u64) {
@@ -1025,6 +1042,10 @@ impl ClusterInfo {
         shred: &Shred,
         other_payload: &[u8],
     ) -> Result<(), GossipError> {
+        if self.is_full_alpenglow_epoch() {
+            // Alpenglow does not propagate duplicate-shred proofs via gossip.
+            return Ok(());
+        }
         self.gossip.push_duplicate_shred(
             &self.keypair(),
             shred,
@@ -1302,12 +1323,18 @@ impl ClusterInfo {
         stakes: &HashMap<Pubkey, u64>,
     ) -> impl Iterator<Item = (SocketAddr, Protocol)> + use<> {
         let self_id = self.id();
+        let is_full_alpenglow_epoch = self.is_full_alpenglow_epoch();
         let (entries, push_messages, num_pushes) = {
             let _st = ScopedTimer::from(&self.stats.new_push_requests);
             self.flush_push_queue();
             self.gossip
                 .new_push_messages(&self_id, timestamp(), stakes, |value| {
-                    should_retain_crds_value(value, stakes, GossipFilterDirection::EgressPush)
+                    should_retain_crds_value(
+                        value,
+                        stakes,
+                        GossipFilterDirection::EgressPush,
+                        is_full_alpenglow_epoch,
+                    )
                 })
         };
         self.stats
@@ -1712,6 +1739,7 @@ impl ClusterInfo {
         });
         let now = timestamp();
         let self_id = self.id();
+        let is_full_alpenglow_epoch = self.is_full_alpenglow_epoch();
         let pull_responses = {
             let _st = ScopedTimer::from(&self.stats.generate_pull_responses);
             self.gossip.generate_pull_responses(
@@ -1724,6 +1752,7 @@ impl ClusterInfo {
                         value,
                         stakes,
                         GossipFilterDirection::EgressPullResponse,
+                        is_full_alpenglow_epoch,
                     )
                 },
                 |request, crds_len| self.try_consume_pull_request_scan_budget(request, crds_len),
@@ -2153,6 +2182,7 @@ impl ClusterInfo {
             stakes: &HashMap<Pubkey, u64>,
             stats: &GossipStats,
             sigverify_cache: &SigVerifyCache,
+            is_full_alpenglow_epoch: bool,
         ) -> Option<(SocketAddr, Protocol)> {
             let result: wincode::ReadResult<Protocol> = packet
                 .data(..)
@@ -2164,7 +2194,12 @@ impl ClusterInfo {
                 &mut protocol
             {
                 values.retain(|value| {
-                    should_retain_crds_value(value, stakes, GossipFilterDirection::Ingress)
+                    should_retain_crds_value(
+                        value,
+                        stakes,
+                        GossipFilterDirection::Ingress,
+                        is_full_alpenglow_epoch,
+                    )
                 });
                 if values.is_empty() {
                     return None;
@@ -2178,6 +2213,7 @@ impl ClusterInfo {
         let stakes = epoch_specs
             .map(|es| es.current_epoch_staked_nodes())
             .unwrap_or_default();
+        let is_full_alpenglow_epoch = self.is_full_alpenglow_epoch();
         let packets_verified: Vec<_> = {
             let _st = ScopedTimer::from(&self.stats.verify_gossip_packets_time);
             thread_pool.install(|| {
@@ -2185,7 +2221,13 @@ impl ClusterInfo {
                     packet_buf[0]
                         .par_iter()
                         .filter_map(|packet| {
-                            verify_packet(packet, &stakes, &self.stats, &self.sigverify_cache)
+                            verify_packet(
+                                packet,
+                                &stakes,
+                                &self.stats,
+                                &self.sigverify_cache,
+                                is_full_alpenglow_epoch,
+                            )
                         })
                         .collect()
                 } else {
@@ -2193,7 +2235,13 @@ impl ClusterInfo {
                         .par_iter()
                         .flatten()
                         .filter_map(|packet| {
-                            verify_packet(packet, &stakes, &self.stats, &self.sigverify_cache)
+                            verify_packet(
+                                packet,
+                                &stakes,
+                                &self.stats,
+                                &self.sigverify_cache,
+                                is_full_alpenglow_epoch,
+                            )
                         })
                         .collect()
                 }

--- a/gossip/src/crds_filter.rs
+++ b/gossip/src/crds_filter.rs
@@ -20,13 +20,15 @@ pub(crate) const MIN_STAKE_FOR_GOSSIP: u64 = solana_native_token::LAMPORTS_PER_S
 /// Returns false if the CRDS value should be discarded.
 /// `direction` controls whether we are looking at
 /// incoming packet (via Push or PullResponse) or
-/// we are about to make a packet
+/// we are about to make a packet.
+/// `is_full_alpenglow_epoch` tells the filter if Alpenglow migration is complete.
 #[inline]
 #[must_use]
 pub(crate) fn should_retain_crds_value(
     value: &CrdsValue,
     stakes: &HashMap<Pubkey, u64>,
     direction: GossipFilterDirection,
+    is_full_alpenglow_epoch: bool,
 ) -> bool {
     let retain_if_staked = || {
         stakes.len() < MIN_NUM_STAKED_NODES || {
@@ -41,20 +43,25 @@ pub(crate) fn should_retain_crds_value(
         CrdsData::ContactInfo(_) => true,
         // Unstaked nodes can still serve snapshots.
         CrdsData::SnapshotHashes(_) => true,
+        // Disabled once Alpenglow is active.
+        CrdsData::DuplicateShred(_, _) => !is_full_alpenglow_epoch && retain_if_staked(),
         // Consensus related messages only allowed for staked nodes
-        CrdsData::DuplicateShred(_, _)
-        | CrdsData::LowestSlot(0, _)
+        CrdsData::LowestSlot(0, _)
         | CrdsData::RestartHeaviestFork(_)
         | CrdsData::RestartLastVotedForkSlots(_) => retain_if_staked(),
+        CrdsData::EpochSlots(_, _) if is_full_alpenglow_epoch => false,
         // Unstaked nodes can technically send EpochSlots, but we do not want them
-        // eating gossip bandwidth
-        CrdsData::EpochSlots(_, _) => match direction {
-            // always store if we have received them
-            // to avoid getting them again in PullResponses
-            Ingress => true,
-            // only forward if the origin is staked
-            EgressPush | EgressPullResponse => retain_if_staked(),
-        },
+        // eating gossip bandwidth.
+        CrdsData::EpochSlots(_, _) => {
+            match direction {
+                // always store if we have received them
+                // to avoid getting them again in PullResponses
+                Ingress => true,
+                // only forward if the origin is staked
+                EgressPush | EgressPullResponse => retain_if_staked(),
+            }
+        }
+        CrdsData::Vote(_, _) if is_full_alpenglow_epoch => false,
         CrdsData::Vote(_, _) => match direction {
             Ingress | EgressPush => true,
             EgressPullResponse => retain_if_staked(),

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -4,6 +4,7 @@ use {
         duplicate_shred_listener::DuplicateShredHandlerTrait,
         epoch_specs::EpochSpecs,
     },
+    agave_votor_messages::migration::MigrationStatus,
     crossbeam_channel::Sender,
     log::error,
     solana_clock::Slot,
@@ -39,12 +40,19 @@ pub struct DuplicateShredHandler {
     // Used to notify duplicate consensus state machine
     duplicate_slots_sender: Sender<Slot>,
     shred_version: u16,
+    /// Alpenglow migration status
+    migration_status: Arc<MigrationStatus>,
 }
 
 impl DuplicateShredHandlerTrait for DuplicateShredHandler {
     // Here we are sending data one by one rather than in a batch because in the future
     // we may send different type of CrdsData to different senders.
     fn handle(&mut self, shred_data: DuplicateShred) {
+        if self.migration_status.is_full_alpenglow_epoch() {
+            // turn into noop and clear any existing buffer
+            self.buffer.clear();
+            return;
+        }
         self.cache_root_info();
         self.maybe_prune_buffer();
         let slot = shred_data.slot;
@@ -72,6 +80,7 @@ impl DuplicateShredHandler {
         epoch_specs: Box<dyn EpochSpecs>,
         duplicate_slots_sender: Sender<Slot>,
         shred_version: u16,
+        migration_status: Arc<MigrationStatus>,
     ) -> Self {
         Self {
             buffer: HashMap::<(Slot, Pubkey), BufferEntry>::default(),
@@ -83,6 +92,7 @@ impl DuplicateShredHandler {
             epoch_specs,
             duplicate_slots_sender,
             shred_version,
+            migration_status,
         }
     }
 
@@ -314,12 +324,14 @@ mod tests {
         let (sender, receiver) = bounded(1024);
         let start_slot: Slot = 10;
 
+        let migration_status = bank_forks_arc.read().unwrap().migration_status();
         let mut duplicate_shred_handler = DuplicateShredHandler::new(
             blockstore.clone(),
             leader_schedule_cache,
             epoch_specs.clone_box(),
             sender,
             shred_version,
+            migration_status,
         );
         let chunks = create_duplicate_proof(
             my_keypair.clone(),
@@ -416,12 +428,14 @@ mod tests {
             &bank_forks_arc.read().unwrap().working_bank(),
         ));
         let (sender, receiver) = bounded(1024);
+        let migration_status = bank_forks_arc.read().unwrap().migration_status();
         let mut duplicate_shred_handler = DuplicateShredHandler::new(
             blockstore.clone(),
             leader_schedule_cache,
             epoch_specs.clone_box(),
             sender,
             shred_version,
+            migration_status,
         );
         let start_slot: Slot = 10;
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7040,6 +7040,7 @@ version = "4.3.0-alpha.0"
 dependencies = [
  "agave-logger",
  "agave-random",
+ "agave-votor-messages",
  "arc-swap",
  "assert_matches",
  "bv",


### PR DESCRIPTION
#### Problem

Once Alpenglow is active gossip no longer needs to process duplicate shreds, votes and epoch slots.

#### Summary of Changes

- Wire migration_status into gossip (specifically is_full_alpenglow_epoch - its ok for gossip to keep propagating deprecated values a bit longer than necessary).
- Patch should_retain_crds_value to ensure we do not propagate invalid CRDS post migration in any direction 
- Disable dupshred handler, ingest of dupshred proofs into CRDS, as well as service in pull responses once migration is complete.