### PR TITLE
bench(accounts-db): migrate accounts_index bench to criterion

### DIFF
--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -118,6 +118,10 @@ test-case = { workspace = true }
 jemallocator = { workspace = true }
 
 [[bench]]
+name = "accounts_index"
+harness = false
+
+[[bench]]
 name = "bench_accounts_file"
 harness = false
 

--- a/accounts-db/benches/accounts_index.rs
+++ b/accounts-db/benches/accounts_index.rs
@@ -1,8 +1,5 @@
-#![feature(test)]
-
-extern crate test;
-
 use {
+    criterion::{Criterion, criterion_group, criterion_main},
     rand::{Rng, rng},
     solana_accounts_db::{
         account_info::AccountInfo,
@@ -11,15 +8,13 @@ use {
         },
     },
     std::sync::Arc,
-    test::Bencher,
 };
 
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-#[bench]
-fn bench_accounts_index(bencher: &mut Bencher) {
+fn bench_accounts_index(c: &mut Criterion) {
     const NUM_PUBKEYS: usize = 10_000;
     let pubkeys: Vec<_> = (0..NUM_PUBKEYS)
         .map(|_| solana_pubkey::new_rand())
@@ -47,21 +42,26 @@ fn bench_accounts_index(bencher: &mut Bencher) {
 
     let mut fork = NUM_FORKS;
     let mut root = 0;
-    bencher.iter(|| {
-        for _p in 0..NUM_PUBKEYS {
-            let pubkey = rng().random_range(0..NUM_PUBKEYS);
-            index.upsert(
-                fork,
-                fork,
-                &pubkeys[pubkey],
-                AccountInfo::default(),
-                &mut reclaims,
-                UpsertReclaim::PopulateReclaims,
-            );
-            reclaims.clear();
-        }
-        index.add_root(root);
-        root += 1;
-        fork += 1;
+    c.bench_function("accounts_index", |b| {
+        b.iter(|| {
+            for _p in 0..NUM_PUBKEYS {
+                let pubkey = rng().random_range(0..NUM_PUBKEYS);
+                index.upsert(
+                    fork,
+                    fork,
+                    &pubkeys[pubkey],
+                    AccountInfo::default(),
+                    &mut reclaims,
+                    UpsertReclaim::PopulateReclaims,
+                );
+                reclaims.clear();
+            }
+            index.add_root(root);
+            root += 1;
+            fork += 1;
+        });
     });
 }
+
+criterion_group!(benches, bench_accounts_index);
+criterion_main!(benches);

--- a/accounts-db/benches/accounts_index.rs
+++ b/accounts-db/benches/accounts_index.rs
@@ -57,8 +57,8 @@ fn bench_accounts_index(c: &mut Criterion) {
                 reclaims.clear();
             }
             index.add_root(root);
-            root += 1;
-            fork += 1;
+            root = root.checked_add(1).expect("root overflow");
+            fork = fork.checked_add(1).expect("fork overflow");
         });
     });
 }


### PR DESCRIPTION
#### Problem
built-in bench requires nightly, bechmarks could be migrated to bencher or criterion crates.

#### Summary of Changes
Switch accounts_index bench to criterion, similar to all other benches in accounts-db