### PR TITLE
Refactor: use existing sigverify worker stats reporting infrastructure

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1351,7 +1351,9 @@ mod tests {
                 })
                 .unwrap()
         })
-        .for_each(|handle| handle.join().unwrap());
+        .for_each(|handle| {
+            handle.join().unwrap();
+        });
 
         banking_stage.join().unwrap();
         exit.store(true, Ordering::Relaxed);

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -7,16 +7,14 @@ use {
     serde::{Deserialize, Serialize},
     solana_clock::Slot,
     solana_hash::Hash,
-    solana_metrics::datapoint_info,
     solana_streamer::{evicting_sender::EvictingSender, streamer::ChannelSend},
-    solana_time_utils::timestamp,
     std::{
         fs::{create_dir_all, remove_dir_all},
         io::{self, Write},
         path::PathBuf,
         sync::{
             Arc,
-            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+            atomic::{AtomicBool, Ordering},
         },
         thread::{self, JoinHandle, sleep},
         time::{Duration, SystemTime},
@@ -31,9 +29,6 @@ const VOTE_CHANNEL_CAPACITY: usize = 1024 * 8;
 /// Capacity of the non-vote (transaction) channel between sigverify and the banking-stage.
 /// Larger than the vote channel to absorb bursty TPU load.
 const NON_VOTE_CHANNEL_CAPACITY: usize = 1024 * 16;
-
-/// Period between metric emissions per channel from inside `TracedSender::send`.
-const STATS_REPORT_INTERVAL: Duration = Duration::from_secs(5);
 
 pub type BankingPacketSender = TracedSender;
 pub type TracerThreadResult = Result<(), TraceError>;
@@ -96,17 +91,6 @@ pub enum ChannelLabel {
     TpuVote,
     GossipVote,
     Dummy,
-}
-
-impl ChannelLabel {
-    fn metric_name(&self) -> &'static str {
-        match self {
-            ChannelLabel::NonVote => "banking_trace_channel_non_vote",
-            ChannelLabel::TpuVote => "banking_trace_channel_tpu_vote",
-            ChannelLabel::GossipVote => "banking_trace_channel_gossip_vote",
-            ChannelLabel::Dummy => "banking_trace_channel_dummy",
-        }
-    }
 }
 
 struct RollingConditionGrouped {
@@ -394,20 +378,7 @@ impl BankingTracer {
 pub struct TracedSender {
     label: ChannelLabel,
     sender: EvictingSender<BankingPacketBatch>,
-    stats: Arc<TracedSenderStats>,
     active_tracer: Option<ActiveTracer>,
-}
-
-#[derive(Default)]
-struct TracedSenderStats {
-    /// Total number of batches sent downstream.
-    sent: AtomicU64,
-    /// Max channel length observed since last report.
-    max_len: AtomicUsize,
-    /// Number of batches the EvictingSender dropped due to a full channel since last report.
-    eviction_drops: AtomicU64,
-    /// `solana_time_utils::timestamp` of the last report.
-    last_report_ms: AtomicU64,
 }
 
 impl TracedSender {
@@ -419,12 +390,14 @@ impl TracedSender {
         Self {
             label,
             sender,
-            stats: Arc::new(TracedSenderStats::default()),
             active_tracer,
         }
     }
 
-    pub fn send(&self, batch: BankingPacketBatch) -> Result<(), SendError<BankingPacketBatch>> {
+    /// Send a batch on the channel. This may evict an existing batch to make
+    /// room; in that case `Ok(n)` is returned where `n` is the number of
+    /// evicted packets. On channel disconnect returns `Err(SendError)`.
+    pub fn send(&self, batch: BankingPacketBatch) -> Result<usize, SendError<BankingPacketBatch>> {
         if let Some(ActiveTracer { trace_sender, exit }) = &self.active_tracer {
             if !exit.load(Ordering::Relaxed) {
                 // Ignore errors in sending to tracer - it is a non-critical component.
@@ -434,23 +407,11 @@ impl TracedSender {
                 ));
             }
         }
-        let (result, sent) = match self.sender.try_send(batch) {
-            // New batch queued; nothing was evicted.
-            Ok(()) => (Ok(()), self.stats.sent.fetch_add(1, Ordering::Relaxed)),
-            // EvictingSender popped the oldest to make room.
-            Err(TrySendError::Full(_)) => {
-                self.stats.eviction_drops.fetch_add(1, Ordering::Relaxed);
-                (Ok(()), 0)
-            }
-            Err(TrySendError::Disconnected(b)) => (Err(SendError(b)), 0),
-        };
-        let len = self.sender.len();
-        self.stats.max_len.fetch_max(len, Ordering::Relaxed);
-        // if we've made reasonable progress, or dropped packets
-        if sent % 128 == 0 {
-            self.maybe_report_stats();
+        match self.sender.try_send(batch) {
+            Ok(()) => Ok(0),
+            Err(TrySendError::Full(b)) => Ok(b.iter().map(|pb| pb.len()).sum()),
+            Err(TrySendError::Disconnected(b)) => Err(SendError(b)),
         }
-        result
     }
 
     pub fn len(&self) -> usize {
@@ -459,29 +420,6 @@ impl TracedSender {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
-    }
-
-    fn maybe_report_stats(&self) {
-        let now_ms = timestamp();
-        let last = self.stats.last_report_ms.load(Ordering::Relaxed);
-        if Duration::from_millis(now_ms.saturating_sub(last)) < STATS_REPORT_INTERVAL {
-            return;
-        }
-        if self
-            .stats
-            .last_report_ms
-            .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
-            .is_err()
-        {
-            return;
-        }
-        let max_len = self.stats.max_len.swap(0, Ordering::Relaxed);
-        let eviction_drops = self.stats.eviction_drops.swap(0, Ordering::Relaxed);
-        datapoint_info!(
-            self.label.metric_name(),
-            ("max_len", max_len as i64, i64),
-            ("eviction_drops", eviction_drops as i64, i64),
-        );
     }
 }
 

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1015,6 +1015,9 @@ fn handle_parent_ready(
         let batch: PacketBatch = packets.into();
         let banking_packet_batch = Arc::new(vec![batch]);
         ctx.banking_stage_sender
+            // technically this send can evict to make room (which may drop a few packets)
+            // but this should (hopefully) not be significant amounts since we are evicting
+            // at most 1 batch.
             .send(banking_packet_batch)
             .map_err(|_| PohRecorderError::RescheduleTransactionsError(slot))?;
     }

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -19,7 +19,6 @@ use {
     solana_hash::Hash,
     solana_ledger::blockstore::Blockstore,
     solana_measure::measure::Measure,
-    solana_metrics::inc_new_counter_debug,
     solana_perf::packet::{self, PacketBatch},
     solana_pubkey::Pubkey,
     solana_rpc::{
@@ -497,15 +496,47 @@ impl ClusterInfoVoteListener {
         verified_packets_sender: BankingPacketSender,
         verified_vote_transactions_sender: VerifiedVoteTransactionsSender,
     ) -> Result<()> {
+        #[derive(Default)]
+        struct Stats {
+            received_count: usize,
+            banking_channel_max_len: usize,
+            banking_channel_eviction_drops: usize,
+        }
+        const STATS_REPORT_INTERVAL: Duration = Duration::from_secs(1);
         let mut cursor = Cursor::default();
+        let mut last_report = Instant::now();
+        let mut stats = Stats::default();
         while !exit.load(Ordering::Relaxed) {
             let votes = cluster_info.get_votes(&mut cursor);
-            inc_new_counter_debug!("cluster_info_vote_listener-recv_count", votes.len());
             if !votes.is_empty() {
+                stats.received_count += votes.len();
                 let (vote_txs, packets) =
                     Self::verify_votes(votes, &mut gossip_sigverify_handle, &sharable_banks)?;
                 verified_vote_transactions_sender.send(vote_txs)?;
-                verified_packets_sender.send(BankingPacketBatch::new(packets))?;
+                // Sample backlog before the push.
+                stats.banking_channel_max_len = stats
+                    .banking_channel_max_len
+                    .max(verified_packets_sender.len());
+                stats.banking_channel_eviction_drops +=
+                    verified_packets_sender.send(BankingPacketBatch::new(packets))?;
+            }
+            if last_report.elapsed() >= STATS_REPORT_INTERVAL {
+                datapoint_info!(
+                    "cluster_info_vote_listener",
+                    ("received_count", stats.received_count as i64, i64),
+                    (
+                        "banking_channel_max_len",
+                        stats.banking_channel_max_len as i64,
+                        i64
+                    ),
+                    (
+                        "banking_channel_eviction_drops",
+                        stats.banking_channel_eviction_drops as i64,
+                        i64
+                    ),
+                );
+                stats = Stats::default();
+                last_report = Instant::now();
             }
             sleep(Duration::from_millis(GOSSIP_SLEEP_MILLIS));
         }

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -43,6 +43,10 @@ pub(crate) struct SigVerifyWorkerStats {
     pub(crate) total_dedup_time_us: Arc<AtomicUsize>,
     pub(crate) total_valid_packets: Arc<AtomicUsize>,
     pub(crate) total_verify_time_us: Arc<AtomicUsize>,
+    /// Max occupancy of the banking_stage channel sampled immediately before each send.
+    pub(crate) max_pre_send_len: Arc<AtomicUsize>,
+    /// Count of sends where the EvictingSender had to drop a batch to make room.
+    pub(crate) eviction_drops: Arc<AtomicUsize>,
 }
 
 #[derive(Clone)]
@@ -292,12 +296,28 @@ impl SigVerifyWorkerPool {
             .fetch_add(verify_time_us as usize, Ordering::Relaxed);
 
         let banking_packet_batch = BankingPacketBatch::new(vec![batch]);
-        if let Err(err) = state
+        // Sample backlog before the push: measures consumer health without
+        // including this batch's own contribution.
+        state
+            .stats
+            .max_pre_send_len
+            .fetch_max(state.banking_stage_sender.len(), Ordering::Relaxed);
+        match state
             .banking_stage_sender
             .send(banking_packet_batch.clone())
         {
-            error!("sigverify send failed: {err:?}");
-            return false;
+            Ok(0) => {} // avoid poking atomics if nothing was evicted (typical case)
+            Ok(evicted) => {
+                // record evicted amount into metrics
+                state
+                    .stats
+                    .eviction_drops
+                    .fetch_add(evicted, Ordering::Relaxed);
+            }
+            Err(err) => {
+                error!("sigverify send to banking failed: {err:?}");
+                return false;
+            }
         }
         if should_forward {
             Self::try_forward(forward_stage_sender, banking_packet_batch, is_tpu_vote);

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -61,6 +61,10 @@ struct SigVerifierStats {
     total_valid_packets: Arc<AtomicUsize>,
     total_dedup_time_us: Arc<AtomicUsize>,
     total_verify_time_us: Arc<AtomicUsize>,
+    /// Max occupancy of the banking_stage output channel since last report.
+    max_pre_send_len: Arc<AtomicUsize>,
+    /// Count of sends in which the EvictingSender had to drop a batch.
+    eviction_drops: Arc<AtomicUsize>,
 }
 
 struct ServicerState {
@@ -115,6 +119,16 @@ impl SigVerifierStats {
                 self.total_verify_time_us.swap(0, Ordering::Relaxed) as i64,
                 i64
             ),
+            (
+                "max_pre_send_len",
+                self.max_pre_send_len.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "eviction_drops",
+                self.eviction_drops.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
         );
     }
 }
@@ -157,6 +171,8 @@ impl SigVerifyStage {
                     total_dedup_time_us: non_vote_stats.total_dedup_time_us.clone(),
                     total_valid_packets: non_vote_stats.total_valid_packets.clone(),
                     total_verify_time_us: non_vote_stats.total_verify_time_us.clone(),
+                    max_pre_send_len: non_vote_stats.max_pre_send_len.clone(),
+                    eviction_drops: non_vote_stats.eviction_drops.clone(),
                 },
             ),
             SigVerifyWorkerState::new(
@@ -169,6 +185,8 @@ impl SigVerifyStage {
                     total_dedup_time_us: tpu_vote_stats.total_dedup_time_us.clone(),
                     total_valid_packets: tpu_vote_stats.total_valid_packets.clone(),
                     total_verify_time_us: tpu_vote_stats.total_verify_time_us.clone(),
+                    max_pre_send_len: tpu_vote_stats.max_pre_send_len.clone(),
+                    eviction_drops: tpu_vote_stats.eviction_drops.clone(),
                 },
             ),
         );


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/pull/12734 was a compromise to facilitate backports, metrics reporting could be done better.

#### Summary of Changes

- Use existing metrics infrastructure of sigverify workers
- Use existing metrics infrastructure of gossip vote sender