### PR TITLE
fix: potential wrong repair response due to swapped-out block location

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -990,11 +990,14 @@ impl Blockstore {
         };
 
         // Block was full above, get_block_location returned Some, but may have
-        // been purged by BlockstoreCleanupService in between.
-        let Some(dmm) = self.get_double_merkle_meta_maybe_populate_proofs(slot, location)? else {
-            return Ok(None);
-        };
-        Ok(Some((dmm, location)))
+        // been purged by BlockstoreCleanupService in between, or swapped out.
+        if let Some(dmm) = self.get_double_merkle_meta_maybe_populate_proofs(slot, location)?
+            && dmm.double_merkle_root == block_id
+        {
+            Ok(Some((dmm, location)))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Gets the double merkle meta for the given block.


### PR DESCRIPTION
#### Problem
Addresses the potential wrong repair response by honest nodes when handling block ID-baed repair request `ParentAndFecSetCount`, as explained in https://github.com/anza-xyz/agave/issues/12668#issuecomment-4511322350

#### Summary of Changes
Only return the double-Merkle meta if it matches the requested block in `Blockstore::get_double_merkle_meta_maybe_populate_proofs_for_block_id()`.