### PR TITLE
svm: conformance: internalize compute budget arg

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -7,6 +7,8 @@
 #![allow(clippy::unnecessary_cast)]
 #![allow(clippy::uninlined_format_args)]
 
+#[cfg(not(feature = "sbf_sanity_list"))]
+use solana_program_runtime::execution_budget::MAX_COMPUTE_UNIT_LIMIT;
 #[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
 use solana_runtime::loader_utils::{
     load_upgradeable_program_and_advance_slot, set_upgrade_authority, upgrade_program,
@@ -108,7 +110,6 @@ fn default_program_cache_with_program(
     program_id: &Pubkey,
     program_elf: &[u8],
     feature_set: &SVMFeatureSet,
-    compute_budget: &ComputeBudget,
 ) -> solana_program_runtime::loaded_programs::ProgramCacheForTxBatch {
     let mut program_cache = default_program_cache();
     add_program_to_program_cache(
@@ -117,7 +118,6 @@ fn default_program_cache_with_program(
         &bpf_loader_upgradeable::id(),
         program_elf,
         feature_set,
-        compute_budget,
     );
     program_cache
 }
@@ -308,18 +308,18 @@ fn test_program_sbf_sanity() {
 
         let accounts = vec![(pubkey1, Account::default()), (pubkey2, Account::default())];
 
-        let compute_budget = ComputeBudget::new_with_defaults(false);
-        let mut program_cache = default_program_cache_with_program(
-            &program_id,
-            &program_elf,
-            &feature_set,
-            &compute_budget,
-        );
+        let mut program_cache =
+            default_program_cache_with_program(&program_id, &program_elf, &feature_set);
         let sysvar_cache = default_sysvar_cache();
 
-        let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
+        let context = InstrContext {
+            feature_set,
+            accounts,
+            instruction,
+            cu_avail: MAX_COMPUTE_UNIT_LIMIT as u64, // Widen to 1.4 M
+        };
 
-        let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+        let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
         let result = match effects.result {
             Some(err) => Err(err),
@@ -357,8 +357,6 @@ fn test_program_sbf_loader_deprecated() {
 
         let feature_set = SVMFeatureSet::all_enabled();
 
-        let compute_budget = ComputeBudget::new_with_defaults(false);
-
         let pubkey = Pubkey::new_unique();
         let accounts = vec![
             (program_id, Account::new(0, 0, &bpf_loader_deprecated::id())),
@@ -372,7 +370,6 @@ fn test_program_sbf_loader_deprecated() {
             &bpf_loader_deprecated::id(),
             &program_elf,
             &feature_set,
-            &compute_budget,
         );
         let sysvar_cache = default_sysvar_cache();
 
@@ -381,7 +378,7 @@ fn test_program_sbf_loader_deprecated() {
 
         let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
-        let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+        let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
         assert!(effects.result.is_none());
     }
@@ -409,7 +406,6 @@ fn test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader() {
     let payer_pubkey = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     let (programdata_address, _) =
         Pubkey::find_program_address(&[program_id.as_ref()], &bpf_loader_upgradeable::id());
@@ -498,7 +494,7 @@ fn test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader() {
     // in elf inside syscall table. In this case, `sol_alloc_free_` can't be
     // found in syscall table. Hence, the verification fails and the deployment
     // fails.
-    let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+    let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
     assert_eq!(effects.result, Some(InstructionError::InvalidAccountData));
 }
@@ -524,13 +520,8 @@ fn test_program_sbf_duplicate_accounts() {
         let program_elf = load_program_elf(program);
         let program_id = Pubkey::new_unique();
         let feature_set = SVMFeatureSet::all_enabled();
-        let compute_budget = ComputeBudget::new_with_defaults(false);
-        let mut program_cache = default_program_cache_with_program(
-            &program_id,
-            &program_elf,
-            &feature_set,
-            &compute_budget,
-        );
+        let mut program_cache =
+            default_program_cache_with_program(&program_id, &program_elf, &feature_set);
         let sysvar_cache = default_sysvar_cache();
 
         let payer_pubkey = Pubkey::new_unique();
@@ -553,7 +544,7 @@ fn test_program_sbf_duplicate_accounts() {
             ];
             let instruction = Instruction::new_with_bytes(program_id, data, account_metas.clone());
             let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
-            execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache)
+            execute_instr(&context, &mut program_cache, &sysvar_cache)
         };
 
         let effects = execute(&[1]);
@@ -601,7 +592,7 @@ fn test_program_sbf_duplicate_accounts() {
         ];
         let instruction = Instruction::new_with_bytes(program_id, &[7], account_metas);
         let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
-        let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+        let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
         assert!(effects.result.is_none());
     }
 }
@@ -633,13 +624,8 @@ fn test_program_sbf_error_handling() {
 
         let accounts = vec![(pubkey1, Account::default())];
 
-        let compute_budget = ComputeBudget::new_with_defaults(false);
-        let mut program_cache = default_program_cache_with_program(
-            &program_id,
-            &program_elf,
-            &feature_set,
-            &compute_budget,
-        );
+        let mut program_cache =
+            default_program_cache_with_program(&program_id, &program_elf, &feature_set);
         let sysvar_cache = default_sysvar_cache();
 
         // Helper to execute an instruction with the given data byte.
@@ -650,7 +636,7 @@ fn test_program_sbf_error_handling() {
             let context =
                 InstrContext::new_with_default_budget(feature_set, accounts.clone(), instruction);
 
-            execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache)
+            execute_instr(&context, &mut program_cache, &sysvar_cache)
         };
 
         let effects = execute(&[1]);
@@ -719,17 +705,12 @@ fn test_return_data_and_log_data_syscall() {
         let program_id = Pubkey::new_unique();
 
         let feature_set = SVMFeatureSet::all_enabled();
-        let compute_budget = ComputeBudget::new_with_defaults(false);
 
         let pubkey = Pubkey::new_unique();
         let accounts = vec![(pubkey, Account::default())];
 
-        let mut program_cache = default_program_cache_with_program(
-            &program_id,
-            &program_elf,
-            &feature_set,
-            &compute_budget,
-        );
+        let mut program_cache =
+            default_program_cache_with_program(&program_id, &program_elf, &feature_set);
         let sysvar_cache = default_sysvar_cache();
 
         let account_metas = vec![AccountMeta::new(pubkey, true)];
@@ -738,7 +719,7 @@ fn test_return_data_and_log_data_syscall() {
 
         let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
-        let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+        let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
         assert!(effects.result.is_none());
 
@@ -1392,7 +1373,6 @@ fn test_program_sbf_program_id_spoofing() {
     let malicious_system_pubkey = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     let from_pubkey = Pubkey::new_unique();
     let to_pubkey = Pubkey::new_unique();
@@ -1414,7 +1394,6 @@ fn test_program_sbf_program_id_spoofing() {
         &bpf_loader_upgradeable::id(),
         &spoof1_elf,
         &feature_set,
-        &compute_budget,
     );
     add_program_to_program_cache(
         &mut program_cache,
@@ -1422,7 +1401,6 @@ fn test_program_sbf_program_id_spoofing() {
         &bpf_loader_upgradeable::id(),
         &spoof1_system_elf,
         &feature_set,
-        &compute_budget,
     );
     let sysvar_cache = default_sysvar_cache();
 
@@ -1438,7 +1416,7 @@ fn test_program_sbf_program_id_spoofing() {
 
     let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
-    let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+    let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
     assert_eq!(
         effects.result,
@@ -1461,7 +1439,6 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
     let caller2_pubkey = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     let accounts = vec![
         (
@@ -1481,7 +1458,6 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
         &bpf_loader_upgradeable::id(),
         &caller_access_elf,
         &feature_set,
-        &compute_budget,
     );
     add_program_to_program_cache(
         &mut program_cache,
@@ -1489,7 +1465,6 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
         &bpf_loader_upgradeable::id(),
         &caller_access_elf,
         &feature_set,
-        &compute_budget,
     );
     let sysvar_cache = default_sysvar_cache();
 
@@ -1501,7 +1476,7 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
 
     let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
-    let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+    let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
     assert_eq!(effects.result, Some(InstructionError::MissingAccount));
 }
@@ -1515,7 +1490,6 @@ fn test_program_sbf_ro_modify() {
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     let test_pubkey = Pubkey::new_unique();
     let accounts = vec![
@@ -1523,12 +1497,8 @@ fn test_program_sbf_ro_modify() {
         (test_pubkey, Account::new(10, 0, &system_program::id())),
     ];
 
-    let mut program_cache = default_program_cache_with_program(
-        &program_id,
-        &program_elf,
-        &feature_set,
-        &compute_budget,
-    );
+    let mut program_cache =
+        default_program_cache_with_program(&program_id, &program_elf, &feature_set);
     let sysvar_cache = default_sysvar_cache();
 
     let account_metas = vec![
@@ -1543,7 +1513,7 @@ fn test_program_sbf_ro_modify() {
         let context =
             InstrContext::new_with_default_budget(feature_set, accounts.clone(), instruction);
 
-        let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+        let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
         assert_eq!(
             effects.result,
@@ -1563,12 +1533,8 @@ fn test_program_sbf_call_depth() {
     let feature_set = SVMFeatureSet::all_enabled();
     let compute_budget = ComputeBudget::new_with_defaults(false);
 
-    let mut program_cache = default_program_cache_with_program(
-        &program_id,
-        &program_elf,
-        &feature_set,
-        &compute_budget,
-    );
+    let mut program_cache =
+        default_program_cache_with_program(&program_id, &program_elf, &feature_set);
     let sysvar_cache = default_sysvar_cache();
 
     let mut execute = |depth: usize| {
@@ -1576,7 +1542,7 @@ fn test_program_sbf_call_depth() {
 
         let context = InstrContext::new_with_default_budget(feature_set, vec![], instruction);
 
-        execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache)
+        execute_instr(&context, &mut program_cache, &sysvar_cache)
     };
 
     let effects = execute(compute_budget.max_call_depth - 1);
@@ -1595,20 +1561,14 @@ fn test_program_sbf_compute_budget() {
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let mut compute_budget = ComputeBudget::new_with_defaults(false);
-    compute_budget.compute_unit_limit = 0;
 
     let accounts = vec![(
         program_id,
         Account::new(0, 0, &bpf_loader_upgradeable::id()),
     )];
 
-    let mut program_cache = default_program_cache_with_program(
-        &program_id,
-        &program_elf,
-        &feature_set,
-        &compute_budget,
-    );
+    let mut program_cache =
+        default_program_cache_with_program(&program_id, &program_elf, &feature_set);
     let sysvar_cache = default_sysvar_cache();
 
     let instruction = Instruction::new_with_bincode(program_id, &0, vec![]);
@@ -1617,10 +1577,10 @@ fn test_program_sbf_compute_budget() {
         feature_set,
         accounts,
         instruction,
-        cu_avail: compute_budget.compute_unit_limit,
+        cu_avail: 0,
     };
 
-    let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+    let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
     assert_eq!(
         effects.result,
@@ -1672,7 +1632,6 @@ fn assert_instruction_count() {
     }
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false);
     let sysvar_cache = default_sysvar_cache();
 
     println!("\n  {:36} expected actual  diff", "SBF program");
@@ -1680,12 +1639,8 @@ fn assert_instruction_count() {
         let program_elf = load_program_elf(program_name);
         let program_id = Pubkey::new_unique();
 
-        let mut program_cache = default_program_cache_with_program(
-            &program_id,
-            &program_elf,
-            &feature_set,
-            &compute_budget,
-        );
+        let mut program_cache =
+            default_program_cache_with_program(&program_id, &program_elf, &feature_set);
 
         let account_pubkey = Pubkey::new_unique();
         let accounts = vec![(account_pubkey, Account::new(0, 0, &program_id))];
@@ -1699,11 +1654,9 @@ fn assert_instruction_count() {
 
         let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
-        let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+        let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
-        let consumption = compute_budget
-            .compute_unit_limit
-            .saturating_sub(effects.cu_avail);
+        let consumption = context.cu_avail.saturating_sub(effects.cu_avail);
         let diff: i64 = consumption as i64 - *expected_consumption as i64;
         println!(
             "  {:36} {:8}{:6} {:+5} ({:+3.0}%)",
@@ -1789,14 +1742,9 @@ fn test_program_sbf_r2_instruction_data_pointer(num_accounts: usize, input_data_
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false);
 
-    let mut program_cache = default_program_cache_with_program(
-        &program_id,
-        &program_elf,
-        &feature_set,
-        &compute_budget,
-    );
+    let mut program_cache =
+        default_program_cache_with_program(&program_id, &program_elf, &feature_set);
     let sysvar_cache = default_sysvar_cache();
 
     let mut accounts = Vec::new();
@@ -1823,7 +1771,7 @@ fn test_program_sbf_r2_instruction_data_pointer(num_accounts: usize, input_data_
 
     let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
-    let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+    let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
     assert!(effects.result.is_none());
     assert_eq!(input_data, effects.return_data);
@@ -2326,7 +2274,6 @@ fn test_program_sbf_disguised_as_sbf_loader() {
             remove_bpf_loader_incorrect_program_id: false,
             ..SVMFeatureSet::all_enabled()
         };
-        let compute_budget = ComputeBudget::new_with_defaults(false);
 
         let mut program_cache = default_program_cache();
         add_program_to_program_cache(
@@ -2335,7 +2282,6 @@ fn test_program_sbf_disguised_as_sbf_loader() {
             &bpf_loader::id(),
             &program_elf,
             &feature_set,
-            &compute_budget,
         );
         let sysvar_cache = default_sysvar_cache();
 
@@ -2344,7 +2290,7 @@ fn test_program_sbf_disguised_as_sbf_loader() {
 
         let context = InstrContext::new_with_default_budget(feature_set, vec![], instruction);
 
-        let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+        let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
         assert_eq!(effects.result, Some(InstructionError::UnsupportedProgramId));
     }
 }
@@ -2358,7 +2304,6 @@ fn test_program_reads_from_program_account() {
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false);
 
     let mut program_cache = new_program_cache_with_builtins(0);
     add_program_to_program_cache(
@@ -2367,7 +2312,6 @@ fn test_program_reads_from_program_account() {
         &bpf_loader::id(),
         &program_elf,
         &feature_set,
-        &compute_budget,
     );
 
     let sysvar_cache = default_sysvar_cache();
@@ -2390,7 +2334,7 @@ fn test_program_reads_from_program_account() {
         instruction,
     );
 
-    let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+    let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
     assert!(effects.result.is_none());
 }
 
@@ -2403,7 +2347,6 @@ fn test_program_sbf_c_dup() {
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false);
     let mut program_cache = new_program_cache_with_builtins(0);
     add_program_to_program_cache(
         &mut program_cache,
@@ -2411,7 +2354,6 @@ fn test_program_sbf_c_dup() {
         &bpf_loader_upgradeable::id(),
         &program_elf,
         &feature_set,
-        &compute_budget,
     );
 
     let sysvar_cache = default_sysvar_cache();
@@ -2432,7 +2374,7 @@ fn test_program_sbf_c_dup() {
         instruction,
     );
 
-    let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+    let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
     assert!(effects.result.is_none());
 }
 
@@ -2611,14 +2553,9 @@ fn test_program_sbf_ro_account_modify() {
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false);
 
-    let mut program_cache = default_program_cache_with_program(
-        &program_id,
-        &program_elf,
-        &feature_set,
-        &compute_budget,
-    );
+    let mut program_cache =
+        default_program_cache_with_program(&program_id, &program_elf, &feature_set);
     let sysvar_cache = default_sysvar_cache();
 
     let argument_pubkey = Pubkey::new_unique();
@@ -2635,7 +2572,7 @@ fn test_program_sbf_ro_account_modify() {
         let context =
             InstrContext::new_with_default_budget(feature_set, accounts.clone(), instruction);
 
-        let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+        let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
         assert_eq!(effects.result, Some(InstructionError::ReadonlyDataModified));
     }
@@ -4528,18 +4465,9 @@ fn test_program_sbf_deplete_cost_meter_with_divide_by_zero() {
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = {
-        let mut budget = ComputeBudget::new_with_defaults(false);
-        budget.compute_unit_limit = 10_000u64;
-        budget
-    };
 
-    let mut program_cache = default_program_cache_with_program(
-        &program_id,
-        &program_elf,
-        &feature_set,
-        &compute_budget,
-    );
+    let mut program_cache =
+        default_program_cache_with_program(&program_id, &program_elf, &feature_set);
     let sysvar_cache = default_sysvar_cache();
 
     let instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
@@ -4548,10 +4476,10 @@ fn test_program_sbf_deplete_cost_meter_with_divide_by_zero() {
         feature_set,
         accounts: vec![],
         instruction,
-        cu_avail: compute_budget.compute_unit_limit,
+        cu_avail: 10_000,
     };
 
-    let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+    let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
     assert_eq!(
         effects.result,
@@ -5593,14 +5521,9 @@ fn test_program_sbf_rust_direct_account_pointers(num_accounts: usize, input_data
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let compute_budget = ComputeBudget::new_with_defaults(false);
 
-    let mut program_cache = default_program_cache_with_program(
-        &program_id,
-        &program_elf,
-        &feature_set,
-        &compute_budget,
-    );
+    let mut program_cache =
+        default_program_cache_with_program(&program_id, &program_elf, &feature_set);
     let sysvar_cache = default_sysvar_cache();
 
     let mut accounts = Vec::new();
@@ -5632,7 +5555,7 @@ fn test_program_sbf_rust_direct_account_pointers(num_accounts: usize, input_data
 
     let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
-    let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+    let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
     assert!(effects.result.is_none());
     // `num_accounts * 2` will be added as return data.

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -317,11 +317,7 @@ fn test_program_sbf_sanity() {
         );
         let sysvar_cache = default_sysvar_cache();
 
-        let context = InstrContext {
-            feature_set,
-            accounts,
-            instruction,
-        };
+        let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
         let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
 
@@ -383,11 +379,7 @@ fn test_program_sbf_loader_deprecated() {
         let account_metas = vec![AccountMeta::new(pubkey, true)];
         let instruction = Instruction::new_with_bytes(program_id, &[255], account_metas);
 
-        let context = InstrContext {
-            feature_set,
-            accounts,
-            instruction,
-        };
+        let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
         let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
 
@@ -499,11 +491,7 @@ fn test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader() {
     .pop()
     .unwrap();
 
-    let context = InstrContext {
-        feature_set,
-        accounts,
-        instruction,
-    };
+    let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
     // Expect that deployment to fail. B/C during deployment, there is an elf
     // verification step, which uses the runtime to look up relocatable symbols
@@ -564,11 +552,7 @@ fn test_program_sbf_duplicate_accounts() {
                 (pubkey, account.clone()),
             ];
             let instruction = Instruction::new_with_bytes(program_id, data, account_metas.clone());
-            let context = InstrContext {
-                feature_set,
-                accounts,
-                instruction,
-            };
+            let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
             execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache)
         };
 
@@ -616,11 +600,7 @@ fn test_program_sbf_duplicate_accounts() {
             (pubkey, Account::new(10, 1, &program_id)),
         ];
         let instruction = Instruction::new_with_bytes(program_id, &[7], account_metas);
-        let context = InstrContext {
-            feature_set,
-            accounts,
-            instruction,
-        };
+        let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
         let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
         assert!(effects.result.is_none());
     }
@@ -667,11 +647,8 @@ fn test_program_sbf_error_handling() {
             let account_metas = vec![AccountMeta::new(pubkey1, true)];
             let instruction = Instruction::new_with_bytes(program_id, data, account_metas);
 
-            let context = InstrContext {
-                feature_set,
-                accounts: accounts.clone(),
-                instruction,
-            };
+            let context =
+                InstrContext::new_with_default_budget(feature_set, accounts.clone(), instruction);
 
             execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache)
         };
@@ -759,11 +736,7 @@ fn test_return_data_and_log_data_syscall() {
         let instruction =
             Instruction::new_with_bytes(program_id, &[1, 2, 3, 0, 4, 5, 6], account_metas);
 
-        let context = InstrContext {
-            feature_set,
-            accounts,
-            instruction,
-        };
+        let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
         let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
 
@@ -1463,11 +1436,7 @@ fn test_program_sbf_program_id_spoofing() {
     let instruction =
         Instruction::new_with_bytes(malicious_swap_pubkey, &[], account_metas.clone());
 
-    let context = InstrContext {
-        feature_set,
-        accounts,
-        instruction,
-    };
+    let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
     let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
 
@@ -1530,11 +1499,7 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
     ];
     let instruction = Instruction::new_with_bytes(caller_pubkey, &[1], account_metas);
 
-    let context = InstrContext {
-        feature_set,
-        accounts,
-        instruction,
-    };
+    let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
     let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
 
@@ -1575,11 +1540,8 @@ fn test_program_sbf_ro_modify() {
         let instruction =
             Instruction::new_with_bytes(program_id, &[instr_data], account_metas.clone());
 
-        let context = InstrContext {
-            feature_set,
-            accounts: accounts.clone(),
-            instruction,
-        };
+        let context =
+            InstrContext::new_with_default_budget(feature_set, accounts.clone(), instruction);
 
         let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
 
@@ -1612,11 +1574,7 @@ fn test_program_sbf_call_depth() {
     let mut execute = |depth: usize| {
         let instruction = Instruction::new_with_bincode(program_id, &depth, vec![]);
 
-        let context = InstrContext {
-            feature_set,
-            accounts: vec![],
-            instruction,
-        };
+        let context = InstrContext::new_with_default_budget(feature_set, vec![], instruction);
 
         execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache)
     };
@@ -1659,6 +1617,7 @@ fn test_program_sbf_compute_budget() {
         feature_set,
         accounts,
         instruction,
+        cu_avail: compute_budget.compute_unit_limit,
     };
 
     let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
@@ -1738,11 +1697,7 @@ fn assert_instruction_count() {
         }];
         let instruction = Instruction::new_with_bytes(program_id, &[], instruction_accounts);
 
-        let context = InstrContext {
-            feature_set,
-            accounts,
-            instruction,
-        };
+        let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
         let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
 
@@ -1866,11 +1821,7 @@ fn test_program_sbf_r2_instruction_data_pointer(num_accounts: usize, input_data_
 
     let instruction = Instruction::new_with_bytes(program_id, &input_data, account_metas);
 
-    let context = InstrContext {
-        feature_set,
-        accounts,
-        instruction,
-    };
+    let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
     let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
 
@@ -2391,11 +2342,7 @@ fn test_program_sbf_disguised_as_sbf_loader() {
         let account_metas = vec![AccountMeta::new_readonly(program_id, false)];
         let instruction = Instruction::new_with_bytes(bpf_loader::id(), &[1], account_metas);
 
-        let context = InstrContext {
-            feature_set,
-            accounts: vec![],
-            instruction,
-        };
+        let context = InstrContext::new_with_default_budget(feature_set, vec![], instruction);
 
         let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
         assert_eq!(effects.result, Some(InstructionError::UnsupportedProgramId));
@@ -2437,11 +2384,11 @@ fn test_program_reads_from_program_account() {
     let account_metas = vec![AccountMeta::new_readonly(program_id, false)];
     let instruction = Instruction::new_with_bytes(program_id, &program_elf[..48], account_metas);
 
-    let context = InstrContext {
+    let context = InstrContext::new_with_default_budget(
         feature_set,
-        accounts: vec![(program_id, program_account)],
+        vec![(program_id, program_account)],
         instruction,
-    };
+    );
 
     let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
     assert!(effects.result.is_none());
@@ -2479,11 +2426,11 @@ fn test_program_sbf_c_dup() {
     ];
     let instruction = Instruction::new_with_bytes(program_id, &[4, 5, 6, 7], account_metas);
 
-    let context = InstrContext {
+    let context = InstrContext::new_with_default_budget(
         feature_set,
-        accounts: vec![(account_address, account)],
+        vec![(account_address, account)],
         instruction,
-    };
+    );
 
     let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
     assert!(effects.result.is_none());
@@ -2685,11 +2632,8 @@ fn test_program_sbf_ro_account_modify() {
     for case in [0, 1, 2] {
         let instruction = Instruction::new_with_bytes(program_id, &[case], account_metas.clone());
 
-        let context = InstrContext {
-            feature_set,
-            accounts: accounts.clone(),
-            instruction,
-        };
+        let context =
+            InstrContext::new_with_default_budget(feature_set, accounts.clone(), instruction);
 
         let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
 
@@ -4604,6 +4548,7 @@ fn test_program_sbf_deplete_cost_meter_with_divide_by_zero() {
         feature_set,
         accounts: vec![],
         instruction,
+        cu_avail: compute_budget.compute_unit_limit,
     };
 
     let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
@@ -5685,11 +5630,7 @@ fn test_program_sbf_rust_direct_account_pointers(num_accounts: usize, input_data
 
     let instruction = Instruction::new_with_bytes(program_id, &input_data, account_metas);
 
-    let context = InstrContext {
-        feature_set,
-        accounts,
-        instruction,
-    };
+    let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
     let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
 

--- a/svm/src/conformance/context.rs
+++ b/svm/src/conformance/context.rs
@@ -12,6 +12,7 @@ use {
 use {
     solana_account::Account,
     solana_instruction::{Instruction, error::InstructionError},
+    solana_program_runtime::execution_budget::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
     solana_pubkey::Pubkey,
     solana_svm_feature_set::SVMFeatureSet,
 };
@@ -21,6 +22,24 @@ pub struct InstrContext {
     pub feature_set: SVMFeatureSet,
     pub accounts: Vec<(Pubkey, Account)>,
     pub instruction: Instruction,
+    pub cu_avail: u64,
+}
+
+impl InstrContext {
+    /// Create a new [`InstrContext`] with the default compute unit budget
+    /// (200,000 CUs).
+    pub fn new_with_default_budget(
+        feature_set: SVMFeatureSet,
+        accounts: Vec<(Pubkey, Account)>,
+        instruction: Instruction,
+    ) -> Self {
+        Self {
+            feature_set,
+            accounts,
+            instruction,
+            cu_avail: DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64,
+        }
+    }
 }
 
 #[cfg(feature = "conformance")]
@@ -65,10 +84,13 @@ impl From<ProtoInstrContext> for InstrContext {
             program_id,
         };
 
+        let cu_avail = value.cu_avail;
+
         Self {
             feature_set,
             accounts,
             instruction,
+            cu_avail,
         }
     }
 }

--- a/svm/src/conformance/harness.rs
+++ b/svm/src/conformance/harness.rs
@@ -67,24 +67,16 @@ impl InvokeContextCallback for ConformanceCallback {
 /// (no-precompile) callback.
 pub fn execute_instr(
     input: &InstrContext,
-    compute_budget: &ComputeBudget,
     program_cache: &mut ProgramCacheForTxBatch,
     sysvar_cache: &SysvarCache,
 ) -> InstrEffects {
-    execute_instr_with_callback(
-        input,
-        &DefaultCallback,
-        compute_budget,
-        program_cache,
-        sysvar_cache,
-    )
+    execute_instr_with_callback(input, &DefaultCallback, program_cache, sysvar_cache)
 }
 
 /// Execute a single instruction against the Solana VM with a custom callback.
 pub fn execute_instr_with_callback<C: InvokeContextCallback>(
     input: &InstrContext,
     callback: &C,
-    compute_budget: &ComputeBudget,
     program_cache: &mut ProgramCacheForTxBatch,
     sysvar_cache: &SysvarCache,
 ) -> InstrEffects {
@@ -93,6 +85,10 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
 
     let log_collector = LogCollector::new_ref();
     let feature_set = input.feature_set;
+    let simd_0268_active = feature_set.raise_cpi_nesting_limit_to_8;
+
+    let mut compute_budget = ComputeBudget::new_with_defaults(simd_0268_active);
+    compute_budget.compute_unit_limit = input.cu_avail; // Clamp budget for execution by cu_avail
 
     let rent = sysvar_cache.get_rent().unwrap();
     let program_id = &input.instruction.program_id;
@@ -206,17 +202,7 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
 
 #[cfg(feature = "conformance")]
 pub fn execute_instr_proto(input: ProtoInstrContext) -> ProtoInstrEffects {
-    let cu_avail = input.cu_avail;
     let instr_context = InstrContext::from(input);
-
-    let feature_set = &instr_context.feature_set;
-    let simd_0268_active = feature_set.raise_cpi_nesting_limit_to_8;
-
-    let compute_budget = {
-        let mut budget = ComputeBudget::new_with_defaults(simd_0268_active);
-        budget.compute_unit_limit = cu_avail;
-        budget
-    };
 
     // When testing with protobuf, we fill the sysvar cache from input accounts.
     let sysvar_cache = {
@@ -234,8 +220,12 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> ProtoInstrEffects {
     // When testing with protobuf, we fill the program cache from input accounts.
     let mut program_cache = {
         let slot = sysvar_cache.get_clock().unwrap().slot;
+        let feature_set = &instr_context.feature_set;
+        let simd_0268_active = feature_set.raise_cpi_nesting_limit_to_8;
+        let compute_budget = ComputeBudget::new_with_defaults(simd_0268_active);
+
         let environment = create_program_runtime_environment(
-            &instr_context.feature_set,
+            feature_set,
             &compute_budget.to_budget(),
             false, /* deployment */
             false, /* debugging_features */
@@ -252,7 +242,6 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> ProtoInstrEffects {
     execute_instr_with_callback(
         &instr_context,
         &ConformanceCallback,
-        &compute_budget,
         &mut program_cache,
         &sysvar_cache,
     )
@@ -372,13 +361,6 @@ mod tests {
             cu_avail,
         };
 
-        // Set up the Compute Budget.
-        let compute_budget = {
-            let mut budget = ComputeBudget::new_with_defaults(false);
-            budget.compute_unit_limit = cu_avail;
-            budget
-        };
-
         // Create Sysvar Cache.
         let mut sysvar_cache = SysvarCache::default();
         sysvar_cache.fill_missing_entries(|pubkey, callback| {
@@ -394,7 +376,7 @@ mod tests {
 
         let environments = create_program_runtime_environment(
             &context.feature_set,
-            &compute_budget.to_budget(),
+            &ComputeBudget::new_with_defaults(feature_set.raise_cpi_nesting_limit_to_8).to_budget(),
             false, /* deployment */
             false, /* debugging_features */
         )
@@ -409,7 +391,7 @@ mod tests {
         .unwrap();
 
         // Execute the instruction.
-        let effects = execute_instr(&context, &compute_budget, &mut program_cache, &sysvar_cache);
+        let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
 
         // Verify the results.
         assert_eq!(effects.result, None);

--- a/svm/src/conformance/harness.rs
+++ b/svm/src/conformance/harness.rs
@@ -369,6 +369,7 @@ mod tests {
                     0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                 ],
             },
+            cu_avail,
         };
 
         // Set up the Compute Budget.

--- a/svm/src/conformance/programs.rs
+++ b/svm/src/conformance/programs.rs
@@ -103,8 +103,8 @@ pub fn add_program_to_program_cache(
     loader_key: &Pubkey,
     elf: &[u8],
     feature_set: &SVMFeatureSet,
-    compute_budget: &ComputeBudget,
 ) {
+    let compute_budget = ComputeBudget::new_with_defaults(feature_set.raise_cpi_nesting_limit_to_8);
     let program_runtime_environment = create_program_runtime_environment(
         feature_set,
         &compute_budget.to_budget(),


### PR DESCRIPTION
#### Problem
Originally I had `ComputeBudget` as an input argument for the harness, but it turns out we don't even customize it anywhere in the callers (`programs/sbf`).

Furthermore, FD's fixtures don't actually contain a `ComputeBudget`, so there's no need to make this an argument at all.

#### Summary of Changes
Internalize the construction of the `ComputeBudget` in the instruction harness and rely solely on `cu_avail` to enforce a CU budget for testing.
