### PR TITLE
cli: format unmatched pubkeys plainly in 'solana stakes' error message

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1603,8 +1603,11 @@ pub async fn process_show_stakes(
                 .collect();
 
             if !pubkeys.is_empty() {
+                let mut pubkeys: Vec<String> = pubkeys.into_iter().collect();
+                pubkeys.sort();
                 return Err(CliError::RpcRequestError(format!(
-                    "Failed to retrieve matching vote account for {pubkeys:?}."
+                    "Failed to retrieve matching vote account for {}.",
+                    pubkeys.join(", ")
                 ))
                 .into());
             }


### PR DESCRIPTION
## Problem

When `solana stakes <PUBKEY>...` is given a pubkey that does not match any
known vote account, the error message renders the unmatched pubkeys with
`HashSet`'s debug format:

```
$ solana stakes 5QX7zwiSF2SVfrcsKSBr2ukaPrCDCtY1jeEJpRnV6Rki
Error: RPC request error: Failed to retrieve matching vote account for {"5QX7zwiSF2SVfrcsKSBr2ukaPrCDCtY1jeEJpRnV6Rki"}.
```

The `{"..."}` wrapping looks like a JSON object or set literal, not the
pubkey the user typed. With multiple unmatched pubkeys it gets worse and the
order varies between runs because `HashSet` iteration is unstable.

## Fix

In `cli/src/cluster_query.rs::process_show_stakes`, replace the `{pubkeys:?}`
debug formatting with a sorted, comma-separated list of the unmatched
pubkeys:

```
$ solana stakes 5QX7zwiSF2SVfrcsKSBr2ukaPrCDCtY1jeEJpRnV6Rki
Error: RPC request error: Failed to retrieve matching vote account for 5QX7zwiSF2SVfrcsKSBr2ukaPrCDCtY1jeEJpRnV6Rki.

$ solana stakes 3BARmHb5AvNQqKFfMPGyjx7S54nRcv6BTxBu5DhxxKZy 4yRtfQsQ5rEXyqCkQfvU4hSB6zqnZifbVDfqyBnmxmsH 3LspGsLsePyqwHH5ePSaHyFVGiLDKL23pdMSguNnjEEt
Error: RPC request error: Failed to retrieve matching vote account for 3BARmHb5AvNQqKFfMPGyjx7S54nRcv6BTxBu5DhxxKZy, 3LspGsLsePyqwHH5ePSaHyFVGiLDKL23pdMSguNnjEEt, 4yRtfQsQ5rEXyqCkQfvU4hSB6zqnZifbVDfqyBnmxmsH.
```

Sorting makes the output deterministic across runs (independent of the
`HashSet`'s random hash seed) so it is easier to diff, screenshot, and grep.
