### PR TITLE
SIMD-0232: Add feature key

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1425,7 +1425,7 @@ pub mod commission_rate_in_basis_points {
 }
 
 pub mod custom_commission_collector {
-    solana_pubkey::declare_id!("CustomCommissionCo11ector111111111111111111");
+    solana_pubkey::declare_id!("3HcSrCTGXTUnrTueHi4DAwNuMxZSsm5xui2Ax3mgxHqf");
 }
 
 pub mod enable_bls12_381_syscall {


### PR DESCRIPTION
#### Problem

Now that #12550 has landed, everything is in place for SIMD-0232 to be enabled, but it still doesn't have a feature key.

#### Summary of changes

Add a real feature key!

~~NOTE: Leaving this as a draft for now, just to make sure we don't need to revert the PR again~~ It's been a few days, nothing's reported, so let's go forward