### PR TITLE
flh: gate UpdateParent on first slot in leader window

### DIFF
--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -2828,8 +2828,8 @@ fn test_update_parent_restart() {
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
 
     // Slot 4: 5 shreds, replay_fec_set_index=32; 5 < 32 so cleared.
-    // Slot 5: 40 shreds, replay_fec_set_index=32; 40 >= 32 so skipped.
-    for (slot, shreds) in [(4, 5), (5, 40)] {
+    // Slot 8: 40 shreds, replay_fec_set_index=32; 40 >= 32 so skipped.
+    for (slot, shreds) in [(4, 5), (8, 40)] {
         let bank = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), slot);
         bank_forks.write().unwrap().insert(bank);
         let p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
@@ -2838,7 +2838,7 @@ fn test_update_parent_restart() {
     }
 
     let (tx, rx) = crossbeam_channel::unbounded();
-    for slot in [4, 5] {
+    for slot in [4, 8] {
         let parent_block_id = Hash::new_unique();
         insert_update_parent_slot(
             &blockstore,
@@ -2866,7 +2866,7 @@ fn test_update_parent_restart() {
     );
 
     assert!(progress.get(&4).is_none()); // cleared: 5 < 32
-    assert!(progress.get(&5).is_some()); // skipped: 40 >= 32
+    assert!(progress.get(&8).is_some()); // skipped: 40 >= 32
     assert_eq!(
         replay_vote_receiver.try_recv(),
         Ok(ReplayVoteMessage::InvalidBank {
@@ -2891,7 +2891,7 @@ fn test_headerless_update_parent() {
         ..
     } = vote_simulator;
     let my_pubkey = Pubkey::new_unique();
-    let slot = 1;
+    let slot = 4;
     let migration_status = post_migration_status_for_tests();
 
     let footer_marker = || {
@@ -2994,6 +2994,50 @@ fn test_update_parent_tower_gated() {
         &rx,
         &replay_vote_sender,
         &MigrationStatus::default(),
+    );
+
+    assert!(progress.get(&slot).is_some());
+    assert!(bank_forks.read().unwrap().get(slot).is_some());
+}
+
+#[test]
+fn test_update_parent_interrupt_ignores_non_first_leader_window_slot() {
+    let ReplayBlockstoreComponents {
+        blockstore,
+        vote_simulator,
+        ..
+    } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+    let VoteSimulator {
+        bank_forks,
+        mut progress,
+        ..
+    } = vote_simulator;
+
+    let slot = 1;
+    let mut meta = blockstore.meta(slot).unwrap().unwrap();
+    meta.parent_slot = Some(0);
+    meta.parent_block_id = Hash::new_unique();
+    meta.replay_fec_set_index = 10;
+    blockstore.put_meta(slot, &meta).unwrap();
+
+    let p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+    p.replay_progress.write().unwrap().num_shreds = 5;
+    progress.insert(slot, p);
+
+    let (tx, rx) = crossbeam_channel::unbounded();
+    tx.send(UpdateParentSignal { slot }).unwrap();
+
+    let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+    let mut async_verification_freelist = Vec::new();
+    handle_update_parent_interrupts(
+        &Pubkey::new_unique(),
+        &blockstore,
+        &bank_forks,
+        &mut progress,
+        &mut async_verification_freelist,
+        &rx,
+        &replay_vote_sender,
+        &post_migration_status_for_tests(),
     );
 
     assert!(progress.get(&slot).is_some());
@@ -3172,7 +3216,7 @@ fn test_before_update_soft_dead() {
         ..
     } = vote_simulator;
 
-    let slot = 1;
+    let slot = 4;
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
     let bank = Bank::new_from_parent(bank0, SlotLeader::default(), slot);
     let bank = bank_forks.write().unwrap().insert(bank);
@@ -3403,7 +3447,7 @@ fn test_skip_own_update_full() {
     let my_pubkey = *validator_keypairs.keys().next().unwrap();
     let root_bank = bank_forks.read().unwrap().root_bank();
     let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&root_bank));
-    let slot = 2;
+    let slot = 4;
     let replay_fec_set_index = 32;
 
     insert_update_parent_slot(

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -21,7 +21,10 @@ use {
         blockstore_processor::AsyncVerificationProgress,
     },
     solana_pubkey::Pubkey,
-    solana_runtime::{bank::Bank, bank_forks::BankForks, vote_sender_types::ReplayVoteSender},
+    solana_runtime::{
+        bank::Bank, bank_forks::BankForks, leader_schedule_utils::leader_slot_index,
+        vote_sender_types::ReplayVoteSender,
+    },
     std::{
         collections::BTreeSet,
         sync::{Arc, RwLock},
@@ -42,7 +45,7 @@ pub(super) enum ChildBankReplayStart {
 /// Return the UpdateParent replay offset recorded in SlotMeta, if it is
 /// usable from the currently rooted fork.
 fn update_parent_replay_offset(slot: Slot, slot_meta: &SlotMeta, root: Slot) -> Option<u64> {
-    if !slot_meta.has_update_parent() {
+    if !slot_meta.has_update_parent() || leader_slot_index(slot) != 0 {
         return None;
     }
     let parent_slot = slot_meta.parent_slot?;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -50,7 +50,7 @@ use {
     solana_measure::{measure::Measure, measure_us},
     solana_metrics::datapoint_error,
     solana_pubkey::Pubkey,
-    solana_runtime::bank::Bank,
+    solana_runtime::{bank::Bank, leader_schedule_utils::leader_slot_index},
     solana_sha256_hasher::hashv,
     solana_signature::Signature,
     solana_signer::Signer,
@@ -493,6 +493,14 @@ impl ParentInfo {
     /// True when this metadata came from an `UpdateParent` marker.
     fn has_update_parent(&self) -> bool {
         self.replay_fec_set_index > 0
+    }
+
+    fn validate_update_parent_slot(&self, slot: Slot) -> Result<()> {
+        if self.has_update_parent() && leader_slot_index(slot) != 0 {
+            return Err(BlockstoreError::UpdateParentNotFirstInLeaderWindow(slot));
+        }
+
+        Ok(())
     }
 
     /// True when this metadata came from the slot's block header.
@@ -1149,6 +1157,11 @@ impl Blockstore {
         let Some(new_parent_info) = new_parent_info else {
             return Ok(());
         };
+
+        if let Err(err) = new_parent_info.validate_update_parent_slot(slot) {
+            self.mark_invalid_parent_info_dead(write_batch, new_parent_info, slot, location, &err)?;
+            return Err(err);
+        }
 
         let max_root = self.max_root();
         if let Err(err) = new_parent_info.validate_shred_parent(slot, shred_parent_slot, max_root) {

--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -90,6 +90,8 @@ pub enum BlockstoreError {
         update_parent_slot: Slot,
         shred_parent_slot: Slot,
     },
+    #[error("update parent is only valid in the first slot of a leader window for slot {0}")]
+    UpdateParentNotFirstInLeaderWindow(Slot),
     #[error("unexpected block component")]
     UnexpectedBlockComponent,
     #[error("multiple update parents for slot {0}")]

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -6975,31 +6975,58 @@ fn test_invalid_update_parent_parent_info_marks_dead() {
 }
 
 #[test]
+fn test_update_parent_non_first_leader_window_marks_dead() {
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+    let slot = 10;
+    let shred_parent_slot = 5;
+    let update_parent_slot = 3;
+    let mut shreds = create_block_header_shreds(slot, shred_parent_slot, Hash::new_unique());
+    shreds.extend(create_update_parent_shreds_with_shred_parent(
+        slot,
+        shred_parent_slot,
+        update_parent_slot,
+        Hash::new_unique(),
+        32,
+        true,
+    ));
+
+    blockstore.insert_shreds(shreds, None, true).unwrap();
+
+    let meta = blockstore.meta(slot).unwrap().unwrap();
+    assert!(blockstore.is_dead(slot));
+    assert_eq!(meta.parent_slot, Some(shred_parent_slot));
+    assert!(!meta.has_update_parent());
+}
+
+#[test]
 fn test_block_header_followed_by_update_parent() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
+    let slot = 12;
     let parent_5_id = Hash::new_unique();
     blockstore
-        .insert_shreds(create_block_header_shreds(10, 5, parent_5_id), None, true)
+        .insert_shreds(create_block_header_shreds(slot, 5, parent_5_id), None, true)
         .unwrap();
 
-    assert_eq!(blockstore.meta(10).unwrap().unwrap().parent_slot, Some(5));
-    verify_next_slots(&blockstore, 5, &[10]);
+    assert_eq!(blockstore.meta(slot).unwrap().unwrap().parent_slot, Some(5));
+    verify_next_slots(&blockstore, 5, &[slot]);
 
     let parent_3_id = Hash::new_unique();
     blockstore
         .insert_shreds(
-            create_update_parent_shreds_with_shred_parent(10, 5, 3, parent_3_id, 32, true),
+            create_update_parent_shreds_with_shred_parent(slot, 5, 3, parent_3_id, 32, true),
             None,
             true,
         )
         .unwrap();
 
-    assert_eq!(blockstore.meta(10).unwrap().unwrap().parent_slot, Some(3));
+    assert_eq!(blockstore.meta(slot).unwrap().unwrap().parent_slot, Some(3));
 
     let parent_info = blockstore
-        .get_parent_info(10, BlockLocation::Original)
+        .get_parent_info(slot, BlockLocation::Original)
         .unwrap()
         .unwrap();
     assert_eq!(parent_info.parent_slot, 3);
@@ -7007,7 +7034,7 @@ fn test_block_header_followed_by_update_parent() {
     assert!(parent_info.has_update_parent());
 
     verify_next_slots(&blockstore, 5, &[]);
-    verify_next_slots(&blockstore, 3, &[10]);
+    verify_next_slots(&blockstore, 3, &[slot]);
 }
 
 #[test]
@@ -7015,7 +7042,7 @@ fn test_post_update_orig_after() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
-    let slot = 90;
+    let slot = 92;
     let original_parent = 85;
     let update_parent = 80;
     blockstore
@@ -7072,7 +7099,7 @@ fn test_update_parent_shred_parent(update_parent_first: bool) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
-    let slot = 90;
+    let slot = 92;
     let original_parent = 85;
     let update_parent = 80;
     let bad_shred_parent = 84;
@@ -7134,7 +7161,7 @@ fn test_marker_boundary_ooo() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
-    let slot = 93;
+    let slot = 96;
     let original_parent = 88;
     let update_parent = 80;
     blockstore

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -39,6 +39,7 @@ use {
         commitment::VOTE_THRESHOLD_SIZE,
         dependency_tracker::DependencyTracker,
         installed_scheduler_pool::BankWithScheduler,
+        leader_schedule_utils::leader_slot_index,
         prioritization_fee_cache::PrioritizationFeeCache,
         runtime_config::RuntimeConfig,
         snapshot_controller::SnapshotController,
@@ -1808,6 +1809,7 @@ fn confirm_slot_with_components(
     // UpdateParent as its first parent marker. From-shred-zero replay still
     // requires a block header before UpdateParent.
     let replay_starts_at_update_parent = migration_status.should_allow_fast_leader_handover(slot)
+        && leader_slot_index(slot) == 0
         && blockstore
             .meta(slot)
             .expect("Blockstore operations must succeed")
@@ -2456,7 +2458,9 @@ fn load_frozen_forks(
             // Live replay restarts UpdateParent slots from the marker's FEC set.
             // Startup replay must use the same offset or a restarted validator can
             // execute the obsolete optimistic-parent prefix.
-            if migration_status.should_allow_fast_leader_handover(slot) && meta.has_update_parent()
+            if migration_status.should_allow_fast_leader_handover(slot)
+                && leader_slot_index(slot) == 0
+                && meta.has_update_parent()
             {
                 progress.num_shreds = u64::from(meta.replay_fec_set_index);
             }
@@ -2710,6 +2714,7 @@ pub fn check_chained_block_id(
 
     let slot = bank.slot();
     if migration_status.should_allow_fast_leader_handover(slot)
+        && leader_slot_index(slot) == 0
         && blockstore
             .meta(slot)
             .expect("Blockstore operations must succeed")
@@ -6365,11 +6370,11 @@ pub mod tests {
         ));
 
         // Case 4: UpdateParent metadata does not bypass Tower validation.
-        insert_shreds_with_chained_merkle_root(13, 0, Hash::new_unique());
-        let mut meta = blockstore.meta(13).unwrap().unwrap();
+        insert_shreds_with_chained_merkle_root(16, 0, Hash::new_unique());
+        let mut meta = blockstore.meta(16).unwrap().unwrap();
         meta.replay_fec_set_index = 32;
-        blockstore.put_meta(13, &meta).unwrap();
-        let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 13);
+        blockstore.put_meta(16, &meta).unwrap();
+        let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 16);
         assert!(matches!(
             check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
             ChainedBlockIdCheck::Mismatch
@@ -6386,7 +6391,23 @@ pub mod tests {
             ChainedBlockIdCheck::Pass
         ));
 
-        // Case 6: Parent has no shreds (get_block_merkle_root returns Err) —
+        // Case 6: Non-first-window UpdateParent metadata does not bypass
+        // chained block ID validation.
+        insert_shreds_with_chained_merkle_root(13, 0, Hash::new_unique());
+        let mut meta = blockstore.meta(13).unwrap().unwrap();
+        meta.replay_fec_set_index = 32;
+        blockstore.put_meta(13, &meta).unwrap();
+        let child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 13);
+        assert!(matches!(
+            check_chained_block_id(
+                &blockstore,
+                &child_bank,
+                &MigrationStatus::post_migration_status()
+            ),
+            ChainedBlockIdCheck::Mismatch
+        ));
+
+        // Case 7: Parent has no shreds (get_block_merkle_root returns Err) —
         // should return Pass regardless of chained merkle root.
         let no_shreds_parent_bank = Arc::new(Bank::new_from_parent(
             parent_bank,

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -4,6 +4,7 @@ use {
         block_component_processor::vote_reward::{
             CalcVoteRewardUpdateVoteStatesError, calc_vote_rewards_update_vote_states,
         },
+        leader_schedule_utils::leader_slot_index,
         validated_block_finalization::{
             BlockFinalizationCertError, ValidatedBlockFinalizationCert,
         },
@@ -70,6 +71,8 @@ pub enum BlockComponentProcessorError {
     NanosecondClockOutOfBounds,
     #[error("Spurious update parent")]
     SpuriousUpdateParent,
+    #[error("UpdateParent marker is only valid in the first slot of a leader window: slot {0}")]
+    UpdateParentNotFirstInLeaderWindow(Slot),
     #[error(
         "UpdateParent cannot be the initial parent marker unless replay starts at UpdateParent"
     )]
@@ -102,7 +105,8 @@ impl BlockComponentProcessorError {
             | BlockComponentProcessorError::GenesisCertificateFailedVerification
             | BlockComponentProcessorError::MissingBlockFooter
             | BlockComponentProcessorError::MultipleUpdateParents
-            | BlockComponentProcessorError::SpuriousUpdateParent => false,
+            | BlockComponentProcessorError::SpuriousUpdateParent
+            | BlockComponentProcessorError::UpdateParentNotFirstInLeaderWindow(_) => false,
         }
     }
 }
@@ -207,7 +211,7 @@ impl BlockComponentProcessor {
             ),
 
             BlockMarkerV1::UpdateParent(update_parent) if markers_fully_enabled => {
-                self.on_update_parent(update_parent.inner(), allow_initial_update_parent)
+                self.on_update_parent(slot, update_parent.inner(), allow_initial_update_parent)
             }
 
             // Any other combination means we saw a marker too early
@@ -405,11 +409,16 @@ impl BlockComponentProcessor {
 
     fn on_update_parent(
         &mut self,
+        slot: Slot,
         update_parent: &VersionedUpdateParent,
         allow_initial_update_parent: bool,
     ) -> Result<(), BlockComponentProcessorError> {
         if self.update_parent.is_some() {
             return Err(BlockComponentProcessorError::MultipleUpdateParents);
+        }
+
+        if leader_slot_index(slot) != 0 {
+            return Err(BlockComponentProcessorError::UpdateParentNotFirstInLeaderWindow(slot));
         }
 
         if !self.has_header && !allow_initial_update_parent {
@@ -1301,8 +1310,23 @@ mod tests {
         });
 
         assert!(matches!(
-            processor.on_update_parent(&update_parent, false),
+            processor.on_update_parent(4, &update_parent, false),
             Err(BlockComponentProcessorError::UnexpectedInitialUpdateParent)
+        ));
+        assert!(processor.update_parent.is_none());
+    }
+
+    #[test]
+    fn test_update_parent_rejects_non_first_leader_window_slot() {
+        let mut processor = BlockComponentProcessor::default();
+        let update_parent = VersionedUpdateParent::V1(UpdateParentV1 {
+            new_parent_slot: 0,
+            new_parent_block_id: Hash::default(),
+        });
+
+        assert!(matches!(
+            processor.on_update_parent(5, &update_parent, true),
+            Err(BlockComponentProcessorError::UpdateParentNotFirstInLeaderWindow(5))
         ));
         assert!(processor.update_parent.is_none());
     }
@@ -1315,7 +1339,7 @@ mod tests {
             new_parent_block_id: Hash::default(),
         });
 
-        processor.on_update_parent(&update_parent, true).unwrap();
+        processor.on_update_parent(4, &update_parent, true).unwrap();
         assert!(processor.update_parent.is_some());
     }
 
@@ -1338,7 +1362,7 @@ mod tests {
         });
 
         assert!(matches!(
-            processor.on_update_parent(&update_parent, false),
+            processor.on_update_parent(4, &update_parent, false),
             Err(BlockComponentProcessorError::AbandonedBank(_))
         ));
     }
@@ -1352,11 +1376,11 @@ mod tests {
         });
 
         // First should succeed
-        processor.on_update_parent(&update_parent, true).unwrap();
+        processor.on_update_parent(4, &update_parent, true).unwrap();
 
         // Second should fail
         assert!(matches!(
-            processor.on_update_parent(&update_parent, true),
+            processor.on_update_parent(4, &update_parent, true),
             Err(BlockComponentProcessorError::MultipleUpdateParents)
         ));
     }
@@ -1366,6 +1390,7 @@ mod tests {
         let mut processor = BlockComponentProcessor::default();
         processor
             .on_update_parent(
+                4,
                 &VersionedUpdateParent::V1(UpdateParentV1 {
                     new_parent_slot: 0,
                     new_parent_block_id: Hash::default(),
@@ -1391,10 +1416,11 @@ mod tests {
         let migration_status = MigrationStatus::post_migration_status();
         let mut processor = BlockComponentProcessor::default();
         let (parent, bank_forks) = create_test_bank();
-        let bank = create_child_bank(&bank_forks, &parent, 1);
+        let bank = create_child_bank(&bank_forks, &parent, 4);
 
         processor
             .on_update_parent(
+                bank.slot(),
                 &VersionedUpdateParent::V1(UpdateParentV1 {
                     new_parent_slot: 0,
                     new_parent_block_id: Hash::default(),


### PR DESCRIPTION
#### Problem
We accept the `UpdateParent` marker on any block. We should only allow it on the first slot in a leader window.

#### Summary of Changes
Have BCP return an error (which causes replay to fail and mark the block dead) if it's specified on a intra window slot
(overkill) do the same in the blockstore ingest path

Fixes #12682 