### PR TITLE
Refactor - Adds `account_owner` check to `ProgramCacheEntry::eq()`

### DIFF
--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -173,6 +173,7 @@ impl PartialEq for ProgramCacheEntry {
     fn eq(&self, other: &Self) -> bool {
         self.effective_slot == other.effective_slot
             && self.deployment_slot == other.deployment_slot
+            && self.account_owner == other.account_owner
             && self.is_tombstone() == other.is_tombstone()
     }
 }


### PR DESCRIPTION
#### Problem

In #12683 I forgot not adjust `ProgramCacheEntry::eq()` as well.

#### Summary of Changes

- Adds `account_owner` check to `ProgramCacheEntry::eq()`.