### PR TITLE
refactor: move get_remote_pubkey to tls-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10948,6 +10948,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 name = "solana-tls-utils"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "quinn",
  "rustls",
  "solana-keypair",
  "solana-pubkey 4.2.0",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9194,6 +9194,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 name = "solana-tls-utils"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "quinn",
  "rustls",
  "solana-keypair",
  "solana-pubkey 4.2.0",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9717,6 +9717,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 name = "solana-tls-utils"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "quinn",
  "rustls",
  "solana-keypair",
  "solana-pubkey 4.2.0",

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -22,7 +22,7 @@ use {
     solana_packet::Meta,
     solana_perf::packet::{BytesPacket, PacketBatch},
     solana_pubkey::Pubkey,
-    solana_tls_utils::get_pubkey_from_tls_certificate,
+    solana_tls_utils::get_remote_pubkey,
     std::{
         array, fmt,
         iter::repeat_with,
@@ -401,17 +401,6 @@ where
     }
     tasks.close();
     tasks.wait().await;
-}
-
-pub fn get_remote_pubkey(connection: &Connection) -> Option<Pubkey> {
-    // Use the client cert only if it is self signed and the chain length is 1.
-    connection
-        .peer_identity()?
-        .downcast::<Vec<rustls::pki_types::CertificateDer>>()
-        .ok()
-        .filter(|certs| certs.len() == 1)?
-        .first()
-        .and_then(get_pubkey_from_tls_certificate)
 }
 
 pub fn get_connection_stake(

--- a/tls-utils/Cargo.toml
+++ b/tls-utils/Cargo.toml
@@ -13,6 +13,7 @@ edition = { workspace = true }
 agave-unstable-api = []
 
 [dependencies]
+quinn = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/tls-utils/src/tls_certificates.rs
+++ b/tls-utils/src/tls_certificates.rs
@@ -127,6 +127,22 @@ pub fn get_pubkey_from_tls_certificate(
     }
 }
 
+/// Recover the peer's Solana pubkey from a `quinn::Connection`. Accepts
+/// only a self-signed cert chain of length 1 (matches the cert shape
+/// produced by [`new_dummy_x509_certificate`]).
+///
+/// Single source of truth for anything doing QUIC and using
+/// Solana validator identities for auth.
+pub fn get_remote_pubkey(connection: &quinn::Connection) -> Option<Pubkey> {
+    connection
+        .peer_identity()?
+        .downcast::<Vec<rustls::pki_types::CertificateDer>>()
+        .ok()
+        .filter(|certs| certs.len() == 1)?
+        .first()
+        .and_then(get_pubkey_from_tls_certificate)
+}
+
 /// Translate a SocketAddr into a valid SNI for the purposes of QUIC connection
 ///
 /// We do not actually check if the server holds a cert for this server_name


### PR DESCRIPTION
#### Problem

Pubkey extraction is an operation that any transport using QUIC protocol needs to perform. Pulling in entire streamer crate for it seems unwise.

#### Summary of Changes

Move it from streamer to tls-utils. 

Anything using tls-utils would pull in quinn anyway, so adding the dep there is not a problem. 