### PR TITLE
votor: fix standstill event slot when no finalization is present

### DIFF
--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -241,7 +241,7 @@ impl SigVerifier {
                     }
                 }
                 ConsensusMessage::Certificate(cert) => {
-                    if cert.cert_type.slot() <= root_slot {
+                    if cert.cert_type.slot() < root_slot {
                         self.stats.num_old_certs_received += 1;
                         continue;
                     }

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -296,7 +296,9 @@ impl ConsensusPoolService {
                 // Genesis cert though.
                 if kick_off_parent_ready {
                     events.push(VotorEvent::Standstill(
-                        consensus_pool.highest_finalized_slot().unwrap_or(0),
+                        consensus_pool
+                            .highest_finalized_slot()
+                            .unwrap_or(ctx.sharable_banks.root().slot()),
                     ));
                 }
                 stats.standstill = true;


### PR DESCRIPTION
#### Problem
#12229 broke standstill for the case when a validator restarts (e.g. recovers from panic) and is immediately in standstill.
At this point the consensus pool would be empty so we send `Standstill(0)` which is ignored.

#### Summary of Changes
Instead send `Standstill(root_slot)` if there's no finalization certificate.

Also the cert ingest filters out certificates for the root slot meaning that the finalization cert will never be ingested. We should not be strict in equality here (also fixes a bug where the genesis block could be the latest root slot)