### PR TITLE
chore(rust): bump toolchain to 1.96 and nightly to 2026-04-11

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2026-02-28
+  nightly_version=2026-04-11
 fi
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"


### PR DESCRIPTION
#### Problem
rust 1.96.0 was released today.
https://releases.rs/docs/1.96.0/

#### Summary of Changes
bump toolchain to 1.96.0 and nightly to 2026-04-11
