### PR TITLE
votor: properly handle initial parent ready after a restart

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -7,7 +7,7 @@ use {
             Stake, conflicting_types, vote_to_cert_types,
         },
         consensus_pool::{
-            parent_ready_tracker::ParentReadyTracker,
+            parent_ready_tracker::{ParentReady, ParentReadyTracker},
             slot_stake_counters::SlotStakeCounters,
             stats::ConsensusPoolStats,
             vote_pool::{DuplicateBlockVotePool, SimpleVotePool, VotePool},
@@ -123,8 +123,8 @@ pub(crate) struct ConsensusPool {
     stats: ConsensusPoolStats,
     /// Slot stake counters, used to calculate safe_to_notar and safe_to_skip
     slot_stake_counters_map: BTreeMap<Slot, SlotStakeCounters>,
-    /// Stores details about the genesis vote during the migration
-    migration_status: Option<Arc<MigrationStatus>>,
+    /// Stores details about the genesis vote during the migration.
+    migration_status: Arc<MigrationStatus>,
     /// Pending safe-to-notar blocks for intrawindow slots that need parent verification.
     /// These are blocks that have reached the safe-to-notar threshold but are not the
     /// first block in their leader window. They need to be verified that their parent
@@ -135,26 +135,15 @@ pub(crate) struct ConsensusPool {
 }
 
 impl ConsensusPool {
-    pub(crate) fn new_from_root_bank_pre_migration(
+    pub(crate) fn new(
         cluster_info: Arc<ClusterInfo>,
-        bank: &Bank,
+        root: &Bank,
         generated_cert_types: Arc<GeneratedCertTypes>,
         migration_status: Arc<MigrationStatus>,
+        initial_parent_ready: ParentReady,
     ) -> Self {
-        let mut pool = Self::new_from_root_bank(cluster_info, bank, generated_cert_types);
-        pool.migration_status = Some(migration_status);
-        pool
-    }
-
-    pub fn new_from_root_bank(
-        cluster_info: Arc<ClusterInfo>,
-        bank: &Bank,
-        generated_cert_types: Arc<GeneratedCertTypes>,
-    ) -> Self {
-        // To account for genesis and snapshots we allow default block id until
-        // block id can be serialized as part of the snapshot
-        let root_block = (bank.slot(), bank.block_id().unwrap_or_default());
-        let parent_ready_tracker = ParentReadyTracker::new(cluster_info.clone(), root_block);
+        let parent_ready_tracker =
+            ParentReadyTracker::new(cluster_info.clone(), root.slot(), initial_parent_ready);
 
         Self {
             cluster_info,
@@ -164,7 +153,7 @@ impl ConsensusPool {
             parent_ready_tracker,
             stats: ConsensusPoolStats::default(),
             slot_stake_counters_map: BTreeMap::new(),
-            migration_status: None,
+            migration_status,
             generated_cert_types,
             pending_safe_to_notar: vec![],
             last_pruned_slot: 0,
@@ -373,9 +362,7 @@ impl ConsensusPool {
                 }
             }
             CertificateType::Genesis(slot, block_id) => {
-                if let Some(ref migration_status) = self.migration_status {
-                    migration_status.set_genesis_certificate(cert);
-                }
+                self.migration_status.set_genesis_certificate(cert);
                 // The genesis block is automatically certified
                 self.parent_ready_tracker
                     .add_new_notar_fallback_or_stronger((slot, block_id), events);
@@ -755,12 +742,16 @@ mod tests {
             let root_bank = bank_forks.read().unwrap().root_bank();
             let generated_cert_types = Arc::new(GeneratedCertTypes::default());
             let cluster_info = get_cluster_info(Keypair::new());
+            let root_block = (root_bank.slot(), root_bank.block_id().unwrap_or_default());
+            let initial_parent_ready = (root_bank.slot().checked_add(1).unwrap(), root_block);
             Self {
                 validators: validator_keypairs,
-                pool: ConsensusPool::new_from_root_bank(
+                pool: ConsensusPool::new(
                     cluster_info,
                     &root_bank,
                     generated_cert_types.clone(),
+                    Arc::new(MigrationStatus::post_migration_status()),
+                    initial_parent_ready,
                 ),
                 bank_forks,
                 generated_cert_types,

--- a/votor/src/consensus_pool/parent_ready_tracker.rs
+++ b/votor/src/consensus_pool/parent_ready_tracker.rs
@@ -22,6 +22,8 @@ use {
     std::{collections::HashMap, sync::Arc},
 };
 
+pub(crate) type ParentReady = (Slot, Block);
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum BlockProductionParent {
     MissedWindow,
@@ -63,30 +65,49 @@ struct ParentReadyStatus {
 }
 
 impl ParentReadyTracker {
-    /// Creates a new tracker with the root bank as implicitely notarized fallback
-    pub(super) fn new(cluster_info: Arc<ClusterInfo>, root_block @ (root_slot, _): Block) -> Self {
+    /// Creates a new tracker with the selected startup parent-ready state.
+    pub(super) fn new(
+        cluster_info: Arc<ClusterInfo>,
+        root: Slot,
+        (slot, parent_block @ (parent_slot, _)): ParentReady,
+    ) -> Self {
+        debug_assert!(parent_slot < slot);
         let mut slot_statuses = HashMap::new();
+        // Parent block is notarize fallback
         slot_statuses.insert(
-            root_slot,
+            parent_slot,
             ParentReadyStatus {
                 skip: false,
-                notar_fallbacks: vec![root_block],
+                notar_fallbacks: vec![parent_block],
                 parents_ready: vec![],
             },
         );
+        // Intermediate blocks have skips
+        for s in (parent_slot.checked_add(1).unwrap())..slot {
+            slot_statuses.insert(
+                s,
+                ParentReadyStatus {
+                    skip: true,
+                    notar_fallbacks: vec![],
+                    parents_ready: vec![parent_block],
+                },
+            );
+        }
+        // Initial slot is parent ready
         slot_statuses.insert(
-            root_slot.saturating_add(1),
+            slot,
             ParentReadyStatus {
                 skip: false,
                 notar_fallbacks: vec![],
-                parents_ready: vec![root_block],
+                parents_ready: vec![parent_block],
             },
         );
+
         Self {
             cluster_info: DebugIgnore(cluster_info),
             slot_statuses,
-            root: root_slot,
-            highest_with_parent_ready: root_slot.saturating_add(1),
+            root: parent_slot.min(root),
+            highest_with_parent_ready: slot.max(root),
         }
     }
 
@@ -257,11 +278,22 @@ mod tests {
         solana_keypair::Keypair,
     };
 
+    fn root_parent_ready(root_block @ (root_slot, _): Block) -> ParentReady {
+        (root_slot.saturating_add(1), root_block)
+    }
+
+    fn new_tracker(
+        cluster_info: Arc<ClusterInfo>,
+        root_block @ (root_slot, _): Block,
+    ) -> ParentReadyTracker {
+        ParentReadyTracker::new(cluster_info, root_slot, root_parent_ready(root_block))
+    }
+
     #[test]
     fn basic() {
         let cluster_info = get_cluster_info(Keypair::new());
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(cluster_info, genesis);
+        let mut tracker = new_tracker(cluster_info, genesis);
         let mut events = vec![];
 
         for i in 1..2 * NUM_CONSECUTIVE_LEADER_SLOTS.get() as Slot {
@@ -276,7 +308,7 @@ mod tests {
     fn skips() {
         let cluster_info = get_cluster_info(Keypair::new());
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(cluster_info, genesis);
+        let mut tracker = new_tracker(cluster_info, genesis);
         let mut events = vec![];
         let block = (1, Hash::new_unique());
 
@@ -294,7 +326,7 @@ mod tests {
     fn out_of_order() {
         let cluster_info = get_cluster_info(Keypair::new());
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(cluster_info, genesis);
+        let mut tracker = new_tracker(cluster_info, genesis);
         let mut events = vec![];
         let block = (1, Hash::new_unique());
 
@@ -315,7 +347,7 @@ mod tests {
         let cluster_info = get_cluster_info(Keypair::new());
         let root_slot = 2147;
         let root_block = (root_slot, Hash::new_unique());
-        let mut tracker = ParentReadyTracker::new(cluster_info, root_block);
+        let mut tracker = new_tracker(cluster_info, root_block);
         let mut events = vec![];
 
         assert!(tracker.parent_ready(root_slot + 1, root_block));
@@ -340,10 +372,25 @@ mod tests {
     }
 
     #[test]
+    fn restored_parent_ready() {
+        let cluster_info = get_cluster_info(Keypair::new());
+        let root_slot = 4;
+        let restored = (13, Hash::new_unique());
+        let tracker = ParentReadyTracker::new(cluster_info, root_slot, (16, restored));
+
+        assert!(tracker.parent_ready(16, restored));
+        assert_eq!(tracker.highest_parent_ready(), 16);
+        assert_eq!(
+            tracker.block_production_parent(16),
+            BlockProductionParent::Parent(restored)
+        );
+    }
+
+    #[test]
     fn highest_parent_ready_out_of_order() {
         let cluster_info = get_cluster_info(Keypair::new());
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(cluster_info, genesis);
+        let mut tracker = new_tracker(cluster_info, genesis);
         let mut events = vec![];
         assert_eq!(tracker.highest_parent_ready(), 1);
 
@@ -366,7 +413,7 @@ mod tests {
     fn missed_window() {
         let cluster_info = get_cluster_info(Keypair::new());
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(cluster_info, genesis);
+        let mut tracker = new_tracker(cluster_info, genesis);
         let mut events = vec![];
         assert_eq!(tracker.highest_parent_ready(), 1);
         assert_eq!(
@@ -397,7 +444,7 @@ mod tests {
     fn pick_more_skips() {
         let cluster_info = get_cluster_info(Keypair::new());
         let genesis = Block::default();
-        let mut tracker = ParentReadyTracker::new(cluster_info, genesis);
+        let mut tracker = new_tracker(cluster_info, genesis);
         let mut events = vec![];
 
         for i in 1..=10 {

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -8,7 +8,8 @@ use {
         commitment::{CommitmentAggregationData, CommitmentType, update_commitment_cache},
         common::DELTA_STANDSTILL,
         consensus_pool::{
-            AddVoteError, ConsensusPool, parent_ready_tracker::BlockProductionParent,
+            AddVoteError, ConsensusPool,
+            parent_ready_tracker::{BlockProductionParent, ParentReady},
         },
         event::{LeaderWindowInfo, RepairEvent, RepairEventSender, VotorEvent, VotorEventSender},
         generated_cert_types::GeneratedCertTypes,
@@ -52,6 +53,7 @@ pub(crate) struct ConsensusPoolContext {
     pub(crate) blockstore: Arc<Blockstore>,
     pub(crate) sharable_banks: SharableBanks,
     pub(crate) leader_schedule_cache: Arc<LeaderScheduleCache>,
+    pub(crate) vote_history_highest_parent_ready: Option<(Slot, Block)>,
 
     pub(crate) consensus_message_receiver: Receiver<Vec<ConsensusMessage>>,
 
@@ -224,27 +226,60 @@ impl ConsensusPoolService {
         Err(())
     }
 
+    /// Finds the initial parent ready that we should use for instantiating the ConsensusPool or kicking off votor
+    /// The max of genesis block, root block, or the restored parent ready from vote history
+    fn initial_parent_ready(
+        genesis_block: Option<Block>,
+        root_block @ (root_slot, _): Block,
+        vote_history_highest_parent_ready: Option<(Slot, Block)>,
+    ) -> ParentReady {
+        let Some(genesis_block) = genesis_block else {
+            // Alpenglow is not yet enabled, start with just the root
+            return (root_slot.checked_add(1).unwrap(), root_block);
+        };
+
+        let initial_block @ (initial_slot, _) = genesis_block.max(root_block);
+        let initial_parent_ready = (initial_slot.checked_add(1).unwrap(), initial_block);
+
+        if let Some(restored @ (restored_slot, _)) = vote_history_highest_parent_ready
+            && restored_slot > initial_parent_ready.0
+        {
+            restored
+        } else {
+            initial_parent_ready
+        }
+    }
+
+    fn root_block(root_bank: &Bank) -> Block {
+        (
+            root_bank.slot(),
+            root_bank
+                .block_id()
+                // Once SIMD-0333 is active we can hard unwrap here
+                .unwrap_or_default(),
+        )
+    }
+
     // Main loop for the certificate pool service, it only exits when any channel is disconnected
     fn consensus_pool_ingest_loop(mut ctx: ConsensusPoolContext) -> Result<(), ()> {
         let mut events = vec![];
         let root_bank = ctx.sharable_banks.root();
 
-        // Unlike the other votor threads, consensus pool starts even before alpenglow is enabled
-        // As it is required to track the Genesis Vote.
-        let mut consensus_pool = if ctx.migration_status.is_alpenglow_enabled() {
-            ConsensusPool::new_from_root_bank(
-                ctx.cluster_info.clone(),
-                &root_bank,
-                ctx.generated_cert_types.clone(),
-            )
-        } else {
-            ConsensusPool::new_from_root_bank_pre_migration(
-                ctx.cluster_info.clone(),
-                &root_bank,
-                ctx.generated_cert_types.clone(),
-                ctx.migration_status.clone(),
-            )
-        };
+        let initial_parent_ready = Self::initial_parent_ready(
+            ctx.migration_status.genesis_block(),
+            Self::root_block(&root_bank),
+            ctx.vote_history_highest_parent_ready,
+        );
+
+        // Unlike the other votor threads, consensus pool starts even before Alpenglow is enabled
+        // because it must track the genesis vote.
+        let mut consensus_pool = ConsensusPool::new(
+            ctx.cluster_info.clone(),
+            &root_bank,
+            ctx.generated_cert_types.clone(),
+            ctx.migration_status.clone(),
+            initial_parent_ready,
+        );
 
         info!("{}: Certificate pool loop starting", ctx.cluster_info.id());
         let mut stats = ConsensusPoolServiceStats::new();
@@ -264,22 +299,16 @@ impl ConsensusPoolService {
             // Kick off parent ready event, this either happens:
             // - When we first migrate to alpenglow from TowerBFT - kick off with genesis block
             // - If we startup post alpenglow migration - kick off with root block
+            // - If restored vote history is farther ahead, resume from its highest parent-ready
             if !kick_off_parent_ready && ctx.migration_status.is_alpenglow_enabled() {
-                let genesis_block = ctx
-                    .migration_status
-                    .genesis_block()
-                    .expect("Alpenglow is enabled");
                 let root_bank = ctx.sharable_banks.root();
-                // can expect once we have block id in snapshots (SIMD-0333)
-                let root_block = (root_bank.slot(), root_bank.block_id().unwrap_or_default());
-                let kick_off_block @ (kick_off_slot, _) = genesis_block.max(root_block);
-                let start_slot = kick_off_slot.checked_add(1).unwrap();
-
-                events.push(VotorEvent::ParentReady {
-                    slot: start_slot,
-                    parent_block: kick_off_block,
-                });
-                highest_parent_ready = start_slot;
+                let (slot, parent_block) = Self::initial_parent_ready(
+                    ctx.migration_status.genesis_block(),
+                    Self::root_block(&root_bank),
+                    ctx.vote_history_highest_parent_ready,
+                );
+                events.push(VotorEvent::ParentReady { slot, parent_block });
+                highest_parent_ready = slot;
                 kick_off_parent_ready = true;
             }
 
@@ -661,10 +690,14 @@ mod tests {
 
             let root_bank = sharable_banks.root();
             let cluster_info = get_cluster_info(my_keypair.insecure_clone());
-            let consensus_pool = ConsensusPool::new_from_root_bank(
+            let root_block = (root_bank.slot(), root_bank.block_id().unwrap_or_default());
+            let initial_parent_ready = (root_bank.slot().checked_add(1).unwrap(), root_block);
+            let consensus_pool = ConsensusPool::new(
                 cluster_info.clone(),
                 &root_bank,
                 Arc::new(GeneratedCertTypes::default()),
+                Arc::new(MigrationStatus::post_migration_status()),
+                initial_parent_ready,
             );
             let my_vote_pubkey = Pubkey::new_unique();
 
@@ -892,6 +925,7 @@ mod tests {
             blockstore: ctx.blockstore.clone(),
             sharable_banks: ctx.sharable_banks.clone(),
             leader_schedule_cache: ctx.leader_schedule_cache.clone(),
+            vote_history_highest_parent_ready: None,
             consensus_message_receiver: crossbeam_channel::unbounded().1,
             bls_sender: ctx.bls_sender.clone(),
             event_sender: crossbeam_channel::unbounded().0,
@@ -925,6 +959,28 @@ mod tests {
         assert!(
             produce_event.is_some(),
             "Should have received a ProduceWindow event"
+        );
+    }
+
+    #[test]
+    fn test_kick_off_parent_ready_uses_restored_vote_history() {
+        let genesis_block = Some((10, Hash::new_unique()));
+        let root_block = (12, Hash::new_unique());
+        assert_eq!(
+            ConsensusPoolService::initial_parent_ready(genesis_block, root_block, None),
+            (13, root_block)
+        );
+
+        let restored = (16, (15, Hash::new_unique()));
+        assert_eq!(
+            ConsensusPoolService::initial_parent_ready(genesis_block, root_block, Some(restored)),
+            restored
+        );
+
+        let stale = (12, (11, Hash::new_unique()));
+        assert_eq!(
+            ConsensusPoolService::initial_parent_ready(genesis_block, root_block, Some(stale)),
+            (13, root_block)
         );
     }
 

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -308,8 +308,9 @@ impl ConsensusPoolService {
                     ctx.vote_history_highest_parent_ready,
                 );
                 events.push(VotorEvent::ParentReady { slot, parent_block });
-                highest_parent_ready = slot;
                 kick_off_parent_ready = true;
+                // Intentionally do not increment `highest_parent_ready` in case
+                // this is a cluster restart and we are the very first leader.
             }
 
             Self::add_produce_block_event(
@@ -959,6 +960,80 @@ mod tests {
         assert!(
             produce_event.is_some(),
             "Should have received a ProduceWindow event"
+        );
+    }
+
+    #[test]
+    fn test_can_produce_window_immediately_on_restart() {
+        let ctx = TestContext::default();
+        let (repair_event_sender, _repair_event_receiver) = unbounded();
+        let (event_sender, event_receiver) = unbounded();
+        let (consensus_message_sender, consensus_message_receiver) = unbounded();
+
+        let root_bank = ctx.sharable_banks.root();
+        let next_leader_slot = ctx
+            .leader_schedule_cache
+            .next_leader_slot(&ctx.my_pubkey, 0, &root_bank, None, 1000000)
+            .expect("Should find a leader slot")
+            .0;
+        let restored_parent_ready = (
+            next_leader_slot,
+            (next_leader_slot.checked_sub(1).unwrap(), Hash::new_unique()),
+        );
+        let exit = ctx.exit.clone();
+
+        let pool_ctx = ConsensusPoolContext {
+            exit: exit.clone(),
+            migration_status: Arc::new(MigrationStatus::post_migration_status()),
+            generated_cert_types: Arc::new(GeneratedCertTypes::default()),
+            cluster_info: ctx.cluster_info.clone(),
+            my_vote_pubkey: ctx.my_vote_pubkey,
+            blockstore: ctx.blockstore.clone(),
+            sharable_banks: ctx.sharable_banks.clone(),
+            leader_schedule_cache: ctx.leader_schedule_cache.clone(),
+            vote_history_highest_parent_ready: Some(restored_parent_ready),
+            consensus_message_receiver,
+            bls_sender: ctx.bls_sender.clone(),
+            event_sender,
+            commitment_sender: ctx.commitment_sender.clone(),
+            highest_finalized: ctx.highest_finalized.clone(),
+            repair_event_sender,
+        };
+
+        let handle =
+            thread::spawn(move || ConsensusPoolService::consensus_pool_ingest_loop(pool_ctx));
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut saw_parent_ready = false;
+        let mut saw_produce_window = false;
+        while Instant::now() < deadline && !saw_produce_window {
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            let Ok(event) = event_receiver.recv_timeout(timeout) else {
+                break;
+            };
+
+            match event {
+                VotorEvent::ParentReady { slot, parent_block } => {
+                    saw_parent_ready |= (slot, parent_block) == restored_parent_ready;
+                }
+                VotorEvent::ProduceWindow(LeaderWindowInfo { start_slot, .. }) => {
+                    saw_produce_window |= start_slot == restored_parent_ready.0;
+                }
+                _ => {}
+            }
+        }
+
+        exit.store(true, Ordering::Relaxed);
+        drop(consensus_message_sender);
+        let _ = handle.join().unwrap();
+
+        assert!(
+            saw_parent_ready,
+            "Should have received kick-off ParentReady"
+        );
+        assert!(
+            saw_produce_window,
+            "Should have received ProduceWindow for kick-off ParentReady"
         );
     }
 

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -221,18 +221,18 @@ impl EventHandler {
             request_switch(&ctx.latest_switch_request, *my_pubkey, parent_block);
         }
 
-        let should_set_timeouts = vctx.vote_history.add_parent_ready(slot, parent_block);
+        vctx.vote_history.add_parent_ready(slot, parent_block);
         Self::check_pending_blocks(my_pubkey, &mut local_context.pending_blocks, vctx, votes)?;
-        if should_set_timeouts {
-            let root_bank = vctx.sharable_banks.root();
-            let delta_block = Duration::from_nanos_u128(root_bank.ns_per_slot_at_slot(slot));
-            let delta_first_slice = delta_block;
-            timer_manager.write().set_timeouts(
-                slot,
-                local_context.standstill_slot,
-                delta_first_slice,
-                delta_block,
-            );
+        let root_bank = vctx.sharable_banks.root();
+        let delta_block = Duration::from_nanos_u128(root_bank.ns_per_slot_at_slot(slot));
+        let delta_first_slice = delta_block;
+        let timeout_inserted = timer_manager.write().set_timeouts(
+            slot,
+            local_context.standstill_slot,
+            delta_first_slice,
+            delta_block,
+        );
+        if timeout_inserted {
             local_context.stats.timeout_set = local_context.stats.timeout_set.saturating_add(1);
         }
 
@@ -1486,6 +1486,25 @@ mod tests {
         test_context.check_parent_ready_slot((slot, (2, block_id_2)));
         test_context.check_for_vote(&Vote::new_notarization_vote(slot, block_id_4));
         test_context.check_for_commitment(CommitmentType::Notarize, slot);
+    }
+
+    #[test]
+    fn test_restored_parent_ready_sets_timeout() {
+        let mut test_context = setup();
+        let slot = 4;
+        let parent_block = (3, Hash::new_unique());
+
+        assert!(
+            test_context
+                .voting_context
+                .vote_history
+                .add_parent_ready(slot, parent_block)
+        );
+        assert!(!test_context.timer_manager.read().is_timeout_set(slot));
+
+        test_context.send_parent_ready_event(slot, parent_block);
+        test_context.check_timeout_set(slot);
+        assert_eq!(test_context.local_context.stats.timeout_set, 1);
     }
 
     #[test]

--- a/votor/src/timer_manager.rs
+++ b/votor/src/timer_manager.rs
@@ -63,14 +63,14 @@ impl TimerManager {
         standstill_slot: Option<Slot>,
         delta_first_slice: Duration,
         delta_block: Duration,
-    ) {
+    ) -> bool {
         self.timers.write().set_timeouts(
             slot,
             Instant::now(),
             standstill_slot,
             delta_first_slice,
             delta_block,
-        );
+        )
     }
 
     pub(crate) fn join(self) {
@@ -103,7 +103,8 @@ mod tests {
         let delta_first_slice = delta_block;
         let slot = 52;
         let start = Instant::now();
-        timer_manager.set_timeouts(slot, None, delta_first_slice, delta_block);
+        assert!(timer_manager.set_timeouts(slot, None, delta_first_slice, delta_block));
+        assert!(!timer_manager.set_timeouts(slot, None, delta_first_slice, delta_block));
         // Should see two timeouts at delta_block and DELTA_TIMEOUT
         let mut timeouts_received = 0;
         while timeouts_received < 2 && Instant::now().duration_since(start) < Duration::from_secs(2)

--- a/votor/src/timer_manager/timers.rs
+++ b/votor/src/timer_manager/timers.rs
@@ -205,7 +205,7 @@ impl Timers {
         standstill_slot: Option<Slot>,
         delta_first_slice: Duration,
         delta_block: Duration,
-    ) {
+    ) -> bool {
         assert!(delta_first_slice <= delta_block);
         assert_eq!(self.heap.len(), self.timers.len());
         let timeout_config = TimeoutConfig {
@@ -225,6 +225,7 @@ impl Timers {
         });
         self.stats
             .incr_timeout_count_with_heap_size(self.heap.len(), new_timer_inserted);
+        new_timer_inserted
     }
 
     /// Call to make progress on the timer states.  If there are still active

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -212,8 +212,7 @@ impl VoteHistory {
 
     /// Add a new parent ready slot
     ///
-    /// Returns true if the insertion was successful and this was the
-    /// first parent ready for this slot, indicating we should set timeouts.
+    /// Returns true if this was the first parent ready for this slot.
     pub fn add_parent_ready(&mut self, slot: Slot, parent: Block) -> bool {
         if slot < self.root {
             return false;
@@ -231,7 +230,15 @@ impl VoteHistory {
     }
 
     pub fn highest_parent_ready_slot(&self) -> Option<Slot> {
-        self.parent_ready_slots.keys().max().copied()
+        self.highest_parent_ready().map(|(slot, _)| slot)
+    }
+
+    pub fn highest_parent_ready(&self) -> Option<(Slot, Block)> {
+        let (&slot, parents) = self
+            .parent_ready_slots
+            .iter()
+            .max_by_key(|(slot, _)| *slot)?;
+        parents.iter().min().copied().map(|parent| (slot, parent))
     }
 
     /// Sets the new root slot and cleans up outdated slots < `root`
@@ -496,6 +503,14 @@ mod test {
         assert!(vote_history.is_parent_ready(2, &block_id_2_1));
         assert!(vote_history.is_parent_ready(2, &block_id_0));
         assert_eq!(vote_history.highest_parent_ready_slot(), Some(2));
+        let expected_parent = [block_id_2_0, block_id_2_1, block_id_0]
+            .into_iter()
+            .min()
+            .unwrap();
+        assert_eq!(
+            vote_history.highest_parent_ready(),
+            Some((2, expected_parent))
+        );
 
         // Adding a parent ready for slot before root silently returns false
         assert!(!vote_history.add_parent_ready(1, block_id_0));

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -238,6 +238,9 @@ impl VoteHistory {
             .parent_ready_slots
             .iter()
             .max_by_key(|(slot, _)| *slot)?;
+
+        // Choose the parent that maximizes the amount of slots skipped.
+        // This matches the block production parent selection logic in the `ParentReadyTracker`.
         parents.iter().min().copied().map(|parent| (slot, parent))
     }
 

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -174,6 +174,7 @@ impl Votor {
 
         let migration_status = bank_forks.read().unwrap().migration_status();
         let identity_keypair = cluster_info.keypair();
+        let vote_history_highest_parent_ready = vote_history.highest_parent_ready();
 
         // Get the sharable root bank
         let sharable_banks = bank_forks.read().unwrap().sharable_banks();
@@ -235,6 +236,7 @@ impl Votor {
             blockstore,
             sharable_banks: sharable_banks.clone(),
             leader_schedule_cache: leader_schedule_cache.clone(),
+            vote_history_highest_parent_ready,
             consensus_message_receiver,
             bls_sender,
             event_sender,


### PR DESCRIPTION
#### Problem
Had an issue in the community cluster where after a panic, a validator would restart but not set timeouts properly.

If the validator restarts, the highest parent ready in the saved vote history might be greater than the current root slot.

When we kick off we use `max(genesis, root_slot)` for the initial parent ready. This value could be outdated.
Additionally we don't set timeouts on a `ParentReady` if we've already seen it before (using the vote history as evidence). This means this highest parent ready from the prior restart will never be acted on.

#### Summary of Changes

- Set the kick off to `max(genesis, root_slot, vote_history.highest_parent_ready())`
- When creating the parent ready tracker, take into account the vote history's highest parent ready as well
- Do not use vote history to decide whether to set timeouts, the timeout manager already does deduplication if there are existing timeouts

Note: this doesn't yet take into account set-identity at startup, but i'm not sure it necessarily needs to be handled. The set timeouts fix is more important.