### PR TITLE
bank: properly populate the clock sysvar in alpenglow

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1955,8 +1955,15 @@ impl Bank {
         let (_, update_sysvars_time_us) = measure_us!({
             self.update_slot_hashes();
             self.update_stake_history(Some(parent_epoch));
-            // Keep setting the tower clock sysvar till we have not migrated to Alpenglow.
-            if self.get_alpenglow_genesis_certificate().is_none() {
+
+            if self.get_alpenglow_genesis_certificate().is_some() {
+                // Alpenglow banks have the timestamp populated via the footer
+                // We only populate the slot here
+                self.update_clock_slot_for_alpenglow();
+            } else {
+                // PoH banks have the timestamp and slot populated at the beginning
+                // Note: The first alpenglow bank will have the timestamp populated
+                // here at the beginning as well as at the end via the footer - this is intentional.
                 self.update_clock(Some(parent_epoch));
             }
             self.update_last_restart_slot()
@@ -2455,6 +2462,31 @@ impl Bank {
         });
     }
 
+    /// In Alpenglow the clock sysvar's timestamp is populated from the block footer.
+    /// The timestamp value on the block footer is used as an estimate for when the block *ended*.
+    /// This is applied at the end of execution on the bank for use in the child.
+    ///
+    /// However we still need to update the slot and epoch fields for the clock sysvar at the *start*
+    /// of the bank, as transactions executing in this bank need to be able to read these values.
+    /// This function updates the slot and epoch fields while preserving the timestamp fields from the parent
+    /// bank's footer.
+    fn update_clock_slot_for_alpenglow(&self) {
+        let clock = self.clock();
+        let clock = sysvar::clock::Clock {
+            slot: self.slot,
+            epoch: self.epoch_schedule().get_epoch(self.slot),
+            leader_schedule_epoch: self.epoch_schedule().get_leader_schedule_epoch(self.slot),
+            epoch_start_timestamp: clock.epoch_start_timestamp,
+            unix_timestamp: clock.unix_timestamp,
+        };
+        self.update_sysvar_account(&sysvar::clock::id(), |account| {
+            create_account(
+                &clock,
+                self.inherit_specially_retained_account_fields(account),
+            )
+        });
+    }
+
     pub fn update_last_restart_slot(&self) {
         // First, see what the currently stored last restart slot is.
         let current_last_restart_slot = self
@@ -2502,9 +2534,8 @@ impl Bank {
         });
         // Simply force fill sysvar cache rather than checking which sysvar was
         // actually updated since tests don't need to be optimized for performance.
-        self.transaction_processor.reset_sysvar_cache();
         self.transaction_processor
-            .fill_missing_sysvar_cache_entries(self);
+            .reset_and_fill_sysvar_cache_entries(self);
     }
 
     fn update_slot_history(&self) {
@@ -3279,6 +3310,9 @@ impl Bank {
         alpenclock_acct.set_data_from_slice(&data);
 
         self.store_account_and_update_capitalization(&NANOSECOND_CLOCK_ACCOUNT, &alpenclock_acct);
+
+        self.transaction_processor
+            .reset_and_fill_sysvar_cache_entries(self);
     }
 
     /// Get the nanosecond clock value. Returns `None` if the nanosecond clock has not been

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -4,8 +4,12 @@ use super::Bank;
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::inflation_rewards::points::PointValue,
-        solana_genesis_config::create_genesis_config, solana_leader_schedule::SlotLeader,
+        super::*,
+        crate::{
+            genesis_utils::activate_all_features_alpenglow, inflation_rewards::points::PointValue,
+        },
+        solana_genesis_config::create_genesis_config,
+        solana_leader_schedule::SlotLeader,
         solana_sysvar::epoch_rewards::EpochRewards,
     };
 
@@ -160,5 +164,58 @@ mod tests {
             *bank1_sysvar_cache.get_epoch_rewards().unwrap(),
             expected_epoch_rewards,
         );
+    }
+
+    #[test]
+    fn test_alpenglow_clock_cache_updates_before_and_after_footer() {
+        let (mut genesis_config, _mint_keypair) = create_genesis_config(100_000);
+        activate_all_features_alpenglow(&mut genesis_config);
+        let (bank0, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        assert!(bank0.get_alpenglow_genesis_certificate().is_some());
+
+        let parent_clock = bank0.clock();
+        let bank1_slot = bank0.slot() + 1;
+        let bank1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0,
+            SlotLeader::default(),
+            bank1_slot,
+        );
+
+        let pre_footer_clock = bank1.clock();
+        assert_eq!(pre_footer_clock.slot, bank1_slot);
+        assert_eq!(pre_footer_clock.unix_timestamp, parent_clock.unix_timestamp);
+        assert_eq!(
+            pre_footer_clock.epoch_start_timestamp,
+            parent_clock.epoch_start_timestamp
+        );
+
+        let cached_pre_footer_clock = {
+            let sysvar_cache = bank1.transaction_processor.sysvar_cache();
+            sysvar_cache.get_clock().unwrap()
+        };
+        assert_eq!(cached_pre_footer_clock.slot, bank1_slot);
+        assert_eq!(
+            cached_pre_footer_clock.unix_timestamp,
+            parent_clock.unix_timestamp
+        );
+
+        let footer_timestamp_nanos = parent_clock
+            .unix_timestamp
+            .saturating_add(42)
+            .saturating_mul(1_000_000_000);
+        bank1.update_clock_from_footer(footer_timestamp_nanos);
+        let footer_timestamp = footer_timestamp_nanos / 1_000_000_000;
+
+        assert_eq!(bank1.clock().slot, bank1_slot);
+        assert_eq!(bank1.clock().unix_timestamp, footer_timestamp);
+
+        let cached_post_footer_clock = {
+            let sysvar_cache = bank1.transaction_processor.sysvar_cache();
+            sysvar_cache.get_clock().unwrap()
+        };
+        assert_eq!(cached_post_footer_clock.slot, bank1_slot);
+        assert_eq!(cached_post_footer_clock.unix_timestamp, footer_timestamp);
     }
 }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1185,6 +1185,22 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         callbacks: &CB,
     ) {
         let mut sysvar_cache = self.sysvar_cache.write().unwrap();
+        Self::fill_missing_sysvar_cache_entries_from_accounts(&mut sysvar_cache, callbacks);
+    }
+
+    pub fn reset_and_fill_sysvar_cache_entries<CB: TransactionProcessingCallback>(
+        &self,
+        callbacks: &CB,
+    ) {
+        let mut sysvar_cache = self.sysvar_cache.write().unwrap();
+        sysvar_cache.reset();
+        Self::fill_missing_sysvar_cache_entries_from_accounts(&mut sysvar_cache, callbacks);
+    }
+
+    fn fill_missing_sysvar_cache_entries_from_accounts<CB: TransactionProcessingCallback>(
+        sysvar_cache: &mut SysvarCache,
+        callbacks: &CB,
+    ) {
         sysvar_cache.fill_missing_entries(|pubkey, set_sysvar| {
             if let Some((account, _slot)) = callbacks.get_account_shared_data(pubkey) {
                 set_sysvar(account.data());
@@ -1893,6 +1909,31 @@ mod tests {
         let transaction_processor = TransactionBatchProcessor::<TestForkGraph>::default();
         // Fill the sysvar cache
         transaction_processor.fill_missing_sysvar_cache_entries(&mock_bank);
+
+        let updated_clock = Clock {
+            slot: 6,
+            epoch_start_timestamp: 7,
+            epoch: 8,
+            leader_schedule_epoch: 9,
+            unix_timestamp: 10,
+        };
+        let updated_clock_account = create_account_shared_data_for_test(&updated_clock);
+        mock_bank
+            .account_shared_data
+            .write()
+            .unwrap()
+            .insert(sysvar::clock::id(), updated_clock_account);
+        transaction_processor.reset_and_fill_sysvar_cache_entries(&mock_bank);
+        {
+            let sysvar_cache = transaction_processor.sysvar_cache.read().unwrap();
+            assert_eq!(
+                sysvar_cache
+                    .get_clock()
+                    .expect("clock sysvar missing in cache"),
+                updated_clock.clone().into()
+            );
+        }
+
         // Reset the sysvar cache
         transaction_processor.reset_sysvar_cache();
 
@@ -1918,7 +1959,7 @@ mod tests {
 
         assert_eq!(
             cached_clock.expect("clock sysvar missing in cache"),
-            clock.into()
+            updated_clock.into()
         );
         assert_eq!(
             cached_epoch_schedule.expect("epoch_schedule sysvar missing in cache"),


### PR DESCRIPTION
#### Problem
In Alpenglow we only set the clock sysvar at the end of the bank. This means txs in the bank have an outaded view of `clock.slot`

#### Summary of Changes
Populate `clock.slot` correctly at the start of the bank. The timestamp is still populated at the end of the bank.

Also add the missing 
```rust
        self.transaction_processor.reset_sysvar_cache();
        self.transaction_processor
            .fill_missing_sysvar_cache_entries(self);
```
piece to end of bank clock sysvar update,  otherwise the cache is not properly updated

Fixes https://github.com/anza-xyz/agave/issues/12810
