### PR TITLE
Test fix: fund vote account

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -3505,6 +3505,9 @@ mod tests {
         );
         let pre_balance = bank.get_balance(&collector_into_vote_address);
         assert_ne!(pre_balance, 0);
+        // Fund the converted vote account enough to pass VAT filtering.
+        let pre_balance =
+            pre_balance.max(bank.get_minimum_balance_for_rent_exemption(VoteStateV4::size_of()));
 
         // Transform the collector into a vote account, see that all rewards
         // are burned for this epoch


### PR DESCRIPTION
#### Problem
Tripped on this as part of 200ms slot time changes.

Inflation is less w/ 200ms changes so the vote pre-balance isn't enough to cover rent, so the account gets filtered out as part of VAT and the test fails

#### Summary of Changes
Make sure we at least put enough in the vote account to cover rent