### PR TITLE
core/bls-sigverify: retain root_slot certs in verified cache (follow-up to #12807)

### DIFF
--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -199,7 +199,7 @@ impl SigVerifier {
     fn maybe_prune_caches(&mut self, root_slot: Slot) {
         if self.last_checked_root_slot < root_slot {
             self.last_checked_root_slot = root_slot;
-            self.verified_certs.retain(|cert| cert.slot() > root_slot);
+            self.verified_certs.retain(|cert| cert.slot() >= root_slot);
         }
     }
 


### PR DESCRIPTION
## Problem

#12807 fixed the incoming certificate filter in `bls_sigverifier.rs` from
`<=` to `< root_slot` so that certificates at `slot == root_slot` (notably
the finalization cert for the current root) are no longer dropped on
ingest.

The cache prune in `maybe_prune_caches` (line 202 of the same file) is the
sibling operation but still uses `> root_slot`:

```rust
self.verified_certs.retain(|cert| cert.slot() > root_slot);
```

So as soon as the root advances to slot `S`, the cert that was just
verified at `S` is evicted from `verified_certs`. If the same cert arrives
again (for example from a slow peer), the dedup check at line 247 misses
and the cert is verified a second time.

The sibling cache `generated_cert_types` — checked immediately after
`verified_certs` at line 251 — already handles this correctly:

```rust
// votor/src/generated_cert_types.rs
/// Prunes the container, it drops all certs older than `root_slot` as they are no longer needed.
pub(crate) fn prune(&self, root_slot: Slot) {
    self.0.write().retain(|c| c.slot() >= root_slot);
}
```

## Fix

Align `verified_certs` pruning to keep `root_slot` certs, matching both the
post-#12807 ingest filter and the sibling `generated_cert_types::prune`
semantics:

```rust
-self.verified_certs.retain(|cert| cert.slot() > root_slot);
+self.verified_certs.retain(|cert| cert.slot() >= root_slot);
```

All 28 `bls_sigverify` unit tests still pass; no new test added because
the existing dedup test (`test_verified_certs_are_skipped`) and the prune
trigger (`maybe_prune_caches` is called once per root_bank update from
`verify_packets`) already cover the surrounding flow.
