### PR TITLE
[DRAFT]: SolFuzz-Agave SVM Stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10586,6 +10586,7 @@ dependencies = [
  "solana-native-token",
  "solana-nonce",
  "solana-nonce-account",
+ "solana-poseidon",
  "solana-precompile-error",
  "solana-program-binaries",
  "solana-program-entrypoint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10621,6 +10621,7 @@ dependencies = [
  "spl-token-interface",
  "test-case",
  "thiserror 2.0.18",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -13375,6 +13376,12 @@ dependencies = [
  "linux-raw-sys 0.4.14",
  "rustix 0.38.39",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -563,6 +563,7 @@ winapi = "0.3.8"
 wincode = { version = "0.5.5", features = ["derive"] }
 winreg = "0.55"
 x509-parser = "0.18.1"
+xxhash-rust = "0.8.5"
 zstd = "0.13.3"
 
 [profile.dev]

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -26,7 +26,7 @@ use {
 };
 
 /// CPI-specific error types
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum CpiError {
     #[error("Invalid pointer")]
     InvalidPointer,

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -78,8 +78,7 @@ use {
     solana_program_runtime::sysvar_cache::SysvarCache,
     solana_sdk_ids::sysvar::rent,
     solana_svm::conformance::{
-        context::InstrContext,
-        harness::execute_instr,
+        instr::{context::InstrContext, harness::execute_instr},
         programs::{
             add_program_to_program_cache, keyed_account_for_system_program,
             new_program_cache_with_builtins,

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -25,6 +25,7 @@ conformance = [
     "dep:bincode",
     "dep:prost",
     "dep:protosol",
+    "dep:solana-poseidon",
     "dev-context-only-utils",
     "solana-instruction-error/serde",
     "solana-pubkey/default",
@@ -89,6 +90,7 @@ solana-loader-v4-interface = { workspace = true }
 solana-message = { workspace = true }
 solana-nonce = { workspace = true }
 solana-nonce-account = { workspace = true, features = ["wincode"] }
+solana-poseidon = { workspace = true, optional = true }
 solana-precompile-error = { workspace = true, optional = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-pack = { workspace = true }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -27,6 +27,7 @@ conformance = [
     "dep:protosol",
     "dep:solana-poseidon",
     "dev-context-only-utils",
+    "dep:xxhash-rust",
     "solana-instruction-error/serde",
     "solana-pubkey/default",
 ]
@@ -113,6 +114,7 @@ solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
 spl-generic-token = { workspace = true }
 thiserror = { workspace = true }
+xxhash-rust = { workspace = true, optional = true, features = ["xxh64"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/svm/src/conformance/callback.rs
+++ b/svm/src/conformance/callback.rs
@@ -1,0 +1,39 @@
+//! Invoke-context callbacks shared by the conformance harnesses.
+
+use solana_svm_callback::InvokeContextCallback;
+#[cfg(feature = "conformance")]
+use {
+    agave_feature_set::FeatureSet,
+    agave_precompiles::{get_precompile, is_precompile},
+    solana_precompile_error::PrecompileError,
+    solana_pubkey::Pubkey,
+};
+
+/// Default callback. No precompile support.
+pub struct DefaultCallback;
+
+impl InvokeContextCallback for DefaultCallback {}
+
+/// Conformance callback. Full precompile support across all features.
+#[cfg(feature = "conformance")]
+pub struct ConformanceCallback;
+
+#[cfg(feature = "conformance")]
+impl InvokeContextCallback for ConformanceCallback {
+    fn is_precompile(&self, program_id: &Pubkey) -> bool {
+        is_precompile(program_id, |_| true)
+    }
+
+    fn process_precompile(
+        &self,
+        program_id: &Pubkey,
+        data: &[u8],
+        instruction_datas: Vec<&[u8]>,
+    ) -> Result<(), PrecompileError> {
+        if let Some(precompile) = get_precompile(program_id, |_| true) {
+            precompile.verify(data, &instruction_datas, &FeatureSet::all_enabled())
+        } else {
+            Err(PrecompileError::InvalidPublicKey)
+        }
+    }
+}

--- a/svm/src/conformance/elf_loader.rs
+++ b/svm/src/conformance/elf_loader.rs
@@ -2,6 +2,7 @@
 
 use {
     crate::conformance::{
+        fd_err_map::FiredancerErrorCode,
         fd_hash::{fd_hash_u64_without_seed, fd_hash_without_seed},
         feature_set::feature_set_from_proto,
     },
@@ -10,10 +11,7 @@ use {
         ElfLoaderCtx as ProtoElfLoaderCtx, ElfLoaderEffects as ProtoElfLoaderEffects,
     },
     solana_compute_budget::compute_budget::ComputeBudget,
-    solana_program_runtime::solana_sbpf::{
-        ebpf,
-        elf::{ElfError, Executable},
-    },
+    solana_program_runtime::solana_sbpf::{ebpf, elf::Executable},
     solana_syscalls::create_program_runtime_environment,
     std::{collections::BTreeSet, ffi::c_int},
 };
@@ -41,7 +39,7 @@ pub fn execute_elf_loader(input: &ProtoElfLoaderCtx) -> ProtoElfLoaderEffects {
         Ok(executable) => executable,
         Err(err) => {
             return ProtoElfLoaderEffects {
-                err_code: elf_err_to_num(&err) as u32,
+                err_code: err.error_code() as u32,
                 ..Default::default()
             };
         }
@@ -63,34 +61,6 @@ pub fn execute_elf_loader(input: &ProtoElfLoaderCtx) -> ProtoElfLoaderEffects {
         text_off: text_vaddr.saturating_sub(ebpf::MM_BYTECODE_START),
         text_cnt: (text_bytes.len() / 8) as u64,
         calldests_hash: fd_hash_u64_without_seed(&calldests),
-    }
-}
-
-fn elf_err_to_num(error: &ElfError) -> u8 {
-    match error {
-        ElfError::FailedToParse(_) => 1,
-        ElfError::EntrypointOutOfBounds => 2,
-        ElfError::InvalidEntrypoint => 3,
-        ElfError::FailedToGetSection(_) => 4,
-        ElfError::UnresolvedSymbol(_, _, _) => 5,
-        ElfError::SectionNotFound(_) => 6,
-        ElfError::RelativeJumpOutOfBounds(_) => 7,
-        ElfError::SymbolHashCollision(_) => 8,
-        ElfError::WrongEndianess => 9,
-        ElfError::WrongAbi => 10,
-        ElfError::WrongMachine => 11,
-        ElfError::WrongClass => 12,
-        ElfError::NotOneTextSection => 13,
-        ElfError::WritableSectionNotSupported(_) => 14,
-        ElfError::AddressOutsideLoadableSection(_) => 15,
-        ElfError::InvalidVirtualAddress(_) => 16,
-        ElfError::UnknownRelocation(_) => 17,
-        ElfError::FailedToReadRelocationInfo => 18,
-        ElfError::WrongType => 19,
-        ElfError::UnknownSymbol(_) => 20,
-        ElfError::ValueOutOfBounds => 21,
-        ElfError::UnsupportedSBPFVersion => 22,
-        ElfError::InvalidProgramHeader => 23,
     }
 }
 

--- a/svm/src/conformance/elf_loader.rs
+++ b/svm/src/conformance/elf_loader.rs
@@ -1,7 +1,10 @@
 //! ELF loader conformance harness.
 
 use {
-    crate::conformance::feature_set::feature_set_from_proto,
+    crate::conformance::{
+        fd_hash::{fd_hash_u64_without_seed, fd_hash_without_seed},
+        feature_set::feature_set_from_proto,
+    },
     prost::Message,
     protosol::protos::{
         ElfLoaderCtx as ProtoElfLoaderCtx, ElfLoaderEffects as ProtoElfLoaderEffects,
@@ -89,106 +92,6 @@ fn elf_err_to_num(error: &ElfError) -> u8 {
         ElfError::UnsupportedSBPFVersion => 22,
         ElfError::InvalidProgramHeader => 23,
     }
-}
-
-fn fd_hash_without_seed(buf: &[u8]) -> u64 {
-    fd_hash(0, buf)
-}
-
-fn fd_hash_u64_without_seed(buf: &[u64]) -> u64 {
-    let bytes = unsafe {
-        std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), std::mem::size_of_val(buf))
-    };
-    fd_hash(0, bytes)
-}
-
-/// Rust port of Firedancer's fd_hash.
-/// https://github.com/firedancer-io/firedancer/blob/main/src/util/fd_hash.c
-fn fd_hash(seed: u64, buf: &[u8]) -> u64 {
-    const C1: u64 = 11400714785074694791;
-    const C2: u64 = 14029467366897019727;
-    const C3: u64 = 1609587929392839161;
-    const C4: u64 = 9650029242287828579;
-    const C5: u64 = 2870177450012600261;
-
-    let mut p = buf;
-    let sz = buf.len() as u64;
-    let mut h: u64;
-
-    if sz < 32 {
-        h = seed.wrapping_add(C5);
-    } else {
-        let mut w = seed.wrapping_add(C1.wrapping_add(C2));
-        let mut x = seed.wrapping_add(C2);
-        let mut y = seed;
-        let mut z = seed.wrapping_sub(C1);
-
-        while p.len() >= 32 {
-            let p0 = u64::from_le_bytes(p[0..8].try_into().unwrap());
-            let p1 = u64::from_le_bytes(p[8..16].try_into().unwrap());
-            let p2 = u64::from_le_bytes(p[16..24].try_into().unwrap());
-            let p3 = u64::from_le_bytes(p[24..32].try_into().unwrap());
-            w = w
-                .wrapping_add(p0.wrapping_mul(C2))
-                .rotate_left(31)
-                .wrapping_mul(C1);
-            x = x
-                .wrapping_add(p1.wrapping_mul(C2))
-                .rotate_left(31)
-                .wrapping_mul(C1);
-            y = y
-                .wrapping_add(p2.wrapping_mul(C2))
-                .rotate_left(31)
-                .wrapping_mul(C1);
-            z = z
-                .wrapping_add(p3.wrapping_mul(C2))
-                .rotate_left(31)
-                .wrapping_mul(C1);
-            p = &p[32..];
-        }
-
-        h = w
-            .rotate_left(1)
-            .wrapping_add(x.rotate_left(7))
-            .wrapping_add(y.rotate_left(12))
-            .wrapping_add(z.rotate_left(18));
-
-        for v in [w, x, y, z] {
-            let vv = v.wrapping_mul(C2).rotate_left(31).wrapping_mul(C1);
-            h ^= vv;
-            h = h.wrapping_mul(C1).wrapping_add(C4);
-        }
-    }
-
-    h = h.wrapping_add(sz);
-
-    while p.len() >= 8 {
-        let w = u64::from_le_bytes(p[0..8].try_into().unwrap());
-        let ww = w.wrapping_mul(C2).rotate_left(31).wrapping_mul(C1);
-        h ^= ww;
-        h = h.rotate_left(27).wrapping_mul(C1).wrapping_add(C4);
-        p = &p[8..];
-    }
-
-    if p.len() >= 4 {
-        let w = u32::from_le_bytes(p[0..4].try_into().unwrap()) as u64;
-        h ^= w.wrapping_mul(C1);
-        h = h.rotate_left(23).wrapping_mul(C2).wrapping_add(C3);
-        p = &p[4..];
-    }
-
-    for &byte in p {
-        h ^= (byte as u64).wrapping_mul(C5);
-        h = h.rotate_left(11).wrapping_mul(C1);
-    }
-
-    h ^= h >> 33;
-    h = h.wrapping_mul(C2);
-    h ^= h >> 29;
-    h = h.wrapping_mul(C3);
-    h ^= h >> 32;
-
-    h
 }
 
 /// # Safety

--- a/svm/src/conformance/elf_loader.rs
+++ b/svm/src/conformance/elf_loader.rs
@@ -1,0 +1,273 @@
+//! ELF loader conformance harness.
+
+use {
+    crate::conformance::feature_set::feature_set_from_proto,
+    prost::Message,
+    protosol::protos::{
+        ElfLoaderCtx as ProtoElfLoaderCtx, ElfLoaderEffects as ProtoElfLoaderEffects,
+    },
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_program_runtime::solana_sbpf::{
+        ebpf,
+        elf::{ElfError, Executable},
+    },
+    solana_syscalls::create_program_runtime_environment,
+    std::{collections::BTreeSet, ffi::c_int},
+};
+
+pub fn execute_elf_loader(input: &ProtoElfLoaderCtx) -> ProtoElfLoaderEffects {
+    let feature_set = input
+        .features
+        .as_ref()
+        .map(feature_set_from_proto)
+        .unwrap_or_default()
+        .runtime_features();
+    let simd_0268_active = feature_set.raise_cpi_nesting_limit_to_8;
+    let compute_budget = ComputeBudget::new_with_defaults(simd_0268_active);
+
+    let program_runtime_environment = create_program_runtime_environment(
+        &feature_set,
+        &compute_budget.to_budget(),
+        input.deploy_checks,
+        std::env::var("ENABLE_VM_TRACING").is_ok(),
+    )
+    .unwrap();
+
+    let executable = match Executable::load(&input.elf_data, (*program_runtime_environment).clone())
+    {
+        Ok(executable) => executable,
+        Err(err) => {
+            return ProtoElfLoaderEffects {
+                err_code: elf_err_to_num(&err) as u32,
+                ..Default::default()
+            };
+        }
+    };
+
+    let (text_vaddr, text_bytes) = executable.get_text_bytes();
+    let calldests: Vec<u64> = executable
+        .get_function_registry()
+        .iter()
+        .map(|(_, (_, address))| address as u64)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    ProtoElfLoaderEffects {
+        err_code: 0,
+        rodata_hash: fd_hash_without_seed(executable.get_ro_section()),
+        entry_pc: executable.get_entrypoint_instruction_offset() as u64,
+        text_off: text_vaddr.saturating_sub(ebpf::MM_BYTECODE_START),
+        text_cnt: (text_bytes.len() / 8) as u64,
+        calldests_hash: fd_hash_u64_without_seed(&calldests),
+    }
+}
+
+fn elf_err_to_num(error: &ElfError) -> u8 {
+    match error {
+        ElfError::FailedToParse(_) => 1,
+        ElfError::EntrypointOutOfBounds => 2,
+        ElfError::InvalidEntrypoint => 3,
+        ElfError::FailedToGetSection(_) => 4,
+        ElfError::UnresolvedSymbol(_, _, _) => 5,
+        ElfError::SectionNotFound(_) => 6,
+        ElfError::RelativeJumpOutOfBounds(_) => 7,
+        ElfError::SymbolHashCollision(_) => 8,
+        ElfError::WrongEndianess => 9,
+        ElfError::WrongAbi => 10,
+        ElfError::WrongMachine => 11,
+        ElfError::WrongClass => 12,
+        ElfError::NotOneTextSection => 13,
+        ElfError::WritableSectionNotSupported(_) => 14,
+        ElfError::AddressOutsideLoadableSection(_) => 15,
+        ElfError::InvalidVirtualAddress(_) => 16,
+        ElfError::UnknownRelocation(_) => 17,
+        ElfError::FailedToReadRelocationInfo => 18,
+        ElfError::WrongType => 19,
+        ElfError::UnknownSymbol(_) => 20,
+        ElfError::ValueOutOfBounds => 21,
+        ElfError::UnsupportedSBPFVersion => 22,
+        ElfError::InvalidProgramHeader => 23,
+    }
+}
+
+fn fd_hash_without_seed(buf: &[u8]) -> u64 {
+    fd_hash(0, buf)
+}
+
+fn fd_hash_u64_without_seed(buf: &[u64]) -> u64 {
+    let bytes = unsafe {
+        std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), std::mem::size_of_val(buf))
+    };
+    fd_hash(0, bytes)
+}
+
+/// Rust port of Firedancer's fd_hash.
+/// https://github.com/firedancer-io/firedancer/blob/main/src/util/fd_hash.c
+fn fd_hash(seed: u64, buf: &[u8]) -> u64 {
+    const C1: u64 = 11400714785074694791;
+    const C2: u64 = 14029467366897019727;
+    const C3: u64 = 1609587929392839161;
+    const C4: u64 = 9650029242287828579;
+    const C5: u64 = 2870177450012600261;
+
+    let mut p = buf;
+    let sz = buf.len() as u64;
+    let mut h: u64;
+
+    if sz < 32 {
+        h = seed.wrapping_add(C5);
+    } else {
+        let mut w = seed.wrapping_add(C1.wrapping_add(C2));
+        let mut x = seed.wrapping_add(C2);
+        let mut y = seed;
+        let mut z = seed.wrapping_sub(C1);
+
+        while p.len() >= 32 {
+            let p0 = u64::from_le_bytes(p[0..8].try_into().unwrap());
+            let p1 = u64::from_le_bytes(p[8..16].try_into().unwrap());
+            let p2 = u64::from_le_bytes(p[16..24].try_into().unwrap());
+            let p3 = u64::from_le_bytes(p[24..32].try_into().unwrap());
+            w = w
+                .wrapping_add(p0.wrapping_mul(C2))
+                .rotate_left(31)
+                .wrapping_mul(C1);
+            x = x
+                .wrapping_add(p1.wrapping_mul(C2))
+                .rotate_left(31)
+                .wrapping_mul(C1);
+            y = y
+                .wrapping_add(p2.wrapping_mul(C2))
+                .rotate_left(31)
+                .wrapping_mul(C1);
+            z = z
+                .wrapping_add(p3.wrapping_mul(C2))
+                .rotate_left(31)
+                .wrapping_mul(C1);
+            p = &p[32..];
+        }
+
+        h = w
+            .rotate_left(1)
+            .wrapping_add(x.rotate_left(7))
+            .wrapping_add(y.rotate_left(12))
+            .wrapping_add(z.rotate_left(18));
+
+        for v in [w, x, y, z] {
+            let vv = v.wrapping_mul(C2).rotate_left(31).wrapping_mul(C1);
+            h ^= vv;
+            h = h.wrapping_mul(C1).wrapping_add(C4);
+        }
+    }
+
+    h = h.wrapping_add(sz);
+
+    while p.len() >= 8 {
+        let w = u64::from_le_bytes(p[0..8].try_into().unwrap());
+        let ww = w.wrapping_mul(C2).rotate_left(31).wrapping_mul(C1);
+        h ^= ww;
+        h = h.rotate_left(27).wrapping_mul(C1).wrapping_add(C4);
+        p = &p[8..];
+    }
+
+    if p.len() >= 4 {
+        let w = u32::from_le_bytes(p[0..4].try_into().unwrap()) as u64;
+        h ^= w.wrapping_mul(C1);
+        h = h.rotate_left(23).wrapping_mul(C2).wrapping_add(C3);
+        p = &p[4..];
+    }
+
+    for &byte in p {
+        h ^= (byte as u64).wrapping_mul(C5);
+        h = h.rotate_left(11).wrapping_mul(C1);
+    }
+
+    h ^= h >> 33;
+    h = h.wrapping_mul(C2);
+    h ^= h >> 29;
+    h = h.wrapping_mul(C3);
+    h ^= h >> 32;
+
+    h
+}
+
+/// # Safety
+///
+/// `in_ptr` must point to `in_sz` initialized bytes. `out_ptr` must point
+/// to a writable buffer of at least `*out_psz` bytes. On return, `*out_psz`
+/// is updated to the number of bytes written.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sol_compat_elf_loader_v1(
+    out_ptr: *mut u8,
+    out_psz: *mut u64,
+    in_ptr: *mut u8,
+    in_sz: u64,
+) -> c_int {
+    if in_ptr.is_null() || in_sz == 0 {
+        return 0;
+    }
+    if out_psz.is_null() || out_ptr.is_null() {
+        return 0;
+    }
+    let in_slice = unsafe { std::slice::from_raw_parts(in_ptr, in_sz as usize) };
+    let Ok(ctx) = ProtoElfLoaderCtx::decode(in_slice) else {
+        return 0;
+    };
+
+    let effects = execute_elf_loader(&ctx);
+
+    let out_slice = unsafe { std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize) };
+    let out_vec = effects.encode_to_vec();
+    if out_vec.len() > out_slice.len() {
+        return 0;
+    }
+    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
+    unsafe { *out_psz = out_vec.len() as u64 };
+
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, agave_feature_set::enable_sbpf_v3_deployment_and_execution,
+        protosol::protos::FeatureSet as ProtoFeatureSet,
+    };
+
+    const NOOP_ALIGNED: &[u8] =
+        include_bytes!("../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
+    const NOOP_UNALIGNED: &[u8] =
+        include_bytes!("../../../programs/bpf_loader/test_elfs/out/noop_unaligned.so");
+    const SBPFV3_RETURN_OK: &[u8] =
+        include_bytes!("../../../programs/bpf_loader/test_elfs/out/sbpfv3_return_ok.so");
+
+    fn assert_loads_ok(elf: &[u8], deploy_checks: bool, features: Option<ProtoFeatureSet>) {
+        let effects = execute_elf_loader(&ProtoElfLoaderCtx {
+            features,
+            elf_data: elf.to_vec(),
+            deploy_checks,
+        });
+        assert_eq!(effects.err_code, 0);
+        assert!(effects.text_cnt > 0);
+    }
+
+    #[test]
+    fn test_load_noop_aligned() {
+        assert_loads_ok(NOOP_ALIGNED, false, None);
+    }
+
+    #[test]
+    fn test_load_noop_unaligned_with_deploy_checks() {
+        assert_loads_ok(NOOP_UNALIGNED, true, None);
+    }
+
+    #[test]
+    fn test_load_sbpf_v3_with_feature_enabled() {
+        // The v3 ELF only loads when the SBPF v3 feature is active.
+        let v3 = enable_sbpf_v3_deployment_and_execution::id();
+        let features = ProtoFeatureSet {
+            features: vec![u64::from_le_bytes(v3.to_bytes()[..8].try_into().unwrap())],
+        };
+        assert_loads_ok(SBPFV3_RETURN_OK, false, Some(features));
+    }
+}

--- a/svm/src/conformance/fd_err_map.rs
+++ b/svm/src/conformance/fd_err_map.rs
@@ -1,0 +1,54 @@
+//! Error-code mapping for VM execution results.
+//!
+//! Kept aligned with Firedancer so cross-implementation conformance fixtures
+//! compare equal. The error number is generally the Agave enum variant index
+//! `+ 1` (Agave uses the positive value; Firedancer uses its negation). Error
+//! strings in Agave may carry parameters that Firedancer truncates; where they
+//! diverge it is made explicit, otherwise `error.to_string()` is the expected
+//! value.
+
+use {
+    solana_instruction::error::InstructionError, solana_program_runtime::solana_sbpf::elf::ElfError,
+};
+
+pub(crate) trait FiredancerErrorCode {
+    fn error_code(&self) -> i32;
+}
+
+impl FiredancerErrorCode for ElfError {
+    fn error_code(&self) -> i32 {
+        let index: i32 = match self {
+            ElfError::FailedToParse(_) => 0,
+            ElfError::EntrypointOutOfBounds => 1,
+            ElfError::InvalidEntrypoint => 2,
+            ElfError::FailedToGetSection(_) => 3,
+            ElfError::UnresolvedSymbol(_, _, _) => 4,
+            ElfError::SectionNotFound(_) => 5,
+            ElfError::RelativeJumpOutOfBounds(_) => 6,
+            ElfError::SymbolHashCollision(_) => 7,
+            ElfError::WrongEndianess => 8,
+            ElfError::WrongAbi => 9,
+            ElfError::WrongMachine => 10,
+            ElfError::WrongClass => 11,
+            ElfError::NotOneTextSection => 12,
+            ElfError::WritableSectionNotSupported(_) => 13,
+            ElfError::AddressOutsideLoadableSection(_) => 14,
+            ElfError::InvalidVirtualAddress(_) => 15,
+            ElfError::UnknownRelocation(_) => 16,
+            ElfError::FailedToReadRelocationInfo => 17,
+            ElfError::WrongType => 18,
+            ElfError::UnknownSymbol(_) => 19,
+            ElfError::ValueOutOfBounds => 20,
+            ElfError::UnsupportedSBPFVersion => 21,
+            ElfError::InvalidProgramHeader => 22,
+        };
+        index.saturating_add(1)
+    }
+}
+
+impl FiredancerErrorCode for InstructionError {
+    fn error_code(&self) -> i32 {
+        let serialized = bincode::serialize(self).unwrap();
+        i32::from_le_bytes(serialized[0..4].try_into().unwrap()).saturating_add(1)
+    }
+}

--- a/svm/src/conformance/fd_err_map.rs
+++ b/svm/src/conformance/fd_err_map.rs
@@ -8,11 +8,87 @@
 //! value.
 
 use {
-    solana_instruction::error::InstructionError, solana_program_runtime::solana_sbpf::elf::ElfError,
+    solana_instruction::error::InstructionError,
+    solana_poseidon::PoseidonSyscallError,
+    solana_program_runtime::{
+        cpi::CpiError,
+        memory::MemoryTranslationError,
+        solana_sbpf::{
+            elf::ElfError,
+            error::{EbpfError, StableResult},
+        },
+        stable_log,
+    },
+    solana_pubkey::Pubkey,
+    solana_svm_log_collector::LogCollector,
+    solana_syscalls::SyscallError,
+    std::{cell::RefCell, rc::Rc},
 };
+
+const ERR_KIND_UNSPECIFIED: i32 = 0;
+const ERR_KIND_EBPF: i32 = 1;
+const ERR_KIND_SYSCALL: i32 = 2;
+const ERR_KIND_INSTRUCTION: i32 = 3;
 
 pub(crate) trait FiredancerErrorCode {
     fn error_code(&self) -> i32;
+}
+
+impl FiredancerErrorCode for SyscallError {
+    fn error_code(&self) -> i32 {
+        let index: i32 = match self {
+            SyscallError::InvalidString(_, _) => 0,
+            SyscallError::Abort => 1,
+            SyscallError::Panic(_, _, _) => 2,
+            SyscallError::InvokeContextBorrowFailed => 3,
+            SyscallError::MalformedSignerSeed(_, _) => 4,
+            SyscallError::BadSeeds(_) => 5,
+            SyscallError::ProgramNotSupported(_) => 6,
+            SyscallError::UnalignedPointer => 7,
+            SyscallError::TooManySigners => 8,
+            SyscallError::InstructionTooLarge(_, _) => 9,
+            SyscallError::TooManyAccounts => 10,
+            SyscallError::CopyOverlapping => 11,
+            SyscallError::ReturnDataTooLarge(_, _) => 12,
+            SyscallError::TooManySlices => 13,
+            SyscallError::InvalidLength => 14,
+            SyscallError::MaxInstructionDataLenExceeded { .. } => 15,
+            SyscallError::MaxInstructionAccountsExceeded { .. } => 16,
+            SyscallError::MaxInstructionAccountInfosExceeded { .. } => 17,
+            SyscallError::InvalidAttribute => 18,
+            SyscallError::InvalidPointer => 19,
+            SyscallError::ArithmeticOverflow => 20,
+        };
+        index.saturating_add(1)
+    }
+}
+
+impl FiredancerErrorCode for EbpfError {
+    fn error_code(&self) -> i32 {
+        let index: i32 = match self {
+            EbpfError::ElfError(_) => 0,
+            EbpfError::FunctionAlreadyRegistered(_) => 1,
+            EbpfError::CallDepthExceeded => 2,
+            EbpfError::ExitRootCallFrame => 3,
+            EbpfError::DivideByZero => 4,
+            EbpfError::DivideOverflow => 5,
+            EbpfError::ExecutionOverrun => 6,
+            EbpfError::CallOutsideTextSegment => 7,
+            EbpfError::ExceededMaxInstructions => 8,
+            EbpfError::JitNotCompiled => 9,
+            EbpfError::InvalidMemoryRegion(_) => 11,
+            EbpfError::AccessViolation(_, _, _, _) => 12,
+            EbpfError::StackAccessViolation(_, _, _, _) => 13,
+            EbpfError::InvalidInstruction => 14,
+            EbpfError::UnsupportedInstruction => 15,
+            EbpfError::ExhaustedTextSegment(_) => 16,
+            EbpfError::LibcInvocationFailed(_, _, _) => 17,
+            EbpfError::VerifierError(_) => 18,
+            // `SyscallError` is unpacked separately via downcasting.
+            EbpfError::SyscallError(_) => -10,
+        };
+        index.saturating_add(1)
+    }
 }
 
 impl FiredancerErrorCode for ElfError {
@@ -51,4 +127,58 @@ impl FiredancerErrorCode for InstructionError {
         let serialized = bincode::serialize(self).unwrap();
         i32::from_le_bytes(serialized[0..4].try_into().unwrap()).saturating_add(1)
     }
+}
+
+/// Map a VM `program_result` to `(error, error_kind, r0)`. The failure log is
+/// reproduced here because Firedancer logs at the point of failure rather than
+/// propagating error data.
+pub(crate) fn unpack_stable_result(
+    program_result: StableResult<u64, EbpfError>,
+    log_collector: &Option<Rc<RefCell<LogCollector>>>,
+    program_id: &Pubkey,
+) -> (i64, i32, u64) {
+    let err = match program_result {
+        StableResult::Ok(n) => return (0, ERR_KIND_UNSPECIFIED, n),
+        StableResult::Err(err) => err,
+    };
+
+    let log = |error: &dyn std::fmt::Display| {
+        stable_log::program_failure(log_collector, program_id, &error);
+    };
+
+    // Agave wraps syscall-side failures in `EbpfError::SyscallError`; recover
+    // the concrete error by downcasting so we report the matching code and
+    // kind. Anything else is a plain VM error.
+    let (err_no, err_kind) = match &err {
+        EbpfError::SyscallError(boxed) => {
+            if let Some(e) = boxed.downcast_ref::<InstructionError>() {
+                log(e);
+                (e.error_code(), ERR_KIND_INSTRUCTION)
+            } else if let Some(e) = boxed.downcast_ref::<SyscallError>() {
+                log(e);
+                (e.error_code(), ERR_KIND_SYSCALL)
+            } else if let Some(e) = boxed.downcast_ref::<MemoryTranslationError>() {
+                let e: SyscallError = e.clone().into();
+                log(&e);
+                (e.error_code(), ERR_KIND_SYSCALL)
+            } else if let Some(e) = boxed.downcast_ref::<CpiError>() {
+                let e: SyscallError = e.clone().into();
+                log(&e);
+                (e.error_code(), ERR_KIND_SYSCALL)
+            } else if let Some(e) = boxed.downcast_ref::<EbpfError>() {
+                log(e);
+                (e.error_code(), ERR_KIND_EBPF)
+            } else if boxed.downcast_ref::<PoseidonSyscallError>().is_some() {
+                (-1, ERR_KIND_SYSCALL) // not logged in Agave
+            } else {
+                log(&err); // unknown downcast: -1 highlights the gap
+                (-1, ERR_KIND_UNSPECIFIED)
+            }
+        }
+        _ => {
+            log(&err);
+            (err.error_code(), ERR_KIND_EBPF)
+        }
+    };
+    (err_no as i64, err_kind, 0)
 }

--- a/svm/src/conformance/fd_err_map.rs
+++ b/svm/src/conformance/fd_err_map.rs
@@ -125,12 +125,27 @@ impl FiredancerErrorCode for InstructionError {
     }
 }
 
-/// Map a VM `program_result` to `(error, error_kind, r0)`.
-pub(crate) fn unpack_stable_result(
-    program_result: StableResult<u64, EbpfError>,
-) -> (i64, i32, u64) {
+/// A VM `program_result` mapped into the fields a conformance fixture compares.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct UnpackedResult {
+    /// Firedancer error number (negated Agave enum index), or `0` on success.
+    pub error: i64,
+    /// Which error taxonomy `error` belongs to (`ERR_KIND_*`).
+    pub error_kind: i32,
+    /// The program return value (`r0`), only meaningful on success.
+    pub r0: u64,
+}
+
+/// Map a VM `program_result` to its [`UnpackedResult`].
+pub(crate) fn unpack_stable_result(program_result: StableResult<u64, EbpfError>) -> UnpackedResult {
     let err = match program_result {
-        StableResult::Ok(n) => return (0, ERR_KIND_UNSPECIFIED, n),
+        StableResult::Ok(n) => {
+            return UnpackedResult {
+                error: 0,
+                error_kind: ERR_KIND_UNSPECIFIED,
+                r0: n,
+            };
+        }
         StableResult::Err(err) => err,
     };
 
@@ -159,5 +174,9 @@ pub(crate) fn unpack_stable_result(
         }
         _ => (err.error_code(), ERR_KIND_EBPF),
     };
-    (err_no as i64, err_kind, 0)
+    UnpackedResult {
+        error: err_no as i64,
+        error_kind: err_kind,
+        r0: 0,
+    }
 }

--- a/svm/src/conformance/fd_err_map.rs
+++ b/svm/src/conformance/fd_err_map.rs
@@ -17,12 +17,8 @@ use {
             elf::ElfError,
             error::{EbpfError, StableResult},
         },
-        stable_log,
     },
-    solana_pubkey::Pubkey,
-    solana_svm_log_collector::LogCollector,
     solana_syscalls::SyscallError,
-    std::{cell::RefCell, rc::Rc},
 };
 
 const ERR_KIND_UNSPECIFIED: i32 = 0;
@@ -129,21 +125,13 @@ impl FiredancerErrorCode for InstructionError {
     }
 }
 
-/// Map a VM `program_result` to `(error, error_kind, r0)`. The failure log is
-/// reproduced here because Firedancer logs at the point of failure rather than
-/// propagating error data.
+/// Map a VM `program_result` to `(error, error_kind, r0)`.
 pub(crate) fn unpack_stable_result(
     program_result: StableResult<u64, EbpfError>,
-    log_collector: &Option<Rc<RefCell<LogCollector>>>,
-    program_id: &Pubkey,
 ) -> (i64, i32, u64) {
     let err = match program_result {
         StableResult::Ok(n) => return (0, ERR_KIND_UNSPECIFIED, n),
         StableResult::Err(err) => err,
-    };
-
-    let log = |error: &dyn std::fmt::Display| {
-        stable_log::program_failure(log_collector, program_id, &error);
     };
 
     // Agave wraps syscall-side failures in `EbpfError::SyscallError`; recover
@@ -152,33 +140,24 @@ pub(crate) fn unpack_stable_result(
     let (err_no, err_kind) = match &err {
         EbpfError::SyscallError(boxed) => {
             if let Some(e) = boxed.downcast_ref::<InstructionError>() {
-                log(e);
                 (e.error_code(), ERR_KIND_INSTRUCTION)
             } else if let Some(e) = boxed.downcast_ref::<SyscallError>() {
-                log(e);
                 (e.error_code(), ERR_KIND_SYSCALL)
             } else if let Some(e) = boxed.downcast_ref::<MemoryTranslationError>() {
                 let e: SyscallError = e.clone().into();
-                log(&e);
                 (e.error_code(), ERR_KIND_SYSCALL)
             } else if let Some(e) = boxed.downcast_ref::<CpiError>() {
                 let e: SyscallError = e.clone().into();
-                log(&e);
                 (e.error_code(), ERR_KIND_SYSCALL)
             } else if let Some(e) = boxed.downcast_ref::<EbpfError>() {
-                log(e);
                 (e.error_code(), ERR_KIND_EBPF)
             } else if boxed.downcast_ref::<PoseidonSyscallError>().is_some() {
-                (-1, ERR_KIND_SYSCALL) // not logged in Agave
+                (-1, ERR_KIND_SYSCALL)
             } else {
-                log(&err); // unknown downcast: -1 highlights the gap
-                (-1, ERR_KIND_UNSPECIFIED)
+                (-1, ERR_KIND_UNSPECIFIED) // unknown downcast: -1 highlights the gap
             }
         }
-        _ => {
-            log(&err);
-            (err.error_code(), ERR_KIND_EBPF)
-        }
+        _ => (err.error_code(), ERR_KIND_EBPF),
     };
     (err_no as i64, err_kind, 0)
 }

--- a/svm/src/conformance/fd_hash.rs
+++ b/svm/src/conformance/fd_hash.rs
@@ -1,0 +1,101 @@
+//! Rust port of Firedancer's fd_hash, used to summarize binary blobs (e.g.
+//! ELF sections, serialized VM memory) for conformance comparisons.
+//! https://github.com/firedancer-io/firedancer/blob/main/src/util/fd_hash.c
+
+pub fn fd_hash_without_seed(buf: &[u8]) -> u64 {
+    fd_hash(0, buf)
+}
+
+pub fn fd_hash_u64_without_seed(buf: &[u64]) -> u64 {
+    let bytes = unsafe {
+        std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), std::mem::size_of_val(buf))
+    };
+    fd_hash(0, bytes)
+}
+
+pub fn fd_hash(seed: u64, buf: &[u8]) -> u64 {
+    const C1: u64 = 11400714785074694791;
+    const C2: u64 = 14029467366897019727;
+    const C3: u64 = 1609587929392839161;
+    const C4: u64 = 9650029242287828579;
+    const C5: u64 = 2870177450012600261;
+
+    let mut p = buf;
+    let sz = buf.len() as u64;
+    let mut h: u64;
+
+    if sz < 32 {
+        h = seed.wrapping_add(C5);
+    } else {
+        let mut w = seed.wrapping_add(C1.wrapping_add(C2));
+        let mut x = seed.wrapping_add(C2);
+        let mut y = seed;
+        let mut z = seed.wrapping_sub(C1);
+
+        while p.len() >= 32 {
+            let p0 = u64::from_le_bytes(p[0..8].try_into().unwrap());
+            let p1 = u64::from_le_bytes(p[8..16].try_into().unwrap());
+            let p2 = u64::from_le_bytes(p[16..24].try_into().unwrap());
+            let p3 = u64::from_le_bytes(p[24..32].try_into().unwrap());
+            w = w
+                .wrapping_add(p0.wrapping_mul(C2))
+                .rotate_left(31)
+                .wrapping_mul(C1);
+            x = x
+                .wrapping_add(p1.wrapping_mul(C2))
+                .rotate_left(31)
+                .wrapping_mul(C1);
+            y = y
+                .wrapping_add(p2.wrapping_mul(C2))
+                .rotate_left(31)
+                .wrapping_mul(C1);
+            z = z
+                .wrapping_add(p3.wrapping_mul(C2))
+                .rotate_left(31)
+                .wrapping_mul(C1);
+            p = &p[32..];
+        }
+
+        h = w
+            .rotate_left(1)
+            .wrapping_add(x.rotate_left(7))
+            .wrapping_add(y.rotate_left(12))
+            .wrapping_add(z.rotate_left(18));
+
+        for v in [w, x, y, z] {
+            let vv = v.wrapping_mul(C2).rotate_left(31).wrapping_mul(C1);
+            h ^= vv;
+            h = h.wrapping_mul(C1).wrapping_add(C4);
+        }
+    }
+
+    h = h.wrapping_add(sz);
+
+    while p.len() >= 8 {
+        let w = u64::from_le_bytes(p[0..8].try_into().unwrap());
+        let ww = w.wrapping_mul(C2).rotate_left(31).wrapping_mul(C1);
+        h ^= ww;
+        h = h.rotate_left(27).wrapping_mul(C1).wrapping_add(C4);
+        p = &p[8..];
+    }
+
+    if p.len() >= 4 {
+        let w = u32::from_le_bytes(p[0..4].try_into().unwrap()) as u64;
+        h ^= w.wrapping_mul(C1);
+        h = h.rotate_left(23).wrapping_mul(C2).wrapping_add(C3);
+        p = &p[4..];
+    }
+
+    for &byte in p {
+        h ^= (byte as u64).wrapping_mul(C5);
+        h = h.rotate_left(11).wrapping_mul(C1);
+    }
+
+    h ^= h >> 33;
+    h = h.wrapping_mul(C2);
+    h ^= h >> 29;
+    h = h.wrapping_mul(C3);
+    h ^= h >> 32;
+
+    h
+}

--- a/svm/src/conformance/fd_hash.rs
+++ b/svm/src/conformance/fd_hash.rs
@@ -1,6 +1,7 @@
-//! Rust port of Firedancer's fd_hash, used to summarize binary blobs (e.g.
-//! ELF sections, serialized VM memory) for conformance comparisons.
-//! https://github.com/firedancer-io/firedancer/blob/main/src/util/fd_hash.c
+//! Hashing used to summarize binary blobs (e.g. ELF sections, serialized VM
+//! memory) for conformance comparisons.
+
+use xxhash_rust::xxh64::xxh64;
 
 pub fn fd_hash_without_seed(buf: &[u8]) -> u64 {
     fd_hash(0, buf)
@@ -14,88 +15,21 @@ pub fn fd_hash_u64_without_seed(buf: &[u64]) -> u64 {
 }
 
 pub fn fd_hash(seed: u64, buf: &[u8]) -> u64 {
-    const C1: u64 = 11400714785074694791;
-    const C2: u64 = 14029467366897019727;
-    const C3: u64 = 1609587929392839161;
-    const C4: u64 = 9650029242287828579;
-    const C5: u64 = 2870177450012600261;
+    xxh64(buf, seed)
+}
 
-    let mut p = buf;
-    let sz = buf.len() as u64;
-    let mut h: u64;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    if sz < 32 {
-        h = seed.wrapping_add(C5);
-    } else {
-        let mut w = seed.wrapping_add(C1.wrapping_add(C2));
-        let mut x = seed.wrapping_add(C2);
-        let mut y = seed;
-        let mut z = seed.wrapping_sub(C1);
-
-        while p.len() >= 32 {
-            let p0 = u64::from_le_bytes(p[0..8].try_into().unwrap());
-            let p1 = u64::from_le_bytes(p[8..16].try_into().unwrap());
-            let p2 = u64::from_le_bytes(p[16..24].try_into().unwrap());
-            let p3 = u64::from_le_bytes(p[24..32].try_into().unwrap());
-            w = w
-                .wrapping_add(p0.wrapping_mul(C2))
-                .rotate_left(31)
-                .wrapping_mul(C1);
-            x = x
-                .wrapping_add(p1.wrapping_mul(C2))
-                .rotate_left(31)
-                .wrapping_mul(C1);
-            y = y
-                .wrapping_add(p2.wrapping_mul(C2))
-                .rotate_left(31)
-                .wrapping_mul(C1);
-            z = z
-                .wrapping_add(p3.wrapping_mul(C2))
-                .rotate_left(31)
-                .wrapping_mul(C1);
-            p = &p[32..];
-        }
-
-        h = w
-            .rotate_left(1)
-            .wrapping_add(x.rotate_left(7))
-            .wrapping_add(y.rotate_left(12))
-            .wrapping_add(z.rotate_left(18));
-
-        for v in [w, x, y, z] {
-            let vv = v.wrapping_mul(C2).rotate_left(31).wrapping_mul(C1);
-            h ^= vv;
-            h = h.wrapping_mul(C1).wrapping_add(C4);
-        }
+    #[test]
+    fn test_fd_hash_matches_xxh64() {
+        // Reference values from Firedancer's `fd_hash` (XXH64). The empty-input,
+        // seed-0 case is the canonical XXH64 test vector.
+        let long: Vec<u8> = (0u8..100).collect();
+        assert_eq!(fd_hash(0, &[]), 0xef46db3751d8e999);
+        assert_eq!(fd_hash(0, b"hello world"), 0x45ab6734b21e6968);
+        assert_eq!(fd_hash(42, b"hello world"), 0x69c2b68f9d9352a1);
+        assert_eq!(fd_hash(0, &long), 0x6ac1e58032166597);
     }
-
-    h = h.wrapping_add(sz);
-
-    while p.len() >= 8 {
-        let w = u64::from_le_bytes(p[0..8].try_into().unwrap());
-        let ww = w.wrapping_mul(C2).rotate_left(31).wrapping_mul(C1);
-        h ^= ww;
-        h = h.rotate_left(27).wrapping_mul(C1).wrapping_add(C4);
-        p = &p[8..];
-    }
-
-    if p.len() >= 4 {
-        let w = u32::from_le_bytes(p[0..4].try_into().unwrap()) as u64;
-        h ^= w.wrapping_mul(C1);
-        h = h.rotate_left(23).wrapping_mul(C2).wrapping_add(C3);
-        p = &p[4..];
-    }
-
-    for &byte in p {
-        h ^= (byte as u64).wrapping_mul(C5);
-        h = h.rotate_left(11).wrapping_mul(C1);
-    }
-
-    h ^= h >> 33;
-    h = h.wrapping_mul(C2);
-    h ^= h >> 29;
-    h = h.wrapping_mul(C3);
-    h ^= h >> 32;
-
-    h
 }

--- a/svm/src/conformance/instr/context.rs
+++ b/svm/src/conformance/instr/context.rs
@@ -1,20 +1,15 @@
-//! Instruction context and effects (input + output).
+//! Instruction context (input).
 
 #[cfg(feature = "conformance")]
 use {
-    super::{
-        account_state::{account_from_proto, account_to_proto},
-        feature_set::feature_set_from_proto,
-    },
-    protosol::protos::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
+    crate::conformance::{account_state::account_from_proto, feature_set::feature_set_from_proto},
+    protosol::protos::InstrContext as ProtoInstrContext,
     solana_instruction::AccountMeta,
 };
 use {
-    solana_account::Account,
-    solana_instruction::{Instruction, error::InstructionError},
+    solana_account::Account, solana_instruction::Instruction,
     solana_program_runtime::execution_budget::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
-    solana_pubkey::Pubkey,
-    solana_svm_feature_set::SVMFeatureSet,
+    solana_pubkey::Pubkey, solana_svm_feature_set::SVMFeatureSet,
 };
 
 /// Inputs to a single instruction.
@@ -91,58 +86,6 @@ impl From<ProtoInstrContext> for InstrContext {
             accounts,
             instruction,
             cu_avail,
-        }
-    }
-}
-
-/// Represents the effects of a single instruction.
-pub struct InstrEffects {
-    pub result: Option<InstructionError>,
-    pub custom_err: Option<u32>,
-    pub resulting_accounts: Vec<(Pubkey, Account)>,
-    pub cu_avail: u64,
-    pub return_data: Vec<u8>,
-    pub logs: Vec<String>,
-}
-
-impl InstrEffects {
-    /// Returns the resulting account for the given pubkey, if it exists.
-    pub fn get_account(&self, pubkey: &Pubkey) -> Option<&Account> {
-        self.resulting_accounts
-            .iter()
-            .find(|(pk, _)| pk == pubkey)
-            .map(|(_, acc)| acc)
-    }
-}
-
-#[cfg(feature = "conformance")]
-impl From<InstrEffects> for ProtoInstrEffects {
-    fn from(value: InstrEffects) -> Self {
-        let InstrEffects {
-            result,
-            custom_err,
-            resulting_accounts,
-            cu_avail,
-            return_data,
-            ..
-        } = value;
-
-        Self {
-            result: result
-                .as_ref()
-                .map(|error| {
-                    let serialized_err = bincode::serialize(error).unwrap();
-                    i32::from_le_bytes((&serialized_err[0..4]).try_into().unwrap())
-                        .saturating_add(1)
-                })
-                .unwrap_or_default(),
-            custom_err: custom_err.unwrap_or_default(),
-            modified_accounts: resulting_accounts
-                .into_iter()
-                .map(account_to_proto)
-                .collect(),
-            cu_avail,
-            return_data,
         }
     }
 }

--- a/svm/src/conformance/instr/effects.rs
+++ b/svm/src/conformance/instr/effects.rs
@@ -1,0 +1,60 @@
+//! Instruction effects (output).
+
+#[cfg(feature = "conformance")]
+use {
+    crate::conformance::account_state::account_to_proto,
+    protosol::protos::InstrEffects as ProtoInstrEffects,
+};
+use {solana_account::Account, solana_instruction::error::InstructionError, solana_pubkey::Pubkey};
+
+/// Represents the effects of a single instruction.
+pub struct InstrEffects {
+    pub result: Option<InstructionError>,
+    pub custom_err: Option<u32>,
+    pub resulting_accounts: Vec<(Pubkey, Account)>,
+    pub cu_avail: u64,
+    pub return_data: Vec<u8>,
+    pub logs: Vec<String>,
+}
+
+impl InstrEffects {
+    /// Returns the resulting account for the given pubkey, if it exists.
+    pub fn get_account(&self, pubkey: &Pubkey) -> Option<&Account> {
+        self.resulting_accounts
+            .iter()
+            .find(|(pk, _)| pk == pubkey)
+            .map(|(_, acc)| acc)
+    }
+}
+
+#[cfg(feature = "conformance")]
+impl From<InstrEffects> for ProtoInstrEffects {
+    fn from(value: InstrEffects) -> Self {
+        let InstrEffects {
+            result,
+            custom_err,
+            resulting_accounts,
+            cu_avail,
+            return_data,
+            ..
+        } = value;
+
+        Self {
+            result: result
+                .as_ref()
+                .map(|error| {
+                    let serialized_err = bincode::serialize(error).unwrap();
+                    i32::from_le_bytes((&serialized_err[0..4]).try_into().unwrap())
+                        .saturating_add(1)
+                })
+                .unwrap_or_default(),
+            custom_err: custom_err.unwrap_or_default(),
+            modified_accounts: resulting_accounts
+                .into_iter()
+                .map(account_to_proto)
+                .collect(),
+            cu_avail,
+            return_data,
+        }
+    }
+}

--- a/svm/src/conformance/instr/effects.rs
+++ b/svm/src/conformance/instr/effects.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "conformance")]
 use {
-    crate::conformance::account_state::account_to_proto,
+    crate::conformance::{account_state::account_to_proto, fd_err_map::FiredancerErrorCode},
     protosol::protos::InstrEffects as ProtoInstrEffects,
 };
 use {solana_account::Account, solana_instruction::error::InstructionError, solana_pubkey::Pubkey};
@@ -42,11 +42,7 @@ impl From<InstrEffects> for ProtoInstrEffects {
         Self {
             result: result
                 .as_ref()
-                .map(|error| {
-                    let serialized_err = bincode::serialize(error).unwrap();
-                    i32::from_le_bytes((&serialized_err[0..4]).try_into().unwrap())
-                        .saturating_add(1)
-                })
+                .map(|error| error.error_code())
                 .unwrap_or_default(),
             custom_err: custom_err.unwrap_or_default(),
             modified_accounts: resulting_accounts

--- a/svm/src/conformance/instr/harness.rs
+++ b/svm/src/conformance/instr/harness.rs
@@ -2,7 +2,7 @@
 
 use {
     super::{context::InstrContext, effects::InstrEffects},
-    crate::message_processor::process_message,
+    crate::{conformance::callback::DefaultCallback, message_processor::process_message},
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_instruction::error::InstructionError,
     solana_program_runtime::{
@@ -24,46 +24,15 @@ use {
 };
 #[cfg(feature = "conformance")]
 use {
-    crate::conformance::programs::{
-        fill_program_cache_from_accounts, new_program_cache_with_builtins,
+    crate::conformance::{
+        callback::ConformanceCallback,
+        programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
     },
-    agave_feature_set::FeatureSet,
-    agave_precompiles::{get_precompile, is_precompile},
     prost::Message,
     protosol::protos::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
     solana_account::ReadableAccount,
-    solana_precompile_error::PrecompileError,
     std::ffi::c_int,
 };
-
-/// Default callback. No precompile support.
-struct DefaultCallback;
-
-impl InvokeContextCallback for DefaultCallback {}
-
-/// Conformance callback. Full precompile support across all features.
-#[cfg(feature = "conformance")]
-struct ConformanceCallback;
-
-#[cfg(feature = "conformance")]
-impl InvokeContextCallback for ConformanceCallback {
-    fn is_precompile(&self, program_id: &Pubkey) -> bool {
-        is_precompile(program_id, |_| true)
-    }
-
-    fn process_precompile(
-        &self,
-        program_id: &Pubkey,
-        data: &[u8],
-        instruction_datas: Vec<&[u8]>,
-    ) -> Result<(), PrecompileError> {
-        if let Some(precompile) = get_precompile(program_id, |_| true) {
-            precompile.verify(data, &instruction_datas, &FeatureSet::all_enabled())
-        } else {
-            Err(PrecompileError::InvalidPublicKey)
-        }
-    }
-}
 
 /// Execute a single instruction against the Solana VM with the default
 /// (no-precompile) callback.

--- a/svm/src/conformance/instr/harness.rs
+++ b/svm/src/conformance/instr/harness.rs
@@ -2,23 +2,24 @@
 
 use {
     super::{context::InstrContext, effects::InstrEffects},
-    crate::{conformance::callback::DefaultCallback, message_processor::process_message},
+    crate::{
+        conformance::{
+            callback::DefaultCallback,
+            setup::{compile_transaction_context, program_runtime_environments, recent_blockhash},
+        },
+        message_processor::process_message,
+    },
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_instruction::error::InstructionError,
     solana_program_runtime::{
-        invoke_context::{EnvironmentConfig, InvokeContext, mock_compile_message},
-        loaded_programs::{
-            ProgramCacheForTxBatch, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
-        },
+        invoke_context::{EnvironmentConfig, InvokeContext},
+        loaded_programs::ProgramCacheForTxBatch,
         sysvar_cache::SysvarCache,
     },
     solana_pubkey::Pubkey,
     solana_svm_callback::InvokeContextCallback,
     solana_svm_log_collector::LogCollector,
     solana_svm_timings::ExecuteTimings,
-    solana_svm_transaction::svm_message::SVMStaticMessage,
-    solana_syscalls::create_program_runtime_environment,
-    solana_transaction_context::transaction::TransactionContext,
     solana_transaction_error::TransactionError,
     std::rc::Rc,
 };
@@ -27,10 +28,10 @@ use {
     crate::conformance::{
         callback::ConformanceCallback,
         programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
+        setup::sysvar_cache_from_accounts,
     },
     prost::Message,
     protosol::protos::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
-    solana_account::ReadableAccount,
     std::ffi::c_int,
 };
 
@@ -68,45 +69,27 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
         .expect("program not loaded in cache")
         .account_owner();
 
-    let (sanitized_message, transaction_accounts) =
-        mock_compile_message(&input.instruction, &input.accounts, program_id, &loader_key);
-
-    let mut transaction_context = TransactionContext::new(
-        transaction_accounts,
+    let (sanitized_message, mut transaction_context) = compile_transaction_context(
+        &input.instruction,
+        &input.accounts,
+        program_id,
+        &loader_key,
+        &compute_budget,
         (*rent).clone(),
-        compute_budget.max_instruction_stack_depth,
-        compute_budget.max_instruction_trace_length,
-        sanitized_message.num_instructions(),
     );
 
-    let program_runtime_environment = create_program_runtime_environment(
-        &input.feature_set,
-        &compute_budget.to_budget(),
-        false, /* deployment */
-        false, /* debugging_features */
-    )
-    .unwrap();
+    let runtime_environments = program_runtime_environments(&input.feature_set, &compute_budget);
 
     let result = {
-        #[expect(deprecated)]
-        let (blockhash, blockhash_lamports_per_signature) = sysvar_cache
-            .get_recent_blockhashes()
-            .ok()
-            .and_then(|x| (*x).last().cloned())
-            .map(|x| (x.blockhash, x.fee_calculator.lamports_per_signature))
-            .unwrap_or_default();
+        let (blockhash, blockhash_lamports_per_signature) = recent_blockhash(sysvar_cache);
 
-        let program_runtime_environments = ProgramRuntimeEnvironments::new(
-            ProgramRuntimeEnvironment::clone(&program_runtime_environment),
-            program_runtime_environment,
-        );
         let environment_config = EnvironmentConfig::new(
             blockhash,
             blockhash_lamports_per_signature,
             false,
             callback,
             &feature_set,
-            &program_runtime_environments,
+            &runtime_environments,
             sysvar_cache,
         );
 
@@ -176,17 +159,7 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> ProtoInstrEffects {
     let instr_context = InstrContext::from(input);
 
     // When testing with protobuf, we fill the sysvar cache from input accounts.
-    let sysvar_cache = {
-        let mut cache = SysvarCache::default();
-        cache.fill_missing_entries(|pubkey, callbackback| {
-            if let Some(account) = instr_context.accounts.iter().find(|(key, _)| key == pubkey)
-                && account.1.lamports() > 0
-            {
-                callbackback(account.1.data());
-            }
-        });
-        cache
-    };
+    let sysvar_cache = sysvar_cache_from_accounts(&instr_context.accounts);
 
     // When testing with protobuf, we fill the program cache from input accounts.
     let mut program_cache = {
@@ -194,18 +167,16 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> ProtoInstrEffects {
         let feature_set = &instr_context.feature_set;
         let simd_0268_active = feature_set.raise_cpi_nesting_limit_to_8;
         let compute_budget = ComputeBudget::new_with_defaults(simd_0268_active);
-
-        let environment = create_program_runtime_environment(
-            feature_set,
-            &compute_budget.to_budget(),
-            false, /* deployment */
-            false, /* debugging_features */
-        )
-        .unwrap();
+        let environments = program_runtime_environments(feature_set, &compute_budget);
 
         let mut cache = new_program_cache_with_builtins(slot);
-        fill_program_cache_from_accounts(&mut cache, &environment, &instr_context.accounts, slot)
-            .unwrap();
+        fill_program_cache_from_accounts(
+            &mut cache,
+            environments.get_env_for_deployment(),
+            &instr_context.accounts,
+            slot,
+        )
+        .unwrap();
 
         cache
     };

--- a/svm/src/conformance/instr/harness.rs
+++ b/svm/src/conformance/instr/harness.rs
@@ -1,7 +1,7 @@
 //! Conformance harness.
 
 use {
-    super::context::{InstrContext, InstrEffects},
+    super::{context::InstrContext, effects::InstrEffects},
     crate::message_processor::process_message,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_instruction::error::InstructionError,
@@ -24,7 +24,9 @@ use {
 };
 #[cfg(feature = "conformance")]
 use {
-    super::programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
+    crate::conformance::programs::{
+        fill_program_cache_from_accounts, new_program_cache_with_builtins,
+    },
     agave_feature_set::FeatureSet,
     agave_precompiles::{get_precompile, is_precompile},
     prost::Message,
@@ -281,11 +283,11 @@ pub unsafe extern "C" fn sol_compat_instr_execute_v1(
 #[cfg(test)]
 mod tests {
     use {
-        super::{
-            super::programs::{add_program_to_program_cache, new_program_cache_with_builtins},
-            *,
+        super::*,
+        crate::conformance::programs::{
+            add_program_to_program_cache, keyed_account_for_system_program,
+            new_program_cache_with_builtins,
         },
-        crate::conformance::programs::keyed_account_for_system_program,
         solana_account::Account,
         solana_instruction::Instruction,
         solana_rent::Rent,
@@ -296,7 +298,7 @@ mod tests {
     };
 
     const NOOP_ELF: &[u8] =
-        include_bytes!("../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
+        include_bytes!("../../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
 
     const FROM_BASE_LAMPORTS: u64 = 5_000;
     const TO_BASE_LAMPORTS: u64 = 1_000;

--- a/svm/src/conformance/instr/mod.rs
+++ b/svm/src/conformance/instr/mod.rs
@@ -1,0 +1,5 @@
+//! Instruction conformance harness.
+
+pub mod context;
+pub mod effects;
+pub mod harness;

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -6,6 +6,8 @@ pub mod callback;
 #[cfg(feature = "conformance")]
 pub mod elf_loader;
 #[cfg(feature = "conformance")]
+mod fd_err_map;
+#[cfg(feature = "conformance")]
 pub mod fd_hash;
 #[cfg(feature = "conformance")]
 pub mod feature_set;

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -16,3 +16,5 @@ pub mod programs;
 #[cfg(feature = "conformance")]
 pub mod serialization;
 mod setup;
+#[cfg(feature = "conformance")]
+pub mod syscall;

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -11,3 +11,4 @@ pub mod fd_hash;
 pub mod feature_set;
 pub mod instr;
 pub mod programs;
+mod setup;

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -11,4 +11,6 @@ pub mod fd_hash;
 pub mod feature_set;
 pub mod instr;
 pub mod programs;
+#[cfg(feature = "conformance")]
+pub mod serialization;
 mod setup;

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -2,8 +2,7 @@
 
 #[cfg(feature = "conformance")]
 pub mod account_state;
-pub mod context;
 #[cfg(feature = "conformance")]
 pub mod feature_set;
-pub mod harness;
+pub mod instr;
 pub mod programs;

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -3,6 +3,8 @@
 #[cfg(feature = "conformance")]
 pub mod account_state;
 #[cfg(feature = "conformance")]
+pub mod elf_loader;
+#[cfg(feature = "conformance")]
 pub mod feature_set;
 pub mod instr;
 pub mod programs;

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -6,6 +6,8 @@ pub mod callback;
 #[cfg(feature = "conformance")]
 pub mod elf_loader;
 #[cfg(feature = "conformance")]
+pub mod fd_hash;
+#[cfg(feature = "conformance")]
 pub mod feature_set;
 pub mod instr;
 pub mod programs;

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "conformance")]
 pub mod account_state;
+pub mod callback;
 #[cfg(feature = "conformance")]
 pub mod elf_loader;
 #[cfg(feature = "conformance")]

--- a/svm/src/conformance/serialization.rs
+++ b/svm/src/conformance/serialization.rs
@@ -1,0 +1,272 @@
+//! VM serialization conformance harness.
+
+use {
+    crate::conformance::{
+        callback::DefaultCallback,
+        fd_hash::fd_hash,
+        instr::context::InstrContext,
+        setup::{
+            compile_transaction_context, program_runtime_environments, recent_blockhash,
+            sysvar_cache_from_accounts,
+        },
+    },
+    prost::Message,
+    protosol::protos::{
+        InstrContext as ProtoInstrContext, VmInputMemoryRegion as ProtoVmInputMemoryRegion,
+        VmSerializationEffects as ProtoVmSerializationEffects,
+        VmSerializedAccountMetadata as ProtoVmSerializedAccountMetadata,
+    },
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_program_runtime::{
+        invoke_context::{EnvironmentConfig, InvokeContext},
+        loaded_programs::ProgramCacheForTxBatch,
+        memory_context::SerializedAccountMetadata,
+        serialization::serialize_parameters,
+        solana_sbpf::memory_region::MemoryRegion,
+    },
+    solana_svm_log_collector::LogCollector,
+    std::ffi::c_int,
+};
+
+pub fn execute_vm_serialize(input: ProtoInstrContext) -> ProtoVmSerializationEffects {
+    let instr_context = InstrContext::from(input);
+
+    let log_collector = LogCollector::new_ref();
+    let feature_set = instr_context.feature_set;
+    let virtual_address_space_adjustments = feature_set.virtual_address_space_adjustments;
+    let direct_mapping = feature_set.account_data_direct_mapping;
+    let direct_account_pointers = feature_set.direct_account_pointers_in_program_input;
+
+    let compute_budget = ComputeBudget::new_with_defaults(feature_set.raise_cpi_nesting_limit_to_8);
+    // No CU limit for this harness.
+
+    let sysvar_cache = sysvar_cache_from_accounts(&instr_context.accounts);
+    let rent = sysvar_cache.get_rent().unwrap();
+    let program_id = instr_context.instruction.program_id;
+    let loader_key = instr_context
+        .accounts
+        .iter()
+        .find(|(key, _)| *key == program_id)
+        .map(|(_, account)| account.owner)
+        .expect("program not found in accounts");
+
+    let (sanitized_message, mut transaction_context) = compile_transaction_context(
+        &instr_context.instruction,
+        &instr_context.accounts,
+        &program_id,
+        &loader_key,
+        &compute_budget,
+        (*rent).clone(),
+    );
+
+    // We're only testing the parameter serialization, so use an empty cache.
+    let mut program_cache = ProgramCacheForTxBatch::default();
+
+    let runtime_environments = program_runtime_environments(&feature_set, &compute_budget);
+    let (blockhash, lamports_per_signature) = recent_blockhash(&sysvar_cache);
+    let environment_config = EnvironmentConfig::new(
+        blockhash,
+        lamports_per_signature,
+        false,
+        &DefaultCallback,
+        &feature_set,
+        &runtime_environments,
+        &sysvar_cache,
+    );
+
+    let mut invoke_context = InvokeContext::new(
+        &mut transaction_context,
+        &mut program_cache,
+        environment_config,
+        Some(log_collector.clone()),
+        compute_budget.to_budget(),
+        compute_budget.to_cost(),
+    );
+
+    invoke_context
+        .prepare_top_level_instructions(&sanitized_message)
+        .unwrap();
+    invoke_context.push().unwrap();
+
+    let instruction_context = invoke_context
+        .transaction_context
+        .get_current_instruction_context()
+        .unwrap();
+
+    match serialize_parameters(
+        &instruction_context,
+        virtual_address_space_adjustments,
+        direct_mapping,
+        direct_account_pointers,
+    ) {
+        Ok((aligned_memory, input_memory_regions, account_metadatas, _instruction_data_offset)) => {
+            let serialized_memory_hash = fd_hash(0, aligned_memory.as_slice());
+            let vm_input_memory_regions = input_memory_regions
+                .iter()
+                .map(memory_region_to_proto)
+                .collect();
+            let serialized_account_metadata = account_metadatas
+                .iter()
+                .map(serialized_acct_meta_to_proto)
+                .collect();
+            ProtoVmSerializationEffects {
+                has_error: false,
+                serialized_memory_hash,
+                vm_input_memory_regions,
+                serialized_account_metadata,
+            }
+        }
+        Err(_) => ProtoVmSerializationEffects {
+            has_error: true,
+            ..Default::default()
+        },
+    }
+}
+
+fn memory_region_to_proto(region: &MemoryRegion) -> ProtoVmInputMemoryRegion {
+    ProtoVmInputMemoryRegion {
+        vm_address: region.vm_addr,
+        region_size: region.len,
+        is_writable: region.writable,
+    }
+}
+
+fn serialized_acct_meta_to_proto(
+    meta: &SerializedAccountMetadata,
+) -> ProtoVmSerializedAccountMetadata {
+    ProtoVmSerializedAccountMetadata {
+        original_data_len: meta.original_data_len as u64,
+        vm_data_addr: meta.vm_data_addr,
+        vm_key_addr: meta.vm_key_addr,
+        vm_lamports_addr: meta.vm_lamports_addr,
+        vm_owner_addr: meta.vm_owner_addr,
+    }
+}
+
+/// # Safety
+///
+/// `in_ptr` must point to `in_sz` initialized bytes. `out_ptr` must point
+/// to a writable buffer of at least `*out_psz` bytes. On return, `*out_psz`
+/// is updated to the number of bytes written.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sol_compat_vm_serialize_execute_v1(
+    out_ptr: *mut u8,
+    out_psz: *mut u64,
+    in_ptr: *mut u8,
+    in_sz: u64,
+) -> c_int {
+    let in_slice = unsafe { std::slice::from_raw_parts(in_ptr, in_sz as usize) };
+    let Ok(instr_context) = ProtoInstrContext::decode(in_slice) else {
+        return 0;
+    };
+
+    let effects = execute_vm_serialize(instr_context);
+    let out_slice = unsafe { std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize) };
+    let out_vec = effects.encode_to_vec();
+    if out_vec.len() > out_slice.len() {
+        return 0;
+    }
+    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
+    unsafe { *out_psz = out_vec.len() as u64 };
+
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        protosol::protos::{AcctState as ProtoAcctState, InstrAcct as ProtoInstrAcct},
+        solana_pubkey::Pubkey,
+        solana_rent::Rent,
+        solana_sdk_ids::{bpf_loader_deprecated, bpf_loader_upgradeable, sysvar},
+    };
+
+    const PROGRAM_ID: [u8; 32] = [7; 32];
+
+    fn account(address: u8, owner: Pubkey, data_len: usize) -> ProtoAcctState {
+        ProtoAcctState {
+            address: vec![address; 32],
+            lamports: 1,
+            data: vec![0; data_len],
+            executable: false,
+            owner: owner.to_bytes().to_vec(),
+        }
+    }
+
+    fn instr_acct(index: u32, is_writable: bool, is_signer: bool) -> ProtoInstrAcct {
+        ProtoInstrAcct {
+            index,
+            is_writable,
+            is_signer,
+        }
+    }
+
+    fn rent_sysvar() -> ProtoAcctState {
+        ProtoAcctState {
+            address: sysvar::rent::id().to_bytes().to_vec(),
+            lamports: 1,
+            data: bincode::serialize(&Rent::default()).unwrap(),
+            executable: false,
+            owner: sysvar::id().to_bytes().to_vec(),
+        }
+    }
+
+    fn serialize(
+        mut accounts: Vec<ProtoAcctState>,
+        instr_accounts: Vec<ProtoInstrAcct>,
+    ) -> ProtoVmSerializationEffects {
+        accounts.push(rent_sysvar()); // <-- Loads Rent into SysvarCache
+        execute_vm_serialize(ProtoInstrContext {
+            program_id: PROGRAM_ID.to_vec(),
+            accounts,
+            instr_accounts,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn test_serialize_single_account() {
+        let program_id = Pubkey::new_from_array(PROGRAM_ID);
+        let effects = serialize(
+            vec![
+                account(1, program_id, 8),
+                account(PROGRAM_ID[0], bpf_loader_upgradeable::id(), 0),
+            ],
+            vec![instr_acct(0, true, false)],
+        );
+        assert!(!effects.has_error);
+        assert_eq!(effects.serialized_account_metadata.len(), 1);
+    }
+
+    #[test]
+    fn test_serialize_multiple_accounts() {
+        let program_id = Pubkey::new_from_array(PROGRAM_ID);
+        let effects = serialize(
+            vec![
+                account(1, program_id, 4),
+                account(2, program_id, 16),
+                account(PROGRAM_ID[0], bpf_loader_upgradeable::id(), 0),
+            ],
+            vec![instr_acct(0, true, true), instr_acct(1, false, false)],
+        );
+        assert!(!effects.has_error);
+        assert_eq!(effects.serialized_account_metadata.len(), 2);
+    }
+
+    #[test]
+    fn test_serialize_deprecated_loader_program() {
+        // A program owned by the deprecated loader exercises the unaligned
+        // serialization path.
+        let program_id = Pubkey::new_from_array(PROGRAM_ID);
+        let effects = serialize(
+            vec![
+                account(1, program_id, 8),
+                account(PROGRAM_ID[0], bpf_loader_deprecated::id(), 0),
+            ],
+            vec![instr_acct(0, true, false)],
+        );
+        assert!(!effects.has_error);
+        assert_eq!(effects.serialized_account_metadata.len(), 1);
+    }
+}

--- a/svm/src/conformance/serialization.rs
+++ b/svm/src/conformance/serialization.rs
@@ -6,8 +6,8 @@ use {
         fd_hash::fd_hash,
         instr::context::InstrContext,
         setup::{
-            compile_transaction_context, program_runtime_environments, recent_blockhash,
-            sysvar_cache_from_accounts,
+            compile_transaction_context, program_loader_key, program_runtime_environments,
+            recent_blockhash, sysvar_cache_from_accounts,
         },
     },
     prost::Message,
@@ -43,12 +43,7 @@ pub fn execute_vm_serialize(input: ProtoInstrContext) -> ProtoVmSerializationEff
     let sysvar_cache = sysvar_cache_from_accounts(&instr_context.accounts);
     let rent = sysvar_cache.get_rent().unwrap();
     let program_id = instr_context.instruction.program_id;
-    let loader_key = instr_context
-        .accounts
-        .iter()
-        .find(|(key, _)| *key == program_id)
-        .map(|(_, account)| account.owner)
-        .expect("program not found in accounts");
+    let loader_key = program_loader_key(&instr_context.accounts, &program_id);
 
     let (sanitized_message, mut transaction_context) = compile_transaction_context(
         &instr_context.instruction,

--- a/svm/src/conformance/serialization.rs
+++ b/svm/src/conformance/serialization.rs
@@ -24,14 +24,12 @@ use {
         serialization::serialize_parameters,
         solana_sbpf::memory_region::MemoryRegion,
     },
-    solana_svm_log_collector::LogCollector,
     std::ffi::c_int,
 };
 
 pub fn execute_vm_serialize(input: ProtoInstrContext) -> ProtoVmSerializationEffects {
     let instr_context = InstrContext::from(input);
 
-    let log_collector = LogCollector::new_ref();
     let feature_set = instr_context.feature_set;
     let virtual_address_space_adjustments = feature_set.virtual_address_space_adjustments;
     let direct_mapping = feature_set.account_data_direct_mapping;
@@ -73,7 +71,7 @@ pub fn execute_vm_serialize(input: ProtoInstrContext) -> ProtoVmSerializationEff
         &mut transaction_context,
         &mut program_cache,
         environment_config,
-        Some(log_collector.clone()),
+        None,
         compute_budget.to_budget(),
         compute_budget.to_cost(),
     );

--- a/svm/src/conformance/setup.rs
+++ b/svm/src/conformance/setup.rs
@@ -1,0 +1,94 @@
+//! Shared setup helpers for the execution harnesses.
+//!
+//! Each helper builds one owned prerequisite for an `InvokeContext` (the
+//! transaction context, the runtime environments, the blockhash). The harness
+//! still assembles its own `EnvironmentConfig`/`InvokeContext`, since those
+//! borrow these pieces — so rather than one big `create_invoke_context_fields`
+//! returning a tuple of everything, this is a handful of small, composable
+//! pieces the harnesses pick from.
+
+#[cfg(feature = "conformance")]
+use solana_account::ReadableAccount;
+use {
+    solana_account::Account,
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_hash::Hash,
+    solana_instruction::Instruction,
+    solana_message::SanitizedMessage,
+    solana_program_runtime::{
+        invoke_context::mock_compile_message,
+        loaded_programs::{ProgramRuntimeEnvironment, ProgramRuntimeEnvironments},
+        sysvar_cache::SysvarCache,
+    },
+    solana_pubkey::Pubkey,
+    solana_rent::Rent,
+    solana_svm_feature_set::SVMFeatureSet,
+    solana_svm_transaction::svm_message::SVMStaticMessage,
+    solana_syscalls::create_program_runtime_environment,
+    solana_transaction_context::transaction::TransactionContext,
+};
+
+/// Compile `instruction` into a sanitized message and a fresh transaction
+/// context sized for a single top-level instruction.
+pub(crate) fn compile_transaction_context(
+    instruction: &Instruction,
+    accounts: &[(Pubkey, Account)],
+    program_id: &Pubkey,
+    loader_key: &Pubkey,
+    compute_budget: &ComputeBudget,
+    rent: Rent,
+) -> (SanitizedMessage, TransactionContext<'static>) {
+    let (sanitized_message, transaction_accounts) =
+        mock_compile_message(instruction, accounts, program_id, loader_key);
+    let transaction_context = TransactionContext::new(
+        transaction_accounts,
+        rent,
+        compute_budget.max_instruction_stack_depth,
+        compute_budget.max_instruction_trace_length,
+        sanitized_message.num_instructions(),
+    );
+    (sanitized_message, transaction_context)
+}
+
+/// The paired (execution + deployment) program runtime environments for a
+/// harness invocation. Both halves share one environment.
+pub(crate) fn program_runtime_environments(
+    feature_set: &SVMFeatureSet,
+    compute_budget: &ComputeBudget,
+) -> ProgramRuntimeEnvironments {
+    let environment = create_program_runtime_environment(
+        feature_set,
+        &compute_budget.to_budget(),
+        false, /* deployment */
+        false, /* debugging_features */
+    )
+    .unwrap();
+    ProgramRuntimeEnvironments::new(ProgramRuntimeEnvironment::clone(&environment), environment)
+}
+
+/// The most recent blockhash and its lamports-per-signature from the sysvar
+/// cache, or defaults when unavailable.
+pub(crate) fn recent_blockhash(sysvar_cache: &SysvarCache) -> (Hash, u64) {
+    #[expect(deprecated)]
+    sysvar_cache
+        .get_recent_blockhashes()
+        .ok()
+        .and_then(|entries| entries.last().cloned())
+        .map(|entry| (entry.blockhash, entry.fee_calculator.lamports_per_signature))
+        .unwrap_or_default()
+}
+
+/// Build a sysvar cache populated from any sysvar accounts present in the
+/// input account set.
+#[cfg(feature = "conformance")]
+pub(crate) fn sysvar_cache_from_accounts(accounts: &[(Pubkey, Account)]) -> SysvarCache {
+    let mut cache = SysvarCache::default();
+    cache.fill_missing_entries(|pubkey, set_sysvar| {
+        if let Some(account) = accounts.iter().find(|(key, _)| key == pubkey)
+            && account.1.lamports() > 0
+        {
+            set_sysvar(account.1.data());
+        }
+    });
+    cache
+}

--- a/svm/src/conformance/setup.rs
+++ b/svm/src/conformance/setup.rs
@@ -28,6 +28,18 @@ use {
     solana_transaction_context::transaction::TransactionContext,
 };
 
+/// The loader that owns the program account in `accounts`, used as the program
+/// account's owner when compiling the transaction. `None` if the program
+/// account isn't present.
+#[cfg(feature = "conformance")]
+pub(crate) fn program_loader_key(accounts: &[(Pubkey, Account)], program_id: &Pubkey) -> Pubkey {
+    accounts
+        .iter()
+        .find(|(key, _)| key == program_id)
+        .map(|(_, account)| account.owner)
+        .expect("program not found in accounts")
+}
+
 /// Compile `instruction` into a sanitized message and a fresh transaction
 /// context sized for a single top-level instruction.
 pub(crate) fn compile_transaction_context(

--- a/svm/src/conformance/syscall.rs
+++ b/svm/src/conformance/syscall.rs
@@ -33,7 +33,6 @@ use {
         },
     },
     solana_pubkey::Pubkey,
-    solana_svm_log_collector::LogCollector,
     std::{ffi::c_int, sync::Arc},
 };
 
@@ -50,7 +49,6 @@ pub fn execute_vm_syscall(input: ProtoSyscallContext) -> ProtoSyscallEffects {
     let syscall_invocation = input.syscall_invocation.unwrap_or_default();
     let registers = get_registers(&vm_context);
 
-    let log_collector = LogCollector::new_ref();
     let feature_set = instr_context.feature_set;
     let virtual_address_space_adjustments = feature_set.virtual_address_space_adjustments;
     let account_data_direct_mapping = feature_set.account_data_direct_mapping;
@@ -126,7 +124,7 @@ pub fn execute_vm_syscall(input: ProtoSyscallContext) -> ProtoSyscallEffects {
         &mut transaction_context,
         &mut program_cache,
         environment_config,
-        Some(log_collector.clone()),
+        None,
         compute_budget.to_budget(),
         compute_budget.to_cost(),
     );
@@ -227,18 +225,11 @@ pub fn execute_vm_syscall(input: ProtoSyscallContext) -> ProtoSyscallEffects {
         virtual_address_space_adjustments,
     );
 
-    let (error, error_kind, r0) =
-        unpack_stable_result(program_result, &Some(log_collector.clone()), &program_id);
+    let (error, error_kind, r0) = unpack_stable_result(program_result);
     let cu_avail = invoke_context.get_remaining();
     invoke_context
         .pop()
         .expect("failed to pop instruction context");
-
-    let log = log_collector
-        .borrow()
-        .get_recorded_content()
-        .join("\n")
-        .into_bytes();
 
     ProtoSyscallEffects {
         error,
@@ -249,7 +240,6 @@ pub fn execute_vm_syscall(input: ProtoSyscallContext) -> ProtoSyscallEffects {
         stack: stack.as_slice().to_vec(),
         input_data_regions,
         frame_count: call_depth,
-        log,
         rodata: rodata.as_slice().to_vec(),
         pc: 0,
         ..Default::default()
@@ -424,8 +414,9 @@ mod tests {
         ));
 
         assert_eq!(effects.error, 0);
-        let log = String::from_utf8(effects.log).unwrap();
-        assert!(log.contains("hello"), "got: {log:?}");
+        // Logs are no longer collected (the harness runs without a log
+        // collector), so the syscall succeeding is all we assert here.
+        assert!(effects.cu_avail < 200_000, "syscall should consume compute");
     }
 
     #[test]

--- a/svm/src/conformance/syscall.rs
+++ b/svm/src/conformance/syscall.rs
@@ -1,0 +1,464 @@
+//! VM syscall conformance harness.
+
+use {
+    crate::conformance::{
+        callback::DefaultCallback,
+        fd_err_map::unpack_stable_result,
+        instr::context::InstrContext,
+        programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
+        setup::{
+            compile_transaction_context, program_loader_key, program_runtime_environments,
+            recent_blockhash, sysvar_cache_from_accounts,
+        },
+    },
+    prost::Message,
+    protosol::protos::{
+        InputDataRegion as ProtoInputDataRegion, SyscallContext as ProtoSyscallContext,
+        SyscallEffects as ProtoSyscallEffects, SyscallInvocation as ProtoSyscallInvocation,
+        VmContext as ProtoVmContext,
+    },
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_program_runtime::{
+        invoke_context::{BpfAllocator, EnvironmentConfig, InvokeContext},
+        loaded_programs::ProgramCacheForTxBatch,
+        memory_context::MemoryContext,
+        serialization::serialize_parameters,
+        solana_sbpf::{
+            aligned_memory::AlignedMemory,
+            ebpf::{HOST_ALIGN, MM_BYTECODE_START, MM_HEAP_START, MM_INPUT_START, MM_STACK_START},
+            error::{ProgramResult, StableResult},
+            memory_region::{MemoryMapping, MemoryRegion},
+            program::{BuiltinProgram, SBPFVersion},
+            vm::{ContextObject, EbpfVm},
+        },
+    },
+    solana_pubkey::Pubkey,
+    solana_svm_log_collector::LogCollector,
+    std::{ffi::c_int, sync::Arc},
+};
+
+const STACK_GAP_SIZE: u64 = 4_096;
+const STACK_SIZE: usize = 64 * STACK_GAP_SIZE as usize;
+/// Upper bound on `vm_context.heap_max` — matches Firedancer's cap so the same
+/// fuzzer inputs run on either implementation.
+const HEAP_MAX: usize = 256 * 1024;
+const SBPF_VERSION: SBPFVersion = SBPFVersion::V0;
+
+pub fn execute_vm_syscall(input: ProtoSyscallContext) -> ProtoSyscallEffects {
+    let instr_context = InstrContext::from(input.instr_ctx.expect("missing instr context"));
+    let vm_context = input.vm_ctx.expect("missing vm context");
+    let syscall_invocation = input.syscall_invocation.unwrap_or_default();
+    let registers = get_registers(&vm_context);
+
+    let log_collector = LogCollector::new_ref();
+    let feature_set = instr_context.feature_set;
+    let virtual_address_space_adjustments = feature_set.virtual_address_space_adjustments;
+    let account_data_direct_mapping = feature_set.account_data_direct_mapping;
+    let direct_account_pointers_in_program_input =
+        feature_set.direct_account_pointers_in_program_input;
+
+    let mut compute_budget =
+        ComputeBudget::new_with_defaults(feature_set.raise_cpi_nesting_limit_to_8);
+    compute_budget.compute_unit_limit = instr_context.cu_avail; // Clamp budget for execution by cu_avail
+
+    let sysvar_cache = sysvar_cache_from_accounts(&instr_context.accounts);
+
+    let rent = sysvar_cache.get_rent().unwrap();
+    let program_id = instr_context.instruction.program_id;
+    let loader_key = program_loader_key(&instr_context.accounts, &program_id);
+
+    let (sanitized_message, mut transaction_context) = compile_transaction_context(
+        &instr_context.instruction,
+        &instr_context.accounts,
+        &program_id,
+        &loader_key,
+        &compute_budget,
+        (*rent).clone(),
+    );
+
+    // Replay any prior return data the fuzzer wants in scope before the syscall.
+    if let Some(return_data) = vm_context.return_data {
+        let return_program_id =
+            Pubkey::try_from(return_data.program_id).expect("invalid return data program id");
+        transaction_context
+            .set_return_data(return_program_id, return_data.data)
+            .expect("failed to set return data");
+    }
+
+    let environments = program_runtime_environments(&feature_set, &compute_budget);
+
+    // Only build out the program cache if the syscall is CPI.
+    let mut program_cache = if contains_cpi(&syscall_invocation) {
+        let mut cache = new_program_cache_with_builtins(0);
+        fill_program_cache_from_accounts(
+            &mut cache,
+            environments.get_env_for_deployment(),
+            &instr_context.accounts,
+            0,
+        )
+        .expect("failed to fill program cache from accounts");
+        cache
+    } else {
+        ProgramCacheForTxBatch::default()
+    };
+
+    let execution_environment = environments.get_env_for_execution();
+    let config = execution_environment.get_config().clone();
+    let syscall_function = execution_environment
+        .get_function_registry()
+        .lookup_by_name(&syscall_invocation.function_name)
+        .expect("syscall function not registered")
+        .1
+        .0;
+
+    let (blockhash, lamports_per_signature) = recent_blockhash(&sysvar_cache);
+    let environment_config = EnvironmentConfig::new(
+        blockhash,
+        lamports_per_signature,
+        false,
+        &DefaultCallback,
+        &feature_set,
+        &environments,
+        &sysvar_cache,
+    );
+
+    let mut invoke_context = InvokeContext::new(
+        &mut transaction_context,
+        &mut program_cache,
+        environment_config,
+        Some(log_collector.clone()),
+        compute_budget.to_budget(),
+        compute_budget.to_cost(),
+    );
+
+    invoke_context
+        .prepare_top_level_instructions(&sanitized_message)
+        .expect("failed to prepare top-level instructions");
+    invoke_context
+        .push()
+        .expect("failed to push instruction context");
+
+    let caller_instr_context = invoke_context
+        .transaction_context
+        .get_current_instruction_context()
+        .unwrap();
+    let (_aligned_memory, input_memory_regions, accounts_metadata, _instruction_data_offset) =
+        serialize_parameters(
+            &caller_instr_context,
+            virtual_address_space_adjustments,
+            account_data_direct_mapping,
+            direct_account_pointers_in_program_input,
+        )
+        .expect("failed to serialize parameters");
+
+    assert!(
+        vm_context.heap_max as usize <= HEAP_MAX,
+        "vm_context.heap_max ({}) exceeds HEAP_MAX ({HEAP_MAX})",
+        vm_context.heap_max,
+    );
+    let rodata = AlignedMemory::<HOST_ALIGN>::from(&vm_context.rodata);
+    let mut stack = AlignedMemory::<HOST_ALIGN>::from(&vec![0; STACK_SIZE]);
+    let mut heap = AlignedMemory::<HOST_ALIGN>::from(&vec![0; vm_context.heap_max as usize]);
+
+    copy_memory_prefix(heap.as_slice_mut(), &syscall_invocation.heap_prefix);
+    copy_memory_prefix(stack.as_slice_mut(), &syscall_invocation.stack_prefix);
+
+    let stack_frame_gap = if SBPF_VERSION.stack_frame_gaps() && config.enable_stack_frame_gaps {
+        config.stack_frame_size as u64
+    } else {
+        0
+    };
+    let regions = [
+        MemoryRegion::new(rodata.as_slice() as *const [u8], MM_BYTECODE_START),
+        MemoryRegion::new_gapped(
+            stack.as_slice_mut() as *mut [u8],
+            MM_STACK_START,
+            stack_frame_gap,
+        ),
+        MemoryRegion::new(heap.as_slice_mut() as *mut [u8], MM_HEAP_START),
+    ]
+    .into_iter()
+    .chain(input_memory_regions)
+    .collect();
+    // SAFETY: the backing memory for rodata/stack/heap (and any input regions)
+    // lives until the end of this function, which outlives the `MemoryMapping`.
+    let memory_mapping = unsafe {
+        MemoryMapping::new_with_access_violation_handler(
+            regions,
+            &config,
+            SBPF_VERSION,
+            invoke_context.transaction_context.access_violation_handler(
+                virtual_address_space_adjustments,
+                account_data_direct_mapping,
+            ),
+        )
+    }
+    .expect("failed to create memory mapping");
+
+    invoke_context
+        .memory_contexts
+        .set_memory_context_abi_v1(MemoryContext::new(
+            BpfAllocator::new(vm_context.heap_max),
+            accounts_metadata,
+            memory_mapping,
+        ))
+        .expect("failed to set memory context");
+
+    let (program_result, call_depth) = {
+        // Invoke the syscall with a `&'static` InvokeContext, then take the
+        // result, dropping the VM. Avoids dangling memory.
+        let loader = Arc::new(BuiltinProgram::new_loader(config));
+        let invoke_context_static: &mut InvokeContext<'static, 'static> =
+            unsafe { std::mem::transmute(&mut invoke_context) };
+
+        let mut vm = EbpfVm::new(loader, SBPF_VERSION, invoke_context_static, STACK_SIZE);
+        vm.registers = registers;
+
+        vm.invoke_function(syscall_function);
+
+        let program_result = std::mem::replace(&mut vm.program_result, ProgramResult::Ok(0));
+        let call_depth = vm.call_depth;
+        (program_result, call_depth)
+    };
+
+    let input_data_regions = extract_input_data_regions(
+        &invoke_context,
+        &program_result,
+        virtual_address_space_adjustments,
+    );
+
+    let (error, error_kind, r0) =
+        unpack_stable_result(program_result, &Some(log_collector.clone()), &program_id);
+    let cu_avail = invoke_context.get_remaining();
+    invoke_context
+        .pop()
+        .expect("failed to pop instruction context");
+
+    let log = log_collector
+        .borrow()
+        .get_recorded_content()
+        .join("\n")
+        .into_bytes();
+
+    ProtoSyscallEffects {
+        error,
+        error_kind,
+        r0,
+        cu_avail,
+        heap: heap.as_slice().to_vec(),
+        stack: stack.as_slice().to_vec(),
+        input_data_regions,
+        frame_count: call_depth,
+        log,
+        rodata: rodata.as_slice().to_vec(),
+        pc: 0,
+        ..Default::default()
+    }
+}
+
+fn contains_cpi(syscall_invocation: &ProtoSyscallInvocation) -> bool {
+    syscall_invocation.function_name == b"sol_invoke_signed_c"
+        || syscall_invocation.function_name == b"sol_invoke_signed_rust"
+}
+
+fn copy_memory_prefix(dst: &mut [u8], src: &[u8]) {
+    let size = dst.len().min(src.len());
+    dst[..size].copy_from_slice(&src[..size]);
+}
+
+fn get_registers(vm_context: &ProtoVmContext) -> [u64; 12] {
+    [
+        vm_context.r0,
+        vm_context.r1,
+        vm_context.r2,
+        vm_context.r3,
+        vm_context.r4,
+        vm_context.r5,
+        vm_context.r6,
+        vm_context.r7,
+        vm_context.r8,
+        vm_context.r9,
+        vm_context.r10,
+        vm_context.r11,
+    ]
+}
+
+fn extract_input_data_regions(
+    invoke_context: &InvokeContext,
+    program_result: &ProgramResult,
+    virtual_address_space_adjustments: bool,
+) -> Vec<ProtoInputDataRegion> {
+    // When virtual_address_space_adjustments is enabled, Agave calls
+    // update_caller_account_region only after a _successful_ CPI execution, so
+    // on failure the input regions can hold stale data — return empty instead.
+    if virtual_address_space_adjustments && matches!(program_result, StableResult::Err(_)) {
+        return Vec::new();
+    }
+    invoke_context
+        .memory_contexts
+        .memory_mapping()
+        .ok()
+        .map(|mapping| {
+            let mut regions: Vec<ProtoInputDataRegion> = mapping
+                .get_regions()
+                .iter()
+                .filter(|region| region.vm_addr >= MM_INPUT_START)
+                .map(mem_region_to_input_data_region)
+                .collect();
+            regions.sort_by_key(|region| region.offset);
+            regions
+        })
+        .unwrap_or_default()
+}
+
+fn mem_region_to_input_data_region(region: &MemoryRegion) -> ProtoInputDataRegion {
+    ProtoInputDataRegion {
+        content: unsafe {
+            std::slice::from_raw_parts(region.host_addr as *const u8, region.len as usize).to_vec()
+        },
+        offset: region.vm_addr.saturating_sub(MM_INPUT_START),
+        is_writable: region.writable,
+    }
+}
+
+/// # Safety
+///
+/// `in_ptr` must point to `in_sz` initialized bytes. `out_ptr` must point
+/// to a writable buffer of at least `*out_psz` bytes. On return, `*out_psz`
+/// is updated to the number of bytes written.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sol_compat_vm_syscall_execute_v1(
+    out_ptr: *mut u8,
+    out_psz: *mut u64,
+    in_ptr: *mut u8,
+    in_sz: u64,
+) -> c_int {
+    let in_slice = unsafe { std::slice::from_raw_parts(in_ptr, in_sz as usize) };
+    let Ok(syscall_context) = ProtoSyscallContext::decode(in_slice) else {
+        return 0;
+    };
+
+    let syscall_effects = execute_vm_syscall(syscall_context);
+    let out_slice = unsafe { std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize) };
+    let out_vec = syscall_effects.encode_to_vec();
+    if out_vec.len() > out_slice.len() {
+        return 0;
+    }
+    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
+    unsafe { *out_psz = out_vec.len() as u64 };
+
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        protosol::protos::{
+            AcctState as ProtoAcctState, InstrContext as ProtoInstrContext,
+            SyscallInvocation as ProtoSyscallInvocation, VmContext as ProtoVmContext,
+        },
+        solana_rent::Rent,
+        solana_sdk_ids::sysvar,
+    };
+
+    const PROGRAM_ID: [u8; 32] = [7; 32];
+
+    fn syscall_context(
+        function_name: &[u8],
+        r1: u64,
+        r2: u64,
+        r3: u64,
+        r4: u64,
+        heap_prefix: Vec<u8>,
+    ) -> ProtoSyscallContext {
+        let program_account = ProtoAcctState {
+            address: PROGRAM_ID.to_vec(),
+            lamports: 0,
+            data: vec![],
+            executable: true,
+            owner: Pubkey::default().to_bytes().to_vec(),
+        };
+        let rent_sysvar = ProtoAcctState {
+            address: sysvar::rent::id().to_bytes().to_vec(),
+            lamports: 1,
+            data: bincode::serialize(&Rent::default()).unwrap(),
+            executable: false,
+            owner: sysvar::id().to_bytes().to_vec(),
+        };
+        ProtoSyscallContext {
+            instr_ctx: Some(ProtoInstrContext {
+                program_id: PROGRAM_ID.to_vec(),
+                accounts: vec![program_account, rent_sysvar],
+                instr_accounts: vec![],
+                data: vec![],
+                cu_avail: 200_000,
+                features: None,
+            }),
+            vm_ctx: Some(ProtoVmContext {
+                heap_max: 1024,
+                r1,
+                r2,
+                r3,
+                r4,
+                ..Default::default()
+            }),
+            syscall_invocation: Some(ProtoSyscallInvocation {
+                function_name: function_name.to_vec(),
+                heap_prefix,
+                stack_prefix: vec![],
+            }),
+        }
+    }
+
+    #[test]
+    fn test_sol_log() {
+        let msg = b"hello";
+        let effects = execute_vm_syscall(syscall_context(
+            b"sol_log_",
+            MM_HEAP_START,    // r1: msg address in heap
+            msg.len() as u64, // r2: length
+            0,
+            0,
+            msg.to_vec(),
+        ));
+
+        assert_eq!(effects.error, 0);
+        let log = String::from_utf8(effects.log).unwrap();
+        assert!(log.contains("hello"), "got: {log:?}");
+    }
+
+    #[test]
+    fn test_sol_memset() {
+        let effects = execute_vm_syscall(syscall_context(
+            b"sol_memset_",
+            MM_HEAP_START, // r1: dst
+            0x42,          // r2: byte
+            8,             // r3: count
+            0,
+            vec![0u8; 16],
+        ));
+
+        assert_eq!(effects.error, 0);
+        assert_eq!(&effects.heap[..8], &[0x42; 8]);
+        assert_eq!(
+            &effects.heap[8..16],
+            &[0u8; 8],
+            "must not write past length"
+        );
+    }
+
+    #[test]
+    fn test_sol_panic_surfaces_error() {
+        let effects = execute_vm_syscall(syscall_context(
+            b"sol_panic_",
+            MM_HEAP_START, // r1: file address
+            1,             // r2: file length
+            10,            // r3: line
+            5,             // r4: column
+            b"x".to_vec(),
+        ));
+
+        assert_ne!(effects.error, 0);
+    }
+}

--- a/svm/src/conformance/syscall.rs
+++ b/svm/src/conformance/syscall.rs
@@ -225,16 +225,16 @@ pub fn execute_vm_syscall(input: ProtoSyscallContext) -> ProtoSyscallEffects {
         virtual_address_space_adjustments,
     );
 
-    let (error, error_kind, r0) = unpack_stable_result(program_result);
+    let unpacked = unpack_stable_result(program_result);
     let cu_avail = invoke_context.get_remaining();
     invoke_context
         .pop()
         .expect("failed to pop instruction context");
 
     ProtoSyscallEffects {
-        error,
-        error_kind,
-        r0,
+        error: unpacked.error,
+        error_kind: unpacked.error_kind,
+        r0: unpacked.r0,
         cu_avail,
         heap: heap.as_slice().to_vec(),
         stack: stack.as_slice().to_vec(),


### PR DESCRIPTION
Draft implementation of the following SolFuzz-Agave harnesses, as described in #12378:

* `sol_compat_elf_loader_v1`
* `sol_compat_vm_serialize_execute_v1`
* `sol_compat_vm_syscall_execute_v1`

Some items open for discussion:

1. I placed all harnesses for SVM-level entrypoints in `solana-svm`. A case could be made for a dedicated crate as well. The main reason was due to the dependencies the harnesses required. Even `sol_compat_elf_loader_v1` - arguably the lowest-level harness of the bunch - needed the syscall-register function `create_program_runtime_environment` from `solana-syscalls`, so placing it in `solana-program-runtime` or `solana-sbpf` is difficult.
2. The `sol_compat_elf_loader_v1` and `sol_compat_vm_serialize_execute_v1` harnesses are fairly light on setup code, and they adequately test production paths via `Executable::load` and `serialize_parameters`, respectively. However, the syscall harness still duplicates a lot of code from `solana-program-runtime/src/vm.rs`. If we want to reduce this duplicode, we'll want to factor some of the APIs like `configure_program_regions`, `set_memory_context`, and `execute` to be more composable when calling from a harness that does not produce an `Executable`.