### PR TITLE
refactor(snapshots): remove thread pool from snapshot storage rebuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9948,7 +9948,6 @@ dependencies = [
  "mockall",
  "num-derive",
  "num-traits",
- "num_cpus",
  "percentage",
  "proptest",
  "qualifier_attr",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8337,7 +8337,6 @@ dependencies = [
  "mockall",
  "num-derive",
  "num-traits",
- "num_cpus",
  "percentage",
  "qualifier_attr",
  "rand 0.9.4",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8144,7 +8144,6 @@ dependencies = [
  "mockall",
  "num-derive",
  "num-traits",
- "num_cpus",
  "percentage",
  "qualifier_attr",
  "rand 0.9.4",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -75,7 +75,6 @@ log = { workspace = true }
 mockall = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
-num_cpus = { workspace = true }
 percentage = { workspace = true }
 qualifier_attr = { workspace = true }
 rand = { workspace = true }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -50,7 +50,7 @@ use {
         result::Result,
         sync::{
             Arc,
-            atomic::{AtomicBool, AtomicUsize, Ordering},
+            atomic::{AtomicBool, Ordering},
         },
         thread,
         time::Instant,
@@ -905,7 +905,7 @@ pub(crate) fn remap_append_vec_file(
     old_append_vec_id: SerializedAccountsFileId,
     append_vec_file_info: FileInfo,
     next_append_vec_id: &AtomicAccountsFileId,
-    num_collisions: &AtomicUsize,
+    num_collisions: &mut usize,
 ) -> io::Result<(AccountsFileId, FileInfo)> {
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
     let append_vec_path_cstr = cstring_from_path(&append_vec_file_info.path)?;
@@ -957,7 +957,7 @@ pub(crate) fn remap_append_vec_file(
 
         // If we made it this far, a file exists at the new path.  Record the collision
         // and try again.
-        num_collisions.fetch_add(1, Ordering::Relaxed);
+        *num_collisions += 1;
     };
 
     // Only rename the file if the new ID is actually different from the original. In the target_os
@@ -985,7 +985,7 @@ pub(crate) fn remap_and_reconstruct_single_storage(
     current_len: usize,
     append_vec_file_info: FileInfo,
     next_append_vec_id: &AtomicAccountsFileId,
-    num_collisions: &AtomicUsize,
+    num_collisions: &mut usize,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
     let (remapped_append_vec_id, remapped_append_vec_file_info) = remap_append_vec_file(
         slot,

--- a/runtime/src/serde_snapshot/obsolete_accounts.rs
+++ b/runtime/src/serde_snapshot/obsolete_accounts.rs
@@ -1,6 +1,5 @@
 use {
     crate::serde_snapshot::SerializedAccountsFileId,
-    dashmap::DashMap,
     rayon::iter::{IntoParallelIterator, ParallelIterator},
     serde::Serialize,
     solana_accounts_db::{
@@ -8,7 +7,7 @@ use {
         account_storage_entry::AccountStorageEntry, accounts_db::AccountsFileId,
     },
     solana_clock::Slot,
-    std::sync::Arc,
+    std::{collections::HashMap, sync::Arc},
     wincode::{SchemaRead, SchemaWrite},
 };
 
@@ -116,7 +115,7 @@ impl SerdeObsoleteAccountsMap {
         SerdeObsoleteAccountsMap { map }
     }
 
-    pub(crate) fn into_dashmap(self) -> DashMap<Slot, SerdeObsoleteAccounts> {
+    pub(crate) fn into_hashmap(self) -> HashMap<Slot, SerdeObsoleteAccounts> {
         self.map.into_iter().collect()
     }
 }
@@ -139,7 +138,7 @@ mod test {
         num_obsolete_accounts_per_storage: usize,
     ) {
         // Create a set of obsolete accounts
-        let obsolete_accounts = DashMap::<Slot, ObsoleteAccounts>::new();
+        let mut obsolete_accounts = HashMap::<Slot, ObsoleteAccounts>::new();
         for slot in 1..=num_storages {
             let obsolete_accounts_list = ObsoleteAccounts {
                 accounts: (0..num_obsolete_accounts_per_storage)
@@ -157,15 +156,13 @@ mod test {
         // Convert the obsolete accounts into a SerdeObsoleteAccountsMap
         let map = obsolete_accounts
             .iter()
-            .map(|entry| {
+            .map(|(slot, accounts)| {
                 let serde_obsolete_accounts = SerdeObsoleteAccounts {
-                    id: *entry.key() as SerializedAccountsFileId,
+                    id: *slot as SerializedAccountsFileId,
                     bytes: num_obsolete_accounts_per_storage as u64 * 1000,
-                    accounts: SerdeObsoleteAccounts::items_from_obsolete_accounts(
-                        entry.value().clone(),
-                    ),
+                    accounts: SerdeObsoleteAccounts::items_from_obsolete_accounts(accounts.clone()),
                 };
-                (*entry.key(), serde_obsolete_accounts)
+                (*slot, serde_obsolete_accounts)
             })
             .collect();
         let obsolete_accounts_map = SerdeObsoleteAccountsMap { map };
@@ -178,7 +175,7 @@ mod test {
         let cursor = Cursor::new(buf.as_slice());
         let deserialized_obsolete_accounts: SerdeObsoleteAccountsMap =
             deserialize_wincode_from(cursor).unwrap();
-        let map = deserialized_obsolete_accounts.into_dashmap();
+        let mut map = deserialized_obsolete_accounts.into_hashmap();
 
         // Verify the deserialized data matches the original obsolete accounts
         assert_eq!(map.len(), obsolete_accounts.len());
@@ -186,7 +183,7 @@ mod test {
             let deserialized_obsolete_accounts = map.remove(&slot).unwrap();
             assert_eq!(
                 obsolete_accounts,
-                deserialized_obsolete_accounts.1.into_tuple().0
+                deserialized_obsolete_accounts.into_tuple().0
             );
         }
     }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -36,10 +36,7 @@ mod serde_snapshot_tests {
             io::{self, BufReader, Cursor, Read, Write},
             ops::RangeFull,
             path::{Path, PathBuf},
-            sync::{
-                Arc,
-                atomic::{AtomicUsize, Ordering},
-            },
+            sync::{Arc, atomic::Ordering},
         },
         tempfile::TempDir,
         test_case::test_case,
@@ -851,18 +848,18 @@ mod serde_snapshot_tests {
         become_ungovernable(tmp.path());
 
         let next_append_vec_id = AtomicAccountsFileId::new(next_id as u32);
-        let num_collisions = AtomicUsize::new(0);
+        let mut num_collisions = 0;
         let (remapped_id, remapped_file_info) = remap_append_vec_file(
             123,
             old_id,
             old_file_info,
             &next_append_vec_id,
-            &num_collisions,
+            &mut num_collisions,
         )
         .unwrap();
         assert_eq!(remapped_id as usize, expected_remapped_id);
         assert_eq!(&remapped_file_info.path, &expected_remapped_path);
-        assert_eq!(num_collisions.load(Ordering::Relaxed), expected_collisions);
+        assert_eq!(num_collisions, expected_collisions);
     }
 
     #[test]
@@ -880,13 +877,13 @@ mod serde_snapshot_tests {
         // In remap_append_vec_file() we want to handle EEXIST (collisions), but we want to return all
         // other errors
         let next_append_vec_id = AtomicAccountsFileId::new(457);
-        let num_collisions = AtomicUsize::new(0);
+        let mut num_collisions = 0;
         remap_append_vec_file(
             123,
             456,
             original_file_info,
             &next_append_vec_id,
-            &num_collisions,
+            &mut num_collisions,
         )
         .unwrap();
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1246,7 +1246,6 @@ fn unarchive_snapshot(
             io_setup,
         );
 
-        let num_rebuilder_threads = num_cpus::get_physical().saturating_sub(1).max(1);
         let snapshot_result = snapshot_fields_from_files(&file_receiver).and_then(
             |SnapshotFieldsBundle {
                  snapshot_version,
@@ -1258,11 +1257,9 @@ fn unarchive_snapshot(
                 let snapshot_storage_lengths =
                     accounts_db_fields.get_storage_lengths_for_snapshot_slots(base_slot)?;
                 let (storage, measure_untar) = measure_time!(
-                    SnapshotStorageRebuilder::spawn_rebuilder_threads(
+                    SnapshotStorageRebuilder::rebuild_storages(
                         snapshot_storage_lengths,
-                        append_vec_files,
-                        file_receiver,
-                        num_rebuilder_threads,
+                        append_vec_files.into_iter().chain(file_receiver),
                         next_append_vec_id,
                         SnapshotFrom::Archive,
                         None,
@@ -1528,15 +1525,11 @@ pub(crate) fn rebuild_storages_from_snapshot_dir(
         ..
     } = snapshot_fields_from_files(&file_receiver)?;
 
-    let num_rebuilder_threads = num_cpus::get_physical().saturating_sub(1).max(1);
-
     let snapshot_storage_lengths =
         accounts_db_fields.get_storage_lengths_for_snapshot_slots(None)?;
-    let storage = SnapshotStorageRebuilder::spawn_rebuilder_threads(
+    let storage = SnapshotStorageRebuilder::rebuild_storages(
         snapshot_storage_lengths,
-        append_vec_files,
-        file_receiver,
-        num_rebuilder_threads,
+        append_vec_files.into_iter().chain(file_receiver),
         next_append_vec_id,
         SnapshotFrom::Dir,
         obsolete_accounts,
@@ -2705,14 +2698,14 @@ mod tests {
         .unwrap();
 
         // Deserialize
-        let deserialized_accounts =
+        let mut deserialized_accounts =
             deserialize_obsolete_accounts(bank_snapshot_dir, MAX_OBSOLETE_ACCOUNTS_FILE_SIZE)
                 .unwrap()
-                .into_dashmap();
+                .into_hashmap();
 
         // Verify
         for storage in &snapshot_storages {
-            let obsolete_accounts = deserialized_accounts.remove(&storage.slot()).unwrap().1;
+            let obsolete_accounts = deserialized_accounts.remove(&storage.slot()).unwrap();
             assert!(obsolete_accounts.into_tuple().2 == 0);
         }
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1282,8 +1282,15 @@ fn unarchive_snapshot(
                 })
             },
         );
-        unarchive_handle.join().unwrap()?;
-        snapshot_result
+        // Producer errors are usually the root cause (no files -> no reception).
+        let unarchive_result = unarchive_handle.join().expect("must join unarchive thread");
+        match (unarchive_result, snapshot_result) {
+            // Rebuilder closed the receiver early; the producer's send failure is just the
+            // downstream symptom — surface the rebuilder's error instead.
+            (Err(SnapshotError::CrossbeamSend(_)), snap @ Err(_)) => snap,
+            (Err(err), _) => Err(err),
+            (Ok(()), snap) => snap,
+        }
     })
 }
 
@@ -1518,26 +1525,35 @@ pub(crate) fn rebuild_storages_from_snapshot_dir(
         account_paths,
     );
 
-    let SnapshotFieldsBundle {
-        bank_fields,
-        accounts_db_fields,
-        append_vec_files,
-        ..
-    } = snapshot_fields_from_files(&file_receiver)?;
+    let snapshot_result = snapshot_fields_from_files(&file_receiver).and_then(
+        |SnapshotFieldsBundle {
+             bank_fields,
+             accounts_db_fields,
+             append_vec_files,
+             ..
+         }| {
+            let snapshot_storage_lengths =
+                accounts_db_fields.get_storage_lengths_for_snapshot_slots(None)?;
+            let storage = SnapshotStorageRebuilder::rebuild_storages(
+                snapshot_storage_lengths,
+                append_vec_files.into_iter().chain(file_receiver),
+                next_append_vec_id,
+                SnapshotFrom::Dir,
+                obsolete_accounts,
+            )?;
+            Ok((storage, bank_fields, accounts_db_fields))
+        },
+    );
 
-    let snapshot_storage_lengths =
-        accounts_db_fields.get_storage_lengths_for_snapshot_slots(None)?;
-    let storage = SnapshotStorageRebuilder::rebuild_storages(
-        snapshot_storage_lengths,
-        append_vec_files.into_iter().chain(file_receiver),
-        next_append_vec_id,
-        SnapshotFrom::Dir,
-        obsolete_accounts,
-    )?;
-    stream_files_handle
-        .join()
-        .expect("should join file stream thread")?;
-    Ok((storage, bank_fields, accounts_db_fields))
+    // Producer errors are usually the root cause (no files -> no reception).
+    let stream_files_result = stream_files_handle.join().expect("must join dir thread");
+    match (stream_files_result, snapshot_result) {
+        // Rebuilder closed the receiver early; the producer's send failure is just the
+        // downstream symptom — surface the rebuilder's error instead.
+        (Err(SnapshotError::CrossbeamSend(_)), snap @ Err(_)) => snap,
+        (Err(err), _) => Err(err),
+        (Ok(()), snap) => snap,
+    }
 }
 
 /// Reads the `snapshot_version` from a file. Before opening the file, its size

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -7,13 +7,7 @@ use {
         remap_and_reconstruct_single_storage,
     },
     agave_fs::FileInfo,
-    crossbeam_channel::{Receiver, Sender, select, unbounded},
-    dashmap::DashMap,
     log::*,
-    rayon::{
-        ThreadPool, ThreadPoolBuilder,
-        iter::{IntoParallelIterator, ParallelIterator},
-    },
     solana_accounts_db::{
         account_storage::AccountStorageMap,
         accounts_db::{AccountsFileId, AtomicAccountsFileId},
@@ -23,139 +17,77 @@ use {
         collections::HashMap,
         path::PathBuf,
         str::FromStr as _,
-        sync::{
-            Arc,
-            atomic::{AtomicUsize, Ordering},
-        },
-        time::Instant,
+        sync::{Arc, atomic::Ordering},
+        time::{Duration, Instant},
     },
 };
+
+const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Stores state for rebuilding snapshot storages
 #[derive(Debug)]
 pub(crate) struct SnapshotStorageRebuilder {
-    /// Receiver for unpacked snapshot storage files
-    file_receiver: Receiver<FileInfo>,
-    /// Number of threads to rebuild with
-    num_threads: usize,
     /// Snapshot storage lengths - from the snapshot file
     snapshot_storage_lengths: HashMap<Slot, usize>,
     /// Container for storing rebuilt snapshot storages
     storage: AccountStorageMap,
     /// Tracks next append_vec_id
     next_append_vec_id: Arc<AtomicAccountsFileId>,
-    /// Tracker for number of processed slots
-    processed_slot_count: AtomicUsize,
     /// Tracks the number of collisions in AccountsFileId
-    num_collisions: AtomicUsize,
+    num_collisions: usize,
+    /// Number of storage slots that have been rebuilt so far
+    processed_slot_count: usize,
     /// Rebuild from the snapshot files or archives
     snapshot_from: SnapshotFrom,
     /// obsolete accounts for all storages
-    obsolete_accounts: DashMap<Slot, SerdeObsoleteAccounts>,
+    obsolete_accounts: HashMap<Slot, SerdeObsoleteAccounts>,
 }
 
 impl SnapshotStorageRebuilder {
-    /// Create the SnapshotStorageRebuilder for storing state during rebuilding
-    ///     - pre-allocates data for storage file infos
-    fn new(
-        file_receiver: Receiver<FileInfo>,
-        num_threads: usize,
-        next_append_vec_id: Arc<AtomicAccountsFileId>,
+    /// Rebuild snapshot storages on the current thread by consuming `files`.
+    pub(crate) fn rebuild_storages(
         snapshot_storage_lengths: HashMap<Slot, usize>,
-        snapshot_from: SnapshotFrom,
-        obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
-    ) -> Self {
-        let storage = AccountStorageMap::with_capacity(snapshot_storage_lengths.len());
-        Self {
-            file_receiver,
-            num_threads,
-            snapshot_storage_lengths,
-            storage,
-            next_append_vec_id,
-            processed_slot_count: AtomicUsize::new(0),
-            num_collisions: AtomicUsize::new(0),
-            snapshot_from,
-            obsolete_accounts: obsolete_accounts
-                .map(|map| map.into_dashmap())
-                .unwrap_or_default(),
-        }
-    }
-
-    /// Synchronously spawns threads to rebuild snapshot storages returning when they complete
-    ///
-    /// Spawn threads for processing buffered append_vec_files, and then received files
-    pub(crate) fn spawn_rebuilder_threads(
-        snapshot_storage_lengths: HashMap<Slot, usize>,
-        append_vec_files: Vec<FileInfo>,
-        file_receiver: Receiver<FileInfo>,
-        num_threads: usize,
+        files: impl IntoIterator<Item = FileInfo>,
         next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_from: SnapshotFrom,
         obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
     ) -> Result<AccountStorageMap, SnapshotError> {
-        let rebuilder = Arc::new(SnapshotStorageRebuilder::new(
-            file_receiver,
-            num_threads,
-            next_append_vec_id,
+        let mut rebuilder = Self {
+            storage: AccountStorageMap::with_capacity(snapshot_storage_lengths.len()),
             snapshot_storage_lengths,
+            next_append_vec_id,
+            num_collisions: 0,
+            processed_slot_count: 0,
             snapshot_from,
-            obsolete_accounts,
-        ));
+            obsolete_accounts: obsolete_accounts
+                .map(|map| map.into_hashmap())
+                .unwrap_or_default(),
+        };
 
-        let thread_pool = rebuilder.build_thread_pool();
+        let mut last_log_time = Instant::now();
 
-        if snapshot_from == SnapshotFrom::Archive {
-            // Synchronously process buffered append_vec_files
-            thread_pool.install(|| rebuilder.process_buffered_files(append_vec_files))?;
-        }
-
-        // Asynchronously spawn threads to process received append_vec_files
-        let (exit_sender, exit_receiver) = unbounded();
-        for _ in 0..rebuilder.num_threads {
-            Self::spawn_receiver_thread(&thread_pool, exit_sender.clone(), rebuilder.clone());
-        }
-        drop(exit_sender); // drop otherwise loop below will never end
-
-        // wait for asynchronous threads to complete
-        rebuilder.wait_for_completion(exit_receiver)?;
-        Ok(Arc::try_unwrap(rebuilder).unwrap().storage)
-    }
-
-    /// Processes buffered append_vec_files
-    fn process_buffered_files(&self, append_vec_files: Vec<FileInfo>) -> Result<(), SnapshotError> {
-        append_vec_files
-            .into_par_iter()
-            .map(|file_info| self.process_append_vec_file(file_info))
-            .collect::<Result<(), SnapshotError>>()
-    }
-
-    /// Spawn a single thread to process received append_vec_files
-    fn spawn_receiver_thread(
-        thread_pool: &ThreadPool,
-        exit_sender: Sender<Result<(), SnapshotError>>,
-        rebuilder: Arc<SnapshotStorageRebuilder>,
-    ) {
-        thread_pool.spawn(move || {
-            for file_info in rebuilder.file_receiver.iter() {
-                match rebuilder.process_append_vec_file(file_info) {
-                    Ok(_) => {}
-                    Err(err) => {
-                        exit_sender
-                            .send(Err(err))
-                            .expect("sender should be connected");
-                        return;
-                    }
-                }
+        for file_info in files {
+            rebuilder.process_append_vec_file(file_info)?;
+            let now = Instant::now();
+            if now.duration_since(last_log_time) >= PROGRESS_LOG_INTERVAL {
+                rebuilder.log_progress();
+                last_log_time = now;
             }
+        }
 
-            exit_sender
-                .send(Ok(()))
-                .expect("sender should be connected");
-        })
+        Ok(rebuilder.storage)
     }
 
-    /// Process an append_vec_file
-    fn process_append_vec_file(&self, file_info: FileInfo) -> Result<(), SnapshotError> {
+    fn log_progress(&self) {
+        info!(
+            "rebuilt storages for {}/{} slots with {} collisions",
+            self.processed_slot_count,
+            self.snapshot_storage_lengths.len(),
+            self.num_collisions,
+        );
+    }
+
+    fn process_append_vec_file(&mut self, file_info: FileInfo) -> Result<(), SnapshotError> {
         let filename = file_info.path.file_name().unwrap().to_str().unwrap();
         if let Ok((slot, append_vec_id)) = get_slot_and_append_vec_id(filename) {
             if self.snapshot_from == SnapshotFrom::Dir {
@@ -167,13 +99,17 @@ impl SnapshotStorageRebuilder {
                     .fetch_max((append_vec_id + 1) as AccountsFileId, Ordering::Relaxed);
             }
             self.process_complete_slot(slot, file_info)?;
-            self.processed_slot_count.fetch_add(1, Ordering::AcqRel);
+            self.processed_slot_count += 1;
         }
         Ok(())
     }
 
     /// Process a slot that has received all storage entries
-    fn process_complete_slot(&self, slot: Slot, file_info: FileInfo) -> Result<(), SnapshotError> {
+    fn process_complete_slot(
+        &mut self,
+        slot: Slot,
+        file_info: FileInfo,
+    ) -> Result<(), SnapshotError> {
         let filename = file_info.path.file_name().unwrap().to_str().unwrap();
         let (_, old_append_vec_id) = get_slot_and_append_vec_id(filename)?;
         let Some(&current_len) = self.snapshot_storage_lengths.get(&slot) else {
@@ -189,7 +125,7 @@ impl SnapshotStorageRebuilder {
                 current_len,
                 file_info,
                 &self.next_append_vec_id,
-                &self.num_collisions,
+                &mut self.num_collisions,
             )?,
             SnapshotFrom::Dir => reconstruct_single_storage(
                 &slot,
@@ -198,7 +134,7 @@ impl SnapshotStorageRebuilder {
                 old_append_vec_id as AccountsFileId,
                 self.obsolete_accounts
                     .remove(&slot)
-                    .map(|(_, accounts)| accounts.into_tuple()),
+                    .map(|accounts| accounts.into_tuple()),
             )?,
         };
 
@@ -212,48 +148,6 @@ impl SnapshotStorageRebuilder {
         } else {
             Ok(())
         }
-    }
-
-    /// Wait for the completion of the rebuilding threads
-    fn wait_for_completion(
-        &self,
-        exit_receiver: Receiver<Result<(), SnapshotError>>,
-    ) -> Result<(), SnapshotError> {
-        let num_slots = self.snapshot_storage_lengths.len();
-        let mut last_log_time = Instant::now();
-        loop {
-            select! {
-                recv(exit_receiver) -> maybe_exit_signal => {
-                    match maybe_exit_signal {
-                        Ok(Ok(_)) => continue, // thread exited successfully
-                        Ok(Err(err)) => { // thread exited with error
-                            return Err(err);
-                        }
-                        Err(_) => break, // all threads have exited - channel disconnected
-                    }
-                }
-                default(std::time::Duration::from_millis(100)) => {
-                    let now = Instant::now();
-                    if now.duration_since(last_log_time).as_millis() >= 2000 {
-                        let num_processed_slots = self.processed_slot_count.load(Ordering::Relaxed);
-                        let num_collisions = self.num_collisions.load(Ordering::Relaxed);
-                        info!("rebuilt storages for {num_processed_slots}/{num_slots} slots with {num_collisions} collisions");
-                        last_log_time = now;
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Builds thread pool to rebuild with
-    fn build_thread_pool(&self) -> ThreadPool {
-        ThreadPoolBuilder::default()
-            .thread_name(|i| format!("solRbuildSnap{i:02}"))
-            .num_threads(self.num_threads)
-            .build()
-            .expect("new rayon threadpool")
     }
 }
 

--- a/snapshots/src/hardened_unpack.rs
+++ b/snapshots/src/hardened_unpack.rs
@@ -87,7 +87,7 @@ enum UnpackPath<'a> {
 #[allow(clippy::arithmetic_side_effects)]
 fn unpack_archive<'a, C>(
     input: impl Read,
-    mut file_creator: Box<dyn FileCreator>,
+    mut file_creator: Box<dyn FileCreator + '_>,
     apparent_limit_size: u64,
     actual_limit_size: u64,
     limit_count: u64,
@@ -315,7 +315,7 @@ fn validate_inside_dst(dst: &Path, file_dst: &Path) -> Result<PathBuf> {
 /// sends entry file paths through the `sender` channel
 pub(super) fn streaming_unpack_snapshot(
     input: impl Read,
-    file_creator: Box<dyn FileCreator>,
+    file_creator: Box<dyn FileCreator + '_>,
     ledger_dir: &Path,
     account_paths: &[PathBuf],
 ) -> Result<()> {
@@ -324,7 +324,7 @@ pub(super) fn streaming_unpack_snapshot(
 
 fn unpack_snapshot_with_processors<F>(
     input: impl Read,
-    file_creator: Box<dyn FileCreator>,
+    file_creator: Box<dyn FileCreator + '_>,
     ledger_dir: &Path,
     account_paths: &[PathBuf],
     mut accounts_path_processor: F,
@@ -417,7 +417,7 @@ fn is_valid_snapshot_archive_entry(parts: &[&str], kind: tar::EntryType) -> bool
 
 pub(super) fn unpack_genesis(
     input: impl Read,
-    file_creator: Box<dyn FileCreator>,
+    file_creator: Box<dyn FileCreator + '_>,
     unpack_dir: &Path,
     max_genesis_archive_unpacked_size: u64,
 ) -> Result<()> {

--- a/snapshots/src/unarchive.rs
+++ b/snapshots/src/unarchive.rs
@@ -1,15 +1,17 @@
 use {
     crate::{
         ArchiveFormat, ArchiveFormatDecompressor,
+        error::SnapshotError,
         hardened_unpack::{self, UnpackError},
     },
     agave_fs::{FileInfo, buffered_reader, file_io::file_creator, io_setup::IoSetupState},
     bzip2::bufread::BzDecoder,
-    crossbeam_channel::Sender,
+    crossbeam_channel::{SendError, Sender},
     std::{
         fs,
         io::{self, BufRead, BufReader},
         path::{Path, PathBuf},
+        sync::OnceLock,
         thread::{self, Scope, ScopedJoinHandle},
         time::Instant,
     },
@@ -33,8 +35,10 @@ pub fn streaming_unarchive_snapshot<'scope, 'env: 'scope>(
     snapshot_archive_path: PathBuf,
     archive_format: ArchiveFormat,
     io_setup: &'env IoSetupState,
-) -> ScopedJoinHandle<'scope, Result<(), UnpackError>> {
+) -> ScopedJoinHandle<'scope, Result<(), SnapshotError>> {
     let do_unpack = move |archive_path: &Path| {
+        let first_failed_send = OnceLock::<PathBuf>::new();
+        let first_failed_send_ref = &first_failed_send;
         let (decompressor, file_creator) = {
             // Bound the buffers based on input archive size (decompression multiplies content size,
             // but buffering more than origin isn't necessary).
@@ -47,15 +51,15 @@ pub fn streaming_unarchive_snapshot<'scope, 'env: 'scope>(
             (
                 decompressor,
                 file_creator(write_buf_size, io_setup, move |file_info| {
-                    let result = file_sender.send(file_info);
-                    if let Err(err) = result {
-                        panic!(
-                            "failed to send path '{}' from unpacker to rebuilder: {err}",
-                            err.0.path.display(),
-                        );
+                    match file_sender.send(file_info) {
+                        // Channel owns the file now — don't pass it back for closing.
+                        Ok(()) => None,
+                        Err(SendError(FileInfo { file, path, .. })) => {
+                            let _ = first_failed_send_ref.set(path);
+                            // Hand the file back so the creator closes it.
+                            Some(file)
+                        }
                     }
-                    // Don't pass `File` back to file creator, so it's not closed (owned by channel now)
-                    None
                 })?,
             )
         };
@@ -66,13 +70,16 @@ pub fn streaming_unarchive_snapshot<'scope, 'env: 'scope>(
             ledger_dir.as_path(),
             &account_paths,
         )
+        .map(|()| first_failed_send.into_inner())
     };
-
     thread::Builder::new()
         .name("solTarUnpack".to_string())
-        .spawn_scoped(scope, move || {
-            do_unpack(&snapshot_archive_path)
-                .map_err(|err| UnpackError::Unpack(Box::new(err), snapshot_archive_path))
+        .spawn_scoped(scope, move || -> Result<(), SnapshotError> {
+            match do_unpack(&snapshot_archive_path) {
+                Err(err) => Err(UnpackError::Unpack(Box::new(err), snapshot_archive_path).into()),
+                Ok(Some(path)) => Err(SnapshotError::CrossbeamSend(SendError(path))),
+                Ok(None) => Ok(()),
+            }
         })
         .unwrap()
 }


### PR DESCRIPTION
#### Problem
`SnapshotStorageRebuilder` is using lots of threds to a workload that is nowdays very light. It would as well (or faster) be done on single thread.

#### Summary of Changes
Remove threadpool usage in `SnapshotStorageRebuilder`, however still do the processing on different thread than:
* unpacking archive (when loading from snapshot archives)
* opening files and producing `FileInfo` for all storages (when loading from dir / fastboot)

File opening (from dir) / file renaming (consolidating incremental and full archive storages names) becomes a bottleneck for startup, however overall we are still the same or faster than before. 

##### Performance analysis
###### Load from archive
Rebuilding storages happens on separate thread from unpacking, so most of the processing (updating maps and renaming) happens in parallel with writing out files. The exception is the incremental unpack at the end, which is pretty fast, but we pay a const high price for deserializing snapshot manifest from it on the rebuilder thread. Only after that rebuilder goes on to rename files which takes around 1.4s. Note that the gap between end of unpacking and start of index generation is ~800ms, this is how long deserialization + rename stays on the critical path:
<img width="2866" height="1852" alt="from-archive-pr" src="https://github.com/user-attachments/assets/7209346c-61a5-4b4b-8c6c-aeb3b421920c" />

Compare it to master where waiting for rayon threads to complete takes 1.9s and it's actually the same as gap between end of unpacking and generating index:
<img width="2616" height="1714" alt="from-archive-master" src="https://github.com/user-attachments/assets/ca1a9f93-9fcd-4a5d-b08e-e50658584b74" />

###### Fastboot
During fastboot we do open files on separate thread (`solSnapDirFiles`) and it is the bottleneck now, after it's done, we start indexing.
[
<img width="2594" height="1828" alt="from-dir-pr" src="https://github.com/user-attachments/assets/71985d11-4e19-4df3-9a21-594652aa3d9d" />
](url)

Validator log shows a slight speedup:
```
master:
solana_runtime::snapshot_bank_utils] rebuild storages from snapshot dir took 1.4s

PR:
solana_runtime::snapshot_bank_utils] rebuild storages from snapshot dir took 1.2s
```