### PR TITLE
Gossip sigverify optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,6 +2598,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "ed25519 2.2.3",
+ "merlin",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
@@ -8458,6 +8459,7 @@ dependencies = [
  "bv",
  "criterion",
  "crossbeam-channel",
+ "ed25519-dalek 2.2.0",
  "flate2",
  "indexmap 2.14.0",
  "itertools 0.14.0",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -39,6 +39,7 @@ arc-swap = { workspace = true }
 assert_matches = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 crossbeam-channel = { workspace = true }
+ed25519-dalek = { version = "2.1", features = ["batch"] }
 flate2 = { workspace = true }
 indexmap = { workspace = true, features = ["rayon"] }
 itertools = { workspace = true }

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -4,7 +4,7 @@ use {
         crds_data::{CrdsData, EpochSlotsIndex, VoteIndex},
         duplicate_shred::DuplicateShredIndex,
         epoch_slots::EpochSlots,
-        verifying_key_cache,
+        verified_crds_cache, verifying_key_cache,
     },
     rand::Rng,
     serde::{Deserialize, Serialize, de::Deserializer},
@@ -54,27 +54,40 @@ impl Signable for CrdsValue {
     }
 
     fn set_signature(&mut self, signature: Signature) {
-        self.signature = signature
+        self.signature = signature;
+        // Keep self.hash consistent with the new signature: callers (CRDS
+        // shards, pull filters, the verified-CRDS cache) treat hash as the
+        // value's identity.
+        let serialized_data =
+            wincode::serialize(&self.data).expect("failed to serialize CrdsData");
+        self.hash = solana_sha256_hasher::hashv(&[signature.as_ref(), &serialized_data]);
     }
 
     fn verify(&self) -> bool {
+        if verified_crds_cache::contains(&self.hash) {
+            return true;
+        }
         let pubkey = self.pubkey();
         let signable_data = self.signable_data();
         let message = signable_data.borrow();
         let sig_bytes: [u8; 64] = self.signature.into();
         let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
-        if let Some(vk) = verifying_key_cache::get(&pubkey) {
-            return vk.verify_strict(message, &signature).is_ok();
-        }
-        let Ok(vk) = ed25519_dalek::VerifyingKey::try_from(pubkey.as_ref()) else {
-            return false;
-        };
-        if vk.verify_strict(message, &signature).is_ok() {
-            verifying_key_cache::insert(pubkey, vk);
-            true
+        let (vk, fresh_vk) = if let Some(vk) = verifying_key_cache::get(&pubkey) {
+            (vk, false)
         } else {
-            false
+            let Ok(vk) = ed25519_dalek::VerifyingKey::try_from(pubkey.as_ref()) else {
+                return false;
+            };
+            (vk, true)
+        };
+        if vk.verify_strict(message, &signature).is_err() {
+            return false;
         }
+        if fresh_vk {
+            verifying_key_cache::insert(pubkey, vk);
+        }
+        verified_crds_cache::insert(self.hash);
+        true
     }
 }
 
@@ -82,18 +95,27 @@ impl Signable for CrdsValue {
 /// basepoint scalar multiplication. Returns true only if every signature
 /// verifies; on any failure the whole slice is rejected.
 pub(crate) fn verify_signatures_batch(values: &[CrdsValue]) -> bool {
-    // For a single value the batch transcript + RNG setup outweighs the saved
-    // basepoint multiplication, so fall back to scalar verify.
-    if values.len() < 2 {
-        return values.iter().all(CrdsValue::verify);
+    // Drop values whose (signature, data) hash is already known-verified.
+    // Gossip flood-broadcasts mean most incoming values are re-broadcasts of
+    // ones we've already processed, so this typically removes the bulk of the
+    // batch.
+    let unverified: Vec<&CrdsValue> = values
+        .iter()
+        .filter(|v| !verified_crds_cache::contains(&v.hash))
+        .collect();
+    if unverified.len() < 2 {
+        // For a single value the batch transcript + RNG setup outweighs the
+        // saved basepoint multiplication, so fall back to scalar verify.
+        return unverified.iter().all(|v| v.verify());
     }
-    let mut messages_owned: Vec<Vec<u8>> = Vec::with_capacity(values.len());
-    let mut signatures: Vec<ed25519_dalek::Signature> = Vec::with_capacity(values.len());
-    let mut verifying_keys: Vec<ed25519_dalek::VerifyingKey> = Vec::with_capacity(values.len());
-    // Indices in `values`/`verifying_keys` whose VK was freshly decompressed on
-    // this call. Promoted into the cache only if the batch verifies.
+    let mut messages_owned: Vec<Vec<u8>> = Vec::with_capacity(unverified.len());
+    let mut signatures: Vec<ed25519_dalek::Signature> = Vec::with_capacity(unverified.len());
+    let mut verifying_keys: Vec<ed25519_dalek::VerifyingKey> =
+        Vec::with_capacity(unverified.len());
+    // Indices in `unverified` whose VK was freshly decompressed on this call.
+    // Promoted into the cache only if the batch verifies.
     let mut miss_indices: Vec<usize> = Vec::new();
-    for (i, value) in values.iter().enumerate() {
+    for (i, value) in unverified.iter().enumerate() {
         let pubkey = value.pubkey();
         let vk = if let Some(vk) = verifying_key_cache::get(&pubkey) {
             vk
@@ -114,7 +136,10 @@ pub(crate) fn verify_signatures_batch(values: &[CrdsValue]) -> bool {
         return false;
     }
     for i in miss_indices {
-        verifying_key_cache::insert(values[i].pubkey(), verifying_keys[i]);
+        verifying_key_cache::insert(unverified[i].pubkey(), verifying_keys[i]);
+    }
+    for value in &unverified {
+        verified_crds_cache::insert(value.hash);
     }
     true
 }

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -4,6 +4,7 @@ use {
         crds_data::{CrdsData, EpochSlotsIndex, VoteIndex},
         duplicate_shred::DuplicateShredIndex,
         epoch_slots::EpochSlots,
+        verifying_key_cache,
     },
     rand::Rng,
     serde::{Deserialize, Serialize, de::Deserializer},
@@ -57,9 +58,65 @@ impl Signable for CrdsValue {
     }
 
     fn verify(&self) -> bool {
-        self.get_signature()
-            .verify(self.pubkey().as_ref(), self.signable_data().borrow())
+        let pubkey = self.pubkey();
+        let signable_data = self.signable_data();
+        let message = signable_data.borrow();
+        let sig_bytes: [u8; 64] = self.signature.into();
+        let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
+        if let Some(vk) = verifying_key_cache::get(&pubkey) {
+            return vk.verify_strict(message, &signature).is_ok();
+        }
+        let Ok(vk) = ed25519_dalek::VerifyingKey::try_from(pubkey.as_ref()) else {
+            return false;
+        };
+        if vk.verify_strict(message, &signature).is_ok() {
+            verifying_key_cache::insert(pubkey, vk);
+            true
+        } else {
+            false
+        }
     }
+}
+
+/// Batch-verifies signatures via `ed25519_dalek::verify_batch`, amortizing the
+/// basepoint scalar multiplication. Returns true only if every signature
+/// verifies; on any failure the whole slice is rejected.
+pub(crate) fn verify_signatures_batch(values: &[CrdsValue]) -> bool {
+    // For a single value the batch transcript + RNG setup outweighs the saved
+    // basepoint multiplication, so fall back to scalar verify.
+    if values.len() < 2 {
+        return values.iter().all(CrdsValue::verify);
+    }
+    let mut messages_owned: Vec<Vec<u8>> = Vec::with_capacity(values.len());
+    let mut signatures: Vec<ed25519_dalek::Signature> = Vec::with_capacity(values.len());
+    let mut verifying_keys: Vec<ed25519_dalek::VerifyingKey> = Vec::with_capacity(values.len());
+    // Indices in `values`/`verifying_keys` whose VK was freshly decompressed on
+    // this call. Promoted into the cache only if the batch verifies.
+    let mut miss_indices: Vec<usize> = Vec::new();
+    for (i, value) in values.iter().enumerate() {
+        let pubkey = value.pubkey();
+        let vk = if let Some(vk) = verifying_key_cache::get(&pubkey) {
+            vk
+        } else {
+            let Ok(vk) = ed25519_dalek::VerifyingKey::try_from(pubkey.as_ref()) else {
+                return false;
+            };
+            miss_indices.push(i);
+            vk
+        };
+        verifying_keys.push(vk);
+        let sig_bytes: [u8; 64] = (*value.signature()).into();
+        signatures.push(ed25519_dalek::Signature::from_bytes(&sig_bytes));
+        messages_owned.push(wincode::serialize(value.data()).expect("failed to serialize CrdsData"));
+    }
+    let messages: Vec<&[u8]> = messages_owned.iter().map(Vec::as_slice).collect();
+    if ed25519_dalek::verify_batch(&messages, &signatures, &verifying_keys).is_err() {
+        return false;
+    }
+    for i in miss_indices {
+        verifying_key_cache::insert(values[i].pubkey(), verifying_keys[i]);
+    }
+    true
 }
 
 /// Type of the replicated value

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -31,6 +31,7 @@ mod protocol;
 mod push_active_set;
 mod received_cache;
 pub mod restart_crds_values;
+mod verifying_key_cache;
 pub mod weighted_shuffle;
 
 #[macro_use]

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -31,6 +31,7 @@ mod protocol;
 mod push_active_set;
 mod received_cache;
 pub mod restart_crds_values;
+mod verified_crds_cache;
 mod verifying_key_cache;
 pub mod weighted_shuffle;
 

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -3,7 +3,7 @@ use {
     crate::{
         crds_data::{CrdsData, MAX_WALLCLOCK},
         crds_gossip_pull::CrdsFilter,
-        crds_value::CrdsValue,
+        crds_value::{CrdsValue, verify_signatures_batch},
         ping_pong::{self, Pong},
     },
     serde::{Deserialize, Serialize},
@@ -109,8 +109,8 @@ impl Protocol {
     pub(crate) fn verify(&self) -> bool {
         match self {
             Self::PullRequest(_, caller) => caller.verify(),
-            Self::PullResponse(_, data) => data.iter().all(CrdsValue::verify),
-            Self::PushMessage(_, data) => data.iter().all(CrdsValue::verify),
+            Self::PullResponse(_, data) => verify_signatures_batch(data),
+            Self::PushMessage(_, data) => verify_signatures_batch(data),
             Self::PruneMessage(_, data) => data.verify(),
             Self::PingMessage(ping) => ping.verify(),
             Self::PongMessage(pong) => pong.verify(),

--- a/gossip/src/verified_crds_cache.rs
+++ b/gossip/src/verified_crds_cache.rs
@@ -1,0 +1,41 @@
+//! Process-wide LRU of CrdsValue hashes whose Ed25519 signature has already
+//! been verified. Gossip flood-broadcasts mean the same (signature, data)
+//! tuple arrives many times within seconds; consulting this cache before
+//! sigverify lets duplicates skip the curve arithmetic entirely.
+//!
+//! The cache is keyed by `sha256(signature || serialized_data)` (already
+//! pre-computed and stored on each `CrdsValue`), so a hit is a guarantee that
+//! the *same* bytes were previously verified — no risk of confusing two
+//! different CrdsValues that happen to share a pubkey.
+//!
+//! Insertion policy mirrors [`crate::verifying_key_cache`]: only insert after
+//! a successful signature verification. An attacker who wants to churn this
+//! cache must produce a valid signature per entry, which costs them the same
+//! as honest gossip.
+
+use {
+    lazy_lru::LruCache,
+    solana_hash::Hash,
+    std::sync::{OnceLock, RwLock},
+};
+
+// 64Ki entries × (32-byte Hash + LRU overhead) ≈ a few MiB, covering several
+// seconds of worst-case gossip throughput from the live cluster.
+const CAPACITY: usize = 65536;
+
+fn cache() -> &'static RwLock<LruCache<Hash, ()>> {
+    static CACHE: OnceLock<RwLock<LruCache<Hash, ()>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(LruCache::new(CAPACITY)))
+}
+
+/// Returns true if a CrdsValue with this hash has already been verified during
+/// this process's lifetime (modulo LRU eviction).
+pub(crate) fn contains(hash: &Hash) -> bool {
+    cache().read().unwrap().get(hash).is_some()
+}
+
+/// Marks `hash` as verified. Call only after the surrounding signature has
+/// actually verified — see the module-level note on insertion policy.
+pub(crate) fn insert(hash: Hash) {
+    cache().write().unwrap().put(hash, ());
+}

--- a/gossip/src/verifying_key_cache.rs
+++ b/gossip/src/verifying_key_cache.rs
@@ -1,15 +1,8 @@
-//! Process-wide cache of decompressed Ed25519 verifying keys, keyed by the
-//! 32-byte pubkey. Decompressing the wire-format y-coordinate into an
-//! `EdwardsPoint` (`sqrt_ratio_i` / `pow_p58`) accounts for ~6-7% of CPU on the
-//! gossip receive path because the same validator pubkeys recur across every
-//! push/pull message. Memoising the decompressed point lets repeat verifies
-//! reuse it.
-//!
-//! Insertion policy: callers must only insert *after* the surrounding
-//! signature has verified. That forces an attacker who wants to churn cache
-//! entries to first produce a valid signature for each pubkey they insert,
-//! which means paying full sigverify cost. With a bounded LRU on top, the
-//! cache cannot be made cheaper to displace than honest gossip traffic.
+//! Process-wide cache of decompressed Ed25519 verifying keys. Pubkey
+//! decompression is ~6-7% of CPU on the gossip receive path; memoising it lets
+//! repeat verifies skip `sqrt_ratio_i`. Callers must only insert after the
+//! signature has verified, so churning the LRU costs an attacker a full
+//! sigverify per entry.
 
 use {
     lazy_lru::LruCache,
@@ -17,10 +10,7 @@ use {
     std::sync::{OnceLock, RwLock},
 };
 
-// Capacity in entries. Each entry is ~200 bytes (the `VerifyingKey` struct
-// holds the compressed bytes plus the decompressed `EdwardsPoint`), so 8192
-// entries is ~1.6 MiB. A live cluster has on the order of 1-3k validators, so
-// this comfortably covers the working set with headroom for transient peers.
+// 8192 entries × ~200 B/entry ≈ 1.6 MiB; covers a 1-3k-validator cluster.
 const CAPACITY: usize = 8192;
 
 fn cache() -> &'static RwLock<LruCache<Pubkey, ed25519_dalek::VerifyingKey>> {
@@ -28,15 +18,11 @@ fn cache() -> &'static RwLock<LruCache<Pubkey, ed25519_dalek::VerifyingKey>> {
     CACHE.get_or_init(|| RwLock::new(LruCache::new(CAPACITY)))
 }
 
-/// Returns the cached decompressed verifying key for `pubkey`, or `None` on
-/// miss. Does not insert; the caller is responsible for decompressing on miss
-/// and calling [`insert`] after the surrounding signature has verified.
 pub(crate) fn get(pubkey: &Pubkey) -> Option<ed25519_dalek::VerifyingKey> {
     cache().read().unwrap().get(pubkey).copied()
 }
 
-/// Inserts `vk` into the cache. Call only after a signature has been verified
-/// against `vk` — see the module-level note on insertion policy.
+/// Insert only after a signature against `vk` has verified.
 pub(crate) fn insert(pubkey: Pubkey, vk: ed25519_dalek::VerifyingKey) {
     cache().write().unwrap().put(pubkey, vk);
 }

--- a/gossip/src/verifying_key_cache.rs
+++ b/gossip/src/verifying_key_cache.rs
@@ -1,0 +1,42 @@
+//! Process-wide cache of decompressed Ed25519 verifying keys, keyed by the
+//! 32-byte pubkey. Decompressing the wire-format y-coordinate into an
+//! `EdwardsPoint` (`sqrt_ratio_i` / `pow_p58`) accounts for ~6-7% of CPU on the
+//! gossip receive path because the same validator pubkeys recur across every
+//! push/pull message. Memoising the decompressed point lets repeat verifies
+//! reuse it.
+//!
+//! Insertion policy: callers must only insert *after* the surrounding
+//! signature has verified. That forces an attacker who wants to churn cache
+//! entries to first produce a valid signature for each pubkey they insert,
+//! which means paying full sigverify cost. With a bounded LRU on top, the
+//! cache cannot be made cheaper to displace than honest gossip traffic.
+
+use {
+    lazy_lru::LruCache,
+    solana_pubkey::Pubkey,
+    std::sync::{OnceLock, RwLock},
+};
+
+// Capacity in entries. Each entry is ~200 bytes (the `VerifyingKey` struct
+// holds the compressed bytes plus the decompressed `EdwardsPoint`), so 8192
+// entries is ~1.6 MiB. A live cluster has on the order of 1-3k validators, so
+// this comfortably covers the working set with headroom for transient peers.
+const CAPACITY: usize = 8192;
+
+fn cache() -> &'static RwLock<LruCache<Pubkey, ed25519_dalek::VerifyingKey>> {
+    static CACHE: OnceLock<RwLock<LruCache<Pubkey, ed25519_dalek::VerifyingKey>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(LruCache::new(CAPACITY)))
+}
+
+/// Returns the cached decompressed verifying key for `pubkey`, or `None` on
+/// miss. Does not insert; the caller is responsible for decompressing on miss
+/// and calling [`insert`] after the surrounding signature has verified.
+pub(crate) fn get(pubkey: &Pubkey) -> Option<ed25519_dalek::VerifyingKey> {
+    cache().read().unwrap().get(pubkey).copied()
+}
+
+/// Inserts `vk` into the cache. Call only after a signature has been verified
+/// against `vk` — see the module-level note on insertion policy.
+pub(crate) fn insert(pubkey: Pubkey, vk: ed25519_dalek::VerifyingKey) {
+    cache().write().unwrap().put(pubkey, vk);
+}


### PR DESCRIPTION
#### Problem

Sigverify is the number one consumer of CPU in gossip. Lots of the work is redundant
and can be removed.

#### Summary of Changes

1. Use batch signature verification.
2. Cache the decompressed form of each pubkey seen in gossip traffic (total keys in thousands).
3. Do not call sigverify on CrdsValues we already have and would drop anyway.