### PR TITLE
ci: Specify user-agent for crates.io curl

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -8,8 +8,10 @@ source ci/rust-version.sh stable
 is_crate_version_uploaded() {
   name=$1
   version=$2
-  curl https://crates.io/api/v1/crates/${name}/${version} | \
-  python3 -c "import sys,json; print('version' in json.load(sys.stdin));"
+  # crates.io API docs state to include a user-agent header:
+  # https://crates.io/data-access#api
+  curl --user-agent 'Anza (https://github.com/anza-xyz/agave)' https://crates.io/api/v1/crates/${name}/${version} |
+    python3 -c "import sys,json; print('version' in json.load(sys.stdin));"
 }
 
 # Only package/publish if this is a tagged release


### PR DESCRIPTION
#### Problem

From https://crates.io/data-access#api

> you are welcome to use the crates.io API provided you abide by the following limits:
> ...
> A user-agent header that identifies your application. We strongly suggest providing a way for us to contact you (whether through a repository, or an e-mail address, or whatever is appropriate) so that we can reach out to work with you should there be issues.

#### Summary of Changes

Set the user agent the same as in https://github.com/anza-xyz/agave/pull/12775