### PR TITLE
rpc-client: Add method to get latest blockhash with response context (notably `context.slot`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Release channels have their own copy of this changelog:
 ### RPC
 #### Breaking
 #### Changes
+* Added `RpcClient::get_latest_blockhash_with_commitment_and_context`, which returns the
+  `getLatestBlockhash` response together with its context (notably `context.slot`).
 ### Validator
 #### Breaking
 #### Deprecations

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -4942,20 +4942,46 @@ impl RpcClient {
         &self,
         commitment: CommitmentConfig,
     ) -> ClientResult<(Hash, u64)> {
-        let RpcBlockhash {
-            blockhash,
-            last_valid_block_height,
+        Ok(self
+            .get_latest_blockhash_with_commitment_and_context(commitment)
+            .await?
+            .value)
+    }
+
+    /// Returns the most recent blockhash and last valid block height along with the response
+    /// context, which includes the slot at which the node observed the blockhash.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getLatestBlockhash`] RPC method and uses the
+    /// provided [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    /// [`getLatestBlockhash`]: https://solana.com/docs/rpc/http/getlatestblockhash
+    pub async fn get_latest_blockhash_with_commitment_and_context(
+        &self,
+        commitment: CommitmentConfig,
+    ) -> RpcResult<(Hash, u64)> {
+        let Response {
+            context,
+            value:
+                RpcBlockhash {
+                    blockhash,
+                    last_valid_block_height,
+                },
         } = self
             .send::<Response<RpcBlockhash>>(RpcRequest::GetLatestBlockhash, json!([commitment]))
-            .await?
-            .value;
+            .await?;
         let blockhash = blockhash.parse().map_err(|_| {
             ClientError::new_with_request(
                 RpcError::ParseError("Hash".to_string()).into(),
                 RpcRequest::GetLatestBlockhash,
             )
         })?;
-        Ok((blockhash, last_valid_block_height))
+        Ok(Response {
+            context,
+            value: (blockhash, last_valid_block_height),
+        })
     }
 
     /// Checks whether a blockhash is still valid for submitting transactions.

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -4211,6 +4211,25 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).get_latest_blockhash_with_commitment(commitment))
     }
 
+    /// Returns the most recent blockhash and last valid block height along with the response
+    /// context, which includes the slot at which the node observed the blockhash.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getLatestBlockhash`] RPC method and uses the
+    /// provided [commitment level][cl].
+    ///
+    /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
+    /// [`getLatestBlockhash`]: https://solana.com/docs/rpc/http/getlatestblockhash
+    pub fn get_latest_blockhash_with_commitment_and_context(
+        &self,
+        commitment: CommitmentConfig,
+    ) -> RpcResult<(Hash, u64)> {
+        self.invoke(
+            (self.rpc_client.as_ref()).get_latest_blockhash_with_commitment_and_context(commitment),
+        )
+    }
+
     /// Checks whether a blockhash is still valid for submitting transactions.
     ///
     /// # RPC Reference
@@ -5123,5 +5142,22 @@ mod tests {
 
         let fee: u64 = rpc_client.get_fee_for_message(&message).unwrap();
         assert_eq!(fee, 42);
+    }
+
+    #[test]
+    fn test_get_latest_blockhash_with_commitment_and_context() {
+        let rpc_client = RpcClient::new_mock("succeeds".to_string());
+        let expected_blockhash: Hash = PUBKEY.parse().unwrap();
+
+        let response = rpc_client
+            .get_latest_blockhash_with_commitment_and_context(CommitmentConfig::default())
+            .unwrap();
+        assert_eq!(response.context.slot, 1);
+        assert_eq!(response.value, (expected_blockhash, 1234));
+
+        let value = rpc_client
+            .get_latest_blockhash_with_commitment(CommitmentConfig::default())
+            .unwrap();
+        assert_eq!(value, response.value);
     }
 }


### PR DESCRIPTION
#### Problem

`RpcClient::get_latest_blockhash_with_commitment` returns only (Hash, last_valid_block_height), dropping the `context.slot` from the `getLatestBlockhash` response. Callers that need both the blockhash and the slot it was observed at currently have to bypass the typed API and issue a raw `send::<Response<RpcBlockhash>>(...)`.

#### Summary of Changes

- Add `get_latest_blockhash_with_commitment_and_context` (blocking and nonblocking), returning `RpcResult<(Hash, u64)>` so the response context is preserved.
- Route the existing `get_latest_blockhash_with_commitment` through it; behavior is unchanged and the parse logic is not duplicated.
- Add a unit test and a changelog entry.
