### PR TITLE
perf(gossip): batch-verify signatures on push/pull-response packets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,6 +2598,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "ed25519 2.2.3",
+ "merlin",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
@@ -8458,6 +8459,7 @@ dependencies = [
  "bv",
  "criterion",
  "crossbeam-channel",
+ "ed25519-dalek 2.2.0",
  "flate2",
  "indexmap 2.14.0",
  "itertools 0.14.0",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -2188,6 +2188,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "ed25519 2.2.3",
+ "merlin",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
@@ -7169,6 +7170,7 @@ dependencies = [
  "assert_matches",
  "bv",
  "crossbeam-channel",
+ "ed25519-dalek 2.2.0",
  "flate2",
  "indexmap",
  "itertools 0.14.0",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -39,6 +39,7 @@ arc-swap = { workspace = true }
 assert_matches = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 crossbeam-channel = { workspace = true }
+ed25519-dalek = { version = "2.1", features = ["batch"] }
 flate2 = { workspace = true }
 indexmap = { workspace = true, features = ["rayon"] }
 itertools = { workspace = true }

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -62,6 +62,31 @@ impl Signable for CrdsValue {
     }
 }
 
+/// Batch-verifies signatures via `ed25519_dalek::verify_batch`, amortizing the
+/// basepoint scalar multiplication. Returns true only if every signature
+/// verifies; on any failure the whole slice is rejected.
+pub(crate) fn verify_signatures_batch(values: &[CrdsValue]) -> bool {
+    // For a single value the batch transcript + RNG setup outweighs the saved
+    // basepoint multiplication, so fall back to scalar verify.
+    if values.len() < 2 {
+        return values.iter().all(CrdsValue::verify);
+    }
+    let mut messages_owned: Vec<Vec<u8>> = Vec::with_capacity(values.len());
+    let mut signatures: Vec<ed25519_dalek::Signature> = Vec::with_capacity(values.len());
+    let mut verifying_keys: Vec<ed25519_dalek::VerifyingKey> = Vec::with_capacity(values.len());
+    for value in values {
+        let Ok(vk) = ed25519_dalek::VerifyingKey::try_from(value.pubkey().as_ref()) else {
+            return false;
+        };
+        verifying_keys.push(vk);
+        let sig_bytes: [u8; 64] = value.signature.into();
+        signatures.push(ed25519_dalek::Signature::from_bytes(&sig_bytes));
+        messages_owned.push(wincode::serialize(&value.data).expect("failed to serialize CrdsData"));
+    }
+    let messages: Vec<&[u8]> = messages_owned.iter().map(Vec::as_slice).collect();
+    ed25519_dalek::verify_batch(&messages, &signatures, &verifying_keys).is_ok()
+}
+
 /// Type of the replicated value
 /// These are labels for values in a record that is associated with `Pubkey`
 #[derive(PartialEq, Hash, Eq, Clone, Debug)]

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -3,7 +3,7 @@ use {
     crate::{
         crds_data::{CrdsData, MAX_WALLCLOCK},
         crds_gossip_pull::CrdsFilter,
-        crds_value::CrdsValue,
+        crds_value::{CrdsValue, verify_signatures_batch},
         ping_pong::{self, Pong},
     },
     serde::{Deserialize, Serialize},
@@ -109,8 +109,8 @@ impl Protocol {
     pub(crate) fn verify(&self) -> bool {
         match self {
             Self::PullRequest(_, caller) => caller.verify(),
-            Self::PullResponse(_, data) => data.iter().all(CrdsValue::verify),
-            Self::PushMessage(_, data) => data.iter().all(CrdsValue::verify),
+            Self::PullResponse(_, data) => verify_signatures_batch(data),
+            Self::PushMessage(_, data) => verify_signatures_batch(data),
             Self::PruneMessage(_, data) => data.verify(),
             Self::PingMessage(ping) => ping.verify(),
             Self::PongMessage(pong) => pong.verify(),

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -2098,6 +2098,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "ed25519 2.2.3",
+ "merlin",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
@@ -7002,6 +7003,7 @@ dependencies = [
  "assert_matches",
  "bv",
  "crossbeam-channel",
+ "ed25519-dalek 2.2.0",
  "flate2",
  "indexmap",
  "itertools 0.14.0",


### PR DESCRIPTION
### perf(gossip): batch-verify signatures on push/pull-response packets

`Protocol::verify` for `PullResponse` and `PushMessage` calls
`ed25519_dalek::VerifyingKey::verify_strict` once per `CrdsValue`. Profiling a
`solana-gossip spy` against mainnet shows ~50 % of consumer-thread CPU lives
inside those per-signature `verify_strict` calls, dominated by the basepoint
scalar multiplication in `vartime_double_scalar_mul_basepoint`.

This change replaces the per-item loop with `ed25519_dalek::verify_batch` for
the multi-value variants, which uses Straus multi-scalar multiplication to
amortize the basepoint mul across all signatures in the packet. For a single
value the function falls back to scalar verify (batch transcript + RNG setup
outweighs the saved basepoint mul at n=1). On any batch failure the whole
packet is dropped, matching the prior `iter().all(CrdsValue::verify)`
semantics.

`ed25519_dalek::verify_batch` is slightly looser than `verify_strict` — it
doesn't enforce canonical encoding of the signature's R point. This is the
documented malleability quirk in ed25519-dalek's `batch` module and is not a
forgery vector (the signature still binds to message + pubkey). Gossip
downstream identifies values by their precomputed CrdsValue hash, not by R
canonicalization, so the looser check is acceptable here.

### Results

30 s `perf record -F 99 --call-graph dwarf` against `solana-gossip spy` on the
live cluster, this branch vs `origin/master` (apples-to-apples build flags).
Total cycles per window vary with offered cluster traffic — share-of-CPU is
the stable signal.

| Symbol / metric (sum across 8 consumer threads) | baseline | this PR | Δ |
|---|---|---|---|
| `run_socket_consume::verify_packet` share | 47.1 % | 41.9 % | −11 % rel |
| `VerifyingKey::verify_strict` share | 42.1 % | 17.7 % | **−58 % rel** |
| `ed25519_dalek::batch::verify_batch` share | 0 % | 17.3 % | new path |
| `FieldElement2625x4::square_and_negate_D` (self) | 9.6 % | 6.5 % | −32 % rel |
| `ExtendedPoint::double` (self) | 1.5 % | <0.5 % | −66 %+ rel |
| `FieldElement51::pow2k` (self) | 11.8 % | 11.9 % | unchanged |

The doubling-chain symbols inside `vartime_double_scalar_mul_basepoint` are
exactly the work Straus amortizes; `pow2k` is unchanged because it lives
inside the per-signature `CompressedEdwardsY::decompress` and is not affected
by batching.
