### PR TITLE
ci: have GitHub Actions only check repository owner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   benchmark:
-    if: github.repository == 'anza-xyz/agave'
+    if: github.repository_owner == 'anza-xyz'
     name: benchmark
     runs-on: benchmark
     strategy:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   version-bump:
-    if: github.repository == 'anza-xyz/agave'
+    if: github.repository_owner == 'anza-xyz'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   clippy-nightly:
-    if: github.repository == 'anza-xyz/agave'
+    if: github.repository_owner == 'anza-xyz'
     strategy:
       matrix:
         os:
@@ -69,7 +69,7 @@ jobs:
 
   clippy-nightly-windows-2025:
     name: clippy-nightly (windows-2025)
-    if: github.repository == 'anza-xyz/agave' && github.event_name == 'push'
+    if: github.repository_owner == 'anza-xyz' && github.event_name == 'push'
     runs-on: windows-2025
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/crate-check.yml
+++ b/.github/workflows/crate-check.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   check:
     name: crate check
-    if: github.repository == 'anza-xyz/agave'
+    if: github.repository_owner == 'anza-xyz'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'anza-xyz/agave'
+    if: github.repository_owner == 'anza-xyz'
     outputs:
       continue: ${{ steps.check.outputs.need_to_build }}
     runs-on: ubuntu-22.04
@@ -70,7 +70,7 @@ jobs:
     needs:
       - check
     if: >
-      github.repository == 'anza-xyz/agave' &&
+      github.repository_owner == 'anza-xyz' &&
       needs.check.outputs.continue == 1
     runs-on: ubuntu-22.04
     steps:
@@ -106,7 +106,7 @@ jobs:
     needs:
       - build
     if: >
-      github.repository == 'anza-xyz/agave' &&
+      github.repository_owner == 'anza-xyz' &&
       github.event_name == 'push'
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/downstream-project-anchor.yml
+++ b/.github/workflows/downstream-project-anchor.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   test:
-    #if: github.repository == 'anza-xyz/agave'
+    #if: github.repository_owner == 'anza-xyz'
     if: false # restore once all program-specific repos are ready
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/downstream-project-spl-nightly.yml
+++ b/.github/workflows/downstream-project-spl-nightly.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   main:
-    if: github.repository == 'anza-xyz/agave'
+    if: github.repository_owner == 'anza-xyz'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   check:
-    #if: github.repository == 'anza-xyz/agave'
+    #if: github.repository_owner == 'anza-xyz'
     if: false
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -75,7 +75,7 @@ jobs:
           cargo check
 
   test_cli:
-    #if: github.repository == 'anza-xyz/agave'
+    #if: github.repository_owner == 'anza-xyz'
     if: false
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -106,7 +106,7 @@ jobs:
           cargo test --manifest-path clients/cli/Cargo.toml
 
   cargo-test-sbf:
-    #if: github.repository == 'anza-xyz/agave'
+    #if: github.repository_owner == 'anza-xyz'
     if: false
     runs-on: ubuntu-24.04
     timeout-minutes: 60

--- a/.github/workflows/manage-stale-issues.yml
+++ b/.github/workflows/manage-stale-issues.yml
@@ -21,7 +21,7 @@ jobs:
     # Forks do not need to run this, especially on cron schedule.
     if: >
       github.event_name != 'schedule'
-      || github.repository == 'anza-xyz/agave'
+      || github.repository_owner == 'anza-xyz'
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   trigger-buildkite-pipeline:
-    if: github.repository == 'anza-xyz/agave'
+    if: github.repository_owner == 'anza-xyz'
     runs-on: ubuntu-24.04
     steps:
       - name: Trigger a Buildkite Build
@@ -21,7 +21,7 @@ jobs:
           message: ":github: Triggered from a GitHub Action"
 
   draft-release:
-    if: github.repository == 'anza-xyz/agave'
+    if: github.repository_owner == 'anza-xyz'
     runs-on: ubuntu-24.04
     steps:
       - name: Create Release

--- a/.github/workflows/trigger-buildkite-pipeline.yml
+++ b/.github/workflows/trigger-buildkite-pipeline.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   member_check:
     runs-on: ubuntu-24.04
-    if: github.repository == 'anza-xyz/agave' && github.event.action != 'labeled'
+    if: github.repository_owner == 'anza-xyz' && github.event.action != 'labeled'
     outputs:
       should_trigger: ${{ steps.check.outputs.should_trigger }}
     permissions:
@@ -51,7 +51,7 @@ jobs:
 
   label_check:
     runs-on: ubuntu-24.04
-    if: github.repository == 'anza-xyz/agave' && github.event.action == 'labeled' && github.event.label.name == 'CI'
+    if: github.repository_owner == 'anza-xyz' && github.event.action == 'labeled' && github.event.label.name == 'CI'
     outputs:
       should_trigger: ${{ steps.check.outputs.should_trigger }}
     permissions:


### PR DESCRIPTION
#### Problem

AFAICS, We'll have a some more different feature-based forks. However, the current GitHub Actions validation is too strict.     Each fork would need a custom workaround before it is fully ready.

#### Summary of Changes

let's just check owner instead of owner + repo