### PR TITLE
ChannelSend: remove blocking send

### DIFF
--- a/streamer/src/evicting_sender.rs
+++ b/streamer/src/evicting_sender.rs
@@ -1,6 +1,6 @@
 use {
     crate::streamer::ChannelSend,
-    crossbeam_channel::{Receiver, SendError, Sender, TryRecvError, TrySendError, bounded},
+    crossbeam_channel::{Receiver, Sender, TryRecvError, TrySendError, bounded},
 };
 
 /// A sender implementation that evicts the oldest message when the channel is full.
@@ -38,11 +38,6 @@ impl<T> ChannelSend<T> for EvictingSender<T>
 where
     T: Send + 'static,
 {
-    #[inline]
-    fn send(&self, msg: T) -> std::result::Result<(), SendError<T>> {
-        self.sender.send(msg)
-    }
-
     fn try_send(&self, msg: T) -> std::result::Result<(), TrySendError<T>> {
         let Err(e) = self.sender.try_send(msg) else {
             return Ok(());

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -40,8 +40,6 @@ use {
 };
 
 pub trait ChannelSend<T>: Send + 'static {
-    fn send(&self, msg: T) -> std::result::Result<(), SendError<T>>;
-
     fn try_send(&self, msg: T) -> std::result::Result<(), TrySendError<T>>;
 
     fn is_empty(&self) -> bool;
@@ -53,11 +51,6 @@ impl<T> ChannelSend<T> for Sender<T>
 where
     T: Send + 'static,
 {
-    #[inline]
-    fn send(&self, msg: T) -> std::result::Result<(), SendError<T>> {
-        self.send(msg)
-    }
-
     #[inline]
     fn try_send(&self, msg: T) -> std::result::Result<(), TrySendError<T>> {
         self.try_send(msg)


### PR DESCRIPTION
#### Problem
- Implementing a *blocking* send on `EvictingSender` is a footgun. It defeats the entire purpose of the type
- We missed a blocking send when converting banking_trace to use `EvictingSender`:
	- https://github.com/anza-xyz/agave/pull/12778 (bug here)
	- https://github.com/anza-xyz/agave/pull/12812 (revert here)
	- https://github.com/anza-xyz/agave/pull/12816 (fixed here)

#### Summary of Changes
- Remove `send` fn from `ChannelSend` trait
- Remove unused imports

Fixes #
