### PR TITLE
WIP: perf(svm): reuse BPF VM input buffer via thread-local pool

### DIFF
--- a/program-runtime/src/aligned_buffer.rs
+++ b/program-runtime/src/aligned_buffer.rs
@@ -1,0 +1,334 @@
+//! Aligned byte buffer with a thread-local pool for reuse.
+//!
+//! The BPF VM input region (the buffer holding serialized instruction
+//! parameters) is allocated fresh on every program invocation in
+//! [`crate::serialization::serialize_parameters`]. On a live validator this
+//! is the single largest source of page faults — ~36% of all faults — because
+//! the buffer grows large enough that jemalloc obtains it via `mmap` and
+//! returns it to the OS on free, faulting on every first touch the next time.
+//!
+//! `solana_sbpf::AlignedMemory` cannot be cleared or reset (its internal
+//! length is private and `debug_assert!`s against shrinking), so this module
+//! provides a minimal local equivalent that supports `clear` + `reserve` and
+//! ships with a per-thread pool. Each [`serialize_parameters`] call checks
+//! out a buffer; on drop the buffer returns to the pool with its capacity
+//! intact, so subsequent invocations reuse the same backing allocation and
+//! no longer fault.
+//!
+//! The buffer is `HOST_ALIGN`-aligned (16 bytes) to match
+//! `solana_sbpf`'s requirement on the BPF input region.
+//!
+//! [`serialize_parameters`]: crate::serialization::serialize_parameters
+
+use {
+    solana_sbpf::{aligned_memory::Pod, ebpf::HOST_ALIGN},
+    std::{
+        alloc::{Layout, alloc, dealloc, handle_alloc_error},
+        cell::RefCell,
+        mem::{ManuallyDrop, size_of},
+        ops::{Deref, DerefMut},
+        ptr::NonNull,
+    },
+};
+
+/// Upper bound on pooled buffers per thread. A SVM worker only holds a few
+/// buffers at once (one per CPI nesting level, bounded by
+/// `MAX_INSTRUCTION_STACK_HEIGHT`), so this cap is generous.
+const POOL_CAPACITY: usize = 16;
+
+/// Owned `HOST_ALIGN`-aligned byte buffer with separate length and capacity,
+/// supporting `clear` / `reserve` (which `solana_sbpf::AlignedMemory` does
+/// not). Used as the BPF VM input region in
+/// [`crate::serialization::serialize_parameters`].
+pub struct AlignedBuffer {
+    /// Dangling when `capacity == 0`; otherwise a `HOST_ALIGN`-aligned
+    /// allocation of `capacity` bytes.
+    ptr: NonNull<u8>,
+    len: usize,
+    capacity: usize,
+}
+
+// SAFETY: `AlignedBuffer` owns its allocation uniquely; transferring it
+// across threads is safe.
+unsafe impl Send for AlignedBuffer {}
+
+impl AlignedBuffer {
+    /// Allocates a new buffer with `capacity` bytes, length 0.
+    pub fn with_capacity(capacity: usize) -> Self {
+        if capacity == 0 {
+            return Self {
+                ptr: NonNull::dangling(),
+                len: 0,
+                capacity: 0,
+            };
+        }
+        let layout = Self::layout(capacity);
+        // SAFETY: `layout` is non-zero size and a valid power-of-two alignment.
+        let ptr = unsafe { alloc(layout) };
+        let ptr = NonNull::new(ptr).unwrap_or_else(|| handle_alloc_error(layout));
+        Self {
+            ptr,
+            len: 0,
+            capacity,
+        }
+    }
+
+    fn layout(capacity: usize) -> Layout {
+        Layout::from_size_align(capacity, HOST_ALIGN).expect("AlignedBuffer layout")
+    }
+
+    /// Number of bytes written.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Allocated capacity in bytes.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Returns `true` when no bytes have been written.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Reset the write position to 0. Retains the allocated capacity.
+    pub fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    /// Ensures `capacity() >= new_capacity`, reallocating if necessary. Does
+    /// not change `len()`.
+    pub fn reserve(&mut self, new_capacity: usize) {
+        if new_capacity <= self.capacity {
+            return;
+        }
+        let new_layout = Self::layout(new_capacity);
+        // SAFETY: layout is valid; we copy the existing initialized prefix
+        // and free the old allocation.
+        unsafe {
+            let new_ptr = alloc(new_layout);
+            let new_ptr = NonNull::new(new_ptr).unwrap_or_else(|| handle_alloc_error(new_layout));
+            if self.capacity > 0 {
+                std::ptr::copy_nonoverlapping(self.ptr.as_ptr(), new_ptr.as_ptr(), self.len);
+                dealloc(self.ptr.as_ptr(), Self::layout(self.capacity));
+            }
+            self.ptr = new_ptr;
+            self.capacity = new_capacity;
+        }
+    }
+
+    /// View the written prefix.
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: `len <= capacity`; bytes are initialized by prior writes.
+        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+
+    /// View the written prefix mutably.
+    pub fn as_slice_mut(&mut self) -> &mut [u8] {
+        // SAFETY: see `as_slice`.
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
+    }
+
+    /// Append `value` and advance the length by `size_of::<T>()`.
+    ///
+    /// # Safety
+    /// Caller must ensure `self.len() + size_of::<T>() <= self.capacity()`.
+    /// Matches `solana_sbpf::AlignedMemory::write_unchecked`.
+    pub unsafe fn write_unchecked<T: Pod>(&mut self, value: T) {
+        let pos = self.len;
+        let new_len = pos.saturating_add(size_of::<T>());
+        debug_assert!(new_len <= self.capacity);
+        // SAFETY: caller guaranteed capacity; pointer is aligned to HOST_ALIGN
+        // which is at least 8, sufficient for any `Pod` integer we write.
+        unsafe {
+            self.ptr
+                .as_ptr()
+                .add(pos)
+                .cast::<T>()
+                .write_unaligned(value);
+        }
+        self.len = new_len;
+    }
+
+    /// Append all bytes in `value` and advance the length.
+    ///
+    /// # Safety
+    /// Caller must ensure `self.len() + value.len() <= self.capacity()`.
+    /// Matches `solana_sbpf::AlignedMemory::write_all_unchecked`.
+    pub unsafe fn write_all_unchecked(&mut self, value: &[u8]) {
+        let pos = self.len;
+        let new_len = pos.saturating_add(value.len());
+        debug_assert!(new_len <= self.capacity);
+        // SAFETY: caller guaranteed capacity; non-overlapping copy from
+        // external slice into our owned allocation.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                value.as_ptr(),
+                self.ptr.as_ptr().add(pos),
+                value.len(),
+            );
+        }
+        self.len = new_len;
+    }
+
+    /// Fill `num` bytes with `value` and advance the length.
+    /// Returns an error if the write would exceed capacity.
+    pub fn fill_write(&mut self, num: usize, value: u8) -> std::io::Result<()> {
+        let new_len = self.len.checked_add(num).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "fill_write overflow")
+        })?;
+        if new_len > self.capacity {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "fill_write past capacity",
+            ));
+        }
+        // SAFETY: bounds checked above.
+        unsafe {
+            std::ptr::write_bytes(self.ptr.as_ptr().add(self.len), value, num);
+        }
+        self.len = new_len;
+        Ok(())
+    }
+}
+
+impl Drop for AlignedBuffer {
+    fn drop(&mut self) {
+        if self.capacity == 0 {
+            return;
+        }
+        // SAFETY: `ptr` was allocated with this layout in `with_capacity` /
+        // `reserve` and is not aliased.
+        unsafe {
+            dealloc(self.ptr.as_ptr(), Self::layout(self.capacity));
+        }
+    }
+}
+
+thread_local! {
+    static POOL: RefCell<Vec<AlignedBuffer>> = const { RefCell::new(Vec::new()) };
+}
+
+/// A pooled [`AlignedBuffer`]. Checked out of a thread-local free-list on
+/// construction; returns to the pool on drop with capacity preserved, so
+/// later checkouts on the same thread reuse the same allocation and avoid
+/// page-faulting the BPF VM input region every transaction.
+pub struct PooledAlignedBuffer {
+    inner: ManuallyDrop<AlignedBuffer>,
+}
+
+impl PooledAlignedBuffer {
+    /// Check out a buffer with at least `min_capacity` bytes. If the pool
+    /// has a buffer with sufficient capacity, it is cleared and returned;
+    /// otherwise a buffer is allocated (and may grow via `reserve` after
+    /// checkout if the caller needs more).
+    pub fn checkout(min_capacity: usize) -> Self {
+        let buf = POOL.with(|pool| {
+            let mut pool = pool.borrow_mut();
+            // Pick the first buffer that fits — pool entries are small so
+            // a linear scan is cheap.
+            if let Some(idx) = pool.iter().position(|b| b.capacity() >= min_capacity) {
+                let mut b = pool.swap_remove(idx);
+                b.clear();
+                b
+            } else {
+                AlignedBuffer::with_capacity(min_capacity)
+            }
+        });
+        Self {
+            inner: ManuallyDrop::new(buf),
+        }
+    }
+}
+
+impl Deref for PooledAlignedBuffer {
+    type Target = AlignedBuffer;
+    fn deref(&self) -> &AlignedBuffer {
+        &self.inner
+    }
+}
+
+impl DerefMut for PooledAlignedBuffer {
+    fn deref_mut(&mut self) -> &mut AlignedBuffer {
+        &mut self.inner
+    }
+}
+
+impl Drop for PooledAlignedBuffer {
+    fn drop(&mut self) {
+        // SAFETY: `self.inner` is not used after this line; we move it out
+        // and either push to the pool or let it drop normally.
+        let buf = unsafe { ManuallyDrop::take(&mut self.inner) };
+        POOL.with(|pool| {
+            let mut pool = pool.borrow_mut();
+            if pool.len() < POOL_CAPACITY {
+                pool.push(buf);
+            }
+            // Otherwise the pool is full; let `buf` drop and free its memory.
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_and_clear() {
+        let mut b = AlignedBuffer::with_capacity(32);
+        assert_eq!(b.len(), 0);
+        assert_eq!(b.capacity(), 32);
+        unsafe {
+            b.write_unchecked::<u64>(0xdead_beef_u64.to_le());
+            b.write_all_unchecked(&[1, 2, 3, 4]);
+        }
+        b.fill_write(8, 0).unwrap();
+        assert_eq!(b.len(), 20);
+        b.clear();
+        assert_eq!(b.len(), 0);
+        // The allocation is retained.
+        assert_eq!(b.capacity(), 32);
+    }
+
+    #[test]
+    fn reserve_preserves_data() {
+        let mut b = AlignedBuffer::with_capacity(8);
+        unsafe {
+            b.write_all_unchecked(&[1, 2, 3, 4]);
+        }
+        b.reserve(64);
+        assert!(b.capacity() >= 64);
+        assert_eq!(b.as_slice(), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn fill_write_rejects_overflow() {
+        let mut b = AlignedBuffer::with_capacity(4);
+        assert!(b.fill_write(5, 0).is_err());
+        assert_eq!(b.len(), 0);
+    }
+
+    #[test]
+    fn pool_reuses_allocation() {
+        let ptr_first;
+        {
+            let mut buf = PooledAlignedBuffer::checkout(128);
+            unsafe { buf.write_all_unchecked(&[7u8; 16]) };
+            ptr_first = buf.as_slice().as_ptr();
+        }
+        let buf = PooledAlignedBuffer::checkout(128);
+        assert_eq!(buf.len(), 0);
+        // After checkout the pool returned the same backing allocation.
+        // Use the raw pointer of the underlying buffer (length is 0 so
+        // as_slice() yields an empty slice; we test the dangling-or-real
+        // pointer of the storage directly).
+        assert_eq!(buf.inner.ptr.as_ptr(), ptr_first as *mut u8);
+    }
+
+    #[test]
+    fn alignment_is_host_align() {
+        let buf = AlignedBuffer::with_capacity(1);
+        assert_eq!(buf.ptr.as_ptr() as usize % HOST_ALIGN, 0);
+    }
+}

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -4,6 +4,7 @@
 #![deny(clippy::indexing_slicing)]
 
 pub use solana_sbpf;
+pub mod aligned_buffer;
 pub mod cpi;
 pub mod deploy;
 pub mod execution_budget;

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -1,15 +1,11 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
-    crate::memory_context::SerializedAccountMetadata,
+    crate::{aligned_buffer::PooledAlignedBuffer, memory_context::SerializedAccountMetadata},
     solana_instruction::error::InstructionError,
     solana_program_entrypoint::{BPF_ALIGN_OF_U128, MAX_PERMITTED_DATA_INCREASE, NON_DUP_MARKER},
     solana_pubkey::Pubkey,
-    solana_sbpf::{
-        aligned_memory::{AlignedMemory, Pod},
-        ebpf::{HOST_ALIGN, MM_INPUT_START},
-        memory_region::MemoryRegion,
-    },
+    solana_sbpf::{aligned_memory::Pod, ebpf::MM_INPUT_START, memory_region::MemoryRegion},
     solana_sdk_ids::bpf_loader_deprecated,
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     solana_transaction_context::{
@@ -58,7 +54,7 @@ enum SerializeAccount<'a, 'ix_data> {
 }
 
 struct Serializer {
-    buffer: AlignedMemory<HOST_ALIGN>,
+    buffer: PooledAlignedBuffer,
     regions: Vec<MemoryRegion>,
     vaddr: u64,
     region_start: usize,
@@ -76,7 +72,7 @@ impl Serializer {
         account_data_direct_mapping: bool,
     ) -> Serializer {
         Serializer {
-            buffer: AlignedMemory::with_capacity(size),
+            buffer: PooledAlignedBuffer::checkout(size),
             regions: Vec::new(),
             region_start: 0,
             vaddr: start_addr,
@@ -198,7 +194,7 @@ impl Serializer {
         self.vaddr += range.len() as u64;
     }
 
-    fn finish(mut self) -> (AlignedMemory<HOST_ALIGN>, Vec<MemoryRegion>) {
+    fn finish(mut self) -> (PooledAlignedBuffer, Vec<MemoryRegion>) {
         self.push_region();
         debug_assert_eq!(self.region_start, self.buffer.len());
         (self.buffer, self.regions)
@@ -225,7 +221,7 @@ pub fn serialize_parameters(
     direct_account_pointers_in_program_input: bool,
 ) -> Result<
     (
-        AlignedMemory<HOST_ALIGN>,
+        PooledAlignedBuffer,
         Vec<MemoryRegion>,
         Vec<SerializedAccountMetadata>,
         usize,
@@ -323,7 +319,7 @@ fn serialize_parameters_for_abiv0(
     account_data_direct_mapping: bool,
 ) -> Result<
     (
-        AlignedMemory<HOST_ALIGN>,
+        PooledAlignedBuffer,
         Vec<MemoryRegion>,
         Vec<SerializedAccountMetadata>,
         usize,
@@ -478,7 +474,7 @@ fn serialize_parameters_for_abiv1(
     direct_account_pointers_program_input: bool,
 ) -> Result<
     (
-        AlignedMemory<HOST_ALIGN>,
+        PooledAlignedBuffer,
         Vec<MemoryRegion>,
         Vec<SerializedAccountMetadata>,
         usize,
@@ -689,7 +685,10 @@ mod tests {
         solana_account_info::AccountInfo,
         solana_program_entrypoint::deserialize,
         solana_rent::Rent,
-        solana_sbpf::{memory_region::MemoryMapping, program::SBPFVersion, vm::Config},
+        solana_sbpf::{
+            aligned_memory::AlignedMemory, ebpf::HOST_ALIGN, memory_region::MemoryMapping,
+            program::SBPFVersion, vm::Config,
+        },
         solana_sdk_ids::bpf_loader,
         solana_system_interface::MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION,
         solana_transaction_context::{


### PR DESCRIPTION
### perf(svm): reuse BPF VM input buffer via thread-local pool

Each invocation of `solana_program_runtime::serialization::serialize_parameters` allocates a fresh `AlignedMemory<HOST_ALIGN>` to hold the BPF VM input region — the buffer that carries serialized account data, lamports, owner pubkeys, instruction data, etc. into the eBPF program. The buffer is sized to the worst case for the transaction (often tens of KB once account data + `MAX_PERMITTED_DATA_INCREASE` padding are included), and is freed at the end of `vm::execute`.

On a live mainnet validator (mainnet-beta, `--no-voting`, ~12 SVM workers), this single allocation is the largest source of page faults in the entire process. A 60-second `perf record -e page-faults` on a running validator showed:

- **71.6 %** of all process-wide page faults came from the `solScHandleV*` SVM worker threads.
- Of those, ~3 % per worker per second (≈ 36 % of *all* validator faults) was attributable to the per-instruction allocation + first-touch of the BPF input region inside `serialize_parameters → Serializer::write_account → __memcpy/__memset`.

The buffer is large enough that jemalloc routes it through `mmap`, which returns the pages to the OS on free and faults them in again on every next transaction. There's no allocator-side caching to save us here — the only fix is to keep the buffer resident.

#### Why we can't just reuse `solana_sbpf::AlignedMemory`

`AlignedMemory<HOST_ALIGN>` has no public way to reset the write position once data has been written: its inner `AlignedVec::set_len` is private and asserts `new_len >= current_len`, actively rejecting shrinking. There's no `clear()` or `reserve()` either. The type is suitable for one-shot use and that's how the SVM uses it today.

Since solana-sbpf's structs aren't `#[repr(C)]`, we can't legally bypass that via an unsafe transmute either. A clean fix needs either an upstream sbpf API change or a local replacement type.

#### What this PR does

Adds `program-runtime/src/aligned_buffer.rs`, which defines:

- `AlignedBuffer` — a raw, `HOST_ALIGN`-aligned, growable byte buffer with the same write API the `Serializer` already used (`write_unchecked`, `write_all_unchecked`, `fill_write`, `as_slice`, `as_slice_mut`, `len`) plus the operations `AlignedMemory` lacks: `clear()` and `reserve()`.
- A thread-local `Vec<AlignedBuffer>` free-list with a fixed cap.
- `PooledAlignedBuffer` — a RAII wrapper that checks out a buffer at construction and returns it to the pool on `Drop` with capacity intact.

`Serializer::buffer` (and the return type of `serialize_parameters` and the two ABI helpers) now uses `PooledAlignedBuffer` instead of `AlignedMemory<HOST_ALIGN>`. Through `Deref`, the existing `vm::execute` call site (`parameter_bytes.as_slice()`) is unchanged. The first call on each SVM worker still allocates; subsequent calls reuse the same backing allocation. The pool converges in seconds to the per-thread max tx size and stays resident.

#### Why a new type rather than wrapping `AlignedMemory`

We can't reset `AlignedMemory`'s write position, and using `mem::replace` to swap in a fresh one defeats the entire optimization (we'd allocate-then-deallocate every call). The new type only takes the API surface we actually use inside `Serializer`, so it's small enough to fully audit, and it leaves the door open to migrating to an upstream sbpf API once one exists.

#### Results

Measured on the running validator with a 60-second `perf record -e page-faults`, before and after this patch:

| Metric | Before | After | Δ |
|---|---|---|---|
| Total page faults (60 s) | 2,691,310 | 1,903,129 | **−29 % absolute** |
| Page faults attributable to SVM threads | 1.93 M (71.6 %) | 1.14 M (59.8 %) | **−41 % absolute** |
| SVM CPU work in the window | 15.0 G cycles | 70.8 G cycles (4.7× more activity) | — |
| Faults per million SVM cycles | 128 | 16 | **−87 %** |

The after-fix sample window happened to land on a busier traffic slice (~4.7× more SVM CPU consumed in the same wall-clock), yet **absolute** SVM-attributable faults still dropped 41 %. Per unit of actual SVM work the fault rate fell about 8× — well above the 36 % reduction the original analysis predicted.

The remaining ~60 % of validator faults that still come from SVM threads are dominated by `TransactionAccountViewMut::set_data_from_slice` on the deserialize side — writing modified account data back out via `solana_account::AccountSharedData::set_data`, which allocates a fresh `Vec<u8>` per touched account. That's a separate allocation path and a candidate for a follow-up PR.

#### Safety

`AlignedBuffer` uses raw `alloc::alloc` + `dealloc` with a `Layout::from_size_align(capacity, HOST_ALIGN)`. The `unsafe` blocks are isolated to the four obvious places: alloc/dealloc, the bounds-checked write methods (`write_unchecked`, `write_all_unchecked`, `fill_write`), and the `ManuallyDrop::take` in `PooledAlignedBuffer::drop`. Each carries a `// SAFETY:` comment explaining its invariant. The same write-bounds invariants the existing `Serializer` already relied on (the size is pre-computed in `serialize_parameters_for_abiv*` before writes start) are preserved.

#### Test plan

- [x] `cargo test -p solana-program-runtime` — 113/113 pass, including 5 new tests in `aligned_buffer::tests` (`write_and_clear`, `reserve_preserves_data`, `fill_write_rejects_overflow`, `pool_reuses_allocation` which directly asserts the same backing allocation is returned across checkouts, and `alignment_is_host_align`).
- [x] `cargo test -p solana-bpf-loader-program` — 16/16 pass.
- [x] `cargo test -p solana-svm` — 93/93 pass.
- [x] `cargo clippy -p solana-program-runtime --all-targets --no-deps` — clean.
- [x] `cargo build -p agave-validator` — clean.
- [x] Validated on a mainnet-beta non-voting RPC node: 60 s `perf record -e page-faults` before / after, results in the table above.