### PR TITLE
Refactor - `Bank::prune_program_cache()`

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2580,11 +2580,7 @@ fn load_frozen_forks(
                 root = new_root_bank.slot();
 
                 leader_schedule_cache.set_root(new_root_bank);
-                new_root_bank.prune_program_cache(
-                    root,
-                    new_root_bank.epoch(),
-                    &bank_forks.read().unwrap(),
-                );
+                new_root_bank.prune_program_cache(&bank_forks.read().unwrap());
                 let _ = bank_forks
                     .write()
                     .unwrap()

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -492,7 +492,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     pub fn prune(
         &mut self,
         new_root_slot: Slot,
-        upcoming_environment: Option<ProgramRuntimeEnvironment>,
+        new_environment: Option<ProgramRuntimeEnvironment>,
         fork_graph: &FG,
     ) {
         match &mut self.index {
@@ -539,8 +539,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                         })
                         .filter(|entry| {
                             // Remove outdated environment of previous feature set
-                            if let Some(upcoming_environment) = upcoming_environment.as_ref()
-                                && !Self::matches_environment(entry, upcoming_environment)
+                            if let Some(new_environment) = new_environment.as_ref()
+                                && !Self::matches_environment(entry, new_environment)
                             {
                                 self.stats
                                     .prunes_environment

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1648,23 +1648,18 @@ impl Bank {
         }
     }
 
-    pub fn prune_program_cache(
-        &self,
-        new_root_slot: Slot,
-        new_root_epoch: Epoch,
-        bank_forks: &BankForks,
-    ) {
+    pub fn prune_program_cache(&self, bank_forks: &BankForks) {
         let upcoming_environment = self
             .transaction_processor
             .epoch_boundary_preparation
             .write()
             .unwrap()
-            .reroot(new_root_epoch);
+            .reroot(self.epoch());
         self.transaction_processor
             .global_program_cache
             .write()
             .unwrap()
-            .prune(new_root_slot, upcoming_environment, bank_forks);
+            .prune(self.slot(), upcoming_environment, bank_forks);
     }
 
     pub fn prune_program_cache_by_deployment_slot(&self, deployment_slot: Slot) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1659,7 +1659,15 @@ impl Bank {
             .global_program_cache
             .write()
             .unwrap()
-            .prune(self.slot(), upcoming_environment, bank_forks);
+            .prune(
+                self.slot(),
+                upcoming_environment.map(|_| {
+                    ProgramRuntimeEnvironment::clone(
+                        &self.transaction_processor.program_runtime_environment,
+                    )
+                }),
+                bank_forks,
+            );
     }
 
     pub fn prune_program_cache_by_deployment_slot(&self, deployment_slot: Slot) {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -540,7 +540,7 @@ impl BankForks {
 
     pub fn prune_program_cache(&self, root: Slot) {
         if let Some(root_bank) = self.banks.get(&root) {
-            root_bank.prune_program_cache(root, root_bank.epoch(), self);
+            root_bank.prune_program_cache(self);
         }
     }
 


### PR DESCRIPTION
#### Problem

In case the estimate is incorrect and a different program runtime environment became valid, then that should be used instead of the estimate to cleanup the outdated cache entries.

#### Summary of Changes

- Removes `new_root_slot` and `new_root_epoch` parameters from `Bank::prune_program_cache()`.
- Use the actual new environment, not the estimate, in `Bank::prune_program_cache()`.