### PR TITLE
Update the lt hash from index to also updates that are in the cache but not in the index

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7001,4 +7001,38 @@ impl AccountsDb {
             0
         }
     }
+
+    /// Calls calculate_accounts_lt_hash_at_startup_from_index, but also folds in account
+    /// updates from the write cache. Use this in tests when the cache may not have been
+    /// flushed; Non test paths should always flush the cache first
+    ///
+    /// This path is NOT safe with concurrent flush operations
+    pub fn calculate_accounts_lt_hash_for_tests(&self, ancestors: &Ancestors) -> AccountsLtHash {
+        let AccountsLtHash(mut lt_hash) =
+            self.calculate_accounts_lt_hash_at_startup_from_index(ancestors);
+        for pubkey in self.accounts_cache.cached_pubkeys().iter() {
+            // mix out whatever older version the index walk produced (if any)
+            self.accounts_index.get_with_and_then(
+                pubkey,
+                ancestors,
+                false,
+                |(slot, account_info)| {
+                    self.get_account_accessor(slot, pubkey, &account_info.storage_location())
+                        .get_loaded_account(|loaded_account| {
+                            lt_hash.mix_out(&Self::lt_hash_account(&loaded_account, pubkey).0);
+                        });
+                },
+            );
+            // mix in the cache version
+            if let Some((account, _slot)) = self.load(
+                ancestors,
+                pubkey,
+                LoadHint::FixedMaxRoot,
+                PopulateReadCache::False,
+            ) {
+                lt_hash.mix_in(&Self::lt_hash_account(&account, pubkey).0);
+            }
+        }
+        AccountsLtHash(lt_hash)
+    }
 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4846,6 +4846,7 @@ impl AccountsDb {
     ///
     /// Only intended to be called at startup (or by tests).
     /// Only intended to be used while testing the experimental accumulator hash.
+    /// NOT safe to call concurrently with flush operations
     pub fn calculate_accounts_lt_hash_at_startup_from_index(
         &self,
         ancestors: &Ancestors,
@@ -4857,7 +4858,7 @@ impl AccountsDb {
         // A different parallel implementation that iterated over the bins *sequentially* and then
         // hashed the accounts *within* a bin in parallel took about 600 seconds.  That impl uses
         // less memory, as only a single index bin is loaded into mem at a time.
-        let lt_hash = self
+        let mut lt_hash = self
             .accounts_index
             .account_maps
             .par_iter()
@@ -4894,6 +4895,36 @@ impl AccountsDb {
                 accum.mix_in(&elem);
                 accum
             });
+
+        let cache_lt_hash = {
+            let mut cache_lt_hash = LtHash::identity();
+            for pubkey in self.accounts_cache.cached_pubkeys().iter() {
+                // mix out whatever older version the index walk produced (if any)
+                self.accounts_index.get_with_and_then(
+                    pubkey,
+                    ancestors,
+                    false,
+                    |(slot, account_info)| {
+                        self.get_account_accessor(slot, pubkey, &account_info.storage_location())
+                            .get_loaded_account(|loaded_account| {
+                                cache_lt_hash
+                                    .mix_out(&Self::lt_hash_account(&loaded_account, pubkey).0);
+                            });
+                    },
+                );
+                // mix in the cache version
+                if let Some((account, _slot)) = self.load(
+                    ancestors,
+                    pubkey,
+                    LoadHint::FixedMaxRoot,
+                    PopulateReadCache::False,
+                ) {
+                    cache_lt_hash.mix_in(&Self::lt_hash_account(&account, pubkey).0);
+                }
+            }
+            cache_lt_hash
+        };
+        lt_hash.mix_in(&cache_lt_hash);
 
         AccountsLtHash(lt_hash)
     }
@@ -7000,39 +7031,5 @@ impl AccountsDb {
         } else {
             0
         }
-    }
-
-    /// Calls calculate_accounts_lt_hash_at_startup_from_index, but also folds in account
-    /// updates from the write cache. Use this in tests when the cache may not have been
-    /// flushed; Non test paths should always flush the cache first
-    ///
-    /// This path is NOT safe with concurrent flush operations
-    pub fn calculate_accounts_lt_hash_for_tests(&self, ancestors: &Ancestors) -> AccountsLtHash {
-        let AccountsLtHash(mut lt_hash) =
-            self.calculate_accounts_lt_hash_at_startup_from_index(ancestors);
-        for pubkey in self.accounts_cache.cached_pubkeys().iter() {
-            // mix out whatever older version the index walk produced (if any)
-            self.accounts_index.get_with_and_then(
-                pubkey,
-                ancestors,
-                false,
-                |(slot, account_info)| {
-                    self.get_account_accessor(slot, pubkey, &account_info.storage_location())
-                        .get_loaded_account(|loaded_account| {
-                            lt_hash.mix_out(&Self::lt_hash_account(&loaded_account, pubkey).0);
-                        });
-                },
-            );
-            // mix in the cache version
-            if let Some((account, _slot)) = self.load(
-                ancestors,
-                pubkey,
-                LoadHint::FixedMaxRoot,
-                PopulateReadCache::False,
-            ) {
-                lt_hash.mix_in(&Self::lt_hash_account(&account, pubkey).0);
-            }
-        }
-        AccountsLtHash(lt_hash)
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6681,7 +6681,7 @@ impl Bank {
         self.rc
             .accounts
             .accounts_db
-            .calculate_accounts_lt_hash_for_tests(&self.ancestors)
+            .calculate_accounts_lt_hash_at_startup_from_index(&self.ancestors)
     }
 
     pub fn get_transaction_processor(&self) -> &TransactionBatchProcessor<BankForks> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6681,7 +6681,7 @@ impl Bank {
         self.rc
             .accounts
             .accounts_db
-            .calculate_accounts_lt_hash_at_startup_from_index(&self.ancestors)
+            .calculate_accounts_lt_hash_for_tests(&self.ancestors)
     }
 
     pub fn get_transaction_processor(&self) -> &TransactionBatchProcessor<BankForks> {


### PR DESCRIPTION
#### Problem
When accounts in the write cache are removed from the accounts index (future PR) any test that calculates the lattice hash from the index will calculate the incorrect hash. They will need to either be updated to include the cache when generating the lattice hash from the index or updated to flush cache slots first.

#### Summary of Changes
- Modify the function that calculates the lattice hash from the index to also fold in updates from the accounts_cache

Fixes #
