### PR TITLE
Check cache in get_account_at_slot

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3465,6 +3465,11 @@ impl AccountsDb {
     }
 
     fn get_account_at_slot(&self, pubkey: &Pubkey, slot: Slot) -> Option<AccountSharedData> {
+        // Check the cache for the pubkey first
+        if let Some(cached) = self.accounts_cache.load(slot, pubkey) {
+            return Some(cached.account.clone());
+        }
+
         // Add the slot to ancestors so unrooted slots will be selected
         let mut ancestors = Ancestors::default();
         ancestors.insert(slot);


### PR DESCRIPTION
#### Problem
When accounts in the cache are removed from the index, get_account_at_slot will need to check the cache as well

#### Summary of Changes
- Update it

Fixes #
