### PR TITLE
Epoch rewards AG fix

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1823,10 +1823,10 @@ impl Bank {
         // the vote reward account state should be created at the epoch boundary in which we
         // activate alpenglow as it will need info from the previous epoch.
         if self.feature_set.snapshot().alpenglow {
+            let epoch_start_capitalization = parent_capitalization;
             EpochInflationAccountState::new_epoch_update_account(
                 self,
-                parent_epoch,
-                parent_capitalization,
+                epoch_start_capitalization,
                 epoch_validator_rewards,
             );
         }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5257,9 +5257,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "9ycftRwjpQ17PrhnwhGPbVzDKd3Q9BybmLYU8UD1Pg1T"
+                    "F4ns41hFn3ignVHqaVehaTZ8LMUxPaELAgvN8iTcowDD"
                 } else {
-                    "4XzjZMjhP9s8iBeFQsnHFwaQ991dpiBGHEkzj1ifAcpS"
+                    "FyxeAqHjieaKMA6mLK3yfSD46Xcw2U6hzKfyeu1qVuCD"
                 },
             );
         }
@@ -5268,9 +5268,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "7sbqfkN4W3PkBREyduDc3R2eiKu68JKYRXZt6gCWNt4N"
+                    "sF1tuUv3r5JCr9smYyhm9Qv27f5jcoJ75LnoLGV5Scd"
                 } else {
-                    "ArB3XNVLJsyV7AtrG3C3Bj4akb8s7AzpS5rHJnqGW5sw"
+                    "DrpEs59czmKpLQvR9kBjSmWJUYMNKDdQ4Zsyu4WjfoPb"
                 },
             );
             break;

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -700,13 +700,14 @@ mod tests {
     }
 
     fn calc_reward_for_test(
-        prev_bank: &Bank,
         bank: &Bank,
+        epoch_start_capitalization: u64,
+        reward_epoch: Epoch,
         total_stake: u64,
         stake_voted: u64,
     ) -> (u64, u64) {
         let epoch_inflation =
-            bank.calculate_epoch_inflation_rewards(prev_bank.capitalization(), prev_bank.epoch());
+            bank.calculate_epoch_inflation_rewards(epoch_start_capitalization, reward_epoch);
         let numerator = epoch_inflation as u128 * stake_voted as u128;
         let denominator = bank.epoch_schedule.slots_per_epoch as u128 * total_stake as u128;
         let reward: u64 = (numerator / denominator).try_into().unwrap();
@@ -778,8 +779,15 @@ mod tests {
                     .epoch_stakes_from_slot(reward_slot)
                     .unwrap()
                     .total_stake();
+                let reward_epoch = bank.epoch_schedule.get_epoch(reward_slot);
                 let (expected_validator_reward, expected_leader_reward_per_validator) =
-                    calc_reward_for_test(&prev_bank, &bank, total_stake, per_validator_stake);
+                    calc_reward_for_test(
+                        &bank,
+                        prev_bank.capitalization(),
+                        reward_epoch,
+                        total_stake,
+                        per_validator_stake,
+                    );
                 if *validator != leader_vote_pubkey {
                     assert_eq!(got_reward, expected_validator_reward);
                 }

--- a/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
+++ b/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
@@ -37,13 +37,12 @@ pub(super) struct EpochInflationState {
 impl EpochInflationState {
     fn new_from_bank(
         bank: &Bank,
-        prev_epoch: Epoch,
-        prev_epoch_capitalization: u64,
+        epoch_start_capitalization: u64,
         additional_validator_rewards: u64,
     ) -> Self {
         let max_possible_validator_reward = bank.calculate_epoch_inflation_rewards(
-            prev_epoch_capitalization + additional_validator_rewards,
-            prev_epoch,
+            epoch_start_capitalization + additional_validator_rewards,
+            bank.epoch(),
         );
         EpochInflationState {
             max_possible_validator_reward,
@@ -121,15 +120,13 @@ impl EpochInflationAccountState {
     /// compute the vote rewards.
     pub(crate) fn new_epoch_update_account(
         bank: &Bank,
-        prev_epoch: Epoch,
-        prev_epoch_capitalization: u64,
+        epoch_start_capitalization: u64,
         additional_validator_rewards: u64,
     ) {
         let prev = Self::new_from_bank(bank).map(|s| s.current);
         let current = EpochInflationState::new_from_bank(
             bank,
-            prev_epoch,
-            prev_epoch_capitalization,
+            epoch_start_capitalization,
             additional_validator_rewards,
         );
         let state = Self { prev, current };
@@ -162,7 +159,9 @@ mod tests {
             },
         },
         rand::Rng,
+        solana_epoch_schedule::EpochSchedule,
         solana_genesis_config::GenesisConfig,
+        solana_inflation::Inflation,
         solana_leader_schedule::SlotLeader,
         std::sync::Arc,
     };
@@ -221,22 +220,65 @@ mod tests {
         assert_eq!(bank_epoch_1.epoch(), 1);
         assert_eq!(bank_epoch_2.epoch(), 2);
 
-        let expected_prev = EpochInflationState::new_from_bank(
-            &bank_epoch_1,
-            bank_epoch_0.epoch(),
-            bank_epoch_0.capitalization(),
-            0,
-        );
-        let expected_current = EpochInflationState::new_from_bank(
-            &bank_epoch_2,
-            bank_epoch_1.epoch(),
-            bank_epoch_1.capitalization(),
-            0,
-        );
+        let expected_prev =
+            EpochInflationState::new_from_bank(&bank_epoch_1, bank_epoch_0.capitalization(), 0);
+        let expected_current =
+            EpochInflationState::new_from_bank(&bank_epoch_2, bank_epoch_1.capitalization(), 0);
         let EpochInflationAccountState { current, prev } =
             EpochInflationAccountState::new_from_bank(&bank_epoch_2).unwrap();
         assert_eq!(current, expected_current);
         assert_eq!(prev.unwrap(), expected_prev);
+    }
+
+    #[test]
+    fn new_epoch_update_account_use_current_reward_budget() {
+        let GenesisConfigInfo {
+            mut genesis_config, ..
+        } = create_genesis_config(1_000_000_000);
+        genesis_config.inflation = Inflation::full();
+        // Warmup is necessary here to give epoch 0 and epoch 1 different reward
+        // budgets.
+        genesis_config.epoch_schedule = EpochSchedule::custom(64, 64, true);
+
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let bank_epoch_0 = bank_forks.read().unwrap().root_bank();
+        let epoch_1_first_slot = bank_epoch_0.epoch_schedule().get_first_slot_in_epoch(1);
+        let bank_epoch_1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank_epoch_0.clone(),
+            SlotLeader::new_unique(),
+            epoch_1_first_slot,
+        );
+
+        assert_eq!(bank_epoch_0.epoch(), 0);
+        assert_eq!(bank_epoch_1.epoch(), 1);
+        assert_ne!(
+            bank_epoch_1.epoch_schedule().get_slots_in_epoch(0),
+            bank_epoch_1.epoch_schedule().get_slots_in_epoch(1)
+        );
+
+        let epoch_start_capitalization = bank_epoch_0.capitalization();
+        let expected_current_epoch_rewards = bank_epoch_1
+            .calculate_epoch_inflation_rewards(epoch_start_capitalization, bank_epoch_1.epoch());
+        assert_ne!(
+            expected_current_epoch_rewards,
+            bank_epoch_1.calculate_epoch_inflation_rewards(
+                epoch_start_capitalization,
+                bank_epoch_0.epoch()
+            )
+        );
+
+        EpochInflationAccountState::new_epoch_update_account(
+            &bank_epoch_1,
+            epoch_start_capitalization,
+            0,
+        );
+        let state = EpochInflationAccountState::new_from_bank(&bank_epoch_1).unwrap();
+        assert_eq!(state.current.epoch, bank_epoch_1.epoch());
+        assert_eq!(
+            state.current.max_possible_validator_reward,
+            expected_current_epoch_rewards
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix Alpenglow epoch inflation state creation so the reward epoch and time parameters used to budget vote rewards match.

Previously, epoch inflation state was stored for the current epoch while calculating the reward budget with the previous epoch. This was latent while epoch durations were unchanged, but after slot-time changes or slots per epoch change (e.g. warmup slots or changing leader span), Alpenglow vote rewards and PER recalculation could disagree on the epoch reward budget and trip the PER accounting assertion.

## Root Cause

We're basically calling `self.epoch_duration_in_years(epoch)` with the wrong epoch.

At an epoch boundary, Alpenglow vote reward state was created with:

- `epoch = bank.epoch()`
- reward budget calculated using `prev_epoch`

After a slot-time transition, those two epochs can have different effective durations. Vote rewards for the new epoch could therefore be budgeted with old slot params, while later PER recalculation used the correct epoch duration.

That mismatch could make:

```rust
point_value.rewards < distributed_lamports + burned_lamports + total_stake_rewards_lamports
```

and halt replay during partitioned epoch rewards processing.

## Fix

- Change `EpochInflationState::new_from_bank()` to take the actual `reward_epoch`.
- Make `new_epoch_update_account()` use `bank.epoch()` as the epoch being budgeted.
- Keep capitalization input explicit as `epoch_start_capitalization`.
- Update vote reward tests to compute expectations for the epoch of the reward slot.
- Add a regression test proving new epoch inflation state uses the current epoch reward budget when adjacent epochs have different durations.