### PR TITLE
perf(gossip): pre-size peer-collection Vecs to num_nodes

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1052,48 +1052,61 @@ impl ClusterInfo {
     pub fn rpc_peers(&self) -> Vec<ContactInfo> {
         let self_pubkey = self.id();
         let gossip_crds = self.gossip.crds.read().unwrap();
-        gossip_crds
-            .get_nodes_contact_info()
-            .filter(|node| {
-                node.pubkey() != &self_pubkey && self.check_socket_addr_space(&node.rpc())
-            })
-            .cloned()
-            .collect()
+        // Pre-size to the known upper bound. Without this, `.collect()` grows
+        // geometrically and reallocates ~log2(num_nodes) times per call —
+        // visible on a live validator as ~7% of all process page faults via
+        // the same pattern in `repair_peers`.
+        let mut peers = Vec::with_capacity(gossip_crds.num_nodes());
+        peers.extend(
+            gossip_crds
+                .get_nodes_contact_info()
+                .filter(|node| {
+                    node.pubkey() != &self_pubkey && self.check_socket_addr_space(&node.rpc())
+                })
+                .cloned(),
+        );
+        peers
     }
 
     // All nodes in gossip (including spy nodes) and the last time we heard about them
     pub fn all_peers(&self) -> Vec<(ContactInfo, u64)> {
         let gossip_crds = self.gossip.crds.read().unwrap();
-        gossip_crds
-            .get_nodes()
-            .filter_map(|node| {
-                let contact_info = node.value.contact_info()?;
-                Some((contact_info.clone(), node.local_timestamp))
-            })
-            .collect()
+        let mut peers = Vec::with_capacity(gossip_crds.num_nodes());
+        peers.extend(gossip_crds.get_nodes().filter_map(|node| {
+            let contact_info = node.value.contact_info()?;
+            Some((contact_info.clone(), node.local_timestamp))
+        }));
+        peers
     }
 
     pub fn gossip_peers(&self) -> Vec<ContactInfo> {
         let me = self.id();
         let gossip_crds = self.gossip.crds.read().unwrap();
-        gossip_crds
-            .get_nodes_contact_info()
-            .filter(|node| node.pubkey() != &me && self.check_socket_addr_space(&node.gossip()))
-            .cloned()
-            .collect()
+        let mut peers = Vec::with_capacity(gossip_crds.num_nodes());
+        peers.extend(
+            gossip_crds
+                .get_nodes_contact_info()
+                .filter(|node| node.pubkey() != &me && self.check_socket_addr_space(&node.gossip()))
+                .cloned(),
+        );
+        peers
     }
 
     /// all validators that have a valid tvu port.
     pub fn tvu_peers<R>(&self, query: impl ContactInfoQuery<R>) -> Vec<R> {
         let self_pubkey = self.id();
-        self.time_gossip_read_lock("tvu_peers", &self.stats.tvu_peers)
-            .get_nodes_contact_info()
-            .filter(|node| {
-                node.pubkey() != &self_pubkey
-                    && self.check_socket_addr_space(&node.tvu(contact_info::Protocol::UDP))
-            })
-            .map(query)
-            .collect()
+        let gossip_crds = self.time_gossip_read_lock("tvu_peers", &self.stats.tvu_peers);
+        let mut peers = Vec::with_capacity(gossip_crds.num_nodes());
+        peers.extend(
+            gossip_crds
+                .get_nodes_contact_info()
+                .filter(|node| {
+                    node.pubkey() != &self_pubkey
+                        && self.check_socket_addr_space(&node.tvu(contact_info::Protocol::UDP))
+                })
+                .map(query),
+        );
+        peers
     }
 
     /// all tvu peers with valid gossip addrs that likely have the slot being requested
@@ -1101,19 +1114,24 @@ impl ClusterInfo {
         let _st = ScopedTimer::from(&self.stats.repair_peers);
         let self_pubkey = self.id();
         let gossip_crds = self.gossip.crds.read().unwrap();
-        gossip_crds
-            .get_nodes_contact_info()
-            .filter(|node| {
-                node.pubkey() != &self_pubkey
-                    && self.check_socket_addr_space(&node.tvu(contact_info::Protocol::UDP))
-                    && self.check_socket_addr_space(&node.serve_repair(contact_info::Protocol::UDP))
-                    && match gossip_crds.get::<&LowestSlot>(*node.pubkey()) {
-                        None => true, // fallback to legacy behavior
-                        Some(lowest_slot) => lowest_slot.lowest <= slot,
-                    }
-            })
-            .cloned()
-            .collect()
+        let mut peers = Vec::with_capacity(gossip_crds.num_nodes());
+        peers.extend(
+            gossip_crds
+                .get_nodes_contact_info()
+                .filter(|node| {
+                    node.pubkey() != &self_pubkey
+                        && self.check_socket_addr_space(&node.tvu(contact_info::Protocol::UDP))
+                        && self.check_socket_addr_space(
+                            &node.serve_repair(contact_info::Protocol::UDP),
+                        )
+                        && match gossip_crds.get::<&LowestSlot>(*node.pubkey()) {
+                            None => true, // fallback to legacy behavior
+                            Some(lowest_slot) => lowest_slot.lowest <= slot,
+                        }
+                })
+                .cloned(),
+        );
+        peers
     }
 
     fn is_spy_node(node: &ContactInfo, socket_addr_space: &SocketAddrSpace) -> bool {
@@ -1133,14 +1151,17 @@ impl ClusterInfo {
     pub fn tpu_peers(&self) -> Vec<ContactInfo> {
         let self_pubkey = self.id();
         let gossip_crds = self.gossip.crds.read().unwrap();
-        gossip_crds
-            .get_nodes_contact_info()
-            .filter(|node| {
-                node.pubkey() != &self_pubkey
-                    && self.check_socket_addr_space(&node.tpu(contact_info::Protocol::QUIC))
-            })
-            .cloned()
-            .collect()
+        let mut peers = Vec::with_capacity(gossip_crds.num_nodes());
+        peers.extend(
+            gossip_crds
+                .get_nodes_contact_info()
+                .filter(|node| {
+                    node.pubkey() != &self_pubkey
+                        && self.check_socket_addr_space(&node.tpu(contact_info::Protocol::QUIC))
+                })
+                .cloned(),
+        );
+        peers
     }
 
     fn refresh_my_gossip_contact_info(&self) {


### PR DESCRIPTION
### perf(gossip): pre-size peer-collection Vecs to num_nodes

#### Problem

`ClusterInfo` has six methods that collect a `Vec<ContactInfo>` from the gossip
CRDS via the same shape:

```rust
gossip_crds.get_nodes_contact_info().filter(...).cloned().collect()
```

On a mainnet-beta non-voting validator, a 60 s `perf record -e page-faults`
attributed **~8.1 %** of all process page faults to
`solRepairSvc → ClusterInfo::repair_peers → Vec::from_iter → __memcpy_avx512`
inside `RawVec::grow_one`, plus another **~1.1 %** to `_rjem_je_arena_ralloc`
on the same stack. With this PR the `solRepairSvc` share drops to **~6.1 %**
(**−25 % relative**) and the `_rjem_je_arena_ralloc` contribution falls to ~0.9 %.

#### Why it faults

`Filter::size_hint()` is `(0, Some(N))`, so `.collect()` starts at capacity 0
and grows geometrically (4, 8, 16, …) — ~11 reallocations to reach the
~1.86 MiB final size on a 3 k-node cluster. Each grow step allocates a larger
buffer and `memcpy`s the data across; the chain crosses jemalloc's small→large
threshold (~14 KiB) early, so the upper steps walk every power-of-two
large-size class on the way up.

Two costs follow:

1. **Per-call memcpy faults.** Every grow step copies the live data into a
   larger buffer. When that buffer's pages aren't already resident in
   jemalloc's dirty-extent cache, the `memcpy` write first-touches them and
   takes a minor page fault. The ladder pays this on each step.

2. **Cross-call churn under time-based decay.** The intermediate buffers freed
   during the ladder are *not* returned to the OS immediately — jemalloc keeps
   them as dirty (resident) pages and purges them later under its time-based
   decay (`dirty_decay_ms`, default 10 s). If the next call lands before a
   decay tick, those pages are reused warm. But the workload is cyclical
   (gossip services rebuild these Vecs every loop with idle gaps in between),
   so decay frequently fires in an idle window and purges pages that are about
   to be reallocated. Each such purge re-touches cold pages on the next call.

The purge cost is amplified by jemalloc's current configuration: Agave runs
stock `tikv-jemallocator` (jemalloc 5.3) with no decay tuning, i.e.
`muzzy_decay_ms = 0`, which disables the first-phase `MADV_FREE` step. Decay
therefore goes straight to `MADV_DONTNEED`, the expensive path that triggers
TLB-shootdown IPIs and hard repopulation faults when the pages are touched
again. (Enabling the `MADV_FREE` phase is a separate, complementary
mitigation — see Follow-up.)

`Crds::num_nodes()` is the exact count of contact-infos and an exact upper
bound on the filter chain's output.

#### Summary of Changes

Replace `.filter(...).cloned().collect()` with
`Vec::with_capacity(num_nodes()) + extend(...)` across all six methods. This
yields a single allocation in the final size class: no growth chain, no
per-step memcpy, and the ladder of intermediate large-class extents — each a
candidate for decay churn — is gone. The one remaining allocation is reused
from the dirty-extent cache far more reliably across calls.

#### Follow-up

This PR does not eliminate first-touch faults on the *final* allocation
itself, which dominate the residual ~6 % share. Two independent directions:

- A per-thread pool that keeps the allocation resident across calls. Separate
  PR because it changes the return-type surface of the six methods.
- Enabling jemalloc's first-phase `MADV_FREE` decay (`muzzy_decay_ms > 0`) so
  that purged-then-reused pages avoid the `MADV_DONTNEED` IPI/refault path.
  This is a global allocator-config change, orthogonal to this PR.

#### Test plan

- [x] `cargo test -p solana-gossip` — 218/218 pass.
- [x] `cargo clippy -p solana-gossip --all-targets --no-deps` — clean.
- [x] `cargo build -p agave-validator -p solana-core` — clean.
