### PR TITLE
Marks zero lamport single ref accounts in newly shrunk storages

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -258,4 +258,8 @@ impl AccountStorageEntry {
     pub(crate) fn obsolete_accounts(&self) -> &RwLock<ObsoleteAccounts> {
         &self.obsolete_accounts
     }
+
+    pub(crate) fn zero_lamport_single_ref_offsets(&self) -> &RwLock<IntSet<Offset>> {
+        &self.zero_lamport_single_ref_offsets
+    }
 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -138,6 +138,8 @@ pub(crate) struct AliveAccounts<'a> {
     /// slot the accounts are currently stored in
     pub(crate) slot: Slot,
     pub(crate) accounts: Vec<&'a AccountFromStorage>,
+    /// Indices into `accounts` for accounts known to be zero-lamport single-ref.
+    pub(crate) zero_lamport_single_ref_account_indices: Vec<usize>,
     pub(crate) bytes: usize,
 }
 
@@ -160,6 +162,7 @@ pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
         ref_count: RefCount,
         account: &'a AccountFromStorage,
         slot_list: &[(Slot, AccountInfo)],
+        is_zero_lamport_single_ref: bool,
     );
     fn len(&self) -> usize;
     fn alive_bytes(&self) -> usize;
@@ -169,11 +172,19 @@ pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
 impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
     fn collect(&mut self, mut other: Self) {
         self.bytes = self.bytes.saturating_add(other.bytes);
+        let account_index_offset = self.accounts.len();
         self.accounts.append(&mut other.accounts);
+        self.zero_lamport_single_ref_account_indices.extend(
+            other
+                .zero_lamport_single_ref_account_indices
+                .into_iter()
+                .map(|index| index + account_index_offset),
+        );
     }
     fn with_capacity(capacity: usize, slot: Slot) -> Self {
         Self {
             accounts: Vec::with_capacity(capacity),
+            zero_lamport_single_ref_account_indices: Vec::new(),
             bytes: 0,
             slot,
         }
@@ -183,8 +194,14 @@ impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
         _ref_count: RefCount,
         account: &'a AccountFromStorage,
         _slot_list: &[(Slot, AccountInfo)],
+        is_zero_lamport_single_ref: bool,
     ) {
+        let account_index = self.accounts.len();
         self.accounts.push(account);
+        if is_zero_lamport_single_ref {
+            self.zero_lamport_single_ref_account_indices
+                .push(account_index);
+        }
         self.bytes = self.bytes.saturating_add(account.stored_size());
     }
     fn len(&self) -> usize {
@@ -217,6 +234,7 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
         ref_count: RefCount,
         account: &'a AccountFromStorage,
         slot_list: &[(Slot, AccountInfo)],
+        is_zero_lamport_single_ref: bool,
     ) {
         let other = if ref_count == 1 {
             &mut self.one_ref
@@ -232,7 +250,7 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
             // We would expect clean to get rid of the entry for THIS slot at some point, but clean hasn't done that yet.
             &mut self.many_refs_old_alive
         };
-        other.add(ref_count, account, slot_list);
+        other.add(ref_count, account, slot_list, is_zero_lamport_single_ref);
     }
     fn len(&self) -> usize {
         self.one_ref
@@ -2404,10 +2422,9 @@ impl AccountsDb {
             |pubkey, slots_refs| {
                 let stored_account = &accounts[index];
                 let mut do_populate_accounts_for_shrink = |ref_count, slot_list| {
-                    if stored_account.is_zero_lamport()
-                        && ref_count == 1
-                        && can_purge_zero_lamport_single_ref
-                    {
+                    let is_zero_lamport = stored_account.is_zero_lamport();
+                    let is_zero_lamport_single_ref = is_zero_lamport && ref_count == 1;
+                    if is_zero_lamport_single_ref && can_purge_zero_lamport_single_ref {
                         // only do this if our slot is prior to the latest full snapshot
                         // we found a zero lamport account that is the only instance of this account. We can delete it completely.
                         zero_lamport_single_ref_pubkeys.push(pubkey);
@@ -2416,8 +2433,13 @@ impl AccountsDb {
                             [*pubkey].into_iter(),
                         );
                     } else {
-                        all_are_zero_lamports &= stored_account.is_zero_lamport();
-                        alive_accounts.add(ref_count, stored_account, slot_list);
+                        all_are_zero_lamports &= is_zero_lamport;
+                        alive_accounts.add(
+                            ref_count,
+                            stored_account,
+                            slot_list,
+                            is_zero_lamport_single_ref,
+                        );
                         alive += 1;
                     }
                 };
@@ -2663,6 +2685,24 @@ impl AccountsDb {
         });
     }
 
+    /// After shrink or pack, check if `store` should be visited by
+    /// `clean` or `shrink` based on its zero lamport accounts.
+    fn handle_rewritten_storage_zero_lamport_accounts(
+        &self,
+        store: Arc<AccountStorageEntry>,
+        are_all_accounts_zero_lamports: bool,
+        stats: &ShrinkStats,
+    ) {
+        let num_zero_lamport_single_ref_accounts = store.num_zero_lamport_single_ref_accounts();
+        if are_all_accounts_zero_lamports && num_zero_lamport_single_ref_accounts != store.count() {
+            self.dirty_stores.insert(store.slot(), Arc::clone(&store));
+        }
+
+        self.maybe_add_to_clean_or_shrink_candidates_based_on_zero_lamport_single_ref_accounts(
+            store, true, stats,
+        );
+    }
+
     /// common code from shrink and combine_ancient_slots
     /// get rid of all original store_ids in the slot
     pub(crate) fn remove_old_stores_shrink<'a, T: ShrinkCollectRefs<'a>>(
@@ -2684,18 +2724,33 @@ impl AccountsDb {
             false,
         );
 
+        let maybe_shrunk_store = shrink_in_progress
+            .as_ref()
+            .map(|shrink_in_progress| Arc::clone(shrink_in_progress.new_storage()));
+
         // Purge old, overwritten storage entries
         // This has the side effect of dropping `shrink_in_progress`, which removes the old storage completely. The
         // index has to be correct before we drop the old storage.
         let dead_storages = self.mark_dirty_dead_stores(
             shrink_collect.slot,
-            // If all accounts are zero lamports, then we want to mark the entire OLD append vec as dirty.
+            // If all accounts are zero lamports and there is no replacement storage, then we want
+            // to mark the entire old append vec as dirty. If shrink rewrote the storage, mark the
+            // replacement after `shrink_in_progress` is dropped.
             // otherwise, we'll call 'add_uncleaned_pubkeys_after_shrink' just on the unref'd keys below.
-            shrink_collect.all_are_zero_lamports,
+            shrink_collect.all_are_zero_lamports && maybe_shrunk_store.is_none(),
             shrink_in_progress,
             shrink_can_be_active,
         );
         let dead_storages_len = dead_storages.len();
+
+        if let Some(shrunk_store) = maybe_shrunk_store {
+            debug_assert_eq!(shrunk_store.slot(), shrink_collect.slot);
+            self.handle_rewritten_storage_zero_lamport_accounts(
+                shrunk_store,
+                shrink_collect.all_are_zero_lamports,
+                stats,
+            );
+        }
 
         if !shrink_collect.all_are_zero_lamports {
             self.add_uncleaned_pubkeys_after_shrink(
@@ -2732,10 +2787,7 @@ impl AccountsDb {
                         if slot_list.len() == 1 && ref_count == 2 {
                             if let Some((slot_alive, acct_info)) = slot_list.first() {
                                 if acct_info.is_zero_lamport() && !acct_info.is_cached() {
-                                    self.zero_lamport_single_ref_found(
-                                        *slot_alive,
-                                        acct_info.offset(),
-                                    );
+                                    self.zero_lamport_single_ref_found(*slot_alive, *acct_info);
                                 }
                             }
                         }
@@ -2762,51 +2814,66 @@ impl AccountsDb {
         );
     }
 
+    /// Check if `store` should be visited by `clean` or `shrink`
+    /// based on its zero lamport single ref accounts.
+    fn maybe_add_to_clean_or_shrink_candidates_based_on_zero_lamport_single_ref_accounts(
+        &self,
+        store: Arc<AccountStorageEntry>,
+        replace_dirty_store: bool,
+        stats: &ShrinkStats,
+    ) {
+        if store.num_zero_lamport_single_ref_accounts() == 0 {
+            return;
+        }
+
+        let slot = store.slot();
+        if store.num_zero_lamport_single_ref_accounts() == store.count() {
+            // all accounts in this storage could be dead; have `clean` visit again
+            if replace_dirty_store {
+                self.dirty_stores.insert(slot, store);
+            } else {
+                self.dirty_stores.entry(slot).or_insert(store);
+            }
+            stats
+                .num_dead_slots_added_to_clean
+                .fetch_add(1, Ordering::Relaxed);
+        } else if self.is_shrinking_productive(&store) && self.is_candidate_for_shrink(&store) {
+            // `store` might be eligible for shrinking now
+            let is_new = self.shrink_candidate_slots.lock().unwrap().insert(slot);
+            if is_new {
+                stats
+                    .num_slots_with_zero_lamport_accounts_added_to_shrink
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        } else {
+            stats
+                .marking_zero_dead_accounts_in_non_shrinkable_store
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
     /// This function handles the case when zero lamport single ref accounts are found during shrink.
-    pub(crate) fn zero_lamport_single_ref_found(&self, slot: Slot, offset: Offset) {
+    pub(crate) fn zero_lamport_single_ref_found(&self, slot: Slot, account_info: AccountInfo) {
+        debug_assert!(!account_info.is_cached());
         // This function can be called when a zero lamport single ref account is
-        // found during shrink. Therefore, we can't use the safe version of
-        // `get_slot_storage_entry` because shrink_in_progress map may not be
-        // empty. We have to use the unsafe version to avoid to assert failure.
-        // However, there is a possibility that the storage entry that we get is
-        // an old one, which is being shrunk away, because multiple slots can be
-        // shrunk away in parallel by thread pool. If this happens, any zero
-        // lamport single ref offset marked on the storage will be lost when the
-        // storage is dropped. However, this is not a problem, because after the
-        // storage being shrunk, the new storage will not have any zero lamport
-        // single ref account anyway. Therefore, we don't need to worry about
-        // marking zero lamport single ref offset on the new storage.
+        // found during shrink. Look up the exact storage from the account index
+        // entry's info (slot and store id), so a concurrent shrink of the same
+        // slot marks the correct storage the index entry points to.
         if let Some(store) = self
             .storage
-            .get_slot_storage_entry_shrinking_in_progress_ok(slot)
+            .get_account_storage_entry(slot, account_info.store_id())
         {
-            if store.insert_zero_lamport_single_ref_account_offset(offset) {
+            debug_assert_eq!(store.slot(), slot);
+            if store.insert_zero_lamport_single_ref_account_offset(account_info.offset()) {
                 // this wasn't previously marked as zero lamport single ref
                 self.shrink_stats
                     .num_zero_lamport_single_ref_accounts_found
                     .fetch_add(1, Ordering::Relaxed);
-
-                if store.num_zero_lamport_single_ref_accounts() == store.count() {
-                    // all accounts in this storage can be dead
-                    self.dirty_stores.entry(slot).or_insert(store);
-                    self.shrink_stats
-                        .num_dead_slots_added_to_clean
-                        .fetch_add(1, Ordering::Relaxed);
-                } else if self.is_shrinking_productive(&store)
-                    && self.is_candidate_for_shrink(&store)
-                {
-                    // this store might be eligible for shrinking now
-                    let is_new = self.shrink_candidate_slots.lock().unwrap().insert(slot);
-                    if is_new {
-                        self.shrink_stats
-                            .num_slots_with_zero_lamport_accounts_added_to_shrink
-                            .fetch_add(1, Ordering::Relaxed);
-                    }
-                } else {
-                    self.shrink_stats
-                        .marking_zero_dead_accounts_in_non_shrinkable_store
-                        .fetch_add(1, Ordering::Relaxed);
-                }
+                self.maybe_add_to_clean_or_shrink_candidates_based_on_zero_lamport_single_ref_accounts(
+                    store,
+                    false,
+                    &self.shrink_stats,
+                );
             }
         }
     }
@@ -2893,6 +2960,9 @@ impl AccountsDb {
         stats_sub.store_accounts_timing = self.store_accounts_for_shrink(
             storable_accounts,
             shrink_in_progress.new_storage(),
+            &shrink_collect
+                .alive_accounts
+                .zero_lamport_single_ref_account_indices,
             UpdateIndexThreadSelection::PoolWithThreshold,
         );
 
@@ -5064,7 +5134,7 @@ impl AccountsDb {
     /// The element of the returned vector is guaranteed to be non-empty.
     fn update_index_stored_accounts<'a>(
         &self,
-        infos: Vec<AccountInfo>,
+        infos: &[AccountInfo],
         accounts: &impl StorableAccounts<'a>,
         reclaim: UpsertReclaim,
         update_index_thread_selection: UpdateIndexThreadSelection,
@@ -5145,7 +5215,7 @@ impl AccountsDb {
     /// not touched, since shrink only changes `(store_id, offset)` and they index by pubkey.
     fn update_index_for_shrink<'a>(
         &self,
-        infos: Vec<AccountInfo>,
+        infos: &[AccountInfo],
         accounts: &impl StorableAccounts<'a>,
         update_index_thread_selection: UpdateIndexThreadSelection,
         thread_pool: &ThreadPool,
@@ -5406,10 +5476,7 @@ impl AccountsDb {
                             if slot_list.len() == 1 && ref_count == 2 {
                                 if let Some((slot_alive, acct_info)) = slot_list.first() {
                                     if acct_info.is_zero_lamport() && !acct_info.is_cached() {
-                                        self.zero_lamport_single_ref_found(
-                                            *slot_alive,
-                                            acct_info.offset(),
-                                        );
+                                        self.zero_lamport_single_ref_found(*slot_alive, *acct_info);
                                     }
                                 }
                             }
@@ -5572,6 +5639,45 @@ impl AccountsDb {
         self.report_store_timings();
     }
 
+    /// This fn marks zero lamport single ref (ZLSR) accounts in the newly shrunk `storage`.
+    ///
+    /// Returns the number of newly marked ZLSR accounts.
+    fn mark_zero_lamport_single_ref_accounts_for_shrink(
+        &self,
+        storage: &AccountStorageEntry,
+        account_infos: &[AccountInfo],
+        zero_lamport_single_ref_account_indices: &[usize],
+    ) -> u64 {
+        if zero_lamport_single_ref_account_indices.is_empty() {
+            return 0;
+        }
+
+        let mut zero_lamport_single_ref_offsets =
+            Vec::with_capacity(zero_lamport_single_ref_account_indices.len());
+        for &index in zero_lamport_single_ref_account_indices {
+            debug_assert!(index < account_infos.len());
+            let Some(account_info) = account_infos.get(index) else {
+                // there had better be an account_info at `index`, otherwise we have a bug
+                panic!(
+                    "account info missing for zero lamport single ref account index {index} when \
+                     marking zlsr accounts in newly shrunk storage! storage slot.id: {}.{}, num \
+                     zlsr: {}, num account infos: {}",
+                    storage.slot(),
+                    storage.id(),
+                    zero_lamport_single_ref_account_indices.len(),
+                    account_infos.len(),
+                );
+            };
+            debug_assert!(!account_info.is_cached());
+            debug_assert!(account_info.is_zero_lamport());
+            debug_assert_eq!(account_info.store_id(), storage.id());
+            zero_lamport_single_ref_offsets.push(account_info.offset());
+        }
+
+        storage
+            .batch_insert_zero_lamport_single_ref_account_offsets(&zero_lamport_single_ref_offsets)
+    }
+
     /// Stores accounts in the storage and updates the index.
     /// This function is intended for accounts that are being shrunk (moving from one store to another)
     /// - `UpsertReclaims` is set to `IgnoreReclaims`. If the slot in `accounts` differs from the new slot,
@@ -5581,6 +5687,7 @@ impl AccountsDb {
         &self,
         accounts: impl StorableAccounts<'a>,
         storage: &AccountStorageEntry,
+        zero_lamport_single_ref_account_indices: &[usize],
         update_index_thread_selection: UpdateIndexThreadSelection,
     ) -> StoreAccountsTiming {
         let slot = accounts.target_slot();
@@ -5608,12 +5715,18 @@ impl AccountsDb {
 
         let update_index_time = Measure::start("update_index");
         self.update_index_for_shrink(
-            infos,
+            &infos,
             &accounts,
             update_index_thread_selection,
             &self.thread_pool_background,
         );
         let update_index_us = update_index_time.end_as_us();
+
+        self.mark_zero_lamport_single_ref_accounts_for_shrink(
+            storage,
+            &infos,
+            zero_lamport_single_ref_account_indices,
+        );
 
         stats
             .flush_read_cache_us
@@ -5661,12 +5774,12 @@ impl AccountsDb {
 
         let mark_zero_lamport_time = Measure::start("mark_zero_lamport");
         let num_zero_lamport_single_ref_accounts_marked =
-            self.mark_zero_lamport_single_ref_accounts(&infos, storage, reclaim_handling);
+            self.mark_zero_lamport_single_ref_accounts_for_flush(&infos, storage, reclaim_handling);
         let mark_zero_lamport_us = mark_zero_lamport_time.end_as_us();
 
         let update_index_time = Measure::start("update_index");
         let reclaims = self.update_index_stored_accounts(
-            infos,
+            &infos,
             &accounts,
             reclaim_handling,
             update_index_thread_selection,
@@ -5871,7 +5984,7 @@ impl AccountsDb {
     /// Marks zero lamport single reference accounts in the storage during store_accounts_for_flush
     ///
     /// Returns the number of accounts marked.
-    fn mark_zero_lamport_single_ref_accounts(
+    fn mark_zero_lamport_single_ref_accounts_for_flush(
         &self,
         account_infos: &[AccountInfo],
         storage: &AccountStorageEntry,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1155,6 +1155,13 @@ fn test_shrink_zero_lamport_single_ref_account() {
             expected_alive_count,
             "{latest_full_snapshot_slot:?}"
         );
+        assert_eq!(
+            accounts
+                .get_and_assert_single_storage(slot)
+                .num_zero_lamport_single_ref_accounts(),
+            expected_alive_count - 1,
+            "{latest_full_snapshot_slot:?}"
+        );
 
         // other account should still be alive
         assert!(accounts.contains(&pubkey2), "{latest_full_snapshot_slot:?}");
@@ -1289,7 +1296,7 @@ fn test_alive_bytes_after_shrink_with_zero_lamport_single_ref_accounts() {
             let (indexed_slot, acct_info) = slot_list.first().unwrap();
             assert_eq!(*indexed_slot, slot);
             assert!(acct_info.is_zero_lamport());
-            accounts_db.zero_lamport_single_ref_found(*indexed_slot, acct_info.offset());
+            accounts_db.zero_lamport_single_ref_found(*indexed_slot, *acct_info);
             AccountsIndexScanResult::KeepInMemory
         },
         None,
@@ -1322,6 +1329,120 @@ fn test_alive_bytes_after_shrink_with_zero_lamport_single_ref_accounts() {
     for pubkey in &dead_pubkeys {
         assert!(!accounts_db.contains(pubkey));
     }
+}
+
+/// Ensure that `shrink` marks zero lamport single ref accounts in the new storage.
+#[test]
+fn test_shrink_marks_zero_lamport_single_ref_account_in_new_storage() {
+    let accounts_db = AccountsDb::new_single_for_tests();
+    let slot0 = 0;
+    let slot1 = slot0 + 1;
+    // latest full snapshot must be older than the slot(s) we plan to shrink,
+    // otherwise zero lamport single ref accounts will be purged
+    accounts_db.set_latest_full_snapshot_slot(slot0);
+
+    let obsolete_pubkey = Pubkey::new_unique();
+    let obsolete_zero_lamport_pubkey = Pubkey::new_unique();
+    let zero_lamport_single_ref_pubkey = Pubkey::new_unique();
+    let zero_lamport_multi_ref_pubkey = Pubkey::new_unique();
+    let alive_pubkey = Pubkey::new_unique();
+    let closed_account = AccountSharedData::new(0, 0, &Pubkey::default());
+    let open_account = AccountSharedData::new(1, 0, &Pubkey::default());
+
+    let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
+    let storage1 = Arc::new(AccountStorageEntry::new(
+        &paths[0],
+        slot1,
+        10,
+        DEFAULT_FILE_SIZE,
+        AccountsFileProvider::AppendVec,
+    ));
+    append_single_account_with_default_hash(
+        &storage1,
+        &obsolete_pubkey,
+        &open_account,
+        true,
+        Some(&accounts_db.accounts_index),
+    );
+    append_single_account_with_default_hash(
+        &storage1,
+        &obsolete_zero_lamport_pubkey,
+        &closed_account,
+        true,
+        Some(&accounts_db.accounts_index),
+    );
+    append_single_account_with_default_hash(
+        &storage1,
+        &zero_lamport_single_ref_pubkey,
+        &closed_account,
+        true,
+        Some(&accounts_db.accounts_index),
+    );
+    append_single_account_with_default_hash(
+        &storage1,
+        &zero_lamport_multi_ref_pubkey,
+        &closed_account,
+        true,
+        Some(&accounts_db.accounts_index),
+    );
+    append_single_account_with_default_hash(
+        &storage1,
+        &alive_pubkey,
+        &open_account,
+        true,
+        Some(&accounts_db.accounts_index),
+    );
+    insert_store(&accounts_db, Arc::clone(&storage1));
+    accounts_db.add_root(slot1);
+
+    assert_eq!(storage1.num_zero_lamport_single_ref_accounts(), 0);
+
+    let slot2 = slot1 + 1;
+    accounts_db.store_for_tests((
+        slot2,
+        [(&zero_lamport_multi_ref_pubkey, &closed_account)].as_slice(),
+    ));
+    accounts_db.add_root(slot2);
+    accounts_db.flush_rooted_accounts_cache_without_clean();
+
+    let ancestors = Ancestors::from(vec![slot2]);
+    for pubkey in [obsolete_pubkey, obsolete_zero_lamport_pubkey] {
+        let account_info = accounts_db
+            .accounts_index
+            .get_with_and_then(&pubkey, &ancestors, false, |account_info| account_info)
+            .unwrap();
+        accounts_db.remove_dead_accounts(
+            [account_info].iter(),
+            None,
+            MarkAccountsObsolete::Yes(slot1),
+        );
+    }
+
+    accounts_db.shrink_slot_forced(slot1);
+
+    let new_storage1 = accounts_db.get_and_assert_single_storage(slot1);
+    let new_zero_lamport_single_ref_info = accounts_db
+        .accounts_index
+        .get_with_and_then(
+            &zero_lamport_single_ref_pubkey,
+            &ancestors,
+            false,
+            |(_slot, account_info)| account_info,
+        )
+        .unwrap();
+
+    assert_ne!(new_storage1.id(), storage1.id());
+    assert_eq!(new_storage1.count(), 3);
+    assert_eq!(
+        new_zero_lamport_single_ref_info.store_id(),
+        new_storage1.id(),
+    );
+    assert_eq!(new_storage1.num_zero_lamport_single_ref_accounts(), 1);
+    let new_storage_zlsr_offsets = new_storage1
+        .zero_lamport_single_ref_offsets()
+        .read()
+        .unwrap();
+    assert!(new_storage_zlsr_offsets.contains(&new_zero_lamport_single_ref_info.offset()));
 }
 
 #[test]
@@ -3574,7 +3695,7 @@ define_accounts_db_test!(
 
                 let (slot, acct_info) = slot_list.first().unwrap();
                 assert_eq!(*slot, 0);
-                accounts_db.zero_lamport_single_ref_found(*slot, acct_info.offset());
+                accounts_db.zero_lamport_single_ref_found(*slot, *acct_info);
                 AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
             },
             None,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -554,6 +554,7 @@ impl AccountsDb {
         &'b self,
         bytes: u64,
         accounts_to_write: impl StorableAccounts<'a>,
+        zero_lamport_single_ref_account_indices: &[usize],
         write_ancient_accounts: &mut WriteAncientAccounts<'b>,
     ) {
         let target_slot = accounts_to_write.target_slot();
@@ -567,6 +568,7 @@ impl AccountsDb {
             measure_us!(self.store_accounts_for_shrink(
                 accounts_to_write,
                 shrink_in_progress.new_storage(),
+                zero_lamport_single_ref_account_indices,
                 UpdateIndexThreadSelection::PoolWithThreshold
             ));
 
@@ -750,15 +752,16 @@ impl AccountsDb {
                 reopen = true;
             }
 
+            // Remove the slot from the shrink candidates.  If the new packed storage still has any
+            // zero lamport single ref accounts, `remove_old_stores_shrink()` will re-add as needed.
+            self.shrink_candidate_slots.lock().unwrap().remove(&slot);
+
             self.remove_old_stores_shrink(
                 &shrink_collect,
                 &self.shrink_ancient_stats.shrink_stats,
                 shrink_in_progress,
                 true,
             );
-
-            // If the slot is dead, remove the need to shrink the storage as the storage entries will be purged.
-            self.shrink_candidate_slots.lock().unwrap().remove(&slot);
 
             if reopen {
                 // 'shrink_in_progress' is dead now. We can safely 'reopen' the new storage for 'slot'.
@@ -933,6 +936,7 @@ impl AccountsDb {
         let PackedAncientStorage {
             bytes: bytes_total,
             accounts: accounts_to_write,
+            zero_lamport_single_ref_account_indices,
         } = packed;
         let accounts_to_write = StorableAccountsBySlot::new(target_slot, accounts_to_write, self);
 
@@ -943,7 +947,12 @@ impl AccountsDb {
             .shrink_stats
             .num_slots_shrunk
             .fetch_add(1, Ordering::Relaxed);
-        self.write_ancient_accounts(*bytes_total, accounts_to_write, write_ancient_accounts)
+        self.write_ancient_accounts(
+            *bytes_total,
+            accounts_to_write,
+            zero_lamport_single_ref_account_indices,
+            write_ancient_accounts,
+        )
     }
 
     /// For each slot and alive accounts in 'accounts_to_combine'
@@ -961,6 +970,9 @@ impl AccountsDb {
             let packed = PackedAncientStorage {
                 bytes: alive_accounts.bytes as u64,
                 accounts: vec![(alive_accounts.slot, &alive_accounts.accounts[..])],
+                zero_lamport_single_ref_account_indices: alive_accounts
+                    .zero_lamport_single_ref_account_indices
+                    .clone(),
             };
 
             self.write_one_packed_storage(&packed, alive_accounts.slot, write_ancient_accounts);
@@ -999,6 +1011,8 @@ struct AccountsToCombine<'a> {
 struct PackedAncientStorage<'a> {
     /// accounts to move into this storage, along with the slot the accounts are currently stored in
     accounts: Vec<(Slot, &'a [&'a AccountFromStorage])>,
+    /// Indices into the `accounts`, as if it were flattened.
+    zero_lamport_single_ref_account_indices: Vec<usize>,
     /// total bytes required to hold 'accounts'
     bytes: u64,
 }
@@ -1022,6 +1036,8 @@ impl<'a> PackedAncientStorage<'a> {
         loop {
             let mut bytes_total = 0usize;
             let mut accounts_to_write = Vec::default();
+            let mut zero_lamport_single_ref_account_indices = Vec::new();
+            let mut next_account_index = 0usize;
 
             // walk through each set of alive accounts to pack the current new storage up to ideal_size
             let mut full = false;
@@ -1065,13 +1081,30 @@ impl<'a> PackedAncientStorage<'a> {
                 }
 
                 if partial_inner_index < partial_inner_index_max_exclusive {
+                    let accounts_inner = &alive_accounts.accounts
+                        [partial_inner_index..partial_inner_index_max_exclusive];
+                    if !alive_accounts
+                        .zero_lamport_single_ref_account_indices
+                        .is_empty()
+                    {
+                        zero_lamport_single_ref_account_indices.extend(
+                            alive_accounts
+                                .zero_lamport_single_ref_account_indices
+                                .iter()
+                                .filter(|index| {
+                                    **index >= partial_inner_index
+                                        && **index < partial_inner_index_max_exclusive
+                                })
+                                .map(|index| next_account_index + *index - partial_inner_index),
+                        );
+                    }
                     // these accounts belong in the current packed storage we're working on
                     accounts_to_write.push((
                         alive_accounts.slot,
                         // maybe all alive accounts from the current or could be partial
-                        &alive_accounts.accounts
-                            [partial_inner_index..partial_inner_index_max_exclusive],
+                        accounts_inner,
                     ));
+                    next_account_index += accounts_inner.len();
                 }
                 // start next storage with the account we ended with
                 // this could be the end of the current alive accounts or could be anywhere within that vec
@@ -1085,6 +1118,7 @@ impl<'a> PackedAncientStorage<'a> {
             result.push(PackedAncientStorage {
                 bytes: bytes_total as u64,
                 accounts: accounts_to_write,
+                zero_lamport_single_ref_account_indices,
             });
         }
         result
@@ -1121,7 +1155,7 @@ mod tests {
         crate::{
             account_info::{AccountInfo, StorageLocation},
             accounts_db::{
-                ShrinkCollectRefs,
+                ShrinkCollectRefs, get_temp_accounts_paths,
                 tests::{
                     CAN_RANDOMLY_SHRINK_FALSE, append_single_account_with_default_hash,
                     compare_all_accounts, create_db_with_storages_and_index,
@@ -1129,6 +1163,7 @@ mod tests {
                     get_all_accounts, remove_account_for_tests,
                 },
             },
+            accounts_file::AccountsFileProvider,
             accounts_index::{
                 AccountsIndexScanResult, ReclaimsSlotList, RefCount, ScanFilter, UpsertReclaim,
             },
@@ -1235,6 +1270,7 @@ mod tests {
         let packed_contents = vec![PackedAncientStorage {
             bytes: 0,
             accounts: vec![(slots.start, &accounts[..])],
+            zero_lamport_single_ref_account_indices: Vec::new(),
         }];
         db.write_packed_storages(&accounts_to_combine, packed_contents);
     }
@@ -1269,6 +1305,7 @@ mod tests {
                     .zip(slots_vec.iter().cloned())
                     .map(|(accounts, slot)| AliveAccounts {
                         accounts: accounts.stored_accounts.iter().collect::<Vec<_>>(),
+                        zero_lamport_single_ref_account_indices: Vec::new(),
                         bytes: accounts
                             .stored_accounts
                             .iter()
@@ -1348,6 +1385,7 @@ mod tests {
                     .zip(slots_vec.iter().cloned())
                     .map(|((_slot, accounts), slot)| AliveAccounts {
                         accounts: accounts.stored_accounts.iter().collect::<Vec<_>>(),
+                        zero_lamport_single_ref_account_indices: Vec::new(),
                         bytes: accounts
                             .stored_accounts
                             .iter()
@@ -1458,6 +1496,7 @@ mod tests {
                     .zip(slots_vec.iter().cloned())
                     .map(|((_slot, accounts), slot)| AliveAccounts {
                         accounts: accounts.stored_accounts.iter().collect::<Vec<_>>(),
+                        zero_lamport_single_ref_account_indices: Vec::new(),
                         bytes: accounts
                             .stored_accounts
                             .iter()
@@ -3207,11 +3246,16 @@ mod tests {
                                 TestWriteAncient::AncientAccounts => db.write_ancient_accounts(
                                     bytes,
                                     accounts_to_write,
+                                    &[],
                                     &mut write_ancient_accounts,
                                 ),
 
                                 TestWriteAncient::OnePackedStorage => {
-                                    let packed = PackedAncientStorage { accounts, bytes };
+                                    let packed = PackedAncientStorage {
+                                        accounts,
+                                        zero_lamport_single_ref_account_indices: Vec::new(),
+                                        bytes,
+                                    };
                                     db.write_one_packed_storage(
                                         &packed,
                                         target_slot,
@@ -3219,7 +3263,11 @@ mod tests {
                                     );
                                 }
                                 TestWriteAncient::PackedStorages => {
-                                    let packed = PackedAncientStorage { accounts, bytes };
+                                    let packed = PackedAncientStorage {
+                                        accounts,
+                                        zero_lamport_single_ref_account_indices: Vec::new(),
+                                        bytes,
+                                    };
 
                                     let accounts_to_combine = AccountsToCombine {
                                         // target slots are supposed to be read in reverse order, so test that
@@ -3622,7 +3670,7 @@ mod tests {
                         0 => {
                             // empty slot list (ignored anyway) because ref_count = 1
                             let slot_list = vec![];
-                            alive_accounts.add(1, &account, &slot_list);
+                            alive_accounts.add(1, &account, &slot_list, false);
                             assert!(!alive_accounts.one_ref.accounts.is_empty());
                             assert!(alive_accounts.many_refs_old_alive.accounts.is_empty());
                             assert!(
@@ -3638,7 +3686,7 @@ mod tests {
                                 slot,
                                 AccountInfo::new(StorageLocation::Cached, lamports == 0),
                             )];
-                            alive_accounts.add(2, &account, &slot_list);
+                            alive_accounts.add(2, &account, &slot_list, false);
                             assert!(alive_accounts.one_ref.accounts.is_empty());
                             assert!(alive_accounts.many_refs_old_alive.accounts.is_empty());
                             assert!(
@@ -3660,7 +3708,7 @@ mod tests {
                                     AccountInfo::new(StorageLocation::Cached, lamports == 0),
                                 ),
                             ];
-                            alive_accounts.add(2, &account, &slot_list);
+                            alive_accounts.add(2, &account, &slot_list, false);
                             assert!(alive_accounts.one_ref.accounts.is_empty());
                             assert!(!alive_accounts.many_refs_old_alive.accounts.is_empty());
                             assert!(
@@ -3682,7 +3730,7 @@ mod tests {
                                     AccountInfo::new(StorageLocation::Cached, lamports == 0),
                                 ),
                             ];
-                            alive_accounts.add(2, &account, &slot_list);
+                            alive_accounts.add(2, &account, &slot_list, false);
                             assert!(alive_accounts.one_ref.accounts.is_empty());
                             assert!(alive_accounts.many_refs_old_alive.accounts.is_empty());
                             assert!(
@@ -3725,6 +3773,7 @@ mod tests {
             bytes: 1,
             slot,
             accounts: Vec::default(),
+            zero_lamport_single_ref_account_indices: Vec::new(),
         }];
         assert!(!AccountsDb::many_ref_accounts_can_be_moved(
             &many_refs_newest,
@@ -3745,6 +3794,7 @@ mod tests {
             bytes: tuning.ideal_storage_size.get() as usize,
             slot,
             accounts: Vec::default(),
+            zero_lamport_single_ref_account_indices: Vec::new(),
         }];
         assert!(!AccountsDb::many_ref_accounts_can_be_moved(
             &many_refs_newest,
@@ -3873,5 +3923,98 @@ mod tests {
         let max_resulting_storages = tuning.max_resulting_storages.get();
         let expected_all_infos_len = max_resulting_storages * ideal_storage_size / data_size;
         assert_eq!(infos.all_infos.len(), expected_all_infos_len as usize);
+    }
+
+    /// Ensure that `pack` marks zero lamport single ref accounts in the new storage.
+    ///
+    /// Note that this is highly unlikely in practice, as it would require the
+    /// latest full snapshot slot to be *older* than the ancient storages being packed.
+    /// With defaul/normal setup/configuration, this does not happen.
+    #[test]
+    fn test_pack_marks_zero_lamport_single_ref_account() {
+        let accounts_db = AccountsDb::new_single_for_tests();
+        let slot0 = 0;
+        let slot1 = 1;
+        let slot2 = 2;
+        // latest full snapshot must be older than the slot(s) we plan to pack,
+        // otherwise zero lamport single ref accounts will be purged
+        accounts_db.set_latest_full_snapshot_slot(slot0);
+
+        let alive_pubkey = Pubkey::new_unique();
+        let zero_lamport_single_ref_pubkey = Pubkey::new_unique();
+        let open_account = AccountSharedData::new(1, 0, &Pubkey::default());
+        let closed_account = AccountSharedData::new(0, 0, &Pubkey::default());
+
+        let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
+        let storage1 = Arc::new(AccountStorageEntry::new(
+            &paths[0],
+            slot1,
+            10,
+            2048,
+            AccountsFileProvider::AppendVec,
+        ));
+        append_single_account_with_default_hash(
+            &storage1,
+            &alive_pubkey,
+            &open_account,
+            true,
+            Some(&accounts_db.accounts_index),
+        );
+        accounts_db.storage.insert(Arc::clone(&storage1));
+        accounts_db.accounts_index.add_root(slot1);
+
+        let storage2 = Arc::new(AccountStorageEntry::new(
+            &paths[0],
+            slot2,
+            11,
+            4096,
+            AccountsFileProvider::AppendVec,
+        ));
+        // note: put the zlsr account in storage 2 to exercise the packing logic that tracks
+        // the flattened zlsr offsets across the accounts from multiple storages
+        append_single_account_with_default_hash(
+            &storage2,
+            &zero_lamport_single_ref_pubkey,
+            &closed_account,
+            true,
+            Some(&accounts_db.accounts_index),
+        );
+        accounts_db.storage.insert(Arc::clone(&storage2));
+        accounts_db.accounts_index.add_root(slot2);
+
+        combine_ancient_slots_packed_for_tests(&accounts_db, vec![slot1, slot2]);
+
+        let alive_slot_list = accounts_db
+            .accounts_index
+            .get_and_then(&alive_pubkey, |entry| {
+                let entry = entry.expect("alive account should still be indexed");
+                (false, entry.slot_list_read_lock().clone_list())
+            });
+        assert_eq!(alive_slot_list.len(), 1);
+        let (_slot, alive_account_info) = alive_slot_list[0];
+
+        let zlsr_slot_list =
+            accounts_db
+                .accounts_index
+                .get_and_then(&zero_lamport_single_ref_pubkey, |entry| {
+                    let entry = entry.expect("zlsr account should still be indexed");
+                    (false, entry.slot_list_read_lock().clone_list())
+                });
+        assert_eq!(zlsr_slot_list.len(), 1);
+        let (new_slot, zlsr_account_info) = zlsr_slot_list[0];
+
+        assert_eq!(alive_account_info.store_id(), zlsr_account_info.store_id());
+        let new_storage = accounts_db
+            .storage
+            .get_account_storage_entry(new_slot, zlsr_account_info.store_id())
+            .expect("new storage should exist");
+
+        let new_storage_zlsr_offsets = new_storage
+            .zero_lamport_single_ref_offsets()
+            .read()
+            .unwrap();
+        assert_eq!(new_storage.num_zero_lamport_single_ref_accounts(), 1);
+        assert!(new_storage_zlsr_offsets.contains(&zlsr_account_info.offset()));
+        assert!(!new_storage_zlsr_offsets.contains(&alive_account_info.offset()));
     }
 }

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -320,6 +320,7 @@ impl<'a> SnapshotMinimizer<'a> {
             self.accounts_db().store_accounts_for_shrink(
                 storable_accounts,
                 new_storage,
+                &[],
                 UpdateIndexThreadSelection::Inline,
             );
 


### PR DESCRIPTION
#### Problem

If a zero lamport single ref account is marked in a storage, then shrunk, all while that storage is for a slot newer than the latest full snapshot slot, then we won't re-mark the zero lamport single ref accounts in the new shrunk storage.


#### Summary of Changes

Re-mark zero lamport single ref accounts in new shrunk storages.