### PR TITLE
streamer: Remove percentage crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10522,7 +10522,6 @@ dependencies = [
  "nix",
  "num_cpus",
  "pem",
- "percentage",
  "quinn",
  "rand 0.9.4",
  "rustls",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8829,7 +8829,6 @@ dependencies = [
  "nix",
  "num_cpus",
  "pem",
- "percentage",
  "quinn",
  "rand 0.9.4",
  "rustls",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9350,7 +9350,6 @@ dependencies = [
  "nix",
  "num_cpus",
  "pem",
- "percentage",
  "quinn",
  "rand 0.9.4",
  "rustls",

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -33,7 +33,6 @@ log = { workspace = true }
 nix = { workspace = true, features = ["net", "poll", "signal"] }
 num_cpus = { workspace = true }
 pem = { workspace = true }
-percentage = { workspace = true }
 quinn = { workspace = true }
 rand = { workspace = true }
 rustls = { workspace = true }

--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -3,7 +3,6 @@ use {
         nonblocking::{qos::OpaqueStreamerCounter, quic::ConnectionPeerType},
         quic::StreamerStats,
     },
-    percentage::Percentage,
     std::{
         sync::{
             Arc, RwLock,
@@ -16,8 +15,8 @@ use {
 
 /// Max TPS allowed for unstaked connection
 const MAX_UNSTAKED_TPS: u64 = 200;
-/// Expected % of max TPS to be consumed by unstaked connections
-const EXPECTED_UNSTAKED_STREAMS_PERCENT: u64 = 20;
+/// Expected fraction of max TPS to be consumed by unstaked connections
+const EXPECTED_UNSTAKED_STREAMS_RATIO: f64 = 0.20;
 
 pub const STREAM_THROTTLING_INTERVAL_MS: u64 = 100;
 pub const STREAM_THROTTLING_INTERVAL: Duration =
@@ -30,7 +29,7 @@ const STREAM_LOAD_EMA_INTERVAL_MS: u64 = 5;
 // before throttling activates.
 const STREAM_LOAD_EMA_INTERVAL_COUNT: u64 = 40;
 
-const STAKED_THROTTLING_ON_LOAD_THRESHOLD_PERCENT: u64 = 95;
+const STAKED_THROTTLING_ON_LOAD_THRESHOLD_RATIO: f64 = 0.95;
 
 pub(crate) struct StakedStreamLoadEMA {
     current_load_ema: AtomicU64,
@@ -53,7 +52,7 @@ impl StakedStreamLoadEMA {
         let allow_unstaked_streams = max_unstaked_connections > 0;
         let max_staked_load_in_ms = if allow_unstaked_streams {
             max_streams_per_ms
-                - Percentage::from(EXPECTED_UNSTAKED_STREAMS_PERCENT).apply_to(max_streams_per_ms)
+                - ((EXPECTED_UNSTAKED_STREAMS_RATIO * (max_streams_per_ms as f64)) as u64)
         } else {
             max_streams_per_ms
         };
@@ -68,9 +67,9 @@ impl StakedStreamLoadEMA {
             0
         };
 
-        let staked_throttling_on_load_threshold =
-            Percentage::from(STAKED_THROTTLING_ON_LOAD_THRESHOLD_PERCENT)
-                .apply_to(max_staked_load_in_ema_interval);
+        let staked_throttling_on_load_threshold = (STAKED_THROTTLING_ON_LOAD_THRESHOLD_RATIO
+            * (max_staked_load_in_ema_interval as f64))
+            as u64;
 
         Self {
             current_load_ema: AtomicU64::default(),

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -20,7 +20,6 @@ use {
         },
         streamer::StakedNodes,
     },
-    percentage::Percentage,
     quinn::{Connection, VarInt},
     solana_time_utils as timing,
     std::{
@@ -246,10 +245,9 @@ impl SwQos {
         stats: Arc<StreamerStats>,
     ) {
         if unstaked_connection_table.total_size >= max_unstaked_connections {
-            const PRUNE_TABLE_TO_PERCENTAGE: u8 = 90;
-            let max_percentage_full = Percentage::from(PRUNE_TABLE_TO_PERCENTAGE);
-
-            let max_connections = max_percentage_full.apply_to(max_unstaked_connections);
+            // Prune the connection table down to 90% capacity
+            const PRUNE_TABLE_RATIO: f64 = 0.90;
+            let max_connections = (PRUNE_TABLE_RATIO * (max_unstaked_connections as f64)) as usize;
             let num_pruned = unstaked_connection_table.prune_oldest(max_connections);
             stats
                 .num_evictions_unstaked


### PR DESCRIPTION
#### Problem
    We have the technology to do multiplication internally; no need to add
    the risk/overhead of another dependency for this