### PR TITLE
blockstore: add secondary feature flag for SIMD-0340

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -131,14 +131,26 @@ fn run_check_duplicate(
             shred_slot,
             &root_bank,
         );
+        let validate_chained_block_id_2 = shred::filter::check_feature_activation_from_bank(
+            &feature_set::validate_chained_block_id_2::id(),
+            shred_slot,
+            &root_bank,
+        );
+
         let (shred1, shred2) = match shred {
             PossibleDuplicateShred::LastIndexConflict(shred, conflict)
             | PossibleDuplicateShred::ErasureConflict(shred, conflict)
             | PossibleDuplicateShred::MerkleRootConflict(shred, conflict) => (shred, conflict),
-            PossibleDuplicateShred::ChainedMerkleRootConflict(_shred, _conflict) => {
-                if validate_chained_block_id {
+            PossibleDuplicateShred::ChainedMerkleRootConflict(_slot) => {
+                if validate_chained_block_id || validate_chained_block_id_2 {
                     // Although chained merkle roots are not necessary for agave duplicate resolution protocols,
                     // We still need to mark the block as dead for other client teams.
+                    blockstore.set_dead_slot(shred_slot)?;
+                }
+                return Ok(());
+            }
+            PossibleDuplicateShred::FixedFECChainedMerkleRootConflict(_slot) => {
+                if validate_chained_block_id_2 {
                     blockstore.set_dead_slot(shred_slot)?;
                 }
                 return Ok(());

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -87,6 +87,7 @@ pub struct FeatureSnapshot {
     pub relax_post_exec_min_balance_check: bool,
     pub enable_tx_v1: bool,
     pub define_ltds_fee_only_semantics: bool,
+    pub validate_chained_block_id_2: bool,
 }
 
 impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
@@ -200,6 +201,7 @@ impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
             relax_post_exec_min_balance_check: is_active(&relax_post_exec_min_balance_check::ID),
             enable_tx_v1: is_active(&enable_tx_v1::ID),
             define_ltds_fee_only_semantics: is_active(&define_ltds_fee_only_semantics::ID),
+            validate_chained_block_id_2: is_active(&validate_chained_block_id_2::ID),
         }
     }
 }
@@ -1483,6 +1485,10 @@ pub mod validate_chained_block_id {
     solana_pubkey::declare_id!("vcmrbYbiMVKaq1snKP6eCacNDcr6qZvpCNUjmk6gxvZ");
 }
 
+pub mod validate_chained_block_id_2 {
+    solana_pubkey::declare_id!("vcmrw431aNM8ngQ46derkZXipoTGQdbHkEygBDh12dA");
+}
+
 pub mod validator_admission_ticket {
     solana_pubkey::declare_id!("VAT9huvhPjRN9cyrPytq9rwvEJ3J4ADtjdncgZRyANJ");
 }
@@ -2582,6 +2588,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             set_lamports_per_byte_to_6960::id(),
             "SIMD-0438: Reset lamports per byte to legacy value of 6960",
+        ),
+        (
+            validate_chained_block_id_2::id(),
+            "SIMD-340: Encompassing check for validate chained block ID",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
         /***** ADD NEW FEATURE BOOL TO `FeatureSnapshot` *****/

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -197,10 +197,11 @@ pub enum PossibleDuplicateShred {
         shred::Payload, // conflict
     ),
     // Merkle root chaining conflict with previous fec set
-    ChainedMerkleRootConflict(
-        Shred,          // original
-        shred::Payload, // conflict
-    ),
+    // As part of SIMD-0340
+    ChainedMerkleRootConflict(Slot),
+    // Secondary chained merkle root conflict with previous fec set
+    // As part of SIMD-0340
+    FixedFECChainedMerkleRootConflict(Slot),
 }
 
 impl PossibleDuplicateShred {
@@ -210,7 +211,8 @@ impl PossibleDuplicateShred {
             Self::LastIndexConflict(shred, _) => shred.slot(),
             Self::ErasureConflict(shred, _) => shred.slot(),
             Self::MerkleRootConflict(shred, _) => shred.slot(),
-            Self::ChainedMerkleRootConflict(shred, _) => shred.slot(),
+            Self::ChainedMerkleRootConflict(slot)
+            | Self::FixedFECChainedMerkleRootConflict(slot) => *slot,
         }
     }
 }
@@ -868,6 +870,33 @@ impl Blockstore {
             (slot, u64::from(fec_set_index)),
             &wincode::serialize(erasure_meta).unwrap(),
         )
+    }
+
+    /// Attempts to find the previous consecutive erasure set for `erasure_set`
+    /// using the fact that FEC sets are fixed in size at DATA_SHREDS_PER_FEC_BLOCK
+    /// data shreds.
+    ///
+    /// Only for use in the `Original` column
+    fn previous_fec_set_shred_id(
+        &self,
+        erasure_set: &ErasureSetId,
+        merkle_root_metas: &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
+    ) -> Option<ShredId> {
+        let prev_erasure_set = erasure_set.previous_fec_set()?;
+        let prev_merkle_root_meta = merkle_root_metas
+            .get(&(BlockLocation::Original, prev_erasure_set))
+            .map(WorkingEntry::as_ref)
+            .map(Cow::Borrowed)
+            .or_else(|| {
+                self.merkle_root_meta(prev_erasure_set)
+                    .unwrap()
+                    .map(Cow::Owned)
+            })?;
+        Some(ShredId::new(
+            erasure_set.slot(),
+            prev_merkle_root_meta.first_received_shred_index(),
+            prev_merkle_root_meta.first_received_shred_type(),
+        ))
     }
 
     /// Attempts to find the previous consecutive erasure set for `erasure_set`.
@@ -1727,9 +1756,6 @@ impl Blockstore {
                 continue;
             }
             let (slot, _) = erasure_set.store_key();
-            if self.has_duplicate_shreds_in_slot(slot) {
-                continue;
-            }
 
             // First coding shred from this erasure batch, check the forward merkle root chaining
             // Note: This check is not performed on Alternate columns, as we cannot repair coding shreds
@@ -1747,13 +1773,20 @@ impl Blockstore {
                 .get(&(BlockLocation::Original, shred_id))
                 .expect("Erasure meta was just created, initial shred must exist");
 
-            self.check_forward_chained_merkle_root_consistency(
-                shred,
-                erasure_meta,
-                &shred_insertion_tracker.just_inserted_shreds,
-                &shred_insertion_tracker.merkle_root_metas,
-                &mut shred_insertion_tracker.duplicate_shreds,
-            );
+            // Forward check for SIMD-0340
+            if let Some(next_fec_set_index) = erasure_meta.next_fec_set_index() {
+                let next_erasure_set = ErasureSetId::new(slot, next_fec_set_index);
+                if !self.check_forward_chained_merkle_root_consistency(
+                    shred,
+                    next_erasure_set,
+                    &shred_insertion_tracker.just_inserted_shreds,
+                    &shred_insertion_tracker.merkle_root_metas,
+                ) {
+                    shred_insertion_tracker
+                        .duplicate_shreds
+                        .push(PossibleDuplicateShred::ChainedMerkleRootConflict(slot));
+                }
+            }
         }
 
         for ((location, erasure_set), working_merkle_root_meta) in
@@ -1764,9 +1797,6 @@ impl Blockstore {
                 continue;
             }
             let (slot, _) = erasure_set.store_key();
-            if self.has_duplicate_shreds_in_slot(slot) {
-                continue;
-            }
 
             // First shred from this erasure batch, check the backwards merkle root chaining
             // Note: this check is not performed on Alternate columns as they are already validated
@@ -1786,12 +1816,60 @@ impl Blockstore {
                 .get(&(*location, shred_id))
                 .expect("Merkle root meta was just created, initial shred must exist");
 
-            self.check_backwards_chained_merkle_root_consistency(
-                shred,
-                &shred_insertion_tracker.just_inserted_shreds,
-                &shred_insertion_tracker.erasure_metas,
-                &mut shred_insertion_tracker.duplicate_shreds,
-            );
+            // Backward check for SIMD-0340
+            if let Some((_prev_erasure_set, prev_erasure_meta)) = self
+                .previous_erasure_set(*erasure_set, &shred_insertion_tracker.erasure_metas)
+                .expect("Expect database operations to succeed")
+            {
+                let prev_shred_id = ShredId::new(
+                    slot,
+                    prev_erasure_meta
+                        .first_received_coding_shred_index()
+                        .expect("First received coding index must fit in u32"),
+                    ShredType::Code,
+                );
+                if !self.check_backwards_chained_merkle_root_consistency(
+                    shred,
+                    prev_shred_id,
+                    &shred_insertion_tracker.just_inserted_shreds,
+                ) {
+                    shred_insertion_tracker
+                        .duplicate_shreds
+                        .push(PossibleDuplicateShred::ChainedMerkleRootConflict(slot));
+                    continue;
+                }
+            }
+
+            // Encompassing forward check for SIMD-0340
+            if let Some(next_erasure_set) = erasure_set.next_fec_set() {
+                if !self.check_forward_chained_merkle_root_consistency(
+                    shred,
+                    next_erasure_set,
+                    &shred_insertion_tracker.just_inserted_shreds,
+                    &shred_insertion_tracker.merkle_root_metas,
+                ) {
+                    shred_insertion_tracker.duplicate_shreds.push(
+                        PossibleDuplicateShred::FixedFECChainedMerkleRootConflict(slot),
+                    );
+                    continue;
+                }
+            }
+
+            // Encompassing backward check for SIMD-0340
+            if let Some(prev_shred_id) = self
+                .previous_fec_set_shred_id(erasure_set, &shred_insertion_tracker.merkle_root_metas)
+            {
+                if !self.check_backwards_chained_merkle_root_consistency(
+                    shred,
+                    prev_shred_id,
+                    &shred_insertion_tracker.just_inserted_shreds,
+                ) {
+                    shred_insertion_tracker.duplicate_shreds.push(
+                        PossibleDuplicateShred::FixedFECChainedMerkleRootConflict(slot),
+                    );
+                    continue;
+                }
+            }
         }
     }
 
@@ -3032,21 +3110,14 @@ impl Blockstore {
     fn check_forward_chained_merkle_root_consistency(
         &self,
         shred: &Shred,
-        erasure_meta: &ErasureMeta,
+        next_erasure_set: ErasureSetId,
         just_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
         merkle_root_metas: &HashMap<(BlockLocation, ErasureSetId), WorkingEntry<MerkleRootMeta>>,
-        duplicate_shreds: &mut Vec<PossibleDuplicateShred>,
     ) -> bool {
-        debug_assert!(erasure_meta.check_coding_shred(shred));
         let slot = shred.slot();
         let erasure_set = shred.erasure_set();
 
         // If a shred from the next fec set has already been inserted, check the chaining
-        let Some(next_fec_set_index) = erasure_meta.next_fec_set_index() else {
-            error!("Invalid erasure meta, unable to compute next fec set index {erasure_meta:?}");
-            return false;
-        };
-        let next_erasure_set = ErasureSetId::new(slot, next_fec_set_index);
         let Some(next_merkle_root_meta) = merkle_root_metas
             .get(&(BlockLocation::Original, next_erasure_set))
             .map(WorkingEntry::as_ref)
@@ -3073,10 +3144,9 @@ impl Blockstore {
         )
         .map(Cow::into_owned) else {
             error!(
-                "Shred {next_shred_id:?} indicated by merkle root meta {next_merkle_root_meta:?} \
-                 is missing from blockstore. This should only happen in extreme cases where \
-                 blockstore cleanup has caught up to the root. Skipping the forward chained \
-                 merkle root consistency check"
+                "Shred {next_shred_id:?} is missing from blockstore. This should only happen in \
+                 extreme cases where  blockstore cleanup has caught up to the root. Skipping the \
+                 forward chained merkle root consistency check"
             );
             return true;
         };
@@ -3093,12 +3163,6 @@ impl Blockstore {
                 next_merkle_root_meta.first_received_shred_type(),
             );
 
-            if !self.has_duplicate_shreds_in_slot(shred.slot()) {
-                duplicate_shreds.push(PossibleDuplicateShred::ChainedMerkleRootConflict(
-                    shred.clone(),
-                    next_shred,
-                ));
-            }
             return false;
         }
 
@@ -3120,12 +3184,10 @@ impl Blockstore {
     fn check_backwards_chained_merkle_root_consistency(
         &self,
         shred: &Shred,
+        prev_shred_id: ShredId,
         just_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
-        erasure_metas: &BTreeMap<ErasureSetId, WorkingEntry<ErasureMeta>>,
-        duplicate_shreds: &mut Vec<PossibleDuplicateShred>,
     ) -> bool {
         let slot = shred.slot();
-        let erasure_set = shred.erasure_set();
         let fec_set_index = shred.fec_set_index();
 
         if fec_set_index == 0 {
@@ -3136,26 +3198,6 @@ impl Blockstore {
             return true;
         }
 
-        // If a shred from the previous fec set has already been inserted, check the chaining.
-        // Since we cannot compute the previous fec set index, we check the in memory map, otherwise
-        // check the previous key from blockstore to see if it is consecutive with our current set.
-        let Some((prev_erasure_set, prev_erasure_meta)) = self
-            .previous_erasure_set(erasure_set, erasure_metas)
-            .expect("Expect database operations to succeed")
-        else {
-            // No shreds from the previous erasure batch have been received,
-            // so nothing to check. Once the previous erasure batch is received,
-            // we will verify this chain through the forward check above.
-            return true;
-        };
-
-        let prev_shred_id = ShredId::new(
-            slot,
-            prev_erasure_meta
-                .first_received_coding_shred_index()
-                .expect("First received coding index must fit in u32"),
-            ShredType::Code,
-        );
         let Some(prev_shred) = Self::get_shred_from_just_inserted_or_db(
             self,
             just_inserted_shreds,
@@ -3164,10 +3206,9 @@ impl Blockstore {
         )
         .map(Cow::into_owned) else {
             warn!(
-                "Shred {prev_shred_id:?} indicated by the erasure meta {prev_erasure_meta:?} is \
-                 missing from blockstore. This can happen if you have recently upgraded from a \
-                 version < v1.18.13, or if blockstore cleanup has caught up to the root. Skipping \
-                 the backwards chained merkle root consistency check"
+                "Shred {prev_shred_id:?} is missing from blockstore. This can happen if \
+                 blockstore cleanup has caught up to the root. Skipping the backwards chained \
+                 merkle root consistency check"
             );
             return true;
         };
@@ -3177,19 +3218,12 @@ impl Blockstore {
         if !self.check_chaining(merkle_root, chained_merkle_root) {
             warn!(
                 "Received conflicting chained merkle roots for slot: {slot}, shred {:?} type {:?} \
-                 chains to merkle root {chained_merkle_root:?}, however previous fec set coding \
-                 shred {prev_erasure_set:?} has merkle root {merkle_root:?}. Reporting as \
-                 duplicate",
+                 chains to merkle root {chained_merkle_root:?}, however previous fec set shred \
+                 {prev_shred_id:?} has merkle root {merkle_root:?}. Reporting as duplicate",
                 shred.erasure_set(),
                 shred.shred_type(),
             );
 
-            if !self.has_duplicate_shreds_in_slot(shred.slot()) {
-                duplicate_shreds.push(PossibleDuplicateShred::ChainedMerkleRootConflict(
-                    shred.clone(),
-                    prev_shred,
-                ));
-            }
             return false;
         }
 

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -6160,10 +6160,7 @@ fn test_chained_merkle_root_inconsistency_backwards_insert_code() {
     assert_eq!(duplicate_shreds.len(), 1);
     assert_eq!(
         duplicate_shreds[0],
-        PossibleDuplicateShred::ChainedMerkleRootConflict(
-            coding_shred,
-            coding_shred_previous.into_payload()
-        )
+        PossibleDuplicateShred::ChainedMerkleRootConflict(coding_shred.slot())
     );
 
     // Should not check again, even though this shred conflicts as well
@@ -6213,10 +6210,7 @@ fn test_chained_merkle_root_inconsistency_backwards_insert_data() {
     assert_eq!(duplicate_shreds.len(), 1);
     assert_eq!(
         duplicate_shreds[0],
-        PossibleDuplicateShred::ChainedMerkleRootConflict(
-            data_shred,
-            coding_shred_previous.into_payload(),
-        )
+        PossibleDuplicateShred::ChainedMerkleRootConflict(data_shred.slot())
     );
     // Should not check again, even though this shred conflicts as well
     assert!(
@@ -6263,13 +6257,58 @@ fn test_chained_merkle_root_inconsistency_forwards() {
     let duplicate_shreds =
         blockstore.insert_shred_return_duplicate(coding_shred.clone(), &leader_schedule);
 
+    assert_eq!(duplicate_shreds.len(), 2);
+    assert!(
+        duplicate_shreds.contains(&PossibleDuplicateShred::ChainedMerkleRootConflict(
+            coding_shred.slot(),
+        ))
+    );
+    assert!(
+        duplicate_shreds.contains(&PossibleDuplicateShred::FixedFECChainedMerkleRootConflict(
+            coding_shred.slot(),
+        ))
+    );
+}
+
+#[test]
+fn test_chained_merkle_root_inconsistency_data_shreds_only() {
+    // Insert data shreds from consecutive FEC sets without any coding shreds.
+    // The ErasureMeta-based SIMD-0340 check cannot run, so the fixed-FEC
+    // MerkleRootMeta check must catch the inconsistent chain.
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+    let parent_slot = 0;
+    let slot = 1;
+    let fec_set_index = 0;
+    let (data_shreds, _, leader_schedule) =
+        setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
+    let data_shred_previous = data_shreds[0].clone();
+    let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
+
+    assert!(
+        blockstore
+            .insert_shred_return_duplicate(data_shred_previous.clone(), &leader_schedule,)
+            .is_empty()
+    );
+
+    let merkle_root = Hash::new_unique();
+    assert!(merkle_root != data_shred_previous.merkle_root().unwrap());
+    let (data_shreds, _, leader_schedule) = setup_erasure_shreds_with_index_and_chained_merkle(
+        slot,
+        parent_slot,
+        10,
+        next_fec_set_index,
+        merkle_root,
+    );
+    let data_shred = data_shreds[0].clone();
+
+    let duplicate_shreds =
+        blockstore.insert_shred_return_duplicate(data_shred.clone(), &leader_schedule);
     assert_eq!(duplicate_shreds.len(), 1);
     assert_eq!(
         duplicate_shreds[0],
-        PossibleDuplicateShred::ChainedMerkleRootConflict(
-            coding_shred,
-            next_data_shred.into_payload(),
-        )
+        PossibleDuplicateShred::FixedFECChainedMerkleRootConflict(data_shred.slot())
     );
 }
 
@@ -6337,10 +6376,7 @@ fn test_chained_merkle_root_inconsistency_both() {
     assert_eq!(duplicate_shreds.len(), 1);
     assert_eq!(
         duplicate_shreds[0],
-        PossibleDuplicateShred::ChainedMerkleRootConflict(
-            data_shred,
-            prev_coding_shred.into_payload(),
-        )
+        PossibleDuplicateShred::ChainedMerkleRootConflict(data_shred.slot())
     );
 
     // Insert coding shred
@@ -6351,10 +6387,7 @@ fn test_chained_merkle_root_inconsistency_both() {
     assert_eq!(duplicate_shreds.len(), 1);
     assert_eq!(
         duplicate_shreds[0],
-        PossibleDuplicateShred::ChainedMerkleRootConflict(
-            coding_shred,
-            next_data_shred.into_payload(),
-        )
+        PossibleDuplicateShred::ChainedMerkleRootConflict(coding_shred.slot())
     );
 }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2713,7 +2713,9 @@ pub fn check_chained_block_id(
     bank: &Bank,
     migration_status: &MigrationStatus,
 ) -> ChainedBlockIdCheck {
-    if !bank.feature_set.snapshot().validate_chained_block_id {
+    let feature_snapshot = bank.feature_set.snapshot();
+    if !(feature_snapshot.validate_chained_block_id || feature_snapshot.validate_chained_block_id_2)
+    {
         return ChainedBlockIdCheck::Inactive;
     }
 
@@ -6371,6 +6373,27 @@ pub mod tests {
         assert!(matches!(
             check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
             ChainedBlockIdCheck::Mismatch
+        ));
+
+        // Case 3a: With only the replacement feature active, replay should
+        // still run the existing inter-slot SIMD-0340 check.
+        insert_shreds_with_chained_merkle_root(14, 0, Hash::new_unique());
+        let mut child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 14);
+        child_bank.deactivate_feature(&agave_feature_set::validate_chained_block_id::id());
+        child_bank.activate_feature(&agave_feature_set::validate_chained_block_id_2::id());
+        assert!(matches!(
+            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
+            ChainedBlockIdCheck::Mismatch
+        ));
+
+        // Case 3b: With both feature gates inactive, replay should not run the
+        // chained block ID check.
+        let mut child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 14);
+        child_bank.deactivate_feature(&agave_feature_set::validate_chained_block_id::id());
+        child_bank.deactivate_feature(&agave_feature_set::validate_chained_block_id_2::id());
+        assert!(matches!(
+            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
+            ChainedBlockIdCheck::Inactive
         ));
 
         // Case 4: UpdateParent metadata does not bypass Tower validation.

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -352,6 +352,18 @@ impl ErasureSetId {
         self.1
     }
 
+    pub(crate) fn previous_fec_set(&self) -> Option<Self> {
+        self.1
+            .checked_sub(DATA_SHREDS_PER_FEC_BLOCK as u32)
+            .map(|fec_set_index| Self::new(self.0, fec_set_index))
+    }
+
+    pub(crate) fn next_fec_set(&self) -> Option<Self> {
+        self.1
+            .checked_add(DATA_SHREDS_PER_FEC_BLOCK as u32)
+            .map(|fec_set_index| Self::new(self.0, fec_set_index))
+    }
+
     // Storage key for ErasureMeta and MerkleRootMeta in blockstore db.
     // Note: ErasureMeta column uses u64 so this will need to be typecast
     pub(crate) fn store_key(&self) -> (Slot, /*fec_set_index:*/ u32) {


### PR DESCRIPTION
Part of the https://github.com/anza-xyz/agave/issues/11032 effort
#### Problem
When checking the merkle root chaining for adjacent FEC sets for SIMD-0340 we perform an expensive scan and delay until we've received the `ErasureMeta`

This was because the code predates SIMD-0317 (fixed FEC sets of 32:32) so it needed the scan / `ErasureMeta` to deal with the dynamic sizing.

#### Summary of Changes
Now that SIMD-0317 is active we can just use +-32 offsets and remove the scan
The check can be performed immediately as soon as we receive any shred from the FEC set, rather than waiting for the `ErasureMeta` to figure out the FEC set size.
