### PR TITLE
core/bls-sigverify: votes channel-full does blocking send too (follow-up to #12685)

### DIFF
--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -653,16 +653,33 @@ mod tests {
         ctx.verifier
             .verify_and_send_batches(messages_to_batches(std::slice::from_ref(&msg1)))
             .unwrap();
+
+        // The cap-1 channel is now full.  The second send hits Full and falls
+        // back to a blocking send (see `send_votes_to_pool`); drain in a
+        // background thread so the blocking send can complete.
+        let pool_receiver = ctx.pool_receiver.clone();
+        let drain = std::thread::spawn(move || {
+            let m1 = pool_receiver.recv().expect("recv msg1");
+            let m2 = pool_receiver.recv().expect("recv msg2");
+            // No leftover messages on the channel after both deliveries.
+            assert!(matches!(
+                pool_receiver.try_recv(),
+                Err(crossbeam_channel::TryRecvError::Empty)
+            ));
+            (m1, m2)
+        });
+
         ctx.verifier
-            .verify_and_send_batches(messages_to_batches(&[msg2]))
+            .verify_and_send_batches(messages_to_batches(std::slice::from_ref(&msg2)))
             .unwrap();
 
-        // We failed to send the second message because the channel is full.
-        let msgs = ctx.pool_receiver.try_iter().flatten().collect::<Vec<_>>();
-        assert_eq!(msgs.len(), 1);
-        assert_eq!(msgs, vec![msg1]);
-        assert_eq!(ctx.verifier.stats.vote_stats.pool_sent, 1);
-        assert_eq!(ctx.verifier.stats.vote_stats.pool_channel_full, 1);
+        let (m1_recv, m2_recv) = drain.join().expect("drain joined");
+        // Both messages were eventually delivered (no silent drop).
+        assert_eq!(m1_recv, vec![msg1]);
+        assert_eq!(m2_recv, vec![msg2]);
+        // pool_sent counts every message that made it onto the channel,
+        // whether via try_send or the blocking fallback.
+        assert_eq!(ctx.verifier.stats.vote_stats.pool_sent, 2);
     }
 
     #[test]

--- a/core/src/bls_sigverify/stats.rs
+++ b/core/src/bls_sigverify/stats.rs
@@ -304,9 +304,11 @@ pub(super) struct SigVerifyVoteStats {
     pub(super) rewards_sent: u64,
     /// Number of times the channel to rewards was full.
     pub(super) rewards_channel_full: u64,
+    /// How many messages are outstanding on the channel.
+    pub(super) pool_outstanding_msgs: u64,
     /// Number of votes sent successfully over the channel to consensus pool.
     pub(super) pool_sent: u64,
-    /// Number of times the channel to consensus pool was full.
+    /// Number of times the channel to consensus pool was full and we resorted to blocking send.
     pub(super) pool_channel_full: u64,
     /// Number of votes sent successfully over the channel to repair.
     pub(super) repair_sent: u64,
@@ -337,6 +339,7 @@ impl SigVerifyVoteStats {
             rewards_channel_full,
             repair_sent,
             repair_channel_full,
+            pool_outstanding_msgs,
             pool_sent,
             pool_channel_full,
             fn_verify_and_send_votes_stats,
@@ -354,6 +357,7 @@ impl SigVerifyVoteStats {
         self.rewards_channel_full += rewards_channel_full;
         self.repair_sent += repair_sent;
         self.repair_channel_full += repair_channel_full;
+        self.pool_outstanding_msgs += pool_outstanding_msgs;
         self.pool_sent += pool_sent;
         self.pool_channel_full += pool_channel_full;
         self.fn_verify_and_send_votes_stats
@@ -377,6 +381,7 @@ impl SigVerifyVoteStats {
             rewards_channel_full,
             repair_sent,
             repair_channel_full,
+            pool_outstanding_msgs,
             pool_sent,
             pool_channel_full,
             fn_verify_and_send_votes_stats,
@@ -396,6 +401,7 @@ impl SigVerifyVoteStats {
             ("rewards_channel_full", *rewards_channel_full, i64),
             ("repair_sent", *repair_sent, i64),
             ("repair_channel_full", *repair_channel_full, i64),
+            ("pool_outstanding_msgs", *pool_outstanding_msgs, i64),
             ("pool_sent", *pool_sent, i64),
             ("pool_channel_full", *pool_channel_full, i64),
             (

--- a/core/src/bls_sigverify/utils.rs
+++ b/core/src/bls_sigverify/utils.rs
@@ -54,23 +54,34 @@ pub(super) fn send_votes_to_rewards(
     }
 }
 
+/// Sends the `votes` to the consensus pool.  If the channel is full, then does a
+/// blocking send.
 pub(super) fn send_votes_to_pool(
     votes: Vec<ConsensusMessage>,
     channel: &Sender<Vec<ConsensusMessage>>,
     stats: &mut SigVerifyVoteStats,
 ) -> Result<(), SigVerifyVoteError> {
-    let len = votes.len();
-    if len == 0 {
+    if votes.is_empty() {
         return Ok(());
     }
+    let len = votes.len();
     match channel.try_send(votes) {
         Ok(()) => {
             stats.pool_sent += len as u64;
+            stats.pool_outstanding_msgs = channel.len() as u64;
             Ok(())
         }
-        Err(TrySendError::Full(_)) => {
+        Err(TrySendError::Full(msgs)) => {
             stats.pool_channel_full += 1;
-            Ok(())
+            error!("votes channel to consensus pool is full.  Doing a blocking send.");
+            match channel.send(msgs) {
+                Ok(()) => {
+                    info!("votes channel to consensus pool has space again");
+                    stats.pool_sent += len as u64;
+                    Ok(())
+                }
+                Err(_) => Err(SigVerifyVoteError::ConsensusPoolChannelDisconnected),
+            }
         }
         Err(TrySendError::Disconnected(_)) => {
             Err(SigVerifyVoteError::ConsensusPoolChannelDisconnected)
@@ -122,6 +133,7 @@ pub(super) fn send_certs_to_pool(
             match channel_to_pool.send(msgs) {
                 Ok(()) => {
                     info!("certs channel to consensus pool has space again");
+                    stats.pool_sent += len as u64;
                     Ok(())
                 }
                 Err(_) => Err(SigVerifyCertError::ConsensusPoolChannelDisconnected),


### PR DESCRIPTION
## Problem

#12685 fixed `send_certs_to_pool` to fall back to a blocking send when the
bounded `channel_to_pool` is full, so a flood does not silently drop
certificates (per #12660: a dropped cert that the sigverifier has cached
would be re-suppressed by the `verified_certs` check on retry, potentially
preventing finalization).

`send_votes_to_pool` writes to the same `channel_to_pool` (a single
`Sender<Vec<ConsensusMessage>>` shared between certs and votes) but still
silently drops on Full:

```rust
Err(TrySendError::Full(_)) => {
    stats.pool_channel_full += 1;
    Ok(())   // dropped
}
```

Under load both halves of the pool feed are at risk of the same outage
mode, but #12685 only addressed half.

A loose end sat in the stats already: `SigVerifyCertStats` got a
`pool_outstanding_msgs` field as part of #12685, but the symmetric field
was not added to `SigVerifyVoteStats`, leaving operators blind to vote-side
backlog.

## Fix

Mirror `send_certs_to_pool`'s shape onto `send_votes_to_pool`:

- On `TrySendError::Full`, do a blocking `channel.send(msgs)` instead of
  dropping, with `error!`/`info!` logs around it (same wording as the cert
  version, scoped to "votes").
- Update `pool_outstanding_msgs` on the fast path so the new metric stays
  current.

Add the matching `pool_outstanding_msgs` field to `SigVerifyVoteStats` (plus
its `merge` and `report` wiring) and update the `pool_channel_full` doc to
note that it now counts batches that fell back to a blocking send.

Update `test_blssigverifier_send_packets_channel_full` to match the new
"no drop" contract: drain the cap-1 receiver from a background thread so
the blocking send can complete, and assert both messages are delivered
(only the first via `try_send`, the second via the blocking fallback).

## Notes

- `send_votes_to_metrics`, `send_votes_to_rewards`, and `send_votes_to_repair`
  still drop on Full and that is left alone. They go to different channels
  (metrics is best-effort sampling; rewards/repair are retry-driven). This
  change is scoped to the `channel_to_pool` symmetry with #12685.
- Stats keep #12685's convention: `pool_sent` counts `try_send`-OK fast sends
  by message count, `pool_channel_full` counts batches that took the blocking
  fallback.
