### PR TITLE
Slot range duration plumbing

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -469,18 +469,14 @@ fn select_freshest_window(
 /// Clamps the block producer timestamp to ensure that the leader produces a timestamp that conforms
 /// to Alpenglow clock bounds.
 fn skew_block_producer_time_nanos(
-    parent_slot: Slot,
     parent_time_nanos: i64,
-    working_bank_slot: Slot,
     working_bank_time_nanos: i64,
-    ns_per_slot: u64,
+    elapsed_slot_duration_nanos: u128,
 ) -> i64 {
     let (min_working_bank_time, max_working_bank_time) =
         BlockComponentProcessor::nanosecond_time_bounds(
-            parent_slot,
             parent_time_nanos,
-            working_bank_slot,
-            ns_per_slot,
+            elapsed_slot_duration_nanos,
         );
 
     working_bank_time_nanos
@@ -509,14 +505,13 @@ fn produce_block_footer(
             .get_nanosecond_clock()
             .unwrap_or_else(|| bank.clock().unix_timestamp.saturating_mul(1_000_000_000));
         let parent_slot = parent_bank.slot();
-        let ns_per_slot = u64::try_from(bank.ns_per_slot_at_slot(slot)).unwrap_or(u64::MAX);
+        let elapsed_slot_duration_nanos =
+            bank.slot_range_duration_nanos(parent_slot.saturating_add(1), slot);
 
         block_producer_time_nanos = skew_block_producer_time_nanos(
-            parent_slot,
             parent_time_nanos,
-            slot,
             block_producer_time_nanos,
-            ns_per_slot,
+            elapsed_slot_duration_nanos,
         );
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2755,20 +2755,26 @@ impl Bank {
         let mut duration = 0.0;
 
         for (effective_slot, effective_params) in self.slot_params.param_transitions() {
-            if *effective_slot <= start_slot {
-                params = *effective_params;
+            if effective_slot <= start_slot {
+                params = effective_params;
                 continue;
             }
-            if *effective_slot >= end_slot {
+            if effective_slot >= end_slot {
                 break;
             }
 
-            duration += (*effective_slot - cursor) as f64 / params.slots_per_year();
-            cursor = *effective_slot;
-            params = *effective_params;
+            duration += (effective_slot - cursor) as f64 / params.slots_per_year();
+            cursor = effective_slot;
+            params = effective_params;
         }
 
         duration + (end_slot - cursor) as f64 / params.slots_per_year()
+    }
+
+    /// Returns the exact wall-clock duration in nanoseconds for `start_slot..=end_slot`.
+    pub fn slot_range_duration_nanos(&self, start_slot: Slot, end_slot: Slot) -> u128 {
+        self.slot_params
+            .slot_range_duration_nanos(start_slot, end_slot)
     }
 
     pub fn epoch_duration_in_years(&self, epoch: Epoch) -> f64 {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6656,6 +6656,12 @@ fn test_slot_params_use_genesis_baseline_without_features() {
         bank.slot_range_duration_in_years(0, 64).to_bits(),
         (64.0 / genesis_slots_per_year).to_bits()
     );
+    assert_eq!(bank.slot_range_duration_nanos(1, 0), 0);
+    assert_eq!(bank.slot_range_duration_nanos(0, 0), genesis_ns_per_slot);
+    assert_eq!(
+        bank.slot_range_duration_nanos(0, 63),
+        64 * genesis_ns_per_slot
+    );
     assert_eq!(
         bank.partitioned_rewards_stake_account_stores_per_block,
         stake_account_stores_per_block

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -456,10 +456,11 @@ impl BlockComponentProcessor {
         let current_time_nanos =
             Self::block_producer_time_nanos_as_i64(footer.block_producer_time_nanos)?;
         let current_slot = bank.slot();
-        let ns_per_slot = bank.ns_per_slot.try_into().expect("ns_per_slot overflow");
+        let elapsed_slot_duration_nanos =
+            bank.slot_range_duration_nanos(parent_slot.saturating_add(1), current_slot);
 
         let (lower_bound_nanos, upper_bound_nanos) =
-            Self::nanosecond_time_bounds(parent_slot, parent_time_nanos, current_slot, ns_per_slot);
+            Self::nanosecond_time_bounds(parent_time_nanos, elapsed_slot_duration_nanos);
 
         let is_valid =
             lower_bound_nanos <= current_time_nanos && current_time_nanos <= upper_bound_nanos;
@@ -483,26 +484,24 @@ impl BlockComponentProcessor {
             .map_err(|_| BlockComponentProcessorError::NanosecondClockOutOfBounds)
     }
 
-    /// Given the parent slot, parent time, slot, and default nanoseconds per
-    /// slot, calculate the lower and upper bounds for the block producer time.
-    /// We return (lower_bound, upper_bound), where both bounds are inclusive.
-    /// I.e., the working bank time is valid if lower_bound <= working_bank_time
-    /// <= upper_bound.
+    /// Given a parent time and elapsed slot duration, calculates inclusive
+    /// block producer timestamp bounds.
+    ///
+    /// `parent_time_nanos` describes the parent bank's nanosecond clock.
+    /// `elapsed_slot_duration_nanos` is the summed duration for all skipped
+    /// and working slots after the parent. The returned `(lower_bound,
+    /// upper_bound)` accepts timestamps where
+    /// `lower_bound <= working_bank_time <= upper_bound`.
     ///
     /// Refer to
     /// https://github.com/solana-foundation/solana-improvement-documents/pull/363
     /// for details on the bounds calculation.
     pub fn nanosecond_time_bounds(
-        parent_slot: Slot,
         parent_time_nanos: i64,
-        slot: Slot,
-        ns_per_slot: u64,
+        elapsed_slot_duration_nanos: u128,
     ) -> (i64, i64) {
-        let diff_slots = slot.saturating_sub(parent_slot);
-
         let min_working_bank_time = parent_time_nanos.saturating_add(1);
-        let max_working_bank_time_offset = u128::from(diff_slots)
-            .saturating_mul(u128::from(ns_per_slot))
+        let max_working_bank_time_offset = elapsed_slot_duration_nanos
             .saturating_mul(2)
             .min(i64::MAX as u128) as i64;
         let max_working_bank_time = parent_time_nanos.saturating_add(max_working_bank_time_offset);
@@ -1086,14 +1085,13 @@ mod tests {
         let parent_slot = parent.slot();
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
         let current_slot = bank.slot();
-        let ns_per_slot = bank.ns_per_slot.try_into().expect("ns_per_slot overflow");
+        let elapsed_slot_duration_nanos =
+            bank.slot_range_duration_nanos(parent_slot.saturating_add(1), current_slot);
 
         // Use a timestamp in the middle of the valid range
         let (lower_bound, upper_bound) = BlockComponentProcessor::nanosecond_time_bounds(
-            parent_slot,
             parent_time_nanos,
-            current_slot,
-            ns_per_slot,
+            elapsed_slot_duration_nanos,
         );
         let footer_time_nanos = (lower_bound + upper_bound) / 2;
         let expected_time_secs = footer_time_nanos / 1_000_000_000;
@@ -1136,13 +1134,11 @@ mod tests {
         parent.update_clock_from_footer(parent_time_nanos);
 
         let bank: Arc<Bank> = create_child_bank(&bank_forks, &parent, slot_gap);
-        let ns_per_slot = bank.ns_per_slot.try_into().expect("ns_per_slot overflow");
+        let elapsed_slot_duration_nanos = bank.slot_range_duration_nanos(1, slot_gap);
 
         let (lower_bound, upper_bound) = BlockComponentProcessor::nanosecond_time_bounds(
-            0,
             parent_time_nanos,
-            slot_gap,
-            ns_per_slot,
+            elapsed_slot_duration_nanos,
         );
 
         let footer_time_nanos = timestamp_fn(parent_time_nanos, lower_bound, upper_bound);
@@ -1235,18 +1231,14 @@ mod tests {
 
     // Helper function to test nanosecond_time_bounds calculation
     fn test_nanosecond_time_bounds_helper(
-        parent_slot: u64,
         parent_time_nanos: i64,
-        working_slot: u64,
-        ns_per_slot: u64,
+        elapsed_slot_duration_nanos: u128,
         expected_lower: i64,
         expected_upper: i64,
     ) {
         let (lower, upper) = BlockComponentProcessor::nanosecond_time_bounds(
-            parent_slot,
             parent_time_nanos,
-            working_slot,
-            ns_per_slot,
+            elapsed_slot_duration_nanos,
         );
 
         assert_eq!(lower, expected_lower);
@@ -1264,10 +1256,8 @@ mod tests {
         let working_slot = 15;
         let slot_delta = working_slot - parent_slot;
         test_nanosecond_time_bounds_helper(
-            parent_slot,
             parent_time,
-            working_slot,
-            DEFAULT_NS_PER_SLOT,
+            u128::from(slot_delta).saturating_mul(u128::from(DEFAULT_NS_PER_SLOT)),
             parent_time + 1,
             parent_time + (2 * DEFAULT_NS_PER_SLOT * slot_delta) as i64,
         );
@@ -1282,21 +1272,14 @@ mod tests {
         // Note: In this case, lower > upper, so no timestamp would be valid
         // This is expected since we shouldn't have the same slot for parent and working bank
         let parent_time = 1_000_000_000_000;
-        test_nanosecond_time_bounds_helper(
-            10,
-            parent_time,
-            10,
-            DEFAULT_NS_PER_SLOT,
-            parent_time + 1,
-            parent_time,
-        );
+        test_nanosecond_time_bounds_helper(parent_time, 0, parent_time + 1, parent_time);
     }
 
     #[test]
     fn test_nanosecond_time_bounds_saturates_upper_bound() {
         let parent_time = i64::MAX - 5;
         let (lower, upper) =
-            BlockComponentProcessor::nanosecond_time_bounds(0, parent_time, u64::MAX, u64::MAX);
+            BlockComponentProcessor::nanosecond_time_bounds(parent_time, u128::MAX);
 
         assert_eq!(lower, parent_time + 1);
         assert_eq!(upper, i64::MAX);

--- a/runtime/src/slot_params.rs
+++ b/runtime/src/slot_params.rs
@@ -1,4 +1,11 @@
-use {solana_clock::Slot, solana_epoch_schedule::EpochSchedule};
+use {
+    solana_clock::Slot,
+    solana_epoch_schedule::EpochSchedule,
+    std::{
+        collections::BTreeMap,
+        ops::Bound::{Excluded, Included},
+    },
+};
 
 pub const DEFAULT_MAX_ENTRY_BYTES_PER_SLOT: u64 = 20 * 1024 * 1024; // 20 MiB
 
@@ -118,7 +125,7 @@ pub(crate) struct SlotParamsArchive {
     /// parameters apply to some other slot?" Examples include shred filtering
     /// for incoming shreds and inflation calculations that span historical slot
     /// ranges.
-    param_transitions: Vec<(Slot, SlotParams)>,
+    param_transitions: BTreeMap<Slot, SlotParams>,
 }
 
 impl Default for SlotParamsArchive {
@@ -134,14 +141,14 @@ impl SlotParamsArchive {
     /// right shape for delayed, epoch-boundary-effective feature transitions.
     pub(crate) fn new(_epoch_schedule: &EpochSchedule, baseline_params: SlotParams) -> Self {
         Self {
-            param_transitions: vec![(0, baseline_params)],
+            param_transitions: BTreeMap::from([(0, baseline_params)]),
         }
     }
 
     /// Returns the baseline params supplied at genesis or snapshot restore.
     pub(crate) fn baseline_params(&self) -> SlotParams {
         self.param_transitions
-            .first()
+            .first_key_value()
             .map(|(_, params)| *params)
             .unwrap_or(LEGACY_SLOT_PARAMS)
     }
@@ -149,14 +156,43 @@ impl SlotParamsArchive {
     /// Returns the slot params effective at `slot`.
     pub(crate) fn params_at_slot(&self, slot: Slot) -> SlotParams {
         self.param_transitions
-            .iter()
-            .rev()
-            .find_map(|(effective_slot, params)| (*effective_slot <= slot).then_some(*params))
+            .range(..=slot)
+            .next_back()
+            .map(|(_, params)| *params)
             .unwrap_or(LEGACY_SLOT_PARAMS)
     }
 
     /// Returns sorted slot-parameter transitions.
-    pub(crate) fn param_transitions(&self) -> &[(Slot, SlotParams)] {
-        &self.param_transitions
+    pub(crate) fn param_transitions(&self) -> impl Iterator<Item = (Slot, SlotParams)> + '_ {
+        self.param_transitions
+            .iter()
+            .map(|(slot, params)| (*slot, *params))
+    }
+
+    /// Returns the exact wall-clock duration in nanoseconds for
+    /// `start_slot..=end_slot`.
+    pub(crate) fn slot_range_duration_nanos(&self, start_slot: Slot, end_slot: Slot) -> u128 {
+        if start_slot > end_slot {
+            return 0;
+        }
+
+        let mut cursor = start_slot;
+        let mut params = self.params_at_slot(start_slot);
+        let mut duration = 0u128;
+
+        for (&effective_slot, &effective_params) in self
+            .param_transitions
+            .range((Excluded(start_slot), Included(end_slot)))
+        {
+            duration = duration.saturating_add(
+                u128::from(effective_slot.saturating_sub(cursor))
+                    .saturating_mul(params.ns_per_slot()),
+            );
+            cursor = effective_slot;
+            params = effective_params;
+        }
+
+        let remaining_slots = u128::from(end_slot.saturating_sub(cursor)) + 1;
+        duration.saturating_add(remaining_slots.saturating_mul(params.ns_per_slot()))
     }
 }


### PR DESCRIPTION
## Summary

Adds slot-range duration plumbing to `Bank` / `SlotParamsArchive` and uses it for Alpenglow nanosecond-clock bounds.

This is a behavior-preserving prep change ahead of future slot-time feature work. With only the current legacy slot params active, the new range-duration helper produces the same result as the old `slot_delta * ns_per_slot` calculation.

## What Changed

- Changed `SlotParamsArchive` transition storage from `Vec<(Slot, SlotParams)>` to `BTreeMap<Slot, SlotParams>`.
- Updated slot-param lookup to use ordered map range queries.
- Added `SlotParamsArchive::slot_range_duration_nanos(start_slot, end_slot)`.
- Added `Bank::slot_range_duration_nanos(start_slot, end_slot)`.
- Updated Alpenglow block timestamp bound calculation to accept elapsed slot duration instead of `(parent_slot, working_slot, ns_per_slot)`.
- Updated block footer timestamp clamping to use `Bank::slot_range_duration_nanos()`.
- Added focused coverage for genesis-baseline nanos range duration.

## Why

Future slot-time changes can make skipped-slot ranges span multiple slot-duration regimes. Passing a single `ns_per_slot` scalar is not sufficient in that world.

This patch sets up the dynamic range-duration API independently, before adding any feature gates or reduced slot-time values, keeping the later feature-switch PR smaller and easier to review.