### PR TITLE
replay: plug in bank switch metrics

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2499,6 +2499,7 @@ impl ReplayStage {
 
             // Switch the blockstore data atomically, handles slot meta chaining so generate new bank forks can proceed
             blockstore.switch_block_from_alternate(slot, location)?;
+            progress.increment_num_bank_switches(slot);
             info!("{my_pubkey}: Switched {slot} from {location:?}");
         }
 


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/12754 upstreamed the bank switch metrics but forgot to plug them in.

Missed it because the layout of this function was changed and it was clobbered when rebasing the mega diff😓 

#### Summary of Changes
Plug it in
