### PR TITLE
replay: root progress map normally

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1055,8 +1055,6 @@ impl ReplayStage {
                         &optimistic_parent_receiver,
                         &replay_highest_frozen,
                         &mut highest_frozen_slot,
-                        &mut progress,
-                        did_complete_bank,
                     );
                     let mut process_switch_bank_events_time =
                         Measure::start("process_switch_bank_events_time");
@@ -1579,7 +1577,6 @@ impl ReplayStage {
         Ok(Self { t_replay })
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn alpenglow_handle_newly_frozen_banks(
         new_frozen_slots: &[Slot],
         migration_status: &MigrationStatus,
@@ -1590,8 +1587,6 @@ impl ReplayStage {
         optimistic_parent_receiver: &Receiver<LeaderWindowInfo>,
         replay_highest_frozen: &ReplayHighestFrozen,
         highest_frozen_slot: &mut Slot,
-        progress: &mut ProgressMap,
-        did_complete_bank: bool,
     ) {
         let flh_candidate_banks = {
             let bank_forks_r = bank_forks.read().unwrap();
@@ -1620,10 +1615,6 @@ impl ReplayStage {
                 *l_highest_frozen = *highest;
                 replay_highest_frozen.freeze_notification.notify_one();
             }
-        }
-        if did_complete_bank {
-            let bank_forks_r = bank_forks.read().unwrap();
-            progress.handle_new_root(&bank_forks_r);
         }
     }
 
@@ -5037,7 +5028,7 @@ impl ReplayStage {
         async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
     ) -> Result<(), TryRecvError> {
         if let Some(command) = bank_forks_controller_receiver.take_set_root_command() {
-            Self::process_set_root_command(command, context, my_pubkey);
+            Self::process_set_root_command(command, context, my_pubkey, progress);
         }
 
         loop {
@@ -5055,6 +5046,7 @@ impl ReplayStage {
         command: SetRootCommand,
         context: &ProcessBankForksContext,
         my_pubkey: &Pubkey,
+        progress: &mut ProgressMap,
     ) {
         let SetRootCommand {
             parent_slot,
@@ -5073,7 +5065,7 @@ impl ReplayStage {
             &context.bank_forks,
             context.rpc_subscriptions.as_deref(),
             my_pubkey,
-            |_| {},
+            |bank_forks| progress.handle_new_root(bank_forks),
         );
     }
 


### PR DESCRIPTION
#### Problem
When we split out rooting to the votor thread we special cased `ProgressMap` as it was a non TBFT structure that still had to exist and be rooted in Alpenglow.

Now that we've moved back rooting to replay stage we don't need to special case it anymore.

#### Summary of Changes
Instead of checking it every iteration for a possible root, just root it normally using the callback
