### PR TITLE
rpc: perf fix for solana stakes

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1700,9 +1700,11 @@ pub async fn process_show_stakes(
         .await?;
     let stake_history_account = rpc_client.get_account(&stake_history::id()).await?;
     let clock_account = rpc_client.get_account(&sysvar::clock::id()).await?;
+    let rent_account = rpc_client.get_account(&sysvar::rent::id()).await?;
     let clock: Clock = from_account(&clock_account).ok_or_else(|| {
         CliError::RpcRequestError("Failed to deserialize clock sysvar".to_string())
     })?;
+    let rent: Rent = rent_account.deserialize_data()?;
     let stake_history: StakeHistory =
         bincode::deserialize(&stake_history_account.data).map_err(|_| {
             CliError::RpcRequestError("Failed to deserialize stake history".to_string())
@@ -1721,9 +1723,7 @@ pub async fn process_show_stakes(
              Ensure that the account was fetched using a binary encoding.",
         );
         if let Ok(stake_state) = stake_account.state() {
-            let rent_exempt_balance = rpc_client
-                .get_minimum_balance_for_rent_exemption(stake_account.data.len())
-                .await?;
+            let rent_exempt_balance = rent.minimum_balance(stake_account.data.len()).max(1);
 
             match stake_state {
                 StakeStateV2::Initialized(_) if vote_account_pubkeys.is_empty() => {


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/issues/12856
We make one `getMinimumBalanceForRentExemption` call per stake account when calling `solana stakes`.
Rent is the same within this call, so no reason to hit RPC

#### Summary of Changes
Get the rent account once and use it for every stake account.

Fixes #12856
