### PR TITLE
docs: fix typo in quic stream documentation

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -90,7 +90,7 @@ pub(crate) const MIN_RTT: Duration = Duration::from_millis(2);
 /// before considering stream to be "too late". 1.5 RTT should be enough
 /// for any reasonable fragmentation to be resolved, so the only way
 /// a stream reassembly would be delayed more is when something
-/// extraordinary has occured (congestion control or flow control blocking)
+/// extraordinary has occurred (congestion control or flow control blocking)
 const LATE_REASSEMBLY_THRESHOLD: f32 = 1.5;
 
 // A struct to accumulate the bytes making up


### PR DESCRIPTION
## Description

This PR fixes a minor spelling error in the documentation comments within the QUIC streamer module (`streamer/src/nonblocking/quic.rs`). Specifically, it corrects `occured` to `occurred` to ensure better searchability and readability of the codebase comments.

---
*Payout Address (Solana):* `6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp`