### PR TITLE
genesis_utils: Inserts a valid genesis cert bitmap

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8331,6 +8331,7 @@ dependencies = [
  "assert_matches",
  "base64 0.22.1",
  "bincode",
+ "bitvec",
  "bytemuck",
  "crossbeam-channel",
  "dashmap",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8138,6 +8138,7 @@ dependencies = [
  "assert_matches",
  "base64 0.22.1",
  "bincode",
+ "bitvec",
  "bytemuck",
  "crossbeam-channel",
  "dashmap",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -65,6 +65,7 @@ arrayref = { workspace = true }
 assert_matches = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
+bitvec = { workspace = true }
 bytemuck = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api", "serde"] }

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -14,6 +14,7 @@ use {
         migration::GENESIS_CERTIFICATE_ACCOUNT,
     },
     bincode::serialize,
+    bitvec::vec::BitVec,
     log::*,
     solana_account::{Account, AccountSharedData, ReadableAccount, state_traits::StateMut},
     solana_bls_signatures::{
@@ -34,6 +35,7 @@ use {
     solana_sdk_ids::{stake as stake_program, sysvar},
     solana_seed_derivable::SeedDerivable,
     solana_signer::Signer,
+    solana_signer_store::encode_base2,
     solana_stake_interface::state::{Authorized, Lockup, Meta, StakeStateV2},
     solana_system_interface::program as system_program,
     solana_sysvar::{
@@ -325,7 +327,7 @@ pub fn activate_all_features_alpenglow(genesis_config: &mut GenesisConfig) {
     let cert = Certificate {
         cert_type: CertificateType::Genesis(0, Hash::default()),
         signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-        bitmap: Vec::default(),
+        bitmap: encode_base2(&BitVec::new()).unwrap(),
     };
     let cert_size = bincode::serialized_size(&cert).unwrap();
     let lamports = Rent::default().minimum_balance(cert_size as usize);


### PR DESCRIPTION
#### Problem

An empty Vec is not a valid base2 encoding of an empty bitvec and decoding it as a base2 bitmap fails.


#### Summary of Changes

Updates the code to use a proper base2 encoded empty bitmap.