### PR TITLE
feat(multinode-demo): adds solana-transaction-bench as a primary in scripts

### DIFF
--- a/multinode-demo/bench-tps.sh
+++ b/multinode-demo/bench-tps.sh
@@ -5,19 +5,33 @@ here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
 
+deprecation_notice() {
+  echo "WARNING: bench-tps is deprecated and will be removed in a future release."
+  echo "Please use multinode-demo/txs-bench.sh / solana-transaction-bench instead."
+}
+
 usage() {
-  if [[ -n $1 ]]; then
-    echo "$*"
+  declare message=${1:-}
+  if [[ -n $message ]]; then
+    echo "$message"
     echo
   fi
   echo "usage: $0 [extra args]"
   echo
   echo " Run bench-tps "
   echo
+  deprecation_notice
+  echo
   echo "   extra args: additional arguments are passed along to solana-bench-tps"
   echo
   exit 1
 }
+
+if [[ ${1:-} = "-h" || ${1:-} = "--help" ]]; then
+  usage ""
+fi
+
+deprecation_notice >&2
 
 args=("$@")
 default_arg --url "http://127.0.0.1:8899"

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -5,10 +5,12 @@
 # The following directive disable complaints about unused variables in this
 # file:
 # shellcheck disable=2034
+# shellcheck shell=bash
 #
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. || exit 1; pwd)"
-# shellcheck source=net/common.sh
+# shellcheck disable=SC1091
+# shellcheck source=../net/common.sh
 source "$here"/net/common.sh
 
 prebuild=
@@ -64,6 +66,7 @@ else
 fi
 
 solana_bench_tps=$(solana_program bench-tps)
+solana_transaction_bench=${SOLANA_TRANSACTION_BENCH:-solana-transaction-bench}
 solana_faucet=$(solana_program faucet)
 agave_validator=$(solana_program validator)
 solana_genesis=$(solana_program genesis)

--- a/multinode-demo/txs-bench.sh
+++ b/multinode-demo/txs-bench.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -e
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=multinode-demo/common.sh
+source "$here"/common.sh
+
+program="${solana_transaction_bench}"
+default_staked_identity_file_count=4
+
+usage() {
+  if [[ -n $1 ]]; then
+    echo "$*"
+    echo
+  fi
+  cat <<EOF
+usage: $0 [extra args]
+
+ Run solana-transaction-bench against the local multinode demo.
+
+   extra args: additional arguments are passed along to solana-transaction-bench.
+               Use solana-transaction-bench argument names, not bench-tps names.
+
+ Defaults:
+   --url http://127.0.0.1:8899
+   --authority ${SOLANA_CONFIG_DIR}/faucet.json
+   run
+   --num-payers 256
+   --payer-account-balance 10SOL
+   --duration 90
+   --bind 127.0.0.1:0
+   --staked-identity-file ${SOLANA_CONFIG_DIR}/bootstrap-validator/identity.json
+     (repeated ${default_staked_identity_file_count} times)
+   --transfer-tx-cu-budget 600
+   pinned-leader-tracker <TPU from getClusterNodes tpuQuic>
+
+ Examples:
+   $0 --duration 30 --target-tps 5000
+   $0 --num-payers 1024 --send-fanout 2 ws-leader-tracker
+
+EOF
+  exit 1
+}
+
+contains_arg() {
+  declare name=$1
+  shift
+
+  for arg in "$@"; do
+    if [[ $arg = "$name" || $arg = "$name="* ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+contains_url_arg() {
+  for arg in "$@"; do
+    if [[ $arg = --url || $arg = --url=* || $arg = -u || $arg = -u?* ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+add_default_arg() {
+  declare -n target_args=$1
+  declare name=$2
+  declare value=$3
+
+  if ! contains_arg "$name" "${target_args[@]}"; then
+    target_args+=("$name" "$value")
+  fi
+}
+
+get_rpc_url() {
+  declare arg
+  declare -i expect_value=0
+
+  for arg in "${global_args[@]}"; do
+    if ((expect_value)); then
+      printf '%s' "$arg"
+      return 0
+    fi
+    case "$arg" in
+    --url=*)
+      printf '%s' "${arg#--url=}"
+      return 0
+      ;;
+    -u?*)
+      printf '%s' "${arg#-u}"
+      return 0
+      ;;
+    --url | -u)
+      expect_value=1
+      ;;
+    esac
+  done
+
+  printf '%s' 'http://127.0.0.1:8899'
+}
+
+# Query getClusterNodes over RPC and return host:port for the bootstrap validator's
+# QUIC TPU (tpuQuic), falling back to UDP tpu. Requires curl and jq.
+resolve_pinned_leader_target() {
+  declare rpc_url=$1
+  declare identity="${SOLANA_CONFIG_DIR}/bootstrap-validator/identity.json"
+  declare identity_pubkey=
+  declare nodes_json tpu
+
+  if [[ -f $identity ]]; then
+    identity_pubkey=$($solana_keygen pubkey "$identity" 2> /dev/null) || identity_pubkey=
+  fi
+
+  if ! command -v jq > /dev/null 2>&1; then
+    echo "$0: jq is required to parse getClusterNodes (e.g. brew install jq)" >&2
+    return 1
+  fi
+
+  if ! nodes_json=$(curl -sf -X POST -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"getClusterNodes"}' \
+    "$rpc_url"); then
+    echo "$0: getClusterNodes request to $rpc_url failed (is the validator RPC up?)" >&2
+    return 1
+  fi
+
+  if [[ -n $identity_pubkey ]]; then
+    tpu=$(echo "$nodes_json" | jq -r --arg pk "$identity_pubkey" '
+      [.result[] | select(.pubkey == $pk) | .tpuQuic // .tpu // empty][0] // empty
+    ')
+  fi
+
+  if [[ -z $tpu || $tpu = null ]]; then
+    tpu=$(echo "$nodes_json" | jq -r '
+      [.result[] | .tpuQuic // .tpu // empty][0] // empty
+    ')
+  fi
+
+  if [[ -z $tpu || $tpu = null ]]; then
+    echo "$0: getClusterNodes returned no tpuQuic/tpu address" >&2
+    return 1
+  fi
+
+  printf '%s' "$tpu"
+}
+
+global_args=()
+run_args=()
+leader_tracker_args=()
+
+while [[ -n $1 ]]; do
+  case "$1" in
+  -h | --help)
+    usage
+    ;;
+  --url | -u | --commitment-config | --authority)
+    [[ -n ${2:-} ]] || usage "Missing value for $1"
+    global_args+=("$1" "$2")
+    shift 2
+    ;;
+  --url=* | --commitment-config=* | --authority=* | -u?*)
+    global_args+=("$1")
+    shift
+    ;;
+  --validate-accounts | --mock-rpc)
+    global_args+=("$1")
+    shift
+    ;;
+  run | read-accounts-run | write-accounts)
+    usage "Do not pass a solana-transaction-bench subcommand; this wrapper always uses run."
+    ;;
+  pinned-leader-tracker | legacy-leader-tracker | ws-leader-tracker | \
+    yellowstone-leader-tracker | custom-leader-tracker)
+    leader_tracker_args=("$@")
+    break
+    ;;
+  *)
+    run_args+=("$1")
+    shift
+    ;;
+  esac
+done
+
+if ! command -v "$program" > /dev/null 2>&1; then
+  echo "$program not found."
+  echo "Install it with: cargo install solana-transaction-bench"
+  echo "Or set SOLANA_TRANSACTION_BENCH=/path/to/solana-transaction-bench."
+  exit 1
+fi
+
+if ! contains_url_arg "${global_args[@]}"; then
+  global_args+=(--url "http://127.0.0.1:8899")
+fi
+add_default_arg global_args --authority "${SOLANA_CONFIG_DIR}/faucet.json"
+
+add_default_arg run_args --num-payers 256
+add_default_arg run_args --payer-account-balance 10SOL
+add_default_arg run_args --duration 90
+add_default_arg run_args --bind "127.0.0.1:0"
+
+for ((i = 0; i < default_staked_identity_file_count; i++)); do
+  run_args+=(--staked-identity-file "${SOLANA_CONFIG_DIR}/bootstrap-validator/identity.json")
+done
+
+add_default_arg run_args --transfer-tx-cu-budget 600
+
+if [[ ${#leader_tracker_args[@]} -eq 0 ]]; then
+  rpc_url=$(get_rpc_url)
+  pinned_leader_target=$(resolve_pinned_leader_target "$rpc_url") || exit 1
+  leader_tracker_args=(pinned-leader-tracker "$pinned_leader_target")
+fi
+
+"$program" "${global_args[@]}" run "${run_args[@]}" "${leader_tracker_args[@]}"

--- a/net/net.sh
+++ b/net/net.sh
@@ -15,19 +15,22 @@ usage() {
   fi
   CLIENT_OPTIONS=$(cat << EOM
 -c clientType=numClients=extraArgs - Number of clientTypes to start.  This options can be specified
-                                     more than once.  Defaults to bench-tps for all clients if not
-                                     specified.
+                                     more than once.  Defaults to transaction-bench for all clients
+                                     if not specified.
                                      Valid client types are:
                                          idle
-                                         bench-tps
+                                         transaction-bench
+                                         bench-tps (deprecated)
                                      User can optionally provide extraArgs that are transparently
                                      supplied to the client program as command line parameters.
+                                     extraArgs use the argument names of the selected client program
+                                     (solana-transaction-bench or, for bench-tps, solana-bench-tps).
                                      For example,
-                                         -c bench-tps=2="--tx_count 25000"
-                                     This will start 2 bench-tps clients, and supply "--tx_count 25000"
-                                     to the bench-tps client.
+                                         -c transaction-bench=2="--target-tps 5000 ws-leader-tracker"
+                                     This will start 2 solana-transaction-bench clients, and supply
+                                     "--target-tps 5000 ws-leader-tracker" to each of them.
 --use-unstaked-connection          - Use unstaked connection. By default, staked connection with
-                                     bootstrap node credendials is used.
+                                     bootstrap node credentials is used.
 EOM
 )
   cat <<EOF
@@ -114,7 +117,8 @@ Operate a configured testnet
                                       - Enable UDP for tpu transactions
 
    --client-type
-                                      - Specify backend client type for bench-tps. Valid options are (rpc-client|tpu-client), tpu-client is default
+                                      - Specify backend client type for the deprecated bench-tps. Valid options are (rpc-client|tpu-client), tpu-client is default.
+                                        Ignored by solana-transaction-bench, which always sends over QUIC to the TPU.
 
  sanity/start-specific options:
    -F                   - Discard validator nodes that didn't bootup successfully
@@ -323,7 +327,7 @@ startBootstrapLeader() {
          \"$internalNodesStakeLamports\" \
          \"$internalNodesLamports\" \
          $nodeIndex \
-         ${#clientIpList[@]} \"$benchTpsExtraArgs\" \
+         $numBenchTpsClients \"$benchTpsExtraArgs\" \
          \"$genesisOptions\" \
          \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAccountsDbSkipShrink $maybeSkipRequireTower\" \
          \"$maybeWarpSlot\" \
@@ -398,7 +402,7 @@ startNode() {
          \"$internalNodesStakeLamports\" \
          \"$internalNodesLamports\" \
          $nodeIndex \
-         ${#clientIpList[@]} \"$benchTpsExtraArgs\" \
+         $numBenchTpsClients \"$benchTpsExtraArgs\" \
          \"$genesisOptions\" \
          \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAccountsDbSkipShrink $maybeSkipRequireTower\" \
          \"$maybeWarpSlot\" \
@@ -421,6 +425,12 @@ startClient() {
   declare clientToRun="$2"
   declare clientIndex="$3"
 
+  # Forward the extra args that belong to the selected client program.
+  declare clientExtraArgs=$benchTpsExtraArgs
+  if [[ $clientToRun = solana-transaction-bench ]]; then
+    clientExtraArgs=$transactionBenchExtraArgs
+  fi
+
   initLogDir
   declare logFile="$netLogDir/client-$clientToRun-$ipAddress.log"
 
@@ -431,7 +441,7 @@ startClient() {
     startCommon "$ipAddress"
     ssh "${sshOptions[@]}" -f "$ipAddress" \
       "./solana/net/remote/remote-client.sh $deployMethod $entrypointIp \
-      $clientToRun \"$RUST_LOG\" \"$benchTpsExtraArgs\" $clientIndex $clientType \
+      $clientToRun \"$RUST_LOG\" \"$clientExtraArgs\" $clientIndex $clientType \
       $maybeUseUnstakedConnection"
   ) >> "$logFile" 2>&1 || {
     cat "$logFile"
@@ -441,11 +451,15 @@ startClient() {
 }
 
 startClients() {
-  for ((i=0; i < "$numClients" && i < "$numClientsRequested"; i++)) do
-    if [[ $i -lt "$numBenchTpsClients" ]]; then
-      startClient "${clientIpList[$i]}" "solana-bench-tps" "$i"
+  benchTpsIndex=0
+  for ((i=0; i < numClients && i < numClientsRequested; i++)) do
+    if [[ $i -lt $numTransactionBenchClients ]]; then
+      startClient "${clientIpList[$i]}" "solana-transaction-bench" "$i"
+    elif [[ $i -lt $((numTransactionBenchClients + numBenchTpsClients)) ]]; then
+      startClient "${clientIpList[$i]}" "solana-bench-tps" "$benchTpsIndex"
+      ((benchTpsIndex++))
     else
-      startClient "${clientIpList[$i]}" "idle"
+      startClient "${clientIpList[$i]}" "idle" "$i"
     fi
   done
 }
@@ -511,6 +525,52 @@ getNodeType() {
   exit 1
 }
 
+# solana-transaction-bench lives in the external anza-xyz/tpu-tools repository
+# and is therefore not produced by the agave build. When transaction-bench
+# clients are requested, stage the binary into the deploy artifacts so it ships
+# to the nodes alongside the agave binaries (clients fetch ~/.cargo/bin/* from
+# the entrypoint).
+stageTransactionBenchBinary() {
+  [[ $numTransactionBenchClients -gt 0 ]] || return 0
+
+  declare destDir
+  case $deployMethod in
+  local) destDir="$SOLANA_ROOT"/farf/bin ;;
+  tar)   destDir="$SOLANA_ROOT"/solana-release/bin ;;
+  *)     return 0 ;;
+  esac
+  mkdir -p "$destDir"
+
+  if [[ -x "$destDir"/solana-transaction-bench ]]; then
+    echo "solana-transaction-bench already staged in $destDir"
+    return 0
+  fi
+
+  declare src="${SOLANA_TRANSACTION_BENCH:-}"
+  if [[ -z $src ]]; then
+    src="$(command -v solana-transaction-bench || true)"
+  fi
+  if [[ -n $src && -x $src ]]; then
+    echo "Staging solana-transaction-bench from $src"
+    cp -f "$src" "$destDir"/solana-transaction-bench
+    return 0
+  fi
+
+  echo "solana-transaction-bench not found locally, installing it from crates.io"
+  declare -a cargoArgs=(install --root "$SOLANA_ROOT"/farf --locked)
+  [[ -z ${SOLANA_TRANSACTION_BENCH_VERSION:-} ]] || cargoArgs+=(--version "$SOLANA_TRANSACTION_BENCH_VERSION")
+  cargoArgs+=(solana-transaction-bench)
+  if cargo "${cargoArgs[@]}"; then
+    if [[ $destDir != "$SOLANA_ROOT"/farf/bin ]]; then
+      cp -f "$SOLANA_ROOT"/farf/bin/solana-transaction-bench "$destDir"/solana-transaction-bench
+    fi
+  else
+    echo "Warning: failed to stage solana-transaction-bench."
+    echo "         Clients will try to install it themselves at start time."
+    echo "         Alternatively set SOLANA_TRANSACTION_BENCH to a prebuilt binary path before deploying."
+  fi
+}
+
 prepareDeploy() {
   case $deployMethod in
   tar)
@@ -546,6 +606,8 @@ prepareDeploy() {
     usage "Internal error: invalid deployMethod: $deployMethod"
     ;;
   esac
+
+  stageTransactionBenchBinary
 
   if [[ -n $deployIfNewer ]]; then
     if [[ $deployMethod != tar ]]; then
@@ -764,6 +826,8 @@ nodeAddress=
 numIdleClients=0
 numBenchTpsClients=0
 benchTpsExtraArgs=
+numTransactionBenchClients=0
+transactionBenchExtraArgs=
 failOnValidatorBootupFailure=true
 genesisOptions=
 numValidatorsRequested=
@@ -992,6 +1056,10 @@ while getopts "h?T:t:o:f:rc:Fn:i:d" opt "${shortArgs[@]}"; do
           numIdleClients=$numClients
           # $extraArgs ignored for 'idle'
         ;;
+        transaction-bench)
+          numTransactionBenchClients=$numClients
+          transactionBenchExtraArgs=$extraArgs
+        ;;
         bench-tps)
           numBenchTpsClients=$numClients
           benchTpsExtraArgs=$extraArgs
@@ -1028,9 +1096,10 @@ if [[ -n $numValidatorsRequested ]]; then
 fi
 
 numClients=${#clientIpList[@]}
-numClientsRequested=$((numBenchTpsClients + numIdleClients))
+numClientsRequested=$((numTransactionBenchClients + numBenchTpsClients + numIdleClients))
 if [[ "$numClientsRequested" -eq 0 ]]; then
-  numBenchTpsClients=$numClients
+  # Default to solana-transaction-bench on every available client node.
+  numTransactionBenchClients=$numClients
   numClientsRequested=$numClients
 else
   if [[ "$numClientsRequested" -gt "$numClients" ]]; then

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -57,7 +57,146 @@ case "$clientType" in
     ;;
 esac
 
+# Does "$@" (beyond the first arg, which is the name to look for) contain $name,
+# either as a bare flag or as --flag=value?
+contains_arg() {
+  declare name=$1
+  shift
+  declare arg
+  for arg in "$@"; do
+    if [[ $arg = "$name" || $arg = "$name="* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+contains_url_arg() {
+  declare arg
+  for arg in "$@"; do
+    case "$arg" in
+    --url | --url=* | -u | -u?*)
+      return 0
+      ;;
+    esac
+  done
+  return 1
+}
+
+# Ensure the external solana-transaction-bench binary is available. Prefer a
+# path provided via SOLANA_TRANSACTION_BENCH, then one already on PATH (e.g.
+# rsynced from the entrypoint's ~/.cargo/bin), and finally fall back to
+# installing it from crates.io.
+ensureTransactionBench() {
+  transactionBench="${SOLANA_TRANSACTION_BENCH:-solana-transaction-bench}"
+  if command -v "$transactionBench" > /dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "$transactionBench not found, installing solana-transaction-bench from crates.io"
+  declare -a cargoArgs=(install --locked)
+  [[ -z ${SOLANA_TRANSACTION_BENCH_VERSION:-} ]] || cargoArgs+=(--version "$SOLANA_TRANSACTION_BENCH_VERSION")
+  cargoArgs+=(solana-transaction-bench)
+  if ! cargo "${cargoArgs[@]}"; then
+    echo "Error: unable to obtain solana-transaction-bench."
+    echo "Stage it into the entrypoint's ~/.cargo/bin or set SOLANA_TRANSACTION_BENCH to a prebuilt binary path."
+    exit 1
+  fi
+  transactionBench=solana-transaction-bench
+}
+
 case $clientToRun in
+solana-transaction-bench)
+  ensureTransactionBench
+
+  # transaction-bench creates and funds ephemeral payer accounts from the
+  # faucet (the genesis mint) at runtime, so unlike bench-tps it needs no
+  # pre-generated client account keys. We only need the faucet keypair as the
+  # funding authority and, for a staked QUIC connection, a staked validator
+  # identity.
+  net/scripts/rsync-retry.sh -vPrc \
+    "$entrypointIp":~/solana/config/faucet.json ./faucet.json
+
+  net/scripts/rsync-retry.sh -vPrc \
+    "$entrypointIp":~/solana/config/validator-identity-1.json ./validator-identity.json
+
+  if [[ $clientType = rpc-client ]]; then
+    echo "Note: clientType=rpc-client is ignored by solana-transaction-bench; it always sends over QUIC to the TPU."
+  fi
+
+  # solana-transaction-bench expects its arguments in positional buckets:
+  #   <global args> run <run args> <leader-tracker subcommand>
+  # Split the operator-supplied extra args into those buckets so that, e.g.,
+  # a --url override lands before "run" while --duration lands after it.
+  globalArgs=()
+  runArgs=()
+  leaderTrackerArgs=()
+
+  # shellcheck disable=SC2206 # Intentional word-splitting of the extra args string
+  extraArgs=($benchTpsExtraArgs)
+  argIndex=0
+  while [[ $argIndex -lt ${#extraArgs[@]} ]]; do
+    arg="${extraArgs[$argIndex]}"
+    case "$arg" in
+    -u | --url | --authority | --commitment-config)
+      if [[ $((argIndex + 1)) -ge ${#extraArgs[@]} ]]; then
+        echo "Error: missing value for $arg in extra args"
+        exit 1
+      fi
+      globalArgs+=("$arg" "${extraArgs[$((argIndex + 1))]}")
+      argIndex=$((argIndex + 2))
+      ;;
+    --url=* | --authority=* | --commitment-config=* | -u?*)
+      globalArgs+=("$arg")
+      argIndex=$((argIndex + 1))
+      ;;
+    --validate-accounts | --mock-rpc)
+      globalArgs+=("$arg")
+      argIndex=$((argIndex + 1))
+      ;;
+    run | read-accounts-run | write-accounts)
+      echo "Error: do not pass a solana-transaction-bench subcommand in extra args; this wrapper always uses 'run'."
+      exit 1
+      ;;
+    pinned-leader-tracker | legacy-leader-tracker | ws-leader-tracker | \
+      yellowstone-leader-tracker | custom-leader-tracker)
+      leaderTrackerArgs=("${extraArgs[@]:$argIndex}")
+      break
+      ;;
+    *)
+      runArgs+=("$arg")
+      argIndex=$((argIndex + 1))
+      ;;
+    esac
+  done
+
+  contains_url_arg "${globalArgs[@]}" || globalArgs+=(--url "http://$entrypointIp:8899")
+  contains_arg --authority "${globalArgs[@]}" || globalArgs+=(--authority ./faucet.json)
+
+  contains_arg --duration "${runArgs[@]}" || runArgs+=(--duration 7500)
+  contains_arg --num-payers "${runArgs[@]}" || runArgs+=(--num-payers 256)
+  contains_arg --payer-account-balance "${runArgs[@]}" || runArgs+=(--payer-account-balance 10SOL)
+  contains_arg --transfer-tx-cu-budget "${runArgs[@]}" || runArgs+=(--transfer-tx-cu-budget 600)
+
+  if [[ -z "$maybeUseUnstakedConnection" ]]; then
+    contains_arg --staked-identity-file "${runArgs[@]}" || runArgs+=(--staked-identity-file ./validator-identity.json)
+  fi
+
+  # In a multinode cluster the leader rotates, so follow the leader schedule
+  # over the RPC websocket by default. Operators can override by passing a
+  # leader-tracker subcommand in the extra args.
+  if [[ ${#leaderTrackerArgs[@]} -eq 0 ]]; then
+    leaderTrackerArgs=(ws-leader-tracker)
+  fi
+
+  clientCommand="\
+    $transactionBench \
+      ${globalArgs[*]} \
+      run \
+      ${runArgs[*]} \
+      ${leaderTrackerArgs[*]} \
+  "
+  ;;
 solana-bench-tps)
   net/scripts/rsync-retry.sh -vPrc \
     "$entrypointIp":~/solana/config/bench-tps"$clientIndex".yml ./client-accounts.yml


### PR DESCRIPTION
## Summary

Migrate the `multinode-demo/` and `net/` load-test scripts from the deprecated
`solana-bench-tps` to `solana-transaction-bench` (from `anza-xyz/tpu-tools`).
`solana-bench-tps` is retained during the transition.

## Changes

- Add `multinode-demo/txs-bench.sh` wrapping `solana-transaction-bench`, and
  resolve the binary via `solana_transaction_bench` in `common.sh`
  (overridable with `SOLANA_TRANSACTION_BENCH`). Mark `bench-tps.sh` deprecated.
- Add a `transaction-bench` client type to `net.sh` (`-c`) and make it the
  default; add a launch path in `remote-client.sh` that buckets args, fetches
  the faucet authority and staked identity, and defaults to `ws-leader-tracker`.
- Stage the external `solana-transaction-bench` binary into deploy artifacts
  when transaction-bench clients are requested.
- Pass the bench-tps client count (not the total) to `remote-node.sh` so
  genesis accounts are generated only for bench-tps; transaction-bench funds
  payers from the faucet at runtime.

CC: @KirillLykov 