### PR TITLE
svm: conformance: add elf loading harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10620,6 +10620,7 @@ dependencies = [
  "spl-token-interface",
  "test-case",
  "thiserror 2.0.18",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -13374,6 +13375,12 @@ dependencies = [
  "linux-raw-sys 0.4.14",
  "rustix 0.38.39",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -563,6 +563,7 @@ winapi = "0.3.8"
 wincode = { version = "0.5.5", features = ["derive"] }
 winreg = "0.55"
 x509-parser = "0.18.1"
+xxhash-rust = "0.8.5"
 zstd = "0.13.3"
 
 [profile.dev]

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -78,8 +78,7 @@ use {
     solana_program_runtime::sysvar_cache::SysvarCache,
     solana_sdk_ids::sysvar::rent,
     solana_svm::conformance::{
-        context::InstrContext,
-        harness::execute_instr,
+        instr::{context::InstrContext, harness::execute_instr},
         programs::{
             add_program_to_program_cache, keyed_account_for_system_program,
             new_program_cache_with_builtins,

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -25,6 +25,7 @@ conformance = [
     "dep:bincode",
     "dep:prost",
     "dep:protosol",
+    "dep:xxhash-rust",
     "dev-context-only-utils",
     "solana-instruction-error/serde",
     "solana-pubkey/default",
@@ -111,6 +112,7 @@ solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
 spl-generic-token = { workspace = true }
 thiserror = { workspace = true }
+xxhash-rust = { workspace = true, optional = true, features = ["xxh64"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/svm/src/conformance/elf_loader.rs
+++ b/svm/src/conformance/elf_loader.rs
@@ -13,6 +13,7 @@ use {
     },
     solana_syscalls::create_program_runtime_environment,
     std::{collections::BTreeSet, ffi::c_int},
+    xxhash_rust::xxh64::xxh64,
 };
 
 pub fn execute_elf_loader(input: &ProtoElfLoaderCtx) -> ProtoElfLoaderEffects {
@@ -102,93 +103,10 @@ fn fd_hash_u64_without_seed(buf: &[u64]) -> u64 {
     fd_hash(0, bytes)
 }
 
-/// Rust port of Firedancer's fd_hash.
-/// https://github.com/firedancer-io/firedancer/blob/main/src/util/fd_hash.c
+/// Hashing used to summarize binary blobs (e.g. ELF sections) for conformance
+/// comparisons. Firedancer's `fd_hash` is XXH64.
 fn fd_hash(seed: u64, buf: &[u8]) -> u64 {
-    const C1: u64 = 11400714785074694791;
-    const C2: u64 = 14029467366897019727;
-    const C3: u64 = 1609587929392839161;
-    const C4: u64 = 9650029242287828579;
-    const C5: u64 = 2870177450012600261;
-
-    let mut p = buf;
-    let sz = buf.len() as u64;
-    let mut h: u64;
-
-    if sz < 32 {
-        h = seed.wrapping_add(C5);
-    } else {
-        let mut w = seed.wrapping_add(C1.wrapping_add(C2));
-        let mut x = seed.wrapping_add(C2);
-        let mut y = seed;
-        let mut z = seed.wrapping_sub(C1);
-
-        while p.len() >= 32 {
-            let p0 = u64::from_le_bytes(p[0..8].try_into().unwrap());
-            let p1 = u64::from_le_bytes(p[8..16].try_into().unwrap());
-            let p2 = u64::from_le_bytes(p[16..24].try_into().unwrap());
-            let p3 = u64::from_le_bytes(p[24..32].try_into().unwrap());
-            w = w
-                .wrapping_add(p0.wrapping_mul(C2))
-                .rotate_left(31)
-                .wrapping_mul(C1);
-            x = x
-                .wrapping_add(p1.wrapping_mul(C2))
-                .rotate_left(31)
-                .wrapping_mul(C1);
-            y = y
-                .wrapping_add(p2.wrapping_mul(C2))
-                .rotate_left(31)
-                .wrapping_mul(C1);
-            z = z
-                .wrapping_add(p3.wrapping_mul(C2))
-                .rotate_left(31)
-                .wrapping_mul(C1);
-            p = &p[32..];
-        }
-
-        h = w
-            .rotate_left(1)
-            .wrapping_add(x.rotate_left(7))
-            .wrapping_add(y.rotate_left(12))
-            .wrapping_add(z.rotate_left(18));
-
-        for v in [w, x, y, z] {
-            let vv = v.wrapping_mul(C2).rotate_left(31).wrapping_mul(C1);
-            h ^= vv;
-            h = h.wrapping_mul(C1).wrapping_add(C4);
-        }
-    }
-
-    h = h.wrapping_add(sz);
-
-    while p.len() >= 8 {
-        let w = u64::from_le_bytes(p[0..8].try_into().unwrap());
-        let ww = w.wrapping_mul(C2).rotate_left(31).wrapping_mul(C1);
-        h ^= ww;
-        h = h.rotate_left(27).wrapping_mul(C1).wrapping_add(C4);
-        p = &p[8..];
-    }
-
-    if p.len() >= 4 {
-        let w = u32::from_le_bytes(p[0..4].try_into().unwrap()) as u64;
-        h ^= w.wrapping_mul(C1);
-        h = h.rotate_left(23).wrapping_mul(C2).wrapping_add(C3);
-        p = &p[4..];
-    }
-
-    for &byte in p {
-        h ^= (byte as u64).wrapping_mul(C5);
-        h = h.rotate_left(11).wrapping_mul(C1);
-    }
-
-    h ^= h >> 33;
-    h = h.wrapping_mul(C2);
-    h ^= h >> 29;
-    h = h.wrapping_mul(C3);
-    h ^= h >> 32;
-
-    h
+    xxh64(buf, seed)
 }
 
 /// # Safety
@@ -269,5 +187,16 @@ mod tests {
             features: vec![u64::from_le_bytes(v3.to_bytes()[..8].try_into().unwrap())],
         };
         assert_loads_ok(SBPFV3_RETURN_OK, false, Some(features));
+    }
+
+    #[test]
+    fn test_fd_hash_matches_xxh64() {
+        // Reference values from Firedancer's `fd_hash` (XXH64). The empty-input,
+        // seed-0 case is the canonical XXH64 test vector.
+        let long: Vec<u8> = (0u8..100).collect();
+        assert_eq!(fd_hash(0, &[]), 0xef46db3751d8e999);
+        assert_eq!(fd_hash(0, b"hello world"), 0x45ab6734b21e6968);
+        assert_eq!(fd_hash(42, b"hello world"), 0x69c2b68f9d9352a1);
+        assert_eq!(fd_hash(0, &long), 0x6ac1e58032166597);
     }
 }

--- a/svm/src/conformance/elf_loader.rs
+++ b/svm/src/conformance/elf_loader.rs
@@ -1,0 +1,273 @@
+//! ELF loader conformance harness.
+
+use {
+    crate::conformance::feature_set::feature_set_from_proto,
+    prost::Message,
+    protosol::protos::{
+        ElfLoaderCtx as ProtoElfLoaderCtx, ElfLoaderEffects as ProtoElfLoaderEffects,
+    },
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_program_runtime::solana_sbpf::{
+        ebpf,
+        elf::{ElfError, Executable},
+    },
+    solana_syscalls::create_program_runtime_environment,
+    std::{collections::BTreeSet, ffi::c_int},
+};
+
+pub fn execute_elf_loader(input: &ProtoElfLoaderCtx) -> ProtoElfLoaderEffects {
+    let feature_set = input
+        .features
+        .as_ref()
+        .map(feature_set_from_proto)
+        .unwrap_or_default()
+        .runtime_features();
+    let simd_0268_active = feature_set.raise_cpi_nesting_limit_to_8;
+    let compute_budget = ComputeBudget::new_with_defaults(simd_0268_active);
+
+    let program_runtime_environment = create_program_runtime_environment(
+        &feature_set,
+        &compute_budget.to_budget(),
+        input.deploy_checks,
+        std::env::var("ENABLE_VM_TRACING").is_ok(),
+    )
+    .unwrap();
+
+    let executable = match Executable::load(&input.elf_data, (*program_runtime_environment).clone())
+    {
+        Ok(executable) => executable,
+        Err(err) => {
+            return ProtoElfLoaderEffects {
+                err_code: elf_err_to_num(&err) as u32,
+                ..Default::default()
+            };
+        }
+    };
+
+    let (text_vaddr, text_bytes) = executable.get_text_bytes();
+    let calldests: Vec<u64> = executable
+        .get_function_registry()
+        .iter()
+        .map(|(_, (_, address))| address as u64)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    ProtoElfLoaderEffects {
+        err_code: 0,
+        rodata_hash: fd_hash_without_seed(executable.get_ro_section()),
+        entry_pc: executable.get_entrypoint_instruction_offset() as u64,
+        text_off: text_vaddr.saturating_sub(ebpf::MM_BYTECODE_START),
+        text_cnt: (text_bytes.len() / 8) as u64,
+        calldests_hash: fd_hash_u64_without_seed(&calldests),
+    }
+}
+
+fn elf_err_to_num(error: &ElfError) -> u8 {
+    match error {
+        ElfError::FailedToParse(_) => 1,
+        ElfError::EntrypointOutOfBounds => 2,
+        ElfError::InvalidEntrypoint => 3,
+        ElfError::FailedToGetSection(_) => 4,
+        ElfError::UnresolvedSymbol(_, _, _) => 5,
+        ElfError::SectionNotFound(_) => 6,
+        ElfError::RelativeJumpOutOfBounds(_) => 7,
+        ElfError::SymbolHashCollision(_) => 8,
+        ElfError::WrongEndianess => 9,
+        ElfError::WrongAbi => 10,
+        ElfError::WrongMachine => 11,
+        ElfError::WrongClass => 12,
+        ElfError::NotOneTextSection => 13,
+        ElfError::WritableSectionNotSupported(_) => 14,
+        ElfError::AddressOutsideLoadableSection(_) => 15,
+        ElfError::InvalidVirtualAddress(_) => 16,
+        ElfError::UnknownRelocation(_) => 17,
+        ElfError::FailedToReadRelocationInfo => 18,
+        ElfError::WrongType => 19,
+        ElfError::UnknownSymbol(_) => 20,
+        ElfError::ValueOutOfBounds => 21,
+        ElfError::UnsupportedSBPFVersion => 22,
+        ElfError::InvalidProgramHeader => 23,
+    }
+}
+
+fn fd_hash_without_seed(buf: &[u8]) -> u64 {
+    fd_hash(0, buf)
+}
+
+fn fd_hash_u64_without_seed(buf: &[u64]) -> u64 {
+    let bytes = unsafe {
+        std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), std::mem::size_of_val(buf))
+    };
+    fd_hash(0, bytes)
+}
+
+/// Rust port of Firedancer's fd_hash.
+/// https://github.com/firedancer-io/firedancer/blob/main/src/util/fd_hash.c
+fn fd_hash(seed: u64, buf: &[u8]) -> u64 {
+    const C1: u64 = 11400714785074694791;
+    const C2: u64 = 14029467366897019727;
+    const C3: u64 = 1609587929392839161;
+    const C4: u64 = 9650029242287828579;
+    const C5: u64 = 2870177450012600261;
+
+    let mut p = buf;
+    let sz = buf.len() as u64;
+    let mut h: u64;
+
+    if sz < 32 {
+        h = seed.wrapping_add(C5);
+    } else {
+        let mut w = seed.wrapping_add(C1.wrapping_add(C2));
+        let mut x = seed.wrapping_add(C2);
+        let mut y = seed;
+        let mut z = seed.wrapping_sub(C1);
+
+        while p.len() >= 32 {
+            let p0 = u64::from_le_bytes(p[0..8].try_into().unwrap());
+            let p1 = u64::from_le_bytes(p[8..16].try_into().unwrap());
+            let p2 = u64::from_le_bytes(p[16..24].try_into().unwrap());
+            let p3 = u64::from_le_bytes(p[24..32].try_into().unwrap());
+            w = w
+                .wrapping_add(p0.wrapping_mul(C2))
+                .rotate_left(31)
+                .wrapping_mul(C1);
+            x = x
+                .wrapping_add(p1.wrapping_mul(C2))
+                .rotate_left(31)
+                .wrapping_mul(C1);
+            y = y
+                .wrapping_add(p2.wrapping_mul(C2))
+                .rotate_left(31)
+                .wrapping_mul(C1);
+            z = z
+                .wrapping_add(p3.wrapping_mul(C2))
+                .rotate_left(31)
+                .wrapping_mul(C1);
+            p = &p[32..];
+        }
+
+        h = w
+            .rotate_left(1)
+            .wrapping_add(x.rotate_left(7))
+            .wrapping_add(y.rotate_left(12))
+            .wrapping_add(z.rotate_left(18));
+
+        for v in [w, x, y, z] {
+            let vv = v.wrapping_mul(C2).rotate_left(31).wrapping_mul(C1);
+            h ^= vv;
+            h = h.wrapping_mul(C1).wrapping_add(C4);
+        }
+    }
+
+    h = h.wrapping_add(sz);
+
+    while p.len() >= 8 {
+        let w = u64::from_le_bytes(p[0..8].try_into().unwrap());
+        let ww = w.wrapping_mul(C2).rotate_left(31).wrapping_mul(C1);
+        h ^= ww;
+        h = h.rotate_left(27).wrapping_mul(C1).wrapping_add(C4);
+        p = &p[8..];
+    }
+
+    if p.len() >= 4 {
+        let w = u32::from_le_bytes(p[0..4].try_into().unwrap()) as u64;
+        h ^= w.wrapping_mul(C1);
+        h = h.rotate_left(23).wrapping_mul(C2).wrapping_add(C3);
+        p = &p[4..];
+    }
+
+    for &byte in p {
+        h ^= (byte as u64).wrapping_mul(C5);
+        h = h.rotate_left(11).wrapping_mul(C1);
+    }
+
+    h ^= h >> 33;
+    h = h.wrapping_mul(C2);
+    h ^= h >> 29;
+    h = h.wrapping_mul(C3);
+    h ^= h >> 32;
+
+    h
+}
+
+/// # Safety
+///
+/// `in_ptr` must point to `in_sz` initialized bytes. `out_ptr` must point
+/// to a writable buffer of at least `*out_psz` bytes. On return, `*out_psz`
+/// is updated to the number of bytes written.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sol_compat_elf_loader_v1(
+    out_ptr: *mut u8,
+    out_psz: *mut u64,
+    in_ptr: *mut u8,
+    in_sz: u64,
+) -> c_int {
+    if in_ptr.is_null() || in_sz == 0 {
+        return 0;
+    }
+    if out_psz.is_null() || out_ptr.is_null() {
+        return 0;
+    }
+    let in_slice = unsafe { std::slice::from_raw_parts(in_ptr, in_sz as usize) };
+    let Ok(ctx) = ProtoElfLoaderCtx::decode(in_slice) else {
+        return 0;
+    };
+
+    let effects = execute_elf_loader(&ctx);
+
+    let out_slice = unsafe { std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize) };
+    let out_vec = effects.encode_to_vec();
+    if out_vec.len() > out_slice.len() {
+        return 0;
+    }
+    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
+    unsafe { *out_psz = out_vec.len() as u64 };
+
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, agave_feature_set::enable_sbpf_v3_deployment_and_execution,
+        protosol::protos::FeatureSet as ProtoFeatureSet,
+    };
+
+    const NOOP_ALIGNED: &[u8] =
+        include_bytes!("../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
+    const NOOP_UNALIGNED: &[u8] =
+        include_bytes!("../../../programs/bpf_loader/test_elfs/out/noop_unaligned.so");
+    const SBPFV3_RETURN_OK: &[u8] =
+        include_bytes!("../../../programs/bpf_loader/test_elfs/out/sbpfv3_return_ok.so");
+
+    fn assert_loads_ok(elf: &[u8], deploy_checks: bool, features: Option<ProtoFeatureSet>) {
+        let effects = execute_elf_loader(&ProtoElfLoaderCtx {
+            features,
+            elf_data: elf.to_vec(),
+            deploy_checks,
+        });
+        assert_eq!(effects.err_code, 0);
+        assert!(effects.text_cnt > 0);
+    }
+
+    #[test]
+    fn test_load_noop_aligned() {
+        assert_loads_ok(NOOP_ALIGNED, false, None);
+    }
+
+    #[test]
+    fn test_load_noop_unaligned_with_deploy_checks() {
+        assert_loads_ok(NOOP_UNALIGNED, true, None);
+    }
+
+    #[test]
+    fn test_load_sbpf_v3_with_feature_enabled() {
+        // The v3 ELF only loads when the SBPF v3 feature is active.
+        let v3 = enable_sbpf_v3_deployment_and_execution::id();
+        let features = ProtoFeatureSet {
+            features: vec![u64::from_le_bytes(v3.to_bytes()[..8].try_into().unwrap())],
+        };
+        assert_loads_ok(SBPFV3_RETURN_OK, false, Some(features));
+    }
+}

--- a/svm/src/conformance/instr/context.rs
+++ b/svm/src/conformance/instr/context.rs
@@ -1,20 +1,15 @@
-//! Instruction context and effects (input + output).
+//! Instruction context (input).
 
 #[cfg(feature = "conformance")]
 use {
-    super::{
-        account_state::{account_from_proto, account_to_proto},
-        feature_set::feature_set_from_proto,
-    },
-    protosol::protos::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
+    crate::conformance::{account_state::account_from_proto, feature_set::feature_set_from_proto},
+    protosol::protos::InstrContext as ProtoInstrContext,
     solana_instruction::AccountMeta,
 };
 use {
-    solana_account::Account,
-    solana_instruction::{Instruction, error::InstructionError},
+    solana_account::Account, solana_instruction::Instruction,
     solana_program_runtime::execution_budget::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT,
-    solana_pubkey::Pubkey,
-    solana_svm_feature_set::SVMFeatureSet,
+    solana_pubkey::Pubkey, solana_svm_feature_set::SVMFeatureSet,
 };
 
 /// Inputs to a single instruction.
@@ -91,58 +86,6 @@ impl From<ProtoInstrContext> for InstrContext {
             accounts,
             instruction,
             cu_avail,
-        }
-    }
-}
-
-/// Represents the effects of a single instruction.
-pub struct InstrEffects {
-    pub result: Option<InstructionError>,
-    pub custom_err: Option<u32>,
-    pub resulting_accounts: Vec<(Pubkey, Account)>,
-    pub cu_avail: u64,
-    pub return_data: Vec<u8>,
-    pub logs: Vec<String>,
-}
-
-impl InstrEffects {
-    /// Returns the resulting account for the given pubkey, if it exists.
-    pub fn get_account(&self, pubkey: &Pubkey) -> Option<&Account> {
-        self.resulting_accounts
-            .iter()
-            .find(|(pk, _)| pk == pubkey)
-            .map(|(_, acc)| acc)
-    }
-}
-
-#[cfg(feature = "conformance")]
-impl From<InstrEffects> for ProtoInstrEffects {
-    fn from(value: InstrEffects) -> Self {
-        let InstrEffects {
-            result,
-            custom_err,
-            resulting_accounts,
-            cu_avail,
-            return_data,
-            ..
-        } = value;
-
-        Self {
-            result: result
-                .as_ref()
-                .map(|error| {
-                    let serialized_err = bincode::serialize(error).unwrap();
-                    i32::from_le_bytes((&serialized_err[0..4]).try_into().unwrap())
-                        .saturating_add(1)
-                })
-                .unwrap_or_default(),
-            custom_err: custom_err.unwrap_or_default(),
-            modified_accounts: resulting_accounts
-                .into_iter()
-                .map(account_to_proto)
-                .collect(),
-            cu_avail,
-            return_data,
         }
     }
 }

--- a/svm/src/conformance/instr/effects.rs
+++ b/svm/src/conformance/instr/effects.rs
@@ -1,0 +1,60 @@
+//! Instruction effects (output).
+
+#[cfg(feature = "conformance")]
+use {
+    crate::conformance::account_state::account_to_proto,
+    protosol::protos::InstrEffects as ProtoInstrEffects,
+};
+use {solana_account::Account, solana_instruction::error::InstructionError, solana_pubkey::Pubkey};
+
+/// Represents the effects of a single instruction.
+pub struct InstrEffects {
+    pub result: Option<InstructionError>,
+    pub custom_err: Option<u32>,
+    pub resulting_accounts: Vec<(Pubkey, Account)>,
+    pub cu_avail: u64,
+    pub return_data: Vec<u8>,
+    pub logs: Vec<String>,
+}
+
+impl InstrEffects {
+    /// Returns the resulting account for the given pubkey, if it exists.
+    pub fn get_account(&self, pubkey: &Pubkey) -> Option<&Account> {
+        self.resulting_accounts
+            .iter()
+            .find(|(pk, _)| pk == pubkey)
+            .map(|(_, acc)| acc)
+    }
+}
+
+#[cfg(feature = "conformance")]
+impl From<InstrEffects> for ProtoInstrEffects {
+    fn from(value: InstrEffects) -> Self {
+        let InstrEffects {
+            result,
+            custom_err,
+            resulting_accounts,
+            cu_avail,
+            return_data,
+            ..
+        } = value;
+
+        Self {
+            result: result
+                .as_ref()
+                .map(|error| {
+                    let serialized_err = bincode::serialize(error).unwrap();
+                    i32::from_le_bytes((&serialized_err[0..4]).try_into().unwrap())
+                        .saturating_add(1)
+                })
+                .unwrap_or_default(),
+            custom_err: custom_err.unwrap_or_default(),
+            modified_accounts: resulting_accounts
+                .into_iter()
+                .map(account_to_proto)
+                .collect(),
+            cu_avail,
+            return_data,
+        }
+    }
+}

--- a/svm/src/conformance/instr/harness.rs
+++ b/svm/src/conformance/instr/harness.rs
@@ -1,7 +1,7 @@
 //! Conformance harness.
 
 use {
-    super::context::{InstrContext, InstrEffects},
+    super::{context::InstrContext, effects::InstrEffects},
     crate::message_processor::process_message,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_instruction::error::InstructionError,
@@ -24,7 +24,9 @@ use {
 };
 #[cfg(feature = "conformance")]
 use {
-    super::programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
+    crate::conformance::programs::{
+        fill_program_cache_from_accounts, new_program_cache_with_builtins,
+    },
     agave_feature_set::FeatureSet,
     agave_precompiles::{get_precompile, is_precompile},
     prost::Message,
@@ -281,11 +283,11 @@ pub unsafe extern "C" fn sol_compat_instr_execute_v1(
 #[cfg(test)]
 mod tests {
     use {
-        super::{
-            super::programs::{add_program_to_program_cache, new_program_cache_with_builtins},
-            *,
+        super::*,
+        crate::conformance::programs::{
+            add_program_to_program_cache, keyed_account_for_system_program,
+            new_program_cache_with_builtins,
         },
-        crate::conformance::programs::keyed_account_for_system_program,
         solana_account::Account,
         solana_instruction::Instruction,
         solana_rent::Rent,
@@ -296,7 +298,7 @@ mod tests {
     };
 
     const NOOP_ELF: &[u8] =
-        include_bytes!("../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
+        include_bytes!("../../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
 
     const FROM_BASE_LAMPORTS: u64 = 5_000;
     const TO_BASE_LAMPORTS: u64 = 1_000;

--- a/svm/src/conformance/instr/mod.rs
+++ b/svm/src/conformance/instr/mod.rs
@@ -1,0 +1,5 @@
+//! Instruction conformance harness.
+
+pub mod context;
+pub mod effects;
+pub mod harness;

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -2,8 +2,7 @@
 
 #[cfg(feature = "conformance")]
 pub mod account_state;
-pub mod context;
 #[cfg(feature = "conformance")]
 pub mod feature_set;
-pub mod harness;
+pub mod instr;
 pub mod programs;

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -3,6 +3,8 @@
 #[cfg(feature = "conformance")]
 pub mod account_state;
 #[cfg(feature = "conformance")]
+pub mod elf_loader;
+#[cfg(feature = "conformance")]
 pub mod feature_set;
 pub mod instr;
 pub mod programs;


### PR DESCRIPTION
#### Problem
Continuing the work in #12378, we need to add the ELF loading harness from SolFuzz-Agave into Agave.

#### Summary of Changes
First repackage the instruction harness so we can reuse some of the components/converters, then land the ELF loading harness `sol_compat_elf_loader_v1`.

Note: since the ELF loading harness requires the syscalls to be registered in the harness's loader, it made sense to at least hoist this harness up to the syscall level, but later harnesses proved to be difficult residing outside of `solana-svm`, so I'll be placing all SVM-level harnesses here for now. They're trivial to move around later.

Broken off #12822
Part of #12378