### PR TITLE
fix: consider Genesis cert in safe-to-notar

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -593,6 +593,9 @@ impl ConsensusPool {
             || self
                 .completed_certificates
                 .contains_key(&CertificateType::FinalizeFast(slot, block_id))
+            || self
+                .completed_certificates
+                .contains_key(&CertificateType::Genesis(slot, block_id))
     }
 
     /// Takes the pending safe-to-notar blocks that need parent verification.


### PR DESCRIPTION
#### Problem
The method `block_has_notar_fallback_or_stronger` called in the safe-to-notar path:
https://github.com/anza-xyz/agave/blob/3bd0fa80438a868f2ec3b4cf32c2c979d0b3fbf5/votor/src/consensus_pool_service.rs#L568
currently only considers `NotarizeFallback`, `Notarize`, and `FinalizeFast` certificates as "notar fallback or stronger", however, it should probably also consider the `Genesis` certificate for that, in order to prevent a liveness issue in a migration edge case.

#### Summary of Changes
Add `Genesis` cert to the certs checked in `block_has_notar_fallback_or_stronger`.