### PR TITLE
fix: consider snapshot root in safe-to-notar

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -584,18 +584,8 @@ impl ConsensusPool {
     /// Checks if a specific block has a NotarizeFallback certificate (or stronger).
     /// This is used for verifying that an intrawindow block's parent has been certified.
     pub(crate) fn block_has_notar_fallback_or_stronger(&self, block: Block) -> bool {
-        let (slot, block_id) = block;
-        self.completed_certificates
-            .contains_key(&CertificateType::NotarizeFallback(slot, block_id))
-            || self
-                .completed_certificates
-                .contains_key(&CertificateType::Notarize(slot, block_id))
-            || self
-                .completed_certificates
-                .contains_key(&CertificateType::FinalizeFast(slot, block_id))
-            || self
-                .completed_certificates
-                .contains_key(&CertificateType::Genesis(slot, block_id))
+        self.parent_ready_tracker
+            .has_notar_fallback_or_stronger(block)
     }
 
     /// Takes the pending safe-to-notar blocks that need parent verification.

--- a/votor/src/consensus_pool/parent_ready_tracker.rs
+++ b/votor/src/consensus_pool/parent_ready_tracker.rs
@@ -231,6 +231,15 @@ impl ParentReadyTracker {
         }
     }
 
+    /// Returns whether the block is notarized or notarized-fallback
+    ///
+    /// This includes any special cases like: genesis, snapshot root, migration Genesis cert
+    pub(super) fn has_notar_fallback_or_stronger(&self, block @ (slot, _): Block) -> bool {
+        self.slot_statuses
+            .get(&slot)
+            .is_some_and(|ss| ss.notar_fallbacks.contains(&block))
+    }
+
     fn highest_parent_ready(&self) -> Slot {
         self.highest_with_parent_ready
     }


### PR DESCRIPTION
#### Problem
I think there is another edge-case liveness issue related to the same safe-to-notar logic as #12884. This time it not the `Genesis`-certified migration block but the snapshot root that is not considered to be notar-fallback (also regular genesis, if it weren't for an exception in another place treating it as a "first in window" slot).

#### Summary of Changes
Remove the manual logic of determining the notion of "notar-fallback or stronger" from `block_has_notar_fallback_or_stronger` in the consensus pool. Expose existing `ParentReadyState::notar_fallback` through new `has_notar_fallback_or_stronger` method of `ParentReadyTracker` and use that instead.