### PR TITLE
svm: conformance: add vm serialization harness

### DIFF
--- a/svm/src/conformance/callback.rs
+++ b/svm/src/conformance/callback.rs
@@ -1,0 +1,39 @@
+//! Invoke-context callbacks shared by the conformance harnesses.
+
+use solana_svm_callback::InvokeContextCallback;
+#[cfg(feature = "conformance")]
+use {
+    agave_feature_set::FeatureSet,
+    agave_precompiles::{get_precompile, is_precompile},
+    solana_precompile_error::PrecompileError,
+    solana_pubkey::Pubkey,
+};
+
+/// Default callback. No precompile support.
+pub struct DefaultCallback;
+
+impl InvokeContextCallback for DefaultCallback {}
+
+/// Conformance callback. Full precompile support across all features.
+#[cfg(feature = "conformance")]
+pub struct ConformanceCallback;
+
+#[cfg(feature = "conformance")]
+impl InvokeContextCallback for ConformanceCallback {
+    fn is_precompile(&self, program_id: &Pubkey) -> bool {
+        is_precompile(program_id, |_| true)
+    }
+
+    fn process_precompile(
+        &self,
+        program_id: &Pubkey,
+        data: &[u8],
+        instruction_datas: Vec<&[u8]>,
+    ) -> Result<(), PrecompileError> {
+        if let Some(precompile) = get_precompile(program_id, |_| true) {
+            precompile.verify(data, &instruction_datas, &FeatureSet::all_enabled())
+        } else {
+            Err(PrecompileError::InvalidPublicKey)
+        }
+    }
+}

--- a/svm/src/conformance/elf_loader.rs
+++ b/svm/src/conformance/elf_loader.rs
@@ -1,7 +1,10 @@
 //! ELF loader conformance harness.
 
 use {
-    crate::conformance::feature_set::feature_set_from_proto,
+    crate::conformance::{
+        fd_hash::{fd_hash_u64_without_seed, fd_hash_without_seed},
+        feature_set::feature_set_from_proto,
+    },
     prost::Message,
     protosol::protos::{
         ElfLoaderCtx as ProtoElfLoaderCtx, ElfLoaderEffects as ProtoElfLoaderEffects,
@@ -13,7 +16,6 @@ use {
     },
     solana_syscalls::create_program_runtime_environment,
     std::{collections::BTreeSet, ffi::c_int},
-    xxhash_rust::xxh64::xxh64,
 };
 
 pub fn execute_elf_loader(input: &ProtoElfLoaderCtx) -> ProtoElfLoaderEffects {
@@ -90,23 +92,6 @@ fn elf_err_to_num(error: &ElfError) -> u8 {
         ElfError::UnsupportedSBPFVersion => 22,
         ElfError::InvalidProgramHeader => 23,
     }
-}
-
-fn fd_hash_without_seed(buf: &[u8]) -> u64 {
-    fd_hash(0, buf)
-}
-
-fn fd_hash_u64_without_seed(buf: &[u64]) -> u64 {
-    let bytes = unsafe {
-        std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), std::mem::size_of_val(buf))
-    };
-    fd_hash(0, bytes)
-}
-
-/// Hashing used to summarize binary blobs (e.g. ELF sections) for conformance
-/// comparisons. Firedancer's `fd_hash` is XXH64.
-fn fd_hash(seed: u64, buf: &[u8]) -> u64 {
-    xxh64(buf, seed)
 }
 
 /// # Safety
@@ -187,16 +172,5 @@ mod tests {
             features: vec![u64::from_le_bytes(v3.to_bytes()[..8].try_into().unwrap())],
         };
         assert_loads_ok(SBPFV3_RETURN_OK, false, Some(features));
-    }
-
-    #[test]
-    fn test_fd_hash_matches_xxh64() {
-        // Reference values from Firedancer's `fd_hash` (XXH64). The empty-input,
-        // seed-0 case is the canonical XXH64 test vector.
-        let long: Vec<u8> = (0u8..100).collect();
-        assert_eq!(fd_hash(0, &[]), 0xef46db3751d8e999);
-        assert_eq!(fd_hash(0, b"hello world"), 0x45ab6734b21e6968);
-        assert_eq!(fd_hash(42, b"hello world"), 0x69c2b68f9d9352a1);
-        assert_eq!(fd_hash(0, &long), 0x6ac1e58032166597);
     }
 }

--- a/svm/src/conformance/fd_hash.rs
+++ b/svm/src/conformance/fd_hash.rs
@@ -1,0 +1,35 @@
+//! Hashing used to summarize binary blobs (e.g. ELF sections, serialized VM
+//! memory) for conformance comparisons.
+
+use xxhash_rust::xxh64::xxh64;
+
+pub fn fd_hash_without_seed(buf: &[u8]) -> u64 {
+    fd_hash(0, buf)
+}
+
+pub fn fd_hash_u64_without_seed(buf: &[u64]) -> u64 {
+    let bytes = unsafe {
+        std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), std::mem::size_of_val(buf))
+    };
+    fd_hash(0, bytes)
+}
+
+pub fn fd_hash(seed: u64, buf: &[u8]) -> u64 {
+    xxh64(buf, seed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fd_hash_matches_xxh64() {
+        // Reference values from Firedancer's `fd_hash` (XXH64). The empty-input,
+        // seed-0 case is the canonical XXH64 test vector.
+        let long: Vec<u8> = (0u8..100).collect();
+        assert_eq!(fd_hash(0, &[]), 0xef46db3751d8e999);
+        assert_eq!(fd_hash(0, b"hello world"), 0x45ab6734b21e6968);
+        assert_eq!(fd_hash(42, b"hello world"), 0x69c2b68f9d9352a1);
+        assert_eq!(fd_hash(0, &long), 0x6ac1e58032166597);
+    }
+}

--- a/svm/src/conformance/instr/harness.rs
+++ b/svm/src/conformance/instr/harness.rs
@@ -2,7 +2,7 @@
 
 use {
     super::{context::InstrContext, effects::InstrEffects},
-    crate::message_processor::process_message,
+    crate::{conformance::callback::DefaultCallback, message_processor::process_message},
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_instruction::error::InstructionError,
     solana_program_runtime::{
@@ -24,46 +24,15 @@ use {
 };
 #[cfg(feature = "conformance")]
 use {
-    crate::conformance::programs::{
-        fill_program_cache_from_accounts, new_program_cache_with_builtins,
+    crate::conformance::{
+        callback::ConformanceCallback,
+        programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
     },
-    agave_feature_set::FeatureSet,
-    agave_precompiles::{get_precompile, is_precompile},
     prost::Message,
     protosol::protos::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
     solana_account::ReadableAccount,
-    solana_precompile_error::PrecompileError,
     std::ffi::c_int,
 };
-
-/// Default callback. No precompile support.
-struct DefaultCallback;
-
-impl InvokeContextCallback for DefaultCallback {}
-
-/// Conformance callback. Full precompile support across all features.
-#[cfg(feature = "conformance")]
-struct ConformanceCallback;
-
-#[cfg(feature = "conformance")]
-impl InvokeContextCallback for ConformanceCallback {
-    fn is_precompile(&self, program_id: &Pubkey) -> bool {
-        is_precompile(program_id, |_| true)
-    }
-
-    fn process_precompile(
-        &self,
-        program_id: &Pubkey,
-        data: &[u8],
-        instruction_datas: Vec<&[u8]>,
-    ) -> Result<(), PrecompileError> {
-        if let Some(precompile) = get_precompile(program_id, |_| true) {
-            precompile.verify(data, &instruction_datas, &FeatureSet::all_enabled())
-        } else {
-            Err(PrecompileError::InvalidPublicKey)
-        }
-    }
-}
 
 /// Execute a single instruction against the Solana VM with the default
 /// (no-precompile) callback.

--- a/svm/src/conformance/instr/harness.rs
+++ b/svm/src/conformance/instr/harness.rs
@@ -2,23 +2,24 @@
 
 use {
     super::{context::InstrContext, effects::InstrEffects},
-    crate::{conformance::callback::DefaultCallback, message_processor::process_message},
+    crate::{
+        conformance::{
+            callback::DefaultCallback,
+            setup::{compile_transaction_context, program_runtime_environments, recent_blockhash},
+        },
+        message_processor::process_message,
+    },
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_instruction::error::InstructionError,
     solana_program_runtime::{
-        invoke_context::{EnvironmentConfig, InvokeContext, mock_compile_message},
-        loaded_programs::{
-            ProgramCacheForTxBatch, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
-        },
+        invoke_context::{EnvironmentConfig, InvokeContext},
+        loaded_programs::ProgramCacheForTxBatch,
         sysvar_cache::SysvarCache,
     },
     solana_pubkey::Pubkey,
     solana_svm_callback::InvokeContextCallback,
     solana_svm_log_collector::LogCollector,
     solana_svm_timings::ExecuteTimings,
-    solana_svm_transaction::svm_message::SVMStaticMessage,
-    solana_syscalls::create_program_runtime_environment,
-    solana_transaction_context::transaction::TransactionContext,
     solana_transaction_error::TransactionError,
     std::rc::Rc,
 };
@@ -27,10 +28,10 @@ use {
     crate::conformance::{
         callback::ConformanceCallback,
         programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
+        setup::sysvar_cache_from_accounts,
     },
     prost::Message,
     protosol::protos::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
-    solana_account::ReadableAccount,
     std::ffi::c_int,
 };
 
@@ -68,45 +69,27 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
         .expect("program not loaded in cache")
         .account_owner();
 
-    let (sanitized_message, transaction_accounts) =
-        mock_compile_message(&input.instruction, &input.accounts, program_id, &loader_key);
-
-    let mut transaction_context = TransactionContext::new(
-        transaction_accounts,
+    let (sanitized_message, mut transaction_context) = compile_transaction_context(
+        &input.instruction,
+        &input.accounts,
+        program_id,
+        &loader_key,
+        &compute_budget,
         (*rent).clone(),
-        compute_budget.max_instruction_stack_depth,
-        compute_budget.max_instruction_trace_length,
-        sanitized_message.num_instructions(),
     );
 
-    let program_runtime_environment = create_program_runtime_environment(
-        &input.feature_set,
-        &compute_budget.to_budget(),
-        false, /* deployment */
-        false, /* debugging_features */
-    )
-    .unwrap();
+    let runtime_environments = program_runtime_environments(&input.feature_set, &compute_budget);
 
     let result = {
-        #[expect(deprecated)]
-        let (blockhash, blockhash_lamports_per_signature) = sysvar_cache
-            .get_recent_blockhashes()
-            .ok()
-            .and_then(|x| (*x).last().cloned())
-            .map(|x| (x.blockhash, x.fee_calculator.lamports_per_signature))
-            .unwrap_or_default();
+        let (blockhash, blockhash_lamports_per_signature) = recent_blockhash(sysvar_cache);
 
-        let program_runtime_environments = ProgramRuntimeEnvironments::new(
-            ProgramRuntimeEnvironment::clone(&program_runtime_environment),
-            program_runtime_environment,
-        );
         let environment_config = EnvironmentConfig::new(
             blockhash,
             blockhash_lamports_per_signature,
             false,
             callback,
             &feature_set,
-            &program_runtime_environments,
+            &runtime_environments,
             sysvar_cache,
         );
 
@@ -176,17 +159,7 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> ProtoInstrEffects {
     let instr_context = InstrContext::from(input);
 
     // When testing with protobuf, we fill the sysvar cache from input accounts.
-    let sysvar_cache = {
-        let mut cache = SysvarCache::default();
-        cache.fill_missing_entries(|pubkey, callbackback| {
-            if let Some(account) = instr_context.accounts.iter().find(|(key, _)| key == pubkey)
-                && account.1.lamports() > 0
-            {
-                callbackback(account.1.data());
-            }
-        });
-        cache
-    };
+    let sysvar_cache = sysvar_cache_from_accounts(&instr_context.accounts);
 
     // When testing with protobuf, we fill the program cache from input accounts.
     let mut program_cache = {
@@ -194,18 +167,16 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> ProtoInstrEffects {
         let feature_set = &instr_context.feature_set;
         let simd_0268_active = feature_set.raise_cpi_nesting_limit_to_8;
         let compute_budget = ComputeBudget::new_with_defaults(simd_0268_active);
-
-        let environment = create_program_runtime_environment(
-            feature_set,
-            &compute_budget.to_budget(),
-            false, /* deployment */
-            false, /* debugging_features */
-        )
-        .unwrap();
+        let environments = program_runtime_environments(feature_set, &compute_budget);
 
         let mut cache = new_program_cache_with_builtins(slot);
-        fill_program_cache_from_accounts(&mut cache, &environment, &instr_context.accounts, slot)
-            .unwrap();
+        fill_program_cache_from_accounts(
+            &mut cache,
+            environments.get_env_for_deployment(),
+            &instr_context.accounts,
+            slot,
+        )
+        .unwrap();
 
         cache
     };

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -11,3 +11,4 @@ pub mod fd_hash;
 pub mod feature_set;
 pub mod instr;
 pub mod programs;
+mod setup;

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -11,4 +11,6 @@ pub mod fd_hash;
 pub mod feature_set;
 pub mod instr;
 pub mod programs;
+#[cfg(feature = "conformance")]
+pub mod serialization;
 mod setup;

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -6,6 +6,8 @@ pub mod callback;
 #[cfg(feature = "conformance")]
 pub mod elf_loader;
 #[cfg(feature = "conformance")]
+pub mod fd_hash;
+#[cfg(feature = "conformance")]
 pub mod feature_set;
 pub mod instr;
 pub mod programs;

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "conformance")]
 pub mod account_state;
+pub mod callback;
 #[cfg(feature = "conformance")]
 pub mod elf_loader;
 #[cfg(feature = "conformance")]

--- a/svm/src/conformance/serialization.rs
+++ b/svm/src/conformance/serialization.rs
@@ -1,0 +1,272 @@
+//! VM serialization conformance harness.
+
+use {
+    crate::conformance::{
+        callback::DefaultCallback,
+        fd_hash::fd_hash,
+        instr::context::InstrContext,
+        setup::{
+            compile_transaction_context, program_runtime_environments, recent_blockhash,
+            sysvar_cache_from_accounts,
+        },
+    },
+    prost::Message,
+    protosol::protos::{
+        InstrContext as ProtoInstrContext, VmInputMemoryRegion as ProtoVmInputMemoryRegion,
+        VmSerializationEffects as ProtoVmSerializationEffects,
+        VmSerializedAccountMetadata as ProtoVmSerializedAccountMetadata,
+    },
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_program_runtime::{
+        invoke_context::{EnvironmentConfig, InvokeContext},
+        loaded_programs::ProgramCacheForTxBatch,
+        memory_context::SerializedAccountMetadata,
+        serialization::serialize_parameters,
+        solana_sbpf::memory_region::MemoryRegion,
+    },
+    solana_svm_log_collector::LogCollector,
+    std::ffi::c_int,
+};
+
+pub fn execute_vm_serialize(input: ProtoInstrContext) -> ProtoVmSerializationEffects {
+    let instr_context = InstrContext::from(input);
+
+    let log_collector = LogCollector::new_ref();
+    let feature_set = instr_context.feature_set;
+    let virtual_address_space_adjustments = feature_set.virtual_address_space_adjustments;
+    let direct_mapping = feature_set.account_data_direct_mapping;
+    let direct_account_pointers = feature_set.direct_account_pointers_in_program_input;
+
+    let compute_budget = ComputeBudget::new_with_defaults(feature_set.raise_cpi_nesting_limit_to_8);
+    // No CU limit for this harness.
+
+    let sysvar_cache = sysvar_cache_from_accounts(&instr_context.accounts);
+    let rent = sysvar_cache.get_rent().unwrap();
+    let program_id = instr_context.instruction.program_id;
+    let loader_key = instr_context
+        .accounts
+        .iter()
+        .find(|(key, _)| *key == program_id)
+        .map(|(_, account)| account.owner)
+        .expect("program not found in accounts");
+
+    let (sanitized_message, mut transaction_context) = compile_transaction_context(
+        &instr_context.instruction,
+        &instr_context.accounts,
+        &program_id,
+        &loader_key,
+        &compute_budget,
+        (*rent).clone(),
+    );
+
+    // We're only testing the parameter serialization, so use an empty cache.
+    let mut program_cache = ProgramCacheForTxBatch::default();
+
+    let runtime_environments = program_runtime_environments(&feature_set, &compute_budget);
+    let (blockhash, lamports_per_signature) = recent_blockhash(&sysvar_cache);
+    let environment_config = EnvironmentConfig::new(
+        blockhash,
+        lamports_per_signature,
+        false,
+        &DefaultCallback,
+        &feature_set,
+        &runtime_environments,
+        &sysvar_cache,
+    );
+
+    let mut invoke_context = InvokeContext::new(
+        &mut transaction_context,
+        &mut program_cache,
+        environment_config,
+        Some(log_collector.clone()),
+        compute_budget.to_budget(),
+        compute_budget.to_cost(),
+    );
+
+    invoke_context
+        .prepare_top_level_instructions(&sanitized_message)
+        .unwrap();
+    invoke_context.push().unwrap();
+
+    let instruction_context = invoke_context
+        .transaction_context
+        .get_current_instruction_context()
+        .unwrap();
+
+    match serialize_parameters(
+        &instruction_context,
+        virtual_address_space_adjustments,
+        direct_mapping,
+        direct_account_pointers,
+    ) {
+        Ok((aligned_memory, input_memory_regions, account_metadatas, _instruction_data_offset)) => {
+            let serialized_memory_hash = fd_hash(0, aligned_memory.as_slice());
+            let vm_input_memory_regions = input_memory_regions
+                .iter()
+                .map(memory_region_to_proto)
+                .collect();
+            let serialized_account_metadata = account_metadatas
+                .iter()
+                .map(serialized_acct_meta_to_proto)
+                .collect();
+            ProtoVmSerializationEffects {
+                has_error: false,
+                serialized_memory_hash,
+                vm_input_memory_regions,
+                serialized_account_metadata,
+            }
+        }
+        Err(_) => ProtoVmSerializationEffects {
+            has_error: true,
+            ..Default::default()
+        },
+    }
+}
+
+fn memory_region_to_proto(region: &MemoryRegion) -> ProtoVmInputMemoryRegion {
+    ProtoVmInputMemoryRegion {
+        vm_address: region.vm_addr,
+        region_size: region.len,
+        is_writable: region.writable,
+    }
+}
+
+fn serialized_acct_meta_to_proto(
+    meta: &SerializedAccountMetadata,
+) -> ProtoVmSerializedAccountMetadata {
+    ProtoVmSerializedAccountMetadata {
+        original_data_len: meta.original_data_len as u64,
+        vm_data_addr: meta.vm_data_addr,
+        vm_key_addr: meta.vm_key_addr,
+        vm_lamports_addr: meta.vm_lamports_addr,
+        vm_owner_addr: meta.vm_owner_addr,
+    }
+}
+
+/// # Safety
+///
+/// `in_ptr` must point to `in_sz` initialized bytes. `out_ptr` must point
+/// to a writable buffer of at least `*out_psz` bytes. On return, `*out_psz`
+/// is updated to the number of bytes written.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sol_compat_vm_serialize_execute_v1(
+    out_ptr: *mut u8,
+    out_psz: *mut u64,
+    in_ptr: *mut u8,
+    in_sz: u64,
+) -> c_int {
+    let in_slice = unsafe { std::slice::from_raw_parts(in_ptr, in_sz as usize) };
+    let Ok(instr_context) = ProtoInstrContext::decode(in_slice) else {
+        return 0;
+    };
+
+    let effects = execute_vm_serialize(instr_context);
+    let out_slice = unsafe { std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize) };
+    let out_vec = effects.encode_to_vec();
+    if out_vec.len() > out_slice.len() {
+        return 0;
+    }
+    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
+    unsafe { *out_psz = out_vec.len() as u64 };
+
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        protosol::protos::{AcctState as ProtoAcctState, InstrAcct as ProtoInstrAcct},
+        solana_pubkey::Pubkey,
+        solana_rent::Rent,
+        solana_sdk_ids::{bpf_loader_deprecated, bpf_loader_upgradeable, sysvar},
+    };
+
+    const PROGRAM_ID: [u8; 32] = [7; 32];
+
+    fn account(address: u8, owner: Pubkey, data_len: usize) -> ProtoAcctState {
+        ProtoAcctState {
+            address: vec![address; 32],
+            lamports: 1,
+            data: vec![0; data_len],
+            executable: false,
+            owner: owner.to_bytes().to_vec(),
+        }
+    }
+
+    fn instr_acct(index: u32, is_writable: bool, is_signer: bool) -> ProtoInstrAcct {
+        ProtoInstrAcct {
+            index,
+            is_writable,
+            is_signer,
+        }
+    }
+
+    fn rent_sysvar() -> ProtoAcctState {
+        ProtoAcctState {
+            address: sysvar::rent::id().to_bytes().to_vec(),
+            lamports: 1,
+            data: bincode::serialize(&Rent::default()).unwrap(),
+            executable: false,
+            owner: sysvar::id().to_bytes().to_vec(),
+        }
+    }
+
+    fn serialize(
+        mut accounts: Vec<ProtoAcctState>,
+        instr_accounts: Vec<ProtoInstrAcct>,
+    ) -> ProtoVmSerializationEffects {
+        accounts.push(rent_sysvar()); // <-- Loads Rent into SysvarCache
+        execute_vm_serialize(ProtoInstrContext {
+            program_id: PROGRAM_ID.to_vec(),
+            accounts,
+            instr_accounts,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn test_serialize_single_account() {
+        let program_id = Pubkey::new_from_array(PROGRAM_ID);
+        let effects = serialize(
+            vec![
+                account(1, program_id, 8),
+                account(PROGRAM_ID[0], bpf_loader_upgradeable::id(), 0),
+            ],
+            vec![instr_acct(0, true, false)],
+        );
+        assert!(!effects.has_error);
+        assert_eq!(effects.serialized_account_metadata.len(), 1);
+    }
+
+    #[test]
+    fn test_serialize_multiple_accounts() {
+        let program_id = Pubkey::new_from_array(PROGRAM_ID);
+        let effects = serialize(
+            vec![
+                account(1, program_id, 4),
+                account(2, program_id, 16),
+                account(PROGRAM_ID[0], bpf_loader_upgradeable::id(), 0),
+            ],
+            vec![instr_acct(0, true, true), instr_acct(1, false, false)],
+        );
+        assert!(!effects.has_error);
+        assert_eq!(effects.serialized_account_metadata.len(), 2);
+    }
+
+    #[test]
+    fn test_serialize_deprecated_loader_program() {
+        // A program owned by the deprecated loader exercises the unaligned
+        // serialization path.
+        let program_id = Pubkey::new_from_array(PROGRAM_ID);
+        let effects = serialize(
+            vec![
+                account(1, program_id, 8),
+                account(PROGRAM_ID[0], bpf_loader_deprecated::id(), 0),
+            ],
+            vec![instr_acct(0, true, false)],
+        );
+        assert!(!effects.has_error);
+        assert_eq!(effects.serialized_account_metadata.len(), 1);
+    }
+}

--- a/svm/src/conformance/setup.rs
+++ b/svm/src/conformance/setup.rs
@@ -1,0 +1,94 @@
+//! Shared setup helpers for the execution harnesses.
+//!
+//! Each helper builds one owned prerequisite for an `InvokeContext` (the
+//! transaction context, the runtime environments, the blockhash). The harness
+//! still assembles its own `EnvironmentConfig`/`InvokeContext`, since those
+//! borrow these pieces — so rather than one big `create_invoke_context_fields`
+//! returning a tuple of everything, this is a handful of small, composable
+//! pieces the harnesses pick from.
+
+#[cfg(feature = "conformance")]
+use solana_account::ReadableAccount;
+use {
+    solana_account::Account,
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_hash::Hash,
+    solana_instruction::Instruction,
+    solana_message::SanitizedMessage,
+    solana_program_runtime::{
+        invoke_context::mock_compile_message,
+        loaded_programs::{ProgramRuntimeEnvironment, ProgramRuntimeEnvironments},
+        sysvar_cache::SysvarCache,
+    },
+    solana_pubkey::Pubkey,
+    solana_rent::Rent,
+    solana_svm_feature_set::SVMFeatureSet,
+    solana_svm_transaction::svm_message::SVMStaticMessage,
+    solana_syscalls::create_program_runtime_environment,
+    solana_transaction_context::transaction::TransactionContext,
+};
+
+/// Compile `instruction` into a sanitized message and a fresh transaction
+/// context sized for a single top-level instruction.
+pub(crate) fn compile_transaction_context(
+    instruction: &Instruction,
+    accounts: &[(Pubkey, Account)],
+    program_id: &Pubkey,
+    loader_key: &Pubkey,
+    compute_budget: &ComputeBudget,
+    rent: Rent,
+) -> (SanitizedMessage, TransactionContext<'static>) {
+    let (sanitized_message, transaction_accounts) =
+        mock_compile_message(instruction, accounts, program_id, loader_key);
+    let transaction_context = TransactionContext::new(
+        transaction_accounts,
+        rent,
+        compute_budget.max_instruction_stack_depth,
+        compute_budget.max_instruction_trace_length,
+        sanitized_message.num_instructions(),
+    );
+    (sanitized_message, transaction_context)
+}
+
+/// The paired (execution + deployment) program runtime environments for a
+/// harness invocation. Both halves share one environment.
+pub(crate) fn program_runtime_environments(
+    feature_set: &SVMFeatureSet,
+    compute_budget: &ComputeBudget,
+) -> ProgramRuntimeEnvironments {
+    let environment = create_program_runtime_environment(
+        feature_set,
+        &compute_budget.to_budget(),
+        false, /* deployment */
+        false, /* debugging_features */
+    )
+    .unwrap();
+    ProgramRuntimeEnvironments::new(ProgramRuntimeEnvironment::clone(&environment), environment)
+}
+
+/// The most recent blockhash and its lamports-per-signature from the sysvar
+/// cache, or defaults when unavailable.
+pub(crate) fn recent_blockhash(sysvar_cache: &SysvarCache) -> (Hash, u64) {
+    #[expect(deprecated)]
+    sysvar_cache
+        .get_recent_blockhashes()
+        .ok()
+        .and_then(|entries| entries.last().cloned())
+        .map(|entry| (entry.blockhash, entry.fee_calculator.lamports_per_signature))
+        .unwrap_or_default()
+}
+
+/// Build a sysvar cache populated from any sysvar accounts present in the
+/// input account set.
+#[cfg(feature = "conformance")]
+pub(crate) fn sysvar_cache_from_accounts(accounts: &[(Pubkey, Account)]) -> SysvarCache {
+    let mut cache = SysvarCache::default();
+    cache.fill_missing_entries(|pubkey, set_sysvar| {
+        if let Some(account) = accounts.iter().find(|(key, _)| key == pubkey)
+            && account.1.lamports() > 0
+        {
+            set_sysvar(account.1.data());
+        }
+    });
+    cache
+}


### PR DESCRIPTION
#### Problem
Continuing the work in #12378, we need to add the VM serialization harness from SolFuzz-Agave into Agave.

#### Summary of Changes
Building on the pattern laid down by #12881, first extract some of the helpers used by the ELF harness into shared modules, then implement the VM serialization harness from SolFuzz-Agave.

Broken off #12822
Part of #12378