### PR TITLE
chore: Remove instances of &Arc<RwLock<BankForks>>

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -506,7 +506,7 @@ pub async fn start_tcp_server(
             let client = create_client(None, tpu_addr, exit.clone());
 
             SendTransactionService::new(
-                &bank_forks,
+                bank_forks.clone(),
                 receiver,
                 client,
                 Config {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1783,7 +1783,7 @@ impl ReplayStage {
         tower_storage: &dyn TowerStorage,
         node_pubkey: &Pubkey,
         vote_account: &Pubkey,
-        bank_forks: &Arc<RwLock<BankForks>>,
+        bank_forks: &RwLock<BankForks>,
     ) -> Result<Tower, TowerError> {
         let tower = Tower::restore(tower_storage, node_pubkey).and_then(|restored_tower| {
             let root_bank = bank_forks.read().unwrap().root_bank();
@@ -2826,7 +2826,7 @@ impl ReplayStage {
     #[allow(clippy::too_many_arguments)]
     fn maybe_start_leader(
         my_pubkey: &Pubkey,
-        bank_forks: &Arc<RwLock<BankForks>>,
+        bank_forks: &RwLock<BankForks>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         poh_controller: &mut PohController,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
@@ -3006,7 +3006,7 @@ impl ReplayStage {
     fn handle_votable_bank(
         bank: &Arc<Bank>,
         switch_fork_decision: &SwitchForkDecision,
-        bank_forks: &Arc<RwLock<BankForks>>,
+        bank_forks: &RwLock<BankForks>,
         tower: &mut Tower,
         progress: &mut ProgressMap,
         vote_account_pubkey: &Pubkey,
@@ -5313,7 +5313,7 @@ impl ReplayStage {
 
     fn log_heaviest_fork_failures(
         heaviest_fork_failures: &Vec<HeaviestForkFailures>,
-        bank_forks: &Arc<RwLock<BankForks>>,
+        bank_forks: &RwLock<BankForks>,
         tower: &Tower,
         progress: &ProgressMap,
         ancestors: &HashMap<Slot, HashSet<Slot>>,

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -300,7 +300,7 @@ pub(super) fn handle_abandoned_bank(
     bank: &Arc<Bank>,
     bank_slot: Slot,
     update_parent: &VersionedUpdateParent,
-    bank_forks: &Arc<RwLock<BankForks>>,
+    bank_forks: &RwLock<BankForks>,
     progress: &mut ProgressMap,
     async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
     duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
@@ -367,7 +367,7 @@ pub(super) fn handle_abandoned_bank(
     // parent by generate_new_bank_forks on the next iteration.
     ReplayStage::clear_banks(
         &BTreeSet::from([bank_slot]),
-        bank_forks.as_ref(),
+        bank_forks,
         progress,
         async_verification_freelist,
     );

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -20,12 +20,10 @@ pub struct SamplePerformanceService {
 
 impl SamplePerformanceService {
     pub fn new(
-        bank_forks: &Arc<RwLock<BankForks>>,
+        bank_forks: Arc<RwLock<BankForks>>,
         blockstore: Arc<Blockstore>,
         exit: Arc<AtomicBool>,
     ) -> Self {
-        let bank_forks = bank_forks.clone();
-
         let thread_hdl = Builder::new()
             .name("solSamplePerf".to_string())
             .spawn(move || {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -200,7 +200,7 @@ impl Tvu {
     pub fn new(
         vote_account: &Pubkey,
         authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
-        bank_forks: &Arc<RwLock<BankForks>>,
+        bank_forks: Arc<RwLock<BankForks>>,
         cluster_info: &Arc<ClusterInfo>,
         sockets: TvuSockets,
         blockstore: Arc<Blockstore>,
@@ -621,7 +621,7 @@ impl Tvu {
         );
 
         let epoch_specs: Box<dyn solana_gossip::epoch_specs::EpochSpecs> =
-            Box::new(EpochSpecs::from(bank_forks.clone()));
+            Box::new(EpochSpecs::from(bank_forks));
 
         let duplicate_shred_listener = DuplicateShredListener::new(
             exit,
@@ -830,7 +830,7 @@ pub mod tests {
         let tvu = Tvu::new(
             &vote_keypair.pubkey(),
             Arc::new(RwLock::new(vec![Arc::new(vote_keypair)])),
-            &bank_forks,
+            bank_forks.clone(),
             &cref1,
             TvuSockets {
                 repair: target1.sockets.repair,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1356,7 +1356,7 @@ impl Validator {
 
             let sample_performance_service = if config.rpc_config.enable_rpc_transaction_history {
                 Some(SamplePerformanceService::new(
-                    &bank_forks,
+                    bank_forks.clone(),
                     blockstore.clone(),
                     exit.clone(),
                 ))
@@ -1579,7 +1579,7 @@ impl Validator {
         let tvu = Tvu::new(
             vote_account,
             authorized_voter_keypairs,
-            &bank_forks,
+            bank_forks.clone(),
             &cluster_info,
             TvuSockets {
                 repair: node.sockets.repair.try_clone().unwrap(),
@@ -2030,7 +2030,7 @@ pub fn should_require_vote_history_file(
 
 fn restore_vote_history(
     config: &ValidatorConfig,
-    bank_forks: &Arc<RwLock<BankForks>>,
+    bank_forks: &RwLock<BankForks>,
     identity: &Pubkey,
     vote_account: &Pubkey,
 ) -> VoteHistory {

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -34,7 +34,7 @@ pub struct OptimisticallyConfirmedBank {
 }
 
 impl OptimisticallyConfirmedBank {
-    pub fn locked_from_bank_forks_root(bank_forks: &Arc<RwLock<BankForks>>) -> Arc<RwLock<Self>> {
+    pub fn locked_from_bank_forks_root(bank_forks: &RwLock<BankForks>) -> Arc<RwLock<Self>> {
         Arc::new(RwLock::new(Self {
             bank: bank_forks.read().unwrap().root_bank(),
         }))

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -481,7 +481,7 @@ impl JsonRpcRequestProcessor {
         let client = create_client_for_tests(runtime.handle().clone(), my_tpu_address, None, 1);
 
         SendTransactionService::new(
-            &bank_forks,
+            bank_forks.clone(),
             transaction_receiver,
             client,
             SendTransactionServiceConfig {
@@ -6958,7 +6958,7 @@ pub mod tests {
 
         let client = create_client_for_tests(runtime.handle().clone(), my_tpu_address, None, 1);
         SendTransactionService::new(
-            &bank_forks,
+            bank_forks.clone(),
             receiver,
             client,
             SendTransactionServiceConfig {
@@ -7270,7 +7270,7 @@ pub mod tests {
         );
 
         SendTransactionService::new(
-            &bank_forks,
+            bank_forks,
             receiver,
             client,
             SendTransactionServiceConfig {

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -394,7 +394,7 @@ impl RequestMiddleware for RpcRequestMiddleware {
         }
 
         if let Some(path) = match_supply_path(request.uri().path()) {
-            process_rest(&self.bank_forks, path)
+            process_rest(self.bank_forks.clone(), path)
         } else if self.is_file_get_path(request.uri().path()) {
             self.process_file_get(request.uri().path())
         } else if request.uri().path() == "/health" {
@@ -433,7 +433,7 @@ async fn calculate_circulating_supply_async(bank: &Arc<Bank>) -> Result<u64, Sup
     Ok(total_supply.saturating_sub(non_circulating_supply.lamports))
 }
 
-async fn handle_rest(bank_forks: &Arc<RwLock<BankForks>>, path: &str) -> Option<String> {
+async fn handle_rest(bank_forks: &RwLock<BankForks>, path: &str) -> Option<String> {
     match path {
         "/v0/circulating-supply" => {
             let bank = bank_forks.read().unwrap().root_bank();
@@ -452,8 +452,7 @@ async fn handle_rest(bank_forks: &Arc<RwLock<BankForks>>, path: &str) -> Option<
     }
 }
 
-fn process_rest(bank_forks: &Arc<RwLock<BankForks>>, path: &str) -> RequestMiddlewareAction {
-    let bank_forks = bank_forks.clone();
+fn process_rest(bank_forks: Arc<RwLock<BankForks>>, path: &str) -> RequestMiddlewareAction {
     let path = path.to_string();
 
     RequestMiddlewareAction::Respond {
@@ -692,7 +691,7 @@ impl JsonRpcService {
         );
 
         let _send_transaction_service = Arc::new(SendTransactionService::new(
-            &bank_forks,
+            bank_forks.clone(),
             receiver,
             client.clone(),
             send_transaction_service_config,
@@ -723,7 +722,7 @@ impl JsonRpcService {
                 let request_middleware = RpcRequestMiddleware::new(
                     ledger_path,
                     snapshot_config,
-                    bank_forks.clone(),
+                    bank_forks,
                     health.clone(),
                 );
                 let server = ServerBuilder::with_meta_extractor(

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -136,7 +136,7 @@ impl std::fmt::Debug for NotificationEntry {
 fn check_commitment_and_notify<P, S, B, F, X, I>(
     params: &P,
     subscription: &SubscriptionInfo,
-    bank_forks: &Arc<RwLock<BankForks>>,
+    bank_forks: &RwLock<BankForks>,
     slot: Slot,
     bank_method: B,
     filter_results: F,
@@ -895,7 +895,7 @@ impl RpcSubscriptions {
     fn notify_watchers(
         max_complete_transaction_status_slot: Arc<AtomicU64>,
         subscriptions: &HashMap<SubscriptionId, Arc<SubscriptionInfo>>,
-        bank_forks: &Arc<RwLock<BankForks>>,
+        bank_forks: &RwLock<BankForks>,
         blockstore: &Blockstore,
         commitment_slots: &CommitmentSlots,
         notifier: &RpcNotifier,

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -559,7 +559,7 @@ mod tests {
     }
 
     fn create_child_bank(
-        bank_forks: &Arc<RwLock<BankForks>>,
+        bank_forks: &RwLock<BankForks>,
         parent: &Arc<Bank>,
         slot: u64,
     ) -> Arc<Bank> {

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -158,7 +158,7 @@ pub const MAX_RETRY_SLEEP_MS: u64 = 1000;
 
 impl SendTransactionService {
     pub fn new<Client: TransactionClient + Clone + std::marker::Send + 'static>(
-        bank_forks: &Arc<RwLock<BankForks>>,
+        bank_forks: Arc<RwLock<BankForks>>,
         receiver: Receiver<TransactionInfo>,
         client: Client,
         config: Config,
@@ -178,7 +178,7 @@ impl SendTransactionService {
         );
 
         let retry_thread = Self::retry_thread(
-            bank_forks.clone(),
+            bank_forks,
             client,
             retry_transactions,
             config,
@@ -561,7 +561,7 @@ mod test {
             create_client_for_tests(Handle::current(), "127.0.0.1:0".parse().unwrap(), None, 1);
 
         let send_transaction_service = SendTransactionService::new(
-            &bank_forks,
+            bank_forks,
             receiver,
             client.clone(),
             Config {
@@ -598,7 +598,7 @@ mod test {
         let client =
             create_client_for_tests(Handle::current(), "127.0.0.1:0".parse().unwrap(), None, 1);
         let _send_transaction_service = SendTransactionService::new(
-            &bank_forks,
+            bank_forks,
             receiver,
             client.clone(),
             Config {


### PR DESCRIPTION
#### Problem
Using &Arc<T> is a bit of an anti-pattern; functions can either:
- Take an Arc<T> if they need the Arc OR
- Take &T if they just need the ref

