### PR TITLE
refactor replay-stage's process-active-bank()

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -233,6 +233,15 @@ struct BankReplayResultTracker {
     bank_replay_tracker: Option<BankReplayTracker>,
 }
 
+struct CompletedBankReplay {
+    // Metrics around replaying this bank.
+    replay_stats: Arc<RwLock<ReplaySlotStats>>,
+    // Accounting around replaying this bank.
+    replay_progress: Arc<RwLock<ConfirmationProgress>>,
+    // True when the bank completed via the unified scheduler path.
+    is_unified_scheduler_enabled: bool,
+}
+
 struct ProcessActiveBanksContext {
     bank_forks: Arc<RwLock<BankForks>>,
     blockstore: Arc<Blockstore>,
@@ -3833,6 +3842,92 @@ impl ReplayStage {
         mark_replay_dead_slot(bank, err, progress, &mut dead_slot_context);
     }
 
+    fn complete_scheduler_replay(
+        bank: &BankWithScheduler,
+        replay_stats: &RwLock<ReplaySlotStats>,
+    ) -> (Result<(), BlockstoreProcessorError>, bool) {
+        let Some((result, completed_execute_timings)) = bank.wait_for_completed_scheduler() else {
+            return (Ok(()), false);
+        };
+
+        let metrics = ExecuteBatchesInternalMetrics::new_with_timings_from_all_threads(
+            completed_execute_timings,
+        );
+        replay_stats
+            .write()
+            .unwrap()
+            .batch_execute
+            .accumulate(metrics, true);
+
+        (
+            result.map_err(BlockstoreProcessorError::InvalidTransaction),
+            true,
+        )
+    }
+
+    fn complete_replay_verification(
+        replay_stats: &RwLock<ReplaySlotStats>,
+        replay_progress: &RwLock<ConfirmationProgress>,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+    ) -> Result<(), BlockstoreProcessorError> {
+        let mut poh_verify_elapsed = 0;
+        let mut tx_verify_elapsed = 0;
+        let (verify_result, async_verification) = {
+            let mut replay_progress = replay_progress.write().unwrap();
+            (
+                replay_progress.wait_for_all_verification_results(
+                    &mut poh_verify_elapsed,
+                    &mut tx_verify_elapsed,
+                ),
+                replay_progress.take_async_verification(),
+            )
+        };
+
+        {
+            let mut stats = replay_stats.write().unwrap();
+            stats.poh_verify_elapsed += poh_verify_elapsed;
+            stats.transaction_verify_elapsed += tx_verify_elapsed;
+        }
+
+        Self::recycle_async_verification(async_verification_freelist, async_verification);
+        verify_result
+    }
+
+    fn complete_bank_replay(
+        process_active_banks_context: &ProcessActiveBanksContext,
+        bank: &BankWithScheduler,
+        bank_progress: &mut ForkProgress,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+    ) -> Result<CompletedBankReplay, BlockstoreProcessorError> {
+        let replay_stats = bank_progress.replay_stats.clone();
+
+        let (replay_result, is_unified_scheduler_enabled) =
+            Self::complete_scheduler_replay(bank, &replay_stats);
+        let verify_result = Self::complete_replay_verification(
+            &replay_stats,
+            &bank_progress.replay_progress,
+            async_verification_freelist,
+        );
+
+        // Send this whether the block was valid or not. It is only used to
+        // release buffered votes, if any.
+        let _ =
+            process_active_banks_context
+                .replay_vote_sender
+                .send(ReplayVoteMessage::BankComplete {
+                    replay_bank_id: bank.bank_id(),
+                    replay_slot: bank.slot(),
+                });
+
+        replay_result.and(verify_result)?;
+
+        Ok(CompletedBankReplay {
+            replay_stats,
+            replay_progress: bank_progress.replay_progress.clone(),
+            is_unified_scheduler_enabled,
+        })
+    }
+
     fn process_replay_results(
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
@@ -3901,73 +3996,27 @@ impl ReplayStage {
                     .get_mut(&bank.slot())
                     .expect("Bank fork progress entry missing for completed bank");
 
-                let replay_stats = bank_progress.replay_stats.clone();
-                let mut is_unified_scheduler_enabled = false;
-
-                let replay_res = if let Some((result, completed_execute_timings)) =
-                    bank.wait_for_completed_scheduler()
-                {
-                    // It's guaranteed that wait_for_completed_scheduler() returns Some(_), iff the
-                    // unified scheduler is enabled for the bank.
-                    is_unified_scheduler_enabled = true;
-                    let metrics = ExecuteBatchesInternalMetrics::new_with_timings_from_all_threads(
-                        completed_execute_timings,
-                    );
-                    replay_stats
-                        .write()
-                        .unwrap()
-                        .batch_execute
-                        .accumulate(metrics, is_unified_scheduler_enabled);
-
-                    result.map_err(BlockstoreProcessorError::InvalidTransaction)
-                } else {
-                    Ok(())
-                };
-                let verify_res = {
-                    let mut poh_verify_elapsed = 0;
-                    let mut tx_verify_elapsed = 0;
-                    let (res, async_verification) = {
-                        let mut replay_progress = bank_progress.replay_progress.write().unwrap();
-                        (
-                            replay_progress.wait_for_all_verification_results(
-                                &mut poh_verify_elapsed,
-                                &mut tx_verify_elapsed,
-                            ),
-                            replay_progress.take_async_verification(),
-                        )
-                    };
-                    {
-                        let mut stats = replay_stats.write().unwrap();
-                        stats.poh_verify_elapsed += poh_verify_elapsed;
-                        stats.transaction_verify_elapsed += tx_verify_elapsed;
+                let completed_replay = match Self::complete_bank_replay(
+                    process_active_banks_context,
+                    bank,
+                    bank_progress,
+                    async_verification_freelist,
+                ) {
+                    Ok(completed_replay) => completed_replay,
+                    Err(err) => {
+                        Self::mark_replay_result_dead_slot(
+                            process_active_banks_context,
+                            bank,
+                            &err,
+                            progress,
+                            duplicate_slots_to_repair,
+                            purge_repair_slot_counter,
+                            &mut tbft_structs,
+                        );
+                        // don't try to run the remaining normal processing for the completed bank
+                        continue;
                     }
-                    Self::recycle_async_verification(
-                        async_verification_freelist,
-                        async_verification,
-                    );
-                    res
                 };
-                // we send this whether the block was valid or not. It's only
-                // used to release buffered votes if any.
-                let _ = process_active_banks_context.replay_vote_sender.send(
-                    ReplayVoteMessage::BankComplete {
-                        replay_bank_id: bank.bank_id(),
-                        replay_slot: bank.slot(),
-                    },
-                );
-                if let Err(err) = replay_res.and(verify_res) {
-                    Self::mark_replay_result_dead_slot(
-                        process_active_banks_context,
-                        bank,
-                        &err,
-                        progress,
-                        duplicate_slots_to_repair,
-                        purge_repair_slot_counter,
-                        &mut tbft_structs,
-                    );
-                    // don't try to run the remaining normal processing for the completed bank
-                    continue;
-                }
                 let is_leader_block = Self::leader_is_me(bank.leader_id(), my_pubkey);
 
                 // The block id is the merkle root of the last data shred
@@ -4038,9 +4087,8 @@ impl ReplayStage {
                     continue;
                 }
 
-                let r_replay_stats = replay_stats.read().unwrap();
-                let replay_progress = bank_progress.replay_progress.clone();
-                let r_replay_progress = replay_progress.read().unwrap();
+                let r_replay_stats = completed_replay.replay_stats.read().unwrap();
+                let r_replay_progress = completed_replay.replay_progress.read().unwrap();
                 debug!(
                     "bank {} has completed replay from blockstore, contribute to update cost with \
                      {:?}",
@@ -4226,7 +4274,7 @@ impl ReplayStage {
                     r_replay_progress.num_entries,
                     r_replay_progress.num_shreds,
                     bank_complete_time.as_us(),
-                    is_unified_scheduler_enabled,
+                    completed_replay.is_unified_scheduler_enabled,
                 );
             } else {
                 trace!(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -93,7 +93,6 @@ use {
         vote_sender_types::{ReplayVoteMessage, ReplayVoteSender},
     },
     solana_signer::Signer,
-    solana_svm_timings::ExecuteTimings,
     solana_time_utils::timestamp,
     solana_transaction::Transaction,
     solana_vote::vote_transaction::VoteTransaction,
@@ -114,6 +113,8 @@ use {
 mod dead_slots;
 mod update_parent;
 
+#[cfg(test)]
+use solana_svm_timings::ExecuteTimings;
 use {
     dead_slots::{
         DeadSlotContext, DeadSlotDuplicateContext, DeadSlotNotifications, mark_replay_dead_slot,
@@ -3822,8 +3823,6 @@ impl ReplayStage {
         let bank_forks = &process_active_banks_context.bank_forks;
 
         // TODO: See if processing of blockstore replay results and bank completion can be made thread safe.
-        let mut tx_count = 0;
-        let mut execute_timings = ExecuteTimings::default();
         let mut new_frozen_slots = vec![];
         for replay_result in replay_result_vec {
             if replay_result.is_slot_dead {
@@ -3837,7 +3836,7 @@ impl ReplayStage {
             };
             if let Some(replay_result) = &replay_result.replay_result {
                 match replay_result {
-                    Ok(replay_tx_count) => tx_count += replay_tx_count,
+                    Ok(_) => {}
                     Err(BlockstoreProcessorError::BlockComponentProcessor(
                         BlockComponentProcessorError::AbandonedBank(update_parent),
                     )) => {
@@ -4207,7 +4206,6 @@ impl ReplayStage {
                     bank_complete_time.as_us(),
                     is_unified_scheduler_enabled,
                 );
-                execute_timings.accumulate(&r_replay_stats.batch_execute.totals);
             } else {
                 trace!(
                     "bank {} not completed tick_height: {}, max_tick_height: {}",

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3928,6 +3928,73 @@ impl ReplayStage {
         })
     }
 
+    fn freeze_completed_bank(
+        process_active_banks_context: &ProcessActiveBanksContext,
+        bank: &BankWithScheduler,
+        my_pubkey: &Pubkey,
+    ) -> Result<bool, BlockstoreProcessorError> {
+        let is_leader_block = Self::leader_is_me(bank.leader_id(), my_pubkey);
+
+        // The block id is the merkle root of the last data shred. For leader
+        // blocks, shredding may still be running; broadcast sets the block id
+        // when it finishes.
+        let block_id = process_active_banks_context
+            .blockstore
+            .get_block_id(bank.slot(), &process_active_banks_context.migration_status)
+            .expect("Blockstore operations must succeed");
+        debug_assert!(block_id.is_some() || is_leader_block);
+        if block_id.is_some() {
+            bank.set_block_id(block_id);
+        }
+
+        // Freeze before notifying auxiliary threads that expect a frozen bank.
+        // Non-leader blocks also verify that the computed hash matches the
+        // block footer.
+        let verify_result = if process_active_banks_context
+            .migration_status
+            .should_allow_block_markers(bank.slot())
+            && !is_leader_block
+        {
+            bank.freeze_and_verify_bank_hash()
+        } else {
+            bank.freeze();
+            Ok(())
+        };
+
+        let bank_slot = bank.slot();
+        datapoint_info!(
+            "bank_frozen",
+            ("slot", bank_slot, i64),
+            ("hash", bank.hash().to_string(), String),
+        );
+
+        if let Err((expected_hash, computed_hash)) = verify_result {
+            warn!(
+                "Bank hash mismatch for slot {bank_slot}: expected {expected_hash}, computed \
+                 {computed_hash}",
+            );
+
+            datapoint_warn!(
+                "bank_hash_mismatch",
+                ("slot", bank_slot, i64),
+                ("expected", expected_hash.to_string(), String),
+                ("computed", computed_hash.to_string(), String),
+            );
+
+            if let Err(err) = bank_hash_details::write_bank_hash_details_file(bank) {
+                warn!("Unable to write bank hash details file: {err}");
+            }
+
+            return Err(BlockstoreProcessorError::BankHashMismatch(
+                bank_slot,
+                expected_hash,
+                computed_hash,
+            ));
+        }
+
+        Ok(is_leader_block)
+    }
+
     fn process_replay_results(
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
@@ -4017,75 +4084,23 @@ impl ReplayStage {
                         continue;
                     }
                 };
-                let is_leader_block = Self::leader_is_me(bank.leader_id(), my_pubkey);
-
-                // The block id is the merkle root of the last data shred
-                // For leader blocks, we might not have finished shredding (as it happens asynchronously)
-                // so this can return None. If that is the case, broadcast will set the block id once shredding
-                // finishes.
-                let block_id = process_active_banks_context
-                    .blockstore
-                    .get_block_id(bank.slot(), &process_active_banks_context.migration_status)
-                    .expect("Blockstore operations must succeed");
-                debug_assert!(block_id.is_some() || is_leader_block);
-                if block_id.is_some() {
-                    bank.set_block_id(block_id);
-                }
-
-                // Freeze the bank before sending to any auxiliary threads that may expect to be
-                // operating on a frozen bank.
-                // Also if we are not the leader, ensure that our computed hash matches the hash in
-                // the block footer.
-                let verify_result = if process_active_banks_context
-                    .migration_status
-                    .should_allow_block_markers(bank.slot())
-                    && !Self::leader_is_me(bank.leader_id(), my_pubkey)
-                {
-                    bank.freeze_and_verify_bank_hash()
-                } else {
-                    bank.freeze();
-                    Ok(())
-                };
-
-                datapoint_info!(
-                    "bank_frozen",
-                    ("slot", bank_slot, i64),
-                    ("hash", bank.hash().to_string(), String),
-                );
-
-                if let Err((expected_hash, computed_hash)) = verify_result {
-                    warn!(
-                        "For slot {bank_slot} the leader said the bank hash should be: \
-                         {expected_hash} however we computed: {computed_hash}",
-                    );
-
-                    datapoint_warn!(
-                        "bank_hash_mismatch",
-                        ("slot", bank_slot, i64),
-                        ("expected", expected_hash.to_string(), String),
-                        ("computed", computed_hash.to_string(), String),
-                    );
-
-                    if let Err(err) = bank_hash_details::write_bank_hash_details_file(bank) {
-                        warn!("Unable to write bank hash details file: {err}");
-                    }
-
-                    Self::mark_replay_result_dead_slot(
-                        process_active_banks_context,
-                        bank,
-                        &BlockstoreProcessorError::BankHashMismatch(
-                            bank_slot,
-                            expected_hash,
-                            computed_hash,
-                        ),
-                        progress,
-                        duplicate_slots_to_repair,
-                        purge_repair_slot_counter,
-                        &mut tbft_structs,
-                    );
-
-                    continue;
-                }
+                let is_leader_block =
+                    match Self::freeze_completed_bank(process_active_banks_context, bank, my_pubkey)
+                    {
+                        Ok(is_leader_block) => is_leader_block,
+                        Err(err) => {
+                            Self::mark_replay_result_dead_slot(
+                                process_active_banks_context,
+                                bank,
+                                &err,
+                                progress,
+                                duplicate_slots_to_repair,
+                                purge_repair_slot_counter,
+                                &mut tbft_structs,
+                            );
+                            continue;
+                        }
+                    };
 
                 let r_replay_stats = completed_replay.replay_stats.read().unwrap();
                 let r_replay_progress = completed_replay.replay_progress.read().unwrap();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3995,6 +3995,242 @@ impl ReplayStage {
         Ok(is_leader_block)
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn update_frozen_bank_fork_choice(
+        process_active_banks_context: &ProcessActiveBanksContext,
+        bank: &BankWithScheduler,
+        duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
+        purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
+        tbft_structs: &mut Option<&mut TowerBFTStructures>,
+    ) {
+        let Some(TowerBFTStructures {
+            heaviest_subtree_fork_choice,
+            duplicate_slots_tracker,
+            duplicate_confirmed_slots,
+            epoch_slots_frozen_slots,
+            ..
+        }) = tbft_structs.as_deref_mut()
+        else {
+            return;
+        };
+
+        // Needs to be updated before `check_slot_agrees_with_cluster()` so that
+        // any updates in `check_slot_agrees_with_cluster()` on fork choice take
+        // effect.
+        heaviest_subtree_fork_choice.add_new_leaf_slot(
+            (bank.slot(), bank.hash()),
+            Some((bank.parent_slot(), bank.parent_hash())),
+        );
+        heaviest_subtree_fork_choice.maybe_print_state();
+        let bank_frozen_state = BankFrozenState::new_from_state(
+            bank.slot(),
+            bank.hash(),
+            duplicate_slots_tracker,
+            duplicate_confirmed_slots,
+            heaviest_subtree_fork_choice,
+            epoch_slots_frozen_slots,
+        );
+        check_slot_agrees_with_cluster(
+            bank.slot(),
+            process_active_banks_context
+                .bank_forks
+                .read()
+                .unwrap()
+                .root(),
+            &process_active_banks_context.blockstore,
+            duplicate_slots_tracker,
+            epoch_slots_frozen_slots,
+            heaviest_subtree_fork_choice,
+            duplicate_slots_to_repair,
+            &process_active_banks_context.ancestor_hashes_replay_update_sender,
+            purge_repair_slot_counter,
+            SlotStateUpdate::BankFrozen(bank_frozen_state),
+        );
+
+        // If we previously marked this slot as duplicate in blockstore, let the
+        // state machine know.
+        if !duplicate_slots_tracker.contains(&bank.slot())
+            && process_active_banks_context
+                .blockstore
+                .get_duplicate_slot(bank.slot())
+                .is_some()
+        {
+            let duplicate_state = DuplicateState::new_from_state(
+                bank.slot(),
+                duplicate_confirmed_slots,
+                heaviest_subtree_fork_choice,
+                || false,
+                || Some(bank.hash()),
+            );
+            check_slot_agrees_with_cluster(
+                bank.slot(),
+                process_active_banks_context
+                    .bank_forks
+                    .read()
+                    .unwrap()
+                    .root(),
+                &process_active_banks_context.blockstore,
+                duplicate_slots_tracker,
+                epoch_slots_frozen_slots,
+                heaviest_subtree_fork_choice,
+                duplicate_slots_to_repair,
+                &process_active_banks_context.ancestor_hashes_replay_update_sender,
+                purge_repair_slot_counter,
+                SlotStateUpdate::Duplicate(duplicate_state),
+            );
+        }
+    }
+
+    fn notify_votor_of_completed_block(
+        process_active_banks_context: &ProcessActiveBanksContext,
+        bank: &BankWithScheduler,
+    ) {
+        // For leader banks:
+        // 1) Replay finishes before shredding; broadcast_stage notifies Votor.
+        // 2) Shredding finishes before replay; notify here.
+        //
+        // For non-leader banks (2) is always true, so notify here.
+        if process_active_banks_context
+            .migration_status
+            .should_send_votor_event(bank.slot())
+            && bank.block_id().is_some()
+        {
+            let _ = process_active_banks_context
+                .votor_event_sender
+                .send(VotorEvent::Block(CompletedBlock {
+                    slot: bank.slot(),
+                    bank: bank.clone_without_scheduler(),
+                }));
+        }
+    }
+
+    fn notify_bank_frozen(
+        process_active_banks_context: &ProcessActiveBanksContext,
+        bank: &BankWithScheduler,
+    ) {
+        if let Some(sender) = process_active_banks_context
+            .bank_notification_sender
+            .as_ref()
+        {
+            let dependency_work = sender
+                .dependency_tracker
+                .as_ref()
+                .map(|s| s.get_current_declared_work());
+            sender
+                .sender
+                .send((
+                    BankNotification::Frozen(bank.clone_without_scheduler()),
+                    dependency_work,
+                ))
+                .unwrap_or_else(|err| warn!("bank_notification_sender failed: {err:?}"));
+        }
+    }
+
+    fn notify_block_metadata(
+        process_active_banks_context: &ProcessActiveBanksContext,
+        bank: &BankWithScheduler,
+        replay_progress: &ConfirmationProgress,
+    ) {
+        if let Some(block_metadata_notifier) = process_active_banks_context
+            .block_metadata_notifier
+            .as_ref()
+        {
+            let parent_blockhash = bank
+                .parent()
+                .map(|bank| bank.last_blockhash())
+                .unwrap_or_default();
+            let commission_rate_in_basis_points =
+                bank.feature_set.snapshot().commission_rate_in_basis_points;
+            block_metadata_notifier.notify_block_metadata(
+                bank.parent_slot(),
+                &parent_blockhash.to_string(),
+                bank.slot(),
+                &bank.last_blockhash().to_string(),
+                &bank.get_rewards_and_num_partitions(),
+                Some(bank.clock().unix_timestamp),
+                Some(bank.block_height()),
+                bank.executed_transaction_count(),
+                replay_progress.num_entries as u64,
+                commission_rate_in_basis_points,
+            )
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn publish_frozen_bank(
+        process_active_banks_context: &ProcessActiveBanksContext,
+        bank: &BankWithScheduler,
+        bank_progress: &mut ForkProgress,
+        replay_stats: &ReplaySlotStats,
+        replay_progress: &ConfirmationProgress,
+        latest_validator_votes_for_frozen_banks: &mut LatestValidatorVotesForFrozenBanks,
+        duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
+        purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
+        tbft_structs: &mut Option<&mut TowerBFTStructures>,
+        is_leader_block: bool,
+    ) {
+        let bank_slot = bank.slot();
+        debug!(
+            "bank {} has completed replay from blockstore, contribute to update cost with {:?}",
+            bank.slot(),
+            replay_stats.batch_execute.totals
+        );
+
+        if process_active_banks_context
+            .migration_status
+            .should_publish_epoch_slots(bank_slot)
+        {
+            let _ = process_active_banks_context
+                .cluster_slots_update_sender
+                .send(vec![bank_slot]);
+        }
+
+        if let Some(transaction_status_sender) = process_active_banks_context
+            .transaction_status_sender
+            .as_ref()
+        {
+            transaction_status_sender.send_transaction_status_freeze_message(bank);
+        }
+
+        process_active_banks_context
+            .cost_update_sender
+            .send(CostUpdate::FrozenBank {
+                bank: bank.clone_without_scheduler(),
+                is_leader_block,
+            })
+            .unwrap_or_else(|err| warn!("cost_update_sender failed sending bank stats: {err:?}"));
+
+        assert_ne!(bank.hash(), Hash::default());
+        bank_progress.fork_stats.bank_hash = Some(bank.hash());
+        Self::update_frozen_bank_fork_choice(
+            process_active_banks_context,
+            bank,
+            duplicate_slots_to_repair,
+            purge_repair_slot_counter,
+            tbft_structs,
+        );
+
+        Self::notify_votor_of_completed_block(process_active_banks_context, bank);
+        Self::notify_bank_frozen(process_active_banks_context, bank);
+
+        let bank_hash = bank.hash();
+        if let Some(new_frozen_voters) = tbft_structs.as_deref_mut().and_then(|tbft| {
+            tbft.unfrozen_gossip_verified_vote_hashes
+                .remove_slot_hash(bank.slot(), &bank_hash)
+        }) {
+            for pubkey in new_frozen_voters {
+                latest_validator_votes_for_frozen_banks.check_add_vote(
+                    pubkey,
+                    bank.slot(),
+                    Some(bank_hash),
+                    false,
+                );
+            }
+        }
+
+        Self::notify_block_metadata(process_active_banks_context, bank, replay_progress);
+    }
+
     fn process_replay_results(
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
@@ -4104,183 +4340,19 @@ impl ReplayStage {
 
                 let r_replay_stats = completed_replay.replay_stats.read().unwrap();
                 let r_replay_progress = completed_replay.replay_progress.read().unwrap();
-                debug!(
-                    "bank {} has completed replay from blockstore, contribute to update cost with \
-                     {:?}",
-                    bank.slot(),
-                    r_replay_stats.batch_execute.totals
-                );
                 new_frozen_slots.push(bank.slot());
-                if process_active_banks_context
-                    .migration_status
-                    .should_publish_epoch_slots(bank_slot)
-                {
-                    let _ = process_active_banks_context
-                        .cluster_slots_update_sender
-                        .send(vec![bank_slot]);
-                }
-
-                if let Some(transaction_status_sender) = process_active_banks_context
-                    .transaction_status_sender
-                    .as_ref()
-                {
-                    transaction_status_sender.send_transaction_status_freeze_message(bank);
-                }
-                // report cost tracker stats
-                process_active_banks_context
-                    .cost_update_sender
-                    .send(CostUpdate::FrozenBank {
-                        bank: bank.clone_without_scheduler(),
-                        is_leader_block,
-                    })
-                    .unwrap_or_else(|err| {
-                        warn!("cost_update_sender failed sending bank stats: {err:?}")
-                    });
-
-                assert_ne!(bank.hash(), Hash::default());
-                bank_progress.fork_stats.bank_hash = Some(bank.hash());
-                if let Some(TowerBFTStructures {
-                    heaviest_subtree_fork_choice,
-                    duplicate_slots_tracker,
-                    duplicate_confirmed_slots,
-                    epoch_slots_frozen_slots,
-                    ..
-                }) = &mut tbft_structs
-                {
-                    // Needs to be updated before `check_slot_agrees_with_cluster()` so that
-                    // any updates in `check_slot_agrees_with_cluster()` on fork choice take
-                    // effect
-                    heaviest_subtree_fork_choice.add_new_leaf_slot(
-                        (bank.slot(), bank.hash()),
-                        Some((bank.parent_slot(), bank.parent_hash())),
-                    );
-                    heaviest_subtree_fork_choice.maybe_print_state();
-                    let bank_frozen_state = BankFrozenState::new_from_state(
-                        bank.slot(),
-                        bank.hash(),
-                        duplicate_slots_tracker,
-                        duplicate_confirmed_slots,
-                        heaviest_subtree_fork_choice,
-                        epoch_slots_frozen_slots,
-                    );
-                    check_slot_agrees_with_cluster(
-                        bank.slot(),
-                        bank_forks.read().unwrap().root(),
-                        &process_active_banks_context.blockstore,
-                        duplicate_slots_tracker,
-                        epoch_slots_frozen_slots,
-                        heaviest_subtree_fork_choice,
-                        duplicate_slots_to_repair,
-                        &process_active_banks_context.ancestor_hashes_replay_update_sender,
-                        purge_repair_slot_counter,
-                        SlotStateUpdate::BankFrozen(bank_frozen_state),
-                    );
-                    // If we previously marked this slot as duplicate in blockstore, let the state machine know
-                    if !duplicate_slots_tracker.contains(&bank.slot())
-                        && process_active_banks_context
-                            .blockstore
-                            .get_duplicate_slot(bank.slot())
-                            .is_some()
-                    {
-                        let duplicate_state = DuplicateState::new_from_state(
-                            bank.slot(),
-                            duplicate_confirmed_slots,
-                            heaviest_subtree_fork_choice,
-                            || false,
-                            || Some(bank.hash()),
-                        );
-                        check_slot_agrees_with_cluster(
-                            bank.slot(),
-                            bank_forks.read().unwrap().root(),
-                            &process_active_banks_context.blockstore,
-                            duplicate_slots_tracker,
-                            epoch_slots_frozen_slots,
-                            heaviest_subtree_fork_choice,
-                            duplicate_slots_to_repair,
-                            &process_active_banks_context.ancestor_hashes_replay_update_sender,
-                            purge_repair_slot_counter,
-                            SlotStateUpdate::Duplicate(duplicate_state),
-                        );
-                    }
-                }
-
-                // For leader banks:
-                // 1) Replay finishes before shredding, broadcast_stage will take care of
-                //      notifying votor
-                // 2) Shredding finishes before replay, we notify here
-                //
-                // For non leader banks (2) is always true, so notify here
-                if process_active_banks_context
-                    .migration_status
-                    .should_send_votor_event(bank.slot())
-                    && bank.block_id().is_some()
-                {
-                    // Leader blocks will not have a block id, broadcast stage will
-                    // take care of notifying the voting loop
-                    let _ =
-                        process_active_banks_context
-                            .votor_event_sender
-                            .send(VotorEvent::Block(CompletedBlock {
-                                slot: bank.slot(),
-                                bank: bank.clone_without_scheduler(),
-                            }));
-                }
-
-                if let Some(sender) = process_active_banks_context
-                    .bank_notification_sender
-                    .as_ref()
-                {
-                    let dependency_work = sender
-                        .dependency_tracker
-                        .as_ref()
-                        .map(|s| s.get_current_declared_work());
-                    sender
-                        .sender
-                        .send((
-                            BankNotification::Frozen(bank.clone_without_scheduler()),
-                            dependency_work,
-                        ))
-                        .unwrap_or_else(|err| warn!("bank_notification_sender failed: {err:?}"));
-                }
-
-                let bank_hash = bank.hash();
-                if let Some(new_frozen_voters) = tbft_structs.as_mut().and_then(|tbft| {
-                    tbft.unfrozen_gossip_verified_vote_hashes
-                        .remove_slot_hash(bank.slot(), &bank_hash)
-                }) {
-                    for pubkey in new_frozen_voters {
-                        latest_validator_votes_for_frozen_banks.check_add_vote(
-                            pubkey,
-                            bank.slot(),
-                            Some(bank_hash),
-                            false,
-                        );
-                    }
-                }
-
-                if let Some(block_metadata_notifier) = process_active_banks_context
-                    .block_metadata_notifier
-                    .as_ref()
-                {
-                    let parent_blockhash = bank
-                        .parent()
-                        .map(|bank| bank.last_blockhash())
-                        .unwrap_or_default();
-                    let commission_rate_in_basis_points =
-                        bank.feature_set.snapshot().commission_rate_in_basis_points;
-                    block_metadata_notifier.notify_block_metadata(
-                        bank.parent_slot(),
-                        &parent_blockhash.to_string(),
-                        bank.slot(),
-                        &bank.last_blockhash().to_string(),
-                        &bank.get_rewards_and_num_partitions(),
-                        Some(bank.clock().unix_timestamp),
-                        Some(bank.block_height()),
-                        bank.executed_transaction_count(),
-                        r_replay_progress.num_entries as u64,
-                        commission_rate_in_basis_points,
-                    )
-                }
+                Self::publish_frozen_bank(
+                    process_active_banks_context,
+                    bank,
+                    bank_progress,
+                    &r_replay_stats,
+                    &r_replay_progress,
+                    latest_validator_votes_for_frozen_banks,
+                    duplicate_slots_to_repair,
+                    purge_repair_slot_counter,
+                    &mut tbft_structs,
+                    is_leader_block,
+                );
                 bank_complete_time.stop();
 
                 r_replay_stats.report_stats(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4231,6 +4231,90 @@ impl ReplayStage {
         Self::notify_block_metadata(process_active_banks_context, bank, replay_progress);
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn process_completed_bank(
+        process_active_banks_context: &ProcessActiveBanksContext,
+        bank: &BankWithScheduler,
+        progress: &mut ProgressMap,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+        latest_validator_votes_for_frozen_banks: &mut LatestValidatorVotesForFrozenBanks,
+        duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
+        purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
+        tbft_structs: &mut Option<&mut TowerBFTStructures>,
+        my_pubkey: &Pubkey,
+    ) -> Option<Slot> {
+        let bank_slot = bank.slot();
+        let mut bank_complete_time = Measure::start("bank_complete_time");
+        let bank_progress = progress
+            .get_mut(&bank_slot)
+            .expect("Bank fork progress entry missing for completed bank");
+
+        let completed_replay = match Self::complete_bank_replay(
+            process_active_banks_context,
+            bank,
+            bank_progress,
+            async_verification_freelist,
+        ) {
+            Ok(completed_replay) => completed_replay,
+            Err(err) => {
+                Self::mark_replay_result_dead_slot(
+                    process_active_banks_context,
+                    bank,
+                    &err,
+                    progress,
+                    duplicate_slots_to_repair,
+                    purge_repair_slot_counter,
+                    tbft_structs,
+                );
+                return None;
+            }
+        };
+
+        let is_leader_block =
+            match Self::freeze_completed_bank(process_active_banks_context, bank, my_pubkey) {
+                Ok(is_leader_block) => is_leader_block,
+                Err(err) => {
+                    Self::mark_replay_result_dead_slot(
+                        process_active_banks_context,
+                        bank,
+                        &err,
+                        progress,
+                        duplicate_slots_to_repair,
+                        purge_repair_slot_counter,
+                        tbft_structs,
+                    );
+                    return None;
+                }
+            };
+
+        let replay_stats = completed_replay.replay_stats.read().unwrap();
+        let replay_progress = completed_replay.replay_progress.read().unwrap();
+        Self::publish_frozen_bank(
+            process_active_banks_context,
+            bank,
+            bank_progress,
+            &replay_stats,
+            &replay_progress,
+            latest_validator_votes_for_frozen_banks,
+            duplicate_slots_to_repair,
+            purge_repair_slot_counter,
+            tbft_structs,
+            is_leader_block,
+        );
+        bank_complete_time.stop();
+
+        replay_stats.report_stats(
+            bank.slot(),
+            replay_progress.num_txs,
+            replay_progress.num_entries,
+            replay_progress.num_shreds,
+            bank_complete_time.as_us(),
+            completed_replay.is_unified_scheduler_enabled,
+        );
+
+        Some(bank_slot)
+    }
+
     fn process_replay_results(
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
@@ -4252,7 +4336,7 @@ impl ReplayStage {
             }
 
             let bank_slot = replay_result.bank_slot;
-            let Some(bank) = &bank_forks.read().unwrap().get_with_scheduler(bank_slot) else {
+            let Some(bank) = bank_forks.read().unwrap().get_with_scheduler(bank_slot) else {
                 info!("Abandoning replay of unrooted slot {bank_slot}");
                 continue;
             };
@@ -4264,7 +4348,7 @@ impl ReplayStage {
                     )) => {
                         handle_abandoned_bank(
                             process_active_banks_context,
-                            bank,
+                            &bank,
                             bank_slot,
                             update_parent,
                             bank_forks,
@@ -4279,14 +4363,13 @@ impl ReplayStage {
                     Err(err) => {
                         Self::mark_replay_result_dead_slot(
                             process_active_banks_context,
-                            bank,
+                            &bank,
                             err,
                             progress,
                             duplicate_slots_to_repair,
                             purge_repair_slot_counter,
                             &mut tbft_structs,
                         );
-                        // don't try to run the below logic to check if the bank is completed
                         continue;
                     }
                 }
@@ -4294,75 +4377,19 @@ impl ReplayStage {
 
             assert_eq!(bank_slot, bank.slot());
             if bank.is_complete() {
-                let mut bank_complete_time = Measure::start("bank_complete_time");
-                let bank_progress = progress
-                    .get_mut(&bank.slot())
-                    .expect("Bank fork progress entry missing for completed bank");
-
-                let completed_replay = match Self::complete_bank_replay(
+                if let Some(new_frozen_slot) = Self::process_completed_bank(
                     process_active_banks_context,
-                    bank,
-                    bank_progress,
+                    &bank,
+                    progress,
                     async_verification_freelist,
-                ) {
-                    Ok(completed_replay) => completed_replay,
-                    Err(err) => {
-                        Self::mark_replay_result_dead_slot(
-                            process_active_banks_context,
-                            bank,
-                            &err,
-                            progress,
-                            duplicate_slots_to_repair,
-                            purge_repair_slot_counter,
-                            &mut tbft_structs,
-                        );
-                        // don't try to run the remaining normal processing for the completed bank
-                        continue;
-                    }
-                };
-                let is_leader_block =
-                    match Self::freeze_completed_bank(process_active_banks_context, bank, my_pubkey)
-                    {
-                        Ok(is_leader_block) => is_leader_block,
-                        Err(err) => {
-                            Self::mark_replay_result_dead_slot(
-                                process_active_banks_context,
-                                bank,
-                                &err,
-                                progress,
-                                duplicate_slots_to_repair,
-                                purge_repair_slot_counter,
-                                &mut tbft_structs,
-                            );
-                            continue;
-                        }
-                    };
-
-                let r_replay_stats = completed_replay.replay_stats.read().unwrap();
-                let r_replay_progress = completed_replay.replay_progress.read().unwrap();
-                new_frozen_slots.push(bank.slot());
-                Self::publish_frozen_bank(
-                    process_active_banks_context,
-                    bank,
-                    bank_progress,
-                    &r_replay_stats,
-                    &r_replay_progress,
                     latest_validator_votes_for_frozen_banks,
                     duplicate_slots_to_repair,
                     purge_repair_slot_counter,
                     &mut tbft_structs,
-                    is_leader_block,
-                );
-                bank_complete_time.stop();
-
-                r_replay_stats.report_stats(
-                    bank.slot(),
-                    r_replay_progress.num_txs,
-                    r_replay_progress.num_entries,
-                    r_replay_progress.num_shreds,
-                    bank_complete_time.as_us(),
-                    completed_replay.is_unified_scheduler_enabled,
-                );
+                    my_pubkey,
+                ) {
+                    new_frozen_slots.push(new_frozen_slot);
+                }
             } else {
                 trace!(
                     "bank {} not completed tick_height: {}, max_tick_height: {}",

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3809,6 +3809,30 @@ impl ReplayStage {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn mark_replay_result_dead_slot(
+        process_active_banks_context: &ProcessActiveBanksContext,
+        bank: &BankWithScheduler,
+        err: &BlockstoreProcessorError,
+        progress: &mut ProgressMap,
+        duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
+        purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
+        tbft_structs: &mut Option<&mut TowerBFTStructures>,
+    ) {
+        let root = process_active_banks_context
+            .bank_forks
+            .read()
+            .unwrap()
+            .root();
+        let mut dead_slot_context = process_active_banks_context.dead_slot_context(
+            root,
+            duplicate_slots_to_repair,
+            purge_repair_slot_counter,
+            tbft_structs.as_deref_mut(),
+        );
+        mark_replay_dead_slot(bank, err, progress, &mut dead_slot_context);
+    }
+
     fn process_replay_results(
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
@@ -3855,14 +3879,15 @@ impl ReplayStage {
                         continue;
                     }
                     Err(err) => {
-                        let root = bank_forks.read().unwrap().root();
-                        let mut dead_slot_context = process_active_banks_context.dead_slot_context(
-                            root,
+                        Self::mark_replay_result_dead_slot(
+                            process_active_banks_context,
+                            bank,
+                            err,
+                            progress,
                             duplicate_slots_to_repair,
                             purge_repair_slot_counter,
-                            tbft_structs.as_deref_mut(),
+                            &mut tbft_structs,
                         );
-                        mark_replay_dead_slot(bank, err, progress, &mut dead_slot_context);
                         // don't try to run the below logic to check if the bank is completed
                         continue;
                     }
@@ -3931,14 +3956,15 @@ impl ReplayStage {
                     },
                 );
                 if let Err(err) = replay_res.and(verify_res) {
-                    let root = bank_forks.read().unwrap().root();
-                    let mut dead_slot_context = process_active_banks_context.dead_slot_context(
-                        root,
+                    Self::mark_replay_result_dead_slot(
+                        process_active_banks_context,
+                        bank,
+                        &err,
+                        progress,
                         duplicate_slots_to_repair,
                         purge_repair_slot_counter,
-                        tbft_structs.as_deref_mut(),
+                        &mut tbft_structs,
                     );
-                    mark_replay_dead_slot(bank, &err, progress, &mut dead_slot_context);
                     // don't try to run the remaining normal processing for the completed bank
                     continue;
                 }
@@ -3995,14 +4021,8 @@ impl ReplayStage {
                         warn!("Unable to write bank hash details file: {err}");
                     }
 
-                    let root = bank_forks.read().unwrap().root();
-                    let mut dead_slot_context = process_active_banks_context.dead_slot_context(
-                        root,
-                        duplicate_slots_to_repair,
-                        purge_repair_slot_counter,
-                        tbft_structs.as_deref_mut(),
-                    );
-                    mark_replay_dead_slot(
+                    Self::mark_replay_result_dead_slot(
+                        process_active_banks_context,
                         bank,
                         &BlockstoreProcessorError::BankHashMismatch(
                             bank_slot,
@@ -4010,7 +4030,9 @@ impl ReplayStage {
                             computed_hash,
                         ),
                         progress,
-                        &mut dead_slot_context,
+                        duplicate_slots_to_repair,
+                        purge_repair_slot_counter,
+                        &mut tbft_structs,
                     );
 
                     continue;

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -19,7 +19,7 @@ use {
         ConfirmationProgress, ProcessOptions, confirm_full_slot, fill_blockstore_slot_with_ticks,
         process_bank_0,
     },
-    crossbeam_channel::bounded,
+    crossbeam_channel::{bounded, unbounded},
     itertools::Itertools,
     solana_account::{ReadableAccount, state_traits::StateMut},
     solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
@@ -662,6 +662,51 @@ fn test_handle_new_root_ahead_of_highest_super_majority_root() {
     assert!(progress.get(&root).is_some());
     assert!(progress.get(&confirmed_root).is_some());
     assert!(progress.get(&fork).is_none());
+}
+
+#[test]
+fn test_process_set_root_command_prunes_progress() {
+    let ReplayBlockstoreComponents {
+        blockstore,
+        leader_schedule_cache,
+        my_pubkey,
+        vote_simulator,
+        ..
+    } = replay_blockstore_components(Some(tr(0) / (tr(1)) / (tr(2))), 1, None::<GenerateVotes>);
+    let VoteSimulator {
+        bank_forks,
+        mut progress,
+        ..
+    } = vote_simulator;
+
+    assert!(bank_forks.read().unwrap().get(2).is_some());
+    assert!(progress.get(&2).is_some());
+
+    let (drop_bank_sender, _drop_bank_receiver) = unbounded();
+    let context = ProcessBankForksContext {
+        bank_forks: bank_forks.clone(),
+        blockstore,
+        snapshot_controller: None,
+        bank_notification_sender: None,
+        rpc_subscriptions: None,
+        drop_bank_sender,
+        leader_schedule_cache,
+    };
+    ReplayStage::process_set_root_command(
+        SetRootCommand {
+            parent_slot: 0,
+            new_root: 1,
+            highest_super_majority_root: None,
+        },
+        &context,
+        &my_pubkey,
+        &mut progress,
+    );
+
+    assert_eq!(bank_forks.read().unwrap().root(), 1);
+    assert!(bank_forks.read().unwrap().get(2).is_none());
+    assert!(progress.get(&1).is_some());
+    assert!(progress.get(&2).is_none());
 }
 
 #[test]


### PR DESCRIPTION
#### Problem

completed-bank block is a giant replay-results loop, hard to read, and hard to identify a clear path to remove unifier-scheduler.

#### Summary of Changes

the old completed-bank block is split into named phases:

  - scheduler completion isolated in complete_scheduler_replay() at core/src/replay_stage.rs:3780
  - verification completion in complete_replay_verification()
  - freeze in freeze_completed_bank()
  - publication in publish_frozen_bank()
  - orchestration in process_completed_bank()

That makes the unified-scheduler removal path clearer: most scheduler-specific behavior is now concentrated around complete_scheduler_replay() plus the is_unified_scheduler_enabled reporting field, instead of being embedded in the giant replay-results loop.

Fixes #
