### PR TITLE
move XdpSender from Turbine to net-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9039,10 +9039,12 @@ name = "solana-net-utils"
 version = "4.2.0-alpha.0"
 dependencies = [
  "agave-logger",
+ "agave-xdp",
  "anyhow",
  "bincode",
  "bytes",
  "cfg-if 1.0.4",
+ "crossbeam-channel",
  "dashmap",
  "hxdmp",
  "itertools 0.14.0",
@@ -11214,7 +11216,6 @@ dependencies = [
  "agave-logger",
  "agave-votor",
  "agave-votor-messages",
- "agave-xdp",
  "assert_matches",
  "bencher",
  "bs58",

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -77,7 +77,7 @@ use {
         quic::{QuicStreamerConfig, SpawnServerResult, spawn_simple_qos_server},
         streamer::StakedNodes,
     },
-    solana_turbine::{XdpSender, retransmit_stage::RetransmitStage},
+    solana_turbine::{XdpSender as TurbineXdpSender, retransmit_stage::RetransmitStage},
     std::{
         collections::HashSet,
         net::UdpSocket,
@@ -143,7 +143,7 @@ pub struct TvuConfig {
     pub replay_transactions_threads: NonZeroUsize,
     pub shred_sigverify_threads: NonZeroUsize,
     pub bls_sigverify_threads: NonZeroUsize,
-    pub turbine_xdp_sender: Option<XdpSender>,
+    pub turbine_xdp_sender: Option<TurbineXdpSender>,
 }
 
 impl Default for TvuConfig {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -144,7 +144,7 @@ use {
     },
     solana_time_utils::timestamp,
     solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_VOTE_USE_QUIC},
-    solana_turbine::{self, XdpSender, broadcast_stage::BroadcastStageType},
+    solana_turbine::{self, XdpSender as TurbineXdpSender, broadcast_stage::BroadcastStageType},
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     solana_validator_exit::Exit,
     solana_vote_program::vote_state::{VoteStateV4, handler::VoteStateHandler},
@@ -1560,7 +1560,7 @@ impl Validator {
                 let (transmitter, sender) = xdp_transmit_builder.build();
                 (
                     Some(transmitter),
-                    Some(XdpSender::new(sender.clone(), src_addr)),
+                    Some(TurbineXdpSender::new(sender.clone(), src_addr)),
                     Some((sender, *src_addr.ip())),
                 )
             } else {

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7654,9 +7654,11 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 name = "solana-net-utils"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "agave-xdp",
  "bincode",
  "bytes",
  "cfg-if 1.0.4",
+ "crossbeam-channel",
  "dashmap",
  "itertools 0.14.0",
  "log",
@@ -9383,7 +9385,6 @@ dependencies = [
  "agave-feature-set",
  "agave-votor",
  "agave-votor-messages",
- "agave-xdp",
  "bytes",
  "crossbeam-channel",
  "itertools 0.14.0",

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -21,10 +21,12 @@ dev-context-only-utils = ["dep:anyhow", "dep:pcap-file", "dep:hxdmp"]
 shuttle-test = ["dep:shuttle", "solana-svm-type-overrides/shuttle-test"]
 
 [dependencies]
+agave-xdp = { workspace = true }
 anyhow = { workspace = true, optional = true }
 bincode = { workspace = true }
 bytes = { workspace = true }
 cfg-if = { workspace = true }
+crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["raw-api"] }
 hxdmp = { version = "0.2.1", optional = true }
 itertools = { workspace = true }

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -5,6 +5,7 @@ pub mod banlist;
 mod ip_echo_client;
 mod ip_echo_server;
 pub mod multihomed_sockets;
+pub mod pinned_xdp_sender;
 pub mod socket_addr_space;
 pub mod sockets;
 #[cfg(any(target_os = "android", target_os = "windows"))]
@@ -22,6 +23,7 @@ pub use {
     ip_echo_server::{
         DEFAULT_IP_ECHO_SERVER_THREADS, IpEchoServer, MAX_PORT_COUNT_PER_MESSAGE, ip_echo_server,
     },
+    pinned_xdp_sender::PinnedXdpSender,
     socket_addr_space::SocketAddrSpace,
 };
 use {

--- a/net-utils/src/pinned_xdp_sender.rs
+++ b/net-utils/src/pinned_xdp_sender.rs
@@ -1,20 +1,19 @@
-//! This module defines [`XdpSender`] which is a convenience wrapper around
-//! [`agave_xdp::transmitter::XdpSender`] for the case when source address is fixed for all
-//! items like it is in turbine.
+//! This module defines [`PinnedXdpSender`] which is a convenience wrapper around
+//! [`agave_xdp::transmitter::XdpSender`] for the case when source address is fixed.
 use {
     agave_xdp::transmitter as tx, bytes::Bytes, crossbeam_channel::TrySendError,
     std::net::SocketAddrV4,
 };
 
-/// [`XdpSender`] is a structure that simplifies sending packets over XDP with `XdpSender`
+/// [`PinnedXdpSender`] simplifies sending packets over XDP
 /// when source address is fixed for all items.
 #[derive(Clone)]
-pub struct XdpSender {
+pub struct PinnedXdpSender {
     sender: tx::XdpSender,
     src_addr: SocketAddrV4,
 }
 
-impl XdpSender {
+impl PinnedXdpSender {
     pub fn new(sender: tx::XdpSender, src_addr: SocketAddrV4) -> Self {
         Self { sender, src_addr }
     }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7420,9 +7420,11 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 name = "solana-net-utils"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "agave-xdp",
  "bincode",
  "bytes",
  "cfg-if 1.0.4",
+ "crossbeam-channel",
  "dashmap",
  "itertools 0.14.0",
  "log",
@@ -9876,7 +9878,6 @@ dependencies = [
  "agave-feature-set",
  "agave-votor",
  "agave-votor-messages",
- "agave-xdp",
  "bytes",
  "crossbeam-channel",
  "itertools 0.14.0",

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -16,7 +16,6 @@ agave-unstable-api = []
 agave-feature-set = { workspace = true }
 agave-votor = { workspace = true }
 agave-votor-messages = { workspace = true }
-agave-xdp = { workspace = true }
 bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
 itertools = { workspace = true }

--- a/turbine/src/lib.rs
+++ b/turbine/src/lib.rs
@@ -11,9 +11,7 @@ pub mod retransmit_stage;
 
 pub mod sigverify_shreds;
 
-pub mod xdp_sender;
-
-pub use crate::xdp_sender::XdpSender;
+pub use solana_net_utils::PinnedXdpSender as XdpSender;
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
#### Problem

XdpSender with pinned source address is used in Turbine at the moment.
But we will also need it for repair and gossip.

#### Summary of Changes

Move it to some shared place, rename to PinnedXdpSender
