### PR TITLE
renames entry types to distinguish from certs

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -22,7 +22,7 @@ use {
     crossbeam_channel::{Receiver, Sender, select_biased},
     solana_clock::Slot,
     solana_entry::block_component::{
-        BlockFooterV1, GenesisCertificate, UpdateParentV1, VersionedBlockMarker,
+        BlockFooterV1, GenesisCertBlockMarker, UpdateParentV1, VersionedBlockMarker,
     },
     solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
@@ -167,7 +167,7 @@ struct LeaderContext {
     slot_metrics: SlotMetrics,
 
     // Migration information
-    genesis_cert: GenesisCertificate,
+    genesis_cert_block_marker: GenesisCertBlockMarker,
 }
 
 #[derive(Default)]
@@ -266,7 +266,7 @@ fn start_loop(config: BlockCreationLoopConfig, reward_certs_requestor: CertsRequ
         .migration_status()
         .genesis_certificate()
         .expect("Migration complete, genesis certificate must exist");
-    let genesis_cert = GenesisCertificate::try_from((*genesis_cert).clone())
+    let genesis_cert_block_marker = GenesisCertBlockMarker::try_from((*genesis_cert).clone())
         .expect("Genesis certificate must be valid");
 
     info!("{my_pubkey}: PohService has shutdown, BlockCreationLoop is enabled");
@@ -292,7 +292,7 @@ fn start_loop(config: BlockCreationLoopConfig, reward_certs_requestor: CertsRequ
         metrics: LoopMetrics::default(),
         slot_metrics: SlotMetrics::default(),
         highest_finalized,
-        genesis_cert,
+        genesis_cert_block_marker,
     };
 
     // Setup poh
@@ -533,13 +533,14 @@ fn produce_block_footer(
     }
 
     // Convert finalization certs into block marker
-    let final_cert = highest_finalized.map(ValidatedBlockFinalizationCert::to_final_certificate);
+    let block_final_cert =
+        highest_finalized.map(ValidatedBlockFinalizationCert::to_block_final_cert);
 
     BlockFooterV1 {
         bank_hash: Hash::default(),
         block_producer_time_nanos: block_producer_time_nanos as u64,
         block_user_agent: format!("agave/{}", version!()).into_bytes(),
-        final_cert,
+        block_final_cert,
         skip_reward_cert,
         notar_reward_cert,
     }
@@ -874,7 +875,7 @@ fn send_update_parent(
         new_parent_slot,
         new_parent_block_id,
     };
-    let marker = VersionedBlockMarker::new_update_parent(update_parent);
+    let marker = VersionedBlockMarker::from_update_parent(update_parent);
     poh_recorder.write().unwrap().send_marker(marker)?;
     Ok(())
 }
@@ -1268,7 +1269,7 @@ fn create_and_insert_leader_bank(
     // If this is the first alpenglow block, set PoH to low power mode.
     // This is persisted in the recorder when we set bank.
     // Replayers will update hashes_per_tick when they process the genesis certificate block marker.
-    if should_include_genesis_certificate(parent_slot, &ctx.genesis_cert) {
+    if should_include_genesis_certificate(parent_slot, &ctx.genesis_cert_block_marker) {
         tpu_bank.set_hashes_per_tick(None);
     }
 
@@ -1305,22 +1306,23 @@ fn maybe_include_genesis_certificate(
     parent_slot: Slot,
     ctx: &LeaderContext,
 ) -> Result<(), PohRecorderError> {
-    if !should_include_genesis_certificate(parent_slot, &ctx.genesis_cert) {
+    if !should_include_genesis_certificate(parent_slot, &ctx.genesis_cert_block_marker) {
         return Ok(());
     }
 
     // Send the genesis certificate
-    let genesis_marker = VersionedBlockMarker::new_genesis_certificate(ctx.genesis_cert.clone());
+    let block_marker =
+        VersionedBlockMarker::from_genesis_cert_block_marker(ctx.genesis_cert_block_marker.clone());
     let mut poh_recorder = ctx.poh_recorder.write().unwrap();
-    poh_recorder.send_marker(genesis_marker)?;
+    poh_recorder.send_marker(block_marker)?;
 
     // Process the genesis certificate
     let bank = poh_recorder.bank().expect("Bank cannot have been cleared");
     let processor = bank.block_component_processor.read().unwrap();
     processor
-        .on_genesis_certificate(
+        .on_genesis_cert_block_marker(
             bank.clone(),
-            ctx.genesis_cert.clone(),
+            ctx.genesis_cert_block_marker.clone(),
             &ctx.bank_forks.read().unwrap().migration_status(),
         )
         .expect("Recording genesis certificate should not fail");
@@ -1329,9 +1331,9 @@ fn maybe_include_genesis_certificate(
 
 fn should_include_genesis_certificate(
     parent_slot: Slot,
-    genesis_cert: &GenesisCertificate,
+    genesis_cert_block_marker: &GenesisCertBlockMarker,
 ) -> bool {
-    parent_slot == genesis_cert.slot && parent_slot != 0
+    parent_slot == genesis_cert_block_marker.slot && parent_slot != 0
 }
 
 #[cfg(test)]
@@ -1369,8 +1371,8 @@ mod tests {
         ))
     }
 
-    fn test_genesis_certificate() -> GenesisCertificate {
-        GenesisCertificate {
+    fn test_genesis_cert_block_marker() -> GenesisCertBlockMarker {
+        GenesisCertBlockMarker {
             slot: Slot::MAX,
             block_id: Hash::default(),
             bls_signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
@@ -1557,7 +1559,7 @@ mod tests {
             banking_stage_sender,
             metrics: LoopMetrics::default(),
             slot_metrics: SlotMetrics::default(),
-            genesis_cert: test_genesis_certificate(),
+            genesis_cert_block_marker: test_genesis_cert_block_marker(),
         };
 
         create_and_insert_leader_bank(1, root_bank.clone(), &mut ctx).unwrap();
@@ -1643,8 +1645,8 @@ mod tests {
         let (_record_sender, record_receiver) = record_channels(false);
         let (_leader_window_info_sender, leader_window_info_receiver) = unbounded();
         let (banking_stage_sender, _banking_stage_receiver) = BankingTracer::channel_for_test();
-        let mut genesis_cert = test_genesis_certificate();
-        genesis_cert.slot = parent_bank.slot();
+        let mut genesis_cert_block_marker = test_genesis_cert_block_marker();
+        genesis_cert_block_marker.slot = parent_bank.slot();
         let bank_forks_controller = test_bank_forks_controller(bank_forks.clone());
         let (reward_certs_requestor, _receiver) = CertsRequestor::new();
 
@@ -1669,7 +1671,7 @@ mod tests {
             banking_stage_sender,
             metrics: LoopMetrics::default(),
             slot_metrics: SlotMetrics::default(),
-            genesis_cert,
+            genesis_cert_block_marker,
         };
 
         let err = create_and_insert_leader_bank(2, parent_bank, &mut ctx).unwrap_err();
@@ -1738,7 +1740,7 @@ mod tests {
             banking_stage_sender,
             metrics: LoopMetrics::default(),
             slot_metrics: SlotMetrics::default(),
-            genesis_cert: test_genesis_certificate(),
+            genesis_cert_block_marker: test_genesis_cert_block_marker(),
         };
 
         create_and_insert_leader_bank(1, root_bank, &mut ctx).unwrap();
@@ -1841,7 +1843,7 @@ mod tests {
             banking_stage_sender,
             metrics: LoopMetrics::default(),
             slot_metrics: SlotMetrics::default(),
-            genesis_cert: test_genesis_certificate(),
+            genesis_cert_block_marker: test_genesis_cert_block_marker(),
         };
 
         let leader_slot = 4;

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -185,11 +185,11 @@ fn insert_update_parent_slot(
     update_parent_block_id: Hash,
     replay_fec_set_index: u32,
 ) {
-    let header = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+    let header = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
         parent_slot: block_header_parent_slot,
         parent_block_id: Hash::new_unique(),
     });
-    let update_parent = VersionedBlockMarker::new_update_parent(UpdateParentV1 {
+    let update_parent = VersionedBlockMarker::from_update_parent(UpdateParentV1 {
         new_parent_slot: update_parent_slot,
         new_parent_block_id: update_parent_block_id,
     });
@@ -2895,16 +2895,16 @@ fn test_headerless_update_parent() {
     let migration_status = post_migration_status_for_tests();
 
     let footer_marker = || {
-        VersionedBlockMarker::new_block_footer(BlockFooterV1 {
+        VersionedBlockMarker::from_block_footer(BlockFooterV1 {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: 0,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         })
     };
-    let update_parent = VersionedBlockMarker::new_update_parent(UpdateParentV1 {
+    let update_parent = VersionedBlockMarker::from_update_parent(UpdateParentV1 {
         new_parent_slot: 0,
         new_parent_block_id: Hash::default(),
     });
@@ -3220,11 +3220,11 @@ fn test_before_update_soft_dead() {
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
     let bank = Bank::new_from_parent(bank0, SlotLeader::default(), slot);
     let bank = bank_forks.write().unwrap().insert(bank);
-    let header = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+    let header = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
         parent_slot: 0,
         parent_block_id: Hash::default(),
     });
-    let update_parent = VersionedBlockMarker::new_update_parent(UpdateParentV1 {
+    let update_parent = VersionedBlockMarker::from_update_parent(UpdateParentV1 {
         new_parent_slot: 0,
         new_parent_block_id: Hash::default(),
     });

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -66,30 +66,30 @@
 ///
 /// ### BlockFooterV1 Layout
 /// ```text
-/// ┌─────────────────────────────────────────┐
-/// │ Bank Hash                   (32 bytes)  │
-/// ├─────────────────────────────────────────┤
-/// │ Producer Time Nanos          (8 bytes)  │
-/// ├─────────────────────────────────────────┤
-/// │ User Agent Length            (1 byte)   │
-/// ├─────────────────────────────────────────┤
-/// │ User Agent Bytes          (0-255 bytes) │
-/// ├─────────────────────────────────────────┤
-/// │ Final Cert Present           (1 byte)   │
-/// ├─────────────────────────────────────────┤
-/// │ FinalCertificate (if present, variable) │
-/// ├─────────────────────────────────────────┤
-/// │ Skip reward cert Present     (1 byte)   │
-/// ├─────────────────────────────────────────┤
-/// │ SkipRewardCert (if present, variable)   │
-/// ├─────────────────────────────────────────┤
-/// │ Notar reward cert Present    (1 byte)   │
-/// ├─────────────────────────────────────────┤
-/// │ NotarRewardCert (if present, variable)  │
-/// └─────────────────────────────────────────┘
+/// ┌──────────────────────────────────────────────┐
+/// │ Bank Hash                        (32 bytes)  │
+/// ├──────────────────────────────────────────────┤
+/// │ Producer Time Nanos               (8 bytes)  │
+/// ├──────────────────────────────────────────────┤
+/// │ User Agent Length                 (1 byte)   │
+/// ├──────────────────────────────────────────────┤
+/// │ User Agent Bytes               (0-255 bytes) │
+/// ├──────────────────────────────────────────────┤
+/// │ Block Final Cert Present          (1 byte)   │
+/// ├──────────────────────────────────────────────┤
+/// │ BlockFinalizationCert (if present, variable) │
+/// ├──────────────────────────────────────────────┤
+/// │ Skip reward cert Present     (1 byte)        │
+/// ├──────────────────────────────────────────────┤
+/// │ SkipRewardCert (if present, variable)        │
+/// ├──────────────────────────────────────────────┤
+/// │ Notar reward cert Present    (1 byte)        │
+/// ├──────────────────────────────────────────────┤
+/// │ NotarRewardCert (if present, variable)       │
+/// └──────────────────────────────────────────────┘
 /// ```
 ///
-/// ### FinalCertificate Layout
+/// ### BlockFinalizationCert Layout
 /// ```text
 /// ┌─────────────────────────────────────────┐
 /// │ Slot                         (8 bytes)  │
@@ -210,7 +210,7 @@ pub struct BlockFooterV1 {
     pub block_producer_time_nanos: u64,
     #[wincode(with = "WincodeVec<u8, FixIntLen<u8>>")]
     pub block_user_agent: Vec<u8>,
-    pub final_cert: Option<FinalCertificate>,
+    pub block_final_cert: Option<BlockFinalizationCert>,
     pub skip_reward_cert: Option<SkipRewardCertificate>,
     pub notar_reward_cert: Option<NotarRewardCertificate>,
 }
@@ -229,7 +229,7 @@ pub struct UpdateParentV1 {
 
 /// Attests to genesis block finalization with a BLS aggregate signature.
 #[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
-pub struct GenesisCertificate {
+pub struct GenesisCertBlockMarker {
     pub slot: Slot,
     pub block_id: Hash,
     #[wincode(with = "PodBLSSignature")]
@@ -238,12 +238,12 @@ pub struct GenesisCertificate {
     pub bitmap: Vec<u8>,
 }
 
-impl GenesisCertificate {
+impl GenesisCertBlockMarker {
     /// Max bitmap size in bytes (supports up to 4096 validators).
     pub const MAX_BITMAP_SIZE: usize = 512;
 }
 
-impl TryFrom<Certificate> for GenesisCertificate {
+impl TryFrom<Certificate> for GenesisCertBlockMarker {
     type Error = String;
 
     fn try_from(cert: Certificate) -> Result<Self, Self::Error> {
@@ -266,8 +266,8 @@ impl TryFrom<Certificate> for GenesisCertificate {
     }
 }
 
-impl From<GenesisCertificate> for Certificate {
-    fn from(cert: GenesisCertificate) -> Self {
+impl From<GenesisCertBlockMarker> for Certificate {
+    fn from(cert: GenesisCertBlockMarker) -> Self {
         Self {
             cert_type: CertificateType::Genesis(cert.slot, cert.block_id),
             signature: cert.bls_signature,
@@ -277,17 +277,17 @@ impl From<GenesisCertificate> for Certificate {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, SchemaWrite, SchemaRead)]
-pub struct FinalCertificate {
+pub struct BlockFinalizationCert {
     pub slot: Slot,
     pub block_id: Hash,
     pub final_aggregate: VotesAggregate,
     pub notar_aggregate: Option<VotesAggregate>,
 }
 
-impl FinalCertificate {
+impl BlockFinalizationCert {
     #[cfg(feature = "dev-context-only-utils")]
-    pub fn new_for_tests() -> FinalCertificate {
-        FinalCertificate {
+    pub fn new_for_tests() -> BlockFinalizationCert {
+        BlockFinalizationCert {
             slot: 1234567890,
             block_id: Hash::new_from_array([1u8; 32]),
             final_aggregate: VotesAggregate {
@@ -363,7 +363,7 @@ pub enum BlockMarkerV1 {
     BlockFooter(LengthPrefixed<VersionedBlockFooter>),
     BlockHeader(LengthPrefixed<VersionedBlockHeader>),
     UpdateParent(LengthPrefixed<VersionedUpdateParent>),
-    GenesisCertificate(LengthPrefixed<GenesisCertificate>),
+    GenesisCertificate(LengthPrefixed<GenesisCertBlockMarker>),
 }
 
 impl BlockMarkerV1 {
@@ -379,7 +379,7 @@ impl BlockMarkerV1 {
         Self::UpdateParent(LengthPrefixed::new(u))
     }
 
-    pub fn new_genesis_certificate(c: GenesisCertificate) -> Self {
+    pub fn new_genesis_certificate(c: GenesisCertBlockMarker) -> Self {
         Self::GenesisCertificate(LengthPrefixed::new(c))
     }
 
@@ -404,7 +404,7 @@ impl BlockMarkerV1 {
         }
     }
 
-    pub fn as_genesis_certificate(&self) -> Option<&GenesisCertificate> {
+    pub fn as_genesis_certificate(&self) -> Option<&GenesisCertBlockMarker> {
         match self {
             Self::GenesisCertificate(lp) => Some(lp.inner()),
             _ => None,
@@ -424,40 +424,40 @@ impl VersionedBlockMarker {
         Self::V1(marker)
     }
 
-    pub fn new_block_footer(f: BlockFooterV1) -> Self {
+    pub fn from_block_footer(f: BlockFooterV1) -> Self {
         let f = VersionedBlockFooter::V1(f);
         let f = BlockMarkerV1::BlockFooter(LengthPrefixed::new(f));
-        VersionedBlockMarker::V1(f)
+        Self::new(f)
     }
 
-    pub fn new_block_header(h: BlockHeaderV1) -> Self {
+    pub fn from_block_header(h: BlockHeaderV1) -> Self {
         let h = VersionedBlockHeader::V1(h);
         let h = BlockMarkerV1::BlockHeader(LengthPrefixed::new(h));
-        VersionedBlockMarker::V1(h)
+        Self::new(h)
     }
 
-    pub fn new_update_parent(u: UpdateParentV1) -> Self {
+    pub fn from_update_parent(u: UpdateParentV1) -> Self {
         let u = VersionedUpdateParent::V1(u);
         let u = BlockMarkerV1::UpdateParent(LengthPrefixed::new(u));
-        VersionedBlockMarker::V1(u)
+        Self::new(u)
     }
 
-    pub fn new_genesis_certificate(g: GenesisCertificate) -> Self {
+    pub fn from_genesis_cert_block_marker(g: GenesisCertBlockMarker) -> Self {
         let g = BlockMarkerV1::GenesisCertificate(LengthPrefixed::new(g));
-        VersionedBlockMarker::V1(g)
+        Self::new(g)
     }
 
     pub fn is_update_parent(&self) -> bool {
         match self {
-            VersionedBlockMarker::V1(BlockMarkerV1::UpdateParent(_)) => true,
-            VersionedBlockMarker::V1(_) => false,
+            Self::V1(BlockMarkerV1::UpdateParent(_)) => true,
+            Self::V1(_) => false,
         }
     }
 
     pub fn is_footer(&self) -> bool {
         match self {
-            VersionedBlockMarker::V1(BlockMarkerV1::BlockFooter(_)) => true,
-            VersionedBlockMarker::V1(_) => false,
+            Self::V1(BlockMarkerV1::BlockFooter(_)) => true,
+            Self::V1(_) => false,
         }
     }
 }
@@ -497,7 +497,7 @@ impl BlockComponent {
             parent_slot,
             parent_block_id,
         };
-        Self::new_block_marker(VersionedBlockMarker::new_block_header(header))
+        Self::new_block_marker(VersionedBlockMarker::from_block_header(header))
     }
 
     pub const fn as_marker(&self) -> Option<&VersionedBlockMarker> {
@@ -584,7 +584,7 @@ mod tests {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: 1234567890,
             block_user_agent: b"test-agent".to_vec(),
-            final_cert: Some(FinalCertificate::new_for_tests()),
+            block_final_cert: Some(BlockFinalizationCert::new_for_tests()),
             skip_reward_cert: None,
             notar_reward_cert: None,
         }
@@ -609,19 +609,19 @@ mod tests {
             wincode::deserialize::<BlockFooterV1>(&bytes).unwrap()
         );
 
-        let cert = GenesisCertificate {
+        let marker = GenesisCertBlockMarker {
             slot: 999,
             block_id: Hash::new_unique(),
             bls_signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: vec![1, 2, 3],
         };
-        let bytes = wincode::serialize(&cert).unwrap();
+        let bytes = wincode::serialize(&marker).unwrap();
         assert_eq!(
-            cert,
-            wincode::deserialize::<GenesisCertificate>(&bytes).unwrap()
+            marker,
+            wincode::deserialize::<GenesisCertBlockMarker>(&bytes).unwrap()
         );
 
-        let marker = VersionedBlockMarker::new_block_footer(footer.clone());
+        let marker = VersionedBlockMarker::from_block_footer(footer.clone());
         let bytes = wincode::serialize(&marker).unwrap();
         assert_eq!(
             marker,

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -77,7 +77,7 @@ fn create_update_parent_shreds_with_shred_parent(
     is_last_in_slot: bool,
 ) -> Vec<Shred> {
     use solana_entry::block_component::UpdateParentV1;
-    let component = VersionedBlockMarker::new_update_parent(UpdateParentV1 {
+    let component = VersionedBlockMarker::from_update_parent(UpdateParentV1 {
         new_parent_slot: parent_slot,
         new_parent_block_id: parent_block_id,
     });
@@ -109,7 +109,7 @@ fn create_block_header_shreds_with_shred_parent(
     parent_block_id: Hash,
 ) -> Vec<Shred> {
     use solana_entry::block_component::BlockHeaderV1;
-    let component = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+    let component = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
         parent_slot,
         parent_block_id,
     });
@@ -166,11 +166,11 @@ fn create_block_footer_shreds_with_last(
         bank_hash: Hash::new_unique(),
         block_producer_time_nanos: 0,
         block_user_agent: vec![],
-        final_cert: None,
+        block_final_cert: None,
         skip_reward_cert: None,
         notar_reward_cert: None,
     };
-    let component = VersionedBlockMarker::new_block_footer(footer);
+    let component = VersionedBlockMarker::from_block_footer(footer);
     let component = BlockComponent::new_block_marker(component);
 
     Shredder::new(slot, parent_slot, 0, 0)

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -6096,17 +6096,17 @@ pub mod tests {
         let keypair = Arc::new(Keypair::new());
         let reed_solomon_cache = ReedSolomonCache::default();
 
-        let header = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+        let header = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
             parent_slot: 0,
             parent_block_id: Hash::default(),
         });
         let header_component = BlockComponent::new_block_marker(header);
 
-        let footer = VersionedBlockMarker::new_block_footer(BlockFooterV1 {
+        let footer = VersionedBlockMarker::from_block_footer(BlockFooterV1 {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: 1_000_000_000,
             block_user_agent: b"test".to_vec(),
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -627,7 +627,7 @@ impl PohRecorder {
         // Send out the block footer - we now have the bank hash
         footer.bank_hash = working_bank.bank.hash();
 
-        let footer = VersionedBlockMarker::new_block_footer(footer);
+        let footer = VersionedBlockMarker::from_block_footer(footer);
         let footer_entry_marker = (
             EntryOrMarker::Marker(footer),
             working_bank.max_tick_height - 1,
@@ -1389,11 +1389,11 @@ mod tests {
         poh_recorder.set_bank_for_test(bank);
         drop(entry_receiver);
 
-        let marker = VersionedBlockMarker::new_block_footer(BlockFooterV1 {
+        let marker = VersionedBlockMarker::from_block_footer(BlockFooterV1 {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: 0,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
@@ -1406,7 +1406,7 @@ mod tests {
             bank_hash: Hash::default(),
             block_producer_time_nanos: 0,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         }

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -20,7 +20,7 @@ use {
     log::*,
     solana_clock::Slot,
     solana_entry::block_component::{
-        BlockFooterV1, BlockMarkerV1, GenesisCertificate, VersionedBlockFooter,
+        BlockFooterV1, BlockMarkerV1, GenesisCertBlockMarker, VersionedBlockFooter,
         VersionedBlockHeader, VersionedBlockMarker, VersionedUpdateParent,
     },
     solana_hash::Hash,
@@ -197,10 +197,14 @@ impl BlockComponentProcessor {
             BlockMarkerV1::BlockHeader(header) if markers_fully_enabled || in_migration => {
                 self.on_header(header.inner(), bank.parent_slot())
             }
-            BlockMarkerV1::GenesisCertificate(genesis_cert)
+            BlockMarkerV1::GenesisCertificate(genesis_cert_block_marker)
                 if markers_fully_enabled || in_migration =>
             {
-                self.on_genesis_certificate(bank, genesis_cert.into_inner(), migration_status)
+                self.on_genesis_cert_block_marker(
+                    bank,
+                    genesis_cert_block_marker.into_inner(),
+                    migration_status,
+                )
             }
 
             // Everything else is only valid once migration is complete
@@ -220,10 +224,10 @@ impl BlockComponentProcessor {
         }
     }
 
-    pub fn on_genesis_certificate(
+    pub fn on_genesis_cert_block_marker(
         &self,
         bank: Arc<Bank>,
-        genesis_cert: GenesisCertificate,
+        genesis_block_marker: GenesisCertBlockMarker,
         migration_status: &MigrationStatus,
     ) -> Result<(), BlockComponentProcessorError> {
         // Genesis Certificate is only allowed for direct child of genesis
@@ -234,7 +238,9 @@ impl BlockComponentProcessor {
         let parent_block_id = bank
             .parent_block_id()
             .expect("Block id is populated for all slots > 0");
-        if (bank.parent_slot(), parent_block_id) != (genesis_cert.slot, genesis_cert.block_id) {
+        if (bank.parent_slot(), parent_block_id)
+            != (genesis_block_marker.slot, genesis_block_marker.block_id)
+        {
             return Err(BlockComponentProcessorError::GenesisCertificateOnNonChild);
         }
 
@@ -242,7 +248,7 @@ impl BlockComponentProcessor {
             return Err(BlockComponentProcessorError::GenesisCertificateAlreadyPopulated);
         }
 
-        let genesis_cert = Certificate::from(genesis_cert);
+        let genesis_cert = Certificate::from(genesis_block_marker);
         Self::verify_genesis_certificate(&bank, &genesis_cert)?;
         bank.set_alpenglow_genesis_certificate(&genesis_cert);
         bank.set_hashes_per_tick(None);
@@ -326,7 +332,7 @@ impl BlockComponentProcessor {
             bank_hash,
             block_producer_time_nanos,
             block_user_agent: _,
-            final_cert,
+            block_final_cert,
             skip_reward_cert,
             notar_reward_cert,
         } = footer;
@@ -335,7 +341,7 @@ impl BlockComponentProcessor {
             ValidatedRewardCert::try_new(&bank, &skip_reward_cert, &notar_reward_cert)?;
         let block_producer_time_nanos =
             Self::block_producer_time_nanos_as_i64(block_producer_time_nanos)?;
-        let final_cert = final_cert
+        let final_cert = block_final_cert
             .map(|final_cert| {
                 ValidatedBlockFinalizationCert::try_from_footer(final_cert, &bank)
                     .map_err(BlockComponentProcessorError::InvalidFinalizationCertificate)
@@ -637,7 +643,7 @@ mod tests {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: footer_time_nanos as u64,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
@@ -676,7 +682,7 @@ mod tests {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: footer_time_nanos as u64,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
@@ -724,7 +730,7 @@ mod tests {
     fn test_on_marker_processes_header() {
         let migration_status = MigrationStatus::post_migration_status();
         let mut processor = BlockComponentProcessor::default();
-        let marker = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+        let marker = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
             parent_slot: 0,
             parent_block_id: Hash::default(),
         });
@@ -742,7 +748,7 @@ mod tests {
     fn test_on_marker_rejects_header_parent_slot_mismatch() {
         let migration_status = MigrationStatus::post_migration_status();
         let mut processor = BlockComponentProcessor::default();
-        let marker = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+        let marker = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
             parent_slot: 7, // mismatches bank.parent_slot() below (0)
             parent_block_id: Hash::default(),
         });
@@ -775,11 +781,11 @@ mod tests {
         let footer_time_nanos = parent_time_nanos + 300_000_000; // parent + 300ms
         let expected_time_secs = footer_time_nanos / 1_000_000_000;
 
-        let marker = VersionedBlockMarker::new_block_footer(BlockFooterV1 {
+        let marker = VersionedBlockMarker::from_block_footer(BlockFooterV1 {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: footer_time_nanos as u64,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
@@ -820,7 +826,7 @@ mod tests {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: footer_time_nanos as u64,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
@@ -844,7 +850,7 @@ mod tests {
         let bank = create_child_bank(&bank_forks, &parent, 1);
 
         // Try to process a block header marker pre-migration - should fail
-        let marker = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+        let marker = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
             parent_slot: 0,
             parent_block_id: Hash::default(),
         });
@@ -863,11 +869,11 @@ mod tests {
         let bank = create_child_bank(&bank_forks, &parent, 1);
 
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
-        let footer_marker = VersionedBlockMarker::new_block_footer(BlockFooterV1 {
+        let footer_marker = VersionedBlockMarker::from_block_footer(BlockFooterV1 {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: (parent_time_nanos + 500_000_000) as u64,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
@@ -885,7 +891,7 @@ mod tests {
             Err(BlockComponentProcessorError::BlockComponentPreMigration)
         ));
 
-        let update_parent_marker = VersionedBlockMarker::new_update_parent(UpdateParentV1 {
+        let update_parent_marker = VersionedBlockMarker::from_update_parent(UpdateParentV1 {
             new_parent_slot: 0,
             new_parent_block_id: Hash::default(),
         });
@@ -926,7 +932,7 @@ mod tests {
         let bank = create_child_bank(&bank_forks, &parent, 1);
 
         // Process header marker
-        let header_marker = VersionedBlockMarker::new_block_header(BlockHeaderV1 {
+        let header_marker = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
             parent_slot: 0,
             parent_block_id: Hash::default(),
         });
@@ -950,11 +956,11 @@ mod tests {
         let expected_time_secs = footer_time_nanos / 1_000_000_000;
 
         // Process footer marker
-        let footer_marker = VersionedBlockMarker::new_block_footer(BlockFooterV1 {
+        let footer_marker = VersionedBlockMarker::from_block_footer(BlockFooterV1 {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: footer_time_nanos as u64,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
@@ -987,7 +993,7 @@ mod tests {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: 1_000_000_000,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
@@ -1016,11 +1022,11 @@ mod tests {
         let expected_time_secs = footer_time_nanos / 1_000_000_000;
 
         // Process footer marker
-        let footer_marker = VersionedBlockMarker::new_block_footer(BlockFooterV1 {
+        let footer_marker = VersionedBlockMarker::from_block_footer(BlockFooterV1 {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: footer_time_nanos as u64,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
@@ -1101,7 +1107,7 @@ mod tests {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: footer_time_nanos as u64,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
@@ -1148,7 +1154,7 @@ mod tests {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: footer_time_nanos as u64,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
@@ -1219,7 +1225,7 @@ mod tests {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: u64::MAX,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
@@ -1421,7 +1427,7 @@ mod tests {
             bank_hash: Hash::new_unique(),
             block_producer_time_nanos: (parent_time_nanos + 100_000_000) as u64,
             block_user_agent: vec![],
-            final_cert: None,
+            block_final_cert: None,
             skip_reward_cert: None,
             notar_reward_cert: None,
         });

--- a/runtime/src/validated_block_finalization.rs
+++ b/runtime/src/validated_block_finalization.rs
@@ -13,7 +13,7 @@ use {
     log::warn,
     solana_bls_signatures::BlsError,
     solana_clock::Slot,
-    solana_entry::block_component::{FinalCertificate, VotesAggregate},
+    solana_entry::block_component::{BlockFinalizationCert, VotesAggregate},
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_signer_store::{DecodeError, Decoded, decode},
@@ -92,12 +92,12 @@ impl ValidatedBlockFinalizationCert {
     /// - Certificate signature verification fails
     /// - The certificates don't meet the required stake thresholds
     pub fn try_from_footer(
-        final_cert: FinalCertificate,
+        block_final_cert: BlockFinalizationCert,
         bank: &Bank,
     ) -> Result<Self, BlockFinalizationCertError> {
-        let (slot, block_id) = (final_cert.slot, final_cert.block_id);
+        let (slot, block_id) = (block_final_cert.slot, block_final_cert.block_id);
 
-        if let Some(notar_aggregate) = final_cert.notar_aggregate {
+        if let Some(notar_aggregate) = block_final_cert.notar_aggregate {
             // Slow finalization
             let notarize_cert_type = CertificateType::Notarize(slot, block_id);
             let finalize_cert_type = CertificateType::Finalize(slot);
@@ -111,11 +111,11 @@ impl ValidatedBlockFinalizationCert {
             };
             let finalize_cert = Certificate {
                 cert_type: finalize_cert_type,
-                signature: final_cert
+                signature: block_final_cert
                     .final_aggregate
                     .uncompress_signature()
                     .map_err(|e| BlockFinalizationCertError::BlsError(finalize_cert_type, e))?,
-                bitmap: final_cert.final_aggregate.into_bitmap(),
+                bitmap: block_final_cert.final_aggregate.into_bitmap(),
             };
 
             // Verify both certificates
@@ -171,13 +171,13 @@ impl ValidatedBlockFinalizationCert {
 
             let fast_finalize_cert = Certificate {
                 cert_type: fast_finalize_cert_type,
-                signature: final_cert
+                signature: block_final_cert
                     .final_aggregate
                     .uncompress_signature()
                     .map_err(|e| {
                         BlockFinalizationCertError::BlsError(fast_finalize_cert_type, e)
                     })?,
-                bitmap: final_cert.final_aggregate.into_bitmap(),
+                bitmap: block_final_cert.final_aggregate.into_bitmap(),
             };
 
             let (finalize_stake, total_stake) =
@@ -321,8 +321,8 @@ impl ValidatedBlockFinalizationCert {
         (signers, final_cert, notar_cert)
     }
 
-    /// Converts this validated certificate into a [`FinalCertificate`] for inclusion in a block footer.
-    pub fn to_final_certificate(&self) -> FinalCertificate {
+    /// Converts this validated certificate into a [`BlockFinalizationCert`] for inclusion in a block footer.
+    pub fn to_block_final_cert(&self) -> BlockFinalizationCert {
         match &self.kind {
             ValidatedBlockFinalizationCertKind::Finalize {
                 finalize_cert,
@@ -334,7 +334,7 @@ impl ValidatedBlockFinalizationCert {
                     .to_block()
                     .expect("notarize certificates correspond to blocks")
                     .1;
-                FinalCertificate {
+                BlockFinalizationCert {
                     slot,
                     block_id,
                     final_aggregate: VotesAggregate::from_certificate(finalize_cert),
@@ -346,7 +346,7 @@ impl ValidatedBlockFinalizationCert {
                     .cert_type
                     .to_block()
                     .expect("fast finalizations correspond to blocks");
-                FinalCertificate {
+                BlockFinalizationCert {
                     slot,
                     block_id,
                     final_aggregate: VotesAggregate::from_certificate(cert),
@@ -487,14 +487,14 @@ mod tests {
             let fast_finalize_cert =
                 build_certificate_manual(cert_type, vote, &signing_ranks, &validator_keypairs);
 
-            let final_cert = FinalCertificate {
+            let block_final_cert = BlockFinalizationCert {
                 slot,
                 block_id,
                 final_aggregate: VotesAggregate::from_certificate(&fast_finalize_cert),
                 notar_aggregate: None,
             };
 
-            let result = ValidatedBlockFinalizationCert::try_from_footer(final_cert, &bank);
+            let result = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank);
             assert!(
                 result.is_ok(),
                 "Valid fast finalize certificate should pass verification: {result:?}"
@@ -524,14 +524,14 @@ mod tests {
                 &validator_keypairs,
             );
 
-            let final_cert = FinalCertificate {
+            let block_final_cert = BlockFinalizationCert {
                 slot,
                 block_id,
                 final_aggregate: VotesAggregate::from_certificate(&finalize_cert),
                 notar_aggregate: Some(VotesAggregate::from_certificate(&notarize_cert)),
             };
 
-            let result = ValidatedBlockFinalizationCert::try_from_footer(final_cert, &bank);
+            let result = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank);
             assert!(
                 result.is_ok(),
                 "Valid slow finalize certificate should pass verification: {result:?}"
@@ -561,14 +561,14 @@ mod tests {
             let fast_finalize_cert =
                 build_certificate_manual(cert_type, vote, &signing_ranks, &validator_keypairs);
 
-            let final_cert = FinalCertificate {
+            let block_final_cert = BlockFinalizationCert {
                 slot,
                 block_id,
                 final_aggregate: VotesAggregate::from_certificate(&fast_finalize_cert),
                 notar_aggregate: None,
             };
 
-            let result = ValidatedBlockFinalizationCert::try_from_footer(final_cert, &bank);
+            let result = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank);
             assert!(
                 matches!(
                     result,
@@ -602,14 +602,14 @@ mod tests {
                 &validator_keypairs,
             );
 
-            let final_cert = FinalCertificate {
+            let block_final_cert = BlockFinalizationCert {
                 slot,
                 block_id,
                 final_aggregate: VotesAggregate::from_certificate(&finalize_cert),
                 notar_aggregate: Some(VotesAggregate::from_certificate(&notarize_cert)),
             };
 
-            let result = ValidatedBlockFinalizationCert::try_from_footer(final_cert, &bank);
+            let result = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank);
             assert!(
                 matches!(
                     result,
@@ -645,14 +645,14 @@ mod tests {
                 &validator_keypairs,
             );
 
-            let final_cert = FinalCertificate {
+            let block_final_cert = BlockFinalizationCert {
                 slot,
                 block_id,
                 final_aggregate: VotesAggregate::from_certificate(&finalize_cert),
                 notar_aggregate: Some(VotesAggregate::from_certificate(&notarize_cert)),
             };
 
-            let result = ValidatedBlockFinalizationCert::try_from_footer(final_cert, &bank);
+            let result = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank);
             assert!(
                 matches!(
                     result,

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -444,7 +444,7 @@ mod tests {
                 .unwrap();
         }
 
-        let marker = solana_entry::block_component::VersionedBlockMarker::new_block_header(
+        let marker = solana_entry::block_component::VersionedBlockMarker::from_block_header(
             solana_entry::block_component::BlockHeaderV1 {
                 parent_slot: 0,
                 parent_block_id: Hash::default(),
@@ -480,7 +480,7 @@ mod tests {
         s.send((bank1.clone(), (EntryOrMarker::Entry(entry1.clone()), 1)))
             .unwrap();
 
-        let marker = solana_entry::block_component::VersionedBlockMarker::new_block_header(
+        let marker = solana_entry::block_component::VersionedBlockMarker::from_block_header(
             solana_entry::block_component::BlockHeaderV1 {
                 parent_slot: 0,
                 parent_block_id: Hash::default(),
@@ -546,7 +546,7 @@ mod tests {
         // Bank changes to bank2, but the next item is a marker with tick_height=3 — this should
         // leave entries empty after the clear. The stale last_tick_height (5, from bank1) must not
         // leak into subsequent results.
-        let marker = solana_entry::block_component::VersionedBlockMarker::new_block_header(
+        let marker = solana_entry::block_component::VersionedBlockMarker::from_block_header(
             solana_entry::block_component::BlockHeaderV1 {
                 parent_slot: 1,
                 parent_block_id: Hash::default(),

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -1264,7 +1264,7 @@ mod test {
 
         let new_parent_slot = 7;
         let new_parent_block_id = Hash::new_unique();
-        let component = BlockComponent::new_block_marker(VersionedBlockMarker::new_update_parent(
+        let component = BlockComponent::new_block_marker(VersionedBlockMarker::from_update_parent(
             solana_entry::block_component::UpdateParentV1 {
                 new_parent_slot,
                 new_parent_block_id,


### PR DESCRIPTION
#### Problem

- Various entry types are too similarly named as certificate types e.g. we have a `GenesisCertificate` in the entry module.  This sounds like it is an actual `Certificate`.
- Various bindings for entry types overlap with bindings we use for certificate types e.g. we use `genesis_cert` to refer to `GenesisCertificate` type in the entry module and to refer to the genesis `Certificate`.
- This causes unnecessary confusion when reading code especially if the reader happens to not have IDE support (e.g. looking at git diff, etc.)


#### Summary of Changes

- Renames `GenesisCertificate` to `GenesisCertBlockMarker` and adds the `_block_marker` suffix to various bindings referring to this type.
- Renames `FinalCertificate` to `BlockFinalizationCert` and renames the bindings referring to this type to `block_final_cert`.
- Also renamed some constructors from `new_*` to `from_*` as that is more correct.