### PR TITLE
startup: bubble up error when vote_history_file is not present

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2033,20 +2033,21 @@ fn restore_vote_history(
     bank_forks: &RwLock<BankForks>,
     identity: &Pubkey,
     vote_account: &Pubkey,
-) -> VoteHistory {
+) -> Result<VoteHistory, String> {
     match VoteHistory::restore(config.vote_history_storage.as_ref(), identity) {
-        Ok(vote_history) => vote_history,
+        Ok(vote_history) => Ok(vote_history),
         Err(err) => {
             let should_require_vote_history = {
                 let bank_forks = bank_forks.read().unwrap();
                 should_require_vote_history_file(&bank_forks.working_bank(), vote_account, identity)
             };
             if config.require_vote_history && should_require_vote_history {
-                panic!(
+                return Err(format!(
                     "Unable to retrieve vote history for identity {identity}. The vote account \
                      {vote_account} has prior Alpenglow votes. If this is intentional, use \
                      --do-not-require-vote-history: {err:?}"
-                );
+                )
+                .to_string());
             }
             if err.is_file_missing() && !should_require_vote_history {
                 info!(
@@ -2056,7 +2057,7 @@ fn restore_vote_history(
             } else {
                 warn!("Unable to retrieve vote history: {err:?} creating default vote history...");
             }
-            VoteHistory::new(*identity, 0)
+            Ok(VoteHistory::new(*identity, 0))
         }
     }
 }
@@ -2561,7 +2562,7 @@ impl<'a> ProcessBlockStore<'a> {
         // Load and post process vote history
         let vote_history = {
             let vote_history =
-                restore_vote_history(self.config, self.bank_forks, self.id, self.vote_account);
+                restore_vote_history(self.config, self.bank_forks, self.id, self.vote_account)?;
             // reconciliation attempt 1 of 2 with vote history
             reconcile_blockstore_roots_with_external_source(
                 ExternalRootSource::VoteHistory(vote_history.root()),

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -916,7 +916,7 @@ impl AdminRpcImpl {
                 let should_require_vote_history = {
                     let bank_forks = post_init.bank_forks.read().unwrap();
                     should_require_vote_history_file(
-                        &bank_forks.root_bank(),
+                        &bank_forks.working_bank(),
                         &post_init.vote_account,
                         &identity_keypair.pubkey(),
                     )


### PR DESCRIPTION
Addresses @steviez's comments from #12750 

Rather than panicking, bubble up the error properly.

Also use `working_bank` in both call sites.

### On the usage of `working_bank`:

Typically we avoid using `working_bank` as it could refer to a bank that is still in the process of executing (and thus not finalized). If we require state to be synchronized then this could cause divergences.

In this case I think it's preferable - when restarting from a snapshot prior to the migration we might have local blocks that have crossed the migration and are alpenglow. We want to use the most up to date information we have for this check.

The other risk with the `working_bank` is that a leader could send out their block early and we would use the state from that block. In this case I don't think it matters - there's no way to "erase" a VoteState such that we could get a false negative in this check.