### PR TITLE
svm: conformance: add vote and zk-elgamal proof program builtins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10615,6 +10615,8 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
+ "solana-vote-program",
+ "solana-zk-elgamal-proof-program",
  "spl-generic-token",
  "spl-token-interface",
  "test-case",

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -25,6 +25,8 @@ conformance = [
     "dep:bincode",
     "dep:prost",
     "dep:protosol",
+    "dep:solana-vote-program",
+    "dep:solana-zk-elgamal-proof-program",
     "dep:xxhash-rust",
     "dev-context-only-utils",
     "solana-instruction-error/serde",
@@ -110,6 +112,8 @@ solana-system-program = { workspace = true, optional = true }
 solana-sysvar-id = { workspace = true }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
+solana-vote-program = { workspace = true, optional = true }
+solana-zk-elgamal-proof-program = { workspace = true, optional = true }
 spl-generic-token = { workspace = true }
 thiserror = { workspace = true }
 xxhash-rust = { workspace = true, optional = true, features = ["xxh64"] }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -1155,14 +1155,14 @@ mod tests {
             acc.increase_calculated_data_size(data_size, &mut error_metrics)
                 .is_ok()
         );
-        assert_eq!(data_size as u32, acc.clone().into());
+        assert_eq!(data_size as u32, u32::from(acc.clone()));
 
         // OK - loaded data size meets limit
         assert!(
             acc.increase_calculated_data_size(1, &mut error_metrics)
                 .is_ok()
         );
-        assert_eq!(requested_data_size_limit, acc.clone().into());
+        assert_eq!(requested_data_size_limit, u32::from(acc.clone()));
 
         // fail - loading more data would exceed limit
         // data size helper reports the limit only
@@ -1170,7 +1170,7 @@ mod tests {
             acc.increase_calculated_data_size(1, &mut error_metrics),
             Err(TransactionError::MaxLoadedAccountsDataSizeExceeded)
         );
-        assert_eq!(requested_data_size_limit, acc.into());
+        assert_eq!(requested_data_size_limit, u32::from(acc));
 
         let mut acc = LoadedTransactionDataSize::with_max_size(requested_data_size_limit);
 
@@ -1180,7 +1180,7 @@ mod tests {
             acc.increase_calculated_data_size(u32::MAX as usize + 1, &mut error_metrics),
             Err(TransactionError::MaxLoadedAccountsDataSizeExceeded)
         );
-        assert_eq!(requested_data_size_limit, acc.into());
+        assert_eq!(requested_data_size_limit, u32::from(acc));
     }
 
     struct ValidateFeePayerTestParameter {

--- a/svm/src/conformance/programs.rs
+++ b/svm/src/conformance/programs.rs
@@ -55,6 +55,18 @@ static SVM_BUILTINS: &[SvmBuiltinPrototype] = &[
         name: "compute_budget_program",
         register_fn: solana_compute_budget_program::Entrypoint::register,
     },
+    #[cfg(feature = "conformance")]
+    SvmBuiltinPrototype {
+        program_id: solana_vote_program::id(),
+        name: "vote_program",
+        register_fn: solana_vote_program::vote_processor::Entrypoint::register,
+    },
+    #[cfg(feature = "conformance")]
+    SvmBuiltinPrototype {
+        program_id: solana_sdk_ids::zk_elgamal_proof_program::id(),
+        name: "zk_elgamal_proof_program",
+        register_fn: solana_zk_elgamal_proof_program::Entrypoint::register,
+    },
 ];
 
 fn create_keyed_account_for_builtin_program(program_id: &Pubkey, name: &str) -> (Pubkey, Account) {


### PR DESCRIPTION
#### Problem
Firedancer has test vectors for both of these builtins, but we don't currently support them in the instruction harness.

#### Summary
Add the Vote and ZK-ElGamal progarms under the `conformance` feature to the instruction harness.