### PR TITLE
svm: conformance: port over firedancer instr harness customization

### DIFF
--- a/svm/src/conformance/instr/context.rs
+++ b/svm/src/conformance/instr/context.rs
@@ -68,8 +68,11 @@ impl From<ProtoInstrContext> for InstrContext {
             })
             .collect::<Vec<_>>();
 
+        // Match Firedancer harness limit (FD_INSTR_ACCT_MAX = 1094)
+        // which is derived from the MTU
+        // (see FD_BPF_INSTR_ACCT_MAX comment in Firedancer)
         assert!(
-            instruction_accounts.len() <= 128,
+            instruction_accounts.len() <= 1094,
             "too many instruction accounts",
         );
 

--- a/svm/src/conformance/instr/context.rs
+++ b/svm/src/conformance/instr/context.rs
@@ -71,6 +71,12 @@ impl From<ProtoInstrContext> for InstrContext {
         // Match Firedancer harness limit (FD_INSTR_ACCT_MAX = 1094)
         // which is derived from the MTU
         // (see FD_BPF_INSTR_ACCT_MAX comment in Firedancer)
+        //
+        // TODO: This limit exceeds 255 because native programs can currently
+        // be invoked with more than 255 instruction accounts. Once the
+        // feature gate restricting instruction accounts to 255 is activated
+        // (https://github.com/anza-xyz/feature-gate-tracker/issues/115),
+        // this limit should be tightened to 255, eliminating any ambiguity.
         assert!(
             instruction_accounts.len() <= 1094,
             "too many instruction accounts",

--- a/svm/src/conformance/instr/harness.rs
+++ b/svm/src/conformance/instr/harness.rs
@@ -30,6 +30,7 @@ use {
         programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
         setup::sysvar_cache_from_accounts,
     },
+    agave_precompiles::is_precompile,
     prost::Message,
     protosol::protos::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
     std::ffi::c_int,
@@ -181,13 +182,50 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> ProtoInstrEffects {
         cache
     };
 
-    execute_instr_with_callback(
+    let mut effects = execute_instr_with_callback(
         &instr_context,
         &ConformanceCallback,
         &mut program_cache,
         &sysvar_cache,
-    )
-    .into()
+    );
+
+    // Precompile verification failures surface as `Custom`, but Firedancer
+    // reports a custom error code of 0 for precompiles.
+    if effects.custom_err.is_some()
+        && is_precompile(&instr_context.instruction.program_id, |_| true)
+    {
+        effects.custom_err = Some(0);
+    }
+
+    direct_mapping_handle_cu_exhaustion(
+        instr_context.feature_set.virtual_address_space_adjustments,
+        effects.cu_avail,
+        effects.result.is_some(),
+        effects
+            .resulting_accounts
+            .iter_mut()
+            .map(|(_, account)| &mut account.data),
+    );
+
+    effects.into()
+}
+
+/// Due to how Firedancer's VM CU accounting works, when
+/// virtual_address_space_adjustments is enabled and execution fails with the
+/// CU meter exhausted, we cannot compare the data region of the accounts with
+/// Agave.  Clears each supplied data buffer in that case.
+#[cfg(feature = "conformance")]
+fn direct_mapping_handle_cu_exhaustion<'a>(
+    virtual_address_space_adjustments_active: bool,
+    cu_avail: u64,
+    has_err: bool,
+    account_data: impl IntoIterator<Item = &'a mut Vec<u8>>,
+) {
+    if virtual_address_space_adjustments_active && cu_avail == 0 && has_err {
+        for data in account_data {
+            data.clear();
+        }
+    }
 }
 
 /// # Safety

--- a/svm/src/conformance/instr/harness.rs
+++ b/svm/src/conformance/instr/harness.rs
@@ -197,6 +197,13 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> ProtoInstrEffects {
         effects.custom_err = Some(0);
     }
 
+    // TODO: Firedancer's tooling compares resulting account contents even
+    // when execution fails, so the harness must report them. Account
+    // contents are not meaningful on error (partial writes can diverge based
+    // on timing, e.g. with direct mapping or builtins), so once the tooling
+    // supports it, the harness should skip the account comparison on error
+    // entirely, which would also make the CU-exhaustion workaround below
+    // unnecessary.
     direct_mapping_handle_cu_exhaustion(
         instr_context.feature_set.virtual_address_space_adjustments,
         effects.cu_avail,


### PR DESCRIPTION
#### Problem
SolFuzz-Agave has a few quirks with how it handles fixture inputs and effects that we didn't have included in our reimplementation.

#### Summary of Changes
In just the `_proto` harness - under the `conformance` feature - add the custom logic.

Tapping @mjain-jump for additional review.