### PR TITLE
docs: Add information about setting the BLS Public Key

### DIFF
--- a/docs/src/operations/guides/validator-start.md
+++ b/docs/src/operations/guides/validator-start.md
@@ -250,6 +250,10 @@ solana create-vote-account ~/vote-account-keypair.json ~/validator-keypair.json 
 
 Remember to move your authorized withdrawer keypair into a very secure location after running the above command.
 
+After SIMD-0387 has been activated on your cluster, set the BLS public key for
+your vote account before starting the validator. Follow the
+[BLS public key instructions](./vote-accounts.md#set-the-bls-public-key).
+
 Read more about [creating and managing a vote account](./vote-accounts.md).
 
 ## Known validators

--- a/docs/src/operations/guides/vote-accounts.md
+++ b/docs/src/operations/guides/vote-accounts.md
@@ -23,10 +23,61 @@ of the account.
   [vote-update-validator](../../cli/usage.md#solana-vote-update-validator).
 - To change the [vote authority](#vote-authority), use
   [vote-authorize-voter-checked](../../cli/usage.md#solana-vote-authorize-voter-checked).
+- To set the BLS public key associated with the
+  [vote authority](#vote-authority), use
+  [vote-authorize-voter-checked](../../cli/usage.md#solana-vote-authorize-voter-checked)
+  after SIMD-0387 is active on the cluster.
 - To change the [authorized withdrawer](#authorized-withdrawer), use
   [vote-authorize-withdrawer-checked](../../cli/usage.md#solana-vote-authorize-withdrawer-checked).
 - To change the [commission](#commission), use
   [vote-update-commission](../../cli/usage.md#solana-vote-update-commission).
+
+### Set the BLS Public Key
+
+Voting validators must set the BLS public key associated with their authorized voter
+after SIMD-0387, BLS pubkey management, is active on the target cluster. The
+Solana CLI will not set the BLS public key before the feature is active.
+
+> **IMPORTANT** As of June 2026, SIMD-0387 is active only on testnet. Setting
+> the BLS public key is a prerequisite for SIMD-0357. Beginning with Agave v4.2,
+> a voting validator will fail to start if its BLS public key has not been set.
+
+For almost all validators, the authorized voter is the validator identity. If
+you are unsure which keypair is the current authorized voter, run:
+
+```bash
+solana vote-account <VOTE_ACCOUNT> | grep "Vote Authority"
+```
+
+Then set the BLS public key by running the following command. For almost all
+validators, `<AUTHORIZED_VOTER_KEYPAIR>` should be the identity keypair:
+
+```bash
+solana vote-authorize-voter-checked <VOTE_ACCOUNT> <AUTHORIZED_VOTER_KEYPAIR> <AUTHORIZED_VOTER_KEYPAIR>
+```
+
+This does not change the authorized voter. It fills in the BLS public key
+associated with the authorized voter.
+
+For a new vote account, follow the normal
+[create vote account](#create-a-vote-account) instructions first, then run the
+same `vote-authorize-voter-checked` command above to set the BLS public key.
+
+To check whether the BLS public key is set on chain, run:
+
+```bash
+solana vote-account <VOTE_ACCOUNT> | grep "BLS Public Key"
+```
+
+If the command does not print a `BLS Public Key` line, the vote account does not
+have a BLS public key set.
+
+To view the BLS public key derived from the authorized voter keypair locally,
+run:
+
+```bash
+solana-keygen bls_pubkey <AUTHORIZED_VOTER_KEYPAIR>
+```
 
 ## Vote Account Structure
 

--- a/docs/src/operations/guides/vote-accounts.md
+++ b/docs/src/operations/guides/vote-accounts.md
@@ -39,8 +39,8 @@ after SIMD-0387, BLS pubkey management, is active on the target cluster. The
 Solana CLI will not set the BLS public key before the feature is active.
 
 > **IMPORTANT** As of June 2026, SIMD-0387 is active only on testnet. Setting
-> the BLS public key is a prerequisite for SIMD-0357. Beginning with Agave v4.2,
-> a voting validator will fail to start if its BLS public key has not been set.
+> the BLS public key is a prerequisite for SIMD-0357. If the BLS public key is
+> not set, the vote account will behave as unstaked once SIMD-0357 is active.
 
 For almost all validators, the authorized voter is the validator identity. If
 you are unsure which keypair is the current authorized voter, run:
@@ -49,8 +49,7 @@ you are unsure which keypair is the current authorized voter, run:
 solana vote-account <VOTE_ACCOUNT> | grep "Vote Authority"
 ```
 
-Then set the BLS public key by running the following command. For almost all
-validators, `<AUTHORIZED_VOTER_KEYPAIR>` should be the identity keypair:
+Then set the BLS public key by running the following command.
 
 ```bash
 solana vote-authorize-voter-checked <VOTE_ACCOUNT> <AUTHORIZED_VOTER_KEYPAIR> <AUTHORIZED_VOTER_KEYPAIR>

--- a/docs/src/operations/setup-a-validator.md
+++ b/docs/src/operations/setup-a-validator.md
@@ -158,6 +158,10 @@ solana create-vote-account -ut \
 > cli properly above but they are useful to ensure you're using the intended
 > cluster and keypair.
 
+After SIMD-0387 has been activated on your cluster, set the BLS public key for
+your vote account before starting the validator. Follow the
+[BLS public key instructions](./guides/vote-accounts.md#set-the-bls-public-key).
+
 ## Save the Withdrawer Keypair Securely
 
 Make sure your `authorized-withdrawer-keypair.json` is stored in a safe place.


### PR DESCRIPTION
#### Problem
Now that SIMD-0387 is active on testnet, validators can set their BLS Pubkey on their vote accounts.
This is a requirement to be selected as part of the VAT. The VAT (SIMD-0357) is planning to be activated in 7 epochs so it is imperative we add instructions.

#### Summary of Changes
Add instructions - I have tested this out on my staked testnet validator