### PR TITLE
gossip/repair: further optimize ping cache

### DIFF
--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -13,7 +13,7 @@ use {
             duplicate_repair_status::get_ancestor_hash_repair_sample_size,
             outstanding_requests::OutstandingRequests,
             repair_handler::RepairHandler,
-            repair_service::{OutstandingShredRepairs, REPAIR_MS, RepairInfo, RepairStats},
+            repair_service::{OutstandingShredRepairs, RepairInfo, RepairStats},
             request_response::RequestResponse,
             result::{Error, RepairVerifyError, Result},
         },
@@ -65,6 +65,7 @@ use {
         cmp::Reverse,
         collections::{HashMap, HashSet},
         net::{SocketAddr, UdpSocket},
+        ops::Range,
         sync::{
             Arc, RwLock,
             atomic::{AtomicBool, Ordering},
@@ -96,7 +97,7 @@ pub const MAX_ANCESTOR_RESPONSES: usize =
 const REPAIR_PING_TOKEN_SIZE: usize = HASH_BYTES;
 pub const REPAIR_PING_CACHE_CAPACITY: usize = 65536;
 pub const REPAIR_PING_CACHE_TTL: Duration = Duration::from_secs(1280);
-const REPAIR_PING_CACHE_RATE_LIMIT_DELAY: Duration = Duration::from_secs(2);
+const REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS: Range<u64> = 1000..2000;
 pub(crate) const REPAIR_RESPONSE_SERIALIZED_PING_BYTES: usize =
     4 /*enum discriminator*/ + PUBKEY_BYTES + REPAIR_PING_TOKEN_SIZE + SIGNATURE_BYTES;
 const SIGNED_REPAIR_TIME_WINDOW: Duration = Duration::from_secs(60 * 10); // 10 min
@@ -1377,12 +1378,9 @@ impl ServeRepair {
     ) -> JoinHandle<()> {
         const MAX_BYTES_PER_SECOND: u64 = 12_000_000;
 
-        // rate limit delay should be greater than the repair request iteration delay
-        assert!(REPAIR_PING_CACHE_RATE_LIMIT_DELAY > Duration::from_millis(REPAIR_MS));
-
         let mut ping_cache = PingCache::new(
             REPAIR_PING_CACHE_TTL,
-            REPAIR_PING_CACHE_RATE_LIMIT_DELAY,
+            REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
             REPAIR_PING_CACHE_CAPACITY,
         );
 
@@ -2043,7 +2041,7 @@ mod tests {
         let from_addr = socketaddr!(Ipv4Addr::LOCALHOST, 1234);
         let mut ping_cache = PingCache::new(
             REPAIR_PING_CACHE_TTL,
-            REPAIR_PING_CACHE_RATE_LIMIT_DELAY,
+            REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
             REPAIR_PING_CACHE_CAPACITY,
         );
         let slot = 42;
@@ -3215,11 +3213,11 @@ mod tests {
         assert!(!repair.verify_response(&AncestorHashesResponse::Hashes(response)));
     }
 
-    // A second check() within REPAIR_PING_CACHE_RATE_LIMIT_DELAY must not generate
+    // A second check() within REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT must not generate
     // a new ping. If it did, it would overwrite the stored token and invalidate the Pong,
     // making Ping fail for no reason.
     #[test]
-    fn test_repair_no_ping_overwrite_within_rate_limit_delay() {
+    fn test_repair_no_ping_overwrite_while_already_probing() {
         let mut rng = rand::rng();
         let this_node = Keypair::new();
         let remote_socket = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8001));
@@ -3227,7 +3225,7 @@ mod tests {
         let remote_node = (remote_keypair.pubkey(), remote_socket);
         let mut cache = PingCache::new(
             REPAIR_PING_CACHE_TTL,
-            REPAIR_PING_CACHE_RATE_LIMIT_DELAY,
+            REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
             REPAIR_PING_CACHE_CAPACITY,
         );
         let now = Instant::now();
@@ -3235,13 +3233,13 @@ mod tests {
         let (_, ping1) = cache.check(&mut rng, &this_node, now, remote_node);
         let ping1 = ping1.expect("should generate ping for unknown node");
 
-        // Second check within REPAIR_PING_CACHE_RATE_LIMIT_DELAY must not generate
-        // a new ping — that would overwrite the stored hash and invalidate the in-flight pong.
-        let within_delay = now + REPAIR_PING_CACHE_RATE_LIMIT_DELAY - Duration::from_millis(1);
+        // Use the minimum possible expiry minus 1ms — guaranteed to be before any expiry.
+        let within_delay =
+            now + Duration::from_millis(REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS.start - 1);
         let (_, ping2) = cache.check(&mut rng, &this_node, within_delay, remote_node);
         assert!(
             ping2.is_none(),
-            "must not generate a second ping within REPAIR_PING_CACHE_RATE_LIMIT_DELAY"
+            "must not generate a second ping within REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT"
         );
 
         // Pong for ping1 must still be valid — token was not overwritten.

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -11,7 +11,7 @@ use {
             duplicate_repair_status::get_ancestor_hash_repair_sample_size,
             outstanding_requests::OutstandingRequests,
             repair_handler::RepairHandler,
-            repair_service::{OutstandingShredRepairs, REPAIR_MS, RepairInfo, RepairStats},
+            repair_service::{OutstandingShredRepairs, RepairInfo, RepairStats},
             request_response::RequestResponse,
             result::{Error, RepairVerifyError, Result},
         },
@@ -64,6 +64,7 @@ use {
         cmp::Reverse,
         collections::{HashMap, HashSet},
         net::{SocketAddr, UdpSocket},
+        ops::Range,
         sync::{
             Arc, RwLock,
             atomic::{AtomicBool, Ordering},
@@ -95,7 +96,7 @@ pub const MAX_ANCESTOR_RESPONSES: usize =
 const REPAIR_PING_TOKEN_SIZE: usize = HASH_BYTES;
 pub const REPAIR_PING_CACHE_CAPACITY: usize = 65536;
 pub const REPAIR_PING_CACHE_TTL: Duration = Duration::from_secs(1280);
-const REPAIR_PING_CACHE_RATE_LIMIT_DELAY: Duration = Duration::from_secs(2);
+const REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS: Range<u64> = 1_000..2_000;
 pub(crate) const REPAIR_RESPONSE_SERIALIZED_PING_BYTES: usize =
     4 /*enum discriminator*/ + PUBKEY_BYTES + REPAIR_PING_TOKEN_SIZE + SIGNATURE_BYTES;
 const SIGNED_REPAIR_TIME_WINDOW: Duration = Duration::from_secs(60 * 10); // 10 min
@@ -1339,12 +1340,9 @@ impl ServeRepair {
     ) -> JoinHandle<()> {
         const MAX_BYTES_PER_SECOND: u64 = 12_000_000;
 
-        // rate limit delay should be greater than the repair request iteration delay
-        assert!(REPAIR_PING_CACHE_RATE_LIMIT_DELAY > Duration::from_millis(REPAIR_MS));
-
         let mut ping_cache = PingCache::new(
             REPAIR_PING_CACHE_TTL,
-            REPAIR_PING_CACHE_RATE_LIMIT_DELAY,
+            REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
             REPAIR_PING_CACHE_CAPACITY,
         );
 
@@ -2007,7 +2005,7 @@ mod tests {
         let from_addr = socketaddr!(Ipv4Addr::LOCALHOST, 1234);
         let mut ping_cache = PingCache::new(
             REPAIR_PING_CACHE_TTL,
-            REPAIR_PING_CACHE_RATE_LIMIT_DELAY,
+            REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
             REPAIR_PING_CACHE_CAPACITY,
         );
         let slot = 42;
@@ -3178,11 +3176,11 @@ mod tests {
         assert!(!repair.verify_response(&AncestorHashesResponse::Hashes(response)));
     }
 
-    // A second check() within REPAIR_PING_CACHE_RATE_LIMIT_DELAY must not generate
+    // A second check() within REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT must not generate
     // a new ping. If it did, it would overwrite the stored token and invalidate the Pong,
     // making Ping fail for no reason.
     #[test]
-    fn test_repair_no_ping_overwrite_within_rate_limit_delay() {
+    fn test_repair_no_ping_overwrite_while_already_probing() {
         let mut rng = rand::rng();
         let this_node = Keypair::new();
         let remote_socket = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8001));
@@ -3190,7 +3188,7 @@ mod tests {
         let remote_node = (remote_keypair.pubkey(), remote_socket);
         let mut cache = PingCache::new(
             REPAIR_PING_CACHE_TTL,
-            REPAIR_PING_CACHE_RATE_LIMIT_DELAY,
+            REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
             REPAIR_PING_CACHE_CAPACITY,
         );
         let now = Instant::now();
@@ -3198,13 +3196,13 @@ mod tests {
         let (_, ping1) = cache.check(&mut rng, &this_node, now, remote_node);
         let ping1 = ping1.expect("should generate ping for unknown node");
 
-        // Second check within REPAIR_PING_CACHE_RATE_LIMIT_DELAY must not generate
-        // a new ping — that would overwrite the stored hash and invalidate the in-flight pong.
-        let within_delay = now + REPAIR_PING_CACHE_RATE_LIMIT_DELAY - Duration::from_millis(1);
+        // Use the minimum possible expiry minus 1ms — guaranteed to be before any expiry.
+        let within_delay =
+            now + Duration::from_millis(REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS.start - 1);
         let (_, ping2) = cache.check(&mut rng, &this_node, within_delay, remote_node);
         assert!(
             ping2.is_none(),
-            "must not generate a second ping within REPAIR_PING_CACHE_RATE_LIMIT_DELAY"
+            "must not generate a second ping within REPAIR_PING_CACHE_OUTSTANDING_PING_TIMEOUT"
         );
 
         // Pong for ping1 must still be valid — token was not overwritten.

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -82,7 +82,7 @@ use {
         iter::repeat,
         net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, UdpSocket},
         num::NonZeroUsize,
-        ops::Div,
+        ops::{Div, Range},
         path::{Path, PathBuf},
         rc::Rc,
         result::Result,
@@ -122,8 +122,9 @@ const CHANNEL_CONSUME_CAPACITY: usize = 1024;
 /// of `MAX_GOSSIP_TRAFFIC` (103,896).
 pub(crate) const GOSSIP_CHANNEL_CAPACITY: usize = 4096; // 2^12
 const GOSSIP_PING_CACHE_CAPACITY: usize = 126976;
-const GOSSIP_PING_CACHE_TTL: Duration = Duration::from_secs(1280);
-const GOSSIP_PING_CACHE_RATE_LIMIT_DELAY: Duration = Duration::from_secs(1280 / 64);
+pub(crate) const GOSSIP_PING_CACHE_TTL: Duration = Duration::from_secs(1280);
+/// Per-entry Pong wait timeout is drawn uniformly from this range (in milliseconds).
+pub(crate) const GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS: Range<u64> = 1000..2000;
 // Per-IP scan budget for incoming pull requests; validators are assumed not
 // to share IPs. Mirrors the ping-pong cache capacity.
 const GOSSIP_PULL_SCAN_BUDGET_CACHE_CAPACITY: usize = GOSSIP_PING_CACHE_CAPACITY;
@@ -216,7 +217,7 @@ impl ClusterInfo {
             my_contact_info: RwLock::new(contact_info),
             ping_cache: Mutex::new(PingCache::new(
                 GOSSIP_PING_CACHE_TTL,
-                GOSSIP_PING_CACHE_RATE_LIMIT_DELAY,
+                GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
                 GOSSIP_PING_CACHE_CAPACITY,
             )),
             pull_request_budget: KeyedRateLimiter::new(

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -80,7 +80,7 @@ use {
         iter::repeat,
         net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, UdpSocket},
         num::NonZeroUsize,
-        ops::Div,
+        ops::{Div, Range},
         path::{Path, PathBuf},
         rc::Rc,
         result::Result,
@@ -120,8 +120,9 @@ const CHANNEL_CONSUME_CAPACITY: usize = 1024;
 /// of `MAX_GOSSIP_TRAFFIC` (103,896).
 pub(crate) const GOSSIP_CHANNEL_CAPACITY: usize = 4096; // 2^12
 const GOSSIP_PING_CACHE_CAPACITY: usize = 126976;
-const GOSSIP_PING_CACHE_TTL: Duration = Duration::from_secs(1280);
-const GOSSIP_PING_CACHE_RATE_LIMIT_DELAY: Duration = Duration::from_secs(1280 / 64);
+pub(crate) const GOSSIP_PING_CACHE_TTL: Duration = Duration::from_secs(1280);
+/// Per-entry Pong wait timeout is drawn uniformly from this range (in milliseconds).
+pub(crate) const GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS: Range<u64> = 1_000..2_000;
 // Per-IP scan budget for incoming pull requests; validators are assumed not
 // to share IPs. Mirrors the ping-pong cache capacity.
 const GOSSIP_PULL_SCAN_BUDGET_CACHE_CAPACITY: usize = GOSSIP_PING_CACHE_CAPACITY;
@@ -211,7 +212,7 @@ impl ClusterInfo {
             my_contact_info: RwLock::new(contact_info),
             ping_cache: Mutex::new(PingCache::new(
                 GOSSIP_PING_CACHE_TTL,
-                GOSSIP_PING_CACHE_RATE_LIMIT_DELAY,
+                GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
                 GOSSIP_PING_CACHE_CAPACITY,
             )),
             pull_request_budget: KeyedRateLimiter::new(

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -392,7 +392,12 @@ pub(crate) fn maybe_ping_gossip_addresses<R: Rng + CryptoRng>(
 #[cfg(test)]
 mod test {
     use {
-        super::*, crate::contact_info::ContactInfo, solana_sha256_hasher::hash,
+        super::*,
+        crate::{
+            cluster_info::{GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS, GOSSIP_PING_CACHE_TTL},
+            contact_info::ContactInfo,
+        },
+        solana_sha256_hasher::hash,
         solana_time_utils::timestamp,
     };
 
@@ -414,9 +419,9 @@ mod test {
             )
             .unwrap();
         let ping_cache = PingCache::new(
-            Duration::from_secs(20 * 60),      // ttl
-            Duration::from_secs(20 * 60) / 64, // rate_limit_delay
-            128,                               // capacity
+            GOSSIP_PING_CACHE_TTL,
+            GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
+            128, // capacity (small for tests)
         );
         let ping_cache = Mutex::new(ping_cache);
         crds_gossip.refresh_push_active_set(

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -394,7 +394,12 @@ pub(crate) fn maybe_ping_gossip_addresses<R: Rng + CryptoRng>(
 #[cfg(test)]
 mod test {
     use {
-        super::*, crate::contact_info::ContactInfo, solana_sha256_hasher::hash,
+        super::*,
+        crate::{
+            cluster_info::{GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS, GOSSIP_PING_CACHE_TTL},
+            contact_info::ContactInfo,
+        },
+        solana_sha256_hasher::hash,
         solana_time_utils::timestamp,
     };
 
@@ -416,9 +421,9 @@ mod test {
             )
             .unwrap();
         let ping_cache = PingCache::new(
-            Duration::from_secs(20 * 60),      // ttl
-            Duration::from_secs(20 * 60) / 64, // rate_limit_delay
-            128,                               // capacity
+            GOSSIP_PING_CACHE_TTL,
+            GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
+            128, // capacity (small for tests)
         );
         let ping_cache = Mutex::new(ping_cache);
         crds_gossip.refresh_push_active_set(

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -683,7 +683,11 @@ pub(crate) fn get_max_bloom_filter_bytes(caller: &CrdsValue) -> usize {
 pub(crate) mod tests {
     use {
         super::*,
-        crate::{crds_data::CrdsData, protocol::Protocol},
+        crate::{
+            cluster_info::{GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS, GOSSIP_PING_CACHE_TTL},
+            crds_data::CrdsData,
+            protocol::Protocol,
+        },
         itertools::Itertools,
         rand::{SeedableRng, prelude::IndexedRandom as _},
         rand_chacha::ChaChaRng,
@@ -754,9 +758,9 @@ pub(crate) mod tests {
 
     fn new_ping_cache() -> PingCache {
         PingCache::new(
-            Duration::from_secs(20 * 60),      // ttl
-            Duration::from_secs(20 * 60) / 64, // rate_limit_delay
-            128,                               // capacity
+            GOSSIP_PING_CACHE_TTL,
+            GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
+            128, // capacity (small for tests)
         )
     }
 

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -678,7 +678,11 @@ pub(crate) fn get_max_bloom_filter_bytes(caller: &CrdsValue) -> usize {
 pub(crate) mod tests {
     use {
         super::*,
-        crate::{crds_data::CrdsData, protocol::Protocol},
+        crate::{
+            cluster_info::{GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS, GOSSIP_PING_CACHE_TTL},
+            crds_data::CrdsData,
+            protocol::Protocol,
+        },
         itertools::Itertools,
         rand::{SeedableRng, prelude::IndexedRandom as _},
         rand_chacha::ChaChaRng,
@@ -747,9 +751,9 @@ pub(crate) mod tests {
 
     fn new_ping_cache() -> PingCache {
         PingCache::new(
-            Duration::from_secs(20 * 60),      // ttl
-            Duration::from_secs(20 * 60) / 64, // rate_limit_delay
-            128,                               // capacity
+            GOSSIP_PING_CACHE_TTL,
+            GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
+            128, // capacity (small for tests)
         )
     }
 

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -288,15 +288,19 @@ impl CrdsGossipPush {
 mod tests {
     use {
         super::*,
-        crate::{contact_info::ContactInfo, crds_data::CrdsData},
-        std::time::{Duration, Instant},
+        crate::{
+            cluster_info::{GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS, GOSSIP_PING_CACHE_TTL},
+            contact_info::ContactInfo,
+            crds_data::CrdsData,
+        },
+        std::time::Instant,
     };
 
     fn new_ping_cache() -> PingCache {
         PingCache::new(
-            Duration::from_secs(20 * 60),      // ttl
-            Duration::from_secs(20 * 60) / 64, // rate_limit_delay
-            128,                               // capacity
+            GOSSIP_PING_CACHE_TTL,
+            GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
+            128, // capacity (small for tests)
         )
     }
 

--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -1,5 +1,6 @@
 use {
     crate::cluster_info_metrics::should_report_message_signature,
+    indexmap::IndexMap,
     lazy_lru::LruCache,
     rand::{CryptoRng, Rng},
     serde::{Deserialize, Serialize},
@@ -13,6 +14,7 @@ use {
     std::{
         borrow::Cow,
         net::{IpAddr, SocketAddr},
+        ops::Range,
         time::{Duration, Instant},
     },
     wincode::{SchemaRead, SchemaWrite},
@@ -58,16 +60,24 @@ pub struct Pong {
 pub struct PingCache<const N: usize> {
     // Time-to-live of received pong messages.
     ttl: Duration,
-    // Rate limit delay to generate pings for a given address
-    rate_limit_delay: Duration,
-    // Timestamp and expected pong hash for each pinged remote node.
-    // Used for rate-limiting and pong validation.
-    pings: LruCache<(Pubkey, SocketAddr), (Instant, Hash)>,
+    // Timeout range (ms) waiting for a Pong. Randomized per-entry to stagger expiry.
+    outstanding_ping_timeout_ms: Range<u64>,
+    // Capacity for the pings store.
+    max_pings: usize,
+    // Expiry time and expected pong hash for each pinged remote node.
+    pings: IndexMap<(Pubkey, SocketAddr), (Instant, Hash)>,
     // Verified pong responses from remote nodes.
     pongs: LruCache<(Pubkey, SocketAddr), Instant>,
     // Timestamp of last ping message sent to a remote IP.
     ping_times: LruCache<IpAddr, Instant>,
 }
+
+/// max number of slots in [`PingCache::pings`] to probe when looking for a
+/// reclaimable entry for a new ping. Probing only happens once the cache is
+/// full. The chance of hitting at least one timed-out (evictable) slot is
+/// `1 - (1 - f)^MAX_PING_PROBES`, where `f` is the fraction of entries that
+/// have timed out. E.g. with `f = 0.5` that is `1 - 0.5^8` ~ 99.6%.
+const MAX_PING_PROBES: usize = 8;
 
 impl<const N: usize> Ping<N> {
     pub fn new(token: [u8; N], keypair: &Keypair) -> Self {
@@ -156,15 +166,23 @@ impl Signable for Pong {
 }
 
 impl<const N: usize> PingCache<N> {
-    pub fn new(ttl: Duration, rate_limit_delay: Duration, cap: usize) -> Self {
-        // Sanity check ttl/rate_limit_delay
-        assert!(rate_limit_delay <= ttl / 2);
+    pub fn new(ttl: Duration, outstanding_ping_timeout_ms: Range<u64>, max_pings: usize) -> Self {
+        assert!(
+            outstanding_ping_timeout_ms.start < outstanding_ping_timeout_ms.end,
+            "outstanding_ping_timeout_ms must be non-empty"
+        );
+        assert!(
+            outstanding_ping_timeout_ms.end <= (ttl / 2).as_millis() as u64,
+            "outstanding_ping_timeout_ms.end must be <= ttl/2"
+        );
+        assert!(max_pings > 0, "Must cache nonzero amount of hosts");
         Self {
             ttl,
-            rate_limit_delay,
-            pings: LruCache::new(cap),
-            pongs: LruCache::new(cap),
-            ping_times: LruCache::new(cap),
+            outstanding_ping_timeout_ms,
+            max_pings,
+            pings: IndexMap::with_capacity(max_pings),
+            pongs: LruCache::new(max_pings),
+            ping_times: LruCache::new(max_pings),
         }
     }
 
@@ -173,10 +191,18 @@ impl<const N: usize> PingCache<N> {
     /// Note: Does not verify the signature.
     pub fn add(&mut self, pong: &Pong, socket: SocketAddr, now: Instant) -> bool {
         let remote_node = (pong.pubkey(), socket);
-        if !matches!(self.pings.peek(&remote_node), Some((_, h)) if *h == pong.hash) {
+        // We can not just pop an entry from self.pings based on remote_node
+        // contents - that value is attacker controlled and could invalidate an
+        // in-flight ping.
+        let Some((index, _, (_timeout, hash))) = self.pings.get_full(&remote_node) else {
             return false;
         };
-        self.pings.pop(&remote_node);
+        // check only hash, a late Pong is still perfectly valid.
+        if *hash != pong.hash {
+            return false;
+        }
+        // at this point we are certain the pong is valid.
+        self.pings.swap_remove_index(index);
         self.pongs.put(remote_node, now);
         if let Some(sent_time) = self.ping_times.pop(&socket.ip())
             && should_report_message_signature(
@@ -204,12 +230,39 @@ impl<const N: usize> PingCache<N> {
         now: Instant,
         remote_node: (Pubkey, SocketAddr),
     ) -> Option<Ping<N>> {
-        // Rate limit consecutive pings sent to a remote node.
-        if matches!(self.pings.peek(&remote_node),
-            Some((t, _)) if now.saturating_duration_since(*t) < self.rate_limit_delay)
-        {
-            return None;
+        // If the existing ping is still in-flight don't send another one.
+        let is_new_key = if let Some((expiry, _)) = self.pings.get(&remote_node) {
+            if now < *expiry {
+                return None;
+            }
+            false // existing entry will be updated in-place
+        } else {
+            true // no entry for this node yet
+        };
+
+        // If this is a new entry and the pings store is at capacity,
+        // probe random existing entries and evict the first timed-out one
+        // (expiry in the past, peer never responded).
+        // Decline if all probes are in-flight — avoids evicting challenges
+        // still awaiting a Pong.
+        if is_new_key && self.pings.len() >= self.max_pings {
+            let n = self.pings.len();
+            let mut evicted = false;
+            for _ in 0..MAX_PING_PROBES {
+                let idx = rng.random_range(0..n);
+                if let Some((_, (expiry, _))) = self.pings.get_index(idx)
+                    && now >= *expiry
+                {
+                    self.pings.swap_remove_index(idx);
+                    evicted = true;
+                    break;
+                }
+            }
+            if !evicted {
+                return None;
+            }
         }
+
         let token = {
             let mut token = [0u8; N];
             const FILL: usize = std::mem::size_of::<u64>();
@@ -220,9 +273,14 @@ impl<const N: usize> PingCache<N> {
                 .expect("token is known to fit FILL bytes") = entropy;
             token
         };
+        // Deadline by which we expect a reply. Randomized to stagger expiries across entries.
+        let expiry = now
+            + Duration::from_millis(rng.random_range(
+                self.outstanding_ping_timeout_ms.start..self.outstanding_ping_timeout_ms.end,
+            ));
         // The hash we expect to see in the Pong message
         let ping_hash = hash_ping_token(&token);
-        self.pings.put(remote_node, (now, ping_hash));
+        self.pings.insert(remote_node, (expiry, ping_hash));
         self.ping_times.put(remote_node.1.ip(), Instant::now());
         Some(Ping::new(token, keypair))
     }
@@ -277,6 +335,9 @@ fn hash_ping_token<const N: usize>(token: &[u8; N]) -> Hash {
 mod tests {
     use {
         super::*,
+        crate::cluster_info::{
+            GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS, GOSSIP_PING_CACHE_TTL,
+        },
         std::{
             collections::HashSet,
             iter::repeat_with,
@@ -307,7 +368,8 @@ mod tests {
         let mut rng = rand::rng();
         let ttl = Duration::from_millis(256);
         let delay = ttl / 64;
-        let mut cache = PingCache::new(ttl, delay, /*cap=*/ 1000);
+        let delay_ms = delay.as_millis() as u64;
+        let mut cache = PingCache::new(ttl, delay_ms..delay_ms + 1, /*cap=*/ 1000);
         let this_node = Keypair::new();
         let sockets: Vec<_> = (1u8..=3)
             .map(|i| {
@@ -466,16 +528,125 @@ mod tests {
     }
 
     #[test]
+    fn test_ping_cache_full_no_stale() {
+        // Verify that when the pings cache is at capacity and all entries are
+        // fresh, new pings are declined rather than evicting in-flight ones.
+        let mut rng = rand::rng();
+        let this_node = Keypair::new();
+        let cap = 3usize;
+        let mut cache = PingCache::<32>::new(
+            GOSSIP_PING_CACHE_TTL,
+            GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
+            cap,
+        );
+        let sockets: Vec<SocketAddr> = (1u8..=4)
+            .map(|i| SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(i, i, i, i), 8000)))
+            .collect();
+        let keypairs: Vec<Keypair> = (0..4).map(|_| Keypair::new()).collect();
+
+        // Fill cache to capacity (3 entries)
+        let mut pings = Vec::new();
+        for i in 0..cap {
+            let node = (keypairs[i].pubkey(), sockets[i]);
+            let (check, ping) = cache.check(&mut rng, &this_node, Instant::now(), node);
+            assert!(!check, "No pong yet, check should be false");
+            assert!(ping.is_some(), "Should issue ping for entry {i}");
+            pings.push((i, ping.unwrap()));
+        }
+        assert_eq!(cache.pings.len(), cap, "Cache should be at capacity");
+
+        // 4th new node must be declined — cache full, no stale entries
+        let node4 = (keypairs[3].pubkey(), sockets[3]);
+        let (check, ping) = cache.check(&mut rng, &this_node, Instant::now(), node4);
+        assert!(!check, "No pong, check should be false");
+        assert!(
+            ping.is_none(),
+            "Must decline new ping when cache is full and no stale entries"
+        );
+
+        // Complete handshake for node 0 — frees one slot
+        let (idx0, ping0) = &pings[0];
+        let pong0 = Pong::new(ping0, &keypairs[*idx0]);
+        assert!(
+            cache.add(&pong0, sockets[0], Instant::now()),
+            "Valid pong should be accepted"
+        );
+        assert_eq!(
+            cache.pings.len(),
+            cap - 1,
+            "One slot should have been freed"
+        );
+
+        // Now 4th node should get a ping
+        let (check, ping) = cache.check(&mut rng, &this_node, Instant::now(), node4);
+        assert!(!check, "No pong for node4 yet");
+        assert!(
+            ping.is_some(),
+            "Should issue ping for node4 after slot freed"
+        );
+    }
+
+    #[test]
+    fn test_ping_cache_full_with_stale() {
+        // Verify that when the pings cache is at capacity and entries are timed
+        // out (age >= outstanding_ping_timeout, peer never responded), a new
+        // ping reclaims a stale slot.
+        let mut rng = rand::rng();
+        let this_node = Keypair::new();
+        let cap = 3usize;
+        let mut cache = PingCache::<32>::new(
+            GOSSIP_PING_CACHE_TTL,
+            GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
+            cap,
+        );
+        let sockets: Vec<SocketAddr> = (1u8..=4)
+            .map(|i| SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(i, i, i, i), 8000)))
+            .collect();
+        let keypairs: Vec<Keypair> = (0..4).map(|_| Keypair::new()).collect();
+        let now = Instant::now();
+
+        // Fill cache to capacity with nodes that won't answer pongs
+        for i in 0..cap {
+            let node = (keypairs[i].pubkey(), sockets[i]);
+            let (_, ping) = cache.check(&mut rng, &this_node, now, node);
+            assert!(ping.is_some(), "Should issue ping for entry {i}");
+        }
+        assert_eq!(cache.pings.len(), cap, "Cache should be at capacity");
+
+        // Advance time so all in-flight pings are now stale
+        let expired =
+            now + Duration::from_millis(GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS.end + 1);
+
+        // 4th node should get a ping by reclaiming a stale slot
+        let node4 = (keypairs[3].pubkey(), sockets[3]);
+        // The 8-probe eviction is normally probabilistic; but with all entries
+        // stale, we expect it to always succeed.
+        let (check, ping) = cache.check(&mut rng, &this_node, expired, node4);
+        assert!(!check, "No pong for node4");
+        assert!(
+            ping.is_some(),
+            "Should issue ping for node4 by reclaiming a stale entry"
+        );
+        assert_eq!(
+            cache.pings.len(),
+            cap,
+            "Net size unchanged: one evicted, one inserted"
+        );
+    }
+
+    #[test]
     fn test_expired_pong_returns_check_false() {
         let mut rng = rand::rng();
         let this_node = Keypair::new();
         let remote_socket = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 10, 10, 10), 8000));
         let remote_node_keypair = Keypair::new();
         let remote_node = (remote_node_keypair.pubkey(), remote_socket);
-        let ttl = Duration::from_secs(20 * 60); // 20 minutes
-        let delay = ttl / 64;
         let mut now = Instant::now();
-        let mut cache = PingCache::<32>::new(ttl, delay, /*cap=*/ 1000);
+        let mut cache = PingCache::<32>::new(
+            GOSSIP_PING_CACHE_TTL,
+            GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
+            /*cap=*/ 1000,
+        );
 
         // Add a pong for the remote node
         cache.mock_pong(remote_node.0, remote_node.1, now);
@@ -486,7 +657,7 @@ mod tests {
         assert!(ping.is_none(), "Should not generate ping for recent pong");
 
         // Advance time past TTL to expire the pong
-        now = now + ttl + Duration::from_secs(1);
+        now = now + GOSSIP_PING_CACHE_TTL + Duration::from_secs(1);
 
         // After expiration, check should return false but should_ping should be true (to re-verify)
         let (check, ping) = cache.check(&mut rng, &this_node, now, remote_node);

--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -1,5 +1,6 @@
 use {
     crate::cluster_info_metrics::should_report_message_signature,
+    indexmap::IndexMap,
     lazy_lru::LruCache,
     rand::{CryptoRng, Rng},
     serde::{Deserialize, Serialize},
@@ -13,6 +14,7 @@ use {
     std::{
         borrow::Cow,
         net::{IpAddr, SocketAddr},
+        ops::Range,
         time::{Duration, Instant},
     },
     wincode::{SchemaRead, SchemaWrite},
@@ -58,16 +60,22 @@ pub struct Pong {
 pub struct PingCache<const N: usize> {
     // Time-to-live of received pong messages.
     ttl: Duration,
-    // Rate limit delay to generate pings for a given address
-    rate_limit_delay: Duration,
-    // Timestamp and expected pong hash for each pinged remote node.
-    // Used for rate-limiting and pong validation.
-    pings: LruCache<(Pubkey, SocketAddr), (Instant, Hash)>,
+    // Timeout range (ms) waiting for a Pong. Randomized per-entry to stagger expiry.
+    outstanding_ping_timeout_ms: Range<u64>,
+    // Capacity for the pings store.
+    max_pings: usize,
+    // Expiry time and expected pong hash for each pinged remote node.
+    pings: IndexMap<(Pubkey, SocketAddr), (Instant, Hash)>,
     // Verified pong responses from remote nodes.
     pongs: LruCache<(Pubkey, SocketAddr), Instant>,
     // Timestamp of last ping message sent to a remote IP.
     ping_times: LruCache<IpAddr, Instant>,
 }
+
+/// max number of slots in [`PingCache::pings`] to check when looking for
+/// a free entry for a new ping probe.
+/// Gives ~90% success rate for a cache that is half full: 0.5^(1/8) ~ 0.917
+const MAX_PING_PROBES: usize = 8;
 
 impl<const N: usize> Ping<N> {
     pub fn new(token: [u8; N], keypair: &Keypair) -> Self {
@@ -156,15 +164,23 @@ impl Signable for Pong {
 }
 
 impl<const N: usize> PingCache<N> {
-    pub fn new(ttl: Duration, rate_limit_delay: Duration, cap: usize) -> Self {
-        // Sanity check ttl/rate_limit_delay
-        assert!(rate_limit_delay <= ttl / 2);
+    pub fn new(ttl: Duration, outstanding_ping_timeout_ms: Range<u64>, max_pings: usize) -> Self {
+        assert!(
+            outstanding_ping_timeout_ms.start < outstanding_ping_timeout_ms.end,
+            "outstanding_ping_timeout_ms must be non-empty"
+        );
+        assert!(
+            outstanding_ping_timeout_ms.end <= (ttl / 2).as_millis() as u64,
+            "outstanding_ping_timeout_ms.end must be <= ttl/2"
+        );
+        assert!(max_pings > 0, "Must cache nonzero amount of hosts");
         Self {
             ttl,
-            rate_limit_delay,
-            pings: LruCache::new(cap),
-            pongs: LruCache::new(cap),
-            ping_times: LruCache::new(cap),
+            outstanding_ping_timeout_ms,
+            max_pings,
+            pings: IndexMap::with_capacity(max_pings),
+            pongs: LruCache::new(max_pings),
+            ping_times: LruCache::new(max_pings),
         }
     }
 
@@ -173,10 +189,10 @@ impl<const N: usize> PingCache<N> {
     /// Note: Does not verify the signature.
     pub fn add(&mut self, pong: &Pong, socket: SocketAddr, now: Instant) -> bool {
         let remote_node = (pong.pubkey(), socket);
-        if !matches!(self.pings.peek(&remote_node), Some((_, h)) if *h == pong.hash) {
+        if !matches!(self.pings.get(&remote_node), Some((_, h)) if *h == pong.hash) {
             return false;
         };
-        self.pings.pop(&remote_node);
+        self.pings.swap_remove(&remote_node);
         self.pongs.put(remote_node, now);
         if let Some(sent_time) = self.ping_times.pop(&socket.ip())
             && should_report_message_signature(
@@ -204,12 +220,39 @@ impl<const N: usize> PingCache<N> {
         now: Instant,
         remote_node: (Pubkey, SocketAddr),
     ) -> Option<Ping<N>> {
-        // Rate limit consecutive pings sent to a remote node.
-        if matches!(self.pings.peek(&remote_node),
-            Some((t, _)) if now.saturating_duration_since(*t) < self.rate_limit_delay)
-        {
-            return None;
+        // If the existing ping is still in-flight don't send another one.
+        let is_new_key = if let Some((expiry, _)) = self.pings.get(&remote_node) {
+            if now < *expiry {
+                return None;
+            }
+            false // existing entry will be updated in-place
+        } else {
+            true // no entry for this node yet
+        };
+
+        // If this is a new entry and the pings store is at capacity,
+        // probe random existing entries and evict the first timed-out one
+        // (expiry in the past, peer never responded).
+        // Decline if all probes are in-flight — avoids evicting challenges
+        // still awaiting a Pong.
+        if is_new_key && self.pings.len() >= self.max_pings {
+            let n = self.pings.len();
+            let mut evicted = false;
+            for _ in 0..MAX_PING_PROBES {
+                let idx = rng.random_range(0..n);
+                if let Some((_, (expiry, _))) = self.pings.get_index(idx) {
+                    if now >= *expiry {
+                        self.pings.swap_remove_index(idx);
+                        evicted = true;
+                        break;
+                    }
+                }
+            }
+            if !evicted {
+                return None;
+            }
         }
+
         let token = {
             let mut token = [0u8; N];
             const FILL: usize = std::mem::size_of::<u64>();
@@ -220,9 +263,14 @@ impl<const N: usize> PingCache<N> {
                 .expect("token is known to fit FILL bytes") = entropy;
             token
         };
+        // Deadline by which we expect a reply. Randomized to stagger expiries across entries.
+        let expiry = now
+            + Duration::from_millis(rng.random_range(
+                self.outstanding_ping_timeout_ms.start..self.outstanding_ping_timeout_ms.end,
+            ));
         // The hash we expect to see in the Pong message
         let ping_hash = hash_ping_token(&token);
-        self.pings.put(remote_node, (now, ping_hash));
+        self.pings.insert(remote_node, (expiry, ping_hash));
         self.ping_times.put(remote_node.1.ip(), Instant::now());
         Some(Ping::new(token, keypair))
     }
@@ -277,6 +325,9 @@ fn hash_ping_token<const N: usize>(token: &[u8; N]) -> Hash {
 mod tests {
     use {
         super::*,
+        crate::cluster_info::{
+            GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS, GOSSIP_PING_CACHE_TTL,
+        },
         std::{
             collections::HashSet,
             iter::repeat_with,
@@ -307,7 +358,8 @@ mod tests {
         let mut rng = rand::rng();
         let ttl = Duration::from_millis(256);
         let delay = ttl / 64;
-        let mut cache = PingCache::new(ttl, delay, /*cap=*/ 1000);
+        let delay_ms = delay.as_millis() as u64;
+        let mut cache = PingCache::new(ttl, delay_ms..delay_ms + 1, /*cap=*/ 1000);
         let this_node = Keypair::new();
         let sockets: Vec<_> = (1u8..=3)
             .map(|i| {
@@ -466,16 +518,125 @@ mod tests {
     }
 
     #[test]
+    fn test_ping_cache_full_no_stale() {
+        // Verify that when the pings cache is at capacity and all entries are
+        // fresh, new pings are declined rather than evicting in-flight ones.
+        let mut rng = rand::rng();
+        let this_node = Keypair::new();
+        let cap = 3usize;
+        let mut cache = PingCache::<32>::new(
+            GOSSIP_PING_CACHE_TTL,
+            GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
+            cap,
+        );
+        let sockets: Vec<SocketAddr> = (1u8..=4)
+            .map(|i| SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(i, i, i, i), 8000)))
+            .collect();
+        let keypairs: Vec<Keypair> = (0..4).map(|_| Keypair::new()).collect();
+
+        // Fill cache to capacity (3 entries)
+        let mut pings = Vec::new();
+        for i in 0..cap {
+            let node = (keypairs[i].pubkey(), sockets[i]);
+            let (check, ping) = cache.check(&mut rng, &this_node, Instant::now(), node);
+            assert!(!check, "No pong yet, check should be false");
+            assert!(ping.is_some(), "Should issue ping for entry {i}");
+            pings.push((i, ping.unwrap()));
+        }
+        assert_eq!(cache.pings.len(), cap, "Cache should be at capacity");
+
+        // 4th new node must be declined — cache full, no stale entries
+        let node4 = (keypairs[3].pubkey(), sockets[3]);
+        let (check, ping) = cache.check(&mut rng, &this_node, Instant::now(), node4);
+        assert!(!check, "No pong, check should be false");
+        assert!(
+            ping.is_none(),
+            "Must decline new ping when cache is full and no stale entries"
+        );
+
+        // Complete handshake for node 0 — frees one slot
+        let (idx0, ping0) = &pings[0];
+        let pong0 = Pong::new(ping0, &keypairs[*idx0]);
+        assert!(
+            cache.add(&pong0, sockets[0], Instant::now()),
+            "Valid pong should be accepted"
+        );
+        assert_eq!(
+            cache.pings.len(),
+            cap - 1,
+            "One slot should have been freed"
+        );
+
+        // Now 4th node should get a ping
+        let (check, ping) = cache.check(&mut rng, &this_node, Instant::now(), node4);
+        assert!(!check, "No pong for node4 yet");
+        assert!(
+            ping.is_some(),
+            "Should issue ping for node4 after slot freed"
+        );
+    }
+
+    #[test]
+    fn test_ping_cache_full_with_stale() {
+        // Verify that when the pings cache is at capacity and entries are timed
+        // out (age >= outstanding_ping_timeout, peer never responded), a new
+        // ping reclaims a stale slot.
+        let mut rng = rand::rng();
+        let this_node = Keypair::new();
+        let cap = 3usize;
+        let mut cache = PingCache::<32>::new(
+            GOSSIP_PING_CACHE_TTL,
+            GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
+            cap,
+        );
+        let sockets: Vec<SocketAddr> = (1u8..=4)
+            .map(|i| SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(i, i, i, i), 8000)))
+            .collect();
+        let keypairs: Vec<Keypair> = (0..4).map(|_| Keypair::new()).collect();
+        let now = Instant::now();
+
+        // Fill cache to capacity with nodes that won't answer pongs
+        for i in 0..cap {
+            let node = (keypairs[i].pubkey(), sockets[i]);
+            let (_, ping) = cache.check(&mut rng, &this_node, now, node);
+            assert!(ping.is_some(), "Should issue ping for entry {i}");
+        }
+        assert_eq!(cache.pings.len(), cap, "Cache should be at capacity");
+
+        // Advance time so all in-flight pings are now stale
+        let expired =
+            now + Duration::from_millis(GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS.end + 1);
+
+        // 4th node should get a ping by reclaiming a stale slot
+        let node4 = (keypairs[3].pubkey(), sockets[3]);
+        // The 4-probe eviction is normally probabilistic; but with all entries
+        // stale, we expect it to always succeed.
+        let (check, ping) = cache.check(&mut rng, &this_node, expired, node4);
+        assert!(!check, "No pong for node4");
+        assert!(
+            ping.is_some(),
+            "Should issue ping for node4 by reclaiming a stale entry"
+        );
+        assert_eq!(
+            cache.pings.len(),
+            cap,
+            "Net size unchanged: one evicted, one inserted"
+        );
+    }
+
+    #[test]
     fn test_expired_pong_returns_check_false() {
         let mut rng = rand::rng();
         let this_node = Keypair::new();
         let remote_socket = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 10, 10, 10), 8000));
         let remote_node_keypair = Keypair::new();
         let remote_node = (remote_node_keypair.pubkey(), remote_socket);
-        let ttl = Duration::from_secs(20 * 60); // 20 minutes
-        let delay = ttl / 64;
         let mut now = Instant::now();
-        let mut cache = PingCache::<32>::new(ttl, delay, /*cap=*/ 1000);
+        let mut cache = PingCache::<32>::new(
+            GOSSIP_PING_CACHE_TTL,
+            GOSSIP_PING_CACHE_OUTSTANDING_PING_TIMEOUT_MS,
+            /*cap=*/ 1000,
+        );
 
         // Add a pong for the remote node
         cache.mock_pong(remote_node.0, remote_node.1, now);
@@ -486,7 +647,7 @@ mod tests {
         assert!(ping.is_none(), "Should not generate ping for recent pong");
 
         // Advance time past TTL to expire the pong
-        now = now + ttl + Duration::from_secs(1);
+        now = now + GOSSIP_PING_CACHE_TTL + Duration::from_secs(1);
 
         // After expiration, check should return false but should_ping should be true (to re-verify)
         let (check, ping) = cache.check(&mut rng, &this_node, now, remote_node);

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -661,9 +661,9 @@ fn build_gossip_thread_pool() -> ThreadPool {
 
 fn new_ping_cache() -> Mutex<PingCache> {
     let ping_cache = PingCache::new(
-        Duration::from_secs(20 * 60),      // ttl
-        Duration::from_secs(20 * 60) / 64, // rate_limit_delay
-        2048,                              // capacity
+        Duration::from_secs(20 * 60),
+        1000..2000,
+        2048, // capacity
     );
     Mutex::new(ping_cache)
 }

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -662,9 +662,9 @@ fn build_gossip_thread_pool() -> ThreadPool {
 
 fn new_ping_cache() -> Mutex<PingCache> {
     let ping_cache = PingCache::new(
-        Duration::from_secs(20 * 60),      // ttl
-        Duration::from_secs(20 * 60) / 64, // rate_limit_delay
-        2048,                              // capacity
+        Duration::from_secs(20 * 60),
+        1000..2000,
+        2048, // capacity
     );
     Mutex::new(ping_cache)
 }


### PR DESCRIPTION


#### Problem
PR #12585 made Pong validation stateful: the pings LRU can be replaced with an IndexMap.

The pongs and ping_times LRUs are unchanged.

#### Summary of Changes


On insertion when at cap, probe 4 random existing
entries; evict the first one whose age >= ttl (peer never responded in time). If all 4 probes are fresh, decline to send a new ping rather than evicting an in-flight challenge. Stale entries (unresponsive or attacker nodes) are thus reclaimed on demand without touching fresh ones.

The pongs and ping_times LRUs are unchanged.