### PR TITLE
Marks zero lamport single ref accounts in newly shrunk storages

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -258,4 +258,8 @@ impl AccountStorageEntry {
     pub(crate) fn obsolete_accounts(&self) -> &RwLock<ObsoleteAccounts> {
         &self.obsolete_accounts
     }
+
+    pub(crate) fn zero_lamport_single_ref_offsets(&self) -> &RwLock<IntSet<Offset>> {
+        &self.zero_lamport_single_ref_offsets
+    }
 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2684,6 +2684,7 @@ impl AccountsDb {
 
     /// These accounts were found during shrink of `slot` to be slot_list=[slot] and ref_count == 1 and lamports = 0.
     /// This means this slot contained the only account data for this pubkey and it is zero lamport.
+    /// And also `slot` is <= the latest full snapshot slot, and can purge zero lamport accounts.
     /// Thus, we did NOT treat this as an alive account, so we did NOT copy the zero lamport account to the new
     /// storage. So, the account will no longer be alive or exist at `slot`.
     /// So, first, remove the ref count since this newly shrunk storage will no longer access it.
@@ -5268,7 +5269,7 @@ impl AccountsDb {
     /// not touched, since shrink only changes `(store_id, offset)` and they index by pubkey.
     fn update_index_for_shrink<'a>(
         &self,
-        infos: Vec<AccountInfo>,
+        infos: &[AccountInfo],
         accounts: &impl StorableAccounts<'a>,
         update_index_thread_selection: UpdateIndexThreadSelection,
         thread_pool: &ThreadPool,
@@ -5729,9 +5730,14 @@ impl AccountsDb {
         let infos = self.write_accounts_to_storage(slot, storage, &accounts);
         let write_accounts_us = write_accounts_time.end_as_us();
 
+        let mark_zero_lamport_single_ref_time = Measure::start("mark_zero_lamport_single_ref");
+        let num_zero_lamport_single_ref_accounts_marked =
+            self.mark_zero_lamport_single_ref_accounts_for_shrink(&infos, &accounts, storage);
+        let mark_zero_lamport_single_ref_us = mark_zero_lamport_single_ref_time.end_as_us();
+
         let update_index_time = Measure::start("update_index");
         self.update_index_for_shrink(
-            infos,
+            &infos,
             &accounts,
             update_index_thread_selection,
             &self.thread_pool_background,
@@ -5745,11 +5751,18 @@ impl AccountsDb {
             .write_to_storage_us
             .fetch_add(write_accounts_us, Ordering::Relaxed);
         stats
+            .mark_zero_lamport_single_ref_accounts_us
+            .fetch_add(mark_zero_lamport_single_ref_us, Ordering::Relaxed);
+        stats
             .update_index_us
             .fetch_add(update_index_us, Ordering::Relaxed);
         stats
             .num_accounts_stored
             .fetch_add(num_accounts_stored as u64, Ordering::Relaxed);
+        stats.num_zero_lamport_single_ref_accounts_marked.fetch_add(
+            num_zero_lamport_single_ref_accounts_marked,
+            Ordering::Relaxed,
+        );
         stats.report();
 
         StoreAccountsTiming {
@@ -6026,6 +6039,39 @@ impl AccountsDb {
             }
         }
 
+        num_marked
+    }
+
+    /// Marks zero lamport single reference accounts in the storage during store_accounts_for_shrink
+    ///
+    /// Returns the number of accounts marked.
+    fn mark_zero_lamport_single_ref_accounts_for_shrink<'a>(
+        &self,
+        account_infos: &[AccountInfo],
+        accounts: &impl StorableAccounts<'a>,
+        storage: &AccountStorageEntry,
+    ) -> u64 {
+        debug_assert_eq!(account_infos.len(), accounts.len());
+        let mut num_marked = 0;
+        for (i, account_info) in account_infos.iter().enumerate() {
+            if account_info.is_zero_lamport() {
+                let pubkey = accounts.pubkey(i);
+                let is_single_ref = self.accounts_index.get_and_then(pubkey, |entry| {
+                    let is_single_ref = entry.is_some_and(|entry| {
+                        entry.ref_count() == 1 && entry.slot_list_lock_read_len() == 1
+                    });
+                    (false, is_single_ref)
+                });
+                if is_single_ref {
+                    debug_assert!(!account_info.is_cached());
+                    debug_assert_eq!(account_info.store_id(), storage.id());
+                    if storage.insert_zero_lamport_single_ref_account_offset(account_info.offset())
+                    {
+                        num_marked += 1;
+                    }
+                }
+            }
+        }
         num_marked
     }
 

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -107,8 +107,10 @@ pub struct StoreAccountsForShrinkStats {
     pub last_report: AtomicInterval,
     pub flush_read_cache_us: AtomicU64,
     pub write_to_storage_us: AtomicU64,
+    pub mark_zero_lamport_single_ref_accounts_us: AtomicU64,
     pub update_index_us: AtomicU64,
     pub num_accounts_stored: AtomicU64,
+    pub num_zero_lamport_single_ref_accounts_marked: AtomicU64,
 }
 
 impl StoreAccountsForShrinkStats {
@@ -133,6 +135,12 @@ impl StoreAccountsForShrinkStats {
                 i64
             ),
             (
+                "mark_zero_lamport_single_ref_accounts_us",
+                self.mark_zero_lamport_single_ref_accounts_us
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
                 "update_index_us",
                 self.update_index_us.swap(0, Ordering::Relaxed),
                 i64
@@ -140,6 +148,12 @@ impl StoreAccountsForShrinkStats {
             (
                 "num_accounts_stored",
                 self.num_accounts_stored.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "num_zero_lamport_single_ref_accounts_marked",
+                self.num_zero_lamport_single_ref_accounts_marked
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
         );

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1165,6 +1165,134 @@ fn test_shrink_zero_lamport_single_ref_account() {
     }
 }
 
+/// Ensure that `shrink` marks zero lamport single ref accounts in the new storage.
+#[test]
+fn test_shrink_marks_zero_lamport_single_ref_account_in_new_storage() {
+    let accounts_db = AccountsDb::new_single_for_tests();
+    let slot0 = 0;
+    let slot1 = slot0 + 1;
+    // latest full snapshot must be older than the slot(s) we plan to shrink,
+    // otherwise zero lamport single ref accounts will be purged
+    accounts_db.set_latest_full_snapshot_slot(slot0);
+
+    let obsolete_pubkey = Pubkey::new_unique();
+    let obsolete_zero_lamport_pubkey = Pubkey::new_unique();
+    let zero_lamport_single_ref_pubkey = Pubkey::new_unique();
+    let zero_lamport_multi_ref_pubkey = Pubkey::new_unique();
+    let alive_pubkey = Pubkey::new_unique();
+    let closed_account = AccountSharedData::new(0, 0, &Pubkey::default());
+    let open_account = AccountSharedData::new(1, 0, &Pubkey::default());
+
+    let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
+    let storage1 = Arc::new(AccountStorageEntry::new(
+        &paths[0],
+        slot1,
+        10,
+        DEFAULT_FILE_SIZE,
+        AccountsFileProvider::AppendVec,
+    ));
+    // store an obsolete account; it should not be marked ZLSR
+    append_single_account_with_default_hash(
+        &storage1,
+        &obsolete_pubkey,
+        &open_account,
+        true,
+        Some(&accounts_db.accounts_index),
+    );
+    // store an obsolete zero lamport account; it should not be marked ZLSR
+    append_single_account_with_default_hash(
+        &storage1,
+        &obsolete_zero_lamport_pubkey,
+        &closed_account,
+        true,
+        Some(&accounts_db.accounts_index),
+    );
+    // store a zero lamport single ref account; it *should* be marked ZLSR
+    append_single_account_with_default_hash(
+        &storage1,
+        &zero_lamport_single_ref_pubkey,
+        &closed_account,
+        true,
+        Some(&accounts_db.accounts_index),
+    );
+    // store a zero lamport multi ref account; it should not be marked ZLSR
+    append_single_account_with_default_hash(
+        &storage1,
+        &zero_lamport_multi_ref_pubkey,
+        &closed_account,
+        true,
+        Some(&accounts_db.accounts_index),
+    );
+    // store an alive account; it should not be marked ZLSR
+    append_single_account_with_default_hash(
+        &storage1,
+        &alive_pubkey,
+        &open_account,
+        true,
+        Some(&accounts_db.accounts_index),
+    );
+    insert_store(&accounts_db, Arc::clone(&storage1));
+    accounts_db.add_root(slot1);
+
+    // we manually created the storage, so nothing got marked
+    assert_eq!(storage1.num_zero_lamport_single_ref_accounts(), 0);
+
+    // store the multi ref account again, in slot 2, so it becomes multi ref
+    let slot2 = slot1 + 1;
+    accounts_db.store_for_tests((
+        slot2,
+        [(&zero_lamport_multi_ref_pubkey, &closed_account)].as_slice(),
+    ));
+    accounts_db.add_root(slot2);
+    // flush without clean so the ZLMR account isn't marked obsolete in slot 1
+    accounts_db.flush_rooted_accounts_cache_without_clean();
+
+    // mark the obsolete accounts as obsolete
+    let ancestors = Ancestors::from(vec![slot2]);
+    for pubkey in [obsolete_pubkey, obsolete_zero_lamport_pubkey] {
+        let account_info = accounts_db
+            .accounts_index
+            .get_with_and_then(&pubkey, &ancestors, false, |account_info| account_info)
+            .unwrap();
+        accounts_db.remove_dead_accounts(
+            [account_info].iter(),
+            None,
+            MarkAccountsObsolete::Yes(slot1),
+        );
+    }
+
+    accounts_db.shrink_slot_forced(slot1);
+
+    let new_storage1 = accounts_db.get_and_assert_single_storage(slot1);
+    let new_zero_lamport_single_ref_info = accounts_db
+        .accounts_index
+        .get_with_and_then(
+            &zero_lamport_single_ref_pubkey,
+            &ancestors,
+            false,
+            |(_slot, account_info)| account_info,
+        )
+        .unwrap();
+
+    // ensure ids are different, to indicate shrink ran
+    assert_ne!(new_storage1.id(), storage1.id());
+    // ensure there are three accounts in the storage now, removing the two obsolete ones
+    assert_eq!(new_storage1.count(), 3);
+    // ensure the zlsr account info has the correct id for the new shrunk storage
+    assert_eq!(
+        new_zero_lamport_single_ref_info.store_id(),
+        new_storage1.id(),
+    );
+    // ensure the new shrunk storage does have a marked zlsr account
+    assert_eq!(new_storage1.num_zero_lamport_single_ref_accounts(), 1);
+    let new_storage_zlsr_offsets = new_storage1
+        .zero_lamport_single_ref_offsets()
+        .read()
+        .unwrap();
+    // ensure the storage's zlsr offset list contains the zlsr account info's
+    assert!(new_storage_zlsr_offsets.contains(&new_zero_lamport_single_ref_info.offset()));
+}
+
 /// unit test for `alive_bytes_after_shrink()`
 ///
 /// Check all the permutations of latest full snapshot slot w.r.t. if/how


### PR DESCRIPTION
#### Problem

If a zero lamport single ref account is marked in a storage, then shrunk, all while that storage is for a slot newer than the latest full snapshot slot, then we won't re-mark the zero lamport single ref accounts in the new shrunk storage.


#### Summary of Changes

Re-mark zero lamport single ref accounts in new shrunk storages.