### PR TITLE
Fast add_root

### DIFF
--- a/accounts-db/src/ancestors.rs
+++ b/accounts-db/src/ancestors.rs
@@ -46,6 +46,10 @@ impl Ancestors {
         self.ancestors.get_all()
     }
 
+    pub fn iter(&self) -> impl Iterator<Item = Slot> + '_ {
+        self.ancestors.iter_ones()
+    }
+
     pub fn remove(&mut self, slot: &Slot) {
         self.ancestors.remove(slot);
     }
@@ -200,5 +204,17 @@ mod tests {
             );
             assert_eq!(count, count2);
         }
+    }
+
+    #[test]
+    fn test_ancestors_iter_matches_keys() {
+        let ancestors = Ancestors::from(vec![3, 42, 128_007, 128_017, 128_107]);
+
+        let mut keys = ancestors.keys();
+        let mut iter_keys = ancestors.iter().collect::<Vec<_>>();
+        keys.sort_unstable();
+        iter_keys.sort_unstable();
+
+        assert_eq!(iter_keys, keys);
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1486,11 +1486,9 @@ impl Bank {
         };
 
         let (_, ancestors_time_us) = measure_us!({
-            let mut ancestors = Vec::with_capacity(1 + new.parents().len());
+            let mut ancestors = Vec::with_capacity(parent.ancestors.len() + 1);
             ancestors.push(new.slot());
-            new.parents().iter().for_each(|p| {
-                ancestors.push(p.slot());
-            });
+            ancestors.extend(new.parents_iter().map(|parent| parent.slot()));
             new.ancestors = Ancestors::from(ancestors);
         });
 
@@ -2291,17 +2289,21 @@ impl Bank {
     }
 
     pub fn status_cache_ancestors(&self) -> Vec<u64> {
-        let mut roots = self.status_cache.read().unwrap().roots().clone();
-        let min = roots.iter().min().cloned().unwrap_or(0);
-        for ancestor in self.ancestors.keys() {
-            if ancestor >= min {
-                roots.insert(ancestor);
+        let (min, mut ancestors) = {
+            let status_cache = self.status_cache.read().unwrap();
+            let roots = status_cache.roots();
+            let mut ancestors = Vec::with_capacity(roots.len() + self.ancestors.len());
+            let mut min = Slot::MAX;
+            for root in roots {
+                ancestors.push(*root);
+                min = min.min(*root);
             }
-        }
+            (if roots.is_empty() { 0 } else { min }, ancestors)
+        };
 
-        let mut ancestors: Vec<_> = roots.into_iter().collect();
-        #[expect(clippy::stable_sort_primitive)]
-        ancestors.sort();
+        ancestors.extend(self.ancestors.iter().filter(|ancestor| *ancestor >= min));
+        ancestors.sort_unstable();
+        ancestors.dedup();
         ancestors
     }
 
@@ -3041,8 +3043,9 @@ impl Bank {
         self.freeze();
 
         //this bank and all its parents are now on the rooted path
-        let mut roots = vec![self.slot()];
-        roots.append(&mut self.parents().iter().map(|p| p.slot()).collect());
+        let mut roots = Vec::with_capacity(self.ancestors.len());
+        roots.push(self.slot());
+        roots.extend(self.parents_iter().map(|parent| parent.slot()));
 
         let mut total_index_us = 0;
         let mut total_cache_us = 0;
@@ -3059,9 +3062,10 @@ impl Bank {
         *self.rc.parent.write().unwrap() = None;
 
         let mut squash_cache_time = Measure::start("squash_cache_time");
-        roots
-            .iter()
-            .for_each(|slot| self.status_cache.write().unwrap().add_root(*slot));
+        self.status_cache
+            .write()
+            .unwrap()
+            .add_roots(roots.iter().copied());
         squash_cache_time.stop();
 
         SquashTiming {
@@ -3379,13 +3383,14 @@ impl Bank {
     pub fn confirmed_last_blockhash(&self) -> Hash {
         const NUM_BLOCKHASH_CONFIRMATIONS: usize = 3;
 
-        let parents = self.parents();
-        if parents.is_empty() {
-            self.last_blockhash()
-        } else {
-            let index = NUM_BLOCKHASH_CONFIRMATIONS.min(parents.len() - 1);
-            parents[index].last_blockhash()
+        let mut last_parent = None;
+        for (index, parent) in self.parents_iter().enumerate() {
+            if index == NUM_BLOCKHASH_CONFIRMATIONS {
+                return parent.last_blockhash();
+            }
+            last_parent = Some(parent);
         }
+        last_parent.map_or_else(|| self.last_blockhash(), |parent| parent.last_blockhash())
     }
 
     /// Forget all signatures. Useful for benchmarking.
@@ -4598,19 +4603,23 @@ impl Bank {
 
     /// Compute all the parents of the bank in order
     pub fn parents(&self) -> Vec<Arc<Bank>> {
-        let mut parents = vec![];
+        self.parents_iter().collect()
+    }
+
+    pub(crate) fn parents_iter(&self) -> impl Iterator<Item = Arc<Bank>> + '_ {
         let mut bank = self.parent();
-        while let Some(parent) = bank {
-            parents.push(parent.clone());
+        core::iter::from_fn(move || {
+            let parent = bank.take()?;
             bank = parent.parent();
-        }
-        parents
+            Some(parent)
+        })
     }
 
     /// Compute all the parents of the bank including this bank itself
     pub fn parents_inclusive(self: Arc<Self>) -> Vec<Arc<Bank>> {
-        let mut parents = self.parents();
-        parents.insert(0, self);
+        let mut parents = Vec::with_capacity(self.ancestors.len());
+        parents.push(Arc::clone(&self));
+        parents.extend(self.parents_iter());
         parents
     }
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -105,8 +105,7 @@ impl BankForks {
             BankWithScheduler::new_without_scheduler(root_bank.clone()),
         );
 
-        let parents = root_bank.parents();
-        for parent in parents {
+        for parent in root_bank.parents_iter() {
             if banks
                 .insert(
                     parent.slot(),
@@ -488,7 +487,7 @@ impl BankForks {
             }
         }
         let root_tx_count = root_bank
-            .parents()
+            .parents_iter()
             .last()
             .map(|bank| bank.transaction_count())
             .unwrap_or(0);

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -6,6 +6,7 @@ use {
     ahash::{HashMap, HashMapExt as _},
     log::*,
     serde::Serialize,
+    smallvec::SmallVec,
     solana_accounts_db::ancestors::Ancestors,
     solana_clock::{MAX_RECENT_BLOCKHASHES, Slot},
     solana_hash::Hash,
@@ -172,16 +173,10 @@ impl<T: Serialize + Clone> StatusCache<T> {
         key: K,
         ancestors: &Ancestors,
     ) -> Option<(Slot, T)> {
-        let keys: Vec<_> = self.cache.keys().copied().collect();
-
-        for blockhash in keys.iter() {
+        self.cache.keys().find_map(|blockhash| {
             trace!("get_status_any_blockhash: trying {blockhash}");
-            let status = self.get_status(&key, blockhash, ancestors);
-            if status.is_some() {
-                return status;
-            }
-        }
-        None
+            self.get_status(&key, blockhash, ancestors)
+        })
     }
 
     /// Add a known root fork.
@@ -190,6 +185,11 @@ impl<T: Serialize + Clone> StatusCache<T> {
     /// keys are cleared.
     pub fn add_root(&mut self, fork: Slot) {
         self.roots.insert(fork);
+        self.purge_roots();
+    }
+
+    pub fn add_roots<I: IntoIterator<Item = Slot>>(&mut self, forks: I) {
+        self.roots.extend(forks);
         self.purge_roots();
     }
 
@@ -239,12 +239,20 @@ impl<T: Serialize + Clone> StatusCache<T> {
     }
 
     pub fn purge_roots(&mut self) {
-        while self.roots.len() > self.max_root_entries() {
-            if let Some(min) = self.roots.iter().min().cloned() {
-                self.roots.remove(&min);
-                self.cache.retain(|_, (fork, _, _)| *fork > min);
-                self.slot_deltas.retain(|slot, _| *slot > min);
-            }
+        let max_root_entries = self.max_root_entries();
+        if self.roots.len() > max_root_entries {
+            let num_roots_to_purge = self.roots.len() - max_root_entries;
+            let mut roots = self
+                .roots
+                .iter()
+                .copied()
+                .collect::<SmallVec<[Slot; 0x200]>>();
+            let (_, cutoff, _) = roots.select_nth_unstable(num_roots_to_purge - 1);
+            let cutoff = *cutoff;
+
+            self.roots.retain(|root| *root > cutoff);
+            self.cache.retain(|_, (fork, _, _)| *fork > cutoff);
+            self.slot_deltas.retain(|slot, _| *slot > cutoff);
         }
     }
 


### PR DESCRIPTION

<img width="1478" height="511" alt="image" src="https://github.com/user-attachments/assets/bd94430f-dfd2-4c83-b853-d5ae52e3d15b" />


## Description

Speeds up status-cache/root handling on the `Bank::squash` path.

Changes:
- Build the rooted slot list by walking parent links directly instead of collecting `parents()`.
- Add all squash roots through one status-cache write lock via `add_roots`, so status-cache purge runs once per squash instead of once per root.
- Build `status_cache_ancestors` with a preallocated `Vec` plus `sort_unstable`/`dedup` instead of cloning and mutating a `HashSet`.
- Avoid the temporary blockhash-key `Vec` allocation in `get_status_any_blockhash`.
- For bulk root additions, retain the newest `MAX_CACHE_ENTRIES` roots with one cleanup pass over roots/cache/deltas.

## Benchmarks

Local `solana-runtime` benches; lower is better.

| Path | Baseline | Current | Speedup |
| --- | ---: | ---: | ---: |
| `status_cache_ancestors`, 128 ancestors | 3,270.20 ns | 1,519.41 ns | 2.15x |
| `status_cache_ancestors`, 512 ancestors | 8,239.14 ns | 4,256.28 ns | 1.94x |
| `status_cache_ancestors`, 2,048 ancestors | 10,633.82 ns | 7,236.44 ns | 1.47x |
| squash root-slot collection | 3,643.89 ns | 2,589.09 ns | 1.41x |
| `add_roots`, 8 roots | 4,517,989.50 ns | 4,301,591.00 ns | 1.05x |
| `add_roots`, 512 roots | 11,149,234.10 ns | 7,156,647.10 ns | 1.56x |
| `get_status_any_blockhash` miss | 328,597.39 ns | 326,722.56 ns | flat; removes alloc |
