### PR TITLE
ci: get repo info from BUILDKITE_REPO in xtask pipeline generator

### DIFF
--- a/ci/xtask/src/commands/generate_pipeline.rs
+++ b/ci/xtask/src/commands/generate_pipeline.rs
@@ -24,6 +24,54 @@ pub enum Pipeline {
     Private,
 }
 
+struct Repo {
+    owner: String,
+    name: String,
+}
+
+impl Repo {
+    /// Resolve the GitHub repo from Buildkite's built-in `BUILDKITE_REPO`,
+    /// falling back to the agave repo when it is unset or unparseable.
+    fn from_env() -> Self {
+        match env::var("BUILDKITE_REPO")
+            .ok()
+            .and_then(|url| Self::parse_github_url(&url))
+        {
+            Some(repo) => {
+                info!(
+                    "Resolved repo {}/{} from `BUILDKITE_REPO`",
+                    repo.owner, repo.name
+                );
+                repo
+            }
+            None => {
+                info!("Falling back to default repo anza-xyz/agave");
+                Repo {
+                    owner: String::from("anza-xyz"),
+                    name: String::from("agave"),
+                }
+            }
+        }
+    }
+
+    /// Extract `owner` and `name` from a GitHub remote URL, handling both the
+    /// HTTPS (`https://github.com/owner/name.git`) and scp-like SSH
+    /// (`git@github.com:owner/name.git`) forms.
+    fn parse_github_url(url: &str) -> Option<Self> {
+        let trimmed = url.trim().trim_end_matches('/');
+        let trimmed = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+        // Both `/` and `:` separate the path, so splitting on either yields the
+        // trailing `.../owner/name` regardless of URL flavor.
+        let mut parts = trimmed.rsplit(['/', ':']);
+        let name = parts.next().filter(|s| !s.is_empty())?;
+        let owner = parts.next().filter(|s| !s.is_empty())?;
+        Some(Repo {
+            owner: owner.to_string(),
+            name: name.to_string(),
+        })
+    }
+}
+
 pub async fn run(args: CommandArgs) -> Result<()> {
     let pipeline = match args.pipeline {
         Pipeline::Agave => generate_agave_pipeline().await?,
@@ -55,8 +103,9 @@ async fn generate_agave_pipeline() -> Result<buildkite::Pipeline> {
                 .parse::<u64>()
                 .map_err(|e| anyhow::anyhow!("failed to parse PR number: {e}"))?;
 
-            annotate_pull_request(pr_number)?;
-            return generate_pull_request_pipeline(pr_number).await;
+            let repo = Repo::from_env();
+            annotate_pull_request(&repo, pr_number)?;
+            return generate_pull_request_pipeline(&repo, pr_number).await;
         }
 
         info!("failed to get PR number from branch: {branch}, running full pipeline.");
@@ -102,7 +151,7 @@ fn generate_private_pipeline() -> Result<buildkite::Pipeline> {
     Ok(pipeline)
 }
 
-fn annotate_pull_request(pr_number: u64) -> Result<()> {
+fn annotate_pull_request(repo: &Repo, pr_number: u64) -> Result<()> {
     let is_ci = env::var("CI")
         .map(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true"))
         .unwrap_or(false);
@@ -110,8 +159,10 @@ fn annotate_pull_request(pr_number: u64) -> Result<()> {
         return Ok(());
     }
 
-    let annotation =
-        format!("Github Pull Request: https://github.com/anza-xyz/agave/pull/{pr_number}");
+    let annotation = format!(
+        "Github Pull Request: https://github.com/{}/{}/pull/{pr_number}",
+        repo.owner, repo.name
+    );
 
     let status = Command::new("buildkite-agent")
         .args([
@@ -140,7 +191,7 @@ fn generate_merge_queue_pipeline() -> Result<buildkite::Pipeline> {
     Ok(pipeline)
 }
 
-async fn get_changed_files(pr_number: u64) -> Result<Vec<String>> {
+async fn get_changed_files(repo: &Repo, pr_number: u64) -> Result<Vec<String>> {
     let mut changed_files = vec![];
     let github_client_builder = match env::var("GH_TOKEN") {
         Ok(token) if !token.trim().is_empty() => {
@@ -157,7 +208,7 @@ async fn get_changed_files(pr_number: u64) -> Result<Vec<String>> {
     };
     let github_client = github_client_builder.build()?;
     let stream = github_client
-        .pulls("anza-xyz", "agave")
+        .pulls(&repo.owner, &repo.name)
         .list_files(pr_number)
         .await?
         .into_stream(&github_client);
@@ -291,8 +342,11 @@ impl PullRequestPipelineFlags {
     }
 }
 
-pub async fn generate_pull_request_pipeline(pr_number: u64) -> Result<buildkite::Pipeline> {
-    let changed_files = get_changed_files(pr_number).await?;
+async fn generate_pull_request_pipeline(
+    repo: &Repo,
+    pr_number: u64,
+) -> Result<buildkite::Pipeline> {
+    let changed_files = get_changed_files(repo, pr_number).await?;
     let flags = PullRequestPipelineFlags::from_changed_files(&changed_files);
 
     let mut pipeline = buildkite::Pipeline::new();
@@ -679,11 +733,32 @@ fn default_trigger_secondary_step() -> buildkite::Step {
 mod tests {
     use {super::*, pretty_assertions::assert_eq};
 
+    #[test]
+    fn test_parse_github_url() {
+        for url in [
+            "https://github.com/anza-xyz/agave.git",
+            "https://github.com/anza-xyz/agave",
+            "git@github.com:anza-xyz/agave.git",
+            "git@github.com:anza-xyz/agave",
+            "ssh://git@github.com/anza-xyz/agave.git",
+            "  https://github.com/anza-xyz/agave.git/  ",
+        ] {
+            let repo =
+                Repo::parse_github_url(url).unwrap_or_else(|| panic!("failed to parse url: {url}"));
+            assert_eq!(repo.owner, "anza-xyz", "url: {url}");
+            assert_eq!(repo.name, "agave", "url: {url}");
+        }
+    }
+
     // PR 1850 is a good large PR for testing
     #[cfg_attr(not(feature = "integration-tests"), ignore = "requires github api")]
     #[tokio::test]
     async fn test_get_changed_files_for_pr_1850() {
-        let changed_files = get_changed_files(1850).await.unwrap();
+        let repo = Repo {
+            owner: String::from("anza-xyz"),
+            name: String::from("agave"),
+        };
+        let changed_files = get_changed_files(&repo, 1850).await.unwrap();
         assert_eq!(changed_files.len(), 68);
         assert!(changed_files.contains(&String::from("Cargo.lock")));
         assert!(changed_files.contains(&String::from("Cargo.toml")));


### PR DESCRIPTION
#### Problem

we currently need to update the repository owner and name in each feature fork to get it working. it's better to parse them from a known env.

#### Summary of Changes

parse those info from `BUILDKITE_REPO`