### PR TITLE
Rm connection cache tpu senders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8953,6 +8953,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-time-utils",
  "solana-tpu-client",
+ "solana-tpu-client-next",
  "solana-transaction",
  "solana-transaction-error",
  "solana-turbine",
@@ -8963,7 +8964,9 @@ dependencies = [
  "static_assertions",
  "strum",
  "tempfile",
+ "tokio",
  "tokio-util 0.7.18",
+ "wincode",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7575,6 +7575,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-time-utils",
  "solana-tpu-client",
+ "solana-tpu-client-next",
  "solana-transaction",
  "solana-transaction-error",
  "solana-turbine",
@@ -7585,7 +7586,9 @@ dependencies = [
  "static_assertions",
  "strum",
  "tempfile",
+ "tokio",
  "tokio-util 0.7.18",
+ "wincode",
 ]
 
 [[package]]

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -14,17 +14,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = [
-    "solana-core/dev-context-only-utils",
-    "agave-votor-messages/dev-context-only-utils",
-]
+dev-context-only-utils = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-logger = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-votor = { workspace = true }
-agave-votor-messages = { workspace = true }
+agave-votor-messages = { workspace = true, features = ["dev-context-only-utils"] }
 crossbeam-channel = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
@@ -37,7 +34,7 @@ solana-client-traits = { workspace = true }
 solana-clock = { workspace = true }
 solana-cluster-type = { workspace = true }
 solana-commitment-config = { workspace = true }
-solana-core = { workspace = true }
+solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-entry = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-feature-gate-interface = { workspace = true }
@@ -71,6 +68,7 @@ solana-system-interface = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-time-utils = { workspace = true }
 solana-tpu-client = { workspace = true }
+solana-tpu-client-next = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-turbine = { workspace = true }
@@ -81,7 +79,9 @@ solana-vote-program = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -11,11 +11,14 @@ use {
     solana_client::connection_cache::ConnectionCache,
     solana_clock::{self as clock, Slot},
     solana_commitment_config::CommitmentConfig,
+    solana_core::consensus::tower_storage::{
+        FileTowerStorage, SavedTower, SavedTowerVersions, TowerStorage,
+    },
     solana_entry::entry::{self, Entry, EntrySlice},
     solana_epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
     solana_gossip::{
         cluster_info::{self, ClusterInfo},
-        contact_info::ContactInfo,
+        contact_info::{ContactInfo, Protocol},
         crds::Cursor,
         crds_data::{self, CrdsData},
         crds_value::{CrdsValue, CrdsValueLabel},
@@ -25,7 +28,7 @@ use {
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::blockstore::Blockstore,
-    solana_net_utils::SocketAddrSpace,
+    solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
     solana_poh_config::PohConfig,
     solana_pubkey::Pubkey,
     solana_rpc_client::rpc_client::RpcClient,
@@ -38,6 +41,10 @@ use {
     solana_system_transaction as system_transaction,
     solana_time_utils::timestamp,
     solana_tpu_client::tpu_client::{TpuClient, TpuClientConfig, TpuSenderError},
+    solana_tpu_client_next::{
+        client_builder::{ClientBuilder, TransactionSender},
+        leader_updater::create_pinned_leader_updater,
+    },
     solana_transaction::Transaction,
     solana_transaction_error::TransportError,
     solana_validator_exit::Exit,
@@ -46,7 +53,7 @@ use {
     std::{
         collections::{HashMap, HashSet, VecDeque},
         net::{SocketAddr, TcpListener, UdpSocket},
-        path::Path,
+        path::{Path, PathBuf},
         sync::{
             Arc, RwLock,
             atomic::{AtomicBool, Ordering},
@@ -55,14 +62,87 @@ use {
         time::{Duration, Instant},
     },
     tokio_util::sync::CancellationToken,
+    wincode,
 };
-#[cfg(feature = "dev-context-only-utils")]
-use {
-    solana_core::consensus::tower_storage::{
-        FileTowerStorage, SavedTower, SavedTowerVersions, TowerStorage,
-    },
-    std::path::PathBuf,
-};
+
+/// Packages a multi-threaded tokio runtime with a tpu-client-next sender, providing
+/// a synchronous interface for sending transactions in local-cluster tests.
+pub struct TpuSender {
+    runtime: Arc<tokio::runtime::Runtime>,
+}
+
+impl TpuSender {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            runtime: Arc::new(
+                tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(4)
+                    .enable_all()
+                    .build()
+                    .expect("TpuSender: should create tokio runtime"),
+            ),
+        }
+    }
+
+    /// Open a QUIC connection to `tpu_addr`, run `f` with the live sender, then shut down.
+    ///
+    /// Keeps the tpu-client-next scheduler alive for the duration of `f` so that any
+    /// transactions enqueued via [`send_wire_transaction`] are not dropped before wire
+    /// transmission. Shutdown happens synchronously after `f` returns.
+    pub fn with_connection<F, R>(&self, tpu_addr: SocketAddr, f: F) -> R
+    where
+        F: FnOnce(&TransactionSender) -> R,
+    {
+        let bind_socket = bind_to_localhost_unique().expect("TpuSender: should bind UDP socket");
+        let (sender, client) = self
+            .runtime
+            .block_on(async {
+                ClientBuilder::new(create_pinned_leader_updater(tpu_addr))
+                    .bind_socket(bind_socket)
+                    .build()
+            })
+            .expect("TpuSender: should build tpu-client-next client");
+        let result = f(&sender);
+        self.runtime
+            .block_on(async { client.shutdown().await })
+            .ok();
+        result
+    }
+
+    fn send_wire_transaction(&self, sender: &TransactionSender, wire_tx: Vec<u8>) {
+        self.runtime
+            .block_on(async { sender.send_transactions_in_batch(vec![wire_tx]).await })
+            .expect("TpuSender: should send transactions in batch");
+    }
+
+    /// Send and confirm `transaction` with retries via `sender`, using `rpc_client` for
+    /// confirmation and blockhash refresh.
+    fn send_and_confirm_transaction<T: solana_signer::signers::Signers + ?Sized>(
+        &self,
+        sender: &TransactionSender,
+        rpc_client: &RpcClient,
+        signers: &T,
+        transaction: &mut Transaction,
+        max_attempts: usize,
+    ) -> Result<(), TransportError> {
+        for attempt in 1..=max_attempts {
+            let wire_tx = wincode::serialize(transaction)
+                .expect("send_and_confirm_transaction: should serialize transaction");
+            self.send_wire_transaction(sender, wire_tx);
+            if LocalCluster::poll_for_successfully_processed_transaction(rpc_client, transaction)?
+                .is_some()
+            {
+                return Ok(());
+            }
+            let (blockhash, _) =
+                rpc_client.get_latest_blockhash_with_commitment(CommitmentConfig::processed())?;
+            transaction.sign(signers, blockhash);
+            warn!("send_and_confirm_transaction: attempt {attempt} failed, retrying");
+        }
+        Err(std::io::Error::other("failed to confirm transaction after max retries").into())
+    }
+}
 
 /// Spend and verify from every node in the network
 pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher + Sync + Send>(
@@ -71,7 +151,7 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher + Sync + Send>(
     nodes: usize,
     ignore_nodes: HashSet<Pubkey, S>,
     socket_addr_space: SocketAddrSpace,
-    connection_cache: &Arc<ConnectionCache>,
+    tpu_sender: &TpuSender,
 ) {
     let cluster_nodes = discover_validators(
         &entry_point_info.gossip().unwrap(),
@@ -87,34 +167,48 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher + Sync + Send>(
             return;
         }
         let random_keypair = Keypair::new();
-        let client = new_tpu_quic_client(ingress_node, connection_cache.clone()).unwrap();
-        let bal = client
-            .rpc_client()
+        let rpc_client = RpcClient::new(format!("http://{}", ingress_node.rpc().unwrap()));
+        let bal = rpc_client
             .poll_get_balance_with_commitment(
                 &funding_keypair.pubkey(),
                 CommitmentConfig::processed(),
             )
             .expect("balance in source");
         assert!(bal > 0);
-        let (blockhash, _) = client
-            .rpc_client()
+        let (blockhash, _) = rpc_client
             .get_latest_blockhash_with_commitment(CommitmentConfig::confirmed())
             .unwrap();
         let mut transaction =
             system_transaction::transfer(funding_keypair, &random_keypair.pubkey(), 1, blockhash);
-        LocalCluster::send_transaction_with_retries(
-            &client,
-            &[funding_keypair],
-            &mut transaction,
-            10,
-        )
-        .unwrap();
+        // Like send_many_transactions: use ingress_node for RPC but send to the
+        // current slot leader, matching old TpuClient behaviour.
+        let leader_pubkey = rpc_client
+            .get_slot_leader()
+            .expect("spend_and_verify_all_nodes: get_slot_leader");
+        let tpu_addr = rpc_client
+            .get_cluster_nodes()
+            .expect("spend_and_verify_all_nodes: get_cluster_nodes")
+            .into_iter()
+            .find(|n| n.pubkey == leader_pubkey.to_string())
+            .and_then(|n| n.tpu_quic)
+            .or_else(|| ingress_node.tpu(Protocol::QUIC))
+            .expect("spend_and_verify_all_nodes: leader has no QUIC TPU address");
+        tpu_sender.with_connection(tpu_addr, |sender| {
+            tpu_sender
+                .send_and_confirm_transaction(
+                    sender,
+                    &rpc_client,
+                    &[funding_keypair],
+                    &mut transaction,
+                    10,
+                )
+                .unwrap();
+        });
         for validator in &cluster_nodes {
             if ignore_nodes.contains(validator.pubkey()) {
                 continue;
             }
-            let client = new_tpu_quic_client(ingress_node, connection_cache.clone()).unwrap();
-            LocalCluster::poll_for_successfully_processed_transaction(&client, &transaction)
+            LocalCluster::poll_for_successfully_processed_transaction(&rpc_client, &transaction)
                 .unwrap()
                 .unwrap();
         }
@@ -137,47 +231,59 @@ pub fn verify_balances<S: ::std::hash::BuildHasher>(
 pub fn send_many_transactions(
     node: &ContactInfo,
     funding_keypair: &Keypair,
-    connection_cache: &Arc<ConnectionCache>,
+    tpu_sender: &TpuSender,
     max_tokens_per_transfer: u64,
     num_txs: u64,
 ) -> HashMap<Pubkey, u64> {
-    let client = new_tpu_quic_client(node, connection_cache.clone()).unwrap();
-    let mut expected_balances = HashMap::new();
-    for _ in 0..num_txs {
-        let random_keypair = Keypair::new();
-        let bal = client
-            .rpc_client()
-            .poll_get_balance_with_commitment(
-                &funding_keypair.pubkey(),
-                CommitmentConfig::processed(),
-            )
-            .expect("balance in source");
-        assert!(bal > 0);
-        let (blockhash, _) = client
-            .rpc_client()
-            .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
-            .unwrap();
-        let transfer_amount = rng().random_range(1..max_tokens_per_transfer);
-
-        let mut transaction = system_transaction::transfer(
-            funding_keypair,
-            &random_keypair.pubkey(),
-            transfer_amount,
-            blockhash,
-        );
-
-        LocalCluster::send_transaction_with_retries(
-            &client,
-            &[funding_keypair],
-            &mut transaction,
-            5,
-        )
-        .unwrap();
-
-        expected_balances.insert(random_keypair.pubkey(), transfer_amount);
-    }
-
-    expected_balances
+    let rpc_client = RpcClient::new(format!("http://{}", node.rpc().unwrap()));
+    // Replicate old TpuClient behaviour: send to the current slot leader, not to `node`.
+    // `node` is used only as the RPC endpoint; the leader is discovered via RPC + cluster nodes.
+    let leader_pubkey = rpc_client
+        .get_slot_leader()
+        .expect("send_many_transactions: get_slot_leader");
+    let tpu_addr = rpc_client
+        .get_cluster_nodes()
+        .expect("send_many_transactions: get_cluster_nodes")
+        .into_iter()
+        .find(|n| n.pubkey == leader_pubkey.to_string())
+        .and_then(|n| n.tpu_quic)
+        .or_else(|| node.tpu(Protocol::QUIC))
+        .expect("send_many_transactions: leader has no QUIC TPU address");
+    // One persistent QUIC connection for all transactions to avoid per-tx handshake overhead.
+    tpu_sender.with_connection(tpu_addr, |sender| {
+        let mut expected_balances = HashMap::new();
+        for _ in 0..num_txs {
+            let random_keypair = Keypair::new();
+            let bal = rpc_client
+                .poll_get_balance_with_commitment(
+                    &funding_keypair.pubkey(),
+                    CommitmentConfig::processed(),
+                )
+                .expect("balance in source");
+            assert!(bal > 0);
+            let (blockhash, _) = rpc_client
+                .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
+                .unwrap();
+            let transfer_amount = rng().random_range(1..max_tokens_per_transfer);
+            let mut transaction = system_transaction::transfer(
+                funding_keypair,
+                &random_keypair.pubkey(),
+                transfer_amount,
+                blockhash,
+            );
+            tpu_sender
+                .send_and_confirm_transaction(
+                    sender,
+                    &rpc_client,
+                    &[funding_keypair],
+                    &mut transaction,
+                    5,
+                )
+                .unwrap();
+            expected_balances.insert(random_keypair.pubkey(), transfer_amount);
+        }
+        expected_balances
+    })
 }
 
 pub fn verify_ledger_ticks(ledger_path: &Path, ticks_per_slot: usize) {
@@ -231,7 +337,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
     entry_point_info: &ContactInfo,
     entry_point_validator_exit: &Arc<RwLock<Exit>>,
     funding_keypair: &Keypair,
-    connection_cache: &Arc<ConnectionCache>,
+    tpu_sender: &TpuSender,
     nodes: usize,
     slot_millis: u64,
     socket_addr_space: SocketAddrSpace,
@@ -247,10 +353,9 @@ pub fn kill_entry_and_spend_and_verify_rest(
     )
     .unwrap();
     assert!(cluster_nodes.len() >= nodes);
-    let client = new_tpu_quic_client(entry_point_info, connection_cache.clone()).unwrap();
+    let ep_rpc = RpcClient::new(format!("http://{}", entry_point_info.rpc().unwrap()));
     for ingress_node in &cluster_nodes {
-        client
-            .rpc_client()
+        ep_rpc
             .poll_get_balance_with_commitment(ingress_node.pubkey(), CommitmentConfig::processed())
             .unwrap_or_else(|err| panic!("Node {} has no balance: {}", ingress_node.pubkey(), err));
     }
@@ -271,9 +376,8 @@ pub fn kill_entry_and_spend_and_verify_rest(
         }
 
         // Ensure the current ingress node is still funded.
-        let client = new_tpu_quic_client(ingress_node, connection_cache.clone()).unwrap();
-        let balance = client
-            .rpc_client()
+        let rpc_client = RpcClient::new(format!("http://{}", ingress_node.rpc().unwrap()));
+        let balance = rpc_client
             .poll_get_balance_with_commitment(
                 &funding_keypair.pubkey(),
                 CommitmentConfig::processed(),
@@ -281,63 +385,62 @@ pub fn kill_entry_and_spend_and_verify_rest(
             .expect("balance in source");
         assert_ne!(balance, 0);
 
-        let mut result = Ok(());
-        let mut retries = 0;
+        let tpu_addr = ingress_node
+            .tpu(Protocol::QUIC)
+            .expect("ingress_node has no QUIC TPU address");
 
         // Retry sending a transaction to the current ingress node until it is
         // observed by the entire cluster or we exhaust all retries.
-        loop {
-            retries += 1;
-            if retries > 5 {
-                result.unwrap();
-            }
-
-            // Send a simple transfer transaction to the current ingress node.
-            let random_keypair = Keypair::new();
-            let (blockhash, _) = client
-                .rpc_client()
-                .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
-                .unwrap();
-            let mut transaction = system_transaction::transfer(
-                funding_keypair,
-                &random_keypair.pubkey(),
-                1,
-                blockhash,
-            );
-
-            if let Err(err) = LocalCluster::send_transaction_with_retries(
-                &client,
-                &[funding_keypair],
-                &mut transaction,
-                5,
-            ) {
-                result = Err(err);
-                continue;
-            }
-
-            // Ensure all non-entry point nodes are able to confirm the
-            // transaction.
-            info!("poll_all_nodes_for_signature()");
-            match poll_all_nodes_for_signature(
-                entry_point_info,
-                &cluster_nodes,
-                connection_cache,
-                &transaction,
-            ) {
-                Err(e) => {
-                    info!("poll_all_nodes_for_signature() failed {e:?}");
-                    result = Err(e);
+        tpu_sender.with_connection(tpu_addr, |sender| {
+            let mut result = Ok(());
+            let mut retries = 0;
+            loop {
+                retries += 1;
+                if retries > 5 {
+                    result.unwrap();
                 }
-                Ok(()) => {
-                    info!("poll_all_nodes_for_signature() succeeded, done.");
-                    break;
+
+                // Send a simple transfer transaction to the current ingress node.
+                let random_keypair = Keypair::new();
+                let (blockhash, _) = rpc_client
+                    .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
+                    .unwrap();
+                let mut transaction = system_transaction::transfer(
+                    funding_keypair,
+                    &random_keypair.pubkey(),
+                    1,
+                    blockhash,
+                );
+
+                if let Err(err) = tpu_sender.send_and_confirm_transaction(
+                    sender,
+                    &rpc_client,
+                    &[funding_keypair],
+                    &mut transaction,
+                    5,
+                ) {
+                    result = Err(err);
+                    continue;
+                }
+
+                // Ensure all non-entry point nodes are able to confirm the
+                // transaction.
+                info!("poll_all_nodes_for_signature()");
+                match poll_all_nodes_for_signature(entry_point_info, &cluster_nodes, &transaction) {
+                    Err(e) => {
+                        info!("poll_all_nodes_for_signature() failed {e:?}");
+                        result = Err(e);
+                    }
+                    Ok(()) => {
+                        info!("poll_all_nodes_for_signature() succeeded, done.");
+                        break;
+                    }
                 }
             }
-        }
+        });
     }
 }
 
-#[cfg(feature = "dev-context-only-utils")]
 pub fn apply_votes_to_tower(node_keypair: &Keypair, votes: Vec<(Slot, Hash)>, tower_path: PathBuf) {
     let tower_storage = FileTowerStorage::new(tower_path);
     let mut tower = tower_storage.load(&node_keypair.pubkey()).unwrap();
@@ -633,15 +736,15 @@ pub fn check_no_new_roots(
 fn poll_all_nodes_for_signature(
     entry_point_info: &ContactInfo,
     cluster_nodes: &[ContactInfo],
-    connection_cache: &Arc<ConnectionCache>,
     transaction: &Transaction,
 ) -> Result<(), TransportError> {
     for validator in cluster_nodes {
         if validator.pubkey() == entry_point_info.pubkey() {
             continue;
         }
-        let client = new_tpu_quic_client(validator, connection_cache.clone()).unwrap();
-        LocalCluster::poll_for_successfully_processed_transaction(&client, transaction)?.unwrap();
+        let rpc_client = RpcClient::new(format!("http://{}", validator.rpc().unwrap()));
+        LocalCluster::poll_for_successfully_processed_transaction(&rpc_client, transaction)?
+            .unwrap();
     }
 
     Ok(())

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -434,7 +434,7 @@ pub fn run_cluster_partition<C>(
         num_nodes,
         HashSet::new(),
         SocketAddrSpace::Unspecified,
-        &cluster.connection_cache,
+        &cluster_tests::TpuSender::new(),
     );
 
     let cluster_nodes = discover_validators(

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -960,14 +960,14 @@ impl LocalCluster {
     /// Ok(Some(())) if the transaction was processed successfully. Return
     /// Ok(None) if the transaction was not processed.
     pub fn poll_for_successfully_processed_transaction(
-        client: &QuicTpuClient,
+        rpc_client: &RpcClient,
         transaction: &Transaction,
     ) -> std::result::Result<Option<()>, TransportError> {
         loop {
             // Some local cluster tests create conditions where confirmation
             // is unable to be reached. So rather than checking for confirmation,
             // check for the transaction being processed.
-            let status = client.rpc_client().get_signature_status_with_commitment(
+            let status = rpc_client.get_signature_status_with_commitment(
                 &transaction.signatures[0],
                 CommitmentConfig::processed(),
             )?;
@@ -981,7 +981,7 @@ impl LocalCluster {
                 }
             }
 
-            if !client.rpc_client().is_blockhash_valid(
+            if !rpc_client.is_blockhash_valid(
                 &transaction.message.recent_blockhash,
                 CommitmentConfig::processed(),
             )? {
@@ -1009,7 +1009,9 @@ impl LocalCluster {
         // in LocalCluster integration tests
         for attempt in 1..=attempts {
             client.send_transaction_to_upcoming_leaders(transaction)?;
-            if Self::poll_for_successfully_processed_transaction(client, transaction)?.is_some() {
+            if Self::poll_for_successfully_processed_transaction(client.rpc_client(), transaction)?
+                .is_some()
+            {
                 return Ok(());
             }
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -160,7 +160,7 @@ fn test_spend_and_verify_all_nodes() {
         num_nodes,
         HashSet::new(),
         SocketAddrSpace::Unspecified,
-        &local.connection_cache,
+        &cluster_tests::TpuSender::new(),
     );
 }
 
@@ -324,7 +324,7 @@ fn test_forwarding() {
     cluster_tests::send_many_transactions(
         validator_info,
         &cluster.funding_keypair,
-        &cluster.connection_cache,
+        &cluster_tests::TpuSender::new(),
         10,
         20,
     );
@@ -369,7 +369,7 @@ fn test_restart_node() {
     cluster_tests::send_many_transactions(
         &cluster.entry_point_info,
         &cluster.funding_keypair,
-        &cluster.connection_cache,
+        &cluster_tests::TpuSender::new(),
         10,
         1,
     );
@@ -1278,7 +1278,7 @@ fn test_snapshot_restart_tower() {
         2,
         HashSet::new(),
         SocketAddrSpace::Unspecified,
-        &cluster.connection_cache,
+        &cluster_tests::TpuSender::new(),
     );
 }
 
@@ -1429,6 +1429,7 @@ fn test_snapshots_restart_validity() {
     let num_runs = 3;
     let mut expected_balances = HashMap::new();
     let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
+    let tpu_sender = cluster_tests::TpuSender::new();
     for i in 1..num_runs {
         info!("run {i}");
         // Push transactions to one of the nodes and confirm that transactions were
@@ -1437,7 +1438,7 @@ fn test_snapshots_restart_validity() {
         let new_balances = cluster_tests::send_many_transactions(
             &cluster.entry_point_info,
             &cluster.funding_keypair,
-            &cluster.connection_cache,
+            &tpu_sender,
             10,
             10,
         );
@@ -1477,7 +1478,7 @@ fn test_snapshots_restart_validity() {
             1,
             HashSet::new(),
             SocketAddrSpace::Unspecified,
-            &cluster.connection_cache,
+            &tpu_sender,
         );
     }
 }
@@ -4306,7 +4307,7 @@ fn test_leader_failure_4() {
             .config
             .validator_exit,
         &local.funding_keypair,
-        &local.connection_cache,
+        &cluster_tests::TpuSender::new(),
         num_nodes,
         config.ticks_per_slot * config.poh_config.target_tick_duration.as_millis() as u64,
         SocketAddrSpace::Unspecified,
@@ -5632,7 +5633,7 @@ fn test_randomly_mixed_block_verification_methods_between_bootstrap_and_not() {
         num_nodes,
         HashSet::new(),
         SocketAddrSpace::Unspecified,
-        &local.connection_cache,
+        &cluster_tests::TpuSender::new(),
     );
 }
 
@@ -5666,7 +5667,7 @@ fn test_randomly_mixed_block_production_methods_between_bootstrap_and_not() {
         num_nodes,
         HashSet::new(),
         SocketAddrSpace::Unspecified,
-        &local.connection_cache,
+        &cluster_tests::TpuSender::new(),
     );
 }
 
@@ -5864,7 +5865,7 @@ fn test_alpenglow_nodes_basic(num_nodes: usize, num_offline_nodes: usize) {
         num_nodes,
         HashSet::new(),
         SocketAddrSpace::Unspecified,
-        &cluster.connection_cache,
+        &cluster_tests::TpuSender::new(),
     );
 
     if num_offline_nodes > 0 {
@@ -5950,7 +5951,7 @@ fn test_restart_node_alpenglow() {
     cluster_tests::send_many_transactions(
         &cluster.entry_point_info,
         &cluster.funding_keypair,
-        &cluster.connection_cache,
+        &cluster_tests::TpuSender::new(),
         10,
         1,
     );


### PR DESCRIPTION
#### Problem

this is a followup to https://github.com/anza-xyz/agave/pull/12910 removing more usages of connection cache.

#### Summary of Changes

replacing some more of the connection cache stuff with tpu-client-next.

