### PR TITLE
xdp: add 802.1Q vlan encap to the tx loop

### DIFF
--- a/xdp/src/netlink.rs
+++ b/xdp/src/netlink.rs
@@ -34,6 +34,10 @@ const IFLA_GRE_TTL: u16 = 8;
 const IFLA_GRE_TOS: u16 = 9;
 const IFLA_GRE_PMTUDISC: u16 = 10;
 
+// VLAN nested attributes (from include/uapi/linux/if_link.h)
+const IFLA_VLAN_ID: u16 = 1;
+const IFLA_VLAN_PROTOCOL: u16 = 5;
+
 #[repr(C)]
 #[allow(non_camel_case_types)]
 struct ifinfomsg {
@@ -386,11 +390,19 @@ pub struct GreTunnelInfo {
     pub pmtudisc: u8,
 }
 
+/// 802.1Q VLAN sub-interface information from netlink (IFLA_LINKINFO kind "vlan").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VlanLinkInfo {
+    /// VLAN ID (IFLA_VLAN_ID), 1-4094 in practice.
+    pub vid: u16,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InterfaceInfo {
     pub if_index: u32,
     pub mtu: u32,
     pub gre_tunnel: Option<GreTunnelInfo>,
+    pub vlan_link: Option<VlanLinkInfo>,
 }
 
 impl InterfaceInfo {
@@ -453,11 +465,33 @@ pub(crate) fn parse_rtm_ifinfomsg(msg: &NetlinkMessage) -> Option<InterfaceInfo>
 
     // Parse GRE tunnel information if this is a GRE interface
     let gre_tunnel = parse_gre_tunnel_info_from_linkinfo(&attrs);
+    // Parse VLAN information if this is an 802.1Q VLAN sub-interface
+    let vlan_link = parse_vlan_link_info_from_linkinfo(&attrs);
     Some(InterfaceInfo {
         if_index: ifi.ifi_index,
         mtu,
         gre_tunnel,
+        vlan_link,
     })
+}
+
+// Parse 802.1Q VLAN information from netlink
+fn parse_vlan_link_info_from_linkinfo(attrs: &HashMap<u16, NlAttr>) -> Option<VlanLinkInfo> {
+    let vlan = parse_linkinfo_data_for_kind(attrs, b"vlan")?;
+
+    // Only 802.1Q is supported; skip 802.1ad (QinQ) sub-interfaces. The protocol attribute is a
+    // big-endian u16; kernels predating 802.1ad support omit it, which implies 802.1Q.
+    if let Some(proto) = vlan.get(&IFLA_VLAN_PROTOCOL) {
+        let proto = u16::from_be_bytes(proto.data.get(..2)?.try_into().ok()?);
+        if proto != libc::ETH_P_8021Q as u16 {
+            return None;
+        }
+    }
+
+    let vid = vlan
+        .get(&IFLA_VLAN_ID)
+        .and_then(|a| u16_from_ne_bytes(a.data))?;
+    Some(VlanLinkInfo { vid })
 }
 
 // Parse GRE tunnel information from netlink
@@ -782,4 +816,9 @@ fn push_nlattr<T>(buf: &mut Vec<u8>, attr_type: u16, value: &T) {
 fn u32_from_ne_bytes(data: &[u8]) -> Option<u32> {
     let bytes: [u8; 4] = data.get(..4)?.try_into().ok()?;
     Some(u32::from_ne_bytes(bytes))
+}
+
+fn u16_from_ne_bytes(data: &[u8]) -> Option<u16> {
+    let bytes: [u8; 2] = data.get(..2)?.try_into().ok()?;
+    Some(u16::from_ne_bytes(bytes))
 }

--- a/xdp/src/packet.rs
+++ b/xdp/src/packet.rs
@@ -7,14 +7,132 @@ use {
 };
 
 pub const ETH_HEADER_SIZE: usize = 14;
+/// Plain Ethernet header (14B) + 802.1Q tag (4B).
+pub const VLAN_ETH_HEADER_SIZE: usize = ETH_HEADER_SIZE + 4;
 pub const IP_HEADER_SIZE: usize = 20;
 pub const UDP_HEADER_SIZE: usize = 8;
+/// Total header size of an untagged IPv4 UDP frame: Ethernet + IP + UDP.
+pub const PACKET_HEADER_SIZE: usize = ETH_HEADER_SIZE + IP_HEADER_SIZE + UDP_HEADER_SIZE;
+/// Total header size of an 802.1Q tagged IPv4 UDP frame: tagged Ethernet + IP + UDP.
+pub const VLAN_PACKET_HEADER_SIZE: usize = VLAN_ETH_HEADER_SIZE + IP_HEADER_SIZE + UDP_HEADER_SIZE;
 const IP_DONT_FRAGMENT: u16 = 0x4000;
+/// EtherType identifying an 802.1Q tagged frame.
+const ETH_P_8021Q: u16 = 0x8100;
 
 pub fn write_eth_header(packet: &mut [u8], src_mac: &[u8; 6], dst_mac: &[u8; 6]) {
     packet[0..6].copy_from_slice(dst_mac);
     packet[6..12].copy_from_slice(src_mac);
     packet[12..14].copy_from_slice(&(ETH_P_IP as u16).to_be_bytes());
+}
+
+/// Write an 18-byte Ethernet header carrying an 802.1Q VLAN tag.
+///
+/// Layout: `dst MAC (6) | src MAC (6) | TPID=0x8100 (2) | TCI (2) | inner EtherType (2)`.
+/// The TCI packs `pcp` into the high 3 bits, DEI=0, and `vid` into the low 12 bits.
+#[inline]
+pub fn write_vlan_eth_header(
+    packet: &mut [u8],
+    src_mac: &[u8; 6],
+    dst_mac: &[u8; 6],
+    vid: u16,
+    pcp: u8,
+) {
+    packet[0..6].copy_from_slice(dst_mac);
+    packet[6..12].copy_from_slice(src_mac);
+    packet[12..14].copy_from_slice(&ETH_P_8021Q.to_be_bytes());
+    // TCI: PCP in the top 3 bits, then DEI=0 (frames are not marked drop-eligible, matching what
+    // the kernel VLAN driver emits by default), then the VID in the low 12 bits.
+    let tci = (((pcp as u16) & 0x7) << 13) | (vid & 0x0FFF);
+    packet[14..16].copy_from_slice(&tci.to_be_bytes());
+    packet[16..18].copy_from_slice(&(ETH_P_IP as u16).to_be_bytes());
+}
+
+/// Construct a complete untagged IPv4 UDP frame in `packet`.
+///
+/// Layout: `[Eth] [IPv4] [UDP] [payload]`. The caller is responsible for sizing `packet` to at
+/// least `PACKET_HEADER_SIZE + payload.len()`; this function returns `false` and writes nothing
+/// if the buffer is too small.
+#[allow(clippy::too_many_arguments)]
+pub fn construct_packet(
+    packet: &mut [u8],
+    src_mac: &[u8; 6],
+    dst_mac: &[u8; 6],
+    src_ip: &Ipv4Addr,
+    dst_ip: &Ipv4Addr,
+    src_port: u16,
+    dst_port: u16,
+    payload: &[u8],
+    ecn: Option<EcnCodepoint>,
+) -> bool {
+    let payload_len = payload.len();
+    if packet.len() < PACKET_HEADER_SIZE + payload_len {
+        return false;
+    }
+    // write the payload first as it's needed for checksum calculation (if enabled)
+    packet[PACKET_HEADER_SIZE..PACKET_HEADER_SIZE + payload_len].copy_from_slice(payload);
+    write_eth_header(packet, src_mac, dst_mac);
+    write_ip_header_for_udp(
+        &mut packet[ETH_HEADER_SIZE..],
+        src_ip,
+        dst_ip,
+        ecn,
+        (UDP_HEADER_SIZE + payload_len) as u16,
+    );
+    write_udp_header(
+        &mut packet[ETH_HEADER_SIZE + IP_HEADER_SIZE..],
+        src_ip,
+        src_port,
+        dst_ip,
+        dst_port,
+        payload_len as u16,
+        false,
+    );
+    true
+}
+
+/// Construct a complete VLAN-tagged IPv4 UDP frame in `packet`.
+///
+/// Layout: `[Eth + 802.1Q] [IPv4] [UDP] [payload]`. The caller is responsible for sizing `packet`
+/// to at least `VLAN_PACKET_HEADER_SIZE + payload.len()`; this function returns `false` and
+/// writes nothing if the buffer is too small.
+#[allow(clippy::too_many_arguments)]
+pub fn construct_vlan_packet(
+    packet: &mut [u8],
+    src_mac: &[u8; 6],
+    dst_mac: &[u8; 6],
+    src_ip: &Ipv4Addr,
+    dst_ip: &Ipv4Addr,
+    src_port: u16,
+    dst_port: u16,
+    vid: u16,
+    pcp: u8,
+    payload: &[u8],
+    ecn: Option<EcnCodepoint>,
+) -> bool {
+    let payload_len = payload.len();
+    if packet.len() < VLAN_PACKET_HEADER_SIZE + payload_len {
+        return false;
+    }
+    // write the payload first as it's needed for checksum calculation (if enabled)
+    packet[VLAN_PACKET_HEADER_SIZE..VLAN_PACKET_HEADER_SIZE + payload_len].copy_from_slice(payload);
+    write_vlan_eth_header(packet, src_mac, dst_mac, vid, pcp);
+    write_ip_header_for_udp(
+        &mut packet[VLAN_ETH_HEADER_SIZE..],
+        src_ip,
+        dst_ip,
+        ecn,
+        (UDP_HEADER_SIZE + payload_len) as u16,
+    );
+    write_udp_header(
+        &mut packet[VLAN_ETH_HEADER_SIZE + IP_HEADER_SIZE..],
+        src_ip,
+        src_port,
+        dst_ip,
+        dst_port,
+        payload_len as u16,
+        false,
+    );
+    true
 }
 
 pub(crate) fn write_ip_header(
@@ -147,4 +265,169 @@ fn calculate_ip_checksum(header: &[u8]) -> u16 {
     }
 
     !(sum as u16)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_vlan_eth_header_layout() {
+        // dst, src, TPID=0x8100, TCI (pcp=0, dei=0, vid=900 -> 0x0384), inner EtherType=0x0800
+        let src = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+        let dst = [0x01, 0x00, 0x5e, 0x00, 0x00, 0x03];
+        let mut buf = [0u8; VLAN_ETH_HEADER_SIZE];
+        write_vlan_eth_header(&mut buf, &src, &dst, 900, 0);
+        assert_eq!(&buf[0..6], &dst);
+        assert_eq!(&buf[6..12], &src);
+        assert_eq!(&buf[12..14], &[0x81, 0x00]);
+        assert_eq!(&buf[14..16], &[0x03, 0x84]);
+        assert_eq!(&buf[16..18], &[0x08, 0x00]);
+    }
+
+    #[test]
+    fn test_write_vlan_eth_header_packs_pcp_and_vid() {
+        // pcp=5, vid=0x0FFF (max 12-bit value). TCI = (5 << 13) | 0x0FFF = 0xAFFF.
+        let mut buf = [0u8; VLAN_ETH_HEADER_SIZE];
+        write_vlan_eth_header(&mut buf, &[0u8; 6], &[0u8; 6], 0x0FFF, 5);
+        assert_eq!(&buf[14..16], &[0xAF, 0xFF]);
+    }
+
+    #[test]
+    fn test_write_vlan_eth_header_masks_pcp_and_vid_inputs() {
+        // High bits in pcp and vid must not leak into adjacent fields.
+        let mut buf = [0u8; VLAN_ETH_HEADER_SIZE];
+        write_vlan_eth_header(&mut buf, &[0u8; 6], &[0u8; 6], 0xFFFF, 0xFF);
+        // pcp masked to 0x7, then shifted into bits 13..16; vid masked to 0x0FFF.
+        // Expected TCI = (0x7 << 13) | 0x0FFF = 0xEFFF.
+        assert_eq!(&buf[14..16], &[0xEF, 0xFF]);
+    }
+
+    #[test]
+    fn test_construct_packet_layout() {
+        let src_mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+        let dst_mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x02];
+        let src_ip = Ipv4Addr::new(10, 228, 0, 5);
+        let dst_ip = Ipv4Addr::new(10, 228, 0, 9);
+        let payload = b"hello-world";
+        let mut buf = vec![0u8; PACKET_HEADER_SIZE + payload.len()];
+
+        assert!(construct_packet(
+            &mut buf, &src_mac, &dst_mac, &src_ip, &dst_ip, 7000, 7733, payload, None,
+        ));
+
+        // Untagged ethernet header
+        assert_eq!(&buf[0..6], &dst_mac);
+        assert_eq!(&buf[6..12], &src_mac);
+        assert_eq!(&buf[12..14], &[0x08, 0x00]); // ethertype IPv4
+
+        // IPv4 header sanity: version+IHL byte, protocol=UDP, src/dst.
+        assert_eq!(buf[ETH_HEADER_SIZE], 0x45);
+        assert_eq!(buf[ETH_HEADER_SIZE + 9], IPPROTO_UDP as u8);
+        assert_eq!(
+            &buf[ETH_HEADER_SIZE + 12..ETH_HEADER_SIZE + 16],
+            &src_ip.octets()
+        );
+        assert_eq!(
+            &buf[ETH_HEADER_SIZE + 16..ETH_HEADER_SIZE + 20],
+            &dst_ip.octets()
+        );
+
+        // UDP header sanity: src/dst ports, length.
+        let udp_off = ETH_HEADER_SIZE + IP_HEADER_SIZE;
+        assert_eq!(&buf[udp_off..udp_off + 2], &7000u16.to_be_bytes());
+        assert_eq!(&buf[udp_off + 2..udp_off + 4], &7733u16.to_be_bytes());
+        assert_eq!(
+            &buf[udp_off + 4..udp_off + 6],
+            &((UDP_HEADER_SIZE + payload.len()) as u16).to_be_bytes()
+        );
+
+        // Payload tail.
+        assert_eq!(&buf[udp_off + UDP_HEADER_SIZE..], payload.as_slice());
+    }
+
+    #[test]
+    fn test_construct_packet_rejects_undersized_buffer() {
+        let mut tiny = [0u8; 10];
+        let ok = construct_packet(
+            &mut tiny,
+            &[0; 6],
+            &[0; 6],
+            &Ipv4Addr::UNSPECIFIED,
+            &Ipv4Addr::UNSPECIFIED,
+            0,
+            0,
+            b"too big",
+            None,
+        );
+        assert!(!ok);
+        // Buffer must not be partially written.
+        assert!(tiny.iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn test_construct_vlan_packet_layout() {
+        let src_mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+        let dst_mac = [0x01, 0x00, 0x5e, 0x00, 0x00, 0x03];
+        let src_ip = Ipv4Addr::new(10, 228, 0, 5);
+        let dst_ip = Ipv4Addr::new(239, 0, 0, 3);
+        let payload = b"hello-world";
+        let mut buf = vec![0u8; VLAN_PACKET_HEADER_SIZE + payload.len()];
+
+        assert!(construct_vlan_packet(
+            &mut buf, &src_mac, &dst_mac, &src_ip, &dst_ip, 7000, 7733, 900, 0, payload, None,
+        ));
+
+        // VLAN-tagged ethernet header
+        assert_eq!(&buf[0..6], &dst_mac);
+        assert_eq!(&buf[6..12], &src_mac);
+        assert_eq!(&buf[12..14], &[0x81, 0x00]);
+        assert_eq!(&buf[14..16], &[0x03, 0x84]); // vid=900, pcp=0
+        assert_eq!(&buf[16..18], &[0x08, 0x00]); // inner ethertype IPv4
+
+        // IPv4 header sanity: version+IHL byte, protocol=UDP, src/dst.
+        assert_eq!(buf[VLAN_ETH_HEADER_SIZE], 0x45);
+        assert_eq!(buf[VLAN_ETH_HEADER_SIZE + 9], IPPROTO_UDP as u8);
+        assert_eq!(
+            &buf[VLAN_ETH_HEADER_SIZE + 12..VLAN_ETH_HEADER_SIZE + 16],
+            &src_ip.octets()
+        );
+        assert_eq!(
+            &buf[VLAN_ETH_HEADER_SIZE + 16..VLAN_ETH_HEADER_SIZE + 20],
+            &dst_ip.octets()
+        );
+
+        // UDP header sanity: src/dst ports, length.
+        let udp_off = VLAN_ETH_HEADER_SIZE + IP_HEADER_SIZE;
+        assert_eq!(&buf[udp_off..udp_off + 2], &7000u16.to_be_bytes());
+        assert_eq!(&buf[udp_off + 2..udp_off + 4], &7733u16.to_be_bytes());
+        assert_eq!(
+            &buf[udp_off + 4..udp_off + 6],
+            &((UDP_HEADER_SIZE + payload.len()) as u16).to_be_bytes()
+        );
+
+        // Payload tail.
+        assert_eq!(&buf[udp_off + UDP_HEADER_SIZE..], payload.as_slice());
+    }
+
+    #[test]
+    fn test_construct_vlan_packet_rejects_undersized_buffer() {
+        let mut tiny = [0u8; 10];
+        let ok = construct_vlan_packet(
+            &mut tiny,
+            &[0; 6],
+            &[0; 6],
+            &Ipv4Addr::UNSPECIFIED,
+            &Ipv4Addr::UNSPECIFIED,
+            0,
+            0,
+            1,
+            0,
+            b"too big",
+            None,
+        );
+        assert!(!ok);
+        // Buffer must not be partially written.
+        assert!(tiny.iter().all(|&b| b == 0));
+    }
 }

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -40,6 +40,22 @@ pub struct GreRouteInfo {
     pub mac_addr: MacAddress,
 }
 
+/// VLAN encapsulation directive carried on a resolved NextHop.
+///
+/// When present, the tx loop prepends an 802.1Q tag to the Ethernet header before the inner IP
+/// header. The MAC and IP fields on the NextHop are still the real packet destinations: VLAN
+/// encapsulation changes the L2 framing only. XDP cannot transmit on a VLAN sub-interface
+/// directly (it is bound to the physical parent), so the tag has to be written in userspace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VlanRouteInfo {
+    /// if_index of the VLAN sub-interface the route resolved to.
+    pub if_index: u32,
+    pub vid: u16,
+    /// Priority Code Point. Always 0 for now, matching the kernel's default egress QoS mapping;
+    /// a configurable mapping can be added later if needed.
+    pub pcp: u8,
+}
+
 #[derive(Debug, Clone)]
 pub struct NextHop {
     pub mac_addr: Option<MacAddress>,
@@ -48,6 +64,7 @@ pub struct NextHop {
     pub mtu: u32,
     pub preferred_src_ip: Option<Ipv4Addr>,
     pub gre: Option<GreRouteInfo>,
+    pub vlan: Option<VlanRouteInfo>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -406,6 +423,8 @@ pub struct Router {
     cached_default_route: Option<NextHop>,
     // cache for gre route info keyed by interface index. This stays tiny in practice.
     cached_gre_info: Vec<GreRouteInfo>,
+    // cache for vlan encap info keyed by interface index. One entry per VLAN sub-interface.
+    cached_vlan_info: Vec<VlanRouteInfo>,
 }
 
 struct RoutingTableDisplay<'a>(&'a [Route<Ipv4Addr>]);
@@ -441,6 +460,7 @@ impl Router {
             interfaces: tables.interfaces,
             cached_default_route: None,
             cached_gre_info: Vec::new(),
+            cached_vlan_info: Vec::new(),
         };
 
         let mut has_gre_interface = false;
@@ -450,6 +470,14 @@ impl Router {
                 if let Some(gre) = router.interface_gre_route_info(interface) {
                     router.cached_gre_info.push(gre);
                 }
+            }
+            if let Some(vlan) = interface.vlan_link {
+                router.cached_vlan_info.push(VlanRouteInfo {
+                    if_index: interface.if_index,
+                    vid: vlan.vid,
+                    // Kernel default egress QoS mapping; a configurable mapping can come later.
+                    pcp: 0,
+                });
             }
         }
         if router.cached_gre_info.is_empty() && has_gre_interface {
@@ -487,6 +515,13 @@ impl Router {
         self.interface_gre_route_info(interface)
     }
 
+    fn cached_vlan_route_info(&self, if_index: u32) -> Option<VlanRouteInfo> {
+        self.cached_vlan_info
+            .iter()
+            .find(|vlan| vlan.if_index == if_index)
+            .copied()
+    }
+
     fn resolve_next_hop(
         &self,
         route_ip: Ipv4Addr,
@@ -507,6 +542,7 @@ impl Router {
                     mac_addr: default_route.mac_addr,
                     preferred_src_ip,
                     gre: default_route.gre.clone(),
+                    vlan: default_route.vlan,
                 });
             }
         }
@@ -519,6 +555,7 @@ impl Router {
                 mac_addr: Some(gre.mac_addr),
                 preferred_src_ip,
                 gre: Some(gre),
+                vlan: None,
             });
         }
 
@@ -528,6 +565,7 @@ impl Router {
             .find(|interface| interface.if_index == if_index)
             .map(|interface| interface.mtu)
             .ok_or(RouteError::UnknownInterfaceIndex(if_index))?;
+        let vlan = self.cached_vlan_route_info(if_index);
 
         let mac_addr = self.neighbors.lookup(next_hop_ip, if_index).cloned();
         Ok(NextHop {
@@ -537,6 +575,7 @@ impl Router {
             mtu,
             preferred_src_ip,
             gre: None,
+            vlan,
         })
     }
 
@@ -642,7 +681,7 @@ fn format_route(f: &mut fmt::Formatter<'_>, route: &Route<Ipv4Addr>) -> fmt::Res
 mod tests {
     use {
         super::*,
-        crate::netlink::{MacAddress, NeighborEntry, RouteEntry},
+        crate::netlink::{MacAddress, NeighborEntry, RouteEntry, VlanLinkInfo},
         libc::{AF_INET, NUD_REACHABLE},
         std::net::{IpAddr, Ipv4Addr},
     };
@@ -723,11 +762,13 @@ mod tests {
             if_index: 1,
             mtu: DEFAULT_MTU_FOR_TESTS,
             gre_tunnel: None,
+            vlan_link: None,
         }));
         assert!(tables.upsert_interface(InterfaceInfo {
             if_index: 2,
             mtu: DEFAULT_MTU_FOR_TESTS,
             gre_tunnel: None,
+            vlan_link: None,
         }));
         assert!(tables.upsert_neighbor(NeighborEntry {
             destination: Some(IpAddr::V4(primary_gateway)),
@@ -769,6 +810,7 @@ mod tests {
             if_index: 1,
             mtu: DEFAULT_MTU_FOR_TESTS,
             gre_tunnel: None,
+            vlan_link: None,
         }));
 
         let gateway = Ipv4Addr::new(10, 255, 255, 1);
@@ -852,11 +894,13 @@ mod tests {
                     if_index: 2,
                     mtu: DEFAULT_MTU_FOR_TESTS,
                     gre_tunnel: None,
+                    vlan_link: None,
                 },
                 InterfaceInfo {
                     if_index: 3,
                     mtu: DEFAULT_MTU_FOR_TESTS,
                     gre_tunnel: None,
+                    vlan_link: None,
                 },
             ],
         );
@@ -904,6 +948,7 @@ mod tests {
             if_index: test_if_index,
             mtu: DEFAULT_MTU_FOR_TESTS,
             gre_tunnel: None,
+            vlan_link: None,
         };
 
         // Upsert new interface and check that it was inserted
@@ -950,6 +995,7 @@ mod tests {
             if_index: 1,
             mtu: DEFAULT_MTU_FOR_TESTS,
             gre_tunnel: None,
+            vlan_link: None,
         }));
         assert!(tables.upsert_neighbor(NeighborEntry {
             destination: Some(IpAddr::V4(main_gateway)),
@@ -990,6 +1036,7 @@ mod tests {
             if_index: 1,
             mtu: DEFAULT_MTU_FOR_TESTS,
             gre_tunnel: None,
+            vlan_link: None,
         }));
         assert!(tables.upsert_neighbor(NeighborEntry {
             destination: Some(IpAddr::V4(main_gateway)),
@@ -1058,6 +1105,7 @@ mod tests {
                 if_index: if_index_underlay as u32,
                 mtu: DEFAULT_MTU_FOR_TESTS,
                 gre_tunnel: None,
+                vlan_link: None,
             },
             InterfaceInfo {
                 if_index: if_index_gre1 as u32,
@@ -1069,6 +1117,7 @@ mod tests {
                     tos: 0,
                     pmtudisc: 0,
                 }),
+                vlan_link: None,
             },
             InterfaceInfo {
                 if_index: if_index_gre2 as u32,
@@ -1080,6 +1129,7 @@ mod tests {
                     tos: 0,
                     pmtudisc: 0,
                 }),
+                vlan_link: None,
             },
         ];
 
@@ -1140,6 +1190,7 @@ mod tests {
                 if_index: if_index_underlay as u32,
                 mtu: DEFAULT_MTU_FOR_TESTS,
                 gre_tunnel: None,
+                vlan_link: None,
             },
             InterfaceInfo {
                 if_index: if_index_gre as u32,
@@ -1151,6 +1202,7 @@ mod tests {
                     tos: 0,
                     pmtudisc: 0,
                 }),
+                vlan_link: None,
             },
         ];
 
@@ -1189,6 +1241,7 @@ mod tests {
             if_index: 1,
             mtu: DEFAULT_MTU_FOR_TESTS,
             gre_tunnel: None,
+            vlan_link: None,
         }));
         assert!(tables.upsert_neighbor(NeighborEntry {
             destination: Some(IpAddr::V4(default_gateway)),
@@ -1270,5 +1323,147 @@ mod tests {
         let next_hop = router.default().unwrap();
         assert_eq!(next_hop.if_index, 2);
         assert_eq!(next_hop.ip_addr, IpAddr::V4(backup));
+    }
+
+    #[test]
+    fn test_vlan_route_resolves_with_vlan_info() {
+        // A route through a configured VLAN sub-interface attaches VlanRouteInfo to the NextHop;
+        // the MAC still comes from the neighbor cache and no GRE encap is set.
+        let peer = Ipv4Addr::new(10, 228, 0, 99);
+        let vlan_if = 100u32;
+        let vlan_src = Ipv4Addr::new(10, 228, 0, 5);
+        let peer_mac = MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x09]);
+
+        let neighbors = vec![NeighborEntry {
+            destination: Some(IpAddr::V4(peer)),
+            lladdr: Some(peer_mac),
+            ifindex: vlan_if as i32,
+            state: NUD_REACHABLE,
+        }];
+        let interfaces = vec![InterfaceInfo {
+            if_index: vlan_if,
+            mtu: DEFAULT_MTU_FOR_TESTS,
+            gre_tunnel: None,
+            vlan_link: Some(VlanLinkInfo { vid: 900 }),
+        }];
+        let routes = vec![Route {
+            destination: Some(Ipv4Addr::new(10, 228, 0, 0)),
+            gateway: None,
+            preferred_src: Some(vlan_src),
+            out_if_index: Some(vlan_if),
+            priority: None,
+            type_: 0,
+            dst_len: 22,
+        }];
+
+        let router = router_from_tables(neighbors, routes, interfaces);
+        let next_hop = router.route_v4(peer).unwrap();
+        assert_eq!(next_hop.if_index, vlan_if);
+        assert_eq!(next_hop.preferred_src_ip, Some(vlan_src));
+        assert_eq!(next_hop.mac_addr, Some(peer_mac));
+        assert!(next_hop.gre.is_none());
+        let vlan = next_hop.vlan.expect("vlan info must be populated");
+        assert_eq!(vlan.if_index, vlan_if);
+        assert_eq!(vlan.vid, 900);
+        assert_eq!(vlan.pcp, 0);
+    }
+
+    #[test]
+    fn test_multiple_vlan_interfaces_resolve_their_own_vid() {
+        // With more than one VLAN sub-interface, each route is tagged with the vid of the
+        // interface it egresses through.
+        let peer_a = Ipv4Addr::new(10, 1, 0, 9);
+        let peer_b = Ipv4Addr::new(10, 2, 0, 9);
+        let vlan_if_a = 100u32;
+        let vlan_if_b = 101u32;
+        let mac_a = MacAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x0a]);
+        let mac_b = MacAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x0b]);
+
+        let neighbors = vec![
+            NeighborEntry {
+                destination: Some(IpAddr::V4(peer_a)),
+                lladdr: Some(mac_a),
+                ifindex: vlan_if_a as i32,
+                state: NUD_REACHABLE,
+            },
+            NeighborEntry {
+                destination: Some(IpAddr::V4(peer_b)),
+                lladdr: Some(mac_b),
+                ifindex: vlan_if_b as i32,
+                state: NUD_REACHABLE,
+            },
+        ];
+        let interfaces = vec![
+            InterfaceInfo {
+                if_index: vlan_if_a,
+                mtu: DEFAULT_MTU_FOR_TESTS,
+                gre_tunnel: None,
+                vlan_link: Some(VlanLinkInfo { vid: 900 }),
+            },
+            InterfaceInfo {
+                if_index: vlan_if_b,
+                mtu: DEFAULT_MTU_FOR_TESTS,
+                gre_tunnel: None,
+                vlan_link: Some(VlanLinkInfo { vid: 901 }),
+            },
+        ];
+        let routes = vec![
+            test_route(Some(peer_a), vlan_if_a),
+            test_route(Some(peer_b), vlan_if_b),
+        ];
+
+        let router = router_from_tables(neighbors, routes, interfaces);
+        let hop_a = router.route_v4(peer_a).unwrap();
+        assert_eq!(hop_a.vlan.map(|v| v.vid), Some(900));
+        assert_eq!(hop_a.mac_addr, Some(mac_a));
+        let hop_b = router.route_v4(peer_b).unwrap();
+        assert_eq!(hop_b.vlan.map(|v| v.vid), Some(901));
+        assert_eq!(hop_b.mac_addr, Some(mac_b));
+    }
+
+    #[test]
+    fn test_gre_wins_when_both_gre_and_vlan_configured() {
+        // Defensive: if a configured VLAN if_index also happens to be a GRE interface, the resolve
+        // path picks GRE first (single-encap-per-interface contract).
+        let remote = Ipv4Addr::new(10, 0, 0, 1);
+        let gre_dest = Ipv4Addr::new(192, 168, 0, 1);
+        let if_index_underlay = 1u32;
+        let if_index_iface = 100u32;
+        let underlay_mac = MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01]);
+
+        let neighbors = vec![NeighborEntry {
+            destination: Some(IpAddr::V4(remote)),
+            lladdr: Some(underlay_mac),
+            ifindex: if_index_underlay as i32,
+            state: NUD_REACHABLE,
+        }];
+        let routes = vec![
+            test_route(Some(remote), if_index_underlay),
+            test_route(Some(gre_dest), if_index_iface),
+        ];
+        let interfaces = vec![
+            InterfaceInfo {
+                if_index: if_index_underlay,
+                mtu: DEFAULT_MTU_FOR_TESTS,
+                gre_tunnel: None,
+                vlan_link: None,
+            },
+            InterfaceInfo {
+                if_index: if_index_iface,
+                mtu: DEFAULT_MTU_FOR_TESTS,
+                gre_tunnel: Some(GreTunnelInfo {
+                    local: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)),
+                    remote: IpAddr::V4(remote),
+                    ttl: 0,
+                    tos: 0,
+                    pmtudisc: 0,
+                }),
+                vlan_link: Some(VlanLinkInfo { vid: 5 }),
+            },
+        ];
+        let router = router_from_tables(neighbors, routes, interfaces);
+        let next_hop = router.route_v4(gre_dest).unwrap();
+        assert!(next_hop.gre.is_some());
+        assert!(next_hop.vlan.is_none());
     }
 }

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -10,8 +10,8 @@ use {
         },
         netlink::MacAddress,
         packet::{
-            ETH_HEADER_SIZE, IP_HEADER_SIZE, UDP_HEADER_SIZE, write_eth_header,
-            write_ip_header_for_udp, write_udp_header,
+            IP_HEADER_SIZE, PACKET_HEADER_SIZE, UDP_HEADER_SIZE, VLAN_PACKET_HEADER_SIZE,
+            construct_packet, construct_vlan_packet,
         },
         route::NextHop,
         socket::{Socket, Tx, TxRing},
@@ -391,6 +391,72 @@ impl<U: Umem> TxLoop<U> {
                             umem.release(frame.offset());
                             continue;
                         }
+                    } else if let Some(vlan) = &next_hop.vlan {
+                        // we need the MAC address to send the packet
+                        let Some(dest_mac) = next_hop.mac_addr else {
+                            log::warn!(
+                                "dropping packet: peer {addr} must be routed through {} which has \
+                                 no known MAC address",
+                                next_hop.ip_addr
+                            );
+                            batched_packets -= 1;
+                            umem.release(frame.offset());
+                            continue;
+                        };
+
+                        // The 802.1Q tag is added at L2, so the L3 size compared against the MTU
+                        // is the same as the untagged path.
+                        let l3_packet_len = IP_HEADER_SIZE + UDP_HEADER_SIZE + len;
+                        if l3_packet_len > next_hop.mtu as usize {
+                            if !can_overflow_mtu {
+                                log::warn!(
+                                    "dropping packet: packet size {l3_packet_len} exceeds MTU \
+                                     {mtu} for {addr}",
+                                    mtu = next_hop.mtu
+                                );
+                            }
+                            batched_packets -= 1;
+                            umem.release(frame.offset());
+                            continue;
+                        }
+
+                        let packet_len = VLAN_PACKET_HEADER_SIZE + len;
+                        if packet_len > umem_frame_size {
+                            log::warn!(
+                                "dropping packet: VLAN packet size {packet_len} exceeds frame \
+                                 size {umem_frame_size} for {addr}"
+                            );
+                            batched_packets -= 1;
+                            umem.release(frame.offset());
+                            continue;
+                        }
+
+                        frame.set_len(packet_len);
+                        let packet = umem.map_frame_mut(&frame);
+
+                        // The route's preferred src is the IP assigned to the VLAN sub-interface,
+                        // which is the right inner src for traffic egressing this VLAN. Fall back
+                        // to the device's src IP if the route did not carry one.
+                        let inner_src_ip = next_hop.preferred_src_ip.as_ref().unwrap_or(src_ip);
+
+                        if !construct_vlan_packet(
+                            packet,
+                            &src_mac.0,
+                            &dest_mac.0,
+                            inner_src_ip,
+                            &dst_ip,
+                            src_port,
+                            addr.port(),
+                            vlan.vid,
+                            vlan.pcp,
+                            payload,
+                            ecn,
+                        ) {
+                            log::warn!("dropping packet: VLAN frame did not fit in UMEM slot");
+                            batched_packets -= 1;
+                            umem.release(frame.offset());
+                            continue;
+                        }
                     } else {
                         // we need the MAC address to send the packet
                         let Some(dest_mac) = next_hop.mac_addr else {
@@ -418,8 +484,6 @@ impl<U: Umem> TxLoop<U> {
                             continue;
                         }
 
-                        const PACKET_HEADER_SIZE: usize =
-                            ETH_HEADER_SIZE + IP_HEADER_SIZE + UDP_HEADER_SIZE;
                         let packet_len = PACKET_HEADER_SIZE + len;
                         if packet_len > umem_frame_size {
                             log::warn!(
@@ -434,29 +498,22 @@ impl<U: Umem> TxLoop<U> {
                         frame.set_len(packet_len);
                         let packet = umem.map_frame_mut(&frame);
 
-                        // write the payload first as it's needed for checksum calculation (if enabled)
-                        packet[PACKET_HEADER_SIZE..][..len].copy_from_slice(payload);
-
-                        write_eth_header(packet, &src_mac.0, &dest_mac.0);
-
-                        write_ip_header_for_udp(
-                            &mut packet[ETH_HEADER_SIZE..],
+                        if !construct_packet(
+                            packet,
+                            &src_mac.0,
+                            &dest_mac.0,
                             src_ip,
                             &dst_ip,
-                            ecn,
-                            (UDP_HEADER_SIZE + len) as u16,
-                        );
-
-                        write_udp_header(
-                            &mut packet[ETH_HEADER_SIZE + IP_HEADER_SIZE..],
-                            src_ip,
                             src_port,
-                            &dst_ip,
                             addr.port(),
-                            len as u16,
-                            // don't do checksums
-                            false,
-                        );
+                            payload,
+                            ecn,
+                        ) {
+                            log::warn!("dropping packet: frame did not fit in UMEM slot");
+                            batched_packets -= 1;
+                            umem.release(frame.offset());
+                            continue;
+                        }
                     }
 
                     ring.write(frame, 0)


### PR DESCRIPTION
when xdp is on we write raw frames straight to the nic, which bypasses the kernel vlan driver. so if the egress route resolves through a vlanN sub-interface, the frames the kernel would normally tag go out untagged and get dropped by the fabric.

we already do the equivalent for gre (the doublezero ibrl path, #9715). vlan needs the same treatment: build the 4-byte 802.1Q tag in userspace when a route resolves through a vlan sub-interface.

- vlan sub-interfaces are discovered from netlink link attributes (IFLA_LINKINFO kind "vlan", IFLA_VLAN_ID), same machinery as the gre linkinfo parsing. no configuration needed, and the route monitor picks up link changes automatically
- a VlanRouteInfo rides on the resolved NextHop, same shape as the gre info
- the tx loop prepends the tag: [dst|src mac][tpid 0x8100][tci {pcp, dei=0, vid}][ethertype][ip][udp][payload]
- only 802.1Q is handled; 802.1ad (QinQ) sub-interfaces are skipped
- pcp is emitted as 0, matching the kernel's default egress qos mapping; a config option can come later if someone needs priorities
- gre wins if an interface somehow looks like both gre and vlan (defensive, tested)

note the xdp sender is shared, so this tags both retransmit and broadcast traffic that egresses through a vlan, not just retransmit.

tested on a host with a vlan sub-interface: a peer captures correctly tagged shreds (tcpdump -ne "vlan <vid>").