### PR TITLE
nit: replay_stage: simplifies logic

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2395,14 +2395,19 @@ impl ReplayStage {
             .filter(|(slot, _)| *slot > root)
         {
             // Overwrite the pending switch, later switches take precedence
-            if Some(slot) >= pending_switch.map(|(slot, _)| slot) {
-                if let Some(prev_switch_request) = pending_switch.replace((slot, block_id)) {
-                    trace!(
-                        "{my_pubkey}: Overwriting previous switch request {prev_switch_request:?} \
-                         with ({slot}, {block_id})"
-                    );
-                } else {
-                    trace!("{my_pubkey}: Received switch request in {slot} to {block_id}");
+            match pending_switch {
+                None => {
+                    trace!("{my_pubkey}: Setting empty pending_switch to ({slot}, {block_id})");
+                    *pending_switch = Some((slot, block_id));
+                }
+                Some(pending_switch_block) => {
+                    if slot >= pending_switch_block.0 {
+                        trace!(
+                            "{my_pubkey}: Overwriting previous switch request \
+                             {pending_switch_block:?} with ({slot}, {block_id})"
+                        );
+                        *pending_switch_block = (slot, block_id);
+                    }
                 }
             }
         };


### PR DESCRIPTION
#### Problem

`process_switch_bank_events` appears to have some complicated logic that can be simplified if we use `match` instead.

I found that I had to stare at the original code for some time to understand it and it also relies on `None < Some(T)` which the reader may not immediately remember to think of when reading the code.


#### Summary of Changes

Simplifies the logic by using `match`.