### PR TITLE
Adding anza crates to 7 day exception

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,14 @@ updates:
     open-pull-requests-limit: 6
     cooldown:
       default-days: 7
+      # crates published by anza-team bypass the cooldown
+      exclude:
+        - "solana-*"
+        - "agave-*"
+        - "spl-*"
+        - "rts-alloc"
+        - "shaq"
+        - "wincode"
 
   # split from root directory schedule to avoid duplicate checks
   - package-ecosystem: cargo
@@ -24,6 +32,14 @@ updates:
     open-pull-requests-limit: 6
     cooldown:
       default-days: 7
+      # crates published by anza-team bypass the cooldown
+      exclude:
+        - "solana-*"
+        - "agave-*"
+        - "spl-*"
+        - "rts-alloc"
+        - "shaq"
+        - "wincode"
 
   - package-ecosystem: "npm"
     directory: "/docs"


### PR DESCRIPTION
Adding an exception to the 7-day cooldown for the crates we publish ourselves: `solana-*`, `agave-*`, `spl-*`, plus `rts-alloc`, `shaq`, and `wincode`

Related to this discussion https://github.com/anza-xyz/agave/pull/12889#issuecomment-4614183369