### PR TITLE
poh: require low power mode when alpenglow is active

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1089,6 +1089,15 @@ fn verify_ticks(
     }
 
     if migration_status.should_have_alpenglow_ticks(bank.slot()) {
+        // When alpenglow is active, PoH MUST be in low power mode.
+        // We require that each block only has 1 tick at the very end
+        if entries.iter().any(|entry| entry.num_hashes != 1) {
+            warn!(
+                "Alpenglow entry with invalid num_hashes found in slot: {}",
+                bank.slot()
+            );
+            return Err(BlockError::InvalidTickHashCount);
+        }
         return Ok(());
     }
 


### PR DESCRIPTION
#### Problem
If Alpenglow is activated, `verify_ticks` returns early and skips `verify_tick_hash_count`, which normally limits the value to `hashes_per_tick`.

PoH verification still runs in replay, so an attacker could set `num_hashes` and force us to do unecessary verification.

Recent changes set `hashes_per_tick` to `None` but failed to address this verification problem 😓 

#### Summary of Changes
Require that we are in low power mode when alpenglow is active

