### PR TITLE
replay: do not write bank_hash_details when clearing banks for ag

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2549,7 +2549,7 @@ impl ReplayStage {
 
             let root_bank = w_bank_forks.root_bank();
             let (slots_to_purge, removed_banks) =
-                w_bank_forks.dump_slots(slots_to_clear.iter(), true);
+                w_bank_forks.dump_slots(slots_to_clear.iter(), false);
             (root_bank, slots_to_purge, removed_banks)
         };
 


### PR DESCRIPTION
#### Problem
Alpenglow fucntion `clear_banks()` is used by BCL when aborting a leader bank, or when we switch out duplicate blocks
In alpenglow we have a separate mechanism for detecting bank hash mismatches and writing out the files.

#### Summary of Changes
Don't pollute the logs / directory with bank hash details in this case
